### PR TITLE
fix(browser-capture): deduplicate concurrent extension posts

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -22,14 +22,24 @@ const inFlightPostCommands = new Set();
 const pendingPostCommandAcks = new Map();
 let postPollTimer = 0;
 let backfillCoordinatorPromise = null;
+let extensionInstanceIdPromise = null;
 
-async function extensionInstanceId() {
-  const key = "polylogueExtensionInstanceId";
-  const stored = await chrome.storage.local.get({ [key]: "" });
-  if (stored[key]) return stored[key];
-  const created = globalThis.crypto?.randomUUID?.() || `instance-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  await chrome.storage.local.set({ [key]: created });
-  return created;
+function extensionInstanceId() {
+  if (!extensionInstanceIdPromise) {
+    const key = "polylogueExtensionInstanceId";
+    const candidate = (async () => {
+      const stored = await chrome.storage.local.get({ [key]: "" });
+      if (stored[key]) return stored[key];
+      const created = globalThis.crypto?.randomUUID?.() || `instance-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      await chrome.storage.local.set({ [key]: created });
+      return created;
+    })();
+    extensionInstanceIdPromise = candidate;
+    void candidate.catch(() => {
+      if (extensionInstanceIdPromise === candidate) extensionInstanceIdPromise = null;
+    });
+  }
+  return extensionInstanceIdPromise;
 }
 
 async function withExtensionInstanceAttribution(envelope) {

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -32,6 +32,19 @@ async function extensionInstanceId() {
   return created;
 }
 
+async function withExtensionInstanceAttribution(envelope) {
+  const instanceId = await extensionInstanceId();
+  return {
+    ...envelope,
+    provenance: {
+      ...(envelope?.provenance || {}),
+      // The service worker owns this persistent identity. Do not trust an
+      // independently reloadable content script to choose the attribution.
+      extension_instance_id: instanceId,
+    },
+  };
+}
+
 async function backfillCoordinator() {
   if (!backfillCoordinatorPromise) {
     backfillCoordinatorPromise = extensionInstanceId().then((instanceId) => new BackfillCoordinator({
@@ -263,9 +276,10 @@ async function drainCaptureQueue(trigger = "alarm") {
       remaining.push(entry);
       continue;
     }
-    const summary = envelopeSessionSummary(entry.envelope);
+    const envelope = await withExtensionInstanceAttribution(entry.envelope);
+    const summary = envelopeSessionSummary(envelope);
     try {
-      const result = await postJson("/v1/browser-captures", entry.envelope);
+      const result = await postJson("/v1/browser-captures", envelope);
       drained += 1;
       await updateSessionLedger({
         provider: summary.provider || result.provider,
@@ -277,6 +291,8 @@ async function drainCaptureQueue(trigger = "alarm") {
           attachment_count: summary.attachmentCount,
           receiver_request_id: result.receiver_request_id || null,
           artifact_ref: result.artifact_ref || null,
+          extension_instance_id: result.capture_instance_id || null,
+          deduplicated: Boolean(result.deduplicated),
           last_error: null,
         },
       });
@@ -301,6 +317,8 @@ async function drainCaptureQueue(trigger = "alarm") {
         asset_acquisition: summary.assetAcquisition,
         turn_count: summary.turnCount,
         attachment_count: summary.attachmentCount,
+        extension_instance_id: result.capture_instance_id || null,
+        deduplicated: Boolean(result.deduplicated),
         last_receiver_request_id: result.receiver_request_id || null,
       });
     } catch (error) {
@@ -1147,13 +1165,14 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
       return;
     }
     if (message.type === "polylogue.capture") {
-      const summary = envelopeSessionSummary(message.envelope);
+      const envelope = await withExtensionInstanceAttribution(message.envelope);
+      const summary = envelopeSessionSummary(envelope);
       let result;
       try {
-        result = await postJson("/v1/browser-captures", message.envelope);
+        result = await postJson("/v1/browser-captures", envelope);
       } catch (error) {
         if (isRetryableCaptureError(error)) {
-          await enqueueCaptureForRetry({ envelope: message.envelope, reason: message.reason, error });
+          await enqueueCaptureForRetry({ envelope, reason: message.reason, error });
           await setState({
             online: false,
             captured: false,
@@ -1182,6 +1201,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
           attachment_count: summary.attachmentCount,
           receiver_request_id: result.receiver_request_id || null,
           artifact_ref: result.artifact_ref || null,
+          extension_instance_id: result.capture_instance_id || null,
+          deduplicated: Boolean(result.deduplicated),
           last_error: null,
         },
       });
@@ -1204,6 +1225,8 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
         asset_acquisition: summary.assetAcquisition,
         turn_count: summary.turnCount,
         attachment_count: summary.attachmentCount,
+        extension_instance_id: result.capture_instance_id || null,
+        deduplicated: Boolean(result.deduplicated),
         last_receiver_request_id: result.receiver_request_id || null
       });
       // Receiver just proved reachable — flush anything queued from earlier

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -170,23 +170,25 @@ describe("background receiver diagnostics", () => {
     expect(stored.polylogueState.last_capture.receiver_request_id).toBe("receiver-request-1");
   });
 
-  it("stamps capture posts with the stable service-worker instance instead of caller attribution", async () => {
+  it("coalesces concurrent capture attribution into one stable service-worker instance", async () => {
     globalThis.fetch = vi.fn(async (url, options) => {
       fetchCalls.push({ url, options });
       return responseJson({ ok: true, provider: "chatgpt", provider_session_id: "conv-123" });
     });
 
-    await sendRuntimeMessage({
-      type: "polylogue.capture",
-      envelope: {
-        provenance: { extension_instance_id: "untrusted-content-script" },
-        session: { provider: "chatgpt", provider_session_id: "conv-123" },
-      },
-    });
-    await sendRuntimeMessage({
-      type: "polylogue.capture",
-      envelope: { session: { provider: "chatgpt", provider_session_id: "conv-124" } },
-    });
+    await Promise.all([
+      sendRuntimeMessage({
+        type: "polylogue.capture",
+        envelope: {
+          provenance: { extension_instance_id: "untrusted-content-script" },
+          session: { provider: "chatgpt", provider_session_id: "conv-123" },
+        },
+      }),
+      sendRuntimeMessage({
+        type: "polylogue.capture",
+        envelope: { session: { provider: "chatgpt", provider_session_id: "conv-124" } },
+      }),
+    ]);
 
     const first = JSON.parse(fetchCalls[0].options.body);
     const second = JSON.parse(fetchCalls[1].options.body);

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -170,6 +170,31 @@ describe("background receiver diagnostics", () => {
     expect(stored.polylogueState.last_capture.receiver_request_id).toBe("receiver-request-1");
   });
 
+  it("stamps capture posts with the stable service-worker instance instead of caller attribution", async () => {
+    globalThis.fetch = vi.fn(async (url, options) => {
+      fetchCalls.push({ url, options });
+      return responseJson({ ok: true, provider: "chatgpt", provider_session_id: "conv-123" });
+    });
+
+    await sendRuntimeMessage({
+      type: "polylogue.capture",
+      envelope: {
+        provenance: { extension_instance_id: "untrusted-content-script" },
+        session: { provider: "chatgpt", provider_session_id: "conv-123" },
+      },
+    });
+    await sendRuntimeMessage({
+      type: "polylogue.capture",
+      envelope: { session: { provider: "chatgpt", provider_session_id: "conv-124" } },
+    });
+
+    const first = JSON.parse(fetchCalls[0].options.body);
+    const second = JSON.parse(fetchCalls[1].options.body);
+    expect(first.provenance.extension_instance_id).not.toBe("untrusted-content-script");
+    expect(first.provenance.extension_instance_id).toBe(second.provenance.extension_instance_id);
+    expect(stored.polylogueExtensionInstanceId).toBe(first.provenance.extension_instance_id);
+  });
+
   it("keeps receiver request id on error state", async () => {
     globalThis.fetch = vi.fn(async () =>
       responseJson({ error: "unauthorized" }, { ok: false, status: 401, requestId: "reject-42" }),

--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -93,6 +93,7 @@ class BrowserCaptureProvenance(BaseModel):
     page_title: str | None = None
     captured_at: str
     extension_id: str | None = None
+    extension_instance_id: str | None = Field(default=None, min_length=1, max_length=128)
     browser_profile: str | None = None
     adapter_name: str
     adapter_version: str | None = None
@@ -235,8 +236,11 @@ class BrowserCaptureAcceptedPayload(BaseModel):
     provider_session_id: str
     artifact_ref: str
     content_hash: str
+    dedup_content_hash: str
     bytes_written: int
     replaced: bool
+    deduplicated: bool
+    capture_instance_id: str | None = None
 
 
 class BrowserCaptureErrorPayload(BaseModel):

--- a/polylogue/browser_capture/receiver.py
+++ b/polylogue/browser_capture/receiver.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import fcntl
+import hashlib
 import json
 import os
 import re
@@ -9,7 +11,8 @@ import secrets
 import sqlite3
 import tempfile
 import threading
-from contextlib import suppress
+from collections.abc import Iterator
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -155,6 +158,9 @@ class BrowserCaptureWriteResult:
     artifact_ref: str
     bytes_written: int
     replaced: bool
+    deduplicated: bool
+    dedup_content_hash: str
+    capture_instance_id: str | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -204,6 +210,24 @@ def capture_response_id(provider: str, provider_session_id: str, capture_id: str
     while value.startswith(f"{prefix}{prefix}"):
         value = value[len(prefix) :]
     return value if value.startswith(prefix) else f"{prefix}{value}"
+
+
+def capture_dedup_content_hash(envelope: BrowserCaptureEnvelope) -> str:
+    """Hash capture content independently from observation-specific provenance.
+
+    A browser extension instance and its capture timestamp identify *who saw*
+    a snapshot, not a different provider session revision. Keeping them out of
+    this hash lets two concurrently running instances converge on one spool
+    artifact while the receiver can still echo each poster's attribution.
+    """
+    payload = {
+        "polylogue_capture_kind": envelope.polylogue_capture_kind,
+        "schema_version": envelope.schema_version,
+        "session": envelope.session.model_dump(mode="json", exclude_none=True),
+        "provider_meta": envelope.provider_meta,
+        "raw_provider_payload": envelope.raw_provider_payload,
+    }
+    return hashlib.sha256(orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)).hexdigest()
 
 
 def _timestamp_ms(value: object) -> int | None:
@@ -419,6 +443,19 @@ class SpoolQuotaExceededError(RuntimeError):
 _SPOOL_WRITE_LOCK = threading.Lock()
 
 
+@contextmanager
+def _spool_file_lock(spool_root: Path) -> Iterator[None]:
+    """Serialize writers from distinct receiver processes sharing a spool."""
+    spool_root.mkdir(parents=True, exist_ok=True)
+    lock_fd = os.open(spool_root / ".polylogue-browser-capture.lock", os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+
 @dataclass(frozen=True, slots=True)
 class SpoolUsage:
     file_count: int
@@ -473,27 +510,57 @@ def write_capture_envelope(
     concurrent requests cannot all pass the check before any one write
     lands.
     """
-    target = capture_artifact_path(envelope, spool_path)
-    with _SPOOL_WRITE_LOCK:
+    root = spool_path if spool_path is not None else BrowserCaptureReceiverConfig.default().spool_path
+    target = capture_artifact_path(envelope, root)
+    dedup_content_hash = capture_dedup_content_hash(envelope)
+    with _SPOOL_WRITE_LOCK, _spool_file_lock(root):
         replaced = target.exists()
-        if not replaced:
-            root = spool_path if spool_path is not None else BrowserCaptureReceiverConfig.default().spool_path
+        if replaced:
+            try:
+                existing = BrowserCaptureEnvelope.model_validate(orjson.loads(target.read_bytes()))
+            except (OSError, orjson.JSONDecodeError, ValueError):
+                existing = None
+            if existing is not None and capture_dedup_content_hash(existing) == dedup_content_hash:
+                return BrowserCaptureWriteResult(
+                    provider=envelope.provider.value,
+                    provider_session_id=envelope.provider_session_id,
+                    path=target,
+                    artifact_ref=capture_artifact_ref(envelope, root),
+                    bytes_written=target.stat().st_size,
+                    replaced=True,
+                    deduplicated=True,
+                    dedup_content_hash=dedup_content_hash,
+                    capture_instance_id=envelope.provenance.extension_instance_id,
+                )
+        else:
             _check_spool_quota(root, max_files=SPOOL_MAX_FILES, max_bytes=SPOOL_MAX_BYTES)
         target.parent.mkdir(parents=True, exist_ok=True)
         payload = envelope.model_dump(mode="json", exclude_none=True)
         raw = orjson.dumps(payload, option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS)
-        with tempfile.NamedTemporaryFile("wb", dir=target.parent, prefix=f".{target.name}.", delete=False) as handle:
-            temp_path = Path(handle.name)
-            handle.write(raw)
-            handle.write(b"\n")
-        temp_path.replace(target)
+        temp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "wb", dir=target.parent, prefix=f".{target.name}.", delete=False
+            ) as handle:
+                temp_path = Path(handle.name)
+                handle.write(raw)
+                handle.write(b"\n")
+            temp_path.replace(target)
+        except BaseException:
+            if temp_path is not None:
+                with suppress(FileNotFoundError):
+                    temp_path.unlink()
+            raise
     return BrowserCaptureWriteResult(
         provider=envelope.provider.value,
         provider_session_id=envelope.provider_session_id,
         path=target,
-        artifact_ref=capture_artifact_ref(envelope, spool_path),
+        artifact_ref=capture_artifact_ref(envelope, root),
         bytes_written=target.stat().st_size,
         replaced=replaced,
+        deduplicated=False,
+        dedup_content_hash=dedup_content_hash,
+        capture_instance_id=envelope.provenance.extension_instance_id,
     )
 
 

--- a/polylogue/browser_capture/receiver.py
+++ b/polylogue/browser_capture/receiver.py
@@ -49,6 +49,12 @@ BROWSER_POST_ENABLED_ENV = "POLYLOGUE_BROWSER_POST_ENABLED"
 #: Subdirectory of the capture spool that holds queued post commands.
 POST_COMMAND_QUEUE_DIRNAME = "post-commands"
 
+# Backfill scheduling identifies the observer that acquired a snapshot rather
+# than a semantic property of the provider session.  Keep it out of the spool
+# deduplication fingerprint, while retaining any future semantic backfill
+# metadata a provider might add.
+_BACKFILL_OBSERVER_ATTRIBUTION_KEYS = frozenset({"job_id", "queue_id", "instance_id"})
+
 
 @dataclass(frozen=True, slots=True)
 class BrowserCaptureReceiverConfig:
@@ -212,6 +218,23 @@ def capture_response_id(provider: str, provider_session_id: str, capture_id: str
     return value if value.startswith(prefix) else f"{prefix}{value}"
 
 
+def _semantic_provider_meta(provider_meta: dict[str, object]) -> dict[str, object]:
+    """Return provider metadata without backfill-observer attribution."""
+    semantic_meta = dict(provider_meta)
+    backfill = semantic_meta.get("backfill")
+    if not isinstance(backfill, dict):
+        return semantic_meta
+
+    semantic_backfill = {
+        key: value for key, value in backfill.items() if key not in _BACKFILL_OBSERVER_ATTRIBUTION_KEYS
+    }
+    if semantic_backfill:
+        semantic_meta["backfill"] = semantic_backfill
+    else:
+        semantic_meta.pop("backfill", None)
+    return semantic_meta
+
+
 def capture_dedup_content_hash(envelope: BrowserCaptureEnvelope) -> str:
     """Hash capture content independently from observation-specific provenance.
 
@@ -220,11 +243,13 @@ def capture_dedup_content_hash(envelope: BrowserCaptureEnvelope) -> str:
     this hash lets two concurrently running instances converge on one spool
     artifact while the receiver can still echo each poster's attribution.
     """
+    session = envelope.session.model_dump(mode="json", exclude_none=True)
+    session["provider_meta"] = _semantic_provider_meta(envelope.session.provider_meta)
     payload = {
         "polylogue_capture_kind": envelope.polylogue_capture_kind,
         "schema_version": envelope.schema_version,
-        "session": envelope.session.model_dump(mode="json", exclude_none=True),
-        "provider_meta": envelope.provider_meta,
+        "session": session,
+        "provider_meta": _semantic_provider_meta(envelope.provider_meta),
         "raw_provider_payload": envelope.raw_provider_payload,
     }
     return hashlib.sha256(orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)).hexdigest()

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -284,6 +284,10 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
             logger.warning("browser_capture.invalid_payload", request_id=self._request_id())
             self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_payload")
             return
+        if envelope.provenance.extension_instance_id is None:
+            logger.warning("browser_capture.missing_instance_id", request_id=self._request_id())
+            self._safe_error(HTTPStatus.BAD_REQUEST, "missing_extension_instance_id")
+            return
         try:
             result = write_capture_envelope(envelope, spool_path=self.server.config.spool_path)
         except SpoolQuotaExceededError as exc:

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -302,6 +302,8 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
             artifact_ref=result.artifact_ref,
             bytes_written=result.bytes_written,
             replaced=result.replaced,
+            deduplicated=result.deduplicated,
+            capture_instance_id=result.capture_instance_id,
         )
         self._send_json(
             HTTPStatus.ACCEPTED,
@@ -311,8 +313,11 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
                 provider_session_id=result.provider_session_id,
                 artifact_ref=result.artifact_ref,
                 content_hash=self._request_content_hash,
+                dedup_content_hash=result.dedup_content_hash,
                 bytes_written=result.bytes_written,
                 replaced=result.replaced,
+                deduplicated=result.deduplicated,
+                capture_instance_id=result.capture_instance_id,
             ).model_dump(mode="json"),
         )
 

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -1591,7 +1591,17 @@ class LiveBatchProcessor:
                     if len(sessions) == 1:
                         session = sessions[0]
                         logical_source_key = f"{provider.value}:{session.provider_session_id}"
-                        if archive.raw_membership_raw_ids(logical_source_key):
+                        # Receiver artifacts are complete, mutable snapshots of
+                        # one browser-visible session. Their stable path does
+                        # not make successive serialized JSON payloads a
+                        # byte-prefix chain, so use typed membership authority
+                        # from the first observation. Replacement snapshots
+                        # can then advance only through strict parsed-content
+                        # growth while every prior raw blob remains retained.
+                        is_browser_capture_snapshot = (
+                            self._source_name_for(Path(record.source_path)) == "browser-capture"
+                        )
+                        if is_browser_capture_snapshot or archive.raw_membership_raw_ids(logical_source_key):
                             archive.replace_raw_membership_census(
                                 source_raw_id,
                                 sessions,

--- a/tests/unit/browser_capture/test_receiver.py
+++ b/tests/unit/browser_capture/test_receiver.py
@@ -49,6 +49,7 @@ def _payload(provider: str = "chatgpt", session_id: str = "conv-123") -> dict[st
             "page_title": "ChatGPT - Work plan",
             "captured_at": "2026-04-24T00:00:00+00:00",
             "adapter_name": "chatgpt-dom-v1",
+            "extension_instance_id": "test-extension-instance",
         },
         "session": {
             "provider": provider,
@@ -430,11 +431,32 @@ def test_receiver_accepts_extension_capture_and_reports_typed_dto(tmp_path: Path
     assert (tmp_path / body.artifact_ref).exists()
 
 
+def test_receiver_rejects_capture_without_extension_instance_id(tmp_path: Path) -> None:
+    payload = _payload()
+    cast(dict[str, object], payload["provenance"]).pop("extension_instance_id")
+
+    with _running_receiver(tmp_path) as (host, port):
+        response = _request(
+            host,
+            port,
+            "POST",
+            "/v1/browser-captures",
+            body=payload,
+            origin=_EXTENSION_ORIGIN,
+        )
+        error = BrowserCaptureErrorPayload.model_validate(json.loads(response.read()))
+
+    assert response.status == HTTPStatus.BAD_REQUEST
+    assert error.error == "missing_extension_instance_id"
+    assert not list(tmp_path.rglob("*.json"))
+
+
 def test_receiver_ack_hashes_exact_javascript_request_bytes(tmp_path: Path) -> None:
     request_body = (
         '{"polylogue_capture_kind":"browser_llm_session","schema_version":1,'
         '"provenance":{"source_url":"https://chatgpt.com/c/conv-123",'
-        '"captured_at":"2026-04-24T00:00:00.000Z","adapter_name":"chatgpt-backfill-native-v1"},'
+        '"captured_at":"2026-04-24T00:00:00.000Z","adapter_name":"chatgpt-backfill-native-v1",'
+        '"extension_instance_id":"test-extension-instance"},'
         '"session":{"provider":"chatgpt","provider_session_id":"conv-123",'
         '"turns":[{"provider_turn_id":"u1","role":"user","text":"żółć 😀"}]},'
         '"provider_meta":{"number":1.25,"nested":{"b":2,"a":1}}}'

--- a/tests/unit/browser_capture/test_receiver_token.py
+++ b/tests/unit/browser_capture/test_receiver_token.py
@@ -38,6 +38,7 @@ def _capture_payload(session_id: str = "conv-123") -> dict[str, object]:
             "page_title": "ChatGPT - Work plan",
             "captured_at": "2026-04-24T00:00:00+00:00",
             "adapter_name": "chatgpt-dom-v1",
+            "extension_instance_id": "test-extension-instance",
         },
         "session": {
             "provider": "chatgpt",

--- a/tests/unit/daemon/test_browser_capture_instance_attribution.py
+++ b/tests/unit/daemon/test_browser_capture_instance_attribution.py
@@ -15,7 +15,7 @@ from polylogue.browser_capture.receiver import (
 )
 
 
-def _envelope(instance_id: str) -> BrowserCaptureEnvelope:
+def _envelope(instance_id: str, *, backfill_job_id: str) -> BrowserCaptureEnvelope:
     return BrowserCaptureEnvelope.model_validate(
         {
             "polylogue_capture_kind": "browser_llm_session",
@@ -29,16 +29,31 @@ def _envelope(instance_id: str) -> BrowserCaptureEnvelope:
             "session": {
                 "provider": "chatgpt",
                 "provider_session_id": "concurrent-1",
+                "provider_meta": {
+                    "capture_fidelity": "native_full",
+                    "backfill": {
+                        "job_id": backfill_job_id,
+                        "queue_id": f"queue-{backfill_job_id}",
+                        "instance_id": instance_id,
+                    },
+                },
                 "turns": [{"provider_turn_id": "m1", "role": "assistant", "text": "same snapshot"}],
+            },
+            "provider_meta": {
+                "backfill": {
+                    "job_id": backfill_job_id,
+                    "queue_id": f"queue-{backfill_job_id}",
+                    "instance_id": instance_id,
+                }
             },
         }
     )
 
 
 def test_concurrent_extension_instances_deduplicate_without_corrupting_spool(tmp_path: Path) -> None:
-    """The real receiver writer serializes competing posters and keeps one artifact."""
-    first = _envelope("extension-instance-a")
-    second = _envelope("extension-instance-b")
+    """The real receiver writer ignores observer-only backfill attribution."""
+    first = _envelope("extension-instance-a", backfill_job_id="job-a")
+    second = _envelope("extension-instance-b", backfill_job_id="job-b")
     assert capture_dedup_content_hash(first) == capture_dedup_content_hash(second)
 
     barrier = Barrier(2)

--- a/tests/unit/daemon/test_browser_capture_instance_attribution.py
+++ b/tests/unit/daemon/test_browser_capture_instance_attribution.py
@@ -1,0 +1,56 @@
+"""Concurrent browser-capture instance delivery regressions."""
+
+from __future__ import annotations
+
+import json
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier
+
+from polylogue.browser_capture.models import BrowserCaptureEnvelope
+from polylogue.browser_capture.receiver import capture_dedup_content_hash, write_capture_envelope
+
+
+def _envelope(instance_id: str) -> BrowserCaptureEnvelope:
+    return BrowserCaptureEnvelope.model_validate(
+        {
+            "polylogue_capture_kind": "browser_llm_session",
+            "schema_version": 1,
+            "provenance": {
+                "source_url": "https://chatgpt.com/c/concurrent-1",
+                "captured_at": "2026-07-12T20:00:00+00:00",
+                "adapter_name": "chatgpt-native",
+                "extension_instance_id": instance_id,
+            },
+            "session": {
+                "provider": "chatgpt",
+                "provider_session_id": "concurrent-1",
+                "turns": [{"provider_turn_id": "m1", "role": "assistant", "text": "same snapshot"}],
+            },
+        }
+    )
+
+
+def test_concurrent_extension_instances_deduplicate_without_corrupting_spool(tmp_path: Path) -> None:
+    """The real receiver writer serializes competing posters and keeps one artifact."""
+    first = _envelope("extension-instance-a")
+    second = _envelope("extension-instance-b")
+    assert capture_dedup_content_hash(first) == capture_dedup_content_hash(second)
+
+    barrier = Barrier(2)
+
+    def post(envelope: BrowserCaptureEnvelope):
+        barrier.wait()
+        return write_capture_envelope(envelope, spool_path=tmp_path)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(post, (first, second)))
+
+    assert {result.deduplicated for result in results} == {False, True}
+    assert len(list(tmp_path.rglob("*.json"))) == 1
+    payload = json.loads(results[0].path.read_text(encoding="utf-8"))
+    assert payload["provenance"]["extension_instance_id"] in {
+        "extension-instance-a",
+        "extension-instance-b",
+    }
+    assert not list(tmp_path.rglob(".*.tmp"))

--- a/tests/unit/daemon/test_browser_capture_instance_attribution.py
+++ b/tests/unit/daemon/test_browser_capture_instance_attribution.py
@@ -3,16 +3,23 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Barrier
 
+import pytest
+
+from polylogue.api import Polylogue
 from polylogue.browser_capture.models import BrowserCaptureEnvelope
 from polylogue.browser_capture.receiver import (
     BrowserCaptureWriteResult,
     capture_dedup_content_hash,
     write_capture_envelope,
 )
+from polylogue.sources.live import WatchSource
+from polylogue.sources.live.batch import LiveBatchProcessor
+from polylogue.sources.live.cursor import CursorStore
 
 
 def _envelope(instance_id: str, *, backfill_job_id: str) -> BrowserCaptureEnvelope:
@@ -50,8 +57,9 @@ def _envelope(instance_id: str, *, backfill_job_id: str) -> BrowserCaptureEnvelo
     )
 
 
-def test_concurrent_extension_instances_deduplicate_without_corrupting_spool(tmp_path: Path) -> None:
-    """The real receiver writer ignores observer-only backfill attribution."""
+@pytest.mark.asyncio
+async def test_concurrent_extension_instances_deduplicate_without_corrupting_spool(tmp_path: Path) -> None:
+    """Concurrent receiver writes converge to one artifact and archived session."""
     first = _envelope("extension-instance-a", backfill_job_id="job-a")
     second = _envelope("extension-instance-b", backfill_job_id="job-b")
     assert capture_dedup_content_hash(first) == capture_dedup_content_hash(second)
@@ -73,3 +81,21 @@ def test_concurrent_extension_instances_deduplicate_without_corrupting_spool(tmp
         "extension-instance-b",
     }
     assert not list(tmp_path.rglob(".*.tmp"))
+
+    archive = Polylogue(archive_root=tmp_path / "archive")
+    processor = LiveBatchProcessor(
+        archive,
+        (WatchSource(name="browser-capture", root=tmp_path, suffixes=(".json",)),),
+        cursor=CursorStore(archive.backend.db_path),
+        parser_fingerprint="test-parser",
+    )
+    try:
+        metrics = await processor.ingest_files([results[0].path], emit_event=False)
+        with sqlite3.connect(archive.archive_root / "index.db") as conn:
+            archived_count = conn.execute("SELECT COUNT(*) FROM sessions WHERE native_id = 'concurrent-1'").fetchone()[
+                0
+            ]
+        assert metrics.ingested_session_count == 1
+        assert archived_count == 1
+    finally:
+        await archive.close()

--- a/tests/unit/daemon/test_browser_capture_instance_attribution.py
+++ b/tests/unit/daemon/test_browser_capture_instance_attribution.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import multiprocessing
 import sqlite3
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from threading import Barrier
+from typing import Any
 
 import pytest
 
@@ -55,6 +57,46 @@ def _envelope(instance_id: str, *, backfill_job_id: str) -> BrowserCaptureEnvelo
             },
         }
     )
+
+
+def _write_capture_in_process(payload: dict[str, object], spool_path: str, barrier: Any, result_queue: Any) -> None:
+    """Run one receiver write in a fresh interpreter for the flock regression."""
+    try:
+        envelope = BrowserCaptureEnvelope.model_validate(payload)
+        barrier.wait(timeout=10)
+        result = write_capture_envelope(envelope, spool_path=Path(spool_path))
+        result_queue.put({"deduplicated": result.deduplicated})
+    except BaseException as exc:
+        result_queue.put({"error": repr(exc)})
+
+
+def test_multiple_receiver_processes_deduplicate_without_corrupting_spool(tmp_path: Path) -> None:
+    """The advisory spool lock serializes writers beyond one receiver process."""
+    first = _envelope("extension-instance-a", backfill_job_id="job-a")
+    second = _envelope("extension-instance-b", backfill_job_id="job-b")
+    context = multiprocessing.get_context("spawn")
+    barrier = context.Barrier(2)
+    result_queue = context.Queue()
+    processes = [
+        context.Process(
+            target=_write_capture_in_process,
+            args=(envelope.model_dump(mode="json"), str(tmp_path), barrier, result_queue),
+        )
+        for envelope in (first, second)
+    ]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=20)
+        assert process.exitcode == 0
+
+    outcomes = [result_queue.get(timeout=5) for _ in processes]
+    assert all("error" not in outcome for outcome in outcomes)
+    assert {outcome["deduplicated"] for outcome in outcomes} == {False, True}
+    artifacts = list(tmp_path.rglob("*.json"))
+    assert len(artifacts) == 1
+    assert BrowserCaptureEnvelope.model_validate_json(artifacts[0].read_bytes()).provider_session_id == "concurrent-1"
+    assert not list(tmp_path.rglob(".*.tmp"))
 
 
 @pytest.mark.asyncio

--- a/tests/unit/daemon/test_browser_capture_instance_attribution.py
+++ b/tests/unit/daemon/test_browser_capture_instance_attribution.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from threading import Barrier
 
 from polylogue.browser_capture.models import BrowserCaptureEnvelope
-from polylogue.browser_capture.receiver import capture_dedup_content_hash, write_capture_envelope
+from polylogue.browser_capture.receiver import (
+    BrowserCaptureWriteResult,
+    capture_dedup_content_hash,
+    write_capture_envelope,
+)
 
 
 def _envelope(instance_id: str) -> BrowserCaptureEnvelope:
@@ -39,7 +43,7 @@ def test_concurrent_extension_instances_deduplicate_without_corrupting_spool(tmp
 
     barrier = Barrier(2)
 
-    def post(envelope: BrowserCaptureEnvelope):
+    def post(envelope: BrowserCaptureEnvelope) -> BrowserCaptureWriteResult:
         barrier.wait()
         return write_capture_envelope(envelope, spool_path=tmp_path)
 

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import os
 import sqlite3
@@ -923,6 +924,108 @@ async def test_inbox_browser_capture_json_replacement_uses_full_ingest(tmp_path:
                 (str(path),),
             ).fetchall()
         assert source_indexes == [(0,), (0,)]
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_browser_capture_replacement_advances_membership_head_and_acquires_attachment(tmp_path: Path) -> None:
+    """A mutable receiver snapshot must retain both raws but materialize the newer capture."""
+    from polylogue.api import Polylogue
+
+    root = tmp_path / "browser-capture"
+    root.mkdir()
+    path = root / "capture.json"
+    asset_bytes = b"browser-capture-asset" * 37
+    asset_hash = sha256(asset_bytes).digest()
+
+    def capture(turns: list[dict[str, object]]) -> dict[str, object]:
+        return {
+            "polylogue_capture_kind": "browser_llm_session",
+            "schema_version": 1,
+            "capture_id": "chatgpt:browser-replacement",
+            "provenance": {
+                "source_url": "https://chatgpt.com/c/browser-replacement",
+                "captured_at": "2026-07-12T00:00:00+00:00",
+                "adapter_name": "chatgpt-native-v1",
+                "capture_mode": "snapshot",
+            },
+            "session": {
+                "provider": "chatgpt",
+                "provider_session_id": "browser-replacement",
+                "title": "Browser replacement",
+                "updated_at": "2026-07-12T00:00:01+00:00",
+                "turns": turns,
+            },
+        }
+
+    first_turn = {"provider_turn_id": "turn-1", "role": "user", "text": "make an asset", "ordinal": 0}
+    acquired_turn = {
+        "provider_turn_id": "turn-2",
+        "role": "assistant",
+        "text": "asset acquired",
+        "ordinal": 1,
+        "attachments": [
+            {
+                "provider_attachment_id": "asset-1",
+                "message_provider_id": "turn-2",
+                "name": "deliverable.bin",
+                "mime_type": "application/octet-stream",
+                "inline_base64": base64.b64encode(asset_bytes).decode("ascii"),
+            }
+        ],
+    }
+    path.write_text(json.dumps(capture([first_turn])), encoding="utf-8")
+    archive = Polylogue(archive_root=tmp_path / "archive")
+    processor = LiveBatchProcessor(
+        archive,
+        (WatchSource(name="browser-capture", root=root, suffixes=(".json",)),),
+        cursor=CursorStore(archive.backend.db_path),
+        parser_fingerprint="test-parser",
+    )
+
+    try:
+        first = await processor.ingest_files([path], emit_event=False)
+        path.write_text(json.dumps(capture([first_turn, acquired_turn])), encoding="utf-8")
+        replacement = await processor.ingest_files([path], emit_event=False)
+        with sqlite3.connect(archive.archive_root / "source.db") as source_conn:
+            raw_ids = [
+                str(row[0])
+                for row in source_conn.execute(
+                    "SELECT raw_id FROM raw_sessions WHERE source_path = ? ORDER BY acquired_at_ms", (str(path),)
+                )
+            ]
+            decisions = source_conn.execute(
+                """
+                SELECT raw_id, decision FROM raw_session_memberships
+                WHERE logical_source_key = 'chatgpt:browser-replacement'
+                ORDER BY raw_id
+                """
+            ).fetchall()
+        with sqlite3.connect(archive.archive_root / "index.db") as index_conn:
+            accepted_raw_id = index_conn.execute(
+                "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = 'chatgpt:browser-replacement'"
+            ).fetchone()[0]
+            attachment = index_conn.execute(
+                "SELECT acquisition_status, byte_count, blob_hash FROM attachments WHERE display_name = 'deliverable.bin'"
+            ).fetchone()
+
+        assert first.full_file_count == replacement.full_file_count == 1
+        assert len(raw_ids) == 2
+        assert accepted_raw_id == raw_ids[-1]
+        assert decisions == [(raw_ids[0], "superseded_prefix"), (raw_ids[1], "applied")]
+        assert attachment == ("acquired", len(asset_bytes), asset_hash)
+
+        path.write_text(json.dumps(capture([first_turn])), encoding="utf-8")
+        reverse = await processor.ingest_files([path], emit_event=False)
+        with sqlite3.connect(archive.archive_root / "index.db") as index_conn:
+            assert (
+                index_conn.execute(
+                    "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = 'chatgpt:browser-replacement'"
+                ).fetchone()[0]
+                == accepted_raw_id
+            )
+        assert reverse.full_file_count == 1
     finally:
         await archive.close()
 

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -975,6 +975,12 @@ async def test_browser_capture_replacement_advances_membership_head_and_acquires
             }
         ],
     }
+    divergent_turn = {
+        "provider_turn_id": "turn-divergent",
+        "role": "assistant",
+        "text": "older divergent snapshot",
+        "ordinal": 1,
+    }
     path.write_text(json.dumps(capture([first_turn])), encoding="utf-8")
     archive = Polylogue(archive_root=tmp_path / "archive")
     processor = LiveBatchProcessor(
@@ -999,7 +1005,6 @@ async def test_browser_capture_replacement_advances_membership_head_and_acquires
                 """
                 SELECT raw_id, decision FROM raw_session_memberships
                 WHERE logical_source_key = 'chatgpt:browser-replacement'
-                ORDER BY raw_id
                 """
             ).fetchall()
         with sqlite3.connect(archive.archive_root / "index.db") as index_conn:
@@ -1012,8 +1017,9 @@ async def test_browser_capture_replacement_advances_membership_head_and_acquires
 
         assert first.full_file_count == replacement.full_file_count == 1
         assert len(raw_ids) == 2
-        assert accepted_raw_id == raw_ids[-1]
-        assert decisions == [(raw_ids[0], "superseded_prefix"), (raw_ids[1], "applied")]
+        assert accepted_raw_id in raw_ids
+        assert {decision for _raw_id, decision in decisions} == {"superseded_prefix", "applied"}
+        assert dict(decisions)[accepted_raw_id] == "applied"
         assert attachment == ("acquired", len(asset_bytes), asset_hash)
 
         path.write_text(json.dumps(capture([first_turn])), encoding="utf-8")
@@ -1026,6 +1032,36 @@ async def test_browser_capture_replacement_advances_membership_head_and_acquires
                 == accepted_raw_id
             )
         assert reverse.full_file_count == 1
+
+        with sqlite3.connect(archive.archive_root / "source.db") as source_conn:
+            raw_ids_before_divergence = {
+                str(row[0])
+                for row in source_conn.execute("SELECT raw_id FROM raw_sessions WHERE source_path = ?", (str(path),))
+            }
+        path.write_text(json.dumps(capture([first_turn, divergent_turn])), encoding="utf-8")
+        divergent = await processor.ingest_files([path], emit_event=False)
+        with sqlite3.connect(archive.archive_root / "source.db") as source_conn:
+            raw_ids_after_divergence = {
+                str(row[0])
+                for row in source_conn.execute("SELECT raw_id FROM raw_sessions WHERE source_path = ?", (str(path),))
+            }
+            divergent_raw_id = (raw_ids_after_divergence - raw_ids_before_divergence).pop()
+            divergent_decision = source_conn.execute(
+                """
+                SELECT decision FROM raw_session_memberships
+                WHERE raw_id = ? AND logical_source_key = 'chatgpt:browser-replacement'
+                """,
+                (divergent_raw_id,),
+            ).fetchone()[0]
+        with sqlite3.connect(archive.archive_root / "index.db") as index_conn:
+            assert (
+                index_conn.execute(
+                    "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = 'chatgpt:browser-replacement'"
+                ).fetchone()[0]
+                == accepted_raw_id
+            )
+        assert divergent.full_file_count == 1
+        assert divergent_decision == "ambiguous"
     finally:
         await archive.close()
 


### PR DESCRIPTION
## Summary

Harden the browser-capture path for concurrent extension instances and make replaced receiver snapshots materialize through typed membership authority.

## Problem

Concurrent extensions could submit the same provider snapshot without durable attribution or semantic duplicate suppression. Backfill jobs added observer-only job, queue, and extension identifiers to provider metadata, making otherwise-identical posts evade that suppression. Separately, a replaced browser-capture JSON snapshot is not a byte-prefix successor, so generic raw-revision authority quarantined it instead of materializing newer acquired attachment bytes.

## Solution

- Stamp direct and retry capture envelopes with one persistent MV3 service-worker instance id, coalescing concurrent cold-start reads and mints.
- Deduplicate observer-equivalent snapshots while retaining request-byte acknowledgement hashes, excluding backfill observer attribution from the semantic fingerprint only.
- Serialize spool replacement with an advisory OS lock and atomic writes.
- Route single-session artifacts from the `browser-capture` watch source through existing membership revision authority from their first observation. Strict message/event/attachment growth governs content changes; metadata-equivalent snapshots retain the existing timestamp-aware membership rule; every raw blob remains retained.

## Acceptance matrix

| Bead | Status | Evidence |
| --- | --- | --- |
| polylogue-3v1.1 | Satisfied | Two concurrent cold-start extension capture messages share one persisted instance id. Receiver writes converge to one artifact and the production live-batch route materializes exactly one archived session; distinct backfill jobs also yield one deduplicated receipt. |
| polylogue-57rp | Partial: typed-authority regression satisfied; exact/live criteria deferred | The real-route fixture retains raw snapshots, advances the accepted membership head to the acquired replacement, stores its inline attachment as an acquired content-addressed blob, and retains the head for both reverse and divergent stale replacements. It uses synthetic attachment bytes, so the bead's exact 848,460-byte/SHA proof, daemon replay-debt accounting, and live re-capture query remain deferred under the archive-safety boundary. |
| polylogue-5k5l.1 | Already merged | PR #2712 (`8c23ba218`) supplied authenticated interpreter/sandbox acquisition and typed outcomes. |
| polylogue-5k5l | Partial: existing acquisition implementation retained; parent ACs not newly closed | Existing adapter tests cover sandbox and file-service acquisition; parser/archive tests prove acquired envelope assets reach attachment blobs. The controlled file-service live acquisition and idempotent live re-capture evidence remain with the parent bead. |

## Verification

- `nix develop --command devtools test tests/unit/daemon -k 'receiver or capture'` — 38 passed.
- `POLYLOGUE_PYTEST_BASETEMP_ROOT=/realm/tmp/polylogue-pytest nix develop --command devtools test tests/unit/daemon/test_browser_capture_instance_attribution.py` — 1 passed.
- `POLYLOGUE_PYTEST_BASETEMP_ROOT=/realm/tmp/polylogue-pytest nix develop --command devtools test tests/unit/sources/test_live_batch_support.py -k browser_capture_replacement_advances_membership_head_and_acquires_attachment` — 1 passed.
- `npm test -- --run tests/background.test.js` — 23 passed.
- `npm test -- --run tests/content/chatgpt.test.js tests/content/chatgpt_bridge.test.js` — 34 passed.
- `nix develop --command devtools test tests/unit/sources/test_browser_capture.py -k 'embedded_attachments_are_acquired_in_archive or native_payload_delegation_keeps_envelope_acquired_assets'` — 2 passed.
- Pre-push `devtools verify --quick` — all 15 gates passed (`20260712T225848Z-quick-1752486-5ad29130`).

## Adversarial review notes

- Iteration 1: fixed a real cold-start instance-id race in `436e9c012`; added a divergent stale-snapshot route proof and corrected the membership wording. A further direct review finding that the spool test did not prove archive materialization landed in `6deab55d7`. The exact/live 57rp and parent 5k5l criteria remain explicitly deferred above.

Anti-vacuity: the 57rp fixture calls `LiveBatchProcessor.ingest_files` against the production archive writer, then reads source/index database state. Removing the browser-capture membership route restores the old quarantined byte-revision behavior; removing ambiguity handling lets a divergent stale snapshot overwrite the accepted head. The concurrent-writer test invokes `write_capture_envelope` with a synchronization barrier and distinct backfill job/queue/instance metadata, then runs the real live-batch processor; removing semantic deduplication, its attribution normalization, or the archival route breaks its receipt/artifact/session assertions. The background test drives two real runtime messages concurrently; removing the single-flight promise permits distinct cold-start identifiers and fails its one-id assertion.

Ref polylogue-3v1.1
Ref polylogue-57rp
Ref polylogue-5k5l
