### PR TITLE
feat(insights): define time-confidence provenance contract

### DIFF
--- a/polylogue/insights/archive.py
+++ b/polylogue/insights/archive.py
@@ -34,7 +34,14 @@ from polylogue.insights.archive_models import (
     WorkEventEvidencePayload,
     WorkEventInferencePayload,
 )
-from polylogue.insights.temporal_source import time_confidence_for_record
+from polylogue.insights.temporal_source import (
+    TemporalSource,
+    TimeConfidence,
+    is_valid_temporal_source,
+    time_confidence_for_record,
+    time_confidence_for_sources,
+    weakest_of,
+)
 from polylogue.storage.repair import ArchiveDebtStatus
 from polylogue.storage.runtime.store_constants import SESSION_INSIGHT_MATERIALIZER_VERSION
 
@@ -203,6 +210,9 @@ def _record_inference_provenance(record: _InsightRecordWithInference) -> Archive
         materialized_at=record.materialized_at,
         source_updated_at=record.source_updated_at,
         source_sort_key=record.source_sort_key,
+        input_high_water_mark=record.input_high_water_mark,
+        input_high_water_mark_source=record.input_high_water_mark_source,
+        time_confidence=time_confidence_for_record(record),
         inference_version=record.inference_version,
         inference_family=record.inference_family,
     )
@@ -214,6 +224,9 @@ def _record_enrichment_provenance(record: _InsightRecordWithEnrichment) -> Archi
         materialized_at=record.materialized_at,
         source_updated_at=record.source_updated_at,
         source_sort_key=record.source_sort_key,
+        input_high_water_mark=record.input_high_water_mark,
+        input_high_water_mark_source=record.input_high_water_mark_source,
+        time_confidence=time_confidence_for_record(record),
         enrichment_version=record.enrichment_version,
         enrichment_family=record.enrichment_family,
     )
@@ -605,6 +618,8 @@ def records_provenance(
     materialized_at_attr: str = "materialized_at",
     source_updated_at_attr: str = "source_updated_at",
     source_sort_key_attr: str = "source_sort_key",
+    input_high_water_mark_attr: str = "input_high_water_mark",
+    input_high_water_mark_source_attr: str = "input_high_water_mark_source",
 ) -> ArchiveInsightProvenance:
     row_list = list(rows)
     materialized_at_values = [
@@ -627,11 +642,32 @@ def records_provenance(
         ),
         default=None,
     )
+    input_high_water_mark_values = [
+        _parse_iso_timestamp(str(getattr(row, input_high_water_mark_attr)))
+        for row in row_list
+        if getattr(row, input_high_water_mark_attr, None)
+    ]
+    input_high_water_mark = max(input_high_water_mark_values).isoformat() if input_high_water_mark_values else None
+    contributor_sources: list[TemporalSource] = []
+    has_unknown_contributor_source = False
+    for row in row_list:
+        value = getattr(row, input_high_water_mark_source_attr, None)
+        if isinstance(value, str) and is_valid_temporal_source(value):
+            contributor_sources.append(value)
+        else:
+            has_unknown_contributor_source = True
+    input_high_water_mark_source = None if has_unknown_contributor_source else weakest_of(contributor_sources)
+    time_confidence: TimeConfidence = (
+        "unknown" if has_unknown_contributor_source else time_confidence_for_sources(contributor_sources)
+    )
     return ArchiveInsightProvenance(
         materializer_version=SESSION_INSIGHT_MATERIALIZER_VERSION,
         materialized_at=materialized_at,
         source_updated_at=source_updated_at,
         source_sort_key=source_sort_key,
+        input_high_water_mark=input_high_water_mark,
+        input_high_water_mark_source=input_high_water_mark_source,
+        time_confidence=time_confidence,
     )
 
 

--- a/polylogue/insights/archive.py
+++ b/polylogue/insights/archive.py
@@ -34,6 +34,7 @@ from polylogue.insights.archive_models import (
     WorkEventEvidencePayload,
     WorkEventInferencePayload,
 )
+from polylogue.insights.temporal_source import time_confidence_for_record
 from polylogue.storage.repair import ArchiveDebtStatus
 from polylogue.storage.runtime.store_constants import SESSION_INSIGHT_MATERIALIZER_VERSION
 
@@ -170,6 +171,8 @@ class _InsightRecordWithProvenance(Protocol):
     materialized_at: str
     source_updated_at: str | None
     source_sort_key: float | None
+    input_high_water_mark: str | None
+    input_high_water_mark_source: str | None
 
 
 class _InsightRecordWithInference(_InsightRecordWithProvenance, Protocol):
@@ -188,6 +191,9 @@ def _record_provenance(record: _InsightRecordWithProvenance) -> ArchiveInsightPr
         materialized_at=record.materialized_at,
         source_updated_at=record.source_updated_at,
         source_sort_key=record.source_sort_key,
+        input_high_water_mark=record.input_high_water_mark,
+        input_high_water_mark_source=record.input_high_water_mark_source,
+        time_confidence=time_confidence_for_record(record),
     )
 
 
@@ -379,6 +385,9 @@ class ThreadInsight(ArchiveInsightModel):
                 materialized_at=record.materialized_at,
                 source_updated_at=record.end_time or record.start_time,
                 source_sort_key=None,
+                input_high_water_mark=record.input_high_water_mark,
+                input_high_water_mark_source=record.input_high_water_mark_source,
+                time_confidence=time_confidence_for_record(record),
             ),
             thread=record.payload,
         )

--- a/polylogue/insights/archive_models.py
+++ b/polylogue/insights/archive_models.py
@@ -10,8 +10,9 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from polylogue.archive.session.documents import SessionPhaseDocument, WorkEventDocument
 from polylogue.insights.confidence import ConfidenceBand
 from polylogue.insights.fallback import FallbackReason
+from polylogue.insights.temporal_source import TimeConfidence
 
-ARCHIVE_INSIGHT_CONTRACT_VERSION = 9
+ARCHIVE_INSIGHT_CONTRACT_VERSION = 10
 
 
 class ArchiveInsightModel(BaseModel):
@@ -30,6 +31,9 @@ class ArchiveInsightProvenance(ArchiveInsightModel):
     materialized_at: str
     source_updated_at: str | None = None
     source_sort_key: float | None = None
+    input_high_water_mark: str | None = None
+    input_high_water_mark_source: str | None = None
+    time_confidence: TimeConfidence = "unknown"
 
 
 class ArchiveInferenceProvenance(ArchiveInsightProvenance):

--- a/polylogue/insights/registry.py
+++ b/polylogue/insights/registry.py
@@ -405,6 +405,7 @@ register(
             InsightField("tool_s", _nested_ms_as_seconds("evidence", "tool_duration_ms", "0"), group=1),
             InsightField("tpm", _nested("evidence", "tool_calls_per_minute", "-"), group=1),
             InsightField("prov", _nested("evidence", "timing_provenance", "-"), group=1),
+            InsightField("time", _nested("provenance", "time_confidence", "unknown"), group=1),
         ),
     )
 )
@@ -445,6 +446,7 @@ register(
             InsightField("start", _nested("evidence", "start_time"), group=1),
             InsightField("end", _nested("evidence", "end_time"), group=1),
             InsightField("duration_ms", _nested("evidence", "duration_ms", "0"), group=1),
+            InsightField("time", _nested("provenance", "time_confidence", "unknown"), group=1),
         ),
     )
 )
@@ -466,6 +468,7 @@ register(
             InsightField("conv", _attr("session_id"), group=0),
             InsightField("start", _nested("evidence", "start_time"), group=1),
             InsightField("words", _nested("evidence", "word_count", "0"), group=1),
+            InsightField("time", _nested("provenance", "time_confidence", "unknown"), group=1),
         ),
     )
 )
@@ -487,6 +490,7 @@ register(
             InsightField("sessions", _nested("thread", "session_count", "0"), group=0),
             InsightField("messages", _nested("thread", "total_messages", "0"), group=1),
             InsightField("depth", _nested("thread", "depth", "0"), group=1),
+            InsightField("time", _nested("provenance", "time_confidence", "unknown"), group=1),
         ),
     )
 )

--- a/polylogue/insights/temporal_source.py
+++ b/polylogue/insights/temporal_source.py
@@ -62,7 +62,7 @@ from __future__ import annotations
 import ast
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Literal, Protocol, get_args
+from typing import Literal, Protocol, TypeGuard, get_args
 
 TemporalSource = Literal[
     "provider_ts",
@@ -134,7 +134,9 @@ def time_confidence_for_source(source: str | None) -> TimeConfidence:
     fabricating a timestamp.
     """
 
-    return _TIME_CONFIDENCE_BY_SOURCE.get(source, "unknown")
+    if source is None or not is_valid_temporal_source(source):
+        return "unknown"
+    return _TIME_CONFIDENCE_BY_SOURCE[source]
 
 
 def time_confidence_for_sources(sources: Sequence[TemporalSource]) -> TimeConfidence:
@@ -265,7 +267,7 @@ def audit_temporal_source_leaf_callers(package_root: str) -> list[str]:
     return violations
 
 
-def is_valid_temporal_source(value: str) -> bool:
+def is_valid_temporal_source(value: str) -> TypeGuard[TemporalSource]:
     """Return True when *value* is a recognized temporal source token."""
 
     return value in TEMPORAL_SOURCE_VALUES

--- a/polylogue/insights/temporal_source.py
+++ b/polylogue/insights/temporal_source.py
@@ -44,6 +44,17 @@ describes the *coverage shape*: ``timestamped_range`` vs
 ``untimestamped`` vs ``start_timestamp_only`` vs ``end_timestamp_only``)
 and to ``date_provenance`` (which describes how a canonical session date
 was derived). The three axes coexist and answer different questions.
+
+Consumer time-confidence contract
+---------------------------------
+
+Consumer payload adapters project this source tag to ``time_confidence``:
+``recorded`` for provider/hook event time, ``estimated`` for a sort key or
+file mtime, and ``unknown`` for materialization time, synthetic fallback
+dates, absent tags, and legacy unknown tags. Aggregates must first reduce
+their sources through :func:`weakest_of`, then project that result. In
+particular, ``unknown`` renders as unknown; it never licenses substituting
+materialization time or a fallback date as the event timestamp.
 """
 
 from __future__ import annotations
@@ -51,7 +62,7 @@ from __future__ import annotations
 import ast
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Literal, get_args
+from typing import Literal, Protocol, get_args
 
 TemporalSource = Literal[
     "provider_ts",
@@ -64,10 +75,35 @@ TemporalSource = Literal[
 
 TEMPORAL_SOURCE_VALUES: frozenset[TemporalSource] = frozenset(get_args(TemporalSource))
 
+# Public rendering contract for timestamps.  This is intentionally separate
+# from TemporalSource: consumers normally need to decide whether an observed
+# value may be shown as event time, not learn every storage-clock detail.
+#
+# ``unknown`` is the explicit no-time state.  It must render as unknown rather
+# than substituting materialization time or a deterministic fallback date.
+TimeConfidence = Literal["recorded", "estimated", "unknown"]
+TIME_CONFIDENCE_VALUES: frozenset[TimeConfidence] = frozenset(get_args(TimeConfidence))
+
+
+class HasTemporalSource(Protocol):
+    """Structural contract for a consumer record carrying temporal provenance."""
+
+    input_high_water_mark_source: str | None
+
+
 # Provenance lattice, strongest first. A lower rank is a stronger (more
 # trustworthy/recency-anchored) signal; ``weakest_source`` picks the higher
 # rank between two values. Order matches the docstring above verbatim.
 _SOURCE_RANK: dict[TemporalSource, int] = {source: rank for rank, source in enumerate(get_args(TemporalSource))}
+
+_TIME_CONFIDENCE_BY_SOURCE: dict[TemporalSource, TimeConfidence] = {
+    "provider_ts": "recorded",
+    "hook_event_ts": "recorded",
+    "sort_key": "estimated",
+    "file_mtime": "estimated",
+    "materialization_ts": "unknown",
+    "fallback_date": "unknown",
+}
 
 
 def weakest_source(a: TemporalSource, b: TemporalSource) -> TemporalSource:
@@ -85,6 +121,37 @@ def weakest_of(sources: Sequence[TemporalSource]) -> TemporalSource | None:
     for source in sources[1:]:
         result = weakest_source(result, source)
     return result
+
+
+def time_confidence_for_source(source: str | None) -> TimeConfidence:
+    """Project a source clock into the consumer-facing time-confidence signal.
+
+    Provider and hook timestamps are recorded event time. Sort keys and file
+    mtimes preserve ordering evidence but are estimates of event time. A
+    materialization timestamp, deterministic fallback date, missing tag, or
+    unrecognized legacy tag says nothing reliable about when the event happened
+    and therefore returns ``unknown``. Consumers must render that state without
+    fabricating a timestamp.
+    """
+
+    return _TIME_CONFIDENCE_BY_SOURCE.get(source, "unknown")
+
+
+def time_confidence_for_sources(sources: Sequence[TemporalSource]) -> TimeConfidence:
+    """Return aggregate confidence using the temporal lattice's weakest input.
+
+    This keeps confidence propagation aligned with provenance propagation: one
+    weak contributor degrades the aggregate rather than being laundered by a
+    stronger timestamp elsewhere in the input set.
+    """
+
+    return time_confidence_for_source(weakest_of(sources))
+
+
+def time_confidence_for_record(record: HasTemporalSource) -> TimeConfidence:
+    """Project a provenance-bearing API/CLI/MCP record without re-deriving time."""
+
+    return time_confidence_for_source(record.input_high_water_mark_source)
 
 
 def classify_profile_hwm_source(updated_at: datetime | None) -> TemporalSource:
@@ -205,13 +272,19 @@ def is_valid_temporal_source(value: str) -> bool:
 
 
 __all__ = [
+    "HasTemporalSource",
     "TEMPORAL_SOURCE_VALUES",
+    "TIME_CONFIDENCE_VALUES",
     "TemporalSource",
+    "TimeConfidence",
     "audit_temporal_source_leaf_callers",
     "classify_aggregate_hwm_source",
     "classify_profile_hwm_source",
     "classify_thread_hwm_source",
     "is_valid_temporal_source",
+    "time_confidence_for_record",
+    "time_confidence_for_source",
+    "time_confidence_for_sources",
     "weakest_of",
     "weakest_source",
 ]

--- a/tests/unit/cli/test_insights.py
+++ b/tests/unit/cli/test_insights.py
@@ -267,6 +267,7 @@ def test_insights_profiles_json(cli_workspace: CliWorkspace) -> None:
     assert "evidence" in first
     assert "inference" in first
     assert "provenance" in first
+    assert json_object(first["provenance"])["time_confidence"] == "unknown"
 
 
 def test_insights_costs_json(cli_workspace: CliWorkspace) -> None:

--- a/tests/unit/core/test_temporal_confidence.py
+++ b/tests/unit/core/test_temporal_confidence.py
@@ -1,0 +1,83 @@
+"""Consumer-facing temporal-confidence contract tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from pathlib import Path
+from typing import get_args
+
+import pytest
+
+from polylogue.insights.temporal_source import (
+    TIME_CONFIDENCE_VALUES,
+    TemporalSource,
+    time_confidence_for_record,
+    time_confidence_for_source,
+    time_confidence_for_sources,
+    weakest_source,
+)
+from polylogue.storage.insights.session.records import SessionProfileRecord
+from tests.infra.storage_records import SessionBuilder, db_setup
+
+_TEMPORAL_SOURCES: tuple[TemporalSource, ...] = get_args(TemporalSource)
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("provider_ts", "recorded"),
+        ("hook_event_ts", "recorded"),
+        ("sort_key", "estimated"),
+        ("file_mtime", "estimated"),
+        ("materialization_ts", "unknown"),
+        ("fallback_date", "unknown"),
+        (None, "unknown"),
+        ("legacy-unrecognized-source", "unknown"),
+    ],
+)
+def test_time_confidence_projects_source_without_fabricating_event_time(source: str | None, expected: str) -> None:
+    """The production source projection keeps materialization/fallback time unknown."""
+
+    assert time_confidence_for_source(source) == expected
+
+
+@pytest.mark.parametrize("right", _TEMPORAL_SOURCES)
+@pytest.mark.parametrize("left", _TEMPORAL_SOURCES)
+def test_time_confidence_uses_the_weakest_temporal_source(left: TemporalSource, right: TemporalSource) -> None:
+    """Aggregate confidence delegates to the production provenance lattice."""
+
+    weakest = weakest_source(left, right)
+    assert time_confidence_for_sources((left, right)) == time_confidence_for_source(weakest)
+
+
+def test_timeless_profile_record_round_trips_as_unknown_time(
+    workspace_env: Mapping[str, Path],
+) -> None:
+    """The library profile-record route never upgrades timeless provenance."""
+
+    db_path = db_setup(workspace_env)
+    session = SessionBuilder(db_path, "timeless-profile").provider("chatgpt").title("timeless")
+    session.conv = session.conv.model_copy(update={"created_at": None, "updated_at": None, "sort_key": None})
+    session.add_message(role="user", text="no provider timestamp", timestamp=None).add_message(
+        role="assistant", text="still no provider timestamp", timestamp=None
+    ).save()
+
+    from polylogue.api import Polylogue
+
+    async def read_record() -> SessionProfileRecord | None:
+        archive = Polylogue(archive_root=db_path.parent, db_path=db_path)
+        try:
+            await archive.rebuild_insights()
+            return await archive.get_session_profile_record(session.native_session_id())
+        finally:
+            await archive.close()
+
+    record = asyncio.run(read_record())
+    assert record is not None
+    # Current rebuilt rows may carry the explicit fallback tag or the older
+    # absent tag. Both mean event time is unknown; the consumer projection
+    # must stay correct while the storage propagation path converges.
+    assert record.input_high_water_mark_source in {None, "fallback_date"}
+    assert time_confidence_for_record(record) == "unknown"
+    assert time_confidence_for_record(record) in TIME_CONFIDENCE_VALUES

--- a/tests/unit/core/test_temporal_confidence.py
+++ b/tests/unit/core/test_temporal_confidence.py
@@ -9,8 +9,14 @@ from typing import get_args
 
 import pytest
 
-from polylogue.insights.archive import SessionProfileInsight
-from polylogue.insights.archive_models import SessionEnrichmentPayload, SessionEvidencePayload, SessionInferencePayload
+from polylogue.insights.archive import SessionProfileInsight, SessionWorkEventInsight
+from polylogue.insights.archive_models import (
+    SessionEnrichmentPayload,
+    SessionEvidencePayload,
+    SessionInferencePayload,
+    WorkEventEvidencePayload,
+    WorkEventInferencePayload,
+)
 from polylogue.insights.temporal_source import (
     TIME_CONFIDENCE_VALUES,
     TemporalSource,
@@ -20,6 +26,7 @@ from polylogue.insights.temporal_source import (
     weakest_source,
 )
 from polylogue.storage.insights.session.records import SessionProfileRecord
+from polylogue.storage.insights.timeline.records import SessionWorkEventRecord
 from tests.infra.storage_records import SessionBuilder, db_setup
 
 _TEMPORAL_SOURCES: tuple[TemporalSource, ...] = get_args(TemporalSource)
@@ -117,3 +124,38 @@ def test_profile_insight_projects_recorded_temporal_source_to_public_provenance(
 
     assert insight.provenance.input_high_water_mark_source == "provider_ts"
     assert insight.provenance.time_confidence == "recorded"
+
+
+def test_timeline_materialization_time_projects_to_unknown_public_provenance() -> None:
+    """Materialization time orders a timeless event but must not pose as event time."""
+
+    record = SessionWorkEventRecord.model_construct(
+        event_id="event-1",
+        session_id="profile-1",
+        materializer_version=1,
+        materialized_at="2026-07-12T10:00:00+00:00",
+        source_updated_at=None,
+        source_sort_key=None,
+        input_high_water_mark=None,
+        input_high_water_mark_source="materialization_ts",
+        input_row_count=1,
+        source_name="claude-code",
+        event_index=0,
+        heuristic_label="implementation",
+        confidence=0.5,
+        start_index=0,
+        end_index=1,
+        summary="timeless event",
+        evidence_payload=WorkEventEvidencePayload(start_index=0, end_index=1),
+        inference_payload=WorkEventInferencePayload(
+            heuristic_label="implementation",
+            summary="timeless event",
+            confidence=0.5,
+        ),
+        search_text="timeless event",
+    )
+
+    insight = SessionWorkEventInsight.from_record(record)
+
+    assert insight.provenance.input_high_water_mark_source == "materialization_ts"
+    assert insight.provenance.time_confidence == "unknown"

--- a/tests/unit/core/test_temporal_confidence.py
+++ b/tests/unit/core/test_temporal_confidence.py
@@ -9,6 +9,8 @@ from typing import get_args
 
 import pytest
 
+from polylogue.insights.archive import SessionProfileInsight
+from polylogue.insights.archive_models import SessionEnrichmentPayload, SessionEvidencePayload, SessionInferencePayload
 from polylogue.insights.temporal_source import (
     TIME_CONFIDENCE_VALUES,
     TemporalSource,
@@ -81,3 +83,37 @@ def test_timeless_profile_record_round_trips_as_unknown_time(
     assert record.input_high_water_mark_source in {None, "fallback_date"}
     assert time_confidence_for_record(record) == "unknown"
     assert time_confidence_for_record(record) in TIME_CONFIDENCE_VALUES
+
+
+def test_profile_insight_projects_recorded_temporal_source_to_public_provenance() -> None:
+    """The public insight builder projects the record provenance, not a display fallback."""
+
+    record = SessionProfileRecord.model_construct(
+        session_id="profile-1",
+        logical_session_id="profile-1",
+        materializer_version=1,
+        materialized_at="2026-07-12T10:00:00+00:00",
+        source_updated_at="2026-07-12T09:00:00+00:00",
+        source_sort_key=1_784_265_600.0,
+        input_high_water_mark="2026-07-12T09:00:00+00:00",
+        input_high_water_mark_source="provider_ts",
+        input_row_count=1,
+        source_name="claude-code",
+        title="profile",
+        evidence_payload=SessionEvidencePayload(),
+        inference_payload=SessionInferencePayload(),
+        enrichment_payload=SessionEnrichmentPayload(),
+        terminal_state="unknown",
+        terminal_state_confidence=0.0,
+        workflow_shape="unknown",
+        workflow_shape_confidence=0.0,
+        inference_version=1,
+        inference_family="test",
+        enrichment_version=1,
+        enrichment_family="test",
+    )
+
+    insight = SessionProfileInsight.from_record(record)
+
+    assert insight.provenance.input_high_water_mark_source == "provider_ts"
+    assert insight.provenance.time_confidence == "recorded"

--- a/tests/unit/core/test_temporal_confidence.py
+++ b/tests/unit/core/test_temporal_confidence.py
@@ -9,7 +9,7 @@ from typing import get_args
 
 import pytest
 
-from polylogue.insights.archive import SessionProfileInsight, SessionWorkEventInsight
+from polylogue.insights.archive import SessionProfileInsight, SessionWorkEventInsight, records_provenance
 from polylogue.insights.archive_models import (
     SessionEnrichmentPayload,
     SessionEvidencePayload,
@@ -30,6 +30,41 @@ from polylogue.storage.insights.timeline.records import SessionWorkEventRecord
 from tests.infra.storage_records import SessionBuilder, db_setup
 
 _TEMPORAL_SOURCES: tuple[TemporalSource, ...] = get_args(TemporalSource)
+
+
+def _profile_record_with_temporal_source(
+    source: str | None,
+    *,
+    session_id: str = "profile-1",
+    minute: int = 0,
+) -> SessionProfileRecord:
+    """Build the production record consumed by profile and aggregate adapters."""
+
+    timestamp = f"2026-07-12T09:{minute:02d}:00+00:00"
+    return SessionProfileRecord.model_construct(
+        session_id=session_id,
+        logical_session_id=session_id,
+        materializer_version=1,
+        materialized_at=f"2026-07-12T10:{minute:02d}:00+00:00",
+        source_updated_at=timestamp,
+        source_sort_key=1_784_265_600.0 + minute * 60,
+        input_high_water_mark=timestamp,
+        input_high_water_mark_source=source,
+        input_row_count=1,
+        source_name="claude-code",
+        title="profile",
+        evidence_payload=SessionEvidencePayload(),
+        inference_payload=SessionInferencePayload(),
+        enrichment_payload=SessionEnrichmentPayload(),
+        terminal_state="unknown",
+        terminal_state_confidence=0.0,
+        workflow_shape="unknown",
+        workflow_shape_confidence=0.0,
+        inference_version=1,
+        inference_family="test",
+        enrichment_version=1,
+        enrichment_family="test",
+    )
 
 
 @pytest.mark.parametrize(
@@ -95,35 +130,18 @@ def test_timeless_profile_record_round_trips_as_unknown_time(
 def test_profile_insight_projects_recorded_temporal_source_to_public_provenance() -> None:
     """The public insight builder projects the record provenance, not a display fallback."""
 
-    record = SessionProfileRecord.model_construct(
-        session_id="profile-1",
-        logical_session_id="profile-1",
-        materializer_version=1,
-        materialized_at="2026-07-12T10:00:00+00:00",
-        source_updated_at="2026-07-12T09:00:00+00:00",
-        source_sort_key=1_784_265_600.0,
-        input_high_water_mark="2026-07-12T09:00:00+00:00",
-        input_high_water_mark_source="provider_ts",
-        input_row_count=1,
-        source_name="claude-code",
-        title="profile",
-        evidence_payload=SessionEvidencePayload(),
-        inference_payload=SessionInferencePayload(),
-        enrichment_payload=SessionEnrichmentPayload(),
-        terminal_state="unknown",
-        terminal_state_confidence=0.0,
-        workflow_shape="unknown",
-        workflow_shape_confidence=0.0,
-        inference_version=1,
-        inference_family="test",
-        enrichment_version=1,
-        enrichment_family="test",
-    )
+    record = _profile_record_with_temporal_source("provider_ts")
 
     insight = SessionProfileInsight.from_record(record)
 
     assert insight.provenance.input_high_water_mark_source == "provider_ts"
     assert insight.provenance.time_confidence == "recorded"
+    assert insight.inference_provenance is not None
+    assert insight.inference_provenance.input_high_water_mark_source == "provider_ts"
+    assert insight.inference_provenance.time_confidence == "recorded"
+    assert insight.enrichment_provenance is not None
+    assert insight.enrichment_provenance.input_high_water_mark_source == "provider_ts"
+    assert insight.enrichment_provenance.time_confidence == "recorded"
 
 
 def test_timeline_materialization_time_projects_to_unknown_public_provenance() -> None:
@@ -159,3 +177,32 @@ def test_timeline_materialization_time_projects_to_unknown_public_provenance() -
 
     assert insight.provenance.input_high_water_mark_source == "materialization_ts"
     assert insight.provenance.time_confidence == "unknown"
+
+
+def test_aggregate_provenance_uses_the_weakest_contributor_source() -> None:
+    """Aggregate output must not launder one weak contributor into recorded time."""
+
+    provenance = records_provenance(
+        [
+            _profile_record_with_temporal_source("provider_ts", minute=0),
+            _profile_record_with_temporal_source("sort_key", session_id="profile-2", minute=1),
+        ]
+    )
+
+    assert provenance.input_high_water_mark_source == "sort_key"
+    assert provenance.time_confidence == "estimated"
+
+
+@pytest.mark.parametrize("source", [None, "legacy-unrecognized-source"])
+def test_aggregate_provenance_treats_absent_or_legacy_source_as_unknown(source: str | None) -> None:
+    """A mixed rollup cannot upgrade legacy provenance to recorded time."""
+
+    provenance = records_provenance(
+        [
+            _profile_record_with_temporal_source("provider_ts", minute=0),
+            _profile_record_with_temporal_source(source, session_id="profile-2", minute=1),
+        ]
+    )
+
+    assert provenance.input_high_water_mark_source is None
+    assert provenance.time_confidence == "unknown"

--- a/tests/unit/insights/test_registry.py
+++ b/tests/unit/insights/test_registry.py
@@ -532,6 +532,7 @@ class TestRenderInsightItems:
             provenance=ArchiveInsightProvenance(
                 materializer_version=1,
                 materialized_at="2026-01-01T00:00:00Z",
+                time_confidence="estimated",
             ),
         )
         insight_type = get_insight_type("session_profiles")
@@ -542,6 +543,7 @@ class TestRenderInsightItems:
         assert "Session Profiles: 1" in captured.out
         # Should include some field output
         assert "sess-001" in captured.out
+        assert "time=estimated" in captured.out
 
 
 class TestBuildQuery:

--- a/tests/unit/insights/test_registry.py
+++ b/tests/unit/insights/test_registry.py
@@ -169,6 +169,8 @@ class TestInsightItemsPayload:
             provenance=ArchiveInsightProvenance(
                 materializer_version=1,
                 materialized_at="2026-01-01T00:00:00Z",
+                input_high_water_mark_source="sort_key",
+                time_confidence="estimated",
             ),
         )
         insight_type = get_insight_type("session_profiles")
@@ -179,6 +181,8 @@ class TestInsightItemsPayload:
         item_dict = items_list[0]
         # Verify origin projection happened
         assert item_dict["origin"] == "claude-code-session"
+        provenance = cast(dict[str, object], item_dict["provenance"])
+        assert provenance["time_confidence"] == "estimated"
 
 
 class TestRegistryOperations:

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -1185,6 +1185,7 @@ class TestInsightTools:
         payload = json.loads(raw)
         assert payload["insight_kind"] == "session_profile"
         assert payload["session_id"] == "conv-1"
+        assert payload["provenance"]["time_confidence"] == "unknown"
 
     @pytest.mark.asyncio
     async def test_insight_list_tools_use_archive_queries(self, mcp_server: MCPServerUnderTest) -> None:


### PR DESCRIPTION
## Summary\n\nDefine a consumer-visible  contract and propagate it through direct insight record adapters and aggregate provenance: , , or .\n\n## Problem\n\nTemporal-source provenance reached insight records, but consumers lacked a single rule for showing whether event time was recorded, inferred, or unavailable. Materialization and fallback times must not masquerade as event time.\n\n## Solution\n\n- Define the shared  contract and source projection.\n- Reduce aggregate confidence through the existing weakest-source lattice, including absent or legacy source tags.\n- Add , its source, and  to public insight provenance.\n- Preserve those fields in direct profile, work-event, phase, thread, inference, and enrichment adapters.\n- Render materialization/fallback/unknown source tags as ; never fabricate event time.\n\n## Acceptance criteria\n\n- Satisfied: documented consumer contract and a total signal for timeless rows.\n- Satisfied: direct record adapters and aggregate provenance use weakest-source propagation; absent and legacy tags degrade to .\n- Deferred to : the storage-owned ArchiveStore projection must forward the already-stored high-water-mark source into API/CLI/MCP archive reads. It currently defaults to , which is safe but prevents recorded/estimated values from reaching those live surfaces. This PR does not modify , per lane ownership.\n- Satisfied: the real library profile-record route preserves  for a timeless row.\n- Satisfied: a timeline work event with  renders , resolving the Shape-B false-freshness caveat without inventing event time.\n\n## Verification\n\n-  — 50 passed.\n-  — 131 passed.\n- render cli-reference: sync OK: docs/cli-reference.md
render cli-output-schemas: sync OK: docs/schemas/cli-output
render openapi: sync OK: docs/openapi/search.yaml
render devtools-reference: sync OK: docs/devtools.md
render demo-corpus-datasheet: sync OK
render quality-reference: sync OK: docs/test-quality-workflows.md
render product-workflows: sync OK
render docs-surface: sync OK
OK: site sources render and generated local links resolve. — generated surfaces in sync.\n- Pre-push {
  "timestamp": "2026-07-12T22:54:43.892281+00:00",
  "git_head": "445811aae4ea00ac4438763dd28892a9d57d40fe",
  "tier": "quick",
  "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
  "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c",
  "steps": [
    {
      "name": "ruff format",
      "duration_s": 0.06,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/01-ruff-format"
    },
    {
      "name": "ruff check",
      "duration_s": 0.02,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/02-ruff-check"
    },
    {
      "name": "mypy",
      "duration_s": 4.2,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/03-mypy"
    },
    {
      "name": "render all",
      "duration_s": 1663.83,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/04-render-all"
    },
    {
      "name": "verify topology",
      "duration_s": 0.91,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/05-verify-topology"
    },
    {
      "name": "verify layering",
      "duration_s": 16.25,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/06-verify-layering"
    },
    {
      "name": "verify closure-matrix",
      "duration_s": 0.68,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/07-verify-closure-matrix"
    },
    {
      "name": "lab schema roundtrip",
      "duration_s": 3.55,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/08-lab-schema-roundtrip"
    },
    {
      "name": "verify manifests",
      "duration_s": 3.8,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/09-verify-manifests"
    },
    {
      "name": "verify ci-workflows",
      "duration_s": 0.57,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/10-verify-ci-workflows"
    },
    {
      "name": "verify doc-commands",
      "duration_s": 9.22,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/11-verify-doc-commands"
    },
    {
      "name": "verify test-infra-currency",
      "duration_s": 0.66,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/12-verify-test-infra-currency"
    },
    {
      "name": "verify test-clock-hygiene",
      "duration_s": 5.19,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/13-verify-test-clock-hygiene"
    },
    {
      "name": "verify pytest-timeout-overrides",
      "duration_s": 10.65,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/14-verify-pytest-timeout-overrides"
    },
    {
      "name": "verify degrade-loudly",
      "duration_s": 5.42,
      "exit": 0,
      "run_id": "20260712T222556Z-quick-1495891-a945ab1c",
      "artifact_dir": ".cache/verify/runs/20260712T222556Z-quick-1495891-a945ab1c/steps/15-verify-degrade-loudly"
    }
  ],
  "total_duration_s": 1727.08,
  "exit_code": 0
} — format, lint, mypy, rendering, topology, layering, schema, and policy gates passed.\n\n## Anti-vacuity\n\n rebuilds an actual timestamp-less session and reads it through ; it fails if the production record route disappears or if missing/fallback provenance is upgraded.  drives the real profile record-to-insight projection, including nested inference/enrichment. The aggregate tests pass actual  models to ; removing source reduction, excluding legacy contributors, or choosing the strongest source makes them fail.\n\nRef polylogue-cuxz\n