### PR TITLE
test: harden CLI and daemon status contracts

### DIFF
--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -67,6 +67,15 @@ def test_read_projection_expression_rejects_invalid_operator_input(expression: s
         query_verbs._parse_read_projection_expression(expression)
 
 
+def test_read_projection_expression_normalizes_public_aliases() -> None:
+    """Projection aliases must reach the typed projection field names."""
+    assert query_verbs._parse_read_projection_expression("tokens:7 redact=excluded assertions=yes") == {
+        "max_tokens": 7,
+        "redact_paths": False,
+        "include_assertions": True,
+    }
+
+
 def test_execute_query_verb_dispatches_typed_request() -> None:
     _, child = _context_pair()
     request = RootModeRequest.from_params({"query": ("alpha",)})

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -53,6 +53,20 @@ def test_parent_helpers_require_parent_context_and_build_request() -> None:
         query_verbs._require_parent_context(click.Context(click.Command("verb")))
 
 
+@pytest.mark.parametrize(
+    ("expression", "message"),
+    [
+        ("max-tokens=0", "expected integer >= 1"),
+        ("include-assertions=maybe", "expected true/false"),
+        ("max-tokens=4,max-tokens=8", "Duplicate --projection key"),
+    ],
+)
+def test_read_projection_expression_rejects_invalid_operator_input(expression: str, message: str) -> None:
+    """The public --projection DSL must reject malformed budget and boolean input."""
+    with pytest.raises(click.UsageError, match=message):
+        query_verbs._parse_read_projection_expression(expression)
+
+
 def test_execute_query_verb_dispatches_typed_request() -> None:
     _, child = _context_pair()
     request = RootModeRequest.from_params({"query": ("alpha",)})

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -6,6 +6,8 @@ import inspect
 import json
 import os
 import sqlite3
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -104,6 +106,47 @@ def _combined_calls(env: AppEnv) -> str:
     """Get combined output from the capturing console."""
     console: Any = env.ui.console
     return " ".join(console.calls)
+
+
+def test_status_command_reads_a_real_daemon_http_status_route() -> None:
+    """The CLI must consume the daemon's JSON route without a mocked urlopen."""
+
+    class _StatusHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            assert self.path == "/api/status"
+            body = json.dumps({"daemon_liveness": True, "component_state": {}, "checked_at": "now"}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _StatusHandler)
+    worker = threading.Thread(target=server.serve_forever)
+    worker.start()
+    try:
+        env = _make_app_env()
+        callback = getattr(status_command.callback, "__wrapped__", None)
+        assert callable(callback)
+        callback(
+            env,
+            daemon_url=f"http://127.0.0.1:{server.server_port}",
+            output_format="json",
+            json_alias=False,
+            full_payload=False,
+            exact_archive_readiness=False,
+        )
+    finally:
+        server.shutdown()
+        worker.join()
+        server.server_close()
+
+    output = _combined_calls(env)
+    assert '"source": "daemon"' in output
+    assert '"daemon_liveness": true' in output
 
 
 def test_raw_replay_backlog_plain_status_explains_containment() -> None:

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -149,6 +149,53 @@ def test_status_command_reads_a_real_daemon_http_status_route() -> None:
     assert '"daemon_liveness": true' in output
 
 
+def test_status_command_reports_live_daemon_with_unavailable_status_snapshot() -> None:
+    """A malformed status payload must not be mistaken for a stopped daemon."""
+
+    class _UnavailableStatusHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            if self.path == "/api/status":
+                body = b"not-json"
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            if self.path == "/healthz/live":
+                self.send_response(204)
+                self.end_headers()
+                return
+            self.send_error(404)
+
+        def log_message(self, _format: str, *_args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _UnavailableStatusHandler)
+    worker = threading.Thread(target=server.serve_forever)
+    worker.start()
+    try:
+        env = _make_app_env()
+        callback = getattr(status_command.callback, "__wrapped__", None)
+        assert callable(callback)
+        callback(
+            env,
+            daemon_url=f"http://127.0.0.1:{server.server_port}",
+            output_format="json",
+            json_alias=False,
+            full_payload=False,
+            exact_archive_readiness=False,
+        )
+    finally:
+        server.shutdown()
+        worker.join()
+        server.server_close()
+
+    output = _combined_calls(env)
+    assert '"daemon_liveness": true' in output
+    assert '"state": "unavailable"' in output
+
+
 def test_raw_replay_backlog_plain_status_explains_containment() -> None:
     env = _make_app_env()
     reason = "raw source-to-index replay is disabled pending per-session revision authority"

--- a/tests/unit/core/test_operator_inference.py
+++ b/tests/unit/core/test_operator_inference.py
@@ -1,15 +1,15 @@
+"""Infrastructure-backed contracts for schema operator workflows."""
+
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+import json
+import sqlite3
 from pathlib import Path
-from typing import cast
-from unittest.mock import patch
 
 import pytest
 
-from polylogue.core.json import JSONDocument
-from polylogue.schemas.generation.models import GenerationResult
+from polylogue.core.enums import Provider
+from polylogue.core.sources import origin_from_provider
 from polylogue.schemas.operator.inference import (
     audit_schemas,
     compare_schema_versions,
@@ -26,563 +26,130 @@ from polylogue.schemas.operator.models import (
     SchemaListRequest,
     SchemaPromoteRequest,
 )
-from polylogue.schemas.operator.registry import SchemaRegistryLike
-from polylogue.schemas.packages import (
-    SchemaElementManifest,
-    SchemaPackageCatalog,
-    SchemaResolution,
-    SchemaVersionPackage,
-)
-from polylogue.schemas.privacy_config import PrivacyConfig
-from polylogue.schemas.tooling_models import ClusterManifest, SchemaCluster, SchemaDiff
+from polylogue.schemas.registry import SchemaRegistry
+from polylogue.storage.blob_store import get_blob_store
+from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw_session
+from tests.infra.storage_records import db_setup
 
 
-@dataclass(frozen=True)
-class _ProviderConfig:
-    db_source_name: str | None
-
-
-class _FakeSchemaRegistry(SchemaRegistryLike):
-    def __init__(
-        self,
-        *,
-        catalogs: dict[str, SchemaPackageCatalog] | None = None,
-        manifests: dict[str, ClusterManifest | None] | None = None,
-        clustered_manifest: ClusterManifest | None = None,
-        manifest_path: Path | None = None,
-        diff: SchemaDiff | None = None,
-        promoted_version: str = "v99",
-        promoted_package: SchemaVersionPackage | None = None,
-        promoted_schema: JSONDocument | None = None,
-        schema_age_days: dict[str, int | None] | None = None,
-    ) -> None:
-        self._catalogs = catalogs or {}
-        self._manifests = manifests or {}
-        self._clustered_manifest = clustered_manifest
-        self._manifest_path = manifest_path or Path("manifest.json")
-        self._diff = diff or SchemaDiff(provider="test", version_a="v1", version_b="v2")
-        self._promoted_version = promoted_version
-        self._promoted_package = promoted_package
-        self._promoted_schema = promoted_schema
-        self._schema_age_days = schema_age_days or {}
-
-    def load_package_catalog(self, provider: str) -> SchemaPackageCatalog | None:
-        return self._catalogs.get(provider)
-
-    def get_package(self, provider: str, version: str = "default") -> SchemaVersionPackage | None:
-        if self._promoted_package is not None and version == self._promoted_version:
-            return self._promoted_package
-        catalog = self.load_package_catalog(provider)
-        return catalog.package(version) if catalog is not None else None
-
-    def get_element_schema(
-        self,
-        provider: str,
-        *,
-        version: str = "default",
-        element_kind: str | None = None,
-    ) -> JSONDocument | None:
-        if version == self._promoted_version:
-            return self._promoted_schema
-        return None
-
-    def list_versions(self, provider: str) -> list[str]:
-        if self._promoted_package is not None:
-            return [self._promoted_version]
-        catalog = self.load_package_catalog(provider)
-        return [package.version for package in catalog.packages] if catalog is not None else []
-
-    def list_providers(self) -> list[str]:
-        source_names = set(self._catalogs) | set(self._manifests)
-        return sorted(source_names)
-
-    def get_schema_age_days(self, provider: str) -> int | None:
-        return self._schema_age_days.get(provider)
-
-    def resolve_payload(
-        self,
-        provider: str,
-        payload: Mapping[str, object],
-        *,
-        source_path: str | None = None,
-    ) -> SchemaResolution | None:
-        return None
-
-    def compare_versions(
-        self,
-        provider: str,
-        v1: str,
-        v2: str,
-        *,
-        element_kind: str | None = None,
-    ) -> SchemaDiff:
-        return self._diff
-
-    def cluster_samples(self, provider: str, samples: Sequence[Mapping[str, object]]) -> ClusterManifest:
-        if self._clustered_manifest is None:
-            raise AssertionError("cluster_samples should not be called without a manifest")
-        return self._clustered_manifest
-
-    def save_cluster_manifest(self, manifest: ClusterManifest) -> Path:
-        return self._manifest_path
-
-    def load_cluster_manifest(self, provider: str) -> ClusterManifest | None:
-        return self._manifests.get(provider)
-
-    def promote_cluster(
-        self,
-        provider: str,
-        cluster_id: str,
-        *,
-        samples: Sequence[Mapping[str, object]] | None = None,
-    ) -> str:
-        return self._promoted_version
-
-
-def test_infer_schema_emits_default_corpus_specs_without_clustering(tmp_path: Path) -> None:
-    generation = GenerationResult(
-        provider="chatgpt",
-        schema={"type": "object"},
-        sample_count=9,
-        default_version="v3",
-    )
-
-    with patch("polylogue.schemas.generation.workflow.generate_provider_schema", return_value=generation):
-        result = infer_schema(
-            SchemaInferRequest(
-                provider="chatgpt",
-                db_path=tmp_path / "archive.db",
-                cluster=False,
-            )
+def _seed_chatgpt_raw(workspace_env: dict[str, Path]) -> Path:
+    """Store one real ChatGPT-shaped raw payload in the source tier."""
+    index_db = db_setup(workspace_env)
+    payload = json.dumps(
+        {
+            "id": "conversation-1",
+            "title": "Schema inference",
+            "create_time": 1_700_000_000.0,
+            "update_time": 1_700_000_060.0,
+            "mapping": {
+                "node-1": {
+                    "id": "node-1",
+                    "parent": None,
+                    "children": [],
+                    "message": {
+                        "id": "message-1",
+                        "author": {"role": "user"},
+                        "content": {"content_type": "text", "parts": ["infer this schema"]},
+                        "create_time": 1_700_000_000.0,
+                    },
+                }
+            },
+        }
+    ).encode()
+    get_blob_store().write_from_bytes(payload)
+    with sqlite3.connect(workspace_env["archive_root"] / "source.db") as conn:
+        write_source_raw_session(
+            conn,
+            origin=origin_from_provider(Provider.CHATGPT),
+            source_path="/fixtures/chatgpt-export.json",
+            source_index=0,
+            payload=payload,
+            acquired_at_ms=1_700_000_000_000,
         )
+    return index_db
 
+
+def test_infer_schema_builds_schema_from_source_tier_raw(workspace_env: dict[str, Path]) -> None:
+    index_db = _seed_chatgpt_raw(workspace_env)
+
+    result = infer_schema(SchemaInferRequest(provider="chatgpt", db_path=index_db, cluster=False))
+
+    assert result.generation.success
+    assert result.generation.sample_count == 1
+    assert result.generation.schema is not None
     assert result.manifest is None
     assert len(result.corpus_specs) == 1
     assert len(result.corpus_scenarios) == 1
-    assert result.corpus_specs[0].provider == "chatgpt"
-    assert result.corpus_specs[0].package_version == "v3"
-    assert result.corpus_specs[0].profile.observed_sample_count == 9
-    assert result.corpus_scenarios[0].provider == "chatgpt"
-    assert result.corpus_scenarios[0].package_version == "v3"
 
 
-def test_infer_schema_emits_cluster_backed_corpus_specs_when_manifest_exists(tmp_path: Path) -> None:
-    generation = GenerationResult(
-        provider="chatgpt",
-        schema={"type": "object"},
-        sample_count=15,
-        default_version="v4",
-        cluster_count=1,
-    )
-    manifest = ClusterManifest(
-        provider="chatgpt",
-        clusters=[
-            SchemaCluster(
-                cluster_id="cluster-a",
-                provider="chatgpt",
-                sample_count=15,
-                first_seen="2026-04-01T00:00:00Z",
-                last_seen="2026-04-02T00:00:00Z",
-                representative_paths=["/tmp/source.json"],
-                dominant_keys=["id", "messages"],
-                confidence=0.92,
-                artifact_kind="session_document",
-            )
-        ],
-    )
-    fake_registry = _FakeSchemaRegistry(
-        clustered_manifest=manifest,
-        manifest_path=tmp_path / "manifest.json",
-    )
-    fake_provider = _ProviderConfig(db_source_name="chatgpt")
+def test_cluster_promotion_drives_real_operator_registry_views(workspace_env: dict[str, Path]) -> None:
+    index_db = _seed_chatgpt_raw(workspace_env)
+    inferred = infer_schema(SchemaInferRequest(provider="chatgpt", db_path=index_db, cluster=True))
 
-    with (
-        patch("polylogue.schemas.generation.workflow.generate_provider_schema", return_value=generation),
-        patch.dict("polylogue.schemas.observation.PROVIDERS", {"chatgpt": fake_provider}, clear=False),
-        patch("polylogue.schemas.sampling.load_samples_from_db", return_value=[{"id": "1"}]),
-        patch("polylogue.schemas.operator.inference.schema_registry", return_value=fake_registry),
-    ):
-        result = infer_schema(
-            SchemaInferRequest(
-                provider="chatgpt",
-                db_path=tmp_path / "archive.db",
-                cluster=True,
-            )
+    assert inferred.generation.success
+    assert inferred.manifest is not None
+    cluster_id = inferred.manifest.clusters[0].cluster_id
+    promoted = promote_schema_cluster(
+        SchemaPromoteRequest(
+            provider="chatgpt",
+            cluster_id=cluster_id,
+            db_path=index_db,
+            with_samples=False,
         )
-
-    assert result.manifest is manifest
-    assert result.manifest_path == tmp_path / "manifest.json"
-    assert len(result.corpus_specs) == 1
-    assert len(result.corpus_scenarios) == 1
-    assert result.corpus_specs[0].profile.family_ids == ("cluster-a",)
-    assert result.corpus_specs[0].element_kind == "session_document"
-    assert result.corpus_scenarios[0].corpus_specs[0].profile.family_ids == ("cluster-a",)
-
-
-def test_list_inferred_corpus_specs_reads_registry_catalog_and_manifest() -> None:
-    manifest = ClusterManifest(
-        provider="chatgpt",
-        clusters=[
-            SchemaCluster(
-                cluster_id="cluster-a",
-                provider="chatgpt",
-                sample_count=12,
-                first_seen="2026-04-01T00:00:00Z",
-                last_seen="2026-04-02T00:00:00Z",
-                representative_paths=["/tmp/source.json"],
-                dominant_keys=["id", "messages"],
-                confidence=0.92,
-                artifact_kind="session_document",
-                promoted_package_version="v7",
-            )
-        ],
-        default_version="v7",
-    )
-    catalog = SchemaPackageCatalog(
-        provider="chatgpt",
-        default_version="v7",
-        latest_version="v7",
-        recommended_version="v7",
-        packages=[
-            SchemaVersionPackage(
-                provider="chatgpt",
-                version="v7",
-                anchor_kind="session_document",
-                default_element_kind="session_document",
-                first_seen="2026-04-01T00:00:00Z",
-                last_seen="2026-04-02T00:00:00Z",
-                bundle_scope_count=1,
-                sample_count=12,
-                elements=[
-                    SchemaElementManifest(
-                        element_kind="session_document",
-                        schema_file="session_document.schema.json",
-                        sample_count=12,
-                        artifact_count=12,
-                    )
-                ],
-            )
-        ],
-    )
-    fake_registry = _FakeSchemaRegistry(
-        catalogs={"chatgpt": catalog},
-        manifests={"chatgpt": manifest},
     )
 
-    specs = list_inferred_corpus_specs(registry=fake_registry)
+    assert promoted.package_version == "v1"
+    assert promoted.schema is not None
+    specs = list_inferred_corpus_specs(provider="chatgpt")
+    scenarios = list_inferred_corpus_scenarios(provider="chatgpt")
+    registry = SchemaRegistry()
+    registry.register_schema("chatgpt", {"type": "object", "properties": {"mapping": {"type": "object"}}})
+    comparison = compare_schema_versions(SchemaCompareRequest(provider="chatgpt", from_version="v1", to_version="v2"))
+    selected = list_schemas(SchemaListRequest(provider="chatgpt"))
 
-    assert len(specs) == 1
-    assert specs[0].provider == "chatgpt"
-    assert specs[0].package_version == "v7"
-    assert specs[0].profile.family_ids == ("cluster-a",)
-    assert specs[0].profile.observed_sample_count == 12
-
-
-def test_list_inferred_corpus_scenarios_groups_specs_by_provider_and_version() -> None:
-    catalog = SchemaPackageCatalog(
-        provider="chatgpt",
-        default_version="v7",
-        packages=[
-            SchemaVersionPackage(
-                provider="chatgpt",
-                version="v7",
-                anchor_kind="session_document",
-                default_element_kind="session_document",
-                first_seen="2026-04-01T00:00:00Z",
-                last_seen="2026-04-02T00:00:00Z",
-                bundle_scope_count=1,
-                sample_count=12,
-            )
-        ],
-    )
-    manifest = ClusterManifest(
-        provider="chatgpt",
-        clusters=[
-            SchemaCluster(
-                cluster_id="cluster-a",
-                provider="chatgpt",
-                sample_count=7,
-                first_seen="2026-04-01T00:00:00Z",
-                last_seen="2026-04-02T00:00:00Z",
-                representative_paths=["/tmp/source-a.json"],
-                dominant_keys=["id"],
-                confidence=0.9,
-                artifact_kind="session_document",
-            ),
-            SchemaCluster(
-                cluster_id="cluster-b",
-                provider="chatgpt",
-                sample_count=5,
-                first_seen="2026-04-01T00:00:00Z",
-                last_seen="2026-04-02T00:00:00Z",
-                representative_paths=["/tmp/source-b.json"],
-                dominant_keys=["id"],
-                confidence=0.8,
-                artifact_kind="session_document",
-            ),
-        ],
-        default_version="v7",
-    )
-    fake_registry = _FakeSchemaRegistry(
-        catalogs={"chatgpt": catalog},
-        manifests={"chatgpt": manifest},
-    )
-
-    scenarios = list_inferred_corpus_scenarios(registry=fake_registry)
-
-    assert len(scenarios) == 1
-    assert scenarios[0].provider == "chatgpt"
-    assert scenarios[0].package_version == "v7"
-    assert tuple(spec.profile.primary_family_id for spec in scenarios[0].corpus_specs) == ("cluster-a", "cluster-b")
-
-
-def test_list_inferred_corpus_specs_can_scope_to_one_provider() -> None:
-    chatgpt_catalog = SchemaPackageCatalog(
-        provider="chatgpt",
-        default_version="v3",
-        packages=[
-            SchemaVersionPackage(
-                provider="chatgpt",
-                version="v3",
-                anchor_kind="session_document",
-                default_element_kind="session_document",
-                first_seen="2026-04-01T00:00:00Z",
-                last_seen="2026-04-02T00:00:00Z",
-                bundle_scope_count=1,
-                sample_count=9,
-            )
-        ],
-    )
-    codex_catalog = SchemaPackageCatalog(
-        provider="codex",
-        default_version="v1",
-        packages=[
-            SchemaVersionPackage(
-                provider="codex",
-                version="v1",
-                anchor_kind="session_document",
-                default_element_kind="session_document",
-                first_seen="2026-04-01T00:00:00Z",
-                last_seen="2026-04-02T00:00:00Z",
-                bundle_scope_count=1,
-                sample_count=4,
-            )
-        ],
-    )
-    fake_registry = _FakeSchemaRegistry(
-        catalogs={"chatgpt": chatgpt_catalog, "codex": codex_catalog},
-        manifests={"chatgpt": None, "codex": None},
-    )
-
-    specs = list_inferred_corpus_specs(provider="chatgpt", registry=fake_registry)
-
-    assert tuple(spec.provider for spec in specs) == ("chatgpt",)
-    assert specs[0].package_version == "v3"
-
-
-def test_infer_schema_coerces_privacy_config_and_falls_back_without_db_provider(tmp_path: Path) -> None:
-    captured_privacy: list[PrivacyConfig | None] = []
-    generation = GenerationResult(
-        provider="chatgpt",
-        schema={"type": "object"},
-        sample_count=5,
-        default_version="v2",
-    )
-    fake_provider = _ProviderConfig(db_source_name=None)
-
-    def _generate_provider_schema(*args: object, **kwargs: object) -> GenerationResult:
-        captured_privacy.append(cast(PrivacyConfig | None, kwargs["privacy_config"]))
-        return generation
-
-    with (
-        patch("polylogue.schemas.generation.workflow.generate_provider_schema", side_effect=_generate_provider_schema),
-        patch.dict("polylogue.schemas.observation.PROVIDERS", {"chatgpt": fake_provider}, clear=False),
-    ):
-        result = infer_schema(
-            SchemaInferRequest(
-                provider="chatgpt",
-                db_path=tmp_path / "archive.db",
-                cluster=True,
-                privacy_config={
-                    "level": "strict",
-                    "field_overrides": {"$.id": "drop", "bad": 1},
-                    "allow_value_patterns": ["ok", 2],
-                    "deny_value_patterns": ["secret"],
-                    "safe_enum_max_length": "bad",
-                    "high_entropy_min_length": 14,
-                    "cross_conv_min_count": 5,
-                    "cross_conv_proportional": True,
-                },
-            )
-        )
-
-    privacy = cast(PrivacyConfig, captured_privacy[0])
-    assert privacy is not None
-    assert privacy.level == "strict"
-    assert privacy.safe_enum_max_length == 30
-    assert privacy.high_entropy_min_length == 14
-    assert privacy.cross_conv_min_count == 5
-    assert privacy.cross_conv_proportional is True
-    assert privacy.field_overrides == {"$.id": "drop"}
-    assert privacy.allow_value_patterns == ["ok"]
-    assert privacy.deny_value_patterns == ["secret"]
-    assert result.manifest is None
-    assert len(result.corpus_scenarios) == 1
-
-
-def test_list_schemas_returns_selected_and_all_provider_snapshots() -> None:
-    catalog = SchemaPackageCatalog(
-        provider="chatgpt",
-        default_version="v7",
-        latest_version="v7",
-        packages=[
-            SchemaVersionPackage(
-                provider="chatgpt",
-                version="v7",
-                anchor_kind="session_document",
-                default_element_kind="session_document",
-                first_seen="2026-04-01T00:00:00Z",
-                last_seen="2026-04-02T00:00:00Z",
-                bundle_scope_count=1,
-                sample_count=12,
-            )
-        ],
-    )
-    manifest = ClusterManifest(
-        provider="chatgpt",
-        clusters=[
-            SchemaCluster(
-                cluster_id="cluster-a",
-                provider="chatgpt",
-                sample_count=12,
-                first_seen="2026-04-01T00:00:00Z",
-                last_seen="2026-04-02T00:00:00Z",
-                representative_paths=["/tmp/source.json"],
-                dominant_keys=["id"],
-                confidence=0.9,
-                artifact_kind="session_document",
-            )
-        ],
-    )
-    fake_registry = _FakeSchemaRegistry(
-        catalogs={"chatgpt": catalog},
-        manifests={"chatgpt": manifest, "codex": None},
-        schema_age_days={"chatgpt": 3, "codex": None},
-    )
-
-    with patch("polylogue.schemas.operator.inference.schema_registry", return_value=fake_registry):
-        selected = list_schemas(SchemaListRequest(provider="chatgpt"))
-        listing = list_schemas(SchemaListRequest())
-
+    assert comparison.diff.version_a == "v1"
+    assert comparison.diff.version_b == "v2"
     assert selected.selected is not None
-    assert selected.selected.provider == "chatgpt"
-    assert selected.selected.latest_age_days == 3
-    assert selected.selected.to_dict()["provider"] == "chatgpt"
-    assert [snapshot.provider for snapshot in listing.providers] == ["chatgpt", "codex"]
+    assert selected.selected.versions == ["v1", "v2"]
+    assert specs[0].package_version == "v1"
+    assert scenarios[0].provider == "chatgpt"
 
 
-def test_compare_schema_versions_wraps_registry_diff() -> None:
-    diff = SchemaDiff(
-        provider="chatgpt",
-        version_a="v1",
-        version_b="v2",
-        changed_properties=["messages"],
+def test_infer_schema_normalizes_operator_privacy_configuration(workspace_env: dict[str, Path]) -> None:
+    index_db = _seed_chatgpt_raw(workspace_env)
+
+    result = infer_schema(
+        SchemaInferRequest(
+            provider="chatgpt",
+            db_path=index_db,
+            privacy_config={
+                "level": "strict",
+                "field_overrides": {"$.id": "drop", "invalid": 1},
+                "allow_value_patterns": ["safe", 1],
+                "deny_value_patterns": ["secret"],
+                "high_entropy_min_length": 14,
+            },
+        )
     )
-    fake_registry = _FakeSchemaRegistry(diff=diff)
 
-    with patch("polylogue.schemas.operator.inference.schema_registry", return_value=fake_registry):
-        result = compare_schema_versions(SchemaCompareRequest(provider="chatgpt", from_version="v1", to_version="v2"))
-
-    assert result.diff is diff
-    assert result.to_dict()["provider"] == "chatgpt"
+    assert result.generation.success
+    assert result.generation.schema is not None
+    assert result.generation.schema["type"] == "object"
 
 
-def test_promote_schema_cluster_with_samples_filters_matching_cluster(tmp_path: Path) -> None:
-    promoted_package = SchemaVersionPackage(
-        provider="chatgpt",
-        version="v8",
-        anchor_kind="session_document",
-        default_element_kind="session_document",
-        first_seen="2026-04-01T00:00:00Z",
-        last_seen="2026-04-02T00:00:00Z",
-        bundle_scope_count=1,
-        sample_count=2,
-    )
-    fake_registry = _FakeSchemaRegistry(
-        promoted_version="v8",
-        promoted_package=promoted_package,
-        promoted_schema={"type": "object"},
-    )
-    fake_provider = _ProviderConfig(db_source_name="chatgpt")
+def test_operator_inference_reports_real_unknown_provider_and_audits_bundled_schema(
+    workspace_env: dict[str, Path],
+) -> None:
+    index_db = db_setup(workspace_env)
+    unknown = infer_schema(SchemaInferRequest(provider="not-a-provider", db_path=index_db))
 
-    with (
-        patch("polylogue.schemas.operator.inference.schema_registry", return_value=fake_registry),
-        patch.dict("polylogue.schemas.observation.PROVIDERS", {"chatgpt": fake_provider}, clear=False),
-        patch("polylogue.schemas.sampling.load_samples_from_db", return_value=[{"id": "one"}, {"id": "two"}]),
-        patch("polylogue.schemas.shape_fingerprint._structure_fingerprint", lambda sample: sample["id"]),
-        patch(
-            "polylogue.schemas.observation.fingerprint_hash",
-            lambda fingerprint: "cluster-a" if fingerprint == "one" else "other",
-        ),
-    ):
-        result = promote_schema_cluster(
-            SchemaPromoteRequest(
-                provider="chatgpt",
-                cluster_id="cluster-a",
-                db_path=tmp_path / "archive.db",
-                with_samples=True,
-            )
+    assert unknown.generation.success is False
+    assert "Unknown provider" in (unknown.generation.error or "")
+    with pytest.raises(ValueError, match="No cluster manifest"):
+        promote_schema_cluster(
+            SchemaPromoteRequest(provider="chatgpt", cluster_id="missing", db_path=index_db, with_samples=False)
         )
 
-    assert result.package_version == "v8"
-    assert result.package is promoted_package
-    assert result.schema == {"type": "object"}
-    assert result.versions == ["v8"]
-
-
-def test_promote_schema_cluster_rejects_unknown_provider_and_missing_cluster_samples(tmp_path: Path) -> None:
-    fake_registry = _FakeSchemaRegistry()
-
-    with (
-        patch("polylogue.schemas.operator.inference.schema_registry", return_value=fake_registry),
-        patch.dict("polylogue.schemas.observation.PROVIDERS", {}, clear=True),
-    ):
-        with pytest.raises(ValueError, match="Unknown provider"):
-            promote_schema_cluster(
-                SchemaPromoteRequest(
-                    provider="chatgpt",
-                    cluster_id="cluster-a",
-                    db_path=tmp_path / "archive.db",
-                    with_samples=True,
-                )
-            )
-
-    fake_provider = _ProviderConfig(db_source_name="chatgpt")
-    with (
-        patch("polylogue.schemas.operator.inference.schema_registry", return_value=fake_registry),
-        patch.dict("polylogue.schemas.observation.PROVIDERS", {"chatgpt": fake_provider}, clear=False),
-        patch("polylogue.schemas.sampling.load_samples_from_db", return_value=[{"id": "two"}]),
-        patch("polylogue.schemas.shape_fingerprint._structure_fingerprint", lambda sample: sample["id"]),
-        patch("polylogue.schemas.observation.fingerprint_hash", lambda _fingerprint: "other"),
-    ):
-        with pytest.raises(ValueError, match="No samples match cluster"):
-            promote_schema_cluster(
-                SchemaPromoteRequest(
-                    provider="chatgpt",
-                    cluster_id="cluster-a",
-                    db_path=tmp_path / "archive.db",
-                    with_samples=True,
-                )
-            )
-
-
-def test_audit_schemas_selects_provider_or_global_workflow() -> None:
-    provider_report = object()
-    all_report = object()
-
-    with (
-        patch("polylogue.schemas.audit.workflow.audit_provider", return_value=provider_report),
-        patch("polylogue.schemas.audit.workflow.audit_all_providers", return_value=all_report),
-    ):
-        assert audit_schemas(SchemaAuditRequest(provider="chatgpt")) is provider_report
-        assert audit_schemas(SchemaAuditRequest()) is all_report
+    report = audit_schemas(SchemaAuditRequest(provider="chatgpt"))
+    assert report.provider == "chatgpt"
+    assert report.checks

--- a/tests/unit/core/test_operator_inference.py
+++ b/tests/unit/core/test_operator_inference.py
@@ -11,6 +11,7 @@ import pytest
 from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.schemas.operator.inference import (
+    _privacy_config,
     audit_schemas,
     compare_schema_versions,
     infer_schema,
@@ -101,9 +102,10 @@ def test_cluster_promotion_drives_real_operator_registry_views(workspace_env: di
     assert promoted.package_version == "v2"
     assert promoted.schema is not None
     specs = list_inferred_corpus_specs(provider="chatgpt")
-    scenarios = list_inferred_corpus_scenarios(provider="chatgpt")
     registry = SchemaRegistry()
     registry.register_schema("chatgpt", {"type": "object", "properties": {"mapping": {"type": "object"}}})
+    registry.register_schema("codex", {"type": "object", "properties": {"session_id": {"type": "string"}}})
+    scenarios = list_inferred_corpus_scenarios()
     comparison = compare_schema_versions(SchemaCompareRequest(provider="chatgpt", from_version="v2", to_version="v3"))
     selected = list_schemas(SchemaListRequest(provider="chatgpt"))
 
@@ -111,30 +113,45 @@ def test_cluster_promotion_drives_real_operator_registry_views(workspace_env: di
     assert comparison.diff.version_b == "v3"
     assert selected.selected is not None
     assert selected.selected.versions == ["v1", "v2", "v3"]
+    assert {spec.provider for spec in specs} == {"chatgpt"}
     assert specs[0].package_version == "v2"
-    assert scenarios[0].provider == "chatgpt"
+    assert {scenario.provider for scenario in scenarios} >= {"chatgpt", "codex"}
 
 
 def test_infer_schema_normalizes_operator_privacy_configuration(workspace_env: dict[str, Path]) -> None:
     index_db = _seed_chatgpt_raw(workspace_env)
+    privacy_payload = {
+        "level": "strict",
+        "field_overrides": {"$.id": "drop", "invalid": 1},
+        "allow_value_patterns": ["safe", 1],
+        "deny_value_patterns": ["secret"],
+        "safe_enum_max_length": "invalid",
+        "high_entropy_min_length": 14,
+        "cross_conv_min_count": 5,
+        "cross_conv_proportional": True,
+    }
 
     result = infer_schema(
         SchemaInferRequest(
             provider="chatgpt",
             db_path=index_db,
-            privacy_config={
-                "level": "strict",
-                "field_overrides": {"$.id": "drop", "invalid": 1},
-                "allow_value_patterns": ["safe", 1],
-                "deny_value_patterns": ["secret"],
-                "high_entropy_min_length": 14,
-            },
+            privacy_config=privacy_payload,
         )
     )
+    privacy = _privacy_config(privacy_payload)
 
     assert result.generation.success
     assert result.generation.schema is not None
     assert result.generation.schema["type"] == "object"
+    assert privacy is not None
+    assert privacy.level == "strict"
+    assert privacy.safe_enum_max_length == 30
+    assert privacy.high_entropy_min_length == 14
+    assert privacy.cross_conv_min_count == 5
+    assert privacy.cross_conv_proportional is True
+    assert privacy.field_overrides == {"$.id": "drop"}
+    assert privacy.allow_value_patterns == ["safe"]
+    assert privacy.deny_value_patterns == ["secret"]
 
 
 def test_operator_inference_reports_real_unknown_provider_and_audits_bundled_schema(

--- a/tests/unit/core/test_operator_inference.py
+++ b/tests/unit/core/test_operator_inference.py
@@ -98,20 +98,20 @@ def test_cluster_promotion_drives_real_operator_registry_views(workspace_env: di
         )
     )
 
-    assert promoted.package_version == "v1"
+    assert promoted.package_version == "v2"
     assert promoted.schema is not None
     specs = list_inferred_corpus_specs(provider="chatgpt")
     scenarios = list_inferred_corpus_scenarios(provider="chatgpt")
     registry = SchemaRegistry()
     registry.register_schema("chatgpt", {"type": "object", "properties": {"mapping": {"type": "object"}}})
-    comparison = compare_schema_versions(SchemaCompareRequest(provider="chatgpt", from_version="v1", to_version="v2"))
+    comparison = compare_schema_versions(SchemaCompareRequest(provider="chatgpt", from_version="v2", to_version="v3"))
     selected = list_schemas(SchemaListRequest(provider="chatgpt"))
 
-    assert comparison.diff.version_a == "v1"
-    assert comparison.diff.version_b == "v2"
+    assert comparison.diff.version_a == "v2"
+    assert comparison.diff.version_b == "v3"
     assert selected.selected is not None
-    assert selected.selected.versions == ["v1", "v2"]
-    assert specs[0].package_version == "v1"
+    assert selected.selected.versions == ["v1", "v2", "v3"]
+    assert specs[0].package_version == "v2"
     assert scenarios[0].provider == "chatgpt"
 
 

--- a/tests/unit/core/test_operator_inference.py
+++ b/tests/unit/core/test_operator_inference.py
@@ -21,6 +21,7 @@ from polylogue.schemas.operator.inference import (
     promote_schema_cluster,
 )
 from polylogue.schemas.operator.models import (
+    JSONDocument,
     SchemaAuditRequest,
     SchemaCompareRequest,
     SchemaInferRequest,
@@ -120,7 +121,7 @@ def test_cluster_promotion_drives_real_operator_registry_views(workspace_env: di
 
 def test_infer_schema_normalizes_operator_privacy_configuration(workspace_env: dict[str, Path]) -> None:
     index_db = _seed_chatgpt_raw(workspace_env)
-    privacy_payload = {
+    privacy_payload: JSONDocument = {
         "level": "strict",
         "field_overrides": {"$.id": "drop", "invalid": 1},
         "allow_value_patterns": ["safe", 1],

--- a/tests/unit/core/test_operator_inference.py
+++ b/tests/unit/core/test_operator_inference.py
@@ -82,6 +82,9 @@ def test_infer_schema_builds_schema_from_source_tier_raw(workspace_env: dict[str
     assert result.manifest is None
     assert len(result.corpus_specs) == 1
     assert len(result.corpus_scenarios) == 1
+    assert result.corpus_specs[0].provider == "chatgpt"
+    assert result.corpus_scenarios[0].provider == "chatgpt"
+    assert result.corpus_scenarios[0].package_version == result.corpus_specs[0].package_version
 
 
 def test_cluster_promotion_drives_real_operator_registry_views(workspace_env: dict[str, Path]) -> None:
@@ -90,6 +93,7 @@ def test_cluster_promotion_drives_real_operator_registry_views(workspace_env: di
 
     assert inferred.generation.success
     assert inferred.manifest is not None
+    assert inferred.manifest_path is not None and inferred.manifest_path.exists()
     cluster_id = inferred.manifest.clusters[0].cluster_id
     promoted = promote_schema_cluster(
         SchemaPromoteRequest(
@@ -109,6 +113,7 @@ def test_cluster_promotion_drives_real_operator_registry_views(workspace_env: di
     scenarios = list_inferred_corpus_scenarios()
     comparison = compare_schema_versions(SchemaCompareRequest(provider="chatgpt", from_version="v2", to_version="v3"))
     selected = list_schemas(SchemaListRequest(provider="chatgpt"))
+    listing = list_schemas(SchemaListRequest())
 
     assert comparison.diff.version_a == "v2"
     assert comparison.diff.version_b == "v3"
@@ -116,7 +121,9 @@ def test_cluster_promotion_drives_real_operator_registry_views(workspace_env: di
     assert selected.selected.versions == ["v1", "v2", "v3"]
     assert {spec.provider for spec in specs} == {"chatgpt"}
     assert specs[0].package_version == "v2"
+    assert specs[0].profile.family_ids == (cluster_id,)
     assert {scenario.provider for scenario in scenarios} >= {"chatgpt", "codex"}
+    assert {snapshot.provider for snapshot in listing.providers} >= {"chatgpt", "codex"}
 
 
 def test_infer_schema_normalizes_operator_privacy_configuration(workspace_env: dict[str, Path]) -> None:

--- a/tests/unit/core/test_operator_inference.py
+++ b/tests/unit/core/test_operator_inference.py
@@ -269,8 +269,7 @@ def test_list_inferred_corpus_specs_reads_registry_catalog_and_manifest() -> Non
         manifests={"chatgpt": manifest},
     )
 
-    with patch("polylogue.schemas.operator.inference.schema_registry", return_value=fake_registry):
-        specs = list_inferred_corpus_specs()
+    specs = list_inferred_corpus_specs(registry=fake_registry)
 
     assert len(specs) == 1
     assert specs[0].provider == "chatgpt"
@@ -329,8 +328,7 @@ def test_list_inferred_corpus_scenarios_groups_specs_by_provider_and_version() -
         manifests={"chatgpt": manifest},
     )
 
-    with patch("polylogue.schemas.operator.inference.schema_registry", return_value=fake_registry):
-        scenarios = list_inferred_corpus_scenarios()
+    scenarios = list_inferred_corpus_scenarios(registry=fake_registry)
 
     assert len(scenarios) == 1
     assert scenarios[0].provider == "chatgpt"
@@ -376,8 +374,7 @@ def test_list_inferred_corpus_specs_can_scope_to_one_provider() -> None:
         manifests={"chatgpt": None, "codex": None},
     )
 
-    with patch("polylogue.schemas.operator.inference.schema_registry", return_value=fake_registry):
-        specs = list_inferred_corpus_specs(provider="chatgpt")
+    specs = list_inferred_corpus_specs(provider="chatgpt", registry=fake_registry)
 
     assert tuple(spec.provider for spec in specs) == ("chatgpt",)
     assert specs[0].package_version == "v3"

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -52,6 +52,17 @@ def test_polylogued_version_option_reports_version() -> None:
     assert result.output.startswith("polylogued, version ")
 
 
+def test_polylogued_health_json_runs_against_isolated_workspace(workspace_env: dict[str, Path]) -> None:
+    """Health CLI returns structured output without requiring a live daemon."""
+    result = CliRunner().invoke(main, ["health", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    payload = loads(result.output)
+    assert isinstance(payload, dict)
+    assert "overall_status" in payload
+    assert isinstance(payload["alerts"], list)
+
+
 @pytest.mark.contract
 def test_polylogued_status_json_reports_daemon_components(
     tmp_path: Path,

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -18,6 +18,7 @@ from polylogue.config import Config
 from polylogue.core.json import JSONDocument, loads
 from polylogue.daemon.cli import main
 from polylogue.daemon.convergence import ConvergenceStage
+from polylogue.daemon.health import DaemonHealth, HealthSeverity, HealthTier
 from polylogue.sources.live import WatchSource
 from polylogue.sources.live.cursor import CursorStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
@@ -61,6 +62,37 @@ def test_polylogued_health_json_runs_against_isolated_workspace(workspace_env: d
     assert isinstance(payload, dict)
     assert "overall_status" in payload
     assert isinstance(payload["alerts"], list)
+
+
+def test_polylogued_health_error_json_exits_nonzero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI health propagates an unhealthy aggregate through its process status."""
+    monkeypatch.setattr(
+        "polylogue.daemon.cli.check_health",
+        lambda *, tiers: DaemonHealth(overall_status=HealthSeverity.ERROR, checked_at="2026-07-13T00:00:00+00:00"),
+    )
+
+    result = CliRunner().invoke(main, ["health", "--format", "json"])
+
+    assert result.exit_code == 1
+    payload = loads(result.output)
+    assert isinstance(payload, dict)
+    assert payload["overall_status"] == "error"
+
+
+def test_polylogued_health_expensive_flag_selects_all_tiers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The expensive convenience flag must request all health tiers."""
+    observed: list[set[HealthTier]] = []
+
+    def _check_health(*, tiers: set[HealthTier]) -> DaemonHealth:
+        observed.append(tiers)
+        return DaemonHealth(overall_status=HealthSeverity.OK, checked_at="2026-07-13T00:00:00+00:00")
+
+    monkeypatch.setattr("polylogue.daemon.cli.check_health", _check_health)
+
+    result = CliRunner().invoke(main, ["health", "--expensive", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert observed == [{HealthTier.FAST, HealthTier.MEDIUM, HealthTier.EXPENSIVE}]
 
 
 @pytest.mark.contract

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -89,6 +89,39 @@ def test_status_snapshot_serves_cached_payload_without_rebuilding_status(monkeyp
     assert "queued_actors" in writer
 
 
+def test_daemon_status_plain_output_reports_schema_and_cursor_debt() -> None:
+    """Daemon status must surface actionable split-store and cursor-state evidence."""
+    lines = format_daemon_status_lines(
+        {
+            "daemon_liveness": True,
+            "archive_storage": {
+                "active_store": "archive_file_set",
+                "present_tiers": ["source", "index"],
+                "missing_tiers": ["embeddings", "user", "ops"],
+                "schema_mismatches": ["index"],
+                "archive_root_matches_configured": False,
+                "archive_root": "/tmp/active-archive",
+            },
+            "live_cursor": {
+                "tracked_file_count": 3,
+                "failed_file_count": 1,
+                "excluded_file_count": 1,
+                "retry_due_file_count": 1,
+                "in_backoff_file_count": 0,
+                "omitted_file_count": 2,
+            },
+            "failing_files": ["/capture/broken.jsonl"],
+        }
+    )
+
+    assert (
+        "Storage: archive_file_set (source, index); missing embeddings, user, ops; schema mismatch index; active root /tmp/active-archive"
+        in lines
+    )
+    assert "Live cursor: 3 tracked, 1 failed, 1 excluded, 1 retry due, 0 in backoff" in lines
+    assert "Failing files: 1 shown, 2 omitted" in lines
+
+
 def test_status_snapshot_stale_healthy_authority_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
     payload: JSONDocument = {
         "ok": True,

--- a/tests/unit/maintenance/test_planner_contract.py
+++ b/tests/unit/maintenance/test_planner_contract.py
@@ -8,11 +8,8 @@ this contract and depends on the shape staying stable.
 
 from __future__ import annotations
 
-from collections.abc import Iterator
-from contextlib import contextmanager
 from pathlib import Path
 from typing import cast
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -32,7 +29,7 @@ from polylogue.maintenance.planner import (
     preview_backfill,
 )
 from polylogue.maintenance.targets import build_maintenance_target_catalog
-from tests.infra.storage_records import SessionBuilder, db_setup
+from tests.infra.storage_records import DbFactory, db_setup
 
 
 def _make_config(tmp_path: Path) -> Config:
@@ -339,7 +336,7 @@ class TestConfigThreading:
     def test_preview_reads_the_callers_seeded_archive(self, workspace_env: dict[str, Path]) -> None:
         """Planner debt comes from the supplied archive, not ambient paths."""
         index_db = db_setup(workspace_env)
-        SessionBuilder(index_db, "planner-config").provider("chatgpt").save()
+        DbFactory(index_db).create_session(id="planner-config")
         config = Config(
             archive_root=workspace_env["archive_root"],
             render_root=workspace_env["data_root"] / "render",
@@ -353,80 +350,21 @@ class TestConfigThreading:
         assert preview.affected_rows == 1
         assert preview.results
 
-    def test_execute_threads_config_db_path(self, tmp_path: Path) -> None:
-        from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+    def test_execute_dry_run_reads_the_callers_seeded_archive(self, workspace_env: dict[str, Path]) -> None:
+        index_db = db_setup(workspace_env)
+        DbFactory(index_db).create_session(id="planner-execute")
+        config = Config(
+            archive_root=workspace_env["archive_root"],
+            render_root=workspace_env["data_root"] / "render",
+            sources=[],
+            db_path=index_db,
+        )
 
-        config = _make_config(tmp_path)
-        initialize_active_archive_root(config.archive_root)
-        expected_index = config.archive_root / "index.db"
+        operation = execute_backfill(config, targets=("empty_sessions",), dry_run=True)
 
-        seen: list[Path] = []
-
-        def fake_open(path: object, **_: object) -> MagicMock:
-            seen.append(Path(str(path)))
-            return MagicMock()
-
-        with (
-            patch(
-                "polylogue.storage.sqlite.connection_profile.open_readonly_connection",
-                side_effect=fake_open,
-            ),
-            patch(
-                "polylogue.storage.repair.collect_archive_debt_statuses_sync",
-                return_value={},
-            ),
-            patch(
-                "polylogue.storage.repair.preview_counts_from_archive_debt",
-                return_value={},
-            ),
-            patch(
-                "polylogue.storage.repair.run_selected_maintenance",
-                return_value=[],
-            ),
-        ):
-            op = execute_backfill(config, targets=("session_insights",))
-
-        assert seen == [expected_index]
-        # An execute that succeeded with zero results is COMPLETED (all([]) is True).
-        assert op.status is BackfillStatus.COMPLETED
-
-
-class TestExecuteFailureSamples:
-    """When the executor raises, the failure must surface as a bounded sample."""
-
-    def test_unexpected_exception_populates_failure_samples(self, tmp_path: Path) -> None:
-        config = _make_config(tmp_path)
-
-        @contextmanager
-        def fake_connection_context(db_path: object) -> Iterator[object]:
-            yield object()
-
-        with (
-            patch(
-                "polylogue.storage.sqlite.connection.connection_context",
-                fake_connection_context,
-            ),
-            patch(
-                "polylogue.storage.repair.collect_archive_debt_statuses_sync",
-                return_value={},
-            ),
-            patch(
-                "polylogue.storage.repair.preview_counts_from_archive_debt",
-                return_value={},
-            ),
-            patch(
-                "polylogue.storage.repair.run_selected_maintenance",
-                side_effect=RuntimeError("simulated repair failure"),
-            ),
-        ):
-            op = execute_backfill(config, targets=("session_insights",))
-
-        assert op.status is BackfillStatus.FAILED
-        assert op.failure_samples.truncated is False
-        assert len(op.failure_samples.samples) == 1
-        sample = op.failure_samples.samples[0]
-        assert sample.kind == "RuntimeError"
-        assert "simulated repair failure" in sample.message
+        assert operation.status is BackfillStatus.COMPLETED
+        assert operation.affected_rows == 1
+        assert operation.results[0]["name"] == "empty_sessions"
 
 
 class TestDerivedModelStatusInvalidatedReason:

--- a/tests/unit/maintenance/test_planner_contract.py
+++ b/tests/unit/maintenance/test_planner_contract.py
@@ -32,6 +32,7 @@ from polylogue.maintenance.planner import (
     preview_backfill,
 )
 from polylogue.maintenance.targets import build_maintenance_target_catalog
+from tests.infra.storage_records import SessionBuilder, db_setup
 
 
 def _make_config(tmp_path: Path) -> Config:
@@ -335,36 +336,22 @@ class TestConfigThreading:
     (the original scaffold did the latter and broke multi-archive tests).
     """
 
-    def test_preview_threads_config_db_path(self, tmp_path: Path) -> None:
-        from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+    def test_preview_reads_the_callers_seeded_archive(self, workspace_env: dict[str, Path]) -> None:
+        """Planner debt comes from the supplied archive, not ambient paths."""
+        index_db = db_setup(workspace_env)
+        SessionBuilder(index_db, "planner-config").provider("chatgpt").save()
+        config = Config(
+            archive_root=workspace_env["archive_root"],
+            render_root=workspace_env["data_root"] / "render",
+            sources=[],
+            db_path=index_db,
+        )
 
-        config = _make_config(tmp_path)
-        initialize_active_archive_root(config.archive_root)
-        expected_index = config.archive_root / "index.db"
+        preview = preview_backfill(config, targets=("empty_sessions",))
 
-        seen: list[Path] = []
-
-        def fake_open(path: object, **_: object) -> MagicMock:
-            seen.append(Path(str(path)))
-            return MagicMock()
-
-        with (
-            patch(
-                "polylogue.storage.sqlite.connection_profile.open_readonly_connection",
-                side_effect=fake_open,
-            ),
-            patch(
-                "polylogue.storage.repair.collect_archive_debt_statuses_sync",
-                return_value={},
-            ),
-            patch(
-                "polylogue.storage.repair.preview_counts_from_archive_debt",
-                return_value={},
-            ),
-        ):
-            preview_backfill(config, targets=("session_insights",))
-
-        assert seen == [expected_index]
+        assert preview.targets == ("empty_sessions",)
+        assert preview.affected_rows == 1
+        assert preview.results
 
     def test_execute_threads_config_db_path(self, tmp_path: Path) -> None:
         from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root

--- a/tests/unit/maintenance/test_planner_contract.py
+++ b/tests/unit/maintenance/test_planner_contract.py
@@ -45,6 +45,16 @@ def _make_config(tmp_path: Path) -> Config:
     )
 
 
+def _caller_archive_workspace(workspace_env: dict[str, Path]) -> dict[str, Path]:
+    """Initialize a caller archive distinct from the ambient fixture root."""
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    caller_archive_root = workspace_env["data_root"] / "caller-archive"
+    with ArchiveStore(caller_archive_root):
+        pass
+    return {**workspace_env, "archive_root": caller_archive_root}
+
+
 class TestBackfillKindCoverage:
     """Every typed-taxonomy kind from #1144 must be representable."""
 
@@ -335,10 +345,11 @@ class TestConfigThreading:
 
     def test_preview_reads_the_callers_seeded_archive(self, workspace_env: dict[str, Path]) -> None:
         """Planner debt comes from the supplied archive, not ambient paths."""
-        index_db = db_setup(workspace_env)
+        caller_workspace = _caller_archive_workspace(workspace_env)
+        index_db = db_setup(caller_workspace)
         DbFactory(index_db).create_session(id="planner-config")
         config = Config(
-            archive_root=workspace_env["archive_root"],
+            archive_root=caller_workspace["archive_root"],
             render_root=workspace_env["data_root"] / "render",
             sources=[],
             db_path=index_db,
@@ -351,10 +362,11 @@ class TestConfigThreading:
         assert preview.results
 
     def test_execute_dry_run_reads_the_callers_seeded_archive(self, workspace_env: dict[str, Path]) -> None:
-        index_db = db_setup(workspace_env)
+        caller_workspace = _caller_archive_workspace(workspace_env)
+        index_db = db_setup(caller_workspace)
         DbFactory(index_db).create_session(id="planner-execute")
         config = Config(
-            archive_root=workspace_env["archive_root"],
+            archive_root=caller_workspace["archive_root"],
             render_root=workspace_env["data_root"] / "render",
             sources=[],
             db_path=index_db,

--- a/tests/unit/maintenance/test_planner_filter_narrowing.py
+++ b/tests/unit/maintenance/test_planner_filter_narrowing.py
@@ -20,63 +20,26 @@ Pins:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
-from unittest.mock import patch
 
 import pytest
 
 from polylogue.config import Config
 from polylogue.maintenance.planner import preview_backfill
 from polylogue.maintenance.scope import MaintenanceScopeFilter
-from tests.infra.storage_records import SessionBuilder, db_setup
+from tests.infra.storage_records import DbFactory, db_setup
 
 
-def _make_config(tmp_path: Path) -> Config:
-    archive_root = tmp_path / "archive"
-    render_root = tmp_path / "render"
-    archive_root.mkdir(parents=True, exist_ok=True)
-    render_root.mkdir(parents=True, exist_ok=True)
-    return Config(
-        archive_root=archive_root,
-        render_root=render_root,
-        sources=[],
-        db_path=tmp_path / "archive.db",
-    )
-
-
-def _seeded_config(workspace_env: dict[str, Path]) -> Config:
+def _seeded_config(workspace_env: dict[str, Path], *, sessions: int = 3) -> Config:
     index_db = db_setup(workspace_env)
-    for session_id in ("one", "two", "three"):
-        SessionBuilder(index_db, session_id).provider("chatgpt").save()
+    factory = DbFactory(index_db)
+    for index in range(sessions):
+        factory.create_session(id=f"empty-{index}")
     return Config(
         archive_root=workspace_env["archive_root"],
         render_root=workspace_env["data_root"] / "render",
         sources=[],
         db_path=index_db,
     )
-
-
-def _patched_debt(pending: int) -> tuple[Any, Any]:
-    """Build debt doubles for the remaining synthetic filter-dimension cases."""
-    from polylogue.maintenance.models import DerivedModelStatus
-
-    status = DerivedModelStatus(
-        name="session_insights",
-        ready=False,
-        detail=f"{pending} pending",
-        source_documents=pending,
-        materialized_documents=0,
-        stale_rows=pending,
-        missing_provenance_rows=0,
-    )
-
-    def collect(*_args: Any, **_kwargs: Any) -> dict[str, DerivedModelStatus]:
-        return {"session_insights": status}
-
-    def counts(_statuses: dict[str, DerivedModelStatus]) -> dict[str, int]:
-        return {"session_insights": pending}
-
-    return collect, counts
 
 
 class TestPlannerNarrowsBySessionIds:
@@ -95,35 +58,25 @@ class TestPlannerNarrowsBySessionIds:
         assert narrow.scope is not None
         assert narrow.scope.filter.session_ids == ("only-one",)
 
-    def test_multi_session_filter_clamps_to_filter_size(self, tmp_path: Path) -> None:
-        config = _make_config(tmp_path)
-        collect, counts = _patched_debt(1000)
-        with (
-            patch("polylogue.storage.repair.collect_archive_debt_statuses_sync", collect),
-            patch("polylogue.storage.repair.preview_counts_from_archive_debt", counts),
-        ):
-            narrow = preview_backfill(
-                config,
-                targets=("session_insights",),
-                scope_filter=MaintenanceScopeFilter(session_ids=("c1", "c2", "c3")),
-            )
+    def test_multi_session_filter_clamps_to_filter_size(self, workspace_env: dict[str, Path]) -> None:
+        config = _seeded_config(workspace_env)
+        narrow = preview_backfill(
+            config,
+            targets=("empty_sessions",),
+            scope_filter=MaintenanceScopeFilter(session_ids=("c1", "c2", "c3")),
+        )
         assert narrow.affected_rows == 3
         assert narrow.scope is not None
         assert narrow.scope.filter.session_ids == ("c1", "c2", "c3")
 
-    def test_session_filter_does_not_inflate_when_debt_is_smaller(self, tmp_path: Path) -> None:
+    def test_session_filter_does_not_inflate_when_debt_is_smaller(self, workspace_env: dict[str, Path]) -> None:
         """A filter naming 100 ids cannot inflate a 2-row debt to 100."""
-        config = _make_config(tmp_path)
-        collect, counts = _patched_debt(2)
-        with (
-            patch("polylogue.storage.repair.collect_archive_debt_statuses_sync", collect),
-            patch("polylogue.storage.repair.preview_counts_from_archive_debt", counts),
-        ):
-            narrow = preview_backfill(
-                config,
-                targets=("session_insights",),
-                scope_filter=MaintenanceScopeFilter(session_ids=tuple(f"c{i}" for i in range(100))),
-            )
+        config = _seeded_config(workspace_env, sessions=2)
+        narrow = preview_backfill(
+            config,
+            targets=("empty_sessions",),
+            scope_filter=MaintenanceScopeFilter(session_ids=tuple(f"c{i}" for i in range(100))),
+        )
         assert narrow.affected_rows == 2
 
 
@@ -140,7 +93,7 @@ class TestPlannerLeavesFilterPassthroughDimensionsIntact:
         ],
     )
     def test_non_session_filters_do_not_change_affected_rows(
-        self, tmp_path: Path, scope_filter: MaintenanceScopeFilter
+        self, workspace_env: dict[str, Path], scope_filter: MaintenanceScopeFilter
     ) -> None:
         """Filter dimensions the planner doesn't yet honor pass through unchanged.
 
@@ -150,16 +103,11 @@ class TestPlannerLeavesFilterPassthroughDimensionsIntact:
         comes from the full debt status until a repair fn learns to
         narrow on that dimension.
         """
-        config = _make_config(tmp_path)
-        collect, counts = _patched_debt(50)
-        with (
-            patch("polylogue.storage.repair.collect_archive_debt_statuses_sync", collect),
-            patch("polylogue.storage.repair.preview_counts_from_archive_debt", counts),
-        ):
-            broad = preview_backfill(config, targets=("session_insights",))
-            scoped = preview_backfill(config, targets=("session_insights",), scope_filter=scope_filter)
-        assert broad.affected_rows == 50
-        assert scoped.affected_rows == 50
+        config = _seeded_config(workspace_env)
+        broad = preview_backfill(config, targets=("empty_sessions",))
+        scoped = preview_backfill(config, targets=("empty_sessions",), scope_filter=scope_filter)
+        assert broad.affected_rows == 3
+        assert scoped.affected_rows == 3
         # And the filter still rides through on the scope so the
         # envelope can echo it.
         assert scoped.scope is not None
@@ -169,21 +117,16 @@ class TestPlannerLeavesFilterPassthroughDimensionsIntact:
 class TestPlannerWithEmptyFilter:
     """An empty / default filter must not narrow the preview."""
 
-    def test_default_filter_preserves_full_debt(self, tmp_path: Path) -> None:
-        config = _make_config(tmp_path)
-        collect, counts = _patched_debt(200)
-        with (
-            patch("polylogue.storage.repair.collect_archive_debt_statuses_sync", collect),
-            patch("polylogue.storage.repair.preview_counts_from_archive_debt", counts),
-        ):
-            broad = preview_backfill(config, targets=("session_insights",))
-            explicit_empty = preview_backfill(
-                config,
-                targets=("session_insights",),
-                scope_filter=MaintenanceScopeFilter(),
-            )
-        assert broad.affected_rows == 200
-        assert explicit_empty.affected_rows == 200
+    def test_default_filter_preserves_full_debt(self, workspace_env: dict[str, Path]) -> None:
+        config = _seeded_config(workspace_env)
+        broad = preview_backfill(config, targets=("empty_sessions",))
+        explicit_empty = preview_backfill(
+            config,
+            targets=("empty_sessions",),
+            scope_filter=MaintenanceScopeFilter(),
+        )
+        assert broad.affected_rows == 3
+        assert explicit_empty.affected_rows == 3
         # Both ought to attach an empty filter onto the scope.
         assert broad.scope is not None and broad.scope.filter.is_empty()
         assert explicit_empty.scope is not None and explicit_empty.scope.filter.is_empty()

--- a/tests/unit/maintenance/test_planner_filter_narrowing.py
+++ b/tests/unit/maintenance/test_planner_filter_narrowing.py
@@ -28,6 +28,7 @@ import pytest
 from polylogue.config import Config
 from polylogue.maintenance.planner import preview_backfill
 from polylogue.maintenance.scope import MaintenanceScopeFilter
+from tests.infra.storage_records import SessionBuilder, db_setup
 
 
 def _make_config(tmp_path: Path) -> Config:
@@ -43,11 +44,23 @@ def _make_config(tmp_path: Path) -> Config:
     )
 
 
+def _seeded_config(workspace_env: dict[str, Path]) -> Config:
+    index_db = db_setup(workspace_env)
+    for session_id in ("one", "two", "three"):
+        SessionBuilder(index_db, session_id).provider("chatgpt").save()
+    return Config(
+        archive_root=workspace_env["archive_root"],
+        render_root=workspace_env["data_root"] / "render",
+        sources=[],
+        db_path=index_db,
+    )
+
+
 def _patched_debt(pending: int) -> tuple[Any, Any]:
-    """Return patched debt collector + preview callables advertising ``pending`` rows."""
+    """Build debt doubles for the remaining synthetic filter-dimension cases."""
     from polylogue.maintenance.models import DerivedModelStatus
 
-    fake_status = DerivedModelStatus(
+    status = DerivedModelStatus(
         name="session_insights",
         ready=False,
         detail=f"{pending} pending",
@@ -57,30 +70,25 @@ def _patched_debt(pending: int) -> tuple[Any, Any]:
         missing_provenance_rows=0,
     )
 
-    def _fake_collect(*_a: Any, **_kw: Any) -> dict[str, DerivedModelStatus]:
-        return {"session_insights": fake_status}
+    def collect(*_args: Any, **_kwargs: Any) -> dict[str, DerivedModelStatus]:
+        return {"session_insights": status}
 
-    def _fake_counts(_statuses: dict[str, DerivedModelStatus]) -> dict[str, int]:
+    def counts(_statuses: dict[str, DerivedModelStatus]) -> dict[str, int]:
         return {"session_insights": pending}
 
-    return _fake_collect, _fake_counts
+    return collect, counts
 
 
 class TestPlannerNarrowsBySessionIds:
     """A ``session_ids`` filter clamps preview rows to the filter size."""
 
-    def test_single_session_filter_clamps_to_one(self, tmp_path: Path) -> None:
-        config = _make_config(tmp_path)
-        collect, counts = _patched_debt(1000)
-        with (
-            patch("polylogue.storage.repair.collect_archive_debt_statuses_sync", collect),
-            patch("polylogue.storage.repair.preview_counts_from_archive_debt", counts),
-        ):
-            narrow = preview_backfill(
-                config,
-                targets=("session_insights",),
-                scope_filter=MaintenanceScopeFilter(session_ids=("only-one",)),
-            )
+    def test_single_session_filter_clamps_real_archive_debt(self, workspace_env: dict[str, Path]) -> None:
+        config = _seeded_config(workspace_env)
+        narrow = preview_backfill(
+            config,
+            targets=("empty_sessions",),
+            scope_filter=MaintenanceScopeFilter(session_ids=("only-one",)),
+        )
         assert narrow.affected_rows == 1
         # And the filter is echoed back on the returned scope so the
         # envelope can serialize it.


### PR DESCRIPTION
## Summary

Test-only hardening across CLI status/query, daemon health/status, and three formerly mock-heavy operator/maintenance suites.

## Problem

The selected suites depended on foreign-internal mocks or omitted high-risk CLI and daemon error paths. The original PR wording overstated completion because no fresh full-suite coverage measurement establishes the Beads numeric targets.

## Solution

- Use a native source-tier ChatGPT payload plus persisted schema packages for operator inference, promotion, registry list/compare, and audit paths.
- Use DbFactory-created archives for planner preview, dry-run, filtering, and caller-vs-ambient archive routing.
- Exercise malformed projection input, real loopback daemon status success and malformed-snapshot recovery, daemon health JSON failure exits, expensive tier selection, and status debt rendering.

## Acceptance criteria

| Bead | Status | Evidence / residual work |
| --- | --- | --- |
| polylogue-n4hb | Deferred to polylogue-n4hb | All three nominated files now use archive/registry infrastructure and focused tests pass. Equal-or-better coverage is not yet complete: real with-samples promotion selection and several former audit/listing edge contracts need durable infra fixtures. |
| polylogue-c52g | Deferred to polylogue-c52g | Adds query projection validation and real status success/unavailable branches. A fresh full-suite coverage report is still required before claiming the roughly 83 percent target for both CLI files. |
| polylogue-znwj | Deferred to polylogue-znwj | Adds health JSON success/error and expensive-tier branches plus status split-store/cursor rendering. A fresh full-suite coverage report is still required before claiming the daemon CLI/status targets. |

## Anti-vacuity

- Operator inference exercises raw source-tier sampling, clustering, promotion, persisted manifest paths, provider-scoped/global registry enumeration, comparison, and audit. Removing these archive/registry paths changes the asserted outputs. The privacy test deliberately protects the typed normalizer only; it does not claim end-to-end generation propagation.
- Planner tests exercise preview and dry-run against DbFactory-created empty-session debt, including a caller archive distinct from the empty ambient archive. Removing config routing or native debt counting changes row/result assertions.
- Projection tests exercise the public parser; malformed budgets, booleans, duplicate keys, and aliases fail or normalize differently if validation changes.
- Status tests run actual loopback HTTP routes; bypassing daemon JSON handling or liveness recovery changes their output.
- Health tests execute the Click command’s JSON exit and expensive-tier branches; changing the error exit or tier selection fails them.

## Verification

- POLYLOGUE_PYTEST_BASETEMP_ROOT=/realm/tmp/polylogue-pytest nix develop --command devtools test tests/unit/core/test_operator_inference.py — 4 passed in 15.54s.
- POLYLOGUE_PYTEST_BASETEMP_ROOT=/realm/tmp/polylogue-pytest nix develop --command devtools test <6 strengthened nodes> — 6 passed in 32.30s.
- Earlier maintenance conversion verification: devtools test on the three n4hb files — 53 passed in 48.32s.
- Ruff format/check and focused mypy passed; the current pre-push quick baseline passed.

Ref polylogue-n4hb
Ref polylogue-c52g
Ref polylogue-znwj