### PR TITLE
feat(import): declare Hermes source fidelity

### DIFF
--- a/docs/schemas/cli-output/import-explain.schema.json
+++ b/docs/schemas/cli-output/import-explain.schema.json
@@ -92,6 +92,17 @@
           "title": "Detector Evidence",
           "type": "array"
         },
+        "fidelity": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ImportFidelityDeclarationPayload"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "normalization_warnings": {
           "default": [],
           "items": {
@@ -208,6 +219,113 @@
         "detector"
       ],
       "title": "ImportExplainEntryPayload",
+      "type": "object"
+    },
+    "ImportFidelityCapabilityPayload": {
+      "additionalProperties": false,
+      "description": "Coverage and fidelity for one source capability.",
+      "properties": {
+        "counts": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "title": "Counts",
+          "type": "object"
+        },
+        "detail": {
+          "title": "Detail",
+          "type": "string"
+        },
+        "expected": {
+          "default": 0,
+          "title": "Expected",
+          "type": "integer"
+        },
+        "observed": {
+          "default": 0,
+          "title": "Observed",
+          "type": "integer"
+        },
+        "status": {
+          "enum": [
+            "exact",
+            "absent",
+            "redacted",
+            "degraded",
+            "inferred"
+          ],
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "status",
+        "detail"
+      ],
+      "title": "ImportFidelityCapabilityPayload",
+      "type": "object"
+    },
+    "ImportFidelityDeclarationPayload": {
+      "additionalProperties": false,
+      "description": "Per-source declaration of retained import evidence and known gaps.",
+      "properties": {
+        "acquisition_method": {
+          "title": "Acquisition Method",
+          "type": "string"
+        },
+        "capabilities": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ImportFidelityCapabilityPayload"
+          },
+          "title": "Capabilities",
+          "type": "object"
+        },
+        "caveats": {
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "title": "Caveats",
+          "type": "array"
+        },
+        "producer": {
+          "title": "Producer",
+          "type": "string"
+        },
+        "profile_namespace": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Profile Namespace"
+        },
+        "retained_blob_reproducibility": {
+          "$ref": "#/$defs/ImportFidelityCapabilityPayload"
+        },
+        "schema_version": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Schema Version"
+        }
+      },
+      "required": [
+        "producer",
+        "acquisition_method",
+        "retained_blob_reproducibility"
+      ],
+      "title": "ImportFidelityDeclarationPayload",
       "type": "object"
     },
     "ImportProducedRowsPayload": {

--- a/polylogue/sources/import_explain.py
+++ b/polylogue/sources/import_explain.py
@@ -24,12 +24,15 @@ from polylogue.sources.decoder_zip import (
 )
 from polylogue.sources.decoders import _decode_json_bytes, _iter_json_stream
 from polylogue.sources.dispatch import GROUP_PROVIDERS, detect_provider, is_jsonl_source_path, parse_payload
+from polylogue.sources.parsers import hermes_state
 from polylogue.sources.parsers.base import ParsedSession
 from polylogue.sources.source_walk import _resolve_source_paths
 from polylogue.surfaces.payloads import (
     ImportDetectorEvidencePayload,
     ImportExplainEntryPayload,
     ImportExplainPayload,
+    ImportFidelityCapabilityPayload,
+    ImportFidelityDeclarationPayload,
     ImportProducedRowsPayload,
     ImportSkippedRowPayload,
 )
@@ -409,6 +412,9 @@ def _explain_file(path: Path, *, provider_hint: Provider) -> ImportExplainEntryP
     if path.suffix.lower() == ".zip":
         return _explain_zip(path, provider_hint=provider_hint, path_classification=path_classification)
 
+    if hermes_state.looks_like_state_db_path(path):
+        return _explain_hermes_state_db(path, provider_hint=provider_hint)
+
     try:
         raw_bytes = path.read_bytes()
     except OSError as exc:
@@ -424,6 +430,43 @@ def _explain_file(path: Path, *, provider_hint: Provider) -> ImportExplainEntryP
         source_path=str(path),
         provider_hint=provider_hint,
         path_classification=path_classification,
+    )
+
+
+def _explain_hermes_state_db(path: Path, *, provider_hint: Provider) -> ImportExplainEntryPayload:
+    """Inspect the real Hermes SQLite parser path without writing a raw blob."""
+
+    try:
+        sessions = hermes_state.parse_state_db(path, fallback_id=path.stem, profile_root=path.parent)
+    except (OSError, sqlite3.Error, ValueError) as exc:
+        return _skipped_entry(
+            path,
+            provider_hint=provider_hint,
+            artifact=None,
+            reason=f"Hermes state.db parser failure: {type(exc).__name__}: {exc}",
+            detected_provider=Provider.HERMES,
+        )
+    fidelity = hermes_state.import_fidelity_declaration(sessions, acquisition_method="sqlite_backup")
+    return ImportExplainEntryPayload(
+        source_path=str(path),
+        artifact_kind="sqlite_state_database",
+        provider_hint=provider_hint.value,
+        detected_origin=_origin_value(Provider.HERMES),
+        detected_provider=Provider.HERMES.value,
+        detector="hermes_state_db",
+        detector_evidence=(
+            _evidence("hermes_state_db.signature", matched=True, reason="required Hermes tables and signature columns"),
+        ),
+        parser="hermes_state_db",
+        parser_version=None if fidelity.schema_version is None else f"state-db-v{fidelity.schema_version}",
+        parser_mode="sqlite_backup",
+        produced=_produced_rows(sessions),
+        caveats=(
+            "dry-run inspected the live SQLite database read-only; import snapshots bytes before parsing.",
+            *fidelity.caveats,
+        ),
+        raw_evidence_refs=(),
+        fidelity=_fidelity_payload(fidelity),
     )
 
 
@@ -573,6 +616,11 @@ def _explain_bytes(
             detected_provider=detected_provider,
         )
 
+    fidelity = (
+        _fidelity_payload(hermes_state.import_fidelity_declaration(sessions, acquisition_method="json_fallback"))
+        if detected_provider is Provider.HERMES
+        else None
+    )
     return ImportExplainEntryPayload(
         source_path=source_path,
         artifact_kind=artifact.kind.value,
@@ -584,8 +632,32 @@ def _explain_bytes(
         parser=detected_provider.value,
         parser_mode=_parser_mode(detected_provider, payload),
         produced=_produced_rows(sessions),
-        caveats=() if sessions else ("parser produced no sessions",),
+        caveats=(
+            (() if sessions else ("parser produced no sessions",)) + (() if fidelity is None else fidelity.caveats)
+        ),
         raw_evidence_refs=(),
+        fidelity=fidelity,
+    )
+
+
+def _fidelity_payload(fidelity: hermes_state.HermesImportFidelity) -> ImportFidelityDeclarationPayload:
+    def capability(item: hermes_state.HermesFidelityCapability) -> ImportFidelityCapabilityPayload:
+        return ImportFidelityCapabilityPayload(
+            status=item.status,
+            observed=item.observed,
+            expected=item.expected,
+            counts=item.counts,
+            detail=item.detail,
+        )
+
+    return ImportFidelityDeclarationPayload(
+        producer=fidelity.producer,
+        schema_version=fidelity.schema_version,
+        profile_namespace=fidelity.profile_namespace,
+        acquisition_method=fidelity.acquisition_method,
+        retained_blob_reproducibility=capability(fidelity.retained_blob_reproducibility),
+        capabilities={name: capability(item) for name, item in fidelity.capabilities.items()},
+        caveats=fidelity.caveats,
     )
 
 

--- a/polylogue/sources/parsers/hermes_state.py
+++ b/polylogue/sources/parsers/hermes_state.py
@@ -248,7 +248,11 @@ def _sqlite_backup_fidelity(sessions: list[ParsedSession]) -> HermesImportFideli
     }
 
     def source_capability(name: str) -> HermesFidelityCapability:
-        observed = sum(name in payload.get("session_capabilities", ()) for payload in identity_payloads)
+        observed = sum(
+            name in capabilities
+            for payload in identity_payloads
+            if isinstance((capabilities := payload.get("session_capabilities")), list)
+        )
         return _fidelity_capability(
             observed=observed,
             expected=total_sessions,

--- a/polylogue/sources/parsers/hermes_state.py
+++ b/polylogue/sources/parsers/hermes_state.py
@@ -12,9 +12,10 @@ import hashlib
 import json
 import sqlite3
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
+from typing import Literal, TypeAlias, cast
 
 from polylogue.archive.message.roles import Role
 from polylogue.archive.session.branch_type import BranchType
@@ -110,6 +111,32 @@ _SESSION_METADATA_FIELDS = (
     "archived",
 )
 
+HermesFidelityStatus: TypeAlias = Literal["exact", "absent", "redacted", "degraded", "inferred"]
+
+
+@dataclass(frozen=True, slots=True)
+class HermesFidelityCapability:
+    """One source capability and the evidence that supports its status."""
+
+    status: HermesFidelityStatus
+    observed: int
+    expected: int
+    counts: dict[str, int]
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class HermesImportFidelity:
+    """Machine-readable fidelity declaration for one Hermes source artifact."""
+
+    producer: str
+    schema_version: int | None
+    profile_namespace: str | None
+    acquisition_method: str
+    retained_blob_reproducibility: HermesFidelityCapability
+    capabilities: dict[str, HermesFidelityCapability]
+    caveats: tuple[str, ...]
+
 
 def marker_payload(path: Path, *, profile_root: Path | None = None) -> JSONDocument:
     """Return the JSON marker that routes a raw SQLite blob to this parser."""
@@ -185,6 +212,239 @@ def parse_state_db(
         ]
     hydrated = _hydrate_compression_continuations(sessions)
     return [session for session in hydrated if session.messages or session.instructions_text]
+
+
+def import_fidelity_declaration(
+    sessions: list[ParsedSession],
+    *,
+    acquisition_method: Literal["sqlite_backup", "json_fallback"],
+) -> HermesImportFidelity:
+    """Declare the source fidelity that the Hermes parser can substantiate.
+
+    The declaration is deliberately conservative: values derived by the
+    normalizer are marked inferred, and evidence that no source artifact
+    carries is absent rather than represented as an empty successful value.
+    """
+
+    if acquisition_method == "json_fallback":
+        return _json_fallback_fidelity(sessions)
+    return _sqlite_backup_fidelity(sessions)
+
+
+def _sqlite_backup_fidelity(sessions: list[ParsedSession]) -> HermesImportFidelity:
+    total_sessions = len(sessions)
+    messages = [message for session in sessions for message in session.messages]
+    identity_payloads = [
+        event.payload
+        for session in sessions
+        for event in session.session_events
+        if event.event_type == "hermes_identity"
+    ]
+    schema_versions = {
+        value for payload in identity_payloads if isinstance((value := payload.get("schema_version")), int)
+    }
+    profile_keys = {
+        value for payload in identity_payloads if isinstance((value := payload.get("profile_key")), str) and value
+    }
+
+    def source_capability(name: str) -> HermesFidelityCapability:
+        observed = sum(name in payload.get("session_capabilities", ()) for payload in identity_payloads)
+        return _fidelity_capability(
+            observed=observed,
+            expected=total_sessions,
+            detail=f"{name.replace('_', ' ')} columns are present in the inspected Hermes schema.",
+        )
+
+    state_events = [
+        event for session in sessions for event in session.session_events if event.event_type == "hermes_message_state"
+    ]
+    state_counts = {
+        state: sum(event.payload.get("state") == state for event in state_events)
+        for state in ("active", "observed", "rewound", "compacted")
+    }
+    state_capable = sum(bool(event.payload.get("capability_present")) for event in state_events)
+    material_counts = {
+        origin.value: sum(message.material_origin is origin for message in messages)
+        for origin in MaterialOrigin
+        if any(message.material_origin is origin for message in messages)
+    }
+    cost_events = [
+        event
+        for session in sessions
+        for event in session.session_events
+        if event.event_type == "token_count" and any(event.payload.get(field) is not None for field in _COST_FIELDS)
+    ]
+    cost_status = _fidelity_capability(
+        observed=len(cost_events),
+        expected=total_sessions,
+        detail="Cost rows retain actual/estimated values with source, status, pricing, and billing provenance when present.",
+    )
+    capabilities = {
+        "profile_namespace": _fidelity_capability(
+            observed=len(profile_keys),
+            expected=1,
+            detail="Profile roots are hashed into stable namespace qualifiers; raw profile paths are not exposed.",
+        ),
+        "message_state": _fidelity_capability(
+            observed=state_capable,
+            expected=len(messages),
+            counts=state_counts,
+            detail="Active, observed, rewound, and compacted states are retained per source message.",
+        ),
+        "material_origin": HermesFidelityCapability(
+            status="inferred",
+            observed=len(messages),
+            expected=len(messages),
+            counts=material_counts,
+            detail="Material origin is normalized from role plus the source observed flag; Hermes has no explicit addressing field.",
+        ),
+        "cost_provenance": cost_status,
+        "lifecycle": source_capability("lifecycle"),
+        "relationship": source_capability("lineage"),
+        "repository": source_capability("repository"),
+        "runtime_spans": HermesFidelityCapability(
+            status="absent",
+            observed=0,
+            expected=total_sessions,
+            counts={},
+            detail="The SQLite snapshot contains no runtime-span stream.",
+        ),
+        "span_snapshot_merge": HermesFidelityCapability(
+            status="absent",
+            observed=0,
+            expected=total_sessions,
+            counts={},
+            detail="No runtime spans were supplied to enrich this snapshot revision.",
+        ),
+    }
+    caveats = tuple(
+        f"{name}: {capability.detail}" for name, capability in capabilities.items() if capability.status != "exact"
+    )
+    return HermesImportFidelity(
+        producer="Hermes state.db",
+        schema_version=next(iter(schema_versions)) if len(schema_versions) == 1 else None,
+        profile_namespace=next(iter(profile_keys)) if len(profile_keys) == 1 else None,
+        acquisition_method="sqlite_backup",
+        retained_blob_reproducibility=HermesFidelityCapability(
+            status="exact",
+            observed=total_sessions,
+            expected=total_sessions,
+            counts={},
+            detail="The import path snapshots SQLite bytes before parsing; retained bytes reproduce normalized Hermes revisions.",
+        ),
+        capabilities=capabilities,
+        caveats=caveats,
+    )
+
+
+def _json_fallback_fidelity(sessions: list[ParsedSession]) -> HermesImportFidelity:
+    messages = [message for session in sessions for message in session.messages]
+    total_sessions = len(sessions)
+    capabilities = {
+        "profile_namespace": HermesFidelityCapability(
+            status="absent",
+            observed=0,
+            expected=1,
+            counts={},
+            detail="JSON fallback has no installation/profile namespace.",
+        ),
+        "message_state": HermesFidelityCapability(
+            status="absent",
+            observed=0,
+            expected=len(messages),
+            counts={},
+            detail="JSON fallback does not retain Hermes message-state columns.",
+        ),
+        "material_origin": HermesFidelityCapability(
+            status="inferred",
+            observed=len(messages),
+            expected=len(messages),
+            counts={},
+            detail="Material origin is inferred from normalized message roles in the fallback export.",
+        ),
+        "cost_provenance": HermesFidelityCapability(
+            status="absent",
+            observed=0,
+            expected=total_sessions,
+            counts={},
+            detail="JSON fallback has no structured cost provenance.",
+        ),
+        "lifecycle": HermesFidelityCapability(
+            status="inferred",
+            observed=0,
+            expected=total_sessions,
+            counts={},
+            detail="Fallback lifecycle interpretation is limited to document fields.",
+        ),
+        "relationship": HermesFidelityCapability(
+            status="absent",
+            observed=0,
+            expected=total_sessions,
+            counts={},
+            detail="JSON fallback has no state-db lineage evidence.",
+        ),
+        "repository": HermesFidelityCapability(
+            status="absent",
+            observed=0,
+            expected=total_sessions,
+            counts={},
+            detail="JSON fallback has no repository capability declaration.",
+        ),
+        "runtime_spans": HermesFidelityCapability(
+            status="absent",
+            observed=0,
+            expected=total_sessions,
+            counts={},
+            detail="JSON fallback has no runtime-span stream.",
+        ),
+        "span_snapshot_merge": HermesFidelityCapability(
+            status="absent",
+            observed=0,
+            expected=total_sessions,
+            counts={},
+            detail="Fallback data cannot prove a span-plus-snapshot merge.",
+        ),
+    }
+    return HermesImportFidelity(
+        producer="Hermes JSON fallback",
+        schema_version=None,
+        profile_namespace=None,
+        acquisition_method="json_fallback",
+        retained_blob_reproducibility=HermesFidelityCapability(
+            status="absent",
+            observed=0,
+            expected=total_sessions,
+            counts={},
+            detail="Fallback JSON does not prove retained SQLite snapshot reproducibility.",
+        ),
+        capabilities=capabilities,
+        caveats=tuple(
+            f"{name}: {capability.detail}" for name, capability in capabilities.items() if capability.status != "exact"
+        ),
+    )
+
+
+def _fidelity_capability(
+    *,
+    observed: int,
+    expected: int,
+    detail: str,
+    counts: dict[str, int] | None = None,
+) -> HermesFidelityCapability:
+    status: HermesFidelityStatus
+    if observed == 0:
+        status = "absent"
+    elif observed < expected:
+        status = "degraded"
+    else:
+        status = "exact"
+    return HermesFidelityCapability(
+        status=status,
+        observed=observed,
+        expected=expected,
+        counts={} if counts is None else counts,
+        detail=detail,
+    )
 
 
 def _connect_readonly(path: Path) -> sqlite3.Connection:
@@ -670,6 +930,10 @@ def _optional_float(value: object) -> float | None:
 
 __all__ = [
     "HERMES_STATE_DB_MARKER",
+    "HermesFidelityCapability",
+    "HermesFidelityStatus",
+    "HermesImportFidelity",
+    "import_fidelity_declaration",
     "looks_like_state_db_path",
     "looks_like_state_db_payload",
     "marker_payload",

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -209,6 +209,31 @@ class ImportSkippedRowPayload(SurfacePayloadModel):
     raw_ref: str | None = None
 
 
+ImportFidelityStatus: TypeAlias = Literal["exact", "absent", "redacted", "degraded", "inferred"]
+
+
+class ImportFidelityCapabilityPayload(SurfacePayloadModel):
+    """Coverage and fidelity for one source capability."""
+
+    status: ImportFidelityStatus
+    observed: int = 0
+    expected: int = 0
+    counts: Mapping[str, int] = Field(default_factory=dict)
+    detail: str
+
+
+class ImportFidelityDeclarationPayload(SurfacePayloadModel):
+    """Per-source declaration of retained import evidence and known gaps."""
+
+    producer: str
+    schema_version: int | None = None
+    profile_namespace: str | None = None
+    acquisition_method: str
+    retained_blob_reproducibility: ImportFidelityCapabilityPayload
+    capabilities: Mapping[str, ImportFidelityCapabilityPayload] = Field(default_factory=dict)
+    caveats: tuple[str, ...] = ()
+
+
 class ImportExplainEntryPayload(SurfacePayloadModel):
     """Explanation for one raw artifact or archive entry inspected by import explain."""
 
@@ -229,6 +254,7 @@ class ImportExplainEntryPayload(SurfacePayloadModel):
     caveats: tuple[str, ...] = ()
     raw_evidence_refs: tuple[str, ...] = ()
     normalization_warnings: tuple[str, ...] = ()
+    fidelity: ImportFidelityDeclarationPayload | None = None
 
 
 class ImportExplainPayload(SurfacePayloadModel):
@@ -3476,6 +3502,9 @@ __all__ = [
     "ArchiveDebtStatus",
     "ArchiveDebtTotalsPayload",
     "ImportDetectorEvidencePayload",
+    "ImportFidelityCapabilityPayload",
+    "ImportFidelityDeclarationPayload",
+    "ImportFidelityStatus",
     "ImportExplainEntryPayload",
     "ImportExplainPayload",
     "ImportProducedRowsPayload",

--- a/tests/unit/sources/test_hermes_import_explain.py
+++ b/tests/unit/sources/test_hermes_import_explain.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from polylogue.sources.import_explain import explain_import_path
+
+
+def _write_state_db(path: Path, *, include_cost_provenance: bool = True) -> None:
+    cost_columns = (
+        """
+        estimated_cost_usd REAL,
+        actual_cost_usd REAL,
+        cost_status TEXT,
+        cost_source TEXT,
+        pricing_version TEXT,
+        billing_provider TEXT,
+        billing_base_url TEXT,
+        billing_mode TEXT,
+    """
+        if include_cost_provenance
+        else ""
+    )
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            f"""
+            CREATE TABLE schema_version(version INTEGER NOT NULL);
+            INSERT INTO schema_version(version) VALUES (16);
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT,
+                model_config TEXT,
+                parent_session_id TEXT,
+                started_at REAL,
+                ended_at REAL,
+                end_reason TEXT,
+                rewind_count INTEGER,
+                archived INTEGER,
+                {cost_columns}
+                title TEXT
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                timestamp REAL NOT NULL,
+                tool_calls TEXT,
+                observed INTEGER DEFAULT 0,
+                active INTEGER DEFAULT 1,
+                compacted INTEGER DEFAULT 0
+            );
+            """
+        )
+        columns = "id, source, model_config, parent_session_id, started_at, ended_at, end_reason, rewind_count, archived, title"
+        values: list[object] = ["root", "cli", "{}", None, 1.0, 8.0, "completed", 1, 0, "root"]
+        if include_cost_provenance:
+            columns += ", estimated_cost_usd, actual_cost_usd, cost_status, cost_source, pricing_version, billing_provider, billing_base_url, billing_mode"
+            values += [
+                0.03,
+                0.02,
+                "estimated",
+                "litellm",
+                "2026-07-12",
+                "openrouter",
+                "https://example.invalid",
+                "metered",
+            ]
+        conn.execute(f"INSERT INTO sessions ({columns}) VALUES ({','.join('?' for _ in values)})", values)
+        conn.execute(
+            "INSERT INTO sessions (id, source, model_config, parent_session_id, started_at, ended_at, end_reason, rewind_count, archived, title) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            ("child", "cli", json.dumps({"_delegate_from": "root"}), "root", 2.0, 7.0, "completed", 0, 0, "child"),
+        )
+        conn.executemany(
+            "INSERT INTO messages (id, session_id, role, content, timestamp, tool_calls, observed, active, compacted) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                (1, "root", "user", "run checks", 2.0, "[]", 0, 1, 0),
+                (2, "root", "user", "ambient output", 3.0, "[]", 1, 1, 0),
+                (3, "root", "assistant", "rewound", 4.0, "[]", 0, 0, 0),
+                (4, "root", "assistant", "compacted", 5.0, "[]", 0, 0, 1),
+                (5, "child", "assistant", "delegated", 6.0, "[]", 0, 1, 0),
+            ],
+        )
+
+
+def test_hermes_state_db_explain_declares_v16_fidelity_and_coverage(tmp_path: Path) -> None:
+    path = tmp_path / "state.db"
+    _write_state_db(path)
+
+    [entry] = explain_import_path(path, source_name="hermes").entries
+
+    assert entry.detector == "hermes_state_db"
+    assert entry.parser_mode == "sqlite_backup"
+    assert entry.produced.sessions == 2
+    assert entry.fidelity is not None
+    assert entry.fidelity.schema_version == 16
+    assert entry.fidelity.acquisition_method == "sqlite_backup"
+    assert entry.fidelity.retained_blob_reproducibility.status == "exact"
+    assert entry.fidelity.capabilities["message_state"].status == "exact"
+    assert entry.fidelity.capabilities["message_state"].counts == {
+        "active": 2,
+        "observed": 1,
+        "rewound": 1,
+        "compacted": 1,
+    }
+    assert entry.fidelity.capabilities["material_origin"].status == "inferred"
+    assert entry.fidelity.capabilities["cost_provenance"].status == "degraded"
+    assert entry.fidelity.capabilities["cost_provenance"].observed == 1
+    assert entry.fidelity.capabilities["cost_provenance"].expected == 2
+    assert entry.fidelity.capabilities["runtime_spans"].status == "absent"
+    assert any(caveat.startswith("runtime_spans:") for caveat in entry.caveats)
+
+
+def test_hermes_state_db_explain_reports_later_schema_capability(tmp_path: Path) -> None:
+    path = tmp_path / "state.db"
+    _write_state_db(path)
+    with sqlite3.connect(path) as conn:
+        conn.execute("ALTER TABLE sessions ADD COLUMN cwd TEXT")
+        conn.execute("ALTER TABLE sessions ADD COLUMN git_branch TEXT")
+        conn.execute("ALTER TABLE sessions ADD COLUMN git_repo_root TEXT")
+        conn.execute("UPDATE sessions SET cwd = '/repo', git_branch = 'feature/hermes', git_repo_root = '/repo'")
+        conn.execute("UPDATE schema_version SET version = 17")
+
+    [entry] = explain_import_path(path, source_name="unknown").entries
+
+    assert entry.fidelity is not None
+    assert entry.fidelity.schema_version == 17
+    assert entry.fidelity.capabilities["repository"].status == "exact"
+
+
+def test_hermes_json_fallback_explain_declares_missing_state_evidence(tmp_path: Path) -> None:
+    path = tmp_path / "session.json"
+    path.write_text(
+        json.dumps(
+            {
+                "session_id": "fallback-1",
+                "model": "local-model",
+                "platform": "linux",
+                "session_start": "2026-07-12T12:00:00Z",
+                "last_updated": "2026-07-12T12:01:00Z",
+                "messages": [{"role": "user", "content": "inspect evidence"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    [entry] = explain_import_path(path, source_name="hermes").entries
+
+    assert entry.fidelity is not None
+    assert entry.fidelity.acquisition_method == "json_fallback"
+    assert entry.fidelity.retained_blob_reproducibility.status == "absent"
+    assert entry.fidelity.capabilities["message_state"].status == "absent"
+    assert entry.fidelity.capabilities["runtime_spans"].status == "absent"
+
+
+def test_hermes_state_db_explain_marks_removed_cost_provenance_absent(tmp_path: Path) -> None:
+    path = tmp_path / "state.db"
+    _write_state_db(path, include_cost_provenance=False)
+
+    [entry] = explain_import_path(path, source_name="hermes").entries
+
+    assert entry.fidelity is not None
+    cost = entry.fidelity.capabilities["cost_provenance"]
+    assert cost.status == "absent"
+    assert cost.observed == 0
+    assert any(caveat.startswith("cost_provenance:") for caveat in entry.caveats)


### PR DESCRIPTION
## Summary

Add an additive fidelity declaration to import-explain and inspect structurally valid Hermes state.db files through the production parser.

## Problem

Hermes SQLite imports had reproducible parser behavior, but import-explain treated their bytes as opaque JSON failures. Operators could not see which states, provenance fields, or runtime evidence were retained versus unavailable.

## Solution

- Add typed coverage/fidelity payloads with exact, absent, redacted, degraded, and inferred states.
- Route valid Hermes SQLite files through the read-only production parser and describe the sqlite-backup import path.
- Report schema/profile namespace, active/observed/rewound/compacted state counts, material-origin derivation, cost coverage, lifecycle/relationship/repository capability, and explicit span/merge absence.
- Declare JSON fallback gaps rather than presenting it as state-db-equivalent.
- Regenerate the import-explain CLI output schema in a separate commit.

## Acceptance criteria

| Bead | Status | Evidence |
| --- | --- | --- |
| polylogue-fs1.3: v16, later schema, JSON fallback declarations | satisfied | Data-backed fixtures cover v16, v17 repository columns, and JSON fallback. |
| polylogue-fs1.3: retained-blob reproducibility stated | satisfied | SQLite declaration reports the existing sqlite-backup invariant; the selected parser suite exercises the retained-WAL snapshot path. |
| polylogue-fs1.3: message/addressing and cost coverage | satisfied | State counts and material-origin derivation are declared; partial and absent cost provenance are explicit. |
| polylogue-fs1.3: spans plus snapshot merge | deferred | No runtime-span ingestion/merge substrate exists on this branch. The declaration renders runtime spans and span/snapshot merge as absent rather than claiming a merge. |
| polylogue-fs1.11 | deferred | Formally blocked on polylogue-37t.11; no recall machinery added. |
| polylogue-fs1.12 | deferred | Depends on fs1.11 and the forensic consumer; no demo machinery added. |

## Anti-vacuity

- `test_hermes_state_db_explain_declares_v16_fidelity_and_coverage` drives the production SQLite detector, parser, and fidelity projector. Removing the SQLite explain branch or state/count projection makes it fail.
- `test_hermes_state_db_explain_reports_later_schema_capability` drives the parser capability map from a v17-shaped database. Removing repository-capability projection makes it fail.
- `test_hermes_json_fallback_explain_declares_missing_state_evidence` drives the real Hermes JSON detector/parser route. Removing Hermes fallback projection makes it fail.
- `test_hermes_state_db_explain_marks_removed_cost_provenance_absent` uses a valid state database with the optional provenance columns omitted. Removing capability-derived fidelity changes the required absent state and caveat.

## Verification

- `nix develop --command devtools test tests/unit/sources/test_hermes_import_explain.py tests/unit/sources/test_parsers_local_agent.py tests/unit/mcp/test_server_surfaces.py -k 'hermes or recall or manifest'` — 20 passed, 84 deselected.
- `nix develop --command devtools verify --quick` — passed all 15 checks, including mypy and render-all.

Ref polylogue-fs1.3
Ref polylogue-fs1.11
Ref polylogue-fs1.12