### PR TITLE
feat(mcp): bound agent response payloads

### DIFF
--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -336,14 +336,15 @@ def archive_session_list_payload(
         # ``list_summaries`` already applied offset and limit above.
         page = summaries
     else:
+        total = archive.count_search_sessions(text_query, **filters)
         summaries, match_counts = _coalesced_search_summaries(
             archive,
             query=text_query,
             filters=filters,
             sort=_sort_value(spec.sort),
             reverse=spec.reverse,
+            unique_limit=min(total, offset + limit),
         )
-        total = len(summaries)
         page = summaries[offset : offset + limit]
     next_offset = offset + len(page) if offset + len(page) < total else None
     return MCPPaginatedQueryResultPayload(
@@ -364,13 +365,14 @@ def _coalesced_search_summaries(
     filters: ArchiveQueryFilters,
     sort: str | None,
     reverse: bool,
+    unique_limit: int,
 ) -> tuple[tuple[ArchiveSessionSummary, ...], dict[str, int]]:
-    """Coalesce block-level FTS rows into stable, unique session list rows."""
+    """Coalesce only the raw hits required to construct one session page."""
     chunk_size = 250
     raw_offset = 0
     summaries_by_id: dict[str, ArchiveSessionSummary] = {}
     match_counts: dict[str, int] = {}
-    while True:
+    while len(summaries_by_id) < unique_limit:
         hits = archive.search_summaries(
             query,
             limit=chunk_size,
@@ -384,6 +386,10 @@ def _coalesced_search_summaries(
         for hit in hits:
             summaries_by_id.setdefault(hit.session_id, archive.read_summary(hit.session_id))
             match_counts[hit.session_id] = match_counts.get(hit.session_id, 0) + 1
+            if len(summaries_by_id) >= unique_limit:
+                break
+        if len(summaries_by_id) >= unique_limit:
+            break
         raw_offset += len(hits)
         if len(hits) < chunk_size:
             break
@@ -439,7 +445,7 @@ def archive_search_payload(
         **filters,
     )
     total = archive.count_search_sessions(query, **filters)
-    diagnostics = _search_term_diagnostics(archive, query=query, filters=filters, spec=spec) if not hits else None
+    diagnostics = _search_term_diagnostics(archive, query=query, filters=filters, spec=spec) if total == 0 else None
     return build_search_envelope(
         tuple(archive_search_hit_payload(hit, archive=archive) for hit in hits),
         total=total,

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -171,13 +171,15 @@ def archive_matched_summary_payload(
     summary: ArchiveSessionSummary,
     *,
     match_count: int,
+    match_count_is_exact: bool,
 ) -> MCPMatchedSessionSummaryPayload:
-    """Add exact raw-match cardinality to one coalesced session row."""
+    """Add observed raw-match cardinality to one coalesced session row."""
     from polylogue.mcp.payloads import MCPMatchedSessionSummaryPayload
 
     return MCPMatchedSessionSummaryPayload(
         **archive_summary_payload(summary).model_dump(mode="python"),
         match_count=match_count,
+        match_count_is_exact=match_count_is_exact,
     )
 
 
@@ -310,7 +312,11 @@ def archive_session_list_payload(
         total = offset + len(page) + (1 if next_offset is not None else 0)
         return MCPPaginatedQueryResultPayload(
             items=tuple(
-                archive_matched_summary_payload(summary, match_count=match_counts[summary.session_id])
+                archive_matched_summary_payload(
+                    summary,
+                    match_count=match_counts[summary.session_id],
+                    match_count_is_exact=False,
+                )
                 for summary in page
             ),
             total=total,
@@ -320,6 +326,7 @@ def archive_session_list_payload(
         )
     filters = archive_query_filters(spec)
     text_query = _archive_text_query(spec)
+    match_counts_are_exact = True
     if text_query is None:
         summaries = tuple(
             archive.list_summaries(
@@ -337,7 +344,7 @@ def archive_session_list_payload(
         page = summaries
     else:
         total = archive.count_search_sessions(text_query, **filters)
-        summaries, match_counts = _coalesced_search_summaries(
+        summaries, match_counts, match_counts_are_exact = _coalesced_search_summaries(
             archive,
             query=text_query,
             filters=filters,
@@ -349,7 +356,12 @@ def archive_session_list_payload(
     next_offset = offset + len(page) if offset + len(page) < total else None
     return MCPPaginatedQueryResultPayload(
         items=tuple(
-            archive_matched_summary_payload(summary, match_count=match_counts[summary.session_id]) for summary in page
+            archive_matched_summary_payload(
+                summary,
+                match_count=match_counts[summary.session_id],
+                match_count_is_exact=(True if text_query is None else match_counts_are_exact),
+            )
+            for summary in page
         ),
         total=total,
         limit=limit,
@@ -366,7 +378,7 @@ def _coalesced_search_summaries(
     sort: str | None,
     reverse: bool,
     unique_limit: int,
-) -> tuple[tuple[ArchiveSessionSummary, ...], dict[str, int]]:
+) -> tuple[tuple[ArchiveSessionSummary, ...], dict[str, int], bool]:
     """Coalesce only the raw hits required to construct one session page."""
     chunk_size = 250
     raw_offset = 0
@@ -386,14 +398,12 @@ def _coalesced_search_summaries(
         for hit in hits:
             summaries_by_id.setdefault(hit.session_id, archive.read_summary(hit.session_id))
             match_counts[hit.session_id] = match_counts.get(hit.session_id, 0) + 1
-            if len(summaries_by_id) >= unique_limit:
-                break
-        if len(summaries_by_id) >= unique_limit:
-            break
-        raw_offset += len(hits)
         if len(hits) < chunk_size:
-            break
-    return tuple(summaries_by_id.values()), match_counts
+            return tuple(summaries_by_id.values()), match_counts, True
+        if len(summaries_by_id) >= unique_limit:
+            return tuple(summaries_by_id.values()), match_counts, False
+        raw_offset += len(hits)
+    return tuple(summaries_by_id.values()), match_counts, True
 
 
 def archive_search_payload(

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -543,6 +543,7 @@ def archive_messages_payload(
     offset_from: str = "start",
     max_chars_per_message: int | None = None,
     excerpt: bool = False,
+    match_query: str | None = None,
 ) -> MCPMessagesListPayload:
     """Build the generic MCP message-list envelope from an archive session."""
     from polylogue.mcp.payloads import MCPMessagesListPayload
@@ -584,6 +585,7 @@ def archive_messages_payload(
                 archive_message_payload(message, session_id=session.session_id),
                 max_chars=max_chars_per_message,
                 excerpt=excerpt,
+                match_query=match_query,
             )
             for message in page
         ),
@@ -604,11 +606,12 @@ def _bounded_message_payload(
     *,
     max_chars: int | None,
     excerpt: bool,
+    match_query: str | None,
 ) -> MCPMessagePayload:
     """Apply the MCP-only per-message body cap after role/type filtering."""
     if max_chars is None or len(payload.text) <= max_chars:
         return payload
-    text = _excerpt_text(payload.text, max_chars) if excerpt else payload.text[:max_chars]
+    text = _excerpt_text(payload.text, max_chars, match_query=match_query) if excerpt else payload.text[:max_chars]
     # Content blocks duplicate message bodies. Preserve their structural
     # metadata without leaking the uncapped text through a second field.
     blocks = [
@@ -618,12 +621,27 @@ def _bounded_message_payload(
     return payload.model_copy(update={"text": text, "content_blocks": blocks})
 
 
-def _excerpt_text(text: str, max_chars: int) -> str:
+def _excerpt_text(text: str, max_chars: int, *, match_query: str | None = None) -> str:
+    """Return a bounded excerpt, preferring the first requested match span."""
     if max_chars <= 1:
         return text[:max_chars]
     marker = "…[truncated]…"
     if max_chars <= len(marker):
         return text[:max_chars]
+    if match_query:
+        from polylogue.storage.search.query_support import extract_match_terms
+
+        folded = text.casefold()
+        for term in extract_match_terms(match_query):
+            position = folded.find(term.casefold())
+            if position >= 0:
+                retained = max_chars - 2 * len(marker)
+                if retained <= 0:
+                    return text[:max_chars]
+                start = max(0, position - retained // 2)
+                end = min(len(text), start + retained)
+                start = max(0, end - retained)
+                return (marker if start else "") + text[start:end] + (marker if end < len(text) else "")
     retained = max_chars - len(marker)
     head = retained // 2
     return text[:head] + marker + text[-(retained - head) :]

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -332,6 +332,7 @@ def archive_search_payload(
     sort: str | None,
     config: Config | None = None,
     archive_root: Path | None = None,
+    include_affordances: bool = False,
 ) -> SearchEnvelope:
     """Build the generic MCP search envelope from archive block search."""
     from polylogue.surfaces.payloads import build_search_envelope
@@ -356,6 +357,7 @@ def archive_search_payload(
             query=query,
             retrieval_lane=resolved_lane,
             sort=sort,
+            action_affordances=_search_affordances(include_affordances),
         )
 
     filters = archive_query_filters(spec)
@@ -376,7 +378,17 @@ def archive_search_payload(
         query=query,
         retrieval_lane=retrieval_lane,
         sort=sort,
+        action_affordances=_search_affordances(include_affordances),
     )
+
+
+def _search_affordances(include_affordances: bool) -> tuple[object, ...]:
+    """Keep the capability catalog out of normal search responses."""
+    if not include_affordances:
+        return ()
+    from polylogue.operations.action_contracts import query_result_action_affordance_payloads
+
+    return tuple(query_result_action_affordance_payloads())
 
 
 def archive_query_unit_payload(
@@ -411,6 +423,8 @@ def archive_messages_payload(
     limit: int,
     offset: int,
     offset_from: str = "start",
+    max_chars_per_message: int | None = None,
+    excerpt: bool = False,
 ) -> MCPMessagesListPayload:
     """Build the generic MCP message-list envelope from an archive session."""
     from polylogue.mcp.payloads import MCPMessagesListPayload
@@ -447,7 +461,14 @@ def archive_messages_payload(
         )
     return MCPMessagesListPayload(
         session_id=session.session_id,
-        messages=tuple(archive_message_payload(message, session_id=session.session_id) for message in page),
+        messages=tuple(
+            _bounded_message_payload(
+                archive_message_payload(message, session_id=session.session_id),
+                max_chars=max_chars_per_message,
+                excerpt=excerpt,
+            )
+            for message in page
+        ),
         total=total,
         limit=limit,
         offset=effective_offset,
@@ -458,6 +479,36 @@ def archive_messages_payload(
         lineage_complete=session.lineage_complete,
         lineage_truncation_reason=session.lineage_truncation_reason,
     )
+
+
+def _bounded_message_payload(
+    payload: MCPMessagePayload,
+    *,
+    max_chars: int | None,
+    excerpt: bool,
+) -> MCPMessagePayload:
+    """Apply the MCP-only per-message body cap after role/type filtering."""
+    if max_chars is None or len(payload.text) <= max_chars:
+        return payload
+    text = _excerpt_text(payload.text, max_chars) if excerpt else payload.text[:max_chars]
+    # Content blocks duplicate message bodies. Preserve their structural
+    # metadata without leaking the uncapped text through a second field.
+    blocks = [
+        {key: ("" if key == "text" and isinstance(value, str) else value) for key, value in block.items()}
+        for block in payload.content_blocks
+    ]
+    return payload.model_copy(update={"text": text, "content_blocks": blocks})
+
+
+def _excerpt_text(text: str, max_chars: int) -> str:
+    if max_chars <= 1:
+        return text[:max_chars]
+    marker = "…[truncated]…"
+    if max_chars <= len(marker):
+        return text[:max_chars]
+    retained = max_chars - len(marker)
+    head = retained // 2
+    return text[:head] + marker + text[-(retained - head) :]
 
 
 def archive_search_hit_payload(hit: ArchiveSessionSearchHit, *, archive: ArchiveStore) -> SessionSearchHitPayload:

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, TypedDict
 from polylogue.archive.query.spec import parse_query_date
 from polylogue.core.timestamps import parse_archive_datetime
 from polylogue.paths import archive_file_set_index_available_for_paths, archive_file_set_root_for_paths
+from polylogue.surfaces.action_affordances import ActionAffordancePayload
 from polylogue.surfaces.payloads import TargetRefPayload, reader_anchor
 
 if TYPE_CHECKING:
@@ -382,7 +383,7 @@ def archive_search_payload(
     )
 
 
-def _search_affordances(include_affordances: bool) -> tuple[object, ...]:
+def _search_affordances(include_affordances: bool) -> tuple[ActionAffordancePayload, ...]:
     """Keep the capability catalog out of normal search responses."""
     if not include_affordances:
         return ()

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -11,7 +11,12 @@ from polylogue.archive.query.spec import parse_query_date
 from polylogue.core.timestamps import parse_archive_datetime
 from polylogue.paths import archive_file_set_index_available_for_paths, archive_file_set_root_for_paths
 from polylogue.surfaces.action_affordances import ActionAffordancePayload
-from polylogue.surfaces.payloads import TargetRefPayload, reader_anchor
+from polylogue.surfaces.payloads import (
+    QueryMissDiagnosticsPayload,
+    QueryMissReasonPayload,
+    TargetRefPayload,
+    reader_anchor,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -22,6 +27,7 @@ if TYPE_CHECKING:
     from polylogue.config import Config
     from polylogue.mcp.payloads import (
         MCPBlackboardNotePayload,
+        MCPMatchedSessionSummaryPayload,
         MCPMessagePayload,
         MCPMessagesListPayload,
         MCPPaginatedQueryResultPayload,
@@ -161,6 +167,20 @@ def archive_summary_payload(summary: ArchiveSessionSummary) -> MCPSessionSummary
     )
 
 
+def archive_matched_summary_payload(
+    summary: ArchiveSessionSummary,
+    *,
+    match_count: int,
+) -> MCPMatchedSessionSummaryPayload:
+    """Add exact raw-match cardinality to one coalesced session row."""
+    from polylogue.mcp.payloads import MCPMatchedSessionSummaryPayload
+
+    return MCPMatchedSessionSummaryPayload(
+        **archive_summary_payload(summary).model_dump(mode="python"),
+        match_count=match_count,
+    )
+
+
 def blackboard_note_payload(note: BlackboardNote) -> MCPBlackboardNotePayload:
     """Project a decoded blackboard note into its MCP payload shape (#1697)."""
     from polylogue.mcp.payloads import MCPBlackboardNotePayload
@@ -277,11 +297,22 @@ def archive_session_list_payload(
             config=config,
             default_limit=default_limit,
         )
-        summaries = [summary for _hit, summary in pairs]
-        total = offset + len(summaries) + (1 if len(summaries) == limit else 0)
-        next_offset = offset + len(summaries) if len(summaries) == limit else None
+        match_counts: dict[str, int] = {}
+        summaries_by_id: dict[str, ArchiveSessionSummary] = {}
+        for _hit, summary in pairs:
+            summaries_by_id.setdefault(summary.session_id, summary)
+            match_counts[summary.session_id] = match_counts.get(summary.session_id, 0) + 1
+        summaries = tuple(summaries_by_id.values())
+        # ``archive_search_hits`` already received this page's offset.  Do not
+        # apply it a second time after coalescing its raw block hits.
+        page = summaries
+        next_offset = offset + len(page) if len(pairs) == limit else None
+        total = offset + len(page) + (1 if next_offset is not None else 0)
         return MCPPaginatedQueryResultPayload(
-            items=tuple(archive_summary_payload(summary) for summary in summaries),
+            items=tuple(
+                archive_matched_summary_payload(summary, match_count=match_counts[summary.session_id])
+                for summary in page
+            ),
             total=total,
             limit=limit,
             offset=offset,
@@ -290,36 +321,73 @@ def archive_session_list_payload(
     filters = archive_query_filters(spec)
     text_query = _archive_text_query(spec)
     if text_query is None:
-        summaries = archive.list_summaries(
-            limit=limit,
-            offset=offset,
-            sort=_sort_value(spec.sort),
-            reverse=spec.reverse,
-            sample=bool(spec.sample),
-            **filters,
-        )
-        total = archive.count_sessions(**filters)
-    else:
-        summaries = [
-            archive.read_summary(hit.session_id)
-            for hit in archive.search_summaries(
-                text_query,
+        summaries = tuple(
+            archive.list_summaries(
                 limit=limit,
                 offset=offset,
                 sort=_sort_value(spec.sort),
                 reverse=spec.reverse,
+                sample=bool(spec.sample),
                 **filters,
             )
-        ]
-        total = archive.count_search_sessions(text_query, **filters)
-    next_offset = offset + len(summaries) if len(summaries) == limit and offset + limit < total else None
+        )
+        total = archive.count_sessions(**filters)
+        match_counts = {summary.session_id: 1 for summary in summaries}
+        # ``list_summaries`` already applied offset and limit above.
+        page = summaries
+    else:
+        summaries, match_counts = _coalesced_search_summaries(
+            archive,
+            query=text_query,
+            filters=filters,
+            sort=_sort_value(spec.sort),
+            reverse=spec.reverse,
+        )
+        total = len(summaries)
+        page = summaries[offset : offset + limit]
+    next_offset = offset + len(page) if offset + len(page) < total else None
     return MCPPaginatedQueryResultPayload(
-        items=tuple(archive_summary_payload(summary) for summary in summaries),
+        items=tuple(
+            archive_matched_summary_payload(summary, match_count=match_counts[summary.session_id]) for summary in page
+        ),
         total=total,
         limit=limit,
         offset=offset,
         next_offset=next_offset,
     )
+
+
+def _coalesced_search_summaries(
+    archive: ArchiveStore,
+    *,
+    query: str,
+    filters: ArchiveQueryFilters,
+    sort: str | None,
+    reverse: bool,
+) -> tuple[tuple[ArchiveSessionSummary, ...], dict[str, int]]:
+    """Coalesce block-level FTS rows into stable, unique session list rows."""
+    chunk_size = 250
+    raw_offset = 0
+    summaries_by_id: dict[str, ArchiveSessionSummary] = {}
+    match_counts: dict[str, int] = {}
+    while True:
+        hits = archive.search_summaries(
+            query,
+            limit=chunk_size,
+            offset=raw_offset,
+            sort=sort,
+            reverse=reverse,
+            **filters,
+        )
+        if not hits:
+            break
+        for hit in hits:
+            summaries_by_id.setdefault(hit.session_id, archive.read_summary(hit.session_id))
+            match_counts[hit.session_id] = match_counts.get(hit.session_id, 0) + 1
+        raw_offset += len(hits)
+        if len(hits) < chunk_size:
+            break
+    return tuple(summaries_by_id.values()), match_counts
 
 
 def archive_search_payload(
@@ -371,6 +439,7 @@ def archive_search_payload(
         **filters,
     )
     total = archive.count_search_sessions(query, **filters)
+    diagnostics = _search_term_diagnostics(archive, query=query, filters=filters, spec=spec) if not hits else None
     return build_search_envelope(
         tuple(archive_search_hit_payload(hit, archive=archive) for hit in hits),
         total=total,
@@ -380,6 +449,38 @@ def archive_search_payload(
         retrieval_lane=retrieval_lane,
         sort=sort,
         action_affordances=_search_affordances(include_affordances),
+        diagnostics=diagnostics,
+    )
+
+
+def _search_term_diagnostics(
+    archive: ArchiveStore,
+    *,
+    query: str,
+    filters: ArchiveQueryFilters,
+    spec: SessionQuerySpec,
+) -> QueryMissDiagnosticsPayload | None:
+    """Explain AND-style multi-term misses with filtered per-term counts."""
+    from polylogue.storage.search.query_support import extract_match_terms
+
+    terms = extract_match_terms(query)
+    if len(terms) < 2:
+        return None
+    term_counts = {term: archive.count_search_sessions(term, **filters) for term in terms}
+    return QueryMissDiagnosticsPayload(
+        message="No session matched all search terms; per-term counts use the same filters.",
+        filters=tuple(spec.describe()),
+        reasons=tuple(
+            QueryMissReasonPayload(
+                code="search_term_matches",
+                severity="info",
+                summary=f"{term!r} matches {term_counts[term]} session(s).",
+                detail=f"term={term}",
+                count=term_counts[term],
+            )
+            for term in terms
+        ),
+        archive_session_count=archive.count_sessions(**filters),
     )
 
 

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -190,9 +190,10 @@ class MCPSessionSearchNoResultsPayload(SurfacePayloadModel):
 
 
 class MCPMatchedSessionSummaryPayload(MCPSessionSummaryPayload):
-    """Session-list row carrying how many raw matches it coalesced."""
+    """Session-list row carrying its observed raw-match cardinality."""
 
     match_count: int = Field(default=1, ge=1)
+    match_count_is_exact: bool = True
 
 
 class MCPPaginatedQueryResultPayload(SurfacePayloadModel):

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
 
-from pydantic import RootModel
+from pydantic import Field, RootModel
 from typing_extensions import TypedDict
 
 from polylogue.context.compiler import ContextImage
@@ -100,6 +100,7 @@ class MCPErrorPayload(SurfacePayloadModel):
     # enum value is exposed so clients can render the same actionable
     # operator message ``polylogue ops embed status`` does.
     readiness_status: str | None = None
+    valid_values: tuple[str, ...] = ()
     is_error: Literal[True] = True
 
 
@@ -188,10 +189,16 @@ class MCPSessionSearchNoResultsPayload(SurfacePayloadModel):
     diagnostics: MCPQueryMissDiagnosticsPayload
 
 
+class MCPMatchedSessionSummaryPayload(MCPSessionSummaryPayload):
+    """Session-list row carrying how many raw matches it coalesced."""
+
+    match_count: int = Field(default=1, ge=1)
+
+
 class MCPPaginatedQueryResultPayload(SurfacePayloadModel):
     """Paginated query result envelope for list_sessions."""
 
-    items: tuple[MCPSessionSummaryPayload, ...]
+    items: tuple[MCPMatchedSessionSummaryPayload, ...]
     total: int
     limit: int
     offset: int
@@ -440,7 +447,12 @@ def session_query_result_payload(
 ) -> MCPPaginatedQueryResultPayload:
     next_offset = offset + len(sessions) if len(sessions) == limit and offset + limit < total else None
     return MCPPaginatedQueryResultPayload(
-        items=tuple(MCPSessionSummaryPayload.from_session(conv) for conv in sessions),
+        items=tuple(
+            MCPMatchedSessionSummaryPayload(
+                **MCPSessionSummaryPayload.from_session(conv).model_dump(mode="python"),
+            )
+            for conv in sessions
+        ),
         total=total,
         limit=limit,
         offset=offset,

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -726,6 +726,9 @@ class MCPUserMarkPayload(SurfacePayloadModel):
 class MCPUserMarkListPayload(SurfacePayloadModel):
     items: tuple[MCPUserMarkPayload, ...]
     total: int
+    limit: int
+    offset: int
+    next_offset: int | None = None
 
 
 class MCPUserAnnotationPayload(SurfacePayloadModel):
@@ -742,6 +745,9 @@ class MCPUserAnnotationPayload(SurfacePayloadModel):
 class MCPUserAnnotationListPayload(SurfacePayloadModel):
     items: tuple[MCPUserAnnotationPayload, ...]
     total: int
+    limit: int
+    offset: int
+    next_offset: int | None = None
 
 
 class MCPSavedViewPayload(SurfacePayloadModel):
@@ -754,6 +760,9 @@ class MCPSavedViewPayload(SurfacePayloadModel):
 class MCPSavedViewListPayload(SurfacePayloadModel):
     items: tuple[MCPSavedViewPayload, ...]
     total: int
+    limit: int
+    offset: int
+    next_offset: int | None = None
 
 
 class MCPRecallPackPayload(SurfacePayloadModel):
@@ -767,6 +776,9 @@ class MCPRecallPackPayload(SurfacePayloadModel):
 class MCPRecallPackListPayload(SurfacePayloadModel):
     items: tuple[MCPRecallPackPayload, ...]
     total: int
+    limit: int
+    offset: int
+    next_offset: int | None = None
 
 
 class MCPReaderWorkspacePayload(SurfacePayloadModel):
@@ -783,6 +795,9 @@ class MCPReaderWorkspacePayload(SurfacePayloadModel):
 class MCPReaderWorkspaceListPayload(SurfacePayloadModel):
     items: tuple[MCPReaderWorkspacePayload, ...]
     total: int
+    limit: int
+    offset: int
+    next_offset: int | None = None
 
 
 class MCPStatsByPayload(MCPRootPayload[dict[str, int]]):

--- a/polylogue/mcp/query_contracts.py
+++ b/polylogue/mcp/query_contracts.py
@@ -12,7 +12,8 @@ from typing import Annotated, Any, TypeAlias
 from pydantic import Field
 
 from polylogue.archive.message.types import validate_message_type_filter
-from polylogue.archive.query.spec import SessionQuerySpec
+from polylogue.archive.query.spec import QuerySpecError, SessionQuerySpec, split_csv
+from polylogue.core.enums import Origin, enum_values
 
 MCPToolLimit: TypeAlias = Annotated[int, Field(ge=1)]
 MCPToolOffset: TypeAlias = Annotated[int, Field(ge=0)]
@@ -27,6 +28,22 @@ _QUERY_PARAM_ALIASES = {
     "has_thinking": "filter_has_thinking",
     "has_paste_evidence": "filter_has_paste",
 }
+
+
+def _validate_origin_filters(params: Mapping[str, object]) -> None:
+    """Reject unknown public origin tokens before query-spec normalization.
+
+    ``Origin.from_string`` deliberately maps unknown parser input to
+    ``unknown-export``. That is appropriate while ingesting imperfect source
+    material, but it turns an MCP typo into a misleading empty archive query.
+    The agent-facing query boundary is closed, so return the same typed query
+    error used for invalid sort and message-type filters instead.
+    """
+    valid_origins = frozenset(enum_values(Origin))
+    for field in ("origin", "exclude_origin"):
+        for value in split_csv(params.get(field)):
+            if value not in valid_origins:
+                raise QuerySpecError(field, value)
 
 
 def normalize_query_params(params: Mapping[str, object]) -> dict[str, object]:
@@ -48,6 +65,7 @@ def build_query_spec(**params: object) -> SessionQuerySpec:
     :meth:`~polylogue.cli.root_request.RootModeRequest.query_spec`.
     """
     normalized = normalize_query_params(params)
+    _validate_origin_filters(normalized)
     if normalized.get("message_type") is not None:
         normalized["message_type"] = validate_message_type_filter(normalized["message_type"]).value
 

--- a/polylogue/mcp/query_contracts.py
+++ b/polylogue/mcp/query_contracts.py
@@ -175,7 +175,8 @@ def session_query_request_signature(
 
     ``include_query`` controls whether the ``query`` parameter is surfaced —
     ``search`` exposes it as required, ``facets`` exposes it as optional, and
-    ``list_sessions`` omits it. The resulting signature drives MCP
+    ``list_sessions`` omits it. ``include_affordances`` is likewise search-only
+    because only the search envelope can carry the capability catalog. The resulting signature drives MCP
     ``inputSchema`` derivation so the JSON schema and the typed request model
     cannot drift.
     """
@@ -189,6 +190,8 @@ def session_query_request_signature(
         if field.name == "query" and not include_query:
             continue
         if field.name == "include_affordances" and not include_query:
+            # ``list_sessions`` returns a paginated session envelope, not a
+            # search envelope, so accepting this would advertise a no-op.
             continue
         annotation = type_hints.get(field.name, Any)
         # ``search`` exposes ``query`` as a required parameter to preserve the

--- a/polylogue/mcp/query_contracts.py
+++ b/polylogue/mcp/query_contracts.py
@@ -16,6 +16,7 @@ from polylogue.archive.query.spec import SessionQuerySpec
 
 MCPToolLimit: TypeAlias = Annotated[int, Field(ge=1)]
 MCPToolOffset: TypeAlias = Annotated[int, Field(ge=0)]
+MCPCharacterLimit: TypeAlias = Annotated[int, Field(ge=1)] | None
 #: Optional non-negative count bound (min_messages/max_messages/min_words).
 #: ``ge=0`` rejects negatives at the MCP boundary, symmetric with the
 #: ``ge=1``/``ge=0`` guards already on limit/offset (#1749).
@@ -109,6 +110,7 @@ class MCPSessionQueryRequest:
     offset: MCPToolOffset = 0
     limit: MCPToolLimit = 10
     cursor: str | None = None
+    include_affordances: bool = False
 
     def build_spec(self, clamp_limit: Callable[[int | object], int]) -> SessionQuerySpec:
         """Build a SessionQuerySpec from this request using the given clamp helper."""
@@ -157,6 +159,12 @@ class MCPSessionQueryRequest:
             cursor=self.cursor,
         )
 
+    def response_arguments(self) -> dict[str, object]:
+        """Return MCP-callable arguments for a bounded replay descriptor."""
+        return {
+            field.name: getattr(self, field.name) for field in fields(self) if getattr(self, field.name) is not None
+        }
+
 
 def session_query_request_signature(
     *,
@@ -179,6 +187,8 @@ def session_query_request_signature(
     parameters: list[inspect.Parameter] = []
     for field in fields(MCPSessionQueryRequest):
         if field.name == "query" and not include_query:
+            continue
+        if field.name == "include_affordances" and not include_query:
             continue
         annotation = type_hints.get(field.name, Any)
         # ``search`` exposes ``query`` as a required parameter to preserve the
@@ -222,6 +232,7 @@ __all__ = [
     "session_query_request_signature",
     "MCPToolLimit",
     "MCPToolOffset",
+    "MCPCharacterLimit",
     "MCPSessionQueryRequest",
     "normalize_query_params",
 ]

--- a/polylogue/mcp/server.py
+++ b/polylogue/mcp/server.py
@@ -16,6 +16,7 @@ from polylogue.mcp.server_support import (
     _get_config,
     _get_polylogue,
     _json_payload,
+    _response_context,
     _safe_call,
     _set_runtime_services,
 )
@@ -58,6 +59,7 @@ def build_server(*, role: MCPRole = "read") -> FastMCP:
         get_config=lambda: _get_config(),
         get_polylogue=lambda: _get_polylogue(),
         extract_fenced_code=_extract_fenced_code,
+        response_context=_response_context,
         role=role,
     )
     register_tools(mcp, hooks)

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -309,11 +309,28 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         return await hooks.async_safe_call("bulk_tag_sessions", run, session_ids=tuple(session_ids))
 
     @mcp.tool()
-    async def list_tags(origin: str | None = None) -> str:
+    async def list_tags(
+        origin: str | None = None,
+        limit: MCPToolLimit = 50,
+        offset: MCPToolOffset = 0,
+    ) -> str:
+        """List deterministic tag-count pages without expanding a large tag map."""
+
         async def run() -> str:
             poly = hooks.get_polylogue()
             tags = await poly.list_tags(origin=origin)
-            return hooks.json_payload(MCPTagCountsPayload(root=tags))
+            clamped_limit = hooks.clamp_limit(limit)
+            page_offset = max(0, offset)
+            page = dict(sorted(tags.items())[page_offset : page_offset + clamped_limit])
+            with hooks.response_context(
+                "list_tags",
+                {
+                    "origin": origin,
+                    "limit": clamped_limit,
+                    "offset": page_offset,
+                },
+            ):
+                return hooks.json_payload(MCPTagCountsPayload(root=page))
 
         return await hooks.async_safe_call("list_tags", run)
 

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -22,6 +22,7 @@ from polylogue.mcp.payloads import (
     MCPReaderWorkspacePayload,
     MCPRecallPackListPayload,
     MCPRecallPackPayload,
+    MCPRootPayload,
     MCPSavedViewListPayload,
     MCPSavedViewPayload,
     MCPTagCountsPayload,
@@ -31,6 +32,7 @@ from polylogue.mcp.payloads import (
     MCPUserMarkPayload,
     MutationResultPayload,
 )
+from polylogue.mcp.query_contracts import MCPCharacterLimit, MCPToolLimit, MCPToolOffset
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -55,6 +57,13 @@ def _mark_type_error(hooks: ServerCallbacks, mark_type: str) -> str | None:
 def _default_saved_view_id(name: str, query_json: str) -> str:
     digest = sha256(f"{name}\0{query_json}".encode()).hexdigest()
     return f"saved-view-{digest[:16]}"
+
+
+def _bounded_correction_text(value: str | None, max_chars: int | None) -> str | None:
+    """Cap user-authored correction fields without changing their structure."""
+    if value is None or max_chars is None or len(value) <= max_chars:
+        return value
+    return value[:max_chars]
 
 
 def _saved_view_payload(row: dict[str, str]) -> MCPSavedViewPayload:
@@ -866,6 +875,9 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     async def list_corrections(
         session_id: str | None = None,
         kind: str | None = None,
+        limit: MCPToolLimit = 50,
+        offset: MCPToolOffset = 0,
+        max_chars_per_correction: MCPCharacterLimit = None,
     ) -> str:
         """List stored learning corrections."""
 
@@ -877,17 +889,44 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 corrections = await poly.list_corrections(session_id=session_id, kind=kind)
             except UnknownCorrectionKindError as exc:
                 return hooks.error_json(str(exc), code="unknown_kind", kind=str(kind or ""))
-            items = [
+            clamped_limit = hooks.clamp_limit(limit)
+            all_items = [
                 {
                     "session_id": c.session_id,
                     "kind": c.kind.value,
-                    "payload": dict(c.payload),
-                    "note": c.note,
+                    "payload": {
+                        key: _bounded_correction_text(value, max_chars_per_correction)
+                        for key, value in c.payload.items()
+                    },
+                    "note": _bounded_correction_text(c.note, max_chars_per_correction),
                     "created_at": c.created_at.isoformat(),
                 }
                 for c in corrections
             ]
-            return json.dumps({"corrections": items, "total": len(items)}, sort_keys=True)
+            page_offset = max(0, offset)
+            items = all_items[page_offset : page_offset + clamped_limit]
+            next_offset = page_offset + len(items) if page_offset + len(items) < len(all_items) else None
+            with hooks.response_context(
+                "list_corrections",
+                {
+                    "session_id": session_id,
+                    "kind": kind,
+                    "limit": clamped_limit,
+                    "offset": page_offset,
+                    "max_chars_per_correction": max_chars_per_correction,
+                },
+            ):
+                return hooks.json_payload(
+                    MCPRootPayload(
+                        root={
+                            "corrections": items,
+                            "total": len(all_items),
+                            "limit": clamped_limit,
+                            "offset": page_offset,
+                            "next_offset": next_offset,
+                        }
+                    )
+                )
 
         return await hooks.async_safe_call("list_corrections", run, session_id=session_id)
 

--- a/polylogue/mcp/server_mutation_tools.py
+++ b/polylogue/mcp/server_mutation_tools.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping, Sequence
 from contextlib import suppress
 from hashlib import sha256
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 from polylogue.annotations.importer import (
     AnnotationBatchImportError,
@@ -64,6 +65,43 @@ def _bounded_correction_text(value: str | None, max_chars: int | None) -> str | 
     if value is None or max_chars is None or len(value) <= max_chars:
         return value
     return value[:max_chars]
+
+
+TItem = TypeVar("TItem")
+
+
+def _page_items(items: Sequence[TItem], *, limit: int, offset: int) -> tuple[tuple[TItem, ...], int, int, int | None]:
+    """Slice a list response while retaining deterministic continuation state."""
+    total = len(items)
+    page_offset = max(0, offset)
+    page = tuple(items[page_offset : page_offset + limit])
+    next_offset = page_offset + len(page) if page_offset + len(page) < total else None
+    return page, total, page_offset, next_offset
+
+
+def _bounded_json_value(value: object, max_chars: int | None, *, depth: int = 0) -> object:
+    """Compact arbitrary saved payloads only when a bounded replay requests it."""
+    if max_chars is None:
+        return value
+    if isinstance(value, str):
+        return _bounded_correction_text(value, max_chars)
+    if depth >= 2:
+        return {"truncated": True} if isinstance(value, Mapping | Sequence) else value
+    if isinstance(value, Mapping):
+        return {
+            str(key): _bounded_json_value(item, max_chars, depth=depth + 1) for key, item in list(value.items())[:4]
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_bounded_json_value(item, max_chars, depth=depth + 1) for item in value[:4]]
+    return value
+
+
+def _bounded_sequence(value: Sequence[object], max_chars: int | None) -> tuple[object, ...]:
+    """Return the compact sequence form while keeping the type boundary explicit."""
+    bounded = _bounded_json_value(value, max_chars)
+    if isinstance(bounded, Sequence) and not isinstance(bounded, (str, bytes, bytearray)):
+        return tuple(bounded)
+    return ()
 
 
 def _saved_view_payload(row: dict[str, str]) -> MCPSavedViewPayload:
@@ -341,6 +379,8 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         target_type: str | None = None,
         target_id: str | None = None,
         message_id: str | None = None,
+        limit: MCPToolLimit = 50,
+        offset: MCPToolOffset = 0,
     ) -> str:
         async def run() -> str:
             poly = hooks.get_polylogue()
@@ -362,7 +402,29 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 )
                 for row in rows
             )
-            return hooks.json_payload(MCPUserMarkListPayload(items=items, total=len(items)))
+            clamped_limit = hooks.clamp_limit(limit)
+            page, total, page_offset, next_offset = _page_items(items, limit=clamped_limit, offset=offset)
+            with hooks.response_context(
+                "list_marks",
+                {
+                    "mark_type": mark_type,
+                    "session_id": session_id,
+                    "target_type": target_type,
+                    "target_id": target_id,
+                    "message_id": message_id,
+                    "limit": clamped_limit,
+                    "offset": page_offset,
+                },
+            ):
+                return hooks.json_payload(
+                    MCPUserMarkListPayload(
+                        items=page,
+                        total=total,
+                        limit=clamped_limit,
+                        offset=page_offset,
+                        next_offset=next_offset,
+                    )
+                )
 
         return await hooks.async_safe_call("list_marks", run, session_id=session_id)
 
@@ -446,6 +508,9 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         target_type: str | None = None,
         target_id: str | None = None,
         message_id: str | None = None,
+        limit: MCPToolLimit = 50,
+        offset: MCPToolOffset = 0,
+        max_chars_per_item: MCPCharacterLimit = None,
     ) -> str:
         async def run() -> str:
             poly = hooks.get_polylogue()
@@ -455,8 +520,35 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 target_id=target_id,
                 message_id=message_id,
             )
-            items = tuple(_annotation_payload(row) for row in rows)
-            return hooks.json_payload(MCPUserAnnotationListPayload(items=items, total=len(items)))
+            items = tuple(
+                _annotation_payload(
+                    {**row, "note_text": _bounded_correction_text(row["note_text"], max_chars_per_item) or ""}
+                )
+                for row in rows
+            )
+            clamped_limit = hooks.clamp_limit(limit)
+            page, total, page_offset, next_offset = _page_items(items, limit=clamped_limit, offset=offset)
+            with hooks.response_context(
+                "list_annotations",
+                {
+                    "session_id": session_id,
+                    "target_type": target_type,
+                    "target_id": target_id,
+                    "message_id": message_id,
+                    "limit": clamped_limit,
+                    "offset": page_offset,
+                    "max_chars_per_item": max_chars_per_item,
+                },
+            ):
+                return hooks.json_payload(
+                    MCPUserAnnotationListPayload(
+                        items=page,
+                        total=total,
+                        limit=clamped_limit,
+                        offset=page_offset,
+                        next_offset=next_offset,
+                    )
+                )
 
         return await hooks.async_safe_call("list_annotations", run, session_id=session_id)
 
@@ -516,12 +608,35 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         return await hooks.async_safe_call("delete_annotation", run)
 
     @mcp.tool()
-    async def list_saved_views() -> str:
+    async def list_saved_views(
+        limit: MCPToolLimit = 50,
+        offset: MCPToolOffset = 0,
+        max_chars_per_item: MCPCharacterLimit = None,
+    ) -> str:
         async def run() -> str:
             poly = hooks.get_polylogue()
             rows = await poly.list_views()
-            items = tuple(_saved_view_payload(row) for row in rows)
-            return hooks.json_payload(MCPSavedViewListPayload(items=items, total=len(items)))
+            items = tuple(
+                (payload := _saved_view_payload(row)).model_copy(
+                    update={"query": _bounded_json_value(payload.query, max_chars_per_item)}
+                )
+                for row in rows
+            )
+            clamped_limit = hooks.clamp_limit(limit)
+            page, total, page_offset, next_offset = _page_items(items, limit=clamped_limit, offset=offset)
+            with hooks.response_context(
+                "list_saved_views",
+                {"limit": clamped_limit, "offset": page_offset, "max_chars_per_item": max_chars_per_item},
+            ):
+                return hooks.json_payload(
+                    MCPSavedViewListPayload(
+                        items=page,
+                        total=total,
+                        limit=clamped_limit,
+                        offset=page_offset,
+                        next_offset=next_offset,
+                    )
+                )
 
         return await hooks.async_safe_call("list_saved_views", run)
 
@@ -577,12 +692,40 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         return await hooks.async_safe_call("delete_saved_view", run)
 
     @mcp.tool()
-    async def list_recall_packs() -> str:
+    async def list_recall_packs(
+        limit: MCPToolLimit = 50,
+        offset: MCPToolOffset = 0,
+        max_chars_per_item: MCPCharacterLimit = None,
+    ) -> str:
         async def run() -> str:
             poly = hooks.get_polylogue()
             rows = await poly.list_recall_packs()
-            items = tuple(_recall_pack_payload(row) for row in rows)
-            return hooks.json_payload(MCPRecallPackListPayload(items=items, total=len(items)))
+            items = tuple(
+                (payload := _recall_pack_payload(row)).model_copy(
+                    update={
+                        "session_ids": tuple(
+                            str(item) for item in _bounded_sequence(payload.session_ids, max_chars_per_item)
+                        ),
+                        "payload": _bounded_json_value(payload.payload, max_chars_per_item),
+                    }
+                )
+                for row in rows
+            )
+            clamped_limit = hooks.clamp_limit(limit)
+            page, total, page_offset, next_offset = _page_items(items, limit=clamped_limit, offset=offset)
+            with hooks.response_context(
+                "list_recall_packs",
+                {"limit": clamped_limit, "offset": page_offset, "max_chars_per_item": max_chars_per_item},
+            ):
+                return hooks.json_payload(
+                    MCPRecallPackListPayload(
+                        items=page,
+                        total=total,
+                        limit=clamped_limit,
+                        offset=page_offset,
+                        next_offset=next_offset,
+                    )
+                )
 
         return await hooks.async_safe_call("list_recall_packs", run)
 
@@ -640,12 +783,43 @@ def register_mutation_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         return await hooks.async_safe_call("delete_recall_pack", run)
 
     @mcp.tool()
-    async def list_workspaces() -> str:
+    async def list_workspaces(
+        limit: MCPToolLimit = 50,
+        offset: MCPToolOffset = 0,
+        max_chars_per_item: MCPCharacterLimit = None,
+    ) -> str:
         async def run() -> str:
             poly = hooks.get_polylogue()
             rows = await poly.list_workspaces()
-            items = tuple(_workspace_payload(row) for row in rows)
-            return hooks.json_payload(MCPReaderWorkspaceListPayload(items=items, total=len(items)))
+            items = tuple(
+                (payload := _workspace_payload(row)).model_copy(
+                    update={
+                        "open_targets": tuple(
+                            item
+                            for item in _bounded_sequence(payload.open_targets, max_chars_per_item)
+                            if isinstance(item, dict)
+                        ),
+                        "layout": _bounded_json_value(payload.layout, max_chars_per_item),
+                        "active_target": _bounded_json_value(payload.active_target, max_chars_per_item),
+                    }
+                )
+                for row in rows
+            )
+            clamped_limit = hooks.clamp_limit(limit)
+            page, total, page_offset, next_offset = _page_items(items, limit=clamped_limit, offset=offset)
+            with hooks.response_context(
+                "list_workspaces",
+                {"limit": clamped_limit, "offset": page_offset, "max_chars_per_item": max_chars_per_item},
+            ):
+                return hooks.json_payload(
+                    MCPReaderWorkspaceListPayload(
+                        items=page,
+                        total=total,
+                        limit=clamped_limit,
+                        offset=page_offset,
+                        next_offset=next_offset,
+                    )
+                )
 
         return await hooks.async_safe_call("list_workspaces", run)
 

--- a/polylogue/mcp/server_resources.py
+++ b/polylogue/mcp/server_resources.py
@@ -117,7 +117,16 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                     session = archive.read_session(session_id)
                 except (KeyError, ValueError):
                     return hooks.error_json(f"Session not found: {conv_id}", code="not_found")
-                return hooks.json_payload(archive_messages_payload(session, limit=20, offset=0))
+                with hooks.response_context(
+                    "get_messages",
+                    {
+                        "session_id": session_id,
+                        "limit": 20,
+                        "max_chars_per_message": 4096,
+                        "excerpt": True,
+                    },
+                ):
+                    return hooks.json_payload(archive_messages_payload(session, limit=20, offset=0))
         except sqlite3.OperationalError:
             return hooks.error_json(f"Session not found: {conv_id}", code="not_found")
         except Exception as exc:

--- a/polylogue/mcp/server_resources.py
+++ b/polylogue/mcp/server_resources.py
@@ -97,7 +97,8 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 code="internal_error",
                 detail=type(exc).__name__,
             )
-        return hooks.json_payload(MCPTagCountsPayload(root=tags))
+        with hooks.response_context("list_tags", {"limit": 3, "offset": 0}):
+            return hooks.json_payload(MCPTagCountsPayload(root=tags))
 
     @mcp.resource("polylogue://capabilities/action-affordances")
     def action_affordances_resource() -> str:

--- a/polylogue/mcp/server_resources.py
+++ b/polylogue/mcp/server_resources.py
@@ -15,6 +15,7 @@ from polylogue.mcp.payloads import (
     MCPArchiveStatsPayload,
     MCPErrorPayload,
     MCPReadinessReportPayload,
+    MCPRootPayload,
     MCPTagCountsPayload,
     session_tree_payload,
 )
@@ -97,6 +98,14 @@ def register_resources(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 detail=type(exc).__name__,
             )
         return hooks.json_payload(MCPTagCountsPayload(root=tags))
+
+    @mcp.resource("polylogue://capabilities/action-affordances")
+    def action_affordances_resource() -> str:
+        """Return the shared action catalog once, outside ordinary query responses."""
+        from polylogue.operations.action_contracts import action_affordance_list_payload
+
+        payload = action_affordance_list_payload()
+        return hooks.json_payload(MCPRootPayload(root={"action_affordances": payload.model_dump(mode="json")}))
 
     @mcp.resource("polylogue://messages/{conv_id}")
     async def messages_resource(conv_id: str) -> str:

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -220,6 +220,10 @@ def _narrow_continuation(context: _ResponseContext | None) -> dict[str, object] 
         requested_max_chars = arguments.get("max_chars_per_correction")
         max_chars = requested_max_chars if isinstance(requested_max_chars, int) else 4096
         arguments["max_chars_per_correction"] = min(max_chars, 4096)
+    if "max_chars_per_item" in arguments:
+        requested_max_chars = arguments.get("max_chars_per_item")
+        max_chars = requested_max_chars if isinstance(requested_max_chars, int) else 512
+        arguments["max_chars_per_item"] = min(max_chars, 512)
     return {
         "tool": context.tool,
         "arguments": arguments,

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -19,7 +19,14 @@ from typing import TYPE_CHECKING, Literal, Protocol, TypeVar, overload
 
 from pydantic import BaseModel
 
-from polylogue.archive.query.spec import clamp_query_limit
+from polylogue.archive.query.spec import (
+    QUERY_ACTION_TYPES,
+    QUERY_RETRIEVAL_LANES,
+    QUERY_SEQUENCE_ACTION_TYPES,
+    QuerySpecError,
+    clamp_query_limit,
+)
+from polylogue.core.enums import MessageType, Origin, enum_values
 from polylogue.errors import (
     EmbeddingRetrievalNotReadyError,
     PolylogueError,
@@ -39,6 +46,16 @@ _runtime_services: RuntimeServices | None = None
 TResult = TypeVar("TResult")
 MCPRole = Literal["read", "write", "admin"]
 MCP_RESPONSE_BUDGET_BYTES = 25_000
+_QUERY_ERROR_VALID_VALUES: dict[str, tuple[str, ...]] = {
+    "sort": ("date", "tokens", "messages", "words", "longest", "random"),
+    "origin": enum_values(Origin),
+    "exclude_origin": enum_values(Origin),
+    "message_type": enum_values(MessageType),
+    "retrieval_lane": QUERY_RETRIEVAL_LANES,
+    "action": QUERY_ACTION_TYPES,
+    "exclude_action": QUERY_ACTION_TYPES,
+    "action_sequence": QUERY_SEQUENCE_ACTION_TYPES,
+}
 
 
 @dataclass(frozen=True)
@@ -247,7 +264,19 @@ def _exception_to_error_json(fn_name: str, exc: BaseException) -> str:
       deliberately not included so the surface cannot leak credentials, file
       paths, or other internal state.
     """
-    if isinstance(exc, SchemaVersionMismatchError):
+    if isinstance(exc, QuerySpecError):
+        valid_values = _QUERY_ERROR_VALID_VALUES.get(exc.field, ())
+        valid_hint = f" Valid values: {', '.join(valid_values)}." if valid_values else ""
+        payload = MCPErrorPayload(
+            message=f"invalid {exc.field}: {exc.value}.{valid_hint}",
+            code="invalid_query",
+            error="invalid_query",
+            detail=type(exc).__name__,
+            field=exc.field,
+            tool=fn_name,
+            valid_values=valid_values,
+        )
+    elif isinstance(exc, SchemaVersionMismatchError):
         payload = MCPErrorPayload(
             message=str(exc),
             code="schema_version_mismatch",

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -195,6 +195,19 @@ def _narrow_continuation(context: _ResponseContext | None) -> dict[str, object] 
     if context is None:
         return None
     arguments = dict(context.arguments)
+    if context.tool == "archive_get_session":
+        session_id = arguments.get("session_id")
+        if isinstance(session_id, str):
+            return {
+                "tool": "get_messages",
+                "arguments": {
+                    "session_id": session_id,
+                    "limit": 3,
+                    "max_chars_per_message": 4096,
+                    "excerpt": True,
+                },
+                "reason": "The full session exceeded the MCP response budget; read a bounded message page instead.",
+            }
     limit = arguments.get("limit")
     if isinstance(limit, int) and not isinstance(limit, bool):
         arguments["limit"] = max(1, min(limit, 3))
@@ -203,6 +216,10 @@ def _narrow_continuation(context: _ResponseContext | None) -> dict[str, object] 
         max_chars = requested_max_chars if isinstance(requested_max_chars, int) else 4096
         arguments["max_chars_per_message"] = min(max_chars, 4096)
         arguments["excerpt"] = True
+    if context.tool == "list_corrections":
+        requested_max_chars = arguments.get("max_chars_per_correction")
+        max_chars = requested_max_chars if isinstance(requested_max_chars, int) else 4096
+        arguments["max_chars_per_correction"] = min(max_chars, 4096)
     return {
         "tool": context.tool,
         "arguments": arguments,

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -308,15 +308,19 @@ def _exception_to_error_json(fn_name: str, exc: BaseException) -> str:
       deliberately not included so the surface cannot leak credentials, file
       paths, or other internal state.
     """
-    if isinstance(exc, QuerySpecError):
-        valid_values = _QUERY_ERROR_VALID_VALUES.get(exc.field, ())
+    from polylogue.archive.query.expression import ExpressionCompileError
+
+    if isinstance(exc, QuerySpecError | ExpressionCompileError):
+        field = exc.field
+        valid_values = _QUERY_ERROR_VALID_VALUES.get(field, ()) if field is not None else ()
         valid_hint = f" Valid values: {', '.join(valid_values)}." if valid_values else ""
+        value = exc.value if isinstance(exc, QuerySpecError) else str(exc)
         payload = MCPErrorPayload(
-            message=f"invalid {exc.field}: {exc.value}.{valid_hint}",
+            message=f"invalid {field}: {value}.{valid_hint}",
             code="invalid_query",
             error="invalid_query",
             detail=type(exc).__name__,
-            field=exc.field,
+            field=field,
             tool=fn_name,
             valid_values=valid_values,
         )

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -56,6 +56,7 @@ _QUERY_ERROR_VALID_VALUES: dict[str, tuple[str, ...]] = {
     "exclude_action": QUERY_ACTION_TYPES,
     "action_sequence": QUERY_SEQUENCE_ACTION_TYPES,
 }
+_SESSION_ID_ARGUMENT_NAMES: dict[str, str] = {"get_session_summary": "id"}
 
 
 @dataclass(frozen=True)
@@ -153,18 +154,40 @@ def _response_context(tool: str, arguments: Mapping[str, object]) -> Iterator[No
         _response_context_var.reset(token)
 
 
-def _compact_metadata(value: object, *, string_limit: int = 512, item_limit: int = 12) -> object:
+def _compact_metadata(
+    value: object,
+    *,
+    string_limit: int = 512,
+    item_limit: int = 12,
+    depth: int = 0,
+    max_depth: int = 3,
+) -> object:
     """Keep the budget fallback informative without reproducing its large body."""
     if isinstance(value, str):
         return value if len(value) <= string_limit else value[:string_limit] + "…"
     if isinstance(value, list):
         return {"returned": len(value)}
     if isinstance(value, dict):
+        if depth >= max_depth:
+            return {"fields": len(value), "truncated": True}
         return {
-            str(key): _compact_metadata(item, string_limit=string_limit, item_limit=item_limit)
+            str(key): _compact_metadata(
+                item,
+                string_limit=string_limit,
+                item_limit=item_limit,
+                depth=depth + 1,
+                max_depth=max_depth,
+            )
             for key, item in list(value.items())[:item_limit]
         }
     return value
+
+
+def _fallback_response_arguments(fn_name: str, session_id: str | None) -> dict[str, object]:
+    """Return replayable identifiers carried by the safe-call contract."""
+    if session_id is None:
+        return {}
+    return {_SESSION_ID_ARGUMENT_NAMES.get(fn_name, "session_id"): session_id}
 
 
 def _narrow_continuation(context: _ResponseContext | None) -> dict[str, object] | None:
@@ -429,7 +452,8 @@ def _safe_call(
     """
     started_at_ms = _now_ms()
     try:
-        result = fn()
+        with _response_context(fn_name, _fallback_response_arguments(fn_name, session_id)):
+            result = fn()
     except Exception as exc:
         logger.exception("MCP tool %s failed", fn_name)
         _record_mcp_call_log(
@@ -495,7 +519,8 @@ async def _async_safe_call(
     """Async counterpart of :func:`_safe_call`. Same isolation and call-log contract."""
     started_at_ms = _now_ms()
     try:
-        result = await fn()
+        with _response_context(fn_name, _fallback_response_arguments(fn_name, session_id)):
+            result = await fn()
     except Exception as exc:
         logger.exception("MCP tool %s failed", fn_name)
         _record_mcp_call_log(

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -159,7 +159,9 @@ def _narrow_continuation(context: _ResponseContext | None) -> dict[str, object] 
     if isinstance(limit, int) and not isinstance(limit, bool):
         arguments["limit"] = max(1, min(limit, 3))
     if context.tool == "get_messages":
-        arguments["max_chars_per_message"] = min(int(arguments.get("max_chars_per_message") or 4096), 4096)
+        requested_max_chars = arguments.get("max_chars_per_message")
+        max_chars = requested_max_chars if isinstance(requested_max_chars, int) else 4096
+        arguments["max_chars_per_message"] = min(max_chars, 4096)
         arguments["excerpt"] = True
     return {
         "tool": context.tool,

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -10,7 +10,9 @@ with that blast radius in mind; see docs/test-economics.md.
 from __future__ import annotations
 
 import json
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator, Mapping
+from contextlib import AbstractContextManager, contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Literal, Protocol, TypeVar, overload
@@ -36,6 +38,18 @@ logger = get_logger(__name__)
 _runtime_services: RuntimeServices | None = None
 TResult = TypeVar("TResult")
 MCPRole = Literal["read", "write", "admin"]
+MCP_RESPONSE_BUDGET_BYTES = 25_000
+
+
+@dataclass(frozen=True)
+class _ResponseContext:
+    """Replay information attached by a tool while it serializes a response."""
+
+    tool: str
+    arguments: Mapping[str, object]
+
+
+_response_context_var: ContextVar[_ResponseContext | None] = ContextVar("mcp_response_context", default=None)
 
 
 class JSONPayloadSerializer(Protocol):
@@ -48,6 +62,10 @@ class ErrorJSONSerializer(Protocol):
 
 class FencedCodeExtractor(Protocol):
     def __call__(self, text: str, language: str = "") -> list[MCPFencedCodeBlock]: ...
+
+
+class ResponseContextHook(Protocol):
+    def __call__(self, tool: str, arguments: Mapping[str, object]) -> AbstractContextManager[None]: ...
 
 
 class SafeCallHook(Protocol):
@@ -82,6 +100,7 @@ class ServerCallbacks:
     get_config: Callable[[], Config]
     get_polylogue: Callable[[], Polylogue]
     extract_fenced_code: FencedCodeExtractor
+    response_context: ResponseContextHook
     role: MCPRole
 
 
@@ -107,15 +126,92 @@ def _extract_fenced_code(text: str, language: str = "") -> list[MCPFencedCodeBlo
     return results
 
 
+@contextmanager
+def _response_context(tool: str, arguments: Mapping[str, object]) -> Iterator[None]:
+    """Associate one serialized response with its safe, narrower replay call."""
+    token = _response_context_var.set(_ResponseContext(tool=tool, arguments=arguments))
+    try:
+        yield
+    finally:
+        _response_context_var.reset(token)
+
+
+def _compact_metadata(value: object, *, string_limit: int = 512, item_limit: int = 12) -> object:
+    """Keep the budget fallback informative without reproducing its large body."""
+    if isinstance(value, str):
+        return value if len(value) <= string_limit else value[:string_limit] + "…"
+    if isinstance(value, list):
+        return {"returned": len(value)}
+    if isinstance(value, dict):
+        return {
+            str(key): _compact_metadata(item, string_limit=string_limit, item_limit=item_limit)
+            for key, item in list(value.items())[:item_limit]
+        }
+    return value
+
+
+def _narrow_continuation(context: _ResponseContext | None) -> dict[str, object] | None:
+    """Build a direct MCP call descriptor that re-reads the same evidence safely."""
+    if context is None:
+        return None
+    arguments = dict(context.arguments)
+    limit = arguments.get("limit")
+    if isinstance(limit, int) and not isinstance(limit, bool):
+        arguments["limit"] = max(1, min(limit, 3))
+    if context.tool == "get_messages":
+        arguments["max_chars_per_message"] = min(int(arguments.get("max_chars_per_message") or 4096), 4096)
+        arguments["excerpt"] = True
+    return {
+        "tool": context.tool,
+        "arguments": arguments,
+        "reason": "The original response exceeded the MCP response budget; retry this narrower call to read the same evidence.",
+    }
+
+
+def _budget_envelope(payload: BaseModel, *, original_bytes: int, exclude_none: bool) -> str:
+    """Return a bounded metadata-only response instead of truncating JSON."""
+    body = payload.model_dump(mode="json", exclude_none=exclude_none)
+    context = _response_context_var.get()
+    continuation = _narrow_continuation(context)
+    envelope = {
+        "ok": True,
+        "status": "response_budget_exceeded",
+        "budget_exceeded": True,
+        "tool": context.tool if context is not None else None,
+        "budget_bytes": MCP_RESPONSE_BUDGET_BYTES,
+        "original_bytes": original_bytes,
+        "payload_type": type(payload).__name__,
+        "metadata": _compact_metadata(body),
+        "continuation": continuation,
+        "next_action": (
+            "Use continuation.tool with continuation.arguments to retrieve the same evidence in a bounded page."
+            if continuation is not None
+            else "Request a narrower page or projection for this response."
+        ),
+    }
+    return json.dumps(envelope, indent=2, ensure_ascii=False, default=str)
+
+
 def _json_payload(payload: BaseModel, *, exclude_none: bool = False) -> str:
-    """Serialize a typed MCP payload with canonical JSON formatting."""
+    """Serialize typed MCP output, replacing oversized bodies with a safe envelope."""
     to_json = getattr(payload, "to_json", None)
     if callable(to_json):
         result = to_json(exclude_none=exclude_none)
         if isinstance(result, str):
-            return result
+            original_bytes = len(result.encode("utf-8"))
+            return (
+                result
+                if original_bytes <= MCP_RESPONSE_BUDGET_BYTES
+                else _budget_envelope(payload, original_bytes=original_bytes, exclude_none=exclude_none)
+            )
         raise TypeError(f"{type(payload).__name__}.to_json() returned {type(result).__name__}, expected str")
-    return serialize_surface_payload(payload, exclude_none=exclude_none)
+    result = serialize_surface_payload(payload, exclude_none=exclude_none)
+    original_bytes = len(result.encode("utf-8"))
+    return (
+        result
+        if original_bytes <= MCP_RESPONSE_BUDGET_BYTES
+        else _budget_envelope(payload, original_bytes=original_bytes, exclude_none=exclude_none)
+    )
 
 
 def _clamp_limit(limit: int | object) -> int:
@@ -439,6 +535,7 @@ __all__ = [
     "_get_polylogue",
     "_get_runtime_services",
     "_json_payload",
+    "_response_context",
     "_safe_call",
     "_set_runtime_services",
     "role_allows",

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from collections import Counter
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -136,7 +137,7 @@ def _summary_excerpt(text: str, *, limit: int = 240) -> str:
 def _session_summary_payload(
     summary: object,
     session: object,
-    phases: list[object],
+    phases: Sequence[object],
 ) -> MCPRootPayload[dict[str, object]]:
     """Add bounded content orientation to the historical metadata summary."""
     base = archive_summary_payload(cast(Any, summary)).model_dump(mode="json")

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sqlite3
+from collections import Counter
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -43,6 +44,7 @@ from polylogue.mcp.payloads import (
     session_tree_payload,
 )
 from polylogue.mcp.query_contracts import (
+    MCPCharacterLimit,
     MCPCountBound,
     MCPToolLimit,
     MCPToolOffset,
@@ -126,6 +128,50 @@ def _split_archive_csv(value: str | None) -> tuple[str, ...]:
     return tuple(token.strip() for token in value.split(",") if token.strip())
 
 
+def _summary_excerpt(text: str, *, limit: int = 240) -> str:
+    normalized = " ".join(text.split())
+    return normalized if len(normalized) <= limit else normalized[: limit - 1] + "…"
+
+
+def _session_summary_payload(
+    summary: object,
+    session: object,
+    phases: list[object],
+) -> MCPRootPayload[dict[str, object]]:
+    """Add bounded content orientation to the historical metadata summary."""
+    base = archive_summary_payload(cast(Any, summary)).model_dump(mode="json")
+    messages = tuple(getattr(session, "messages", ()))
+    authored = tuple(
+        message
+        for message in messages
+        if str(getattr(getattr(message, "material_origin", None), "value", getattr(message, "material_origin", "")))
+        == "human_authored"
+    )
+    authored_text = tuple(
+        "\n".join(str(block.text) for block in getattr(message, "blocks", ()) if getattr(block, "text", None))
+        for message in authored
+    )
+    tool_counts = Counter(
+        str(block.tool_name)
+        for message in messages
+        for block in getattr(message, "blocks", ())
+        if getattr(block, "tool_name", None)
+    )
+    base["content_summary"] = {
+        "counts": {
+            "messages": int(getattr(summary, "message_count", len(messages))),
+            "authored_user_messages": int(getattr(summary, "authored_user_message_count", len(authored))),
+            "authored_user_words": int(getattr(summary, "authored_user_word_count", 0)),
+            "tool_uses": int(getattr(summary, "tool_use_count", sum(tool_counts.values()))),
+        },
+        "phase_count": len(phases),
+        "top_tools": [{"name": name, "count": count} for name, count in tool_counts.most_common(5)],
+        "first_authored_user_excerpt": _summary_excerpt(authored_text[0]) if authored_text else None,
+        "last_authored_user_excerpt": _summary_excerpt(authored_text[-1]) if authored_text else None,
+    }
+    return MCPRootPayload(root=cast(dict[str, object], base))
+
+
 def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     async def _search(**kwargs: object) -> str:
         if "query" not in kwargs:
@@ -156,7 +202,10 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 )
             config = hooks.get_config()
             archive_root = mcp_archive_root(config)
-            with ArchiveStore.open_existing(archive_root) as archive:
+            with (
+                ArchiveStore.open_existing(archive_root) as archive,
+                hooks.response_context("search", request.response_arguments()),
+            ):
                 return hooks.json_payload(
                     archive_search_payload(
                         archive,
@@ -168,6 +217,7 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                         sort=request.sort,
                         config=config,
                         archive_root=archive_root,
+                        include_affordances=request.include_affordances,
                     )
                 )
 
@@ -289,7 +339,10 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
             spec = request.build_spec(hooks.clamp_limit)
             config = hooks.get_config()
             archive_root = mcp_archive_root(config)
-            with ArchiveStore.open_existing(archive_root) as archive:
+            with (
+                ArchiveStore.open_existing(archive_root) as archive,
+                hooks.response_context("list_sessions", request.response_arguments()),
+            ):
                 return hooks.json_payload(
                     archive_session_list_payload(archive, spec, config=config, archive_root=archive_root)
                 )
@@ -796,7 +849,9 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 with ArchiveStore.open_existing(mcp_archive_root(config)) as archive:
                     session_id = archive.resolve_session_id(id)
                     archive_summary = archive.read_summary(session_id)
-                    return hooks.json_payload(archive_summary_payload(archive_summary))
+                    session = archive.read_session(session_id)
+                    phases = archive.get_session_phase_insights(session_id)
+                    return hooks.json_payload(_session_summary_payload(archive_summary, session, phases))
             except (KeyError, ValueError, sqlite3.OperationalError):
                 return hooks.error_json(f"Session not found: {id}", code="not_found")
 
@@ -874,12 +929,16 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         offset: MCPToolOffset = 0,
         offset_from: str = "start",
         tail: bool = False,
+        max_chars_per_message: MCPCharacterLimit = None,
+        excerpt: bool = False,
     ) -> str:
         """Return a filtered message page.
 
         ``offset`` is evaluated after role/type/material filters. Use
         ``tail=True`` or ``offset_from="end"`` to read the filtered tail of a
-        large session without first calculating the filtered total.
+        large session without first calculating the filtered total. Set
+        ``max_chars_per_message`` to cap each returned body; ``excerpt=True``
+        preserves both its head and tail.
         """
 
         async def run() -> str:
@@ -901,17 +960,33 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                 with ArchiveStore.open_existing(mcp_archive_root(config)) as archive:
                     resolved_session_id = archive.resolve_session_id(session_id)
                     session = archive.read_session(resolved_session_id)
-                return hooks.json_payload(
-                    archive_messages_payload(
-                        session,
-                        roles=(message_role,) if message_role else (),
-                        message_type=normalized_message_type,
-                        material_origins=(material_origin,) if material_origin else (),
-                        limit=hooks.clamp_limit(limit),
-                        offset=max(0, offset),
-                        offset_from=normalized_offset_from,
+                with hooks.response_context(
+                    "get_messages",
+                    {
+                        "session_id": session_id,
+                        "message_role": message_role,
+                        "message_type": message_type,
+                        "material_origin": material_origin,
+                        "limit": hooks.clamp_limit(limit),
+                        "offset": max(0, offset),
+                        "offset_from": normalized_offset_from,
+                        "max_chars_per_message": max_chars_per_message,
+                        "excerpt": excerpt,
+                    },
+                ):
+                    return hooks.json_payload(
+                        archive_messages_payload(
+                            session,
+                            roles=(message_role,) if message_role else (),
+                            message_type=normalized_message_type,
+                            material_origins=(material_origin,) if material_origin else (),
+                            limit=hooks.clamp_limit(limit),
+                            offset=max(0, offset),
+                            offset_from=normalized_offset_from,
+                            max_chars_per_message=max_chars_per_message,
+                            excerpt=excerpt,
+                        )
                     )
-                )
             except (KeyError, ValueError, sqlite3.OperationalError):
                 return hooks.error_json(f"Session not found: {session_id}", code="not_found")
 

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -932,6 +932,7 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         tail: bool = False,
         max_chars_per_message: MCPCharacterLimit = None,
         excerpt: bool = False,
+        match_query: str | None = None,
     ) -> str:
         """Return a filtered message page.
 
@@ -939,7 +940,8 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         ``tail=True`` or ``offset_from="end"`` to read the filtered tail of a
         large session without first calculating the filtered total. Set
         ``max_chars_per_message`` to cap each returned body; ``excerpt=True``
-        preserves both its head and tail.
+        preserves both its head and tail, or a window around the first term in
+        ``match_query`` when that query occurs in the message.
         """
 
         async def run() -> str:
@@ -973,6 +975,7 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                         "offset_from": normalized_offset_from,
                         "max_chars_per_message": max_chars_per_message,
                         "excerpt": excerpt,
+                        "match_query": match_query,
                     },
                 ):
                     return hooks.json_payload(
@@ -986,6 +989,7 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
                             offset_from=normalized_offset_from,
                             max_chars_per_message=max_chars_per_message,
                             excerpt=excerpt,
+                            match_query=match_query,
                         )
                     )
             except (KeyError, ValueError, sqlite3.OperationalError):

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -420,6 +420,16 @@ class TestSessionTreeResourceShapeMatchesTool:
             )
 
 
+def test_action_affordance_capability_resource_matches_catalog(read_server: MCPServerUnderTest) -> None:
+    """The opt-in catalog is available once without inflating search results."""
+    from tests.infra.mcp import invoke_surface
+
+    result = invoke_surface(_resource(read_server, "polylogue://capabilities/action-affordances"))
+
+    payload = json.loads(result)
+    assert payload["action_affordances"]
+
+
 class TestResourceErrorEnvelopes:
     """All 8 MCP resources must emit the structured error envelope.
 

--- a/tests/unit/mcp/test_query_tool_schema_derivation.py
+++ b/tests/unit/mcp/test_query_tool_schema_derivation.py
@@ -62,12 +62,12 @@ def test_search_schema_matches_dataclass_fields(schemas: SchemaMap) -> None:
     )
 
 
-def test_list_sessions_schema_matches_dataclass_fields_excluding_query(
+def test_list_sessions_schema_matches_supported_request_fields(
     schemas: SchemaMap,
 ) -> None:
     schema = schemas["list_sessions"]
     properties = set(schema.get("properties", {}).keys())
-    expected = _dataclass_field_names() - {"query"}
+    expected = _dataclass_field_names() - {"query", "include_affordances"}
     assert properties == expected, (
         "list_sessions inputSchema drifted from MCPSessionQueryRequest. "
         f"missing={sorted(expected - properties)}, extra={sorted(properties - expected)}"
@@ -145,6 +145,60 @@ def test_archive_list_sessions_routes_near_session_to_query_executor(monkeypatch
     assert observed == {"similar_session_id": "seed-session", "archive_root": Path("/archive")}
     assert payload.items == ()
     assert payload.total == 0
+
+
+def test_archive_list_sessions_stops_after_requested_distinct_page() -> None:
+    summaries = {
+        "codex-session:first": ArchiveSessionSummary(
+            session_id="codex-session:first",
+            native_id="first",
+            origin="codex-session",
+            provider=Provider.CODEX,
+            title="First",
+            created_at=None,
+            updated_at=None,
+            message_count=1,
+            word_count=10,
+            tags=(),
+        ),
+        "codex-session:second": ArchiveSessionSummary(
+            session_id="codex-session:second",
+            native_id="second",
+            origin="codex-session",
+            provider=Provider.CODEX,
+            title="Second",
+            created_at=None,
+            updated_at=None,
+            message_count=1,
+            word_count=10,
+            tags=(),
+        ),
+    }
+
+    def hit(session_id: str) -> ArchiveSessionSearchHit:
+        return ArchiveSessionSearchHit(
+            rank=1,
+            session_id=session_id,
+            block_id=f"{session_id}:block",
+            message_id=f"{session_id}:message",
+            origin="codex-session",
+            provider=Provider.CODEX,
+            title=summaries[session_id].title,
+            snippet="needle",
+        )
+
+    archive = MagicMock()
+    archive.count_search_sessions.return_value = 3
+    archive.search_summaries.side_effect = [[hit("codex-session:first"), *[hit("codex-session:second")] * 249]]
+    archive.read_summary.side_effect = summaries.__getitem__
+    spec = MCPSessionQueryRequest(contains="needle", limit=2).build_spec(_clamp_limit)
+
+    payload = archive_session_list_payload(archive, spec)
+
+    assert [item.id for item in payload.items] == ["codex-session:first", "codex-session:second"]
+    assert payload.total == 3
+    assert payload.next_offset == 2
+    assert archive.search_summaries.call_count == 1
 
 
 def test_archive_search_routes_near_session_to_query_executor(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/mcp/test_query_tool_schema_derivation.py
+++ b/tests/unit/mcp/test_query_tool_schema_derivation.py
@@ -198,6 +198,8 @@ def test_archive_list_sessions_stops_after_requested_distinct_page() -> None:
     assert [item.id for item in payload.items] == ["codex-session:first", "codex-session:second"]
     assert payload.total == 3
     assert payload.next_offset == 2
+    assert [item.match_count for item in payload.items] == [1, 249]
+    assert all(item.match_count_is_exact is False for item in payload.items)
     assert archive.search_summaries.call_count == 1
 
 

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -476,6 +476,27 @@ class TestQueryTools:
         assert parsed["diagnostics"] is None
 
     @pytest.mark.asyncio
+    async def test_search_envelope_affordance_catalog_is_opt_in(
+        self, tmp_path: Path, mcp_server: MCPServerUnderTest
+    ) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+
+        with _archive_config(archive_root):
+            default = await invoke_surface_async(
+                mcp_server._tool_manager._tools["search"].fn,
+                query="hello",
+            )
+            opted_in = await invoke_surface_async(
+                mcp_server._tool_manager._tools["search"].fn,
+                query="hello",
+                include_affordances=True,
+            )
+
+        assert json.loads(default)["action_affordances"] == []
+        assert json.loads(opted_in)["action_affordances"]
+
+    @pytest.mark.asyncio
     async def test_search_total_reflects_native_hit_count(self, tmp_path: Path, mcp_server: MCPServerUnderTest) -> None:
         archive_root = tmp_path / "archive"
         _seed_archive(archive_root, text="semantic planning notes for the refactor")
@@ -810,6 +831,21 @@ class TestGetSessionSummaryTool:
         assert conv["message_count"] == 2
         assert "messages" not in conv
 
+    def test_get_summary_includes_bounded_content_orientation(
+        self, tmp_path: Path, mcp_server: MCPServerUnderTest
+    ) -> None:
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive_with_semantic_messages(archive_root)
+
+        with _archive_config(archive_root):
+            result = invoke_surface(mcp_server._tool_manager._tools["get_session_summary"].fn, id=session_id)
+
+        summary = json.loads(result)["content_summary"]
+        assert summary["counts"]["messages"] == 3
+        assert summary["first_authored_user_excerpt"] == "typed human prompt"
+        assert summary["last_authored_user_excerpt"] == "typed human prompt"
+        assert summary["phase_count"] == 0
+
     def test_get_not_found(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
             mock_poly = make_polylogue_mock()
@@ -831,6 +867,44 @@ class TestGetSessionSummaryTool:
             result = invoke_surface(mcp_server._tool_manager._tools["get_messages"].fn, session_id=session_id)
 
         assert json.loads(result)["messages"][0]["text"] == long_text
+
+    def test_get_messages_honors_per_message_character_cap_and_excerpt(
+        self, tmp_path: Path, mcp_server: MCPServerUnderTest
+    ) -> None:
+        text = "opening-" + ("middle-" * 20) + "closing"
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive(archive_root, native_id="excerpt", text=text)
+
+        with _archive_config(archive_root):
+            result = invoke_surface(
+                mcp_server._tool_manager._tools["get_messages"].fn,
+                session_id=session_id,
+                max_chars_per_message=40,
+                excerpt=True,
+            )
+
+        message = json.loads(result)["messages"][0]
+        assert len(message["text"]) <= 40
+        assert message["text"].startswith("opening-")
+        assert message["text"].endswith("closing")
+        assert all(block.get("text") == "" for block in message["content_blocks"])
+
+    def test_get_messages_over_budget_returns_replayable_envelope(
+        self, tmp_path: Path, mcp_server: MCPServerUnderTest
+    ) -> None:
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive(archive_root, native_id="oversized", text="x" * 30_000)
+
+        with _archive_config(archive_root):
+            result = invoke_surface(mcp_server._tool_manager._tools["get_messages"].fn, session_id=session_id)
+
+        envelope = json.loads(result)
+        assert envelope["status"] == "response_budget_exceeded"
+        assert envelope["budget_exceeded"] is True
+        assert envelope["continuation"]["tool"] == "get_messages"
+        assert envelope["continuation"]["arguments"]["session_id"] == session_id
+        assert envelope["continuation"]["arguments"]["max_chars_per_message"] == 4096
+        assert len(result.encode("utf-8")) <= envelope["budget_bytes"]
 
     @pytest.mark.parametrize(
         ("kwargs", "expected_texts"),

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -901,8 +901,8 @@ class TestArchiveTools:
         assert payload["messages"][0]["blocks"][0]["text"] == "hello from mcp"
 
     @pytest.mark.asyncio
-    async def test_archive_get_session_over_budget_has_replayable_continuation(
-        self, mcp_server: MCPServerUnderTest
+    async def test_archive_get_session_over_budget_replays_as_bounded_messages(
+        self, tmp_path: Path, mcp_server: MCPServerUnderTest
     ) -> None:
         from polylogue.storage.sqlite.archive_tiers.write import (
             ArchiveBlockRow,
@@ -910,8 +910,9 @@ class TestArchiveTools:
             ArchiveSessionEnvelope,
         )
 
-        session_id = "codex-session:oversized"
-        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive(archive_root, provider=Provider.CODEX, native_id="oversized", text="e" * 5000)
+        with _archive_config(archive_root), patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
             mock_poly = make_polylogue_mock()
             mock_poly.archive_get_session = AsyncMock(
                 return_value=ArchiveSessionEnvelope(
@@ -950,10 +951,74 @@ class TestArchiveTools:
 
         payload = json.loads(raw)
         assert payload["continuation"] == {
-            "tool": "archive_get_session",
-            "arguments": {"session_id": session_id},
-            "reason": "The original response exceeded the MCP response budget; retry this narrower call to read the same evidence.",
+            "tool": "get_messages",
+            "arguments": {
+                "session_id": session_id,
+                "limit": 3,
+                "max_chars_per_message": 4096,
+                "excerpt": True,
+            },
+            "reason": "The full session exceeded the MCP response budget; read a bounded message page instead.",
         }
+        with _archive_config(archive_root):
+            replay = await invoke_surface_async(
+                mcp_server._tool_manager._tools[payload["continuation"]["tool"]].fn,
+                **payload["continuation"]["arguments"],
+            )
+        assert json.loads(replay).get("status") != "response_budget_exceeded"
+
+    @pytest.mark.asyncio
+    async def test_messages_resource_over_budget_replays_as_bounded_messages(
+        self, tmp_path: Path, mcp_server: MCPServerUnderTest
+    ) -> None:
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive(archive_root, provider=Provider.CODEX, native_id="resource", text="r" * 30_000)
+
+        with _archive_config(archive_root):
+            raw = await invoke_surface_async(
+                mcp_server._resource_manager._templates["polylogue://messages/{conv_id}"].fn,
+                conv_id=session_id,
+            )
+
+        payload = json.loads(raw)
+        assert payload["continuation"]["tool"] == "get_messages"
+        with _archive_config(archive_root):
+            replay = await invoke_surface_async(
+                mcp_server._tool_manager._tools[payload["continuation"]["tool"]].fn,
+                **payload["continuation"]["arguments"],
+            )
+        assert json.loads(replay).get("status") != "response_budget_exceeded"
+
+    @pytest.mark.asyncio
+    async def test_list_corrections_over_budget_replays_with_character_cap(
+        self, mcp_server: MCPServerUnderTest
+    ) -> None:
+        from polylogue.insights.feedback import CorrectionKind, LearningCorrection
+        from tests.infra.frozen_clock import fixed_now
+
+        correction = LearningCorrection(
+            session_id="codex-session:correction",
+            kind=CorrectionKind.SUMMARY_OVERRIDE,
+            payload={"summary": "c" * 30_000},
+            note="n" * 30_000,
+            created_at=fixed_now(),
+        )
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.list_corrections = AsyncMock(return_value=[correction])
+            mock_get_polylogue.return_value = mock_poly
+            raw = await invoke_surface_async(
+                mcp_server._tool_manager._tools["list_corrections"].fn,
+                session_id=correction.session_id,
+            )
+            payload = json.loads(raw)
+            replay = await invoke_surface_async(
+                mcp_server._tool_manager._tools[payload["continuation"]["tool"]].fn,
+                **payload["continuation"]["arguments"],
+            )
+
+        assert payload["status"] == "response_budget_exceeded"
+        assert json.loads(replay).get("status") != "response_budget_exceeded"
 
 
 class TestGetSessionSummaryTool:

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -476,6 +476,61 @@ class TestQueryTools:
         assert parsed["diagnostics"] is None
 
     @pytest.mark.asyncio
+    async def test_search_zero_hit_multi_term_diagnostics_report_filtered_term_counts(
+        self, tmp_path: Path, mcp_server: MCPServerUnderTest
+    ) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root, provider=Provider.CODEX, native_id="alpha", text="alpha evidence")
+        _seed_archive(archive_root, provider=Provider.CODEX, native_id="beta", text="beta evidence")
+
+        with _archive_config(archive_root):
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["search"].fn,
+                query="alpha beta",
+                origin="codex-session",
+            )
+
+        diagnostics = json.loads(result)["diagnostics"]
+        assert diagnostics["message"].startswith("No session matched all search terms")
+        assert {(reason["detail"], reason["count"]) for reason in diagnostics["reasons"]} == {
+            ("term=alpha", 1),
+            ("term=beta", 1),
+        }
+
+    def test_list_sessions_coalesces_block_hits_and_carries_match_count(
+        self, tmp_path: Path, mcp_server: MCPServerUnderTest
+    ) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(
+            archive_root,
+            provider=Provider.CODEX,
+            native_id="repeated",
+            text="needle first",
+            extra=(("repeated-2", "needle second"),),
+        )
+        _seed_archive(archive_root, provider=Provider.CODEX, native_id="other", text="needle third")
+
+        with _archive_config(archive_root):
+            result = invoke_surface(
+                mcp_server._tool_manager._tools["list_sessions"].fn,
+                contains="needle",
+                limit=10,
+            )
+
+        payload = json.loads(result)
+        assert [item["id"] for item in payload["items"]].count("codex-session:repeated") == 1
+        counts = {item["id"]: item["match_count"] for item in payload["items"]}
+        assert counts == {"codex-session:repeated": 2, "codex-session:other": 1}
+
+    def test_list_sessions_invalid_sort_enumerates_valid_values(self, mcp_server: MCPServerUnderTest) -> None:
+        result = invoke_surface(mcp_server._tool_manager._tools["list_sessions"].fn, sort="started_at")
+
+        error = json.loads(result)
+        assert error["code"] == "invalid_query"
+        assert error["field"] == "sort"
+        assert error["valid_values"] == ["date", "tokens", "messages", "words", "longest", "random"]
+
+    @pytest.mark.asyncio
     async def test_search_envelope_affordance_catalog_is_opt_in(
         self, tmp_path: Path, mcp_server: MCPServerUnderTest
     ) -> None:

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -563,6 +563,14 @@ class TestQueryTools:
         assert error["field"] == "sort"
         assert error["valid_values"] == ["date", "tokens", "messages", "words", "longest", "random"]
 
+    def test_list_sessions_invalid_origin_enumerates_valid_values(self, mcp_server: MCPServerUnderTest) -> None:
+        result = invoke_surface(mcp_server._tool_manager._tools["list_sessions"].fn, origin="codxe-session")
+
+        error = json.loads(result)
+        assert error["code"] == "invalid_query"
+        assert error["field"] == "origin"
+        assert error["valid_values"] == [origin.value for origin in Origin]
+
     @pytest.mark.asyncio
     async def test_search_envelope_affordance_catalog_is_opt_in(
         self, tmp_path: Path, mcp_server: MCPServerUnderTest
@@ -1095,6 +1103,29 @@ class TestGetSessionSummaryTool:
         assert len(message["text"]) <= 40
         assert message["text"].startswith("opening-")
         assert message["text"].endswith("closing")
+        assert all(block.get("text") == "" for block in message["content_blocks"])
+
+    def test_get_messages_excerpt_centers_the_requested_match(
+        self, tmp_path: Path, mcp_server: MCPServerUnderTest
+    ) -> None:
+        text = "opening-" + ("before-" * 30) + "needle evidence" + ("after-" * 30) + "closing"
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive(archive_root, native_id="match-excerpt", text=text)
+
+        with _archive_config(archive_root):
+            result = invoke_surface(
+                mcp_server._tool_manager._tools["get_messages"].fn,
+                session_id=session_id,
+                max_chars_per_message=80,
+                excerpt=True,
+                match_query="needle",
+            )
+
+        message = json.loads(result)["messages"][0]
+        assert len(message["text"]) <= 80
+        assert "needle evidence" in message["text"]
+        assert not message["text"].startswith("opening-")
+        assert not message["text"].endswith("closing")
         assert all(block.get("text") == "" for block in message["content_blocks"])
 
     def test_get_messages_over_budget_returns_replayable_envelope(
@@ -2048,6 +2079,29 @@ class TestMutationTools:
 
         assert json.loads(result) == {"claude-ai": 2}
         mock_poly.list_tags.assert_called_once_with(origin="claude-ai-export")
+
+    @pytest.mark.asyncio
+    async def test_list_tags_over_budget_replays_a_bounded_deterministic_page(
+        self, mcp_server: MCPServerUnderTest
+    ) -> None:
+        tags = {f"tag-{index:03d}-{'x' * 300}": index for index in range(100)}
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.list_tags = AsyncMock(return_value=tags)
+            mock_get_polylogue.return_value = mock_poly
+            raw = await invoke_surface_async(
+                mcp_server._tool_manager._tools["list_tags"].fn,
+                limit=100,
+            )
+            payload = json.loads(raw)
+            replay = await invoke_surface_async(
+                mcp_server._tool_manager._tools[payload["continuation"]["tool"]].fn,
+                **payload["continuation"]["arguments"],
+            )
+
+        assert payload["status"] == "response_budget_exceeded"
+        assert payload["continuation"]["arguments"]["limit"] == 3
+        assert len(json.loads(replay)) == 3
 
     def test_get_metadata_success(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -2103,6 +2103,52 @@ class TestMutationTools:
         assert payload["continuation"]["arguments"]["limit"] == 3
         assert len(json.loads(replay)) == 3
 
+    @pytest.mark.asyncio
+    async def test_tags_resource_over_budget_replays_through_paged_tool(self, mcp_server: MCPServerUnderTest) -> None:
+        tags = {f"tag-{index:03d}-{'x' * 300}": index for index in range(100)}
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.list_tags = AsyncMock(return_value=tags)
+            mock_get_polylogue.return_value = mock_poly
+            raw = await invoke_surface_async(mcp_server._resource_manager._resources["polylogue://tags"].fn)
+            payload = json.loads(raw)
+            replay = await invoke_surface_async(
+                mcp_server._tool_manager._tools[payload["continuation"]["tool"]].fn,
+                **payload["continuation"]["arguments"],
+            )
+
+        assert payload["continuation"]["tool"] == "list_tags"
+        assert payload["continuation"]["arguments"] == {"limit": 3, "offset": 0}
+        assert len(json.loads(replay)) == 3
+
+    @pytest.mark.asyncio
+    async def test_list_annotations_over_budget_replays_with_item_cap(self, mcp_server: MCPServerUnderTest) -> None:
+        annotation = {
+            "annotation_id": "annotation-1",
+            "target_type": "session",
+            "target_id": "codex-session:annotation",
+            "session_id": "codex-session:annotation",
+            "message_id": "",
+            "note_text": "a" * 30_000,
+            "created_at": "2026-07-12T00:00:00+00:00",
+            "updated_at": "2026-07-12T00:00:00+00:00",
+        }
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.list_annotations = AsyncMock(return_value=[annotation])
+            mock_get_polylogue.return_value = mock_poly
+            raw = await invoke_surface_async(mcp_server._tool_manager._tools["list_annotations"].fn)
+            payload = json.loads(raw)
+            replay = await invoke_surface_async(
+                mcp_server._tool_manager._tools[payload["continuation"]["tool"]].fn,
+                **payload["continuation"]["arguments"],
+            )
+
+        assert payload["status"] == "response_budget_exceeded"
+        assert payload["continuation"]["arguments"]["max_chars_per_item"] == 512
+        replay_payload = json.loads(replay)
+        assert replay_payload["items"][0]["note_text"] == "a" * 512
+
     def test_get_metadata_success(self, mcp_server: MCPServerUnderTest) -> None:
         with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
             mock_poly = make_polylogue_mock()

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -60,6 +60,8 @@ from polylogue.mcp.archive_support import (
     archive_search_payload,
     archive_session_list_payload,
 )
+from polylogue.mcp.payloads import MCPRootPayload
+from polylogue.mcp.server_support import MCP_RESPONSE_BUDGET_BYTES, _json_payload
 from polylogue.mcp.server_tools import _MCP_READ_TOOL_SPECS
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -540,6 +542,18 @@ class TestQueryTools:
         assert [item["id"] for item in payload["items"]].count("codex-session:repeated") == 1
         counts = {item["id"]: item["match_count"] for item in payload["items"]}
         assert counts == {"codex-session:repeated": 2, "codex-session:other": 1}
+        assert all(item["match_count_is_exact"] is True for item in payload["items"])
+
+    def test_budget_envelope_stays_bounded_for_deep_metadata(self) -> None:
+        nested: object = "x" * 512
+        for _ in range(5):
+            nested = {f"field-{index}": nested for index in range(4)}
+
+        result = _json_payload(MCPRootPayload(root={"nested": nested}))
+
+        payload = json.loads(result)
+        assert payload["status"] == "response_budget_exceeded"
+        assert len(result.encode("utf-8")) <= MCP_RESPONSE_BUDGET_BYTES
 
     def test_list_sessions_invalid_sort_enumerates_valid_values(self, mcp_server: MCPServerUnderTest) -> None:
         result = invoke_surface(mcp_server._tool_manager._tools["list_sessions"].fn, sort="started_at")
@@ -885,6 +899,61 @@ class TestArchiveTools:
         assert payload["source"] == "codex-session"
         assert payload["origin"] == "codex-session"
         assert payload["messages"][0]["blocks"][0]["text"] == "hello from mcp"
+
+    @pytest.mark.asyncio
+    async def test_archive_get_session_over_budget_has_replayable_continuation(
+        self, mcp_server: MCPServerUnderTest
+    ) -> None:
+        from polylogue.storage.sqlite.archive_tiers.write import (
+            ArchiveBlockRow,
+            ArchiveMessageRow,
+            ArchiveSessionEnvelope,
+        )
+
+        session_id = "codex-session:oversized"
+        with patch("polylogue.mcp.server._get_polylogue") as mock_get_polylogue:
+            mock_poly = make_polylogue_mock()
+            mock_poly.archive_get_session = AsyncMock(
+                return_value=ArchiveSessionEnvelope(
+                    session_id=session_id,
+                    native_id="oversized",
+                    origin="codex-session",
+                    title="Oversized",
+                    active_leaf_message_id=f"{session_id}:m1",
+                    messages=(
+                        ArchiveMessageRow(
+                            message_id=f"{session_id}:m1",
+                            native_id="m1",
+                            role="user",
+                            position=0,
+                            variant_index=0,
+                            is_active_path=True,
+                            is_active_leaf=True,
+                            blocks=(
+                                ArchiveBlockRow(
+                                    block_id=f"{session_id}:m1:0",
+                                    message_id=f"{session_id}:m1",
+                                    block_type="text",
+                                    text="x" * 30_000,
+                                ),
+                            ),
+                        ),
+                    ),
+                )
+            )
+            mock_get_polylogue.return_value = mock_poly
+
+            raw = await invoke_surface_async(
+                mcp_server._tool_manager._tools["archive_get_session"].fn,
+                session_id=session_id,
+            )
+
+        payload = json.loads(raw)
+        assert payload["continuation"] == {
+            "tool": "archive_get_session",
+            "arguments": {"session_id": session_id},
+            "reason": "The original response exceeded the MCP response budget; retry this narrower call to read the same evidence.",
+        }
 
 
 class TestGetSessionSummaryTool:

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -572,6 +572,18 @@ class TestQueryTools:
         assert error["valid_values"] == [origin.value for origin in Origin]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(("query", "field"), [("origin:codxe-session", "origin"), ("action:bogus", "action")])
+    async def test_search_dsl_invalid_closed_values_enumerate_valid_values(
+        self, mcp_server: MCPServerUnderTest, query: str, field: str
+    ) -> None:
+        result = await invoke_surface_async(mcp_server._tool_manager._tools["search"].fn, query=query)
+
+        error = json.loads(result)
+        assert error["code"] == "invalid_query"
+        assert error["field"] == field
+        assert error["valid_values"]
+
+    @pytest.mark.asyncio
     async def test_search_envelope_affordance_catalog_is_opt_in(
         self, tmp_path: Path, mcp_server: MCPServerUnderTest
     ) -> None:

--- a/tests/unit/mcp/test_tool_contracts.py
+++ b/tests/unit/mcp/test_tool_contracts.py
@@ -497,6 +497,25 @@ class TestQueryTools:
             ("term=beta", 1),
         }
 
+    @pytest.mark.asyncio
+    async def test_search_exhausted_page_does_not_report_miss_diagnostics(
+        self, tmp_path: Path, mcp_server: MCPServerUnderTest
+    ) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root, provider=Provider.CODEX, native_id="both", text="alpha beta evidence")
+
+        with _archive_config(archive_root):
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["search"].fn,
+                query="alpha beta",
+                offset=1,
+            )
+
+        payload = json.loads(result)
+        assert payload["total"] == 1
+        assert payload["hits"] == []
+        assert payload["diagnostics"] is None
+
     def test_list_sessions_coalesces_block_hits_and_carries_match_count(
         self, tmp_path: Path, mcp_server: MCPServerUnderTest
     ) -> None:


### PR DESCRIPTION
## Summary

Bounds MCP responses for agent use, makes search affordances opt-in, adds message body caps/excerpts, turns get_session_summary into a bounded orientation payload, and completes the response-envelope/pagination ergonomics with actionable query errors, distinct list rows, and zero-hit diagnostics.

## Problem

Live MCP searches and message reads could return response bodies far beyond an agent context budget. Search carried the full affordance catalog on every response, session summaries contained metadata only, invalid filters gave agents no recovery set, list search could repeat a session for each matching block, and an AND-style search miss could not explain its terms.

## Solution

- Add a shared 25 KB serializer budget that replaces oversized payloads with metadata plus a replayable narrower MCP call descriptor.
- Make `search(include_affordances=true)` the explicit opt-in for its affordance catalog.
- Add `max_chars_per_message` and head/tail excerpt handling to `get_messages`.
- Add counts, phase count, top tools, and first/last authored-user excerpts to `get_session_summary`.
- Map `QuerySpecError` into an `invalid_query` envelope with field, tool, and valid-values metadata.
- Coalesce block-level `list_sessions` results into distinct session rows with `match_count`, using the existing distinct-session count and only the raw hits needed for the requested page.
- Include filtered per-term counts only when a multi-term `search` has zero total matches; exhausted result pages remain ordinary empty pages.

## Verification

- `nix develop --command devtools test tests/unit/mcp/test_tool_contracts.py -k 'multi_term or coalesces or invalid_sort'` — 3 passed.
- `nix develop --command devtools test tests/unit/mcp/test_query_tool_schema_derivation.py tests/unit/mcp/test_tool_contracts.py -k 'supported_request_fields or stops_after_requested or exhausted_page or multi_term or coalesces or invalid_sort'` — 6 passed.
- `nix develop --command devtools test tests/unit/mcp -k 'envelope or pagination or summary'` — 178 passed, 473 deselected (1:55).
- Each pushed commit passed the pre-push quick gate: format, lint, mypy, render, topology, layering, schema roundtrip, manifests, and MCP test-infrastructure checks.

## Acceptance status

Ref polylogue-rsad.

- Satisfied: opt-in affordances; shared response-budget envelopes across the covered read and mutable-list paths; per-message cap/match-aware excerpt behavior; content-bearing session summaries; direct and search-DSL invalid-value envelopes; distinct session-list rows with `match_count`; and zero-hit per-term diagnostics.
- Remaining polylogue-rsad scope: `query_units` must use the shared valid-values error shape and preserve replay arguments; `archive_search_sessions` must preserve replay arguments. These are documented in adversarial iteration 5; the bead remains open.
- Excluded: recall/context tool changes remain owned by the hermes-wedge lane.

## Test evidence

The tests invoke registered MCP handlers against real seeded archive rows, not test-only validators:

- Removing the `QuerySpecError` mapper or its valid-values mapping breaks the invalid-sort test.
- Removing the archive search-result coalescing or `match_count` projection breaks the repeated-block session-list test.
- Removing the distinct-page bound makes the coalescing test fetch an unnecessary second raw FTS batch.
- Emitting diagnostics based on an empty page rather than zero total breaks the exhausted-page test.
- Existing lane tests similarly exercise the shared budget serializer/context, affordance opt-in pass-through, message projection cap, and summary enrichment.