### PR TITLE
feat(context): audit delivery receipts

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -49,6 +49,7 @@ from polylogue.storage.search.models import SearchHit, SearchResult
 from polylogue.storage.search.query_builders import session_web_url
 from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSummary, IndexStatus
+from polylogue.storage.sqlite.archive_tiers.context_delivery_write import ArchiveContextDeliveryEnvelope
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import (
     ArchiveAttachmentRow,
@@ -99,7 +100,6 @@ if TYPE_CHECKING:
     from polylogue.storage.repository import SessionRepository
     from polylogue.storage.search.models import SearchResult
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSearchHit, ArchiveSessionSummary
-    from polylogue.storage.sqlite.archive_tiers.context_delivery_write import ArchiveContextDeliveryEnvelope
     from polylogue.storage.sqlite.archive_tiers.user_write import (
         ArchiveAssertionCandidateReviewEnvelope,
         ArchiveAssertionEnvelope,

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1050,6 +1050,31 @@ def _archive_list_assertion_claims(
         return []
 
 
+def _archive_get_context_delivery(
+    config: Config,
+    *,
+    snapshot_ref: str,
+    recipient_ref: str,
+) -> Any | None:
+    """Read one delivery receipt only when it belongs to its recorded recipient."""
+
+    from polylogue.storage.sqlite.archive_tiers.context_delivery_write import read_context_delivery
+
+    user_db = _active_archive_root(config) / "user.db"
+    if not user_db.exists():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{user_db}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            receipt = read_context_delivery(conn, snapshot_ref)
+            return receipt if receipt is not None and receipt.recipient_ref == recipient_ref else None
+        finally:
+            conn.close()
+    except (sqlite3.Error, ValueError):
+        return None
+
+
 def _archive_list_assertion_candidate_reviews(
     config: Config,
     *,
@@ -2170,6 +2195,19 @@ class PolylogueArchiveMixin:
                 context_inject=context_inject,
                 limit=limit,
             ),
+        )
+
+    async def get_context_delivery(self, snapshot_ref: str, *, recipient_ref: str) -> Any | None:
+        """Return an exact delivery receipt only for its recorded recipient.
+
+        This is a read-only audit seam over the durable user-tier receipt. It
+        does not schedule recall or grant a caller broader archive access.
+        """
+
+        return _archive_get_context_delivery(
+            self.config,
+            snapshot_ref=snapshot_ref,
+            recipient_ref=recipient_ref,
         )
 
     async def list_assertion_claim_payloads(

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -99,6 +99,7 @@ if TYPE_CHECKING:
     from polylogue.storage.repository import SessionRepository
     from polylogue.storage.search.models import SearchResult
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSearchHit, ArchiveSessionSummary
+    from polylogue.storage.sqlite.archive_tiers.context_delivery_write import ArchiveContextDeliveryEnvelope
     from polylogue.storage.sqlite.archive_tiers.user_write import (
         ArchiveAssertionCandidateReviewEnvelope,
         ArchiveAssertionEnvelope,
@@ -1055,7 +1056,7 @@ def _archive_get_context_delivery(
     *,
     snapshot_ref: str,
     recipient_ref: str,
-) -> Any | None:
+) -> ArchiveContextDeliveryEnvelope | None:
     """Read one delivery receipt only when it belongs to its recorded recipient."""
 
     from polylogue.storage.sqlite.archive_tiers.context_delivery_write import read_context_delivery
@@ -2197,7 +2198,9 @@ class PolylogueArchiveMixin:
             ),
         )
 
-    async def get_context_delivery(self, snapshot_ref: str, *, recipient_ref: str) -> Any | None:
+    async def get_context_delivery(
+        self, snapshot_ref: str, *, recipient_ref: str
+    ) -> ArchiveContextDeliveryEnvelope | None:
         """Return an exact delivery receipt only for its recorded recipient.
 
         This is a read-only audit seam over the durable user-tier receipt. It

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -13,6 +13,7 @@ from polylogue.core.json import JSONDocument
 from polylogue.core.user_state_targets import TARGET_SESSION
 from polylogue.core.web_urls import canonical_session_url
 from polylogue.readiness import component_from_outcome_check, component_from_raw_materialization_readiness
+from polylogue.storage.sqlite.archive_tiers.context_delivery_write import ArchiveContextDeliveryEnvelope
 from polylogue.surfaces.payloads import (
     AssertionClaimListPayload,
     AssertionClaimPayload,
@@ -58,7 +59,6 @@ if TYPE_CHECKING:
     from polylogue.readiness import ReadinessCheck, ReadinessReport
     from polylogue.storage.runtime import RawSessionRecord
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSearchHit, ArchiveSessionSummary
-    from polylogue.storage.sqlite.archive_tiers.context_delivery_write import ArchiveContextDeliveryEnvelope
     from polylogue.storage.sqlite.archive_tiers.write import ArchiveBlockRow, ArchiveMessageRow, ArchiveSessionEnvelope
 
 MCPAssertionClaimPayload = AssertionClaimPayload

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
     from polylogue.readiness import ReadinessCheck, ReadinessReport
     from polylogue.storage.runtime import RawSessionRecord
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSearchHit, ArchiveSessionSummary
+    from polylogue.storage.sqlite.archive_tiers.context_delivery_write import ArchiveContextDeliveryEnvelope
     from polylogue.storage.sqlite.archive_tiers.write import ArchiveBlockRow, ArchiveMessageRow, ArchiveSessionEnvelope
 
 MCPAssertionClaimPayload = AssertionClaimPayload
@@ -123,6 +124,46 @@ class MCPBlackboardNoteListPayload(SurfacePayloadModel):
 
     items: tuple[MCPBlackboardNotePayload, ...]
     total: int
+
+
+class MCPContextDeliveryPayload(SurfacePayloadModel):
+    """One immutable context-delivery receipt returned to its recipient."""
+
+    snapshot_ref: str
+    recipient_ref: str
+    run_ref: str | None = None
+    boundary: str
+    inheritance_mode: str
+    context_image_sha256: str
+    context_image: ContextImage
+    segment_refs: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+    assertion_refs: tuple[str, ...]
+    omissions: tuple[dict[str, object], ...]
+    caveats: tuple[str, ...]
+    metadata: dict[str, str]
+    delivered_by_ref: str
+    delivered_at_ms: int
+
+    @classmethod
+    def from_envelope(cls, envelope: ArchiveContextDeliveryEnvelope) -> MCPContextDeliveryPayload:
+        return cls(
+            snapshot_ref=envelope.snapshot_ref,
+            recipient_ref=envelope.recipient_ref,
+            run_ref=envelope.run_ref,
+            boundary=envelope.boundary,
+            inheritance_mode=envelope.inheritance_mode,
+            context_image_sha256=envelope.context_image_sha256,
+            context_image=envelope.context_image,
+            segment_refs=envelope.segment_refs,
+            evidence_refs=envelope.evidence_refs,
+            assertion_refs=envelope.assertion_refs,
+            omissions=envelope.omissions,
+            caveats=envelope.caveats,
+            metadata=envelope.metadata,
+            delivered_by_ref=envelope.delivered_by_ref,
+            delivered_at_ms=envelope.delivered_at_ms,
+        )
 
 
 class MCPFencedCodeBlock(TypedDict):
@@ -927,6 +968,7 @@ def _readiness_components(
 
 __all__ = [
     "MCPArchiveStatsPayload",
+    "MCPContextDeliveryPayload",
     "MCPContextImagePayload",
     "MCPSessionDetailPayload",
     "MCPSessionNeighborCandidateListPayload",

--- a/polylogue/mcp/server_context_tools.py
+++ b/polylogue/mcp/server_context_tools.py
@@ -32,6 +32,33 @@ def _detail_includes_messages(detail_level: str) -> bool:
 
 def register_context_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
     @mcp.tool()
+    async def get_context_delivery(snapshot_ref: str, recipient_ref: str) -> str:
+        """Read the exact persisted context image for its recorded recipient.
+
+        The caller must supply the recipient object ref recorded at delivery.
+        A mismatch is intentionally indistinguishable from a missing receipt.
+        This tool audits an existing delivery; it never creates a context pack
+        or schedules automatic recall.
+        """
+
+        async def run() -> str:
+            from polylogue.mcp.payloads import MCPContextDeliveryPayload
+
+            receipt = await hooks.get_polylogue().get_context_delivery(
+                snapshot_ref,
+                recipient_ref=recipient_ref,
+            )
+            if receipt is None:
+                return hooks.error_json(
+                    "context delivery not found for recipient",
+                    code="not_found",
+                    tool="get_context_delivery",
+                )
+            return hooks.json_payload(MCPContextDeliveryPayload.from_envelope(receipt), exclude_none=True)
+
+        return await hooks.async_safe_call("get_context_delivery", run)
+
+    @mcp.tool()
     async def build_context_image(
         project_path: str | None = None,
         project_repo: str | None = None,

--- a/tests/infra/mcp.py
+++ b/tests/infra/mcp.py
@@ -19,6 +19,7 @@ EXPECTED_TOOL_NAMES = {
     "explain_import",
     "list_sessions",
     "compile_context",
+    "get_context_delivery",
     "build_context_image",
     "blackboard_list",
     "blackboard_post",
@@ -235,6 +236,7 @@ def make_polylogue_mock(*, resolved_id: str | None = None) -> MagicMock:
     poly.list_assertion_claims = AsyncMock(return_value=[])
     poly.list_assertion_claim_payloads = AsyncMock(return_value=[])
     poly.compile_context = AsyncMock(return_value=None)
+    poly.get_context_delivery = AsyncMock(return_value=None)
     poly.explain_import = AsyncMock(return_value=None)
     poly.explain_query_expression = AsyncMock(return_value={})
     poly.query_completions = AsyncMock(return_value={})

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -240,6 +240,7 @@ BESPOKE_METHODS: frozenset[str] = frozenset(
         "explain_import",
         "archive_debt",
         "list_assertion_claim_payloads",
+        "get_context_delivery",
         "list_assertion_candidate_reviews",
         "judge_assertion_candidate",
         "neighbor_candidate_payloads",
@@ -1002,6 +1003,52 @@ async def test_explain_import_exposes_shared_import_payload(tmp_path: Path) -> N
         assert payload.entries[0].detected_origin == "codex-session"
         assert payload.entries[0].parser_mode == "grouped_records"
         assert payload.entries[0].produced.session_refs
+    finally:
+        await archive.close()
+
+
+async def test_get_context_delivery_scopes_exact_receipt_to_recipient(tmp_path: Path) -> None:
+    from polylogue.context.compiler import ContextImage, ContextSegment, ContextSpec, context_snapshot_record_from_image
+    from polylogue.core.refs import EvidenceRef
+    from polylogue.storage.sqlite.archive_tiers.context_delivery_write import write_context_delivery
+
+    image = ContextImage(
+        spec=ContextSpec(seed_refs=("session:codex-session:source",), read_views=()),
+        segments=(
+            ContextSegment(
+                segment_id="read-view:codex-session:source:messages",
+                kind="read_view",
+                title="Exact delivery",
+                markdown="quoted archival evidence",
+                evidence_refs=(EvidenceRef(session_id="codex-session:source", message_id="m1"),),
+                token_estimate=3,
+            ),
+        ),
+        evidence_refs=(EvidenceRef(session_id="codex-session:source", message_id="m1"),),
+        token_estimate=3,
+    )
+    record = context_snapshot_record_from_image(image, boundary="explicit-recall")
+    archive = _archive(tmp_path)
+    with sqlite3.connect(tmp_path / "user.db") as conn:
+        write_context_delivery(
+            conn,
+            image=image,
+            record=record,
+            recipient_ref="agent:hermes-main",
+            delivered_by_ref="user:local",
+            delivered_at_ms=123,
+        )
+        conn.commit()
+
+    try:
+        receipt = await archive.get_context_delivery(record.snapshot_ref, recipient_ref="agent:hermes-main")
+        wrong_recipient = await archive.get_context_delivery(record.snapshot_ref, recipient_ref="agent:other")
+
+        assert receipt is not None
+        assert receipt.context_image == image
+        assert receipt.context_image_sha256 == record.metadata["context_image_sha256"]
+        assert receipt.evidence_refs == ("codex-session:source::m1",)
+        assert wrong_recipient is None
     finally:
         await archive.close()
 

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -31,7 +31,7 @@ import shutil
 import sqlite3
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, cast, get_type_hints
 
 import pytest
 
@@ -1005,6 +1005,15 @@ async def test_explain_import_exposes_shared_import_payload(tmp_path: Path) -> N
         assert payload.entries[0].produced.session_refs
     finally:
         await archive.close()
+
+
+def test_get_context_delivery_return_annotation_resolves_at_runtime() -> None:
+    """Receipt readers can inspect the public facade's concrete return type."""
+    from polylogue.storage.sqlite.archive_tiers.context_delivery_write import ArchiveContextDeliveryEnvelope
+
+    hints = get_type_hints(Polylogue.get_context_delivery)
+
+    assert hints["return"] == ArchiveContextDeliveryEnvelope | None
 
 
 async def test_get_context_delivery_scopes_exact_receipt_to_recipient(tmp_path: Path) -> None:

--- a/tests/unit/mcp/test_envelope_contracts.py
+++ b/tests/unit/mcp/test_envelope_contracts.py
@@ -91,6 +91,7 @@ TOOL_CONTRACT: dict[str, ToolKind] = {
     "list_workspaces": ("envelope", frozenset({"items", "total"})),
     # ------- single record -------
     "get_session_summary": "single_object",
+    "get_context_delivery": "single_object",
     "compile_context": "single_object",
     "archive_get_session": "single_object",
     "get_metadata": "single_object",

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -1082,6 +1082,65 @@ class TestArchiveGenericToolSurfaces:
         assert called_spec.max_tokens == 1000
 
     @pytest.mark.asyncio
+    async def test_get_context_delivery_reads_recipient_scoped_facade_receipt(
+        self: object, mcp_server: MCPServerUnderTest
+    ) -> None:
+        from polylogue.context.compiler import ContextImage, ContextSegment, ContextSpec
+        from polylogue.core.refs import EvidenceRef
+        from polylogue.storage.sqlite.archive_tiers.context_delivery_write import ArchiveContextDeliveryEnvelope
+
+        image = ContextImage(
+            spec=ContextSpec(seed_refs=("session:session-1",), read_views=()),
+            segments=(
+                ContextSegment(
+                    segment_id="read-view:session-1:messages",
+                    kind="read_view",
+                    title="Delivered context",
+                    markdown="exact bytes",
+                    evidence_refs=(EvidenceRef(session_id="session-1"),),
+                    token_estimate=2,
+                ),
+            ),
+            evidence_refs=(EvidenceRef(session_id="session-1"),),
+            token_estimate=2,
+        )
+        receipt = ArchiveContextDeliveryEnvelope(
+            snapshot_ref="context-snapshot:session-1:explicit-recall",
+            recipient_ref="agent:hermes-main",
+            run_ref=None,
+            boundary="explicit-recall",
+            inheritance_mode="explicit",
+            context_image_sha256="a" * 64,
+            context_image=image,
+            segment_refs=("read-view:session-1:messages",),
+            evidence_refs=("session-1",),
+            assertion_refs=(),
+            omissions=(),
+            caveats=("quoted evidence",),
+            metadata={"context_image_sha256": "a" * 64},
+            delivered_by_ref="user:local",
+            delivered_at_ms=123,
+        )
+        mock_poly = make_polylogue_mock()
+        mock_poly.get_context_delivery = AsyncMock(return_value=receipt)
+
+        with patch("polylogue.mcp.server._get_polylogue", return_value=mock_poly):
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["get_context_delivery"].fn,
+                snapshot_ref=receipt.snapshot_ref,
+                recipient_ref=receipt.recipient_ref,
+            )
+
+        payload = json.loads(result)
+        assert payload["snapshot_ref"] == receipt.snapshot_ref
+        assert payload["context_image_sha256"] == receipt.context_image_sha256
+        assert payload["context_image"]["segments"][0]["markdown"] == "exact bytes"
+        mock_poly.get_context_delivery.assert_awaited_once_with(
+            receipt.snapshot_ref,
+            recipient_ref=receipt.recipient_ref,
+        )
+
+    @pytest.mark.asyncio
     async def test_list_assertion_claims_reads_shared_facade_claims(
         self: object, mcp_server: MCPServerUnderTest
     ) -> None:

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -7,7 +7,7 @@ import json
 from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, get_type_hints
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1080,6 +1080,15 @@ class TestArchiveGenericToolSurfaces:
         assert called_spec.seed_refs == ("session:session-1",)
         assert called_spec.read_views == ("messages",)
         assert called_spec.max_tokens == 1000
+
+    def test_context_delivery_payload_mapper_annotations_resolve_at_runtime(self: object) -> None:
+        from polylogue.mcp.payloads import MCPContextDeliveryPayload
+        from polylogue.storage.sqlite.archive_tiers.context_delivery_write import ArchiveContextDeliveryEnvelope
+
+        hints = get_type_hints(MCPContextDeliveryPayload.from_envelope)
+
+        assert hints["envelope"] is ArchiveContextDeliveryEnvelope
+        assert hints["return"] is MCPContextDeliveryPayload
 
     @pytest.mark.asyncio
     async def test_get_context_delivery_reads_recipient_scoped_facade_receipt(

--- a/tests/unit/mcp/test_server_surfaces.py
+++ b/tests/unit/mcp/test_server_surfaces.py
@@ -1085,7 +1085,7 @@ class TestArchiveGenericToolSurfaces:
     async def test_get_context_delivery_reads_recipient_scoped_facade_receipt(
         self: object, mcp_server: MCPServerUnderTest
     ) -> None:
-        from polylogue.context.compiler import ContextImage, ContextSegment, ContextSpec
+        from polylogue.context.compiler import ContextImage, ContextSegment, ContextSpec, context_image_sha256
         from polylogue.core.refs import EvidenceRef
         from polylogue.storage.sqlite.archive_tiers.context_delivery_write import ArchiveContextDeliveryEnvelope
 
@@ -1110,14 +1110,14 @@ class TestArchiveGenericToolSurfaces:
             run_ref=None,
             boundary="explicit-recall",
             inheritance_mode="explicit",
-            context_image_sha256="a" * 64,
+            context_image_sha256=context_image_sha256(image),
             context_image=image,
             segment_refs=("read-view:session-1:messages",),
             evidence_refs=("session-1",),
             assertion_refs=(),
             omissions=(),
             caveats=("quoted evidence",),
-            metadata={"context_image_sha256": "a" * 64},
+            metadata={"context_image_sha256": context_image_sha256(image)},
             delivered_by_ref="user:local",
             delivered_at_ms=123,
         )
@@ -1138,6 +1138,29 @@ class TestArchiveGenericToolSurfaces:
         mock_poly.get_context_delivery.assert_awaited_once_with(
             receipt.snapshot_ref,
             recipient_ref=receipt.recipient_ref,
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_context_delivery_hides_missing_receipt_or_recipient_mismatch(
+        self: object, mcp_server: MCPServerUnderTest
+    ) -> None:
+        mock_poly = make_polylogue_mock()
+        mock_poly.get_context_delivery = AsyncMock(return_value=None)
+
+        with patch("polylogue.mcp.server._get_polylogue", return_value=mock_poly):
+            result = await invoke_surface_async(
+                mcp_server._tool_manager._tools["get_context_delivery"].fn,
+                snapshot_ref="context-snapshot:session-1:explicit-recall",
+                recipient_ref="agent:other-recipient",
+            )
+
+        payload = json.loads(result)
+        assert payload["is_error"] is True
+        assert payload["code"] == "not_found"
+        assert payload["tool"] == "get_context_delivery"
+        mock_poly.get_context_delivery.assert_awaited_once_with(
+            "context-snapshot:session-1:explicit-recall",
+            recipient_ref="agent:other-recipient",
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/mcp/test_tool_discovery.py
+++ b/tests/unit/mcp/test_tool_discovery.py
@@ -30,6 +30,10 @@ _KNOWN_MINIMAL: dict[str, dict[str, object]] = {
     "query_units": {"expression": "messages where text:hello", "limit": 1},
     "resolve_ref": {"ref": f"session:{_SYNTHETIC_CONV_ID}"},
     "compile_context": {"seed_ref": f"session:{_SYNTHETIC_CONV_ID}", "read_views": "messages"},
+    "get_context_delivery": {
+        "snapshot_ref": "context-snapshot:test:conv-discovery-nonexistent:explicit-recall",
+        "recipient_ref": "agent:discovery",
+    },
     "blackboard_list": {},
     "get_session_summary": {"id": _SYNTHETIC_CONV_ID},
     "get_messages": {"session_id": _SYNTHETIC_CONV_ID, "limit": 1},


### PR DESCRIPTION
## Summary

Expose existing immutable context-delivery receipts through a recipient-scoped API lookup and a read-role MCP audit tool.

## Problem

The user-tier receipt writer already persists the exact context image, hash, evidence references, omissions, caveats, recipient, and delivery boundary. There was no supported API/MCP path to recover that evidence after delivery.

## Solution

- Add `Polylogue.get_context_delivery(snapshot_ref, recipient_ref=...)`, which returns a receipt only when its persisted recipient matches.
- Add read-role MCP `get_context_delivery`, returning the exact stored image and SHA-256 through a typed payload; mismatch and absence both return not-found.
- Register the tool in MCP discovery and the single-object envelope contract in a separate test commit.
- Reuse the durable receipt writer and image model unchanged. No scheduler, automatic recall, manifest format, or write endpoint is introduced.

## Acceptance criteria

| Bead | Status | Evidence |
| --- | --- | --- |
| polylogue-fs1.11: persisted delivery manifest is auditable | satisfied | API/MCP resolve the stored image, digest, evidence refs, omissions, and caveats. |
| polylogue-fs1.11: recipient isolation | partially satisfied | The API verifies the recorded recipient and MCP makes mismatch indistinguishable from absence. Scheduler-level owner/session capability enforcement remains deferred. |
| polylogue-fs1.11: explicit/automatic recall, budgets, injection fencing, unavailable delivery outcomes | deferred | Owned by the open polylogue-37t.11 scheduler and later Hermes delivery integration. |
| polylogue-fs1.12 | deferred | Requires the remaining fs1.11 scheduler leg and forensic demo consumer. |

## Anti-vacuity

- `test_get_context_delivery_scopes_exact_receipt_to_recipient` writes a real durable receipt, then exercises the facade against user.db. Removing the user-tier reader or recipient equality check makes it fail.
- `test_get_context_delivery_reads_recipient_scoped_facade_receipt` invokes the real MCP tool and asserts the exact image/hash plus facade call. Removing the tool, facade call, or payload mapper makes it fail.
- MCP registry tests pin discovery and the single-object contract for the registered read tool.

## Verification

- `nix develop --command devtools test tests/unit/api/test_facade_contracts.py tests/unit/mcp/test_server_surfaces.py -k context_delivery` — 3 passed, 337 deselected.
- `nix develop --command devtools test tests/unit/mcp/test_server_surfaces.py tests/unit/mcp/test_envelope_contracts.py -k 'server_surface_contract or RegistryWideClassification'` — 7 passed, 103 deselected.
- `nix develop --command devtools verify --quick` — passed all 15 checks.

The broad MCP discovery test run was interrupted by its supervisor after the envelope suite and produced no result summary; it is not claimed as passing.

Ref polylogue-fs1.11
Ref polylogue-fs1.12