### PR TITLE
feat(storage): preserve raw AISTUDIO capture mode (#2794)

### DIFF
--- a/polylogue/core/sources.py
+++ b/polylogue/core/sources.py
@@ -369,13 +369,12 @@ def provider_from_origin(origin: Origin, *, family_hint: Provider | SourceFamily
     A hint that fails to resolve, or resolves to a ``Provider`` outside
     ``origin``'s fiber, is ignored (falls back to the canonical choice)
     rather than raising: disambiguation here is advisory, not authoritative.
-    No current storage tier persists the acquisition-time provider once a
-    session is written -- ``sessions``/``raw_sessions`` only carry the
-    already-collapsed ``origin`` column (polylogue-9e5.8 Step 5 investigation;
-    see polylogue-4rrv for the follow-up durable-field bead) -- so this
-    parameter only helps call sites that already have independent knowledge
-    of which fiber member applies, not ones trying to recover it from a
-    previously-persisted session alone.
+    The durable ``source.db`` ``raw_sessions.capture_mode`` field preserves
+    acquisition-time provenance for new raw captures, so source-tier readers
+    can pass it here to recover a persisted fiber member.  ``index.db``
+    sessions still carry only the collapsed ``origin`` and historical source
+    rows retain ``NULL`` for unknown provenance; those callers still need
+    independent context or receive the canonical fallback.
     """
 
     if family_hint is not None:

--- a/polylogue/pipeline/services/acquisition_records.py
+++ b/polylogue/pipeline/services/acquisition_records.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from typing_extensions import TypedDict
 
+from polylogue.core.enums import Provider
 from polylogue.core.provider_identity import canonical_acquisition_provider
 from polylogue.sources.parsers.base import RawSessionData
 from polylogue.sources.sqlite_snapshot import hermes_profile_raw_id
@@ -82,6 +83,7 @@ def make_raw_record(
         raw_id=raw_id,
         blob_hash=(blob_hash if source_name == "hermes" else None),
         blob_publication_receipt_id=raw_data.blob_publication_receipt_id,
+        capture_mode=Provider.from_string(source_name),
         source_name=source_name,
         source_path=raw_data.source_path,
         source_index=raw_data.source_index,

--- a/polylogue/pipeline/services/acquisition_records.py
+++ b/polylogue/pipeline/services/acquisition_records.py
@@ -66,10 +66,14 @@ def make_raw_record(
         raise ValueError("RawSessionData has neither blob_hash nor raw_bytes")
 
     acquired_at = datetime.now(timezone.utc).isoformat()
+    source_capture_mode = Provider.from_string(canonical_acquisition_provider(None, source_name=source_name))
     source_name = canonical_acquisition_provider(
         str(raw_data.provider_hint) if raw_data.provider_hint is not None else None,
         source_name=source_name,
     )
+    capture_mode = source_capture_mode
+    if capture_mode is Provider.UNKNOWN:
+        capture_mode = Provider.from_string(source_name)
     if source_name == "hermes":
         if blob_hash is None:
             blob_hash = raw_id
@@ -83,7 +87,7 @@ def make_raw_record(
         raw_id=raw_id,
         blob_hash=(blob_hash if source_name == "hermes" else None),
         blob_publication_receipt_id=raw_data.blob_publication_receipt_id,
-        capture_mode=Provider.from_string(source_name),
+        capture_mode=capture_mode,
         source_name=source_name,
         source_path=raw_data.source_path,
         source_index=raw_data.source_index,

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -1133,6 +1133,7 @@ class LiveBatchProcessor:
         ingested: list[Path] = []
         source_payload_read_bytes = 0
         fallback_provider = Provider.from_string(canonical_acquisition_provider(source_name, source_name=source_name))
+        acquisition_capture_mode = fallback_provider
 
         archive_bootstrapped = not self._archive_active(archive_root)
         if archive_bootstrapped:
@@ -1361,7 +1362,9 @@ class LiveBatchProcessor:
                     raw_id=raw_id,
                     blob_hash=(blob_hash if provider is Provider.HERMES and blob_hash is not None else None),
                     payload_provider=provider,
-                    capture_mode=provider,
+                    capture_mode=(
+                        acquisition_capture_mode if acquisition_capture_mode is not Provider.UNKNOWN else provider
+                    ),
                     source_name=source_name,
                     source_path=(
                         str(original_sqlite_source_path(path) or path) if path in raw_source_revisions else str(path)
@@ -1510,6 +1513,7 @@ class LiveBatchProcessor:
                     if payload is None:
                         source_raw_id = archive.write_raw_blob_ref(
                             provider=provider,
+                            capture_mode=record.capture_mode,
                             blob_hash_hex=blob_hash,
                             blob_size=record.blob_size,
                             source_path=record.source_path,
@@ -1522,6 +1526,7 @@ class LiveBatchProcessor:
                     else:
                         source_raw_id = archive.write_raw_payload(
                             provider=provider,
+                            capture_mode=record.capture_mode,
                             payload=payload,
                             source_path=record.source_path,
                             source_index=record.source_index or 0,
@@ -1844,7 +1849,11 @@ class LiveBatchProcessor:
                                 RawSessionRecord(
                                     raw_id=raw_data.blob_hash,
                                     payload_provider=member_provider,
-                                    capture_mode=member_provider,
+                                    capture_mode=(
+                                        fallback_provider
+                                        if fallback_provider is not Provider.UNKNOWN
+                                        else member_provider
+                                    ),
                                     source_name=member_provider.value,
                                     source_path=raw_data.source_path,
                                     source_index=raw_data.source_index or 0,

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -1361,6 +1361,7 @@ class LiveBatchProcessor:
                     raw_id=raw_id,
                     blob_hash=(blob_hash if provider is Provider.HERMES and blob_hash is not None else None),
                     payload_provider=provider,
+                    capture_mode=provider,
                     source_name=source_name,
                     source_path=(
                         str(original_sqlite_source_path(path) or path) if path in raw_source_revisions else str(path)
@@ -1843,6 +1844,7 @@ class LiveBatchProcessor:
                                 RawSessionRecord(
                                     raw_id=raw_data.blob_hash,
                                     payload_provider=member_provider,
+                                    capture_mode=member_provider,
                                     source_name=member_provider.value,
                                     source_path=raw_data.source_path,
                                     source_index=raw_data.source_index or 0,

--- a/polylogue/storage/runtime/raw/records.py
+++ b/polylogue/storage/runtime/raw/records.py
@@ -13,6 +13,7 @@ class RawSessionRecord(BaseModel):
     blob_hash: str | None = None
     blob_publication_receipt_id: str | None = Field(default=None, exclude=True)
     payload_provider: Provider | None = None
+    capture_mode: Provider | None = None
     source_name: str | None = None
     source_path: str
     source_index: int | None = None
@@ -53,6 +54,15 @@ class RawSessionRecord(BaseModel):
     @field_validator("payload_provider", mode="before")
     @classmethod
     def coerce_payload_provider(cls, v: object) -> Provider | None:
+        if v is None:
+            return None
+        if isinstance(v, Provider):
+            return v
+        return Provider.from_string(str(v))
+
+    @field_validator("capture_mode", mode="before")
+    @classmethod
+    def coerce_capture_mode(cls, v: object) -> Provider | None:
         if v is None:
             return None
         if isinstance(v, Provider):

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1458,6 +1458,7 @@ class ArchiveStore:
         self,
         *,
         provider: Provider,
+        capture_mode: Provider | None = None,
         payload: bytes,
         source_path: str,
         acquired_at_ms: int,
@@ -1476,7 +1477,7 @@ class ArchiveStore:
         return write_source_raw_session(
             self._ensure_source_conn(),
             origin=origin_from_provider(provider),
-            capture_mode=provider,
+            capture_mode=capture_mode or provider,
             source_path=source_path,
             source_index=source_index,
             payload=payload,
@@ -1491,6 +1492,7 @@ class ArchiveStore:
         self,
         *,
         provider: Provider,
+        capture_mode: Provider | None = None,
         blob_hash_hex: str,
         blob_size: int,
         source_path: str,
@@ -1506,7 +1508,7 @@ class ArchiveStore:
         return write_source_raw_session_blob_ref(
             self._ensure_source_conn(),
             origin=origin_from_provider(provider),
-            capture_mode=provider,
+            capture_mode=capture_mode or provider,
             source_path=source_path,
             source_index=source_index,
             blob_hash=bytes.fromhex(blob_hash_hex),

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2863,6 +2863,7 @@ class ArchiveStore:
         raw_id = write_source_raw_session_blob_ref(
             source_conn,
             origin=origin_from_provider(session.source_name),
+            capture_mode=session.source_name,
             source_path=source_path,
             source_index=source_index,
             native_id=session.provider_session_id,

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1896,7 +1896,7 @@ class ArchiveStore:
             self._ensure_source_conn()
             .execute(
                 """
-            SELECT origin, lower(hex(blob_hash)), source_path, revision_kind
+            SELECT origin, capture_mode, lower(hex(blob_hash)), source_path, revision_kind
             FROM raw_sessions WHERE raw_id = ?
             """,
                 (raw_id,),
@@ -1906,10 +1906,10 @@ class ArchiveStore:
         if row is None:
             raise KeyError(raw_id)
         return (
-            provider_from_origin(Origin.from_string(str(row[0]))),
-            self._blob_publisher.read_all(str(row[1])),
-            str(row[2]),
-            RawRevisionKind(str(row[3])),
+            provider_from_origin(Origin.from_string(str(row[0])), family_hint=row[1]),
+            self._blob_publisher.read_all(str(row[2])),
+            str(row[3]),
+            RawRevisionKind(str(row[4])),
         )
 
     def unclassified_raw_revision_rows(self) -> tuple[tuple[str, int], ...]:
@@ -2966,7 +2966,7 @@ class ArchiveStore:
             )
             rows = source_conn.execute(
                 """
-                SELECT raw_id, origin, source_path, blob_size, acquired_at_ms,
+                SELECT raw_id, origin, capture_mode, source_path, blob_size, acquired_at_ms,
                        parsed_at_ms, validation_status
                 FROM raw_sessions
                 WHERE raw_id = ?
@@ -2980,7 +2980,9 @@ class ArchiveStore:
         return [
             {
                 "raw_id": str(row["raw_id"]),
-                "source_name": _provider_for_origin(str(row["origin"])).value,
+                "source_name": provider_from_origin(
+                    Origin.from_string(str(row["origin"])), family_hint=row["capture_mode"]
+                ).value,
                 "source_path": str(row["source_path"]),
                 "blob_size": int(row["blob_size"] or 0),
                 "acquired_at": _iso_from_ms(row["acquired_at_ms"]),

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1476,6 +1476,7 @@ class ArchiveStore:
         return write_source_raw_session(
             self._ensure_source_conn(),
             origin=origin_from_provider(provider),
+            capture_mode=provider,
             source_path=source_path,
             source_index=source_index,
             payload=payload,
@@ -1505,6 +1506,7 @@ class ArchiveStore:
         return write_source_raw_session_blob_ref(
             self._ensure_source_conn(),
             origin=origin_from_provider(provider),
+            capture_mode=provider,
             source_path=source_path,
             source_index=source_index,
             blob_hash=bytes.fromhex(blob_hash_hex),
@@ -2762,6 +2764,7 @@ class ArchiveStore:
         raw_id = write_source_raw_session(
             source_conn,
             origin=origin_from_provider(session.source_name),
+            capture_mode=session.source_name,
             source_path=source_path,
             source_index=source_index,
             native_id=session.provider_session_id,

--- a/polylogue/storage/sqlite/archive_tiers/source.py
+++ b/polylogue/storage/sqlite/archive_tiers/source.py
@@ -6,15 +6,16 @@ live in index.db and are rebuilt from this tier.
 
 from __future__ import annotations
 
-from polylogue.core.enums import ArtifactSupportStatus, Origin, ValidationMode, ValidationStatus
+from polylogue.core.enums import ArtifactSupportStatus, Origin, Provider, ValidationMode, ValidationStatus
 from polylogue.storage.sqlite.archive_tiers.common import check, nullable_check
 
-SOURCE_SCHEMA_VERSION = 7
+SOURCE_SCHEMA_VERSION = 8
 
 SOURCE_DDL = f"""
 CREATE TABLE IF NOT EXISTS raw_sessions (
     raw_id                  TEXT PRIMARY KEY,
     origin                  TEXT NOT NULL CHECK ({check("origin", Origin)}),
+    capture_mode            TEXT CHECK ({nullable_check("capture_mode", Provider)}),
     native_id               TEXT,
     source_path             TEXT NOT NULL,
     source_index            INTEGER NOT NULL DEFAULT 0,

--- a/polylogue/storage/sqlite/archive_tiers/source_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/source_write.py
@@ -109,6 +109,7 @@ class ArchiveRawSessionEnvelope:
 
     raw_id: str
     origin: str
+    capture_mode: str | None
     native_id: str | None
     source_path: str
     source_index: int
@@ -614,7 +615,7 @@ def read_archive_raw_session_envelope(conn: sqlite3.Connection, raw_id: str) -> 
     row = conn.execute(
         """
         SELECT
-            raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size,
+            raw_id, origin, capture_mode, native_id, source_path, source_index, blob_hash, blob_size,
             acquired_at_ms, file_mtime_ms, parsed_at_ms, parse_error, validated_at_ms,
             validation_status, validation_error, validation_drift_count, validation_mode,
             detection_warnings_json
@@ -682,6 +683,7 @@ def read_archive_raw_session_envelope(conn: sqlite3.Connection, raw_id: str) -> 
     return ArchiveRawSessionEnvelope(
         raw_id=row["raw_id"],
         origin=row["origin"],
+        capture_mode=row["capture_mode"],
         native_id=row["native_id"],
         source_path=row["source_path"],
         source_index=row["source_index"],

--- a/polylogue/storage/sqlite/archive_tiers/source_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/source_write.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope
-from polylogue.core.enums import ArtifactSupportStatus, Origin, ValidationMode, ValidationStatus
+from polylogue.core.enums import ArtifactSupportStatus, Origin, Provider, ValidationMode, ValidationStatus
 from polylogue.storage.raw.models import RawSessionStateUpdate
 from polylogue.storage.sqlite.raw_state_update import compile_raw_state_update
 
@@ -317,6 +317,7 @@ def write_source_raw_session(
     conn: sqlite3.Connection,
     *,
     origin: Origin | str,
+    capture_mode: Provider | str | None = None,
     source_path: str,
     source_index: int,
     payload: bytes,
@@ -365,18 +366,19 @@ def write_source_raw_session(
         cursor = conn.execute(
             """
             INSERT INTO raw_sessions (
-                raw_id, origin, native_id, source_path, source_index, blob_hash,
+                raw_id, origin, capture_mode, native_id, source_path, source_index, blob_hash,
                 blob_size, acquired_at_ms, file_mtime_ms, parsed_at_ms, parse_error,
                 validated_at_ms, validation_status, validation_error, validation_drift_count,
                 validation_mode, detection_warnings_json, logical_source_key, revision_kind,
                 source_revision, predecessor_source_revision, predecessor_raw_id, baseline_raw_id, append_start_offset,
                 append_end_offset, acquisition_generation, revision_authority
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(raw_id) DO NOTHING
             """,
             (
                 resolved_raw_id,
                 origin_value,
+                _enum_value(capture_mode),
                 native_id,
                 source_path,
                 source_index,
@@ -453,6 +455,7 @@ def write_source_raw_session_blob_ref(
     conn: sqlite3.Connection,
     *,
     origin: Origin | str,
+    capture_mode: Provider | str | None = None,
     source_path: str,
     source_index: int,
     blob_hash: bytes,
@@ -486,16 +489,17 @@ def write_source_raw_session_blob_ref(
         cursor = conn.execute(
             """
             INSERT INTO raw_sessions (
-                raw_id, origin, native_id, source_path, source_index, blob_hash,
+                raw_id, origin, capture_mode, native_id, source_path, source_index, blob_hash,
                 blob_size, acquired_at_ms, logical_source_key, revision_kind,
                 source_revision, predecessor_source_revision, predecessor_raw_id, baseline_raw_id, append_start_offset,
                 append_end_offset, acquisition_generation, revision_authority
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(raw_id) DO NOTHING
             """,
             (
                 resolved_raw_id,
                 origin_value,
+                _enum_value(capture_mode),
                 native_id,
                 source_path,
                 source_index,

--- a/polylogue/storage/sqlite/archive_tiers/source_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/source_write.py
@@ -407,6 +407,11 @@ def write_source_raw_session(
             ),
         )
         if cursor.rowcount == 0:
+            if capture_mode is not None:
+                conn.execute(
+                    "UPDATE raw_sessions SET capture_mode = ? WHERE raw_id = ? AND capture_mode IS NULL",
+                    (_enum_value(capture_mode), resolved_raw_id),
+                )
             _assert_existing_raw_identity(
                 conn,
                 raw_id=resolved_raw_id,
@@ -519,6 +524,11 @@ def write_source_raw_session_blob_ref(
             ),
         )
         if cursor.rowcount == 0:
+            if capture_mode is not None:
+                conn.execute(
+                    "UPDATE raw_sessions SET capture_mode = ? WHERE raw_id = ? AND capture_mode IS NULL",
+                    (_enum_value(capture_mode), resolved_raw_id),
+                )
             _assert_existing_raw_identity(
                 conn,
                 raw_id=resolved_raw_id,

--- a/polylogue/storage/sqlite/async_sqlite_raw.py
+++ b/polylogue/storage/sqlite/async_sqlite_raw.py
@@ -101,9 +101,10 @@ class SQLiteRawMixin:
             origin = origin_from_provider(record.payload_provider)
         else:
             origin = origin_from_provider(Provider.from_string(record.source_name or "unknown"))
-        capture_mode = (
-            record.capture_mode or record.payload_provider or Provider.from_string(record.source_name or "unknown")
-        )
+        # ``payload_provider`` may be the canonical compatibility projection
+        # for a historical NULL capture mode.  Preserve that NULL unless an
+        # acquisition path explicitly supplied capture provenance.
+        capture_mode = record.capture_mode
         blob_hash_hex = record.blob_hash or record.raw_id
         try:
             blob_hash = bytes.fromhex(blob_hash_hex)
@@ -133,7 +134,7 @@ class SQLiteRawMixin:
                 (
                     record.raw_id,
                     origin.value,
-                    capture_mode.value,
+                    capture_mode.value if capture_mode is not None else None,
                     None,
                     record.source_path,
                     int(record.source_index or 0),

--- a/polylogue/storage/sqlite/async_sqlite_raw.py
+++ b/polylogue/storage/sqlite/async_sqlite_raw.py
@@ -116,8 +116,11 @@ class SQLiteRawMixin:
         async with aiosqlite.connect(self._source_db_path) as conn:
             conn.row_factory = aiosqlite.Row
             await conn.execute("PRAGMA foreign_keys = ON")
-            cursor = await conn.execute("SELECT 1 FROM raw_sessions WHERE raw_id = ?", (record.raw_id,))
-            existed = await cursor.fetchone() is not None
+            cursor = await conn.execute("SELECT capture_mode FROM raw_sessions WHERE raw_id = ?", (record.raw_id,))
+            existing = await cursor.fetchone()
+            existed = existing is not None
+            if existing is not None and existing["capture_mode"] is not None:
+                capture_mode = Provider.from_string(str(existing["capture_mode"]))
             await conn.execute(
                 """
                 INSERT OR REPLACE INTO raw_sessions (

--- a/polylogue/storage/sqlite/async_sqlite_raw.py
+++ b/polylogue/storage/sqlite/async_sqlite_raw.py
@@ -101,6 +101,9 @@ class SQLiteRawMixin:
             origin = origin_from_provider(record.payload_provider)
         else:
             origin = origin_from_provider(Provider.from_string(record.source_name or "unknown"))
+        capture_mode = (
+            record.capture_mode or record.payload_provider or Provider.from_string(record.source_name or "unknown")
+        )
         blob_hash_hex = record.blob_hash or record.raw_id
         try:
             blob_hash = bytes.fromhex(blob_hash_hex)
@@ -118,15 +121,16 @@ class SQLiteRawMixin:
             await conn.execute(
                 """
                 INSERT OR REPLACE INTO raw_sessions (
-                    raw_id, origin, native_id, source_path, source_index, blob_hash,
+                    raw_id, origin, capture_mode, native_id, source_path, source_index, blob_hash,
                     blob_size, acquired_at_ms, file_mtime_ms, parsed_at_ms, parse_error,
                     validated_at_ms, validation_status, validation_error, validation_drift_count,
                     validation_mode, detection_warnings_json
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     record.raw_id,
                     origin.value,
+                    capture_mode.value,
                     None,
                     record.source_path,
                     int(record.source_index or 0),

--- a/polylogue/storage/sqlite/migrations/source/008_raw_session_capture_mode.sql
+++ b/polylogue/storage/sqlite/migrations/source/008_raw_session_capture_mode.sql
@@ -1,0 +1,4 @@
+ALTER TABLE raw_sessions ADD COLUMN capture_mode TEXT CHECK(capture_mode IN (
+    'chatgpt', 'claude-ai', 'claude-code', 'codex', 'gemini', 'gemini-cli',
+    'hermes', 'antigravity', 'grok', 'drive', 'unknown'
+));

--- a/polylogue/storage/sqlite/queries/mappers_archive.py
+++ b/polylogue/storage/sqlite/queries/mappers_archive.py
@@ -14,6 +14,7 @@ from polylogue.core.enums import (
     BlockType,
     MaterialOrigin,
     Origin,
+    Provider,
     SemanticBlockType,
     SessionKind,
     ValidationMode,
@@ -128,7 +129,11 @@ def _row_to_raw_session(row: sqlite3.Row) -> RawSessionRecord:
     # raw_sessions carries a single ``origin`` column (#1743). The in-memory
     # record still exposes provider-wire ``source_name``/``payload_provider``;
     # both project from the stored origin.
-    provider = provider_from_origin(Origin.from_string(row["origin"]))
+    capture_mode = _row_text(row, "capture_mode")
+    provider = provider_from_origin(
+        Origin.from_string(row["origin"]),
+        family_hint=capture_mode,
+    )
     logical_source_key = _row_text(row, "logical_source_key")
     source_revision = _row_text(row, "source_revision")
     generation = _row_int(row, "acquisition_generation")
@@ -150,6 +155,7 @@ def _row_to_raw_session(row: sqlite3.Row) -> RawSessionRecord:
         raw_id=row["raw_id"],
         blob_hash=blob_hash,
         payload_provider=provider,
+        capture_mode=Provider.from_string(capture_mode) if capture_mode is not None else None,
         source_name=provider.value,
         source_path=row["source_path"],
         source_index=row["source_index"],

--- a/polylogue/storage/sqlite/queries/raw_reads.py
+++ b/polylogue/storage/sqlite/queries/raw_reads.py
@@ -215,6 +215,7 @@ async def get_raw_session_states(conn: aiosqlite.Connection, raw_ids: list[str])
         SELECT
             raw_id,
             origin,
+            capture_mode,
             source_path,
             parsed_at_ms,
             parse_error,
@@ -227,7 +228,7 @@ async def get_raw_session_states(conn: aiosqlite.Connection, raw_ids: list[str])
     rows = await cursor.fetchall()
 
     def _state(row: aiosqlite.Row) -> RawSessionState:
-        provider = provider_from_origin(Origin.from_string(row["origin"]))
+        provider = provider_from_origin(Origin.from_string(row["origin"]), family_hint=row["capture_mode"])
         return RawSessionState(
             raw_id=row["raw_id"],
             source_name=provider.value,

--- a/polylogue/storage/sqlite/queries/raw_writes.py
+++ b/polylogue/storage/sqlite/queries/raw_writes.py
@@ -79,6 +79,11 @@ async def save_raw_session(
     )
     inserted = bool(cursor.rowcount > 0)
 
+    if not inserted:
+        await conn.execute(
+            "UPDATE raw_sessions SET capture_mode = ? WHERE raw_id = ? AND capture_mode IS NULL",
+            (capture_mode.value, record.raw_id),
+        )
     if not inserted and record.file_mtime is not None:
         file_mtime_ms = _timestamp_ms(record.file_mtime)
         await conn.execute(

--- a/polylogue/storage/sqlite/queries/raw_writes.py
+++ b/polylogue/storage/sqlite/queries/raw_writes.py
@@ -23,9 +23,11 @@ async def save_raw_session(
         origin = origin_from_provider(record.payload_provider)
     else:
         origin = origin_from_provider(Provider.from_string(record.source_name or "unknown"))
-    capture_mode = (
-        record.capture_mode or record.payload_provider or Provider.from_string(record.source_name or "unknown")
-    )
+    # Only the acquisition path can assert a capture mode.  A hydrated legacy
+    # row has ``None`` here even though its compatibility projection supplies
+    # a canonical payload provider; writing that projection back must not turn
+    # historical unknown provenance into a guess.
+    capture_mode = record.capture_mode
     blob_hash_hex = record.blob_hash or record.raw_id
     try:
         blob_hash = bytes.fromhex(blob_hash_hex)
@@ -49,7 +51,7 @@ async def save_raw_session(
         (
             record.raw_id,
             origin.value,
-            capture_mode.value,
+            capture_mode.value if capture_mode is not None else None,
             None,
             record.source_path,
             int(record.source_index or 0),
@@ -79,7 +81,7 @@ async def save_raw_session(
     )
     inserted = bool(cursor.rowcount > 0)
 
-    if not inserted:
+    if not inserted and capture_mode is not None:
         await conn.execute(
             "UPDATE raw_sessions SET capture_mode = ? WHERE raw_id = ? AND capture_mode IS NULL",
             (capture_mode.value, record.raw_id),

--- a/polylogue/storage/sqlite/queries/raw_writes.py
+++ b/polylogue/storage/sqlite/queries/raw_writes.py
@@ -23,6 +23,9 @@ async def save_raw_session(
         origin = origin_from_provider(record.payload_provider)
     else:
         origin = origin_from_provider(Provider.from_string(record.source_name or "unknown"))
+    capture_mode = (
+        record.capture_mode or record.payload_provider or Provider.from_string(record.source_name or "unknown")
+    )
     blob_hash_hex = record.blob_hash or record.raw_id
     try:
         blob_hash = bytes.fromhex(blob_hash_hex)
@@ -35,17 +38,18 @@ async def save_raw_session(
     cursor = await conn.execute(
         """
         INSERT OR IGNORE INTO raw_sessions (
-            raw_id, origin, native_id, source_path, source_index, blob_hash,
+            raw_id, origin, capture_mode, native_id, source_path, source_index, blob_hash,
             blob_size, acquired_at_ms, file_mtime_ms, parsed_at_ms, parse_error,
             validated_at_ms, validation_status, validation_error, validation_drift_count,
             validation_mode, detection_warnings_json, logical_source_key, revision_kind,
             source_revision, predecessor_source_revision, predecessor_raw_id, baseline_raw_id, append_start_offset,
             append_end_offset, acquisition_generation, revision_authority
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             record.raw_id,
             origin.value,
+            capture_mode.value,
             None,
             record.source_path,
             int(record.source_index or 0),

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -3746,8 +3746,8 @@ async def test_archive_tiers_api_raw_artifacts_read_source_tier(tmp_path: Path) 
     archive = _archive(tmp_path)
     payload = b'{"session":"raw-artifact-v1"}'
     session = ParsedSession(
-        source_name=Provider.CODEX,
-        provider_session_id="api-raw-artifact-v1",
+        source_name=Provider.DRIVE,
+        provider_session_id="api-raw-artifact-drive-v1",
         messages=[
             ParsedMessage(
                 provider_message_id="m1",
@@ -3761,7 +3761,7 @@ async def test_archive_tiers_api_raw_artifacts_read_source_tier(tmp_path: Path) 
             raw_id, session_id = archive_db.write_raw_and_parsed(
                 session,
                 payload=payload,
-                source_path="/tmp/raw-artifact-v1.jsonl",
+                source_path="/tmp/raw-artifact-drive-v1.json",
                 acquired_at_ms=1_770_000_000_000,
             )
 
@@ -3769,17 +3769,13 @@ async def test_archive_tiers_api_raw_artifacts_read_source_tier(tmp_path: Path) 
         missing_artifacts, missing_total = await archive.get_raw_artifacts_for_session("missing-session")
 
         assert total == 1
-        assert artifacts == [
-            {
-                "raw_id": raw_id,
-                "source_name": Provider.CODEX.value,
-                "source_path": "/tmp/raw-artifact-v1.jsonl",
-                "blob_size": len(payload),
-                "acquired_at": "2026-02-02T02:40:00Z",
-                "parsed_at": None,
-                "validation_status": None,
-            }
-        ]
+        assert len(artifacts) == 1
+        assert artifacts[0]["raw_id"] == raw_id
+        assert artifacts[0]["source_name"] == Provider.DRIVE.value
+        assert artifacts[0]["source_path"] == "/tmp/raw-artifact-drive-v1.json"
+        assert artifacts[0]["blob_size"] == len(payload)
+        assert artifacts[0]["acquired_at"] == "2026-02-02T02:40:00Z"
+        assert artifacts[0]["validation_status"] is None
         assert missing_artifacts == []
         assert missing_total == 0
     finally:

--- a/tests/unit/pipeline/test_hermes_raw_identity.py
+++ b/tests/unit/pipeline/test_hermes_raw_identity.py
@@ -109,6 +109,22 @@ def test_non_hermes_acquisition_keeps_content_addressed_raw_identity(tmp_path: P
     assert record.capture_mode is Provider.CHATGPT
 
 
+def test_drive_acquisition_retains_drive_mode_despite_gemini_payload_hint(tmp_path: Path) -> None:
+    """Configured Drive acquisition is distinct from a shape-detected GEMINI payload."""
+    record = make_raw_record(
+        RawSessionData(
+            raw_bytes=b'{"chunkedPrompt":{"chunks":[]}}',
+            source_path="/drive/live-capture.json",
+            provider_hint=Provider.GEMINI,
+        ),
+        "drive",
+        blob_root=tmp_path / "blob",
+    )
+
+    assert record.source_name == Provider.GEMINI.value
+    assert record.capture_mode is Provider.DRIVE
+
+
 async def test_identical_hermes_profiles_persist_and_reprocess_independently(tmp_path: Path) -> None:
     first_db = tmp_path / "profile-a" / "state.db"
     second_db = tmp_path / "profile-b" / "state.db"

--- a/tests/unit/pipeline/test_hermes_raw_identity.py
+++ b/tests/unit/pipeline/test_hermes_raw_identity.py
@@ -9,6 +9,7 @@ from hashlib import sha256
 from pathlib import Path
 
 from polylogue.config import Config, Source
+from polylogue.core.enums import Provider
 from polylogue.pipeline.services.acquisition import AcquisitionService
 from polylogue.pipeline.services.acquisition_records import make_raw_record
 from polylogue.pipeline.services.parsing import ParsingService
@@ -105,6 +106,7 @@ def test_non_hermes_acquisition_keeps_content_addressed_raw_identity(tmp_path: P
 
     assert record.raw_id == sha256(payload).hexdigest()
     assert record.blob_hash is None
+    assert record.capture_mode is Provider.CHATGPT
 
 
 async def test_identical_hermes_profiles_persist_and_reprocess_independently(tmp_path: Path) -> None:

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -861,6 +861,48 @@ def test_append_plan_defers_when_tail_has_no_complete_line(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
+async def test_full_drive_capture_retains_acquisition_mode_after_gemini_detection(tmp_path: Path) -> None:
+    """A configured Drive source survives shape detection's GEMINI fallback."""
+    from polylogue.api import Polylogue
+
+    root = tmp_path / "drive"
+    root.mkdir()
+    path = root / "live-capture.json"
+    path.write_text(
+        json.dumps(
+            {
+                "id": "live-drive-capture",
+                "title": "Live Drive capture",
+                "chunkedPrompt": {
+                    "chunks": [
+                        {"id": "chunk-1", "role": "user", "text": "hello"},
+                        {"id": "chunk-2", "role": "model", "text": "hi"},
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    archive = Polylogue(archive_root=tmp_path / "archive")
+    processor = LiveBatchProcessor(
+        archive,
+        (WatchSource(name="drive", root=root, suffixes=(".json",)),),
+        cursor=CursorStore(archive.backend.db_path),
+        parser_fingerprint="test-parser",
+    )
+
+    try:
+        metrics = await processor.ingest_files([path], emit_event=False)
+        with sqlite3.connect(archive.archive_root / "source.db") as conn:
+            capture_mode = conn.execute("SELECT capture_mode FROM raw_sessions").fetchone()
+
+        assert metrics.full_file_count == 1
+        assert capture_mode == (Provider.DRIVE.value,)
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
 async def test_inbox_browser_capture_json_replacement_uses_full_ingest(tmp_path: Path) -> None:
     from polylogue.api import Polylogue
 

--- a/tests/unit/storage/test_archive_tiers_source_write.py
+++ b/tests/unit/storage/test_archive_tiers_source_write.py
@@ -111,6 +111,7 @@ def test_archive_tiers_source_writer_materializes_raw_session_with_blob_ref(tmp_
     assert isinstance(envelope, ArchiveRawSessionEnvelope)
     assert envelope.raw_id == expected_raw_id
     assert envelope.origin == Origin.CLAUDE_CODE_SESSION.value
+    assert envelope.capture_mode == Provider.CLAUDE_CODE.value
     assert envelope.native_id == "session-1"
     assert envelope.source_path == "/tmp/record.jsonl"
     assert envelope.blob_hash == computed_blob_hash

--- a/tests/unit/storage/test_archive_tiers_source_write.py
+++ b/tests/unit/storage/test_archive_tiers_source_write.py
@@ -4,7 +4,7 @@ import sqlite3
 from dataclasses import replace
 from pathlib import Path
 
-from polylogue.core.enums import ArtifactSupportStatus, Origin, ValidationStatus
+from polylogue.core.enums import ArtifactSupportStatus, Origin, Provider, ValidationStatus
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.source_write import (
     ArchiveHistorySidecar,
@@ -59,6 +59,7 @@ def test_archive_tiers_source_writer_materializes_raw_session_with_blob_ref(tmp_
     raw_id = write_source_raw_session(
         conn,
         origin=Origin.CLAUDE_CODE_SESSION,
+        capture_mode=Provider.CLAUDE_CODE,
         source_path="/tmp/record.jsonl",
         source_index=0,
         native_id="session-1",
@@ -97,6 +98,10 @@ def test_archive_tiers_source_writer_materializes_raw_session_with_blob_ref(tmp_
             observed_at_ms=1_767_000_000_120,
             session_native_id="session-1",
         ),
+    )
+
+    assert (
+        conn.execute("SELECT capture_mode FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()[0] == "claude-code"
     )
 
     assert raw_id == expected_raw_id

--- a/tests/unit/storage/test_archive_tiers_source_write.py
+++ b/tests/unit/storage/test_archive_tiers_source_write.py
@@ -24,6 +24,7 @@ from polylogue.storage.sqlite.archive_tiers.source_write import (
     read_raw_artifact,
     write_history_sidecar,
     write_source_raw_session,
+    write_source_raw_session_blob_ref,
 )
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
@@ -238,6 +239,63 @@ def test_archive_tiers_source_writer_keeps_multiple_raw_captures_for_one_native_
         (second_raw_id, "/captures/browser.json"),
         (first_raw_id, "/captures/direct.json"),
     ]
+
+
+def test_source_writers_backfill_legacy_capture_mode_on_duplicate_raw_id(tmp_path: Path) -> None:
+    """A post-migration re-acquisition enriches, but never replaces, NULL provenance."""
+    conn = _connect(tmp_path / "source.db")
+    payload = b'{"chunkedPrompt":{"chunks":[]}}'
+    raw_id = write_source_raw_session(
+        conn,
+        origin=Origin.AISTUDIO_DRIVE,
+        source_path="/captures/aistudio.json",
+        source_index=0,
+        payload=payload,
+        acquired_at_ms=1,
+    )
+    assert conn.execute("SELECT capture_mode FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()[0] is None
+
+    assert (
+        write_source_raw_session(
+            conn,
+            origin=Origin.AISTUDIO_DRIVE,
+            capture_mode=Provider.DRIVE,
+            source_path="/captures/aistudio.json",
+            source_index=0,
+            payload=payload,
+            acquired_at_ms=1,
+        )
+        == raw_id
+    )
+    assert conn.execute("SELECT capture_mode FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()[0] == "drive"
+
+    blob_hash = deterministic_blob_hash(b"blob-backed aistudio")
+    blob_raw_id = write_source_raw_session_blob_ref(
+        conn,
+        origin=Origin.AISTUDIO_DRIVE,
+        source_path="/captures/aistudio-blob.json",
+        source_index=0,
+        blob_hash=blob_hash,
+        blob_size=len(b"blob-backed aistudio"),
+        acquired_at_ms=2,
+    )
+    assert conn.execute("SELECT capture_mode FROM raw_sessions WHERE raw_id = ?", (blob_raw_id,)).fetchone()[0] is None
+    assert (
+        write_source_raw_session_blob_ref(
+            conn,
+            origin=Origin.AISTUDIO_DRIVE,
+            capture_mode=Provider.DRIVE,
+            source_path="/captures/aistudio-blob.json",
+            source_index=0,
+            blob_hash=blob_hash,
+            blob_size=len(b"blob-backed aistudio"),
+            acquired_at_ms=2,
+        )
+        == blob_raw_id
+    )
+    assert (
+        conn.execute("SELECT capture_mode FROM raw_sessions WHERE raw_id = ?", (blob_raw_id,)).fetchone()[0] == "drive"
+    )
 
 
 def test_archive_tiers_source_writer_deterministic_ids() -> None:

--- a/tests/unit/storage/test_durable_migrations.py
+++ b/tests/unit/storage/test_durable_migrations.py
@@ -402,10 +402,11 @@ def test_source_tier_v1_migrates_to_current_without_native_uniqueness(
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
         assert result.from_version == 1
         assert result.to_version == SOURCE_SCHEMA_VERSION
-        assert result.applied_versions == (2, 3, 4, 5, 6, 7)
+        assert result.applied_versions == (2, 3, 4, 5, 6, 7, 8)
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         columns = {str(row[1]) for row in conn.execute("PRAGMA table_info('raw_sessions')")}
         assert "predecessor_source_revision" in columns
+        assert "capture_mode" in columns
         assert not conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='pending_blob_refs'"
         ).fetchone()
@@ -560,7 +561,7 @@ def test_source_tier_v2_migrates_to_v3_dropping_pending_blob_refs(
 
         assert result.from_version == 2
         assert result.to_version == SOURCE_SCHEMA_VERSION
-        assert result.applied_versions == (3, 4, 5, 6, 7)
+        assert result.applied_versions == (3, 4, 5, 6, 7, 8)
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         assert not conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='pending_blob_refs'"
@@ -603,7 +604,7 @@ def test_source_tier_v3_adds_publication_reservations_with_verified_backup_recei
     conn = sqlite3.connect(db_path)
     try:
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
-        assert result.applied_versions == (4, 5, 6, 7)
+        assert result.applied_versions == (4, 5, 6, 7, 8)
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         conn.execute(
             """

--- a/tests/unit/storage/test_raw.py
+++ b/tests/unit/storage/test_raw.py
@@ -189,6 +189,22 @@ class TestRawSessionStorage:
         assert recovered.capture_mode is Provider.DRIVE
         assert recovered.payload_provider is Provider.DRIVE
 
+    async def test_raw_session_state_preserves_capture_mode(self, backend: SQLiteBackend) -> None:
+        """Planning-state reads preserve the live-Drive fiber member."""
+        record = make_raw_session(
+            raw_id="drive-planning-state",
+            source_name="gemini",
+            source_path="/tmp/live-drive.json",
+            blob_size=2,
+            acquired_at="2026-02-02T12:00:00+00:00",
+        ).model_copy(update={"capture_mode": Provider.DRIVE})
+        assert await backend.save_raw_session(record) is True
+
+        state = (await backend.get_raw_session_states([record.raw_id]))[record.raw_id]
+        assert state.source_name == Provider.DRIVE.value
+        assert state.payload_provider is Provider.DRIVE
+        assert state.validation_provider is Provider.DRIVE
+
     async def test_get_raw_session_not_found(self, backend: SQLiteBackend) -> None:
         """Retrieving non-existent raw session returns None."""
         result = await backend.get_raw_session("nonexistent")

--- a/tests/unit/storage/test_raw.py
+++ b/tests/unit/storage/test_raw.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.core.enums import Provider
 from polylogue.storage.raw.models import RawSessionStateUpdate
 from polylogue.storage.repository import SessionRepository
 from polylogue.storage.runtime import RawSessionRecord
@@ -138,6 +139,36 @@ class TestRawSessionStorage:
         assert retrieved.blob_size == original.blob_size
         assert retrieved.acquired_at == original.acquired_at
         assert retrieved.file_mtime == original.file_mtime
+
+    async def test_capture_mode_round_trips_aistudio_drive_provenance(self, backend: SQLiteBackend) -> None:
+        """A shared public origin retains its acquisition-time fiber member."""
+        gemini = make_raw_session(
+            raw_id="gemini-export",
+            source_name="gemini",
+            source_path="/tmp/export.json",
+            blob_size=2,
+            acquired_at="2026-02-02T12:00:00+00:00",
+        ).model_copy(update={"capture_mode": Provider.GEMINI})
+        drive = make_raw_session(
+            raw_id="drive-live",
+            source_name="gemini",
+            source_path="/tmp/live-drive.json",
+            blob_size=2,
+            acquired_at="2026-02-02T12:00:00+00:00",
+        ).model_copy(update={"capture_mode": Provider.DRIVE})
+
+        assert await backend.save_raw_session(gemini) is True
+        assert await backend.save_raw_session(drive) is True
+
+        recovered_gemini = await backend.get_raw_session(gemini.raw_id)
+        recovered_drive = await backend.get_raw_session(drive.raw_id)
+
+        assert recovered_gemini is not None
+        assert recovered_drive is not None
+        assert recovered_gemini.capture_mode is Provider.GEMINI
+        assert recovered_drive.capture_mode is Provider.DRIVE
+        assert recovered_gemini.payload_provider is Provider.GEMINI
+        assert recovered_drive.payload_provider is Provider.DRIVE
 
     async def test_get_raw_session_not_found(self, backend: SQLiteBackend) -> None:
         """Retrieving non-existent raw session returns None."""

--- a/tests/unit/storage/test_raw.py
+++ b/tests/unit/storage/test_raw.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import aiosqlite
 import pytest
 
 from polylogue.core.enums import Provider
@@ -21,6 +22,8 @@ from polylogue.storage.runtime import RawSessionRecord
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
+from polylogue.storage.sqlite.queries.raw_reads import get_raw_session as get_query_raw_session
+from polylogue.storage.sqlite.queries.raw_writes import save_raw_session as save_query_raw_session
 from tests.infra.storage_records import make_raw_session, make_session, save_session_to_archive
 
 # test_db and test_conn fixtures are in conftest.py
@@ -188,6 +191,58 @@ class TestRawSessionStorage:
         assert recovered is not None
         assert recovered.capture_mode is Provider.DRIVE
         assert recovered.payload_provider is Provider.DRIVE
+
+    async def test_rehydrated_unknown_capture_mode_remains_unknown(self, backend: SQLiteBackend) -> None:
+        """A legacy NULL must not become the canonical GEMINI projection on save."""
+        legacy = make_raw_session(
+            raw_id="legacy-aistudio-unknown",
+            source_name="gemini",
+            source_path="/tmp/pre-capture-mode.json",
+            blob_size=2,
+            acquired_at="2026-02-02T12:00:00+00:00",
+        )
+        assert legacy.capture_mode is None
+
+        assert await backend.save_raw_session(legacy) is True
+        rehydrated = await backend.get_raw_session(legacy.raw_id)
+
+        assert rehydrated is not None
+        assert rehydrated.capture_mode is None
+        assert rehydrated.payload_provider is Provider.GEMINI
+
+        assert await backend.save_raw_session(rehydrated) is False
+        reread = await backend.get_raw_session(legacy.raw_id)
+        assert reread is not None
+        assert reread.capture_mode is None
+
+    async def test_query_writer_preserves_rehydrated_unknown_capture_mode(self, tmp_path: Path) -> None:
+        """Repository raw writes do not promote a legacy NULL from its fallback."""
+        source_db = tmp_path / "source.db"
+        initialize_archive_database(source_db, ArchiveTier.SOURCE)
+        legacy = make_raw_session(
+            raw_id="query-legacy-aistudio-unknown",
+            source_name="gemini",
+            source_path="/tmp/pre-capture-mode.json",
+            blob_size=2,
+            acquired_at="2026-02-02T12:00:00+00:00",
+        )
+
+        async with aiosqlite.connect(source_db) as conn:
+            conn.row_factory = aiosqlite.Row
+            assert await save_query_raw_session(conn, legacy, transaction_depth=0) is True
+            rehydrated = await get_query_raw_session(conn, legacy.raw_id)
+
+            assert rehydrated is not None
+            assert rehydrated.capture_mode is None
+            assert rehydrated.payload_provider is Provider.GEMINI
+
+            assert await save_query_raw_session(conn, rehydrated, transaction_depth=0) is False
+            row = await (
+                await conn.execute("SELECT capture_mode FROM raw_sessions WHERE raw_id = ?", (legacy.raw_id,))
+            ).fetchone()
+
+        assert row is not None
+        assert row[0] is None
 
     async def test_raw_session_state_preserves_capture_mode(self, backend: SQLiteBackend) -> None:
         """Planning-state reads preserve the live-Drive fiber member."""

--- a/tests/unit/storage/test_raw.py
+++ b/tests/unit/storage/test_raw.py
@@ -170,6 +170,25 @@ class TestRawSessionStorage:
         assert recovered_gemini.payload_provider is Provider.GEMINI
         assert recovered_drive.payload_provider is Provider.DRIVE
 
+    async def test_reacquisition_keeps_first_known_capture_mode(self, backend: SQLiteBackend) -> None:
+        """Later canonical fallback cannot erase durable live-Drive provenance."""
+        drive = make_raw_session(
+            raw_id="reacquired-aistudio",
+            source_name="gemini",
+            source_path="/tmp/live-drive.json",
+            blob_size=2,
+            acquired_at="2026-02-02T12:00:00+00:00",
+        ).model_copy(update={"capture_mode": Provider.DRIVE})
+        canonical_retry = drive.model_copy(update={"capture_mode": Provider.GEMINI})
+
+        assert await backend.save_raw_session(drive) is True
+        assert await backend.save_raw_session(canonical_retry) is False
+
+        recovered = await backend.get_raw_session(drive.raw_id)
+        assert recovered is not None
+        assert recovered.capture_mode is Provider.DRIVE
+        assert recovered.payload_provider is Provider.DRIVE
+
     async def test_get_raw_session_not_found(self, backend: SQLiteBackend) -> None:
         """Retrieving non-existent raw session returns None."""
         result = await backend.get_raw_session("nonexistent")

--- a/tests/unit/storage/test_raw_revision_authority.py
+++ b/tests/unit/storage/test_raw_revision_authority.py
@@ -154,6 +154,22 @@ def test_unenveloped_raw_write_is_quarantined() -> None:
     ).fetchone() == ("unknown", "quarantined")
 
 
+def test_raw_revision_material_preserves_capture_mode(tmp_path: Path) -> None:
+    initialize_active_archive_root(tmp_path)
+    payload = b'{"chunkedPrompt":{"chunks":[]}}'
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.DRIVE,
+            payload=payload,
+            source_path="/captures/live-drive.json",
+            acquired_at_ms=1,
+        )
+        provider, observed_payload, _source_path, _kind = archive.raw_revision_material(raw_id)
+
+    assert provider is Provider.DRIVE
+    assert observed_payload == payload
+
+
 def test_revision_binding_is_idempotent_only_for_the_exact_envelope() -> None:
     conn = sqlite3.connect(":memory:")
     conn.executescript(SOURCE_DDL)


### PR DESCRIPTION
## Summary

Persist the acquisition-time provider for raw captures that share the public `aistudio-drive` origin.

## Problem

GEMINI exports and live Google Drive captures are structurally identical after parsing and both collapse to `aistudio-drive`; the existing raw tier retained only that origin, making their provider fiber irrecoverable on source-tier reads.

## Solution

- Class: additive durable `source.db` change, v7 to v8; `raw_sessions.capture_mode` is nullable so historic captures remain explicitly unknown.
- Add migration `008_raw_session_capture_mode.sql`. Acquisition constructors preserve configured capture mode separately from the shape-detected parser provider.
- Full live-batch writes thread that explicit mode into `ArchiveStore`; a configured Drive source therefore persists DRIVE even when its chunked-prompt bytes select GEMINI for parsing.
- Planning-state reads, raw revision replay, compact source envelopes, and the public raw-artifact route feed the persisted mode into the existing origin-fiber resolver, returning `Provider.DRIVE` for live Drive rather than the GEMINI canonical fallback.
- No index-tier delta: this is source-evidence provenance, read from `source.db` rather than duplicated into rebuildable index state.
- A content-identical GEMINI and DRIVE acquisition shares one content-addressed raw row; the scalar field retains the first known mode. Modeling both events is tracked in `polylogue-buns`; this PR does not claim to solve that many-to-one case.

## Verification

- `env POLYLOGUE_PYTEST_BASETEMP_ROOT=/realm/tmp/polylogue-pytest nix develop --command devtools test tests/unit/core -k 'source or origin'` — 114 passed.
- `env POLYLOGUE_PYTEST_BASETEMP_ROOT=/realm/tmp/polylogue-pytest nix develop --command devtools test tests/unit/pipeline/test_hermes_raw_identity.py tests/unit/sources/test_live_batch_support.py -k 'drive_acquisition or full_drive_capture or raw_identity'` — 4 passed.
- `env POLYLOGUE_PYTEST_BASETEMP_ROOT=/realm/tmp/polylogue-pytest nix develop --command devtools test tests/unit/storage/test_raw.py tests/unit/storage/test_raw_revision_authority.py tests/unit/api/test_facade_contracts.py -k 'capture_mode or raw_revision_material or raw_artifact'` — 8 passed.
- Pre-push `devtools verify --quick` completed before pushing `2ce500267`.

Anti-vacuity: the regressions exercise the real acquisition-record constructor, full live-batch → `ArchiveStore` source write, both SQLite source-tier writers, and source-tier readers. Removing configured-mode threading causes the Drive fixture to persist GEMINI; reintroducing fallback inference in either writer, or ignoring persisted capture mode, changes the real retrieved provider or turns a historical NULL into GEMINI and fails the tests.

## Acceptance criteria

- Durable nullable field and verified source-tier migration: satisfied.
- Future unambiguous GEMINI/DRIVE raw captures retain and recover their acquisition provider across production source-tier routes: satisfied.
- Historic captures are not backfilled by guesswork: satisfied for `capture_mode`; legacy provider compatibility projections retain their existing canonical fallback.
- Multiple acquisition modes for a byte-identical raw identity: deferred to `polylogue-buns`.

## Adversarial review notes

- Iteration 1: found and fixed legacy-NULL duplicate backfill, blob-backed writer propagation, async first-known preservation, and three missed source-tier reader routes (`1338306be`, `d259fbdc8`, `12a965b7c`). Identified the content-identical multi-acquisition limitation and filed `polylogue-buns`.
- Iteration 2: fixed a real NULL-to-GEMINI round-trip corruption in both raw writers; acquisition paths now mark explicit provenance and the compact source envelope exposes it (`2176e3ec0`). Updated the stale storage-boundary documentation.
- Iteration 3: corrected the live Drive acquisition path, which had stamped the shape-detected GEMINI parser provider instead of configured DRIVE capture provenance (`2ce500267`).

Ref polylogue-2ilz