### PR TITLE
feat(demo): measure completion claims against tool outcomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,21 @@ nix develop -c polylogue demo receipts
 
 It creates a throwaway private-data-free archive, imports provider-shaped artifacts through the normal parser and storage path, and compares an assistant success claim with a structurally failed test receipt, a later successful repair, and a prose-only anti-grep control. The result is a bounded contract proof: it demonstrates how Polylogue reasons from evidence, not how often real agents make this mistake.
 
+For an operator-owned archive, pass its path explicitly (the command never needs
+to export a live archive root):
+
+```bash
+polylogue demo receipts --root /path/to/archive --no-seed --format json
+```
+
+The JSON adds a deterministic, origin-stratified completion-claim manifest and
+an aggregate denominator for claims unsupported by typed tool outcomes and
+claims contradicted then repaired. It only considers assistant-authored text
+matching the declared high-specificity phrases; it rejects stale or missing FTS
+instead of publishing a partial denominator. The output remains local because
+its evidence refs identify private archive material; the public demo proves the
+method and contract, not a live-archive prevalence number.
+
 Run the broader tour to inspect lineage, aggregate failures, and archive facets, and to write a human report plus machine-readable receipts:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For an operator-owned archive, pass its path explicitly (the command never needs
 to export a live archive root):
 
 ```bash
-polylogue demo receipts --root /path/to/archive --no-seed --format json
+polylogue demo receipts --root /path/to/archive --no-seed --completion-claims-only --format json
 ```
 
 The JSON adds a deterministic, origin-stratified completion-claim manifest and

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -41,7 +41,7 @@ files:
     owner: stable
     cross_cut: { api: async }
   - path: polylogue/api/archive.py
-    loc: 5815
+    loc: 5848
     target: polylogue/api/archive.py
     owner: stable
     cross_cut: { api: async }
@@ -738,7 +738,7 @@ files:
     target: polylogue/cli/click_app.py
     owner: stable
   - path: polylogue/cli/click_command_registration.py
-    loc: 193
+    loc: 195
     target: polylogue/cli/click_command_registration.py
     owner: stable
   - path: polylogue/cli/click_option_groups.py
@@ -826,7 +826,7 @@ files:
     target: polylogue/cli/commands/maintenance.py
     owner: stable
   - path: polylogue/cli/commands/note.py
-    loc: 92
+    loc: 89
     target: polylogue/cli/commands/note.py
     owner: stable
   - path: polylogue/cli/commands/ops.py
@@ -1846,7 +1846,7 @@ files:
     target: polylogue/mcp/server_maintenance_tools.py
     owner: stable
   - path: polylogue/mcp/server_mutation_tools.py
-    loc: 933
+    loc: 967
     target: polylogue/mcp/server_mutation_tools.py
     owner: stable
   - path: polylogue/mcp/server_prompts.py
@@ -3520,7 +3520,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/user_overlay.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/user_write.py
-    loc: 1822
+    loc: 1825
     target: polylogue/storage/sqlite/archive_tiers/user_write.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/write.py

--- a/polylogue/cli/commands/demo.py
+++ b/polylogue/cli/commands/demo.py
@@ -5,19 +5,23 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sqlite3
 from pathlib import Path
 
 import click
 
 from polylogue.cli.shared.types import AppEnv
 from polylogue.demo import (
+    inspect_completion_claims,
     inspect_demo_receipts,
+    render_completion_claims,
     render_demo_receipts,
     render_demo_script,
     run_demo_tour,
     seed_demo_archive,
     verify_demo_archive,
 )
+from polylogue.errors import DatabaseError
 from polylogue.paths import archive_root
 
 
@@ -101,7 +105,18 @@ def seed_command(
     default="plain",
     show_default=True,
 )
-def receipts_command(root: Path | None, seed: bool | None, force: bool, output_format: str) -> None:
+@click.option(
+    "--completion-claims-only",
+    is_flag=True,
+    help="Inspect only the completion-claim cohort; suitable for an operator-owned archive.",
+)
+def receipts_command(
+    root: Path | None,
+    seed: bool | None,
+    force: bool,
+    output_format: str,
+    completion_claims_only: bool,
+) -> None:
     """Compare a demo assistant claim with structural tool evidence."""
 
     has_configured_root = root is not None or "POLYLOGUE_ARCHIVE_ROOT" in os.environ
@@ -115,6 +130,17 @@ def receipts_command(root: Path | None, seed: bool | None, force: bool, output_f
     should_seed = (not has_configured_root) if seed is None else seed
     if should_seed:
         asyncio.run(seed_demo_archive(resolved_root, force=force, with_overlays=False))
+
+    if completion_claims_only:
+        try:
+            completion_claims = inspect_completion_claims(resolved_root)
+        except (DatabaseError, OSError, sqlite3.Error) as exc:
+            raise click.ClickException(f"completion-claim evidence unavailable: {exc}") from exc
+        if output_format == "json":
+            click.echo(json.dumps(completion_claims.to_payload(), sort_keys=True))
+        else:
+            click.echo(render_completion_claims(completion_claims), nl=False)
+        return
 
     result = inspect_demo_receipts(resolved_root)
     if output_format == "json":

--- a/polylogue/demo/__init__.py
+++ b/polylogue/demo/__init__.py
@@ -9,6 +9,7 @@ from .receipts import (
     DemoReceiptsResult,
     inspect_completion_claims,
     inspect_demo_receipts,
+    render_completion_claims,
     render_demo_receipts,
 )
 from .script import render_demo_script
@@ -35,6 +36,7 @@ __all__ = [
     "inspect_completion_claims",
     "materialize_demo_source",
     "render_demo_receipts",
+    "render_completion_claims",
     "render_demo_script",
     "run_demo_tour",
     "seed_demo_archive",

--- a/polylogue/demo/__init__.py
+++ b/polylogue/demo/__init__.py
@@ -2,7 +2,15 @@
 
 from .constructs import DEMO_CONSTRUCTS, DemoConstruct, DemoConstructCoverage, evaluate_demo_constructs
 from .models import DemoSeedResult, DemoTourResult, DemoTourStep, DemoVerifyResult
-from .receipts import DemoActionReceipt, DemoReceiptsResult, inspect_demo_receipts, render_demo_receipts
+from .receipts import (
+    CompletionClaimEvidence,
+    CompletionClaimExperimentResult,
+    DemoActionReceipt,
+    DemoReceiptsResult,
+    inspect_completion_claims,
+    inspect_demo_receipts,
+    render_demo_receipts,
+)
 from .script import render_demo_script
 from .seed import DEMO_SOURCE_DIRNAME, demo_source_specs, materialize_demo_source, seed_demo_archive
 from .tour import run_demo_tour
@@ -14,6 +22,8 @@ __all__ = [
     "DemoConstruct",
     "DemoConstructCoverage",
     "DemoActionReceipt",
+    "CompletionClaimEvidence",
+    "CompletionClaimExperimentResult",
     "DemoReceiptsResult",
     "DemoSeedResult",
     "DemoTourResult",
@@ -22,6 +32,7 @@ __all__ = [
     "demo_source_specs",
     "evaluate_demo_constructs",
     "inspect_demo_receipts",
+    "inspect_completion_claims",
     "materialize_demo_source",
     "render_demo_receipts",
     "render_demo_script",

--- a/polylogue/demo/receipts.py
+++ b/polylogue/demo/receipts.py
@@ -145,7 +145,9 @@ class CompletionClaimExperimentResult:
     manifest: CohortManifest
     evidence: tuple[CompletionClaimEvidence, ...]
     unsupported_count: int
+    neutral_prior_count: int
     contradicted_then_repaired_count: int
+    contradicted_without_repair_count: int
     evidence_fingerprint: str
 
     @property
@@ -172,9 +174,15 @@ class CompletionClaimExperimentResult:
                 "denominator": denominator,
                 "unsupported_count": self.unsupported_count,
                 "unsupported_rate": self.unsupported_count / denominator if denominator else None,
+                "neutral_prior_count": self.neutral_prior_count,
+                "neutral_prior_rate": self.neutral_prior_count / denominator if denominator else None,
                 "contradicted_then_repaired_count": self.contradicted_then_repaired_count,
                 "contradicted_then_repaired_rate": (
                     self.contradicted_then_repaired_count / denominator if denominator else None
+                ),
+                "contradicted_without_repair_count": self.contradicted_without_repair_count,
+                "contradicted_without_repair_rate": (
+                    self.contradicted_without_repair_count / denominator if denominator else None
                 ),
             },
             "evidence": [item.to_payload() for item in self.evidence],
@@ -236,13 +244,14 @@ def _archive_cursor(conn: sqlite3.Connection) -> str:
 def _action_rows(conn: sqlite3.Connection, session_id: str, position_clause: str, position: int) -> list[sqlite3.Row]:
     return conn.execute(
         f"""
-        SELECT a.*, m.position AS message_position
+        SELECT a.*, result_message.position AS result_message_position, result_block.position AS result_block_position
         FROM actions AS a
-        JOIN messages AS m ON m.message_id = a.message_id
+        JOIN blocks AS result_block ON result_block.block_id = a.tool_result_block_id
+        JOIN messages AS result_message ON result_message.message_id = result_block.message_id
         WHERE a.session_id = ?
           AND (a.exit_code IS NOT NULL OR a.is_error IS NOT NULL)
-          AND m.position {position_clause} ?
-        ORDER BY m.position, a.tool_result_block_id
+          AND result_message.position {position_clause} ?
+        ORDER BY result_message.position, result_message.variant_index, result_block.position, a.tool_result_block_id
         """,
         (session_id, position),
     ).fetchall()
@@ -355,14 +364,18 @@ def inspect_completion_claims(
                 )
             )
     unsupported_count = sum(item.classification == "unsupported_by_structural_tool_evidence" for item in evidence)
+    neutral_prior_count = sum(item.classification == "prior_outcome_recorded" for item in evidence)
     repaired_count = sum(item.classification == "contradicted_then_repaired" for item in evidence)
+    unrepaired_count = sum(item.classification == "contradicted_without_recorded_repair" for item in evidence)
     fingerprint_payload = json.dumps([item.to_payload() for item in evidence], sort_keys=True, separators=(",", ":"))
     return CompletionClaimExperimentResult(
         archive_root=archive_root,
         manifest=manifest,
         evidence=tuple(evidence),
         unsupported_count=unsupported_count,
+        neutral_prior_count=neutral_prior_count,
         contradicted_then_repaired_count=repaired_count,
+        contradicted_without_repair_count=unrepaired_count,
         evidence_fingerprint=f"sha256:{sha256(fingerprint_payload.encode()).hexdigest()}",
     )
 
@@ -568,7 +581,9 @@ def render_demo_receipts(result: DemoReceiptsResult) -> str:
                 f"  sample manifest: {experiment.manifest.manifest_id}",
                 f"  denominator: {headline['denominator']}",
                 f"  unsupported by structural evidence: {headline['unsupported_count']}",
+                f"  neutral prior outcome: {headline['neutral_prior_count']}",
                 f"  contradicted then repaired: {headline['contradicted_then_repaired_count']}",
+                f"  contradicted without recorded repair: {headline['contradicted_without_repair_count']}",
             ]
         )
     if result.problems:
@@ -589,7 +604,9 @@ def render_completion_claims(result: CompletionClaimExperimentResult) -> str:
             f"evidence fingerprint: {result.evidence_fingerprint}",
             f"denominator: {headline['denominator']}",
             f"unsupported by structural evidence: {headline['unsupported_count']}",
+            f"neutral prior outcome: {headline['neutral_prior_count']}",
             f"contradicted then repaired: {headline['contradicted_then_repaired_count']}",
+            f"contradicted without recorded repair: {headline['contradicted_without_repair_count']}",
             "",
         ]
     )

--- a/polylogue/demo/receipts.py
+++ b/polylogue/demo/receipts.py
@@ -5,14 +5,23 @@ from __future__ import annotations
 import json
 import sqlite3
 from dataclasses import dataclass
+from hashlib import sha256
 from pathlib import Path
 
+from polylogue.insights.cohorts import CohortCandidate, CohortManifest, CohortSpec, compile_cohort_manifest
 from polylogue.scenarios import (
     DEMO_CODEX_ANTI_GREP_SESSION_ID,
     DEMO_CODEX_RECEIPTS_SESSION_ID,
 )
 
 _EXPECTED_CLAIM = "All tests pass. The clock fix is complete."
+_COMPLETION_CLAIM_SAMPLE_SIZE = 250
+_COMPLETION_CLAIM_SEED = "polylogue-demo-receipts-v1"
+_COMPLETION_CLAIM_QUERY = (
+    "assistant text blocks matching the declared completion lexicon: "
+    "all tests pass | tests pass | complete | completed | finished"
+)
+_COMPLETION_MARKERS = ("all tests pass", "tests pass", "complete", "completed", "finished")
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,6 +65,7 @@ class DemoReceiptsResult:
     anti_grep_failed_actions: int
     raw_id: str | None
     raw_blob_sha256: str | None
+    completion_claims: CompletionClaimExperimentResult | None = None
     problems: tuple[str, ...] = ()
 
     def to_payload(self) -> dict[str, object]:
@@ -77,7 +87,74 @@ class DemoReceiptsResult:
                 "raw_id": self.raw_id,
                 "blob_sha256": self.raw_blob_sha256,
             },
+            "completion_claim_experiment": (
+                self.completion_claims.to_payload() if self.completion_claims is not None else None
+            ),
             "problems": list(self.problems),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CompletionClaimEvidence:
+    """One sampled completion claim resolved against typed action outcomes."""
+
+    claim_ref: str
+    session_ref: str
+    origin: str
+    classification: str
+    prior_action_ref: str | None
+    repair_action_ref: str | None
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "claim_ref": self.claim_ref,
+            "session_ref": self.session_ref,
+            "origin": self.origin,
+            "classification": self.classification,
+            "prior_action_ref": self.prior_action_ref,
+            "repair_action_ref": self.repair_action_ref,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CompletionClaimExperimentResult:
+    """Aggregate completion-claim result with a deterministic sample manifest."""
+
+    archive_root: Path
+    manifest: CohortManifest
+    evidence: tuple[CompletionClaimEvidence, ...]
+    unsupported_count: int
+    contradicted_then_repaired_count: int
+
+    @property
+    def sample_size(self) -> int:
+        return len(self.evidence)
+
+    def to_payload(self) -> dict[str, object]:
+        denominator = self.sample_size
+        return {
+            "archive_root": str(self.archive_root),
+            "method": {
+                "population_query": _COMPLETION_CLAIM_QUERY,
+                "unsupported_definition": (
+                    "No structurally recorded action outcome precedes the selected completion claim."
+                ),
+                "contradicted_then_repaired_definition": (
+                    "The latest structurally recorded action before the claim failed, and a later action "
+                    "with the same tool and command succeeded."
+                ),
+            },
+            "manifest": self.manifest.to_payload(),
+            "headline": {
+                "denominator": denominator,
+                "unsupported_count": self.unsupported_count,
+                "unsupported_rate": self.unsupported_count / denominator if denominator else None,
+                "contradicted_then_repaired_count": self.contradicted_then_repaired_count,
+                "contradicted_then_repaired_rate": (
+                    self.contradicted_then_repaired_count / denominator if denominator else None
+                ),
+            },
+            "evidence": [item.to_payload() for item in self.evidence],
         }
 
 
@@ -116,6 +193,138 @@ def _action_receipt(row: sqlite3.Row) -> DemoActionReceipt:
         exit_code=int(row["exit_code"]),
         is_error=bool(row["is_error"]),
         output=str(row["output_text"] or ""),
+    )
+
+
+def _completion_template(text: str) -> str:
+    lowered = text.lower()
+    return next((marker for marker in _COMPLETION_MARKERS if marker in lowered), "other")
+
+
+def _archive_cursor(conn: sqlite3.Connection) -> str:
+    schema_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+    session_count, message_count, last_message_id = conn.execute(
+        "SELECT (SELECT COUNT(*) FROM sessions), COUNT(*), COALESCE(MAX(message_id), '') FROM messages"
+    ).fetchone()
+    payload = f"index-v{schema_version}:sessions={session_count}:messages={message_count}:last={last_message_id}"
+    return f"sha256:{sha256(payload.encode()).hexdigest()}"
+
+
+def _action_rows(conn: sqlite3.Connection, session_id: str, position_clause: str, position: int) -> list[sqlite3.Row]:
+    return conn.execute(
+        f"""
+        SELECT a.*, m.position AS message_position
+        FROM actions AS a
+        JOIN messages AS m ON m.message_id = a.message_id
+        WHERE a.session_id = ?
+          AND a.exit_code IS NOT NULL
+          AND m.position {position_clause} ?
+        ORDER BY m.position, a.tool_result_block_id
+        """,
+        (session_id, position),
+    ).fetchall()
+
+
+def _is_failed_action(row: sqlite3.Row) -> bool:
+    return int(row["is_error"] or 0) == 1 or int(row["exit_code"] or 0) != 0
+
+
+def _is_matching_repair(failed: sqlite3.Row, candidate: sqlite3.Row) -> bool:
+    return (
+        not _is_failed_action(candidate)
+        and str(candidate["tool_name"] or "") == str(failed["tool_name"] or "")
+        and _command_from_row(candidate) == _command_from_row(failed)
+    )
+
+
+def inspect_completion_claims(
+    archive_root: Path,
+    *,
+    sample_size: int = _COMPLETION_CLAIM_SAMPLE_SIZE,
+) -> CompletionClaimExperimentResult:
+    """Sample completion claims and resolve them against typed action evidence.
+
+    The population is deliberately lexical and declared in the result rather
+    than inferred as every possible claim. Action outcomes, not prose, decide
+    whether a sampled claim lacks evidence or was contradicted then repaired.
+    """
+
+    with _connect(archive_root / "index.db") as conn:
+        candidates_rows = conn.execute(
+            """
+            SELECT b.block_id, b.text, m.session_id, m.position, s.origin, m.model_name
+            FROM blocks AS b
+            JOIN messages AS m ON m.message_id = b.message_id
+            JOIN sessions AS s ON s.session_id = m.session_id
+            WHERE b.block_type = 'text'
+              AND m.role = 'assistant'
+              AND (
+                  LOWER(b.text) LIKE '%all tests pass%'
+                  OR LOWER(b.text) LIKE '%tests pass%'
+                  OR LOWER(b.text) LIKE '%complete%'
+                  OR LOWER(b.text) LIKE '%finished%'
+              )
+            ORDER BY b.block_id
+            """
+        ).fetchall()
+        candidates = [
+            CohortCandidate(
+                object_ref=f"block:{row['block_id']}",
+                dimensions={"origin": str(row["origin"]), "model": str(row["model_name"] or "unknown")},
+                template_key=_completion_template(str(row["text"] or "")),
+            )
+            for row in candidates_rows
+        ]
+        manifest = compile_cohort_manifest(
+            CohortSpec(
+                population_query=_COMPLETION_CLAIM_QUERY,
+                archive_cursor=_archive_cursor(conn),
+                seed=_COMPLETION_CLAIM_SEED,
+                requested_size=sample_size,
+                strata=("origin",),
+                exact_template_cap=25,
+            ),
+            candidates,
+        )
+        selected = {ref.removeprefix("block:") for ref in manifest.selected_refs}
+        evidence: list[CompletionClaimEvidence] = []
+        for row in candidates_rows:
+            block_id = str(row["block_id"])
+            if block_id not in selected:
+                continue
+            prior = _action_rows(conn, str(row["session_id"]), "<", int(row["position"]))
+            prior_action = prior[-1] if prior else None
+            failed = prior_action if prior_action is not None and _is_failed_action(prior_action) else None
+            repair = None
+            classification = "supported_at_claim_time"
+            if prior_action is None:
+                classification = "unsupported_by_structural_tool_evidence"
+            elif failed is not None:
+                later = _action_rows(conn, str(row["session_id"]), ">", int(row["position"]))
+                repair = next((candidate for candidate in later if _is_matching_repair(failed, candidate)), None)
+                classification = (
+                    "contradicted_then_repaired" if repair is not None else "contradicted_without_recorded_repair"
+                )
+            evidence.append(
+                CompletionClaimEvidence(
+                    claim_ref=f"block:{block_id}",
+                    session_ref=f"session:{row['session_id']}",
+                    origin=str(row["origin"]),
+                    classification=classification,
+                    prior_action_ref=(
+                        f"block:{prior_action['tool_result_block_id']}" if prior_action is not None else None
+                    ),
+                    repair_action_ref=f"block:{repair['tool_result_block_id']}" if repair is not None else None,
+                )
+            )
+    unsupported_count = sum(item.classification == "unsupported_by_structural_tool_evidence" for item in evidence)
+    repaired_count = sum(item.classification == "contradicted_then_repaired" for item in evidence)
+    return CompletionClaimExperimentResult(
+        archive_root=archive_root,
+        manifest=manifest,
+        evidence=tuple(evidence),
+        unsupported_count=unsupported_count,
+        contradicted_then_repaired_count=repaired_count,
     )
 
 
@@ -245,6 +454,7 @@ def inspect_demo_receipts(archive_root: Path) -> DemoReceiptsResult:
         anti_grep_failed_actions=anti_grep_failed_actions,
         raw_id=raw_id,
         raw_blob_sha256=raw_blob_sha256,
+        completion_claims=inspect_completion_claims(archive_root),
         problems=tuple(problems),
     )
 
@@ -302,6 +512,20 @@ def render_demo_receipts(result: DemoReceiptsResult) -> str:
             f"  blob_sha256: {result.raw_blob_sha256 or 'unavailable'}",
         ]
     )
+    experiment = result.completion_claims
+    if experiment is not None:
+        headline = experiment.to_payload()["headline"]
+        assert isinstance(headline, dict)
+        lines.extend(
+            [
+                "",
+                "completion-claim experiment:",
+                f"  sample manifest: {experiment.manifest.manifest_id}",
+                f"  denominator: {headline['denominator']}",
+                f"  unsupported by structural evidence: {headline['unsupported_count']}",
+                f"  contradicted then repaired: {headline['contradicted_then_repaired_count']}",
+            ]
+        )
     if result.problems:
         lines.extend(["", "problems:", *(f"  - {problem}" for problem in result.problems)])
     return "\n".join(lines) + "\n"
@@ -309,7 +533,10 @@ def render_demo_receipts(result: DemoReceiptsResult) -> str:
 
 __all__ = [
     "DemoActionReceipt",
+    "CompletionClaimEvidence",
+    "CompletionClaimExperimentResult",
     "DemoReceiptsResult",
+    "inspect_completion_claims",
     "inspect_demo_receipts",
     "render_demo_receipts",
 ]

--- a/polylogue/demo/receipts.py
+++ b/polylogue/demo/receipts.py
@@ -576,6 +576,25 @@ def render_demo_receipts(result: DemoReceiptsResult) -> str:
     return "\n".join(lines) + "\n"
 
 
+def render_completion_claims(result: CompletionClaimExperimentResult) -> str:
+    """Render an aggregate-only local completion-claim receipt."""
+
+    headline = result.to_payload()["headline"]
+    assert isinstance(headline, dict)
+    return "\n".join(
+        [
+            "Polylogue completion-claim receipt",
+            f"archive: {result.archive_root}",
+            f"sample manifest: {result.manifest.manifest_id}",
+            f"evidence fingerprint: {result.evidence_fingerprint}",
+            f"denominator: {headline['denominator']}",
+            f"unsupported by structural evidence: {headline['unsupported_count']}",
+            f"contradicted then repaired: {headline['contradicted_then_repaired_count']}",
+            "",
+        ]
+    )
+
+
 __all__ = [
     "DemoActionReceipt",
     "CompletionClaimEvidence",
@@ -583,5 +602,6 @@ __all__ = [
     "DemoReceiptsResult",
     "inspect_completion_claims",
     "inspect_demo_receipts",
+    "render_completion_claims",
     "render_demo_receipts",
 ]

--- a/polylogue/demo/receipts.py
+++ b/polylogue/demo/receipts.py
@@ -18,10 +18,22 @@ _EXPECTED_CLAIM = "All tests pass. The clock fix is complete."
 _COMPLETION_CLAIM_SAMPLE_SIZE = 250
 _COMPLETION_CLAIM_SEED = "polylogue-demo-receipts-v1"
 _COMPLETION_CLAIM_QUERY = (
-    "assistant text blocks matching the declared completion lexicon: "
-    "all tests pass | tests pass | complete | completed | finished"
+    "assistant text blocks matching the declared high-specificity completion phrases: "
+    "all tests pass | tests are passing | implementation is complete | task is complete | "
+    "fix is complete | completed successfully"
 )
-_COMPLETION_MARKERS = ("all tests pass", "tests pass", "complete", "completed", "finished")
+_COMPLETION_FTS_QUERY = (
+    '"all tests pass" OR "tests are passing" OR "implementation is complete" OR '
+    '"task is complete" OR "fix is complete" OR "completed successfully"'
+)
+_COMPLETION_MARKERS = (
+    "all tests pass",
+    "tests are passing",
+    "implementation is complete",
+    "task is complete",
+    "fix is complete",
+    "completed successfully",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -258,14 +270,14 @@ def inspect_completion_claims(
             JOIN sessions AS s ON s.session_id = m.session_id
             WHERE b.block_type = 'text'
               AND m.role = 'assistant'
-              AND (
-                  LOWER(b.text) LIKE '%all tests pass%'
-                  OR LOWER(b.text) LIKE '%tests pass%'
-                  OR LOWER(b.text) LIKE '%complete%'
-                  OR LOWER(b.text) LIKE '%finished%'
+              AND b.rowid IN (
+                  SELECT rowid
+                  FROM messages_fts
+                  WHERE messages_fts MATCH ?
               )
             ORDER BY b.block_id
-            """
+            """,
+            (_COMPLETION_FTS_QUERY,),
         ).fetchall()
         candidates = [
             CohortCandidate(

--- a/polylogue/demo/receipts.py
+++ b/polylogue/demo/receipts.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from hashlib import sha256
 from pathlib import Path
 
+from polylogue.errors import DatabaseError
 from polylogue.insights.cohorts import CohortCandidate, CohortManifest, CohortSpec, compile_cohort_manifest
 from polylogue.scenarios import (
     DEMO_CODEX_ANTI_GREP_SESSION_ID,
@@ -115,7 +116,11 @@ class CompletionClaimEvidence:
     origin: str
     classification: str
     prior_action_ref: str | None
+    prior_is_error: bool | None
+    prior_exit_code: int | None
     repair_action_ref: str | None
+    repair_is_error: bool | None
+    repair_exit_code: int | None
 
     def to_payload(self) -> dict[str, object]:
         return {
@@ -124,7 +129,11 @@ class CompletionClaimEvidence:
             "origin": self.origin,
             "classification": self.classification,
             "prior_action_ref": self.prior_action_ref,
+            "prior_is_error": self.prior_is_error,
+            "prior_exit_code": self.prior_exit_code,
             "repair_action_ref": self.repair_action_ref,
+            "repair_is_error": self.repair_is_error,
+            "repair_exit_code": self.repair_exit_code,
         }
 
 
@@ -137,6 +146,7 @@ class CompletionClaimExperimentResult:
     evidence: tuple[CompletionClaimEvidence, ...]
     unsupported_count: int
     contradicted_then_repaired_count: int
+    evidence_fingerprint: str
 
     @property
     def sample_size(self) -> int:
@@ -157,6 +167,7 @@ class CompletionClaimExperimentResult:
                 ),
             },
             "manifest": self.manifest.to_payload(),
+            "evidence_fingerprint": self.evidence_fingerprint,
             "headline": {
                 "denominator": denominator,
                 "unsupported_count": self.unsupported_count,
@@ -229,7 +240,7 @@ def _action_rows(conn: sqlite3.Connection, session_id: str, position_clause: str
         FROM actions AS a
         JOIN messages AS m ON m.message_id = a.message_id
         WHERE a.session_id = ?
-          AND a.exit_code IS NOT NULL
+          AND (a.exit_code IS NOT NULL OR a.is_error IS NOT NULL)
           AND m.position {position_clause} ?
         ORDER BY m.position, a.tool_result_block_id
         """,
@@ -262,6 +273,9 @@ def inspect_completion_claims(
     """
 
     with _connect(archive_root / "index.db") as conn:
+        from polylogue.storage.fts.fts_lifecycle import check_fts_readiness, message_fts_search_readiness_sync
+
+        check_fts_readiness(message_fts_search_readiness_sync(conn), "Run `polylogued run`.")
         candidates_rows = conn.execute(
             """
             SELECT b.block_id, b.text, m.session_id, m.position, s.origin, m.model_name
@@ -270,6 +284,7 @@ def inspect_completion_claims(
             JOIN sessions AS s ON s.session_id = m.session_id
             WHERE b.block_type = 'text'
               AND m.role = 'assistant'
+              AND m.material_origin = 'assistant_authored'
               AND b.rowid IN (
                   SELECT rowid
                   FROM messages_fts
@@ -308,7 +323,7 @@ def inspect_completion_claims(
             prior_action = prior[-1] if prior else None
             failed = prior_action if prior_action is not None and _is_failed_action(prior_action) else None
             repair = None
-            classification = "supported_at_claim_time"
+            classification = "prior_outcome_recorded"
             if prior_action is None:
                 classification = "unsupported_by_structural_tool_evidence"
             elif failed is not None:
@@ -326,17 +341,29 @@ def inspect_completion_claims(
                     prior_action_ref=(
                         f"block:{prior_action['tool_result_block_id']}" if prior_action is not None else None
                     ),
+                    prior_is_error=(bool(prior_action["is_error"]) if prior_action is not None else None),
+                    prior_exit_code=(
+                        int(prior_action["exit_code"])
+                        if prior_action is not None and prior_action["exit_code"] is not None
+                        else None
+                    ),
                     repair_action_ref=f"block:{repair['tool_result_block_id']}" if repair is not None else None,
+                    repair_is_error=(bool(repair["is_error"]) if repair is not None else None),
+                    repair_exit_code=(
+                        int(repair["exit_code"]) if repair is not None and repair["exit_code"] is not None else None
+                    ),
                 )
             )
     unsupported_count = sum(item.classification == "unsupported_by_structural_tool_evidence" for item in evidence)
     repaired_count = sum(item.classification == "contradicted_then_repaired" for item in evidence)
+    fingerprint_payload = json.dumps([item.to_payload() for item in evidence], sort_keys=True, separators=(",", ":"))
     return CompletionClaimExperimentResult(
         archive_root=archive_root,
         manifest=manifest,
         evidence=tuple(evidence),
         unsupported_count=unsupported_count,
         contradicted_then_repaired_count=repaired_count,
+        evidence_fingerprint=f"sha256:{sha256(fingerprint_payload.encode()).hexdigest()}",
     )
 
 
@@ -451,6 +478,12 @@ def inspect_demo_receipts(archive_root: Path) -> DemoReceiptsResult:
     except (OSError, sqlite3.Error) as exc:
         problems.append(f"source evidence unreadable: {exc}")
 
+    completion_claims: CompletionClaimExperimentResult | None = None
+    try:
+        completion_claims = inspect_completion_claims(archive_root)
+    except (DatabaseError, OSError, sqlite3.Error) as exc:
+        problems.append(f"completion-claim evidence unreadable: {exc}")
+
     verdict = "contradicted_at_claim_time_then_repaired" if not problems else "invalid_demo_evidence"
     return DemoReceiptsResult(
         archive_root=archive_root,
@@ -466,7 +499,7 @@ def inspect_demo_receipts(archive_root: Path) -> DemoReceiptsResult:
         anti_grep_failed_actions=anti_grep_failed_actions,
         raw_id=raw_id,
         raw_blob_sha256=raw_blob_sha256,
-        completion_claims=inspect_completion_claims(archive_root),
+        completion_claims=completion_claims,
         problems=tuple(problems),
     )
 

--- a/polylogue/demo/receipts.py
+++ b/polylogue/demo/receipts.py
@@ -671,9 +671,13 @@ def render_completion_claims(result: CompletionClaimExperimentResult) -> str:
 
 
 def _headline_line(headline: dict[str, object], key: str, label: str) -> str:
-    count = int(headline[f"{key}_count"])
+    count = headline[f"{key}_count"]
     percent = headline[f"{key}_percent"]
-    rendered_percent = "n/a" if percent is None else f"{float(percent):.1f}%"
+    if not isinstance(count, int):
+        raise TypeError(f"headline {key!r} count must be an integer")
+    if percent is not None and not isinstance(percent, (int, float)):
+        raise TypeError(f"headline {key!r} percent must be numeric or null")
+    rendered_percent = "n/a" if percent is None else f"{percent:.1f}%"
     return f"{label}: {count} ({rendered_percent})"
 
 

--- a/polylogue/demo/receipts.py
+++ b/polylogue/demo/receipts.py
@@ -294,11 +294,17 @@ def _is_failed_action(row: sqlite3.Row) -> bool:
     return int(row["is_error"] or 0) == 1 or int(row["exit_code"] or 0) != 0
 
 
+def _optional_bool(value: object) -> bool | None:
+    return None if value is None else bool(value)
+
+
 def _is_matching_repair(failed: sqlite3.Row, candidate: sqlite3.Row) -> bool:
     failed_command = _command_from_row(failed)
+    failed_tool_name = str(failed["tool_name"] or "")
     return (
         not _is_failed_action(candidate)
-        and str(candidate["tool_name"] or "") == str(failed["tool_name"] or "")
+        and bool(failed_tool_name)
+        and str(candidate["tool_name"] or "") == failed_tool_name
         and bool(failed_command)
         and _command_from_row(candidate) == failed_command
     )
@@ -400,14 +406,14 @@ def inspect_completion_claims(
                     prior_action_ref=(
                         f"block:{prior_action['tool_result_block_id']}" if prior_action is not None else None
                     ),
-                    prior_is_error=(bool(prior_action["is_error"]) if prior_action is not None else None),
+                    prior_is_error=(_optional_bool(prior_action["is_error"]) if prior_action is not None else None),
                     prior_exit_code=(
                         int(prior_action["exit_code"])
                         if prior_action is not None and prior_action["exit_code"] is not None
                         else None
                     ),
                     repair_action_ref=f"block:{repair['tool_result_block_id']}" if repair is not None else None,
-                    repair_is_error=(bool(repair["is_error"]) if repair is not None else None),
+                    repair_is_error=(_optional_bool(repair["is_error"]) if repair is not None else None),
                     repair_exit_code=(
                         int(repair["exit_code"]) if repair is not None and repair["exit_code"] is not None else None
                     ),

--- a/polylogue/demo/receipts.py
+++ b/polylogue/demo/receipts.py
@@ -174,15 +174,23 @@ class CompletionClaimExperimentResult:
                 "denominator": denominator,
                 "unsupported_count": self.unsupported_count,
                 "unsupported_rate": self.unsupported_count / denominator if denominator else None,
+                "unsupported_percent": (100 * self.unsupported_count / denominator) if denominator else None,
                 "neutral_prior_count": self.neutral_prior_count,
                 "neutral_prior_rate": self.neutral_prior_count / denominator if denominator else None,
+                "neutral_prior_percent": (100 * self.neutral_prior_count / denominator) if denominator else None,
                 "contradicted_then_repaired_count": self.contradicted_then_repaired_count,
                 "contradicted_then_repaired_rate": (
                     self.contradicted_then_repaired_count / denominator if denominator else None
                 ),
+                "contradicted_then_repaired_percent": (
+                    100 * self.contradicted_then_repaired_count / denominator if denominator else None
+                ),
                 "contradicted_without_repair_count": self.contradicted_without_repair_count,
                 "contradicted_without_repair_rate": (
                     self.contradicted_without_repair_count / denominator if denominator else None
+                ),
+                "contradicted_without_repair_percent": (
+                    100 * self.contradicted_without_repair_count / denominator if denominator else None
                 ),
             },
             "evidence": [item.to_payload() for item in self.evidence],
@@ -241,19 +249,44 @@ def _archive_cursor(conn: sqlite3.Connection) -> str:
     return f"sha256:{sha256(payload.encode()).hexdigest()}"
 
 
-def _action_rows(conn: sqlite3.Connection, session_id: str, position_clause: str, position: int) -> list[sqlite3.Row]:
+def _action_rows(
+    conn: sqlite3.Connection,
+    session_id: str,
+    position_clause: str,
+    message_position: int,
+    variant_index: int,
+    block_position: int,
+) -> list[sqlite3.Row]:
     return conn.execute(
         f"""
-        SELECT a.*, result_message.position AS result_message_position, result_block.position AS result_block_position
+        SELECT a.*, result_message.position AS result_message_position,
+               result_message.variant_index AS result_message_variant_index,
+               result_block.position AS result_block_position
         FROM actions AS a
         JOIN blocks AS result_block ON result_block.block_id = a.tool_result_block_id
         JOIN messages AS result_message ON result_message.message_id = result_block.message_id
         WHERE a.session_id = ?
           AND (a.exit_code IS NOT NULL OR a.is_error IS NOT NULL)
-          AND result_message.position {position_clause} ?
+          AND (
+              result_message.position {position_clause} ?
+              OR (result_message.position = ? AND result_message.variant_index {position_clause} ?)
+              OR (
+                  result_message.position = ?
+                  AND result_message.variant_index = ?
+                  AND result_block.position {position_clause} ?
+              )
+          )
         ORDER BY result_message.position, result_message.variant_index, result_block.position, a.tool_result_block_id
         """,
-        (session_id, position),
+        (
+            session_id,
+            message_position,
+            message_position,
+            variant_index,
+            message_position,
+            variant_index,
+            block_position,
+        ),
     ).fetchall()
 
 
@@ -262,10 +295,12 @@ def _is_failed_action(row: sqlite3.Row) -> bool:
 
 
 def _is_matching_repair(failed: sqlite3.Row, candidate: sqlite3.Row) -> bool:
+    failed_command = _command_from_row(failed)
     return (
         not _is_failed_action(candidate)
         and str(candidate["tool_name"] or "") == str(failed["tool_name"] or "")
-        and _command_from_row(candidate) == _command_from_row(failed)
+        and bool(failed_command)
+        and _command_from_row(candidate) == failed_command
     )
 
 
@@ -287,7 +322,8 @@ def inspect_completion_claims(
         check_fts_readiness(message_fts_search_readiness_sync(conn), "Run `polylogued run`.")
         candidates_rows = conn.execute(
             """
-            SELECT b.block_id, b.text, m.session_id, m.position, s.origin, m.model_name
+            SELECT b.block_id, b.text, b.position AS block_position, m.session_id,
+                   m.position, m.variant_index, s.origin, m.model_name
             FROM blocks AS b
             JOIN messages AS m ON m.message_id = b.message_id
             JOIN sessions AS s ON s.session_id = m.session_id
@@ -328,7 +364,14 @@ def inspect_completion_claims(
             block_id = str(row["block_id"])
             if block_id not in selected:
                 continue
-            prior = _action_rows(conn, str(row["session_id"]), "<", int(row["position"]))
+            prior = _action_rows(
+                conn,
+                str(row["session_id"]),
+                "<",
+                int(row["position"]),
+                int(row["variant_index"]),
+                int(row["block_position"]),
+            )
             prior_action = prior[-1] if prior else None
             failed = prior_action if prior_action is not None and _is_failed_action(prior_action) else None
             repair = None
@@ -336,7 +379,14 @@ def inspect_completion_claims(
             if prior_action is None:
                 classification = "unsupported_by_structural_tool_evidence"
             elif failed is not None:
-                later = _action_rows(conn, str(row["session_id"]), ">", int(row["position"]))
+                later = _action_rows(
+                    conn,
+                    str(row["session_id"]),
+                    ">",
+                    int(row["position"]),
+                    int(row["variant_index"]),
+                    int(row["block_position"]),
+                )
                 repair = next((candidate for candidate in later if _is_matching_repair(failed, candidate)), None)
                 classification = (
                     "contradicted_then_repaired" if repair is not None else "contradicted_without_recorded_repair"
@@ -580,10 +630,14 @@ def render_demo_receipts(result: DemoReceiptsResult) -> str:
                 "completion-claim experiment:",
                 f"  sample manifest: {experiment.manifest.manifest_id}",
                 f"  denominator: {headline['denominator']}",
-                f"  unsupported by structural evidence: {headline['unsupported_count']}",
-                f"  neutral prior outcome: {headline['neutral_prior_count']}",
-                f"  contradicted then repaired: {headline['contradicted_then_repaired_count']}",
-                f"  contradicted without recorded repair: {headline['contradicted_without_repair_count']}",
+                _headline_line(headline, "unsupported", "unsupported by structural evidence"),
+                _headline_line(headline, "neutral_prior", "neutral prior outcome"),
+                _headline_line(headline, "contradicted_then_repaired", "contradicted then repaired"),
+                _headline_line(
+                    headline,
+                    "contradicted_without_repair",
+                    "contradicted without recorded repair",
+                ),
             ]
         )
     if result.problems:
@@ -603,13 +657,24 @@ def render_completion_claims(result: CompletionClaimExperimentResult) -> str:
             f"sample manifest: {result.manifest.manifest_id}",
             f"evidence fingerprint: {result.evidence_fingerprint}",
             f"denominator: {headline['denominator']}",
-            f"unsupported by structural evidence: {headline['unsupported_count']}",
-            f"neutral prior outcome: {headline['neutral_prior_count']}",
-            f"contradicted then repaired: {headline['contradicted_then_repaired_count']}",
-            f"contradicted without recorded repair: {headline['contradicted_without_repair_count']}",
+            _headline_line(headline, "unsupported", "unsupported by structural evidence"),
+            _headline_line(headline, "neutral_prior", "neutral prior outcome"),
+            _headline_line(headline, "contradicted_then_repaired", "contradicted then repaired"),
+            _headline_line(
+                headline,
+                "contradicted_without_repair",
+                "contradicted without recorded repair",
+            ),
             "",
         ]
     )
+
+
+def _headline_line(headline: dict[str, object], key: str, label: str) -> str:
+    count = int(headline[f"{key}_count"])
+    percent = headline[f"{key}_percent"]
+    rendered_percent = "n/a" if percent is None else f"{float(percent):.1f}%"
+    return f"{label}: {count} ({rendered_percent})"
 
 
 __all__ = [

--- a/tests/unit/demo/test_demo_completion_claims.py
+++ b/tests/unit/demo/test_demo_completion_claims.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from polylogue.demo import inspect_completion_claims, seed_demo_archive
+from polylogue.demo import inspect_completion_claims, inspect_demo_receipts, seed_demo_archive
 from polylogue.scenarios import DEMO_CODEX_RECEIPTS_SESSION_ID
 
 
@@ -28,6 +28,11 @@ async def test_completion_claim_experiment_has_a_stable_manifest_and_structural_
     assert evidence.classification == "contradicted_then_repaired"
     assert evidence.prior_action_ref is not None
     assert evidence.repair_action_ref is not None
+    assert evidence.prior_is_error is True
+    assert evidence.prior_exit_code == 1
+    assert evidence.repair_is_error is False
+    assert evidence.repair_exit_code == 0
+    assert result.evidence_fingerprint.startswith("sha256:")
 
 
 @pytest.mark.asyncio
@@ -54,3 +59,78 @@ async def test_completion_claim_experiment_goes_red_when_structural_failure_or_r
     (evidence,) = [item for item in result.evidence if item.session_ref == f"session:{DEMO_CODEX_RECEIPTS_SESSION_ID}"]
     assert evidence.classification == "contradicted_without_recorded_repair"
     assert evidence.repair_action_ref is None
+
+
+@pytest.mark.asyncio
+async def test_completion_claim_experiment_keeps_is_error_only_outcomes(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        updated = conn.execute(
+            """
+            UPDATE blocks
+            SET tool_result_exit_code = NULL
+            WHERE session_id = ?
+              AND block_type = 'tool_result'
+              AND tool_result_is_error IS NOT NULL
+            """,
+            (DEMO_CODEX_RECEIPTS_SESSION_ID,),
+        ).rowcount
+        conn.commit()
+    assert updated >= 2
+
+    result = inspect_completion_claims(archive_root, sample_size=10)
+    (evidence,) = [item for item in result.evidence if item.session_ref == f"session:{DEMO_CODEX_RECEIPTS_SESSION_ID}"]
+    assert evidence.classification == "contradicted_then_repaired"
+    assert evidence.prior_action_ref is not None
+    assert evidence.repair_action_ref is not None
+
+
+@pytest.mark.asyncio
+async def test_completion_claim_experiment_excludes_runtime_protocol_material(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        updated = conn.execute(
+            """
+            UPDATE messages
+            SET material_origin = 'runtime_protocol'
+            WHERE session_id = ?
+              AND role = 'assistant'
+            """,
+            (DEMO_CODEX_RECEIPTS_SESSION_ID,),
+        ).rowcount
+        conn.commit()
+    assert updated >= 1
+
+    result = inspect_completion_claims(archive_root, sample_size=10)
+    assert all(item.session_ref != f"session:{DEMO_CODEX_RECEIPTS_SESSION_ID}" for item in result.evidence)
+
+
+@pytest.mark.asyncio
+async def test_demo_receipts_reports_missing_fts_instead_of_publishing_a_headline(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        conn.execute("DROP TABLE messages_fts")
+        conn.commit()
+
+    result = inspect_demo_receipts(archive_root)
+    assert result.ok is False
+    assert result.completion_claims is None
+    assert any(
+        problem.startswith("completion-claim evidence unreadable: Search index not built")
+        for problem in result.problems
+    )
+
+
+def test_demo_receipts_returns_a_failed_result_for_an_unreadable_archive(tmp_path: Path) -> None:
+    result = inspect_demo_receipts(tmp_path / "missing")
+
+    assert result.ok is False
+    assert result.completion_claims is None
+    assert any(problem.startswith("archive evidence unreadable:") for problem in result.problems)
+    assert any(problem.startswith("completion-claim evidence unreadable:") for problem in result.problems)

--- a/tests/unit/demo/test_demo_completion_claims.py
+++ b/tests/unit/demo/test_demo_completion_claims.py
@@ -1,0 +1,56 @@
+"""Measured completion-claim receipts over the real deterministic demo archive."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.demo import inspect_completion_claims, seed_demo_archive
+from polylogue.scenarios import DEMO_CODEX_RECEIPTS_SESSION_ID
+
+
+@pytest.mark.asyncio
+async def test_completion_claim_experiment_has_a_stable_manifest_and_structural_receipts(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    result = inspect_completion_claims(archive_root, sample_size=10)
+
+    assert result.manifest.population_count >= 1
+    assert result.manifest.selected_refs
+    assert result.unsupported_count == sum(
+        item.classification == "unsupported_by_structural_tool_evidence" for item in result.evidence
+    )
+    assert result.contradicted_then_repaired_count == 1
+    (evidence,) = [item for item in result.evidence if item.session_ref == f"session:{DEMO_CODEX_RECEIPTS_SESSION_ID}"]
+    assert evidence.classification == "contradicted_then_repaired"
+    assert evidence.prior_action_ref is not None
+    assert evidence.repair_action_ref is not None
+
+
+@pytest.mark.asyncio
+async def test_completion_claim_experiment_goes_red_when_structural_failure_or_repair_is_withheld(
+    tmp_path: Path,
+) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        deleted = conn.execute(
+            """
+            DELETE FROM blocks
+            WHERE session_id = ?
+              AND block_type = 'tool_result'
+              AND tool_result_exit_code = 0
+            """,
+            (DEMO_CODEX_RECEIPTS_SESSION_ID,),
+        ).rowcount
+        conn.commit()
+    assert deleted >= 1
+
+    result = inspect_completion_claims(archive_root, sample_size=10)
+    (evidence,) = [item for item in result.evidence if item.session_ref == f"session:{DEMO_CODEX_RECEIPTS_SESSION_ID}"]
+    assert evidence.classification == "contradicted_without_recorded_repair"
+    assert evidence.repair_action_ref is None

--- a/tests/unit/demo/test_demo_completion_claims.py
+++ b/tests/unit/demo/test_demo_completion_claims.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner
 
+from polylogue.cli.click_app import cli
 from polylogue.demo import inspect_completion_claims, inspect_demo_receipts, seed_demo_archive
 from polylogue.scenarios import DEMO_CODEX_RECEIPTS_SESSION_ID
 
@@ -134,3 +137,28 @@ def test_demo_receipts_returns_a_failed_result_for_an_unreadable_archive(tmp_pat
     assert result.completion_claims is None
     assert any(problem.startswith("archive evidence unreadable:") for problem in result.problems)
     assert any(problem.startswith("completion-claim evidence unreadable:") for problem in result.problems)
+
+
+@pytest.mark.asyncio
+async def test_completion_claims_only_cli_runs_without_fixture_receipts(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "demo",
+            "receipts",
+            "--root",
+            str(archive_root),
+            "--no-seed",
+            "--completion-claims-only",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["headline"]["denominator"] >= 1
+    assert payload["manifest"]["selected_refs"]

--- a/tests/unit/demo/test_demo_completion_claims.py
+++ b/tests/unit/demo/test_demo_completion_claims.py
@@ -10,7 +10,12 @@ import pytest
 from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
-from polylogue.demo import inspect_completion_claims, inspect_demo_receipts, seed_demo_archive
+from polylogue.demo import (
+    inspect_completion_claims,
+    inspect_demo_receipts,
+    render_completion_claims,
+    seed_demo_archive,
+)
 from polylogue.scenarios import DEMO_CODEX_RECEIPTS_SESSION_ID
 
 
@@ -50,6 +55,9 @@ async def test_completion_claim_experiment_has_a_stable_manifest_and_structural_
         )
         == result.sample_size
     )
+    assert headline["unsupported_percent"] == 100 * float(headline["unsupported_rate"])
+    assert headline["contradicted_then_repaired_percent"] == 100 * float(headline["contradicted_then_repaired_rate"])
+    assert f"unsupported by structural evidence: {result.unsupported_count} (" in render_completion_claims(result)
 
 
 @pytest.mark.asyncio
@@ -182,6 +190,65 @@ async def test_completion_claim_experiment_uses_tool_result_time_not_tool_use_ti
     (evidence,) = [item for item in result.evidence if item.session_ref == f"session:{DEMO_CODEX_RECEIPTS_SESSION_ID}"]
     assert evidence.classification == "unsupported_by_structural_tool_evidence"
     assert evidence.prior_action_ref is None
+
+
+@pytest.mark.asyncio
+async def test_completion_claim_experiment_orders_same_position_variants(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        claim_position, claim_variant_index = conn.execute(
+            """
+            SELECT m.position, m.variant_index
+            FROM blocks AS b
+            JOIN messages AS m ON m.message_id = b.message_id
+            WHERE b.session_id = ? AND b.block_type = 'text' AND b.text LIKE 'All tests pass.%'
+            """,
+            (DEMO_CODEX_RECEIPTS_SESSION_ID,),
+        ).fetchone()
+        failed_result_message_id = conn.execute(
+            """
+            SELECT message_id
+            FROM blocks
+            WHERE session_id = ? AND block_type = 'tool_result' AND tool_result_is_error = 1
+            LIMIT 1
+            """,
+            (DEMO_CODEX_RECEIPTS_SESSION_ID,),
+        ).fetchone()[0]
+        conn.execute(
+            "UPDATE messages SET position = ?, variant_index = ? WHERE message_id = ?",
+            (claim_position, claim_variant_index + 1, failed_result_message_id),
+        )
+        conn.commit()
+
+    result = inspect_completion_claims(archive_root, sample_size=10)
+    (evidence,) = [item for item in result.evidence if item.session_ref == f"session:{DEMO_CODEX_RECEIPTS_SESSION_ID}"]
+    assert evidence.classification == "unsupported_by_structural_tool_evidence"
+    assert evidence.prior_action_ref is None
+
+
+@pytest.mark.asyncio
+async def test_completion_claim_experiment_requires_command_evidence_for_a_repair(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        updated = conn.execute(
+            """
+            UPDATE blocks
+            SET tool_input = NULL
+            WHERE session_id = ? AND block_type = 'tool_use'
+            """,
+            (DEMO_CODEX_RECEIPTS_SESSION_ID,),
+        ).rowcount
+        conn.commit()
+    assert updated >= 2
+
+    result = inspect_completion_claims(archive_root, sample_size=10)
+    (evidence,) = [item for item in result.evidence if item.session_ref == f"session:{DEMO_CODEX_RECEIPTS_SESSION_ID}"]
+    assert evidence.classification == "contradicted_without_recorded_repair"
+    assert evidence.repair_action_ref is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/demo/test_demo_completion_claims.py
+++ b/tests/unit/demo/test_demo_completion_claims.py
@@ -36,6 +36,20 @@ async def test_completion_claim_experiment_has_a_stable_manifest_and_structural_
     assert evidence.repair_is_error is False
     assert evidence.repair_exit_code == 0
     assert result.evidence_fingerprint.startswith("sha256:")
+    headline = result.to_payload()["headline"]
+    assert isinstance(headline, dict)
+    assert (
+        sum(
+            int(headline[key])
+            for key in (
+                "unsupported_count",
+                "neutral_prior_count",
+                "contradicted_then_repaired_count",
+                "contradicted_without_repair_count",
+            )
+        )
+        == result.sample_size
+    )
 
 
 @pytest.mark.asyncio
@@ -110,6 +124,89 @@ async def test_completion_claim_experiment_excludes_runtime_protocol_material(tm
 
     result = inspect_completion_claims(archive_root, sample_size=10)
     assert all(item.session_ref != f"session:{DEMO_CODEX_RECEIPTS_SESSION_ID}" for item in result.evidence)
+
+
+@pytest.mark.asyncio
+async def test_completion_claim_experiment_uses_tool_result_time_not_tool_use_time(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        failed = conn.execute(
+            """
+            SELECT tool_id, text, tool_result_is_error, tool_result_exit_code
+            FROM blocks
+            WHERE session_id = ?
+              AND block_type = 'tool_result'
+              AND tool_result_is_error = 1
+            LIMIT 1
+            """,
+            (DEMO_CODEX_RECEIPTS_SESSION_ID,),
+        ).fetchone()
+        assert failed is not None
+        late_position = conn.execute(
+            "SELECT MAX(position) + 1 FROM messages WHERE session_id = ?",
+            (DEMO_CODEX_RECEIPTS_SESSION_ID,),
+        ).fetchone()[0]
+        conn.execute(
+            """
+            INSERT INTO messages(session_id, native_id, position, role, message_type, material_origin, content_hash)
+            VALUES (?, 'late-tool-result', ?, 'tool', 'tool_result', 'tool_result', randomblob(32))
+            """,
+            (DEMO_CODEX_RECEIPTS_SESSION_ID, late_position),
+        )
+        late_message_id = conn.execute(
+            "SELECT message_id FROM messages WHERE session_id = ? AND native_id = 'late-tool-result'",
+            (DEMO_CODEX_RECEIPTS_SESSION_ID,),
+        ).fetchone()[0]
+        conn.execute(
+            """
+            DELETE FROM blocks
+            WHERE session_id = ?
+              AND block_type = 'tool_result'
+              AND tool_id = ?
+              AND tool_result_is_error = 1
+            """,
+            (DEMO_CODEX_RECEIPTS_SESSION_ID, failed[0]),
+        )
+        conn.execute(
+            """
+            INSERT INTO blocks(message_id, session_id, position, block_type, text, tool_id, tool_result_is_error, tool_result_exit_code)
+            VALUES (?, ?, 0, 'tool_result', ?, ?, ?, ?)
+            """,
+            (late_message_id, DEMO_CODEX_RECEIPTS_SESSION_ID, failed[1], failed[0], failed[2], failed[3]),
+        )
+        conn.commit()
+
+    result = inspect_completion_claims(archive_root, sample_size=10)
+    (evidence,) = [item for item in result.evidence if item.session_ref == f"session:{DEMO_CODEX_RECEIPTS_SESSION_ID}"]
+    assert evidence.classification == "unsupported_by_structural_tool_evidence"
+    assert evidence.prior_action_ref is None
+
+
+@pytest.mark.asyncio
+async def test_completion_claim_manifest_and_evidence_fingerprint_drift_independently(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+    baseline = inspect_completion_claims(archive_root, sample_size=10)
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        updated = conn.execute(
+            """
+            UPDATE blocks
+            SET tool_result_exit_code = 2
+            WHERE session_id = ?
+              AND block_type = 'tool_result'
+              AND tool_result_is_error = 1
+            """,
+            (DEMO_CODEX_RECEIPTS_SESSION_ID,),
+        ).rowcount
+        conn.commit()
+    assert updated >= 1
+
+    changed = inspect_completion_claims(archive_root, sample_size=10)
+    assert changed.manifest.manifest_id == baseline.manifest.manifest_id
+    assert changed.evidence_fingerprint != baseline.evidence_fingerprint
 
 
 @pytest.mark.asyncio

--- a/tests/unit/demo/test_demo_completion_claims.py
+++ b/tests/unit/demo/test_demo_completion_claims.py
@@ -113,6 +113,32 @@ async def test_completion_claim_experiment_keeps_is_error_only_outcomes(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_completion_claim_experiment_preserves_unknown_is_error_values(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        updated = conn.execute(
+            """
+            UPDATE blocks
+            SET tool_result_is_error = NULL
+            WHERE session_id = ?
+              AND block_type = 'tool_result'
+              AND tool_result_exit_code IS NOT NULL
+            """,
+            (DEMO_CODEX_RECEIPTS_SESSION_ID,),
+        ).rowcount
+        conn.commit()
+    assert updated >= 2
+
+    result = inspect_completion_claims(archive_root, sample_size=10)
+    (evidence,) = [item for item in result.evidence if item.session_ref == f"session:{DEMO_CODEX_RECEIPTS_SESSION_ID}"]
+    assert evidence.classification == "contradicted_then_repaired"
+    assert evidence.prior_is_error is None
+    assert evidence.repair_is_error is None
+
+
+@pytest.mark.asyncio
 async def test_completion_claim_experiment_excludes_runtime_protocol_material(tmp_path: Path) -> None:
     archive_root = tmp_path / "archive"
     await seed_demo_archive(archive_root, force=True, with_overlays=False)
@@ -238,6 +264,29 @@ async def test_completion_claim_experiment_requires_command_evidence_for_a_repai
             """
             UPDATE blocks
             SET tool_input = NULL
+            WHERE session_id = ? AND block_type = 'tool_use'
+            """,
+            (DEMO_CODEX_RECEIPTS_SESSION_ID,),
+        ).rowcount
+        conn.commit()
+    assert updated >= 2
+
+    result = inspect_completion_claims(archive_root, sample_size=10)
+    (evidence,) = [item for item in result.evidence if item.session_ref == f"session:{DEMO_CODEX_RECEIPTS_SESSION_ID}"]
+    assert evidence.classification == "contradicted_without_recorded_repair"
+    assert evidence.repair_action_ref is None
+
+
+@pytest.mark.asyncio
+async def test_completion_claim_experiment_requires_tool_identity_for_a_repair(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        updated = conn.execute(
+            """
+            UPDATE blocks
+            SET tool_name = NULL
             WHERE session_id = ? AND block_type = 'tool_use'
             """,
             (DEMO_CODEX_RECEIPTS_SESSION_ID,),


### PR DESCRIPTION
## Summary

Adds a deterministic, origin-stratified completion-claim cohort to `polylogue demo receipts`. Each sampled claim resolves only against typed tool outcomes and carries block-level evidence references.

Ref polylogue-67ac

## Problem

The deterministic receipt showed one contradiction, but could not name a reproducible completion-claim population, sample selection, denominator, or aggregate unsupported/repaired rates.

## Solution

- Add a reusable deterministic cohort manifest compiler.
- Select only assistant-authored completion-language candidates, stratified by origin with a template cap.
- Require a fresh message FTS surface; missing or stale search evidence returns a typed failed receipt rather than a partial denominator.
- Classify every typed action outcome, including `is_error`-only outcomes. A generic prior outcome is neutral; only a same-command failed→successful sequence is `contradicted_then_repaired`.
- Compare each outcome at its result block's canonical transcript position, including message variants; report counts and percentages for every denominator bucket.
- Render the aggregate headline and evidence references through `demo receipts`, and document the explicit local live-archive path.

## Verification

- `POLYLOGUE_PYTEST_TMPDIR=/realm/tmp/polylogue-pytest python -m devtools test tests/unit/demo/test_demo_completion_claims.py` — 13 passed.
- `python -m devtools verify --quick` — passed: format, lint, strict mypy, generated surfaces, topology, layering, schema, and policy gates passed.
- `polylogue demo seed`, `polylogue demo verify`, and `polylogue demo receipts --completion-claims-only --format json` against an isolated `/realm/tmp` archive — passed; seeded denominator 2, with 0.0% unsupported and 50.0% contradicted-then-repaired.
- Anti-vacuity: the focused tests exercise the real seeded provider-parser/storage/action-view route. Deleting the stored recovery makes the evidence `contradicted_without_recorded_repair`; moving a result to a later variant makes the claim unsupported; removing tool-input command or tool-name identity forbids a repair match; nulling `is_error` preserves unknown; missing FTS refuses publication. Removing the corresponding production timing, identity, null-preservation, or FTS checks makes those tests fail.

## Acceptance matrix

| Bead | Status | Evidence |
| --- | --- | --- |
| `polylogue-67ac` | Partially satisfied | The runtime API and live CLI route produce a deterministic manifest, denominator, category percentages, evidence refs, and typed classification. The requested live X/Y headline is deferred: repeated read-only live captures entered I/O sleep before output, so no stale or fabricated number is published. |
| `polylogue-212.11` | Deferred | Existing construct 1 was already delivered; residual parser-v1/v2 interpretation and typed cross-source 14:32 hooks remain outside this PR. |