### PR TITLE
test(daemon): cover provider usage periodic drain

### DIFF
--- a/tests/unit/storage/test_session_insight_refresh.py
+++ b/tests/unit/storage/test_session_insight_refresh.py
@@ -9,6 +9,7 @@ import aiosqlite
 import pytest
 
 import polylogue.storage.insights.session.rebuild as rebuild_mod
+from polylogue.daemon import cli as daemon_cli
 from polylogue.storage.insights.session.aggregates import refresh_async_provider_day_aggregates
 from polylogue.storage.insights.session.rebuild import (
     _SESSION_INSIGHT_BLOCK_TEXT_PREVIEW_CHARS,
@@ -603,27 +604,23 @@ def test_session_insight_rebuild_preserves_session_provider_cost(tmp_path: Path)
     assert per_model[0]["provider_model_name"] == "claude-opus-4-5"
 
 
-def test_stale_provider_usage_self_heals_via_session_insight_rebuild(tmp_path: Path) -> None:
+def test_stale_provider_usage_self_heals_via_session_insight_rebuild(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """polylogue-f2qv.5: session_model_usage self-heals like session_profile.
 
     Before this bead, session_model_usage was written once at ingest and never
     revisited by the insight rebuild path, so a stale/buggy rollup could only
     be repaired by a full ``ops reset --index``. This seeds a session with a
     correct rollup, corrupts it to simulate an old materializer, and asserts
-    that (1) the same stale-session selector the daemon's periodic session-
-    insight drain uses (``_schema_archive_session_ids_missing_profiles``) flags
-    the session purely because its provider_usage stamp is stale/missing even
-    though its session_profile is fresh, and (2) running the targeted rebuild
-    (``_archive_insights_execute_ids``, the function the daemon drain calls)
-    re-derives session_model_usage from the still-intact messages table and
-    restamps the materialization version — with zero manual index rebuild.
+    that the daemon's periodic session-insight drain flags the session purely
+    because its provider_usage stamp is stale/missing even though its
+    session_profile is fresh, then re-derives session_model_usage from the
+    still-intact messages table and restamps the materialization version — with
+    zero manual index rebuild.
     """
-    from polylogue.daemon.convergence_stages import (
-        _archive_insights_execute_ids,
-        _schema_archive_session_ids_missing_profiles,
-    )
-
-    db_path = tmp_path / "provider-usage-self-heal.db"
+    db_path = _current_index_db(tmp_path, "provider-usage-self-heal")
+    monkeypatch.setattr("polylogue.paths.active_index_db_path", lambda: db_path)
     with open_connection(db_path) as conn:
         store_records(
             session=make_session(
@@ -680,11 +677,10 @@ def test_stale_provider_usage_self_heals_via_session_insight_rebuild(tmp_path: P
         )
         conn.commit()
 
-        stale_ids = _schema_archive_session_ids_missing_profiles(conn)
-        assert session_id in stale_ids
-
-        result = _archive_insights_execute_ids(conn, [session_id])
-        assert bool(getattr(result, "success", result))
+        # Exercise the periodic daemon entry point rather than calling its
+        # selector and executor directly. Removing provider_usage from either
+        # convergence seam makes this return zero and leaves the corrupt rollup.
+        assert daemon_cli._drain_session_insights_once() == 1
 
         after = conn.execute(
             "SELECT input_tokens, output_tokens FROM session_model_usage WHERE session_id = ?",
@@ -704,8 +700,8 @@ def test_stale_provider_usage_self_heals_via_session_insight_rebuild(tmp_path: P
         assert stamp is not None
         assert stamp["materializer_version"] == SESSION_INSIGHT_MATERIALIZER_VERSION
 
-        # Once healed, the selector no longer flags the session.
-        assert session_id not in _schema_archive_session_ids_missing_profiles(conn)
+        # Once healed, the same bounded periodic pass finds no more work.
+        assert daemon_cli._drain_session_insights_once() == 0
 
 
 def test_session_insight_load_skips_plain_text_blocks(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_session_insight_refresh.py
+++ b/tests/unit/storage/test_session_insight_refresh.py
@@ -10,6 +10,7 @@ import pytest
 
 import polylogue.storage.insights.session.rebuild as rebuild_mod
 from polylogue.daemon import cli as daemon_cli
+from polylogue.operations.archive_debt import archive_debt_list
 from polylogue.storage.insights.session.aggregates import refresh_async_provider_day_aggregates
 from polylogue.storage.insights.session.rebuild import (
     _SESSION_INSIGHT_BLOCK_TEXT_PREVIEW_CHARS,
@@ -625,7 +626,7 @@ def test_stale_provider_usage_self_heals_via_session_insight_rebuild(
         store_records(
             session=make_session(
                 "conv-provider-usage-heal",
-                source_name="claude-code",
+                source_name="codex",
                 title="Provider usage self-heal",
                 created_at="2026-05-12T09:00:00+00:00",
             ),
@@ -634,7 +635,7 @@ def test_stale_provider_usage_self_heals_via_session_insight_rebuild(
                     "conv-provider-usage-heal:msg-1",
                     "conv-provider-usage-heal",
                     text="Run the plan",
-                    model_name="claude-sonnet-4-5",
+                    model_name="gpt-5-codex",
                     input_tokens=1_000,
                     output_tokens=500,
                     cache_read_tokens=200,
@@ -644,13 +645,14 @@ def test_stale_provider_usage_self_heals_via_session_insight_rebuild(
             attachments=[],
             conn=conn,
         )
-        session_id = _sid("conv-provider-usage-heal", "claude-code-session")
+        session_id = _sid("conv-provider-usage-heal", "codex-session")
 
         # Establish a fully fresh session-insight bundle first. The later
         # daemon drain must therefore select this session solely because the
         # provider-usage stamp becomes stale, not through the unrelated
         # missing-session-profile branch.
         rebuild_session_insights_sync(conn, session_ids=[session_id])
+        assert daemon_cli._drain_session_insights_once() == 0
 
         # The real write path already materializes a correct rollup at ingest.
         before = conn.execute(
@@ -683,6 +685,9 @@ def test_stale_provider_usage_self_heals_via_session_insight_rebuild(
         )
         conn.commit()
 
+        debt_before = archive_debt_list(archive_root=db_path.parent, kinds=("provider-usage",))
+        assert {row.debt_ref for row in debt_before.rows} == {"debt:provider-usage:codex-session:zero-token-projection"}
+
         # Exercise the periodic daemon entry point rather than calling its
         # selector and executor directly. Removing provider_usage from either
         # convergence seam makes this return zero and leaves the corrupt rollup.
@@ -708,6 +713,7 @@ def test_stale_provider_usage_self_heals_via_session_insight_rebuild(
 
         # Once healed, the same bounded periodic pass finds no more work.
         assert daemon_cli._drain_session_insights_once() == 0
+        assert archive_debt_list(archive_root=db_path.parent, kinds=("provider-usage",)).rows == ()
 
 
 def test_session_insight_load_skips_plain_text_blocks(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_session_insight_refresh.py
+++ b/tests/unit/storage/test_session_insight_refresh.py
@@ -646,6 +646,12 @@ def test_stale_provider_usage_self_heals_via_session_insight_rebuild(
         )
         session_id = _sid("conv-provider-usage-heal", "claude-code-session")
 
+        # Establish a fully fresh session-insight bundle first. The later
+        # daemon drain must therefore select this session solely because the
+        # provider-usage stamp becomes stale, not through the unrelated
+        # missing-session-profile branch.
+        rebuild_session_insights_sync(conn, session_ids=[session_id])
+
         # The real write path already materializes a correct rollup at ingest.
         before = conn.execute(
             "SELECT input_tokens, output_tokens FROM session_model_usage WHERE session_id = ?",


### PR DESCRIPTION
## Summary

Strengthen the provider-usage convergence regression by running its stale-rollup fixture through the daemon’s bounded periodic session-insight drain.

## Problem

The usage-refresh mechanism was present, but its regression invoked the stale selector and executor directly. That did not prove the bounded daemon drain selected and refreshed stale provider-usage materialization.

## Solution

Update `tests/unit/storage/test_session_insight_refresh.py` to use an isolated active archive root, establish a fresh insight bundle, corrupt a Codex provider-usage rollup, invoke `_drain_session_insights_once()`, and verify the repaired rollup, materialization stamp, and operator-visible debt transition.

## Acceptance criteria

Ref polylogue-f2qv.

- Satisfied: provider-usage materialization is included in the periodic session-insight stale selector.
- Satisfied: the daemon drain refreshes an old provider-usage stamp and re-derives `session_model_usage` without a manual index rebuild.
- Satisfied in an isolated archive: the Codex provider-usage zero-token debt row appears after corruption and clears after the daemon drain. This lane did not access the operator archive.
- Satisfied: focused real-route regression passes.

## Verification

- `POLYLOGUE_PYTEST_BASETEMP_ROOT=/realm/tmp/polylogue-pytest TMPDIR=/realm/tmp devtools test tests/unit/storage/test_session_insight_refresh.py -k stale_provider_usage_self_heals_via_session_insight_rebuild` — `1 passed`.
- `TMPDIR=/realm/tmp git push` — required quick baseline passed all checks.

## Adversarial review notes

- Iteration 1: two real gaps found and fixed — missing-profile selection made the original test vacuous (`8b295bbc0`), and archive-debt AC coverage was absent (`8aaaffa55`).
- Iteration 2: no legitimate gaps found across the f2qv.5 ACs.