### PR TITLE
docs(security): reconcile privacy coverage evidence

### DIFF
--- a/docs/plans/security-privacy-coverage.yaml
+++ b/docs/plans/security-privacy-coverage.yaml
@@ -5,7 +5,7 @@
 # command validation, SSRF prevention, HTML sanitization, schema
 # privacy, and token-store security.
 #
-# Updated 2026-04-29 from realized codebase state.
+# Updated 2026-07-12 from realized codebase state.
 
 description: >
   Security and privacy verification surface for polylogue.
@@ -13,7 +13,7 @@ description: >
 
 areas:
   xss_prevention:
-    description: Cross-site scripting defense in HTML rendering
+    description: Cross-site scripting defense in rendered HTML and the daemon web shell
     implemented: true
     controls:
       - jinja2_autoescape: Jinja2 template autoescaping is active
@@ -24,12 +24,22 @@ areas:
       - regex_defense_in_depth: >
           _SCRIPT_RE tolerates whitespace and junk-attributes in
           closing tags (browser-compatible bypass defense)
+      - web_shell_context_escaping: >
+          The web shell distinguishes HTML text, HTML attributes, and
+          JavaScript strings nested in event-handler attributes. escJsAttr()
+          escapes the JavaScript string before HTML-attribute escaping, while
+          attachment and paste-library innerHTML renderers escape every
+          captured-content field at its sink.
     test_coverage:
-      location: tests/unit/security/ (indirect, via snapshot rendering)
+      location: >
+        tests/unit/rendering/test_html_sanitizer_security.py and
+        tests/unit/daemon/test_web_shell_xss_escaping.py
       hypothesis: false
     notes: >
-      Regex sanitization is defense-in-depth atop Jinja2 autoescape.
-      No dedicated XSS test file. No bleach/HTML-parser dependency.
+      The HTML sanitizer is defense-in-depth atop Jinja2 autoescape. The
+      web-shell suite executes the shipped escaping helpers through Node when
+      available and checks every known JS-string and innerHTML sink, so this is
+      dedicated regression coverage rather than snapshot-only coverage.
 
   file_permissions:
     description: File permission controls on token store and data files
@@ -44,8 +54,29 @@ areas:
       hypothesis: false
     notes: >
       Token store permissions were hardened in commit 3796914
-      (0644 -> 0600). Crawl-source file permissions not under
-      automated verification.
+      (0644 -> 0600). Polylogue has no crawl-source implementation or
+      crawl-owned file artifacts in the current source tree; a crawler must
+      add its own permission contract and coverage when introduced.
+
+  secrets_detection:
+    description: Secret-candidate detection and safe handling of captured content
+    implemented: true
+    controls:
+      - log_secret_guard: >
+          The repository-wide AST guard rejects logger/print calls that
+          interpolate known secret-bearing variable names or credential-shaped
+          literal prefixes.
+      - candidate_only_intake: >
+          Content secret scanning is not implemented yet. polylogue-27m owns
+          a candidate-only scanner that must retain span/evidence references
+          without persisting or logging the matched secret value.
+    test_coverage:
+      location: tests/unit/security/test_no_secret_leak_in_logs.py
+      hypothesis: false
+    notes: >
+      The existing test protects logging boundaries only; it is not evidence
+      that captured-content secret scanning exists. The remaining scanner gap
+      is explicitly tracked by the owning Beads task.
 
   redaction:
     description: PII/private-content redaction in schema inference
@@ -138,30 +169,12 @@ areas:
       on the repo; see the comment block in dep-audit.yml.
 
 coverage_gaps:
-   - id: security.xss-prevention
-     area: xss_prevention
-     gap: No dedicated XSS test file; relies on snapshot rendering
-     owner: security-privacy
-     severity: major
-     declared_at: "2026-05-02"
-     review_after: "2026-08-01"
-     issue: 590
-     next_evidence: pytest -q tests/unit/security
-   - id: security.file-permissions
-     area: file_permissions
-     gap: Crawl-source file permissions not verified
-     owner: security-privacy
-     severity: major
-     declared_at: "2026-05-02"
-     review_after: "2026-08-01"
-     issue: 590
-     next_evidence: pytest -q tests/unit/security
    - id: security.secrets-detection
      area: secrets_detection
-     gap: No automated secrets scanning in CI
+     gap: Captured-content secrets have no candidate-only scanner or excision handoff
      owner: security-privacy
      severity: major
-     declared_at: "2026-05-02"
-     review_after: "2026-08-01"
-     issue: 590
-     next_evidence: devtools verify --quick
+     declared_at: "2026-07-12"
+     review_after: "2026-08-12"
+     bead: polylogue-27m
+     next_evidence: devtools test tests/unit/security/test_no_secret_leak_in_logs.py

--- a/docs/plans/security-privacy-coverage.yaml
+++ b/docs/plans/security-privacy-coverage.yaml
@@ -39,8 +39,9 @@ areas:
     notes: >
       The parser-based HTML sanitizer is defense-in-depth atop Jinja2 autoescape. The
       web-shell suite executes the shipped escaping helpers through Node when
-      available and checks every known JS-string and innerHTML sink, so this is
-      dedicated regression coverage rather than snapshot-only coverage.
+      available and checks the identified JS-string and innerHTML regression
+      paths, so this is dedicated regression coverage rather than snapshot-only
+      coverage.
 
   file_permissions:
     description: File permission controls on token store and data files

--- a/docs/plans/security-privacy-coverage.yaml
+++ b/docs/plans/security-privacy-coverage.yaml
@@ -21,9 +21,10 @@ areas:
           sanitize_html() filter in polylogue/rendering/renderers/
           html_sanitizer.py strips <script> tags, event-handler
           attributes (onclick, onload, etc.), and javascript: URLs
-      - regex_defense_in_depth: >
-          _SCRIPT_RE tolerates whitespace and junk-attributes in
-          closing tags (browser-compatible bypass defense)
+      - parser_based_sanitizer: >
+          nh3's HTML5 parser and conservative allowlist strip scripts,
+          event handlers, unsafe URL schemes, and embedded active-content
+          elements without relying on regex matching.
       - web_shell_context_escaping: >
           The web shell distinguishes HTML text, HTML attributes, and
           JavaScript strings nested in event-handler attributes. escJsAttr()
@@ -36,7 +37,7 @@ areas:
         tests/unit/daemon/test_web_shell_xss_escaping.py
       hypothesis: false
     notes: >
-      The HTML sanitizer is defense-in-depth atop Jinja2 autoescape. The
+      The parser-based HTML sanitizer is defense-in-depth atop Jinja2 autoescape. The
       web-shell suite executes the shipped escaping helpers through Node when
       available and checks every known JS-string and innerHTML sink, so this is
       dedicated regression coverage rather than snapshot-only coverage.
@@ -110,13 +111,12 @@ areas:
     controls:
       - sanitize_path: >
           polylogue/core/security.py::sanitize_path() strips null
-          bytes, control characters, blocks .. traversal, symlink
-          attacks, and absolute paths. Returns _blocked_<hash>
-          for unsafe inputs.
+          bytes and control characters, blocks .. traversal and absolute
+          paths, and returns _blocked_<hash> for unsafe inputs.
       - attachment_sanitization: >
           ParsedAttachment applies sanitize_path to attachment
-          paths. Hypothesis property tests for traversal, symlink,
-          and control-char inputs.
+          paths. Hypothesis property tests cover traversal and
+          control-character inputs.
       - token_store_key_sanitization: >
           FileTokenStore._path_for_key prevents traversal via
           key name (slashes, backslashes, double-dots sanitized).
@@ -125,9 +125,10 @@ areas:
       hypothesis: true
     notes: >
       Hypothesis strategies in tests/infra/strategies/adversarial.py
-      generate path-traversal, symlink-path, and control-char
-      inputs. TestSanitizePathTraversal covers traversal, control
-      chars, absolute paths, symlink OSError handling.
+      generate adversarial path inputs. TestSanitizePathTraversal covers
+      traversal, control characters, and absolute paths. A CWD-relative
+      symlink probe was intentionally removed because it did not protect this
+      metadata-only boundary.
 
   mcp_traceback_exposure:
     description: Traceback and internal path exposure in MCP error responses
@@ -172,4 +173,4 @@ coverage_gaps:
      declared_at: "2026-07-12"
      review_after: "2026-08-12"
      bead: polylogue-27m
-     next_evidence: devtools test tests/unit/security/test_no_secret_leak_in_logs.py
+     next_evidence: devtools test -k secret_candidate

--- a/docs/plans/security-privacy-coverage.yaml
+++ b/docs/plans/security-privacy-coverage.yaml
@@ -58,25 +58,20 @@ areas:
       crawl-owned file artifacts in the current source tree; a crawler must
       add its own permission contract and coverage when introduced.
 
-  secrets_detection:
-    description: Secret-candidate detection and safe handling of captured content
+  secret_log_hygiene:
+    description: Prevent secret values from leaking through Polylogue log and print calls
     implemented: true
     controls:
       - log_secret_guard: >
           The repository-wide AST guard rejects logger/print calls that
           interpolate known secret-bearing variable names or credential-shaped
           literal prefixes.
-      - candidate_only_intake: >
-          Content secret scanning is not implemented yet. polylogue-27m owns
-          a candidate-only scanner that must retain span/evidence references
-          without persisting or logging the matched secret value.
     test_coverage:
       location: tests/unit/security/test_no_secret_leak_in_logs.py
       hypothesis: false
     notes: >
-      The existing test protects logging boundaries only; it is not evidence
-      that captured-content secret scanning exists. The remaining scanner gap
-      is explicitly tracked by the owning Beads task.
+      This log-boundary control is distinct from captured-content secret
+      detection, which remains unimplemented and is tracked as a coverage gap.
 
   redaction:
     description: PII/private-content redaction in schema inference
@@ -169,8 +164,8 @@ areas:
       on the repo; see the comment block in dep-audit.yml.
 
 coverage_gaps:
-   - id: security.secrets-detection
-     area: secrets_detection
+   - id: security.captured-content-secret-detection
+     area: captured_content_secret_detection
      gap: Captured-content secrets have no candidate-only scanner or excision handoff
      owner: security-privacy
      severity: major


### PR DESCRIPTION
## Summary

Reconcile the security/privacy coverage manifest with current, executable evidence and point the remaining captured-content secret-hygiene work at its owning Bead.

## Problem

The manifest still claimed XSS coverage was snapshot-only despite dedicated web-shell regression tests, and tracked a crawl-source permission gap although no crawl source exists. Its secrets entry conflated the existing log-leak guard with the unimplemented captured-content scanner.

## Solution

- Record the real HTML sanitizer and web-shell escaping suites, including the context-specific escaping contract.
- Retire the false crawler premise; a future crawler must add its own permission contract.
- Document the existing AST log-secret guard separately from the unimplemented candidate-only scanner, and link the remaining gap to `polylogue-27m`.

## Acceptance criteria

| Parent AC | Status | Evidence / residual |
| --- | --- | --- |
| Every security/privacy manifest gap has an owner or test | First slice satisfied | Closed XSS and non-existent crawler gaps removed; remaining scanner/excision gap is owned by `polylogue-27m`. |
| Excision shares reset mutation/audit contract | Open | `polylogue-27m` remains the owning implementation task and is blocked by `polylogue-b5l`. |
| MCP destructive/admin path shares the audit-row contract | Not assessed in this slice | No MCP-envelope files were touched. |

## Verification

- `devtools test tests/unit/devtools/test_verify_manifests.py tests/unit/security/test_no_secret_leak_in_logs.py tests/unit/rendering/test_html_sanitizer_security.py tests/unit/daemon/test_web_shell_xss_escaping.py` — 61 passed.
- `devtools verify manifests` — manifest consistency checks passed.
- Pre-push `devtools verify --quick` — passed (ruff, mypy, render, topology/layering, schema roundtrip, manifests, and verifier lanes).

Anti-vacuity: the cited tests exercise the production AST logger/print scan, real HTML sanitizer, and shipped web-shell JavaScript helpers through identified regression paths; removing or weakening those controls fails the tests.

The default affected-test gate was not claimed: this fresh worktree lacked a testmon seed, and the initial seed run was infrastructure-interrupted after its parent terminated.

Ref polylogue-kwsb