### PR TITLE
fix(search): expose Write/Edit body query path

### DIFF
--- a/docs/search.md
+++ b/docs/search.md
@@ -929,10 +929,10 @@ polylogue 'text:css {session_id claude-code}: refactor'
 
 `blocks.search_text` — the generated column FTS5 indexes — concatenates a
 **fixed subset** of block fields, not the whole block. Anything outside that
-subset is invisible to the `dialogue`/`actions`/`hybrid` lanes, `--contains`,
-`contains:`, and bare-text queries, even though the underlying data is stored
-and readable through other surfaces (`read`, `select`, direct block/action
-reads). The live definition lives in
+subset is invisible to the ranked `dialogue`/`actions`/`hybrid` lanes,
+`--contains`, `contains:`, and bare-text queries, even though the underlying
+data is stored and readable through other surfaces (`read`, `select`, direct
+block/action reads). The live definition lives in
 `polylogue/storage/sqlite/archive_tiers/index.py` (`blocks.search_text
 GENERATED ALWAYS AS (...)`); this table is drift-checked against that
 expression by
@@ -945,13 +945,24 @@ expression by
 | `tool_input.$.command` | Yes | Shell/exec command lines (`Bash`, `exec_command`-style tools). |
 | `tool_input.$.file_path` | Yes | Primary path argument for file-oriented tools. |
 | `tool_input.$.path` | Yes | Alternate path key used by some tools (`Grep`, `Glob`). |
-| `tool_input.$.content` — file bodies a **`Write`** tool call authored | **No** | The full text an agent wrote into a new/overwritten file is excluded from `search_text`. A distinctive string that only appears inside a Write body returns zero FTS hits, with no diagnostic pointing at this boundary. |
-| `tool_input.$.old_string` / `$.new_string` — **`Edit`** tool bodies | **No** | Same gap as Write: edited code is excluded unless it also happens to appear in prose, a `tool_result` echo, or one of the four indexed keys above. |
+| `tool_input.$.content` — file bodies a **`Write`** tool call authored | **No** | The full text an agent wrote into a new/overwritten file is excluded from `search_text`. A distinctive string that only appears inside a Write body returns zero FTS hits. |
+| `tool_input.$.old_string` / `tool_input.$.new_string` — **`Edit`** tool bodies | **No** | Same gap as Write: edited code is excluded unless it also happens to appear in prose, a `tool_result` echo, or one of the four indexed keys above. |
 | Any other `tool_input` key (`pattern`, `description`, `url`, ...) | **No** | Only the four `json_extract` paths above are concatenated into `search_text`; every other key is excluded regardless of tool. |
 
-**Workaround:** when you know an agent wrote or edited a specific string into
-a file body, query `tool_input` directly with a JSON-aware SQL probe against
-`index.db` instead of FTS:
+**Dedicated action-evidence lane:** when you know an agent wrote or edited a
+specific string into a file body, use the query DSL's action `text` predicate.
+It searches the action's raw `tool_input` JSON (as well as normalized action
+fields and output), so it covers `Write`'s `content` and `Edit`'s
+`old_string`/`new_string` without putting those bodies in FTS:
+
+```bash
+polylogue 'actions where tool:write AND text:"needle"'
+polylogue 'sessions where exists action(tool:edit AND text:"needle")'
+```
+
+This is an unindexed `LIKE` filter, not FTS; constrain it by action, path,
+session scope, or time on large archives. For direct `index.db` inspection,
+the equivalent JSON-aware SQL probe is:
 
 ```sql
 SELECT block_id, session_id, tool_name,
@@ -965,13 +976,11 @@ WHERE tool_name IN ('Write', 'Edit')
   );
 ```
 
-This is a full unindexed scan (`LIKE`, no FTS acceleration) — bound it with a
-`session_id =` filter or a `messages` time join on large archives. There is no
-query-DSL field for this today; extending `search_text` itself to cover
-`$.content` was considered and deliberately deferred (see polylogue-013x)
-because Write bodies can be large enough to meaningfully bloat the FTS index,
-and that tradeoff needs a size probe against a live archive plus a derived-tier
-index rebuild before it is decided, not a silent schema bump.
+Extending `search_text` itself to cover `$.content` was considered and
+deliberately deferred (see polylogue-013x) because Write bodies can be large
+enough to meaningfully bloat the FTS index, and that tradeoff needs a size
+probe against a live archive plus a derived-tier index rebuild before it is
+decided, not a silent schema bump.
 
 ## Output Formats
 
@@ -1053,7 +1062,7 @@ When a query returns no results:
 5. Run `polylogue ops doctor` for schema and index integrity
 6. If using `--similar`, ensure embeddings are built (check `polylogue ops embed status --detail` for embedding readiness/coverage)
 7. If you know an agent wrote or edited a specific string into a file (a
-   `Write`/`Edit` tool body), FTS will not find it — this is a documented
-   coverage boundary, not a bug. See
-   [Searchable Content Coverage](#searchable-content-coverage) for the exact
-   boundary and a raw-SQL workaround.
+   `Write`/`Edit` tool body), FTS will not find it. Use the action-evidence
+   query path documented in
+   [Searchable Content Coverage](#searchable-content-coverage), such as
+   `actions where tool:write AND text:"needle"`.

--- a/docs/search.md
+++ b/docs/search.md
@@ -936,7 +936,7 @@ block/action reads). The live definition lives in
 `polylogue/storage/sqlite/archive_tiers/index.py` (`blocks.search_text
 GENERATED ALWAYS AS (...)`); this table is drift-checked against that
 expression by
-`tests/unit/storage/test_search_text_write_tool_coverage.py`.
+`tests/unit/pipeline/test_search_text_coverage_contract.py`.
 
 | Source | In `search_text` (FTS-searchable) | Notes |
 |---|---|---|
@@ -946,8 +946,8 @@ expression by
 | `tool_input.$.file_path` | Yes | Primary path argument for file-oriented tools. |
 | `tool_input.$.path` | Yes | Alternate path key used by some tools (`Grep`, `Glob`). |
 | `tool_input.$.content` — file bodies a **`Write`** tool call authored | **No** | The full text an agent wrote into a new/overwritten file is excluded from `search_text`. A distinctive string that only appears inside a Write body returns zero FTS hits. |
-| `tool_input.$.old_string` / `tool_input.$.new_string` — **`Edit`** tool bodies | **No** | Same gap as Write: edited code is excluded unless it also happens to appear in prose, a `tool_result` echo, or one of the four indexed keys above. |
-| Any other `tool_input` key (`pattern`, `description`, `url`, ...) | **No** | Only the four `json_extract` paths above are concatenated into `search_text`; every other key is excluded regardless of tool. |
+| `tool_input.$.old_string` / `tool_input.$.new_string` — **`Edit`** tool bodies | **No** | Same gap as Write: edited code is excluded unless it also happens to appear in prose, a `tool_result` echo, or one of the indexed fields above. |
+| Any other `tool_input` key (`pattern`, `description`, `url`, ...) | **No** | Only the three `json_extract` paths above are concatenated into `search_text`; every other key is excluded regardless of tool. |
 
 **Dedicated action-evidence lane:** when you know an agent wrote or edited a
 specific string into a file body, use the query DSL's action `text` predicate.

--- a/tests/unit/pipeline/test_search_text_coverage_contract.py
+++ b/tests/unit/pipeline/test_search_text_coverage_contract.py
@@ -1,0 +1,123 @@
+"""Executable contract for the documented search-text coverage boundary."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from polylogue.archive.message.roles import Role
+from polylogue.archive.query.expression import compile_expression
+from polylogue.core.enums import BlockType, Provider
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+_REPO_ROOT = Path(__file__).parents[3]
+_SEARCH_DOC = _REPO_ROOT / "docs" / "search.md"
+_INDEX_DDL = _REPO_ROOT / "polylogue" / "storage" / "sqlite" / "archive_tiers" / "index.py"
+
+_WRITE_TOKEN = "quokka-manifesto-9f3c1a"
+_EDIT_TOKEN = "renamed-walrus-descriptor-4e91"
+
+
+def _coverage_section() -> str:
+    document = _SEARCH_DOC.read_text(encoding="utf-8")
+    match = re.search(
+        r"^## Searchable Content Coverage\n(?P<section>.*?)(?=^## )",
+        document,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, "docs/search.md must define Searchable Content Coverage"
+    return match.group("section")
+
+
+def _coverage_decision(section: str, source: str) -> str:
+    for row in section.splitlines():
+        if f"`{source}`" not in row:
+            continue
+        match = re.search(r"\| (?:\*\*)?(Yes|No)(?:\*\*)? \|", row)
+        assert match is not None, f"coverage matrix must declare whether {source} feeds search_text"
+        return match.group(1)
+    raise AssertionError(f"coverage matrix must declare whether {source} feeds search_text")
+
+
+def _documented_sql_probe(section: str) -> str:
+    match = re.search(
+        r"equivalent JSON-aware SQL probe is:\n\n```sql\n(?P<sql>.*?)\n```",
+        section,
+        flags=re.DOTALL,
+    )
+    assert match is not None, "coverage docs must contain the executable JSON-aware SQL probe"
+    return match.group("sql")
+
+
+def test_documented_coverage_matrix_matches_live_search_text_ddl() -> None:
+    """The matrix is derived from the DDL, not separately asserted prose fragments."""
+    section = _coverage_section()
+    ddl_source = _INDEX_DDL.read_text(encoding="utf-8")
+    match = re.search(
+        r"search_text\s+TEXT GENERATED ALWAYS AS \((?P<expr>.*?)\)\s*VIRTUAL,",
+        ddl_source,
+        flags=re.DOTALL,
+    )
+    assert match is not None, "blocks.search_text generated-column definition not found"
+    expression = match.group("expr")
+
+    for source, ddl_fragment in {
+        "blocks.text": "COALESCE(text, '')",
+        "blocks.tool_name": "COALESCE(tool_name, '')",
+        "tool_input.$.command": "json_extract(tool_input, '$.command')",
+        "tool_input.$.file_path": "json_extract(tool_input, '$.file_path')",
+        "tool_input.$.path": "json_extract(tool_input, '$.path')",
+    }.items():
+        assert _coverage_decision(section, source) == "Yes"
+        assert ddl_fragment in expression
+
+    for source, ddl_fragment in {
+        "tool_input.$.content": "json_extract(tool_input, '$.content')",
+        "tool_input.$.old_string": "json_extract(tool_input, '$.old_string')",
+        "tool_input.$.new_string": "json_extract(tool_input, '$.new_string')",
+    }.items():
+        assert _coverage_decision(section, source) == "No"
+        assert ddl_fragment not in expression
+
+
+def test_documented_action_and_sql_body_lookup_paths_execute(tmp_path: Path) -> None:
+    """The documented DSL and fenced SQL both find bodies excluded from FTS."""
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="search-text-coverage-contract",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.ASSISTANT,
+                blocks=[
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_USE,
+                        tool_name="Write",
+                        tool_id="write-body",
+                        tool_input={"file_path": "/tmp/plan.md", "content": _WRITE_TOKEN},
+                    ),
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_USE,
+                        tool_name="Edit",
+                        tool_id="edit-body",
+                        tool_input={"file_path": "/tmp/module.py", "new_string": _EDIT_TOKEN},
+                    ),
+                ],
+            )
+        ],
+    )
+
+    with ArchiveStore(tmp_path / "archive") as archive:
+        session_id = archive.write_parsed(session)
+
+        for tool, token in (("write", _WRITE_TOKEN), ("edit", _EDIT_TOKEN)):
+            spec = compile_expression(f'exists action(tool:{tool} AND text:"{token}")')
+            assert spec.boolean_predicate is not None
+            rows = archive.list_summaries(limit=10, boolean_predicate=spec.boolean_predicate)
+            assert [row.session_id for row in rows] == [session_id]
+
+        sql_probe = _documented_sql_probe(_coverage_section())
+        for token, expected_tool in ((_WRITE_TOKEN, "Write"), (_EDIT_TOKEN, "Edit")):
+            sql_rows = archive._conn.execute(sql_probe.replace("needle", token)).fetchall()
+            assert [row[2] for row in sql_rows] == [expected_tool]

--- a/tests/unit/pipeline/test_search_text_coverage_contract.py
+++ b/tests/unit/pipeline/test_search_text_coverage_contract.py
@@ -54,6 +54,8 @@ def _documented_sql_probe(section: str) -> str:
 def test_documented_coverage_matrix_matches_live_search_text_ddl() -> None:
     """The matrix is derived from the DDL, not separately asserted prose fragments."""
     section = _coverage_section()
+    assert "tests/unit/pipeline/test_search_text_coverage_contract.py" in section
+    assert "Only the three `json_extract` paths above" in section
     ddl_source = _INDEX_DDL.read_text(encoding="utf-8")
     match = re.search(
         r"search_text\s+TEXT GENERATED ALWAYS AS \((?P<expr>.*?)\)\s*VIRTUAL,",

--- a/tests/unit/pipeline/test_search_text_coverage_contract.py
+++ b/tests/unit/pipeline/test_search_text_coverage_contract.py
@@ -6,7 +6,7 @@ import re
 from pathlib import Path
 
 from polylogue.archive.message.roles import Role
-from polylogue.archive.query.expression import compile_expression
+from polylogue.archive.query.expression import compile_expression, parse_unit_source_expression
 from polylogue.core.enums import BlockType, Provider
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -15,8 +15,9 @@ _REPO_ROOT = Path(__file__).parents[3]
 _SEARCH_DOC = _REPO_ROOT / "docs" / "search.md"
 _INDEX_DDL = _REPO_ROOT / "polylogue" / "storage" / "sqlite" / "archive_tiers" / "index.py"
 
-_WRITE_TOKEN = "quokka-manifesto-9f3c1a"
-_EDIT_TOKEN = "renamed-walrus-descriptor-4e91"
+_WRITE_TOKEN = "write-body-needle"
+_EDIT_OLD_TOKEN = "edit-old-body-needle"
+_EDIT_TOKEN = "edit-body-needle"
 
 
 def _coverage_section() -> str:
@@ -61,6 +62,11 @@ def test_documented_coverage_matrix_matches_live_search_text_ddl() -> None:
     )
     assert match is not None, "blocks.search_text generated-column definition not found"
     expression = match.group("expr")
+    assert set(re.findall(r"json_extract\(tool_input, '(\$\.[^']+)'\)", expression)) == {
+        "$.command",
+        "$.file_path",
+        "$.path",
+    }, "the documented 'Any other tool_input key: No' row must stay true"
 
     for source, ddl_fragment in {
         "blocks.text": "COALESCE(text, '')",
@@ -101,7 +107,11 @@ def test_documented_action_and_sql_body_lookup_paths_execute(tmp_path: Path) -> 
                         type=BlockType.TOOL_USE,
                         tool_name="Edit",
                         tool_id="edit-body",
-                        tool_input={"file_path": "/tmp/module.py", "new_string": _EDIT_TOKEN},
+                        tool_input={
+                            "file_path": "/tmp/module.py",
+                            "old_string": _EDIT_OLD_TOKEN,
+                            "new_string": _EDIT_TOKEN,
+                        },
                     ),
                 ],
             )
@@ -111,13 +121,27 @@ def test_documented_action_and_sql_body_lookup_paths_execute(tmp_path: Path) -> 
     with ArchiveStore(tmp_path / "archive") as archive:
         session_id = archive.write_parsed(session)
 
-        for tool, token in (("write", _WRITE_TOKEN), ("edit", _EDIT_TOKEN)):
+        terminal_source = parse_unit_source_expression(f'actions where tool:write AND text:"{_WRITE_TOKEN}"')
+        assert terminal_source is not None
+        assert terminal_source.unit == "action"
+        terminal_rows = archive.query_actions(terminal_source.predicate, limit=10)
+        assert [row.tool_name for row in terminal_rows] == ["Write"]
+
+        for tool, token in (
+            ("write", _WRITE_TOKEN),
+            ("edit", _EDIT_OLD_TOKEN),
+            ("edit", _EDIT_TOKEN),
+        ):
             spec = compile_expression(f'exists action(tool:{tool} AND text:"{token}")')
             assert spec.boolean_predicate is not None
             rows = archive.list_summaries(limit=10, boolean_predicate=spec.boolean_predicate)
             assert [row.session_id for row in rows] == [session_id]
 
         sql_probe = _documented_sql_probe(_coverage_section())
-        for token, expected_tool in ((_WRITE_TOKEN, "Write"), (_EDIT_TOKEN, "Edit")):
+        for token, expected_tool in (
+            (_WRITE_TOKEN, "Write"),
+            (_EDIT_OLD_TOKEN, "Edit"),
+            (_EDIT_TOKEN, "Edit"),
+        ):
             sql_rows = archive._conn.execute(sql_probe.replace("needle", token)).fetchall()
             assert [row[2] for row in sql_rows] == [expected_tool]


### PR DESCRIPTION
## Summary

Correct the search-text coverage guide after adversarial review: Write/Edit bodies remain excluded from FTS, but the documented action-evidence query route searches raw tool input without a direct-SQL detour.

## Problem

Merged PR #2740 incorrectly stated that no query-DSL field could search Write/Edit bodies. Its claimed DDL-to-doc and workaround tests checked independent fragments rather than the documented matrix and fenced SQL themselves.

## Solution

- Document action text predicates as the unindexed, portable route for Write/Edit body lookup; retain the JSON SQL probe for direct index inspection.
- Clarify the FTS versus action-evidence boundary and fully qualify the Edit input keys.
- Add a documentation-derived contract test that compares every matrix entry with the live generated column, compiles and executes the documented action predicates against real Write/Edit blocks, and executes the fenced SQL from the docs.

## Verification

- env POLYLOGUE_PYTEST_BASETEMP_ROOT=/realm/tmp/polylogue-pytest nix develop --command devtools test tests/unit/pipeline/test_search_text_coverage_contract.py — 2 passed.
- nix develop --command devtools verify --quick — passed all format, lint, mypy, render, topology, layering, schema, and policy checks.
- Pre-push quick gate — passed; its mypy phase was delayed by concurrent fanout load but completed successfully.

## Anti-vacuity

The new test invokes the production query compiler and ArchiveStore lowering path against stored Write/Edit tool_input. Removing tool_input from action text lowering makes the DSL assertion fail. It also parses and executes the SQL fence from docs, and derives every documented Yes/No matrix value from the live search_text DDL, so changes to either contract artifact fail the test.

## Adversarial review notes

Iteration 1 found two real gaps in the already-merged #2740 closure: the hidden DSL route and a vacuous docs-to-DDL/workaround test. This PR fixes both; no prior review comments apply to this branch.

## Acceptance criteria

- Satisfied: searchable-content matrix matches live DDL through a documentation-derived test.
- Satisfied: Option B is explicit: Write/Edit bodies stay out of FTS and have an action-evidence route plus a direct SQL inspection path.
- Not applicable: Option A size probe and index rebuild, because this PR retains Option B.

Ref polylogue-013x