### PR TITLE
fix(devtools): link archive tiers in fast-forward generations (#2805)

### DIFF
--- a/devtools/index_fast_forward.py
+++ b/devtools/index_fast_forward.py
@@ -727,6 +727,24 @@ def _reflink_copy(source: Path, destination: Path) -> None:
     _fsync_directory(destination.parent)
 
 
+def _link_generation_siblings(archive_root: Path, generation_dir: Path) -> None:
+    """Expose durable sibling tiers from a derived index generation.
+
+    SQLite reports the resolved ``index.db`` target in ``PRAGMA database_list``.
+    Cross-tier connection setup therefore searches beside the generation file,
+    not beside the stable archive-root symlink.  Match ``IndexGenerationStore``
+    by linking every canonical sibling into the new generation.
+    """
+    for filename in ("source.db", "user.db", "embeddings.db", "ops.db", "blob"):
+        source = archive_root / filename
+        if source.exists() or source.is_symlink():
+            (generation_dir / filename).symlink_to(
+                source.resolve(strict=False),
+                target_is_directory=source.is_dir(),
+            )
+    _fsync_directory(generation_dir)
+
+
 def create_and_fast_forward_generation(
     source_link: Path,
     receipt_path: Path,
@@ -746,6 +764,7 @@ def create_and_fast_forward_generation(
     clone = generation_dir / "index.db"
     before = file_identity(source_link)
     _reflink_copy(source, clone)
+    _link_generation_siblings(archive_root, generation_dir)
     with sqlite3.connect(clone, timeout=120.0) as conn:
         checkpoint = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
         conn.commit()

--- a/tests/unit/devtools/test_index_fast_forward.py
+++ b/tests/unit/devtools/test_index_fast_forward.py
@@ -288,6 +288,15 @@ def test_fast_forward_failure_keeps_user_version_and_source_counts(tmp_path: Pat
 
 def test_generation_activation_and_rollback_only_swap_symlink(tmp_path: Path) -> None:
     archive_root = tmp_path / "archive"
+    sibling_paths: dict[str, Path] = {}
+    for filename in ("source.db", "user.db", "embeddings.db", "ops.db"):
+        sibling = archive_root / filename
+        sibling.parent.mkdir(parents=True, exist_ok=True)
+        sibling.write_bytes(filename.encode())
+        sibling_paths[filename] = sibling
+    blob = archive_root / "blob"
+    blob.mkdir()
+    sibling_paths["blob"] = blob
     active_dir = archive_root / ".index-generations" / "gen-v32"
     active_dir.mkdir(parents=True)
     active_db = active_dir / "index.db"
@@ -306,6 +315,10 @@ def test_generation_activation_and_rollback_only_swap_symlink(tmp_path: Path) ->
     )
 
     clone = Path(str(receipt["clone_path"]))
+    for filename, sibling in sibling_paths.items():
+        generation_sibling = clone.parent / filename
+        assert generation_sibling.is_symlink()
+        assert generation_sibling.resolve() == sibling.resolve()
     assert active_link.resolve() == active_db.resolve()
     assert _sha256(active_db) == active_hash
     activate_generation(receipt_path)


### PR DESCRIPTION
## Summary

Make v35 fast-forward generations expose the same durable sibling tiers as ordinary index generations.

## Problem

Live v35 activation proved that a generation containing only `index.db` breaks cross-tier reads: SQLite reports the resolved generation directory, so Drive catch-up could not attach `source.db` and failed with `no such table: raw_sessions`. The live generation was repaired with the canonical sibling links and Drive catch-up then completed with zero errors.

## Solution

- Link `source.db`, `user.db`, `embeddings.db`, `ops.db`, and `blob` into each fast-forward generation before validation.
- Resolve links to the canonical archive-root targets, matching `IndexGenerationStore.create`.
- Extend the real generation activation/rollback fixture to prove every sibling link is present and resolves correctly.

Ref polylogue-5ucz

## Verification

- `devtools test tests/unit/devtools/test_index_fast_forward.py`
  - `6 passed in 31.37s`
- `devtools verify --quick`
  - `15/15 steps passed`, run `20260712T231116Z-quick-1982816-95cfc11e`
- pre-push `devtools verify --quick`
  - `15/15 steps passed`, run `20260712T231256Z-quick-1990318-c68cbdc5`
- Live postflight after restoring the same links:
  - daemon health `ok`, index v35, user v6
  - Drive catch-up `sources=1 raw=0 sessions=0 changed=0 errors=0`
  - ports 8765 and 8766 owned by the deployed daemon
