### PR TITLE
fix(devtools): keep pytest basetemp on workspace scratch

### DIFF
--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -42,7 +42,7 @@ from devtools.verify import (
     _clear_pytest_report,
     _run,
 )
-from devtools.verify_runs import VerifyRun, git_head
+from devtools.verify_runs import VerifyRun, git_head, normalize_pytest_basetemp_env
 
 ROOT = Path(__file__).resolve().parent.parent
 _LOCK_PATH = ROOT / ".cache" / "test-run.lock"
@@ -50,7 +50,7 @@ _LOCK_PATH = ROOT / ".cache" / "test-run.lock"
 
 def _managed_env() -> dict[str, str]:
     """Mirror devtools.verify's subprocess environment for parity."""
-    env = os.environ.copy()
+    env = normalize_pytest_basetemp_env(os.environ)
     env["POLYLOGUE_ROOT"] = str(ROOT)
     env["POLYLOGUE_REPO_ROOT"] = str(ROOT)
     env["PYTHONPYCACHEPREFIX"] = str(ROOT / ".cache" / "pycache")

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -66,6 +66,7 @@ from devtools.verify_runs import (
     env_for_pytest_step,
     latest_event_from_paths,
     merge_worker_events,
+    normalize_pytest_basetemp_env,
     utc_now,
 )
 
@@ -1437,7 +1438,7 @@ def _run(
 
 
 def _subprocess_env() -> dict[str, str]:
-    env = os.environ.copy()
+    env = normalize_pytest_basetemp_env(os.environ)
     env["POLYLOGUE_ROOT"] = str(ROOT)
     env["POLYLOGUE_REPO_ROOT"] = str(ROOT)
     env["PYTHONPYCACHEPREFIX"] = str(ROOT / ".cache" / "pycache")

--- a/devtools/verify_runs.py
+++ b/devtools/verify_runs.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import time
 import uuid
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -395,6 +396,27 @@ def checkout_hash(root: Path) -> str:
     return hashlib.sha1(str(root).encode("utf-8"), usedforsecurity=False).hexdigest()[:8]
 
 
+DEFAULT_PYTEST_BASETEMP_ROOT = Path("/realm/tmp/polylogue-pytest")
+_CLOUD_PYTEST_BASETEMP_ROOT = Path("/tmp/polylogue-pytest")
+
+
+def normalize_pytest_basetemp_env(env: Mapping[str, str]) -> dict[str, str]:
+    """Keep cloud pytest defaults from escaping a workstation scratch volume.
+
+    ``.claude/settings.json`` supplies ``/tmp/polylogue-pytest`` for cloud
+    sandboxes.  Agent subprocesses can inherit that setting while running in a
+    local linked worktree, where it would fill the host tmpfs instead of the
+    mounted ``/realm/tmp`` scratch volume.  Preserve explicit custom roots and
+    retain the cloud setting when the workstation scratch mount is absent.
+    """
+
+    normalized = dict(env)
+    configured = normalized.get("POLYLOGUE_PYTEST_BASETEMP_ROOT")
+    if configured == str(_CLOUD_PYTEST_BASETEMP_ROOT) and DEFAULT_PYTEST_BASETEMP_ROOT.parent.is_dir():
+        normalized["POLYLOGUE_PYTEST_BASETEMP_ROOT"] = str(DEFAULT_PYTEST_BASETEMP_ROOT)
+    return normalized
+
+
 def pytest_basetemp_path(*, root: Path, run_id: str, env: dict[str, str]) -> Path:
     configured = env.get("POLYLOGUE_PYTEST_BASETEMP_ROOT")
     if configured:
@@ -402,7 +424,7 @@ def pytest_basetemp_path(*, root: Path, run_id: str, env: dict[str, str]) -> Pat
     elif env.get("POLYLOGUE_PYTEST_TMPFS") == "1" and Path("/dev/shm").is_dir():
         scratch_root = Path("/dev/shm")
     else:
-        scratch_root = Path("/realm/tmp/polylogue-pytest")
+        scratch_root = DEFAULT_PYTEST_BASETEMP_ROOT
     return scratch_root / f"pytest-polylogue-{checkout_hash(root)}-{run_id}"
 
 

--- a/tests/unit/devtools/test_run_tests.py
+++ b/tests/unit/devtools/test_run_tests.py
@@ -115,3 +115,20 @@ def test_managed_env_sets_repo_roots() -> None:
     assert env["POLYLOGUE_PYTEST_SELECTION_PATH"] == str(run_tests.ROOT / PYTEST_SELECTION_PATH)
     assert env["POLYLOGUE_PYTEST_SUMMARY_PATH"] == str(run_tests.ROOT / PYTEST_SUMMARY_PATH)
     assert Path(env["POLYLOGUE_ROOT"]).is_dir()
+
+
+def test_managed_env_replaces_cloud_basetemp_in_local_worktree(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise devtools test's child environment, not conftest in isolation."""
+    monkeypatch.setenv("POLYLOGUE_PYTEST_BASETEMP_ROOT", "/tmp/polylogue-pytest")
+
+    env = run_tests._managed_env()
+
+    assert env["POLYLOGUE_PYTEST_BASETEMP_ROOT"] == "/realm/tmp/polylogue-pytest"
+
+
+def test_managed_env_preserves_explicit_custom_basetemp(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("POLYLOGUE_PYTEST_BASETEMP_ROOT", str(tmp_path))
+
+    env = run_tests._managed_env()
+
+    assert env["POLYLOGUE_PYTEST_BASETEMP_ROOT"] == str(tmp_path)

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -517,6 +517,17 @@ def test_run_forces_subprocesses_to_current_checkout(monkeypatch: pytest.MonkeyP
     assert env["POLYLOGUE_PYTEST_EVENTS_PATH"] == str(Path.cwd() / PYTEST_EVENTS_PATH)
 
 
+def test_verify_subprocess_env_replaces_cloud_basetemp_in_local_worktree(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLYLOGUE_PYTEST_BASETEMP_ROOT", "/tmp/polylogue-pytest")
+    completed = subprocess.CompletedProcess(args=["devtools"], returncode=0, stdout="", stderr="")
+
+    with patch("devtools.verify.subprocess.run", return_value=completed) as run:
+        _run("render all", ["devtools", "render all", "--check"])
+
+    env = run.call_args.kwargs["env"]
+    assert env["POLYLOGUE_PYTEST_BASETEMP_ROOT"] == "/realm/tmp/polylogue-pytest"
+
+
 def test_run_reads_structured_pytest_report() -> None:
     """The structured pytest report is the primary metadata source (#1026, #998)."""
     completed = subprocess.CompletedProcess(


### PR DESCRIPTION
## Summary

Keep managed pytest basetemps on the workstation scratch volume when local agent sessions inherit the cloud sandbox default.

## Problem

A fresh linked worktree inherited POLYLOGUE_PYTEST_BASETEMP_ROOT=/tmp/polylogue-pytest from cloud-oriented agent settings. The devtools child environment copied it unchanged, so pytest chose host /tmp even though the local default is /realm/tmp/polylogue-pytest. Three fanout lanes filled the 6 GiB host tmpfs.

## Solution

- Normalize only the known cloud default to /realm/tmp/polylogue-pytest when the workstation scratch mount exists.
- Apply the same normalization to focused devtools test and broad devtools verify subprocess environments.
- Preserve arbitrary caller-selected roots and retain the cloud default where /realm/tmp is unavailable.
- Cover both managed environment construction paths with regression tests.

Ref polylogue-ra3w.

## Verification

- Before: fresh-worktree devtools test printed pytest: basetemp → /tmp/polylogue-pytest/... (configured).
- After: focused devtools test printed pytest: basetemp → /realm/tmp/polylogue-pytest/... (configured).
- devtools test tests/unit/devtools/test_run_tests.py tests/unit/devtools/test_verify.py: 72 passed; 1 unrelated pre-existing failure in test_quick_verify_omits_pytest, rerun alone and confirmed its stale expected command list.
- ruff format --check, ruff check, and mypy on the five changed files: passed.
- devtools verify --quick: passed.

GitHub Actions currently fails at initialization because of account billing, before project checks run.