### PR TITLE
fix(storage): repair proven quarantined raw authority (#2808)

### DIFF
--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -1599,6 +1599,74 @@ def missing_raw_blob_cursors_command(
         click.echo("Next: restart or run polylogued catch-up.")
 
 
+@maintenance_group.command("untyped-accepted-raws")
+@click.option("--raw-id", "raw_ids", multiple=True, required=True, help="Exact retained raw SHA-256 id (repeatable).")
+@click.option("--apply", "apply_changes", is_flag=True, help="Apply only after every target passes exact proof.")
+@click.option("--proof-digest", help="Exact aggregate digest emitted by the matching dry-run.")
+@click.option(
+    "--receipt",
+    "receipt_path",
+    type=click.Path(path_type=Path, dir_okay=False),
+    help="Required append-only operator recovery receipt path for --apply.",
+)
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+)
+@click.pass_obj
+def untyped_accepted_raws_command(
+    env: AppEnv,
+    raw_ids: tuple[str, ...],
+    apply_changes: bool,
+    proof_digest: str | None,
+    receipt_path: Path | None,
+    output_format: str,
+) -> None:
+    """Repair an accepted full raw whose durable source envelope stayed untyped.
+
+    The actuator revalidates the existing immutable selected-baseline receipt,
+    retained blob bytes, parser-normalized session identity/content, and the
+    current accepted head. It never changes the index head or its receipt.
+    Apply additionally writes an exclusive, fsynced planned→applied operator
+    receipt so the source-only refinement is crash-resumable and auditable.
+    """
+    del env
+    if apply_changes and receipt_path is None:
+        raise click.UsageError("--apply requires --receipt PATH")
+    if apply_changes and proof_digest is None:
+        raise click.UsageError("--apply requires --proof-digest from the exact dry-run")
+    root = archive_root()
+    config = Config(archive_root=root, render_root=render_root(), sources=[], db_path=root / "index.db")
+    from polylogue.storage.repair import repair_untyped_accepted_raws
+
+    try:
+        report = repair_untyped_accepted_raws(
+            config,
+            list(raw_ids),
+            apply=apply_changes,
+            receipt_path=receipt_path,
+            proof_digest=proof_digest,
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    payload = asdict(report)
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    click.echo(
+        f"{report.mode}: requested={report.requested_count} eligible={report.eligible_count} "
+        f"already_repaired={report.already_repaired_count} repaired={report.repaired_count} "
+        f"ineligible={report.ineligible_count}"
+    )
+    for item in report.items:
+        click.echo(f"  {item.raw_id} {item.status}: {item.reason}")
+    if report.receipt_path is not None:
+        click.echo(f"Receipt: {report.receipt_path}")
+
+
 @maintenance_group.command("preview")
 @click.option(
     "--scope",

--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -1661,8 +1661,9 @@ def quarantined_accepted_raws_command(
         f"already_repaired={report.already_repaired_count} repaired={report.repaired_count} "
         f"ineligible={report.ineligible_count}"
     )
+    click.echo(f"Proof digest: {report.proof_digest}")
     for item in report.items:
-        click.echo(f"  {item.raw_id} {item.status}: {item.reason}")
+        click.echo(f"  {item.raw_id} {item.status} proof={item.proof_digest or 'unavailable'}: {item.reason}")
     if report.receipt_path is not None:
         click.echo(f"Receipt: {report.receipt_path}")
 

--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -1599,7 +1599,7 @@ def missing_raw_blob_cursors_command(
         click.echo("Next: restart or run polylogued catch-up.")
 
 
-@maintenance_group.command("untyped-accepted-raws")
+@maintenance_group.command("quarantined-accepted-raws")
 @click.option("--raw-id", "raw_ids", multiple=True, required=True, help="Exact retained raw SHA-256 id (repeatable).")
 @click.option("--apply", "apply_changes", is_flag=True, help="Apply only after every target passes exact proof.")
 @click.option("--proof-digest", help="Exact aggregate digest emitted by the matching dry-run.")
@@ -1617,7 +1617,7 @@ def missing_raw_blob_cursors_command(
     show_default=True,
 )
 @click.pass_obj
-def untyped_accepted_raws_command(
+def quarantined_accepted_raws_command(
     env: AppEnv,
     raw_ids: tuple[str, ...],
     apply_changes: bool,
@@ -1625,7 +1625,7 @@ def untyped_accepted_raws_command(
     receipt_path: Path | None,
     output_format: str,
 ) -> None:
-    """Repair an accepted full raw whose durable source envelope stayed untyped.
+    """Repair a typed accepted full raw whose byte authority stayed quarantined.
 
     The actuator revalidates the existing immutable selected-baseline receipt,
     retained blob bytes, parser-normalized session identity/content, and the
@@ -1640,10 +1640,10 @@ def untyped_accepted_raws_command(
         raise click.UsageError("--apply requires --proof-digest from the exact dry-run")
     root = archive_root()
     config = Config(archive_root=root, render_root=render_root(), sources=[], db_path=root / "index.db")
-    from polylogue.storage.repair import repair_untyped_accepted_raws
+    from polylogue.storage.repair import repair_quarantined_accepted_raws
 
     try:
-        report = repair_untyped_accepted_raws(
+        report = repair_quarantined_accepted_raws(
             config,
             list(raw_ids),
             apply=apply_changes,

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -230,11 +230,11 @@ def _inspect_untyped_accepted_raw(
         logical_source_key = str(head["logical_source_key"])
         session_id = str(head["session_id"])
         session_rows = conn.execute(
-            "SELECT session_id, raw_id, content_hash FROM index_tier.sessions WHERE session_id = ? AND raw_id = ?",
-            (session_id, raw_id),
+            "SELECT session_id, raw_id, content_hash FROM index_tier.sessions WHERE raw_id = ?",
+            (raw_id,),
         ).fetchall()
-        if len(session_rows) != 1:
-            return _untyped_raw_item(raw_id, "accepted head and indexed session do not share the raw")
+        if len(session_rows) != 1 or str(session_rows[0]["session_id"]) != session_id:
+            return _untyped_raw_item(raw_id, "accepted head is not the raw's unique indexed session")
         session_row = session_rows[0]
         applications = conn.execute(
             """
@@ -539,13 +539,27 @@ class _LockedUntypedRawRepairReceipt:
     target_hash: str
     terminal: bool
     repair_intent_raw_ids: tuple[str, ...]
+    torn_terminal: bytes | None = None
 
     def close(self) -> None:
         fcntl.flock(self.descriptor, fcntl.LOCK_UN)
         os.close(self.descriptor)
 
 
-def _receipt_records(descriptor: int) -> list[dict[str, object]]:
+def _receipt_write(descriptor: int, payload: bytes) -> int:
+    return os.write(descriptor, payload)
+
+
+def _write_receipt_all(descriptor: int, payload: bytes) -> None:
+    offset = 0
+    while offset < len(payload):
+        written = _receipt_write(descriptor, payload[offset:])
+        if written <= 0:
+            raise RuntimeError("operator repair receipt write made no progress")
+        offset += written
+
+
+def _receipt_records(descriptor: int) -> tuple[list[dict[str, object] | bytes], bool]:
     size = os.fstat(descriptor).st_size
     if size > 16 * 1024 * 1024:
         raise RuntimeError("existing repair receipt exceeds the bounded parser limit")
@@ -559,25 +573,36 @@ def _receipt_records(descriptor: int) -> list[dict[str, object]]:
         chunks.append(chunk)
         remaining -= len(chunk)
     payload = b"".join(chunks)
-    try:
-        lines = payload.decode("utf-8").splitlines()
-        parsed_records: list[object] = [json.loads(line) for line in lines]
-    except (UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
-        raise RuntimeError(f"existing repair receipt is unreadable: {exc}") from exc
-    if any(not isinstance(record, dict) for record in parsed_records):
-        raise RuntimeError("existing repair receipt records must be JSON objects")
-    return [cast(dict[str, object], record) for record in parsed_records]
+    terminated = payload.endswith(b"\n")
+    lines = payload.split(b"\n")
+    if terminated:
+        lines.pop()
+    records: list[dict[str, object] | bytes] = []
+    for index, line in enumerate(lines):
+        if index == len(lines) - 1 and not terminated:
+            records.append(line)
+            continue
+        try:
+            parsed: object = json.loads(line.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError, json.JSONDecodeError):
+            records.append(line)
+            continue
+        records.append(cast(dict[str, object], parsed) if isinstance(parsed, dict) else line)
+    return records, terminated
 
 
 def _validate_repair_receipt_records(
-    records: list[dict[str, object]],
+    parsed_receipt: tuple[list[dict[str, object] | bytes], bool],
     *,
     targets: list[dict[str, object]],
     target_hash: str,
-) -> tuple[bool, tuple[str, ...]]:
+) -> tuple[bool, tuple[str, ...], bytes | None]:
+    records, terminated = parsed_receipt
     if not records:
         raise RuntimeError("existing repair receipt is empty")
     planned = records[0]
+    if not isinstance(planned, dict):
+        raise RuntimeError("existing repair receipt does not start with valid planned JSON")
     planned_keys = {"schema", "state", "target_hash", "targets", "repair_intent_raw_ids", "planned_at_ms"}
     if set(planned) != planned_keys or planned.get("schema") != _UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA:
         raise RuntimeError("existing repair receipt has an invalid planned record schema")
@@ -596,10 +621,24 @@ def _validate_repair_receipt_records(
     if len(set(intent_ids)) != len(intent_ids) or any(raw_id not in raw_ids for raw_id in intent_ids):
         raise RuntimeError("existing repair receipt repair intent does not match its targets")
     if len(records) == 1:
-        return False, intent_ids
-    if len(records) != 2:
+        if not terminated:
+            raise RuntimeError("existing repair receipt has a torn planned record")
+        return False, intent_ids, None
+    torn_terminal: bytes | None = None
+    if len(records) == 2 and isinstance(records[1], bytes) and not terminated:
+        torn_terminal = records[1]
+        if not torn_terminal:
+            raise RuntimeError("existing repair receipt has an empty torn terminal")
+        return False, intent_ids, torn_terminal
+    if len(records) == 2 and isinstance(records[1], dict):
+        applied = records[1]
+        recovered = False
+    elif len(records) == 3 and isinstance(records[1], bytes) and isinstance(records[2], dict) and terminated:
+        torn_terminal = records[1]
+        applied = records[2]
+        recovered = True
+    else:
         raise RuntimeError("existing repair receipt has an invalid state transition")
-    applied = records[1]
     applied_keys = {
         "schema",
         "state",
@@ -608,6 +647,8 @@ def _validate_repair_receipt_records(
         "repaired_raw_ids",
         "proven_raw_ids",
     }
+    if recovered:
+        applied_keys |= {"torn_terminal_bytes", "torn_terminal_sha256"}
     if set(applied) != applied_keys or applied.get("schema") != _UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA:
         raise RuntimeError("existing repair receipt has an invalid applied record schema")
     if applied.get("state") != "applied" or applied.get("target_hash") != target_hash:
@@ -617,7 +658,12 @@ def _validate_repair_receipt_records(
         raise RuntimeError("existing repair receipt applied timestamp is invalid")
     if applied.get("proven_raw_ids") != list(raw_ids) or applied.get("repaired_raw_ids") != list(intent_ids):
         raise RuntimeError("existing repair receipt applied ids do not match the planned targets")
-    return True, intent_ids
+    if recovered and (
+        applied.get("torn_terminal_bytes") != len(torn_terminal or b"")
+        or applied.get("torn_terminal_sha256") != hashlib.sha256(torn_terminal or b"").hexdigest()
+    ):
+        raise RuntimeError("existing repair receipt recovery does not match its preserved torn terminal")
+    return True, intent_ids, torn_terminal
 
 
 def _lock_untyped_raw_repair_receipt(
@@ -643,10 +689,12 @@ def _lock_untyped_raw_repair_receipt(
         if (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino):
             raise RuntimeError("operator repair receipt path changed while it was being locked")
         if opened.st_size:
-            terminal, existing_intent = _validate_repair_receipt_records(
+            terminal, existing_intent, torn_terminal = _validate_repair_receipt_records(
                 _receipt_records(descriptor), targets=targets, target_hash=target_hash
             )
-            return _LockedUntypedRawRepairReceipt(path, descriptor, target_hash, terminal, existing_intent)
+            return _LockedUntypedRawRepairReceipt(
+                path, descriptor, target_hash, terminal, existing_intent, torn_terminal
+            )
         planned = {
             "schema": _UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA,
             "state": "planned",
@@ -656,7 +704,7 @@ def _lock_untyped_raw_repair_receipt(
             "planned_at_ms": int(time.time() * 1000),
         }
         encoded = (json.dumps(planned, sort_keys=True, separators=(",", ":")) + "\n").encode()
-        os.write(descriptor, encoded)
+        _write_receipt_all(descriptor, encoded)
         os.fsync(descriptor)
         _fsync_parent(path)
         return _LockedUntypedRawRepairReceipt(path, descriptor, target_hash, False, repair_intent_raw_ids)
@@ -679,14 +727,18 @@ def _finish_untyped_raw_repair_receipt(
         "repaired_raw_ids": list(receipt.repair_intent_raw_ids),
         "proven_raw_ids": [item.raw_id for item in items],
     }
+    if receipt.torn_terminal is not None:
+        terminal["torn_terminal_bytes"] = len(receipt.torn_terminal)
+        terminal["torn_terminal_sha256"] = hashlib.sha256(receipt.torn_terminal).hexdigest()
     opened = os.fstat(receipt.descriptor)
     named = receipt.path.stat(follow_symlinks=False)
     if (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino):
         raise RuntimeError("operator repair receipt path changed before terminal append")
     os.lseek(receipt.descriptor, 0, os.SEEK_END)
-    os.write(
-        receipt.descriptor,
-        (json.dumps(terminal, sort_keys=True, separators=(",", ":")) + "\n").encode(),
+    if receipt.torn_terminal is not None:
+        _write_receipt_all(receipt.descriptor, b"\n")
+    _write_receipt_all(
+        receipt.descriptor, (json.dumps(terminal, sort_keys=True, separators=(",", ":")) + "\n").encode()
     )
     os.fsync(receipt.descriptor)
     _fsync_parent(receipt.path)
@@ -781,6 +833,10 @@ def repair_untyped_accepted_raws(
                             raise RuntimeError("a repair target became ineligible after acquiring the transaction")
                         if receipt.terminal and any(item.status != "already_repaired" for item in locked_items):
                             raise RuntimeError("terminal operator receipt disagrees with durable source authority")
+                        if receipt.torn_terminal is not None and any(
+                            item.status != "already_repaired" for item in locked_items
+                        ):
+                            raise RuntimeError("torn terminal receipt has no matching committed source refinement")
                         for item in locked_items:
                             if item.status == "eligible":
                                 _cas_refine_untyped_accepted_raw(source_conn, item)

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -969,7 +969,7 @@ def repair_quarantined_accepted_raws(
                         raise
                 items = [
                     dataclasses.replace(after, repaired=before.status == "eligible")
-                    for before, after in zip(items, after_items, strict=True)
+                    for before, after in zip(locked_items, after_items, strict=True)
                 ]
                 if not receipt.terminal:
                     _finish_quarantined_raw_repair_receipt(receipt, items=items)

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -539,7 +539,8 @@ class _LockedUntypedRawRepairReceipt:
     target_hash: str
     terminal: bool
     repair_intent_raw_ids: tuple[str, ...]
-    torn_terminal: bytes | None = None
+    torn_terminals: tuple[bytes, ...] = ()
+    receipt_terminated: bool = True
 
     def close(self) -> None:
         fcntl.flock(self.descriptor, fcntl.LOCK_UN)
@@ -596,7 +597,7 @@ def _validate_repair_receipt_records(
     *,
     targets: list[dict[str, object]],
     target_hash: str,
-) -> tuple[bool, tuple[str, ...], bytes | None]:
+) -> tuple[bool, tuple[str, ...], tuple[bytes, ...], bool]:
     records, terminated = parsed_receipt
     if not records:
         raise RuntimeError("existing repair receipt is empty")
@@ -623,22 +624,22 @@ def _validate_repair_receipt_records(
     if len(records) == 1:
         if not terminated:
             raise RuntimeError("existing repair receipt has a torn planned record")
-        return False, intent_ids, None
-    torn_terminal: bytes | None = None
-    if len(records) == 2 and isinstance(records[1], bytes) and not terminated:
-        torn_terminal = records[1]
-        if not torn_terminal:
-            raise RuntimeError("existing repair receipt has an empty torn terminal")
-        return False, intent_ids, torn_terminal
-    if len(records) == 2 and isinstance(records[1], dict):
-        applied = records[1]
-        recovered = False
-    elif len(records) == 3 and isinstance(records[1], bytes) and isinstance(records[2], dict) and terminated:
-        torn_terminal = records[1]
-        applied = records[2]
-        recovered = True
-    else:
+        return False, intent_ids, (), terminated
+    tail = records[1:]
+    applied = tail[-1] if isinstance(tail[-1], dict) else None
+    torn_terminals = (
+        tuple(record for record in tail[:-1] if isinstance(record, bytes))
+        if applied
+        else tuple(record for record in tail if isinstance(record, bytes))
+    )
+    expected_tail_length = len(torn_terminals) + (1 if applied is not None else 0)
+    if len(tail) != expected_tail_length or any(not fragment for fragment in torn_terminals):
         raise RuntimeError("existing repair receipt has an invalid state transition")
+    if applied is None:
+        return False, intent_ids, torn_terminals, terminated
+    if not terminated:
+        raise RuntimeError("existing repair receipt has an unterminated applied record")
+    recovered = bool(torn_terminals)
     applied_keys = {
         "schema",
         "state",
@@ -648,7 +649,7 @@ def _validate_repair_receipt_records(
         "proven_raw_ids",
     }
     if recovered:
-        applied_keys |= {"torn_terminal_bytes", "torn_terminal_sha256"}
+        applied_keys |= {"torn_terminals"}
     if set(applied) != applied_keys or applied.get("schema") != _UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA:
         raise RuntimeError("existing repair receipt has an invalid applied record schema")
     if applied.get("state") != "applied" or applied.get("target_hash") != target_hash:
@@ -658,12 +659,12 @@ def _validate_repair_receipt_records(
         raise RuntimeError("existing repair receipt applied timestamp is invalid")
     if applied.get("proven_raw_ids") != list(raw_ids) or applied.get("repaired_raw_ids") != list(intent_ids):
         raise RuntimeError("existing repair receipt applied ids do not match the planned targets")
-    if recovered and (
-        applied.get("torn_terminal_bytes") != len(torn_terminal or b"")
-        or applied.get("torn_terminal_sha256") != hashlib.sha256(torn_terminal or b"").hexdigest()
-    ):
+    expected_torn_witnesses = [
+        {"bytes": len(fragment), "sha256": hashlib.sha256(fragment).hexdigest()} for fragment in torn_terminals
+    ]
+    if recovered and applied.get("torn_terminals") != expected_torn_witnesses:
         raise RuntimeError("existing repair receipt recovery does not match its preserved torn terminal")
-    return True, intent_ids, torn_terminal
+    return True, intent_ids, torn_terminals, terminated
 
 
 def _lock_untyped_raw_repair_receipt(
@@ -689,11 +690,17 @@ def _lock_untyped_raw_repair_receipt(
         if (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino):
             raise RuntimeError("operator repair receipt path changed while it was being locked")
         if opened.st_size:
-            terminal, existing_intent, torn_terminal = _validate_repair_receipt_records(
+            terminal, existing_intent, torn_terminals, terminated = _validate_repair_receipt_records(
                 _receipt_records(descriptor), targets=targets, target_hash=target_hash
             )
             return _LockedUntypedRawRepairReceipt(
-                path, descriptor, target_hash, terminal, existing_intent, torn_terminal
+                path,
+                descriptor,
+                target_hash,
+                terminal,
+                existing_intent,
+                torn_terminals,
+                terminated,
             )
         planned = {
             "schema": _UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA,
@@ -727,15 +734,17 @@ def _finish_untyped_raw_repair_receipt(
         "repaired_raw_ids": list(receipt.repair_intent_raw_ids),
         "proven_raw_ids": [item.raw_id for item in items],
     }
-    if receipt.torn_terminal is not None:
-        terminal["torn_terminal_bytes"] = len(receipt.torn_terminal)
-        terminal["torn_terminal_sha256"] = hashlib.sha256(receipt.torn_terminal).hexdigest()
+    if receipt.torn_terminals:
+        terminal["torn_terminals"] = [
+            {"bytes": len(fragment), "sha256": hashlib.sha256(fragment).hexdigest()}
+            for fragment in receipt.torn_terminals
+        ]
     opened = os.fstat(receipt.descriptor)
     named = receipt.path.stat(follow_symlinks=False)
     if (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino):
         raise RuntimeError("operator repair receipt path changed before terminal append")
     os.lseek(receipt.descriptor, 0, os.SEEK_END)
-    if receipt.torn_terminal is not None:
+    if receipt.torn_terminals and not receipt.receipt_terminated:
         _write_receipt_all(receipt.descriptor, b"\n")
     _write_receipt_all(
         receipt.descriptor, (json.dumps(terminal, sort_keys=True, separators=(",", ":")) + "\n").encode()
@@ -833,9 +842,7 @@ def repair_untyped_accepted_raws(
                             raise RuntimeError("a repair target became ineligible after acquiring the transaction")
                         if receipt.terminal and any(item.status != "already_repaired" for item in locked_items):
                             raise RuntimeError("terminal operator receipt disagrees with durable source authority")
-                        if receipt.torn_terminal is not None and any(
-                            item.status != "already_repaired" for item in locked_items
-                        ):
+                        if receipt.torn_terminals and any(item.status != "already_repaired" for item in locked_items):
                             raise RuntimeError("torn terminal receipt has no matching committed source refinement")
                         for item in locked_items:
                             if item.status == "eligible":

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -59,15 +59,15 @@ _PROBE_ONLY_EXACT_MESSAGE_ROW_LIMIT = 100_000
 RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES = 1024 * 1024 * 1024
 RAW_MATERIALIZATION_RESOURCE_BLOCK_REASON = "non-stream-safe raw payload exceeds the bounded replay limit"
 _TRANSIENT_LOCK_PARSE_ERROR = "OperationalError: database is locked"
-_UNTYPED_ACCEPTED_RAW_REPAIR_DETAIL = "repair:accepted_untyped_raw_exact_byte_and_semantic_proof"
-_UNTYPED_ACCEPTED_RAW_REPAIR_LIMIT = 100
-_UNTYPED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES = 256 * 1024 * 1024
-_UNTYPED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES = 512 * 1024 * 1024
-_UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA = "polylogue.untyped-accepted-raw-repair.v1"
+_QUARANTINED_ACCEPTED_RAW_REPAIR_DETAIL = "repair:accepted_quarantined_raw_exact_byte_and_semantic_proof"
+_QUARANTINED_ACCEPTED_RAW_REPAIR_LIMIT = 100
+_QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES = 256 * 1024 * 1024
+_QUARANTINED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES = 512 * 1024 * 1024
+_QUARANTINED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA = "polylogue.quarantined-accepted-raw-repair.v1"
 
 
 @dataclass(frozen=True, slots=True)
-class UntypedAcceptedRawArtifactWitness:
+class QuarantinedAcceptedRawArtifactWitness:
     artifact_id: str
     origin: str
     source_path: str
@@ -87,7 +87,7 @@ class UntypedAcceptedRawArtifactWitness:
 
 
 @dataclass(frozen=True, slots=True)
-class UntypedAcceptedRawApplicationWitness:
+class QuarantinedAcceptedRawApplicationWitness:
     decision_id: str
     raw_id: str
     session_id: str
@@ -106,7 +106,7 @@ class UntypedAcceptedRawApplicationWitness:
 
 
 @dataclass(frozen=True, slots=True)
-class UntypedAcceptedRawRepairItem:
+class QuarantinedAcceptedRawRepairItem:
     raw_id: str
     status: str
     reason: str
@@ -120,7 +120,7 @@ class UntypedAcceptedRawRepairItem:
     blob_ref_hash: str | None = None
     blob_ref_source_path: str | None = None
     blob_ref_size: int | None = None
-    artifact_witnesses: tuple[UntypedAcceptedRawArtifactWitness, ...] = ()
+    artifact_witnesses: tuple[QuarantinedAcceptedRawArtifactWitness, ...] = ()
     accepted_source_revision: str | None = None
     accepted_content_hash: str | None = None
     accepted_frontier_kind: str | None = None
@@ -128,13 +128,17 @@ class UntypedAcceptedRawRepairItem:
     head_decided_at_ms: int | None = None
     acquisition_generation: int | None = None
     application_decision_id: str | None = None
-    application_witness: UntypedAcceptedRawApplicationWitness | None = None
+    application_witness: QuarantinedAcceptedRawApplicationWitness | None = None
+    authority_context_digest: str | None = None
+    parallel_session_head_count: int = 0
+    quarantined_sibling_raw_count: int = 0
+    membership_row_count: int = 0
     proof_digest: str | None = None
     repaired: bool = False
 
 
 @dataclass(frozen=True, slots=True)
-class UntypedAcceptedRawRepairReport:
+class QuarantinedAcceptedRawRepairReport:
     mode: str
     requested_count: int
     eligible_count: int
@@ -143,11 +147,11 @@ class UntypedAcceptedRawRepairReport:
     ineligible_count: int
     proof_digest: str
     receipt_path: str | None
-    items: tuple[UntypedAcceptedRawRepairItem, ...]
+    items: tuple[QuarantinedAcceptedRawRepairItem, ...]
 
 
-def _untyped_raw_item(raw_id: str, reason: str) -> UntypedAcceptedRawRepairItem:
-    return UntypedAcceptedRawRepairItem(raw_id=raw_id, status="ineligible", reason=reason)
+def _quarantined_raw_item(raw_id: str, reason: str) -> QuarantinedAcceptedRawRepairItem:
+    return QuarantinedAcceptedRawRepairItem(raw_id=raw_id, status="ineligible", reason=reason)
 
 
 def _bytes_value(value: object) -> bytes:
@@ -158,12 +162,22 @@ def _bytes_value(value: object) -> bytes:
     raise ValueError("expected SQLite BLOB value")
 
 
+def _authority_rows_digest(*row_sets: list[sqlite3.Row]) -> str:
+    def value_payload(value: object) -> object:
+        if isinstance(value, (bytes, memoryview)):
+            return {"blob_hex": bytes(value).hex()}
+        return value
+
+    payload = [[{key: value_payload(row[key]) for key in row} for row in rows] for rows in row_sets]
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
 def _attach_repair_index(conn: sqlite3.Connection, index_db: Path) -> None:
     conn.row_factory = sqlite3.Row
     conn.execute("ATTACH DATABASE ? AS index_tier", (f"file:{index_db}?mode=ro",))
 
 
-def _validate_untyped_raw_repair_blob_budget(conn: sqlite3.Connection, raw_ids: list[str]) -> None:
+def _validate_quarantined_raw_repair_blob_budget(conn: sqlite3.Connection, raw_ids: list[str]) -> None:
     """Reject a bounded repair set before any retained blob is loaded into memory."""
     rows = conn.execute(
         """
@@ -173,18 +187,18 @@ def _validate_untyped_raw_repair_blob_budget(conn: sqlite3.Connection, raw_ids: 
         (json.dumps(raw_ids),),
     ).fetchall()
     oversized = [
-        str(row["raw_id"]) for row in rows if int(row["blob_size"]) > _UNTYPED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES
+        str(row["raw_id"]) for row in rows if int(row["blob_size"]) > _QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES
     ]
     if oversized:
         raise RuntimeError(
-            "untyped accepted raw repair exceeds the per-target retained-blob limit: " + ", ".join(oversized)
+            "quarantined accepted raw repair exceeds the per-target retained-blob limit: " + ", ".join(oversized)
         )
     total = sum(int(row["blob_size"]) for row in rows)
-    if total > _UNTYPED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES:
-        raise RuntimeError("untyped accepted raw repair exceeds the aggregate retained-blob limit")
+    if total > _QUARANTINED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES:
+        raise RuntimeError("quarantined accepted raw repair exceeds the aggregate retained-blob limit")
 
 
-def _proof_digest(item: UntypedAcceptedRawRepairItem) -> str:
+def _proof_digest(item: QuarantinedAcceptedRawRepairItem) -> str:
     payload = {
         key: value
         for key, value in dataclasses.asdict(item).items()
@@ -193,12 +207,12 @@ def _proof_digest(item: UntypedAcceptedRawRepairItem) -> str:
     return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
 
 
-def _inspect_untyped_accepted_raw(
+def _inspect_quarantined_accepted_raw(
     archive_root: Path,
     raw_id: str,
     *,
     conn: sqlite3.Connection,
-) -> UntypedAcceptedRawRepairItem:
+) -> QuarantinedAcceptedRawRepairItem:
     """Prove one accepted head against source main + attached read-only index."""
     try:
         raw = conn.execute(
@@ -213,7 +227,7 @@ def _inspect_untyped_accepted_raw(
             (raw_id,),
         ).fetchone()
         if raw is None:
-            return _untyped_raw_item(raw_id, "raw row is missing")
+            return _quarantined_raw_item(raw_id, "raw row is missing")
         heads = conn.execute(
             """
             SELECT logical_source_key, session_id, accepted_raw_id,
@@ -225,7 +239,7 @@ def _inspect_untyped_accepted_raw(
             (raw_id,),
         ).fetchall()
         if len(heads) != 1:
-            return _untyped_raw_item(raw_id, f"expected one accepted head, found {len(heads)}")
+            return _quarantined_raw_item(raw_id, f"expected one accepted head, found {len(heads)}")
         head = heads[0]
         logical_source_key = str(head["logical_source_key"])
         session_id = str(head["session_id"])
@@ -234,7 +248,7 @@ def _inspect_untyped_accepted_raw(
             (raw_id,),
         ).fetchall()
         if len(session_rows) != 1 or str(session_rows[0]["session_id"]) != session_id:
-            return _untyped_raw_item(raw_id, "accepted head is not the raw's unique indexed session")
+            return _quarantined_raw_item(raw_id, "accepted head is not the raw's unique indexed session")
         session_row = session_rows[0]
         applications = conn.execute(
             """
@@ -243,42 +257,61 @@ def _inspect_untyped_accepted_raw(
                    accepted_source_revision, accepted_content_hash, append_end_offset,
                    baseline_raw_id, predecessor_raw_id, detail, decided_at_ms
             FROM index_tier.raw_revision_applications
-            WHERE raw_id = ? OR accepted_raw_id = ? OR logical_source_key = ? OR session_id = ?
+            WHERE raw_id = ? OR accepted_raw_id = ? OR logical_source_key = ?
             """,
-            (raw_id, raw_id, logical_source_key, session_id),
+            (raw_id, raw_id, logical_source_key),
         ).fetchall()
         if len(applications) != 1:
-            return _untyped_raw_item(raw_id, "competing raw-revision application authority exists")
+            return _quarantined_raw_item(raw_id, "competing raw-revision application authority exists")
         receipt = applications[0]
         competing_head_count = int(
             conn.execute(
                 """
                 SELECT COUNT(*) FROM index_tier.raw_revision_heads
-                WHERE session_id = ?
-                  AND NOT (accepted_raw_id = ? AND logical_source_key = ?)
+                WHERE logical_source_key = ?
+                  AND NOT (accepted_raw_id = ? AND session_id = ?)
                 """,
-                (session_id, raw_id, logical_source_key),
+                (logical_source_key, raw_id, session_id),
             ).fetchone()[0]
         )
-        competing_revision_count = int(
-            conn.execute(
-                """
-                SELECT COUNT(*) FROM raw_sessions
-                WHERE raw_id != ? AND logical_source_key = ?
-                """,
-                (raw_id, logical_source_key),
-            ).fetchone()[0]
-        )
-        membership_count = int(
-            conn.execute(
-                """
-                SELECT
-                  (SELECT COUNT(*) FROM raw_session_memberships WHERE raw_id = ? OR logical_source_key = ?)
-                  + (SELECT COUNT(*) FROM raw_membership_census WHERE raw_id = ?)
-                """,
-                (raw_id, logical_source_key, raw_id),
-            ).fetchone()[0]
-        )
+        parallel_session_heads = conn.execute(
+            """
+            SELECT logical_source_key, session_id, accepted_raw_id, accepted_source_revision,
+                   accepted_content_hash, accepted_frontier_kind, accepted_frontier, decided_at_ms
+            FROM index_tier.raw_revision_heads
+            WHERE session_id = ? AND logical_source_key != ?
+            ORDER BY logical_source_key
+            """,
+            (session_id, logical_source_key),
+        ).fetchall()
+        competing_revision_rows = conn.execute(
+            """
+            SELECT raw_id, logical_source_key, revision_kind, source_revision,
+                   baseline_raw_id, acquisition_generation, revision_authority
+            FROM raw_sessions
+            WHERE raw_id != ? AND logical_source_key = ?
+            ORDER BY raw_id
+            """,
+            (raw_id, logical_source_key),
+        ).fetchall()
+        membership_rows = conn.execute(
+            """
+            SELECT raw_id, logical_source_key, provider_session_id, source_revision,
+                   normalized_content_hash, message_count, predecessor_raw_id,
+                   acquisition_generation, revision_authority, decision, decided_at_ms
+            FROM raw_session_memberships
+            WHERE raw_id = ? OR logical_source_key = ?
+            ORDER BY logical_source_key, raw_id
+            """,
+            (raw_id, logical_source_key),
+        ).fetchall()
+        census_rows = conn.execute(
+            """
+            SELECT raw_id, parser_fingerprint, status, member_count, censused_at_ms, detail
+            FROM raw_membership_census WHERE raw_id = ?
+            """,
+            (raw_id,),
+        ).fetchall()
         blob_ref_rows = conn.execute(
             """
             SELECT blob_hash, source_path, size_bytes FROM blob_refs
@@ -298,7 +331,8 @@ def _inspect_untyped_accepted_raw(
             (raw_id,),
         ).fetchall()
     except sqlite3.Error as exc:
-        return _untyped_raw_item(raw_id, f"authority tiers are unreadable: {exc}")
+        logger.warning("quarantined raw repair authority read failed", raw_id=raw_id, error=str(exc))
+        return _quarantined_raw_item(raw_id, f"authority tiers are unreadable: {exc}")
 
     try:
         accepted_hash = _bytes_value(head["accepted_content_hash"])
@@ -306,7 +340,7 @@ def _inspect_untyped_accepted_raw(
         receipt_hash = _bytes_value(receipt["accepted_content_hash"])
         blob_hash_bytes = _bytes_value(raw["blob_hash"])
     except ValueError as exc:
-        return _untyped_raw_item(raw_id, str(exc))
+        return _quarantined_raw_item(raw_id, str(exc))
     accepted_revision = str(head["accepted_source_revision"])
     generation = int(head["acquisition_generation"])
     expected_envelope = (
@@ -333,6 +367,18 @@ def _inspect_untyped_accepted_raw(
         raw["acquisition_generation"],
         str(raw["revision_authority"]),
     )
+    quarantined_envelope = (
+        logical_source_key,
+        RawRevisionKind.FULL.value,
+        accepted_revision,
+        None,
+        None,
+        None,
+        None,
+        None,
+        generation,
+        RawRevisionAuthority.QUARANTINED.value,
+    )
     untyped_envelope = (
         None,
         RawRevisionKind.UNKNOWN.value,
@@ -345,14 +391,14 @@ def _inspect_untyped_accepted_raw(
         None,
         RawRevisionAuthority.QUARANTINED.value,
     )
-    if actual_envelope not in {untyped_envelope, expected_envelope}:
-        return _untyped_raw_item(raw_id, "source raw has a non-null or incompatible authority envelope")
+    if actual_envelope not in {untyped_envelope, quarantined_envelope, expected_envelope}:
+        return _quarantined_raw_item(raw_id, "source raw has an incompatible typed authority envelope")
     if str(head["accepted_frontier_kind"]) != "byte" or head["append_end_offset"] is not None:
-        return _untyped_raw_item(raw_id, "accepted head is not a full byte frontier")
+        return _quarantined_raw_item(raw_id, "accepted head is not a full byte frontier")
     if int(raw["source_index"]) < 0 or int(raw["blob_size"]) != int(head["accepted_frontier"]):
-        return _untyped_raw_item(raw_id, "raw shape or byte length differs from the accepted full frontier")
+        return _quarantined_raw_item(raw_id, "raw shape or byte length differs from the accepted full frontier")
     if accepted_hash != stored_hash or accepted_hash != receipt_hash:
-        return _untyped_raw_item(raw_id, "head, session, and application content hashes disagree")
+        return _quarantined_raw_item(raw_id, "head, session, and application content hashes disagree")
     expected_receipt = (
         raw_id,
         session_id,
@@ -384,11 +430,22 @@ def _inspect_untyped_accepted_raw(
         int(receipt["decided_at_ms"]),
     )
     if actual_receipt != expected_receipt:
-        return _untyped_raw_item(raw_id, "immutable baseline receipt does not exactly match the accepted head")
-    if competing_head_count or competing_revision_count or membership_count:
-        return _untyped_raw_item(raw_id, "competing typed or membership authority exists")
+        return _quarantined_raw_item(raw_id, "immutable baseline receipt does not exactly match the accepted head")
+    if competing_head_count or any(str(row["revision_authority"]) != "quarantined" for row in competing_revision_rows):
+        return _quarantined_raw_item(raw_id, "competing accepted or byte-proven source authority exists")
+    target_memberships = [row for row in membership_rows if str(row["raw_id"]) == raw_id]
+    if len(target_memberships) != 1 or len(census_rows) != 1:
+        return _quarantined_raw_item(raw_id, "expected one target membership and one membership census")
+    membership = target_memberships[0]
+    census = census_rows[0]
+    if (
+        str(census["status"]) != "complete"
+        or int(census["member_count"]) != 1
+        or any(row["decision"] == "applied" and str(row["raw_id"]) != raw_id for row in membership_rows)
+    ):
+        return _quarantined_raw_item(raw_id, "membership authority is failed, ambiguous, or competitively applied")
     if len(blob_ref_rows) != 1:
-        return _untyped_raw_item(raw_id, "expected exactly one raw-payload blob reference")
+        return _quarantined_raw_item(raw_id, "expected exactly one raw-payload blob reference")
     blob_ref = blob_ref_rows[0]
     if (
         _bytes_value(blob_ref["blob_hash"]) != blob_hash_bytes
@@ -401,13 +458,13 @@ def _inspect_untyped_accepted_raw(
             for artifact in artifact_rows
         )
     ):
-        return _untyped_raw_item(raw_id, "raw row, blob reference, and artifact identity disagree")
+        return _quarantined_raw_item(raw_id, "raw row, blob reference, and artifact identity disagree")
 
     blob_hash = blob_hash_bytes.hex()
-    if int(raw["blob_size"]) > _UNTYPED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES:
-        return _untyped_raw_item(raw_id, "retained raw exceeds the per-target repair byte limit")
+    if int(raw["blob_size"]) > _QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES:
+        return _quarantined_raw_item(raw_id, "retained raw exceeds the per-target repair byte limit")
     artifact_witnesses = tuple(
-        UntypedAcceptedRawArtifactWitness(
+        QuarantinedAcceptedRawArtifactWitness(
             artifact_id=str(artifact["artifact_id"]),
             origin=str(artifact["origin"]),
             source_path=str(artifact["source_path"]),
@@ -431,10 +488,10 @@ def _inspect_untyped_accepted_raw(
     )
     blob_store = BlobStore(archive_root / "blob")
     if not blob_store.exists(blob_hash) or not blob_store.verify(blob_hash):
-        return _untyped_raw_item(raw_id, "retained raw blob is missing or fails its content hash")
+        return _quarantined_raw_item(raw_id, "retained raw blob is missing or fails its content hash")
     payload = blob_store.read_all(blob_hash)
     if len(payload) != int(raw["blob_size"]) or hashlib.sha256(payload).hexdigest() != accepted_revision:
-        return _untyped_raw_item(raw_id, "retained bytes do not prove the accepted source revision")
+        return _quarantined_raw_item(raw_id, "retained bytes do not prove the accepted source revision")
     try:
         origin = Origin.from_string(str(raw["origin"]))
         provider = provider_from_origin(origin)
@@ -449,9 +506,10 @@ def _inspect_untyped_accepted_raw(
         )
         sessions = [_normalized_session(session, fallback_timestamp=fallback_timestamp) for session in sessions]
     except Exception as exc:
-        return _untyped_raw_item(raw_id, f"retained raw did not normalize cleanly: {type(exc).__name__}: {exc}")
+        logger.warning("quarantined raw repair normalization failed", raw_id=raw_id, error=str(exc))
+        return _quarantined_raw_item(raw_id, f"retained raw did not normalize cleanly: {type(exc).__name__}: {exc}")
     if len(sessions) != 1:
-        return _untyped_raw_item(raw_id, f"retained raw normalized to {len(sessions)} sessions instead of one")
+        return _quarantined_raw_item(raw_id, f"retained raw normalized to {len(sessions)} sessions instead of one")
     parsed = sessions[0]
     if (
         origin_from_provider(parsed.source_name) != origin
@@ -459,16 +517,29 @@ def _inspect_untyped_accepted_raw(
         or f"{provider.value}:{parsed.provider_session_id}" != logical_source_key
         or bytes.fromhex(session_content_hash(parsed)) != accepted_hash
     ):
-        return _untyped_raw_item(raw_id, "normalized parser identity or content differs from the accepted session")
+        return _quarantined_raw_item(raw_id, "normalized parser identity or content differs from the accepted session")
+    parsed_logical_source_key = f"{parsed.source_name.value}:{parsed.provider_session_id}"
+    if (
+        str(membership["logical_source_key"]) != parsed_logical_source_key
+        or str(membership["provider_session_id"]) != parsed.provider_session_id
+        or _bytes_value(membership["normalized_content_hash"]) != accepted_hash
+        or str(membership["source_revision"]) != accepted_hash.hex()
+        or int(membership["message_count"]) != len(parsed.messages)
+        or membership["predecessor_raw_id"] is not None
+        or int(membership["acquisition_generation"]) != generation
+        or str(membership["revision_authority"]) != "quarantined"
+        or membership["decision"] == "applied"
+    ):
+        return _quarantined_raw_item(raw_id, "membership evidence does not match the normalized accepted session")
 
     status = "already_repaired" if actual_envelope == expected_envelope else "eligible"
-    item = UntypedAcceptedRawRepairItem(
+    item = QuarantinedAcceptedRawRepairItem(
         raw_id=raw_id,
         status=status,
         reason=(
             "source envelope already matches the proven accepted head"
             if status == "already_repaired"
-            else _UNTYPED_ACCEPTED_RAW_REPAIR_DETAIL
+            else _QUARANTINED_ACCEPTED_RAW_REPAIR_DETAIL
         ),
         logical_source_key=logical_source_key,
         session_id=session_id,
@@ -488,7 +559,7 @@ def _inspect_untyped_accepted_raw(
         head_decided_at_ms=int(head["decided_at_ms"]),
         acquisition_generation=generation,
         application_decision_id=str(receipt["decision_id"]),
-        application_witness=UntypedAcceptedRawApplicationWitness(
+        application_witness=QuarantinedAcceptedRawApplicationWitness(
             decision_id=str(receipt["decision_id"]),
             raw_id=str(receipt["raw_id"]),
             session_id=str(receipt["session_id"]),
@@ -507,11 +578,21 @@ def _inspect_untyped_accepted_raw(
             detail=str(receipt["detail"]),
             decided_at_ms=int(receipt["decided_at_ms"]),
         ),
+        authority_context_digest=_authority_rows_digest(
+            applications,
+            parallel_session_heads,
+            competing_revision_rows,
+            membership_rows,
+            census_rows,
+        ),
+        parallel_session_head_count=len(parallel_session_heads),
+        quarantined_sibling_raw_count=len(competing_revision_rows),
+        membership_row_count=len(membership_rows),
     )
     return dataclasses.replace(item, proof_digest=_proof_digest(item))
 
 
-def _repair_receipt_targets(items: list[UntypedAcceptedRawRepairItem]) -> list[dict[str, object]]:
+def _repair_receipt_targets(items: list[QuarantinedAcceptedRawRepairItem]) -> list[dict[str, object]]:
     targets = [
         {key: value for key, value in dataclasses.asdict(item).items() if key not in {"reason", "repaired", "status"}}
         for item in items
@@ -519,7 +600,7 @@ def _repair_receipt_targets(items: list[UntypedAcceptedRawRepairItem]) -> list[d
     return cast(list[dict[str, object]], json.loads(json.dumps(targets, sort_keys=True)))
 
 
-def _repair_proof_digest(items: list[UntypedAcceptedRawRepairItem]) -> str:
+def _repair_proof_digest(items: list[QuarantinedAcceptedRawRepairItem]) -> str:
     proof_digests = [item.proof_digest for item in items]
     return hashlib.sha256(json.dumps(proof_digests, separators=(",", ":")).encode()).hexdigest()
 
@@ -533,7 +614,7 @@ def _fsync_parent(path: Path) -> None:
 
 
 @dataclass(slots=True)
-class _LockedUntypedRawRepairReceipt:
+class _LockedQuarantinedRawRepairReceipt:
     path: Path
     descriptor: int
     target_hash: str
@@ -605,7 +686,7 @@ def _validate_repair_receipt_records(
     if not isinstance(planned, dict):
         raise RuntimeError("existing repair receipt does not start with valid planned JSON")
     planned_keys = {"schema", "state", "target_hash", "targets", "repair_intent_raw_ids", "planned_at_ms"}
-    if set(planned) != planned_keys or planned.get("schema") != _UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA:
+    if set(planned) != planned_keys or planned.get("schema") != _QUARANTINED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA:
         raise RuntimeError("existing repair receipt has an invalid planned record schema")
     if planned.get("state") != "planned":
         raise RuntimeError("existing repair receipt must start with a planned record")
@@ -650,7 +731,7 @@ def _validate_repair_receipt_records(
     }
     if recovered:
         applied_keys |= {"torn_terminals"}
-    if set(applied) != applied_keys or applied.get("schema") != _UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA:
+    if set(applied) != applied_keys or applied.get("schema") != _QUARANTINED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA:
         raise RuntimeError("existing repair receipt has an invalid applied record schema")
     if applied.get("state") != "applied" or applied.get("target_hash") != target_hash:
         raise RuntimeError("existing repair receipt has an invalid applied target transition")
@@ -667,10 +748,10 @@ def _validate_repair_receipt_records(
     return True, intent_ids, torn_terminals, terminated
 
 
-def _lock_untyped_raw_repair_receipt(
+def _lock_quarantined_raw_repair_receipt(
     path: Path,
-    items: list[UntypedAcceptedRawRepairItem],
-) -> _LockedUntypedRawRepairReceipt:
+    items: list[QuarantinedAcceptedRawRepairItem],
+) -> _LockedQuarantinedRawRepairReceipt:
     """Lock one stable receipt inode and create or validate its planned record."""
     if path.is_symlink():
         raise RuntimeError("repair receipt path must not be a symbolic link")
@@ -693,7 +774,7 @@ def _lock_untyped_raw_repair_receipt(
             terminal, existing_intent, torn_terminals, terminated = _validate_repair_receipt_records(
                 _receipt_records(descriptor), targets=targets, target_hash=target_hash
             )
-            return _LockedUntypedRawRepairReceipt(
+            return _LockedQuarantinedRawRepairReceipt(
                 path,
                 descriptor,
                 target_hash,
@@ -703,7 +784,7 @@ def _lock_untyped_raw_repair_receipt(
                 terminated,
             )
         planned = {
-            "schema": _UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA,
+            "schema": _QUARANTINED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA,
             "state": "planned",
             "target_hash": target_hash,
             "targets": targets,
@@ -714,17 +795,17 @@ def _lock_untyped_raw_repair_receipt(
         _write_receipt_all(descriptor, encoded)
         os.fsync(descriptor)
         _fsync_parent(path)
-        return _LockedUntypedRawRepairReceipt(path, descriptor, target_hash, False, repair_intent_raw_ids)
+        return _LockedQuarantinedRawRepairReceipt(path, descriptor, target_hash, False, repair_intent_raw_ids)
     except Exception:
         fcntl.flock(descriptor, fcntl.LOCK_UN)
         os.close(descriptor)
         raise
 
 
-def _finish_untyped_raw_repair_receipt(
-    receipt: _LockedUntypedRawRepairReceipt,
+def _finish_quarantined_raw_repair_receipt(
+    receipt: _LockedQuarantinedRawRepairReceipt,
     *,
-    items: list[UntypedAcceptedRawRepairItem],
+    items: list[QuarantinedAcceptedRawRepairItem],
 ) -> None:
     opened = os.fstat(receipt.descriptor)
     named = receipt.path.stat(follow_symlinks=False)
@@ -739,7 +820,7 @@ def _finish_untyped_raw_repair_receipt(
         _write_receipt_all(receipt.descriptor, b"\xff\n")
         preserved_torn_terminals[-1] += b"\xff"
     terminal = {
-        "schema": _UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA,
+        "schema": _QUARANTINED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA,
         "state": "applied",
         "target_hash": receipt.target_hash,
         "applied_at_ms": int(time.time() * 1000),
@@ -758,9 +839,9 @@ def _finish_untyped_raw_repair_receipt(
     _fsync_parent(receipt.path)
 
 
-def _cas_refine_untyped_accepted_raw(
+def _cas_refine_quarantined_accepted_raw(
     source_conn: sqlite3.Connection,
-    item: UntypedAcceptedRawRepairItem,
+    item: QuarantinedAcceptedRawRepairItem,
 ) -> None:
     assert item.logical_source_key is not None
     assert item.accepted_source_revision is not None
@@ -771,37 +852,46 @@ def _cas_refine_untyped_accepted_raw(
         SET logical_source_key = ?, revision_kind = 'full', source_revision = ?,
             baseline_raw_id = raw_id, acquisition_generation = ?,
             revision_authority = 'byte_proven'
-        WHERE raw_id = ? AND logical_source_key IS NULL
-          AND revision_kind = 'unknown' AND source_revision IS NULL
+        WHERE raw_id = ? AND revision_authority = 'quarantined'
           AND predecessor_source_revision IS NULL AND predecessor_raw_id IS NULL
-          AND baseline_raw_id IS NULL AND append_start_offset IS NULL
-          AND append_end_offset IS NULL AND acquisition_generation IS NULL
-          AND revision_authority = 'quarantined'
+          AND append_start_offset IS NULL AND append_end_offset IS NULL
+          AND (
+            (logical_source_key IS NULL AND revision_kind = 'unknown'
+             AND source_revision IS NULL AND baseline_raw_id IS NULL
+             AND acquisition_generation IS NULL)
+            OR
+            (logical_source_key = ? AND revision_kind = 'full'
+             AND source_revision = ? AND baseline_raw_id IS NULL
+             AND acquisition_generation = ?)
+          )
         """,
         (
             item.logical_source_key,
             item.accepted_source_revision,
             item.acquisition_generation,
             item.raw_id,
+            item.logical_source_key,
+            item.accepted_source_revision,
+            item.acquisition_generation,
         ),
     )
     if cursor.rowcount != 1:
         raise RuntimeError(f"source authority CAS failed for {item.raw_id}")
 
 
-def repair_untyped_accepted_raws(
+def repair_quarantined_accepted_raws(
     config: Config,
     raw_ids: list[str],
     *,
     apply: bool = False,
     receipt_path: Path | None = None,
     proof_digest: str | None = None,
-) -> UntypedAcceptedRawRepairReport:
-    """Refine accepted-but-untyped full raws only after exact retained proof."""
+) -> QuarantinedAcceptedRawRepairReport:
+    """Refine accepted untyped or typed-quarantined full raws after exact proof."""
     if len(set(raw_ids)) != len(raw_ids):
         raise ValueError("duplicate raw ids are not allowed")
-    if not raw_ids or len(raw_ids) > _UNTYPED_ACCEPTED_RAW_REPAIR_LIMIT:
-        raise ValueError(f"raw-id list must contain 1..{_UNTYPED_ACCEPTED_RAW_REPAIR_LIMIT} entries")
+    if not raw_ids or len(raw_ids) > _QUARANTINED_ACCEPTED_RAW_REPAIR_LIMIT:
+        raise ValueError(f"raw-id list must contain 1..{_QUARANTINED_ACCEPTED_RAW_REPAIR_LIMIT} entries")
     if any(re.fullmatch(r"[0-9a-f]{64}", raw_id) is None for raw_id in raw_ids):
         raise ValueError("raw ids must be lowercase SHA-256 identifiers")
     block_reason = offline_maintenance_block_reason(config, active=apply, dry_run=not apply)
@@ -814,11 +904,11 @@ def repair_untyped_accepted_raws(
         raise RuntimeError("source or index tier is missing")
     with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as dry_conn:
         _attach_repair_index(dry_conn, index_db)
-        _validate_untyped_raw_repair_blob_budget(dry_conn, raw_ids)
-        items = [_inspect_untyped_accepted_raw(archive_root, raw_id, conn=dry_conn) for raw_id in raw_ids]
+        _validate_quarantined_raw_repair_blob_budget(dry_conn, raw_ids)
+        items = [_inspect_quarantined_accepted_raw(archive_root, raw_id, conn=dry_conn) for raw_id in raw_ids]
     aggregate_proof = _repair_proof_digest(items)
     if apply and any(item.status == "ineligible" for item in items):
-        raise RuntimeError("untyped accepted raw repair refused because one or more targets are ineligible")
+        raise RuntimeError("quarantined accepted raw repair refused because one or more targets are ineligible")
     if apply and receipt_path is None:
         raise ValueError("apply requires an explicit operator repair receipt path")
     if apply and proof_digest != aggregate_proof:
@@ -827,7 +917,7 @@ def repair_untyped_accepted_raws(
         from polylogue.storage.index_generation import ActiveWriterLease
 
         assert receipt_path is not None
-        receipt = _lock_untyped_raw_repair_receipt(receipt_path, items)
+        receipt = _lock_quarantined_raw_repair_receipt(receipt_path, items)
         try:
             lease = ActiveWriterLease(archive_root)
             lease.acquire()
@@ -837,9 +927,10 @@ def repair_untyped_accepted_raws(
                     _attach_repair_index(source_conn, index_db)
                     source_conn.execute("BEGIN IMMEDIATE")
                     try:
-                        _validate_untyped_raw_repair_blob_budget(source_conn, raw_ids)
+                        _validate_quarantined_raw_repair_blob_budget(source_conn, raw_ids)
                         locked_items = [
-                            _inspect_untyped_accepted_raw(archive_root, raw_id, conn=source_conn) for raw_id in raw_ids
+                            _inspect_quarantined_accepted_raw(archive_root, raw_id, conn=source_conn)
+                            for raw_id in raw_ids
                         ]
                         if _repair_proof_digest(locked_items) != proof_digest:
                             raise RuntimeError("authority proof changed after acquiring the repair transaction")
@@ -851,9 +942,10 @@ def repair_untyped_accepted_raws(
                             raise RuntimeError("torn terminal receipt has no matching committed source refinement")
                         for item in locked_items:
                             if item.status == "eligible":
-                                _cas_refine_untyped_accepted_raw(source_conn, item)
+                                _cas_refine_quarantined_accepted_raw(source_conn, item)
                         after_items = [
-                            _inspect_untyped_accepted_raw(archive_root, raw_id, conn=source_conn) for raw_id in raw_ids
+                            _inspect_quarantined_accepted_raw(archive_root, raw_id, conn=source_conn)
+                            for raw_id in raw_ids
                         ]
                         if any(item.status != "already_repaired" for item in after_items):
                             raise RuntimeError("source envelope refinement did not reach the proven terminal state")
@@ -868,10 +960,10 @@ def repair_untyped_accepted_raws(
             finally:
                 lease.close()
             if not receipt.terminal:
-                _finish_untyped_raw_repair_receipt(receipt, items=items)
+                _finish_quarantined_raw_repair_receipt(receipt, items=items)
         finally:
             receipt.close()
-    return UntypedAcceptedRawRepairReport(
+    return QuarantinedAcceptedRawRepairReport(
         mode="apply" if apply else "dry-run",
         requested_count=len(items),
         eligible_count=sum(item.status == "eligible" for item in items),

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -26,7 +26,7 @@ from polylogue.archive.revision_authority import (
 from polylogue.config import Config
 from polylogue.core.enums import Origin, Provider
 from polylogue.core.json import JSONDocument, json_document
-from polylogue.core.sources import origin_from_provider, provider_from_origin
+from polylogue.core.sources import origin_from_provider, origin_provider_fiber, provider_from_origin
 from polylogue.logging import get_logger
 from polylogue.maintenance.models import DerivedModelStatus, MaintenanceCategory
 from polylogue.maintenance.offline_guard import offline_maintenance_block_reason
@@ -113,6 +113,7 @@ class QuarantinedAcceptedRawRepairItem:
     logical_source_key: str | None = None
     session_id: str | None = None
     origin: str | None = None
+    capture_mode: str | None = None
     source_path: str | None = None
     source_index: int | None = None
     blob_hash: str | None = None
@@ -217,7 +218,7 @@ def _inspect_quarantined_accepted_raw(
     try:
         raw = conn.execute(
             """
-            SELECT raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size,
+            SELECT raw_id, origin, capture_mode, native_id, source_path, source_index, blob_hash, blob_size,
                    file_mtime_ms, logical_source_key, revision_kind, source_revision,
                    predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
                    append_start_offset, append_end_offset, acquisition_generation,
@@ -494,7 +495,14 @@ def _inspect_quarantined_accepted_raw(
         return _quarantined_raw_item(raw_id, "retained bytes do not prove the accepted source revision")
     try:
         origin = Origin.from_string(str(raw["origin"]))
-        provider = provider_from_origin(origin)
+        capture_mode = str(raw["capture_mode"]) if raw["capture_mode"] is not None else None
+        fiber = origin_provider_fiber(origin)
+        if len(fiber) > 1 and capture_mode is None:
+            return _quarantined_raw_item(raw_id, "non-injective origin lacks durable capture-mode authority")
+        capture_provider = Provider.from_string(capture_mode) if capture_mode is not None else None
+        if capture_provider is not None and capture_provider not in fiber:
+            return _quarantined_raw_item(raw_id, "capture mode falls outside the raw origin provider fiber")
+        provider = provider_from_origin(origin, family_hint=capture_provider)
         from polylogue.pipeline.services.ingest_worker import _normalized_session
         from polylogue.sources.revision_backfill import _parse_one
 
@@ -544,6 +552,7 @@ def _inspect_quarantined_accepted_raw(
         logical_source_key=logical_source_key,
         session_id=session_id,
         origin=str(raw["origin"]),
+        capture_mode=capture_mode,
         source_path=str(raw["source_path"]),
         source_index=int(raw["source_index"]),
         blob_hash=blob_hash,
@@ -738,7 +747,14 @@ def _validate_repair_receipt_records(
     applied_at_ms = applied.get("applied_at_ms")
     if not isinstance(applied_at_ms, int) or applied_at_ms < 0:
         raise RuntimeError("existing repair receipt applied timestamp is invalid")
-    if applied.get("proven_raw_ids") != list(raw_ids) or applied.get("repaired_raw_ids") != list(intent_ids):
+    repaired_ids = applied.get("repaired_raw_ids")
+    if (
+        applied.get("proven_raw_ids") != list(raw_ids)
+        or not isinstance(repaired_ids, list)
+        or any(not isinstance(raw_id, str) for raw_id in repaired_ids)
+        or len(set(cast(list[str], repaired_ids))) != len(repaired_ids)
+        or any(raw_id not in intent_ids for raw_id in cast(list[str], repaired_ids))
+    ):
         raise RuntimeError("existing repair receipt applied ids do not match the planned targets")
     expected_torn_witnesses = [
         {"bytes": len(fragment), "sha256": hashlib.sha256(fragment).hexdigest()} for fragment in torn_terminals
@@ -824,7 +840,7 @@ def _finish_quarantined_raw_repair_receipt(
         "state": "applied",
         "target_hash": receipt.target_hash,
         "applied_at_ms": int(time.time() * 1000),
-        "repaired_raw_ids": list(receipt.repair_intent_raw_ids),
+        "repaired_raw_ids": [item.raw_id for item in items if item.repaired],
         "proven_raw_ids": [item.raw_id for item in items],
     }
     if preserved_torn_terminals:
@@ -914,13 +930,11 @@ def repair_quarantined_accepted_raws(
     if apply and proof_digest != aggregate_proof:
         raise RuntimeError("apply proof digest does not match the exact dry-run target list")
     if apply:
-        from polylogue.storage.index_generation import ActiveWriterLease
+        from polylogue.storage.index_generation import RebuildLease
 
         assert receipt_path is not None
-        receipt = _lock_quarantined_raw_repair_receipt(receipt_path, items)
-        try:
-            lease = ActiveWriterLease(archive_root)
-            lease.acquire()
+        with RebuildLease(archive_root):
+            receipt = _lock_quarantined_raw_repair_receipt(receipt_path, items)
             try:
                 with closing(sqlite3.connect(f"file:{source_db}?mode=rw", uri=True)) as source_conn:
                     source_conn.execute("PRAGMA foreign_keys = ON")
@@ -957,12 +971,10 @@ def repair_quarantined_accepted_raws(
                     dataclasses.replace(after, repaired=before.status == "eligible")
                     for before, after in zip(items, after_items, strict=True)
                 ]
+                if not receipt.terminal:
+                    _finish_quarantined_raw_repair_receipt(receipt, items=items)
             finally:
-                lease.close()
-            if not receipt.terminal:
-                _finish_quarantined_raw_repair_receipt(receipt, items=items)
-        finally:
-            receipt.close()
+                receipt.close()
     return QuarantinedAcceptedRawRepairReport(
         mode="apply" if apply else "dry-run",
         requested_count=len(items),

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -2,15 +2,25 @@
 
 from __future__ import annotations
 
+import dataclasses
+import hashlib
+import json
+import os
 import re
 import sqlite3
+import time
 from collections.abc import Callable
 from contextlib import closing
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 
 from polylogue.archive.raw_materialization import parsed_non_session_artifact_reason
-from polylogue.archive.revision_authority import BYTE_AUTHORITY_CENSUS_DETAIL
+from polylogue.archive.revision_authority import (
+    BYTE_AUTHORITY_CENSUS_DETAIL,
+    RawRevisionAuthority,
+    RawRevisionKind,
+)
 from polylogue.config import Config
 from polylogue.core.enums import Origin, Provider
 from polylogue.core.json import JSONDocument, json_document
@@ -25,6 +35,8 @@ from polylogue.maintenance.targets import (
     build_maintenance_target_catalog,
 )
 from polylogue.paths import archive_file_set_root_for_paths
+from polylogue.pipeline.ids import session_content_hash
+from polylogue.pipeline.ids import session_id as make_session_id
 from polylogue.protocols import ProgressCallback
 from polylogue.sources.dispatch import is_stream_record_provider
 from polylogue.storage.blob_repair import count_orphaned_blobs_sync, repair_orphaned_blobs_data
@@ -45,6 +57,504 @@ _PROBE_ONLY_EXACT_MESSAGE_ROW_LIMIT = 100_000
 RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES = 1024 * 1024 * 1024
 RAW_MATERIALIZATION_RESOURCE_BLOCK_REASON = "non-stream-safe raw payload exceeds the bounded replay limit"
 _TRANSIENT_LOCK_PARSE_ERROR = "OperationalError: database is locked"
+_UNTYPED_ACCEPTED_RAW_REPAIR_DETAIL = "repair:accepted_untyped_raw_exact_byte_and_semantic_proof"
+_UNTYPED_ACCEPTED_RAW_REPAIR_LIMIT = 100
+
+
+@dataclass(frozen=True, slots=True)
+class UntypedAcceptedRawRepairItem:
+    raw_id: str
+    status: str
+    reason: str
+    logical_source_key: str | None = None
+    session_id: str | None = None
+    source_path: str | None = None
+    blob_size: int | None = None
+    accepted_source_revision: str | None = None
+    accepted_content_hash: str | None = None
+    acquisition_generation: int | None = None
+    application_decision_id: str | None = None
+    proof_digest: str | None = None
+    repaired: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class UntypedAcceptedRawRepairReport:
+    mode: str
+    requested_count: int
+    eligible_count: int
+    repaired_count: int
+    already_repaired_count: int
+    ineligible_count: int
+    proof_digest: str
+    receipt_path: str | None
+    items: tuple[UntypedAcceptedRawRepairItem, ...]
+
+
+def _untyped_raw_item(raw_id: str, reason: str) -> UntypedAcceptedRawRepairItem:
+    return UntypedAcceptedRawRepairItem(raw_id=raw_id, status="ineligible", reason=reason)
+
+
+def _bytes_value(value: object) -> bytes:
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, memoryview):
+        return bytes(value)
+    raise ValueError("expected SQLite BLOB value")
+
+
+def _attach_repair_index(conn: sqlite3.Connection, index_db: Path) -> None:
+    conn.row_factory = sqlite3.Row
+    conn.execute("ATTACH DATABASE ? AS index_tier", (f"file:{index_db}?mode=ro",))
+
+
+def _proof_digest(item: UntypedAcceptedRawRepairItem) -> str:
+    payload = {
+        key: value
+        for key, value in dataclasses.asdict(item).items()
+        if key not in {"proof_digest", "reason", "repaired", "status"}
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _inspect_untyped_accepted_raw(
+    archive_root: Path,
+    raw_id: str,
+    *,
+    conn: sqlite3.Connection,
+) -> UntypedAcceptedRawRepairItem:
+    """Prove one accepted head against source main + attached read-only index."""
+    try:
+        raw = conn.execute(
+            """
+            SELECT raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size,
+                   file_mtime_ms, logical_source_key, revision_kind, source_revision,
+                   predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
+                   append_start_offset, append_end_offset, acquisition_generation,
+                   revision_authority
+            FROM raw_sessions WHERE raw_id = ?
+            """,
+            (raw_id,),
+        ).fetchone()
+        if raw is None:
+            return _untyped_raw_item(raw_id, "raw row is missing")
+        heads = conn.execute(
+            """
+            SELECT logical_source_key, session_id, accepted_raw_id,
+                   accepted_source_revision, accepted_content_hash,
+                   accepted_frontier_kind, accepted_frontier,
+                   acquisition_generation, append_end_offset, decided_at_ms
+            FROM index_tier.raw_revision_heads WHERE accepted_raw_id = ?
+            """,
+            (raw_id,),
+        ).fetchall()
+        if len(heads) != 1:
+            return _untyped_raw_item(raw_id, f"expected one accepted head, found {len(heads)}")
+        head = heads[0]
+        logical_source_key = str(head["logical_source_key"])
+        session_rows = conn.execute(
+            "SELECT session_id, raw_id, content_hash FROM index_tier.sessions WHERE session_id = ? AND raw_id = ?",
+            (str(head["session_id"]), raw_id),
+        ).fetchall()
+        if len(session_rows) != 1:
+            return _untyped_raw_item(raw_id, "accepted head and indexed session do not share the raw")
+        session_row = session_rows[0]
+        applications = conn.execute(
+            """
+            SELECT decision_id, raw_id, session_id, logical_source_key, source_revision,
+                   acquisition_generation, decision, accepted_raw_id,
+                   accepted_source_revision, accepted_content_hash, append_end_offset,
+                   decided_at_ms
+            FROM index_tier.raw_revision_applications
+            WHERE raw_id = ? OR accepted_raw_id = ? OR logical_source_key = ?
+            """,
+            (raw_id, raw_id, logical_source_key),
+        ).fetchall()
+        if len(applications) != 1:
+            return _untyped_raw_item(raw_id, "competing raw-revision application authority exists")
+        receipt = applications[0]
+        competing_revision_count = int(
+            conn.execute(
+                """
+                SELECT COUNT(*) FROM raw_sessions
+                WHERE raw_id != ? AND logical_source_key = ?
+                  AND revision_authority != 'quarantined'
+                """,
+                (raw_id, logical_source_key),
+            ).fetchone()[0]
+        )
+        membership_count = int(
+            conn.execute(
+                """
+                SELECT
+                  (SELECT COUNT(*) FROM raw_session_memberships WHERE raw_id = ? OR logical_source_key = ?)
+                  + (SELECT COUNT(*) FROM raw_membership_census WHERE raw_id = ?)
+                """,
+                (raw_id, logical_source_key, raw_id),
+            ).fetchone()[0]
+        )
+        blob_ref_rows = conn.execute(
+            """
+            SELECT blob_hash, source_path, size_bytes FROM blob_refs
+            WHERE ref_id = ? AND ref_type = 'raw_payload'
+            """,
+            (raw_id,),
+        ).fetchall()
+        artifact_mismatch_count = int(
+            conn.execute(
+                """
+                SELECT COUNT(*) FROM raw_artifacts
+                WHERE raw_id = ? AND (
+                    origin != ? OR source_path != ? OR source_index != ?
+                )
+                """,
+                (raw_id, raw["origin"], raw["source_path"], raw["source_index"]),
+            ).fetchone()[0]
+        )
+    except sqlite3.Error as exc:
+        return _untyped_raw_item(raw_id, f"authority tiers are unreadable: {exc}")
+
+    try:
+        accepted_hash = _bytes_value(head["accepted_content_hash"])
+        stored_hash = _bytes_value(session_row["content_hash"])
+        receipt_hash = _bytes_value(receipt["accepted_content_hash"])
+        blob_hash_bytes = _bytes_value(raw["blob_hash"])
+    except ValueError as exc:
+        return _untyped_raw_item(raw_id, str(exc))
+    accepted_revision = str(head["accepted_source_revision"])
+    generation = int(head["acquisition_generation"])
+    expected_envelope = (
+        logical_source_key,
+        RawRevisionKind.FULL.value,
+        accepted_revision,
+        None,
+        None,
+        raw_id,
+        None,
+        None,
+        generation,
+        RawRevisionAuthority.BYTE_PROVEN.value,
+    )
+    actual_envelope = (
+        raw["logical_source_key"],
+        str(raw["revision_kind"]),
+        raw["source_revision"],
+        raw["predecessor_source_revision"],
+        raw["predecessor_raw_id"],
+        raw["baseline_raw_id"],
+        raw["append_start_offset"],
+        raw["append_end_offset"],
+        raw["acquisition_generation"],
+        str(raw["revision_authority"]),
+    )
+    untyped_envelope = (
+        None,
+        RawRevisionKind.UNKNOWN.value,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        RawRevisionAuthority.QUARANTINED.value,
+    )
+    if actual_envelope not in {untyped_envelope, expected_envelope}:
+        return _untyped_raw_item(raw_id, "source raw has a non-null or incompatible authority envelope")
+    if str(head["accepted_frontier_kind"]) != "byte" or head["append_end_offset"] is not None:
+        return _untyped_raw_item(raw_id, "accepted head is not a full byte frontier")
+    if int(raw["source_index"]) < 0 or int(raw["blob_size"]) != int(head["accepted_frontier"]):
+        return _untyped_raw_item(raw_id, "raw shape or byte length differs from the accepted full frontier")
+    if accepted_hash != stored_hash or accepted_hash != receipt_hash:
+        return _untyped_raw_item(raw_id, "head, session, and application content hashes disagree")
+    expected_receipt = (
+        raw_id,
+        str(head["session_id"]),
+        logical_source_key,
+        accepted_revision,
+        generation,
+        "selected_baseline",
+        raw_id,
+        accepted_revision,
+        accepted_hash,
+        None,
+        int(head["decided_at_ms"]),
+    )
+    actual_receipt = (
+        str(receipt["raw_id"]),
+        str(receipt["session_id"]),
+        str(receipt["logical_source_key"]),
+        str(receipt["source_revision"]),
+        int(receipt["acquisition_generation"]),
+        str(receipt["decision"]),
+        str(receipt["accepted_raw_id"]),
+        str(receipt["accepted_source_revision"]),
+        receipt_hash,
+        receipt["append_end_offset"],
+        int(receipt["decided_at_ms"]),
+    )
+    if actual_receipt != expected_receipt:
+        return _untyped_raw_item(raw_id, "immutable baseline receipt does not exactly match the accepted head")
+    if competing_revision_count or membership_count:
+        return _untyped_raw_item(raw_id, "competing typed or membership authority exists")
+    if len(blob_ref_rows) != 1:
+        return _untyped_raw_item(raw_id, "expected exactly one raw-payload blob reference")
+    blob_ref = blob_ref_rows[0]
+    if (
+        _bytes_value(blob_ref["blob_hash"]) != blob_hash_bytes
+        or str(blob_ref["source_path"] or "") != str(raw["source_path"] or "")
+        or int(blob_ref["size_bytes"]) != int(raw["blob_size"])
+        or artifact_mismatch_count
+    ):
+        return _untyped_raw_item(raw_id, "raw row, blob reference, and artifact identity disagree")
+
+    blob_hash = blob_hash_bytes.hex()
+    blob_store = BlobStore(archive_root / "blob")
+    if not blob_store.exists(blob_hash) or not blob_store.verify(blob_hash):
+        return _untyped_raw_item(raw_id, "retained raw blob is missing or fails its content hash")
+    payload = blob_store.read_all(blob_hash)
+    if len(payload) != int(raw["blob_size"]) or hashlib.sha256(payload).hexdigest() != accepted_revision:
+        return _untyped_raw_item(raw_id, "retained bytes do not prove the accepted source revision")
+    try:
+        origin = Origin.from_string(str(raw["origin"]))
+        provider = provider_from_origin(origin)
+        from polylogue.pipeline.services.ingest_worker import _normalized_session
+        from polylogue.sources.revision_backfill import _parse_one
+
+        sessions = _parse_one(provider, payload, str(raw["source_path"]))
+        fallback_timestamp = (
+            datetime.fromtimestamp(int(raw["file_mtime_ms"]) / 1000, UTC).isoformat()
+            if raw["file_mtime_ms"] is not None
+            else None
+        )
+        sessions = [_normalized_session(session, fallback_timestamp=fallback_timestamp) for session in sessions]
+    except Exception as exc:
+        return _untyped_raw_item(raw_id, f"retained raw did not normalize cleanly: {type(exc).__name__}: {exc}")
+    if len(sessions) != 1:
+        return _untyped_raw_item(raw_id, f"retained raw normalized to {len(sessions)} sessions instead of one")
+    parsed = sessions[0]
+    if (
+        origin_from_provider(parsed.source_name) != origin
+        or str(make_session_id(parsed.source_name, parsed.provider_session_id)) != str(head["session_id"])
+        or f"{provider.value}:{parsed.provider_session_id}" != logical_source_key
+        or bytes.fromhex(session_content_hash(parsed)) != accepted_hash
+    ):
+        return _untyped_raw_item(raw_id, "normalized parser identity or content differs from the accepted session")
+
+    status = "already_repaired" if actual_envelope == expected_envelope else "eligible"
+    item = UntypedAcceptedRawRepairItem(
+        raw_id=raw_id,
+        status=status,
+        reason=(
+            "source envelope already matches the proven accepted head"
+            if status == "already_repaired"
+            else _UNTYPED_ACCEPTED_RAW_REPAIR_DETAIL
+        ),
+        logical_source_key=logical_source_key,
+        session_id=str(head["session_id"]),
+        source_path=str(raw["source_path"]),
+        blob_size=int(raw["blob_size"]),
+        accepted_source_revision=accepted_revision,
+        accepted_content_hash=accepted_hash.hex(),
+        acquisition_generation=generation,
+        application_decision_id=str(receipt["decision_id"]),
+    )
+    return dataclasses.replace(item, proof_digest=_proof_digest(item))
+
+
+def _repair_receipt_targets(items: list[UntypedAcceptedRawRepairItem]) -> list[dict[str, object]]:
+    return [
+        {key: value for key, value in dataclasses.asdict(item).items() if key not in {"reason", "repaired", "status"}}
+        for item in items
+    ]
+
+
+def _repair_proof_digest(items: list[UntypedAcceptedRawRepairItem]) -> str:
+    proof_digests = [item.proof_digest for item in items]
+    return hashlib.sha256(json.dumps(proof_digests, separators=(",", ":")).encode()).hexdigest()
+
+
+def _fsync_parent(path: Path) -> None:
+    descriptor = os.open(path.parent, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _prepare_untyped_raw_repair_receipt(
+    path: Path,
+    items: list[UntypedAcceptedRawRepairItem],
+) -> tuple[str, bool]:
+    """Exclusively create or validate an append-only operator repair receipt."""
+    if path.is_symlink():
+        raise RuntimeError("repair receipt path must not be a symbolic link")
+    targets = _repair_receipt_targets(items)
+    target_hash = hashlib.sha256(json.dumps(targets, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    planned = {
+        "schema": "polylogue.untyped-accepted-raw-repair.v1",
+        "state": "planned",
+        "target_hash": target_hash,
+        "targets": targets,
+        "planned_at_ms": int(time.time() * 1000),
+    }
+    encoded = (json.dumps(planned, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        lines = path.read_text(encoding="utf-8").splitlines()
+        try:
+            records = [json.loads(line) for line in lines]
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"existing repair receipt is unreadable: {exc}") from exc
+        if not records or records[0].get("schema") != planned["schema"]:
+            raise RuntimeError("existing repair receipt has the wrong schema") from None
+        if records[0].get("target_hash") != target_hash or records[0].get("targets") != targets:
+            raise RuntimeError("existing repair receipt targets do not match the proven repair set") from None
+        terminal = len(records) == 2 and records[1].get("state") == "applied"
+        if len(records) not in {1, 2} or (len(records) == 2 and not terminal):
+            raise RuntimeError("existing repair receipt has an invalid state transition") from None
+        return target_hash, terminal
+    try:
+        os.write(descriptor, encoded)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    _fsync_parent(path)
+    return target_hash, False
+
+
+def _finish_untyped_raw_repair_receipt(
+    path: Path,
+    *,
+    target_hash: str,
+    items: list[UntypedAcceptedRawRepairItem],
+) -> None:
+    terminal = {
+        "schema": "polylogue.untyped-accepted-raw-repair.v1",
+        "state": "applied",
+        "target_hash": target_hash,
+        "applied_at_ms": int(time.time() * 1000),
+        "repaired_raw_ids": [item.raw_id for item in items if item.repaired],
+        "proven_raw_ids": [item.raw_id for item in items],
+    }
+    with path.open("ab", buffering=0) as handle:
+        handle.write((json.dumps(terminal, sort_keys=True, separators=(",", ":")) + "\n").encode())
+        os.fsync(handle.fileno())
+    _fsync_parent(path)
+
+
+def repair_untyped_accepted_raws(
+    config: Config,
+    raw_ids: list[str],
+    *,
+    apply: bool = False,
+    receipt_path: Path | None = None,
+    proof_digest: str | None = None,
+) -> UntypedAcceptedRawRepairReport:
+    """Refine accepted-but-untyped full raws only after exact retained proof."""
+    if len(set(raw_ids)) != len(raw_ids):
+        raise ValueError("duplicate raw ids are not allowed")
+    if not raw_ids or len(raw_ids) > _UNTYPED_ACCEPTED_RAW_REPAIR_LIMIT:
+        raise ValueError(f"raw-id list must contain 1..{_UNTYPED_ACCEPTED_RAW_REPAIR_LIMIT} entries")
+    if any(re.fullmatch(r"[0-9a-f]{64}", raw_id) is None for raw_id in raw_ids):
+        raise ValueError("raw ids must be lowercase SHA-256 identifiers")
+    block_reason = offline_maintenance_block_reason(config, active=apply, dry_run=not apply)
+    if block_reason is not None:
+        raise RuntimeError(block_reason)
+    archive_root = _raw_materialization_archive_root(config)
+    source_db = archive_root / "source.db"
+    index_db = archive_root / "index.db"
+    if not source_db.exists() or not index_db.exists():
+        raise RuntimeError("source or index tier is missing")
+    with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as dry_conn:
+        _attach_repair_index(dry_conn, index_db)
+        items = [_inspect_untyped_accepted_raw(archive_root, raw_id, conn=dry_conn) for raw_id in raw_ids]
+    aggregate_proof = _repair_proof_digest(items)
+    if apply and any(item.status == "ineligible" for item in items):
+        raise RuntimeError("untyped accepted raw repair refused because one or more targets are ineligible")
+    if apply and receipt_path is None:
+        raise ValueError("apply requires an explicit operator repair receipt path")
+    if apply and proof_digest != aggregate_proof:
+        raise RuntimeError("apply proof digest does not match the exact dry-run target list")
+    if apply:
+        from polylogue.storage.index_generation import ActiveWriterLease
+
+        assert receipt_path is not None
+        target_hash, terminal = _prepare_untyped_raw_repair_receipt(receipt_path, items)
+        lease = ActiveWriterLease(archive_root)
+        lease.acquire()
+        try:
+            with closing(sqlite3.connect(f"file:{source_db}?mode=rw", uri=True)) as source_conn:
+                source_conn.execute("PRAGMA foreign_keys = ON")
+                _attach_repair_index(source_conn, index_db)
+                source_conn.execute("BEGIN IMMEDIATE")
+                try:
+                    locked_items = [
+                        _inspect_untyped_accepted_raw(archive_root, raw_id, conn=source_conn) for raw_id in raw_ids
+                    ]
+                    if _repair_proof_digest(locked_items) != proof_digest:
+                        raise RuntimeError("authority proof changed after acquiring the repair transaction")
+                    if any(item.status == "ineligible" for item in locked_items):
+                        raise RuntimeError("a repair target became ineligible after acquiring the transaction")
+                    if terminal and any(item.status != "already_repaired" for item in locked_items):
+                        raise RuntimeError("terminal operator receipt disagrees with durable source authority")
+                    for item in locked_items:
+                        if item.status != "eligible":
+                            continue
+                        assert item.logical_source_key is not None
+                        assert item.accepted_source_revision is not None
+                        assert item.acquisition_generation is not None
+                        cursor = source_conn.execute(
+                            """
+                            UPDATE raw_sessions
+                            SET logical_source_key = ?, revision_kind = 'full', source_revision = ?,
+                                baseline_raw_id = raw_id, acquisition_generation = ?,
+                                revision_authority = 'byte_proven'
+                            WHERE raw_id = ? AND logical_source_key IS NULL
+                              AND revision_kind = 'unknown' AND source_revision IS NULL
+                              AND predecessor_source_revision IS NULL AND predecessor_raw_id IS NULL
+                              AND baseline_raw_id IS NULL AND append_start_offset IS NULL
+                              AND append_end_offset IS NULL AND acquisition_generation IS NULL
+                              AND revision_authority = 'quarantined'
+                            """,
+                            (
+                                item.logical_source_key,
+                                item.accepted_source_revision,
+                                item.acquisition_generation,
+                                item.raw_id,
+                            ),
+                        )
+                        if cursor.rowcount != 1:
+                            raise RuntimeError(f"source authority CAS failed for {item.raw_id}")
+                    after_items = [
+                        _inspect_untyped_accepted_raw(archive_root, raw_id, conn=source_conn) for raw_id in raw_ids
+                    ]
+                    if any(item.status != "already_repaired" for item in after_items):
+                        raise RuntimeError("source envelope refinement did not reach the proven terminal state")
+                    source_conn.commit()
+                except Exception:
+                    source_conn.rollback()
+                    raise
+            items = [
+                dataclasses.replace(after, repaired=before.status == "eligible")
+                for before, after in zip(items, after_items, strict=True)
+            ]
+        finally:
+            lease.close()
+        if not terminal:
+            _finish_untyped_raw_repair_receipt(receipt_path, target_hash=target_hash, items=items)
+    return UntypedAcceptedRawRepairReport(
+        mode="apply" if apply else "dry-run",
+        requested_count=len(items),
+        eligible_count=sum(item.status == "eligible" for item in items),
+        repaired_count=sum(item.repaired for item in items),
+        already_repaired_count=sum(item.status == "already_repaired" for item in items),
+        ineligible_count=sum(item.status == "ineligible" for item in items),
+        proof_digest=aggregate_proof,
+        receipt_path=str(receipt_path) if receipt_path is not None else None,
+        items=tuple(items),
+    )
 
 
 def _format_bytes(value: int) -> str:

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -726,6 +726,18 @@ def _finish_untyped_raw_repair_receipt(
     *,
     items: list[UntypedAcceptedRawRepairItem],
 ) -> None:
+    opened = os.fstat(receipt.descriptor)
+    named = receipt.path.stat(follow_symlinks=False)
+    if (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino):
+        raise RuntimeError("operator repair receipt path changed before terminal append")
+    os.lseek(receipt.descriptor, 0, os.SEEK_END)
+    preserved_torn_terminals = list(receipt.torn_terminals)
+    if preserved_torn_terminals and not receipt.receipt_terminated:
+        # Make even a complete-JSON prefix permanently distinguishable from a
+        # terminal record after the newline is appended. The exact sealed bytes
+        # remain in the append-only receipt and are bound into the terminal.
+        _write_receipt_all(receipt.descriptor, b"\xff\n")
+        preserved_torn_terminals[-1] += b"\xff"
     terminal = {
         "schema": _UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA,
         "state": "applied",
@@ -734,18 +746,11 @@ def _finish_untyped_raw_repair_receipt(
         "repaired_raw_ids": list(receipt.repair_intent_raw_ids),
         "proven_raw_ids": [item.raw_id for item in items],
     }
-    if receipt.torn_terminals:
+    if preserved_torn_terminals:
         terminal["torn_terminals"] = [
             {"bytes": len(fragment), "sha256": hashlib.sha256(fragment).hexdigest()}
-            for fragment in receipt.torn_terminals
+            for fragment in preserved_torn_terminals
         ]
-    opened = os.fstat(receipt.descriptor)
-    named = receipt.path.stat(follow_symlinks=False)
-    if (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino):
-        raise RuntimeError("operator repair receipt path changed before terminal append")
-    os.lseek(receipt.descriptor, 0, os.SEEK_END)
-    if receipt.torn_terminals and not receipt.receipt_terminated:
-        _write_receipt_all(receipt.descriptor, b"\n")
     _write_receipt_all(
         receipt.descriptor, (json.dumps(terminal, sort_keys=True, separators=(",", ":")) + "\n").encode()
     )

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -168,7 +168,7 @@ def _authority_rows_digest(*row_sets: list[sqlite3.Row]) -> str:
             return {"blob_hex": bytes(value).hex()}
         return value
 
-    payload = [[{key: value_payload(row[key]) for key in row} for row in rows] for rows in row_sets]
+    payload = [[{key: value_payload(value) for key, value in dict(row).items()} for row in rows] for rows in row_sets]
     return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
 
 

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import fcntl
 import hashlib
 import json
 import os
@@ -14,6 +15,7 @@ from contextlib import closing
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import cast
 
 from polylogue.archive.raw_materialization import parsed_non_session_artifact_reason
 from polylogue.archive.revision_authority import (
@@ -59,6 +61,48 @@ RAW_MATERIALIZATION_RESOURCE_BLOCK_REASON = "non-stream-safe raw payload exceeds
 _TRANSIENT_LOCK_PARSE_ERROR = "OperationalError: database is locked"
 _UNTYPED_ACCEPTED_RAW_REPAIR_DETAIL = "repair:accepted_untyped_raw_exact_byte_and_semantic_proof"
 _UNTYPED_ACCEPTED_RAW_REPAIR_LIMIT = 100
+_UNTYPED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES = 256 * 1024 * 1024
+_UNTYPED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES = 512 * 1024 * 1024
+_UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA = "polylogue.untyped-accepted-raw-repair.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class UntypedAcceptedRawArtifactWitness:
+    artifact_id: str
+    origin: str
+    source_path: str
+    source_index: int
+    artifact_kind: str
+    support_status: str
+    classification_reason: str
+    parse_as_session: int
+    schema_eligible: int
+    malformed_jsonl_lines: int
+    decode_error: str | None
+    cohort_id: str | None
+    link_group_key: str | None
+    sidecar_agent_type: str | None
+    first_observed_at_ms: int
+    last_observed_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class UntypedAcceptedRawApplicationWitness:
+    decision_id: str
+    raw_id: str
+    session_id: str
+    logical_source_key: str
+    source_revision: str
+    acquisition_generation: int
+    decision: str
+    accepted_raw_id: str
+    accepted_source_revision: str
+    accepted_content_hash: str
+    baseline_raw_id: str | None
+    predecessor_raw_id: str | None
+    append_end_offset: int | None
+    detail: str
+    decided_at_ms: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -68,12 +112,23 @@ class UntypedAcceptedRawRepairItem:
     reason: str
     logical_source_key: str | None = None
     session_id: str | None = None
+    origin: str | None = None
     source_path: str | None = None
+    source_index: int | None = None
+    blob_hash: str | None = None
     blob_size: int | None = None
+    blob_ref_hash: str | None = None
+    blob_ref_source_path: str | None = None
+    blob_ref_size: int | None = None
+    artifact_witnesses: tuple[UntypedAcceptedRawArtifactWitness, ...] = ()
     accepted_source_revision: str | None = None
     accepted_content_hash: str | None = None
+    accepted_frontier_kind: str | None = None
+    accepted_frontier: int | None = None
+    head_decided_at_ms: int | None = None
     acquisition_generation: int | None = None
     application_decision_id: str | None = None
+    application_witness: UntypedAcceptedRawApplicationWitness | None = None
     proof_digest: str | None = None
     repaired: bool = False
 
@@ -106,6 +161,27 @@ def _bytes_value(value: object) -> bytes:
 def _attach_repair_index(conn: sqlite3.Connection, index_db: Path) -> None:
     conn.row_factory = sqlite3.Row
     conn.execute("ATTACH DATABASE ? AS index_tier", (f"file:{index_db}?mode=ro",))
+
+
+def _validate_untyped_raw_repair_blob_budget(conn: sqlite3.Connection, raw_ids: list[str]) -> None:
+    """Reject a bounded repair set before any retained blob is loaded into memory."""
+    rows = conn.execute(
+        """
+        SELECT raw_id, blob_size FROM raw_sessions
+        WHERE raw_id IN (SELECT value FROM json_each(?))
+        """,
+        (json.dumps(raw_ids),),
+    ).fetchall()
+    oversized = [
+        str(row["raw_id"]) for row in rows if int(row["blob_size"]) > _UNTYPED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES
+    ]
+    if oversized:
+        raise RuntimeError(
+            "untyped accepted raw repair exceeds the per-target retained-blob limit: " + ", ".join(oversized)
+        )
+    total = sum(int(row["blob_size"]) for row in rows)
+    if total > _UNTYPED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES:
+        raise RuntimeError("untyped accepted raw repair exceeds the aggregate retained-blob limit")
 
 
 def _proof_digest(item: UntypedAcceptedRawRepairItem) -> str:
@@ -152,9 +228,10 @@ def _inspect_untyped_accepted_raw(
             return _untyped_raw_item(raw_id, f"expected one accepted head, found {len(heads)}")
         head = heads[0]
         logical_source_key = str(head["logical_source_key"])
+        session_id = str(head["session_id"])
         session_rows = conn.execute(
             "SELECT session_id, raw_id, content_hash FROM index_tier.sessions WHERE session_id = ? AND raw_id = ?",
-            (str(head["session_id"]), raw_id),
+            (session_id, raw_id),
         ).fetchall()
         if len(session_rows) != 1:
             return _untyped_raw_item(raw_id, "accepted head and indexed session do not share the raw")
@@ -164,21 +241,30 @@ def _inspect_untyped_accepted_raw(
             SELECT decision_id, raw_id, session_id, logical_source_key, source_revision,
                    acquisition_generation, decision, accepted_raw_id,
                    accepted_source_revision, accepted_content_hash, append_end_offset,
-                   decided_at_ms
+                   baseline_raw_id, predecessor_raw_id, detail, decided_at_ms
             FROM index_tier.raw_revision_applications
-            WHERE raw_id = ? OR accepted_raw_id = ? OR logical_source_key = ?
+            WHERE raw_id = ? OR accepted_raw_id = ? OR logical_source_key = ? OR session_id = ?
             """,
-            (raw_id, raw_id, logical_source_key),
+            (raw_id, raw_id, logical_source_key, session_id),
         ).fetchall()
         if len(applications) != 1:
             return _untyped_raw_item(raw_id, "competing raw-revision application authority exists")
         receipt = applications[0]
+        competing_head_count = int(
+            conn.execute(
+                """
+                SELECT COUNT(*) FROM index_tier.raw_revision_heads
+                WHERE session_id = ?
+                  AND NOT (accepted_raw_id = ? AND logical_source_key = ?)
+                """,
+                (session_id, raw_id, logical_source_key),
+            ).fetchone()[0]
+        )
         competing_revision_count = int(
             conn.execute(
                 """
                 SELECT COUNT(*) FROM raw_sessions
                 WHERE raw_id != ? AND logical_source_key = ?
-                  AND revision_authority != 'quarantined'
                 """,
                 (raw_id, logical_source_key),
             ).fetchone()[0]
@@ -200,17 +286,17 @@ def _inspect_untyped_accepted_raw(
             """,
             (raw_id,),
         ).fetchall()
-        artifact_mismatch_count = int(
-            conn.execute(
-                """
-                SELECT COUNT(*) FROM raw_artifacts
-                WHERE raw_id = ? AND (
-                    origin != ? OR source_path != ? OR source_index != ?
-                )
-                """,
-                (raw_id, raw["origin"], raw["source_path"], raw["source_index"]),
-            ).fetchone()[0]
-        )
+        artifact_rows = conn.execute(
+            """
+            SELECT artifact_id, origin, source_path, source_index, artifact_kind,
+                   support_status, classification_reason, parse_as_session,
+                   schema_eligible, malformed_jsonl_lines, decode_error, cohort_id,
+                   link_group_key, sidecar_agent_type, first_observed_at_ms,
+                   last_observed_at_ms
+            FROM raw_artifacts WHERE raw_id = ? ORDER BY artifact_id
+            """,
+            (raw_id,),
+        ).fetchall()
     except sqlite3.Error as exc:
         return _untyped_raw_item(raw_id, f"authority tiers are unreadable: {exc}")
 
@@ -269,7 +355,7 @@ def _inspect_untyped_accepted_raw(
         return _untyped_raw_item(raw_id, "head, session, and application content hashes disagree")
     expected_receipt = (
         raw_id,
-        str(head["session_id"]),
+        session_id,
         logical_source_key,
         accepted_revision,
         generation,
@@ -277,6 +363,8 @@ def _inspect_untyped_accepted_raw(
         raw_id,
         accepted_revision,
         accepted_hash,
+        raw_id,
+        None,
         None,
         int(head["decided_at_ms"]),
     )
@@ -290,12 +378,14 @@ def _inspect_untyped_accepted_raw(
         str(receipt["accepted_raw_id"]),
         str(receipt["accepted_source_revision"]),
         receipt_hash,
+        receipt["baseline_raw_id"],
+        receipt["predecessor_raw_id"],
         receipt["append_end_offset"],
         int(receipt["decided_at_ms"]),
     )
     if actual_receipt != expected_receipt:
         return _untyped_raw_item(raw_id, "immutable baseline receipt does not exactly match the accepted head")
-    if competing_revision_count or membership_count:
+    if competing_head_count or competing_revision_count or membership_count:
         return _untyped_raw_item(raw_id, "competing typed or membership authority exists")
     if len(blob_ref_rows) != 1:
         return _untyped_raw_item(raw_id, "expected exactly one raw-payload blob reference")
@@ -304,11 +394,41 @@ def _inspect_untyped_accepted_raw(
         _bytes_value(blob_ref["blob_hash"]) != blob_hash_bytes
         or str(blob_ref["source_path"] or "") != str(raw["source_path"] or "")
         or int(blob_ref["size_bytes"]) != int(raw["blob_size"])
-        or artifact_mismatch_count
+        or any(
+            str(artifact["origin"]) != str(raw["origin"])
+            or str(artifact["source_path"]) != str(raw["source_path"])
+            or int(artifact["source_index"]) != int(raw["source_index"])
+            for artifact in artifact_rows
+        )
     ):
         return _untyped_raw_item(raw_id, "raw row, blob reference, and artifact identity disagree")
 
     blob_hash = blob_hash_bytes.hex()
+    if int(raw["blob_size"]) > _UNTYPED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES:
+        return _untyped_raw_item(raw_id, "retained raw exceeds the per-target repair byte limit")
+    artifact_witnesses = tuple(
+        UntypedAcceptedRawArtifactWitness(
+            artifact_id=str(artifact["artifact_id"]),
+            origin=str(artifact["origin"]),
+            source_path=str(artifact["source_path"]),
+            source_index=int(artifact["source_index"]),
+            artifact_kind=str(artifact["artifact_kind"]),
+            support_status=str(artifact["support_status"]),
+            classification_reason=str(artifact["classification_reason"]),
+            parse_as_session=int(artifact["parse_as_session"]),
+            schema_eligible=int(artifact["schema_eligible"]),
+            malformed_jsonl_lines=int(artifact["malformed_jsonl_lines"]),
+            decode_error=str(artifact["decode_error"]) if artifact["decode_error"] is not None else None,
+            cohort_id=str(artifact["cohort_id"]) if artifact["cohort_id"] is not None else None,
+            link_group_key=str(artifact["link_group_key"]) if artifact["link_group_key"] is not None else None,
+            sidecar_agent_type=(
+                str(artifact["sidecar_agent_type"]) if artifact["sidecar_agent_type"] is not None else None
+            ),
+            first_observed_at_ms=int(artifact["first_observed_at_ms"]),
+            last_observed_at_ms=int(artifact["last_observed_at_ms"]),
+        )
+        for artifact in artifact_rows
+    )
     blob_store = BlobStore(archive_root / "blob")
     if not blob_store.exists(blob_hash) or not blob_store.verify(blob_hash):
         return _untyped_raw_item(raw_id, "retained raw blob is missing or fails its content hash")
@@ -351,22 +471,52 @@ def _inspect_untyped_accepted_raw(
             else _UNTYPED_ACCEPTED_RAW_REPAIR_DETAIL
         ),
         logical_source_key=logical_source_key,
-        session_id=str(head["session_id"]),
+        session_id=session_id,
+        origin=str(raw["origin"]),
         source_path=str(raw["source_path"]),
+        source_index=int(raw["source_index"]),
+        blob_hash=blob_hash,
         blob_size=int(raw["blob_size"]),
+        blob_ref_hash=_bytes_value(blob_ref["blob_hash"]).hex(),
+        blob_ref_source_path=str(blob_ref["source_path"] or ""),
+        blob_ref_size=int(blob_ref["size_bytes"]),
+        artifact_witnesses=artifact_witnesses,
         accepted_source_revision=accepted_revision,
         accepted_content_hash=accepted_hash.hex(),
+        accepted_frontier_kind=str(head["accepted_frontier_kind"]),
+        accepted_frontier=int(head["accepted_frontier"]),
+        head_decided_at_ms=int(head["decided_at_ms"]),
         acquisition_generation=generation,
         application_decision_id=str(receipt["decision_id"]),
+        application_witness=UntypedAcceptedRawApplicationWitness(
+            decision_id=str(receipt["decision_id"]),
+            raw_id=str(receipt["raw_id"]),
+            session_id=str(receipt["session_id"]),
+            logical_source_key=str(receipt["logical_source_key"]),
+            source_revision=str(receipt["source_revision"]),
+            acquisition_generation=int(receipt["acquisition_generation"]),
+            decision=str(receipt["decision"]),
+            accepted_raw_id=str(receipt["accepted_raw_id"]),
+            accepted_source_revision=str(receipt["accepted_source_revision"]),
+            accepted_content_hash=receipt_hash.hex(),
+            baseline_raw_id=str(receipt["baseline_raw_id"]) if receipt["baseline_raw_id"] is not None else None,
+            predecessor_raw_id=(
+                str(receipt["predecessor_raw_id"]) if receipt["predecessor_raw_id"] is not None else None
+            ),
+            append_end_offset=(int(receipt["append_end_offset"]) if receipt["append_end_offset"] is not None else None),
+            detail=str(receipt["detail"]),
+            decided_at_ms=int(receipt["decided_at_ms"]),
+        ),
     )
     return dataclasses.replace(item, proof_digest=_proof_digest(item))
 
 
 def _repair_receipt_targets(items: list[UntypedAcceptedRawRepairItem]) -> list[dict[str, object]]:
-    return [
+    targets = [
         {key: value for key, value in dataclasses.asdict(item).items() if key not in {"reason", "repaired", "status"}}
         for item in items
     ]
+    return cast(list[dict[str, object]], json.loads(json.dumps(targets, sort_keys=True)))
 
 
 def _repair_proof_digest(items: list[UntypedAcceptedRawRepairItem]) -> str:
@@ -382,66 +532,195 @@ def _fsync_parent(path: Path) -> None:
         os.close(descriptor)
 
 
-def _prepare_untyped_raw_repair_receipt(
+@dataclass(slots=True)
+class _LockedUntypedRawRepairReceipt:
+    path: Path
+    descriptor: int
+    target_hash: str
+    terminal: bool
+    repair_intent_raw_ids: tuple[str, ...]
+
+    def close(self) -> None:
+        fcntl.flock(self.descriptor, fcntl.LOCK_UN)
+        os.close(self.descriptor)
+
+
+def _receipt_records(descriptor: int) -> list[dict[str, object]]:
+    size = os.fstat(descriptor).st_size
+    if size > 16 * 1024 * 1024:
+        raise RuntimeError("existing repair receipt exceeds the bounded parser limit")
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining:
+        chunk = os.read(descriptor, remaining)
+        if not chunk:
+            raise RuntimeError("existing repair receipt changed during its locked read")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    payload = b"".join(chunks)
+    try:
+        lines = payload.decode("utf-8").splitlines()
+        parsed_records: list[object] = [json.loads(line) for line in lines]
+    except (UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"existing repair receipt is unreadable: {exc}") from exc
+    if any(not isinstance(record, dict) for record in parsed_records):
+        raise RuntimeError("existing repair receipt records must be JSON objects")
+    return [cast(dict[str, object], record) for record in parsed_records]
+
+
+def _validate_repair_receipt_records(
+    records: list[dict[str, object]],
+    *,
+    targets: list[dict[str, object]],
+    target_hash: str,
+) -> tuple[bool, tuple[str, ...]]:
+    if not records:
+        raise RuntimeError("existing repair receipt is empty")
+    planned = records[0]
+    planned_keys = {"schema", "state", "target_hash", "targets", "repair_intent_raw_ids", "planned_at_ms"}
+    if set(planned) != planned_keys or planned.get("schema") != _UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA:
+        raise RuntimeError("existing repair receipt has an invalid planned record schema")
+    if planned.get("state") != "planned":
+        raise RuntimeError("existing repair receipt must start with a planned record")
+    if planned.get("target_hash") != target_hash or planned.get("targets") != targets:
+        raise RuntimeError("existing repair receipt targets do not match the proven repair set")
+    planned_at_ms = planned.get("planned_at_ms")
+    if not isinstance(planned_at_ms, int) or planned_at_ms < 0:
+        raise RuntimeError("existing repair receipt planned timestamp is invalid")
+    raw_ids = tuple(str(target["raw_id"]) for target in targets)
+    intent = planned.get("repair_intent_raw_ids")
+    if not isinstance(intent, list) or any(not isinstance(raw_id, str) for raw_id in intent):
+        raise RuntimeError("existing repair receipt repair intent is invalid")
+    intent_ids = tuple(cast(list[str], intent))
+    if len(set(intent_ids)) != len(intent_ids) or any(raw_id not in raw_ids for raw_id in intent_ids):
+        raise RuntimeError("existing repair receipt repair intent does not match its targets")
+    if len(records) == 1:
+        return False, intent_ids
+    if len(records) != 2:
+        raise RuntimeError("existing repair receipt has an invalid state transition")
+    applied = records[1]
+    applied_keys = {
+        "schema",
+        "state",
+        "target_hash",
+        "applied_at_ms",
+        "repaired_raw_ids",
+        "proven_raw_ids",
+    }
+    if set(applied) != applied_keys or applied.get("schema") != _UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA:
+        raise RuntimeError("existing repair receipt has an invalid applied record schema")
+    if applied.get("state") != "applied" or applied.get("target_hash") != target_hash:
+        raise RuntimeError("existing repair receipt has an invalid applied target transition")
+    applied_at_ms = applied.get("applied_at_ms")
+    if not isinstance(applied_at_ms, int) or applied_at_ms < 0:
+        raise RuntimeError("existing repair receipt applied timestamp is invalid")
+    if applied.get("proven_raw_ids") != list(raw_ids) or applied.get("repaired_raw_ids") != list(intent_ids):
+        raise RuntimeError("existing repair receipt applied ids do not match the planned targets")
+    return True, intent_ids
+
+
+def _lock_untyped_raw_repair_receipt(
     path: Path,
     items: list[UntypedAcceptedRawRepairItem],
-) -> tuple[str, bool]:
-    """Exclusively create or validate an append-only operator repair receipt."""
+) -> _LockedUntypedRawRepairReceipt:
+    """Lock one stable receipt inode and create or validate its planned record."""
     if path.is_symlink():
         raise RuntimeError("repair receipt path must not be a symbolic link")
     targets = _repair_receipt_targets(items)
     target_hash = hashlib.sha256(json.dumps(targets, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
-    planned = {
-        "schema": "polylogue.untyped-accepted-raw-repair.v1",
-        "state": "planned",
-        "target_hash": target_hash,
-        "targets": targets,
-        "planned_at_ms": int(time.time() * 1000),
-    }
-    encoded = (json.dumps(planned, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    repair_intent_raw_ids = tuple(item.raw_id for item in items if item.status == "eligible")
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags, 0o600)
     try:
-        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    except FileExistsError:
-        lines = path.read_text(encoding="utf-8").splitlines()
-        try:
-            records = [json.loads(line) for line in lines]
-        except (OSError, ValueError, json.JSONDecodeError) as exc:
-            raise RuntimeError(f"existing repair receipt is unreadable: {exc}") from exc
-        if not records or records[0].get("schema") != planned["schema"]:
-            raise RuntimeError("existing repair receipt has the wrong schema") from None
-        if records[0].get("target_hash") != target_hash or records[0].get("targets") != targets:
-            raise RuntimeError("existing repair receipt targets do not match the proven repair set") from None
-        terminal = len(records) == 2 and records[1].get("state") == "applied"
-        if len(records) not in {1, 2} or (len(records) == 2 and not terminal):
-            raise RuntimeError("existing repair receipt has an invalid state transition") from None
-        return target_hash, terminal
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        os.close(descriptor)
+        raise RuntimeError("operator repair receipt is already locked by another apply") from exc
     try:
+        opened = os.fstat(descriptor)
+        named = path.stat(follow_symlinks=False)
+        if (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino):
+            raise RuntimeError("operator repair receipt path changed while it was being locked")
+        if opened.st_size:
+            terminal, existing_intent = _validate_repair_receipt_records(
+                _receipt_records(descriptor), targets=targets, target_hash=target_hash
+            )
+            return _LockedUntypedRawRepairReceipt(path, descriptor, target_hash, terminal, existing_intent)
+        planned = {
+            "schema": _UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA,
+            "state": "planned",
+            "target_hash": target_hash,
+            "targets": targets,
+            "repair_intent_raw_ids": list(repair_intent_raw_ids),
+            "planned_at_ms": int(time.time() * 1000),
+        }
+        encoded = (json.dumps(planned, sort_keys=True, separators=(",", ":")) + "\n").encode()
         os.write(descriptor, encoded)
         os.fsync(descriptor)
-    finally:
+        _fsync_parent(path)
+        return _LockedUntypedRawRepairReceipt(path, descriptor, target_hash, False, repair_intent_raw_ids)
+    except Exception:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
         os.close(descriptor)
-    _fsync_parent(path)
-    return target_hash, False
+        raise
 
 
 def _finish_untyped_raw_repair_receipt(
-    path: Path,
+    receipt: _LockedUntypedRawRepairReceipt,
     *,
-    target_hash: str,
     items: list[UntypedAcceptedRawRepairItem],
 ) -> None:
     terminal = {
-        "schema": "polylogue.untyped-accepted-raw-repair.v1",
+        "schema": _UNTYPED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA,
         "state": "applied",
-        "target_hash": target_hash,
+        "target_hash": receipt.target_hash,
         "applied_at_ms": int(time.time() * 1000),
-        "repaired_raw_ids": [item.raw_id for item in items if item.repaired],
+        "repaired_raw_ids": list(receipt.repair_intent_raw_ids),
         "proven_raw_ids": [item.raw_id for item in items],
     }
-    with path.open("ab", buffering=0) as handle:
-        handle.write((json.dumps(terminal, sort_keys=True, separators=(",", ":")) + "\n").encode())
-        os.fsync(handle.fileno())
-    _fsync_parent(path)
+    opened = os.fstat(receipt.descriptor)
+    named = receipt.path.stat(follow_symlinks=False)
+    if (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino):
+        raise RuntimeError("operator repair receipt path changed before terminal append")
+    os.lseek(receipt.descriptor, 0, os.SEEK_END)
+    os.write(
+        receipt.descriptor,
+        (json.dumps(terminal, sort_keys=True, separators=(",", ":")) + "\n").encode(),
+    )
+    os.fsync(receipt.descriptor)
+    _fsync_parent(receipt.path)
+
+
+def _cas_refine_untyped_accepted_raw(
+    source_conn: sqlite3.Connection,
+    item: UntypedAcceptedRawRepairItem,
+) -> None:
+    assert item.logical_source_key is not None
+    assert item.accepted_source_revision is not None
+    assert item.acquisition_generation is not None
+    cursor = source_conn.execute(
+        """
+        UPDATE raw_sessions
+        SET logical_source_key = ?, revision_kind = 'full', source_revision = ?,
+            baseline_raw_id = raw_id, acquisition_generation = ?,
+            revision_authority = 'byte_proven'
+        WHERE raw_id = ? AND logical_source_key IS NULL
+          AND revision_kind = 'unknown' AND source_revision IS NULL
+          AND predecessor_source_revision IS NULL AND predecessor_raw_id IS NULL
+          AND baseline_raw_id IS NULL AND append_start_offset IS NULL
+          AND append_end_offset IS NULL AND acquisition_generation IS NULL
+          AND revision_authority = 'quarantined'
+        """,
+        (
+            item.logical_source_key,
+            item.accepted_source_revision,
+            item.acquisition_generation,
+            item.raw_id,
+        ),
+    )
+    if cursor.rowcount != 1:
+        raise RuntimeError(f"source authority CAS failed for {item.raw_id}")
 
 
 def repair_untyped_accepted_raws(
@@ -469,6 +748,7 @@ def repair_untyped_accepted_raws(
         raise RuntimeError("source or index tier is missing")
     with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as dry_conn:
         _attach_repair_index(dry_conn, index_db)
+        _validate_untyped_raw_repair_blob_budget(dry_conn, raw_ids)
         items = [_inspect_untyped_accepted_raw(archive_root, raw_id, conn=dry_conn) for raw_id in raw_ids]
     aggregate_proof = _repair_proof_digest(items)
     if apply and any(item.status == "ineligible" for item in items):
@@ -481,69 +761,48 @@ def repair_untyped_accepted_raws(
         from polylogue.storage.index_generation import ActiveWriterLease
 
         assert receipt_path is not None
-        target_hash, terminal = _prepare_untyped_raw_repair_receipt(receipt_path, items)
-        lease = ActiveWriterLease(archive_root)
-        lease.acquire()
+        receipt = _lock_untyped_raw_repair_receipt(receipt_path, items)
         try:
-            with closing(sqlite3.connect(f"file:{source_db}?mode=rw", uri=True)) as source_conn:
-                source_conn.execute("PRAGMA foreign_keys = ON")
-                _attach_repair_index(source_conn, index_db)
-                source_conn.execute("BEGIN IMMEDIATE")
-                try:
-                    locked_items = [
-                        _inspect_untyped_accepted_raw(archive_root, raw_id, conn=source_conn) for raw_id in raw_ids
-                    ]
-                    if _repair_proof_digest(locked_items) != proof_digest:
-                        raise RuntimeError("authority proof changed after acquiring the repair transaction")
-                    if any(item.status == "ineligible" for item in locked_items):
-                        raise RuntimeError("a repair target became ineligible after acquiring the transaction")
-                    if terminal and any(item.status != "already_repaired" for item in locked_items):
-                        raise RuntimeError("terminal operator receipt disagrees with durable source authority")
-                    for item in locked_items:
-                        if item.status != "eligible":
-                            continue
-                        assert item.logical_source_key is not None
-                        assert item.accepted_source_revision is not None
-                        assert item.acquisition_generation is not None
-                        cursor = source_conn.execute(
-                            """
-                            UPDATE raw_sessions
-                            SET logical_source_key = ?, revision_kind = 'full', source_revision = ?,
-                                baseline_raw_id = raw_id, acquisition_generation = ?,
-                                revision_authority = 'byte_proven'
-                            WHERE raw_id = ? AND logical_source_key IS NULL
-                              AND revision_kind = 'unknown' AND source_revision IS NULL
-                              AND predecessor_source_revision IS NULL AND predecessor_raw_id IS NULL
-                              AND baseline_raw_id IS NULL AND append_start_offset IS NULL
-                              AND append_end_offset IS NULL AND acquisition_generation IS NULL
-                              AND revision_authority = 'quarantined'
-                            """,
-                            (
-                                item.logical_source_key,
-                                item.accepted_source_revision,
-                                item.acquisition_generation,
-                                item.raw_id,
-                            ),
-                        )
-                        if cursor.rowcount != 1:
-                            raise RuntimeError(f"source authority CAS failed for {item.raw_id}")
-                    after_items = [
-                        _inspect_untyped_accepted_raw(archive_root, raw_id, conn=source_conn) for raw_id in raw_ids
-                    ]
-                    if any(item.status != "already_repaired" for item in after_items):
-                        raise RuntimeError("source envelope refinement did not reach the proven terminal state")
-                    source_conn.commit()
-                except Exception:
-                    source_conn.rollback()
-                    raise
-            items = [
-                dataclasses.replace(after, repaired=before.status == "eligible")
-                for before, after in zip(items, after_items, strict=True)
-            ]
+            lease = ActiveWriterLease(archive_root)
+            lease.acquire()
+            try:
+                with closing(sqlite3.connect(f"file:{source_db}?mode=rw", uri=True)) as source_conn:
+                    source_conn.execute("PRAGMA foreign_keys = ON")
+                    _attach_repair_index(source_conn, index_db)
+                    source_conn.execute("BEGIN IMMEDIATE")
+                    try:
+                        _validate_untyped_raw_repair_blob_budget(source_conn, raw_ids)
+                        locked_items = [
+                            _inspect_untyped_accepted_raw(archive_root, raw_id, conn=source_conn) for raw_id in raw_ids
+                        ]
+                        if _repair_proof_digest(locked_items) != proof_digest:
+                            raise RuntimeError("authority proof changed after acquiring the repair transaction")
+                        if any(item.status == "ineligible" for item in locked_items):
+                            raise RuntimeError("a repair target became ineligible after acquiring the transaction")
+                        if receipt.terminal and any(item.status != "already_repaired" for item in locked_items):
+                            raise RuntimeError("terminal operator receipt disagrees with durable source authority")
+                        for item in locked_items:
+                            if item.status == "eligible":
+                                _cas_refine_untyped_accepted_raw(source_conn, item)
+                        after_items = [
+                            _inspect_untyped_accepted_raw(archive_root, raw_id, conn=source_conn) for raw_id in raw_ids
+                        ]
+                        if any(item.status != "already_repaired" for item in after_items):
+                            raise RuntimeError("source envelope refinement did not reach the proven terminal state")
+                        source_conn.commit()
+                    except Exception:
+                        source_conn.rollback()
+                        raise
+                items = [
+                    dataclasses.replace(after, repaired=before.status == "eligible")
+                    for before, after in zip(items, after_items, strict=True)
+                ]
+            finally:
+                lease.close()
+            if not receipt.terminal:
+                _finish_untyped_raw_repair_receipt(receipt, items=items)
         finally:
-            lease.close()
-        if not terminal:
-            _finish_untyped_raw_repair_receipt(receipt_path, target_hash=target_hash, items=items)
+            receipt.close()
     return UntypedAcceptedRawRepairReport(
         mode="apply" if apply else "dry-run",
         requested_count=len(items),

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -1354,6 +1354,15 @@ def test_quarantined_accepted_raw_repair_cli_dry_run_is_bounded_json(
     assert len(payload["proof_digest"]) == 64
     assert payload["items"][0]["raw_id"] == raw_id
 
+    plain = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "quarantined-accepted-raws", "--raw-id", raw_id],
+        catch_exceptions=False,
+    )
+    assert plain.exit_code == 0
+    assert f"Proof digest: {payload['proof_digest']}" in plain.output
+    assert f"{raw_id} ineligible proof=unavailable" in plain.output
+
 
 def test_quarantined_accepted_raw_repair_cli_apply_requires_receipt_and_proof(
     cli_workspace: dict[str, Path],

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -1326,7 +1326,7 @@ def test_missing_raw_blob_cursor_repair_apply_deletes_only_cursor(
         assert conn.execute("SELECT 1 FROM raw_sessions WHERE source_path = ?", (str(source),)).fetchone() == (1,)
 
 
-def test_untyped_accepted_raw_repair_cli_dry_run_is_bounded_json(
+def test_quarantined_accepted_raw_repair_cli_dry_run_is_bounded_json(
     cli_workspace: dict[str, Path],
     cli_runner: CliRunner,
 ) -> None:
@@ -1338,7 +1338,7 @@ def test_untyped_accepted_raw_repair_cli_dry_run_is_bounded_json(
             "--plain",
             "ops",
             "maintenance",
-            "untyped-accepted-raws",
+            "quarantined-accepted-raws",
             "--raw-id",
             raw_id,
             "--output-format",
@@ -1355,7 +1355,7 @@ def test_untyped_accepted_raw_repair_cli_dry_run_is_bounded_json(
     assert payload["items"][0]["raw_id"] == raw_id
 
 
-def test_untyped_accepted_raw_repair_cli_apply_requires_receipt_and_proof(
+def test_quarantined_accepted_raw_repair_cli_apply_requires_receipt_and_proof(
     cli_workspace: dict[str, Path],
     cli_runner: CliRunner,
 ) -> None:
@@ -1363,7 +1363,7 @@ def test_untyped_accepted_raw_repair_cli_apply_requires_receipt_and_proof(
     raw_id = "a" * 64
     missing_receipt = cli_runner.invoke(
         cli,
-        ["--plain", "ops", "maintenance", "untyped-accepted-raws", "--raw-id", raw_id, "--apply"],
+        ["--plain", "ops", "maintenance", "quarantined-accepted-raws", "--raw-id", raw_id, "--apply"],
     )
     assert missing_receipt.exit_code == 2
     assert "--receipt" in missing_receipt.output
@@ -1373,7 +1373,7 @@ def test_untyped_accepted_raw_repair_cli_apply_requires_receipt_and_proof(
             "--plain",
             "ops",
             "maintenance",
-            "untyped-accepted-raws",
+            "quarantined-accepted-raws",
             "--raw-id",
             raw_id,
             "--apply",

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -1326,6 +1326,65 @@ def test_missing_raw_blob_cursor_repair_apply_deletes_only_cursor(
         assert conn.execute("SELECT 1 FROM raw_sessions WHERE source_path = ?", (str(source),)).fetchone() == (1,)
 
 
+def test_untyped_accepted_raw_repair_cli_dry_run_is_bounded_json(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    del cli_workspace
+    raw_id = "a" * 64
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "untyped-accepted-raws",
+            "--raw-id",
+            raw_id,
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["mode"] == "dry-run"
+    assert payload["requested_count"] == 1
+    assert payload["ineligible_count"] == 1
+    assert len(payload["proof_digest"]) == 64
+    assert payload["items"][0]["raw_id"] == raw_id
+
+
+def test_untyped_accepted_raw_repair_cli_apply_requires_receipt_and_proof(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    del cli_workspace
+    raw_id = "a" * 64
+    missing_receipt = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "untyped-accepted-raws", "--raw-id", raw_id, "--apply"],
+    )
+    assert missing_receipt.exit_code == 2
+    assert "--receipt" in missing_receipt.output
+    missing_proof = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "untyped-accepted-raws",
+            "--raw-id",
+            raw_id,
+            "--apply",
+            "--receipt",
+            "repair.jsonl",
+        ],
+    )
+    assert missing_proof.exit_code == 2
+    assert "--proof-digest" in missing_proof.output
+
+
 def test_archive_read_cli_lists_archive_sessions(
     cli_workspace: dict[str, Path],
     cli_runner: CliRunner,

--- a/tests/unit/storage/test_quarantined_accepted_raw_repair.py
+++ b/tests/unit/storage/test_quarantined_accepted_raw_repair.py
@@ -512,6 +512,50 @@ def test_quarantined_accepted_raw_repair_does_not_claim_a_competing_receipt_comm
     assert json.loads(interrupted_receipt.read_text().splitlines()[-1])["repaired_raw_ids"] == []
 
 
+def test_quarantined_accepted_raw_repair_attributes_from_locked_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    raw_id = _seed_invalid_head(tmp_path)
+    dry_run = repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])
+    receipt = tmp_path / "pre-lease-competitor.jsonl"
+    from polylogue.storage import index_generation
+
+    class CompetingRepairLease:
+        def __init__(self, archive_root: Path) -> None:
+            self.archive_root = archive_root
+
+        def __enter__(self) -> CompetingRepairLease:
+            with sqlite3.connect(self.archive_root / "source.db") as source:
+                source.execute(
+                    """
+                    UPDATE raw_sessions
+                    SET logical_source_key = ?, revision_kind = 'full', source_revision = ?,
+                        baseline_raw_id = raw_id, acquisition_generation = 0,
+                        revision_authority = 'byte_proven'
+                    WHERE raw_id = ?
+                    """,
+                    ("chatgpt:repair-one", dry_run.items[0].accepted_source_revision, raw_id),
+                )
+                source.commit()
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            del args
+
+    monkeypatch.setattr(index_generation, "RebuildLease", CompetingRepairLease)
+    result = repair_quarantined_accepted_raws(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+
+    assert result.repaired_count == 0
+    assert result.already_repaired_count == 1
+    assert json.loads(receipt.read_text().splitlines()[-1])["repaired_raw_ids"] == []
+
+
 def test_quarantined_accepted_raw_repair_acquires_exclusive_archive_lock_before_receipt(tmp_path: Path) -> None:
     raw_id = _seed_invalid_head(tmp_path)
     dry_run = repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])

--- a/tests/unit/storage/test_quarantined_accepted_raw_repair.py
+++ b/tests/unit/storage/test_quarantined_accepted_raw_repair.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -14,7 +15,7 @@ from polylogue.core.enums import Provider
 from polylogue.pipeline.ids import session_content_hash
 from polylogue.sources.revision_backfill import _parse_one
 from polylogue.storage.blob_store import BlobStore
-from polylogue.storage.repair import repair_untyped_accepted_raws
+from polylogue.storage.repair import repair_quarantined_accepted_raws
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.revision_application import (
@@ -51,7 +52,13 @@ def _config(root: Path) -> Config:
     return Config(archive_root=root, render_root=root / "render", sources=[], db_path=root / "index.db")
 
 
-def _seed_invalid_head(root: Path, native_id: str = "repair-one", *, multi_session: bool = False) -> str:
+def _seed_invalid_head(
+    root: Path,
+    native_id: str = "repair-one",
+    *,
+    multi_session: bool = False,
+    typed_quarantined: bool = True,
+) -> str:
     initialize_active_archive_root(root)
     records = [_chatgpt_session(native_id, "proof text")]
     if multi_session:
@@ -99,6 +106,37 @@ def _seed_invalid_head(root: Path, native_id: str = "repair-one", *, multi_sessi
             decided_at_ms=decided_at_ms,
         )
         archive.commit()
+    with sqlite3.connect(root / "source.db") as source:
+        if typed_quarantined:
+            source.execute(
+                """
+                UPDATE raw_sessions
+                SET logical_source_key = ?, revision_kind = 'full', source_revision = ?,
+                    baseline_raw_id = NULL, acquisition_generation = 0,
+                    revision_authority = 'quarantined'
+                WHERE raw_id = ?
+                """,
+                (logical_source_key, source_revision, raw_id),
+            )
+        source.execute(
+            """
+            INSERT INTO raw_session_memberships (
+                raw_id, logical_source_key, provider_session_id, source_revision,
+                normalized_content_hash, message_count, acquisition_generation,
+                revision_authority
+            ) VALUES (?, ?, ?, ?, ?, ?, 0, 'quarantined')
+            """,
+            (raw_id, logical_source_key, native_id, content_hash.hex(), content_hash, len(session.messages)),
+        )
+        source.execute(
+            """
+            INSERT INTO raw_membership_census (
+                raw_id, parser_fingerprint, status, member_count, censused_at_ms
+            ) VALUES (?, 'revision-membership-v1', 'complete', 1, 0)
+            """,
+            (raw_id,),
+        )
+        source.commit()
     return raw_id
 
 
@@ -124,8 +162,11 @@ def _raw_session_row(root: Path, raw_id: str) -> dict[str, object]:
     return dict(row)
 
 
-def test_untyped_accepted_raw_repair_roundtrip_is_receipted_and_idempotent(tmp_path: Path) -> None:
-    raw_id = _seed_invalid_head(tmp_path)
+@pytest.mark.parametrize("typed_quarantined", [False, True])
+def test_quarantined_accepted_raw_repair_roundtrip_is_receipted_and_idempotent(
+    tmp_path: Path, typed_quarantined: bool
+) -> None:
+    raw_id = _seed_invalid_head(tmp_path, typed_quarantined=typed_quarantined)
     with sqlite3.connect(tmp_path / "source.db") as source:
         source.execute(
             """
@@ -141,9 +182,9 @@ def test_untyped_accepted_raw_repair_roundtrip_is_receipted_and_idempotent(tmp_p
     before = _logical_state(tmp_path, raw_id)
     before_raw = _raw_session_row(tmp_path, raw_id)
 
-    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+    dry_run = repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])
 
-    assert dry_run.eligible_count == 1
+    assert dry_run.eligible_count == 1, dry_run.items[0].reason
     assert dry_run.items[0].proof_digest
     assert dry_run.items[0].application_decision_id
     assert dry_run.items[0].origin == "chatgpt-export"
@@ -158,9 +199,9 @@ def test_untyped_accepted_raw_repair_roundtrip_is_receipted_and_idempotent(tmp_p
     assert dry_run.items[0].application_witness.detail == "newest unique byte-proven full baseline"
     assert _logical_state(tmp_path, raw_id) == before
 
-    receipt_path = tmp_path / "recovery" / "untyped-raw-repair.jsonl"
+    receipt_path = tmp_path / "recovery" / "quarantined-raw-repair.jsonl"
     receipt_path.parent.mkdir()
-    applied = repair_untyped_accepted_raws(
+    applied = repair_quarantined_accepted_raws(
         _config(tmp_path),
         [raw_id],
         apply=True,
@@ -202,10 +243,12 @@ def test_untyped_accepted_raw_repair_roundtrip_is_receipted_and_idempotent(tmp_p
         "acquisition_generation": 0,
         "revision_authority": "byte_proven",
     }
+    if typed_quarantined:
+        expected_updates = {"baseline_raw_id": raw_id, "revision_authority": "byte_proven"}
     assert {key: after_raw[key] for key in expected_updates} == expected_updates
     assert {key for key in before_raw if before_raw[key] != after_raw[key]} == set(expected_updates)
 
-    reapplied = repair_untyped_accepted_raws(
+    reapplied = repair_quarantined_accepted_raws(
         _config(tmp_path),
         [raw_id],
         apply=True,
@@ -229,16 +272,13 @@ def test_untyped_accepted_raw_repair_roundtrip_is_receipted_and_idempotent(tmp_p
         "application",
         "receipt_time",
         "typed_competitor",
-        "typed_quarantined_competitor",
-        "other_session_head",
-        "other_session_application",
         "second_indexed_session",
         "membership",
         "envelope",
         "multi_session",
     ],
 )
-def test_untyped_accepted_raw_repair_mutations_fail_closed(tmp_path: Path, mutation: str) -> None:
+def test_quarantined_accepted_raw_repair_mutations_fail_closed(tmp_path: Path, mutation: str) -> None:
     raw_id = _seed_invalid_head(tmp_path, multi_session=mutation == "multi_session")
     with sqlite3.connect(tmp_path / "source.db") as source, sqlite3.connect(tmp_path / "index.db") as index:
         if mutation == "head_raw":
@@ -294,44 +334,6 @@ def test_untyped_accepted_raw_repair_mutations_fail_closed(tmp_path: Path, mutat
                 """,
                 ("1" * 64, "2" * 64, "1" * 64, raw_id),
             )
-        elif mutation == "typed_quarantined_competitor":
-            source.execute(
-                """
-                INSERT INTO raw_sessions (
-                    raw_id, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms,
-                    logical_source_key, revision_kind, source_revision, baseline_raw_id,
-                    acquisition_generation, revision_authority
-                ) SELECT ?, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms,
-                         'chatgpt:repair-one', 'full', ?, ?, 1, 'quarantined'
-                  FROM raw_sessions WHERE raw_id = ?
-                """,
-                ("1" * 64, "2" * 64, "1" * 64, raw_id),
-            )
-        elif mutation == "other_session_head":
-            index.execute(
-                """
-                INSERT INTO raw_revision_heads (
-                    logical_source_key, session_id, accepted_raw_id, accepted_source_revision,
-                    accepted_content_hash, accepted_frontier_kind, accepted_frontier,
-                    acquisition_generation, append_end_offset, decided_at_ms
-                ) SELECT 'chatgpt:different-key', session_id, accepted_raw_id,
-                         accepted_source_revision, accepted_content_hash, accepted_frontier_kind,
-                         accepted_frontier, acquisition_generation, append_end_offset, decided_at_ms
-                  FROM raw_revision_heads LIMIT 1
-                """
-            )
-        elif mutation == "other_session_application":
-            index.execute(
-                """
-                INSERT INTO raw_revision_applications (
-                    decision_id, raw_id, session_id, logical_source_key, source_revision,
-                    acquisition_generation, decision, detail, decided_at_ms
-                ) SELECT 'other-session-application', ?, session_id, 'chatgpt:different-key', ?,
-                         acquisition_generation + 1, 'ambiguous', 'test', decided_at_ms + 1
-                  FROM raw_revision_applications LIMIT 1
-                """,
-                ("3" * 64, "4" * 64),
-            )
         elif mutation == "second_indexed_session":
             index.execute(
                 """
@@ -342,11 +344,7 @@ def test_untyped_accepted_raw_repair_mutations_fail_closed(tmp_path: Path, mutat
             )
         elif mutation == "membership":
             source.execute(
-                """
-                INSERT INTO raw_membership_census (
-                    raw_id, parser_fingerprint, status, member_count, censused_at_ms, detail
-                ) VALUES (?, 'test', 'failed', 0, 1, 'ambiguous')
-                """,
+                "UPDATE raw_membership_census SET status = 'failed', member_count = 0, detail = 'ambiguous' WHERE raw_id = ?",
                 (raw_id,),
             )
         elif mutation == "envelope":
@@ -355,40 +353,78 @@ def test_untyped_accepted_raw_repair_mutations_fail_closed(tmp_path: Path, mutat
         index.commit()
     before = _logical_state(tmp_path, raw_id)
 
-    report = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+    report = repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])
 
     assert report.ineligible_count == 1
     assert _logical_state(tmp_path, raw_id) == before
 
 
-def test_untyped_accepted_raw_repair_rejects_duplicates_and_rolls_back_batch(
+def test_quarantined_accepted_raw_repair_preserves_parallel_provenance_context(tmp_path: Path) -> None:
+    raw_id = _seed_invalid_head(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as source, sqlite3.connect(tmp_path / "index.db") as index:
+        source.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms,
+                logical_source_key, revision_kind, source_revision,
+                acquisition_generation, revision_authority
+            ) SELECT ?, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms,
+                     logical_source_key, 'full', ?, 0, 'quarantined'
+              FROM raw_sessions WHERE raw_id = ?
+            """,
+            ("1" * 64, "2" * 64, raw_id),
+        )
+        index.execute(
+            """
+            INSERT INTO raw_revision_heads (
+                logical_source_key, session_id, accepted_raw_id, accepted_source_revision,
+                accepted_content_hash, accepted_frontier_kind, accepted_frontier,
+                acquisition_generation, append_end_offset, decided_at_ms
+            ) SELECT 'chatgpt:parallel-provenance', session_id, ?, ?,
+                     accepted_content_hash, 'semantic', 1, 0, NULL, decided_at_ms - 1
+              FROM raw_revision_heads LIMIT 1
+            """,
+            ("3" * 64, "4" * 64),
+        )
+        source.commit()
+        index.commit()
+
+    report = repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])
+
+    assert report.eligible_count == 1, report.items[0].reason
+    assert report.items[0].parallel_session_head_count == 1
+    assert report.items[0].quarantined_sibling_raw_count == 1
+    assert report.items[0].authority_context_digest
+
+
+def test_quarantined_accepted_raw_repair_rejects_duplicates_and_rolls_back_batch(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     first = _seed_invalid_head(tmp_path, "first")
     second = _seed_invalid_head(tmp_path, "second")
     with pytest.raises(ValueError, match="duplicate"):
-        repair_untyped_accepted_raws(_config(tmp_path), [first, first])
-    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [first, second])
+        repair_quarantined_accepted_raws(_config(tmp_path), [first, first])
+    dry_run = repair_quarantined_accepted_raws(_config(tmp_path), [first, second])
     before = _logical_state(tmp_path, first)
     receipt = tmp_path / "rollback-receipt.jsonl"
 
     from polylogue.storage import repair as repair_module
 
-    original = repair_module._inspect_untyped_accepted_raw
+    original = repair_module._inspect_quarantined_accepted_raw
     calls = 0
 
-    def fail_postproof(*args: object, **kwargs: object):
+    def fail_postproof(archive_root: Path, raw_id: str, *, conn: sqlite3.Connection) -> Any:
         nonlocal calls
         calls += 1
-        item = original(*args, **kwargs)
+        item = original(archive_root, raw_id, conn=conn)
         if calls == 5:
-            return repair_module._untyped_raw_item(item.raw_id, "injected post-proof failure")
+            return repair_module._quarantined_raw_item(item.raw_id, "injected post-proof failure")
         return item
 
-    monkeypatch.setattr(repair_module, "_inspect_untyped_accepted_raw", fail_postproof)
+    monkeypatch.setattr(repair_module, "_inspect_quarantined_accepted_raw", fail_postproof)
     with pytest.raises(RuntimeError, match="terminal state"):
-        repair_untyped_accepted_raws(
+        repair_quarantined_accepted_raws(
             _config(tmp_path),
             [first, second],
             apply=True,
@@ -400,23 +436,23 @@ def test_untyped_accepted_raw_repair_rejects_duplicates_and_rolls_back_batch(
     assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned"]
 
 
-def test_untyped_accepted_raw_repair_resumes_planned_receipt_after_committed_source(
+def test_quarantined_accepted_raw_repair_resumes_planned_receipt_after_committed_source(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     raw_id = _seed_invalid_head(tmp_path)
-    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+    dry_run = repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])
     receipt = tmp_path / "planned-resume.jsonl"
     from polylogue.storage import repair as repair_module
 
-    original_finish = repair_module._finish_untyped_raw_repair_receipt
+    original_finish = repair_module._finish_quarantined_raw_repair_receipt
     monkeypatch.setattr(
         repair_module,
-        "_finish_untyped_raw_repair_receipt",
+        "_finish_quarantined_raw_repair_receipt",
         lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("injected terminal append crash")),
     )
     with pytest.raises(RuntimeError, match="terminal append crash"):
-        repair_untyped_accepted_raws(
+        repair_quarantined_accepted_raws(
             _config(tmp_path),
             [raw_id],
             apply=True,
@@ -426,8 +462,8 @@ def test_untyped_accepted_raw_repair_resumes_planned_receipt_after_committed_sou
     assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned"]
     assert _raw_session_row(tmp_path, raw_id)["revision_authority"] == "byte_proven"
 
-    monkeypatch.setattr(repair_module, "_finish_untyped_raw_repair_receipt", original_finish)
-    resumed = repair_untyped_accepted_raws(
+    monkeypatch.setattr(repair_module, "_finish_quarantined_raw_repair_receipt", original_finish)
+    resumed = repair_quarantined_accepted_raws(
         _config(tmp_path),
         [raw_id],
         apply=True,
@@ -440,12 +476,12 @@ def test_untyped_accepted_raw_repair_resumes_planned_receipt_after_committed_sou
     assert records[1]["repaired_raw_ids"] == [raw_id]
 
 
-def test_untyped_accepted_raw_repair_writes_every_receipt_record_in_full(
+def test_quarantined_accepted_raw_repair_writes_every_receipt_record_in_full(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     raw_id = _seed_invalid_head(tmp_path)
-    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+    dry_run = repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])
     receipt = tmp_path / "short-write.jsonl"
     from polylogue.storage import repair as repair_module
 
@@ -455,7 +491,7 @@ def test_untyped_accepted_raw_repair_writes_every_receipt_record_in_full(
         return original_write(descriptor, payload[: max(1, min(11, len(payload)))])
 
     monkeypatch.setattr(repair_module, "_receipt_write", short_write)
-    repair_untyped_accepted_raws(
+    repair_quarantined_accepted_raws(
         _config(tmp_path),
         [raw_id],
         apply=True,
@@ -466,28 +502,28 @@ def test_untyped_accepted_raw_repair_writes_every_receipt_record_in_full(
     assert [record["state"] for record in records] == ["planned", "applied"]
 
 
-def test_untyped_accepted_raw_repair_recovers_preserved_torn_terminal(
+def test_quarantined_accepted_raw_repair_recovers_preserved_torn_terminal(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     raw_id = _seed_invalid_head(tmp_path)
-    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+    dry_run = repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])
     receipt = tmp_path / "torn-terminal.jsonl"
     from polylogue.storage import repair as repair_module
 
-    original_finish = repair_module._finish_untyped_raw_repair_receipt
+    original_finish = repair_module._finish_quarantined_raw_repair_receipt
 
     def tear_terminal(locked: Any, *, items: list[Any]) -> None:
         del items
         # A complete JSON prefix without its newline must remain distinguishable
         # from the eventual applied record after recovery seals the torn line.
         repair_module._write_receipt_all(locked.descriptor, b"{}")
-        repair_module.os.fsync(locked.descriptor)
+        os.fsync(locked.descriptor)
         raise RuntimeError("injected torn terminal")
 
-    monkeypatch.setattr(repair_module, "_finish_untyped_raw_repair_receipt", tear_terminal)
+    monkeypatch.setattr(repair_module, "_finish_quarantined_raw_repair_receipt", tear_terminal)
     with pytest.raises(RuntimeError, match="torn terminal"):
-        repair_untyped_accepted_raws(
+        repair_quarantined_accepted_raws(
             _config(tmp_path),
             [raw_id],
             apply=True,
@@ -502,12 +538,12 @@ def test_untyped_accepted_raw_repair_recovers_preserved_torn_terminal(
         if locked.torn_terminals and not locked.receipt_terminated:
             repair_module._write_receipt_all(locked.descriptor, b"\xff\n")
         repair_module._write_receipt_all(locked.descriptor, b'{"state":')
-        repair_module.os.fsync(locked.descriptor)
+        os.fsync(locked.descriptor)
         raise RuntimeError("injected torn recovery terminal")
 
-    monkeypatch.setattr(repair_module, "_finish_untyped_raw_repair_receipt", tear_recovery)
+    monkeypatch.setattr(repair_module, "_finish_quarantined_raw_repair_receipt", tear_recovery)
     with pytest.raises(RuntimeError, match="torn recovery terminal"):
-        repair_untyped_accepted_raws(
+        repair_quarantined_accepted_raws(
             _config(tmp_path),
             [raw_id],
             apply=True,
@@ -515,8 +551,8 @@ def test_untyped_accepted_raw_repair_recovers_preserved_torn_terminal(
             proof_digest=dry_run.proof_digest,
         )
 
-    monkeypatch.setattr(repair_module, "_finish_untyped_raw_repair_receipt", original_finish)
-    repair_untyped_accepted_raws(
+    monkeypatch.setattr(repair_module, "_finish_quarantined_raw_repair_receipt", original_finish)
+    repair_quarantined_accepted_raws(
         _config(tmp_path),
         [raw_id],
         apply=True,
@@ -533,7 +569,7 @@ def test_untyped_accepted_raw_repair_recovers_preserved_torn_terminal(
         {"bytes": len(fragment), "sha256": hashlib.sha256(fragment).hexdigest()} for fragment in lines[1:3]
     ]
 
-    reapplied = repair_untyped_accepted_raws(
+    reapplied = repair_quarantined_accepted_raws(
         _config(tmp_path),
         [raw_id],
         apply=True,
@@ -543,19 +579,19 @@ def test_untyped_accepted_raw_repair_recovers_preserved_torn_terminal(
     assert reapplied.already_repaired_count == 1
 
 
-def test_untyped_accepted_raw_repair_rejects_torn_terminal_without_source_commit(tmp_path: Path) -> None:
+def test_quarantined_accepted_raw_repair_rejects_torn_terminal_without_source_commit(tmp_path: Path) -> None:
     raw_id = _seed_invalid_head(tmp_path)
-    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+    dry_run = repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])
     receipt_path = tmp_path / "false-torn-terminal.jsonl"
     from polylogue.storage import repair as repair_module
 
-    locked = repair_module._lock_untyped_raw_repair_receipt(receipt_path, list(dry_run.items))
+    locked = repair_module._lock_quarantined_raw_repair_receipt(receipt_path, list(dry_run.items))
     repair_module._write_receipt_all(locked.descriptor, b'{"state":')
-    repair_module.os.fsync(locked.descriptor)
+    os.fsync(locked.descriptor)
     locked.close()
 
     with pytest.raises(RuntimeError, match="no matching committed source refinement"):
-        repair_untyped_accepted_raws(
+        repair_quarantined_accepted_raws(
             _config(tmp_path),
             [raw_id],
             apply=True,
@@ -576,16 +612,16 @@ def test_untyped_accepted_raw_repair_rejects_torn_terminal_without_source_commit
         (1, "repaired_raw_ids", []),
     ],
 )
-def test_untyped_accepted_raw_repair_rejects_corrupt_receipt_records(
+def test_quarantined_accepted_raw_repair_rejects_corrupt_receipt_records(
     tmp_path: Path,
     record_index: int,
     field: str,
     value: object,
 ) -> None:
     raw_id = _seed_invalid_head(tmp_path)
-    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+    dry_run = repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])
     receipt = tmp_path / "corrupt.jsonl"
-    repair_untyped_accepted_raws(
+    repair_quarantined_accepted_raws(
         _config(tmp_path),
         [raw_id],
         apply=True,
@@ -597,7 +633,7 @@ def test_untyped_accepted_raw_repair_rejects_corrupt_receipt_records(
     receipt.write_text("".join(json.dumps(record) + "\n" for record in records))
 
     with pytest.raises(RuntimeError, match="receipt"):
-        repair_untyped_accepted_raws(
+        repair_quarantined_accepted_raws(
             _config(tmp_path),
             [raw_id],
             apply=True,
@@ -606,16 +642,16 @@ def test_untyped_accepted_raw_repair_rejects_corrupt_receipt_records(
         )
 
 
-def test_untyped_accepted_raw_repair_serializes_one_receipt_inode(tmp_path: Path) -> None:
+def test_quarantined_accepted_raw_repair_serializes_one_receipt_inode(tmp_path: Path) -> None:
     raw_id = _seed_invalid_head(tmp_path)
-    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+    dry_run = repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])
     receipt_path = tmp_path / "locked.jsonl"
     from polylogue.storage import repair as repair_module
 
-    locked = repair_module._lock_untyped_raw_repair_receipt(receipt_path, list(dry_run.items))
+    locked = repair_module._lock_quarantined_raw_repair_receipt(receipt_path, list(dry_run.items))
     try:
         with pytest.raises(RuntimeError, match="already locked"):
-            repair_untyped_accepted_raws(
+            repair_quarantined_accepted_raws(
                 _config(tmp_path),
                 [raw_id],
                 apply=True,
@@ -627,17 +663,17 @@ def test_untyped_accepted_raw_repair_serializes_one_receipt_inode(tmp_path: Path
         locked.close()
 
 
-def test_untyped_accepted_raw_repair_cas_failure_rolls_back_entire_batch(
+def test_quarantined_accepted_raw_repair_cas_failure_rolls_back_entire_batch(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     first = _seed_invalid_head(tmp_path, "cas-first")
     second = _seed_invalid_head(tmp_path, "cas-second")
-    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [first, second])
+    dry_run = repair_quarantined_accepted_raws(_config(tmp_path), [first, second])
     before = {raw_id: _raw_session_row(tmp_path, raw_id) for raw_id in (first, second)}
     from polylogue.storage import repair as repair_module
 
-    original = repair_module._cas_refine_untyped_accepted_raw
+    original = repair_module._cas_refine_quarantined_accepted_raw
     calls = 0
 
     def fail_second(conn: sqlite3.Connection, item: Any) -> None:
@@ -647,9 +683,9 @@ def test_untyped_accepted_raw_repair_cas_failure_rolls_back_entire_batch(
             raise RuntimeError("injected CAS failure")
         original(conn, item)
 
-    monkeypatch.setattr(repair_module, "_cas_refine_untyped_accepted_raw", fail_second)
+    monkeypatch.setattr(repair_module, "_cas_refine_quarantined_accepted_raw", fail_second)
     with pytest.raises(RuntimeError, match="injected CAS failure"):
-        repair_untyped_accepted_raws(
+        repair_quarantined_accepted_raws(
             _config(tmp_path),
             [first, second],
             apply=True,
@@ -660,7 +696,7 @@ def test_untyped_accepted_raw_repair_cas_failure_rolls_back_entire_batch(
 
 
 @pytest.mark.parametrize("limit_kind", ["target", "aggregate"])
-def test_untyped_accepted_raw_repair_checks_blob_budget_before_read(
+def test_quarantined_accepted_raw_repair_checks_blob_budget_before_read(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     limit_kind: str,
@@ -670,14 +706,14 @@ def test_untyped_accepted_raw_repair_checks_blob_budget_before_read(
         raw_ids.append(_seed_invalid_head(tmp_path, "budget-second"))
     from polylogue.storage import repair as repair_module
 
-    blob_sizes = [_raw_session_row(tmp_path, raw_id)["blob_size"] for raw_id in raw_ids]
+    blob_sizes = [int(str(_raw_session_row(tmp_path, raw_id)["blob_size"])) for raw_id in raw_ids]
     if limit_kind == "target":
-        monkeypatch.setattr(repair_module, "_UNTYPED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES", int(blob_sizes[0]) - 1)
+        monkeypatch.setattr(repair_module, "_QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES", int(blob_sizes[0]) - 1)
     else:
         monkeypatch.setattr(
-            repair_module, "_UNTYPED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES", sum(map(int, blob_sizes)) - 1
+            repair_module, "_QUARANTINED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES", sum(blob_sizes) - 1
         )
     monkeypatch.setattr(BlobStore, "read_all", lambda *args, **kwargs: pytest.fail("blob was read before budget check"))
 
     with pytest.raises(RuntimeError, match="blob limit"):
-        repair_untyped_accepted_raws(_config(tmp_path), raw_ids)
+        repair_quarantined_accepted_raws(_config(tmp_path), raw_ids)

--- a/tests/unit/storage/test_quarantined_accepted_raw_repair.py
+++ b/tests/unit/storage/test_quarantined_accepted_raw_repair.py
@@ -15,6 +15,7 @@ from polylogue.core.enums import Provider
 from polylogue.pipeline.ids import session_content_hash
 from polylogue.sources.revision_backfill import _parse_one
 from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.index_generation import RebuildLease
 from polylogue.storage.repair import repair_quarantined_accepted_raws
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
@@ -269,6 +270,7 @@ def test_quarantined_accepted_raw_repair_roundtrip_is_receipted_and_idempotent(
         "frontier",
         "session_hash",
         "origin",
+        "capture_mode",
         "application",
         "receipt_time",
         "typed_competitor",
@@ -308,6 +310,10 @@ def test_quarantined_accepted_raw_repair_mutations_fail_closed(tmp_path: Path, m
             index.execute("UPDATE sessions SET content_hash = zeroblob(32)")
         elif mutation == "origin":
             source.execute("UPDATE raw_sessions SET origin = 'claude-ai-export' WHERE raw_id = ?", (raw_id,))
+        elif mutation == "capture_mode":
+            source.execute(
+                "UPDATE raw_sessions SET origin = 'aistudio-drive', capture_mode = NULL WHERE raw_id = ?", (raw_id,)
+            )
         elif mutation == "application":
             index.execute(
                 """
@@ -473,7 +479,53 @@ def test_quarantined_accepted_raw_repair_resumes_planned_receipt_after_committed
     assert resumed.already_repaired_count == 1
     records = [json.loads(line) for line in receipt.read_text().splitlines()]
     assert [record["state"] for record in records] == ["planned", "applied"]
-    assert records[1]["repaired_raw_ids"] == [raw_id]
+    assert records[1]["repaired_raw_ids"] == []
+
+
+def test_quarantined_accepted_raw_repair_does_not_claim_a_competing_receipt_commit(tmp_path: Path) -> None:
+    raw_id = _seed_invalid_head(tmp_path)
+    dry_run = repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])
+    interrupted_receipt = tmp_path / "interrupted.jsonl"
+    competing_receipt = tmp_path / "competing.jsonl"
+    from polylogue.storage import repair as repair_module
+
+    planned = repair_module._lock_quarantined_raw_repair_receipt(interrupted_receipt, list(dry_run.items))
+    planned.close()
+    competing = repair_quarantined_accepted_raws(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=competing_receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+    resumed = repair_quarantined_accepted_raws(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=interrupted_receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+
+    assert competing.repaired_count == 1
+    assert resumed.repaired_count == 0
+    assert json.loads(competing_receipt.read_text().splitlines()[-1])["repaired_raw_ids"] == [raw_id]
+    assert json.loads(interrupted_receipt.read_text().splitlines()[-1])["repaired_raw_ids"] == []
+
+
+def test_quarantined_accepted_raw_repair_acquires_exclusive_archive_lock_before_receipt(tmp_path: Path) -> None:
+    raw_id = _seed_invalid_head(tmp_path)
+    dry_run = repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])
+    receipt = tmp_path / "blocked.jsonl"
+
+    with RebuildLease(tmp_path), pytest.raises(RuntimeError, match="rebuild lease is already held"):
+        repair_quarantined_accepted_raws(
+            _config(tmp_path),
+            [raw_id],
+            apply=True,
+            receipt_path=receipt,
+            proof_digest=dry_run.proof_digest,
+        )
+    assert not receipt.exists()
 
 
 def test_quarantined_accepted_raw_repair_writes_every_receipt_record_in_full(
@@ -609,7 +661,7 @@ def test_quarantined_accepted_raw_repair_rejects_torn_terminal_without_source_co
         (1, "schema", "wrong"),
         (1, "target_hash", "0" * 64),
         (1, "proven_raw_ids", []),
-        (1, "repaired_raw_ids", []),
+        (1, "repaired_raw_ids", ["0" * 64]),
     ],
 )
 def test_quarantined_accepted_raw_repair_rejects_corrupt_receipt_records(

--- a/tests/unit/storage/test_untyped_accepted_raw_repair.py
+++ b/tests/unit/storage/test_untyped_accepted_raw_repair.py
@@ -495,6 +495,24 @@ def test_untyped_accepted_raw_repair_recovers_preserved_torn_terminal(
     assert _raw_session_row(tmp_path, raw_id)["revision_authority"] == "byte_proven"
     assert not receipt.read_bytes().endswith(b"\n")
 
+    def tear_recovery(locked: Any, *, items: list[Any]) -> None:
+        del items
+        if locked.torn_terminals and not locked.receipt_terminated:
+            repair_module._write_receipt_all(locked.descriptor, b"\n")
+        repair_module._write_receipt_all(locked.descriptor, b'{"state":')
+        repair_module.os.fsync(locked.descriptor)
+        raise RuntimeError("injected torn recovery terminal")
+
+    monkeypatch.setattr(repair_module, "_finish_untyped_raw_repair_receipt", tear_recovery)
+    with pytest.raises(RuntimeError, match="torn recovery terminal"):
+        repair_untyped_accepted_raws(
+            _config(tmp_path),
+            [raw_id],
+            apply=True,
+            receipt_path=receipt,
+            proof_digest=dry_run.proof_digest,
+        )
+
     monkeypatch.setattr(repair_module, "_finish_untyped_raw_repair_receipt", original_finish)
     repair_untyped_accepted_raws(
         _config(tmp_path),
@@ -504,12 +522,14 @@ def test_untyped_accepted_raw_repair_recovers_preserved_torn_terminal(
         proof_digest=dry_run.proof_digest,
     )
     lines = receipt.read_bytes().splitlines()
-    assert len(lines) == 3
+    assert len(lines) == 4
     assert lines[1] == b'{"schema":'
-    recovered = json.loads(lines[2])
+    assert lines[2] == b'{"state":'
+    recovered = json.loads(lines[3])
     assert recovered["state"] == "applied"
-    assert recovered["torn_terminal_bytes"] == len(lines[1])
-    assert recovered["torn_terminal_sha256"] == hashlib.sha256(lines[1]).hexdigest()
+    assert recovered["torn_terminals"] == [
+        {"bytes": len(fragment), "sha256": hashlib.sha256(fragment).hexdigest()} for fragment in lines[1:3]
+    ]
 
     reapplied = repair_untyped_accepted_raws(
         _config(tmp_path),

--- a/tests/unit/storage/test_untyped_accepted_raw_repair.py
+++ b/tests/unit/storage/test_untyped_accepted_raw_repair.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.revision_replay import ApplicationDecision
+from polylogue.config import Config
+from polylogue.core.enums import Provider
+from polylogue.pipeline.ids import session_content_hash
+from polylogue.sources.revision_backfill import _parse_one
+from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.repair import repair_untyped_accepted_raws
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from polylogue.storage.sqlite.archive_tiers.revision_application import (
+    RevisionApplicationReceipt,
+    record_revision_application_sync,
+)
+
+
+def _chatgpt_session(native_id: str, text: str) -> dict[str, object]:
+    return {
+        "id": native_id,
+        "conversation_id": native_id,
+        "title": native_id,
+        "create_time": 1_700_000_000,
+        "update_time": 1_700_000_001,
+        "current_node": "node-1",
+        "mapping": {
+            "node-1": {
+                "id": "node-1",
+                "parent": None,
+                "children": [],
+                "message": {
+                    "id": "message-1",
+                    "author": {"role": "user"},
+                    "content": {"content_type": "text", "parts": [text]},
+                    "create_time": 1_700_000_000,
+                },
+            }
+        },
+    }
+
+
+def _config(root: Path) -> Config:
+    return Config(archive_root=root, render_root=root / "render", sources=[], db_path=root / "index.db")
+
+
+def _seed_invalid_head(root: Path, native_id: str = "repair-one", *, multi_session: bool = False) -> str:
+    initialize_active_archive_root(root)
+    records = [_chatgpt_session(native_id, "proof text")]
+    if multi_session:
+        records.append(_chatgpt_session(f"{native_id}-other", "other text"))
+    payload = json.dumps(records if multi_session else records[0], sort_keys=True).encode()
+    parsed = _parse_one(Provider.CHATGPT, payload, f"{native_id}.json")
+    assert parsed
+    session = parsed[0]
+    source_revision = hashlib.sha256(payload).hexdigest()
+    content_hash = bytes.fromhex(session_content_hash(session))
+    logical_source_key = f"chatgpt:{native_id}"
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CHATGPT,
+            payload=payload,
+            source_path=f"{native_id}.json",
+            acquired_at_ms=1,
+        )
+        _raw_id, session_id = archive.write_parsed_for_retained_raw(
+            session,
+            raw_id=raw_id,
+            source_path=f"{native_id}.json",
+            acquired_at_ms=1,
+            revision_authoritative=True,
+        )
+        assert session_id == f"chatgpt-export:{native_id}"
+        decided_at_ms = 2
+        record_revision_application_sync(
+            archive._conn,
+            RevisionApplicationReceipt(
+                raw_id=raw_id,
+                session_id=session_id,
+                logical_source_key=logical_source_key,
+                source_revision=source_revision,
+                acquisition_generation=0,
+                decision=ApplicationDecision.SELECTED_BASELINE,
+                accepted_raw_id=raw_id,
+                accepted_source_revision=source_revision,
+                accepted_content_hash=content_hash,
+                accepted_frontier_kind="byte",
+                accepted_frontier=len(payload),
+                baseline_raw_id=raw_id,
+                detail="newest unique byte-proven full baseline",
+            ),
+            decided_at_ms=decided_at_ms,
+        )
+        archive.commit()
+    return raw_id
+
+
+def _logical_state(root: Path, raw_id: str) -> dict[str, list[tuple[object, ...]]]:
+    result: dict[str, list[tuple[object, ...]]] = {}
+    for tier, tables in {
+        "source": ("raw_sessions", "blob_refs", "raw_artifacts", "raw_session_memberships", "raw_membership_census"),
+        "index": ("sessions", "messages", "blocks", "raw_revision_heads", "raw_revision_applications"),
+    }.items():
+        with sqlite3.connect(root / f"{tier}.db") as conn:
+            for table in tables:
+                rows = conn.execute(f"SELECT * FROM {table} ORDER BY 1").fetchall()
+                result[f"{tier}.{table}"] = [tuple(row) for row in rows]
+    result["raw_id"] = [(raw_id,)]
+    return result
+
+
+def test_untyped_accepted_raw_repair_roundtrip_is_receipted_and_idempotent(tmp_path: Path) -> None:
+    raw_id = _seed_invalid_head(tmp_path)
+    before = _logical_state(tmp_path, raw_id)
+
+    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+
+    assert dry_run.eligible_count == 1
+    assert dry_run.items[0].proof_digest
+    assert dry_run.items[0].application_decision_id
+    assert _logical_state(tmp_path, raw_id) == before
+
+    receipt_path = tmp_path / "recovery" / "untyped-raw-repair.jsonl"
+    receipt_path.parent.mkdir()
+    applied = repair_untyped_accepted_raws(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=receipt_path,
+        proof_digest=dry_run.proof_digest,
+    )
+
+    assert applied.repaired_count == 1
+    assert applied.items[0].status == "already_repaired"
+    records = [json.loads(line) for line in receipt_path.read_text().splitlines()]
+    assert [record["state"] for record in records] == ["planned", "applied"]
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        envelope = conn.execute(
+            """
+            SELECT logical_source_key, revision_kind, source_revision, baseline_raw_id,
+                   acquisition_generation, revision_authority
+            FROM raw_sessions WHERE raw_id = ?
+            """,
+            (raw_id,),
+        ).fetchone()
+    assert envelope == (
+        "chatgpt:repair-one",
+        "full",
+        dry_run.items[0].accepted_source_revision,
+        raw_id,
+        0,
+        "byte_proven",
+    )
+    after = _logical_state(tmp_path, raw_id)
+    for key in before:
+        if key != "source.raw_sessions":
+            assert after[key] == before[key]
+
+    reapplied = repair_untyped_accepted_raws(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=receipt_path,
+        proof_digest=dry_run.proof_digest,
+    )
+    assert reapplied.repaired_count == 0
+    assert receipt_path.read_text().count("\n") == 2
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "head_raw",
+        "missing_blob",
+        "blob_ref",
+        "artifact",
+        "frontier",
+        "session_hash",
+        "origin",
+        "application",
+        "receipt_time",
+        "typed_competitor",
+        "membership",
+        "envelope",
+        "multi_session",
+    ],
+)
+def test_untyped_accepted_raw_repair_mutations_fail_closed(tmp_path: Path, mutation: str) -> None:
+    raw_id = _seed_invalid_head(tmp_path, multi_session=mutation == "multi_session")
+    with sqlite3.connect(tmp_path / "source.db") as source, sqlite3.connect(tmp_path / "index.db") as index:
+        if mutation == "head_raw":
+            index.execute("UPDATE raw_revision_heads SET accepted_raw_id = ?", ("0" * 64,))
+        elif mutation == "missing_blob":
+            blob_hash = source.execute(
+                "SELECT hex(blob_hash) FROM raw_sessions WHERE raw_id = ?", (raw_id,)
+            ).fetchone()[0]
+            BlobStore(tmp_path / "blob").blob_path(str(blob_hash).lower()).unlink()
+        elif mutation == "blob_ref":
+            source.execute("UPDATE blob_refs SET size_bytes = size_bytes + 1 WHERE ref_id = ?", (raw_id,))
+        elif mutation == "artifact":
+            source.execute(
+                """
+                INSERT INTO raw_artifacts (
+                    artifact_id, raw_id, origin, source_path, source_index, artifact_kind,
+                    support_status, classification_reason, parse_as_session, schema_eligible,
+                    malformed_jsonl_lines, first_observed_at_ms, last_observed_at_ms
+                ) VALUES ('artifact', ?, 'chatgpt-export', 'wrong.json', 0, 'session',
+                          'supported_parseable', 'test', 1, 1, 0, 1, 1)
+                """,
+                (raw_id,),
+            )
+        elif mutation == "frontier":
+            index.execute("UPDATE raw_revision_heads SET accepted_frontier = accepted_frontier + 1")
+        elif mutation == "session_hash":
+            index.execute("UPDATE sessions SET content_hash = zeroblob(32)")
+        elif mutation == "origin":
+            source.execute("UPDATE raw_sessions SET origin = 'claude-ai-export' WHERE raw_id = ?", (raw_id,))
+        elif mutation == "application":
+            index.execute(
+                """
+                INSERT INTO raw_revision_applications (
+                    decision_id, raw_id, session_id, logical_source_key, source_revision,
+                    acquisition_generation, decision, detail, decided_at_ms
+                ) SELECT 'competing', raw_id, session_id, logical_source_key, source_revision,
+                         acquisition_generation, 'ambiguous', 'test', decided_at_ms + 1
+                  FROM raw_revision_applications LIMIT 1
+                """
+            )
+        elif mutation == "receipt_time":
+            index.execute("UPDATE raw_revision_applications SET decided_at_ms = decided_at_ms + 1")
+        elif mutation == "typed_competitor":
+            source.execute(
+                """
+                INSERT INTO raw_sessions (
+                    raw_id, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms,
+                    logical_source_key, revision_kind, source_revision, baseline_raw_id,
+                    acquisition_generation, revision_authority
+                ) SELECT ?, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms,
+                         'chatgpt:repair-one', 'full', ?, ?, 1, 'byte_proven'
+                  FROM raw_sessions WHERE raw_id = ?
+                """,
+                ("1" * 64, "2" * 64, "1" * 64, raw_id),
+            )
+        elif mutation == "membership":
+            source.execute(
+                """
+                INSERT INTO raw_membership_census (
+                    raw_id, parser_fingerprint, status, member_count, censused_at_ms, detail
+                ) VALUES (?, 'test', 'failed', 0, 1, 'ambiguous')
+                """,
+                (raw_id,),
+            )
+        elif mutation == "envelope":
+            source.execute("UPDATE raw_sessions SET logical_source_key = 'partial' WHERE raw_id = ?", (raw_id,))
+        source.commit()
+        index.commit()
+    before = _logical_state(tmp_path, raw_id)
+
+    report = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+
+    assert report.ineligible_count == 1
+    assert _logical_state(tmp_path, raw_id) == before
+
+
+def test_untyped_accepted_raw_repair_rejects_duplicates_and_rolls_back_batch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = _seed_invalid_head(tmp_path, "first")
+    second = _seed_invalid_head(tmp_path, "second")
+    with pytest.raises(ValueError, match="duplicate"):
+        repair_untyped_accepted_raws(_config(tmp_path), [first, first])
+    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [first, second])
+    before = _logical_state(tmp_path, first)
+    receipt = tmp_path / "rollback-receipt.jsonl"
+
+    from polylogue.storage import repair as repair_module
+
+    original = repair_module._inspect_untyped_accepted_raw
+    calls = 0
+
+    def fail_postproof(*args: object, **kwargs: object):
+        nonlocal calls
+        calls += 1
+        item = original(*args, **kwargs)
+        if calls == 5:
+            return repair_module._untyped_raw_item(item.raw_id, "injected post-proof failure")
+        return item
+
+    monkeypatch.setattr(repair_module, "_inspect_untyped_accepted_raw", fail_postproof)
+    with pytest.raises(RuntimeError, match="terminal state"):
+        repair_untyped_accepted_raws(
+            _config(tmp_path),
+            [first, second],
+            apply=True,
+            receipt_path=receipt,
+            proof_digest=dry_run.proof_digest,
+        )
+
+    assert _logical_state(tmp_path, first) == before
+    assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned"]

--- a/tests/unit/storage/test_untyped_accepted_raw_repair.py
+++ b/tests/unit/storage/test_untyped_accepted_raw_repair.py
@@ -232,6 +232,7 @@ def test_untyped_accepted_raw_repair_roundtrip_is_receipted_and_idempotent(tmp_p
         "typed_quarantined_competitor",
         "other_session_head",
         "other_session_application",
+        "second_indexed_session",
         "membership",
         "envelope",
         "multi_session",
@@ -331,6 +332,14 @@ def test_untyped_accepted_raw_repair_mutations_fail_closed(tmp_path: Path, mutat
                 """,
                 ("3" * 64, "4" * 64),
             )
+        elif mutation == "second_indexed_session":
+            index.execute(
+                """
+                INSERT INTO sessions (native_id, origin, raw_id, content_hash)
+                SELECT 'unexpected-second-session', origin, raw_id, content_hash
+                FROM sessions LIMIT 1
+                """
+            )
         elif mutation == "membership":
             source.execute(
                 """
@@ -429,6 +438,109 @@ def test_untyped_accepted_raw_repair_resumes_planned_receipt_after_committed_sou
     records = [json.loads(line) for line in receipt.read_text().splitlines()]
     assert [record["state"] for record in records] == ["planned", "applied"]
     assert records[1]["repaired_raw_ids"] == [raw_id]
+
+
+def test_untyped_accepted_raw_repair_writes_every_receipt_record_in_full(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw_id = _seed_invalid_head(tmp_path)
+    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+    receipt = tmp_path / "short-write.jsonl"
+    from polylogue.storage import repair as repair_module
+
+    original_write = repair_module._receipt_write
+
+    def short_write(descriptor: int, payload: bytes) -> int:
+        return original_write(descriptor, payload[: max(1, min(11, len(payload)))])
+
+    monkeypatch.setattr(repair_module, "_receipt_write", short_write)
+    repair_untyped_accepted_raws(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+    records = [json.loads(line) for line in receipt.read_text().splitlines()]
+    assert [record["state"] for record in records] == ["planned", "applied"]
+
+
+def test_untyped_accepted_raw_repair_recovers_preserved_torn_terminal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw_id = _seed_invalid_head(tmp_path)
+    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+    receipt = tmp_path / "torn-terminal.jsonl"
+    from polylogue.storage import repair as repair_module
+
+    original_finish = repair_module._finish_untyped_raw_repair_receipt
+
+    def tear_terminal(locked: Any, *, items: list[Any]) -> None:
+        del items
+        repair_module._write_receipt_all(locked.descriptor, b'{"schema":')
+        repair_module.os.fsync(locked.descriptor)
+        raise RuntimeError("injected torn terminal")
+
+    monkeypatch.setattr(repair_module, "_finish_untyped_raw_repair_receipt", tear_terminal)
+    with pytest.raises(RuntimeError, match="torn terminal"):
+        repair_untyped_accepted_raws(
+            _config(tmp_path),
+            [raw_id],
+            apply=True,
+            receipt_path=receipt,
+            proof_digest=dry_run.proof_digest,
+        )
+    assert _raw_session_row(tmp_path, raw_id)["revision_authority"] == "byte_proven"
+    assert not receipt.read_bytes().endswith(b"\n")
+
+    monkeypatch.setattr(repair_module, "_finish_untyped_raw_repair_receipt", original_finish)
+    repair_untyped_accepted_raws(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+    lines = receipt.read_bytes().splitlines()
+    assert len(lines) == 3
+    assert lines[1] == b'{"schema":'
+    recovered = json.loads(lines[2])
+    assert recovered["state"] == "applied"
+    assert recovered["torn_terminal_bytes"] == len(lines[1])
+    assert recovered["torn_terminal_sha256"] == hashlib.sha256(lines[1]).hexdigest()
+
+    reapplied = repair_untyped_accepted_raws(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+    assert reapplied.already_repaired_count == 1
+
+
+def test_untyped_accepted_raw_repair_rejects_torn_terminal_without_source_commit(tmp_path: Path) -> None:
+    raw_id = _seed_invalid_head(tmp_path)
+    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+    receipt_path = tmp_path / "false-torn-terminal.jsonl"
+    from polylogue.storage import repair as repair_module
+
+    locked = repair_module._lock_untyped_raw_repair_receipt(receipt_path, list(dry_run.items))
+    repair_module._write_receipt_all(locked.descriptor, b'{"state":')
+    repair_module.os.fsync(locked.descriptor)
+    locked.close()
+
+    with pytest.raises(RuntimeError, match="no matching committed source refinement"):
+        repair_untyped_accepted_raws(
+            _config(tmp_path),
+            [raw_id],
+            apply=True,
+            receipt_path=receipt_path,
+            proof_digest=dry_run.proof_digest,
+        )
+    assert _raw_session_row(tmp_path, raw_id)["revision_authority"] == "quarantined"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/storage/test_untyped_accepted_raw_repair.py
+++ b/tests/unit/storage/test_untyped_accepted_raw_repair.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -115,15 +116,46 @@ def _logical_state(root: Path, raw_id: str) -> dict[str, list[tuple[object, ...]
     return result
 
 
+def _raw_session_row(root: Path, raw_id: str) -> dict[str, object]:
+    with sqlite3.connect(root / "source.db") as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()
+    assert row is not None
+    return dict(row)
+
+
 def test_untyped_accepted_raw_repair_roundtrip_is_receipted_and_idempotent(tmp_path: Path) -> None:
     raw_id = _seed_invalid_head(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        source.execute(
+            """
+            INSERT INTO raw_artifacts (
+                artifact_id, raw_id, origin, source_path, source_index, artifact_kind,
+                support_status, classification_reason, parse_as_session, schema_eligible,
+                malformed_jsonl_lines, first_observed_at_ms, last_observed_at_ms
+            ) VALUES ('artifact-witness', ?, 'chatgpt-export', 'repair-one.json', 0,
+                      'session', 'supported_parseable', 'witness', 1, 1, 0, 1, 2)
+            """,
+            (raw_id,),
+        )
     before = _logical_state(tmp_path, raw_id)
+    before_raw = _raw_session_row(tmp_path, raw_id)
 
     dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
 
     assert dry_run.eligible_count == 1
     assert dry_run.items[0].proof_digest
     assert dry_run.items[0].application_decision_id
+    assert dry_run.items[0].origin == "chatgpt-export"
+    assert dry_run.items[0].source_index == 0
+    assert dry_run.items[0].blob_hash == dry_run.items[0].accepted_source_revision
+    assert dry_run.items[0].blob_ref_hash == dry_run.items[0].blob_hash
+    assert dry_run.items[0].accepted_frontier_kind == "byte"
+    assert dry_run.items[0].accepted_frontier == dry_run.items[0].blob_size
+    assert dry_run.items[0].head_decided_at_ms == 2
+    assert [artifact.artifact_id for artifact in dry_run.items[0].artifact_witnesses] == ["artifact-witness"]
+    assert dry_run.items[0].application_witness is not None
+    assert dry_run.items[0].application_witness.detail == "newest unique byte-proven full baseline"
     assert _logical_state(tmp_path, raw_id) == before
 
     receipt_path = tmp_path / "recovery" / "untyped-raw-repair.jsonl"
@@ -161,6 +193,17 @@ def test_untyped_accepted_raw_repair_roundtrip_is_receipted_and_idempotent(tmp_p
     for key in before:
         if key != "source.raw_sessions":
             assert after[key] == before[key]
+    after_raw = _raw_session_row(tmp_path, raw_id)
+    expected_updates = {
+        "logical_source_key": "chatgpt:repair-one",
+        "revision_kind": "full",
+        "source_revision": dry_run.items[0].accepted_source_revision,
+        "baseline_raw_id": raw_id,
+        "acquisition_generation": 0,
+        "revision_authority": "byte_proven",
+    }
+    assert {key: after_raw[key] for key in expected_updates} == expected_updates
+    assert {key for key in before_raw if before_raw[key] != after_raw[key]} == set(expected_updates)
 
     reapplied = repair_untyped_accepted_raws(
         _config(tmp_path),
@@ -186,6 +229,9 @@ def test_untyped_accepted_raw_repair_roundtrip_is_receipted_and_idempotent(tmp_p
         "application",
         "receipt_time",
         "typed_competitor",
+        "typed_quarantined_competitor",
+        "other_session_head",
+        "other_session_application",
         "membership",
         "envelope",
         "multi_session",
@@ -247,6 +293,44 @@ def test_untyped_accepted_raw_repair_mutations_fail_closed(tmp_path: Path, mutat
                 """,
                 ("1" * 64, "2" * 64, "1" * 64, raw_id),
             )
+        elif mutation == "typed_quarantined_competitor":
+            source.execute(
+                """
+                INSERT INTO raw_sessions (
+                    raw_id, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms,
+                    logical_source_key, revision_kind, source_revision, baseline_raw_id,
+                    acquisition_generation, revision_authority
+                ) SELECT ?, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms,
+                         'chatgpt:repair-one', 'full', ?, ?, 1, 'quarantined'
+                  FROM raw_sessions WHERE raw_id = ?
+                """,
+                ("1" * 64, "2" * 64, "1" * 64, raw_id),
+            )
+        elif mutation == "other_session_head":
+            index.execute(
+                """
+                INSERT INTO raw_revision_heads (
+                    logical_source_key, session_id, accepted_raw_id, accepted_source_revision,
+                    accepted_content_hash, accepted_frontier_kind, accepted_frontier,
+                    acquisition_generation, append_end_offset, decided_at_ms
+                ) SELECT 'chatgpt:different-key', session_id, accepted_raw_id,
+                         accepted_source_revision, accepted_content_hash, accepted_frontier_kind,
+                         accepted_frontier, acquisition_generation, append_end_offset, decided_at_ms
+                  FROM raw_revision_heads LIMIT 1
+                """
+            )
+        elif mutation == "other_session_application":
+            index.execute(
+                """
+                INSERT INTO raw_revision_applications (
+                    decision_id, raw_id, session_id, logical_source_key, source_revision,
+                    acquisition_generation, decision, detail, decided_at_ms
+                ) SELECT 'other-session-application', ?, session_id, 'chatgpt:different-key', ?,
+                         acquisition_generation + 1, 'ambiguous', 'test', decided_at_ms + 1
+                  FROM raw_revision_applications LIMIT 1
+                """,
+                ("3" * 64, "4" * 64),
+            )
         elif mutation == "membership":
             source.execute(
                 """
@@ -305,3 +389,161 @@ def test_untyped_accepted_raw_repair_rejects_duplicates_and_rolls_back_batch(
 
     assert _logical_state(tmp_path, first) == before
     assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned"]
+
+
+def test_untyped_accepted_raw_repair_resumes_planned_receipt_after_committed_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw_id = _seed_invalid_head(tmp_path)
+    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+    receipt = tmp_path / "planned-resume.jsonl"
+    from polylogue.storage import repair as repair_module
+
+    original_finish = repair_module._finish_untyped_raw_repair_receipt
+    monkeypatch.setattr(
+        repair_module,
+        "_finish_untyped_raw_repair_receipt",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("injected terminal append crash")),
+    )
+    with pytest.raises(RuntimeError, match="terminal append crash"):
+        repair_untyped_accepted_raws(
+            _config(tmp_path),
+            [raw_id],
+            apply=True,
+            receipt_path=receipt,
+            proof_digest=dry_run.proof_digest,
+        )
+    assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned"]
+    assert _raw_session_row(tmp_path, raw_id)["revision_authority"] == "byte_proven"
+
+    monkeypatch.setattr(repair_module, "_finish_untyped_raw_repair_receipt", original_finish)
+    resumed = repair_untyped_accepted_raws(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+    assert resumed.already_repaired_count == 1
+    records = [json.loads(line) for line in receipt.read_text().splitlines()]
+    assert [record["state"] for record in records] == ["planned", "applied"]
+    assert records[1]["repaired_raw_ids"] == [raw_id]
+
+
+@pytest.mark.parametrize(
+    ("record_index", "field", "value"),
+    [
+        (0, "state", "applied"),
+        (0, "planned_at_ms", "not-an-int"),
+        (1, "schema", "wrong"),
+        (1, "target_hash", "0" * 64),
+        (1, "proven_raw_ids", []),
+        (1, "repaired_raw_ids", []),
+    ],
+)
+def test_untyped_accepted_raw_repair_rejects_corrupt_receipt_records(
+    tmp_path: Path,
+    record_index: int,
+    field: str,
+    value: object,
+) -> None:
+    raw_id = _seed_invalid_head(tmp_path)
+    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+    receipt = tmp_path / "corrupt.jsonl"
+    repair_untyped_accepted_raws(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+    records = [json.loads(line) for line in receipt.read_text().splitlines()]
+    records[record_index][field] = value
+    receipt.write_text("".join(json.dumps(record) + "\n" for record in records))
+
+    with pytest.raises(RuntimeError, match="receipt"):
+        repair_untyped_accepted_raws(
+            _config(tmp_path),
+            [raw_id],
+            apply=True,
+            receipt_path=receipt,
+            proof_digest=dry_run.proof_digest,
+        )
+
+
+def test_untyped_accepted_raw_repair_serializes_one_receipt_inode(tmp_path: Path) -> None:
+    raw_id = _seed_invalid_head(tmp_path)
+    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [raw_id])
+    receipt_path = tmp_path / "locked.jsonl"
+    from polylogue.storage import repair as repair_module
+
+    locked = repair_module._lock_untyped_raw_repair_receipt(receipt_path, list(dry_run.items))
+    try:
+        with pytest.raises(RuntimeError, match="already locked"):
+            repair_untyped_accepted_raws(
+                _config(tmp_path),
+                [raw_id],
+                apply=True,
+                receipt_path=receipt_path,
+                proof_digest=dry_run.proof_digest,
+            )
+        assert _raw_session_row(tmp_path, raw_id)["revision_authority"] == "quarantined"
+    finally:
+        locked.close()
+
+
+def test_untyped_accepted_raw_repair_cas_failure_rolls_back_entire_batch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = _seed_invalid_head(tmp_path, "cas-first")
+    second = _seed_invalid_head(tmp_path, "cas-second")
+    dry_run = repair_untyped_accepted_raws(_config(tmp_path), [first, second])
+    before = {raw_id: _raw_session_row(tmp_path, raw_id) for raw_id in (first, second)}
+    from polylogue.storage import repair as repair_module
+
+    original = repair_module._cas_refine_untyped_accepted_raw
+    calls = 0
+
+    def fail_second(conn: sqlite3.Connection, item: Any) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("injected CAS failure")
+        original(conn, item)
+
+    monkeypatch.setattr(repair_module, "_cas_refine_untyped_accepted_raw", fail_second)
+    with pytest.raises(RuntimeError, match="injected CAS failure"):
+        repair_untyped_accepted_raws(
+            _config(tmp_path),
+            [first, second],
+            apply=True,
+            receipt_path=tmp_path / "cas-rollback.jsonl",
+            proof_digest=dry_run.proof_digest,
+        )
+    assert {raw_id: _raw_session_row(tmp_path, raw_id) for raw_id in (first, second)} == before
+
+
+@pytest.mark.parametrize("limit_kind", ["target", "aggregate"])
+def test_untyped_accepted_raw_repair_checks_blob_budget_before_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    limit_kind: str,
+) -> None:
+    raw_ids = [_seed_invalid_head(tmp_path, "budget-first")]
+    if limit_kind == "aggregate":
+        raw_ids.append(_seed_invalid_head(tmp_path, "budget-second"))
+    from polylogue.storage import repair as repair_module
+
+    blob_sizes = [_raw_session_row(tmp_path, raw_id)["blob_size"] for raw_id in raw_ids]
+    if limit_kind == "target":
+        monkeypatch.setattr(repair_module, "_UNTYPED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES", int(blob_sizes[0]) - 1)
+    else:
+        monkeypatch.setattr(
+            repair_module, "_UNTYPED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES", sum(map(int, blob_sizes)) - 1
+        )
+    monkeypatch.setattr(BlobStore, "read_all", lambda *args, **kwargs: pytest.fail("blob was read before budget check"))
+
+    with pytest.raises(RuntimeError, match="blob limit"):
+        repair_untyped_accepted_raws(_config(tmp_path), raw_ids)

--- a/tests/unit/storage/test_untyped_accepted_raw_repair.py
+++ b/tests/unit/storage/test_untyped_accepted_raw_repair.py
@@ -479,7 +479,9 @@ def test_untyped_accepted_raw_repair_recovers_preserved_torn_terminal(
 
     def tear_terminal(locked: Any, *, items: list[Any]) -> None:
         del items
-        repair_module._write_receipt_all(locked.descriptor, b'{"schema":')
+        # A complete JSON prefix without its newline must remain distinguishable
+        # from the eventual applied record after recovery seals the torn line.
+        repair_module._write_receipt_all(locked.descriptor, b"{}")
         repair_module.os.fsync(locked.descriptor)
         raise RuntimeError("injected torn terminal")
 
@@ -498,7 +500,7 @@ def test_untyped_accepted_raw_repair_recovers_preserved_torn_terminal(
     def tear_recovery(locked: Any, *, items: list[Any]) -> None:
         del items
         if locked.torn_terminals and not locked.receipt_terminated:
-            repair_module._write_receipt_all(locked.descriptor, b"\n")
+            repair_module._write_receipt_all(locked.descriptor, b"\xff\n")
         repair_module._write_receipt_all(locked.descriptor, b'{"state":')
         repair_module.os.fsync(locked.descriptor)
         raise RuntimeError("injected torn recovery terminal")
@@ -523,8 +525,8 @@ def test_untyped_accepted_raw_repair_recovers_preserved_torn_terminal(
     )
     lines = receipt.read_bytes().splitlines()
     assert len(lines) == 4
-    assert lines[1] == b'{"schema":'
-    assert lines[2] == b'{"state":'
+    assert lines[1] == b"{}\xff"
+    assert lines[2] == b'{"state":\xff'
     recovered = json.loads(lines[3])
     assert recovered["state"] == "applied"
     assert recovered["torn_terminals"] == [


### PR DESCRIPTION
## Summary

Adds a receipted, fail-closed maintenance actuator that promotes only retained accepted raws whose byte, parser, head, application, membership, census, blob, and artifact evidence all agree. Ref polylogue-yla8.10.

## Problem

Three current ChatGPT byte heads are backed by durable source raws whose authority envelope remains untyped/quarantined even though the accepted index head has an immutable selected-baseline receipt. The deployed v35 archive also contains three newer browser captures typed under `unknown-export`; their bytes normalize as ChatGPT, so promoting those rows would launder an origin mismatch.

## Solution

- Add `ops maintenance quarantined-accepted-raws` with separate dry-run and exact proof-digest apply phases.
- Persist an exclusive, fsynced planned-to-applied operator receipt and re-prove under one source-main/index-readonly transaction.
- CAS only the exact untyped/quarantined or typed-full/quarantined transitional envelope to the byte-proven terminal envelope.
- Bind the complete application, membership/census, parallel-head, sibling-raw, blob, artifact, parser, and content context into each proof digest.
- Preserve crash resume, torn receipt recovery, idempotent reapply, all-or-nothing batches, and bounded retained-blob loading.
- Keep raw-origin/parser disagreement fail-closed. The three mismatched browser rows are tracked separately in P0 polylogue-lkrc.

## Acceptance criteria

- Original yla8.10 cohort: exact live dry-run reports three eligible raws: `a7d004c9…`, `f19944c8…`, `fa0574f8…`.
- Origin-mismatch cohort: exact live dry-run refuses `282983b4…`, `86298651…`, `affadd9d…` because raw origin/logical identity disagrees with normalized ChatGPT identity; deferred to polylogue-lkrc.
- Mutation matrix fails closed for head/raw, blob/ref/artifact, frontier, normalized identity/content, application/receipt time, byte-proven competitors, indexed-session ambiguity, membership census, partial envelope, and multi-session inputs.
- Apply requires the matching target list, aggregate digest, exclusive receipt path, writer lease, and transaction-time reproof.
- Receipt recovery, idempotency, batch rollback, CAS rollback, short-write handling, and blob budgets remain covered.
- No schema change, v32 artifact, raw replay, or index rebuild is required.

## Verification

- `devtools test tests/unit/storage/test_quarantined_accepted_raw_repair.py` — `32 passed`.
- `devtools test tests/unit/cli/test_archive_maintenance_cli.py -k quarantined_accepted_raw` — `2 passed, 48 deselected`.
- `devtools verify --quick` — 15/15 steps green, run `20260713T000015Z-quick-2139915-a2f6c119`.
- Rebased pre-push gate — 15/15 steps green, run `20260713T000136Z-quick-2143482-162dbe1c`.
- Read-only live v35 dry-run — original cohort `eligible=3`; origin-mismatch cohort `ineligible=3`; no mutation.

## Postflight

After merge/deployment: stop the daemon, take a verified durable backup, repeat the exact three-target dry-run, apply with a stored operator receipt, verify only the source authority envelope changed, reapply idempotently, restart, and attach the bounded census/journal evidence to polylogue-yla8.10.