### PR TITLE
fix(test): repair source-tier migration assertions after v9 landed

### DIFF
--- a/tests/unit/storage/test_durable_migrations.py
+++ b/tests/unit/storage/test_durable_migrations.py
@@ -454,6 +454,7 @@ def test_source_tier_v7_expands_origin_checks_with_verified_backup(
 ) -> None:
     """The Beads origin copy-forward retains v7 evidence and accepts new raws."""
     db_path = workspace_env["archive_root"] / "source.db"
+    db_path.unlink(missing_ok=True)
     old_ddl = SOURCE_DDL.replace(", 'beads-issue'", "")
     old_ddl = old_ddl.replace(
         "    capture_mode            TEXT CHECK ((capture_mode IN "
@@ -636,7 +637,7 @@ def test_source_tier_v2_migrates_to_v3_dropping_pending_blob_refs(
 
         assert result.from_version == 2
         assert result.to_version == SOURCE_SCHEMA_VERSION
-        assert result.applied_versions == (3, 4, 5, 6, 7, 8)
+        assert result.applied_versions == (3, 4, 5, 6, 7, 8, 9)
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         assert not conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='pending_blob_refs'"
@@ -694,7 +695,7 @@ def test_source_tier_v3_adds_publication_reservations_with_verified_backup_recei
     conn = sqlite3.connect(db_path)
     try:
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
-        assert result.applied_versions == (4, 5, 6, 7, 8)
+        assert result.applied_versions == (4, 5, 6, 7, 8, 9)
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         conn.execute(
             """


### PR DESCRIPTION
## Summary

Repairs 3 failing source-tier durable migration tests on `master`, introduced
by an incomplete fix-forward during merge-conductor rebase work on PR #2800.

## Problem

PR #2794 (origin-interop) claimed source-tier migration slot `008` for
`capture_mode`. PR #2800 (beads-ingest) also numbered its own migration
`008`, requiring a rebase to renumber it to `009` (and preserve the
`capture_mode` column through the copy-forward rebuild it performs). The
test-file edits accompanying that rebase were made to the working tree
*after* the rebase commit but never actually `git add`ed/committed, so
PR #2800 merged without them. `master` currently fails:

- `test_source_tier_v2_migrates_to_v3_dropping_pending_blob_refs`
- `test_source_tier_v3_adds_publication_reservations_with_verified_backup_receipt`
- `test_source_tier_v7_expands_origin_checks_with_verified_backup`

## Solution

- Updated the two `applied_versions`/`to_version` literal assertions to
  include migration `9` (was pinned to the old 8-step chain).
- `test_source_tier_v7_expands_origin_checks_with_verified_backup` relied on
  the `workspace_env` fixture's `ArchiveStore` pre-creating `source.db` at
  the *current* schema (already including `capture_mode`, since
  `CREATE TABLE IF NOT EXISTS` silently no-ops against it) before the test's
  own stripped-down "v7" DDL ever ran. Under a forced `PRAGMA
  user_version=7` stamp, migration 8's `ALTER TABLE ADD COLUMN capture_mode`
  then hit a real `duplicate column name` error. Added
  `db_path.unlink(missing_ok=True)` before the `executescript`, matching the
  pattern `_create_source_v1` already uses in the same file for the same
  fixture.

## Verification

- `devtools test tests/unit/storage/test_durable_migrations.py` — 33 passed.
- `devtools verify --quick` — 15/15 checks green.