### PR TITLE
fix(storage): authorize legacy yla authority cohort (#2811)

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -64,6 +64,13 @@ _QUARANTINED_ACCEPTED_RAW_REPAIR_LIMIT = 100
 _QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES = 256 * 1024 * 1024
 _QUARANTINED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES = 512 * 1024 * 1024
 _QUARANTINED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA = "polylogue.quarantined-accepted-raw-repair.v1"
+_LEGACY_YLA_AUTHORITY_RAW_IDS = frozenset(
+    {
+        "a7d004c9aa943f6a10211851904105ee1c647c331552646e1b9cbe268940ed11",
+        "f19944c8fe19cd59aab2e67d2c8dc04569834d1557a7441c5dc628a117a15176",
+        "fa0574f82a49e6ba58a3abdfd0a49c81189d81c4217f888ffe18ff909dacbd01",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -208,6 +215,10 @@ def _proof_digest(item: QuarantinedAcceptedRawRepairItem) -> str:
     return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
 
 
+def _raw_sessions_capture_mode_available(conn: sqlite3.Connection) -> bool:
+    return any(str(row[1]) == "capture_mode" for row in conn.execute("PRAGMA main.table_info(raw_sessions)").fetchall())
+
+
 def _inspect_quarantined_accepted_raw(
     archive_root: Path,
     raw_id: str,
@@ -215,16 +226,20 @@ def _inspect_quarantined_accepted_raw(
     conn: sqlite3.Connection,
 ) -> QuarantinedAcceptedRawRepairItem:
     """Prove one accepted head against source main + attached read-only index."""
+    capture_mode_available = _raw_sessions_capture_mode_available(conn)
+    if not capture_mode_available and raw_id not in _LEGACY_YLA_AUTHORITY_RAW_IDS:
+        return _quarantined_raw_item(raw_id, "legacy source tier authorizes only the fixed yla8.10 repair cohort")
+    capture_mode_projection = "capture_mode" if capture_mode_available else "NULL AS capture_mode"
     try:
         raw = conn.execute(
-            """
-            SELECT raw_id, origin, capture_mode, native_id, source_path, source_index, blob_hash, blob_size,
+            f"""
+            SELECT raw_id, origin, {capture_mode_projection}, native_id, source_path, source_index, blob_hash, blob_size,
                    file_mtime_ms, logical_source_key, revision_kind, source_revision,
                    predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
                    append_start_offset, append_end_offset, acquisition_generation,
                    revision_authority
             FROM raw_sessions WHERE raw_id = ?
-            """,
+            """,  # nosec B608 - projection is selected from two fixed identifiers above
             (raw_id,),
         ).fetchone()
         if raw is None:

--- a/tests/unit/storage/test_quarantined_accepted_raw_repair.py
+++ b/tests/unit/storage/test_quarantined_accepted_raw_repair.py
@@ -163,6 +163,33 @@ def _raw_session_row(root: Path, raw_id: str) -> dict[str, object]:
     return dict(row)
 
 
+def _retarget_fixture_raw_id(root: Path, old_raw_id: str, new_raw_id: str) -> None:
+    with sqlite3.connect(root / "source.db") as source:
+        source.execute("PRAGMA foreign_keys = OFF")
+        source.execute("UPDATE raw_sessions SET raw_id = ? WHERE raw_id = ?", (new_raw_id, old_raw_id))
+        source.execute("UPDATE blob_refs SET ref_id = ? WHERE ref_id = ?", (new_raw_id, old_raw_id))
+        source.execute("UPDATE raw_session_memberships SET raw_id = ? WHERE raw_id = ?", (new_raw_id, old_raw_id))
+        source.execute("UPDATE raw_membership_census SET raw_id = ? WHERE raw_id = ?", (new_raw_id, old_raw_id))
+        source.execute("UPDATE raw_artifacts SET raw_id = ? WHERE raw_id = ?", (new_raw_id, old_raw_id))
+        source.commit()
+    with sqlite3.connect(root / "index.db") as index:
+        index.execute("PRAGMA foreign_keys = OFF")
+        index.execute("UPDATE sessions SET raw_id = ? WHERE raw_id = ?", (new_raw_id, old_raw_id))
+        index.execute(
+            "UPDATE raw_revision_heads SET accepted_raw_id = ? WHERE accepted_raw_id = ?",
+            (new_raw_id, old_raw_id),
+        )
+        index.execute(
+            """
+            UPDATE raw_revision_applications
+            SET raw_id = ?, accepted_raw_id = ?, baseline_raw_id = ?
+            WHERE raw_id = ?
+            """,
+            (new_raw_id, new_raw_id, new_raw_id, old_raw_id),
+        )
+        index.commit()
+
+
 @pytest.mark.parametrize("typed_quarantined", [False, True])
 def test_quarantined_accepted_raw_repair_roundtrip_is_receipted_and_idempotent(
     tmp_path: Path, typed_quarantined: bool
@@ -403,17 +430,25 @@ def test_quarantined_accepted_raw_repair_preserves_parallel_provenance_context(t
     assert report.items[0].authority_context_digest
 
 
-def test_quarantined_accepted_raw_repair_legacy_source_refuses_arbitrary_raw_ids(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    raw_id = _seed_invalid_head(tmp_path)
+def test_quarantined_accepted_raw_repair_source_v7_authorizes_only_fixed_cohort(tmp_path: Path) -> None:
+    authorized_fixture_raw = _seed_invalid_head(tmp_path, "authorized")
+    arbitrary_raw = _seed_invalid_head(tmp_path, "arbitrary")
     from polylogue.storage import repair as repair_module
 
-    monkeypatch.setattr(repair_module, "_raw_sessions_capture_mode_available", lambda conn: False)
-    report = repair_module.repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])
+    authorized_raw = sorted(repair_module._LEGACY_YLA_AUTHORITY_RAW_IDS)[0]
+    _retarget_fixture_raw_id(tmp_path, authorized_fixture_raw, authorized_raw)
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        source.execute("ALTER TABLE raw_sessions DROP COLUMN capture_mode")
+        source.execute("PRAGMA user_version = 7")
+        source.commit()
 
-    assert report.ineligible_count == 1
-    assert report.items[0].reason == "legacy source tier authorizes only the fixed yla8.10 repair cohort"
+    eligible = repair_module.repair_quarantined_accepted_raws(_config(tmp_path), [authorized_raw])
+    refused = repair_module.repair_quarantined_accepted_raws(_config(tmp_path), [arbitrary_raw])
+
+    assert eligible.eligible_count == 1, eligible.items[0].reason
+    assert eligible.items[0].capture_mode is None
+    assert refused.ineligible_count == 1
+    assert refused.items[0].reason == "legacy source tier authorizes only the fixed yla8.10 repair cohort"
 
 
 def test_quarantined_accepted_raw_repair_rejects_duplicates_and_rolls_back_batch(

--- a/tests/unit/storage/test_quarantined_accepted_raw_repair.py
+++ b/tests/unit/storage/test_quarantined_accepted_raw_repair.py
@@ -403,6 +403,19 @@ def test_quarantined_accepted_raw_repair_preserves_parallel_provenance_context(t
     assert report.items[0].authority_context_digest
 
 
+def test_quarantined_accepted_raw_repair_legacy_source_refuses_arbitrary_raw_ids(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    raw_id = _seed_invalid_head(tmp_path)
+    from polylogue.storage import repair as repair_module
+
+    monkeypatch.setattr(repair_module, "_raw_sessions_capture_mode_available", lambda conn: False)
+    report = repair_module.repair_quarantined_accepted_raws(_config(tmp_path), [raw_id])
+
+    assert report.ineligible_count == 1
+    assert report.items[0].reason == "legacy source tier authorizes only the fixed yla8.10 repair cohort"
+
+
 def test_quarantined_accepted_raw_repair_rejects_duplicates_and_rolls_back_batch(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Keeps the merged quarantined-authority actuator compatible with the live source-v7/index-v35 archive without weakening its modern provider-fiber proof. Ref polylogue-yla8.10.

## Problem

PR #2808 correctly binds `raw_sessions.capture_mode` for non-injective origins, but the live durable source tier is v7 and predates that additive column. Current master is source v9/index v36; migrating/deploying it solely for this one-time repair would also introduce the unrelated index-v36 rebuild boundary.

## Solution

- Detect whether the durable source tier has `capture_mode`.
- On modern tiers, retain the complete capture-mode/provider-fiber proof from #2808.
- On legacy tiers, project capture mode as NULL and authorize only the three exact yla8.10 raw IDs. Every other raw refuses before authority inspection.
- Keep the same retained-byte, parser, head, application, membership/census, receipt, and exclusive-lock proofs.

## Verification

- `devtools test tests/unit/storage/test_quarantined_accepted_raw_repair.py -k source_v7` — 1 passed, 36 deselected.
- `devtools verify --quick` — 15/15 green, run `20260713T002456Z-quick-2197090-5dc61039`.
- Pre-push quick — 15/15 green, run `20260713T002548Z-quick-2199014-5bef733d`.
- Read-only live source-v7/index-v35 dry-run — requested=3, eligible=3, ineligible=0; aggregate proof `8735245c2f0afa271d1a1329bcb7d88ec07b0e29cf8f043bf1389e86033fcac7`.

## Postflight

Merge, stop the daemon, create and verify a durable backup, repeat the exact dry-run, apply with the stored receipt, verify only the three source authority envelopes changed, reapply idempotently, and restart. No source migration or index rebuild is part of this PR.