### PR TITLE
feat(assertions): persist finding candidates

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -278,6 +278,26 @@ def assertion_id_for_pathology_finding(
     )
 
 
+def assertion_id_for_finding(
+    *,
+    claim_key: str,
+    target_ref: str,
+    value: Mapping[str, object],
+    evidence_refs: Sequence[str],
+    detector_ref: str,
+) -> str:
+    """Return the deterministic id for one ``polylogue.finding.v1`` claim."""
+
+    return _deterministic_id(
+        f"assertion-{AssertionKind.FINDING}",
+        claim_key,
+        target_ref,
+        _json_dumps(dict(value)),
+        *sorted(evidence_refs),
+        detector_ref,
+    )
+
+
 def assertion_id_for_candidate_judgment(candidate_assertion_id: str, decision: str) -> str:
     return _deterministic_id(f"assertion-{AssertionKind.JUDGMENT}", candidate_assertion_id, decision)
 
@@ -448,6 +468,32 @@ class ArchiveAssertionBulkJudgmentEnvelope:
 class ArchiveAssertionCandidateReviewEnvelope:
     candidate: ArchiveAssertionEnvelope
     latest_judgment: ArchiveAssertionEnvelope | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FindingAssertion:
+    """One detector-produced claim stored through the assertion lifecycle.
+
+    Query and result-set refs deliberately remain opaque at this layer. The
+    rxdo substrate owns their grammar; this writer preserves them as public
+    evidence refs so future provenance readers can resolve ancestry.
+    """
+
+    claim_key: str
+    target_ref: str
+    body_text: str
+    finding_kind: str
+    statistic: Mapping[str, JSONValue]
+    n: int
+    query_ref: str
+    result_set_ref: str
+    detector_ref: str
+    baseline_ref: str | None = None
+    current_ref: str | None = None
+    expected: Mapping[str, JSONValue] | None = None
+    evidence_refs: Sequence[str] = ()
+    scope_ref: str | None = None
+    confidence: float | None = None
 
 
 def upsert_suppression(
@@ -1231,64 +1277,95 @@ def upsert_pathology_findings_as_assertions(
     return envelopes
 
 
-@dataclass(frozen=True, slots=True)
-class FindingAssertionInput:
-    """One deterministic, evidence-backed finding awaiting operator judgment."""
-
-    finding_kind: str
-    target_ref: str
-    body_text: str
-    evidence_refs: Sequence[str]
-    detector_ref: str
-    value: Mapping[str, object]
-    scope_ref: str | None = None
+_FINDING_KINDS: Final[frozenset[str]] = frozenset(
+    {"query-delta", "query-drift", "measure", "pathology", "claim-vs-evidence"}
+)
 
 
-def assertion_id_for_finding(
-    *,
-    finding_kind: str,
-    target_ref: str,
-    value: Mapping[str, object],
-    evidence_refs: Sequence[str],
-    detector_ref: str,
-) -> str:
-    """Return a stable identity for a materialized finding assertion."""
+def _validate_finding_ref(value: str, *, field: str) -> str:
+    """Keep finding evidence refs opaque until the rxdo substrate owns grammar."""
 
-    return _deterministic_id(
-        f"assertion-{AssertionKind.FINDING}",
-        finding_kind,
-        target_ref,
-        _json_dumps(dict(value)),
-        *sorted(evidence_refs),
-        detector_ref,
-    )
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"finding {field} must be a non-empty ref")
+    return normalized
+
+
+def _finding_value(finding: FindingAssertion) -> dict[str, object]:
+    """Validate and project the additive ``polylogue.finding.v1`` payload."""
+
+    if finding.finding_kind not in _FINDING_KINDS:
+        raise ValueError(f"unsupported finding_kind: {finding.finding_kind!r}")
+    if not finding.claim_key.strip():
+        raise ValueError("finding claim_key must be non-empty")
+    if isinstance(finding.n, bool) or finding.n < 0:
+        raise ValueError("finding n must be a non-negative integer")
+    statistic = dict(finding.statistic)
+    if not {"op", "value", "unit"}.issubset(statistic):
+        raise ValueError("finding statistic must contain op, value, and unit")
+
+    query_ref = _validate_finding_ref(finding.query_ref, field="query_ref")
+    result_set_ref = _validate_finding_ref(finding.result_set_ref, field="result_set_ref")
+    value: dict[str, object] = {
+        "_schema": "polylogue.finding.v1",
+        "finding_kind": finding.finding_kind,
+        "statistic": statistic,
+        "n": finding.n,
+        "query_ref": query_ref,
+        "result_set_ref": result_set_ref,
+    }
+    if finding.baseline_ref is not None:
+        value["baseline_ref"] = _validate_finding_ref(finding.baseline_ref, field="baseline_ref")
+    if finding.current_ref is not None:
+        value["current_ref"] = _validate_finding_ref(finding.current_ref, field="current_ref")
+    if finding.finding_kind == "query-delta" and {"baseline_ref", "current_ref"} - value.keys():
+        raise ValueError("query-delta findings require baseline_ref and current_ref")
+    if finding.expected is not None:
+        expected = dict(finding.expected)
+        if not {"measure", "op", "value"}.issubset(expected):
+            raise ValueError("finding expected must contain measure, op, and value")
+        # Future rigor work can add bands, tolerances, or direction-only
+        # expectations without a user-tier schema migration.
+        value["expected"] = expected
+    return value
 
 
 def upsert_findings_as_assertions(
     conn: sqlite3.Connection,
-    findings: Sequence[FindingAssertionInput],
+    findings: Sequence[FindingAssertion],
     *,
     now_ms: int | None = None,
 ) -> list[ArchiveAssertionEnvelope]:
-    """Materialize detector findings as private, non-injected candidates.
+    """Write detector findings as private, non-injected assertion candidates.
 
-    Findings deliberately use the same assertion candidate -> judgment ->
-    promoted-active path as pathology rows.  Their deterministic identity
-    makes a repeated materialization a no-op at the row-identity level.
+    This mirrors :func:`upsert_pathology_findings_as_assertions`: repeated
+    materialization maps identical claim/evidence inputs to the same row, and
+    terminal operator judgments are never overwritten by a detector.
     """
 
     timestamp = now_ms if now_ms is not None else _now_ms()
     envelopes: list[ArchiveAssertionEnvelope] = []
     for finding in findings:
-        value = dict(finding.value)
-        value.setdefault("format", "polylogue.finding.v1")
-        value.setdefault("finding_kind", finding.finding_kind)
+        value = _finding_value(finding)
+        query_ref = str(value["query_ref"])
+        result_set_ref = str(value["result_set_ref"])
+        evidence_refs = [
+            query_ref,
+            result_set_ref,
+            *(_validate_finding_ref(ref, field="evidence_ref") for ref in finding.evidence_refs),
+        ]
+        for field in ("baseline_ref", "current_ref"):
+            ref = value.get(field)
+            if isinstance(ref, str):
+                evidence_refs.append(ref)
+        evidence_refs = sorted(set(evidence_refs))
+        detector_ref = _validate_finding_ref(finding.detector_ref, field="detector_ref")
         assertion_id = assertion_id_for_finding(
-            finding_kind=finding.finding_kind,
+            claim_key=finding.claim_key.strip(),
             target_ref=finding.target_ref,
             value=value,
-            evidence_refs=finding.evidence_refs,
-            detector_ref=finding.detector_ref,
+            evidence_refs=evidence_refs,
+            detector_ref=detector_ref,
         )
         existing = read_assertion_envelope(conn, assertion_id)
         if existing is not None and existing.status != AssertionStatus.CANDIDATE:
@@ -1298,18 +1375,19 @@ def upsert_findings_as_assertions(
             upsert_assertion(
                 conn,
                 assertion_id=assertion_id,
-                scope_ref=finding.scope_ref,
+                scope_ref=finding.scope_ref or detector_ref,
                 target_ref=finding.target_ref,
-                key=finding.finding_kind,
+                key=finding.claim_key.strip(),
                 kind=AssertionKind.FINDING,
                 value=value,
                 body_text=finding.body_text,
-                author_ref=finding.detector_ref,
+                author_ref=detector_ref,
                 author_kind="detector",
-                evidence_refs=finding.evidence_refs,
+                evidence_refs=evidence_refs,
                 status=AssertionStatus.CANDIDATE,
                 visibility=AssertionVisibility.PRIVATE,
-                context_policy=_ASSERTION_AGENT_CANDIDATE_CONTEXT_POLICY,
+                confidence=finding.confidence,
+                context_policy={"inject": False, "promotion_required": True},
                 now_ms=timestamp,
             )
         )
@@ -1389,6 +1467,7 @@ ASSERTION_CANDIDATE_JUDGMENT_KINDS: tuple[AssertionKind, ...] = (
     AssertionKind.RUN_STATE,
     AssertionKind.TRANSFORM_CANDIDATE,
     AssertionKind.PATHOLOGY,
+    AssertionKind.FINDING,
     AssertionKind.NOTE,
     AssertionKind.CORRECTION,
 )
@@ -2091,6 +2170,7 @@ __all__ = [
     "ArchiveRecallPackEnvelope",
     "ArchiveSavedViewEnvelope",
     "ArchiveWorkspaceEnvelope",
+    "FindingAssertion",
     "AssertionKind",
     "AssertionStatus",
     "AssertionVisibility",
@@ -2099,6 +2179,7 @@ __all__ = [
     "assertion_id_for_blackboard_note",
     "assertion_id_for_candidate_judgment",
     "assertion_id_for_correction",
+    "assertion_id_for_finding",
     "assertion_id_for_mark",
     "assertion_id_for_promoted_candidate",
     "assertion_id_for_session_metadata",
@@ -2107,7 +2188,6 @@ __all__ = [
     "assertion_id_for_session_tag",
     "assertion_id_for_suppression",
     "assertion_id_for_pathology_finding",
-    "assertion_id_for_finding",
     "assertion_id_for_transform_candidate",
     "assertion_id_for_workspace",
     "correction_id_for",
@@ -2136,6 +2216,7 @@ __all__ = [
     "upsert_assertion",
     "upsert_blackboard_note",
     "upsert_correction",
+    "upsert_findings_as_assertions",
     "upsert_mark",
     "upsert_recall_pack",
     "upsert_saved_view",
@@ -2143,8 +2224,6 @@ __all__ = [
     "upsert_session_tag_assertion",
     "upsert_suppression",
     "upsert_pathology_findings_as_assertions",
-    "FindingAssertionInput",
-    "upsert_findings_as_assertions",
     "upsert_transform_candidate_assertions",
     "upsert_workspace",
 ]

--- a/tests/unit/storage/test_archive_tiers_assertions.py
+++ b/tests/unit/storage/test_archive_tiers_assertions.py
@@ -27,7 +27,7 @@ from polylogue.storage.sqlite.archive_tiers.user_write import (
     AssertionKind,
     AssertionStatus,
     AssertionVisibility,
-    FindingAssertionInput,
+    FindingAssertion,
     assertion_envelope_to_payload,
     assertion_id_for_candidate_judgment,
     assertion_id_for_finding,
@@ -1337,64 +1337,6 @@ def test_bulk_judgment_rolls_back_on_unexpected_batch_error(tmp_path: Path, monk
         conn.close()
 
 
-def test_findings_reuse_candidate_judgment_lifecycle_and_deduplicate(tmp_path: Path) -> None:
-    """A repeated detector finding is one candidate assertion, not a new lifecycle."""
-
-    conn = _connect(tmp_path / "user.db")
-    try:
-        finding = FindingAssertionInput(
-            finding_kind="measure",
-            target_ref="session:codex-session:finding-demo",
-            body_text="The measure changed enough to require operator review.",
-            evidence_refs=("session:codex-session:finding-demo",),
-            detector_ref="agent:finding-detector",
-            value={"statistic": {"op": "eq", "value": 3, "unit": "runs"}, "n": 3},
-        )
-        first = upsert_findings_as_assertions(conn, (finding,), now_ms=10)
-        second = upsert_findings_as_assertions(conn, (finding,), now_ms=11)
-        assert [row.assertion_id for row in first] == [row.assertion_id for row in second]
-        assert first[0].assertion_id == assertion_id_for_finding(
-            finding_kind="measure",
-            target_ref=finding.target_ref,
-            value={"format": "polylogue.finding.v1", "finding_kind": "measure", **finding.value},
-            evidence_refs=finding.evidence_refs,
-            detector_ref=finding.detector_ref,
-        )
-        assert first[0].kind is AssertionKind.FINDING
-        assert first[0].status is AssertionStatus.CANDIDATE
-        assert first[0].context_policy == {"inject": False, "promotion_required": True}
-        accepted = judge_assertion_candidate(
-            conn,
-            candidate_ref=f"assertion:{first[0].assertion_id}",
-            decision="accept",
-            inject=False,
-            now_ms=12,
-        )
-        assert accepted.resulting_assertion is not None
-        assert accepted.resulting_assertion.kind is AssertionKind.FINDING
-        rematerialized = upsert_findings_as_assertions(
-            conn,
-            (
-                FindingAssertionInput(
-                    finding_kind=finding.finding_kind,
-                    target_ref=finding.target_ref,
-                    body_text="Detector wording changed after operator review.",
-                    evidence_refs=finding.evidence_refs,
-                    detector_ref=finding.detector_ref,
-                    value=finding.value,
-                    scope_ref="insight:changed-detector-scope",
-                ),
-            ),
-            now_ms=13,
-        )
-        assert rematerialized == [accepted.candidate]
-        assert rematerialized[0].body_text == finding.body_text
-        assert rematerialized[0].scope_ref is None
-        assert rematerialized[0].updated_at_ms == accepted.candidate.updated_at_ms
-    finally:
-        conn.close()
-
-
 def test_candidate_reviews_survive_remirror_without_becoming_authoritative(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "user.db")
     try:
@@ -1558,3 +1500,117 @@ def test_assertion_id_for_pathology_finding_is_stable() -> None:
     assert first == assertion_id_for_pathology_finding(**base)  # type: ignore[arg-type]
     changed = assertion_id_for_pathology_finding(**{**base, "finding_kind": "stale_context"})  # type: ignore[arg-type]
     assert changed != first
+
+
+def test_upsert_findings_reuses_candidate_lifecycle_and_evidence_refs(tmp_path: Path) -> None:
+    """Real writer path: detector evidence remains reviewable and never auto-injects."""
+    conn = _connect(tmp_path / "user.db")
+    try:
+        finding = FindingAssertion(
+            claim_key="tool-failure-rate",
+            target_ref="query:tool-failure-rate-v1",
+            body_text="The failure rate increased from the pre-registered baseline.",
+            finding_kind="query-delta",
+            statistic={"op": "rate", "value": 0.18, "unit": "fraction"},
+            n=200,
+            query_ref="query:tool-failure-rate-v1",
+            result_set_ref="result-set:tool-failure-rate-run-2",
+            baseline_ref="result-set:tool-failure-rate-run-1",
+            current_ref="result-set:tool-failure-rate-run-2",
+            expected={"measure": "tool-failure-rate", "op": "<=", "value": 0.1, "tolerance": 0.02},
+            detector_ref="insight:tool-failure-detector@v1",
+        )
+
+        written = upsert_findings_as_assertions(conn, [finding], now_ms=1_700_000_000_000)
+        assert len(written) == 1
+        candidate = written[0]
+        assert candidate.kind is AssertionKind.FINDING
+        assert candidate.status is AssertionStatus.CANDIDATE
+        assert candidate.visibility is AssertionVisibility.PRIVATE
+        assert candidate.context_policy == {"inject": False, "promotion_required": True}
+        assert candidate.evidence_refs == [
+            "query:tool-failure-rate-v1",
+            "result-set:tool-failure-rate-run-1",
+            "result-set:tool-failure-rate-run-2",
+        ]
+        assert candidate.value == {
+            "_schema": "polylogue.finding.v1",
+            "finding_kind": "query-delta",
+            "statistic": {"op": "rate", "value": 0.18, "unit": "fraction"},
+            "n": 200,
+            "query_ref": "query:tool-failure-rate-v1",
+            "result_set_ref": "result-set:tool-failure-rate-run-2",
+            "baseline_ref": "result-set:tool-failure-rate-run-1",
+            "current_ref": "result-set:tool-failure-rate-run-2",
+            "expected": {"measure": "tool-failure-rate", "op": "<=", "value": 0.1, "tolerance": 0.02},
+        }
+
+        # Idempotency uses canonical payload + sorted evidence, not call order.
+        rerun = upsert_findings_as_assertions(conn, [finding], now_ms=1_700_000_001_000)
+        assert [item.assertion_id for item in rerun] == [candidate.assertion_id]
+        assert len(list_assertion_claims(conn, kinds=(AssertionKind.FINDING,))) == 1
+        assert (
+            assertion_id_for_finding(
+                claim_key=finding.claim_key,
+                target_ref=finding.target_ref,
+                value=candidate.value,
+                evidence_refs=tuple(reversed(candidate.evidence_refs)),
+                detector_ref=finding.detector_ref,
+            )
+            == candidate.assertion_id
+        )
+
+        # The generic judgment queue and promotion code operate without a
+        # finding-specific lifecycle implementation.
+        assert [row.assertion_id for row in list_assertion_candidates(conn)] == [candidate.assertion_id]
+        judged = judge_assertion_candidate(
+            conn,
+            candidate_ref=f"assertion:{candidate.assertion_id}",
+            decision="accept",
+            reason="sample frame and result refs checked",
+            actor_ref="user:local",
+            now_ms=1_700_000_002_000,
+        )
+        assert judged.candidate.status is AssertionStatus.ACCEPTED
+        assert judged.resulting_assertion is not None
+        assert judged.resulting_assertion.kind is AssertionKind.FINDING
+        assert judged.resulting_assertion.context_policy == {"inject": False}
+        assert judged.judgment.kind is AssertionKind.JUDGMENT
+    finally:
+        conn.close()
+
+
+def test_upsert_findings_rejects_incomplete_delta_and_unresolved_ref_shapes(tmp_path: Path) -> None:
+    """Schema validation fails before a detector can create an unauditable claim."""
+    conn = _connect(tmp_path / "user.db")
+    try:
+        incomplete_delta = FindingAssertion(
+            claim_key="missing-baseline",
+            target_ref="query:delta",
+            body_text="missing baseline",
+            finding_kind="query-delta",
+            statistic={"op": "count", "value": 3, "unit": "sessions"},
+            n=3,
+            query_ref="query:delta",
+            result_set_ref="result-set:current",
+            current_ref="result-set:current",
+            detector_ref="insight:detector",
+        )
+        with pytest.raises(ValueError, match="baseline_ref"):
+            upsert_findings_as_assertions(conn, [incomplete_delta])
+
+        malformed_ref = FindingAssertion(
+            claim_key="bad-ref",
+            target_ref="query:delta",
+            body_text="invalid result ref",
+            finding_kind="measure",
+            statistic={"op": "count", "value": 3, "unit": "sessions"},
+            n=3,
+            query_ref="query:delta",
+            result_set_ref=" ",
+            detector_ref="insight:detector",
+        )
+        with pytest.raises(ValueError, match="result_set_ref"):
+            upsert_findings_as_assertions(conn, [malformed_ref])
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Adds `AssertionKind.FINDING` and a `polylogue.finding.v1` writer that stores detector claims in the existing candidate/judge/promotion lifecycle.

## Problem

Detector results with denominators, statistics, and query/result evidence had no durable claim row, so they could not be reviewed, judged, or cited through the assertion lifecycle.

## Solution

- Adds `FindingAssertion`, deterministic identity over claim, target, canonical value, sorted evidence, and detector ref, plus the `upsert_findings_as_assertions` writer.
- Persists required finding evidence (`query_ref`, `result_set_ref`), optional delta baseline/current refs, and an additive `expected` shape for later rigor work.
- Registers the kind in claim/candidate-review/audit inventories and regenerated OpenAPI/CLI schemas; no user-tier migration is needed because `assertions.kind` is schema-free `TEXT`.
- Keeps query/result refs opaque at this writer boundary; the parallel substrate owns their canonical identity grammar.

## Acceptance criteria

| Criterion | Status | Evidence |
| --- | --- | --- |
| Pathology-style deterministic writer | Satisfied | `upsert_findings_as_assertions` and idempotency test |
| Judgment queue and lifecycle reuse | Satisfied | candidate and acceptance assertions use `judge_assertion_candidate` unchanged |
| Evidence refs retained | Satisfied | query/result/baseline/current refs are assertion evidence |
| Schemas and user audit | Satisfied | regenerated artifacts and every-kind audit invariant |
| Identical rerun adds no row | Satisfied | focused idempotency assertion |

## Verification

- `TMPDIR=/realm/tmp POLYLOGUE_PYTEST_WORKERS=1 devtools test tests/unit/storage/test_archive_tiers_assertions.py tests/unit/storage/test_archive_tiers_user_audit.py` → `30 passed`.
- `TMPDIR=/realm/tmp devtools verify --quick` → all 15 steps passed.
- `devtools render all --check` → exit 0; no `out of sync` output.

Anti-vacuity: the new lifecycle test invokes the production writer against a real user-tier SQLite database, then sends its resulting candidate through the production judgment function. Removing candidate coercion, evidence propagation, or deterministic identity makes that test fail.

## Adversarial review notes

Iteration 1: no legitimate gaps found across all 5 ACs.

Ref polylogue-rxdo.4