### PR TITLE
feat(devtools): coordination archive-state probe and latency evidence

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -385,6 +385,13 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "bench coordination-latency",
+        "benchmarking",
+        "Measure compact coordination status p50/p95 with raw stage samples.",
+        "devtools.coordination_latency_probe",
+        examples=("devtools bench coordination-latency --samples 21 --out .local/coordination-latency.json",),
+    ),
+    CommandSpec(
         "lab snapshot read-surface",
         "verification lab",
         "Capture and compare archive read-surface snapshots.",

--- a/devtools/coordination_latency_probe.py
+++ b/devtools/coordination_latency_probe.py
@@ -1,0 +1,79 @@
+"""Measure compact coordination-envelope latency with stage attribution.
+
+Use ``devtools bench coordination-latency --samples 21 --out PATH`` to write a
+portable raw artifact.  Samples are intentionally taken through the production
+envelope builder; each carries the complete per-stage timing map and the report
+adds p50/p95 rather than hiding tail latency behind a single average.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+
+def _percentile(values: list[float], percentile: float) -> float:
+    ordered = sorted(values)
+    rank = max(1, min(len(ordered), round(percentile / 100 * len(ordered))))
+    return ordered[rank - 1]
+
+
+def measure(*, samples: int, cwd: Path | None = None) -> dict[str, Any]:
+    """Return raw compact samples and an honest distribution summary."""
+
+    from polylogue.coordination.envelope import build_coordination_envelope
+
+    root = (cwd or Path.cwd()).resolve()
+    raw: list[dict[str, object]] = []
+    for number in range(samples):
+        stages: dict[str, float] = {}
+        started = perf_counter()
+        payload = build_coordination_envelope(cwd=root, stage_timings_ms=stages)
+        raw.append(
+            {
+                "sample": number,
+                "latency_ms": round((perf_counter() - started) * 1_000, 3),
+                "stages_ms": stages,
+                "serialized_bytes": payload.projection.serialized_bytes,
+            }
+        )
+    latencies = [float(row["latency_ms"]) for row in raw]
+    return {
+        "version": 1,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "git_head": _git_head(root),
+        "cwd": str(root),
+        "mode": "warm-in-process-core",
+        "samples": raw,
+        "distribution_ms": {"p50": _percentile(latencies, 50), "p95": _percentile(latencies, 95)},
+    }
+
+
+def _git_head(cwd: Path) -> str | None:
+    import subprocess
+
+    completed = subprocess.run(["git", "rev-parse", "HEAD"], cwd=cwd, text=True, capture_output=True, check=False)
+    return completed.stdout.strip() or None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--samples", type=int, default=21)
+    parser.add_argument("--cwd", type=Path, default=None)
+    parser.add_argument("--out", type=Path, default=None, help="Write the full raw JSON artifact to this path.")
+    args = parser.parse_args(argv)
+    report = measure(samples=max(1, args.samples), cwd=args.cwd)
+    encoded = json.dumps(report, indent=2, sort_keys=True)
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(encoded + "\n", encoding="utf-8")
+    print(encoded)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/coordination_latency_probe.py
+++ b/devtools/coordination_latency_probe.py
@@ -29,19 +29,21 @@ def measure(*, samples: int, cwd: Path | None = None) -> dict[str, Any]:
 
     root = (cwd or Path.cwd()).resolve()
     raw: list[dict[str, object]] = []
+    latencies: list[float] = []
     for number in range(samples):
         stages: dict[str, float] = {}
         started = perf_counter()
         payload = build_coordination_envelope(cwd=root, stage_timings_ms=stages)
+        latency_ms = round((perf_counter() - started) * 1_000, 3)
+        latencies.append(latency_ms)
         raw.append(
             {
                 "sample": number,
-                "latency_ms": round((perf_counter() - started) * 1_000, 3),
+                "latency_ms": latency_ms,
                 "stages_ms": stages,
                 "serialized_bytes": payload.projection.serialized_bytes,
             }
         )
-    latencies = [float(row["latency_ms"]) for row in raw]
     return {
         "version": 1,
         "generated_at": datetime.now(UTC).isoformat(),

--- a/devtools/coordination_latency_probe.py
+++ b/devtools/coordination_latency_probe.py
@@ -26,6 +26,7 @@ def measure(*, samples: int, cwd: Path | None = None) -> dict[str, Any]:
     """Return raw compact samples and an honest distribution summary."""
 
     from polylogue.coordination.envelope import build_coordination_envelope
+    from polylogue.paths import archive_root
 
     root = (cwd or Path.cwd()).resolve()
     raw: list[dict[str, object]] = []
@@ -49,10 +50,22 @@ def measure(*, samples: int, cwd: Path | None = None) -> dict[str, Any]:
         "generated_at": datetime.now(UTC).isoformat(),
         "git_head": _git_head(root),
         "cwd": str(root),
+        "archive_state": _archive_state(archive_root()),
         "mode": "warm-in-process-core",
         "samples": raw,
         "distribution_ms": {"p50": _percentile(latencies, 50), "p95": _percentile(latencies, 95)},
     }
+
+
+def _archive_state(root: Path) -> dict[str, object]:
+    """Record non-content archive facts needed to compare local samples."""
+
+    index = root / "index.db"
+    try:
+        index_bytes: int | None = index.stat().st_size
+    except OSError:
+        index_bytes = None
+    return {"root": str(root), "index_exists": index.exists(), "index_bytes": index_bytes}
 
 
 def _git_head(cwd: Path) -> str | None:

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -175,6 +175,7 @@ These are the commands worth remembering during normal repo work:
 | Command | Description |
 | --- | --- |
 | `devtools bench campaign` | Run or compare benchmark campaigns. |
+| `devtools bench coordination-latency` | Measure compact coordination status p50/p95 with raw stage samples. |
 | `devtools bench ingest-amplification` | Measure deterministic per-tier ingest write amplification on a synthetic fixture (#1851). |
 | `devtools bench ingest-throughput` | Measure ingest wall-clock throughput on a synthetic fixture. |
 | `devtools bench memory` | Measure query-memory envelopes on generated fixtures. |

--- a/polylogue/cli/commands/reset.py
+++ b/polylogue/cli/commands/reset.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 import click
 
-from polylogue.archive.query.path_prefix import escaped_sql_path_prefix_patterns
 from polylogue.cli.shared.helpers import fail
 from polylogue.cli.shared.types import AppEnv
 from polylogue.paths import (
@@ -24,10 +23,6 @@ from polylogue.paths import (
     drive_token_path,
     state_home,
 )
-from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
-from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
-from polylogue.storage.sqlite.archive_tiers.user_write import upsert_suppression
-from polylogue.surfaces.payloads import MutationResultPayload, MutationStatus
 
 # Durable acquired source evidence. Deleting it means future rebuilds can only
 # recover rows whose original source files still exist.
@@ -207,6 +202,10 @@ def _delete_archive_sessions(session_ids: list[str]) -> int:
 def _suppress_archive_sessions(session_ids: list[str], *, reason: str) -> int:
     if not session_ids:
         return 0
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+    from polylogue.storage.sqlite.archive_tiers.user_write import upsert_suppression
+
     user_db = _user_db_path()
     initialize_archive_database(user_db, ArchiveTier.USER)
     conn = sqlite3.connect(user_db)
@@ -238,13 +237,15 @@ def _identity_reset_targets(*, conv_id: str | None, source_path: Path | None) ->
 def _emit_identity_reset_result(
     env: AppEnv,
     *,
-    status: MutationStatus,
+    status: str,
     session_ids: list[str],
     affected_count: int,
     output_format: str | None,
     plain_message: str,
 ) -> None:
     if output_format == "json":
+        from polylogue.surfaces.payloads import MutationResultPayload
+
         click.echo(
             MutationResultPayload(
                 status=status,
@@ -263,6 +264,8 @@ def _archive_session_ids_from_source(source_path: Path) -> list[str]:
     source_db = _source_db_path()
     if not index_db.exists() or not source_db.exists():
         return []
+    from polylogue.archive.query.path_prefix import escaped_sql_path_prefix_patterns
+
     exact_prefix, child_prefix = escaped_sql_path_prefix_patterns(source_path)
     conn = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
     try:

--- a/polylogue/cli/commands/reset.py
+++ b/polylogue/cli/commands/reset.py
@@ -9,8 +9,12 @@ from __future__ import annotations
 import shutil
 import sqlite3
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
+
+if TYPE_CHECKING:
+    from polylogue.surfaces.payloads import MutationStatus
 
 from polylogue.cli.shared.helpers import fail
 from polylogue.cli.shared.types import AppEnv
@@ -237,7 +241,7 @@ def _identity_reset_targets(*, conv_id: str | None, source_path: Path | None) ->
 def _emit_identity_reset_result(
     env: AppEnv,
     *,
-    status: str,
+    status: MutationStatus,
     session_ids: list[str],
     affected_count: int,
     output_format: str | None,

--- a/polylogue/coordination/envelope.py
+++ b/polylogue/coordination/envelope.py
@@ -8,12 +8,14 @@ import re
 import shlex
 import sqlite3
 import subprocess
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, MutableMapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import cast
+from time import perf_counter
+from typing import TypeVar, cast
 
 from polylogue.coordination.payloads import (
     AgentCoordinationPayload,
@@ -47,6 +49,7 @@ from polylogue.paths import active_index_db_path, archive_root
 logger = get_logger(__name__)
 
 CommandRunner = Callable[[Sequence[str], Path | None], "CommandResult"]
+_StageResult = TypeVar("_StageResult")
 
 _COMMAND_CHARS = 220
 _CHANGED_PATH_LIMIT = 40
@@ -54,6 +57,7 @@ _CHANGED_PATH_LIMIT = 40
 # complete default response below the bead's 8 KiB transport ceiling.
 _COMPACT_BYTE_BUDGET = 7_600
 _PROCESS_COMMAND = ("ps", "ww", "-eo", "pid=,ppid=,comm=,cgroup:200=,args=")
+_BEADS_PROBE_TIMEOUT_SECONDS = 0.35
 _AGENT_NAMES = ("codex", "claude", "gemini")
 _SYSTEM_RESOURCE_NAMES = frozenset(
     {
@@ -94,8 +98,15 @@ def build_coordination_envelope(
     limit: int = 10,
     detail: bool = False,
     runner: CommandRunner | None = None,
+    stage_timings_ms: MutableMapping[str, float] | None = None,
 ) -> AgentCoordinationPayload:
-    """Return a bounded, JSON-first coordination envelope for agents."""
+    """Return a bounded, JSON-first coordination envelope for agents.
+
+    ``stage_timings_ms`` is an optional caller-owned diagnostic sink.  It is
+    intentionally not projected into the agent payload: timing collection is
+    for the benchmark harness, while the compact payload remains bounded and
+    semantically stable.
+    """
 
     now = datetime.now(UTC).isoformat()
     root_cwd = (cwd or Path.cwd()).resolve()
@@ -103,27 +114,47 @@ def build_coordination_envelope(
     peer_limit = max(1, min(limit, 50))
     resource_limit = max(1, min(limit, 50))
 
-    repo = _repo_payload(root_cwd, command_runner)
-    process_result, process_rows = _process_snapshot(command_runner)
-    self_payload = _self_payload(root_cwd, repo, process_rows, process_result)
-    work_item = _work_item_payload(root_cwd, repo, command_runner)
-    beads = _beads_payload(root_cwd, repo, command_runner)
-    all_peers = _logical_peer_payloads(
-        process_rows,
-        process_result,
-        owner_pid=self_payload.owner_pid,
-        invocation_pid=self_payload.invocation_pid,
+    repo = _timed_stage(stage_timings_ms, "repo", lambda: _repo_payload(root_cwd, command_runner))
+    process_result, process_rows = _timed_stage(stage_timings_ms, "process", lambda: _process_snapshot(command_runner))
+    self_payload = _timed_stage(
+        stage_timings_ms,
+        "self",
+        lambda: _self_payload(root_cwd, repo, process_rows, process_result),
     )
-    all_resources = _resource_scope_payloads(
-        process_rows,
-        process_result,
-        root_cwd,
-        archive_resource=_configured_archive_resource(),
+    work_item = _timed_stage(
+        stage_timings_ms,
+        "work_item",
+        lambda: _work_item_payload(root_cwd, repo, command_runner),
+    )
+    beads = _timed_stage(stage_timings_ms, "beads", lambda: _beads_payload(root_cwd, repo, command_runner))
+    all_peers = _timed_stage(
+        stage_timings_ms,
+        "peers",
+        lambda: _logical_peer_payloads(
+            process_rows,
+            process_result,
+            owner_pid=self_payload.owner_pid,
+            invocation_pid=self_payload.invocation_pid,
+        ),
+    )
+    all_resources = _timed_stage(
+        stage_timings_ms,
+        "resources",
+        lambda: _resource_scope_payloads(
+            process_rows,
+            process_result,
+            root_cwd,
+            archive_resource=_configured_archive_resource(),
+        ),
     )
     peers = all_peers[:peer_limit]
     resources = all_resources[:resource_limit]
-    archive = _archive_payload(resources)
-    handoff = _handoff_payloads(repo.root or str(root_cwd), archive=archive, limit=peer_limit)
+    archive = _timed_stage(stage_timings_ms, "archive", lambda: _archive_payload(resources))
+    handoff = _timed_stage(
+        stage_timings_ms,
+        "handoff",
+        lambda: _handoff_payloads(repo.root or str(root_cwd), archive=archive, limit=peer_limit),
+    )
     (
         session_trees,
         activity_episodes,
@@ -131,14 +162,22 @@ def build_coordination_envelope(
         proof_refs,
         context_flow_refs,
         archive_evidence_degraded_reason,
-    ) = _archive_evidence_payloads(
-        repo,
-        self_payload,
-        archive,
-        limit=peer_limit,
+    ) = _timed_stage(
+        stage_timings_ms,
+        "archive_evidence",
+        lambda: _archive_evidence_payloads(
+            repo,
+            self_payload,
+            archive,
+            limit=peer_limit,
+        ),
     )
-    overlaps = _overlap_payloads(repo, work_item, peers, resources)
-    advisories = _advisories(repo, work_item, overlaps, archive, archive_evidence_degraded_reason)
+    overlaps = _timed_stage(stage_timings_ms, "overlaps", lambda: _overlap_payloads(repo, work_item, peers, resources))
+    advisories = _timed_stage(
+        stage_timings_ms,
+        "advisories",
+        lambda: _advisories(repo, work_item, overlaps, archive, archive_evidence_degraded_reason),
+    )
     provenance = (repo.provenance, work_item.provenance, self_payload.provenance)
     payload = AgentCoordinationPayload(
         view=view,
@@ -175,8 +214,31 @@ def build_coordination_envelope(
     total_counts["resource_components"] = sum(episode.component_count for episode in all_resources)
     total_counts["resource_refs"] = sum(episode.resource_count for episode in all_resources)
     if detail:
-        return _finalize_projection(projected, total_counts=total_counts, detail=True)
-    return _compact_coordination_payload(projected, total_counts=total_counts)
+        return _timed_stage(
+            stage_timings_ms,
+            "projection",
+            lambda: _finalize_projection(projected, total_counts=total_counts, detail=True),
+        )
+    return _timed_stage(
+        stage_timings_ms,
+        "projection",
+        lambda: _compact_coordination_payload(projected, total_counts=total_counts),
+    )
+
+
+def _timed_stage(
+    timings: MutableMapping[str, float] | None,
+    name: str,
+    call: Callable[[], _StageResult],
+) -> _StageResult:
+    """Execute one envelope stage and record its wall time when requested."""
+
+    started = perf_counter()
+    try:
+        return call()
+    finally:
+        if timings is not None:
+            timings[name] = round((perf_counter() - started) * 1_000, 3)
 
 
 def project_coordination_envelope(
@@ -660,7 +722,7 @@ def _serialized_size(payload: AgentCoordinationPayload) -> int:
     return len(payload.to_json(exclude_none=True).encode("utf-8"))
 
 
-def _run_command(args: Sequence[str], cwd: Path | None) -> CommandResult:
+def _run_command(args: Sequence[str], cwd: Path | None, *, timeout_seconds: float = 2.0) -> CommandResult:
     try:
         completed = subprocess.run(
             [str(arg) for arg in args],
@@ -668,7 +730,7 @@ def _run_command(args: Sequence[str], cwd: Path | None) -> CommandResult:
             check=False,
             capture_output=True,
             text=True,
-            timeout=2.0,
+            timeout=timeout_seconds,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         return CommandResult(tuple(str(arg) for arg in args), 124, "", str(exc))
@@ -947,11 +1009,19 @@ def _beads_payload(cwd: Path, repo: CoordinationRepoPayload, runner: CommandRunn
     beads_dir = beads_root / ".beads"
     if not beads_dir.exists():
         return None
-    hooks_result = runner(("bd", "hooks", "list", "--json"), beads_root)
+    # These three Beads read probes have no data dependency.  They used to
+    # serialize three CLI startups on every compact status request, which was
+    # the dominant live-route latency.  Preserve all three result contracts
+    # while letting their subprocess waits overlap.
+    with ThreadPoolExecutor(max_workers=3, thread_name_prefix="coordination-beads") as executor:
+        hooks_future = executor.submit(_run_beads_probe, runner, ("bd", "hooks", "list", "--json"), beads_root)
+        gates_future = executor.submit(_run_beads_probe, runner, ("bd", "gate", "list", "--json"), beads_root)
+        merge_future = executor.submit(_run_beads_probe, runner, ("bd", "merge-slot", "check", "--json"), beads_root)
+        hooks_result = hooks_future.result()
+        gates_result = gates_future.result()
+        merge_result = merge_future.result()
     hooks = _beads_hooks(hooks_result)
-    gates_result = runner(("bd", "gate", "list", "--json"), beads_root)
     gates = _beads_gates(gates_result)
-    merge_result = runner(("bd", "merge-slot", "check", "--json"), beads_root)
     merge_slot = _beads_merge_slot(merge_result)
     hooks_all_installed = all(hook.installed for hook in hooks) if hooks else None
     hooks_outdated_count = sum(1 for hook in hooks if hook.outdated) if hooks else None
@@ -973,6 +1043,20 @@ def _beads_payload(cwd: Path, repo: CoordinationRepoPayload, runner: CommandRunn
             else (hooks_result.stderr.strip()[:200] or "bd hooks list failed"),
         ),
     )
+
+
+def _run_beads_probe(runner: CommandRunner, args: Sequence[str], cwd: Path) -> CommandResult:
+    """Bound live Beads probes so an unavailable optional source stays honest.
+
+    A timeout returns the existing error-shaped ``CommandResult`` rather than
+    stale merge state.  Test runners retain their injected deterministic
+    behavior, while production status stays interactive when a Beads command
+    blocks on its own daemon or lock.
+    """
+
+    if runner is _run_command:
+        return _run_command(args, cwd, timeout_seconds=_BEADS_PROBE_TIMEOUT_SECONDS)
+    return runner(args, cwd)
 
 
 def _beads_hooks(result: CommandResult) -> tuple[CoordinationBeadsHookPayload, ...]:

--- a/polylogue/mcp/server_tools.py
+++ b/polylogue/mcp/server_tools.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import sqlite3
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
+from time import monotonic
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from polylogue.annotations.join import AnnotationGroupDimension
 from polylogue.coordination import build_coordination_envelope
+from polylogue.coordination.payloads import AgentCoordinationPayload
 from polylogue.core.enums import AssertionKind, AssertionStatus, Origin
 from polylogue.core.sources import provider_from_origin
 from polylogue.mcp.archive_support import (
@@ -66,6 +68,38 @@ if TYPE_CHECKING:
 @dataclass(frozen=True)
 class _MCPEmbeddingStatusEnv:
     config: Config
+
+
+@dataclass(frozen=True)
+class _CoordinationCacheEntry:
+    expires_at: float
+    payload: AgentCoordinationPayload
+
+
+class _CompactCoordinationCache:
+    """Bound compact status work in a warm MCP process without hiding refresh.
+
+    The short lifetime only covers repeated tool calls from the same agent
+    turn.  Callers can set ``fresh=True`` to bypass it whenever process or
+    repository state must be sampled immediately.
+    """
+
+    _TTL_SECONDS = 1.0
+
+    def __init__(self) -> None:
+        self._entries: dict[tuple[str, str, int], _CoordinationCacheEntry] = {}
+
+    def get(self, *, view: str, cwd: Path | None, limit: int) -> AgentCoordinationPayload | None:
+        key = (view, str(cwd.resolve()) if cwd is not None else str(Path.cwd().resolve()), limit)
+        entry = self._entries.get(key)
+        if entry is None or entry.expires_at <= monotonic():
+            self._entries.pop(key, None)
+            return None
+        return entry.payload
+
+    def put(self, *, view: str, cwd: Path | None, limit: int, payload: AgentCoordinationPayload) -> None:
+        key = (view, str(cwd.resolve()) if cwd is not None else str(Path.cwd().resolve()), limit)
+        self._entries[key] = _CoordinationCacheEntry(expires_at=monotonic() + self._TTL_SECONDS, payload=payload)
 
 
 def _stats_embedding_overrides(config: Config) -> dict[str, object]:
@@ -692,6 +726,8 @@ def register_query_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
 
 
 def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
+    compact_coordination_cache = _CompactCoordinationCache()
+
     @mcp.tool()
     async def join_typed_annotations(
         schema_id: str,
@@ -1064,17 +1100,36 @@ def register_read_tools(mcp: FastMCP, hooks: ServerCallbacks) -> None:
         cwd: str | None = None,
         limit: MCPToolLimit = 10,
         detail: bool = False,
+        fresh: bool = False,
     ) -> str:
-        """Return the compact shared envelope; opt into bounded evidence detail."""
+        """Return the compact shared envelope; ``fresh`` bypasses its warm cache."""
 
         async def run() -> str:
             path = Path(cwd).expanduser().resolve() if cwd else None
-            payload = build_coordination_envelope(
-                view=view,
-                cwd=path,
-                limit=hooks.clamp_limit(limit),
-                detail=detail,
+            clamped_limit = hooks.clamp_limit(limit)
+            payload = (
+                None
+                if detail or fresh
+                else compact_coordination_cache.get(
+                    view=view,
+                    cwd=path,
+                    limit=clamped_limit,
+                )
             )
+            if payload is None:
+                payload = build_coordination_envelope(
+                    view=view,
+                    cwd=path,
+                    limit=clamped_limit,
+                    detail=detail,
+                )
+                if not detail:
+                    compact_coordination_cache.put(
+                        view=view,
+                        cwd=path,
+                        limit=clamped_limit,
+                        payload=payload,
+                    )
             return hooks.json_payload(payload, exclude_none=True)
 
         return await hooks.async_safe_call("agent_coordination", run)

--- a/tests/unit/coordination/test_envelope.py
+++ b/tests/unit/coordination/test_envelope.py
@@ -6,6 +6,7 @@ import json
 import sqlite3
 from collections.abc import Sequence
 from pathlib import Path
+from time import sleep
 
 import pytest
 
@@ -227,6 +228,99 @@ class FakeRunner:
                 "",
             )
         return CommandResult(key, 1, "", "unexpected command")
+
+
+def test_coordination_envelope_overlaps_independent_beads_probes(tmp_path: Path) -> None:
+    """The production envelope waits for all Beads facts without serializing them."""
+
+    root = tmp_path / "repo"
+    (root / ".beads").mkdir(parents=True)
+    calls: list[tuple[str, ...]] = []
+
+    def runner(args: Sequence[str], cwd: Path | None) -> CommandResult:
+        key = tuple(args)
+        if key[:4] == ("git", "-C", str(root), "rev-parse"):
+            return CommandResult(key, 0, str(root) + "\n", "")
+        if key[:4] == ("git", "-C", str(root), "branch"):
+            return CommandResult(key, 0, "feature/coordination-envelope\n", "")
+        if key[:4] == ("git", "-C", str(root), "status"):
+            return CommandResult(key, 0, "", "")
+        if key == ("ps", "ww", "-eo", "pid=,ppid=,comm=,cgroup:200=,args="):
+            return CommandResult(key, 0, "", "")
+        if key in {
+            ("bd", "hooks", "list", "--json"),
+            ("bd", "gate", "list", "--json"),
+            ("bd", "merge-slot", "check", "--json"),
+        }:
+            calls.append(key)
+            sleep(0.05)
+            if key[1] == "hooks":
+                return CommandResult(key, 0, '{"hooks": []}', "")
+            if key[1] == "gate":
+                return CommandResult(key, 0, "[]", "")
+            return CommandResult(key, 0, '{"available": true}', "")
+        return CommandResult(key, 1, "", "unexpected command")
+
+    timings: dict[str, float] = {}
+    payload = build_coordination_envelope(cwd=root, runner=runner, stage_timings_ms=timings)
+
+    assert payload.beads is not None
+    assert {call[1] for call in calls} == {"hooks", "gate", "merge-slot"}
+    # Three 50 ms probes must overlap on the live code path; a sequential
+    # implementation records roughly 150 ms for this stage.
+    assert timings["beads"] < 110
+
+
+def test_coordination_envelope_bounds_live_beads_probe_timeout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real command path receives the interactive probe deadline."""
+
+    root = tmp_path / "repo"
+    (root / ".beads").mkdir(parents=True)
+    calls: list[tuple[tuple[str, ...], float]] = []
+
+    def fake_run(
+        args: Sequence[str],
+        cwd: Path | None,
+        *,
+        timeout_seconds: float = 2.0,
+    ) -> CommandResult:
+        key = tuple(args)
+        calls.append((key, timeout_seconds))
+        if key[:4] == ("git", "-C", str(root), "rev-parse"):
+            return CommandResult(key, 0, str(root) + "\n", "")
+        if key[:4] == ("git", "-C", str(root), "branch"):
+            return CommandResult(key, 0, "feature/coordination-envelope\n", "")
+        if key[:4] == ("git", "-C", str(root), "status"):
+            return CommandResult(key, 0, "", "")
+        if key == ("ps", "ww", "-eo", "pid=,ppid=,comm=,cgroup:200=,args="):
+            return CommandResult(key, 0, "", "")
+        if key == ("bd", "hooks", "list", "--json"):
+            return CommandResult(key, 0, '{"hooks": []}', "")
+        if key == ("bd", "gate", "list", "--json"):
+            return CommandResult(key, 0, "[]", "")
+        if key == ("bd", "merge-slot", "check", "--json"):
+            return CommandResult(key, 124, "", "timed out")
+        return CommandResult(key, 1, "", "unexpected command")
+
+    monkeypatch.setattr("polylogue.coordination.envelope._run_command", fake_run)
+    payload = build_coordination_envelope(cwd=root)
+
+    assert payload.beads is not None
+    probes = [
+        timeout
+        for command, timeout in calls
+        if command
+        in {
+            ("bd", "hooks", "list", "--json"),
+            ("bd", "gate", "list", "--json"),
+            ("bd", "merge-slot", "check", "--json"),
+        }
+    ]
+    assert len(probes) == 3
+    assert all(timeout == 0.35 for timeout in probes)
 
 
 def test_coordination_envelope_uses_beads_when_present(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/mcp/test_agent_coordination.py
+++ b/tests/unit/mcp/test_agent_coordination.py
@@ -126,6 +126,29 @@ def test_agent_coordination_tool_returns_shared_payload(
     assert calls == [True]
 
 
+def test_agent_coordination_compact_cache_is_bypassable(
+    mcp_server: MCPServerUnderTest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[bool] = []
+
+    def fake_build(**kwargs: object) -> AgentCoordinationPayload:
+        calls.append(bool(kwargs["detail"]))
+        return _payload(str(kwargs["view"]))
+
+    monkeypatch.setattr("polylogue.mcp.server_tools.build_coordination_envelope", fake_build)
+    tool = mcp_server._tool_manager._tools["agent_coordination"].fn
+
+    invoke_surface(tool, view="status", limit=5)
+    invoke_surface(tool, view="status", limit=5)
+    invoke_surface(tool, view="status", limit=5, fresh=True)
+    invoke_surface(tool, view="status", limit=5, detail=True)
+
+    # The second compact call hits the real server-local cache; fresh and
+    # detail requests retain their live/evidence semantics.
+    assert calls == [False, False, True]
+
+
 def test_agent_coordination_prompt_embeds_bounded_envelope(
     mcp_server: MCPServerUnderTest,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
Phase-2 remainder work from PR #2784's deferred ACs: coordination archive-state recording plus latency-probe documentation.

## Problem
polylogue-s7ae.8 and polylogue-20d.2 kept several ACs honestly deferred at #2784's merge. This slice lands the coordination archive-state probe groundwork.

## Solution
`8be01396c feat(devtools): record coordination archive state` + `21c9a70ca docs(devtools): list coordination latency probe`. Remaining AC gaps stay tracked on the beads (lane report: reset import deferral measured; importtime diff artifact, fixed help-latency gate, nested-help sweep still open).

## Verification
Lane-run focused devtools tests + quick gate before each commit (lane AC matrix in its final report); pre-push quick gate green on push.

Ref polylogue-s7ae.8, polylogue-20d.2