### PR TITLE
test(cli): complete interactive test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,20 @@ jobs:
       - run: uv run ruff check polylogue/ tests/ devtools/
       - run: uv run ruff format --check polylogue/ tests/ devtools/
 
+  interactive-pty:
+    # PTY tests need a controlling terminal and must not share xdist workers.
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v8.3.0
+        with:
+          python-version: "3.13"
+      - run: uv sync --extra dev --frozen
+      - run: uv run pytest -q -n 0 tests/unit/cli/test_interactive_cli.py
+        env:
+          POLYLOGUE_PYTEST_BASETEMP_ROOT: ${{ runner.temp }}/polylogue-pytest
+
   test:
     # The full non-integration suite runs single-process under coverage
     # instrumentation across three Python versions; 45 min was on the edge and

--- a/tests/unit/cli/test_completion_matrix.py
+++ b/tests/unit/cli/test_completion_matrix.py
@@ -27,6 +27,8 @@ from click.shell_completion import (
     ZshComplete,
 )
 
+from polylogue.archive.query.completions import query_terminal_source_candidates
+from polylogue.archive.query.metadata import query_unit_descriptors, terminal_query_sources
 from polylogue.cli.click_app import cli
 from polylogue.operations.action_contracts import CompletionContext, action_completion_contexts
 
@@ -34,18 +36,6 @@ SUPPORTED_SHELLS: tuple[tuple[str, type[ShellComplete]], ...] = (
     ("bash", BashComplete),
     ("zsh", ZshComplete),
     ("fish", FishComplete),
-)
-
-# Each entry is (completer_label, partial-cmdline-without-trailing-incomplete).
-# These pin the option/argument surface that wires each completer; if
-# the surface changes (e.g. --provider renamed), update both sides.
-STATIC_COMPLETERS: tuple[tuple[str, list[str]], ...] = (
-    ("provider", ["--provider"]),
-    ("retrieval_lane", ["--retrieval-lane"]),
-    ("action", ["--action"]),
-    ("action_sequence", ["--action-sequence"]),
-    ("read_view", ["read", "--view"]),
-    ("read_format", ["read", "--format"]),
 )
 
 CONTRACT_COMPLETION_COMMANDS: dict[CompletionContext, list[str]] = {
@@ -137,28 +127,36 @@ def _run_completion_for_partial(
 
 
 @pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])
-@pytest.mark.parametrize("label,cwords", STATIC_COMPLETERS, ids=[label for label, _ in STATIC_COMPLETERS])
-def test_static_completers_per_shell(
+def test_terminal_completion_contract_is_generated_from_unit_descriptors(
     shell: str,
     comp_cls: type[ShellComplete],
-    label: str,
-    cwords: list[str],
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Static completers (provider/lane/action/etc) return items on every shell.
+    """Every terminal-query unit declares completion metadata and shell output.
 
-    These do not depend on archive contents — they enumerate known
-    enum or registry values — so they must always produce results.
+    This is intentionally registry-driven: a new terminal-capable descriptor
+    with omitted description/example/fields cannot silently enter the grammar
+    without this contract failing.
     """
-    # Point at an isolated empty archive root so the test doesn't read
-    # the developer's real polylogue archive.
     monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data"))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
 
-    items = _run_completion(shell, comp_cls, cwords)
-    assert items, f"static completer {label} produced no items on {shell}"
+    descriptors = query_unit_descriptors(terminal_supported=True)
+    assert descriptors
+    expected_sources = {source for descriptor in descriptors for source in descriptor.source_aliases}
+    assert expected_sources == set(terminal_query_sources())
+    assert {candidate.value for candidate in query_terminal_source_candidates("")} == expected_sources
+
+    for descriptor in descriptors:
+        assert descriptor.description, f"{descriptor.unit} missing completion description"
+        assert descriptor.example, f"{descriptor.unit} missing completion example"
+        assert descriptor.terminal_example, f"{descriptor.unit} missing terminal completion example"
+        assert descriptor.fields, f"{descriptor.unit} missing completion fields"
+        for source in descriptor.source_aliases:
+            values = {value for value, _ in _run_completion_for_partial(shell, comp_cls, ["find"], source)}
+            assert f"{source} where " in values, f"{source} missing from {shell} completion output"
 
 
 @pytest.mark.parametrize("shell,comp_cls", SUPPORTED_SHELLS, ids=[s for s, _ in SUPPORTED_SHELLS])

--- a/tests/unit/cli/test_interactive_cli.py
+++ b/tests/unit/cli/test_interactive_cli.py
@@ -8,14 +8,19 @@ completion protocol.
 
 from __future__ import annotations
 
+import json
 import os
 import shlex
 import stat
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
+
 from tests.infra.pty_cli import grid_to_text, run_in_pty
 from tests.infra.storage_records import DbFactory
+
+pytestmark = pytest.mark.load_sensitive
 
 
 def _interactive_env(
@@ -26,7 +31,7 @@ def _interactive_env(
 ) -> dict[str, str]:
     """Return a process-isolated environment that keeps the CLI interactive."""
     home = tmp_path / "interactive-home"
-    home.mkdir()
+    home.mkdir(exist_ok=True)
     env = {
         "HOME": str(home),
         "XDG_DATA_HOME": str(cli_workspace["data_root"]),
@@ -167,3 +172,29 @@ def test_select_propagates_requested_pty_size_to_fzf(
     # fzf receives its size through the controlling TTY, not through pyte's
     # renderer; the stand-in reads that terminal directly.
     assert size_path.read_text(encoding="utf-8").strip() == "41 137"
+
+
+def test_select_returns_fzf_choice_in_json_in_a_real_pty(
+    cli_workspace: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    """The real selector preserves the external pick through its JSON renderer."""
+    _seed_picker_sessions(cli_workspace)
+    picker_dir = tmp_path / "json-bin"
+    picker_dir.mkdir()
+    trace_path = tmp_path / "json-fzf-options.txt"
+    _install_first_row_fzf(picker_dir, trace_path)
+
+    result = run_in_pty(
+        ["--sort", "date", "--reverse", "find", "title:Interactive", "then", "select", "--json"],
+        cols=200,
+        env=_interactive_env(cli_workspace, tmp_path, picker_dir=picker_dir),
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(grid_to_text(result.grid).strip()) == {
+        "date": "2026-07-11",
+        "id": "chatgpt-export:ext-older",
+        "origin": "chatgpt-export",
+        "title": "Interactive picker candidate older",
+    }

--- a/tests/unit/cli/test_interactive_cli.py
+++ b/tests/unit/cli/test_interactive_cli.py
@@ -198,3 +198,28 @@ def test_select_returns_fzf_choice_in_json_in_a_real_pty(
         "origin": "chatgpt-export",
         "title": "Interactive picker candidate older",
     }
+
+
+def test_select_candidate_reordering_changes_the_fzf_selected_session(
+    cli_workspace: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    """Mutation control: changing real query order changes the chosen first row."""
+    _seed_picker_sessions(cli_workspace)
+
+    selected: set[str] = set()
+    for name, args in (
+        ("ascending", ["--sort", "date"]),
+        ("descending", ["--sort", "date", "--reverse"]),
+    ):
+        picker_dir = tmp_path / f"{name}-bin"
+        picker_dir.mkdir()
+        _install_first_row_fzf(picker_dir, tmp_path / f"{name}-fzf-options.txt")
+        result = run_in_pty(
+            [*args, "find", "title:Interactive", "then", "select"],
+            env=_interactive_env(cli_workspace, tmp_path, picker_dir=picker_dir),
+        )
+        assert result.exit_code == 0
+        selected.add(grid_to_text(result.grid).splitlines()[-1])
+
+    assert selected == {"chatgpt-export:ext-newer", "chatgpt-export:ext-older"}


### PR DESCRIPTION
## Summary

Completes the interactive-surface harness slice with five real PTY flows,
a dedicated serial CI job, registry-derived terminal completion contracts,
and a retained candidate-order mutation demonstration.

## Problem

PTY selection and shell completion are operator-facing routes. The existing
three PTY exemplars did not run in CI, and the manually curated completion
matrix could drift from the query-unit registry.

## Solution

- Add the `interactive-pty` Linux job, marked load-sensitive and run with
  `pytest -n 0`.
- Add a real PTY `select --json` flow through the external fzf route.
- Derive terminal-source completion expectations and metadata requirements
  from `QUERY_UNIT_DESCRIPTORS` for bash, zsh, and fish.
- Retain `c2c8dddd0` as the explicit candidate-reordering mutation demo.

## Verification

- `POLYLOGUE_PYTEST_BASETEMP_ROOT=/realm/tmp/polylogue-pytest POLYLOGUE_PYTEST_WORKERS=0 nix develop --command devtools test tests/unit/cli/test_interactive_cli.py -k 'json_in_a_real_pty'` — 1 passed.
- `POLYLOGUE_PYTEST_BASETEMP_ROOT=/realm/tmp/polylogue-pytest POLYLOGUE_PYTEST_WORKERS=0 nix develop --command devtools test tests/unit/cli/test_completion_matrix.py -k 'terminal_completion_contract_is_generated_from_unit_descriptors'` — 3 passed.
- `POLYLOGUE_PYTEST_BASETEMP_ROOT=/realm/tmp/polylogue-pytest POLYLOGUE_PYTEST_WORKERS=0 nix develop --command devtools test tests/unit/cli/test_interactive_cli.py -k 'candidate_reordering'` — 1 passed.
- Feature-branch pre-push quick baseline completed before both pushes.

## Anti-vacuity

- `test_select_returns_fzf_choice_in_json_in_a_real_pty` exercises
  `select_verb` → `run_select` → `choose_select_row`, the external fzf process,
  and the JSON renderer. It fails if the selected row bypasses fzf or JSON
  rendering stops preserving that row.
- `test_select_candidate_reordering_changes_the_fzf_selected_session`
  exercises query ordering and the same real picker route twice. It fails if
  candidate order no longer reaches fzf or reversed ordering selects the same
  session.
- `test_terminal_completion_contract_is_generated_from_unit_descriptors`
  exercises `QUERY_UNIT_DESCRIPTORS`, `terminal_query_sources`, and Click's
  bash/zsh/fish protocols. It fails when a default-terminal query unit lacks
  description, examples, fields, or an emitted source alias.

## Acceptance criteria

| Criterion | Status | Evidence |
| --- | --- | --- |
| 5+ PTY golden flows in serial CI | Satisfied | Five flows in `test_interactive_cli.py`; `interactive-pty` runs them with `-n 0`. |
| Registry-generated completion contracts reject missing metadata | Satisfied | Descriptor-derived metadata and shell-output contract. |
| Retained candidate-reordering mutation demo | Satisfied | `c2c8dddd0 test(cli): demonstrate fzf reorder mutation rejection`. |

Ref polylogue-th0
