### PR TITLE
fix(browser): preserve backfill receiver and recovery contracts

### DIFF
--- a/browser-extension/src/backfill/coordinator.js
+++ b/browser-extension/src/backfill/coordinator.js
@@ -78,15 +78,24 @@ export class BackfillCoordinator {
     if (action === "resume" && (await this.store.listQueue(jobId)).some((item) => item.state === "recovery_required")) {
       throw new Error("browser_profile_recovery_required");
     }
-    const resumed = await this.store.controlJob(jobId, status, nowIso(now), action === "resume" ? {
+    // Preflight while the job is still paused.  Marking it running first would
+    // let an alarm acquire its next execution generation while an older worker
+    // is still deciding whether this receiver is safe to use.
+    const contractError = status === "running" ? await this.preflightReceiverContract() : null;
+    if (contractError) {
+      await this.store.controlJob(jobId, "paused", nowIso(now), this.receiverContractFailurePatch(contractError));
+      return this.status(jobId);
+    }
+    const resumed = await this.store.controlJob(jobId, status, nowIso(now), status === "running" ? {
       cooldown_until_ms: null,
       cooldown_reason: null,
       throttle_count: 0,
+      receiver_contract_epoch: this.receiverContractEpoch,
+      receiver_contract_checked_at: nowIso(now),
       last_error: null,
     } : {}, action === "resume" ? now : null);
     if (status === "running") {
-      const checked = await this.ensureReceiverContract(resumed, now, true);
-      if (checked.status === "running") await this.schedule(jobId, now);
+      await this.schedule(resumed.id, now);
     }
     return this.status(jobId);
   }
@@ -94,9 +103,12 @@ export class BackfillCoordinator {
   async status(jobId) {
     const job = await this.requireJob(jobId);
     const queue = await this.store.listQueue(jobId);
-    const status = { ...job, progress: progressBuckets(queue) };
-    await this.persistCheckpoint();
-    return status;
+    const checkpointError = await this.persistCheckpoint();
+    return {
+      ...job,
+      progress: progressBuckets(queue),
+      recovery_checkpoint_error: checkpointError,
+    };
   }
 
   async listStatus() {
@@ -415,14 +427,9 @@ export class BackfillCoordinator {
   async ensureReceiverContract(job, now, force = false) {
     if (!this.receiverPreflight) return job;
     if (!force && job.receiver_contract_epoch === this.receiverContractEpoch) return job;
-    try {
-      await this.receiverPreflight();
-    } catch (error) {
-      const message = String(error?.message || error);
-      const reason = message.startsWith("receiver_contract_incompatible:")
-        ? "receiver_contract_incompatible"
-        : "receiver_preflight_unavailable";
-      const next = { ...job, status: "paused", cooldown_reason: reason, last_error: message, updated_at: nowIso(now) };
+    const contractError = await this.preflightReceiverContract();
+    if (contractError) {
+      const next = { ...job, ...this.receiverContractFailurePatch(contractError), updated_at: nowIso(now) };
       if (job.execution_owner === this.instanceId) await this.saveJob(next);
       else await this.store.putJob(next);
       return next;
@@ -433,9 +440,36 @@ export class BackfillCoordinator {
     return next;
   }
 
+  async preflightReceiverContract() {
+    if (!this.receiverPreflight) return null;
+    try {
+      await this.receiverPreflight();
+      return null;
+    } catch (error) {
+      return String(error?.message || error);
+    }
+  }
+
+  receiverContractFailurePatch(message) {
+    return {
+      status: "paused",
+      cooldown_reason: message.startsWith("receiver_contract_incompatible:")
+        ? "receiver_contract_incompatible"
+        : "receiver_preflight_unavailable",
+      last_error: message,
+    };
+  }
+
   async persistCheckpoint() {
-    if (!this.checkpoint) return;
-    await this.checkpoint(await this.store.exportRecoveryCheckpoint());
+    if (!this.checkpoint) return null;
+    try {
+      await this.checkpoint(await this.store.exportRecoveryCheckpoint());
+      return null;
+    } catch (error) {
+      // IndexedDB remains authoritative. A best-effort profile-recovery copy
+      // must never turn an otherwise durable backfill action into a failure.
+      return String(error?.message || error);
+    }
   }
 
   async saveJob(job) {

--- a/browser-extension/src/backfill/coordinator.js
+++ b/browser-extension/src/backfill/coordinator.js
@@ -7,6 +7,7 @@ import {
   retryAfterMs,
   serializedContentHash,
   serializedJson,
+  receiverAckContractError,
 } from "./models.js";
 import { jobFinished, progressBuckets } from "./storage.js";
 
@@ -21,14 +22,17 @@ function mergePolicy(patch = {}) {
 }
 
 export class BackfillCoordinator {
-  constructor({ store, adapters, receiver, alarms, clock = () => Date.now(), random = Math.random, instanceId = "extension-instance" }) {
+  constructor({ store, adapters, receiver, receiverPreflight = null, checkpoint = null, alarms, clock = () => Date.now(), random = Math.random, instanceId = "extension-instance", receiverContractEpoch = instanceId }) {
     this.store = store;
     this.adapters = adapters;
     this.receiver = receiver;
+    this.receiverPreflight = receiverPreflight;
+    this.checkpoint = checkpoint;
     this.alarms = alarms;
     this.clock = clock;
     this.random = random;
     this.instanceId = instanceId;
+    this.receiverContractEpoch = receiverContractEpoch;
   }
 
   async start({ provider, cutoff, policy = {}, provider_options = {} }) {
@@ -62,22 +66,24 @@ export class BackfillCoordinator {
       execution_expires_at_ms: null,
     };
     await this.store.createJob(job);
-    await this.schedule(id, now);
-    return job;
+    const checked = await this.ensureReceiverContract(job, now, true);
+    if (checked.status === "running") await this.schedule(id, now);
+    return this.status(id);
   }
 
   async control(jobId, action) {
     const now = this.clock();
     const status = action === "start" || action === "resume" ? "running" : action === "pause" ? "paused" : action === "cancel" ? "cancelled" : null;
     if (!status) throw new Error(`unknown_backfill_action:${action}`);
-    await this.store.controlJob(jobId, status, nowIso(now), action === "resume" ? {
+    const resumed = await this.store.controlJob(jobId, status, nowIso(now), action === "resume" ? {
       cooldown_until_ms: null,
       cooldown_reason: null,
       throttle_count: 0,
       last_error: null,
     } : {}, action === "resume" ? now : null);
     if (status === "running") {
-      await this.schedule(jobId, now);
+      const checked = await this.ensureReceiverContract(resumed, now, true);
+      if (checked.status === "running") await this.schedule(jobId, now);
     }
     return this.status(jobId);
   }
@@ -85,7 +91,9 @@ export class BackfillCoordinator {
   async status(jobId) {
     const job = await this.requireJob(jobId);
     const queue = await this.store.listQueue(jobId);
-    return { ...job, progress: progressBuckets(queue) };
+    const status = { ...job, progress: progressBuckets(queue) };
+    await this.persistCheckpoint();
+    return status;
   }
 
   async listStatus() {
@@ -120,6 +128,8 @@ export class BackfillCoordinator {
   async runLeasedJob(initialJob, now) {
     let job = initialJob;
     const jobId = job.id;
+    job = await this.ensureReceiverContract(job, now);
+    if (job.status !== "running") return this.status(jobId);
     await this.store.recoverExpiredLeases(jobId, now);
     await this.schedule(jobId, now + job.policy.leaseMs);
     const receiverItem = await this.store.acquireNextLease(jobId, this.instanceId, now, job.policy.leaseMs, true);
@@ -290,7 +300,8 @@ export class BackfillCoordinator {
     try {
       const receipt = await this.receiver(capture, serialized);
       job = await this.store.assertJobExecution(job.id, this.instanceId, job.execution_generation);
-      if (!receipt?.receiver_request_id || receipt.content_hash !== hash) throw new Error("receiver_ack_hash_mismatch");
+      const contractError = receiverAckContractError(receipt, hash);
+      if (contractError) throw contractError;
       const completeItem = { ...item, state: "complete", envelope: null, content_hash: hash, capture_fidelity: "native_full", receiver_receipt: receipt, lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_acked", completed_at: nowIso(now) };
       const revision = item.provider_updated_at
         ? {
@@ -315,6 +326,10 @@ export class BackfillCoordinator {
       return next;
     } catch (error) {
       if (String(error?.message || error).startsWith("stale_backfill_execution:")) throw error;
+      if (error?.code === "receiver_contract_incompatible" || String(error?.message || error).startsWith("receiver_contract_incompatible:")) {
+        await this.saveQueue(job, { ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: "native_full", lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_contract_incompatible", last_error: String(error.message || error) });
+        return this.pauseJob({ ...job, last_error: String(error.message || error) }, "receiver_contract_incompatible", now);
+      }
       const attempt = (item.attempt_count || 0) + 1;
       await this.saveQueue(job, { ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: "native_full", attempt_count: attempt, next_eligible_at_ms: now + fullJitterDelay(attempt, job.policy.baseCadenceMs, job.policy.maxCadenceMs, this.random), lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_down", last_error: String(error.message || error) });
       const exhausted = attempt >= job.policy.maxReceiverAttempts;
@@ -392,6 +407,32 @@ export class BackfillCoordinator {
     const next = { ...job, status: "paused", cooldown_reason: reason, last_error: job.last_error || reason, updated_at: nowIso(now) };
     await this.saveJob(next);
     return next;
+  }
+
+  async ensureReceiverContract(job, now, force = false) {
+    if (!this.receiverPreflight) return job;
+    if (!force && job.receiver_contract_epoch === this.receiverContractEpoch) return job;
+    try {
+      await this.receiverPreflight();
+    } catch (error) {
+      const message = String(error?.message || error);
+      const reason = message.startsWith("receiver_contract_incompatible:")
+        ? "receiver_contract_incompatible"
+        : "receiver_preflight_unavailable";
+      const next = { ...job, status: "paused", cooldown_reason: reason, last_error: message, updated_at: nowIso(now) };
+      if (job.execution_owner === this.instanceId) await this.saveJob(next);
+      else await this.store.putJob(next);
+      return next;
+    }
+    const next = { ...job, receiver_contract_epoch: this.receiverContractEpoch, receiver_contract_checked_at: nowIso(now), last_error: null };
+    if (job.execution_owner === this.instanceId) await this.saveJob(next);
+    else await this.store.putJob(next);
+    return next;
+  }
+
+  async persistCheckpoint() {
+    if (!this.checkpoint) return;
+    await this.checkpoint(await this.store.exportRecoveryCheckpoint());
   }
 
   async saveJob(job) {

--- a/browser-extension/src/backfill/coordinator.js
+++ b/browser-extension/src/backfill/coordinator.js
@@ -75,6 +75,9 @@ export class BackfillCoordinator {
     const now = this.clock();
     const status = action === "start" || action === "resume" ? "running" : action === "pause" ? "paused" : action === "cancel" ? "cancelled" : null;
     if (!status) throw new Error(`unknown_backfill_action:${action}`);
+    if (action === "resume" && (await this.store.listQueue(jobId)).some((item) => item.state === "recovery_required")) {
+      throw new Error("browser_profile_recovery_required");
+    }
     const resumed = await this.store.controlJob(jobId, status, nowIso(now), action === "resume" ? {
       cooldown_until_ms: null,
       cooldown_reason: null,

--- a/browser-extension/src/backfill/coordinator.js
+++ b/browser-extension/src/backfill/coordinator.js
@@ -33,6 +33,7 @@ export class BackfillCoordinator {
     this.random = random;
     this.instanceId = instanceId;
     this.receiverContractEpoch = receiverContractEpoch;
+    this.controlChains = new Map();
   }
 
   async start({ provider, cutoff, policy = {}, provider_options = {} }) {
@@ -72,6 +73,20 @@ export class BackfillCoordinator {
   }
 
   async control(jobId, action) {
+    // A preflight is asynchronous. Serialize operator actions per job so a
+    // delayed resume cannot overwrite a later cancel (or pause) after its
+    // receiver check returns.
+    const previous = this.controlChains.get(jobId) || Promise.resolve();
+    const next = previous.catch(() => undefined).then(() => this.performControl(jobId, action));
+    this.controlChains.set(jobId, next);
+    void next.then(
+      () => { if (this.controlChains.get(jobId) === next) this.controlChains.delete(jobId); },
+      () => { if (this.controlChains.get(jobId) === next) this.controlChains.delete(jobId); },
+    );
+    return next;
+  }
+
+  async performControl(jobId, action) {
     const now = this.clock();
     const status = action === "start" || action === "resume" ? "running" : action === "pause" ? "paused" : action === "cancel" ? "cancelled" : null;
     if (!status) throw new Error(`unknown_backfill_action:${action}`);

--- a/browser-extension/src/backfill/models.js
+++ b/browser-extension/src/backfill/models.js
@@ -1,7 +1,9 @@
 export const BACKFILL_ALARM = "polylogueBackfillWake";
 export const BACKFILL_DB_NAME = "polylogue-browser-backfill";
 export const BACKFILL_DB_VERSION = 2;
+export const BACKFILL_RECOVERY_CHECKPOINT_VERSION = 1;
 export const PROVIDER_REQUEST_TIMEOUT_MS = 60000;
+export const DURABLE_RECEIVER_ACK_FIELDS = Object.freeze(["receiver_request_id", "content_hash"]);
 
 export const DEFAULT_BACKFILL_POLICY = Object.freeze({
   maxQueueSize: 10000,
@@ -24,6 +26,18 @@ export function backfillAlarmName(jobId) {
 
 export function serializedJson(value) {
   return JSON.stringify(value);
+}
+
+export function receiverAckContractError(receipt, expectedContentHash) {
+  const missing = DURABLE_RECEIVER_ACK_FIELDS.filter((field) => {
+    const value = receipt?.[field];
+    return typeof value !== "string" || !value;
+  });
+  if (!missing.length && receipt.content_hash === expectedContentHash) return null;
+  const detail = missing.length ? `missing_${missing.join("_")}` : "content_hash_mismatch";
+  const error = new Error(`receiver_contract_incompatible:${detail}`);
+  error.code = "receiver_contract_incompatible";
+  return error;
 }
 
 export async function serializedContentHash(serialized) {

--- a/browser-extension/src/backfill/storage.js
+++ b/browser-extension/src/backfill/storage.js
@@ -29,7 +29,8 @@ function checkpointQueueItem(item) {
   delete safe.receiver_receipt;
   delete safe.lease_owner;
   delete safe.lease_expires_at_ms;
-  return structuredClone(safe);
+  if (safe.state === "leased") safe.state = safe.resume_state || "recovery_required";
+  return structuredClone(recoveryRequiredItem(safe));
 }
 
 function checkpointRevision(revision) {
@@ -37,6 +38,7 @@ function checkpointRevision(revision) {
 }
 
 function recoveryRequiredItem(item) {
+  if (item.state === "leased") item = { ...item, state: item.resume_state || "recovery_required" };
   if (item.state !== "captured_waiting_receiver") return item;
   return {
     ...item,
@@ -46,6 +48,18 @@ function recoveryRequiredItem(item) {
     last_error: "captured_envelope_not_present_in_recovery_checkpoint",
     lease_owner: null,
     lease_expires_at_ms: null,
+  };
+}
+
+function recoveryCheckpointJob(job) {
+  const wasRunning = job.status === "running";
+  return {
+    ...structuredClone(job),
+    status: wasRunning ? "paused" : job.status,
+    cooldown_reason: wasRunning ? "browser_profile_recovery_required" : job.cooldown_reason,
+    last_error: wasRunning ? "browser_profile_recovery_required" : job.last_error,
+    execution_owner: null,
+    execution_expires_at_ms: null,
   };
 }
 
@@ -353,9 +367,7 @@ export class IndexedDbBackfillStore {
       await transactionDone(tx);
       return { restored: 0, reason: "indexeddb_present" };
     }
-    for (const job of checkpoint.jobs || []) {
-      jobs.put({ ...structuredClone(job), status: "paused", cooldown_reason: "browser_profile_recovery_required", last_error: "browser_profile_recovery_required", execution_owner: null, execution_expires_at_ms: null });
-    }
+    for (const job of checkpoint.jobs || []) jobs.put(recoveryCheckpointJob(job));
     const queue = tx.objectStore("queue");
     for (const item of checkpoint.queue || []) queue.put(recoveryRequiredItem(structuredClone(item)));
     const revisions = tx.objectStore("revisions");
@@ -537,7 +549,7 @@ export class MemoryBackfillStore {
   async restoreRecoveryCheckpoint(checkpoint) {
     if (!checkpoint || checkpoint.version !== BACKFILL_RECOVERY_CHECKPOINT_VERSION) return { restored: 0, reason: "checkpoint_unavailable" };
     if (this.jobs.size) return { restored: 0, reason: "indexeddb_present" };
-    for (const job of checkpoint.jobs || []) this.jobs.set(job.id, structuredClone({ ...job, status: "paused", cooldown_reason: "browser_profile_recovery_required", last_error: "browser_profile_recovery_required", execution_owner: null, execution_expires_at_ms: null }));
+    for (const job of checkpoint.jobs || []) this.jobs.set(job.id, recoveryCheckpointJob(job));
     for (const item of checkpoint.queue || []) this.queue.set(item.id, structuredClone(recoveryRequiredItem(item)));
     for (const revision of checkpoint.revisions || []) this.revisions.set(revision.id, structuredClone(revision));
     return { restored: (checkpoint.jobs || []).length, reason: "browser_profile_recovery_required" };

--- a/browser-extension/src/backfill/storage.js
+++ b/browser-extension/src/backfill/storage.js
@@ -51,13 +51,14 @@ function recoveryRequiredItem(item) {
   };
 }
 
-function recoveryCheckpointJob(job) {
+function recoveryCheckpointJob(job, hasRecoveryRequiredQueueItem = false) {
   const wasRunning = job.status === "running";
+  const needsProfileRecovery = wasRunning || (job.status === "paused" && hasRecoveryRequiredQueueItem);
   return {
     ...structuredClone(job),
-    status: wasRunning ? "paused" : job.status,
-    cooldown_reason: wasRunning ? "browser_profile_recovery_required" : job.cooldown_reason,
-    last_error: wasRunning ? "browser_profile_recovery_required" : job.last_error,
+    status: needsProfileRecovery ? "paused" : job.status,
+    cooldown_reason: needsProfileRecovery ? "browser_profile_recovery_required" : job.cooldown_reason,
+    last_error: needsProfileRecovery ? "browser_profile_recovery_required" : job.last_error,
     execution_owner: null,
     execution_expires_at_ms: null,
   };
@@ -367,9 +368,11 @@ export class IndexedDbBackfillStore {
       await transactionDone(tx);
       return { restored: 0, reason: "indexeddb_present" };
     }
-    for (const job of checkpoint.jobs || []) jobs.put(recoveryCheckpointJob(job));
     const queue = tx.objectStore("queue");
-    for (const item of checkpoint.queue || []) queue.put(recoveryRequiredItem(structuredClone(item)));
+    const restoredQueue = (checkpoint.queue || []).map((item) => recoveryRequiredItem(structuredClone(item)));
+    const recoveryRequiredJobs = new Set(restoredQueue.filter((item) => item.state === "recovery_required").map((item) => item.job_id));
+    for (const job of checkpoint.jobs || []) jobs.put(recoveryCheckpointJob(job, recoveryRequiredJobs.has(job.id)));
+    for (const item of restoredQueue) queue.put(item);
     const revisions = tx.objectStore("revisions");
     for (const revision of checkpoint.revisions || []) revisions.put(structuredClone(revision));
     await transactionDone(tx);
@@ -549,8 +552,10 @@ export class MemoryBackfillStore {
   async restoreRecoveryCheckpoint(checkpoint) {
     if (!checkpoint || checkpoint.version !== BACKFILL_RECOVERY_CHECKPOINT_VERSION) return { restored: 0, reason: "checkpoint_unavailable" };
     if (this.jobs.size) return { restored: 0, reason: "indexeddb_present" };
-    for (const job of checkpoint.jobs || []) this.jobs.set(job.id, recoveryCheckpointJob(job));
-    for (const item of checkpoint.queue || []) this.queue.set(item.id, structuredClone(recoveryRequiredItem(item)));
+    const restoredQueue = (checkpoint.queue || []).map((item) => recoveryRequiredItem(structuredClone(item)));
+    const recoveryRequiredJobs = new Set(restoredQueue.filter((item) => item.state === "recovery_required").map((item) => item.job_id));
+    for (const job of checkpoint.jobs || []) this.jobs.set(job.id, recoveryCheckpointJob(job, recoveryRequiredJobs.has(job.id)));
+    for (const item of restoredQueue) this.queue.set(item.id, structuredClone(item));
     for (const revision of checkpoint.revisions || []) this.revisions.set(revision.id, structuredClone(revision));
     return { restored: (checkpoint.jobs || []).length, reason: "browser_profile_recovery_required" };
   }

--- a/browser-extension/src/backfill/storage.js
+++ b/browser-extension/src/backfill/storage.js
@@ -1,4 +1,4 @@
-import { BACKFILL_DB_NAME, BACKFILL_DB_VERSION, TERMINAL_QUEUE_STATES } from "./models.js";
+import { BACKFILL_DB_NAME, BACKFILL_DB_VERSION, BACKFILL_RECOVERY_CHECKPOINT_VERSION, TERMINAL_QUEUE_STATES } from "./models.js";
 
 function requestResult(request) {
   return new Promise((resolve, reject) => {
@@ -13,6 +13,40 @@ function transactionDone(transaction) {
     transaction.onabort = () => reject(transaction.error || new Error("indexeddb_transaction_aborted"));
     transaction.onerror = () => reject(transaction.error || new Error("indexeddb_transaction_failed"));
   });
+}
+
+function checkpointJob(job) {
+  const safe = { ...job };
+  delete safe.provider_options;
+  delete safe.execution_owner;
+  delete safe.execution_expires_at_ms;
+  return structuredClone(safe);
+}
+
+function checkpointQueueItem(item) {
+  const safe = { ...item };
+  delete safe.envelope;
+  delete safe.receiver_receipt;
+  delete safe.lease_owner;
+  delete safe.lease_expires_at_ms;
+  return structuredClone(safe);
+}
+
+function checkpointRevision(revision) {
+  return structuredClone(revision);
+}
+
+function recoveryRequiredItem(item) {
+  if (item.state !== "captured_waiting_receiver") return item;
+  return {
+    ...item,
+    state: "recovery_required",
+    resume_state: "recovery_required",
+    last_response_class: "browser_profile_recovery_required",
+    last_error: "captured_envelope_not_present_in_recovery_checkpoint",
+    lease_owner: null,
+    lease_expires_at_ms: null,
+  };
 }
 
 export class IndexedDbBackfillStore {
@@ -294,6 +328,42 @@ export class IndexedDbBackfillStore {
     return new TextEncoder().encode(JSON.stringify(items)).length;
   }
 
+  async exportRecoveryCheckpoint() {
+    const db = await this.database();
+    const tx = db.transaction(["jobs", "queue", "revisions"], "readonly");
+    const [jobs, queue, revisions] = await Promise.all([
+      requestResult(tx.objectStore("jobs").getAll()),
+      requestResult(tx.objectStore("queue").getAll()),
+      requestResult(tx.objectStore("revisions").getAll()),
+    ]);
+    return {
+      version: BACKFILL_RECOVERY_CHECKPOINT_VERSION,
+      jobs: jobs.map(checkpointJob),
+      queue: queue.map(checkpointQueueItem),
+      revisions: revisions.map(checkpointRevision),
+    };
+  }
+
+  async restoreRecoveryCheckpoint(checkpoint) {
+    if (!checkpoint || checkpoint.version !== BACKFILL_RECOVERY_CHECKPOINT_VERSION) return { restored: 0, reason: "checkpoint_unavailable" };
+    const db = await this.database();
+    const tx = db.transaction(["jobs", "queue", "revisions"], "readwrite");
+    const jobs = tx.objectStore("jobs");
+    if ((await requestResult(jobs.count())) > 0) {
+      await transactionDone(tx);
+      return { restored: 0, reason: "indexeddb_present" };
+    }
+    for (const job of checkpoint.jobs || []) {
+      jobs.put({ ...structuredClone(job), status: "paused", cooldown_reason: "browser_profile_recovery_required", last_error: "browser_profile_recovery_required", execution_owner: null, execution_expires_at_ms: null });
+    }
+    const queue = tx.objectStore("queue");
+    for (const item of checkpoint.queue || []) queue.put(recoveryRequiredItem(structuredClone(item)));
+    const revisions = tx.objectStore("revisions");
+    for (const revision of checkpoint.revisions || []) revisions.put(structuredClone(revision));
+    await transactionDone(tx);
+    return { restored: (checkpoint.jobs || []).length, reason: "browser_profile_recovery_required" };
+  }
+
   async recoverExpiredLeases(jobId, nowMs) {
     const db = await this.database();
     const tx = db.transaction("queue", "readwrite");
@@ -456,6 +526,22 @@ export class MemoryBackfillStore {
   async getRevision(provider, nativeId) { return structuredClone(this.revisions.get(`${provider}:${nativeId}`)); }
   async putRevision(revision) { this.revisions.set(revision.id, structuredClone(revision)); return revision; }
   async storedBytes(jobId) { return new TextEncoder().encode(JSON.stringify(await this.listQueue(jobId))).length; }
+  async exportRecoveryCheckpoint() {
+    return {
+      version: BACKFILL_RECOVERY_CHECKPOINT_VERSION,
+      jobs: [...this.jobs.values()].map(checkpointJob),
+      queue: [...this.queue.values()].map(checkpointQueueItem),
+      revisions: [...this.revisions.values()].map(checkpointRevision),
+    };
+  }
+  async restoreRecoveryCheckpoint(checkpoint) {
+    if (!checkpoint || checkpoint.version !== BACKFILL_RECOVERY_CHECKPOINT_VERSION) return { restored: 0, reason: "checkpoint_unavailable" };
+    if (this.jobs.size) return { restored: 0, reason: "indexeddb_present" };
+    for (const job of checkpoint.jobs || []) this.jobs.set(job.id, structuredClone({ ...job, status: "paused", cooldown_reason: "browser_profile_recovery_required", last_error: "browser_profile_recovery_required", execution_owner: null, execution_expires_at_ms: null }));
+    for (const item of checkpoint.queue || []) this.queue.set(item.id, structuredClone(recoveryRequiredItem(item)));
+    for (const revision of checkpoint.revisions || []) this.revisions.set(revision.id, structuredClone(revision));
+    return { restored: (checkpoint.jobs || []).length, reason: "browser_profile_recovery_required" };
+  }
   async recoverExpiredLeases(jobId, nowMs) {
     let recovered = 0;
     for (const item of this.queue.values()) {
@@ -492,7 +578,7 @@ export function progressBuckets(items) {
     if (["complete", "unchanged"].includes(item.state)) buckets.complete += 1;
     if (item.state === "no_turns") buckets.no_turns += 1;
     if (["retry_wait", "captured_waiting_receiver"].includes(item.state)) buckets.retry += 1;
-    if (item.state === "auth_required") buckets.operator_action += 1;
+    if (["auth_required", "recovery_required"].includes(item.state)) buckets.operator_action += 1;
     if (item.state === "failed") buckets.error += 1;
   }
   return buckets;

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -89,6 +89,7 @@ async function backfillCoordinator() {
           envelope,
           serialized,
           PROVIDER_REQUEST_TIMEOUT_MS,
+          true,
         ),
         receiverPreflight: backfillReceiverPreflight,
         checkpoint: async (checkpoint) => chrome.storage.local.set({ [BACKFILL_RECOVERY_CHECKPOINT_KEY]: checkpoint }),
@@ -620,7 +621,7 @@ async function requestHeaders({ hasBody = false, requestId = "" } = {}) {
   return headers;
 }
 
-async function postJson(path, payload, serializedBody = null, timeoutMs = null) {
+async function postJson(path, payload, serializedBody = null, timeoutMs = null, requireReceiverRequestId = false) {
   const settings = await receiverSettings();
   const requestId = buildReceiverRequestId();
   await appendDebugLog({ stage: "receiver_request", method: "POST", path, request_id: requestId, has_body: true });
@@ -633,7 +634,8 @@ async function postJson(path, payload, serializedBody = null, timeoutMs = null) 
       body: serializedBody || JSON.stringify(payload),
       signal: controller?.signal,
     });
-    const receiverRequestId = response.headers.get("X-Request-ID") || requestId;
+    const acknowledgedRequestId = response.headers.get("X-Request-ID");
+    const receiverRequestId = acknowledgedRequestId || requestId;
     const body = await response.json().catch(() => ({}));
     await appendDebugLog({
       stage: "receiver_response",
@@ -651,6 +653,12 @@ async function postJson(path, payload, serializedBody = null, timeoutMs = null) 
     if (!response.ok) {
       const error = new Error(body.error || `HTTP ${response.status}`);
       error.receiverRequestId = receiverRequestId;
+      error.status = response.status;
+      throw error;
+    }
+    if (requireReceiverRequestId && !acknowledgedRequestId) {
+      const error = new Error("receiver_contract_incompatible:missing_receiver_request_id");
+      error.receiverRequestId = null;
       error.status = response.status;
       throw error;
     }

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -698,6 +698,7 @@ async function getJson(path, timeoutMs = null) {
     if (!response.ok) {
       const error = new Error(body.error || `HTTP ${response.status}`);
       error.receiverRequestId = receiverRequestId;
+      error.status = response.status;
       throw error;
     }
     return { ...body, receiver_request_id: receiverRequestId };
@@ -717,7 +718,13 @@ async function getJson(path, timeoutMs = null) {
 }
 
 async function backfillReceiverPreflight() {
-  const capability = await getJson("/v1/browser-captures/capabilities", PROVIDER_REQUEST_TIMEOUT_MS);
+  let capability;
+  try {
+    capability = await getJson("/v1/browser-captures/capabilities", PROVIDER_REQUEST_TIMEOUT_MS);
+  } catch (error) {
+    if (error?.status === 404) throw new Error("receiver_contract_incompatible:capability_endpoint_missing");
+    throw error;
+  }
   const fields = capability?.durable_ack_fields;
   if (!Array.isArray(fields) || DURABLE_RECEIVER_ACK_FIELDS.some((field) => !fields.includes(field))) {
     throw new Error("receiver_contract_incompatible:durable_ack_fields_missing");

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -76,7 +76,7 @@ async function withExtensionInstanceAttribution(envelope) {
 
 async function backfillCoordinator() {
   if (!backfillCoordinatorPromise) {
-    backfillCoordinatorPromise = (async () => {
+    const candidate = (async () => {
       const store = new IndexedDbBackfillStore();
       const stored = await chrome.storage.local.get({ [BACKFILL_RECOVERY_CHECKPOINT_KEY]: null });
       await store.restoreRecoveryCheckpoint(stored[BACKFILL_RECOVERY_CHECKPOINT_KEY]);
@@ -97,6 +97,10 @@ async function backfillCoordinator() {
         receiverContractEpoch: BACKFILL_WORKER_EPOCH,
       });
     })();
+    backfillCoordinatorPromise = candidate;
+    void candidate.catch(() => {
+      if (backfillCoordinatorPromise === candidate) backfillCoordinatorPromise = null;
+    });
   }
   return backfillCoordinatorPromise;
 }
@@ -666,13 +670,16 @@ async function postJson(path, payload, serializedBody = null, timeoutMs = null) 
   }
 }
 
-async function getJson(path) {
+async function getJson(path, timeoutMs = null) {
   const settings = await receiverSettings();
   const requestId = buildReceiverRequestId();
   await appendDebugLog({ stage: "receiver_request", method: "GET", path, request_id: requestId });
+  const controller = timeoutMs ? new AbortController() : null;
+  const timeout = timeoutMs ? globalThis.setTimeout(() => controller.abort("receiver_request_timeout"), timeoutMs) : 0;
   try {
     const response = await fetch(`${settings.baseUrl}${path}`, {
       headers: await requestHeaders({ requestId }),
+      signal: controller?.signal,
     });
     const receiverRequestId = response.headers.get("X-Request-ID") || requestId;
     const body = await response.json().catch(() => ({}));
@@ -704,11 +711,13 @@ async function getJson(path) {
       error: String(error.message || error),
     });
     throw error;
+  } finally {
+    if (timeout) globalThis.clearTimeout(timeout);
   }
 }
 
 async function backfillReceiverPreflight() {
-  const capability = await getJson("/v1/browser-captures/capabilities");
+  const capability = await getJson("/v1/browser-captures/capabilities", PROVIDER_REQUEST_TIMEOUT_MS);
   const fields = capability?.durable_ack_fields;
   if (!Array.isArray(fields) || DURABLE_RECEIVER_ACK_FIELDS.some((field) => !fields.includes(field))) {
     throw new Error("receiver_contract_incompatible:durable_ack_fields_missing");

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1,5 +1,5 @@
 import { BackfillCoordinator } from "./backfill/coordinator.js";
-import { BACKFILL_ALARM, PROVIDER_REQUEST_TIMEOUT_MS } from "./backfill/models.js";
+import { BACKFILL_ALARM, DURABLE_RECEIVER_ACK_FIELDS, PROVIDER_REQUEST_TIMEOUT_MS } from "./backfill/models.js";
 import { providerAdapters } from "./backfill/providers.js";
 import { executeProviderPageRequest } from "./backfill/page_transport.js";
 import { IndexedDbBackfillStore } from "./backfill/storage.js";
@@ -11,6 +11,8 @@ const CAPTURE_LOG_LIMIT = 80;
 const DEBUG_LOG_LIMIT = 160;
 const CONVERSATION_TIMELINE_KEY = "polylogueConversationTimeline";
 const CONVERSATION_TIMELINE_EVENT_LIMIT = 24;
+const BACKFILL_RECOVERY_CHECKPOINT_KEY = "polylogueBackfillRecoveryCheckpoint";
+const BACKFILL_WORKER_EPOCH = globalThis.crypto?.randomUUID?.() || `worker-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 const CONVERSATION_TIMELINE_CONVERSATION_LIMIT = 80;
 const POST_POLL_INTERVAL_MS = 5000;
 const CAPTURE_MESSAGE_TIMEOUT_MS = 15000;
@@ -74,18 +76,27 @@ async function withExtensionInstanceAttribution(envelope) {
 
 async function backfillCoordinator() {
   if (!backfillCoordinatorPromise) {
-    backfillCoordinatorPromise = extensionInstanceId().then((instanceId) => new BackfillCoordinator({
-      store: new IndexedDbBackfillStore(),
-      adapters: providerAdapters(providerPageFetch, { requirePageContext: true }),
-      receiver: (envelope, serialized) => postJson(
-        "/v1/browser-captures",
-        envelope,
-        serialized,
-        PROVIDER_REQUEST_TIMEOUT_MS,
-      ),
-      alarms: chrome.alarms,
-      instanceId,
-    }));
+    backfillCoordinatorPromise = (async () => {
+      const store = new IndexedDbBackfillStore();
+      const stored = await chrome.storage.local.get({ [BACKFILL_RECOVERY_CHECKPOINT_KEY]: null });
+      await store.restoreRecoveryCheckpoint(stored[BACKFILL_RECOVERY_CHECKPOINT_KEY]);
+      const instanceId = await extensionInstanceId();
+      return new BackfillCoordinator({
+        store,
+        adapters: providerAdapters(providerPageFetch, { requirePageContext: true }),
+        receiver: (envelope, serialized) => postJson(
+          "/v1/browser-captures",
+          envelope,
+          serialized,
+          PROVIDER_REQUEST_TIMEOUT_MS,
+        ),
+        receiverPreflight: backfillReceiverPreflight,
+        checkpoint: async (checkpoint) => chrome.storage.local.set({ [BACKFILL_RECOVERY_CHECKPOINT_KEY]: checkpoint }),
+        alarms: chrome.alarms,
+        instanceId,
+        receiverContractEpoch: BACKFILL_WORKER_EPOCH,
+      });
+    })();
   }
   return backfillCoordinatorPromise;
 }
@@ -694,6 +705,15 @@ async function getJson(path) {
     });
     throw error;
   }
+}
+
+async function backfillReceiverPreflight() {
+  const capability = await getJson("/v1/browser-captures/capabilities");
+  const fields = capability?.durable_ack_fields;
+  if (!Array.isArray(fields) || DURABLE_RECEIVER_ACK_FIELDS.some((field) => !fields.includes(field))) {
+    throw new Error("receiver_contract_incompatible:durable_ack_fields_missing");
+  }
+  return capability;
 }
 
 async function refreshReceiverState() {

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -389,6 +389,8 @@ function renderBackfill(jobs) {
     ? "Receiver ACK contract is stale. Upgrade/restart receiver, then Resume."
     : recoveryBlocked
       ? "Browser profile was replaced. Inspect exported ledger before starting a new job."
+      : job.recovery_checkpoint_error
+        ? `Profile recovery checkpoint failed: ${job.recovery_checkpoint_error}`
       : job.last_ack?.receiver_request_id || job.last_error || "--";
   const resumeButton = document.getElementById("backfill-resume");
   if (resumeButton) resumeButton.disabled = recoveryBlocked;

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -373,13 +373,23 @@ function renderBackfill(jobs) {
   }
   selectedBackfillJobId = job.id;
   if (selector) selector.value = job.id;
-  statusNode.textContent = `${job.provider} · ${job.status}`;
+  const contractBlocked = job.cooldown_reason === "receiver_contract_incompatible";
+  const recoveryBlocked = job.cooldown_reason === "browser_profile_recovery_required";
+  statusNode.textContent = contractBlocked
+    ? `${job.provider} · receiver upgrade required`
+    : recoveryBlocked
+      ? `${job.provider} · profile recovery required`
+      : `${job.provider} · ${job.status}`;
   document.getElementById("backfill-cursor").textContent = job.inventory_complete ? `${job.inventory_cursor} · complete` : job.inventory_cursor || "--";
   const progress = job.progress || {};
   document.getElementById("backfill-progress").textContent = `${progress.complete || 0}/${progress.total || 0} · ${progress.retry || 0} retry · ${progress.no_turns || 0} empty · ${(progress.error || 0) + (progress.operator_action || 0)} attention`;
   const cooldown = job.cooldown_until_ms ? new Date(job.cooldown_until_ms).toLocaleTimeString() : "none";
   document.getElementById("backfill-rate").textContent = `${Math.round((job.learned_cadence_ms || 0) / 1000)}s · ${cooldown}`;
-  document.getElementById("backfill-last").textContent = job.last_ack?.receiver_request_id || job.last_error || "--";
+  document.getElementById("backfill-last").textContent = contractBlocked
+    ? "Receiver ACK contract is stale. Upgrade/restart receiver, then Resume."
+    : recoveryBlocked
+      ? "Browser profile was replaced. Inspect exported ledger before starting a new job."
+      : job.last_ack?.receiver_request_id || job.last_error || "--";
 }
 
 async function refreshBackfills() {

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -390,6 +390,8 @@ function renderBackfill(jobs) {
     : recoveryBlocked
       ? "Browser profile was replaced. Inspect exported ledger before starting a new job."
       : job.last_ack?.receiver_request_id || job.last_error || "--";
+  const resumeButton = document.getElementById("backfill-resume");
+  if (resumeButton) resumeButton.disabled = recoveryBlocked;
 }
 
 async function refreshBackfills() {

--- a/browser-extension/tests/backfill.test.js
+++ b/browser-extension/tests/backfill.test.js
@@ -259,6 +259,33 @@ describe("background backfill coordinator", () => {
     expect(receiver).not.toHaveBeenCalled();
   });
 
+  it("preserves terminal jobs and releases stripped leases when restoring a profile-loss checkpoint", async () => {
+    const store = new MemoryBackfillStore();
+    const checkpoint = {
+      version: 1,
+      jobs: [
+        { id: "complete", provider: "chatgpt", status: "complete", policy: { maxDailyRequests: 10 } },
+        { id: "cancelled", provider: "claude-ai", status: "cancelled", policy: { maxDailyRequests: 10 } },
+        { id: "running", provider: "chatgpt", status: "running", policy: { maxDailyRequests: 10 } },
+      ],
+      queue: [
+        { id: "leased-eligible", job_id: "running", provider: "chatgpt", native_id: "one", state: "leased", resume_state: "eligible", next_eligible_at_ms: 0 },
+        { id: "leased-envelope", job_id: "running", provider: "chatgpt", native_id: "two", state: "leased", resume_state: "captured_waiting_receiver", next_eligible_at_ms: 0 },
+      ],
+      revisions: [],
+    };
+    await store.restoreRecoveryCheckpoint(checkpoint);
+    expect(await store.getJob("complete")).toMatchObject({ status: "complete" });
+    expect(await store.getJob("cancelled")).toMatchObject({ status: "cancelled" });
+    expect(await store.getJob("running")).toMatchObject({ status: "paused", cooldown_reason: "browser_profile_recovery_required" });
+    expect(await store.listQueue("running")).toMatchObject([
+      { id: "leased-eligible", state: "eligible" },
+      { id: "leased-envelope", state: "recovery_required" },
+    ]);
+    const coordinator = new BackfillCoordinator({ store, adapters: { chatgpt: new FixtureAdapter(["one"]) }, receiver: vi.fn(), alarms: { create: vi.fn() }, clock: () => 100000 });
+    await expect(coordinator.control("running", "resume")).rejects.toThrow("browser_profile_recovery_required");
+  });
+
   it("honors Retry-After exactly and opens a circuit after repeated 429s", async () => {
     const adapter = new FixtureAdapter(["one"]);
     adapter.responses = [response({}, { status: 429, retryAfter: "60" }), response({}, { status: 429, retryAfter: "60" })];

--- a/browser-extension/tests/backfill.test.js
+++ b/browser-extension/tests/backfill.test.js
@@ -59,7 +59,7 @@ class FixtureAdapter {
   }
 }
 
-function harness({ adapter = new FixtureAdapter(), receiver = null, receiverPreflight = null, start = 100000, instanceId = "instance-a", policy = {}, store = new MemoryBackfillStore() } = {}) {
+function harness({ adapter = new FixtureAdapter(), receiver = null, receiverPreflight = null, checkpoint = null, start = 100000, instanceId = "instance-a", policy = {}, store = new MemoryBackfillStore() } = {}) {
   let now = start;
   const alarms = { create: vi.fn(async () => undefined) };
   const durableReceiver = receiver || vi.fn(async (envelope, serialized) => ({ receiver_request_id: `ack-${envelope.session.provider_session_id}`, content_hash: await serializedContentHash(serialized) }));
@@ -68,6 +68,7 @@ function harness({ adapter = new FixtureAdapter(), receiver = null, receiverPref
     adapters: { chatgpt: adapter },
     receiver: durableReceiver,
     receiverPreflight,
+    checkpoint,
     alarms,
     clock: () => now,
     random: () => 0,
@@ -179,6 +180,35 @@ describe("background backfill coordinator", () => {
     expect(h.receiver).not.toHaveBeenCalled();
   });
 
+  it("keeps a paused job non-runnable until its resume preflight succeeds", async () => {
+    let releasePreflight;
+    const receiverPreflight = vi.fn(async () => new Promise((resolve) => { releasePreflight = resolve; }));
+    receiverPreflight.mockResolvedValueOnce(undefined);
+    const h = harness({ receiverPreflight });
+    const job = await startJob(h);
+    await h.coordinator.control(job.id, "pause");
+
+    const resuming = h.coordinator.control(job.id, "resume");
+    await vi.waitFor(() => expect(receiverPreflight).toHaveBeenCalledTimes(2));
+    expect((await h.store.getJob(job.id)).status).toBe("paused");
+    await h.coordinator.wake(job.id);
+    expect(h.adapter.enumerateCalls).toBe(0);
+
+    releasePreflight();
+    await resuming;
+    expect(await h.store.getJob(job.id)).toMatchObject({ status: "running", receiver_contract_epoch: "instance-a" });
+  });
+
+  it("reports a recovery-checkpoint write failure without failing durable backfill work", async () => {
+    const checkpoint = vi.fn(async () => { throw new Error("storage_local_quota"); });
+    const h = harness({ checkpoint });
+    const job = await startJob(h);
+    expect(job).toMatchObject({ status: "running", recovery_checkpoint_error: "storage_local_quota" });
+    await h.coordinator.wake(job.id);
+    expect(h.adapter.enumerateCalls).toBe(1);
+    expect((await h.coordinator.status(job.id)).recovery_checkpoint_error).toBe("storage_local_quota");
+  });
+
   it("pauses exactly once on a 202-shaped ACK missing durable fields, then explicitly drains its stored envelope", async () => {
     let compatible = false;
     const receiver = vi.fn(async (_envelope, serialized) => compatible
@@ -267,10 +297,12 @@ describe("background backfill coordinator", () => {
         { id: "complete", provider: "chatgpt", status: "complete", policy: { maxDailyRequests: 10 } },
         { id: "cancelled", provider: "claude-ai", status: "cancelled", policy: { maxDailyRequests: 10 } },
         { id: "running", provider: "chatgpt", status: "running", policy: { maxDailyRequests: 10 } },
+        { id: "paused-recovery", provider: "chatgpt", status: "paused", cooldown_reason: "receiver_contract_incompatible", policy: { maxDailyRequests: 10 } },
       ],
       queue: [
         { id: "leased-eligible", job_id: "running", provider: "chatgpt", native_id: "one", state: "leased", resume_state: "eligible", next_eligible_at_ms: 0 },
         { id: "leased-envelope", job_id: "running", provider: "chatgpt", native_id: "two", state: "leased", resume_state: "captured_waiting_receiver", next_eligible_at_ms: 0 },
+        { id: "paused-envelope", job_id: "paused-recovery", provider: "chatgpt", native_id: "three", state: "captured_waiting_receiver", next_eligible_at_ms: 0 },
       ],
       revisions: [],
     };
@@ -278,12 +310,14 @@ describe("background backfill coordinator", () => {
     expect(await store.getJob("complete")).toMatchObject({ status: "complete" });
     expect(await store.getJob("cancelled")).toMatchObject({ status: "cancelled" });
     expect(await store.getJob("running")).toMatchObject({ status: "paused", cooldown_reason: "browser_profile_recovery_required" });
+    expect(await store.getJob("paused-recovery")).toMatchObject({ status: "paused", cooldown_reason: "browser_profile_recovery_required" });
     expect(await store.listQueue("running")).toMatchObject([
       { id: "leased-eligible", state: "eligible" },
       { id: "leased-envelope", state: "recovery_required" },
     ]);
     const coordinator = new BackfillCoordinator({ store, adapters: { chatgpt: new FixtureAdapter(["one"]) }, receiver: vi.fn(), alarms: { create: vi.fn() }, clock: () => 100000 });
     await expect(coordinator.control("running", "resume")).rejects.toThrow("browser_profile_recovery_required");
+    await expect(coordinator.control("paused-recovery", "resume")).rejects.toThrow("browser_profile_recovery_required");
   });
 
   it("honors Retry-After exactly and opens a circuit after repeated 429s", async () => {

--- a/browser-extension/tests/backfill.test.js
+++ b/browser-extension/tests/backfill.test.js
@@ -59,7 +59,7 @@ class FixtureAdapter {
   }
 }
 
-function harness({ adapter = new FixtureAdapter(), receiver = null, start = 100000, instanceId = "instance-a", policy = {}, store = new MemoryBackfillStore() } = {}) {
+function harness({ adapter = new FixtureAdapter(), receiver = null, receiverPreflight = null, start = 100000, instanceId = "instance-a", policy = {}, store = new MemoryBackfillStore() } = {}) {
   let now = start;
   const alarms = { create: vi.fn(async () => undefined) };
   const durableReceiver = receiver || vi.fn(async (envelope, serialized) => ({ receiver_request_id: `ack-${envelope.session.provider_session_id}`, content_hash: await serializedContentHash(serialized) }));
@@ -67,6 +67,7 @@ function harness({ adapter = new FixtureAdapter(), receiver = null, start = 1000
     store,
     adapters: { chatgpt: adapter },
     receiver: durableReceiver,
+    receiverPreflight,
     alarms,
     clock: () => now,
     random: () => 0,
@@ -105,6 +106,45 @@ describe("background backfill coordinator", () => {
     expect(h.receiver).toHaveBeenCalledTimes(2);
   });
 
+  it("recovers the durable job, queue, revision, and ACK ledgers from real IndexedDB after a worker restart", async () => {
+    const databaseName = `polylogue-restart-${globalThis.crypto.randomUUID()}`;
+    const adapter = new FixtureAdapter(["one", "two"]);
+    const store = new IndexedDbBackfillStore(indexedDB, databaseName);
+    const h = harness({ adapter, store });
+    const job = await startJob(h);
+    await enumerateThenAdvance(h, job);
+    await h.coordinator.wake(job.id);
+    const before = await h.coordinator.status(job.id);
+    const restarted = new BackfillCoordinator({
+      store: new IndexedDbBackfillStore(indexedDB, databaseName),
+      adapters: { chatgpt: adapter }, receiver: h.receiver, alarms: h.alarms,
+      clock: h.now, random: () => 0, instanceId: "instance-after-restart",
+    });
+    h.advance(h.policy.baseCadenceMs);
+    await restarted.wake(job.id);
+    const after = await restarted.status(job.id);
+    expect(after).toMatchObject({ id: job.id, inventory_cursor: before.inventory_cursor, last_ack: expect.objectContaining({ content_hash: expect.any(String) }) });
+    expect(after.progress.complete).toBe(2);
+    expect(adapter.fetchCalls).toEqual(["one", "two"]);
+    expect(h.receiver).toHaveBeenCalledTimes(2);
+    indexedDB.deleteDatabase(databaseName);
+  });
+
+  it("rechecks the receiver contract after a worker restart even when its durable extension identity is unchanged", async () => {
+    const receiverPreflight = vi.fn(async () => undefined);
+    const h = harness({ receiverPreflight, instanceId: "stable-extension-id" });
+    const job = await startJob(h);
+    const restarted = new BackfillCoordinator({
+      store: h.store, adapters: { chatgpt: h.adapter }, receiver: h.receiver, receiverPreflight,
+      alarms: h.alarms, clock: h.now, random: () => 0, instanceId: "stable-extension-id", receiverContractEpoch: "new-worker-epoch",
+    });
+    receiverPreflight.mockRejectedValueOnce(new Error("receiver_contract_incompatible:durable_ack_fields_missing"));
+    await restarted.wake(job.id);
+    expect(await restarted.status(job.id)).toMatchObject({ status: "paused", cooldown_reason: "receiver_contract_incompatible" });
+    expect(receiverPreflight).toHaveBeenCalledTimes(2);
+    expect(h.adapter.enumerateCalls).toBe(0);
+  });
+
   it("keeps a receiver-down capture durable and retries the ACK without refetching provider data", async () => {
     let calls = 0;
     const receiver = vi.fn(async (_envelope, serialized) => {
@@ -127,6 +167,96 @@ describe("background backfill coordinator", () => {
     expect(item.receiver_receipt.content_hash).toBe(item.content_hash);
     expect(h.adapter.fetchCalls).toHaveLength(1);
     expect((await h.coordinator.status(job.id)).daily_requests).toBe(providerRequests);
+  });
+
+  it("preflights the receiver contract before any provider request", async () => {
+    const receiverPreflight = vi.fn(async () => { throw new Error("receiver_contract_incompatible:durable_ack_fields_missing"); });
+    const h = harness({ receiverPreflight });
+    const job = await startJob(h);
+    const status = await h.coordinator.status(job.id);
+    expect(status).toMatchObject({ status: "paused", cooldown_reason: "receiver_contract_incompatible" });
+    expect(h.adapter.enumerateCalls).toBe(0);
+    expect(h.receiver).not.toHaveBeenCalled();
+  });
+
+  it("pauses exactly once on a 202-shaped ACK missing durable fields, then explicitly drains its stored envelope", async () => {
+    let compatible = false;
+    const receiver = vi.fn(async (_envelope, serialized) => compatible
+      ? { receiver_request_id: "ack-after-upgrade", content_hash: await serializedContentHash(serialized) }
+      : { receiver_request_id: "accepted-but-stale" });
+    const receiverPreflight = vi.fn(async () => undefined);
+    const h = harness({ adapter: new FixtureAdapter(["one"]), receiver, receiverPreflight });
+    const job = await startJob(h);
+    await h.coordinator.wake(job.id);
+    h.advance(h.policy.baseCadenceMs);
+    await h.coordinator.wake(job.id);
+    expect((await h.coordinator.status(job.id)).cooldown_reason).toBe("receiver_contract_incompatible");
+    expect(h.receiver).toHaveBeenCalledTimes(1);
+    expect(h.adapter.fetchCalls).toEqual(["one"]);
+
+    h.advance(60000);
+    await h.coordinator.wake(job.id);
+    expect(h.receiver).toHaveBeenCalledTimes(1);
+    expect(h.adapter.fetchCalls).toEqual(["one"]);
+
+    compatible = true;
+    await h.coordinator.control(job.id, "resume");
+    await h.coordinator.wake(job.id);
+    const resumed = await h.coordinator.status(job.id);
+    expect(resumed.progress.complete).toBe(1);
+    expect(h.adapter.fetchCalls).toEqual(["one"]);
+    expect(h.receiver).toHaveBeenCalledTimes(2);
+  });
+
+  it("turns a stale accepted ACK into a receiver-contract pause without retrying or refetching", async () => {
+    const receiver = vi.fn(async () => ({ receiver_request_id: "accepted-but-no-hash" }));
+    const h = harness({ adapter: new FixtureAdapter(["one"]), receiver });
+    const job = await startJob(h);
+    await enumerateThenAdvance(h, job);
+    await h.coordinator.wake(job.id);
+    const first = await h.coordinator.status(job.id);
+    const item = (await h.store.listQueue(job.id))[0];
+    expect(first).toMatchObject({ status: "paused", cooldown_reason: "receiver_contract_incompatible" });
+    expect(item).toMatchObject({ state: "captured_waiting_receiver", attempt_count: 0, last_response_class: "receiver_contract_incompatible" });
+    expect(h.adapter.fetchCalls).toEqual(["one"]);
+    expect(receiver).toHaveBeenCalledTimes(1);
+
+    h.advance(60000);
+    await h.coordinator.wake(job.id);
+    expect(h.adapter.fetchCalls).toEqual(["one"]);
+    expect(receiver).toHaveBeenCalledTimes(1);
+  });
+
+  it("exports no credentials and restores profile-loss evidence without replaying a missing envelope", async () => {
+    const store = new MemoryBackfillStore();
+    await store.createJob({
+      id: "checkpoint-job", provider: "chatgpt", cutoff: "2026-01-01T00:00:00Z", provider_options: { claudeOrganizationId: "account-should-not-survive" },
+      status: "running", policy: { maxDailyRequests: 10 }, learned_cadence_ms: 40000, daily_requests: 7,
+      last_ack: { receiver_request_id: "ack-1", content_hash: "abc" }, execution_generation: 0,
+    });
+    await store.putQueue({
+      id: "checkpoint-q", job_id: "checkpoint-job", provider: "chatgpt", native_id: "conversation-1", state: "captured_waiting_receiver",
+      envelope: { raw_provider_payload: { authorization: "Bearer secret", account_id: "account-should-not-survive" } },
+      receiver_receipt: { cookie: "secret" }, content_hash: "abc", attempt_count: 2,
+    });
+    const checkpoint = await store.exportRecoveryCheckpoint();
+    const encoded = JSON.stringify(checkpoint);
+    expect(encoded).not.toContain("Bearer secret");
+    expect(encoded).not.toContain("account-should-not-survive");
+    expect(encoded).not.toContain("cookie");
+    expect(checkpoint.jobs[0]).toMatchObject({ learned_cadence_ms: 40000, daily_requests: 7, last_ack: { receiver_request_id: "ack-1" } });
+
+    const restoredStore = new MemoryBackfillStore();
+    expect(await restoredStore.restoreRecoveryCheckpoint(checkpoint)).toEqual({ restored: 1, reason: "browser_profile_recovery_required" });
+    const restored = await restoredStore.getJob("checkpoint-job");
+    expect(restored).toMatchObject({ status: "paused", cooldown_reason: "browser_profile_recovery_required", last_ack: { receiver_request_id: "ack-1" } });
+    const restoredQueue = await restoredStore.listQueue("checkpoint-job");
+    expect(restoredQueue).toMatchObject([{ state: "recovery_required" }]);
+    expect(restoredQueue[0]).not.toHaveProperty("envelope");
+    const receiver = vi.fn();
+    const coordinator = new BackfillCoordinator({ store: restoredStore, adapters: { chatgpt: new FixtureAdapter(["one"]) }, receiver, alarms: { create: vi.fn() }, clock: () => 200000 });
+    await coordinator.wake("checkpoint-job");
+    expect(receiver).not.toHaveBeenCalled();
   });
 
   it("honors Retry-After exactly and opens a circuit after repeated 429s", async () => {

--- a/browser-extension/tests/backfill.test.js
+++ b/browser-extension/tests/backfill.test.js
@@ -194,9 +194,12 @@ describe("background backfill coordinator", () => {
     await h.coordinator.wake(job.id);
     expect(h.adapter.enumerateCalls).toBe(0);
 
+    const cancelling = h.coordinator.control(job.id, "cancel");
     releasePreflight();
-    await resuming;
-    expect(await h.store.getJob(job.id)).toMatchObject({ status: "running", receiver_contract_epoch: "instance-a" });
+    await Promise.all([resuming, cancelling]);
+    expect(await h.store.getJob(job.id)).toMatchObject({ status: "cancelled", receiver_contract_epoch: "instance-a" });
+    await h.coordinator.wake(job.id);
+    expect(h.adapter.enumerateCalls).toBe(0);
   });
 
   it("reports a recovery-checkpoint write failure without failing durable backfill work", async () => {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -575,6 +575,13 @@ describe("background receiver diagnostics", () => {
     expect(fetchCalls[0].options.signal).toBeDefined();
   });
 
+  it("classifies a reachable receiver missing the capability route as contract-incompatible", async () => {
+    globalThis.fetch = vi.fn(async () => responseJson({ error: "not_found" }, { ok: false, status: 404 }));
+    const started = await sendRuntimeMessage({ type: "polylogue.backfill.start", provider: "chatgpt", cutoff: "2026-01-01T00:00:00Z" });
+    expect(started.job).toMatchObject({ status: "paused", cooldown_reason: "receiver_contract_incompatible" });
+    expect(globalThis.chrome.scripting.executeScript).not.toHaveBeenCalled();
+  });
+
   it("restores a packaged recovery checkpoint as an actionable paused job and ignores its alarm", async () => {
     await loadBackground({
       polylogueBackfillRecoveryCheckpoint: {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -106,6 +106,13 @@ function installChromeMock() {
       }),
     },
   };
+  globalThis.fetch = vi.fn(async (url, options = {}) => {
+    fetchCalls.push({ url, options });
+    if (String(url).endsWith("/v1/browser-captures/capabilities")) {
+      return responseJson({ durable_ack_fields: ["receiver_request_id", "content_hash"] }, { requestId: "capability-1" });
+    }
+    return responseJson({ error: "unexpected_receiver_request" }, { ok: false, status: 500 });
+  });
 }
 
 async function loadBackground() {
@@ -521,7 +528,13 @@ describe("background receiver diagnostics", () => {
   });
 
   it("routes backfill inventory through an existing provider page instead of service-worker fetch", async () => {
-    globalThis.fetch = vi.fn(async () => responseJson({ error: "unexpected_service_worker_provider_fetch" }, { ok: false, status: 500 }));
+    globalThis.fetch = vi.fn(async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      if (String(url).endsWith("/v1/browser-captures/capabilities")) {
+        return responseJson({ durable_ack_fields: ["receiver_request_id", "content_hash"] }, { requestId: "capability-1" });
+      }
+      return responseJson({ error: "unexpected_service_worker_provider_fetch" }, { ok: false, status: 500 });
+    });
 
     const started = await sendRuntimeMessage({
       type: "polylogue.backfill.start",
@@ -537,7 +550,8 @@ describe("background receiver diagnostics", () => {
       func: expect.any(Function),
       args: [expect.objectContaining({ provider: "chatgpt", operation: "inventory" })],
     })));
-    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(fetchCalls[0].url).toContain("/v1/browser-captures/capabilities");
     expect(globalThis.chrome.tabs.create).not.toHaveBeenCalled();
     expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
   });

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -557,6 +557,24 @@ describe("background receiver diagnostics", () => {
     expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("retries coordinator initialization after recovery storage fails once", async () => {
+    globalThis.chrome.storage.local.get = vi.fn()
+      .mockRejectedValueOnce(new Error("synthetic_recovery_storage_failure"))
+      .mockImplementation(async (defaults) => ({ ...defaults, ...stored }));
+    expect(await sendRuntimeMessage({ type: "polylogue.backfill.status" })).toMatchObject({ ok: false, error: "synthetic_recovery_storage_failure" });
+    expect(await sendRuntimeMessage({ type: "polylogue.backfill.status" })).toMatchObject({ ok: true, jobs: [] });
+  });
+
+  it("bounds receiver capability preflight with the provider request timeout", async () => {
+    globalThis.fetch = vi.fn(async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      return responseJson({ durable_ack_fields: ["receiver_request_id", "content_hash"] }, { requestId: "capability-1" });
+    });
+    await sendRuntimeMessage({ type: "polylogue.backfill.start", provider: "chatgpt", cutoff: "2026-01-01T00:00:00Z" });
+    expect(fetchCalls[0]).toMatchObject({ url: expect.stringContaining("/v1/browser-captures/capabilities") });
+    expect(fetchCalls[0].options.signal).toBeDefined();
+  });
+
   it("restores a packaged recovery checkpoint as an actionable paused job and ignores its alarm", async () => {
     await loadBackground({
       polylogueBackfillRecoveryCheckpoint: {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -10,10 +10,11 @@ let stored;
 let fetchCalls;
 let tabs;
 
-function installChromeMock() {
+function installChromeMock(storagePatch = {}) {
   stored = {
     receiverAuthToken: "token-1",
     receiverBaseUrl: "http://127.0.0.1:8875",
+    ...storagePatch,
   };
   messageListener = null;
   installedListener = null;
@@ -115,10 +116,10 @@ function installChromeMock() {
   });
 }
 
-async function loadBackground() {
+async function loadBackground(storagePatch = {}) {
   vi.resetModules();
   globalThis.indexedDB = new IDBFactory();
-  installChromeMock();
+  installChromeMock(storagePatch);
   await import("../src/background.js");
   expect(messageListener).toBeTypeOf("function");
 }
@@ -554,6 +555,30 @@ describe("background receiver diagnostics", () => {
     expect(fetchCalls[0].url).toContain("/v1/browser-captures/capabilities");
     expect(globalThis.chrome.tabs.create).not.toHaveBeenCalled();
     expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("restores a packaged recovery checkpoint as an actionable paused job and ignores its alarm", async () => {
+    await loadBackground({
+      polylogueBackfillRecoveryCheckpoint: {
+        version: 1,
+        jobs: [{
+          id: "recovered-job", provider: "chatgpt", cutoff: "2026-01-01T00:00:00Z", status: "running",
+          inventory_cursor: "17", policy: { leaseMs: 180000, maxDailyRequests: 10 }, execution_generation: 0,
+          learned_cadence_ms: 40000, daily_requests: 7, last_ack: { receiver_request_id: "ack-1", content_hash: "hash-1" },
+        }],
+        queue: [{ id: "recovered-item", job_id: "recovered-job", provider: "chatgpt", native_id: "one", state: "captured_waiting_receiver", content_hash: "hash-1" }],
+        revisions: [],
+      },
+    });
+    const status = await sendRuntimeMessage({ type: "polylogue.backfill.status" });
+    expect(status.jobs[0]).toMatchObject({
+      id: "recovered-job", status: "paused", cooldown_reason: "browser_profile_recovery_required",
+      inventory_cursor: "17", daily_requests: 7, last_ack: { receiver_request_id: "ack-1" },
+      progress: { operator_action: 1 },
+    });
+    alarmListener({ name: "polylogueBackfillWake:recovered-job" });
+    await Promise.resolve();
+    expect(globalThis.chrome.scripting.executeScript).not.toHaveBeenCalled();
   });
 
   it("does not reuse unsupported provider subdomains as authenticated transport roots", async () => {

--- a/browser-extension/tests/build.test.js
+++ b/browser-extension/tests/build.test.js
@@ -176,11 +176,18 @@ describe("build.mjs full archive emission", () => {
       tabs: { ...tabs, get: vi.fn(), onActivated: { addListener: vi.fn() }, onUpdated: { addListener: vi.fn() } },
     };
     const fetchCalls = [];
+    let receiverPosts = 0;
     globalThis.fetch = vi.fn(async (url, options = {}) => {
       fetchCalls.push({ url, options });
       let body;
+      if (String(url).endsWith("/v1/browser-captures/capabilities")) {
+        return { ok: true, status: 200, headers: { get: (name) => name === "X-Request-ID" ? "packaged-capability" : null }, json: async () => ({ durable_ack_fields: ["receiver_request_id", "content_hash"] }) };
+      }
       const contentHash = createHash("sha256").update(options.body, "utf8").digest("hex");
-      body = { ok: true, provider: "chatgpt", provider_session_id: "fixture-1", content_hash: contentHash };
+      receiverPosts += 1;
+      body = receiverPosts === 1
+        ? { ok: true, provider: "chatgpt", provider_session_id: "fixture-1" }
+        : { ok: true, provider: "chatgpt", provider_session_id: "fixture-1", content_hash: contentHash };
       return { ok: true, status: 200, headers: { get: (name) => name === "X-Request-ID" ? "packaged-ack" : null }, json: async () => body };
     });
     const packagedWorkerUrl = `${pathToFileURL(join(unpacked, "src", "background.js")).href}?smoke=${Date.now()}`;
@@ -193,7 +200,16 @@ describe("build.mjs full archive emission", () => {
       await vi.waitFor(() => expect(pageRequests.filter((message) => message.operation === "inventory")).toHaveLength(inventoryCount));
     }
     alarmListener({ name: `polylogueBackfillWake:${started.job.id}` });
-    await vi.waitFor(() => expect(fetchCalls.some((call) => String(call.url).includes("/v1/browser-captures"))).toBe(true));
+    await vi.waitFor(() => expect(receiverPosts).toBe(1));
+    const paused = await send({ type: "polylogue.backfill.status" });
+    expect(paused.jobs[0]).toMatchObject({ status: "paused", cooldown_reason: "receiver_contract_incompatible" });
+    expect(receiverPosts).toBe(1);
+    await send({ type: "polylogue.backfill.control", job_id: started.job.id, action: "resume" });
+    alarmListener({ name: `polylogueBackfillWake:${started.job.id}` });
+    await vi.waitFor(() => expect(receiverPosts).toBe(2));
+    const recovered = await send({ type: "polylogue.backfill.status" });
+    expect(recovered.jobs[0].progress.complete).toBe(1);
+    expect(pageRequests.filter((message) => message.operation === "conversation")).toHaveLength(1);
     expect(tabs.create).toHaveBeenCalledWith({ url: "https://chatgpt.com/", active: false });
     expect(tabs.update).not.toHaveBeenCalled();
     expect(pageRequests.map((message) => message.operation)).toEqual(["inventory", "inventory", "inventory", "inventory", "conversation"]);

--- a/browser-extension/tests/build.test.js
+++ b/browser-extension/tests/build.test.js
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { indexedDB } from "fake-indexeddb";
+import { IDBFactory, indexedDB } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -218,6 +218,33 @@ describe("build.mjs full archive emission", () => {
     expect(JSON.stringify(pageRequests)).not.toContain(pageAccount);
     expect(tabs.sendMessage).not.toHaveBeenCalled();
     expect(fetchCalls.every((call) => String(call.url).includes("127.0.0.1"))).toBe(true);
+
+    globalThis.indexedDB = new IDBFactory();
+    stored = {
+      receiverBaseUrl: "http://127.0.0.1:8765",
+      receiverAuthToken: "token",
+      polylogueBackfillRecoveryCheckpoint: {
+        version: 1,
+        jobs: [{
+          id: "packaged-recovered", provider: "chatgpt", cutoff: "2026-01-01T00:00:00Z", status: "running",
+          inventory_cursor: "17", policy: { leaseMs: 180000, maxDailyRequests: 10 }, execution_generation: 0,
+          learned_cadence_ms: 40000, daily_requests: 7, last_ack: { receiver_request_id: "ack-1", content_hash: "hash-1" },
+        }],
+        queue: [{ id: "packaged-recovered-item", job_id: "packaged-recovered", provider: "chatgpt", native_id: "one", state: "captured_waiting_receiver", content_hash: "hash-1" }],
+        revisions: [],
+      },
+    };
+    const pageRequestCount = pageRequests.length;
+    const recoveredWorkerUrl = `${pathToFileURL(join(unpacked, "src", "background.js")).href}?recovery=${Date.now()}`;
+    await import(/* @vite-ignore */ recoveredWorkerUrl);
+    const recoveredStatus = await send({ type: "polylogue.backfill.status" });
+    expect(recoveredStatus.jobs[0]).toMatchObject({
+      id: "packaged-recovered", status: "paused", cooldown_reason: "browser_profile_recovery_required",
+      progress: { operator_action: 1 },
+    });
+    alarmListener({ name: "polylogueBackfillWake:packaged-recovered" });
+    await Promise.resolve();
+    expect(pageRequests).toHaveLength(pageRequestCount);
     rmSync(smokeRoot, { recursive: true, force: true });
   });
 });

--- a/browser-extension/tests/build.test.js
+++ b/browser-extension/tests/build.test.js
@@ -186,9 +186,9 @@ describe("build.mjs full archive emission", () => {
       const contentHash = createHash("sha256").update(options.body, "utf8").digest("hex");
       receiverPosts += 1;
       body = receiverPosts === 1
-        ? { ok: true, provider: "chatgpt", provider_session_id: "fixture-1" }
+        ? { ok: true, provider: "chatgpt", provider_session_id: "fixture-1", content_hash: contentHash }
         : { ok: true, provider: "chatgpt", provider_session_id: "fixture-1", content_hash: contentHash };
-      return { ok: true, status: 200, headers: { get: (name) => name === "X-Request-ID" ? "packaged-ack" : null }, json: async () => body };
+      return { ok: true, status: 200, headers: { get: (name) => name === "X-Request-ID" && receiverPosts > 1 ? "packaged-ack" : null }, json: async () => body };
     });
     const packagedWorkerUrl = `${pathToFileURL(join(unpacked, "src", "background.js")).href}?smoke=${Date.now()}`;
     await import(/* @vite-ignore */ packagedWorkerUrl);
@@ -202,7 +202,11 @@ describe("build.mjs full archive emission", () => {
     alarmListener({ name: `polylogueBackfillWake:${started.job.id}` });
     await vi.waitFor(() => expect(receiverPosts).toBe(1));
     const paused = await send({ type: "polylogue.backfill.status" });
-    expect(paused.jobs[0]).toMatchObject({ status: "paused", cooldown_reason: "receiver_contract_incompatible" });
+    expect(paused.jobs[0]).toMatchObject({
+      status: "paused",
+      cooldown_reason: "receiver_contract_incompatible",
+      last_error: "receiver_contract_incompatible:missing_receiver_request_id",
+    });
     expect(receiverPosts).toBe(1);
     await send({ type: "polylogue.backfill.control", job_id: started.job.id, action: "resume" });
     alarmListener({ name: `polylogueBackfillWake:${started.job.id}` });

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -75,7 +75,7 @@ function installDom() {
   dom.window.HTMLAnchorElement.prototype.click = vi.fn();
 }
 
-function installChromeMock(storagePatch = {}, tabs = [CHATGPT_TAB]) {
+function installChromeMock(storagePatch = {}, tabs = [CHATGPT_TAB], sendMessage = null) {
   let captureAttempts = 0;
   const defaults = {
     polylogueCaptureLog: [],
@@ -87,7 +87,7 @@ function installChromeMock(storagePatch = {}, tabs = [CHATGPT_TAB]) {
   };
   globalThis.chrome = {
     runtime: {
-      sendMessage: vi.fn(async () => ({ ok: true })),
+      sendMessage: vi.fn(async (message) => sendMessage ? sendMessage(message) : ({ ok: true })),
     },
     scripting: {
       executeScript: vi.fn(async () => undefined),
@@ -115,10 +115,10 @@ function installChromeMock(storagePatch = {}, tabs = [CHATGPT_TAB]) {
   };
 }
 
-async function loadPopup(storagePatch = {}, tabs = [CHATGPT_TAB]) {
+async function loadPopup(storagePatch = {}, tabs = [CHATGPT_TAB], sendMessage = null) {
   vi.resetModules();
   installDom();
-  installChromeMock(storagePatch, tabs);
+  installChromeMock(storagePatch, tabs, sendMessage);
   await import("../src/operator_status.js");
   await import("../src/popup.js");
   await vi.waitFor(() => expect(globalThis.document.getElementById("page").textContent).not.toContain("Unknown"));
@@ -218,6 +218,29 @@ describe("popup capture", () => {
     expect(globalThis.document.getElementById("badge").textContent).toBe("missing");
     expect(globalThis.document.getElementById("archive").textContent).toBe("Not archived");
     expect(globalThis.document.getElementById("state").textContent).toContain("not been saved");
+  });
+
+  it("names a stale receiver ACK contract and recovery loss as actionable backfill states", async () => {
+    const job = (cooldown_reason) => ({
+      id: `job-${cooldown_reason}`,
+      provider: "chatgpt",
+      status: "paused",
+      cooldown_reason,
+      inventory_cursor: "17",
+      learned_cadence_ms: 40000,
+      progress: { total: 1, complete: 0, retry: 1, no_turns: 0, error: 0, operator_action: 0 },
+    });
+    await loadPopup({}, [CHATGPT_TAB], async (message) => message.type === "polylogue.backfill.status"
+      ? { ok: true, jobs: [job("receiver_contract_incompatible")] }
+      : { ok: true });
+    await vi.waitFor(() => expect(document.getElementById("backfill-status").textContent).toContain("receiver upgrade required"));
+    expect(document.getElementById("backfill-last").textContent).toContain("Upgrade/restart receiver");
+
+    await loadPopup({}, [CHATGPT_TAB], async (message) => message.type === "polylogue.backfill.status"
+      ? { ok: true, jobs: [job("browser_profile_recovery_required")] }
+      : { ok: true });
+    await vi.waitFor(() => expect(document.getElementById("backfill-status").textContent).toContain("profile recovery required"));
+    expect(document.getElementById("backfill-last").textContent).toContain("profile was replaced");
   });
 
   it("renders mission-control status, open tabs, and the active decision timeline", async () => {

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -241,6 +241,7 @@ describe("popup capture", () => {
       : { ok: true });
     await vi.waitFor(() => expect(document.getElementById("backfill-status").textContent).toContain("profile recovery required"));
     expect(document.getElementById("backfill-last").textContent).toContain("profile was replaced");
+    expect(document.getElementById("backfill-resume").disabled).toBe(true);
   });
 
   it("renders mission-control status, open tabs, and the active decision timeline", async () => {

--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -243,6 +243,18 @@ class BrowserCaptureAcceptedPayload(BaseModel):
     capture_instance_id: str | None = None
 
 
+class BrowserCaptureCapabilitiesPayload(BaseModel):
+    """Receiver-declared browser-capture contract required before backfill."""
+
+    ok: Literal[True] = True
+    receiver: Literal["polylogue-browser-capture"] = BROWSER_CAPTURE_RECEIVER
+    schema_version: Literal[1] = BROWSER_CAPTURE_SCHEMA_VERSION
+    durable_ack_fields: tuple[Literal["receiver_request_id"], Literal["content_hash"]] = (
+        "receiver_request_id",
+        "content_hash",
+    )
+
+
 class BrowserCaptureErrorPayload(BaseModel):
     """Safe receiver error payload with no paths or stack traces."""
 
@@ -373,6 +385,7 @@ __all__ = [
     "BROWSER_CAPTURE_SCHEMA_VERSION",
     "BROWSER_CAPTURE_TRANSPORT_SOURCE",
     "BrowserCaptureAcceptedPayload",
+    "BrowserCaptureCapabilitiesPayload",
     "BrowserCaptureArchiveLifecycle",
     "BrowserCaptureArchiveStatePayload",
     "BrowserCaptureAttachment",

--- a/polylogue/browser_capture/route_contracts.py
+++ b/polylogue/browser_capture/route_contracts.py
@@ -13,6 +13,7 @@ from typing import Literal
 
 BrowserCaptureAuthPolicy = Literal["extension_origin", "bearer_if_web_origin", "bearer_if_configured"]
 BrowserCaptureRouteKind = Literal[
+    "capabilities",
     "status",
     "archive_state",
     "capture_ingest",
@@ -36,6 +37,15 @@ class BrowserCaptureRouteContract:
 
 
 BROWSER_CAPTURE_ROUTE_CONTRACTS: tuple[BrowserCaptureRouteContract, ...] = (
+    BrowserCaptureRouteContract(
+        "GET",
+        "/v1/browser-captures/capabilities",
+        "capabilities",
+        "bearer_if_configured",
+        None,
+        "BrowserCaptureCapabilitiesPayload",
+        "Declares the durable acknowledgement fields required by browser backfill.",
+    ),
     BrowserCaptureRouteContract(
         "GET",
         "/v1/status",

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -18,6 +18,7 @@ from pydantic import ValidationError
 from polylogue.browser_capture.models import (
     BROWSER_CAPTURE_EXTENSION_ORIGIN_WILDCARD,
     BrowserCaptureAcceptedPayload,
+    BrowserCaptureCapabilitiesPayload,
     BrowserCaptureEnvelope,
     BrowserCaptureErrorPayload,
     BrowserPostAckPayload,
@@ -199,6 +200,9 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
         if self._reject_origin() or self._reject_token():
             return
         parsed = urlparse(self.path)
+        if parsed.path == "/v1/browser-captures/capabilities":
+            self._send_json(HTTPStatus.OK, BrowserCaptureCapabilitiesPayload().model_dump(mode="json"))
+            return
         if parsed.path == "/v1/status":
             self._send_json(HTTPStatus.OK, receiver_status_payload(self.server.config))
             return

--- a/tests/unit/browser_capture/test_receiver.py
+++ b/tests/unit/browser_capture/test_receiver.py
@@ -19,6 +19,7 @@ from click.testing import CliRunner
 from polylogue.browser_capture.models import (
     BrowserCaptureAcceptedPayload,
     BrowserCaptureArchiveStatePayload,
+    BrowserCaptureCapabilitiesPayload,
     BrowserCaptureEnvelope,
     BrowserCaptureErrorPayload,
     BrowserCaptureReceiverStatusPayload,
@@ -385,6 +386,7 @@ def test_browser_capture_route_contracts_cover_receiver_boundary() -> None:
     concrete_routes = {(contract.method, contract.pattern) for contract in BROWSER_CAPTURE_ROUTE_CONTRACTS}
 
     assert ("GET", "/v1/status") in concrete_routes
+    assert ("GET", "/v1/browser-captures/capabilities") in concrete_routes
     assert ("GET", "/v1/archive-state") in concrete_routes
     assert ("POST", "/v1/browser-captures") in concrete_routes
     assert browser_capture_route_contract_for("POST", "/v1/browser-captures") is not None
@@ -398,6 +400,16 @@ def test_receiver_rejects_web_origins_by_default(tmp_path: Path) -> None:
     assert response.status == HTTPStatus.FORBIDDEN
     assert response.getheader("X-Request-ID")
     assert error.error == "origin_not_allowed"
+
+
+def test_receiver_declares_durable_browser_backfill_ack_contract(tmp_path: Path) -> None:
+    with _running_receiver(tmp_path) as (host, port):
+        response = _request(host, port, "GET", "/v1/browser-captures/capabilities", origin=_EXTENSION_ORIGIN)
+        body = BrowserCaptureCapabilitiesPayload.model_validate(json.loads(response.read()))
+
+    assert response.status == HTTPStatus.OK
+    assert response.getheader("X-Request-ID")
+    assert body.durable_ack_fields == ("receiver_request_id", "content_hash")
 
 
 def test_receiver_rejects_extra_web_origin_without_token(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Makes browser backfill reject incompatible durable acknowledgements, preserve recovery evidence across worker or profile loss, and serialize operator controls safely.

## Problem

A receiver could accept a capture without proving the durable acknowledgement contract, while profile replacement could erase the IndexedDB ledger. A slow resume preflight could also race a later operator cancel.

## Solution

- Preflight declared receiver capabilities on start, resume, and every new service-worker lifetime.
- Require a receiver-returned `X-Request-ID` plus the exact content hash before treating a capture as acknowledged.
- Persist a credential-free recovery checkpoint; expose checkpoint-write failure without aborting durable IndexedDB work.
- Restore profile-loss evidence as an explicit paused recovery state and serialize per-job controls so cancel wins over a delayed resume.
- Render receiver-contract, profile-recovery, and checkpoint-copy failures distinctly in the popup.

## Acceptance matrix

| Bead | Status | Evidence |
| --- | --- | --- |
| polylogue-jlme.3 AC1 | satisfied | Missing durable fields or a receiver-returned request ID pause once while retaining the stored envelope. |
| polylogue-jlme.3 AC2 | satisfied | Popup renders receiver-upgrade guidance rather than a receiver-down retry. |
| polylogue-jlme.3 AC3 | satisfied | Explicit compatible resume drains the saved envelope without a provider refetch. |
| polylogue-jlme.3 AC4 | satisfied | Packaged worker fixture covers preflight, stale ACK pause, resume, and no foreground activation. |
| polylogue-jlme.4 AC1 | satisfied | Real fake-IndexedDB restart coverage preserves job, cursor, queue/revisions, ACK, and exactly-once work. |
| polylogue-jlme.4 AC2 | satisfied | Credential-free checkpoint restoration is explicit; companion Sinnix PR #1 is merged and preserves extension local settings on ordinary restart/reseed. |
| polylogue-jlme.4 AC3 | satisfied | Checkpoint tests exclude provider options, raw envelopes, receipts, cookies, and account identifiers. |
| polylogue-jlme.4 AC4 | satisfied | Packaged recovery fixture plus private-profile stale-lock/reseed smoke cover the browser and control-plane paths. |

## Verification

- `npm test` — 204 passed.
- `npm test -- --run tests/backfill.test.js` — 36 passed.
- `npm run lint` and `npm run validate` — clean; manifest valid.
- `devtools test tests/unit/browser_capture/test_receiver.py` — 34 passed.
- `devtools verify --quick` — 15/15 steps passed (`20260713T014640Z-quick-2575750-c65b5b95`).
- Sinnix companion: shell syntax, temporary stale-lock smoke, and NixOS toplevel evaluation passed; PR #1 merged as `3e9b54e`.

GitHub Actions checks dispatched as immediate runner failures with empty step lists and no retrievable failed logs; the affected local gates above are green.

Ref polylogue-jlme.3, polylogue-jlme.4, polylogue-jlme.4.1.

## Adversarial review notes

Two independent cold passes found and then verified fixes for checkpoint isolation, receiver preflight/ACK races, restored recovery state, stale Chrome locks, and concurrent resume/cancel ordering. Final pass: clear.
