### PR TITLE
fix(browser): preserve canonical origin authority

### DIFF
--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -1668,6 +1668,77 @@ def quarantined_accepted_raws_command(
         click.echo(f"Receipt: {report.receipt_path}")
 
 
+@maintenance_group.command("browser-capture-origin-mismatches")
+@click.option("--raw-id", "raw_ids", multiple=True, required=True, help="Exact mismatched raw id (repeatable).")
+@click.option("--apply", "apply_changes", is_flag=True, help="Copy forward only after every target passes proof.")
+@click.option("--proof-digest", help="Exact aggregate digest emitted by the matching dry-run.")
+@click.option(
+    "--receipt",
+    "receipt_path",
+    type=click.Path(path_type=Path, dir_okay=False),
+    help="Required append-only operator recovery receipt path for --apply.",
+)
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+)
+@click.pass_obj
+def browser_capture_origin_mismatches_command(
+    env: AppEnv,
+    raw_ids: tuple[str, ...],
+    apply_changes: bool,
+    proof_digest: str | None,
+    receipt_path: Path | None,
+    output_format: str,
+) -> None:
+    """Copy mismatched browser captures forward under parsed origin authority.
+
+    The old raw, blob, membership, byte head, and application receipts remain
+    immutable.  Apply creates a new raw reference to the exact retained blob,
+    records a canonical head, and advances only the derived session raw pointer.
+    """
+    del env
+    if apply_changes and receipt_path is None:
+        raise click.UsageError("--apply requires --receipt PATH")
+    if apply_changes and proof_digest is None:
+        raise click.UsageError("--apply requires --proof-digest from the exact dry-run")
+    root = archive_root()
+    config = Config(archive_root=root, render_root=render_root(), sources=[], db_path=root / "index.db")
+    from polylogue.storage.repair import repair_browser_capture_origin_mismatches
+
+    try:
+        report = repair_browser_capture_origin_mismatches(
+            config,
+            list(raw_ids),
+            apply=apply_changes,
+            receipt_path=receipt_path,
+            proof_digest=proof_digest,
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    payload = asdict(report)
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    click.echo(
+        f"{report.mode}: requested={report.requested_count} eligible={report.eligible_count} "
+        f"already_repaired={report.already_repaired_count} repaired={report.repaired_count} "
+        f"ineligible={report.ineligible_count}"
+    )
+    click.echo(f"Proof digest: {report.proof_digest}")
+    for item in report.items:
+        click.echo(
+            f"  {item.raw_id} {item.status} strategy={item.repair_strategy or 'unavailable'} "
+            f"replacement={item.replacement_raw_id or 'unavailable'} "
+            f"proof={item.proof_digest or 'unavailable'}: {item.reason}"
+        )
+    if report.receipt_path is not None:
+        click.echo(f"Receipt: {report.receipt_path}")
+
+
 @maintenance_group.command("preview")
 @click.option(
     "--scope",

--- a/polylogue/sources/source_acquisition_components.py
+++ b/polylogue/sources/source_acquisition_components.py
@@ -376,7 +376,7 @@ def _stream_browser_capture_provider(blob_store: BlobStore, blob_hash: str) -> P
                     break
     except ijson.JSONError:
         return Provider.UNKNOWN
-    if capture_kind != "browser_llm_session" or provider in {None, Provider.UNKNOWN}:
+    if capture_kind != "browser_llm_session" or provider is None or provider is Provider.UNKNOWN:
         return Provider.UNKNOWN
     return provider
 

--- a/polylogue/sources/source_acquisition_components.py
+++ b/polylogue/sources/source_acquisition_components.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import IO, TypeAlias
 
+import ijson
+
 from polylogue.archive.artifact_taxonomy import classify_artifact
 from polylogue.config import Source
 from polylogue.core.enums import Provider
@@ -327,6 +329,8 @@ def read_plain_source_file(context: SourceReadContext) -> RawSessionData:
             context.provider_hint,
             truncated_tail_ok=blob_size > len(prefix),
         )
+        if detected_provider is Provider.UNKNOWN and context.source.name == "browser-capture":
+            detected_provider = _stream_browser_capture_provider(context.blob_store, blob_hash)
         from polylogue.storage.blob_publication import publication_receipt_id
 
         publication_id = publication_receipt_id(context.blob_store, blob_hash)
@@ -346,6 +350,35 @@ def read_plain_source_file(context: SourceReadContext) -> RawSessionData:
         blob_size=blob_size,
         blob_publication_receipt_id=publication_id,
     )
+
+
+def _stream_browser_capture_provider(blob_store: BlobStore, blob_hash: str) -> Provider:
+    """Read the typed envelope provider without materializing a large capture.
+
+    Native browser captures can place a multi-megabyte ``raw_provider_payload``
+    before ``session.provider``.  Prefix detection therefore cannot prove the
+    provider even though the complete retained artifact can.  Parse the scalar
+    event stream until both the envelope kind and nested provider are known;
+    ijson keeps this bounded regardless of the native payload size.
+    """
+    capture_kind: str | None = None
+    provider: Provider | None = None
+    try:
+        with blob_store.open(blob_hash) as handle:
+            for prefix, event, value in ijson.parse(handle):
+                if event != "string":
+                    continue
+                if prefix == "polylogue_capture_kind":
+                    capture_kind = str(value)
+                elif prefix == "session.provider":
+                    provider = Provider.from_string(str(value))
+                if capture_kind is not None and provider is not None:
+                    break
+    except ijson.JSONError:
+        return Provider.UNKNOWN
+    if capture_kind != "browser_llm_session" or provider in {None, Provider.UNKNOWN}:
+        return Provider.UNKNOWN
+    return provider
 
 
 def _stream_preserved_zip_entry(

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -1087,6 +1087,200 @@ def _browser_origin_copy_raw_id(
     return digest.hexdigest()
 
 
+def _verify_browser_origin_copy_forward_source_stage(
+    archive_root: Path,
+    conn: sqlite3.Connection,
+    item: BrowserCaptureOriginRepairItem,
+) -> None:
+    """Reprove source-only witnesses while its write transaction is held."""
+    assert item.canonical_origin is not None
+    assert item.canonical_provider is not None
+    assert item.canonical_logical_source_key is not None
+    assert item.session_id is not None
+    assert item.old_logical_source_key is not None
+    assert item.source_path is not None
+    assert item.source_index is not None
+    assert item.blob_hash is not None
+    assert item.blob_size is not None
+    assert item.accepted_content_hash is not None
+    raw = conn.execute(
+        """
+        SELECT origin, source_path, source_index, blob_hash, blob_size,
+               logical_source_key, revision_kind, source_revision, baseline_raw_id,
+               acquisition_generation, revision_authority
+        FROM raw_sessions WHERE raw_id = ?
+        """,
+        (item.raw_id,),
+    ).fetchone()
+    expected = (
+        Origin.UNKNOWN_EXPORT.value,
+        item.source_path,
+        item.source_index,
+        bytes.fromhex(item.blob_hash),
+        item.blob_size,
+        item.old_logical_source_key,
+        RawRevisionKind.FULL.value,
+        item.blob_hash,
+        None,
+        0,
+        RawRevisionAuthority.QUARANTINED.value,
+    )
+    if raw is None or tuple(raw) != expected:
+        raise RuntimeError(f"source evidence changed before copy-forward stage for {item.raw_id}")
+    blob_ref = conn.execute(
+        """
+        SELECT blob_hash, size_bytes FROM blob_refs
+        WHERE ref_id = ? AND ref_type = 'raw_payload'
+        """,
+        (item.raw_id,),
+    ).fetchone()
+    if blob_ref is None or tuple(blob_ref) != (bytes.fromhex(item.blob_hash), item.blob_size):
+        raise RuntimeError(f"raw blob reference changed before copy-forward stage for {item.raw_id}")
+    store = BlobStore(archive_root / "blob")
+    payload = store.read_all(item.blob_hash)
+    if len(payload) != item.blob_size or hashlib.sha256(payload).hexdigest() != item.blob_hash:
+        raise RuntimeError(f"retained blob changed before copy-forward stage for {item.raw_id}")
+    try:
+        provider = detect_provider(json.loads(payload))
+        if provider is None or provider.value != item.canonical_provider:
+            raise ValueError("provider identity changed")
+        from polylogue.sources.revision_backfill import _parse_one
+
+        sessions = _parse_one(provider, payload, item.source_path)
+    except Exception as exc:
+        raise RuntimeError(f"browser parser evidence changed before copy-forward stage for {item.raw_id}") from exc
+    if len(sessions) != 1 or str(make_session_id(provider, sessions[0].provider_session_id)) != item.session_id:
+        raise RuntimeError(f"normalized session identity changed before copy-forward stage for {item.raw_id}")
+    projection = session_revision_projection(sessions[0])
+    if projection.session_hash.hex() != item.accepted_content_hash:
+        raise RuntimeError(f"normalized session content changed before copy-forward stage for {item.raw_id}")
+    membership = conn.execute(
+        """
+        SELECT provider_session_id, source_revision, normalized_content_hash,
+               message_count, acquisition_generation, revision_authority, decision
+        FROM raw_session_memberships WHERE raw_id = ? AND logical_source_key = ?
+        """,
+        (item.raw_id, item.canonical_logical_source_key),
+    ).fetchone()
+    census = conn.execute(
+        "SELECT status, member_count FROM raw_membership_census WHERE raw_id = ?", (item.raw_id,)
+    ).fetchone()
+    if (
+        membership is None
+        or tuple(membership)
+        != (
+            sessions[0].provider_session_id,
+            item.accepted_content_hash,
+            projection.session_hash,
+            len(projection.message_hashes),
+            0,
+            RawRevisionAuthority.QUARANTINED.value,
+            "applied",
+        )
+        or census is None
+        or tuple(census) != ("complete", 1)
+    ):
+        raise RuntimeError(f"membership evidence changed before copy-forward stage for {item.raw_id}")
+
+
+def _canonical_browser_origin_head_is_exact(
+    conn: sqlite3.Connection,
+    *,
+    canonical_head: sqlite3.Row,
+    canonical_key: str,
+    canonical_origin: Origin,
+    session_id: str,
+    accepted_hash: bytes,
+    message_count: int,
+) -> bool:
+    """Return whether an existing canonical head has full byte authority witnesses."""
+    raw_id = str(canonical_head["accepted_raw_id"])
+    source_revision = str(canonical_head["accepted_source_revision"])
+    frontier = int(canonical_head["accepted_frontier"])
+    generation = int(canonical_head["acquisition_generation"])
+    raw = conn.execute(
+        """
+        SELECT origin, blob_hash, blob_size, logical_source_key, revision_kind,
+               source_revision, baseline_raw_id, acquisition_generation, revision_authority
+        FROM source.raw_sessions WHERE raw_id = ?
+        """,
+        (raw_id,),
+    ).fetchone()
+    blob_ref = conn.execute(
+        "SELECT blob_hash, size_bytes FROM source.blob_refs WHERE ref_id = ? AND ref_type = 'raw_payload'",
+        (raw_id,),
+    ).fetchone()
+    membership = conn.execute(
+        """
+        SELECT provider_session_id, source_revision, normalized_content_hash, message_count,
+               acquisition_generation, revision_authority, decision
+        FROM source.raw_session_memberships WHERE raw_id = ? AND logical_source_key = ?
+        """,
+        (raw_id, canonical_key),
+    ).fetchone()
+    census = conn.execute(
+        "SELECT status, member_count FROM source.raw_membership_census WHERE raw_id = ?", (raw_id,)
+    ).fetchone()
+    application = conn.execute(
+        """
+        SELECT session_id, source_revision, acquisition_generation, decision, accepted_raw_id,
+               accepted_source_revision, accepted_content_hash, baseline_raw_id
+        FROM raw_revision_applications
+        WHERE raw_id = ? AND logical_source_key = ? AND decision = 'selected_baseline'
+        """,
+        (raw_id, canonical_key),
+    ).fetchone()
+    native_id = session_id.split(":", 1)[1]
+    if (
+        raw is None
+        or blob_ref is None
+        or membership is None
+        or census is None
+        or application is None
+        or str(canonical_head["session_id"]) != session_id
+        or _bytes_value(canonical_head["accepted_content_hash"]) != accepted_hash
+        or str(canonical_head["accepted_frontier_kind"]) != "byte"
+    ):
+        return False
+    return (
+        tuple(raw)
+        == (
+            canonical_origin.value,
+            bytes.fromhex(source_revision),
+            frontier,
+            canonical_key,
+            RawRevisionKind.FULL.value,
+            source_revision,
+            raw_id,
+            generation,
+            RawRevisionAuthority.BYTE_PROVEN.value,
+        )
+        and tuple(blob_ref) == (bytes.fromhex(source_revision), frontier)
+        and tuple(membership)
+        == (
+            native_id,
+            source_revision,
+            accepted_hash,
+            message_count,
+            generation,
+            RawRevisionAuthority.BYTE_PROVEN.value,
+            "applied",
+        )
+        and tuple(census) == ("complete", 1)
+        and tuple(application)
+        == (
+            session_id,
+            source_revision,
+            generation,
+            ApplicationDecision.SELECTED_BASELINE.value,
+            raw_id,
+            source_revision,
+            accepted_hash,
+            raw_id,
+        )
+    )
+
+
 def _inspect_browser_capture_origin_mismatch(
     archive_root: Path,
     raw_id: str,
@@ -1248,7 +1442,8 @@ def _inspect_browser_capture_origin_mismatch(
     canonical_head = conn.execute(
         """
         SELECT session_id, accepted_raw_id, accepted_source_revision,
-               accepted_content_hash, accepted_frontier_kind, accepted_frontier
+               accepted_content_hash, accepted_frontier_kind, accepted_frontier,
+               acquisition_generation
         FROM raw_revision_heads WHERE logical_source_key = ?
         """,
         (canonical_key,),
@@ -1358,15 +1553,14 @@ def _inspect_browser_capture_origin_mismatch(
         replacement_source_revision = str(canonical_head["accepted_source_revision"])
         replacement_frontier_kind = str(canonical_head["accepted_frontier_kind"])
         replacement_frontier = int(canonical_head["accepted_frontier"])
-        replacement_source = conn.execute(
-            "SELECT origin FROM source.raw_sessions WHERE raw_id = ?",
-            (replacement_raw_id,),
-        ).fetchone()
-        if (
-            str(canonical_head["session_id"]) != session_id
-            or _bytes_value(canonical_head["accepted_content_hash"]) != accepted_hash
-            or replacement_source is None
-            or str(replacement_source["origin"]) != canonical_origin.value
+        if not _canonical_browser_origin_head_is_exact(
+            conn,
+            canonical_head=canonical_head,
+            canonical_key=canonical_key,
+            canonical_origin=canonical_origin,
+            session_id=session_id,
+            accepted_hash=accepted_hash,
+            message_count=len(projection.message_hashes),
         ):
             return _browser_origin_ineligible(raw_id, "canonical logical source has an incompatible accepted head")
         supersession = conn.execute(
@@ -1796,6 +1990,7 @@ def repair_browser_capture_origin_mismatches(
                                 and item.repair_strategy == "copy_forward"
                                 and not item.copy_forward_source_complete
                             ):
+                                _verify_browser_origin_copy_forward_source_stage(archive_root, source_conn, item)
                                 _stage_browser_origin_copy_forward_source(source_conn, item)
                         source_conn.commit()
                     except Exception:

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -11,7 +11,7 @@ import re
 import sqlite3
 import time
 from collections.abc import Callable
-from contextlib import closing
+from contextlib import closing, suppress
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -23,6 +23,7 @@ from polylogue.archive.revision_authority import (
     RawRevisionAuthority,
     RawRevisionKind,
 )
+from polylogue.archive.revision_replay import ApplicationDecision
 from polylogue.config import Config
 from polylogue.core.enums import Origin, Provider
 from polylogue.core.json import JSONDocument, json_document
@@ -37,10 +38,10 @@ from polylogue.maintenance.targets import (
     build_maintenance_target_catalog,
 )
 from polylogue.paths import archive_file_set_root_for_paths
-from polylogue.pipeline.ids import session_content_hash
+from polylogue.pipeline.ids import session_content_hash, session_revision_projection
 from polylogue.pipeline.ids import session_id as make_session_id
 from polylogue.protocols import ProgressCallback
-from polylogue.sources.dispatch import is_stream_record_provider
+from polylogue.sources.dispatch import detect_provider, is_stream_record_provider
 from polylogue.storage.blob_repair import count_orphaned_blobs_sync, repair_orphaned_blobs_data
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.insights.session.repair_assessment import (
@@ -64,6 +65,7 @@ _QUARANTINED_ACCEPTED_RAW_REPAIR_LIMIT = 100
 _QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES = 256 * 1024 * 1024
 _QUARANTINED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES = 512 * 1024 * 1024
 _QUARANTINED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA = "polylogue.quarantined-accepted-raw-repair.v1"
+_BROWSER_CAPTURE_ORIGIN_REPAIR_RECEIPT_SCHEMA = "polylogue.browser-capture-origin-copy-forward.v1"
 _LEGACY_YLA_AUTHORITY_RAW_IDS = frozenset(
     {
         "a7d004c9aa943f6a10211851904105ee1c647c331552646e1b9cbe268940ed11",
@@ -156,6 +158,48 @@ class QuarantinedAcceptedRawRepairReport:
     proof_digest: str
     receipt_path: str | None
     items: tuple[QuarantinedAcceptedRawRepairItem, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserCaptureOriginRepairItem:
+    raw_id: str
+    status: str
+    reason: str
+    origin: str | None = None
+    source_path: str | None = None
+    source_index: int | None = None
+    blob_hash: str | None = None
+    blob_size: int | None = None
+    old_logical_source_key: str | None = None
+    canonical_provider: str | None = None
+    canonical_origin: str | None = None
+    canonical_logical_source_key: str | None = None
+    session_id: str | None = None
+    accepted_content_hash: str | None = None
+    accepted_frontier: int | None = None
+    repair_strategy: str | None = None
+    replacement_raw_id: str | None = None
+    replacement_source_revision: str | None = None
+    replacement_frontier_kind: str | None = None
+    replacement_frontier: int | None = None
+    copy_forward_raw_id: str | None = None
+    copy_forward_source_path: str | None = None
+    evidence_digest: str | None = None
+    proof_digest: str | None = None
+    repaired: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserCaptureOriginRepairReport:
+    mode: str
+    requested_count: int
+    eligible_count: int
+    repaired_count: int
+    already_repaired_count: int
+    ineligible_count: int
+    proof_digest: str
+    receipt_path: str | None
+    items: tuple[BrowserCaptureOriginRepairItem, ...]
 
 
 def _quarantined_raw_item(raw_id: str, reason: str) -> QuarantinedAcceptedRawRepairItem:
@@ -998,6 +1042,773 @@ def repair_quarantined_accepted_raws(
         already_repaired_count=sum(item.status == "already_repaired" for item in items),
         ineligible_count=sum(item.status == "ineligible" for item in items),
         proof_digest=aggregate_proof,
+        receipt_path=str(receipt_path) if receipt_path is not None else None,
+        items=tuple(items),
+    )
+
+
+def _browser_origin_ineligible(raw_id: str, reason: str) -> BrowserCaptureOriginRepairItem:
+    return BrowserCaptureOriginRepairItem(raw_id=raw_id, status="ineligible", reason=reason)
+
+
+def _browser_origin_item_payload(item: BrowserCaptureOriginRepairItem) -> dict[str, object]:
+    return {
+        key: value
+        for key, value in dataclasses.asdict(item).items()
+        if key not in {"status", "reason", "proof_digest", "repaired"}
+    }
+
+
+def _browser_origin_item_digest(item: BrowserCaptureOriginRepairItem) -> str:
+    return hashlib.sha256(
+        json.dumps(_browser_origin_item_payload(item), sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+
+
+def _browser_origin_proof_digest(items: list[BrowserCaptureOriginRepairItem]) -> str:
+    return hashlib.sha256(json.dumps([item.proof_digest for item in items], separators=(",", ":")).encode()).hexdigest()
+
+
+def _browser_origin_copy_raw_id(
+    origin: Origin,
+    source_path: str,
+    source_index: int,
+    blob_hash: bytes,
+    native_id: str,
+) -> str:
+    digest = hashlib.sha256()
+    for value in (origin.value, source_path, str(source_index)):
+        digest.update(value.encode("utf-8", errors="surrogatepass"))
+        digest.update(b"\0")
+    digest.update(blob_hash)
+    digest.update(b"\0")
+    digest.update(native_id.encode("utf-8", errors="surrogatepass"))
+    return digest.hexdigest()
+
+
+def _inspect_browser_capture_origin_mismatch(
+    archive_root: Path,
+    raw_id: str,
+    *,
+    conn: sqlite3.Connection,
+) -> BrowserCaptureOriginRepairItem:
+    conn.row_factory = sqlite3.Row
+    raw = conn.execute(
+        """
+        SELECT raw_id, origin, native_id, source_path, source_index, blob_hash,
+               blob_size, logical_source_key, revision_kind, source_revision,
+               predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
+               append_start_offset, append_end_offset, acquisition_generation,
+               revision_authority
+        FROM source.raw_sessions WHERE raw_id = ?
+        """,
+        (raw_id,),
+    ).fetchone()
+    if raw is None:
+        return _browser_origin_ineligible(raw_id, "source raw is missing")
+    if str(raw["origin"]) != Origin.UNKNOWN_EXPORT.value:
+        return _browser_origin_ineligible(raw_id, "source raw is not typed under unknown-export")
+    source_path = str(raw["source_path"])
+    if "browser-capture" not in source_path:
+        return _browser_origin_ineligible(raw_id, "source raw is not a browser-capture artifact")
+    if (
+        str(raw["revision_kind"]) != RawRevisionKind.FULL.value
+        or str(raw["revision_authority"]) != RawRevisionAuthority.QUARANTINED.value
+        or raw["source_revision"] is None
+        or raw["acquisition_generation"] is None
+        or any(
+            raw[name] is not None
+            for name in (
+                "predecessor_source_revision",
+                "predecessor_raw_id",
+                "baseline_raw_id",
+                "append_start_offset",
+                "append_end_offset",
+            )
+        )
+    ):
+        return _browser_origin_ineligible(raw_id, "source raw is not the exact quarantined full mismatch shape")
+    blob_hash = _bytes_value(raw["blob_hash"])
+    blob_size = int(raw["blob_size"])
+    if len(blob_hash) != 32 or blob_size < 1 or blob_size > _QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES:
+        return _browser_origin_ineligible(raw_id, "retained browser capture exceeds the bounded proof shape")
+    blob_hash_hex = blob_hash.hex()
+    if str(raw["source_revision"]) != blob_hash_hex:
+        return _browser_origin_ineligible(raw_id, "source revision does not equal the retained blob digest")
+    blob_ref = conn.execute(
+        """
+        SELECT blob_hash, source_path, size_bytes FROM source.blob_refs
+        WHERE ref_id = ? AND ref_type = 'raw_payload'
+        """,
+        (raw_id,),
+    ).fetchone()
+    if blob_ref is None or _bytes_value(blob_ref["blob_hash"]) != blob_hash or int(blob_ref["size_bytes"]) != blob_size:
+        return _browser_origin_ineligible(raw_id, "raw payload blob reference does not match the source envelope")
+    store = BlobStore(archive_root / "blob")
+    blob_path = store.blob_path(blob_hash_hex)
+    if not blob_path.is_file() or blob_path.stat().st_size != blob_size:
+        return _browser_origin_ineligible(raw_id, "retained raw blob is missing or has the wrong size")
+    payload = store.read_all(blob_hash_hex)
+    if hashlib.sha256(payload).digest() != blob_hash:
+        return _browser_origin_ineligible(raw_id, "retained raw blob digest does not match durable source evidence")
+    try:
+        decoded = json.loads(payload)
+        provider = detect_provider(decoded)
+        if provider is None or provider is Provider.UNKNOWN:
+            return _browser_origin_ineligible(raw_id, "complete browser envelope has no canonical provider identity")
+        from polylogue.sources.revision_backfill import _parse_one
+
+        sessions = _parse_one(provider, payload, source_path)
+    except Exception as exc:
+        logger.warning(
+            "browser capture origin repair normalization failed",
+            raw_id=raw_id,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+        return _browser_origin_ineligible(
+            raw_id, f"retained browser capture did not parse cleanly: {type(exc).__name__}"
+        )
+    if len(sessions) != 1:
+        return _browser_origin_ineligible(raw_id, f"retained browser capture normalized to {len(sessions)} sessions")
+    session = sessions[0]
+    canonical_origin = origin_from_provider(provider)
+    canonical_key = f"{provider.value}:{session.provider_session_id}"
+    session_id = str(make_session_id(provider, session.provider_session_id))
+    old_key = str(raw["logical_source_key"] or "")
+    if old_key != f"{Provider.UNKNOWN.value}:{session.provider_session_id}":
+        return _browser_origin_ineligible(raw_id, "unknown source key does not match the normalized session identity")
+    if canonical_origin is Origin.UNKNOWN_EXPORT or canonical_key == old_key:
+        return _browser_origin_ineligible(raw_id, "normalized provider does not establish a different canonical origin")
+    accepted_hash = bytes.fromhex(session_content_hash(session))
+    head = conn.execute(
+        """
+        SELECT session_id, accepted_source_revision, accepted_content_hash,
+               accepted_frontier_kind, accepted_frontier, acquisition_generation
+        FROM raw_revision_heads WHERE logical_source_key = ? AND accepted_raw_id = ?
+        """,
+        (old_key, raw_id),
+    ).fetchone()
+    indexed = conn.execute(
+        "SELECT raw_id, content_hash FROM sessions WHERE session_id = ?",
+        (session_id,),
+    ).fetchone()
+    indexed_evidence = conn.execute(
+        "SELECT session_id, origin, native_id, content_hash FROM sessions WHERE session_id = ?",
+        (session_id,),
+    ).fetchone()
+    if (
+        head is None
+        or indexed is None
+        or indexed_evidence is None
+        or str(head["session_id"]) != session_id
+        or str(head["accepted_source_revision"]) != blob_hash_hex
+        or _bytes_value(head["accepted_content_hash"]) != accepted_hash
+        or str(head["accepted_frontier_kind"]) != "byte"
+        or int(head["accepted_frontier"]) != blob_size
+        or int(head["acquisition_generation"]) != int(raw["acquisition_generation"])
+        or _bytes_value(indexed["content_hash"]) != accepted_hash
+    ):
+        return _browser_origin_ineligible(raw_id, "current accepted head does not exactly prove the normalized session")
+    membership = conn.execute(
+        """
+        SELECT provider_session_id, source_revision, normalized_content_hash,
+               message_count, acquisition_generation, revision_authority, decision
+        FROM source.raw_session_memberships
+        WHERE raw_id = ? AND logical_source_key = ?
+        """,
+        (raw_id, canonical_key),
+    ).fetchone()
+    census = conn.execute(
+        "SELECT status, member_count FROM source.raw_membership_census WHERE raw_id = ?",
+        (raw_id,),
+    ).fetchone()
+    projection = session_revision_projection(session)
+    if (
+        membership is None
+        or census is None
+        or str(membership["provider_session_id"]) != session.provider_session_id
+        or _bytes_value(membership["normalized_content_hash"]) != projection.session_hash
+        or int(membership["message_count"]) != len(projection.message_hashes)
+        or int(membership["acquisition_generation"]) != int(raw["acquisition_generation"])
+        or str(membership["revision_authority"]) != RawRevisionAuthority.QUARANTINED.value
+        or str(census["status"]) != "complete"
+        or int(census["member_count"]) != 1
+    ):
+        return _browser_origin_ineligible(raw_id, "membership census does not exactly reproduce the accepted session")
+    copy_path = f"browser-capture-origin-copy-forward/{raw_id}.json"
+    copy_raw_id = _browser_origin_copy_raw_id(
+        canonical_origin,
+        copy_path,
+        int(raw["source_index"]),
+        blob_hash,
+        session.provider_session_id,
+    )
+    canonical_head = conn.execute(
+        """
+        SELECT session_id, accepted_raw_id, accepted_source_revision,
+               accepted_content_hash, accepted_frontier_kind, accepted_frontier
+        FROM raw_revision_heads WHERE logical_source_key = ?
+        """,
+        (canonical_key,),
+    ).fetchone()
+    copy_raw = conn.execute(
+        """
+        SELECT origin, native_id, source_path, source_index, blob_hash, blob_size,
+               logical_source_key, revision_kind, source_revision, baseline_raw_id,
+               acquisition_generation, revision_authority
+        FROM source.raw_sessions WHERE raw_id = ?
+        """,
+        (copy_raw_id,),
+    ).fetchone()
+    copy_membership = conn.execute(
+        """
+        SELECT provider_session_id, source_revision, normalized_content_hash,
+               message_count, acquisition_generation, revision_authority, decision
+        FROM source.raw_session_memberships
+        WHERE raw_id = ? AND logical_source_key = ?
+        """,
+        (copy_raw_id, canonical_key),
+    ).fetchone()
+    copy_census = conn.execute(
+        "SELECT status, member_count FROM source.raw_membership_census WHERE raw_id = ?",
+        (copy_raw_id,),
+    ).fetchone()
+    copy_application = conn.execute(
+        """
+        SELECT session_id, logical_source_key, source_revision, acquisition_generation,
+               decision, accepted_raw_id, accepted_source_revision, accepted_content_hash,
+               baseline_raw_id, detail
+        FROM raw_revision_applications
+        WHERE raw_id = ? AND logical_source_key = ?
+        """,
+        (copy_raw_id, canonical_key),
+    ).fetchone()
+    copy_raw_exact = copy_raw is not None and (
+        str(copy_raw["origin"]),
+        str(copy_raw["native_id"]),
+        str(copy_raw["source_path"]),
+        int(copy_raw["source_index"]),
+        _bytes_value(copy_raw["blob_hash"]),
+        int(copy_raw["blob_size"]),
+        str(copy_raw["logical_source_key"]),
+        str(copy_raw["revision_kind"]),
+        str(copy_raw["source_revision"]),
+        str(copy_raw["baseline_raw_id"]),
+        int(copy_raw["acquisition_generation"]),
+        str(copy_raw["revision_authority"]),
+    ) == (
+        canonical_origin.value,
+        session.provider_session_id,
+        copy_path,
+        int(raw["source_index"]),
+        blob_hash,
+        blob_size,
+        canonical_key,
+        RawRevisionKind.FULL.value,
+        blob_hash_hex,
+        copy_raw_id,
+        0,
+        RawRevisionAuthority.BYTE_PROVEN.value,
+    )
+    copy_forward_terminal = (
+        copy_raw_exact
+        and canonical_head is not None
+        and str(canonical_head["session_id"]) == session_id
+        and str(canonical_head["accepted_raw_id"]) == copy_raw_id
+        and _bytes_value(canonical_head["accepted_content_hash"]) == accepted_hash
+        and str(indexed["raw_id"]) == copy_raw_id
+        and copy_membership is not None
+        and str(copy_membership["provider_session_id"]) == session.provider_session_id
+        and str(copy_membership["source_revision"]) == accepted_hash.hex()
+        and _bytes_value(copy_membership["normalized_content_hash"]) == accepted_hash
+        and int(copy_membership["message_count"]) == len(projection.message_hashes)
+        and int(copy_membership["acquisition_generation"]) == 0
+        and str(copy_membership["revision_authority"]) == RawRevisionAuthority.BYTE_PROVEN.value
+        and str(copy_membership["decision"]) == "applied"
+        and copy_census is not None
+        and tuple(copy_census) == ("complete", 1)
+        and copy_application is not None
+        and tuple(copy_application)
+        == (
+            session_id,
+            canonical_key,
+            blob_hash_hex,
+            0,
+            ApplicationDecision.SELECTED_BASELINE.value,
+            copy_raw_id,
+            blob_hash_hex,
+            accepted_hash,
+            copy_raw_id,
+            f"browser_capture_origin_copy_forward:{raw_id}",
+        )
+    )
+    repair_strategy = "copy_forward"
+    replacement_raw_id = copy_raw_id
+    replacement_source_revision = blob_hash_hex
+    replacement_frontier_kind = "byte"
+    replacement_frontier = blob_size
+    already_repaired = copy_forward_terminal
+    if canonical_head is not None and not copy_forward_terminal:
+        replacement_raw_id = str(canonical_head["accepted_raw_id"])
+        replacement_source_revision = str(canonical_head["accepted_source_revision"])
+        replacement_frontier_kind = str(canonical_head["accepted_frontier_kind"])
+        replacement_frontier = int(canonical_head["accepted_frontier"])
+        replacement_source = conn.execute(
+            "SELECT origin FROM source.raw_sessions WHERE raw_id = ?",
+            (replacement_raw_id,),
+        ).fetchone()
+        if (
+            str(canonical_head["session_id"]) != session_id
+            or _bytes_value(canonical_head["accepted_content_hash"]) != accepted_hash
+            or replacement_source is None
+            or str(replacement_source["origin"]) != canonical_origin.value
+        ):
+            return _browser_origin_ineligible(raw_id, "canonical logical source has an incompatible accepted head")
+        supersession = conn.execute(
+            """
+            SELECT accepted_raw_id, accepted_source_revision, accepted_content_hash,
+                   detail FROM raw_revision_applications
+            WHERE raw_id = ? AND logical_source_key = ? AND decision = 'superseded'
+            """,
+            (raw_id, canonical_key),
+        ).fetchone()
+        repair_strategy = "restore_canonical_head"
+        already_repaired = (
+            str(indexed["raw_id"]) == replacement_raw_id
+            and supersession is not None
+            and tuple(supersession)
+            == (
+                replacement_raw_id,
+                replacement_source_revision,
+                accepted_hash,
+                f"browser_capture_origin_supersession:{raw_id}",
+            )
+        )
+    if copy_raw is not None and repair_strategy == "copy_forward" and not already_repaired:
+        return _browser_origin_ineligible(
+            raw_id, "copy-forward raw id already exists without the terminal canonical head"
+        )
+    if str(indexed["raw_id"]) not in {raw_id, replacement_raw_id}:
+        return _browser_origin_ineligible(raw_id, "indexed session points at unrelated raw evidence")
+    evidence_rows = conn.execute(
+        """
+        SELECT decision_id, raw_id, logical_source_key, decision, accepted_raw_id,
+               accepted_source_revision, accepted_content_hash, decided_at_ms
+        FROM raw_revision_applications WHERE session_id = ? ORDER BY decision_id
+        """,
+        (session_id,),
+    ).fetchall()
+    evidence_rows = [row for row in evidence_rows if str(row["logical_source_key"]) == old_key]
+    evidence_digest = _authority_rows_digest([raw], [head], [indexed_evidence], [membership], [census], evidence_rows)
+    item = BrowserCaptureOriginRepairItem(
+        raw_id=raw_id,
+        status="already_repaired" if already_repaired else "eligible",
+        reason=(
+            "canonical replacement head already supersedes the mismatched current pointer"
+            if already_repaired
+            else "exact retained browser capture can be repaired without rewriting historical evidence"
+        ),
+        origin=str(raw["origin"]),
+        source_path=source_path,
+        source_index=int(raw["source_index"]),
+        blob_hash=blob_hash_hex,
+        blob_size=blob_size,
+        old_logical_source_key=old_key,
+        canonical_provider=provider.value,
+        canonical_origin=canonical_origin.value,
+        canonical_logical_source_key=canonical_key,
+        session_id=session_id,
+        accepted_content_hash=accepted_hash.hex(),
+        accepted_frontier=blob_size,
+        repair_strategy=repair_strategy,
+        replacement_raw_id=replacement_raw_id,
+        replacement_source_revision=replacement_source_revision,
+        replacement_frontier_kind=replacement_frontier_kind,
+        replacement_frontier=replacement_frontier,
+        copy_forward_raw_id=copy_raw_id if repair_strategy == "copy_forward" else None,
+        copy_forward_source_path=copy_path if repair_strategy == "copy_forward" else None,
+        evidence_digest=evidence_digest,
+    )
+    return dataclasses.replace(item, proof_digest=_browser_origin_item_digest(item))
+
+
+@dataclass(slots=True)
+class _BrowserOriginReceipt:
+    path: Path
+    descriptor: int
+    target_hash: str
+    terminal: bool
+    torn: bytes = b""
+
+    def close(self) -> None:
+        fcntl.flock(self.descriptor, fcntl.LOCK_UN)
+        os.close(self.descriptor)
+
+
+def _lock_browser_origin_receipt(path: Path, items: list[BrowserCaptureOriginRepairItem]) -> _BrowserOriginReceipt:
+    if path.is_symlink():
+        raise RuntimeError("repair receipt path must not be a symbolic link")
+    targets = [_browser_origin_item_payload(item) for item in items]
+    target_hash = hashlib.sha256(json.dumps(targets, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    descriptor = os.open(path, os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0), 0o600)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        opened = os.fstat(descriptor)
+        named = path.stat(follow_symlinks=False)
+        if (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino):
+            raise RuntimeError("repair receipt path changed while it was being locked")
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        chunks: list[bytes] = []
+        remaining = opened.st_size
+        while remaining:
+            chunk = os.read(descriptor, remaining)
+            if not chunk:
+                raise RuntimeError("existing repair receipt changed during its locked read")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        existing = b"".join(chunks)
+        if existing:
+            first, separator, tail = existing.partition(b"\n")
+            if not separator:
+                raise RuntimeError("existing repair receipt has a torn planned record")
+            try:
+                planned = json.loads(first)
+            except (ValueError, json.JSONDecodeError) as exc:
+                raise RuntimeError("existing repair receipt has invalid planned JSON") from exc
+            expected = {
+                "schema": _BROWSER_CAPTURE_ORIGIN_REPAIR_RECEIPT_SCHEMA,
+                "state": "planned",
+                "target_hash": target_hash,
+                "targets": targets,
+            }
+            if {key: planned.get(key) for key in expected} != expected:
+                raise RuntimeError("existing repair receipt targets do not match the exact proof")
+            terminal = False
+            torn = tail
+            if tail.endswith(b"\n") and tail:
+                lines = tail.splitlines()
+                try:
+                    applied = json.loads(lines[-1])
+                except (ValueError, json.JSONDecodeError):
+                    applied = None
+                if isinstance(applied, dict) and applied.get("state") == "applied":
+                    if (
+                        applied.get("schema") != _BROWSER_CAPTURE_ORIGIN_REPAIR_RECEIPT_SCHEMA
+                        or applied.get("target_hash") != target_hash
+                        or applied.get("replacement_raw_ids") != [item.replacement_raw_id for item in items]
+                    ):
+                        raise RuntimeError("existing repair receipt has a conflicting terminal record")
+                    terminal = True
+                    torn = b""
+            return _BrowserOriginReceipt(path, descriptor, target_hash, terminal, torn)
+        planned = {
+            "schema": _BROWSER_CAPTURE_ORIGIN_REPAIR_RECEIPT_SCHEMA,
+            "state": "planned",
+            "target_hash": target_hash,
+            "targets": targets,
+            "planned_at_ms": int(time.time() * 1000),
+        }
+        _write_receipt_all(descriptor, (json.dumps(planned, sort_keys=True, separators=(",", ":")) + "\n").encode())
+        os.fsync(descriptor)
+        _fsync_parent(path)
+        return _BrowserOriginReceipt(path, descriptor, target_hash, False)
+    except Exception:
+        with suppress(OSError):
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+        raise
+
+
+def _finish_browser_origin_receipt(
+    receipt: _BrowserOriginReceipt,
+    items: list[BrowserCaptureOriginRepairItem],
+) -> None:
+    os.lseek(receipt.descriptor, 0, os.SEEK_END)
+    terminal: dict[str, object] = {
+        "schema": _BROWSER_CAPTURE_ORIGIN_REPAIR_RECEIPT_SCHEMA,
+        "state": "applied",
+        "target_hash": receipt.target_hash,
+        "applied_at_ms": int(time.time() * 1000),
+        "replacement_raw_ids": [item.replacement_raw_id for item in items],
+    }
+    if receipt.torn:
+        if not receipt.torn.endswith(b"\n"):
+            _write_receipt_all(receipt.descriptor, b"\xff\n")
+        terminal["preserved_torn_terminal"] = {
+            "bytes": len(receipt.torn),
+            "sha256": hashlib.sha256(receipt.torn).hexdigest(),
+        }
+    _write_receipt_all(
+        receipt.descriptor,
+        (json.dumps(terminal, sort_keys=True, separators=(",", ":")) + "\n").encode(),
+    )
+    os.fsync(receipt.descriptor)
+    _fsync_parent(receipt.path)
+
+
+def _insert_browser_origin_copy_forward(conn: sqlite3.Connection, item: BrowserCaptureOriginRepairItem) -> None:
+    from polylogue.storage.sqlite.archive_tiers.revision_application import (
+        RevisionApplicationReceipt,
+        record_revision_application_sync,
+    )
+
+    assert item.copy_forward_raw_id is not None
+    assert item.copy_forward_source_path is not None
+    assert item.canonical_origin is not None
+    assert item.canonical_provider is not None
+    assert item.canonical_logical_source_key is not None
+    assert item.session_id is not None
+    assert item.blob_hash is not None
+    assert item.blob_size is not None
+    assert item.source_index is not None
+    assert item.accepted_content_hash is not None
+    assert item.accepted_frontier is not None
+    native_id = item.session_id.split(":", 1)[1]
+    blob_hash = bytes.fromhex(item.blob_hash)
+    columns = {str(row[1]) for row in conn.execute("PRAGMA source.table_info(raw_sessions)")}
+    names = [
+        "raw_id",
+        "origin",
+        "native_id",
+        "source_path",
+        "source_index",
+        "blob_hash",
+        "blob_size",
+        "acquired_at_ms",
+        "logical_source_key",
+        "revision_kind",
+        "source_revision",
+        "baseline_raw_id",
+        "acquisition_generation",
+        "revision_authority",
+    ]
+    values: list[object] = [
+        item.copy_forward_raw_id,
+        item.canonical_origin,
+        native_id,
+        item.copy_forward_source_path,
+        item.source_index,
+        blob_hash,
+        item.blob_size,
+        int(time.time() * 1000),
+        item.canonical_logical_source_key,
+        RawRevisionKind.FULL.value,
+        item.blob_hash,
+        item.copy_forward_raw_id,
+        0,
+        RawRevisionAuthority.BYTE_PROVEN.value,
+    ]
+    if "capture_mode" in columns:
+        names.insert(2, "capture_mode")
+        values.insert(2, item.canonical_provider)
+    conn.execute(
+        f"INSERT INTO source.raw_sessions ({', '.join(names)}) VALUES ({', '.join('?' for _ in names)})",
+        values,
+    )
+    acquired_at_ms = int(time.time() * 1000)
+    conn.execute(
+        """
+        INSERT INTO source.blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+        VALUES (?, ?, 'raw_payload', ?, ?, ?)
+        """,
+        (blob_hash, item.copy_forward_raw_id, item.copy_forward_source_path, item.blob_size, acquired_at_ms),
+    )
+    conn.execute(
+        """
+        INSERT INTO source.raw_session_memberships (
+            raw_id, logical_source_key, provider_session_id, source_revision,
+            normalized_content_hash, message_count, acquisition_generation,
+            revision_authority, decision, decided_at_ms
+        )
+        SELECT ?, ?, ?, ?, ?, message_count, 0, 'byte_proven', 'applied', ?
+        FROM source.raw_session_memberships
+        WHERE raw_id = ? AND logical_source_key = ?
+        """,
+        (
+            item.copy_forward_raw_id,
+            item.canonical_logical_source_key,
+            native_id,
+            item.accepted_content_hash,
+            bytes.fromhex(item.accepted_content_hash),
+            acquired_at_ms,
+            item.raw_id,
+            item.canonical_logical_source_key,
+        ),
+    )
+    conn.execute(
+        """
+        INSERT INTO source.raw_membership_census (
+            raw_id, parser_fingerprint, status, member_count, censused_at_ms, detail
+        ) VALUES (?, 'browser-origin-copy-forward-v1', 'complete', 1, ?, ?)
+        """,
+        (
+            item.copy_forward_raw_id,
+            acquired_at_ms,
+            f"origin copy-forward from immutable raw {item.raw_id}",
+        ),
+    )
+    cursor = conn.execute(
+        "UPDATE sessions SET raw_id = ? WHERE session_id = ? AND raw_id = ?",
+        (item.copy_forward_raw_id, item.session_id, item.raw_id),
+    )
+    if cursor.rowcount != 1:
+        raise RuntimeError(f"session raw pointer CAS failed for {item.raw_id}")
+    record_revision_application_sync(
+        conn,
+        RevisionApplicationReceipt(
+            raw_id=item.copy_forward_raw_id,
+            session_id=item.session_id,
+            logical_source_key=item.canonical_logical_source_key,
+            source_revision=item.blob_hash,
+            acquisition_generation=0,
+            decision=ApplicationDecision.SELECTED_BASELINE,
+            accepted_raw_id=item.copy_forward_raw_id,
+            accepted_source_revision=item.blob_hash,
+            accepted_content_hash=bytes.fromhex(item.accepted_content_hash),
+            accepted_frontier_kind="byte",
+            accepted_frontier=item.accepted_frontier,
+            baseline_raw_id=item.copy_forward_raw_id,
+            detail=f"browser_capture_origin_copy_forward:{item.raw_id}",
+        ),
+        decided_at_ms=acquired_at_ms,
+    )
+
+
+def _restore_browser_origin_canonical_head(conn: sqlite3.Connection, item: BrowserCaptureOriginRepairItem) -> None:
+    from polylogue.storage.sqlite.archive_tiers.revision_application import (
+        RevisionApplicationReceipt,
+        record_revision_application_sync,
+    )
+
+    assert item.session_id is not None
+    assert item.canonical_logical_source_key is not None
+    assert item.blob_hash is not None
+    assert item.accepted_content_hash is not None
+    assert item.replacement_raw_id is not None
+    assert item.replacement_source_revision is not None
+    assert item.replacement_frontier_kind is not None
+    assert item.replacement_frontier is not None
+    decided_at_ms = int(time.time() * 1000)
+    cursor = conn.execute(
+        "UPDATE sessions SET raw_id = ? WHERE session_id = ? AND raw_id = ?",
+        (item.replacement_raw_id, item.session_id, item.raw_id),
+    )
+    if cursor.rowcount != 1:
+        raise RuntimeError(f"session raw pointer CAS failed for {item.raw_id}")
+    record_revision_application_sync(
+        conn,
+        RevisionApplicationReceipt(
+            raw_id=item.raw_id,
+            session_id=item.session_id,
+            logical_source_key=item.canonical_logical_source_key,
+            source_revision=item.blob_hash,
+            acquisition_generation=0,
+            decision=ApplicationDecision.SUPERSEDED,
+            accepted_raw_id=item.replacement_raw_id,
+            accepted_source_revision=item.replacement_source_revision,
+            accepted_content_hash=bytes.fromhex(item.accepted_content_hash),
+            accepted_frontier_kind=item.replacement_frontier_kind,
+            accepted_frontier=item.replacement_frontier,
+            detail=f"browser_capture_origin_supersession:{item.raw_id}",
+        ),
+        decided_at_ms=decided_at_ms,
+    )
+
+
+def _apply_browser_origin_repair_item(conn: sqlite3.Connection, item: BrowserCaptureOriginRepairItem) -> None:
+    if item.repair_strategy == "copy_forward":
+        _insert_browser_origin_copy_forward(conn, item)
+        return
+    if item.repair_strategy == "restore_canonical_head":
+        _restore_browser_origin_canonical_head(conn, item)
+        return
+    raise RuntimeError(f"unsupported browser-capture origin repair strategy: {item.repair_strategy}")
+
+
+def repair_browser_capture_origin_mismatches(
+    config: Config,
+    raw_ids: list[str],
+    *,
+    apply: bool = False,
+    receipt_path: Path | None = None,
+    proof_digest: str | None = None,
+) -> BrowserCaptureOriginRepairReport:
+    """Copy exact browser-capture evidence forward under parsed origin authority."""
+    if len(set(raw_ids)) != len(raw_ids):
+        raise ValueError("duplicate raw ids are not allowed")
+    if not raw_ids or len(raw_ids) > _QUARANTINED_ACCEPTED_RAW_REPAIR_LIMIT:
+        raise ValueError("raw-id list must contain 1..100 entries")
+    if any(re.fullmatch(r"[0-9a-f]{64}", raw_id) is None for raw_id in raw_ids):
+        raise ValueError("raw ids must be lowercase SHA-256 identifiers")
+    block_reason = offline_maintenance_block_reason(config, active=apply, dry_run=not apply)
+    if block_reason is not None:
+        raise RuntimeError(block_reason)
+    archive_root = _raw_materialization_archive_root(config)
+    source_db = archive_root / "source.db"
+    index_db = archive_root / "index.db"
+    if not source_db.exists() or not index_db.exists():
+        raise RuntimeError("source or index tier is missing")
+
+    def inspect(connection: sqlite3.Connection) -> list[BrowserCaptureOriginRepairItem]:
+        return [_inspect_browser_capture_origin_mismatch(archive_root, raw_id, conn=connection) for raw_id in raw_ids]
+
+    with closing(sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)) as conn:
+        conn.execute("ATTACH DATABASE ? AS source", (str(source_db),))
+        items = inspect(conn)
+    aggregate = _browser_origin_proof_digest(items)
+    if apply and any(item.status == "ineligible" for item in items):
+        raise RuntimeError("browser-capture origin repair refused because one or more targets are ineligible")
+    if apply and receipt_path is None:
+        raise ValueError("apply requires an explicit operator repair receipt path")
+    if apply and proof_digest != aggregate:
+        raise RuntimeError("apply proof digest does not match the exact dry-run target list")
+    if apply:
+        from polylogue.storage.index_generation import RebuildLease
+
+        assert receipt_path is not None
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        with RebuildLease(archive_root):
+            receipt = _lock_browser_origin_receipt(receipt_path, items)
+            try:
+                with closing(sqlite3.connect(f"file:{index_db}?mode=rw", uri=True)) as conn:
+                    conn.execute("PRAGMA foreign_keys = ON")
+                    conn.execute("ATTACH DATABASE ? AS source", (str(source_db),))
+                    conn.execute("BEGIN IMMEDIATE")
+                    try:
+                        locked = inspect(conn)
+                        if _browser_origin_proof_digest(locked) != proof_digest:
+                            raise RuntimeError("authority proof changed after acquiring the repair transaction")
+                        if any(item.status == "ineligible" for item in locked):
+                            raise RuntimeError("a browser-capture origin target became ineligible")
+                        if receipt.terminal and any(item.status != "already_repaired" for item in locked):
+                            raise RuntimeError("terminal operator receipt disagrees with durable copy-forward state")
+                        for item in locked:
+                            if item.status == "eligible":
+                                _apply_browser_origin_repair_item(conn, item)
+                        after = inspect(conn)
+                        if any(item.status != "already_repaired" for item in after):
+                            raise RuntimeError("browser-capture origin copy-forward did not reach terminal state")
+                        conn.commit()
+                    except Exception:
+                        conn.rollback()
+                        raise
+                items = [
+                    dataclasses.replace(after_item, repaired=before.status == "eligible")
+                    for before, after_item in zip(locked, after, strict=True)
+                ]
+                if not receipt.terminal:
+                    _finish_browser_origin_receipt(receipt, items)
+            finally:
+                receipt.close()
+    return BrowserCaptureOriginRepairReport(
+        mode="apply" if apply else "dry-run",
+        requested_count=len(items),
+        eligible_count=sum(item.status == "eligible" for item in items),
+        repaired_count=sum(item.repaired for item in items),
+        already_repaired_count=sum(item.status == "already_repaired" for item in items),
+        ineligible_count=sum(item.status == "ineligible" for item in items),
+        proof_digest=aggregate,
         receipt_path=str(receipt_path) if receipt_path is not None else None,
         items=tuple(items),
     )

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -184,6 +184,7 @@ class BrowserCaptureOriginRepairItem:
     replacement_frontier: int | None = None
     copy_forward_raw_id: str | None = None
     copy_forward_source_path: str | None = None
+    copy_forward_source_complete: bool = False
     evidence_digest: str | None = None
     proof_digest: str | None = None
     repaired: bool = False
@@ -1055,7 +1056,7 @@ def _browser_origin_item_payload(item: BrowserCaptureOriginRepairItem) -> dict[s
     return {
         key: value
         for key, value in dataclasses.asdict(item).items()
-        if key not in {"status", "reason", "proof_digest", "repaired"}
+        if key not in {"status", "reason", "proof_digest", "repaired", "copy_forward_source_complete"}
     }
 
 
@@ -1311,13 +1312,8 @@ def _inspect_browser_capture_origin_mismatch(
         0,
         RawRevisionAuthority.BYTE_PROVEN.value,
     )
-    copy_forward_terminal = (
+    copy_forward_source_complete = (
         copy_raw_exact
-        and canonical_head is not None
-        and str(canonical_head["session_id"]) == session_id
-        and str(canonical_head["accepted_raw_id"]) == copy_raw_id
-        and _bytes_value(canonical_head["accepted_content_hash"]) == accepted_hash
-        and str(indexed["raw_id"]) == copy_raw_id
         and copy_membership is not None
         and str(copy_membership["provider_session_id"]) == session.provider_session_id
         and str(copy_membership["source_revision"]) == accepted_hash.hex()
@@ -1328,6 +1324,14 @@ def _inspect_browser_capture_origin_mismatch(
         and str(copy_membership["decision"]) == "applied"
         and copy_census is not None
         and tuple(copy_census) == ("complete", 1)
+    )
+    copy_forward_terminal = (
+        copy_forward_source_complete
+        and canonical_head is not None
+        and str(canonical_head["session_id"]) == session_id
+        and str(canonical_head["accepted_raw_id"]) == copy_raw_id
+        and _bytes_value(canonical_head["accepted_content_hash"]) == accepted_hash
+        and str(indexed["raw_id"]) == copy_raw_id
         and copy_application is not None
         and tuple(copy_application)
         == (
@@ -1385,9 +1389,9 @@ def _inspect_browser_capture_origin_mismatch(
                 f"browser_capture_origin_supersession:{raw_id}",
             )
         )
-    if copy_raw is not None and repair_strategy == "copy_forward" and not already_repaired:
+    if copy_raw is not None and repair_strategy == "copy_forward" and not copy_forward_source_complete:
         return _browser_origin_ineligible(
-            raw_id, "copy-forward raw id already exists without the terminal canonical head"
+            raw_id, "copy-forward raw id exists but its durable source stage is not exact"
         )
     if str(indexed["raw_id"]) not in {raw_id, replacement_raw_id}:
         return _browser_origin_ineligible(raw_id, "indexed session points at unrelated raw evidence")
@@ -1428,6 +1432,7 @@ def _inspect_browser_capture_origin_mismatch(
         replacement_frontier=replacement_frontier,
         copy_forward_raw_id=copy_raw_id if repair_strategy == "copy_forward" else None,
         copy_forward_source_path=copy_path if repair_strategy == "copy_forward" else None,
+        copy_forward_source_complete=copy_forward_source_complete,
         evidence_digest=evidence_digest,
     )
     return dataclasses.replace(item, proof_digest=_browser_origin_item_digest(item))
@@ -1547,12 +1552,7 @@ def _finish_browser_origin_receipt(
     _fsync_parent(receipt.path)
 
 
-def _insert_browser_origin_copy_forward(conn: sqlite3.Connection, item: BrowserCaptureOriginRepairItem) -> None:
-    from polylogue.storage.sqlite.archive_tiers.revision_application import (
-        RevisionApplicationReceipt,
-        record_revision_application_sync,
-    )
-
+def _stage_browser_origin_copy_forward_source(conn: sqlite3.Connection, item: BrowserCaptureOriginRepairItem) -> None:
     assert item.copy_forward_raw_id is not None
     assert item.copy_forward_source_path is not None
     assert item.canonical_origin is not None
@@ -1566,7 +1566,7 @@ def _insert_browser_origin_copy_forward(conn: sqlite3.Connection, item: BrowserC
     assert item.accepted_frontier is not None
     native_id = item.session_id.split(":", 1)[1]
     blob_hash = bytes.fromhex(item.blob_hash)
-    columns = {str(row[1]) for row in conn.execute("PRAGMA source.table_info(raw_sessions)")}
+    columns = {str(row[1]) for row in conn.execute("PRAGMA table_info(raw_sessions)")}
     names = [
         "raw_id",
         "origin",
@@ -1603,26 +1603,26 @@ def _insert_browser_origin_copy_forward(conn: sqlite3.Connection, item: BrowserC
         names.insert(2, "capture_mode")
         values.insert(2, item.canonical_provider)
     conn.execute(
-        f"INSERT INTO source.raw_sessions ({', '.join(names)}) VALUES ({', '.join('?' for _ in names)})",
+        f"INSERT INTO raw_sessions ({', '.join(names)}) VALUES ({', '.join('?' for _ in names)})",
         values,
     )
     acquired_at_ms = int(time.time() * 1000)
     conn.execute(
         """
-        INSERT INTO source.blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+        INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
         VALUES (?, ?, 'raw_payload', ?, ?, ?)
         """,
         (blob_hash, item.copy_forward_raw_id, item.copy_forward_source_path, item.blob_size, acquired_at_ms),
     )
     conn.execute(
         """
-        INSERT INTO source.raw_session_memberships (
+        INSERT INTO raw_session_memberships (
             raw_id, logical_source_key, provider_session_id, source_revision,
             normalized_content_hash, message_count, acquisition_generation,
             revision_authority, decision, decided_at_ms
         )
         SELECT ?, ?, ?, ?, ?, message_count, 0, 'byte_proven', 'applied', ?
-        FROM source.raw_session_memberships
+        FROM raw_session_memberships
         WHERE raw_id = ? AND logical_source_key = ?
         """,
         (
@@ -1638,7 +1638,7 @@ def _insert_browser_origin_copy_forward(conn: sqlite3.Connection, item: BrowserC
     )
     conn.execute(
         """
-        INSERT INTO source.raw_membership_census (
+        INSERT INTO raw_membership_census (
             raw_id, parser_fingerprint, status, member_count, censused_at_ms, detail
         ) VALUES (?, 'browser-origin-copy-forward-v1', 'complete', 1, ?, ?)
         """,
@@ -1648,6 +1648,21 @@ def _insert_browser_origin_copy_forward(conn: sqlite3.Connection, item: BrowserC
             f"origin copy-forward from immutable raw {item.raw_id}",
         ),
     )
+
+
+def _finalize_browser_origin_copy_forward_index(conn: sqlite3.Connection, item: BrowserCaptureOriginRepairItem) -> None:
+    from polylogue.storage.sqlite.archive_tiers.revision_application import (
+        RevisionApplicationReceipt,
+        record_revision_application_sync,
+    )
+
+    assert item.copy_forward_raw_id is not None
+    assert item.canonical_logical_source_key is not None
+    assert item.session_id is not None
+    assert item.blob_hash is not None
+    assert item.accepted_content_hash is not None
+    assert item.accepted_frontier is not None
+    acquired_at_ms = int(time.time() * 1000)
     cursor = conn.execute(
         "UPDATE sessions SET raw_id = ? WHERE session_id = ? AND raw_id = ?",
         (item.copy_forward_raw_id, item.session_id, item.raw_id),
@@ -1718,7 +1733,7 @@ def _restore_browser_origin_canonical_head(conn: sqlite3.Connection, item: Brows
 
 def _apply_browser_origin_repair_item(conn: sqlite3.Connection, item: BrowserCaptureOriginRepairItem) -> None:
     if item.repair_strategy == "copy_forward":
-        _insert_browser_origin_copy_forward(conn, item)
+        _finalize_browser_origin_copy_forward_index(conn, item)
         return
     if item.repair_strategy == "restore_canonical_head":
         _restore_browser_origin_canonical_head(conn, item)
@@ -1771,6 +1786,21 @@ def repair_browser_capture_origin_mismatches(
         with RebuildLease(archive_root):
             receipt = _lock_browser_origin_receipt(receipt_path, items)
             try:
+                with closing(sqlite3.connect(f"file:{source_db}?mode=rw", uri=True)) as source_conn:
+                    source_conn.execute("PRAGMA foreign_keys = ON")
+                    source_conn.execute("BEGIN IMMEDIATE")
+                    try:
+                        for item in items:
+                            if (
+                                item.status == "eligible"
+                                and item.repair_strategy == "copy_forward"
+                                and not item.copy_forward_source_complete
+                            ):
+                                _stage_browser_origin_copy_forward_source(source_conn, item)
+                        source_conn.commit()
+                    except Exception:
+                        source_conn.rollback()
+                        raise
                 with closing(sqlite3.connect(f"file:{index_db}?mode=rw", uri=True)) as conn:
                     conn.execute("PRAGMA foreign_keys = ON")
                     conn.execute("ATTACH DATABASE ? AS source", (str(source_db),))

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -1394,6 +1394,65 @@ def test_quarantined_accepted_raw_repair_cli_apply_requires_receipt_and_proof(
     assert "--proof-digest" in missing_proof.output
 
 
+def test_browser_capture_origin_repair_cli_is_bounded_and_requires_receipt_proof(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    del cli_workspace
+    raw_id = "b" * 64
+    dry_run = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "browser-capture-origin-mismatches",
+            "--raw-id",
+            raw_id,
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert dry_run.exit_code == 0
+    payload = json.loads(dry_run.output)
+    assert payload["mode"] == "dry-run"
+    assert payload["requested_count"] == 1
+    assert payload["ineligible_count"] == 1
+    assert len(payload["proof_digest"]) == 64
+
+    missing_receipt = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "browser-capture-origin-mismatches",
+            "--raw-id",
+            raw_id,
+            "--apply",
+        ],
+    )
+    assert missing_receipt.exit_code == 2
+    assert "--receipt" in missing_receipt.output
+    missing_proof = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "browser-capture-origin-mismatches",
+            "--raw-id",
+            raw_id,
+            "--apply",
+            "--receipt",
+            "repair.jsonl",
+        ],
+    )
+    assert missing_proof.exit_code == 2
+    assert "--proof-digest" in missing_proof.output
+
+
 def test_archive_read_cli_lists_archive_sessions(
     cli_workspace: dict[str, Path],
     cli_runner: CliRunner,

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -454,6 +454,7 @@ def test_streaming_sized_browser_capture_json_uses_native_payload_detection(
                 },
             },
         },
+        "preserved_native_bytes": "x" * 32_000,
     }
     capture_payload = {
         "polylogue_capture_kind": "browser_llm_session",
@@ -466,6 +467,10 @@ def test_streaming_sized_browser_capture_json_uses_native_payload_detection(
             "adapter_name": "chatgpt-native-v1",
             "capture_mode": "snapshot",
         },
+        # Real receiver artifacts are key-sorted, so a large native payload
+        # precedes the typed session and can push ``session.provider`` beyond
+        # the ordinary 8 KiB acquisition prefix.
+        "raw_provider_payload": native_payload,
         "session": {
             "provider": "chatgpt",
             "provider_session_id": "dom-fallback",
@@ -473,7 +478,6 @@ def test_streaming_sized_browser_capture_json_uses_native_payload_detection(
             "updated_at": "2026-04-24T00:00:01+00:00",
             "turns": [{"provider_turn_id": "dom-u1", "role": "user", "text": "DOM fallback", "ordinal": 0}],
         },
-        "raw_provider_payload": native_payload,
         "padding": "x" * 256,
     }
     source.write_text(json.dumps(capture_payload), encoding="utf-8")
@@ -498,10 +502,11 @@ def test_streaming_sized_browser_capture_json_uses_native_payload_detection(
     assert result.ingested_session_count == 1
     assert result.ingested_message_count == 2
     assert result.raw_source_names[source] == "chatgpt"
+    assert source.read_bytes().find(b'"provider": "chatgpt"') > 8192
     with sqlite3.connect(source_db) as conn:
-        assert conn.execute("SELECT origin, native_id FROM raw_sessions").fetchone() == (
-            "chatgpt-export",
-            "native-large",
+        assert conn.execute("SELECT origin FROM raw_sessions").fetchone() == ("chatgpt-export",)
+        assert conn.execute("SELECT logical_source_key FROM raw_session_memberships").fetchone() == (
+            "chatgpt:native-large",
         )
     with sqlite3.connect(index_db) as conn:
         assert conn.execute("SELECT native_id, title FROM sessions").fetchone() == (
@@ -521,6 +526,10 @@ def test_streaming_sized_browser_capture_json_uses_native_payload_detection(
             """
             ).fetchone()[0]
             == "user:Native user text|assistant:Native answer text"
+        )
+        assert conn.execute("SELECT logical_source_key, session_id FROM raw_revision_heads").fetchone() == (
+            "chatgpt:native-large",
+            "chatgpt-export:native-large",
         )
 
 

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.revision_replay import ApplicationDecision
+from polylogue.config import Config
+from polylogue.core.enums import Provider
+from polylogue.pipeline.ids import session_content_hash
+from polylogue.sources.revision_backfill import _parse_one
+from polylogue.storage.repair import (
+    repair_browser_capture_origin_mismatches,
+    repair_quarantined_accepted_raws,
+)
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from polylogue.storage.sqlite.archive_tiers.revision_application import (
+    RevisionApplicationReceipt,
+    record_revision_application_sync,
+)
+
+
+def _config(root: Path) -> Config:
+    return Config(archive_root=root, render_root=root / "render", sources=[], db_path=root / "index.db")
+
+
+def _browser_payload(native_id: str = "browser-origin-one") -> bytes:
+    payload = {
+        "capture_id": f"chatgpt:{native_id}",
+        "polylogue_capture_kind": "browser_llm_session",
+        "provenance": {
+            "adapter_name": "chatgpt-native-v1",
+            "capture_mode": "snapshot",
+            "captured_at": "2026-07-13T00:00:00Z",
+            "source_url": f"https://chatgpt.com/c/{native_id}",
+        },
+        "raw_provider_payload": {
+            "id": native_id,
+            "title": "Historical browser capture",
+            "create_time": 1_700_000_000,
+            "update_time": 1_700_000_001,
+            "current_node": "node-1",
+            "mapping": {
+                "node-1": {
+                    "id": "node-1",
+                    "parent": None,
+                    "children": [],
+                    "message": {
+                        "id": "message-1",
+                        "author": {"role": "user"},
+                        "content": {"content_type": "text", "parts": ["preserved text"]},
+                        "create_time": 1_700_000_000,
+                    },
+                }
+            },
+            "preserved_padding": "x" * 16_000,
+        },
+        "schema_version": 1,
+        "session": {
+            "provider": "chatgpt",
+            "provider_session_id": native_id,
+            "title": "DOM fallback",
+            "turns": [{"provider_turn_id": "dom-1", "role": "user", "text": "fallback"}],
+        },
+        "source": "browser-extension",
+    }
+    return json.dumps(payload, sort_keys=True).encode()
+
+
+def _seed_mismatched_browser_head(root: Path) -> str:
+    initialize_active_archive_root(root)
+    payload = _browser_payload()
+    session = _parse_one(Provider.CHATGPT, payload, "browser-capture/chatgpt/one.json")[0]
+    accepted_hash = bytes.fromhex(session_content_hash(session))
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.UNKNOWN,
+            payload=payload,
+            source_path="browser-capture/chatgpt/one.json",
+            acquired_at_ms=1,
+        )
+        blob_hash = (
+            archive._ensure_source_conn()
+            .execute("SELECT hex(blob_hash) FROM raw_sessions WHERE raw_id = ?", (raw_id,))
+            .fetchone()[0]
+            .lower()
+        )
+        _stored_raw, session_id = archive.write_parsed_for_retained_raw(
+            session,
+            raw_id=raw_id,
+            source_path="browser-capture/chatgpt/one.json",
+            acquired_at_ms=1,
+            revision_authoritative=True,
+        )
+        record_revision_application_sync(
+            archive._conn,
+            RevisionApplicationReceipt(
+                raw_id=raw_id,
+                session_id=session_id,
+                logical_source_key="unknown:browser-origin-one",
+                source_revision=blob_hash,
+                acquisition_generation=0,
+                decision=ApplicationDecision.SELECTED_BASELINE,
+                accepted_raw_id=raw_id,
+                accepted_source_revision=blob_hash,
+                accepted_content_hash=accepted_hash,
+                accepted_frontier_kind="byte",
+                accepted_frontier=len(payload),
+                detail="historical mismatched browser head",
+            ),
+            decided_at_ms=2,
+        )
+        archive.commit()
+    with sqlite3.connect(root / "source.db") as source:
+        source.execute(
+            """
+            UPDATE raw_sessions
+            SET origin = 'unknown-export',
+                logical_source_key = 'unknown:browser-origin-one', revision_kind = 'full',
+                source_revision = lower(hex(blob_hash)), acquisition_generation = 0,
+                revision_authority = 'quarantined'
+            WHERE raw_id = ?
+            """,
+            (raw_id,),
+        )
+        source.execute(
+            """
+            INSERT INTO raw_session_memberships (
+                raw_id, logical_source_key, provider_session_id, source_revision,
+                normalized_content_hash, message_count, acquisition_generation,
+                revision_authority, decision, decided_at_ms
+            ) VALUES (?, 'chatgpt:browser-origin-one', 'browser-origin-one', ?, ?, 1, 0,
+                      'quarantined', 'applied', 2)
+            """,
+            (raw_id, accepted_hash.hex(), accepted_hash),
+        )
+        source.execute(
+            """
+            INSERT INTO raw_membership_census (
+                raw_id, parser_fingerprint, status, member_count, censused_at_ms, detail
+            ) VALUES (?, 'historical-parser', 'complete', 1, 2, 'historical mismatch')
+            """,
+            (raw_id,),
+        )
+    return raw_id
+
+
+def _seed_equivalent_canonical_head(root: Path, mismatched_raw_id: str) -> str:
+    payload = _browser_payload()
+    session = _parse_one(Provider.CHATGPT, payload, "browser-capture/chatgpt/canonical.json")[0]
+    accepted_hash = bytes.fromhex(session_content_hash(session))
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CHATGPT,
+            payload=payload,
+            source_path="browser-capture/chatgpt/canonical.json",
+            acquired_at_ms=3,
+        )
+        blob_hash = (
+            archive._ensure_source_conn()
+            .execute("SELECT hex(blob_hash) FROM raw_sessions WHERE raw_id = ?", (raw_id,))
+            .fetchone()[0]
+            .lower()
+        )
+        _stored_raw, session_id = archive.write_parsed_for_retained_raw(
+            session,
+            raw_id=raw_id,
+            source_path="browser-capture/chatgpt/canonical.json",
+            acquired_at_ms=3,
+            revision_authoritative=True,
+        )
+        record_revision_application_sync(
+            archive._conn,
+            RevisionApplicationReceipt(
+                raw_id=raw_id,
+                session_id=session_id,
+                logical_source_key="chatgpt:browser-origin-one",
+                source_revision=blob_hash,
+                acquisition_generation=0,
+                decision=ApplicationDecision.SELECTED_BASELINE,
+                accepted_raw_id=raw_id,
+                accepted_source_revision=blob_hash,
+                accepted_content_hash=accepted_hash,
+                accepted_frontier_kind="byte",
+                accepted_frontier=len(payload),
+                baseline_raw_id=raw_id,
+                detail="pre-existing canonical head",
+            ),
+            decided_at_ms=4,
+        )
+        archive._conn.execute(
+            "UPDATE sessions SET raw_id = ? WHERE session_id = ?",
+            (mismatched_raw_id, session_id),
+        )
+        archive.commit()
+    return raw_id
+
+
+def _rows(root: Path, tier: str, table: str, where: str, params: tuple[object, ...]) -> list[tuple[object, ...]]:
+    with sqlite3.connect(root / f"{tier}.db") as conn:
+        return [tuple(row) for row in conn.execute(f"SELECT * FROM {table} WHERE {where} ORDER BY 1", params)]
+
+
+def test_browser_capture_origin_copy_forward_preserves_old_evidence_and_is_idempotent(tmp_path: Path) -> None:
+    raw_id = _seed_mismatched_browser_head(tmp_path)
+    old_evidence = {
+        "raw": _rows(tmp_path, "source", "raw_sessions", "raw_id = ?", (raw_id,)),
+        "blob": _rows(tmp_path, "source", "blob_refs", "ref_id = ?", (raw_id,)),
+        "membership": _rows(tmp_path, "source", "raw_session_memberships", "raw_id = ?", (raw_id,)),
+        "census": _rows(tmp_path, "source", "raw_membership_census", "raw_id = ?", (raw_id,)),
+        "head": _rows(tmp_path, "index", "raw_revision_heads", "accepted_raw_id = ?", (raw_id,)),
+        "application": _rows(tmp_path, "index", "raw_revision_applications", "raw_id = ?", (raw_id,)),
+    }
+
+    dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id])
+
+    assert dry_run.eligible_count == 1, dry_run.items[0].reason
+    item = dry_run.items[0]
+    assert item.canonical_origin == "chatgpt-export"
+    assert item.canonical_logical_source_key == "chatgpt:browser-origin-one"
+    assert item.copy_forward_raw_id not in {None, raw_id}
+    assert repair_quarantined_accepted_raws(_config(tmp_path), [raw_id]).ineligible_count == 1
+
+    receipt = tmp_path / "recovery" / "browser-origin.jsonl"
+    applied = repair_browser_capture_origin_mismatches(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+
+    assert applied.repaired_count == 1
+    assert applied.items[0].status == "already_repaired"
+    assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned", "applied"]
+    for name, before in old_evidence.items():
+        tier = "index" if name in {"head", "application"} else "source"
+        table = {
+            "raw": "raw_sessions",
+            "blob": "blob_refs",
+            "membership": "raw_session_memberships",
+            "census": "raw_membership_census",
+            "head": "raw_revision_heads",
+            "application": "raw_revision_applications",
+        }[name]
+        key = "accepted_raw_id" if name == "head" else "raw_id" if name not in {"blob"} else "ref_id"
+        assert _rows(tmp_path, tier, table, f"{key} = ?", (raw_id,)) == before
+    copy_raw_id = applied.items[0].copy_forward_raw_id
+    assert copy_raw_id is not None
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        assert source.execute(
+            "SELECT origin, logical_source_key, revision_authority FROM raw_sessions WHERE raw_id = ?",
+            (copy_raw_id,),
+        ).fetchone() == ("chatgpt-export", "chatgpt:browser-origin-one", "byte_proven")
+    with sqlite3.connect(tmp_path / "index.db") as index:
+        index.execute("ATTACH DATABASE ? AS source", (str(tmp_path / "source.db"),))
+        assert index.execute(
+            "SELECT raw_id FROM sessions WHERE session_id = 'chatgpt-export:browser-origin-one'"
+        ).fetchone() == (copy_raw_id,)
+        assert index.execute(
+            "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = 'chatgpt:browser-origin-one'"
+        ).fetchone() == (copy_raw_id,)
+        assert index.execute(
+            """
+            SELECT COUNT(*) FROM raw_revision_heads AS h
+            JOIN sessions AS s ON s.session_id = h.session_id AND s.raw_id = h.accepted_raw_id
+            JOIN source.raw_sessions AS r ON r.raw_id = h.accepted_raw_id
+            WHERE r.origin = 'unknown-export'
+            """
+        ).fetchone() == (0,)
+
+    reapplied = repair_browser_capture_origin_mismatches(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+    assert reapplied.repaired_count == 0
+    assert receipt.read_text().count("\n") == 2
+
+
+@pytest.mark.parametrize("mutation", ["blob", "head", "origin", "canonical_head"])
+def test_browser_capture_origin_copy_forward_mutations_fail_closed(tmp_path: Path, mutation: str) -> None:
+    raw_id = _seed_mismatched_browser_head(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as source, sqlite3.connect(tmp_path / "index.db") as index:
+        if mutation == "blob":
+            source.execute("UPDATE blob_refs SET size_bytes = size_bytes + 1 WHERE ref_id = ?", (raw_id,))
+        elif mutation == "head":
+            index.execute("UPDATE raw_revision_heads SET accepted_frontier = accepted_frontier + 1")
+        elif mutation == "origin":
+            source.execute("UPDATE raw_sessions SET origin = 'chatgpt-export' WHERE raw_id = ?", (raw_id,))
+        else:
+            index.execute(
+                """
+                INSERT INTO raw_revision_heads (
+                    logical_source_key, session_id, accepted_raw_id, accepted_source_revision,
+                    accepted_content_hash, accepted_frontier_kind, accepted_frontier,
+                    acquisition_generation, decided_at_ms
+                ) SELECT 'chatgpt:browser-origin-one', session_id, accepted_raw_id,
+                         accepted_source_revision, accepted_content_hash, accepted_frontier_kind,
+                         accepted_frontier, acquisition_generation, decided_at_ms
+                  FROM raw_revision_heads
+                """
+            )
+
+    report = repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id])
+    assert report.ineligible_count == 1
+
+
+def test_browser_capture_origin_copy_forward_accepts_source_v7_without_capture_mode(tmp_path: Path) -> None:
+    raw_id = _seed_mismatched_browser_head(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        source.execute("ALTER TABLE raw_sessions DROP COLUMN capture_mode")
+        source.execute("PRAGMA user_version = 7")
+    dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id])
+    receipt = tmp_path / "source-v7-receipt.jsonl"
+
+    applied = repair_browser_capture_origin_mismatches(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+
+    assert applied.repaired_count == 1
+    assert applied.items[0].status == "already_repaired"
+
+
+def test_browser_capture_origin_repair_restores_equivalent_canonical_head(tmp_path: Path) -> None:
+    mismatched_raw_id = _seed_mismatched_browser_head(tmp_path)
+    canonical_raw_id = _seed_equivalent_canonical_head(tmp_path, mismatched_raw_id)
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        source_count = source.execute("SELECT COUNT(*) FROM raw_sessions").fetchone()[0]
+    dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [mismatched_raw_id])
+
+    assert dry_run.items[0].repair_strategy == "restore_canonical_head"
+    assert dry_run.items[0].replacement_raw_id == canonical_raw_id
+    applied = repair_browser_capture_origin_mismatches(
+        _config(tmp_path),
+        [mismatched_raw_id],
+        apply=True,
+        receipt_path=tmp_path / "restore-receipt.jsonl",
+        proof_digest=dry_run.proof_digest,
+    )
+
+    assert applied.repaired_count == 1
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        assert source.execute("SELECT COUNT(*) FROM raw_sessions").fetchone()[0] == source_count
+    with sqlite3.connect(tmp_path / "index.db") as index:
+        assert index.execute(
+            "SELECT raw_id FROM sessions WHERE session_id = 'chatgpt-export:browser-origin-one'"
+        ).fetchone() == (canonical_raw_id,)
+        assert index.execute(
+            """
+            SELECT accepted_raw_id, detail FROM raw_revision_applications
+            WHERE raw_id = ? AND logical_source_key = 'chatgpt:browser-origin-one'
+              AND decision = 'superseded'
+            """,
+            (mismatched_raw_id,),
+        ).fetchone() == (
+            canonical_raw_id,
+            f"browser_capture_origin_supersession:{mismatched_raw_id}",
+        )

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -9,7 +9,7 @@ import pytest
 from polylogue.archive.revision_replay import ApplicationDecision
 from polylogue.config import Config
 from polylogue.core.enums import Provider
-from polylogue.pipeline.ids import session_content_hash
+from polylogue.pipeline.ids import session_content_hash, session_revision_projection
 from polylogue.sources.revision_backfill import _parse_one
 from polylogue.storage.repair import (
     repair_browser_capture_origin_mismatches,
@@ -152,6 +152,7 @@ def _seed_equivalent_canonical_head(root: Path, mismatched_raw_id: str) -> str:
     payload = _browser_payload()
     session = _parse_one(Provider.CHATGPT, payload, "browser-capture/chatgpt/canonical.json")[0]
     accepted_hash = bytes.fromhex(session_content_hash(session))
+    projection = session_revision_projection(session)
     with ArchiveStore.open_existing(root, read_only=False) as archive:
         raw_id = archive.write_raw_payload(
             provider=Provider.CHATGPT,
@@ -196,6 +197,36 @@ def _seed_equivalent_canonical_head(root: Path, mismatched_raw_id: str) -> str:
             (mismatched_raw_id, session_id),
         )
         archive.commit()
+    with sqlite3.connect(root / "source.db") as source:
+        source.execute(
+            """
+            UPDATE raw_sessions
+            SET logical_source_key = 'chatgpt:browser-origin-one', revision_kind = 'full',
+                source_revision = lower(hex(blob_hash)), baseline_raw_id = raw_id,
+                acquisition_generation = 0, revision_authority = 'byte_proven'
+            WHERE raw_id = ?
+            """,
+            (raw_id,),
+        )
+        source.execute(
+            """
+            INSERT INTO raw_session_memberships (
+                raw_id, logical_source_key, provider_session_id, source_revision,
+                normalized_content_hash, message_count, acquisition_generation,
+                revision_authority, decision, decided_at_ms
+            ) VALUES (?, 'chatgpt:browser-origin-one', 'browser-origin-one', ?, ?, ?, 0,
+                      'byte_proven', 'applied', 4)
+            """,
+            (raw_id, blob_hash, accepted_hash, len(projection.message_hashes)),
+        )
+        source.execute(
+            """
+            INSERT INTO raw_membership_census (
+                raw_id, parser_fingerprint, status, member_count, censused_at_ms, detail
+            ) VALUES (?, 'canonical-parser', 'complete', 1, 4, 'canonical evidence')
+            """,
+            (raw_id,),
+        )
     return raw_id
 
 
@@ -366,6 +397,65 @@ def test_browser_capture_origin_repair_restores_equivalent_canonical_head(tmp_pa
             canonical_raw_id,
             f"browser_capture_origin_supersession:{mismatched_raw_id}",
         )
+
+
+@pytest.mark.parametrize("mutation", ["envelope", "membership", "application"])
+def test_browser_capture_origin_repair_rejects_underproven_canonical_head(tmp_path: Path, mutation: str) -> None:
+    mismatched_raw_id = _seed_mismatched_browser_head(tmp_path)
+    canonical_raw_id = _seed_equivalent_canonical_head(tmp_path, mismatched_raw_id)
+    if mutation == "envelope":
+        with sqlite3.connect(tmp_path / "source.db") as source:
+            source.execute(
+                "UPDATE raw_sessions SET revision_authority = 'quarantined' WHERE raw_id = ?", (canonical_raw_id,)
+            )
+    elif mutation == "membership":
+        with sqlite3.connect(tmp_path / "source.db") as source:
+            source.execute(
+                "UPDATE raw_session_memberships SET decision = 'ambiguous' WHERE raw_id = ?", (canonical_raw_id,)
+            )
+    else:
+        with sqlite3.connect(tmp_path / "index.db") as index:
+            index.execute(
+                "DELETE FROM raw_revision_applications WHERE raw_id = ? AND decision = 'selected_baseline'",
+                (canonical_raw_id,),
+            )
+
+    report = repair_browser_capture_origin_mismatches(_config(tmp_path), [mismatched_raw_id])
+
+    assert report.ineligible_count == 1
+
+
+def test_browser_capture_origin_copy_forward_reproves_before_source_stage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import polylogue.storage.repair as repair_module
+
+    raw_id = _seed_mismatched_browser_head(tmp_path)
+    dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id])
+    original_lock = repair_module._lock_browser_origin_receipt
+
+    def mutate_after_receipt(
+        path: Path,
+        items: list[repair_module.BrowserCaptureOriginRepairItem],
+    ) -> repair_module._BrowserOriginReceipt:
+        receipt = original_lock(path, items)
+        with sqlite3.connect(tmp_path / "source.db") as source:
+            source.execute("UPDATE raw_sessions SET blob_size = blob_size + 1 WHERE raw_id = ?", (raw_id,))
+        return receipt
+
+    monkeypatch.setattr(repair_module, "_lock_browser_origin_receipt", mutate_after_receipt)
+    with pytest.raises(RuntimeError, match="source evidence changed"):
+        repair_browser_capture_origin_mismatches(
+            _config(tmp_path),
+            [raw_id],
+            apply=True,
+            receipt_path=tmp_path / "source-race.jsonl",
+            proof_digest=dry_run.proof_digest,
+        )
+    assert (
+        _rows(tmp_path, "source", "raw_sessions", "source_path LIKE ?", ("browser-capture-origin-copy-forward/%",))
+        == []
+    )
 
 
 def test_browser_capture_origin_copy_forward_resumes_after_source_stage_interrupt(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -366,3 +366,26 @@ def test_browser_capture_origin_repair_restores_equivalent_canonical_head(tmp_pa
             canonical_raw_id,
             f"browser_capture_origin_supersession:{mismatched_raw_id}",
         )
+
+
+def test_browser_capture_origin_copy_forward_resumes_after_source_stage_interrupt(tmp_path: Path) -> None:
+    import polylogue.storage.repair as repair_module
+
+    raw_id = _seed_mismatched_browser_head(tmp_path)
+    dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id])
+    item = dry_run.items[0]
+    assert item.repair_strategy == "copy_forward"
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        repair_module._stage_browser_origin_copy_forward_source(source, item)
+
+    resumed = repair_browser_capture_origin_mismatches(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=tmp_path / "resume-receipt.jsonl",
+        proof_digest=dry_run.proof_digest,
+    )
+
+    assert resumed.repaired_count == 1
+    assert resumed.items[0].status == "already_repaired"
+    assert resumed.items[0].copy_forward_source_complete is True


### PR DESCRIPTION
## Summary

Preserves parsed provider authority for large browser captures and repairs the three historical unknown-origin ChatGPT heads through a proof-gated, receipted copy-forward or equivalent-head path.

## Problem

The live v35 census identified three current byte heads whose retained browser-capture bytes normalize as ChatGPT while their source raws remain `unknown-export`. Prefix-only acquisition can miss `session.provider` when a large native payload appears first. Existing quarantine repair correctly refuses origin/parser mismatches and cannot safely relabel immutable raw evidence.

## Solution

- Stream browser-capture envelope scalars from retained blobs when prefix detection is inconclusive.
- Add `ops maintenance browser-capture-origin-mismatches`, which reproves source/index/blob/parser witnesses and either restores an equivalent canonical head or copy-forwards exact blob evidence under canonical origin.
- Preserve old raw, blob, head, application, membership, and census rows; only add new evidence and CAS-advance the derived session raw pointer.
- Split copy-forward into a committed source stage and index finalization, with source-stage reproof and crash recovery.
- Require a fully byte-proven canonical source envelope, membership/census, head, and selected-baseline application before reusing an existing canonical head.

Ref polylogue-lkrc.

## Acceptance criteria

| AC | Status | Evidence |
| --- | --- | --- |
| Browser ChatGPT capture gets canonical identity | Satisfied | Full `LiveBatch` route test with provider past 8KiB |
| Three historical rows repair without mutation/deletion | Satisfied by actuator; live apply pending merged artifact | preservation, restore-head, copy-forward tests |
| Origin/parser mismatch stays fail-closed | Satisfied | existing quarantine route rejection plus mutation tests |
| Dynamic census reaches zero | Pending stopped-daemon postflight | exact three raw IDs and receipt are supplied by this actuator |
| Focused checks and quick gate | Satisfied | focused storage/source/CLI tests; quick gate |

## Adversarial review notes

- Iteration 1 found the attached source/index WAL transaction was not crash-atomic; `bcc87e6cd` adds a source-stage resume protocol and regression test.
- Iteration 2 found (a) a source-side TOCTOU before that stage and (b) an under-proven canonical-head restore; `ccbf6d1ce` reproves source witnesses under the write transaction, requires all canonical authority witnesses, and adds regressions.
- Iteration 3 will be run against this final commit before merge.

## Verification

- `devtools test tests/unit/storage/test_browser_capture_origin_repair.py` — 12 passed.
- `devtools test tests/unit/sources/test_live_batch_support.py -k "streaming_sized_browser_capture_json_uses_native_payload_detection"` — 1 passed.
- `devtools test tests/unit/cli/test_archive_maintenance_cli.py -k "browser_capture_origin_repair_cli or quarantined_accepted_raw_repair_cli"` — 3 passed.
- `devtools verify --quick` — 15 steps passed (including the pre-push gate for `ccbf6d1ce`).

All GitHub Actions jobs fail at setup with zero executed steps, a known account/quota infrastructure failure; local verification above is the merge evidence.