### PR TITLE
fix(storage): retain browser repair authority

### DIFF
--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -162,7 +162,10 @@ def backfill_historical_revision_evidence(
             revisions: list[MembershipRevision] = []
             projections = {}
             retained_bytes = 0
+            candidate_raw_ids = set(archive.raw_membership_rebuild_raw_ids(logical_key))
             for raw_id, session, payload_bytes in spill.for_logical_key(logical_key):
+                if raw_id not in candidate_raw_ids:
+                    continue
                 projection = session_revision_projection(session)
                 member_sessions[raw_id] = session
                 projections[raw_id] = projection

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -1186,6 +1186,7 @@ def _verify_browser_origin_copy_forward_source_stage(
 def _canonical_browser_origin_head_is_exact(
     conn: sqlite3.Connection,
     *,
+    archive_root: Path,
     canonical_head: sqlite3.Row,
     canonical_key: str,
     canonical_origin: Origin,
@@ -1200,7 +1201,7 @@ def _canonical_browser_origin_head_is_exact(
     generation = int(canonical_head["acquisition_generation"])
     raw = conn.execute(
         """
-        SELECT origin, blob_hash, blob_size, logical_source_key, revision_kind,
+        SELECT origin, source_path, blob_hash, blob_size, logical_source_key, revision_kind,
                source_revision, baseline_raw_id, acquisition_generation, revision_authority
         FROM source.raw_sessions WHERE raw_id = ?
         """,
@@ -1242,10 +1243,34 @@ def _canonical_browser_origin_head_is_exact(
         or str(canonical_head["accepted_frontier_kind"]) != "byte"
     ):
         return False
+    try:
+        blob_hash = bytes.fromhex(source_revision)
+        store = BlobStore(archive_root / "blob")
+        blob_path = store.blob_path(source_revision)
+        if not blob_path.is_file() or blob_path.stat().st_size != frontier:
+            return False
+        payload = store.read_all(source_revision)
+        provider = detect_provider(json.loads(payload))
+        if provider is None or origin_from_provider(provider) is not canonical_origin:
+            return False
+        from polylogue.sources.revision_backfill import _parse_one
+
+        sessions = _parse_one(provider, payload, str(raw["source_path"]))
+    except (OSError, ValueError, json.JSONDecodeError):
+        return False
+    if (
+        hashlib.sha256(payload).digest() != blob_hash
+        or len(sessions) != 1
+        or str(make_session_id(provider, sessions[0].provider_session_id)) != session_id
+        or f"{provider.value}:{sessions[0].provider_session_id}" != canonical_key
+        or bytes.fromhex(session_content_hash(sessions[0])) != accepted_hash
+    ):
+        return False
     return (
         tuple(raw)
         == (
             canonical_origin.value,
+            str(raw["source_path"]),
             bytes.fromhex(source_revision),
             frontier,
             canonical_key,
@@ -1423,10 +1448,12 @@ def _inspect_browser_capture_origin_mismatch(
         membership is None
         or census is None
         or str(membership["provider_session_id"]) != session.provider_session_id
+        or str(membership["source_revision"]) != accepted_hash.hex()
         or _bytes_value(membership["normalized_content_hash"]) != projection.session_hash
         or int(membership["message_count"]) != len(projection.message_hashes)
         or int(membership["acquisition_generation"]) != int(raw["acquisition_generation"])
         or str(membership["revision_authority"]) != RawRevisionAuthority.QUARANTINED.value
+        or str(membership["decision"]) != "applied"
         or str(census["status"]) != "complete"
         or int(census["member_count"]) != 1
     ):
@@ -1454,6 +1481,13 @@ def _inspect_browser_capture_origin_mismatch(
                logical_source_key, revision_kind, source_revision, baseline_raw_id,
                acquisition_generation, revision_authority
         FROM source.raw_sessions WHERE raw_id = ?
+        """,
+        (copy_raw_id,),
+    ).fetchone()
+    copy_blob_ref = conn.execute(
+        """
+        SELECT blob_hash, source_path, size_bytes FROM source.blob_refs
+        WHERE ref_id = ? AND ref_type = 'raw_payload'
         """,
         (copy_raw_id,),
     ).fetchone()
@@ -1509,6 +1543,8 @@ def _inspect_browser_capture_origin_mismatch(
     )
     copy_forward_source_complete = (
         copy_raw_exact
+        and copy_blob_ref is not None
+        and tuple(copy_blob_ref) == (blob_hash, copy_path, blob_size)
         and copy_membership is not None
         and str(copy_membership["provider_session_id"]) == session.provider_session_id
         and str(copy_membership["source_revision"]) == accepted_hash.hex()
@@ -1555,6 +1591,7 @@ def _inspect_browser_capture_origin_mismatch(
         replacement_frontier = int(canonical_head["accepted_frontier"])
         if not _canonical_browser_origin_head_is_exact(
             conn,
+            archive_root=archive_root,
             canonical_head=canonical_head,
             canonical_key=canonical_key,
             canonical_origin=canonical_origin,

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2224,10 +2224,15 @@ class ArchiveStore:
         return tuple(sorted(selected)), logical_keys
 
     def raw_membership_raw_ids(self, logical_source_key: str) -> tuple[str, ...]:
+        """Return only byte-proven membership candidates for replay classification."""
         rows = (
             self._ensure_source_conn()
             .execute(
-                "SELECT raw_id FROM raw_session_memberships WHERE logical_source_key = ? ORDER BY raw_id",
+                """
+                SELECT raw_id FROM raw_session_memberships
+                WHERE logical_source_key = ? AND revision_authority = 'byte_proven'
+                ORDER BY raw_id
+                """,
                 (logical_source_key,),
             )
             .fetchall()

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2224,7 +2224,7 @@ class ArchiveStore:
         return tuple(sorted(selected)), logical_keys
 
     def raw_membership_raw_ids(self, logical_source_key: str) -> tuple[str, ...]:
-        """Return only byte-proven membership candidates for replay classification."""
+        """Return only byte-proven membership candidates for live classification."""
         rows = (
             self._ensure_source_conn()
             .execute(
@@ -2232,6 +2232,24 @@ class ArchiveStore:
                 SELECT raw_id FROM raw_session_memberships
                 WHERE logical_source_key = ? AND revision_authority = 'byte_proven'
                 ORDER BY raw_id
+                """,
+                (logical_source_key,),
+            )
+            .fetchall()
+        )
+        return tuple(str(row[0]) for row in rows)
+
+    def raw_membership_rebuild_raw_ids(self, logical_source_key: str) -> tuple[str, ...]:
+        """Return census candidates excluding quarantined full rows with another authority key."""
+        rows = (
+            self._ensure_source_conn()
+            .execute(
+                """
+                SELECT m.raw_id
+                FROM raw_session_memberships AS m
+                JOIN raw_sessions AS r ON r.raw_id = m.raw_id
+                WHERE m.logical_source_key = ? AND r.revision_authority = 'byte_proven'
+                ORDER BY m.raw_id
                 """,
                 (logical_source_key,),
             )

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -11,6 +11,7 @@ from polylogue.config import Config
 from polylogue.core.enums import Provider
 from polylogue.pipeline.ids import session_content_hash, session_revision_projection
 from polylogue.sources.revision_backfill import _parse_one
+from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.repair import (
     repair_browser_capture_origin_mismatches,
     repair_quarantined_accepted_raws,
@@ -302,6 +303,8 @@ def test_browser_capture_origin_copy_forward_preserves_old_evidence_and_is_idemp
             WHERE r.origin = 'unknown-export'
             """
         ).fetchone() == (0,)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        assert archive.raw_membership_raw_ids("chatgpt:browser-origin-one") == (copy_raw_id,)
 
     reapplied = repair_browser_capture_origin_mismatches(
         _config(tmp_path),
@@ -339,6 +342,16 @@ def test_browser_capture_origin_copy_forward_mutations_fail_closed(tmp_path: Pat
             )
 
     report = repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id])
+    assert report.ineligible_count == 1
+
+
+def test_browser_capture_origin_rejects_unresolved_source_membership(tmp_path: Path) -> None:
+    raw_id = _seed_mismatched_browser_head(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        source.execute("UPDATE raw_session_memberships SET decision = 'ambiguous' WHERE raw_id = ?", (raw_id,))
+
+    report = repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id])
+
     assert report.ineligible_count == 1
 
 
@@ -425,6 +438,20 @@ def test_browser_capture_origin_repair_rejects_underproven_canonical_head(tmp_pa
     assert report.ineligible_count == 1
 
 
+def test_browser_capture_origin_repair_rejects_missing_canonical_blob(tmp_path: Path) -> None:
+    mismatched_raw_id = _seed_mismatched_browser_head(tmp_path)
+    canonical_raw_id = _seed_equivalent_canonical_head(tmp_path, mismatched_raw_id)
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        blob_hash = source.execute(
+            "SELECT hex(blob_hash) FROM raw_sessions WHERE raw_id = ?", (canonical_raw_id,)
+        ).fetchone()[0]
+    BlobStore(tmp_path / "blob").blob_path(blob_hash.lower()).unlink()
+
+    report = repair_browser_capture_origin_mismatches(_config(tmp_path), [mismatched_raw_id])
+
+    assert report.ineligible_count == 1
+
+
 def test_browser_capture_origin_copy_forward_reproves_before_source_stage(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -479,3 +506,28 @@ def test_browser_capture_origin_copy_forward_resumes_after_source_stage_interrup
     assert resumed.repaired_count == 1
     assert resumed.items[0].status == "already_repaired"
     assert resumed.items[0].copy_forward_source_complete is True
+
+
+def test_browser_capture_origin_copy_forward_refuses_incomplete_blob_reference(tmp_path: Path) -> None:
+    import polylogue.storage.repair as repair_module
+
+    raw_id = _seed_mismatched_browser_head(tmp_path)
+    dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id])
+    item = dry_run.items[0]
+    assert item.copy_forward_raw_id is not None
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        repair_module._stage_browser_origin_copy_forward_source(source, item)
+        source.execute("DELETE FROM blob_refs WHERE ref_id = ?", (item.copy_forward_raw_id,))
+
+    with pytest.raises(RuntimeError, match="ineligible"):
+        repair_browser_capture_origin_mismatches(
+            _config(tmp_path),
+            [raw_id],
+            apply=True,
+            receipt_path=tmp_path / "incomplete-copy-receipt.jsonl",
+            proof_digest=dry_run.proof_digest,
+        )
+    with sqlite3.connect(tmp_path / "index.db") as index:
+        assert index.execute(
+            "SELECT raw_id FROM sessions WHERE session_id = 'chatgpt-export:browser-origin-one'"
+        ).fetchone() == (raw_id,)

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -3,14 +3,19 @@ from __future__ import annotations
 import json
 import sqlite3
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 
 from polylogue.archive.revision_replay import ApplicationDecision
+from polylogue.archive.session_revision_membership import MembershipClassification
 from polylogue.config import Config
 from polylogue.core.enums import Provider
 from polylogue.pipeline.ids import session_content_hash, session_revision_projection
-from polylogue.sources.revision_backfill import _parse_one
+from polylogue.sources.live.batch import LiveBatchProcessor
+from polylogue.sources.live.cursor import CursorStore
+from polylogue.sources.revision_backfill import _parse_one, backfill_historical_revision_evidence
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.repair import (
     repair_browser_capture_origin_mismatches,
@@ -303,9 +308,6 @@ def test_browser_capture_origin_copy_forward_preserves_old_evidence_and_is_idemp
             WHERE r.origin = 'unknown-export'
             """
         ).fetchone() == (0,)
-    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
-        assert archive.raw_membership_raw_ids("chatgpt:browser-origin-one") == (copy_raw_id,)
-
     reapplied = repair_browser_capture_origin_mismatches(
         _config(tmp_path),
         [raw_id],
@@ -315,6 +317,27 @@ def test_browser_capture_origin_copy_forward_preserves_old_evidence_and_is_idemp
     )
     assert reapplied.repaired_count == 0
     assert receipt.read_text().count("\n") == 2
+
+
+def test_browser_capture_origin_rebuild_keeps_copy_forward_head(tmp_path: Path) -> None:
+    raw_id = _seed_mismatched_browser_head(tmp_path)
+    dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id])
+    applied = repair_browser_capture_origin_mismatches(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=tmp_path / "rebuild-repair.jsonl",
+        proof_digest=dry_run.proof_digest,
+    )
+    copy_raw_id = applied.items[0].copy_forward_raw_id
+    assert copy_raw_id is not None
+
+    backfill_historical_revision_evidence(tmp_path, selected_raw_ids=[raw_id, copy_raw_id])
+
+    with sqlite3.connect(tmp_path / "index.db") as index:
+        assert index.execute(
+            "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = 'chatgpt:browser-origin-one'"
+        ).fetchone() == (copy_raw_id,)
 
 
 @pytest.mark.parametrize("mutation", ["blob", "head", "origin", "canonical_head"])
@@ -531,3 +554,74 @@ def test_browser_capture_origin_copy_forward_refuses_incomplete_blob_reference(t
         assert index.execute(
             "SELECT raw_id FROM sessions WHERE session_id = 'chatgpt-export:browser-origin-one'"
         ).fetchone() == (raw_id,)
+
+
+def test_browser_capture_origin_live_membership_ignores_quarantined_conflict(tmp_path: Path) -> None:
+    raw_id = _seed_mismatched_browser_head(tmp_path)
+    dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id])
+    applied = repair_browser_capture_origin_mismatches(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=tmp_path / "live-membership-repair.jsonl",
+        proof_digest=dry_run.proof_digest,
+    )
+    copy_raw_id = applied.items[0].copy_forward_raw_id
+    assert copy_raw_id is not None
+    session = _parse_one(Provider.CHATGPT, _browser_payload(), "browser-capture/chatgpt/one.json")[0]
+    cursor = CursorStore(tmp_path / "cursor.sqlite")
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=tmp_path / "index.db"))),
+        (),
+        cursor=cursor,
+        parser_fingerprint="browser-origin-test",
+    )
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        parsed_by_raw_id = {
+            raw_id: session,
+            copy_raw_id: session,
+        }
+        projections = {raw_id: session_revision_projection(session), copy_raw_id: session_revision_projection(session)}
+        # Production guard reproduction: an unresolved quarantined member
+        # chosen over the existing byte head raises at the real archive writer.
+        with pytest.raises(RuntimeError, match="membership replay cannot retire"):
+            archive.apply_raw_membership_classification(
+                "chatgpt:browser-origin-one",
+                MembershipClassification((raw_id,), (), ()),
+                parsed_by_raw_id,
+                projections,
+                acquired_at_ms=5,
+            )
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        processor._apply_membership_sessions(archive, copy_raw_id, [session], acquired_at_ms=6)
+        assert archive.raw_revision_head_raw_id("chatgpt:browser-origin-one") == copy_raw_id
+
+
+def test_browser_capture_origin_live_membership_defers_all_quarantined_rows(tmp_path: Path) -> None:
+    raw_id = _seed_mismatched_browser_head(tmp_path)
+    dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id])
+    applied = repair_browser_capture_origin_mismatches(
+        _config(tmp_path),
+        [raw_id],
+        apply=True,
+        receipt_path=tmp_path / "all-quarantined-repair.jsonl",
+        proof_digest=dry_run.proof_digest,
+    )
+    copy_raw_id = applied.items[0].copy_forward_raw_id
+    assert copy_raw_id is not None
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        source.execute(
+            "UPDATE raw_session_memberships SET revision_authority = 'quarantined' "
+            "WHERE logical_source_key = 'chatgpt:browser-origin-one'"
+        )
+    session = _parse_one(Provider.CHATGPT, _browser_payload(), "browser-capture/chatgpt/one.json")[0]
+    cursor = CursorStore(tmp_path / "all-quarantined-cursor.sqlite")
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=tmp_path / "index.db"))),
+        (),
+        cursor=cursor,
+        parser_fingerprint="browser-origin-test",
+    )
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        processor._apply_membership_sessions(archive, copy_raw_id, [session], acquired_at_ms=7)
+        assert archive.raw_revision_head_raw_id("chatgpt:browser-origin-one") == copy_raw_id


### PR DESCRIPTION
## Summary

Completes the durability and convergence fixes identified after #2821 merged: preserve repair authority across a future rebuild and defer quarantined membership cohorts instead of letting them replace established byte heads.

## Problem

The merged actuator left a quarantined historical membership in the canonical replay set, allowing the live watcher to enter `membership replay cannot retire an unrelated accepted head`. Canonical-head reuse also omitted retained-byte proof, and a resumed copy-forward stage omitted its new blob reference.

## Solution

- Live membership replay accepts only byte-proven membership candidates; all-quarantined cohorts defer while preserving the existing accepted head.
- Rebuild replay considers only byte-proven source evidence.
- Require canonical retained-blob existence, digest, parser identity, and content proof.
- Require the copy-forward `raw_payload` blob reference before terminalizing a staged repair.
- Tighten original membership proof to require source revision and `applied` decision.

Ref polylogue-lkrc.

## Verification

- `devtools test tests/unit/storage/test_browser_capture_origin_repair.py` — 18 passed.
- `devtools verify --quick` — 15 steps passed for the parent witness patch; the pushed follow-up passed the enforced pre-push quick gate.

The suite includes a real `ArchiveStore.apply_raw_membership_classification` reproduction of the production guard and a `LiveBatchProcessor` all-quarantined cohort that must leave the existing head unchanged. No v35 rebuild or live archive mutation was run.