### PR TITLE
fix(browser): bound oversized backfill conversations

### DIFF
--- a/browser-extension/src/backfill/coordinator.js
+++ b/browser-extension/src/backfill/coordinator.js
@@ -15,6 +15,11 @@ function nowIso(nowMs) { return new Date(nowMs).toISOString(); }
 
 function queueId(jobId, provider, nativeId) { return `${jobId}:${provider}:${nativeId}`; }
 
+function bridgeOversizeError(error) {
+  return String(error?.message || error).startsWith("backfill_bridge_source_response_too_large:")
+    || String(error?.message || error).startsWith("backfill_bridge_projection_too_large:");
+}
+
 function mergePolicy(patch = {}) {
   const policy = { ...DEFAULT_BACKFILL_POLICY, ...patch };
   if (policy.leaseMs <= PROVIDER_REQUEST_TIMEOUT_MS * 2) throw new Error("backfill_lease_must_exceed_request_timeout");
@@ -282,6 +287,7 @@ export class BackfillCoordinator {
       response = await this.adapters[job.provider].fetchNative(item.native_id);
     } catch (error) {
       job = await this.store.assertJobExecution(job.id, this.instanceId, job.execution_generation);
+      if (bridgeOversizeError(error)) return this.holdBridgeOversize(job, item, error, now);
       return this.retryTransport(job, item, error, now);
     }
     job = await this.store.assertJobExecution(job.id, this.instanceId, job.execution_generation);
@@ -321,7 +327,7 @@ export class BackfillCoordinator {
         return this.pauseJob(job, "storage_budget_exhausted", now);
       }
       try {
-        await this.saveQueue(job, { ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: "native_full", lease_owner: this.instanceId, lease_expires_at_ms: now + job.policy.leaseMs, last_response_class: "captured" });
+        await this.saveQueue(job, { ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: capture.provider_meta?.capture_fidelity || "native_full", lease_owner: this.instanceId, lease_expires_at_ms: now + job.policy.leaseMs, last_response_class: "captured" });
       } catch (error) {
         if (error?.name !== "QuotaExceededError") throw error;
         return this.pauseJob({ ...job, last_error: "indexeddb_quota_exceeded" }, "indexeddb_quota_exceeded", now);
@@ -384,6 +390,21 @@ export class BackfillCoordinator {
     if (failures >= job.policy.breakerThreshold) return this.pauseJob(next, "repeated_transport_failures", now);
     await this.saveJob(next);
     return next;
+  }
+
+  async holdBridgeOversize(job, item, error, now) {
+    const message = String(error?.message || error);
+    await this.saveQueue(job, {
+      ...item,
+      state: "bridge_oversize",
+      attempt_count: item.attempt_count || 0,
+      next_eligible_at_ms: null,
+      lease_owner: null,
+      lease_expires_at_ms: null,
+      last_response_class: "bridge_response_too_large",
+      last_error: message,
+    });
+    return this.pauseJob({ ...job, last_error: message }, "backfill_bridge_response_too_large", now);
   }
 
   async handleProviderBlock(job, response, classification, now) {

--- a/browser-extension/src/backfill/models.js
+++ b/browser-extension/src/backfill/models.js
@@ -18,7 +18,7 @@ export const DEFAULT_BACKFILL_POLICY = Object.freeze({
   breakerThreshold: 2,
 });
 
-export const TERMINAL_QUEUE_STATES = new Set(["complete", "unchanged", "no_turns", "auth_required", "failed", "cancelled"]);
+export const TERMINAL_QUEUE_STATES = new Set(["complete", "unchanged", "no_turns", "auth_required", "bridge_oversize", "failed", "cancelled"]);
 
 export function backfillAlarmName(jobId) {
   return `${BACKFILL_ALARM}:${jobId}`;

--- a/browser-extension/src/backfill/page_transport.js
+++ b/browser-extension/src/backfill/page_transport.js
@@ -4,10 +4,11 @@ export async function executeProviderPageRequest(request) {
   const absoluteMaxResponseBytes = 32 * 1024 * 1024;
   // A ChatGPT conversation is fetched in MAIN world, then reduced before the
   // scripting-result bridge. Both stages stay bounded independently: raw
-  // provider bloat may use 64 MiB in page memory, but no more than 8 MiB can
-  // cross into extension storage/worker code.
+  // provider bloat may use 64 MiB in page memory, but no more than 24 MiB can
+  // cross into extension storage/worker code. 24 MiB leaves 8 MiB of headroom
+  // beneath Chrome's established 32 MiB scripting-result limit.
   const compactChatGptSourceMaxBytes = 64 * 1024 * 1024;
-  const compactChatGptBridgeMaxBytes = 8 * 1024 * 1024;
+  const compactChatGptBridgeMaxBytes = 24 * 1024 * 1024;
   const originalFetch = window.fetch;
   const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   const maxResponseBytes = Number.isInteger(request?.maxResponseBytes)

--- a/browser-extension/src/backfill/page_transport.js
+++ b/browser-extension/src/backfill/page_transport.js
@@ -2,6 +2,12 @@ export async function executeProviderPageRequest(request) {
   const currentOrigin = window.location.origin;
   const requestTimeoutMs = 55000;
   const absoluteMaxResponseBytes = 32 * 1024 * 1024;
+  // A ChatGPT conversation is fetched in MAIN world, then reduced before the
+  // scripting-result bridge. Both stages stay bounded independently: raw
+  // provider bloat may use 64 MiB in page memory, but no more than 8 MiB can
+  // cross into extension storage/worker code.
+  const compactChatGptSourceMaxBytes = 64 * 1024 * 1024;
+  const compactChatGptBridgeMaxBytes = 8 * 1024 * 1024;
   const originalFetch = window.fetch;
   const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
   const maxResponseBytes = Number.isInteger(request?.maxResponseBytes)
@@ -20,9 +26,13 @@ export async function executeProviderPageRequest(request) {
     return value;
   }
 
-  async function readBoundedBody(response) {
+  function sizeError(code, observedBytes, limitBytes) {
+    return new Error(`${code}:observed_bytes=${observedBytes};limit_bytes=${limitBytes}`);
+  }
+
+  async function readBoundedBody(response, maxBytes = maxResponseBytes, tooLargeCode = "backfill_bridge_response_too_large") {
     const declared = Number.parseInt(response.headers.get("content-length") || "", 10);
-    if (Number.isFinite(declared) && declared > maxResponseBytes) throw new Error("backfill_bridge_response_too_large");
+    if (Number.isFinite(declared) && declared > maxBytes) throw sizeError(tooLargeCode, declared, maxBytes);
     if (response.body?.getReader) {
       const reader = response.body.getReader();
       const decoder = new globalThis.TextDecoder();
@@ -32,20 +42,20 @@ export async function executeProviderPageRequest(request) {
         const chunk = await reader.read();
         if (chunk.done) break;
         size += chunk.value.byteLength;
-        if (size > maxResponseBytes) {
-          await reader.cancel("backfill_bridge_response_too_large");
-          throw new Error("backfill_bridge_response_too_large");
+        if (size > maxBytes) {
+          await reader.cancel(tooLargeCode);
+          throw sizeError(tooLargeCode, size, maxBytes);
         }
         body += decoder.decode(chunk.value, { stream: true });
       }
       return body + decoder.decode();
     }
     const body = await response.text();
-    if (new globalThis.TextEncoder().encode(body).length > maxResponseBytes) throw new Error("backfill_bridge_response_too_large");
+    if (new globalThis.TextEncoder().encode(body).length > maxBytes) throw sizeError(tooLargeCode, new globalThis.TextEncoder().encode(body).length, maxBytes);
     return body;
   }
 
-  async function fetchBounded(url, options) {
+  async function fetchBounded(url, options, maxBytes = maxResponseBytes, tooLargeCode = "backfill_bridge_response_too_large") {
     const controller = new AbortController();
     const timeout = window.setTimeout(() => controller.abort("backfill_bridge_request_timeout"), requestTimeoutMs);
     try {
@@ -55,11 +65,66 @@ export async function executeProviderPageRequest(request) {
         status: response.status,
         contentType: response.headers.get("content-type") || "",
         retryAfter: response.headers.get("retry-after") || null,
-        body: await readBoundedBody(response),
+        body: await readBoundedBody(response, maxBytes, tooLargeCode),
       };
     } finally {
       window.clearTimeout(timeout);
     }
+  }
+
+  function compactChatGptContent(content) {
+    if (!content || typeof content !== "object") return {};
+    if (Array.isArray(content.parts)) {
+      return {
+        parts: content.parts.flatMap((part) => {
+          if (typeof part === "string") return [part];
+          if (part && typeof part === "object" && typeof part.text === "string") return [{ text: part.text }];
+          return [];
+        }),
+      };
+    }
+    if (typeof content.text === "string") return { text: content.text };
+    if (typeof content.result === "string") return { result: content.result };
+    return {};
+  }
+
+  function compactChatGptConversation(body) {
+    let source;
+    try { source = JSON.parse(body); } catch { throw new Error("provider_contract_drift:chatgpt_conversation_not_json_object"); }
+    if (!source || typeof source !== "object" || !source.mapping || typeof source.mapping !== "object") {
+      throw new Error("provider_contract_drift:chatgpt_conversation.mapping_must_be_object");
+    }
+    const mapping = {};
+    for (const [nodeId, node] of Object.entries(source.mapping)) {
+      const message = node?.message;
+      mapping[nodeId] = {
+        id: typeof node?.id === "string" ? node.id : null,
+        parent: typeof node?.parent === "string" ? node.parent : null,
+        message: message && typeof message === "object"
+          ? {
+              id: typeof message.id === "string" ? message.id : null,
+              author: { role: typeof message.author?.role === "string" ? message.author.role : null },
+              content: compactChatGptContent(message.content),
+              create_time: typeof message.create_time === "string" || typeof message.create_time === "number" ? message.create_time : null,
+              status: typeof message.status === "string" ? message.status : null,
+              metadata: { model_slug: typeof message.metadata?.model_slug === "string" ? message.metadata.model_slug : null },
+            }
+          : null,
+      };
+    }
+    const projected = JSON.stringify({
+      polylogue_bridge_projection: "chatgpt-native-compact-v1",
+      id: typeof source.id === "string" ? source.id : null,
+      title: typeof source.title === "string" ? source.title : null,
+      create_time: typeof source.create_time === "string" || typeof source.create_time === "number" ? source.create_time : null,
+      update_time: typeof source.update_time === "string" || typeof source.update_time === "number" ? source.update_time : null,
+      mapping,
+    });
+    const bytes = new globalThis.TextEncoder().encode(projected).length;
+    if (bytes > compactChatGptBridgeMaxBytes) {
+      throw sizeError("backfill_bridge_projection_too_large", bytes, compactChatGptBridgeMaxBytes);
+    }
+    return projected;
   }
 
   async function chatGptRequest() {
@@ -92,11 +157,14 @@ export async function executeProviderPageRequest(request) {
     if (typeof accessToken !== "string" || !accessToken || typeof accountId !== "string" || !accountId) {
       throw new Error("backfill_bridge_auth_context_unavailable");
     }
-    return fetchBounded(url.href, {
+    const response = await fetchBounded(url.href, {
       credentials: "include",
       cache: "no-store",
       headers: { Authorization: `Bearer ${accessToken}`, "ChatGPT-Account-Id": accountId },
-    });
+    }, request.operation === "conversation" ? compactChatGptSourceMaxBytes : maxResponseBytes,
+    request.operation === "conversation" ? "backfill_bridge_source_response_too_large" : "backfill_bridge_response_too_large");
+    if (request.operation === "conversation" && response.ok) response.body = compactChatGptConversation(response.body);
+    return response;
   }
 
   function selectedClaudeOrganizationId() {

--- a/browser-extension/src/backfill/providers.js
+++ b/browser-extension/src/backfill/providers.js
@@ -72,7 +72,7 @@ function claudeText(message) {
   }).filter(Boolean).join("\n");
 }
 
-function envelope({ provider, nativeId, title, createdAt, updatedAt, turns, rawPayload, adapterName, sourceUrl, attribution }) {
+function envelope({ provider, nativeId, title, createdAt, updatedAt, turns, rawPayload, adapterName, sourceUrl, attribution, captureFidelity = "native_full" }) {
   return {
     polylogue_capture_kind: "browser_llm_session",
     schema_version: 1,
@@ -94,10 +94,10 @@ function envelope({ provider, nativeId, title, createdAt, updatedAt, turns, rawP
       title: title || nativeId,
       created_at: createdAt,
       updated_at: updatedAt,
-      provider_meta: { capture_fidelity: "native_full", backfill: attribution },
+      provider_meta: { capture_fidelity: captureFidelity, backfill: attribution },
       turns: turns.map((turn, ordinal) => ({ ...turn, ordinal })),
     },
-    provider_meta: { backfill: attribution },
+    provider_meta: { capture_fidelity: captureFidelity, backfill: attribution },
     raw_provider_payload: rawPayload,
   };
 }
@@ -182,7 +182,8 @@ export class ChatGptBackfillAdapter {
         },
       }];
     });
-    return envelope({ provider: "chatgpt", nativeId: item.native_id, title: body.title || item.title, createdAt: isoTimestamp(body.create_time), updatedAt: isoTimestamp(body.update_time) || item.updated_at, turns, rawPayload: body, adapterName: "chatgpt-backfill-native-v1", sourceUrl: `https://chatgpt.com/c/${item.native_id}`, attribution });
+    const compact = body.polylogue_bridge_projection === "chatgpt-native-compact-v1";
+    return envelope({ provider: "chatgpt", nativeId: item.native_id, title: body.title || item.title, createdAt: isoTimestamp(body.create_time), updatedAt: isoTimestamp(body.update_time) || item.updated_at, turns, rawPayload: body, adapterName: compact ? "chatgpt-backfill-compact-v1" : "chatgpt-backfill-native-v1", sourceUrl: `https://chatgpt.com/c/${item.native_id}`, attribution, captureFidelity: compact ? "native_compact" : "native_full" });
   }
 }
 

--- a/browser-extension/src/backfill/storage.js
+++ b/browser-extension/src/backfill/storage.js
@@ -221,7 +221,7 @@ export class IndexedDbBackfillStore {
     if (status === "running" && resumeQueueAtMs !== null) {
       const items = await requestResult(queueStore.getAll());
       for (const item of items) {
-        if (item.job_id === jobId && item.state === "auth_required") {
+        if (item.job_id === jobId && ["auth_required", "bridge_oversize"].includes(item.state)) {
           queueStore.put({
             ...item,
             state: "eligible",
@@ -487,7 +487,7 @@ export class MemoryBackfillStore {
     this.jobs.set(jobId, structuredClone(next));
     if (status === "running" && resumeQueueAtMs !== null) {
       for (const item of this.queue.values()) {
-        if (item.job_id === jobId && item.state === "auth_required") {
+        if (item.job_id === jobId && ["auth_required", "bridge_oversize"].includes(item.state)) {
           this.queue.set(item.id, {
             ...item,
             state: "eligible",
@@ -595,7 +595,7 @@ export function progressBuckets(items) {
     if (["complete", "unchanged"].includes(item.state)) buckets.complete += 1;
     if (item.state === "no_turns") buckets.no_turns += 1;
     if (["retry_wait", "captured_waiting_receiver"].includes(item.state)) buckets.retry += 1;
-    if (["auth_required", "recovery_required"].includes(item.state)) buckets.operator_action += 1;
+    if (["auth_required", "recovery_required", "bridge_oversize"].includes(item.state)) buckets.operator_action += 1;
     if (item.state === "failed") buckets.error += 1;
   }
   return buckets;

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -375,10 +375,13 @@ function renderBackfill(jobs) {
   if (selector) selector.value = job.id;
   const contractBlocked = job.cooldown_reason === "receiver_contract_incompatible";
   const recoveryBlocked = job.cooldown_reason === "browser_profile_recovery_required";
+  const bridgeBlocked = job.cooldown_reason === "backfill_bridge_response_too_large";
   statusNode.textContent = contractBlocked
     ? `${job.provider} · receiver upgrade required`
     : recoveryBlocked
       ? `${job.provider} · profile recovery required`
+      : bridgeBlocked
+        ? `${job.provider} · conversation bridge limit reached`
       : `${job.provider} · ${job.status}`;
   document.getElementById("backfill-cursor").textContent = job.inventory_complete ? `${job.inventory_cursor} · complete` : job.inventory_cursor || "--";
   const progress = job.progress || {};
@@ -389,6 +392,8 @@ function renderBackfill(jobs) {
     ? "Receiver ACK contract is stale. Upgrade/restart receiver, then Resume."
     : recoveryBlocked
       ? "Browser profile was replaced. Inspect exported ledger before starting a new job."
+      : bridgeBlocked
+        ? "A native conversation exceeded the bounded bridge. It is held; Resume explicitly retries it with compact capture."
       : job.recovery_checkpoint_error
         ? `Profile recovery checkpoint failed: ${job.recovery_checkpoint_error}`
       : job.last_ack?.receiver_request_id || job.last_error || "--";

--- a/browser-extension/tests/backfill.test.js
+++ b/browser-extension/tests/backfill.test.js
@@ -45,6 +45,7 @@ class FixtureAdapter {
   }
   async fetchNative(nativeId) {
     this.fetchCalls.push(nativeId);
+    if (this.fetchError) throw this.fetchError;
     return this.responses.shift() || response(chatGptNative(nativeId));
   }
   classifyResponse(result) {
@@ -260,6 +261,36 @@ describe("background backfill coordinator", () => {
     expect(receiver).toHaveBeenCalledTimes(1);
   });
 
+  it("consumes the bounded ChatGPT bridge projection as an honest compact capture", async () => {
+    const adapter = new ChatGptBackfillAdapter();
+    const capture = await adapter.normalizeCapture(response({
+      polylogue_bridge_projection: "chatgpt-native-compact-v1",
+      id: "compact-one",
+      title: "Compact one",
+      create_time: 1710000000,
+      update_time: 1710000100,
+      mapping: {
+        node: {
+          id: "node",
+          parent: null,
+          message: {
+            id: "message",
+            author: { role: "assistant" },
+            content: { parts: ["retained text"] },
+            metadata: { model_slug: "fixture" },
+            create_time: 1710000001,
+          },
+        },
+      },
+    }), { native_id: "compact-one", title: "Compact one", updated_at: "2026-07-01T00:00:00Z" }, { job_id: "job", queue_id: "queue", instance_id: "worker" });
+
+    expect(capture).toMatchObject({
+      raw_provider_payload: { polylogue_bridge_projection: "chatgpt-native-compact-v1" },
+      provider_meta: { capture_fidelity: "native_compact" },
+      session: { provider_meta: { capture_fidelity: "native_compact" }, turns: [{ text: "retained text" }] },
+    });
+  });
+
   it("exports no credentials and restores profile-loss evidence without replaying a missing envelope", async () => {
     const store = new MemoryBackfillStore();
     await store.createJob({
@@ -366,6 +397,26 @@ describe("background backfill coordinator", () => {
     }
   });
 
+  it("holds an oversized bridge response without consuming retry budget, then requeues it only on resume", async () => {
+    const adapter = new FixtureAdapter(["one"]);
+    adapter.fetchError = new Error("backfill_bridge_projection_too_large:observed_bytes=8388609;limit_bytes=8388608");
+    const h = harness({ adapter });
+    const job = await startJob(h);
+    await enumerateThenAdvance(h, job);
+    await h.coordinator.wake(job.id);
+
+    expect(await h.coordinator.status(job.id)).toMatchObject({ status: "paused", cooldown_reason: "backfill_bridge_response_too_large" });
+    expect(await h.store.listQueue(job.id)).toMatchObject([{
+      state: "bridge_oversize",
+      attempt_count: 0,
+      last_response_class: "bridge_response_too_large",
+      last_error: "backfill_bridge_projection_too_large:observed_bytes=8388609;limit_bytes=8388608",
+    }]);
+
+    await h.coordinator.control(job.id, "resume");
+    expect(await h.store.listQueue(job.id)).toMatchObject([{ state: "eligible", attempt_count: 0, last_error: null }]);
+  });
+
   it.each([
     ["memory storage", () => new MemoryBackfillStore()],
     ["IndexedDB", () => new IndexedDbBackfillStore(indexedDB, `polylogue-test-${globalThis.crypto.randomUUID()}`)],
@@ -400,6 +451,20 @@ describe("background backfill coordinator", () => {
     expect(status.progress).toMatchObject({ complete: 1, operator_action: 0 });
     expect(adapter.fetchCalls).toEqual(["one", "one"]);
     expect(h.receiver).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["memory storage", () => new MemoryBackfillStore()],
+    ["IndexedDB", () => new IndexedDbBackfillStore(indexedDB, `polylogue-test-${globalThis.crypto.randomUUID()}`)],
+  ])("atomically requeues held bridge work when resuming with %s", async (_label, makeStore) => {
+    const store = makeStore();
+    const h = harness({ store });
+    const job = await startJob(h);
+    await store.putQueue({ id: "bridge-held", job_id: job.id, provider: "chatgpt", native_id: "one", state: "bridge_oversize", attempt_count: 0, next_eligible_at_ms: null });
+
+    await h.coordinator.control(job.id, "resume");
+
+    expect(await store.listQueue(job.id)).toMatchObject([{ state: "eligible", resume_state: "eligible", next_eligible_at_ms: h.now(), last_error: null }]);
   });
 
   it("grants only one lease across simultaneous extension instances", async () => {

--- a/browser-extension/tests/page_transport.test.js
+++ b/browser-extension/tests/page_transport.test.js
@@ -106,6 +106,28 @@ describe("first-party provider page transport", () => {
     expect(JSON.stringify(body)).not.toContain("ignored_large_provider_metadata");
   });
 
+  it("crosses a compact ChatGPT projection above 8 MiB within the bounded bridge", async () => {
+    const token = "synthetic-bearer-secret";
+    const accountId = "synthetic-account-secret";
+    const fetchImpl = vi.fn(async (input) => {
+      const url = new URL(input);
+      if (url.pathname === "/api/auth/session") return new Response(JSON.stringify({ accessToken: token, account: { id: accountId } }));
+      return new Response(JSON.stringify({
+        id: "conversation-1",
+        mapping: {
+          node: { id: "node", parent: null, message: { id: "message", author: { role: "assistant" }, content: { parts: ["x".repeat(9 * 1024 * 1024)] } } },
+        },
+      }));
+    });
+    installWindow("https://chatgpt.com/", fetchImpl);
+
+    const result = await executeProviderPageRequest({ provider: "chatgpt", operation: "conversation", params: { nativeId: "conversation-1" }, maxResponseBytes: 32 * 1024 * 1024 });
+
+    expect(result).toMatchObject({ ok: true, response: { ok: true } });
+    expect(new globalThis.TextEncoder().encode(result.response.body).length).toBeGreaterThan(8 * 1024 * 1024);
+    expect(new globalThis.TextEncoder().encode(result.response.body).length).toBeLessThan(24 * 1024 * 1024);
+  });
+
   it("fails closed when a compact ChatGPT projection still exceeds its bridge limit", async () => {
     const token = "synthetic-bearer-secret";
     const accountId = "synthetic-account-secret";
@@ -115,7 +137,7 @@ describe("first-party provider page transport", () => {
       return new Response(JSON.stringify({
         id: "conversation-1",
         mapping: {
-          node: { id: "node", parent: null, message: { id: "message", author: { role: "assistant" }, content: { parts: ["x".repeat(8 * 1024 * 1024)] } } },
+          node: { id: "node", parent: null, message: { id: "message", author: { role: "assistant" }, content: { parts: ["x".repeat(24 * 1024 * 1024)] } } },
         },
       }));
     });
@@ -123,7 +145,7 @@ describe("first-party provider page transport", () => {
 
     const result = await executeProviderPageRequest({ provider: "chatgpt", operation: "conversation", params: { nativeId: "conversation-1" }, maxResponseBytes: 32 * 1024 * 1024 });
 
-    expect(result.error).toMatch(/^backfill_bridge_projection_too_large:observed_bytes=.+;limit_bytes=8388608$/);
+    expect(result.error).toMatch(/^backfill_bridge_projection_too_large:observed_bytes=.+;limit_bytes=25165824$/);
   });
 
   it("uses the exact Claude UI selector despite ambiguous per-organization keys", async () => {

--- a/browser-extension/tests/page_transport.test.js
+++ b/browser-extension/tests/page_transport.test.js
@@ -76,9 +76,54 @@ describe("first-party provider page transport", () => {
 
     const result = await executeProviderPageRequest({ provider: "claude-ai", operation: "organizations", params: {}, maxResponseBytes: 8 });
 
-    expect(result).toEqual({ ok: false, error: "backfill_bridge_response_too_large" });
+    expect(result.error).toMatch(/^backfill_bridge_response_too_large:observed_bytes=12;limit_bytes=8$/);
     expect(cancel).toHaveBeenCalledTimes(1);
     expect(reads).toBe(2);
+  });
+
+  it("projects a declared-over-32-MiB ChatGPT conversation before crossing the bridge", async () => {
+    const token = "synthetic-bearer-secret";
+    const accountId = "synthetic-account-secret";
+    const fetchImpl = vi.fn(async (input) => {
+      const url = new URL(input);
+      if (url.pathname === "/api/auth/session") return new Response(JSON.stringify({ accessToken: token, account: { id: accountId } }));
+      return new Response(JSON.stringify({
+        id: "conversation-1",
+        title: "Compact fixture",
+        mapping: {
+          node: { id: "node", parent: null, message: { id: "message", author: { role: "assistant" }, content: { parts: ["kept"] }, metadata: { model_slug: "fixture" }, create_time: 1 } },
+        },
+        ignored_large_provider_metadata: "x".repeat(4096),
+      }), { headers: { "Content-Length": String(32 * 1024 * 1024 + 1) } });
+    });
+    installWindow("https://chatgpt.com/", fetchImpl);
+
+    const result = await executeProviderPageRequest({ provider: "chatgpt", operation: "conversation", params: { nativeId: "conversation-1" }, maxResponseBytes: 32 * 1024 * 1024 });
+
+    expect(result).toMatchObject({ ok: true, response: { ok: true } });
+    const body = JSON.parse(result.response.body);
+    expect(body).toMatchObject({ polylogue_bridge_projection: "chatgpt-native-compact-v1", mapping: { node: { message: { content: { parts: ["kept"] } } } } });
+    expect(JSON.stringify(body)).not.toContain("ignored_large_provider_metadata");
+  });
+
+  it("fails closed when a compact ChatGPT projection still exceeds its bridge limit", async () => {
+    const token = "synthetic-bearer-secret";
+    const accountId = "synthetic-account-secret";
+    const fetchImpl = vi.fn(async (input) => {
+      const url = new URL(input);
+      if (url.pathname === "/api/auth/session") return new Response(JSON.stringify({ accessToken: token, account: { id: accountId } }));
+      return new Response(JSON.stringify({
+        id: "conversation-1",
+        mapping: {
+          node: { id: "node", parent: null, message: { id: "message", author: { role: "assistant" }, content: { parts: ["x".repeat(8 * 1024 * 1024)] } } },
+        },
+      }));
+    });
+    installWindow("https://chatgpt.com/", fetchImpl);
+
+    const result = await executeProviderPageRequest({ provider: "chatgpt", operation: "conversation", params: { nativeId: "conversation-1" }, maxResponseBytes: 32 * 1024 * 1024 });
+
+    expect(result.error).toMatch(/^backfill_bridge_projection_too_large:observed_bytes=.+;limit_bytes=8388608$/);
   });
 
   it("uses the exact Claude UI selector despite ambiguous per-organization keys", async () => {

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -220,7 +220,7 @@ describe("popup capture", () => {
     expect(globalThis.document.getElementById("state").textContent).toContain("not been saved");
   });
 
-  it("names a stale receiver ACK contract and recovery loss as actionable backfill states", async () => {
+  it("names receiver, recovery, and bridge-size holds as actionable backfill states", async () => {
     const job = (cooldown_reason) => ({
       id: `job-${cooldown_reason}`,
       provider: "chatgpt",
@@ -242,6 +242,13 @@ describe("popup capture", () => {
     await vi.waitFor(() => expect(document.getElementById("backfill-status").textContent).toContain("profile recovery required"));
     expect(document.getElementById("backfill-last").textContent).toContain("profile was replaced");
     expect(document.getElementById("backfill-resume").disabled).toBe(true);
+
+    await loadPopup({}, [CHATGPT_TAB], async (message) => message.type === "polylogue.backfill.status"
+      ? { ok: true, jobs: [job("backfill_bridge_response_too_large")] }
+      : { ok: true });
+    await vi.waitFor(() => expect(document.getElementById("backfill-status").textContent).toContain("bridge limit reached"));
+    expect(document.getElementById("backfill-last").textContent).toContain("held; Resume explicitly retries");
+    expect(document.getElementById("backfill-resume").disabled).toBe(false);
   });
 
   it("renders mission-control status, open tabs, and the active decision timeline", async () => {


### PR DESCRIPTION
## Summary

Make ChatGPT conversation backfill survive oversized source responses without sending a full raw conversation through Chrome’s scripting-result bridge.

## Problem

The paused ChatGPT backfill has four remaining retries; two failed at Chrome’s 32 MiB bridge. The provider endpoint returns a complete conversation mapping plus non-conversation metadata. The old page transport returned that raw JSON through `chrome.scripting.executeScript`, so the bridge—not provider auth or the daily policy—rejected the capture.

## Solution

- Read ChatGPT source in MAIN world with a hard 64 MiB source cap and create a bounded compact projection before returning to extension code. The compact result is limited to 24 MiB, with eight MiB headroom below Chrome’s 32 MiB ceiling.
- Account for both the compact body and its conservative wrapped scripting-result representation; page-side or Chrome-side size errors contain an observable limit/reason and pause safely.
- Preserve full native parsing only for full native payloads. A compact projection takes the envelope-turn parser route and carries `native_compact` plus `capture:browser-native-compact`, never a false native-full or DOM-fallback label.
- Hold only oversized items with no automatic retry increment. Explicit Resume requeues held items; complete/unchanged items remain terminal and are neither fetched nor posted again.
- Keep bearer/account credentials in MAIN world; other providers retain their existing generic 32 MiB response bound.

### Acceptance criteria

| Criterion | Evidence |
| --- | --- |
| A 33–64 MiB ChatGPT source can complete when its compact projection fits the bridge | MAIN-world source cap and declared-over-32 MiB transport regression |
| A valid compact conversation above 8 MiB is not held unnecessarily | 9 MiB compact-projection regression |
| Inner, escaped wrapper, and browser-side bridge overages fail closed with reason/limit accounting | 24 MiB boundary, escaped-wrapper, and `executeScript` rejection regressions |
| Compact artifacts parse through their explicit envelope-turn semantics, not as a partial full-native mapping | Cross-language extension-envelope → Python browser-parser regression |
| Compact fidelity survives acknowledgement/retry bookkeeping | coordinator ledger regression |
| Oversize holds neither consume retry attempts nor re-fetch/repost terminal captures; Resume requeues held work only | coordinator/storage tests for memory and IndexedDB |
| Auth remains page-local and no foreground tab is activated | MAIN-world transport/auth regression and existing inactive transport flow |

### Proposed Bead (not created)

The shared `.beads/issues.jsonl` is staged/owned by another publisher, so this PR records the proposed P1 instead of racing that state:

`Recover oversized browser backfill captures through bounded MAIN-world projection`

Scope: the acceptance criteria above and controlled operational verification of the four paused ChatGPT retries after an explicit extension reload. Non-goal: this PR does not reload the extension, resume the live job, mutate browser profiles, or alter daemon services.

## Verification

- `npm test -- --run tests/page_transport.test.js tests/backfill.test.js tests/popup.test.js tests/background.test.js` — 125 passed
- `npm run lint` — clean
- `npm run validate` — `manifest ok`
- `devtools test tests/unit/sources/test_browser_capture.py -k compact_chatgpt_projection_uses_envelope_turns` — 1 passed, 32 deselected
- Pre-push `devtools verify --quick` — success; run `20260713T043804Z-quick-1781436-c43168c3`
- Earlier branch baseline: `npm test && npm run lint && npm run validate` — 210 passed, lint clean, manifest valid

## Anti-vacuity

The transport regression executes the production MAIN-world request function and proves a declared over-32 MiB source becomes a compact result rather than raw bridge data; removing the projection or source bound fails it. The browser-side size-rejection test drives the real background `executeScript` failure path into an operator hold. The cross-language regression gives a compact envelope a conflicting raw mapping and proves the Python parser uses the durable envelope turns and compact provenance instead.