### PR TITLE
fix(browser): recover bounded backfill captures safely

### DIFF
--- a/browser-extension/src/backfill/coordinator.js
+++ b/browser-extension/src/backfill/coordinator.js
@@ -165,6 +165,17 @@ export class BackfillCoordinator {
     const jobId = job.id;
     job = await this.ensureReceiverContract(job, now);
     if (job.status !== "running") return this.status(jobId);
+    const persistedBridgeHold = (await this.store.listQueue(jobId)).find((item) => item.state === "bridge_oversize");
+    if (persistedBridgeHold) {
+      // A worker can die after durable queue persistence but before the job
+      // pause. Repair that crash window before any alarm can fetch another
+      // item or mark the all-terminal queue complete.
+      return this.pauseJob(
+        { ...job, last_error: persistedBridgeHold.last_error || "backfill_bridge_response_too_large" },
+        "backfill_bridge_response_too_large",
+        now,
+      );
+    }
     await this.store.recoverExpiredLeases(jobId, now);
     await this.schedule(jobId, now + job.policy.leaseMs);
     const receiverItem = await this.store.acquireNextLease(jobId, this.instanceId, now, job.policy.leaseMs, true);

--- a/browser-extension/src/backfill/coordinator.js
+++ b/browser-extension/src/backfill/coordinator.js
@@ -452,6 +452,13 @@ export class BackfillCoordinator {
   }
 
   async handleJobTransport(job, error, now) {
+    if (bridgeOversizeError(error)) {
+      return this.pauseJob(
+        { ...job, last_error: String(error?.message || error) },
+        "backfill_bridge_response_too_large",
+        now,
+      );
+    }
     const failures = (job.transport_failures || 0) + 1;
     const next = { ...job, transport_failures: failures, last_error: String(error.message || error) };
     if (failures >= job.policy.breakerThreshold) return this.pauseJob(next, "repeated_transport_failures", now);

--- a/browser-extension/src/backfill/coordinator.js
+++ b/browser-extension/src/backfill/coordinator.js
@@ -335,14 +335,16 @@ export class BackfillCoordinator {
       await this.saveQueue(job, { ...item, state: "failed", lease_owner: null, lease_expires_at_ms: null, last_response_class: "contract_drift", last_error: String(error.message || error) });
       return job;
     }
+    const captureFidelity = capture.provider_meta?.capture_fidelity || "native_full";
     if (!capture.session?.turns?.length) {
-      await this.saveQueue(job, { ...item, state: "no_turns", lease_owner: null, lease_expires_at_ms: null, last_response_class: "native_empty", capture_fidelity: "native_full" });
+      await this.saveQueue(job, { ...item, state: "no_turns", lease_owner: null, lease_expires_at_ms: null, last_response_class: "native_empty", capture_fidelity: captureFidelity });
       return job;
     }
     return this.submitReceiver(job, item, capture, now);
   }
 
   async submitReceiver(job, item, capture, now) {
+    const captureFidelity = capture.provider_meta?.capture_fidelity || "native_full";
     const serialized = serializedJson(capture);
     const hash = await serializedContentHash(serialized);
     const firstPersistence = item.resume_state !== "captured_waiting_receiver" || !item.envelope;
@@ -364,7 +366,7 @@ export class BackfillCoordinator {
       job = await this.store.assertJobExecution(job.id, this.instanceId, job.execution_generation);
       const contractError = receiverAckContractError(receipt, hash);
       if (contractError) throw contractError;
-      const completeItem = { ...item, state: "complete", envelope: null, content_hash: hash, capture_fidelity: "native_full", receiver_receipt: receipt, lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_acked", completed_at: nowIso(now) };
+      const completeItem = { ...item, state: "complete", envelope: null, content_hash: hash, capture_fidelity: captureFidelity, receiver_receipt: receipt, lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_acked", completed_at: nowIso(now) };
       const revision = item.provider_updated_at
         ? {
           id: `${item.provider}:${item.native_id}`,
@@ -389,11 +391,11 @@ export class BackfillCoordinator {
     } catch (error) {
       if (String(error?.message || error).startsWith("stale_backfill_execution:")) throw error;
       if (error?.code === "receiver_contract_incompatible" || String(error?.message || error).startsWith("receiver_contract_incompatible:")) {
-        await this.saveQueue(job, { ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: "native_full", lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_contract_incompatible", last_error: String(error.message || error) });
+        await this.saveQueue(job, { ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: captureFidelity, lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_contract_incompatible", last_error: String(error.message || error) });
         return this.pauseJob({ ...job, last_error: String(error.message || error) }, "receiver_contract_incompatible", now);
       }
       const attempt = (item.attempt_count || 0) + 1;
-      await this.saveQueue(job, { ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: "native_full", attempt_count: attempt, next_eligible_at_ms: now + fullJitterDelay(attempt, job.policy.baseCadenceMs, job.policy.maxCadenceMs, this.random), lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_down", last_error: String(error.message || error) });
+      await this.saveQueue(job, { ...item, state: "captured_waiting_receiver", envelope: capture, content_hash: hash, capture_fidelity: captureFidelity, attempt_count: attempt, next_eligible_at_ms: now + fullJitterDelay(attempt, job.policy.baseCadenceMs, job.policy.maxCadenceMs, this.random), lease_owner: null, lease_expires_at_ms: null, last_response_class: "receiver_down", last_error: String(error.message || error) });
       const exhausted = attempt >= job.policy.maxReceiverAttempts;
       const next = {
         ...job,

--- a/browser-extension/src/backfill/coordinator.js
+++ b/browser-extension/src/backfill/coordinator.js
@@ -20,6 +20,10 @@ function bridgeOversizeError(error) {
     || String(error?.message || error).startsWith("backfill_bridge_projection_too_large:");
 }
 
+function providerContractDriftError(error) {
+  return String(error?.message || error).startsWith("provider_contract_drift:");
+}
+
 function mergePolicy(patch = {}) {
   const policy = { ...DEFAULT_BACKFILL_POLICY, ...patch };
   if (policy.leaseMs <= PROVIDER_REQUEST_TIMEOUT_MS * 2) throw new Error("backfill_lease_must_exceed_request_timeout");
@@ -299,6 +303,17 @@ export class BackfillCoordinator {
     } catch (error) {
       job = await this.store.assertJobExecution(job.id, this.instanceId, job.execution_generation);
       if (bridgeOversizeError(error)) return this.holdBridgeOversize(job, item, error, now);
+      if (providerContractDriftError(error)) {
+        await this.saveQueue(job, {
+          ...item,
+          state: "failed",
+          lease_owner: null,
+          lease_expires_at_ms: null,
+          last_response_class: "contract_drift",
+          last_error: String(error?.message || error),
+        });
+        return job;
+      }
       return this.retryTransport(job, item, error, now);
     }
     job = await this.store.assertJobExecution(job.id, this.instanceId, job.execution_generation);

--- a/browser-extension/src/backfill/page_transport.js
+++ b/browser-extension/src/backfill/page_transport.js
@@ -128,6 +128,16 @@ export async function executeProviderPageRequest(request) {
     return projected;
   }
 
+  function assertScriptingResultBound(response) {
+    // executeScript returns this exact result shape. JSON encoding is a
+    // conservative byte model for the browser bridge because escaped content
+    // can be larger than the compact conversation string alone.
+    const bytes = new globalThis.TextEncoder().encode(JSON.stringify({ ok: true, response })).length;
+    if (bytes > compactChatGptBridgeMaxBytes) {
+      throw sizeError("backfill_bridge_projection_too_large", bytes, compactChatGptBridgeMaxBytes);
+    }
+  }
+
   async function chatGptRequest() {
     let url;
     if (request.operation === "inventory") {
@@ -164,7 +174,10 @@ export async function executeProviderPageRequest(request) {
       headers: { Authorization: `Bearer ${accessToken}`, "ChatGPT-Account-Id": accountId },
     }, request.operation === "conversation" ? compactChatGptSourceMaxBytes : maxResponseBytes,
     request.operation === "conversation" ? "backfill_bridge_source_response_too_large" : "backfill_bridge_response_too_large");
-    if (request.operation === "conversation" && response.ok) response.body = compactChatGptConversation(response.body);
+    if (request.operation === "conversation" && response.ok) {
+      response.body = compactChatGptConversation(response.body);
+      assertScriptingResultBound(response);
+    }
     return response;
   }
 

--- a/browser-extension/src/backfill/page_transport.js
+++ b/browser-extension/src/backfill/page_transport.js
@@ -92,7 +92,7 @@ export async function executeProviderPageRequest(request) {
   function compactChatGptConversation(body) {
     let source;
     try { source = JSON.parse(body); } catch { throw new Error("provider_contract_drift:chatgpt_conversation_not_json_object"); }
-    if (!source || typeof source !== "object" || !source.mapping || typeof source.mapping !== "object") {
+    if (!source || typeof source !== "object" || !source.mapping || typeof source.mapping !== "object" || Array.isArray(source.mapping)) {
       throw new Error("provider_contract_drift:chatgpt_conversation.mapping_must_be_object");
     }
     const mapping = {};

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -863,6 +863,11 @@ function pageContextResponse(response) {
   };
 }
 
+function scriptingResultTooLarge(error) {
+  const message = String(error?.message || error).toLowerCase();
+  return /(?:result|response|message|script).{0,100}(?:too large|exceed(?:s|ed)?|maximum).{0,100}(?:size|limit|length)/.test(message);
+}
+
 async function providerPageFetch(url, options = {}) {
   if (options.method && options.method !== "GET") throw new Error("backfill_provider_method_not_allowed");
   const request = providerRequestFromUrl(url);
@@ -885,6 +890,9 @@ async function providerPageFetch(url, options = {}) {
     if (transport.owned) {
       await chrome.tabs.remove(transport.tab.id).catch(() => undefined);
       if (transport.cleanupAlarm) await chrome.alarms.clear(transport.cleanupAlarm);
+    }
+    if (scriptingResultTooLarge(error)) {
+      throw new Error("backfill_bridge_projection_too_large:observed_bytes=unavailable;limit_bytes=25165824");
     }
     throw error;
   }

--- a/browser-extension/tests/backfill.test.js
+++ b/browser-extension/tests/backfill.test.js
@@ -434,6 +434,32 @@ describe("background backfill coordinator", () => {
     expect(h.adapter.fetchCalls).toEqual([]);
   });
 
+  it("fails compact provider-contract drift per item and continues the job", async () => {
+    const adapter = new FixtureAdapter(["bad", "good"]);
+    adapter.fetchNative = async (nativeId) => {
+      adapter.fetchCalls.push(nativeId);
+      if (nativeId === "bad") throw new Error("provider_contract_drift:chatgpt_conversation.mapping_must_be_object");
+      return response(chatGptNative(nativeId));
+    };
+    const h = harness({ adapter });
+    const job = await startJob(h);
+    await enumerateThenAdvance(h, job);
+    await h.coordinator.wake(job.id);
+
+    expect((await h.store.listQueue(job.id)).find((item) => item.native_id === "bad")).toMatchObject({
+      native_id: "bad",
+      state: "failed",
+      attempt_count: 0,
+      last_response_class: "contract_drift",
+    });
+    expect((await h.coordinator.status(job.id)).transport_failures).toBe(0);
+
+    h.advance(h.policy.baseCadenceMs);
+    await h.coordinator.wake(job.id);
+    expect(await h.coordinator.status(job.id)).toMatchObject({ status: "complete" });
+    expect(h.adapter.fetchCalls).toEqual(["bad", "good"]);
+  });
+
   it.each([
     ["memory storage", () => new MemoryBackfillStore()],
     ["IndexedDB", () => new IndexedDbBackfillStore(indexedDB, `polylogue-test-${globalThis.crypto.randomUUID()}`)],

--- a/browser-extension/tests/backfill.test.js
+++ b/browser-extension/tests/backfill.test.js
@@ -291,6 +291,17 @@ describe("background backfill coordinator", () => {
     });
   });
 
+  it("preserves compact-capture fidelity after the receiver acknowledges it", async () => {
+    const adapter = new FixtureAdapter(["compact-one"]);
+    adapter.responses = [response({ ...chatGptNative("compact-one"), polylogue_bridge_projection: "chatgpt-native-compact-v1" })];
+    const h = harness({ adapter });
+    const job = await startJob(h);
+    await enumerateThenAdvance(h, job);
+    await h.coordinator.wake(job.id);
+
+    expect(await h.store.listQueue(job.id)).toMatchObject([{ state: "complete", capture_fidelity: "native_compact" }]);
+  });
+
   it("exports no credentials and restores profile-loss evidence without replaying a missing envelope", async () => {
     const store = new MemoryBackfillStore();
     await store.createJob({

--- a/browser-extension/tests/backfill.test.js
+++ b/browser-extension/tests/backfill.test.js
@@ -417,6 +417,23 @@ describe("background backfill coordinator", () => {
     expect(await h.store.listQueue(job.id)).toMatchObject([{ state: "eligible", attempt_count: 0, last_error: null }]);
   });
 
+  it("repairs a persisted bridge hold before a restarted worker fetches or completes it", async () => {
+    const h = harness({ adapter: new FixtureAdapter(["one"]) });
+    const job = await startJob(h);
+    await enumerateThenAdvance(h, job);
+    const [item] = await h.store.listQueue(job.id);
+    await h.store.putQueue({
+      ...item,
+      state: "bridge_oversize",
+      last_error: "backfill_bridge_projection_too_large:observed_bytes=25200000;limit_bytes=25165824",
+    });
+
+    await h.coordinator.wake(job.id);
+
+    expect(await h.coordinator.status(job.id)).toMatchObject({ status: "paused", cooldown_reason: "backfill_bridge_response_too_large" });
+    expect(h.adapter.fetchCalls).toEqual([]);
+  });
+
   it.each([
     ["memory storage", () => new MemoryBackfillStore()],
     ["IndexedDB", () => new IndexedDbBackfillStore(indexedDB, `polylogue-test-${globalThis.crypto.randomUUID()}`)],

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -649,6 +649,30 @@ describe("background receiver diagnostics", () => {
     expect(status.inventory_complete).toBe(false);
   });
 
+  it("holds a browser scripting-result size rejection without spending retry attempts", async () => {
+    globalThis.chrome.scripting.executeScript = vi.fn(async () => {
+      throw new Error("The message length exceeded the maximum allowed size");
+    });
+
+    const started = await sendRuntimeMessage({
+      type: "polylogue.backfill.start",
+      provider: "chatgpt",
+      cutoff: "2026-01-01T00:00:00Z",
+    });
+
+    expect(started.ok).toBe(true);
+    let status;
+    await vi.waitFor(async () => {
+      status = (await sendRuntimeMessage({ type: "polylogue.backfill.status" })).jobs[0];
+      expect(status).toMatchObject({ status: "paused", cooldown_reason: "backfill_bridge_response_too_large" });
+    });
+    expect(status.last_error).toContain("backfill_bridge_projection_too_large:observed_bytes=unavailable;limit_bytes=25165824");
+    // The failed page invocation was a real ChatGPT inventory request (cost
+    // two); it is accounted once but does not enter transport retry backoff.
+    expect(status.daily_requests).toBe(2);
+    expect(status.transport_failures).toBe(0);
+  });
+
   it("schedules cleanup before waiting and removes an inactive tab when readiness fails", async () => {
     tabs = [];
     globalThis.chrome.tabs.create = vi.fn(async ({ url, active }) => ({ id: 99, url, active, status: "loading" }));

--- a/browser-extension/tests/page_transport.test.js
+++ b/browser-extension/tests/page_transport.test.js
@@ -148,6 +148,40 @@ describe("first-party provider page transport", () => {
     expect(result.error).toMatch(/^backfill_bridge_projection_too_large:observed_bytes=.+;limit_bytes=25165824$/);
   });
 
+  it("accounts for escaping in the outer scripting-result bridge payload", async () => {
+    const token = "synthetic-bearer-secret";
+    const accountId = "synthetic-account-secret";
+    const fetchImpl = vi.fn(async (input) => {
+      const url = new URL(input);
+      if (url.pathname === "/api/auth/session") return new Response(JSON.stringify({ accessToken: token, account: { id: accountId } }));
+      return new Response(JSON.stringify({
+        id: "conversation-1",
+        mapping: {
+          node: { id: "node", parent: null, message: { id: "message", author: { role: "assistant" }, content: { parts: ['"'.repeat(13 * 1024 * 1024)] } } },
+        },
+      }));
+    });
+    installWindow("https://chatgpt.com/", fetchImpl);
+
+    const result = await executeProviderPageRequest({ provider: "chatgpt", operation: "conversation", params: { nativeId: "conversation-1" }, maxResponseBytes: 32 * 1024 * 1024 });
+
+    expect(result.error).toMatch(/^backfill_bridge_projection_too_large:observed_bytes=.+;limit_bytes=25165824$/);
+  });
+
+  it("returns malformed compact source as typed provider contract drift", async () => {
+    const token = "synthetic-bearer-secret";
+    const accountId = "synthetic-account-secret";
+    const fetchImpl = vi.fn(async (input) => {
+      const url = new URL(input);
+      if (url.pathname === "/api/auth/session") return new Response(JSON.stringify({ accessToken: token, account: { id: accountId } }));
+      return new Response(JSON.stringify({ id: "conversation-1", mapping: [] }));
+    });
+    installWindow("https://chatgpt.com/", fetchImpl);
+
+    const result = await executeProviderPageRequest({ provider: "chatgpt", operation: "conversation", params: { nativeId: "conversation-1" }, maxResponseBytes: 32 * 1024 * 1024 });
+
+    expect(result).toMatchObject({ ok: false, error: "provider_contract_drift:chatgpt_conversation.mapping_must_be_object" });
+  });
   it("uses the exact Claude UI selector despite ambiguous per-organization keys", async () => {
     const selected = "22222222-2222-4222-8222-222222222222";
     const other = "11111111-1111-4111-8111-111111111111";

--- a/polylogue/archive/ingest_flags.py
+++ b/polylogue/archive/ingest_flags.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 TEMPORARY_CHAT_INGEST_FLAG = "capture:temporary-chat"
 DOM_FALLBACK_INGEST_FLAG = "capture:dom-fallback"
 NATIVE_BROWSER_CAPTURE_INGEST_FLAG = "capture:browser-native-payload"
+COMPACT_BROWSER_CAPTURE_INGEST_FLAG = "capture:browser-native-compact"
 
 __all__ = [
     "DOM_FALLBACK_INGEST_FLAG",
+    "COMPACT_BROWSER_CAPTURE_INGEST_FLAG",
     "NATIVE_BROWSER_CAPTURE_INGEST_FLAG",
     "TEMPORARY_CHAT_INGEST_FLAG",
 ]

--- a/polylogue/sources/parsers/browser_capture.py
+++ b/polylogue/sources/parsers/browser_capture.py
@@ -8,6 +8,7 @@ from collections.abc import Mapping
 from typing import TypeGuard
 
 from polylogue.archive.ingest_flags import (
+    COMPACT_BROWSER_CAPTURE_INGEST_FLAG,
     DOM_FALLBACK_INGEST_FLAG,
     NATIVE_BROWSER_CAPTURE_INGEST_FLAG,
     TEMPORARY_CHAT_INGEST_FLAG,
@@ -37,7 +38,18 @@ def looks_like(payload: object) -> bool:
 
 
 def _has_chatgpt_native_payload(payload: object) -> TypeGuard[Mapping[str, object]]:
-    return isinstance(payload, dict) and isinstance(payload.get("mapping"), dict)
+    return (
+        isinstance(payload, dict)
+        and payload.get("polylogue_bridge_projection") != "chatgpt-native-compact-v1"
+        and isinstance(payload.get("mapping"), dict)
+    )
+
+
+def _is_compact_native_capture(envelope: BrowserCaptureEnvelope) -> bool:
+    return (
+        envelope.provider_meta.get("capture_fidelity") == "native_compact"
+        or envelope.session.provider_meta.get("capture_fidelity") == "native_compact"
+    )
 
 
 def _has_claude_ai_native_payload(payload: object) -> TypeGuard[Mapping[str, object]]:
@@ -319,7 +331,9 @@ def parse(payload: object, fallback_id: str) -> ParsedSession:
             *dict.fromkeys(
                 [
                     *_ingest_flags_for_browser_capture(envelope, provider_session_id),
-                    DOM_FALLBACK_INGEST_FLAG,
+                    COMPACT_BROWSER_CAPTURE_INGEST_FLAG
+                    if _is_compact_native_capture(envelope)
+                    else DOM_FALLBACK_INGEST_FLAG,
                 ]
             )
         ],

--- a/polylogue/sources/parsers/browser_capture.py
+++ b/polylogue/sources/parsers/browser_capture.py
@@ -341,6 +341,7 @@ def parse(payload: object, fallback_id: str) -> ParsedSession:
 
 
 __all__ = [
+    "COMPACT_BROWSER_CAPTURE_INGEST_FLAG",
     "DOM_FALLBACK_INGEST_FLAG",
     "NATIVE_BROWSER_CAPTURE_INGEST_FLAG",
     "TEMPORARY_CHAT_INGEST_FLAG",

--- a/tests/unit/sources/test_browser_capture.py
+++ b/tests/unit/sources/test_browser_capture.py
@@ -13,6 +13,7 @@ from polylogue.config import Source, get_config
 from polylogue.core.enums import Provider
 from polylogue.sources.dispatch import detect_provider, parse_payload
 from polylogue.sources.parsers.browser_capture import (
+    COMPACT_BROWSER_CAPTURE_INGEST_FLAG,
     DOM_FALLBACK_INGEST_FLAG,
     NATIVE_BROWSER_CAPTURE_INGEST_FLAG,
     TEMPORARY_CHAT_INGEST_FLAG,
@@ -189,6 +190,35 @@ def test_browser_capture_prefers_raw_chatgpt_payload_when_present() -> None:
     assert session.messages[1].blocks[0].type.value == "code"
     assert DOM_FALLBACK_INGEST_FLAG not in session.ingest_flags
     assert NATIVE_BROWSER_CAPTURE_INGEST_FLAG in session.ingest_flags
+
+
+def test_browser_capture_compact_chatgpt_projection_uses_envelope_turns() -> None:
+    payload = _capture_payload()
+    session_payload = payload["session"]
+    assert isinstance(session_payload, dict)
+    session_payload["provider_meta"] = {"capture_fidelity": "native_compact"}
+    payload["provider_meta"] = {"capture_fidelity": "native_compact"}
+    payload["raw_provider_payload"] = {
+        "polylogue_bridge_projection": "chatgpt-native-compact-v1",
+        "mapping": {
+            "untrusted-native-shape": {
+                "id": "untrusted-native-shape",
+                "message": {
+                    "id": "wrong-native-message",
+                    "author": {"role": "assistant"},
+                    "content": {"parts": ["must not override envelope turns"]},
+                },
+            }
+        },
+    }
+
+    parsed = parse_payload(Provider.CHATGPT, payload, "fallback")[0]
+
+    assert [message.provider_message_id for message in parsed.messages] == ["u1", "a1"]
+    assert [message.text for message in parsed.messages] == ["Draft the plan", "Here is the plan"]
+    assert COMPACT_BROWSER_CAPTURE_INGEST_FLAG in parsed.ingest_flags
+    assert NATIVE_BROWSER_CAPTURE_INGEST_FLAG not in parsed.ingest_flags
+    assert DOM_FALLBACK_INGEST_FLAG not in parsed.ingest_flags
 
 
 def test_browser_capture_raw_chatgpt_payload_matches_direct_import_identity() -> None:


### PR DESCRIPTION
## Summary

Carry the post-merge safety fixes for bounded ChatGPT browser backfill capture that were identified during cold review of the already-merged bridge-limit PR.

## Problem

The original bridge-limit implementation compacted oversized source responses, but cold review found four completion risks: compact envelopes could be interpreted as a partial full-native mapping; fidelity could be rewritten to `native_full` in durable receiver paths; Chrome’s outer scripting-result boundary was not explicitly accounted for; and a service-worker stop between queue hold and job pause could make the job appear complete. A malformed compact mapping also entered transport retry/backoff instead of failing only that item.

## Solution

- Route `chatgpt-native-compact-v1` artifacts through the envelope-turn parser path and emit `capture:browser-native-compact`, rather than applying full-native ChatGPT parsing to a deliberately reduced mapping.
- Preserve `native_compact` through acknowledgement, retry, and empty outcomes.
- Bound the conservative full scripting-result shape, classify browser-side size rejections as bridge holds, and retain exact/available accounting.
- Repair a persisted bridge hold before an awakened worker schedules, fetches, or evaluates terminal completion.
- Treat malformed compact mappings as per-item `contract_drift`, preserving zero transport retries and allowing later queue items to complete.

### Acceptance criteria

| Criterion | Evidence |
| --- | --- |
| Compact capture never claims full-native parser semantics | Cross-language parser regression selects envelope turns and compact ingest flag |
| Compact fidelity persists in the queue ledger | acknowledgement regression |
| Inner, wrapped, and browser-rejected bridge overages are held without retry churn | transport/background regressions |
| Crash between durable hold and pause cannot complete or fetch the job | restart guard regression with zero provider calls |
| Malformed compact source fails one item and does not block remaining work | bad+good queue regression |

## Verification

- `npm test -- --run tests/page_transport.test.js tests/backfill.test.js tests/popup.test.js tests/background.test.js` — 125 passed
- `npm run lint` — clean
- `npm run validate` — `manifest ok`
- `devtools test tests/unit/sources/test_browser_capture.py -k compact_chatgpt_projection_uses_envelope_turns` — 1 passed, 32 deselected
- Pre-push `devtools verify --quick` — success; run `20260713T044243Z-quick-1788143-981c83d8`

## Anti-vacuity

The parser regression supplies a compact marker plus a conflicting raw mapping and proves the durable envelope turns win. The bridge-hold restart test persists the exact intermediate state then wakes a worker and asserts it performs no provider request. The contract-drift test processes a malformed item followed by a valid one and asserts the latter completes without a transport breaker.