### PR TITLE
fix(browser): admit fresh snapshot membership census (#2832)

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -1626,6 +1626,7 @@ class LiveBatchProcessor:
                                 source_raw_id,
                                 sessions,
                                 acquired_at_ms=acquired_at_ms,
+                                allow_current_complete_raw=is_browser_capture_snapshot,
                             )
                         else:
                             archive.bind_raw_revision(
@@ -1712,6 +1713,7 @@ class LiveBatchProcessor:
         sessions: list[Any],
         *,
         acquired_at_ms: int,
+        allow_current_complete_raw: bool = False,
     ) -> tuple[list[str], int, int, bool]:
         session_ids: list[str] = []
         session_count = 0
@@ -1744,7 +1746,12 @@ class LiveBatchProcessor:
             member_sessions: dict[str, Any] = {}
             projections: dict[str, Any] = {}
             revisions: list[MembershipRevision] = []
-            member_raw_ids = list(archive.raw_membership_raw_ids(logical_source_key))
+            member_raw_ids = list(
+                archive.raw_membership_raw_ids(
+                    logical_source_key,
+                    include_complete_raw_id=source_raw_id if allow_current_complete_raw else None,
+                )
+            )
             accepted_head_raw_id = archive.raw_revision_head_raw_id(logical_source_key)
             if accepted_head_raw_id is not None and accepted_head_raw_id not in member_raw_ids:
                 member_raw_ids.append(accepted_head_raw_id)

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2223,17 +2223,39 @@ class ArchiveStore:
         )
         return tuple(sorted(selected)), logical_keys
 
-    def raw_membership_raw_ids(self, logical_source_key: str) -> tuple[str, ...]:
-        """Return only byte-proven membership candidates for live classification."""
+    def raw_membership_raw_ids(
+        self,
+        logical_source_key: str,
+        *,
+        include_complete_raw_id: str | None = None,
+    ) -> tuple[str, ...]:
+        """Return byte-proven candidates plus the complete raw being classified.
+
+        A newly censused live snapshot has not received a membership decision
+        yet, so it is deliberately quarantined until this classification
+        completes. Admit only that caller-owned complete census alongside
+        established byte-proven evidence; do not reopen unrelated quarantined
+        members from a prior failed or ambiguous replay.
+        """
         rows = (
             self._ensure_source_conn()
             .execute(
                 """
-                SELECT raw_id FROM raw_session_memberships
-                WHERE logical_source_key = ? AND revision_authority = 'byte_proven'
-                ORDER BY raw_id
+                SELECT m.raw_id
+                FROM raw_session_memberships AS m
+                LEFT JOIN raw_membership_census AS c ON c.raw_id = m.raw_id
+                WHERE m.logical_source_key = ?
+                  AND (
+                    m.revision_authority = 'byte_proven'
+                    OR (
+                        m.raw_id = ?
+                        AND c.status = 'complete'
+                        AND m.decision IS NULL
+                    )
+                  )
+                ORDER BY m.raw_id
                 """,
-                (logical_source_key,),
+                (logical_source_key, include_complete_raw_id),
             )
             .fetchall()
         )

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -990,14 +990,18 @@ async def test_browser_capture_replacement_advances_membership_head_and_acquires
     asset_bytes = b"browser-capture-asset" * 37
     asset_hash = sha256(asset_bytes).digest()
 
-    def capture(turns: list[dict[str, object]]) -> dict[str, object]:
+    def capture(
+        turns: list[dict[str, object]],
+        *,
+        captured_at: str = "2026-07-12T00:00:00+00:00",
+    ) -> dict[str, object]:
         return {
             "polylogue_capture_kind": "browser_llm_session",
             "schema_version": 1,
             "capture_id": "chatgpt:browser-replacement",
             "provenance": {
                 "source_url": "https://chatgpt.com/c/browser-replacement",
-                "captured_at": "2026-07-12T00:00:00+00:00",
+                "captured_at": captured_at,
                 "adapter_name": "chatgpt-native-v1",
                 "capture_mode": "snapshot",
             },
@@ -1043,6 +1047,44 @@ async def test_browser_capture_replacement_advances_membership_head_and_acquires
 
     try:
         first = await processor.ingest_files([path], emit_event=False)
+        with sqlite3.connect(archive.archive_root / "source.db") as source_conn:
+            first_raw_id = source_conn.execute(
+                "SELECT raw_id FROM raw_sessions WHERE source_path = ?", (str(path),)
+            ).fetchone()[0]
+        with sqlite3.connect(archive.archive_root / "index.db") as index_conn:
+            assert (
+                index_conn.execute(
+                    "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = 'chatgpt:browser-replacement'"
+                ).fetchone()[0]
+                == first_raw_id
+            )
+        assert first.succeeded_file_count == 1
+
+        foreign_path = root / "foreign-quarantined.json"
+        foreign_payload = json.dumps(
+            capture([first_turn, divergent_turn], captured_at="2026-07-12T00:00:03+00:00")
+        ).encode("utf-8")
+        foreign_sessions = parse_payload(
+            Provider.CHATGPT,
+            [json.loads(foreign_payload)],
+            foreign_path.stem,
+            source_path=str(foreign_path),
+        )
+        assert len(foreign_sessions) == 1
+        with ArchiveStore.open_existing(archive.archive_root, read_only=False) as foreign_archive:
+            foreign_raw_id = foreign_archive.write_raw_payload(
+                provider=Provider.CHATGPT,
+                payload=foreign_payload,
+                source_path=str(foreign_path),
+                acquired_at_ms=1,
+            )
+            foreign_archive.replace_raw_membership_census(
+                foreign_raw_id,
+                foreign_sessions,
+                parser_fingerprint="foreign-quarantined-test",
+                censused_at_ms=1,
+            )
+
         path.write_text(json.dumps(capture([first_turn, acquired_turn])), encoding="utf-8")
         replacement = await processor.ingest_files([path], emit_event=False)
         with sqlite3.connect(archive.archive_root / "source.db") as source_conn:
@@ -1069,12 +1111,42 @@ async def test_browser_capture_replacement_advances_membership_head_and_acquires
         assert first.full_file_count == replacement.full_file_count == 1
         assert len(raw_ids) == 2
         assert accepted_raw_id in raw_ids
-        assert {decision for _raw_id, decision in decisions} == {"superseded_prefix", "applied"}
-        assert dict(decisions)[accepted_raw_id] == "applied"
+        live_decisions = {raw_id: decision for raw_id, decision in decisions if raw_id in raw_ids}
+        assert set(live_decisions.values()) == {"superseded_prefix", "applied"}
+        assert live_decisions[accepted_raw_id] == "applied"
         assert attachment == ("acquired", len(asset_bytes), asset_hash)
+        with sqlite3.connect(archive.archive_root / "source.db") as source_conn:
+            assert source_conn.execute(
+                """
+                SELECT decision FROM raw_session_memberships
+                WHERE raw_id = ? AND logical_source_key = 'chatgpt:browser-replacement'
+                """,
+                (foreign_raw_id,),
+            ).fetchone() == (None,)
 
-        path.write_text(json.dumps(capture([first_turn])), encoding="utf-8")
+        with sqlite3.connect(archive.archive_root / "source.db") as source_conn:
+            raw_ids_before_reverse = {
+                str(row[0])
+                for row in source_conn.execute("SELECT raw_id FROM raw_sessions WHERE source_path = ?", (str(path),))
+            }
+        path.write_text(
+            json.dumps(capture([first_turn], captured_at="2026-07-12T00:00:02+00:00")),
+            encoding="utf-8",
+        )
         reverse = await processor.ingest_files([path], emit_event=False)
+        with sqlite3.connect(archive.archive_root / "source.db") as source_conn:
+            raw_ids_after_reverse = {
+                str(row[0])
+                for row in source_conn.execute("SELECT raw_id FROM raw_sessions WHERE source_path = ?", (str(path),))
+            }
+            reverse_raw_id = (raw_ids_after_reverse - raw_ids_before_reverse).pop()
+            reverse_decision = source_conn.execute(
+                """
+                SELECT decision FROM raw_session_memberships
+                WHERE raw_id = ? AND logical_source_key = 'chatgpt:browser-replacement'
+                """,
+                (reverse_raw_id,),
+            ).fetchone()[0]
         with sqlite3.connect(archive.archive_root / "index.db") as index_conn:
             assert (
                 index_conn.execute(
@@ -1083,6 +1155,10 @@ async def test_browser_capture_replacement_advances_membership_head_and_acquires
                 == accepted_raw_id
             )
         assert reverse.full_file_count == 1
+        # Equivalent parser snapshots may elect either retained raw as the
+        # canonical prefix representative; both are terminal receipts and
+        # neither may displace the newer accepted head.
+        assert reverse_decision in {"superseded_equivalent", "superseded_prefix"}
 
         with sqlite3.connect(archive.archive_root / "source.db") as source_conn:
             raw_ids_before_divergence = {


### PR DESCRIPTION
## Summary

Make the browser-capture live route admit only its own fresh, complete,
undecided membership census alongside byte-proven members.

## Problem

The browser-capture receiver already routes its first snapshot into membership
authority, but the selector admitted only byte-proven memberships. The initial
complete census was therefore excluded before it could create its semantic
head.

## Solution

- Add an optional caller-owned complete-census candidate to the membership
  selector.
- Enable that admission only for the one-session `browser-capture` route;
  every other route retains byte-proven-only selection.
- Extend the real `LiveBatchProcessor` regression to prove first-head
  creation, strict growth with attachment acquisition, stale/divergent
  retention, and exclusion of an unrelated complete quarantined census with
  the same logical key.

No schema or migration files change.

## Verification

- `devtools test tests/unit/sources/test_live_batch_support.py -k
  browser_capture_replacement_advances_membership_head_and_acquires_attachment`
  — 1 passed.
- `devtools test tests/unit/storage/test_browser_capture_origin_repair.py` —
  22 passed.
- `devtools verify --quick` — 15/15 steps passed (run
  `20260713T071420Z-quick-3569709-37cf46c1`).
- Independent adversarial review found no remaining containment gap.

Residual verification evidence: a fresh-worktree `devtools verify
--seed-testmon --skip-slow` seed reached 15,149 selected tests after all 15
static/generated steps passed, then the managed pytest supervisor terminated
it with exit 124 for 600 seconds without a progress marker. Peak test tree
RSS/PSS was about 9.5 GB across 56 processes; no test assertion report was
produced. This is recorded as a harness/resource stall, not a passing test
gate.
