### PR TITLE
fix(live): preserve stable full-prefix handoffs (#2835)

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -16,7 +16,7 @@ from io import BytesIO
 from json import dumps as json_dumps
 from json import loads as json_loads
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypeVar, cast
 
 from polylogue.archive.revision_authority import (
     RawRevisionAuthority,
@@ -140,6 +140,16 @@ P = ParamSpec("P")
 T = TypeVar("T")
 _ARCHIVE_RUNTIME_TIERS = ",".join(spec.tier.value for spec in ARCHIVE_TIER_SPECS.values())
 _ARCHIVE_NATIVE_WRITE_TIERS = "source,index"
+_FULL_CAPTURE_PREFIX_PROOF_ATTEMPTS = 2
+
+
+@dataclass(frozen=True)
+class _FullCapturePrefixProof:
+    """Result of proving a captured full-file prefix is still trustworthy."""
+
+    outcome: Literal["verified", "deferred", "rejected"]
+    stat: os.stat_result | None
+    bytes_read: int
 
 
 def _single_route_stage_payload(*, append_file_count: int, full_file_count: int) -> dict[str, object] | None:
@@ -799,25 +809,36 @@ class LiveBatchProcessor:
             return 0
         raw_fingerprint = raw_fingerprint or self._latest_raw_fingerprint(path)
         byte_size = stat.st_size if raw_byte_size is None else raw_byte_size
-        if not self._full_capture_still_matches(
+        prefix_proof = self._full_capture_still_matches(
             path,
             stat=stat,
             byte_size=byte_size,
             captured_content_hash=captured_content_hash,
             captured_file_observation=captured_file_observation,
-        ):
+        )
+        bytes_read = prefix_proof.bytes_read
+        if prefix_proof.outcome == "deferred":
+            self._last_cursor_write_stale = True
+            logger.info(
+                "live.watcher: captured prefix remained busy; preserving raw for cursor reconciliation: %s",
+                path,
+            )
+            self._defer_full_cursor_retry(path, source_name=resolved_source_name, stat=stat)
+            return bytes_read
+        if prefix_proof.outcome != "verified":
             self._last_cursor_write_stale = True
             logger.warning(
                 "live.watcher: source changed after full capture; cursor invalidated for full retry: %s",
                 path,
             )
             self._invalidate_cursor_for_full_retry(path, source_name=resolved_source_name, stat=stat)
-            return 0
+            return bytes_read
+        assert prefix_proof.stat is not None
+        stat = prefix_proof.stat
         if source_revision is not None:
             fp = source_revision
             last_nl = byte_size
             tail_hash = source_revision
-            bytes_read = 0
             if captured_content_hash is not None:
                 bounded_tail_hash, tail_bytes = tail_hash_from_path(path, byte_size)
                 tail_hash = encode_cursor_hash_authority(
@@ -825,9 +846,9 @@ class LiveBatchProcessor:
                     bounded_tail_hash,
                     ctime_ns=stat.st_ctime_ns,
                 )
-                bytes_read = tail_bytes
+                bytes_read += tail_bytes
         else:
-            fp, last_nl, tail_hash, bytes_read = cursor_state_after_full_ingest(
+            fp, last_nl, tail_hash, cursor_state_bytes = cursor_state_after_full_ingest(
                 path,
                 byte_size,
                 raw_fingerprint=raw_fingerprint,
@@ -838,20 +859,34 @@ class LiveBatchProcessor:
                 end_offset=last_nl,
             )
             tail_hash = encode_cursor_hash_authority(prefix_hash, tail_hash, ctime_ns=stat.st_ctime_ns)
-            bytes_read += prefix_bytes
-        try:
-            final_stat = path.stat()
-        except FileNotFoundError:
-            final_stat = None
-        if final_stat is None or _file_observation(final_stat) != _file_observation(stat):
+            bytes_read += cursor_state_bytes + prefix_bytes
+        final_prefix_proof = self._full_capture_still_matches(
+            path,
+            stat=stat,
+            byte_size=byte_size,
+            captured_content_hash=captured_content_hash,
+            captured_file_observation=captured_file_observation,
+        )
+        bytes_read += final_prefix_proof.bytes_read
+        if final_prefix_proof.outcome == "deferred":
+            self._last_cursor_write_stale = True
+            logger.info(
+                "live.watcher: captured prefix remained busy after cursor proof; preserving raw for reconciliation: %s",
+                path,
+            )
+            self._defer_full_cursor_retry(path, source_name=resolved_source_name, stat=stat)
+            return bytes_read
+        if final_prefix_proof.outcome != "verified":
             self._last_cursor_write_stale = True
             self._invalidate_cursor_for_full_retry(
                 path,
                 source_name=resolved_source_name,
-                stat=final_stat,
+                stat=final_prefix_proof.stat,
                 captured_file_observation=captured_file_observation,
             )
             return bytes_read
+        assert final_prefix_proof.stat is not None
+        final_stat = final_prefix_proof.stat
         updated = self._cursor.set(
             path,
             byte_size,
@@ -861,10 +896,10 @@ class LiveBatchProcessor:
             content_fingerprint=fp,
             tail_hash=tail_hash,
             source_name=resolved_source_name,
-            st_dev=stat.st_dev,
-            st_ino=stat.st_ino,
-            mtime_ns=stat.st_mtime_ns,
-            allow_backward=stat.st_size <= byte_size,
+            st_dev=final_stat.st_dev,
+            st_ino=final_stat.st_ino,
+            mtime_ns=final_stat.st_mtime_ns,
+            allow_backward=final_stat.st_size <= byte_size,
         )
         self._last_cursor_write_stale = not updated
         if not updated:
@@ -890,29 +925,73 @@ class LiveBatchProcessor:
         byte_size: int,
         captured_content_hash: str | None,
         captured_file_observation: tuple[int, int, int, int, int] | None,
-    ) -> bool:
+    ) -> _FullCapturePrefixProof:
         if captured_file_observation is None:
-            return True
+            try:
+                final_stat = path.stat()
+            except OSError:
+                return _FullCapturePrefixProof("rejected", None, 0)
+            initial_outcome: Literal["verified", "rejected"] = (
+                "verified" if _file_observation(final_stat) == _file_observation(stat) else "rejected"
+            )
+            return _FullCapturePrefixProof(initial_outcome, final_stat, 0)
         captured_dev, captured_ino, _captured_size, _captured_mtime_ns, _captured_ctime_ns = captured_file_observation
         if (stat.st_dev, stat.st_ino) != (captured_dev, captured_ino) or stat.st_size < byte_size:
-            return False
+            return _FullCapturePrefixProof("rejected", stat, 0)
         if captured_content_hash is None:
-            return _file_observation(stat) == captured_file_observation
+            try:
+                final_stat = path.stat()
+            except OSError:
+                return _FullCapturePrefixProof("rejected", None, 0)
+            legacy_outcome: Literal["verified", "rejected"] = (
+                "verified"
+                if _file_observation(stat) == captured_file_observation
+                and _file_observation(final_stat) == _file_observation(stat)
+                else "rejected"
+            )
+            return _FullCapturePrefixProof(legacy_outcome, final_stat, 0)
         normalized_fingerprint = captured_content_hash.lower()
         if len(normalized_fingerprint) != 64 or any(char not in "0123456789abcdef" for char in normalized_fingerprint):
-            return False
-        try:
-            current_fingerprint, _bytes_read = sha256_range_from_path(
-                path,
-                start_offset=0,
-                end_offset=byte_size,
-            )
-            final_stat = path.stat()
-        except (EOFError, OSError):
-            return False
-        return current_fingerprint == normalized_fingerprint and _file_observation(final_stat) == _file_observation(
-            stat
-        )
+            return _FullCapturePrefixProof("rejected", stat, 0)
+
+        bytes_read = 0
+        latest_stat = stat
+        for _attempt in range(_FULL_CAPTURE_PREFIX_PROOF_ATTEMPTS):
+            try:
+                proof_start = path.stat()
+                if (proof_start.st_dev, proof_start.st_ino) != (
+                    captured_dev,
+                    captured_ino,
+                ) or proof_start.st_size < byte_size:
+                    return _FullCapturePrefixProof("rejected", proof_start, bytes_read)
+                current_fingerprint, proof_bytes = sha256_range_from_path(
+                    path,
+                    start_offset=0,
+                    end_offset=byte_size,
+                )
+                proof_end = path.stat()
+            except (EOFError, OSError):
+                return _FullCapturePrefixProof("rejected", None, bytes_read)
+            bytes_read += proof_bytes
+            latest_stat = proof_end
+            if current_fingerprint != normalized_fingerprint:
+                return _FullCapturePrefixProof("rejected", proof_end, bytes_read)
+            if _file_observation(proof_start) == _file_observation(proof_end):
+                return _FullCapturePrefixProof("verified", proof_end, bytes_read)
+            if (
+                (proof_end.st_dev, proof_end.st_ino) != (captured_dev, captured_ino)
+                or proof_end.st_size < byte_size
+                or proof_end.st_size <= proof_start.st_size
+            ):
+                return _FullCapturePrefixProof("rejected", proof_end, bytes_read)
+        return _FullCapturePrefixProof("deferred", latest_stat, bytes_read)
+
+    def _defer_full_cursor_retry(self, path: Path, *, source_name: str, stat: os.stat_result) -> None:
+        """Back off a busy full-prefix handoff without discarding its raw evidence."""
+
+        if self._cursor.get_record(path) is None:
+            self._invalidate_cursor_for_full_retry(path, source_name=source_name, stat=stat)
+        self._cursor.mark_failed(path)
 
     def _invalidate_cursor_for_full_retry(
         self,

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -989,8 +989,7 @@ class LiveBatchProcessor:
     def _defer_full_cursor_retry(self, path: Path, *, source_name: str, stat: os.stat_result) -> None:
         """Back off a busy full-prefix handoff without discarding its raw evidence."""
 
-        if self._cursor.get_record(path) is None:
-            self._invalidate_cursor_for_full_retry(path, source_name=source_name, stat=stat)
+        self._invalidate_cursor_for_full_retry(path, source_name=source_name, stat=stat)
         self._cursor.defer_full_cursor_reconciliation(path)
 
     def _invalidate_cursor_for_full_retry(

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -991,7 +991,7 @@ class LiveBatchProcessor:
 
         if self._cursor.get_record(path) is None:
             self._invalidate_cursor_for_full_retry(path, source_name=source_name, stat=stat)
-        self._cursor.mark_failed(path)
+        self._cursor.defer_full_cursor_reconciliation(path)
 
     def _invalidate_cursor_for_full_retry(
         self,

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -1155,8 +1155,14 @@ class CursorStore:
             ).fetchall()
         return [str(row[0]) for row in rows]
 
-    def list_failed_records(self) -> list[CursorRecord]:
-        """Return all failed, non-excluded cursor records."""
+    def list_retry_records(self) -> list[CursorRecord]:
+        """Return non-excluded cursor records with a scheduled retry.
+
+        Most records here represent ordinary failed ingestion.  A neutral
+        full-cursor handoff is also deliberately included: it has no failure
+        count because a source that is still appending is healthy, but it does
+        need a timed archive-reconciliation wakeup if filesystem events stop.
+        """
         with self._connect_ops() as conn:
             rows = conn.execute(
                 """
@@ -1179,7 +1185,11 @@ class CursorStore:
                         updated_at_ms,
                     excluded
                 FROM ingest_cursor
-                WHERE failure_count > 0 AND excluded = 0
+                WHERE excluded = 0
+                  AND (
+                      failure_count > 0
+                      OR (content_fingerprint IS NULL AND next_retry_at IS NOT NULL)
+                  )
                 ORDER BY next_retry_at IS NULL DESC, next_retry_at ASC, source_path ASC
                 """
             ).fetchall()

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -14,7 +14,7 @@ import uuid
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
 
@@ -44,6 +44,7 @@ from polylogue.storage.sqlite.connection_profile import open_connection
 
 _INSIGHT_DEFERRED_UNTIL_QUIET = "insights deferred until source quiet"
 _MAX_CURSOR_FAILURES_BEFORE_EXCLUDE = 5
+_FULL_CURSOR_RECONCILIATION_RETRY_DELAY_S = 60
 
 # Per-source-family cursor-lag sample history (#1349). Daemon-runtime state,
 # not part of SCHEMA_VERSION — same lifecycle as live_cursor / live_convergence_debt.
@@ -1085,6 +1086,30 @@ class CursorStore:
                 updated_at=now,
                 failure_count=failures,
                 next_retry_at=datetime.fromtimestamp(retry_at, tz=UTC).isoformat(),
+            )
+
+        self._read_modify_write_cursor_record(path, mutate)
+
+    def defer_full_cursor_reconciliation(self, path: Path) -> None:
+        """Retry archive-backed full-cursor handoff without poisoning the source.
+
+        A raw full capture can be durable and parseable while its live JSONL
+        source is still appending too quickly to establish a stable handoff.
+        This is a scheduling condition, not a parse/persistence failure: it
+        must never consume the finite failure budget that quarantines malformed
+        files.
+        """
+
+        def mutate(current: CursorRecord | None) -> CursorRecord | None:
+            if current is None:
+                return None
+            now = datetime.now(UTC)
+            return replace(
+                current,
+                updated_at=now.isoformat(),
+                failure_count=0,
+                next_retry_at=(now + timedelta(seconds=_FULL_CURSOR_RECONCILIATION_RETRY_DELAY_S)).isoformat(),
+                excluded=False,
             )
 
         self._read_modify_write_cursor_record(path, mutate)

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -20,6 +20,7 @@ import time
 from collections.abc import Awaitable, Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -52,6 +53,14 @@ _CATCH_UP_MAX_BATCH_BYTES = 64 * 1024 * 1024
 _INCOMPLETE_APPEND_PROBE_BYTES = 64 * 1024 * 1024
 _PERIODIC_CATCH_UP_INTERVAL_S = 15.0
 INBOX_SOURCE_SUFFIXES = (".jsonl", ".zip", ".json", ".ndjson", ".db", ".sqlite", ".sqlite3")
+
+
+class _ArchivedCursorReconciliation(str, Enum):
+    """Whether archive evidence can safely restore a live cursor."""
+
+    RECONCILED = "reconciled"
+    UNAVAILABLE = "unavailable"
+    INCOMPATIBLE = "incompatible"
 
 
 def _stage_timing_summary(stage_timings_s: dict[str, float], *, limit: int = 8) -> str:
@@ -453,7 +462,7 @@ class LiveWatcher:
             return
         due_paths: list[Path] = []
         next_retry_at: datetime | None = None
-        for record in self._cursor.list_failed_records():
+        for record in self._cursor.list_retry_records():
             path = Path(record.source_path)
             if not self._source_accepts(path):
                 continue
@@ -627,11 +636,15 @@ class LiveWatcher:
         if cursor.failure_count == 0 and cursor.content_fingerprint is None and cursor.next_retry_at is not None:
             if not _retry_due(cursor.next_retry_at):
                 return False
-            if self._reconcile_archived_cursor(path, stat=stat):
+            reconciliation = self._reconcile_archived_cursor_outcome(path, stat=stat)
+            if reconciliation is _ArchivedCursorReconciliation.RECONCILED:
                 reconciled = self._cursor.get_record(path)
                 return reconciled is not None and size > reconciled.byte_offset
-            self._cursor.defer_full_cursor_reconciliation(path)
-            return False
+            if reconciliation is _ArchivedCursorReconciliation.UNAVAILABLE:
+                self._cursor.defer_full_cursor_reconciliation(path)
+                return False
+            self._invalidate_deferred_full_cursor(path, stat=stat)
+            return True
         if cursor.failure_count > 0:
             if self._reconcile_archived_cursor(path, stat=stat):
                 cursor = self._cursor.get_record(path)
@@ -721,7 +734,40 @@ class LiveWatcher:
         )
         return True
 
+    def _invalidate_deferred_full_cursor(self, path: Path, *, stat: os.stat_result) -> None:
+        """Clear a busy-handoff defer when current bytes reject archive authority."""
+
+        updated = self._cursor.set(
+            path,
+            stat.st_size,
+            byte_offset=0,
+            last_complete_newline=0,
+            parser_fingerprint=_PARSER_FINGERPRINT,
+            content_fingerprint=None,
+            tail_hash=None,
+            source_name=self._source_name_for(path),
+            st_dev=stat.st_dev,
+            st_ino=stat.st_ino,
+            mtime_ns=stat.st_mtime_ns,
+            failure_count=0,
+            next_retry_at=None,
+            excluded=False,
+            allow_backward=True,
+        )
+        if not updated:
+            raise sqlite3.OperationalError(f"failed to invalidate deferred cursor for {path}")
+
     def _reconcile_archived_cursor(self, path: Path, *, stat: os.stat_result) -> bool:
+        """Restore a missing/stale cursor from proven archive raw state."""
+
+        return self._reconcile_archived_cursor_outcome(path, stat=stat) is _ArchivedCursorReconciliation.RECONCILED
+
+    def _reconcile_archived_cursor_outcome(
+        self,
+        path: Path,
+        *,
+        stat: os.stat_result,
+    ) -> _ArchivedCursorReconciliation:
         """Restore a missing/stale cursor from proven archive raw state.
 
         A daemon interruption can leave the archive source tier populated but
@@ -736,7 +782,7 @@ class LiveWatcher:
         source_db = archive_root / "source.db"
         index_db = archive_root / "index.db"
         if not source_db.exists() or not index_db.exists():
-            return False
+            return _ArchivedCursorReconciliation.UNAVAILABLE
         try:
             with sqlite3.connect(f"file:{source_db}?mode=ro", uri=True, timeout=1.0) as conn:
                 rows = conn.execute(
@@ -765,22 +811,22 @@ class LiveWatcher:
                     None,
                 )
         except sqlite3.Error:
-            return False
+            return _ArchivedCursorReconciliation.UNAVAILABLE
         if row is None:
-            return False
+            return _ArchivedCursorReconciliation.INCOMPATIBLE
         _raw_id, origin, blob_hash, blob_size = row
         archived_size = int(blob_size or 0)
         current_size = int(stat.st_size)
         if archived_size <= 0 or archived_size > current_size:
-            return False
+            return _ArchivedCursorReconciliation.INCOMPATIBLE
         if isinstance(blob_hash, bytes):
             content_fingerprint = blob_hash.hex()
         elif isinstance(blob_hash, str):
             content_fingerprint = blob_hash.lower()
         else:
-            return False
+            return _ArchivedCursorReconciliation.INCOMPATIBLE
         if not _archive_blob_exists(archive_root, content_fingerprint):
-            return False
+            return _ArchivedCursorReconciliation.INCOMPATIBLE
         try:
             current_fingerprint, _fingerprint_bytes = sha256_range_from_path(
                 path,
@@ -788,7 +834,7 @@ class LiveWatcher:
                 end_offset=archived_size,
             )
             if current_fingerprint != content_fingerprint:
-                return False
+                return _ArchivedCursorReconciliation.INCOMPATIBLE
             if archived_size == current_size:
                 tail_hash, last_complete_newline, _bytes_read = tail_hash_and_last_complete_newline_from_path(
                     path, current_size
@@ -800,7 +846,7 @@ class LiveWatcher:
                 last_complete_newline = archived_size
             post_read_stat = path.stat()
         except OSError:
-            return False
+            return _ArchivedCursorReconciliation.UNAVAILABLE
         if (
             post_read_stat.st_dev,
             post_read_stat.st_ino,
@@ -808,7 +854,7 @@ class LiveWatcher:
             post_read_stat.st_mtime_ns,
             post_read_stat.st_ctime_ns,
         ) != (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns):
-            return False
+            return _ArchivedCursorReconciliation.UNAVAILABLE
         self._cursor.set(
             path,
             archived_size,
@@ -830,7 +876,7 @@ class LiveWatcher:
         )
         self._cursor.reset_failures(path)
         logger.info("live.watcher: reconciled cursor from archive source row for %s", path)
-        return True
+        return _ArchivedCursorReconciliation.RECONCILED
 
     async def _ingest_files(
         self,

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -624,6 +624,14 @@ class LiveWatcher:
             return cursor is not None and size > cursor.byte_offset
         if cursor.excluded:
             return False
+        if cursor.failure_count == 0 and cursor.content_fingerprint is None and cursor.next_retry_at is not None:
+            if not _retry_due(cursor.next_retry_at):
+                return False
+            if self._reconcile_archived_cursor(path, stat=stat):
+                reconciled = self._cursor.get_record(path)
+                return reconciled is not None and size > reconciled.byte_offset
+            self._cursor.defer_full_cursor_reconciliation(path)
+            return False
         if cursor.failure_count > 0:
             if self._reconcile_archived_cursor(path, stat=stat):
                 cursor = self._cursor.get_record(path)

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -1870,8 +1870,17 @@ def test_busy_full_prefix_proof_defers_to_archived_cursor_reconciliation(
 
     monkeypatch.setattr("polylogue.sources.live.batch.sha256_range_from_path", original_hash)
     watcher = LiveWatcher(polylogue, (WatchSource(name="codex", root=root),), cursor=cursor)
-    original_reconcile = watcher._reconcile_archived_cursor
-    monkeypatch.setattr(watcher, "_reconcile_archived_cursor", lambda _path, *, stat: False)
+    scheduled_retries: list[object] = []
+    monkeypatch.setattr(watcher, "_schedule_failed_retry_wakeup", scheduled_retries.append)
+    watcher._schedule_failed_retry_scan()
+    assert len(scheduled_retries) == 1
+
+    original_reconcile = watcher._reconcile_archived_cursor_outcome
+    monkeypatch.setattr(
+        watcher,
+        "_reconcile_archived_cursor_outcome",
+        lambda _path, *, stat: live_watcher._ArchivedCursorReconciliation.UNAVAILABLE,
+    )
     monkeypatch.setattr(live_watcher, "_retry_due", lambda _retry_at: True)
     for _ in range(5):
         assert not watcher._needs_work(path)
@@ -1880,7 +1889,7 @@ def test_busy_full_prefix_proof_defers_to_archived_cursor_reconciliation(
     assert unavailable.failure_count == 0
     assert not unavailable.excluded
 
-    monkeypatch.setattr(watcher, "_reconcile_archived_cursor", original_reconcile)
+    monkeypatch.setattr(watcher, "_reconcile_archived_cursor_outcome", original_reconcile)
     assert watcher._needs_work(path)
     reconciled = cursor.get_record(path)
     assert reconciled is not None
@@ -1892,6 +1901,22 @@ def test_busy_full_prefix_proof_defers_to_archived_cursor_reconciliation(
     assert second.full_file_count == 0
     assert second.append_file_count == 1
     assert second.succeeded_file_count == 1
+
+    processor._defer_full_cursor_retry(path, source_name="codex", stat=path.stat())
+    replacement = b'{"type":"session_meta","payload":{"id":"busy-replacement"}}\n'
+    path.write_bytes(replacement)
+
+    assert watcher._needs_work(path)
+    invalidated = cursor.get_record(path)
+    assert invalidated is not None
+    assert invalidated.byte_offset == 0
+    assert invalidated.content_fingerprint is None
+    assert invalidated.next_retry_at is None
+
+    third = asyncio.run(processor.ingest_files([path]))
+    assert third.full_file_count == 1
+    assert third.append_file_count == 0
+    assert third.succeeded_file_count == 1
 
 
 @pytest.mark.parametrize("replacement_mode", ["atomic", "in-place"])

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -1795,6 +1795,19 @@ def test_busy_full_prefix_proof_defers_to_archived_cursor_reconciliation(
     index_db = tmp_path / "index.db"
     cursor = CursorStore(index_db)
     polylogue = cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db)))
+    cursor.set(
+        path,
+        len(captured),
+        byte_offset=len(captured),
+        last_complete_newline=len(captured),
+        parser_fingerprint="previous-parser",
+        content_fingerprint=sha256(captured).hexdigest(),
+        tail_hash=_cursor_hash_authority(captured),
+        source_name="codex",
+        st_dev=captured_stat.st_dev,
+        st_ino=captured_stat.st_ino,
+        mtime_ns=captured_stat.st_mtime_ns,
+    )
     processor = LiveBatchProcessor(
         polylogue,
         (WatchSource(name="codex", root=root),),

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -1685,7 +1685,7 @@ def test_live_append_chain_survives_post_ingest_compaction(
     assert cursor_record.byte_offset == len(payload) + sum(len(chunk) for chunk in append_chunks)
 
 
-def test_full_ingest_cursor_stops_at_captured_blob_boundary_when_file_grows(
+def test_full_ingest_cursor_hands_off_captured_prefix_after_growth_during_proof(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1710,17 +1710,24 @@ def test_full_ingest_cursor_stops_at_captured_blob_boundary_when_file_grows(
         cursor=cursor,
         parser_fingerprint="test-parser",
     )
-    grew = False
+    grew_during_prefix_proof = False
+    original_hash = sha256_range_from_path
 
-    def grow_after_acquisition(paths: list[Path]) -> tuple[set[Path], float, dict[str, float], list[object]]:
-        nonlocal grew
-        if not grew:
+    def grow_during_prefix_proof(
+        source_path: Path,
+        *,
+        start_offset: int,
+        end_offset: int,
+    ) -> tuple[str, int]:
+        nonlocal grew_during_prefix_proof
+        result = original_hash(source_path, start_offset=start_offset, end_offset=end_offset)
+        if not grew_during_prefix_proof:
             with path.open("ab") as handle:
                 handle.write(appended_during_parse)
-            grew = True
-        return set(paths), 0.0, {}, []
+            grew_during_prefix_proof = True
+        return result
 
-    monkeypatch.setattr(processor, "_converge_paths", grow_after_acquisition)
+    monkeypatch.setattr("polylogue.sources.live.batch.sha256_range_from_path", grow_during_prefix_proof)
 
     first = asyncio.run(processor.ingest_files([path]))
 
@@ -1769,6 +1776,76 @@ def test_full_ingest_cursor_stops_at_captured_blob_boundary_when_file_grows(
         session_hash = conn.execute("SELECT content_hash FROM sessions").fetchone()[0]
         accepted_hash = conn.execute("SELECT accepted_content_hash FROM raw_revision_heads").fetchone()[0]
         assert session_hash == accepted_hash
+
+
+def test_busy_full_prefix_proof_defers_to_archived_cursor_reconciliation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "sessions"
+    root.mkdir()
+    path = root / "busy-hot.jsonl"
+    captured = (
+        b'{"type":"session_meta","payload":{"id":"busy-hot","timestamp":"2026-06-02T00:00:00Z"}}\n'
+        b'{"type":"response_item","payload":{"type":"message","id":"captured","role":"user",'
+        b'"content":[{"type":"input_text","text":"captured"}]}}\n'
+    )
+    appended_records = (
+        b'{"type":"response_item","payload":{"type":"message","id":"later-a","role":"assistant",'
+        b'"content":[{"type":"output_text","text":"later-a"}]}}\n',
+        b'{"type":"response_item","payload":{"type":"message","id":"later-b","role":"assistant",'
+        b'"content":[{"type":"output_text","text":"later-b"}]}}\n',
+    )
+    path.write_bytes(captured)
+    index_db = tmp_path / "index.db"
+    cursor = CursorStore(index_db)
+    polylogue = cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db)))
+    processor = LiveBatchProcessor(
+        polylogue,
+        (WatchSource(name="codex", root=root),),
+        cursor=cursor,
+        parser_fingerprint="live-batched-v2",
+    )
+    original_hash = sha256_range_from_path
+    next_record = 0
+
+    def grow_on_every_prefix_proof(
+        source_path: Path,
+        *,
+        start_offset: int,
+        end_offset: int,
+    ) -> tuple[str, int]:
+        nonlocal next_record
+        result = original_hash(source_path, start_offset=start_offset, end_offset=end_offset)
+        with path.open("ab") as handle:
+            handle.write(appended_records[next_record])
+        next_record += 1
+        return result
+
+    monkeypatch.setattr("polylogue.sources.live.batch.sha256_range_from_path", grow_on_every_prefix_proof)
+    first = asyncio.run(processor.ingest_files([path]))
+
+    assert first.full_file_count == 1
+    assert first.succeeded_file_count == 1
+    deferred = cursor.get_record(path)
+    assert deferred is not None
+    assert deferred.byte_offset == 0
+    assert deferred.content_fingerprint is None
+    assert deferred.failure_count == 1
+
+    monkeypatch.setattr("polylogue.sources.live.batch.sha256_range_from_path", original_hash)
+    watcher = LiveWatcher(polylogue, (WatchSource(name="codex", root=root),), cursor=cursor)
+    assert watcher._needs_work(path)
+    reconciled = cursor.get_record(path)
+    assert reconciled is not None
+    assert reconciled.byte_offset == len(captured)
+    assert reconciled.content_fingerprint == sha256(captured).hexdigest()
+
+    second = asyncio.run(processor.ingest_files([path]))
+
+    assert second.full_file_count == 0
+    assert second.append_file_count == 1
+    assert second.succeeded_file_count == 1
 
 
 @pytest.mark.parametrize("replacement_mode", ["atomic", "in-place"])

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -1790,13 +1790,8 @@ def test_busy_full_prefix_proof_defers_to_archived_cursor_reconciliation(
         b'{"type":"response_item","payload":{"type":"message","id":"captured","role":"user",'
         b'"content":[{"type":"input_text","text":"captured"}]}}\n'
     )
-    appended_records = (
-        b'{"type":"response_item","payload":{"type":"message","id":"later-a","role":"assistant",'
-        b'"content":[{"type":"output_text","text":"later-a"}]}}\n',
-        b'{"type":"response_item","payload":{"type":"message","id":"later-b","role":"assistant",'
-        b'"content":[{"type":"output_text","text":"later-b"}]}}\n',
-    )
     path.write_bytes(captured)
+    captured_stat = path.stat()
     index_db = tmp_path / "index.db"
     cursor = CursorStore(index_db)
     polylogue = cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db)))
@@ -1818,7 +1813,11 @@ def test_busy_full_prefix_proof_defers_to_archived_cursor_reconciliation(
         nonlocal next_record
         result = original_hash(source_path, start_offset=start_offset, end_offset=end_offset)
         with path.open("ab") as handle:
-            handle.write(appended_records[next_record])
+            handle.write(
+                b'{"type":"response_item","payload":{"type":"message","id":"later-'
+                + str(next_record).encode()
+                + b'","role":"assistant","content":[{"type":"output_text","text":"later"}]}}\n'
+            )
         next_record += 1
         return result
 
@@ -1831,10 +1830,44 @@ def test_busy_full_prefix_proof_defers_to_archived_cursor_reconciliation(
     assert deferred is not None
     assert deferred.byte_offset == 0
     assert deferred.content_fingerprint is None
-    assert deferred.failure_count == 1
+    assert deferred.failure_count == 0
+    assert deferred.next_retry_at is not None
+    assert not deferred.excluded
+
+    for _ in range(4):
+        processor._record_full_cursor(
+            path,
+            raw_fingerprint=sha256(captured).hexdigest(),
+            raw_byte_size=len(captured),
+            source_name="codex",
+            captured_content_hash=sha256(captured).hexdigest(),
+            captured_file_observation=(
+                captured_stat.st_dev,
+                captured_stat.st_ino,
+                captured_stat.st_size,
+                captured_stat.st_mtime_ns,
+                captured_stat.st_ctime_ns,
+            ),
+        )
+    repeatedly_deferred = cursor.get_record(path)
+    assert repeatedly_deferred is not None
+    assert repeatedly_deferred.failure_count == 0
+    assert repeatedly_deferred.next_retry_at is not None
+    assert not repeatedly_deferred.excluded
 
     monkeypatch.setattr("polylogue.sources.live.batch.sha256_range_from_path", original_hash)
     watcher = LiveWatcher(polylogue, (WatchSource(name="codex", root=root),), cursor=cursor)
+    original_reconcile = watcher._reconcile_archived_cursor
+    monkeypatch.setattr(watcher, "_reconcile_archived_cursor", lambda _path, *, stat: False)
+    monkeypatch.setattr(live_watcher, "_retry_due", lambda _retry_at: True)
+    for _ in range(5):
+        assert not watcher._needs_work(path)
+    unavailable = cursor.get_record(path)
+    assert unavailable is not None
+    assert unavailable.failure_count == 0
+    assert not unavailable.excluded
+
+    monkeypatch.setattr(watcher, "_reconcile_archived_cursor", original_reconcile)
     assert watcher._needs_work(path)
     reconciled = cursor.get_record(path)
     assert reconciled is not None


### PR DESCRIPTION
## Summary

Preserves a verified captured JSONL prefix when the file appends during full-capture cursor handoff, preventing repeated whole-file ingestion of active Codex sessions.

## Problem

The cursor path invalidated a captured raw whenever a file changed during prefix proof. Active append-only JSONL files therefore restarted full acquisition on the next watcher interval, amplifying read I/O while leaving durable raw evidence unused.

## Solution

The live batch cursor now retries a bounded stable-prefix proof: device and inode remain fixed, the captured prefix hash matches, and each proof has identical pre/post observations. Benign append growth gets one retry; a continuously busy source is deferred with retry scheduling so Watcher reconciles the just-persisted raw and takes the append route. Replacement, truncation, same-size rewrite, and prefix mismatch remain fail-closed.

Adversarial iteration 1 found that the first version used the finite cursor failure budget for this scheduling state, which could exclude a healthy but continuously appending source after five deferrals. The fix adds a non-poison reconciliation deferral: it preserves failure_count zero and excluded false, while Watcher retries archive reconciliation on the bounded schedule and cannot schedule another full capture until recovery succeeds.

Adversarial iteration 2 found that a busy full path could retain a pre-existing cursor fingerprint. That bypassed the Watcher deferred-recovery sentinel and could schedule another full capture. The fix always installs neutral reconciliation state before scheduling the non-poison retry; the regression starts from an existing valid cursor forced into the full route by parser-fingerprint change.

Adversarial iteration 3 found that archive unavailability and incompatible current bytes were conflated. A rewritten or truncated source could therefore remain deferred forever. Reconciliation now distinguishes reconciled, unavailable, and incompatible: only unavailable renews the neutral defer; incompatible source bytes clear it and authorize one new full capture without append authority. Neutral handoffs are also included in timed retry enumeration, so recovery runs if filesystem events become quiet.

## Verification

- devtools test tests/unit/sources/test_live_batch_support.py -k captured_prefix_after_growth_during_proof or busy_full_prefix_proof or same_size_replacement or rejected_full_cursor_frontier_requires_reauthorization or append_cursor_forces_full_retry_after_source_rewrite: 7 passed.
- The busy-prefix production route proves retry wakeup scheduling, five unavailable reconciliation cycles without poisoning or a full read, archive-backed append recovery, then a deferred replacement admitted as full-only.
- devtools verify --quick: 15/15 passed, run 20260713T083851Z-quick-3699507-4d3de879.
- Pre-push quick baseline: 15/15 passed, run 20260713T083957Z-quick-3700362-2dcb0547.

The broader affected test file was stopped after a no-progress D-state harness stall; the focused production-route matrix above completed successfully.