### PR TITLE
fix(live): retain proven append frontiers

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -2226,6 +2226,14 @@ class LiveBatchProcessor:
             logger.warning("live.watcher: raw snapshot compaction errors: %s", "; ".join(result.errors[:3]))
 
     def _record_append_cursor(self, plan: _AppendPlan) -> bool:
+        """Persist a proven append frontier without mistaking later growth for rewrite.
+
+        ``plan`` carries a prefix witness produced before append persistence.
+        A live JSONL writer may append another record before this method runs;
+        that does not invalidate the accepted range. Keep the plan's original
+        observation in the cursor so a same-size replacement is still forced
+        through the full route on the next batch.
+        """
         latest_stat: os.stat_result | None = None
         expected_observation = (
             plan.st_dev,
@@ -2237,12 +2245,8 @@ class LiveBatchProcessor:
         try:
             stat = plan.path.stat()
             latest_stat = stat
-            observed = _file_observation(stat)
-            if plan.ctime_ns is None:
-                if observed[:4] != expected_observation[:4]:
-                    raise ValueError("source observation changed")
-            elif observed != expected_observation:
-                raise ValueError("source observation changed")
+            if stat.st_dev != plan.st_dev or stat.st_ino != plan.st_ino or stat.st_size < plan.last_complete_newline:
+                raise ValueError("source replaced or truncated")
             payload_hash, _payload_bytes = sha256_range_from_path(
                 plan.path,
                 start_offset=plan.start_offset,
@@ -2251,9 +2255,12 @@ class LiveBatchProcessor:
             tail_hash, _tail_bytes = tail_hash_from_path(plan.path, plan.last_complete_newline)
             final_stat = plan.path.stat()
             latest_stat = final_stat
-            final_observation = _file_observation(final_stat)
-            if final_observation != observed:
-                raise ValueError("source changed during cursor verification")
+            if (
+                final_stat.st_dev != plan.st_dev
+                or final_stat.st_ino != plan.st_ino
+                or final_stat.st_size < plan.last_complete_newline
+            ):
+                raise ValueError("source replaced or truncated during cursor verification")
             if payload_hash != plan.payload_hash:
                 raise ValueError("accepted append bytes changed")
             if plan.accepted_tail_hash is not None and tail_hash != plan.accepted_tail_hash:
@@ -2277,6 +2284,11 @@ class LiveBatchProcessor:
                 ),
             )
             return False
+        if _file_observation(final_stat) != expected_observation:
+            logger.info(
+                "live.watcher: source changed after append persistence; retained proven append frontier: %s",
+                plan.path,
+            )
         content_fingerprint = append_source_revision(plan.cursor_fingerprint or "", plan.payload_hash)
         stored_tail_hash = (
             encode_cursor_hash_authority(

--- a/tests/integration/test_live_read_amplification.py
+++ b/tests/integration/test_live_read_amplification.py
@@ -272,6 +272,75 @@ class TestActiveAppendNoFullReread:
             f"tool-result amplification: appended {appended_bytes}, read {counter.total_bytes}\n{counter.summary()}"
         )
 
+    def test_growth_after_append_persistence_keeps_the_append_frontier(
+        self,
+        processor: tuple[LiveBatchProcessor, Path, Path],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A writer can append while the accepted append is being persisted.
+
+        This is the production race behind repeated ``archive_full`` retries:
+        append planning has already proved and persisted one complete record,
+        then a later record lands before cursor bookkeeping.  That later growth
+        must leave the accepted frontier usable for the next append batch;
+        treating it as a whole-file rewrite turns a small tail into a full raw
+        re-capture.
+
+        The harness keeps parsing/storage lightweight but executes the real
+        planner, cursor writer, and watcher-facing batch route.  It counts any
+        second-tick full-route entry and source/blob reads.
+        """
+        import asyncio
+
+        proc, root, _ = processor
+        session_id = "post-persist-race"
+        path = root / f"{session_id}.jsonl"
+        _write_jsonl(
+            path,
+            [_claude_code_record(session_id=session_id, uuid=f"baseline-{i}") for i in range(8)],
+        )
+        _seed_initial_ingest(proc, path, session_id=session_id)
+
+        _append_jsonl(path, [_claude_code_record(session_id=session_id, uuid="accepted")])
+        accepted_frontier = path.stat().st_size
+        appended_after_persistence = False
+
+        def append_after_persistence(paths: list[Path]) -> tuple[set[Path], float, dict[str, float], list[object]]:
+            nonlocal appended_after_persistence
+            if not appended_after_persistence:
+                _append_jsonl(path, [_claude_code_record(session_id=session_id, uuid="later")])
+                appended_after_persistence = True
+            return set(paths), 0.0, {}, []
+
+        monkeypatch.setattr(proc, "_converge_paths", append_after_persistence)
+        full_route_paths: list[Path] = []
+        original_full_ingest = proc._ingest_full_paths
+
+        async def count_full_route(*args: Any, **kwargs: Any) -> _FullIngestResult:
+            full_route_paths.extend(args[0])
+            return await original_full_ingest(*args, **kwargs)
+
+        monkeypatch.setattr(proc, "_ingest_full_paths", count_full_route)
+
+        first = asyncio.run(proc.ingest_files([path], emit_event=False))
+        assert first.append_file_count == 1
+        assert first.stale_cursor_write_count == 0
+        first_cursor = proc._cursor.get_record(path)
+        assert first_cursor is not None
+        assert first_cursor.byte_offset == accepted_frontier
+
+        with read_counter() as counter:
+            second = asyncio.run(proc.ingest_files([path], emit_event=False))
+
+        assert second.append_file_count == 1
+        assert second.full_file_count == 0
+        assert full_route_paths == []
+        assert counter.calls_by_site.get("blob_store.write_from_path", 0) == 0, counter.summary()
+        second_cursor = proc._cursor.get_record(path)
+        assert second_cursor is not None
+        assert second_cursor.byte_offset == path.stat().st_size
+        assert second_cursor.content_fingerprint != first_cursor.content_fingerprint
+
 
 # ---------------------------------------------------------------------------
 # Scenario 2 — mtime-drift catch-up (H1)

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -33,6 +33,7 @@ from polylogue.sources.live.batch_support import (
     _parse_path_as_session_artifact,
     encode_cursor_hash_authority,
     sha256_range_from_path,
+    tail_hash_from_path,
 )
 from polylogue.sources.live.cursor import CursorStore
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
@@ -2208,7 +2209,7 @@ def test_append_plan_rejects_malformed_hash_authority(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize("rewrite_mode", ["atomic-replacement", "in-place-prefix"])
-def test_append_cursor_forces_full_retry_after_source_rewrite(
+def test_append_cursor_redetects_source_rewrite_after_handoff(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     rewrite_mode: str,
@@ -2283,16 +2284,14 @@ def test_append_cursor_forces_full_retry_after_source_rewrite(
 
     assert appended.append_file_count == 1
     assert appended.succeeded_file_count == 1
-    assert appended.stale_cursor_write_count == 1
     stale_cursor = cursor.get_record(path)
     assert stale_cursor is not None
-    assert stale_cursor.byte_offset == 0
-    assert stale_cursor.content_fingerprint is None
-    assert LiveWatcher(
+    watcher = LiveWatcher(
         polylogue,
         (WatchSource(name="codex", root=root),),
         cursor=cursor,
-    )._needs_work(path)
+    )
+    assert watcher._needs_work(path)
     with sqlite3.connect(index_db) as conn:
         assert conn.execute("SELECT native_id FROM messages ORDER BY native_id").fetchall() == [
             ("message-0a",),
@@ -2304,9 +2303,25 @@ def test_append_cursor_forces_full_retry_after_source_rewrite(
         ]
 
     if rewrite_mode == "in-place-prefix":
+        # The append range itself is still byte-proven, so keep it as a
+        # frontier. The old observation embedded in its tail authority makes
+        # the watcher force this same-size prefix rewrite through the full
+        # route before it can be skipped or appended past.
+        assert appended.stale_cursor_write_count == 0
+        assert stale_cursor.byte_offset == len(baseline_a + append_a)
+        assert stale_cursor.content_fingerprint is not None
         assert b"zerob" in path.read_bytes()
         assert path.read_bytes()[-64 * 1024 :] == accepted_tail_before_rewrite
+        retried = asyncio.run(processor.ingest_files([path]))
+        assert retried.full_file_count == 1
+        assert retried.append_file_count == 0
+        assert retried.succeeded_file_count == 0
+        assert retried.failed_file_count == 1
         return
+
+    assert appended.stale_cursor_write_count == 1
+    assert stale_cursor.byte_offset == 0
+    assert stale_cursor.content_fingerprint is None
 
     retried = asyncio.run(processor.ingest_files([path]))
 
@@ -2323,6 +2338,60 @@ def test_append_cursor_forces_full_retry_after_source_rewrite(
             ("message-aa",),
             ("message-bb",),
         ]
+
+
+def test_append_cursor_rejects_truncation_after_append_persistence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A partial append handoff must fail closed when its source truncates."""
+    root = tmp_path / "sessions"
+    root.mkdir()
+    path = root / "append-truncated.jsonl"
+    baseline = (
+        b'{"type":"session_meta","payload":{"id":"append-truncated"}}\n'
+        b'{"type":"response_item","payload":{"type":"message","id":"message-0","role":"user",'
+        b'"content":[{"type":"input_text","text":"zero"}]}}\n'
+    )
+    append = (
+        b'{"type":"response_item","payload":{"type":"message","id":"message-1","role":"assistant",'
+        b'"content":[{"type":"output_text","text":"one"}]}}\n'
+    )
+    path.write_bytes(baseline)
+    index_db = tmp_path / "index.db"
+    cursor = CursorStore(index_db)
+    polylogue = cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db)))
+    processor = LiveBatchProcessor(
+        polylogue,
+        (WatchSource(name="codex", root=root),),
+        cursor=cursor,
+        parser_fingerprint="test-parser",
+    )
+    assert asyncio.run(processor.ingest_files([path])).succeeded_file_count == 1
+    with path.open("ab") as handle:
+        handle.write(append)
+    plan = processor._append_plan(path)
+    assert isinstance(plan, _AppendPlan)
+
+    original_tail_hash = tail_hash_from_path
+
+    def truncate_after_tail(source_path: Path, byte_size: int) -> tuple[str, int]:
+        result = original_tail_hash(source_path, byte_size)
+        source_path.write_bytes(source_path.read_bytes()[: plan.last_complete_newline - 1])
+        return result
+
+    monkeypatch.setattr("polylogue.sources.live.batch.tail_hash_from_path", truncate_after_tail)
+
+    assert processor._record_append_cursor(plan) is False
+    invalidated = cursor.get_record(path)
+    assert invalidated is not None
+    assert invalidated.byte_offset == 0
+    assert invalidated.content_fingerprint is None
+    assert LiveWatcher(
+        polylogue,
+        (WatchSource(name="codex", root=root),),
+        cursor=cursor,
+    )._needs_work(path)
 
 
 def test_rewrite_plus_growth_before_planning_fails_closed_to_full_route(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Retain an append cursor at the byte-proven accepted newline when a live Claude/Codex JSONL grows after append persistence but before cursor bookkeeping. The following batch consumes only the later tail instead of falling back to `archive_full`.

## Problem

Live daemon logs showed repeated `source changed after append persistence; cursor invalidated for full retry` events for actively written 50–80 MB JSONLs. `_record_append_cursor` treated every observation change as a rewrite, cleared the frontier, and made the next minute-scale batch re-capture the complete raw source. The active-writer case is later append growth, not a replacement.

Static trace and harness results:

| Suspect | Before | After |
| --- | --- | --- |
| later growth after append persistence | `stale_cursor_write_count=1`; next batch enters full route | `0`; next batch is append-only, zero full-route paths |
| atomic replacement | invalidated | invalidated |
| same-size in-place prefix rewrite | invalidated eagerly | watcher requires full route before skip/append |
| truncation during handoff | untested | cursor invalidated, fail closed |

## Solution

`LiveBatchProcessor._record_append_cursor` now accepts only a surviving, byte-proven accepted range: device/inode must match, size may only grow, and the accepted payload plus tail witness must match. It records the original planned observation—not the newest size—as the cursor authority. Therefore later growth resumes from the proven newline, while a same-size rewrite remains observable through the ctime-bearing cursor authority and is forced through the full route on the next authorization.

The regression harness exercises the real planner, cursor writer, and batch routing while lightweight-ingest stubs count a second-tick full route and blob reads. It verifies the cursor moves first to the accepted frontier and then to the file end after consuming only the later record.

## Verification

- `devtools test tests/integration/test_live_read_amplification.py::TestActiveAppendNoFullReread::test_growth_after_append_persistence_keeps_the_append_frontier tests/unit/sources/test_live_batch_support.py::test_append_cursor_redetects_source_rewrite_after_handoff tests/unit/sources/test_live_batch_support.py::test_append_cursor_rejects_truncation_after_append_persistence` — 4 passed.
- `devtools verify --quick` — 15/15 checks passed (run `20260713T093220Z-quick-3756646-fb34ba60`).

## What I decided not to change

No cgroup cache cap, SQLite cache policy, or generic retry/quarantine setting changed: the measured trigger was the append-cursor observation branch, and those controls would only hide its full rereads.