### PR TITLE
fix(storage): retain proven semantic sibling evidence

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -187,6 +187,7 @@ class BrowserCaptureOriginRepairItem:
     semantic_historical_raw_ids: tuple[str, ...] = ()
     semantic_head_snapshot: dict[str, object] | None = None
     semantic_witness_digest: str | None = None
+    terminal_byte_witness_digest: str | None = None
     evidence_digest: str | None = None
     proof_digest: str | None = None
     repaired: bool = False
@@ -1353,7 +1354,15 @@ def _browser_origin_item_payload(item: BrowserCaptureOriginRepairItem) -> dict[s
     payload = {
         key: value
         for key, value in dataclasses.asdict(item).items()
-        if key not in {"status", "reason", "proof_digest", "repaired", "copy_forward_source_complete"}
+        if key
+        not in {
+            "status",
+            "reason",
+            "proof_digest",
+            "repaired",
+            "copy_forward_source_complete",
+            "terminal_byte_witness_digest",
+        }
     }
     # Receipts are JSONL.  Normalize tuples now so an in-memory item has the
     # identical shape when it is compared to a re-read planned record.
@@ -1383,10 +1392,21 @@ def _browser_origin_semantic_witness_bindings(items: list[BrowserCaptureOriginRe
     ]
 
 
+def _browser_origin_terminal_byte_witness_bindings(
+    items: list[BrowserCaptureOriginRepairItem],
+) -> list[dict[str, object]]:
+    return [
+        {
+            "raw_id": item.raw_id,
+            "copy_forward_raw_id": item.copy_forward_raw_id,
+            "terminal_byte_witness_digest": item.terminal_byte_witness_digest,
+        }
+        for item in items
+    ]
+
+
 def _browser_origin_copy_forward_detail(item: BrowserCaptureOriginRepairItem) -> str:
     """Encode the proven semantic-head snapshot in the immutable copy receipt."""
-    if item.semantic_head_snapshot is None:
-        return f"browser_capture_origin_copy_forward:{item.raw_id}"
     return json.dumps(
         {
             "kind": "browser_capture_origin_copy_forward_v2",
@@ -1402,17 +1422,21 @@ def _browser_origin_semantic_head_from_copy_detail(
     detail: object,
     *,
     raw_id: str,
-) -> dict[str, object] | None:
+) -> tuple[bool, dict[str, object] | None]:
     """Read a prior semantic-head snapshot only from the immutable index receipt."""
     try:
         payload = json.loads(str(detail))
     except (TypeError, ValueError, json.JSONDecodeError):
-        return None
+        return False, None
     if not isinstance(payload, dict) or payload.get("kind") != "browser_capture_origin_copy_forward_v2":
-        return None
+        return False, None
     snapshot = payload.get("semantic_head")
-    if not isinstance(snapshot, dict) or payload.get("raw_id") != raw_id:
-        return None
+    if payload.get("raw_id") != raw_id or set(payload) != {"kind", "raw_id", "semantic_head"}:
+        return False, None
+    if snapshot is None:
+        return True, None
+    if not isinstance(snapshot, dict):
+        return False, None
     expected_keys = {
         "session_id",
         "accepted_raw_id",
@@ -1423,7 +1447,7 @@ def _browser_origin_semantic_head_from_copy_detail(
         "acquisition_generation",
     }
     if set(snapshot) != expected_keys:
-        return None
+        return False, None
     try:
         if (
             not isinstance(snapshot["session_id"], str)
@@ -1437,10 +1461,10 @@ def _browser_origin_semantic_head_from_copy_detail(
             or not isinstance(snapshot["acquisition_generation"], int)
             or snapshot["acquisition_generation"] < 0
         ):
-            return None
+            return False, None
     except ValueError:
-        return None
-    return cast(dict[str, object], snapshot)
+        return False, None
+    return True, cast(dict[str, object], snapshot)
 
 
 def _browser_origin_copy_raw_id(
@@ -2204,7 +2228,7 @@ def _inspect_browser_capture_origin_mismatch(
         """
         SELECT session_id, accepted_raw_id, accepted_source_revision,
                accepted_content_hash, accepted_frontier_kind, accepted_frontier,
-               acquisition_generation
+               acquisition_generation, append_end_offset, decided_at_ms
         FROM raw_revision_heads WHERE logical_source_key = ?
         """,
         (canonical_key,),
@@ -2240,9 +2264,9 @@ def _inspect_browser_capture_origin_mismatch(
     ).fetchone()
     copy_application = conn.execute(
         """
-        SELECT session_id, logical_source_key, source_revision, acquisition_generation,
+        SELECT decision_id, raw_id, session_id, logical_source_key, source_revision, acquisition_generation,
                decision, accepted_raw_id, accepted_source_revision, accepted_content_hash,
-               baseline_raw_id, detail
+               baseline_raw_id, predecessor_raw_id, append_end_offset, detail, decided_at_ms
         FROM raw_revision_applications
         WHERE raw_id = ? AND logical_source_key = ?
         """,
@@ -2295,21 +2319,28 @@ def _inspect_browser_capture_origin_mismatch(
         and canonical_head is not None
         and str(canonical_head["session_id"]) == session_id
         and str(canonical_head["accepted_raw_id"]) == copy_raw_id
+        and str(canonical_head["accepted_source_revision"]) == blob_hash_hex
         and _bytes_value(canonical_head["accepted_content_hash"]) == accepted_hash
+        and str(canonical_head["accepted_frontier_kind"]) == "byte"
+        and int(canonical_head["accepted_frontier"]) == blob_size
+        and int(canonical_head["acquisition_generation"]) == 0
+        and canonical_head["append_end_offset"] is None
         and str(indexed["raw_id"]) == copy_raw_id
         and copy_application is not None
-        and tuple(copy_application)[:-1]
-        == (
-            session_id,
-            canonical_key,
-            blob_hash_hex,
-            0,
-            ApplicationDecision.SELECTED_BASELINE.value,
-            copy_raw_id,
-            blob_hash_hex,
-            accepted_hash,
-            copy_raw_id,
-        )
+        and _revision_application_decision_id_is_exact(copy_application)
+        and str(copy_application["session_id"]) == session_id
+        and str(copy_application["logical_source_key"]) == canonical_key
+        and str(copy_application["source_revision"]) == blob_hash_hex
+        and int(copy_application["acquisition_generation"]) == 0
+        and str(copy_application["decision"]) == ApplicationDecision.SELECTED_BASELINE.value
+        and str(copy_application["accepted_raw_id"]) == copy_raw_id
+        and str(copy_application["accepted_source_revision"]) == blob_hash_hex
+        and _bytes_value(copy_application["accepted_content_hash"]) == accepted_hash
+        and str(copy_application["baseline_raw_id"]) == copy_raw_id
+        and copy_application["predecessor_raw_id"] is None
+        and copy_application["append_end_offset"] is None
+        and int(copy_application["decided_at_ms"]) >= 0
+        and int(canonical_head["decided_at_ms"]) == int(copy_application["decided_at_ms"])
     )
     repair_strategy = "copy_forward"
     replacement_raw_id = copy_raw_id
@@ -2321,6 +2352,14 @@ def _inspect_browser_capture_origin_mismatch(
     semantic_historical_raw_ids: tuple[str, ...] = ()
     semantic_head_snapshot: dict[str, object] | None = None
     semantic_witness_digest: str | None = None
+    terminal_byte_witness_digest: str | None = None
+    if (
+        copy_raw is not None
+        and copy_forward_source_complete
+        and str(indexed["raw_id"]) == copy_raw_id
+        and not copy_forward_terminal
+    ):
+        return _browser_origin_ineligible(raw_id, "copy-forward terminal byte authority is not exact")
     if canonical_head is not None and not copy_forward_terminal:
         if _canonical_browser_origin_head_is_exact(
             conn,
@@ -2382,11 +2421,12 @@ def _inspect_browser_capture_origin_mismatch(
         return _browser_origin_ineligible(raw_id, "indexed session points at unrelated raw evidence")
     if copy_forward_terminal:
         assert copy_application is not None
-        terminal_snapshot = _browser_origin_semantic_head_from_copy_detail(copy_application["detail"], raw_id=raw_id)
-        if terminal_snapshot is None:
-            if str(copy_application["detail"]) != f"browser_capture_origin_copy_forward:{raw_id}":
-                return _browser_origin_ineligible(raw_id, "copy-forward receipt detail is not exact")
-        else:
+        detail_is_exact, terminal_snapshot = _browser_origin_semantic_head_from_copy_detail(
+            copy_application["detail"], raw_id=raw_id
+        )
+        if not detail_is_exact:
+            return _browser_origin_ineligible(raw_id, "copy-forward receipt detail is not exact")
+        if terminal_snapshot is not None:
             terminal_witness = _canonical_browser_origin_head_is_semantically_equivalent(
                 conn,
                 archive_root=archive_root,
@@ -2405,6 +2445,7 @@ def _inspect_browser_capture_origin_mismatch(
             semantic_historical_raw_ids = terminal_witness.historical_raw_ids
             semantic_head_snapshot = terminal_witness.head_snapshot
             semantic_witness_digest = terminal_witness.digest
+        terminal_byte_witness_digest = _authority_rows_digest([canonical_head], [copy_application])
     evidence_rows = conn.execute(
         """
         SELECT decision_id, raw_id, logical_source_key, decision, accepted_raw_id,
@@ -2447,6 +2488,7 @@ def _inspect_browser_capture_origin_mismatch(
         semantic_historical_raw_ids=semantic_historical_raw_ids,
         semantic_head_snapshot=semantic_head_snapshot,
         semantic_witness_digest=semantic_witness_digest,
+        terminal_byte_witness_digest=terminal_byte_witness_digest,
         evidence_digest=evidence_digest,
     )
     return dataclasses.replace(item, proof_digest=_browser_origin_item_digest(item))
@@ -2517,6 +2559,8 @@ def _lock_browser_origin_receipt(path: Path, items: list[BrowserCaptureOriginRep
                         or applied.get("target_hash") != target_hash
                         or applied.get("replacement_raw_ids") != [item.replacement_raw_id for item in items]
                         or applied.get("semantic_witness_bindings") != _browser_origin_semantic_witness_bindings(items)
+                        or applied.get("terminal_byte_witness_bindings")
+                        != _browser_origin_terminal_byte_witness_bindings(items)
                     ):
                         raise RuntimeError("existing repair receipt has a conflicting terminal record")
                     terminal = True
@@ -2552,6 +2596,7 @@ def _finish_browser_origin_receipt(
         "applied_at_ms": int(time.time() * 1000),
         "replacement_raw_ids": [item.replacement_raw_id for item in items],
         "semantic_witness_bindings": _browser_origin_semantic_witness_bindings(items),
+        "terminal_byte_witness_bindings": _browser_origin_terminal_byte_witness_bindings(items),
     }
     if receipt.torn:
         if not receipt.torn.endswith(b"\n"):

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -68,6 +68,7 @@ _QUARANTINED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA = "polylogue.quarantined-accepte
 _BROWSER_CAPTURE_ORIGIN_REPAIR_RECEIPT_SCHEMA = "polylogue.browser-capture-origin-copy-forward.v1"
 _QUARANTINED_CENSUS_STAGE_FINGERPRINT = "repair-quarantined-accepted-raw-v1"
 _QUARANTINED_CENSUS_STAGE_DETAIL = "census-only evidence staged before accepted-head authority refinement"
+_BROWSER_ORIGIN_SEMANTIC_HISTORICAL_WITNESS_LIMIT = 8
 
 
 @dataclass(frozen=True, slots=True)
@@ -1655,7 +1656,7 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
         """,
         (canonical_key,),
     ).fetchall()
-    if raw is None or blob_ref is None or len(memberships) != 1 or len(census) != 1 or len(applications) != 1:
+    if raw is None or blob_ref is None or len(memberships) != 1 or len(census) != 1 or not applications:
         return False
     try:
         blob_hash = _bytes_value(raw["blob_hash"])
@@ -1670,7 +1671,99 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
     except (OSError, ValueError, json.JSONDecodeError):
         return False
     membership = memberships[0]
-    application = applications[0]
+    selected_applications = [application for application in applications if str(application["raw_id"]) == raw_id]
+    historical_supersessions = [application for application in applications if str(application["raw_id"]) != raw_id]
+    if (
+        len(selected_applications) != 1
+        or len(historical_supersessions) > _BROWSER_ORIGIN_SEMANTIC_HISTORICAL_WITNESS_LIMIT
+    ):
+        return False
+    application = selected_applications[0]
+    # A semantic head can legitimately retain prior equivalent raw evidence.
+    # It is not replacement authority: every additional application must be an
+    # explicit supersession *to this exact head*.  Any independent selected or
+    # divergent historical receipt still makes the proof ineligible.
+    for historical in historical_supersessions:
+        historical_raw_id = str(historical["raw_id"])
+        if tuple(historical) != (
+            historical_raw_id,
+            session_id,
+            ApplicationDecision.SUPERSEDED.value,
+            raw_id,
+            accepted_hash,
+        ):
+            return False
+        historical_raw = conn.execute(
+            """
+            SELECT origin, native_id, source_path, blob_hash, blob_size,
+                   logical_source_key, revision_kind, source_revision,
+                   predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
+                   append_start_offset, append_end_offset, acquisition_generation,
+                   revision_authority
+            FROM source.raw_sessions WHERE raw_id = ?
+            """,
+            (historical_raw_id,),
+        ).fetchone()
+        historical_blob_ref = conn.execute(
+            """
+            SELECT blob_hash, source_path, size_bytes FROM source.blob_refs
+            WHERE ref_id = ? AND ref_type = 'raw_payload'
+            """,
+            (historical_raw_id,),
+        ).fetchone()
+        historical_memberships = conn.execute(
+            """
+            SELECT provider_session_id, source_revision, normalized_content_hash, message_count,
+                   predecessor_raw_id, acquisition_generation, revision_authority, decision
+            FROM source.raw_session_memberships WHERE raw_id = ? AND logical_source_key = ?
+            """,
+            (historical_raw_id, canonical_key),
+        ).fetchall()
+        historical_census = conn.execute(
+            "SELECT status, member_count FROM source.raw_membership_census WHERE raw_id = ?",
+            (historical_raw_id,),
+        ).fetchall()
+        if historical_raw is None or historical_blob_ref is None:
+            return False
+        historical_blob_hash = _bytes_value(historical_raw["blob_hash"])
+        historical_blob_size = int(historical_raw["blob_size"])
+        if (
+            tuple(historical_raw)
+            != (
+                canonical_origin.value,
+                native_id,
+                str(historical_raw["source_path"]),
+                historical_blob_hash,
+                historical_blob_size,
+                None,
+                RawRevisionKind.UNKNOWN.value,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                RawRevisionAuthority.QUARANTINED.value,
+            )
+            or tuple(historical_blob_ref)
+            != (historical_blob_hash, str(historical_raw["source_path"]), historical_blob_size)
+            or len(historical_memberships) != 1
+            or tuple(historical_memberships[0])
+            != (
+                native_id,
+                accepted_hash.hex(),
+                accepted_hash,
+                message_count,
+                None,
+                0,
+                RawRevisionAuthority.QUARANTINED.value,
+                None,
+            )
+            or len(historical_census) != 1
+            or tuple(historical_census[0]) != ("complete", 1)
+        ):
+            return False
     return (
         len(payload) == int(raw["blob_size"])
         and hashlib.sha256(payload).digest() == blob_hash

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -271,8 +271,86 @@ def _proof_digest(item: QuarantinedAcceptedRawRepairItem) -> str:
     return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
 
 
-def _raw_sessions_capture_mode_available(conn: sqlite3.Connection) -> bool:
-    return any(str(row[1]) == "capture_mode" for row in conn.execute("PRAGMA main.table_info(raw_sessions)").fetchall())
+def _raw_sessions_capture_mode_available(conn: sqlite3.Connection, *, schema: str = "main") -> bool:
+    if schema not in {"main", "source"}:
+        raise ValueError(f"unsupported raw-session schema: {schema}")
+    return any(
+        str(row[1]) == "capture_mode" for row in conn.execute(f"PRAGMA {schema}.table_info(raw_sessions)").fetchall()
+    )
+
+
+def _browser_origin_source_envelope_is_exact(
+    conn: sqlite3.Connection,
+    *,
+    schema: str,
+    raw_id: str,
+    origin: str,
+    capture_mode: str,
+    native_id: str,
+    source_path: str,
+    source_index: int,
+    blob_hash: bytes,
+    blob_size: int,
+    logical_source_key: str | None,
+    revision_kind: RawRevisionKind,
+    source_revision: str | None,
+    baseline_raw_id: str | None,
+    acquisition_generation: int | None,
+    revision_authority: RawRevisionAuthority,
+) -> sqlite3.Row | None:
+    """Prove a complete source envelope and its raw-payload blob reference.
+
+    Browser-origin repair only admits full snapshots.  Keep this one proof
+    shared across preflight, locked staging, exact canonical, and semantic
+    witnesses so lineage/capture metadata cannot drift between those routes.
+    """
+    if schema not in {"main", "source"}:
+        raise ValueError(f"unsupported raw-session schema: {schema}")
+    has_capture_mode = _raw_sessions_capture_mode_available(conn, schema=schema)
+    capture_projection = "capture_mode" if has_capture_mode else "NULL AS capture_mode"
+    row = conn.execute(
+        f"""
+        SELECT origin, {capture_projection}, native_id, source_path, source_index,
+               blob_hash, blob_size, logical_source_key, revision_kind,
+               source_revision, predecessor_source_revision, predecessor_raw_id,
+               baseline_raw_id, append_start_offset, append_end_offset,
+               acquisition_generation, revision_authority
+        FROM {schema}.raw_sessions WHERE raw_id = ?
+        """,
+        (raw_id,),
+    ).fetchone()
+    expected = (
+        origin,
+        capture_mode if has_capture_mode else None,
+        native_id,
+        source_path,
+        source_index,
+        blob_hash,
+        blob_size,
+        logical_source_key,
+        revision_kind.value,
+        source_revision,
+        None,
+        None,
+        baseline_raw_id,
+        None,
+        None,
+        acquisition_generation,
+        revision_authority.value,
+    )
+    if row is None or tuple(row) != expected:
+        return None
+    blob_ref = conn.execute(
+        f"""
+        SELECT blob_hash, source_path, size_bytes
+        FROM {schema}.blob_refs
+        WHERE ref_id = ? AND ref_type = 'raw_payload'
+        """,
+        (raw_id,),
+    ).fetchone()
+    if blob_ref is None or tuple(blob_ref) != (blob_hash, source_path, blob_size):
+        return None
+    return cast(sqlite3.Row, row)
 
 
 def _stageable_quarantined_census_cohort(
@@ -1503,45 +1581,29 @@ def _verify_browser_origin_copy_forward_source_stage(
     assert item.blob_hash is not None
     assert item.blob_size is not None
     assert item.accepted_content_hash is not None
-    raw = conn.execute(
-        """
-        SELECT origin, source_path, source_index, blob_hash, blob_size,
-               logical_source_key, revision_kind, source_revision,
-               predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
-               append_start_offset, append_end_offset, acquisition_generation,
-               revision_authority
-        FROM raw_sessions WHERE raw_id = ?
-        """,
-        (item.raw_id,),
-    ).fetchone()
-    expected = (
-        Origin.UNKNOWN_EXPORT.value,
-        item.source_path,
-        item.source_index,
-        bytes.fromhex(item.blob_hash),
-        item.blob_size,
-        item.old_logical_source_key,
-        RawRevisionKind.FULL.value,
-        item.blob_hash,
-        None,
-        None,
-        None,
-        None,
-        None,
-        0,
-        RawRevisionAuthority.QUARANTINED.value,
-    )
-    if raw is None or tuple(raw) != expected:
+    native_id = item.session_id.split(":", 1)[1]
+    if (
+        _browser_origin_source_envelope_is_exact(
+            conn,
+            schema="main",
+            raw_id=item.raw_id,
+            origin=Origin.UNKNOWN_EXPORT.value,
+            capture_mode=Provider.UNKNOWN.value,
+            native_id=native_id,
+            source_path=item.source_path,
+            source_index=item.source_index,
+            blob_hash=bytes.fromhex(item.blob_hash),
+            blob_size=item.blob_size,
+            logical_source_key=item.old_logical_source_key,
+            revision_kind=RawRevisionKind.FULL,
+            source_revision=item.blob_hash,
+            baseline_raw_id=None,
+            acquisition_generation=0,
+            revision_authority=RawRevisionAuthority.QUARANTINED,
+        )
+        is None
+    ):
         raise RuntimeError(f"source evidence changed before copy-forward stage for {item.raw_id}")
-    blob_ref = conn.execute(
-        """
-        SELECT blob_hash, size_bytes FROM blob_refs
-        WHERE ref_id = ? AND ref_type = 'raw_payload'
-        """,
-        (item.raw_id,),
-    ).fetchone()
-    if blob_ref is None or tuple(blob_ref) != (bytes.fromhex(item.blob_hash), item.blob_size):
-        raise RuntimeError(f"raw blob reference changed before copy-forward stage for {item.raw_id}")
     store = BlobStore(archive_root / "blob")
     payload = store.read_all(item.blob_hash)
     if len(payload) != item.blob_size or hashlib.sha256(payload).hexdigest() != item.blob_hash:
@@ -1605,16 +1667,11 @@ def _canonical_browser_origin_head_is_exact(
     source_revision = str(canonical_head["accepted_source_revision"])
     frontier = int(canonical_head["accepted_frontier"])
     generation = int(canonical_head["acquisition_generation"])
-    raw = conn.execute(
+    raw_locator = conn.execute(
         """
-        SELECT origin, source_path, blob_hash, blob_size, logical_source_key, revision_kind,
-               source_revision, baseline_raw_id, acquisition_generation, revision_authority
+        SELECT source_path, source_index
         FROM source.raw_sessions WHERE raw_id = ?
         """,
-        (raw_id,),
-    ).fetchone()
-    blob_ref = conn.execute(
-        "SELECT blob_hash, size_bytes FROM source.blob_refs WHERE ref_id = ? AND ref_type = 'raw_payload'",
         (raw_id,),
     ).fetchone()
     membership = conn.execute(
@@ -1638,9 +1695,30 @@ def _canonical_browser_origin_head_is_exact(
         (raw_id, canonical_key),
     ).fetchone()
     native_id = session_id.split(":", 1)[1]
+    raw = (
+        _browser_origin_source_envelope_is_exact(
+            conn,
+            schema="source",
+            raw_id=raw_id,
+            origin=canonical_origin.value,
+            capture_mode=canonical_key.split(":", 1)[0],
+            native_id=native_id,
+            source_path=str(raw_locator["source_path"]) if raw_locator is not None else "",
+            source_index=0,
+            blob_hash=bytes.fromhex(source_revision),
+            blob_size=frontier,
+            logical_source_key=canonical_key,
+            revision_kind=RawRevisionKind.FULL,
+            source_revision=source_revision,
+            baseline_raw_id=raw_id,
+            acquisition_generation=generation,
+            revision_authority=RawRevisionAuthority.BYTE_PROVEN,
+        )
+        if raw_locator is not None and int(raw_locator["source_index"]) == 0
+        else None
+    )
     if (
         raw is None
-        or blob_ref is None
         or membership is None
         or census is None
         or application is None
@@ -1679,21 +1757,7 @@ def _canonical_browser_origin_head_is_exact(
     ):
         return False
     return (
-        tuple(raw)
-        == (
-            canonical_origin.value,
-            str(raw["source_path"]),
-            bytes.fromhex(source_revision),
-            frontier,
-            canonical_key,
-            RawRevisionKind.FULL.value,
-            source_revision,
-            raw_id,
-            generation,
-            RawRevisionAuthority.BYTE_PROVEN.value,
-        )
-        and tuple(blob_ref) == (bytes.fromhex(source_revision), frontier)
-        and tuple(membership)
+        tuple(membership)
         == (
             native_id,
             source_revision,
@@ -1796,18 +1860,11 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
         or str(indexed_raw_id) == raw_id
     ):
         return None
-    raw = conn.execute(
+    raw_locator = conn.execute(
         """
-        SELECT origin, source_path, blob_hash, blob_size, logical_source_key,
-               revision_kind, source_revision, predecessor_source_revision,
-               predecessor_raw_id, baseline_raw_id, append_start_offset,
-               append_end_offset, acquisition_generation, revision_authority
+        SELECT source_path, source_index, blob_hash, blob_size
         FROM source.raw_sessions WHERE raw_id = ?
         """,
-        (raw_id,),
-    ).fetchone()
-    blob_ref = conn.execute(
-        "SELECT blob_hash, source_path, size_bytes FROM source.blob_refs WHERE ref_id = ? AND ref_type = 'raw_payload'",
         (raw_id,),
     ).fetchone()
     memberships = conn.execute(
@@ -1832,10 +1889,36 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
         """,
         (canonical_key, excluded_application_decision_id, excluded_application_decision_id),
     ).fetchall()
-    if raw is None or blob_ref is None or len(memberships) != 1 or len(census) != 1 or not applications:
+    if raw_locator is None or len(memberships) != 1 or len(census) != 1 or not applications:
+        return None
+    blob_ref = conn.execute(
+        "SELECT blob_hash, source_path, size_bytes FROM source.blob_refs WHERE ref_id = ? AND ref_type = 'raw_payload'",
+        (raw_id,),
+    ).fetchone()
+    if blob_ref is None:
         return None
     try:
-        blob_hash = _bytes_value(raw["blob_hash"])
+        blob_hash = _bytes_value(raw_locator["blob_hash"])
+        raw = _browser_origin_source_envelope_is_exact(
+            conn,
+            schema="source",
+            raw_id=raw_id,
+            origin=canonical_origin.value,
+            capture_mode=canonical_key.split(":", 1)[0],
+            native_id=native_id,
+            source_path=str(raw_locator["source_path"]),
+            source_index=0,
+            blob_hash=blob_hash,
+            blob_size=int(raw_locator["blob_size"]),
+            logical_source_key=None,
+            revision_kind=RawRevisionKind.UNKNOWN,
+            source_revision=None,
+            baseline_raw_id=None,
+            acquisition_generation=None,
+            revision_authority=RawRevisionAuthority.QUARANTINED,
+        )
+        if raw is None or int(raw_locator["source_index"]) != 0:
+            return None
         store = BlobStore(archive_root / "blob")
         payload = store.read_all(blob_hash.hex())
         provider = detect_provider(json.loads(payload))
@@ -1876,6 +1959,7 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
             or str(historical["accepted_raw_id"]) != raw_id
             or str(historical["accepted_source_revision"]) != str(head_snapshot["accepted_source_revision"])
             or _bytes_value(historical["accepted_content_hash"]) != accepted_hash
+            or int(historical["decided_at_ms"]) < 0
             or any(
                 historical[name] is not None for name in ("baseline_raw_id", "predecessor_raw_id", "append_end_offset")
             )
@@ -1883,7 +1967,7 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
             return None
         historical_raw = conn.execute(
             """
-            SELECT origin, native_id, source_path, blob_hash, blob_size,
+            SELECT origin, native_id, source_path, source_index, blob_hash, blob_size,
                    logical_source_key, revision_kind, source_revision,
                    predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
                    append_start_offset, append_end_offset, acquisition_generation,
@@ -1917,26 +2001,26 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
         historical_blob_size = int(historical_raw["blob_size"])
         if (
             historical_blob_size > _QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES
-            or tuple(historical_raw)
-            != (
-                canonical_origin.value,
-                native_id,
-                str(historical_raw["source_path"]),
-                historical_blob_hash,
-                historical_blob_size,
-                None,
-                RawRevisionKind.UNKNOWN.value,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                None,
-                RawRevisionAuthority.QUARANTINED.value,
+            or int(historical_raw["source_index"]) != 0
+            or _browser_origin_source_envelope_is_exact(
+                conn,
+                schema="source",
+                raw_id=historical_raw_id,
+                origin=canonical_origin.value,
+                capture_mode=canonical_key.split(":", 1)[0],
+                native_id=native_id,
+                source_path=str(historical_raw["source_path"]),
+                source_index=0,
+                blob_hash=historical_blob_hash,
+                blob_size=historical_blob_size,
+                logical_source_key=None,
+                revision_kind=RawRevisionKind.UNKNOWN,
+                source_revision=None,
+                baseline_raw_id=None,
+                acquisition_generation=None,
+                revision_authority=RawRevisionAuthority.QUARANTINED,
             )
-            or tuple(historical_blob_ref)
-            != (historical_blob_hash, str(historical_raw["source_path"]), historical_blob_size)
+            is None
             or len(historical_memberships) != 1
             or tuple(historical_memberships[0])
             != (
@@ -1979,28 +2063,10 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
     if not (
         len(payload) == int(raw["blob_size"])
         and hashlib.sha256(payload).digest() == blob_hash
-        and tuple(blob_ref) == (blob_hash, str(raw["source_path"]), int(raw["blob_size"]))
         and len(sessions) == 1
         and str(make_session_id(provider, sessions[0].provider_session_id)) == session_id
         and f"{provider.value}:{sessions[0].provider_session_id}" == canonical_key
         and bytes.fromhex(session_content_hash(sessions[0])) == accepted_hash
-        and tuple(raw)
-        == (
-            canonical_origin.value,
-            str(raw["source_path"]),
-            blob_hash,
-            int(raw["blob_size"]),
-            None,
-            RawRevisionKind.UNKNOWN.value,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            RawRevisionAuthority.QUARANTINED.value,
-        )
         and str(membership["provider_session_id"]) == native_id
         and str(membership["source_revision"]) == accepted_hash.hex()
         and _bytes_value(membership["normalized_content_hash"]) == accepted_hash
@@ -2135,6 +2201,29 @@ def _inspect_browser_capture_origin_mismatch(
     canonical_key = f"{provider.value}:{session.provider_session_id}"
     session_id = str(make_session_id(provider, session.provider_session_id))
     old_key = str(raw["logical_source_key"] or "")
+    if (
+        _browser_origin_source_envelope_is_exact(
+            conn,
+            schema="source",
+            raw_id=raw_id,
+            origin=Origin.UNKNOWN_EXPORT.value,
+            capture_mode=Provider.UNKNOWN.value,
+            native_id=session.provider_session_id,
+            source_path=source_path,
+            source_index=0,
+            blob_hash=blob_hash,
+            blob_size=blob_size,
+            logical_source_key=old_key,
+            revision_kind=RawRevisionKind.FULL,
+            source_revision=blob_hash_hex,
+            baseline_raw_id=None,
+            acquisition_generation=0,
+            revision_authority=RawRevisionAuthority.QUARANTINED,
+        )
+        is None
+        or int(raw["source_index"]) != 0
+    ):
+        return _browser_origin_ineligible(raw_id, "source envelope does not exactly bind the normalized session")
     if old_key != f"{Provider.UNKNOWN.value}:{session.provider_session_id}":
         return _browser_origin_ineligible(raw_id, "unknown source key does not match the normalized session identity")
     if canonical_origin is Origin.UNKNOWN_EXPORT or canonical_key == old_key:

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -10,7 +10,7 @@ import os
 import re
 import sqlite3
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import closing, suppress
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -185,6 +185,7 @@ class BrowserCaptureOriginRepairItem:
     copy_forward_source_complete: bool = False
     semantic_canonical_raw_id: str | None = None
     semantic_historical_raw_ids: tuple[str, ...] = ()
+    semantic_head_snapshot: dict[str, object] | None = None
     semantic_witness_digest: str | None = None
     evidence_digest: str | None = None
     proof_digest: str | None = None
@@ -208,6 +209,7 @@ class BrowserCaptureOriginRepairReport:
 class _SemanticCanonicalWitness:
     raw_id: str
     historical_raw_ids: tuple[str, ...]
+    head_snapshot: dict[str, object]
     digest: str
 
 
@@ -223,7 +225,7 @@ def _bytes_value(value: object) -> bytes:
     raise ValueError("expected SQLite BLOB value")
 
 
-def _authority_rows_digest(*row_sets: list[sqlite3.Row]) -> str:
+def _authority_rows_digest(*row_sets: Sequence[sqlite3.Row | Mapping[str, object]]) -> str:
     def value_payload(value: object) -> object:
         if isinstance(value, (bytes, memoryview)):
             return {"blob_hex": bytes(value).hex()}
@@ -1348,11 +1350,14 @@ def _browser_origin_ineligible(raw_id: str, reason: str) -> BrowserCaptureOrigin
 
 
 def _browser_origin_item_payload(item: BrowserCaptureOriginRepairItem) -> dict[str, object]:
-    return {
+    payload = {
         key: value
         for key, value in dataclasses.asdict(item).items()
         if key not in {"status", "reason", "proof_digest", "repaired", "copy_forward_source_complete"}
     }
+    # Receipts are JSONL.  Normalize tuples now so an in-memory item has the
+    # identical shape when it is compared to a re-read planned record.
+    return cast(dict[str, object], json.loads(json.dumps(payload, sort_keys=True, separators=(",", ":"))))
 
 
 def _browser_origin_item_digest(item: BrowserCaptureOriginRepairItem) -> str:
@@ -1371,10 +1376,71 @@ def _browser_origin_semantic_witness_bindings(items: list[BrowserCaptureOriginRe
             "raw_id": item.raw_id,
             "semantic_canonical_raw_id": item.semantic_canonical_raw_id,
             "semantic_historical_raw_ids": list(item.semantic_historical_raw_ids),
+            "semantic_head_snapshot": item.semantic_head_snapshot,
             "semantic_witness_digest": item.semantic_witness_digest,
         }
         for item in items
     ]
+
+
+def _browser_origin_copy_forward_detail(item: BrowserCaptureOriginRepairItem) -> str:
+    """Encode the proven semantic-head snapshot in the immutable copy receipt."""
+    if item.semantic_head_snapshot is None:
+        return f"browser_capture_origin_copy_forward:{item.raw_id}"
+    return json.dumps(
+        {
+            "kind": "browser_capture_origin_copy_forward_v2",
+            "raw_id": item.raw_id,
+            "semantic_head": item.semantic_head_snapshot,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _browser_origin_semantic_head_from_copy_detail(
+    detail: object,
+    *,
+    raw_id: str,
+) -> dict[str, object] | None:
+    """Read a prior semantic-head snapshot only from the immutable index receipt."""
+    try:
+        payload = json.loads(str(detail))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("kind") != "browser_capture_origin_copy_forward_v2":
+        return None
+    snapshot = payload.get("semantic_head")
+    if not isinstance(snapshot, dict) or payload.get("raw_id") != raw_id:
+        return None
+    expected_keys = {
+        "session_id",
+        "accepted_raw_id",
+        "accepted_source_revision",
+        "accepted_content_hash",
+        "accepted_frontier_kind",
+        "accepted_frontier",
+        "acquisition_generation",
+    }
+    if set(snapshot) != expected_keys:
+        return None
+    try:
+        if (
+            not isinstance(snapshot["session_id"], str)
+            or not isinstance(snapshot["accepted_raw_id"], str)
+            or not isinstance(snapshot["accepted_source_revision"], str)
+            or not isinstance(snapshot["accepted_content_hash"], str)
+            or len(bytes.fromhex(snapshot["accepted_content_hash"])) != 32
+            or snapshot["accepted_frontier_kind"] != "semantic"
+            or not isinstance(snapshot["accepted_frontier"], int)
+            or snapshot["accepted_frontier"] < 0
+            or not isinstance(snapshot["acquisition_generation"], int)
+            or snapshot["acquisition_generation"] < 0
+        ):
+            return None
+    except ValueError:
+        return None
+    return cast(dict[str, object], snapshot)
 
 
 def _browser_origin_copy_raw_id(
@@ -1619,29 +1685,79 @@ def _canonical_browser_origin_head_is_exact(
     )
 
 
+def _semantic_head_snapshot(head: Mapping[str, object] | sqlite3.Row) -> dict[str, object]:
+    """Normalize the semantic-head fields that survive a copy-forward CAS.
+
+    A byte-proven copy replaces ``raw_revision_heads``.  The copy receipt keeps
+    this compact, typed snapshot in its immutable application detail so a later
+    invocation can prove the original semantic authority rather than trusting a
+    value copied out of an operator receipt.
+    """
+    accepted_content_hash = head["accepted_content_hash"]
+    if isinstance(accepted_content_hash, str):
+        if len(bytes.fromhex(accepted_content_hash)) != 32:
+            raise ValueError("semantic head snapshot has an invalid content hash")
+        content_hash = accepted_content_hash.lower()
+    else:
+        content_hash = _bytes_value(accepted_content_hash).hex()
+    return {
+        "session_id": str(head["session_id"]),
+        "accepted_raw_id": str(head["accepted_raw_id"]),
+        "accepted_source_revision": str(head["accepted_source_revision"]),
+        "accepted_content_hash": content_hash,
+        "accepted_frontier_kind": str(head["accepted_frontier_kind"]),
+        "accepted_frontier": cast(int, head["accepted_frontier"]),
+        "acquisition_generation": cast(int, head["acquisition_generation"]),
+    }
+
+
+def _revision_application_decision_id_is_exact(application: sqlite3.Row) -> bool:
+    """Reject a receipt whose immutable identity no longer matches its fields."""
+    try:
+        decision = ApplicationDecision(str(application["decision"]))
+    except ValueError:
+        return False
+    payload = {
+        "accepted_raw_id": application["accepted_raw_id"],
+        "accepted_source_revision": application["accepted_source_revision"],
+        "decision": decision.value,
+        "logical_source_key": application["logical_source_key"],
+        "raw_id": application["raw_id"],
+        "session_id": application["session_id"],
+        "source_revision": application["source_revision"],
+    }
+    expected = hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    return str(application["decision_id"]) == expected
+
+
 def _canonical_browser_origin_head_is_semantically_equivalent(
     conn: sqlite3.Connection,
     *,
     archive_root: Path,
-    canonical_head: sqlite3.Row,
+    canonical_head: Mapping[str, object] | sqlite3.Row,
     canonical_key: str,
     canonical_origin: Origin,
     session_id: str,
     accepted_hash: bytes,
     message_count: int,
     indexed_raw_id: str,
+    excluded_application_raw_id: str | None = None,
 ) -> _SemanticCanonicalWitness | None:
     """Prove a quarantined semantic head is evidence, not a replacement authority.
 
     The caller deliberately creates a new byte-proven canonical raw instead of
     repointing at this old head.  That keeps semantic and byte evidence distinct.
     """
-    raw_id = str(canonical_head["accepted_raw_id"])
+    head_snapshot = _semantic_head_snapshot(canonical_head)
+    raw_id = str(head_snapshot["accepted_raw_id"])
     native_id = session_id.split(":", 1)[1]
     if (
-        str(canonical_head["session_id"]) != session_id
-        or _bytes_value(canonical_head["accepted_content_hash"]) != accepted_hash
-        or str(canonical_head["accepted_frontier_kind"]) != "semantic"
+        str(head_snapshot["session_id"]) != session_id
+        or str(head_snapshot["accepted_content_hash"]) != accepted_hash.hex()
+        or str(head_snapshot["accepted_source_revision"]) != accepted_hash.hex()
+        or str(head_snapshot["accepted_frontier_kind"]) != "semantic"
+        or cast(int, head_snapshot["accepted_frontier"]) < 0
+        or cast(int, head_snapshot["acquisition_generation"]) < 0
         or str(indexed_raw_id) == raw_id
     ):
         return None
@@ -1672,12 +1788,14 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
     ).fetchall()
     applications = conn.execute(
         """
-        SELECT raw_id, session_id, logical_source_key, source_revision, acquisition_generation,
+        SELECT decision_id, raw_id, session_id, logical_source_key, source_revision, acquisition_generation,
                decision, accepted_raw_id, accepted_source_revision, accepted_content_hash,
-               baseline_raw_id, predecessor_raw_id, append_end_offset
-        FROM raw_revision_applications WHERE logical_source_key = ? ORDER BY raw_id
+               baseline_raw_id, predecessor_raw_id, append_end_offset, detail, decided_at_ms
+        FROM raw_revision_applications
+        WHERE logical_source_key = ? AND (? IS NULL OR raw_id != ?)
+        ORDER BY raw_id
         """,
-        (canonical_key,),
+        (canonical_key, excluded_application_raw_id, excluded_application_raw_id),
     ).fetchall()
     if raw is None or blob_ref is None or len(memberships) != 1 or len(census) != 1 or not applications:
         return None
@@ -1699,6 +1817,7 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
     if (
         len(selected_applications) != 1
         or len(historical_supersessions) > _BROWSER_ORIGIN_SEMANTIC_HISTORICAL_WITNESS_LIMIT
+        or not _revision_application_decision_id_is_exact(selected_applications[0])
     ):
         return None
     application = selected_applications[0]
@@ -1713,13 +1832,14 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
     for historical in historical_supersessions:
         historical_raw_id = str(historical["raw_id"])
         if (
-            str(historical["session_id"]) != session_id
+            not _revision_application_decision_id_is_exact(historical)
+            or str(historical["session_id"]) != session_id
             or str(historical["logical_source_key"]) != canonical_key
             or str(historical["source_revision"]) != accepted_hash.hex()
             or int(historical["acquisition_generation"]) < 0
             or str(historical["decision"]) != ApplicationDecision.SUPERSEDED.value
             or str(historical["accepted_raw_id"]) != raw_id
-            or str(historical["accepted_source_revision"]) != str(canonical_head["accepted_source_revision"])
+            or str(historical["accepted_source_revision"]) != str(head_snapshot["accepted_source_revision"])
             or _bytes_value(historical["accepted_content_hash"]) != accepted_hash
             or any(
                 historical[name] is not None for name in ("baseline_raw_id", "predecessor_raw_id", "append_end_offset")
@@ -1855,28 +1975,25 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
         and str(membership["revision_authority"]) == RawRevisionAuthority.QUARANTINED.value
         and membership["decision"] is None
         and tuple(census[0]) == ("complete", 1)
-        and tuple(application)
-        == (
-            raw_id,
-            session_id,
-            canonical_key,
-            str(canonical_head["accepted_source_revision"]),
-            int(canonical_head["acquisition_generation"]),
-            ApplicationDecision.SELECTED_BASELINE.value,
-            raw_id,
-            str(canonical_head["accepted_source_revision"]),
-            accepted_hash,
-            None,
-            None,
-            None,
-        )
+        and str(application["raw_id"]) == raw_id
+        and str(application["session_id"]) == session_id
+        and str(application["logical_source_key"]) == canonical_key
+        and str(application["source_revision"]) == str(head_snapshot["accepted_source_revision"])
+        and int(application["acquisition_generation"]) == cast(int, head_snapshot["acquisition_generation"])
+        and str(application["decision"]) == ApplicationDecision.SELECTED_BASELINE.value
+        and str(application["accepted_raw_id"]) == raw_id
+        and str(application["accepted_source_revision"]) == str(head_snapshot["accepted_source_revision"])
+        and _bytes_value(application["accepted_content_hash"]) == accepted_hash
+        and all(application[name] is None for name in ("baseline_raw_id", "predecessor_raw_id", "append_end_offset"))
+        and int(application["decided_at_ms"]) >= 0
     ):
         return None
     return _SemanticCanonicalWitness(
         raw_id=raw_id,
         historical_raw_ids=tuple(str(row["raw_id"]) for row in historical_supersessions),
+        head_snapshot=head_snapshot,
         digest=_authority_rows_digest(
-            [canonical_head],
+            [head_snapshot],
             [raw],
             [blob_ref],
             memberships,
@@ -2181,7 +2298,7 @@ def _inspect_browser_capture_origin_mismatch(
         and _bytes_value(canonical_head["accepted_content_hash"]) == accepted_hash
         and str(indexed["raw_id"]) == copy_raw_id
         and copy_application is not None
-        and tuple(copy_application)
+        and tuple(copy_application)[:-1]
         == (
             session_id,
             canonical_key,
@@ -2192,7 +2309,6 @@ def _inspect_browser_capture_origin_mismatch(
             blob_hash_hex,
             accepted_hash,
             copy_raw_id,
-            f"browser_capture_origin_copy_forward:{raw_id}",
         )
     )
     repair_strategy = "copy_forward"
@@ -2203,6 +2319,7 @@ def _inspect_browser_capture_origin_mismatch(
     already_repaired = copy_forward_terminal
     semantic_canonical_raw_id: str | None = None
     semantic_historical_raw_ids: tuple[str, ...] = ()
+    semantic_head_snapshot: dict[str, object] | None = None
     semantic_witness_digest: str | None = None
     if canonical_head is not None and not copy_forward_terminal:
         if _canonical_browser_origin_head_is_exact(
@@ -2255,6 +2372,7 @@ def _inspect_browser_capture_origin_mismatch(
                 return _browser_origin_ineligible(raw_id, "canonical logical source has an incompatible accepted head")
             semantic_canonical_raw_id = semantic_witness.raw_id
             semantic_historical_raw_ids = semantic_witness.historical_raw_ids
+            semantic_head_snapshot = semantic_witness.head_snapshot
             semantic_witness_digest = semantic_witness.digest
     if copy_raw is not None and repair_strategy == "copy_forward" and not copy_forward_source_complete:
         return _browser_origin_ineligible(
@@ -2262,22 +2380,31 @@ def _inspect_browser_capture_origin_mismatch(
         )
     if str(indexed["raw_id"]) not in {raw_id, replacement_raw_id}:
         return _browser_origin_ineligible(raw_id, "indexed session points at unrelated raw evidence")
-    if copy_forward_terminal and semantic_canonical_raw_id is None:
-        prior_semantic = conn.execute(
-            """
-            SELECT application.raw_id
-            FROM raw_revision_applications AS application
-            JOIN source.raw_sessions AS candidate ON candidate.raw_id = application.raw_id
-            WHERE application.logical_source_key = ? AND application.decision = 'selected_baseline'
-              AND application.raw_id != ? AND application.accepted_content_hash = ?
-              AND candidate.origin = ? AND candidate.revision_kind = 'unknown'
-              AND candidate.revision_authority = 'quarantined'
-            ORDER BY application.raw_id
-            """,
-            (canonical_key, copy_raw_id, accepted_hash, canonical_origin.value),
-        ).fetchall()
-        if len(prior_semantic) == 1:
-            semantic_canonical_raw_id = str(prior_semantic[0]["raw_id"])
+    if copy_forward_terminal:
+        assert copy_application is not None
+        terminal_snapshot = _browser_origin_semantic_head_from_copy_detail(copy_application["detail"], raw_id=raw_id)
+        if terminal_snapshot is None:
+            if str(copy_application["detail"]) != f"browser_capture_origin_copy_forward:{raw_id}":
+                return _browser_origin_ineligible(raw_id, "copy-forward receipt detail is not exact")
+        else:
+            terminal_witness = _canonical_browser_origin_head_is_semantically_equivalent(
+                conn,
+                archive_root=archive_root,
+                canonical_head=terminal_snapshot,
+                canonical_key=canonical_key,
+                canonical_origin=canonical_origin,
+                session_id=session_id,
+                accepted_hash=accepted_hash,
+                message_count=len(projection.message_hashes),
+                indexed_raw_id=str(indexed["raw_id"]),
+                excluded_application_raw_id=copy_raw_id,
+            )
+            if terminal_witness is None or terminal_witness.head_snapshot != terminal_snapshot:
+                return _browser_origin_ineligible(raw_id, "copy-forward semantic witness no longer reproves")
+            semantic_canonical_raw_id = terminal_witness.raw_id
+            semantic_historical_raw_ids = terminal_witness.historical_raw_ids
+            semantic_head_snapshot = terminal_witness.head_snapshot
+            semantic_witness_digest = terminal_witness.digest
     evidence_rows = conn.execute(
         """
         SELECT decision_id, raw_id, logical_source_key, decision, accepted_raw_id,
@@ -2318,6 +2445,7 @@ def _inspect_browser_capture_origin_mismatch(
         copy_forward_source_complete=copy_forward_source_complete,
         semantic_canonical_raw_id=semantic_canonical_raw_id,
         semantic_historical_raw_ids=semantic_historical_raw_ids,
+        semantic_head_snapshot=semantic_head_snapshot,
         semantic_witness_digest=semantic_witness_digest,
         evidence_digest=evidence_digest,
     )
@@ -2596,7 +2724,7 @@ def _finalize_browser_origin_copy_forward_index(conn: sqlite3.Connection, item: 
             accepted_frontier_kind="byte",
             accepted_frontier=item.accepted_frontier,
             baseline_raw_id=item.copy_forward_raw_id,
-            detail=f"browser_capture_origin_copy_forward:{item.raw_id}",
+            detail=_browser_origin_copy_forward_detail(item),
         ),
         decided_at_ms=acquired_at_ms,
     )

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -184,6 +184,8 @@ class BrowserCaptureOriginRepairItem:
     copy_forward_source_path: str | None = None
     copy_forward_source_complete: bool = False
     semantic_canonical_raw_id: str | None = None
+    semantic_historical_raw_ids: tuple[str, ...] = ()
+    semantic_witness_digest: str | None = None
     evidence_digest: str | None = None
     proof_digest: str | None = None
     repaired: bool = False
@@ -200,6 +202,13 @@ class BrowserCaptureOriginRepairReport:
     proof_digest: str
     receipt_path: str | None
     items: tuple[BrowserCaptureOriginRepairItem, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _SemanticCanonicalWitness:
+    raw_id: str
+    historical_raw_ids: tuple[str, ...]
+    digest: str
 
 
 def _quarantined_raw_item(raw_id: str, reason: str) -> QuarantinedAcceptedRawRepairItem:
@@ -1356,6 +1365,18 @@ def _browser_origin_proof_digest(items: list[BrowserCaptureOriginRepairItem]) ->
     return hashlib.sha256(json.dumps([item.proof_digest for item in items], separators=(",", ":")).encode()).hexdigest()
 
 
+def _browser_origin_semantic_witness_bindings(items: list[BrowserCaptureOriginRepairItem]) -> list[dict[str, object]]:
+    return [
+        {
+            "raw_id": item.raw_id,
+            "semantic_canonical_raw_id": item.semantic_canonical_raw_id,
+            "semantic_historical_raw_ids": list(item.semantic_historical_raw_ids),
+            "semantic_witness_digest": item.semantic_witness_digest,
+        }
+        for item in items
+    ]
+
+
 def _browser_origin_copy_raw_id(
     origin: Origin,
     source_path: str,
@@ -1479,7 +1500,7 @@ def _canonical_browser_origin_head_is_exact(
     session_id: str,
     accepted_hash: bytes,
     message_count: int,
-) -> bool:
+) -> _SemanticCanonicalWitness | None:
     """Return whether an existing canonical head has full byte authority witnesses."""
     raw_id = str(canonical_head["accepted_raw_id"])
     source_revision = str(canonical_head["accepted_source_revision"])
@@ -1528,7 +1549,7 @@ def _canonical_browser_origin_head_is_exact(
         or _bytes_value(canonical_head["accepted_content_hash"]) != accepted_hash
         or str(canonical_head["accepted_frontier_kind"]) != "byte"
     ):
-        return False
+        return None
     try:
         blob_hash = bytes.fromhex(source_revision)
         store = BlobStore(archive_root / "blob")
@@ -1609,7 +1630,7 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
     accepted_hash: bytes,
     message_count: int,
     indexed_raw_id: str,
-) -> bool:
+) -> _SemanticCanonicalWitness | None:
     """Prove a quarantined semantic head is evidence, not a replacement authority.
 
     The caller deliberately creates a new byte-proven canonical raw instead of
@@ -1623,7 +1644,7 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
         or str(canonical_head["accepted_frontier_kind"]) != "semantic"
         or str(indexed_raw_id) == raw_id
     ):
-        return False
+        return None
     raw = conn.execute(
         """
         SELECT origin, source_path, blob_hash, blob_size, logical_source_key,
@@ -1651,25 +1672,27 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
     ).fetchall()
     applications = conn.execute(
         """
-        SELECT raw_id, session_id, decision, accepted_raw_id, accepted_content_hash
-        FROM raw_revision_applications WHERE logical_source_key = ?
+        SELECT raw_id, session_id, logical_source_key, source_revision, acquisition_generation,
+               decision, accepted_raw_id, accepted_source_revision, accepted_content_hash,
+               baseline_raw_id, predecessor_raw_id, append_end_offset
+        FROM raw_revision_applications WHERE logical_source_key = ? ORDER BY raw_id
         """,
         (canonical_key,),
     ).fetchall()
     if raw is None or blob_ref is None or len(memberships) != 1 or len(census) != 1 or not applications:
-        return False
+        return None
     try:
         blob_hash = _bytes_value(raw["blob_hash"])
         store = BlobStore(archive_root / "blob")
         payload = store.read_all(blob_hash.hex())
         provider = detect_provider(json.loads(payload))
         if provider is None or origin_from_provider(provider) is not canonical_origin:
-            return False
+            return None
         from polylogue.sources.revision_backfill import _parse_one
 
         sessions = _parse_one(provider, payload, str(raw["source_path"]))
     except (OSError, ValueError, json.JSONDecodeError):
-        return False
+        return None
     membership = memberships[0]
     selected_applications = [application for application in applications if str(application["raw_id"]) == raw_id]
     historical_supersessions = [application for application in applications if str(application["raw_id"]) != raw_id]
@@ -1677,22 +1700,32 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
         len(selected_applications) != 1
         or len(historical_supersessions) > _BROWSER_ORIGIN_SEMANTIC_HISTORICAL_WITNESS_LIMIT
     ):
-        return False
+        return None
     application = selected_applications[0]
+    historical_raw_rows: list[sqlite3.Row] = []
+    historical_blob_refs: list[sqlite3.Row] = []
+    historical_membership_rows: list[sqlite3.Row] = []
+    historical_census_rows: list[sqlite3.Row] = []
     # A semantic head can legitimately retain prior equivalent raw evidence.
     # It is not replacement authority: every additional application must be an
     # explicit supersession *to this exact head*.  Any independent selected or
     # divergent historical receipt still makes the proof ineligible.
     for historical in historical_supersessions:
         historical_raw_id = str(historical["raw_id"])
-        if tuple(historical) != (
-            historical_raw_id,
-            session_id,
-            ApplicationDecision.SUPERSEDED.value,
-            raw_id,
-            accepted_hash,
+        if (
+            str(historical["session_id"]) != session_id
+            or str(historical["logical_source_key"]) != canonical_key
+            or str(historical["source_revision"]) != accepted_hash.hex()
+            or int(historical["acquisition_generation"]) < 0
+            or str(historical["decision"]) != ApplicationDecision.SUPERSEDED.value
+            or str(historical["accepted_raw_id"]) != raw_id
+            or str(historical["accepted_source_revision"]) != str(canonical_head["accepted_source_revision"])
+            or _bytes_value(historical["accepted_content_hash"]) != accepted_hash
+            or any(
+                historical[name] is not None for name in ("baseline_raw_id", "predecessor_raw_id", "append_end_offset")
+            )
         ):
-            return False
+            return None
         historical_raw = conn.execute(
             """
             SELECT origin, native_id, source_path, blob_hash, blob_size,
@@ -1724,11 +1757,12 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
             (historical_raw_id,),
         ).fetchall()
         if historical_raw is None or historical_blob_ref is None:
-            return False
+            return None
         historical_blob_hash = _bytes_value(historical_raw["blob_hash"])
         historical_blob_size = int(historical_raw["blob_size"])
         if (
-            tuple(historical_raw)
+            historical_blob_size > _QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES
+            or tuple(historical_raw)
             != (
                 canonical_origin.value,
                 native_id,
@@ -1763,8 +1797,31 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
             or len(historical_census) != 1
             or tuple(historical_census[0]) != ("complete", 1)
         ):
-            return False
-    return (
+            return None
+        try:
+            historical_payload = store.read_all(historical_blob_hash.hex())
+            historical_provider = detect_provider(json.loads(historical_payload))
+            if historical_provider is None or origin_from_provider(historical_provider) is not canonical_origin:
+                return None
+            historical_sessions = _parse_one(
+                historical_provider, historical_payload, str(historical_raw["source_path"])
+            )
+        except (OSError, ValueError, json.JSONDecodeError):
+            return None
+        if (
+            len(historical_payload) != historical_blob_size
+            or hashlib.sha256(historical_payload).digest() != historical_blob_hash
+            or len(historical_sessions) != 1
+            or str(make_session_id(historical_provider, historical_sessions[0].provider_session_id)) != session_id
+            or f"{historical_provider.value}:{historical_sessions[0].provider_session_id}" != canonical_key
+            or bytes.fromhex(session_content_hash(historical_sessions[0])) != accepted_hash
+        ):
+            return None
+        historical_raw_rows.append(historical_raw)
+        historical_blob_refs.append(historical_blob_ref)
+        historical_membership_rows.extend(historical_memberships)
+        historical_census_rows.extend(historical_census)
+    if not (
         len(payload) == int(raw["blob_size"])
         and hashlib.sha256(payload).digest() == blob_hash
         and tuple(blob_ref) == (blob_hash, str(raw["source_path"]), int(raw["blob_size"]))
@@ -1799,7 +1856,38 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
         and membership["decision"] is None
         and tuple(census[0]) == ("complete", 1)
         and tuple(application)
-        == (raw_id, session_id, ApplicationDecision.SELECTED_BASELINE.value, raw_id, accepted_hash)
+        == (
+            raw_id,
+            session_id,
+            canonical_key,
+            str(canonical_head["accepted_source_revision"]),
+            int(canonical_head["acquisition_generation"]),
+            ApplicationDecision.SELECTED_BASELINE.value,
+            raw_id,
+            str(canonical_head["accepted_source_revision"]),
+            accepted_hash,
+            None,
+            None,
+            None,
+        )
+    ):
+        return None
+    return _SemanticCanonicalWitness(
+        raw_id=raw_id,
+        historical_raw_ids=tuple(str(row["raw_id"]) for row in historical_supersessions),
+        digest=_authority_rows_digest(
+            [canonical_head],
+            [raw],
+            [blob_ref],
+            memberships,
+            census,
+            [application],
+            historical_supersessions,
+            historical_raw_rows,
+            historical_blob_refs,
+            historical_membership_rows,
+            historical_census_rows,
+        ),
     )
 
 
@@ -2114,6 +2202,8 @@ def _inspect_browser_capture_origin_mismatch(
     replacement_frontier = blob_size
     already_repaired = copy_forward_terminal
     semantic_canonical_raw_id: str | None = None
+    semantic_historical_raw_ids: tuple[str, ...] = ()
+    semantic_witness_digest: str | None = None
     if canonical_head is not None and not copy_forward_terminal:
         if _canonical_browser_origin_head_is_exact(
             conn,
@@ -2149,20 +2239,23 @@ def _inspect_browser_capture_origin_mismatch(
                     f"browser_capture_origin_supersession:{raw_id}",
                 )
             )
-        elif not _canonical_browser_origin_head_is_semantically_equivalent(
-            conn,
-            archive_root=archive_root,
-            canonical_head=canonical_head,
-            canonical_key=canonical_key,
-            canonical_origin=canonical_origin,
-            session_id=session_id,
-            accepted_hash=accepted_hash,
-            message_count=len(projection.message_hashes),
-            indexed_raw_id=str(indexed["raw_id"]),
-        ):
-            return _browser_origin_ineligible(raw_id, "canonical logical source has an incompatible accepted head")
         else:
-            semantic_canonical_raw_id = str(canonical_head["accepted_raw_id"])
+            semantic_witness = _canonical_browser_origin_head_is_semantically_equivalent(
+                conn,
+                archive_root=archive_root,
+                canonical_head=canonical_head,
+                canonical_key=canonical_key,
+                canonical_origin=canonical_origin,
+                session_id=session_id,
+                accepted_hash=accepted_hash,
+                message_count=len(projection.message_hashes),
+                indexed_raw_id=str(indexed["raw_id"]),
+            )
+            if semantic_witness is None:
+                return _browser_origin_ineligible(raw_id, "canonical logical source has an incompatible accepted head")
+            semantic_canonical_raw_id = semantic_witness.raw_id
+            semantic_historical_raw_ids = semantic_witness.historical_raw_ids
+            semantic_witness_digest = semantic_witness.digest
     if copy_raw is not None and repair_strategy == "copy_forward" and not copy_forward_source_complete:
         return _browser_origin_ineligible(
             raw_id, "copy-forward raw id exists but its durable source stage is not exact"
@@ -2224,6 +2317,8 @@ def _inspect_browser_capture_origin_mismatch(
         copy_forward_source_path=copy_path if repair_strategy == "copy_forward" else None,
         copy_forward_source_complete=copy_forward_source_complete,
         semantic_canonical_raw_id=semantic_canonical_raw_id,
+        semantic_historical_raw_ids=semantic_historical_raw_ids,
+        semantic_witness_digest=semantic_witness_digest,
         evidence_digest=evidence_digest,
     )
     return dataclasses.replace(item, proof_digest=_browser_origin_item_digest(item))
@@ -2293,6 +2388,7 @@ def _lock_browser_origin_receipt(path: Path, items: list[BrowserCaptureOriginRep
                         applied.get("schema") != _BROWSER_CAPTURE_ORIGIN_REPAIR_RECEIPT_SCHEMA
                         or applied.get("target_hash") != target_hash
                         or applied.get("replacement_raw_ids") != [item.replacement_raw_id for item in items]
+                        or applied.get("semantic_witness_bindings") != _browser_origin_semantic_witness_bindings(items)
                     ):
                         raise RuntimeError("existing repair receipt has a conflicting terminal record")
                     terminal = True
@@ -2327,6 +2423,7 @@ def _finish_browser_origin_receipt(
         "target_hash": receipt.target_hash,
         "applied_at_ms": int(time.time() * 1000),
         "replacement_raw_ids": [item.replacement_raw_id for item in items],
+        "semantic_witness_bindings": _browser_origin_semantic_witness_bindings(items),
     }
     if receipt.torn:
         if not receipt.torn.endswith(b"\n"):
@@ -2601,6 +2698,13 @@ def repair_browser_capture_origin_mismatches(
         with RebuildLease(archive_root):
             receipt = _lock_browser_origin_receipt(receipt_path, items)
             try:
+                with closing(sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)) as proof_conn:
+                    proof_conn.execute("ATTACH DATABASE ? AS source", (str(source_db),))
+                    pre_source_items = inspect(proof_conn)
+                if _browser_origin_proof_digest(pre_source_items) != proof_digest:
+                    raise RuntimeError("authority proof changed before copy-forward source staging")
+                if any(item.status == "ineligible" for item in pre_source_items):
+                    raise RuntimeError("a browser-capture origin target became ineligible before source staging")
                 with closing(sqlite3.connect(f"file:{source_db}?mode=rw", uri=True)) as source_conn:
                     source_conn.execute("PRAGMA foreign_keys = ON")
                     source_conn.execute("BEGIN IMMEDIATE")

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -1445,6 +1445,7 @@ def _browser_origin_semantic_head_from_copy_detail(
         "accepted_frontier_kind",
         "accepted_frontier",
         "acquisition_generation",
+        "decided_at_ms",
     }
     if set(snapshot) != expected_keys:
         return False, None
@@ -1460,6 +1461,8 @@ def _browser_origin_semantic_head_from_copy_detail(
             or snapshot["accepted_frontier"] < 0
             or not isinstance(snapshot["acquisition_generation"], int)
             or snapshot["acquisition_generation"] < 0
+            or not isinstance(snapshot["decided_at_ms"], int)
+            or snapshot["decided_at_ms"] < 0
         ):
             return False, None
     except ValueError:
@@ -1503,8 +1506,10 @@ def _verify_browser_origin_copy_forward_source_stage(
     raw = conn.execute(
         """
         SELECT origin, source_path, source_index, blob_hash, blob_size,
-               logical_source_key, revision_kind, source_revision, baseline_raw_id,
-               acquisition_generation, revision_authority
+               logical_source_key, revision_kind, source_revision,
+               predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
+               append_start_offset, append_end_offset, acquisition_generation,
+               revision_authority
         FROM raw_sessions WHERE raw_id = ?
         """,
         (item.raw_id,),
@@ -1518,6 +1523,10 @@ def _verify_browser_origin_copy_forward_source_stage(
         item.old_logical_source_key,
         RawRevisionKind.FULL.value,
         item.blob_hash,
+        None,
+        None,
+        None,
+        None,
         None,
         0,
         RawRevisionAuthority.QUARANTINED.value,
@@ -1732,6 +1741,7 @@ def _semantic_head_snapshot(head: Mapping[str, object] | sqlite3.Row) -> dict[st
         "accepted_frontier_kind": str(head["accepted_frontier_kind"]),
         "accepted_frontier": cast(int, head["accepted_frontier"]),
         "acquisition_generation": cast(int, head["acquisition_generation"]),
+        "decided_at_ms": cast(int, head["decided_at_ms"]),
     }
 
 
@@ -1765,7 +1775,7 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
     accepted_hash: bytes,
     message_count: int,
     indexed_raw_id: str,
-    excluded_application_raw_id: str | None = None,
+    excluded_application_decision_id: str | None = None,
 ) -> _SemanticCanonicalWitness | None:
     """Prove a quarantined semantic head is evidence, not a replacement authority.
 
@@ -1782,6 +1792,7 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
         or str(head_snapshot["accepted_frontier_kind"]) != "semantic"
         or cast(int, head_snapshot["accepted_frontier"]) < 0
         or cast(int, head_snapshot["acquisition_generation"]) < 0
+        or cast(int, head_snapshot["decided_at_ms"]) < 0
         or str(indexed_raw_id) == raw_id
     ):
         return None
@@ -1816,10 +1827,10 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
                decision, accepted_raw_id, accepted_source_revision, accepted_content_hash,
                baseline_raw_id, predecessor_raw_id, append_end_offset, detail, decided_at_ms
         FROM raw_revision_applications
-        WHERE logical_source_key = ? AND (? IS NULL OR raw_id != ?)
+        WHERE logical_source_key = ? AND (? IS NULL OR decision_id != ?)
         ORDER BY raw_id
         """,
-        (canonical_key, excluded_application_raw_id, excluded_application_raw_id),
+        (canonical_key, excluded_application_decision_id, excluded_application_decision_id),
     ).fetchall()
     if raw is None or blob_ref is None or len(memberships) != 1 or len(census) != 1 or not applications:
         return None
@@ -2010,6 +2021,7 @@ def _canonical_browser_origin_head_is_semantically_equivalent(
         and _bytes_value(application["accepted_content_hash"]) == accepted_hash
         and all(application[name] is None for name in ("baseline_raw_id", "predecessor_raw_id", "append_end_offset"))
         and int(application["decided_at_ms"]) >= 0
+        and int(application["decided_at_ms"]) == cast(int, head_snapshot["decided_at_ms"])
     ):
         return None
     return _SemanticCanonicalWitness(
@@ -2131,7 +2143,8 @@ def _inspect_browser_capture_origin_mismatch(
     head = conn.execute(
         """
         SELECT session_id, accepted_source_revision, accepted_content_hash,
-               accepted_frontier_kind, accepted_frontier, acquisition_generation
+               accepted_frontier_kind, accepted_frontier, acquisition_generation,
+               append_end_offset, decided_at_ms
         FROM raw_revision_heads WHERE logical_source_key = ? AND accepted_raw_id = ?
         """,
         (old_key, raw_id),
@@ -2146,15 +2159,19 @@ def _inspect_browser_capture_origin_mismatch(
     ).fetchone()
     old_applications = conn.execute(
         """
-        SELECT session_id, logical_source_key, source_revision, acquisition_generation,
+        SELECT decision_id, raw_id, session_id, logical_source_key, source_revision, acquisition_generation,
                decision, accepted_raw_id, accepted_source_revision,
-               accepted_content_hash, baseline_raw_id, decided_at_ms
+               accepted_content_hash, baseline_raw_id, predecessor_raw_id,
+               append_end_offset, detail, decided_at_ms
         FROM raw_revision_applications
-        WHERE raw_id = ? AND logical_source_key = ? AND decision = 'selected_baseline'
+        WHERE raw_id = ? AND logical_source_key = ?
         ORDER BY decision_id
         """,
         (raw_id, old_key),
     ).fetchall()
+    old_key_application_count = conn.execute(
+        "SELECT COUNT(*) FROM raw_revision_applications WHERE logical_source_key = ?", (old_key,)
+    ).fetchone()
     if (
         head is None
         or indexed is None
@@ -2165,22 +2182,26 @@ def _inspect_browser_capture_origin_mismatch(
         or str(head["accepted_frontier_kind"]) != "byte"
         or int(head["accepted_frontier"]) != blob_size
         or int(head["acquisition_generation"]) != int(raw["acquisition_generation"])
+        or head["append_end_offset"] is not None
         or _bytes_value(indexed["content_hash"]) != accepted_hash
         or len(old_applications) != 1
-        or tuple(old_applications[0])[:-1]
-        != (
-            session_id,
-            old_key,
-            blob_hash_hex,
-            int(raw["acquisition_generation"]),
-            ApplicationDecision.SELECTED_BASELINE.value,
-            raw_id,
-            blob_hash_hex,
-            accepted_hash,
-            raw_id,
-        )
-        or not isinstance(old_applications[0][-1], int)
-        or int(old_applications[0][-1]) < 0
+        or old_key_application_count is None
+        or int(old_key_application_count[0]) != 1
+        or not _revision_application_decision_id_is_exact(old_applications[0])
+        or str(old_applications[0]["raw_id"]) != raw_id
+        or str(old_applications[0]["session_id"]) != session_id
+        or str(old_applications[0]["logical_source_key"]) != old_key
+        or str(old_applications[0]["source_revision"]) != blob_hash_hex
+        or int(old_applications[0]["acquisition_generation"]) != int(raw["acquisition_generation"])
+        or str(old_applications[0]["decision"]) != ApplicationDecision.SELECTED_BASELINE.value
+        or str(old_applications[0]["accepted_raw_id"]) != raw_id
+        or str(old_applications[0]["accepted_source_revision"]) != blob_hash_hex
+        or _bytes_value(old_applications[0]["accepted_content_hash"]) != accepted_hash
+        or str(old_applications[0]["baseline_raw_id"]) != raw_id
+        or old_applications[0]["predecessor_raw_id"] is not None
+        or old_applications[0]["append_end_offset"] is not None
+        or int(old_applications[0]["decided_at_ms"]) < 0
+        or int(head["decided_at_ms"]) != int(old_applications[0]["decided_at_ms"])
     ):
         return _browser_origin_ineligible(raw_id, "current accepted head does not exactly prove the normalized session")
     membership = conn.execute(
@@ -2233,11 +2254,14 @@ def _inspect_browser_capture_origin_mismatch(
         """,
         (canonical_key,),
     ).fetchone()
+    copy_columns = {str(row[1]) for row in conn.execute("PRAGMA source.table_info(raw_sessions)")}
+    copy_capture_mode_projection = "capture_mode" if "capture_mode" in copy_columns else "NULL AS capture_mode"
     copy_raw = conn.execute(
-        """
-        SELECT origin, native_id, source_path, source_index, blob_hash, blob_size,
+        f"""
+        SELECT origin, {copy_capture_mode_projection}, native_id, source_path, source_index, blob_hash, blob_size,
                logical_source_key, revision_kind, source_revision, baseline_raw_id,
-               acquisition_generation, revision_authority
+               predecessor_source_revision, predecessor_raw_id, append_start_offset,
+               append_end_offset, acquisition_generation, revision_authority
         FROM source.raw_sessions WHERE raw_id = ?
         """,
         (copy_raw_id,),
@@ -2262,7 +2286,7 @@ def _inspect_browser_capture_origin_mismatch(
         "SELECT status, member_count FROM source.raw_membership_census WHERE raw_id = ?",
         (copy_raw_id,),
     ).fetchone()
-    copy_application = conn.execute(
+    copy_applications = conn.execute(
         """
         SELECT decision_id, raw_id, session_id, logical_source_key, source_revision, acquisition_generation,
                decision, accepted_raw_id, accepted_source_revision, accepted_content_hash,
@@ -2271,9 +2295,11 @@ def _inspect_browser_capture_origin_mismatch(
         WHERE raw_id = ? AND logical_source_key = ?
         """,
         (copy_raw_id, canonical_key),
-    ).fetchone()
+    ).fetchall()
+    copy_application = copy_applications[0] if len(copy_applications) == 1 else None
     copy_raw_exact = copy_raw is not None and (
         str(copy_raw["origin"]),
+        str(copy_raw["capture_mode"]) if copy_raw["capture_mode"] is not None else None,
         str(copy_raw["native_id"]),
         str(copy_raw["source_path"]),
         int(copy_raw["source_index"]),
@@ -2282,11 +2308,16 @@ def _inspect_browser_capture_origin_mismatch(
         str(copy_raw["logical_source_key"]),
         str(copy_raw["revision_kind"]),
         str(copy_raw["source_revision"]),
+        copy_raw["predecessor_source_revision"],
+        copy_raw["predecessor_raw_id"],
         str(copy_raw["baseline_raw_id"]),
+        copy_raw["append_start_offset"],
+        copy_raw["append_end_offset"],
         int(copy_raw["acquisition_generation"]),
         str(copy_raw["revision_authority"]),
     ) == (
         canonical_origin.value,
+        provider.value if "capture_mode" in copy_columns else None,
         session.provider_session_id,
         copy_path,
         int(raw["source_index"]),
@@ -2295,7 +2326,11 @@ def _inspect_browser_capture_origin_mismatch(
         canonical_key,
         RawRevisionKind.FULL.value,
         blob_hash_hex,
+        None,
+        None,
         copy_raw_id,
+        None,
+        None,
         0,
         RawRevisionAuthority.BYTE_PROVEN.value,
     )
@@ -2437,7 +2472,7 @@ def _inspect_browser_capture_origin_mismatch(
                 accepted_hash=accepted_hash,
                 message_count=len(projection.message_hashes),
                 indexed_raw_id=str(indexed["raw_id"]),
-                excluded_application_raw_id=copy_raw_id,
+                excluded_application_decision_id=str(copy_application["decision_id"]),
             )
             if terminal_witness is None or terminal_witness.head_snapshot != terminal_snapshot:
                 return _browser_origin_ineligible(raw_id, "copy-forward semantic witness no longer reproves")
@@ -2446,16 +2481,9 @@ def _inspect_browser_capture_origin_mismatch(
             semantic_head_snapshot = terminal_witness.head_snapshot
             semantic_witness_digest = terminal_witness.digest
         terminal_byte_witness_digest = _authority_rows_digest([canonical_head], [copy_application])
-    evidence_rows = conn.execute(
-        """
-        SELECT decision_id, raw_id, logical_source_key, decision, accepted_raw_id,
-               accepted_source_revision, accepted_content_hash, decided_at_ms
-        FROM raw_revision_applications WHERE session_id = ? ORDER BY decision_id
-        """,
-        (session_id,),
-    ).fetchall()
-    evidence_rows = [row for row in evidence_rows if str(row["logical_source_key"]) == old_key]
-    evidence_digest = _authority_rows_digest([raw], [head], [indexed_evidence], [membership], [census], evidence_rows)
+    evidence_digest = _authority_rows_digest(
+        [raw], [head], [indexed_evidence], [membership], [census], old_applications
+    )
     item = BrowserCaptureOriginRepairItem(
         raw_id=raw_id,
         status="already_repaired" if already_repaired else "eligible",

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -1500,7 +1500,7 @@ def _canonical_browser_origin_head_is_exact(
     session_id: str,
     accepted_hash: bytes,
     message_count: int,
-) -> _SemanticCanonicalWitness | None:
+) -> bool:
     """Return whether an existing canonical head has full byte authority witnesses."""
     raw_id = str(canonical_head["accepted_raw_id"])
     source_revision = str(canonical_head["accepted_source_revision"])
@@ -1549,7 +1549,7 @@ def _canonical_browser_origin_head_is_exact(
         or _bytes_value(canonical_head["accepted_content_hash"]) != accepted_hash
         or str(canonical_head["accepted_frontier_kind"]) != "byte"
     ):
-        return None
+        return False
     try:
         blob_hash = bytes.fromhex(source_revision)
         store = BlobStore(archive_root / "blob")

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -659,7 +659,7 @@ def test_browser_origin_repair_accepts_exact_semantic_superseded_sibling(tmp_pat
     assert receipt.read_text().count("\n") == 2
 
 
-@pytest.mark.parametrize("mutation", ["receipt", "membership"])
+@pytest.mark.parametrize("mutation", ["receipt", "membership", "selected"])
 def test_browser_origin_repair_rejects_underproven_semantic_supersession(tmp_path: Path, mutation: str) -> None:
     mismatched_raw_id = _seed_mismatched_browser_head(tmp_path)
     semantic_raw_id = _seed_semantic_canonical_head(tmp_path, mismatched_raw_id)
@@ -670,10 +670,16 @@ def test_browser_origin_repair_rejects_underproven_semantic_supersession(tmp_pat
                 "UPDATE raw_revision_applications SET accepted_raw_id = ? WHERE raw_id = ?",
                 (sibling_raw_id, sibling_raw_id),
             )
-    else:
+    elif mutation == "membership":
         with sqlite3.connect(tmp_path / "source.db") as source:
             source.execute(
                 "UPDATE raw_session_memberships SET decision = 'ambiguous', decided_at_ms = 4 WHERE raw_id = ?",
+                (sibling_raw_id,),
+            )
+    else:
+        with sqlite3.connect(tmp_path / "index.db") as index:
+            index.execute(
+                "UPDATE raw_revision_applications SET decision = 'selected_baseline' WHERE raw_id = ?",
                 (sibling_raw_id,),
             )
 

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -656,7 +656,7 @@ def test_browser_origin_repair_accepts_exact_semantic_superseded_sibling(tmp_pat
     )
 
 
-@pytest.mark.parametrize("mutation", ["receipt", "membership", "selected"])
+@pytest.mark.parametrize("mutation", ["receipt", "revision", "membership", "selected", "blob"])
 def test_browser_origin_repair_rejects_underproven_semantic_supersession(tmp_path: Path, mutation: str) -> None:
     mismatched_raw_id = _seed_mismatched_browser_head(tmp_path)
     semantic_raw_id = _seed_semantic_canonical_head(tmp_path, mismatched_raw_id)
@@ -667,17 +667,35 @@ def test_browser_origin_repair_rejects_underproven_semantic_supersession(tmp_pat
                 "UPDATE raw_revision_applications SET accepted_raw_id = ? WHERE raw_id = ?",
                 (sibling_raw_id, sibling_raw_id),
             )
+    elif mutation == "revision":
+        with sqlite3.connect(tmp_path / "index.db") as index:
+            index.execute(
+                "UPDATE raw_revision_applications SET accepted_source_revision = ? WHERE raw_id = ?",
+                ("0" * 64, sibling_raw_id),
+            )
     elif mutation == "membership":
         with sqlite3.connect(tmp_path / "source.db") as source:
             source.execute(
                 "UPDATE raw_session_memberships SET decision = 'ambiguous', decided_at_ms = 4 WHERE raw_id = ?",
                 (sibling_raw_id,),
             )
-    else:
+    elif mutation == "selected":
         with sqlite3.connect(tmp_path / "index.db") as index:
             index.execute(
                 "UPDATE raw_revision_applications SET decision = 'selected_baseline' WHERE raw_id = ?",
                 (sibling_raw_id,),
+            )
+    else:
+        different_payload = _browser_payload("browser-origin-two")
+        blob_hash, blob_size = BlobStore(tmp_path / "blob").write_from_bytes(different_payload)
+        with sqlite3.connect(tmp_path / "source.db") as source:
+            source.execute(
+                "UPDATE raw_sessions SET native_id = 'browser-origin-two', blob_hash = ?, blob_size = ? WHERE raw_id = ?",
+                (bytes.fromhex(blob_hash), blob_size, sibling_raw_id),
+            )
+            source.execute(
+                "UPDATE blob_refs SET blob_hash = ?, size_bytes = ? WHERE ref_id = ?",
+                (bytes.fromhex(blob_hash), blob_size, sibling_raw_id),
             )
 
     report = repair_browser_capture_origin_mismatches(_config(tmp_path), [mismatched_raw_id])

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -272,6 +272,66 @@ def _seed_semantic_canonical_head(root: Path, mismatched_raw_id: str) -> str:
     return raw_id
 
 
+def _seed_semantic_superseded_sibling(root: Path, semantic_raw_id: str) -> str:
+    sibling_raw_id = "a" * 64
+    with sqlite3.connect(root / "source.db") as source:
+        for table, identity in (
+            ("raw_sessions", "raw_id"),
+            ("blob_refs", "ref_id"),
+            ("raw_session_memberships", "raw_id"),
+            ("raw_membership_census", "raw_id"),
+        ):
+            columns = [str(row[1]) for row in source.execute(f"PRAGMA table_info({table})")]
+            projection = ["?" if column == identity else column for column in columns]
+            source.execute(
+                f"INSERT INTO {table} ({', '.join(columns)}) "
+                f"SELECT {', '.join(projection)} FROM {table} WHERE {identity} = ?",
+                (sibling_raw_id, semantic_raw_id),
+            )
+        source.execute(
+            "UPDATE raw_sessions SET native_id = 'browser-origin-one' WHERE raw_id = ?",
+            (sibling_raw_id,),
+        )
+        original_blob_hash = source.execute(
+            "SELECT lower(hex(blob_hash)) FROM raw_sessions WHERE raw_id = ?",
+            (semantic_raw_id,),
+        ).fetchone()[0]
+        store = BlobStore(root / "blob")
+        sibling_blob_hash, sibling_blob_size = store.write_from_bytes(store.read_all(original_blob_hash) + b"\n")
+        source.execute(
+            "UPDATE raw_sessions SET blob_hash = ?, blob_size = ? WHERE raw_id = ?",
+            (bytes.fromhex(sibling_blob_hash), sibling_blob_size, sibling_raw_id),
+        )
+        source.execute(
+            "UPDATE blob_refs SET blob_hash = ?, size_bytes = ? WHERE ref_id = ?",
+            (bytes.fromhex(sibling_blob_hash), sibling_blob_size, sibling_raw_id),
+        )
+        source.commit()
+    with sqlite3.connect(root / "index.db") as index:
+        accepted_hash = index.execute(
+            "SELECT accepted_content_hash FROM raw_revision_heads WHERE accepted_raw_id = ?",
+            (semantic_raw_id,),
+        ).fetchone()[0]
+        record_revision_application_sync(
+            index,
+            RevisionApplicationReceipt(
+                raw_id=sibling_raw_id,
+                session_id="chatgpt-export:browser-origin-one",
+                logical_source_key="chatgpt:browser-origin-one",
+                source_revision=bytes(accepted_hash).hex(),
+                acquisition_generation=0,
+                decision=ApplicationDecision.SUPERSEDED,
+                accepted_raw_id=semantic_raw_id,
+                accepted_source_revision=bytes(accepted_hash).hex(),
+                accepted_content_hash=bytes(accepted_hash),
+                detail="membership:superseded_equivalent",
+            ),
+            decided_at_ms=3,
+        )
+        index.commit()
+    return sibling_raw_id
+
+
 def _rows(root: Path, tier: str, table: str, where: str, params: tuple[object, ...]) -> list[tuple[object, ...]]:
     with sqlite3.connect(root / f"{tier}.db") as conn:
         return [tuple(row) for row in conn.execute(f"SELECT * FROM {table} WHERE {where} ORDER BY 1", params)]
@@ -541,6 +601,85 @@ def test_browser_capture_origin_repair_copy_forwards_from_semantic_canonical_wit
         assert index.execute(
             "SELECT raw_id FROM sessions WHERE session_id = 'chatgpt-export:browser-origin-one'"
         ).fetchone() == (copy_raw_id,)
+
+
+def test_browser_origin_repair_accepts_exact_semantic_superseded_sibling(tmp_path: Path) -> None:
+    mismatched_raw_id = _seed_mismatched_browser_head(tmp_path)
+    semantic_raw_id = _seed_semantic_canonical_head(tmp_path, mismatched_raw_id)
+    sibling_raw_id = _seed_semantic_superseded_sibling(tmp_path, semantic_raw_id)
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        assert (
+            source.execute(
+                "SELECT blob_hash FROM raw_sessions WHERE raw_id = ?",
+                (sibling_raw_id,),
+            ).fetchone()
+            != source.execute(
+                "SELECT blob_hash FROM raw_sessions WHERE raw_id = ?",
+                (semantic_raw_id,),
+            ).fetchone()
+        )
+    historical_before = _rows(
+        tmp_path,
+        "index",
+        "raw_revision_applications",
+        "raw_id = ?",
+        (sibling_raw_id,),
+    )
+
+    dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [mismatched_raw_id])
+
+    assert dry_run.eligible_count == 1, dry_run.items[0].reason
+    receipt = tmp_path / "semantic-sibling-receipt.jsonl"
+    applied = repair_browser_capture_origin_mismatches(
+        _config(tmp_path),
+        [mismatched_raw_id],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+    assert applied.repaired_count == 1
+    assert (
+        _rows(
+            tmp_path,
+            "index",
+            "raw_revision_applications",
+            "raw_id = ?",
+            (sibling_raw_id,),
+        )
+        == historical_before
+    )
+    reapplied = repair_browser_capture_origin_mismatches(
+        _config(tmp_path),
+        [mismatched_raw_id],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+    assert reapplied.repaired_count == 0
+    assert receipt.read_text().count("\n") == 2
+
+
+@pytest.mark.parametrize("mutation", ["receipt", "membership"])
+def test_browser_origin_repair_rejects_underproven_semantic_supersession(tmp_path: Path, mutation: str) -> None:
+    mismatched_raw_id = _seed_mismatched_browser_head(tmp_path)
+    semantic_raw_id = _seed_semantic_canonical_head(tmp_path, mismatched_raw_id)
+    sibling_raw_id = _seed_semantic_superseded_sibling(tmp_path, semantic_raw_id)
+    if mutation == "receipt":
+        with sqlite3.connect(tmp_path / "index.db") as index:
+            index.execute(
+                "UPDATE raw_revision_applications SET accepted_raw_id = ? WHERE raw_id = ?",
+                (sibling_raw_id, sibling_raw_id),
+            )
+    else:
+        with sqlite3.connect(tmp_path / "source.db") as source:
+            source.execute(
+                "UPDATE raw_session_memberships SET decision = 'ambiguous', decided_at_ms = 4 WHERE raw_id = ?",
+                (sibling_raw_id,),
+            )
+
+    report = repair_browser_capture_origin_mismatches(_config(tmp_path), [mismatched_raw_id])
+
+    assert report.ineligible_count == 1
 
 
 @pytest.mark.parametrize("mutation", ["frontier", "pointer", "membership"])

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -278,6 +278,27 @@ def _seed_semantic_canonical_head(root: Path, mismatched_raw_id: str) -> str:
             """,
             (raw_id,),
         )
+        accepted_hash = bytes(
+            index.execute(
+                "SELECT accepted_content_hash FROM raw_revision_heads WHERE accepted_raw_id = ?", (raw_id,)
+            ).fetchone()[0]
+        )
+        semantic_revision = accepted_hash.hex()
+        decision_id = RevisionApplicationReceipt(
+            raw_id=raw_id,
+            session_id="chatgpt-export:browser-origin-one",
+            logical_source_key="chatgpt:browser-origin-one",
+            source_revision=semantic_revision,
+            acquisition_generation=0,
+            decision=ApplicationDecision.SELECTED_BASELINE,
+            accepted_raw_id=raw_id,
+            accepted_source_revision=semantic_revision,
+            accepted_content_hash=accepted_hash,
+        ).decision_id
+        index.execute(
+            "UPDATE raw_revision_applications SET decision_id = ? WHERE raw_id = ? AND decision = 'selected_baseline'",
+            (decision_id, raw_id),
+        )
         source.commit()
         index.commit()
     return raw_id
@@ -654,6 +675,31 @@ def test_browser_origin_repair_accepts_exact_semantic_superseded_sibling(tmp_pat
         )
         == historical_before
     )
+    receipt = tmp_path / "semantic-sibling-receipt.jsonl"
+    applied = repair_browser_capture_origin_mismatches(
+        _config(tmp_path),
+        [mismatched_raw_id],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+    assert applied.repaired_count == 1
+    assert applied.items[0].status == "already_repaired"
+    assert applied.items[0].semantic_canonical_raw_id == semantic_raw_id
+    assert applied.items[0].semantic_historical_raw_ids == (sibling_raw_id,)
+    assert applied.items[0].semantic_witness_digest == item.semantic_witness_digest
+
+    reapplied = repair_browser_capture_origin_mismatches(
+        _config(tmp_path),
+        [mismatched_raw_id],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+
+    assert reapplied.repaired_count == 0
+    assert reapplied.items[0].semantic_witness_digest == item.semantic_witness_digest
+    assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned", "applied"]
 
 
 @pytest.mark.parametrize("mutation", ["receipt", "revision", "membership", "selected", "blob"])
@@ -701,6 +747,48 @@ def test_browser_origin_repair_rejects_underproven_semantic_supersession(tmp_pat
     report = repair_browser_capture_origin_mismatches(_config(tmp_path), [mismatched_raw_id])
 
     assert report.ineligible_count == 1
+
+
+@pytest.mark.parametrize("field", ["decision_id", "detail", "decided_at_ms", "frontier"])
+def test_browser_origin_repair_refuses_changed_semantic_receipt_before_apply(tmp_path: Path, field: str) -> None:
+    mismatched_raw_id = _seed_mismatched_browser_head(tmp_path)
+    semantic_raw_id = _seed_semantic_canonical_head(tmp_path, mismatched_raw_id)
+    sibling_raw_id = _seed_semantic_superseded_sibling(tmp_path, semantic_raw_id)
+    dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [mismatched_raw_id])
+    with sqlite3.connect(tmp_path / "index.db") as index:
+        if field == "decision_id":
+            index.execute(
+                "UPDATE raw_revision_applications SET decision_id = ? WHERE raw_id = ?",
+                ("f" * 64, sibling_raw_id),
+            )
+        elif field == "detail":
+            index.execute(
+                "UPDATE raw_revision_applications SET detail = 'tampered' WHERE raw_id = ?",
+                (sibling_raw_id,),
+            )
+        elif field == "decided_at_ms":
+            index.execute(
+                "UPDATE raw_revision_applications SET decided_at_ms = decided_at_ms + 1 WHERE raw_id = ?",
+                (sibling_raw_id,),
+            )
+        else:
+            index.execute(
+                "UPDATE raw_revision_heads SET accepted_frontier = accepted_frontier + 1 WHERE accepted_raw_id = ?",
+                (semantic_raw_id,),
+            )
+
+    with pytest.raises(RuntimeError, match="(ineligible|proof digest)"):
+        repair_browser_capture_origin_mismatches(
+            _config(tmp_path),
+            [mismatched_raw_id],
+            apply=True,
+            receipt_path=tmp_path / f"semantic-{field}.jsonl",
+            proof_digest=dry_run.proof_digest,
+        )
+    assert (
+        _rows(tmp_path, "source", "raw_sessions", "source_path LIKE ?", ("browser-capture-origin-copy-forward/%",))
+        == []
+    )
 
 
 @pytest.mark.parametrize("mutation", ["frontier", "pointer", "membership"])

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -262,8 +262,19 @@ def _seed_semantic_canonical_head(root: Path, mismatched_raw_id: str) -> str:
         index.execute(
             """
             UPDATE raw_revision_heads
-            SET accepted_frontier_kind = 'semantic', accepted_frontier = 1
+            SET accepted_source_revision = lower(hex(accepted_content_hash)),
+                accepted_frontier_kind = 'semantic', accepted_frontier = 1
             WHERE accepted_raw_id = ?
+            """,
+            (raw_id,),
+        )
+        index.execute(
+            """
+            UPDATE raw_revision_applications
+            SET source_revision = lower(hex(accepted_content_hash)),
+                accepted_source_revision = lower(hex(accepted_content_hash)),
+                baseline_raw_id = NULL
+            WHERE raw_id = ? AND decision = 'selected_baseline'
             """,
             (raw_id,),
         )
@@ -319,7 +330,7 @@ def _seed_semantic_superseded_sibling(root: Path, semantic_raw_id: str) -> str:
                 session_id="chatgpt-export:browser-origin-one",
                 logical_source_key="chatgpt:browser-origin-one",
                 source_revision=bytes(accepted_hash).hex(),
-                acquisition_generation=0,
+                acquisition_generation=1,
                 decision=ApplicationDecision.SUPERSEDED,
                 accepted_raw_id=semantic_raw_id,
                 accepted_source_revision=bytes(accepted_hash).hex(),
@@ -629,15 +640,10 @@ def test_browser_origin_repair_accepts_exact_semantic_superseded_sibling(tmp_pat
     dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [mismatched_raw_id])
 
     assert dry_run.eligible_count == 1, dry_run.items[0].reason
-    receipt = tmp_path / "semantic-sibling-receipt.jsonl"
-    applied = repair_browser_capture_origin_mismatches(
-        _config(tmp_path),
-        [mismatched_raw_id],
-        apply=True,
-        receipt_path=receipt,
-        proof_digest=dry_run.proof_digest,
-    )
-    assert applied.repaired_count == 1
+    item = dry_run.items[0]
+    assert item.semantic_canonical_raw_id == semantic_raw_id
+    assert item.semantic_historical_raw_ids == (sibling_raw_id,)
+    assert item.semantic_witness_digest is not None
     assert (
         _rows(
             tmp_path,
@@ -648,15 +654,6 @@ def test_browser_origin_repair_accepts_exact_semantic_superseded_sibling(tmp_pat
         )
         == historical_before
     )
-    reapplied = repair_browser_capture_origin_mismatches(
-        _config(tmp_path),
-        [mismatched_raw_id],
-        apply=True,
-        receipt_path=receipt,
-        proof_digest=dry_run.proof_digest,
-    )
-    assert reapplied.repaired_count == 0
-    assert receipt.read_text().count("\n") == 2
 
 
 @pytest.mark.parametrize("mutation", ["receipt", "membership", "selected"])

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -126,6 +126,7 @@ def _seed_mismatched_browser_head(root: Path) -> str:
             """
             UPDATE raw_sessions
             SET origin = 'unknown-export',
+                native_id = 'browser-origin-one',
                 logical_source_key = 'unknown:browser-origin-one', revision_kind = 'full',
                 source_revision = lower(hex(blob_hash)), acquisition_generation = 0,
                 revision_authority = 'quarantined'
@@ -208,7 +209,7 @@ def _seed_equivalent_canonical_head(root: Path, mismatched_raw_id: str) -> str:
         source.execute(
             """
             UPDATE raw_sessions
-            SET logical_source_key = 'chatgpt:browser-origin-one', revision_kind = 'full',
+            SET native_id = 'browser-origin-one', logical_source_key = 'chatgpt:browser-origin-one', revision_kind = 'full',
                 source_revision = lower(hex(blob_hash)), baseline_raw_id = raw_id,
                 acquisition_generation = 0, revision_authority = 'byte_proven'
             WHERE raw_id = ?
@@ -487,7 +488,24 @@ def test_browser_capture_origin_rebuild_keeps_copy_forward_head(tmp_path: Path) 
 
 
 @pytest.mark.parametrize(
-    "mutation", ["blob", "head", "origin", "application", "generation", "authority", "canonical_head"]
+    "mutation",
+    [
+        "blob",
+        "head",
+        "origin",
+        "application",
+        "generation",
+        "authority",
+        "native_id",
+        "source_index",
+        "blob_ref_path",
+        "predecessor_source",
+        "predecessor_raw",
+        "append_start",
+        "append_end",
+        "capture_mode",
+        "canonical_head",
+    ],
 )
 def test_browser_capture_origin_copy_forward_mutations_fail_closed(tmp_path: Path, mutation: str) -> None:
     raw_id = _seed_mismatched_browser_head(tmp_path)
@@ -515,6 +533,26 @@ def test_browser_capture_origin_copy_forward_mutations_fail_closed(tmp_path: Pat
             )
         elif mutation == "authority":
             source.execute("UPDATE raw_sessions SET revision_authority = 'byte_proven' WHERE raw_id = ?", (raw_id,))
+        elif mutation == "native_id":
+            source.execute("UPDATE raw_sessions SET native_id = 'wrong-native-id' WHERE raw_id = ?", (raw_id,))
+        elif mutation == "source_index":
+            source.execute("UPDATE raw_sessions SET source_index = 1 WHERE raw_id = ?", (raw_id,))
+        elif mutation == "blob_ref_path":
+            source.execute(
+                "UPDATE blob_refs SET source_path = 'browser-capture/wrong.json' WHERE ref_id = ?", (raw_id,)
+            )
+        elif mutation == "predecessor_source":
+            source.execute(
+                "UPDATE raw_sessions SET predecessor_source_revision = ? WHERE raw_id = ?", ("0" * 64, raw_id)
+            )
+        elif mutation == "predecessor_raw":
+            source.execute("UPDATE raw_sessions SET predecessor_raw_id = ? WHERE raw_id = ?", ("f" * 64, raw_id))
+        elif mutation == "append_start":
+            source.execute("UPDATE raw_sessions SET append_start_offset = 0 WHERE raw_id = ?", (raw_id,))
+        elif mutation == "append_end":
+            source.execute("UPDATE raw_sessions SET append_end_offset = 1 WHERE raw_id = ?", (raw_id,))
+        elif mutation == "capture_mode":
+            source.execute("UPDATE raw_sessions SET capture_mode = 'chatgpt' WHERE raw_id = ?", (raw_id,))
         else:
             index.execute(
                 """
@@ -876,7 +914,25 @@ def test_browser_origin_repair_refuses_head_receipt_timestamp_drift(tmp_path: Pa
     assert repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id]).ineligible_count == 1
 
 
-@pytest.mark.parametrize("mutation", ["receipt", "revision", "membership", "selected", "blob"])
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "receipt",
+        "revision",
+        "membership",
+        "selected",
+        "blob",
+        "native_id",
+        "source_index",
+        "blob_ref_path",
+        "predecessor_source",
+        "predecessor_raw",
+        "append_start",
+        "append_end",
+        "capture_mode",
+        "negative_decided_at",
+    ],
+)
 def test_browser_origin_repair_rejects_underproven_semantic_supersession(tmp_path: Path, mutation: str) -> None:
     mismatched_raw_id = _seed_mismatched_browser_head(tmp_path)
     semantic_raw_id = _seed_semantic_canonical_head(tmp_path, mismatched_raw_id)
@@ -905,7 +961,7 @@ def test_browser_origin_repair_rejects_underproven_semantic_supersession(tmp_pat
                 "UPDATE raw_revision_applications SET decision = 'selected_baseline' WHERE raw_id = ?",
                 (sibling_raw_id,),
             )
-    else:
+    elif mutation == "blob":
         different_payload = _browser_payload("browser-origin-two")
         blob_hash, blob_size = BlobStore(tmp_path / "blob").write_from_bytes(different_payload)
         with sqlite3.connect(tmp_path / "source.db") as source:
@@ -917,6 +973,33 @@ def test_browser_origin_repair_rejects_underproven_semantic_supersession(tmp_pat
                 "UPDATE blob_refs SET blob_hash = ?, size_bytes = ? WHERE ref_id = ?",
                 (bytes.fromhex(blob_hash), blob_size, sibling_raw_id),
             )
+    elif mutation == "negative_decided_at":
+        with sqlite3.connect(tmp_path / "index.db") as index:
+            index.execute("PRAGMA ignore_check_constraints = ON")
+            index.execute(
+                "UPDATE raw_revision_applications SET decided_at_ms = -1 WHERE raw_id = ?",
+                (sibling_raw_id,),
+            )
+    else:
+        updates = {
+            "native_id": ("native_id = 'wrong-native-id'", ()),
+            "source_index": ("source_index = 1", ()),
+            "blob_ref_path": (None, ()),
+            "predecessor_source": ("predecessor_source_revision = ?", ("0" * 64,)),
+            "predecessor_raw": ("predecessor_raw_id = ?", ("f" * 64,)),
+            "append_start": ("append_start_offset = 0", ()),
+            "append_end": ("append_end_offset = 1", ()),
+            "capture_mode": ("capture_mode = 'unknown'", ()),
+        }
+        assignment, params = updates[mutation]
+        with sqlite3.connect(tmp_path / "source.db") as source:
+            if assignment is None:
+                source.execute(
+                    "UPDATE blob_refs SET source_path = 'browser-capture/wrong.json' WHERE ref_id = ?",
+                    (sibling_raw_id,),
+                )
+            else:
+                source.execute(f"UPDATE raw_sessions SET {assignment} WHERE raw_id = ?", (*params, sibling_raw_id))
 
     report = repair_browser_capture_origin_mismatches(_config(tmp_path), [mismatched_raw_id])
 
@@ -965,7 +1048,22 @@ def test_browser_origin_repair_refuses_changed_semantic_receipt_before_apply(tmp
     )
 
 
-@pytest.mark.parametrize("mutation", ["frontier", "pointer", "membership"])
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "frontier",
+        "pointer",
+        "membership",
+        "native_id",
+        "source_index",
+        "blob_ref_path",
+        "predecessor_source",
+        "predecessor_raw",
+        "append_start",
+        "append_end",
+        "capture_mode",
+    ],
+)
 def test_browser_capture_origin_repair_rejects_underproven_semantic_canonical_head(
     tmp_path: Path, mutation: str
 ) -> None:
@@ -983,19 +1081,54 @@ def test_browser_capture_origin_repair_rejects_underproven_semantic_canonical_he
                 "UPDATE sessions SET raw_id = ? WHERE session_id = 'chatgpt-export:browser-origin-one'",
                 (semantic_raw_id,),
             )
-    else:
+    elif mutation == "membership":
         with sqlite3.connect(tmp_path / "source.db") as source:
             source.execute(
                 "UPDATE raw_session_memberships SET decision = 'ambiguous', decided_at_ms = 5 WHERE raw_id = ?",
                 (semantic_raw_id,),
             )
+    else:
+        updates = {
+            "native_id": ("native_id = 'wrong-native-id'", ()),
+            "source_index": ("source_index = 1", ()),
+            "blob_ref_path": (None, ()),
+            "predecessor_source": ("predecessor_source_revision = ?", ("0" * 64,)),
+            "predecessor_raw": ("predecessor_raw_id = ?", ("f" * 64,)),
+            "append_start": ("append_start_offset = 0", ()),
+            "append_end": ("append_end_offset = 1", ()),
+            "capture_mode": ("capture_mode = 'unknown'", ()),
+        }
+        assignment, params = updates[mutation]
+        with sqlite3.connect(tmp_path / "source.db") as source:
+            if assignment is None:
+                source.execute(
+                    "UPDATE blob_refs SET source_path = 'browser-capture/wrong.json' WHERE ref_id = ?",
+                    (semantic_raw_id,),
+                )
+            else:
+                source.execute(f"UPDATE raw_sessions SET {assignment} WHERE raw_id = ?", (*params, semantic_raw_id))
 
     report = repair_browser_capture_origin_mismatches(_config(tmp_path), [mismatched_raw_id])
 
     assert report.ineligible_count == 1
 
 
-@pytest.mark.parametrize("mutation", ["envelope", "membership", "application"])
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "envelope",
+        "membership",
+        "application",
+        "native_id",
+        "source_index",
+        "blob_ref_path",
+        "predecessor_source",
+        "predecessor_raw",
+        "append_start",
+        "append_end",
+        "capture_mode",
+    ],
+)
 def test_browser_capture_origin_repair_rejects_underproven_canonical_head(tmp_path: Path, mutation: str) -> None:
     mismatched_raw_id = _seed_mismatched_browser_head(tmp_path)
     canonical_raw_id = _seed_equivalent_canonical_head(tmp_path, mismatched_raw_id)
@@ -1009,12 +1142,32 @@ def test_browser_capture_origin_repair_rejects_underproven_canonical_head(tmp_pa
             source.execute(
                 "UPDATE raw_session_memberships SET decision = 'ambiguous' WHERE raw_id = ?", (canonical_raw_id,)
             )
-    else:
+    elif mutation == "application":
         with sqlite3.connect(tmp_path / "index.db") as index:
             index.execute(
                 "DELETE FROM raw_revision_applications WHERE raw_id = ? AND decision = 'selected_baseline'",
                 (canonical_raw_id,),
             )
+    else:
+        updates = {
+            "native_id": ("native_id = 'wrong-native-id'", ()),
+            "source_index": ("source_index = 1", ()),
+            "blob_ref_path": (None, ()),
+            "predecessor_source": ("predecessor_source_revision = ?", ("0" * 64,)),
+            "predecessor_raw": ("predecessor_raw_id = ?", ("f" * 64,)),
+            "append_start": ("append_start_offset = 0", ()),
+            "append_end": ("append_end_offset = 1", ()),
+            "capture_mode": ("capture_mode = 'unknown'", ()),
+        }
+        assignment, params = updates[mutation]
+        with sqlite3.connect(tmp_path / "source.db") as source:
+            if assignment is None:
+                source.execute(
+                    "UPDATE blob_refs SET source_path = 'browser-capture/wrong.json' WHERE ref_id = ?",
+                    (canonical_raw_id,),
+                )
+            else:
+                source.execute(f"UPDATE raw_sessions SET {assignment} WHERE raw_id = ?", (*params, canonical_raw_id))
 
     report = repair_browser_capture_origin_mismatches(_config(tmp_path), [mismatched_raw_id])
 
@@ -1035,25 +1188,61 @@ def test_browser_capture_origin_repair_rejects_missing_canonical_blob(tmp_path: 
     assert report.ineligible_count == 1
 
 
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "blob_size",
+        "native_id",
+        "source_index",
+        "blob_ref_path",
+        "predecessor_source",
+        "predecessor_raw",
+        "append_start",
+        "append_end",
+        "capture_mode",
+    ],
+)
 def test_browser_capture_origin_copy_forward_reproves_before_source_stage(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mutation: str
 ) -> None:
     import polylogue.storage.repair as repair_module
 
     raw_id = _seed_mismatched_browser_head(tmp_path)
     dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id])
-    original_lock = repair_module._lock_browser_origin_receipt
+    original_verify = repair_module._verify_browser_origin_copy_forward_source_stage
 
-    def mutate_after_receipt(
-        path: Path,
-        items: list[repair_module.BrowserCaptureOriginRepairItem],
-    ) -> repair_module._BrowserOriginReceipt:
-        receipt = original_lock(path, items)
-        with sqlite3.connect(tmp_path / "source.db") as source:
+    def mutate_at_locked_source_stage(
+        archive_root: Path,
+        source: sqlite3.Connection,
+        item: repair_module.BrowserCaptureOriginRepairItem,
+    ) -> None:
+        if mutation == "blob_size":
             source.execute("UPDATE raw_sessions SET blob_size = blob_size + 1 WHERE raw_id = ?", (raw_id,))
-        return receipt
+        elif mutation == "native_id":
+            source.execute("UPDATE raw_sessions SET native_id = 'wrong-native-id' WHERE raw_id = ?", (raw_id,))
+        elif mutation == "source_index":
+            source.execute("UPDATE raw_sessions SET source_index = 1 WHERE raw_id = ?", (raw_id,))
+        elif mutation == "blob_ref_path":
+            source.execute(
+                "UPDATE blob_refs SET source_path = 'browser-capture/wrong.json' WHERE ref_id = ?", (raw_id,)
+            )
+        elif mutation == "predecessor_source":
+            source.execute(
+                "UPDATE raw_sessions SET predecessor_source_revision = ? WHERE raw_id = ?", ("0" * 64, raw_id)
+            )
+        elif mutation == "predecessor_raw":
+            source.execute("UPDATE raw_sessions SET predecessor_raw_id = ? WHERE raw_id = ?", ("f" * 64, raw_id))
+        elif mutation == "append_start":
+            source.execute("UPDATE raw_sessions SET append_start_offset = 0 WHERE raw_id = ?", (raw_id,))
+        elif mutation == "append_end":
+            source.execute("UPDATE raw_sessions SET append_end_offset = 1 WHERE raw_id = ?", (raw_id,))
+        else:
+            source.execute("UPDATE raw_sessions SET capture_mode = 'chatgpt' WHERE raw_id = ?", (raw_id,))
+        original_verify(archive_root, source, item)
 
-    monkeypatch.setattr(repair_module, "_lock_browser_origin_receipt", mutate_after_receipt)
+    monkeypatch.setattr(
+        repair_module, "_verify_browser_origin_copy_forward_source_stage", mutate_at_locked_source_stage
+    )
     with pytest.raises(RuntimeError, match="source evidence changed"):
         repair_browser_capture_origin_mismatches(
             _config(tmp_path),

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -584,6 +584,17 @@ def test_browser_capture_origin_rejects_unresolved_source_membership(tmp_path: P
     assert report.ineligible_count == 1
 
 
+def test_browser_capture_origin_rejects_legacy_raw_without_native_id(tmp_path: Path) -> None:
+    raw_id = _seed_mismatched_browser_head(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        source.execute("UPDATE raw_sessions SET native_id = NULL WHERE raw_id = ?", (raw_id,))
+
+    report = repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id])
+
+    assert report.ineligible_count == 1
+    assert report.items[0].reason == "source envelope does not exactly bind the normalized session"
+
+
 def test_browser_capture_origin_copy_forward_accepts_source_v7_without_capture_mode(tmp_path: Path) -> None:
     raw_id = _seed_mismatched_browser_head(tmp_path)
     with sqlite3.connect(tmp_path / "source.db") as source:

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -688,6 +688,7 @@ def test_browser_origin_repair_accepts_exact_semantic_superseded_sibling(tmp_pat
     assert applied.items[0].semantic_canonical_raw_id == semantic_raw_id
     assert applied.items[0].semantic_historical_raw_ids == (sibling_raw_id,)
     assert applied.items[0].semantic_witness_digest == item.semantic_witness_digest
+    assert applied.items[0].terminal_byte_witness_digest is not None
 
     reapplied = repair_browser_capture_origin_mismatches(
         _config(tmp_path),
@@ -699,6 +700,59 @@ def test_browser_origin_repair_accepts_exact_semantic_superseded_sibling(tmp_pat
 
     assert reapplied.repaired_count == 0
     assert reapplied.items[0].semantic_witness_digest == item.semantic_witness_digest
+    assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned", "applied"]
+
+
+@pytest.mark.parametrize("mutation", ["head_frontier", "head_revision", "receipt_id", "receipt_time"])
+def test_browser_origin_repair_refuses_mutated_terminal_byte_authority(tmp_path: Path, mutation: str) -> None:
+    mismatched_raw_id = _seed_mismatched_browser_head(tmp_path)
+    semantic_raw_id = _seed_semantic_canonical_head(tmp_path, mismatched_raw_id)
+    _seed_semantic_superseded_sibling(tmp_path, semantic_raw_id)
+    dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [mismatched_raw_id])
+    receipt = tmp_path / "terminal-byte-authority.jsonl"
+    applied = repair_browser_capture_origin_mismatches(
+        _config(tmp_path),
+        [mismatched_raw_id],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+    copy_raw_id = applied.items[0].copy_forward_raw_id
+    assert copy_raw_id is not None
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        source_count = source.execute("SELECT COUNT(*) FROM raw_sessions").fetchone()[0]
+    with sqlite3.connect(tmp_path / "index.db") as index:
+        if mutation == "head_frontier":
+            index.execute(
+                "UPDATE raw_revision_heads SET accepted_frontier = accepted_frontier + 1 WHERE accepted_raw_id = ?",
+                (copy_raw_id,),
+            )
+        elif mutation == "head_revision":
+            index.execute(
+                "UPDATE raw_revision_heads SET accepted_source_revision = ? WHERE accepted_raw_id = ?",
+                ("0" * 64, copy_raw_id),
+            )
+        elif mutation == "receipt_id":
+            index.execute(
+                "UPDATE raw_revision_applications SET decision_id = ? WHERE raw_id = ?",
+                ("e" * 64, copy_raw_id),
+            )
+        else:
+            index.execute(
+                "UPDATE raw_revision_applications SET decided_at_ms = decided_at_ms + 1 WHERE raw_id = ?",
+                (copy_raw_id,),
+            )
+
+    with pytest.raises(RuntimeError, match="ineligible"):
+        repair_browser_capture_origin_mismatches(
+            _config(tmp_path),
+            [mismatched_raw_id],
+            apply=True,
+            receipt_path=receipt,
+            proof_digest=dry_run.proof_digest,
+        )
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        assert source.execute("SELECT COUNT(*) FROM raw_sessions").fetchone() == (source_count,)
     assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned", "applied"]
 
 

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -703,7 +703,20 @@ def test_browser_origin_repair_accepts_exact_semantic_superseded_sibling(tmp_pat
     assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned", "applied"]
 
 
-@pytest.mark.parametrize("mutation", ["head_frontier", "head_revision", "receipt_id", "receipt_time"])
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "head_frontier",
+        "head_revision",
+        "receipt_id",
+        "receipt_time",
+        "copy_predecessor_revision",
+        "copy_predecessor_raw",
+        "copy_append_start",
+        "copy_append_end",
+        "copy_capture_mode",
+    ],
+)
 def test_browser_origin_repair_refuses_mutated_terminal_byte_authority(tmp_path: Path, mutation: str) -> None:
     mismatched_raw_id = _seed_mismatched_browser_head(tmp_path)
     semantic_raw_id = _seed_semantic_canonical_head(tmp_path, mismatched_raw_id)
@@ -737,11 +750,29 @@ def test_browser_origin_repair_refuses_mutated_terminal_byte_authority(tmp_path:
                 "UPDATE raw_revision_applications SET decision_id = ? WHERE raw_id = ?",
                 ("e" * 64, copy_raw_id),
             )
-        else:
+        elif mutation == "receipt_time":
             index.execute(
                 "UPDATE raw_revision_applications SET decided_at_ms = decided_at_ms + 1 WHERE raw_id = ?",
                 (copy_raw_id,),
             )
+        else:
+            with sqlite3.connect(tmp_path / "source.db") as source:
+                if mutation == "copy_predecessor_revision":
+                    source.execute(
+                        "UPDATE raw_sessions SET predecessor_source_revision = ? WHERE raw_id = ?",
+                        ("0" * 64, copy_raw_id),
+                    )
+                elif mutation == "copy_predecessor_raw":
+                    source.execute(
+                        "UPDATE raw_sessions SET predecessor_raw_id = ? WHERE raw_id = ?",
+                        ("f" * 64, copy_raw_id),
+                    )
+                elif mutation == "copy_append_start":
+                    source.execute("UPDATE raw_sessions SET append_start_offset = 0 WHERE raw_id = ?", (copy_raw_id,))
+                elif mutation == "copy_append_end":
+                    source.execute("UPDATE raw_sessions SET append_end_offset = 1 WHERE raw_id = ?", (copy_raw_id,))
+                else:
+                    source.execute("UPDATE raw_sessions SET capture_mode = 'unknown' WHERE raw_id = ?", (copy_raw_id,))
 
     with pytest.raises(RuntimeError, match="ineligible"):
         repair_browser_capture_origin_mismatches(
@@ -754,6 +785,95 @@ def test_browser_origin_repair_refuses_mutated_terminal_byte_authority(tmp_path:
     with sqlite3.connect(tmp_path / "source.db") as source:
         assert source.execute("SELECT COUNT(*) FROM raw_sessions").fetchone() == (source_count,)
     assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned", "applied"]
+
+
+def test_browser_origin_repair_refuses_competing_terminal_copy_application(tmp_path: Path) -> None:
+    raw_id = _seed_mismatched_browser_head(tmp_path)
+    dry_run = repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id])
+    receipt = tmp_path / "competing-copy-application.jsonl"
+    applied = repair_browser_capture_origin_mismatches(
+        _config(tmp_path), [raw_id], apply=True, receipt_path=receipt, proof_digest=dry_run.proof_digest
+    )
+    item = applied.items[0]
+    assert item.copy_forward_raw_id is not None
+    assert item.session_id is not None
+    assert item.canonical_logical_source_key is not None
+    assert item.blob_hash is not None
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        source_count = source.execute("SELECT COUNT(*) FROM raw_sessions").fetchone()[0]
+    with sqlite3.connect(tmp_path / "index.db") as index:
+        record_revision_application_sync(
+            index,
+            RevisionApplicationReceipt(
+                raw_id=item.copy_forward_raw_id,
+                session_id=item.session_id,
+                logical_source_key=item.canonical_logical_source_key,
+                source_revision=item.blob_hash,
+                acquisition_generation=0,
+                decision=ApplicationDecision.DEFERRED,
+                accepted_raw_id=None,
+                accepted_source_revision=None,
+                accepted_content_hash=None,
+                detail="competing copy receipt",
+            ),
+            decided_at_ms=99,
+        )
+
+    with pytest.raises(RuntimeError, match="ineligible"):
+        repair_browser_capture_origin_mismatches(
+            _config(tmp_path), [raw_id], apply=True, receipt_path=receipt, proof_digest=dry_run.proof_digest
+        )
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        assert source.execute("SELECT COUNT(*) FROM raw_sessions").fetchone() == (source_count,)
+    assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned", "applied"]
+
+
+@pytest.mark.parametrize(
+    "decision", [ApplicationDecision.SUPERSEDED, ApplicationDecision.DEFERRED, ApplicationDecision.AMBIGUOUS]
+)
+def test_browser_origin_repair_refuses_extra_old_key_receipt(tmp_path: Path, decision: ApplicationDecision) -> None:
+    raw_id = _seed_mismatched_browser_head(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        blob_hash = source.execute(
+            "SELECT lower(hex(blob_hash)) FROM raw_sessions WHERE raw_id = ?", (raw_id,)
+        ).fetchone()[0]
+    with sqlite3.connect(tmp_path / "index.db") as index:
+        accepted_hash = bytes(
+            index.execute(
+                "SELECT content_hash FROM sessions WHERE session_id = 'chatgpt-export:browser-origin-one'"
+            ).fetchone()[0]
+        )
+        record_revision_application_sync(
+            index,
+            RevisionApplicationReceipt(
+                raw_id=raw_id,
+                session_id="chatgpt-export:browser-origin-one",
+                logical_source_key="unknown:browser-origin-one",
+                source_revision=blob_hash,
+                acquisition_generation=0,
+                decision=decision,
+                accepted_raw_id=raw_id if decision is ApplicationDecision.SUPERSEDED else None,
+                accepted_source_revision=blob_hash if decision is ApplicationDecision.SUPERSEDED else None,
+                accepted_content_hash=accepted_hash if decision is ApplicationDecision.SUPERSEDED else None,
+                detail=f"unexpected {decision.value}",
+            ),
+            decided_at_ms=98,
+        )
+
+    assert repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id]).ineligible_count == 1
+
+
+@pytest.mark.parametrize("head_shape", ["old", "semantic"])
+def test_browser_origin_repair_refuses_head_receipt_timestamp_drift(tmp_path: Path, head_shape: str) -> None:
+    raw_id = _seed_mismatched_browser_head(tmp_path)
+    accepted_raw_id = raw_id if head_shape == "old" else _seed_semantic_canonical_head(tmp_path, raw_id)
+    with sqlite3.connect(tmp_path / "index.db") as index:
+        index.execute(
+            "UPDATE raw_revision_heads SET decided_at_ms = decided_at_ms + 1 WHERE accepted_raw_id = ?",
+            (accepted_raw_id,),
+        )
+
+    assert repair_browser_capture_origin_mismatches(_config(tmp_path), [raw_id]).ineligible_count == 1
 
 
 @pytest.mark.parametrize("mutation", ["receipt", "revision", "membership", "selected", "blob"])


### PR DESCRIPTION
## Summary

Harden browser-origin raw repair so a copy-forward can rely only on a fully
reproven canonical or semantic sibling envelope.

## Problem

The former repair proof checked only part of the raw-source envelope. In
particular, it could not demonstrate that historical sibling provenance,
capture metadata, native identity, and blob-reference metadata all described
the normalized session that would be restored. A patched read-only inspection
also established that the remaining live target has a legacy `native_id` of
`NULL`, which the ordinary route must not reinterpret as a matching identity.

## Solution

- Re-prove original, canonical, semantic, historical-sibling, and locked
  staging source envelopes, including conditional capture mode, native ID,
  source index, blob reference, and predecessor/append fields.
- Re-read and parse historical sibling bytes before accepting them as semantic
  evidence; preserve terminal receipt and re-apply authority checks.
- Add a regression proving that the ordinary route refuses legacy browser raw
  with a missing native identity.

The ordinary route intentionally makes no live mutation for the legacy target.
`polylogue-lkrc.1` owns a separate, evidence-preserving copy-forward route for
that exact `native_id=NULL` legacy shape.

## Verification

- `devtools test tests/unit/storage/test_browser_capture_origin_repair.py`
  — 92 passed in 6m31s before the final regression addition.
- `devtools verify --quick` — passed.
- Patched source-v7 read-only live inspection: `eligible=0`, `ineligible=1`,
  reason `source envelope does not exactly bind the normalized session`, proof
  digest `1d8fc6ce…19bf69fd`; no live data changed.

Ref polylogue-lkrc.

Remaining polylogue-lkrc.1 scope: copy forward the exact proven legacy record
into a new canonical raw with parsed native identity; do not alter or delete
the old record.
