### PR TITLE
fix(site): make documentation section links resolvable

### DIFF
--- a/.github/actions/project-pages/check_site.py
+++ b/.github/actions/project-pages/check_site.py
@@ -12,9 +12,12 @@ class Links(HTMLParser):
     def __init__(self) -> None:
         super().__init__()
         self.values: list[str] = []
+        self.ids: set[str] = set()
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         values = dict(attrs)
+        if values.get("id"):
+            self.ids.add(values["id"] or "")
         attribute = "href" if tag in {"a", "link"} else "src" if tag == "script" else None
         if attribute and values.get(attribute):
             self.values.append(values[attribute] or "")
@@ -22,7 +25,11 @@ class Links(HTMLParser):
 
 def target_for(page: Path, root: Path, value: str) -> Path | None:
     parsed = urlparse(value)
-    if parsed.scheme or parsed.netloc or value.startswith("#") or not parsed.path:
+    if parsed.scheme or parsed.netloc:
+        return None
+    if not parsed.path and parsed.fragment:
+        return page
+    if not parsed.path:
         return None
     target = root / parsed.path.lstrip("/") if parsed.path.startswith("/") else page.parent / parsed.path
     target = target.resolve()
@@ -45,13 +52,22 @@ def main() -> int:
     )
     missing = [path.relative_to(root).as_posix() for path in required if not path.is_file()]
     broken: list[str] = []
+    parsed_pages: dict[Path, Links] = {}
     for page in root.rglob("*.html"):
         parser = Links()
         parser.feed(page.read_text(encoding="utf-8"))
+        parsed_pages[page.resolve()] = parser
+    for page, parser in parsed_pages.items():
         for value in parser.values:
             target = target_for(page, root, value)
             if target is not None and not target.exists():
                 broken.append(f"{page.relative_to(root)}: {value} -> {target.relative_to(root)}")
+                continue
+            fragment = urlparse(value).fragment
+            if target is not None and fragment:
+                target_parser = parsed_pages.get(target.resolve())
+                if target_parser is not None and fragment not in target_parser.ids:
+                    broken.append(f"{page.relative_to(root)}: {value} -> missing #{fragment}")
     if missing or broken:
         for value in missing:
             print(f"missing: {value}", file=sys.stderr)

--- a/devtools/pages_builder.py
+++ b/devtools/pages_builder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import posixpath
+import re
 import shutil
 import subprocess
 import sys
@@ -210,7 +211,19 @@ def _render_markdown(
         return str(renderer.renderToken(tokens, idx, options, env))
 
     renderer.rules["link_open"] = _link_open
-    result: str = md.render(content)
+    tokens = md.parse(content)
+    seen_slugs: dict[str, int] = {}
+    for index, token in enumerate(tokens):
+        if token.type != "heading_open" or index + 1 >= len(tokens):
+            continue
+        title = tokens[index + 1].content
+        base = re.sub(r"[^\w\- ]", "", title.casefold()).replace("_", "")
+        base = re.sub(r"\s+", "-", base).strip("-") or "section"
+        occurrence = seen_slugs.get(base, 0)
+        seen_slugs[base] = occurrence + 1
+        token.attrSet("id", base if occurrence == 0 else f"{base}-{occurrence}")
+
+    result: str = md.renderer.render(tokens, md.options, {})
     return result
 
 
@@ -350,9 +363,12 @@ class _SiteLinkParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__()
         self.links: list[str] = []
+        self.ids: set[str] = set()
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         attr_map = dict(attrs)
+        if attr_map.get("id"):
+            self.ids.add(attr_map["id"] or "")
         if tag == "a" and attr_map.get("href"):
             self.links.append(attr_map["href"] or "")
         elif tag in {"img", "script"} and attr_map.get("src"):
@@ -363,8 +379,10 @@ class _SiteLinkParser(HTMLParser):
 
 def _local_link_target(page_path: Path, site_dir: Path, href: str) -> Path | None:
     parsed = urlparse(href)
-    if parsed.scheme or parsed.netloc or href.startswith("#"):
+    if parsed.scheme or parsed.netloc:
         return None
+    if not parsed.path and parsed.fragment:
+        return page_path
     if parsed.path in {"", "#"}:
         return None
     path = parsed.path
@@ -383,9 +401,13 @@ def _local_link_target(page_path: Path, site_dir: Path, href: str) -> Path | Non
 
 def validate_site_links(site_dir: Path) -> list[BrokenSiteLink]:
     broken: list[BrokenSiteLink] = []
+    parsed_pages: dict[Path, _SiteLinkParser] = {}
     for page in sorted(site_dir.rglob("*.html")):
         parser = _SiteLinkParser()
         parser.feed(page.read_text(encoding="utf-8"))
+        parsed_pages[page.resolve()] = parser
+
+    for page, parser in parsed_pages.items():
         for href in parser.links:
             target = _local_link_target(page, site_dir, href)
             if target is not None and not target.exists():
@@ -396,6 +418,18 @@ def validate_site_links(site_dir: Path) -> list[BrokenSiteLink]:
                         target=target.relative_to(site_dir).as_posix(),
                     )
                 )
+                continue
+            fragment = urlparse(href).fragment
+            if target is not None and fragment:
+                target_parser = parsed_pages.get(target.resolve())
+                if target_parser is not None and fragment not in target_parser.ids:
+                    broken.append(
+                        BrokenSiteLink(
+                            page=page.relative_to(site_dir).as_posix(),
+                            href=href,
+                            target=f"{target.relative_to(site_dir).as_posix()}#{fragment}",
+                        )
+                    )
     return broken
 
 

--- a/tests/unit/site/test_renderer_behavior.py
+++ b/tests/unit/site/test_renderer_behavior.py
@@ -98,12 +98,12 @@ def synthetic_site(
     (docs / "getting-started.md").write_text(
         "# Getting Started\n\n"
         "Welcome to the synthetic site.\n\n"
-        "[Search docs](search.md) and [repo README](../README.md).\n\n"
+        "[Search details](search.md#search-details) and [repo README](../README.md).\n\n"
         "Plain file names such as CLAUDE.md should not become external links.\n",
         encoding="utf-8",
     )
     (docs / "search.md").write_text(
-        "# Search\n\nLook things up here.\n",
+        "# Search\n\nLook things up here.\n\n## Search Details\n\nUse a query.\n",
         encoding="utf-8",
     )
     (docs / "demos.md").write_text("# Demos\n\nRun a proof.\n", encoding="utf-8")
@@ -177,7 +177,7 @@ def test_build_site_emits_expected_pages(synthetic_site: Path) -> None:
 def test_doc_pages_render_markdown_body(synthetic_site: Path) -> None:
     """Markdown sources are rendered into the page body."""
     html = _read(synthetic_site / "docs" / "getting-started" / "index.html")
-    assert "<h1>Getting Started</h1>" in html
+    assert '<h1 id="getting-started">Getting Started</h1>' in html
     assert "Welcome to the synthetic site" in html
 
 
@@ -188,6 +188,12 @@ def test_doc_pages_carry_page_title(synthetic_site: Path) -> None:
     rendered_title = "".join(collector.title_chars).strip()
     assert "Search" in rendered_title
     assert "Polylogue" in rendered_title
+
+
+def test_markdown_headings_receive_linkable_ids(synthetic_site: Path) -> None:
+    html = _read(synthetic_site / "docs" / "search" / "index.html")
+    assert '<h1 id="search">Search</h1>' in html
+    assert '<h2 id="search-details">Search Details</h2>' in html
 
 
 # ---------------------------------------------------------------------------
@@ -245,7 +251,7 @@ def test_markdown_links_rewritten_for_site_and_repo_files(synthetic_site: Path) 
     """Markdown links point at built site pages or stable source blobs."""
     html = _read(synthetic_site / "docs" / "getting-started" / "index.html")
     hrefs = _collect_links(html).hrefs
-    assert "../search/" in hrefs
+    assert "../search/#search-details" in hrefs
     assert "https://github.com/Sinity/polylogue/blob/master/README.md" in hrefs
     assert "http://CLAUDE.md" not in hrefs
 


### PR DESCRIPTION
## Summary

Give rendered Markdown headings stable IDs and make both documentation-site validators check fragments as well as target files.

## Problem

A complete generated-site audit found 20 links that reached the correct HTML page but not the intended section. Markdown headings had no IDs, while the existing validator stopped after proving the target file existed.

## Solution

- assign deterministic, duplicate-safe heading slugs during production Markdown rendering;
- validate same-page and cross-page fragments in Polylogue's site checker;
- apply the same fragment validation to the reusable project-pages action;
- cover heading IDs and a cross-page section link in the production renderer test.

## Verification

- nix develop --command pytest -q tests/unit/site/test_renderer_behavior.py — 18 passed
- nix develop --command devtools render pages --check — all generated page and fragment links resolve
- nix develop --command devtools verify --quick — 15/15 steps passed in 26.64s
- the independent 58-fragment audit now reports zero broken anchors

Anti-vacuity: the test renders the actual MarkdownIt/Jinja production path. Removing heading ID assignment or changing the target slug makes the generated link validator fail.
