### PR TITLE
fix(live): avoid reclassifying established append cohorts

### DIFF
--- a/polylogue/sources/live/append_ingest.py
+++ b/polylogue/sources/live/append_ingest.py
@@ -173,8 +173,16 @@ def _ingest_append_plans_archive(
                     # recovery path for a legacy/crash-interrupted cohort
                     # whose accepted metadata has not yet been established.
                     replay_plan = archive.raw_revision_replay_plan(logical_source_key)
-                    if not replay_plan.accepted_raw_ids:
+                    if raw_id not in replay_plan.accepted_raw_ids:
                         replay_plan = archive.classify_raw_revision_cohort(logical_source_key)
+                    if raw_id not in replay_plan.accepted_raw_ids:
+                        # A non-empty plan can still represent an older
+                        # accepted chain while a newly observed full snapshot
+                        # remains ambiguous.  Never acknowledge this append
+                        # or advance its cursor until its own raw evidence is
+                        # part of the accepted chain.
+                        deferred.append(plan)
+                        continue
                     parsed_by_raw_id: dict[str, Any] = {}
                     for replay_raw_id in replay_plan.accepted_raw_ids:
                         replay_provider, replay_payload, replay_source_path, _kind = archive.raw_revision_material(

--- a/polylogue/sources/live/append_ingest.py
+++ b/polylogue/sources/live/append_ingest.py
@@ -163,7 +163,18 @@ def _ingest_append_plans_archive(
                     if authority is RawRevisionAuthority.QUARANTINED:
                         deferred.append(plan)
                         continue
-                    replay_plan = archive.classify_raw_revision_cohort(logical_source_key)
+                    # The append parent above is a durable byte-contiguous
+                    # witness.  Once the prior full snapshot has been
+                    # classified, its baseline and every accepted append are
+                    # already represented in source-tier metadata.  Rebuild
+                    # the replay plan from that metadata instead of reopening
+                    # every retained historical full snapshot on each small
+                    # append.  The classifier remains the conservative
+                    # recovery path for a legacy/crash-interrupted cohort
+                    # whose accepted metadata has not yet been established.
+                    replay_plan = archive.raw_revision_replay_plan(logical_source_key)
+                    if not replay_plan.accepted_raw_ids:
+                        replay_plan = archive.classify_raw_revision_cohort(logical_source_key)
                     parsed_by_raw_id: dict[str, Any] = {}
                     for replay_raw_id in replay_plan.accepted_raw_ids:
                         replay_provider, replay_payload, replay_source_path, _kind = archive.raw_revision_material(

--- a/tests/infra/append_cohort_memory_counter.py
+++ b/tests/infra/append_cohort_memory_counter.py
@@ -1,10 +1,11 @@
 """Phase-level evidence collection for watcher append/cohort investigations.
 
 The live incident was in ``_ingest_append_plans_archive`` while
-``classify_raw_revision_cohort`` read historical full snapshots.  This helper
-wraps exactly those production boundaries.  It deliberately does not serialize
-parsed object graphs: the observer records kernel-visible process/cgroup/I/O
-state and deterministic route, payload, and batch counts instead.
+``classify_raw_revision_cohort`` reread historical full snapshots.  This
+helper distinguishes the durable metadata replay-plan hot path from that
+conservative classifier fallback.  It deliberately does not serialize parsed
+object graphs: the observer records kernel-visible process/cgroup/I/O state and
+deterministic route, payload, and batch counts instead.
 """
 
 from __future__ import annotations
@@ -149,7 +150,7 @@ def _format_bytes(value: int | None) -> str:
 
 @contextmanager
 def append_cohort_memory_counter() -> Iterator[AppendCohortMemoryCounter]:
-    """Instrument real watcher append ingestion and full-snapshot classification."""
+    """Instrument append ingestion, replay metadata, and classifier fallback."""
     from polylogue.sources.live import append_ingest
     from polylogue.storage.blob_publication import ArchiveBlobPublisher
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -157,6 +158,7 @@ def append_cohort_memory_counter() -> Iterator[AppendCohortMemoryCounter]:
     counter = AppendCohortMemoryCounter()
     real_append_ingest = append_ingest._ingest_append_plans_archive
     real_classify = ArchiveStore.classify_raw_revision_cohort
+    real_replay_plan = ArchiveStore.raw_revision_replay_plan
     real_read_all = ArchiveBlobPublisher.read_all
     in_cohort_classification = False
 
@@ -182,6 +184,14 @@ def append_cohort_memory_counter() -> Iterator[AppendCohortMemoryCounter]:
         counter.snapshot("classify_raw_revision_cohort:after")
         return result
 
+    def counted_replay_plan(archive: ArchiveStore, logical_source_key: str) -> Any:
+        counter.record("raw_revision_replay_plan")
+        counter.snapshot("raw_revision_replay_plan:before")
+        result = real_replay_plan(archive, logical_source_key)
+        counter.record("accepted_raw_ids", len(result.accepted_raw_ids))
+        counter.snapshot("raw_revision_replay_plan:after")
+        return result
+
     def counted_read_all(publisher: ArchiveBlobPublisher, hash_hex: str) -> bytes:
         payload = real_read_all(publisher, hash_hex)
         counter.record(
@@ -192,6 +202,7 @@ def append_cohort_memory_counter() -> Iterator[AppendCohortMemoryCounter]:
     with (
         patch.object(append_ingest, "_ingest_append_plans_archive", counted_append_ingest),
         patch.object(ArchiveStore, "classify_raw_revision_cohort", counted_classify),
+        patch.object(ArchiveStore, "raw_revision_replay_plan", counted_replay_plan),
         patch.object(ArchiveBlobPublisher, "read_all", counted_read_all),
     ):
         yield counter

--- a/tests/integration/test_append_cohort_memory.py
+++ b/tests/integration/test_append_cohort_memory.py
@@ -5,14 +5,14 @@ Static trace from the live daemon:
 | Candidate | Production site | Trigger | Measured signal |
 | --- | --- | --- | --- |
 | H1 | ``_ingest_append_plans_archive`` | watcher append batch | batch/plan counts and process phases |
-| H2 | ``classify_raw_revision_cohort`` | accepted append | classifier calls and accepted replay raws |
-| H3 | ``ArchiveBlobPublisher.read_all`` | every historical full snapshot | exact full-blob bytes loaded |
+| H2 | ``raw_revision_replay_plan`` | accepted append | metadata-plan calls and accepted replay raws |
+| H3 | ``classify_raw_revision_cohort`` | incomplete/recovery cohort | fallback calls and historical full-blob bytes |
 
-The real incident was H1 -> H2, not historical backfill.  This scenario seeds
-a byte-prefix full-snapshot cohort, then executes the production watcher append
-entrypoint.  It reports anon-PSS, cgroup anon/file, process I/O deltas, and
-batch counts at phase boundaries.  Host-dependent numbers have no CI budget;
-route and byte-count assertions keep the harness non-vacuous.
+The real incident was H1 -> H3, not historical backfill.  This scenario seeds
+an already-proven full snapshot plus a live append, then executes the
+production watcher entrypoint.  It reports anon-PSS, cgroup anon/file, process
+I/O deltas, and batch counts at phase boundaries.  Host-dependent numbers have
+no CI budget; route and byte-count assertions keep the harness non-vacuous.
 """
 
 from __future__ import annotations
@@ -56,7 +56,11 @@ def _owner(archive_root: Path) -> object:
     )
 
 
-def _seed_cohort_and_append_plan(archive_root: Path) -> _AppendPlan:
+def _seed_cohort_and_append_plan(
+    archive_root: Path,
+    *,
+    full_authority: RawRevisionAuthority = RawRevisionAuthority.BYTE_PROVEN,
+) -> _AppendPlan:
     initialize_active_archive_root(archive_root)
     session_id = "append-memory-proof"
     snapshots = _full_snapshots(session_id)
@@ -78,10 +82,7 @@ def _seed_cohort_and_append_plan(archive_root: Path) -> _AppendPlan:
                     RawRevisionKind.FULL,
                     f"full-{index}",
                     index,
-                    # The watcher can establish the immediate append parent
-                    # from an asserted full revision; classifier promotion is
-                    # the boundary this harness then measures.
-                    authority=RawRevisionAuthority.ASSERTED,
+                    authority=full_authority,
                 ),
             )
     stat = source_path.stat()
@@ -101,8 +102,8 @@ def _seed_cohort_and_append_plan(archive_root: Path) -> _AppendPlan:
     )
 
 
-def test_watcher_append_reports_cohort_memory_io_and_batch_evidence(tmp_path: Path) -> None:
-    """Real watcher append invokes cohort classification and reads every full blob."""
+def test_watcher_append_uses_durable_replay_metadata_without_historical_full_reads(tmp_path: Path) -> None:
+    """An established append cohort replays only its selected full and tail."""
     plan = _seed_cohort_and_append_plan(tmp_path)
     with append_cohort_memory_counter() as counter:
         result = ingest_append_plans(cast(Any, _owner(tmp_path)), [plan])
@@ -112,18 +113,29 @@ def test_watcher_append_reports_cohort_memory_io_and_batch_evidence(tmp_path: Pa
     assert counter.plan_count == 1
     assert counter.calls_by_site["watcher_append_payload"] == 1
     assert counter.bytes_by_site["watcher_append_payload"] == len(plan.payload)
-    assert counter.calls_by_site["classify_raw_revision_cohort"] == 1
-    assert counter.calls_by_site["historical_full_blob.read_all"] == 3
-    assert counter.bytes_by_site["historical_full_blob.read_all"] == sum(
-        len(item) for item in _full_snapshots("append-memory-proof")
+    assert counter.calls_by_site["raw_revision_replay_plan"] == 1
+    assert counter.calls_by_site["classify_raw_revision_cohort"] == 0
+    assert counter.calls_by_site["historical_full_blob.read_all"] == 0
+    # Each accepted raw is read for parsing, attachment inspection, and
+    # terminal parse-state finalization.  The important bounded invariant is
+    # that these are only the selected baseline and new append, never every
+    # historical full snapshot from classification.
+    assert counter.calls_by_site["replay_raw_blob.read_all"] == 8
+    # Replay may reopen the compact session metadata while finalizing source
+    # state, but it remains bounded to the selected baseline and append.
+    # Reintroducing full-cohort classification would add all three retained
+    # snapshots on top of this bound.
+    assert (
+        counter.bytes_by_site["replay_raw_blob.read_all"]
+        <= 4 * (len(_full_snapshots("append-memory-proof")[-1]) + len(plan.payload)) + 128
     )
     assert counter.calls_by_site["accepted_raw_ids"] == 1
-    assert counter.bytes_by_site["accepted_raw_ids"] >= 1
+    assert counter.bytes_by_site["accepted_raw_ids"] == 2
     phase_names = [phase.name for phase in counter.phases]
     assert phase_names == [
         "watcher_append:before",
-        "classify_raw_revision_cohort:before",
-        "classify_raw_revision_cohort:after",
+        "raw_revision_replay_plan:before",
+        "raw_revision_replay_plan:after",
         "watcher_append:after",
     ], counter.summary()
     for phase in counter.phases:
@@ -134,12 +146,26 @@ def test_watcher_append_reports_cohort_memory_io_and_batch_evidence(tmp_path: Pa
         assert field in summary
 
 
-def test_watcher_append_harness_fails_when_cohort_classification_is_removed(tmp_path: Path) -> None:
-    """Anti-vacuity: the real append route must call its cohort classifier."""
+def test_watcher_append_does_not_reclassify_an_established_cohort(tmp_path: Path) -> None:
+    """Anti-vacuity: restoring unconditional classification breaks this route."""
     plan = _seed_cohort_and_append_plan(tmp_path)
 
     with patch.object(ArchiveStore, "classify_raw_revision_cohort", side_effect=AssertionError("cohort route removed")):
         result = ingest_append_plans(cast(Any, _owner(tmp_path)), [plan])
 
-    assert result.succeeded == []
-    assert result.failed == [plan]
+    assert result.succeeded == [plan]
+
+
+def test_watcher_append_recovers_incomplete_cohort_via_historical_classification(tmp_path: Path) -> None:
+    """Incomplete metadata retains the classifier fallback instead of skipping authority proof."""
+    plan = _seed_cohort_and_append_plan(tmp_path, full_authority=RawRevisionAuthority.ASSERTED)
+
+    with append_cohort_memory_counter() as counter:
+        result = ingest_append_plans(cast(Any, _owner(tmp_path)), [plan])
+
+    assert result.succeeded == [plan]
+    # The fallback itself returns a replay plan after establishing the full
+    # cohort, so both the fast probe and classifier's final plan are observed.
+    assert counter.calls_by_site["raw_revision_replay_plan"] == 2
+    assert counter.calls_by_site["classify_raw_revision_cohort"] == 1
+    assert counter.calls_by_site["historical_full_blob.read_all"] == 3

--- a/tests/integration/test_append_cohort_memory.py
+++ b/tests/integration/test_append_cohort_memory.py
@@ -18,6 +18,7 @@ no CI budget; route and byte-count assertions keep the harness non-vacuous.
 from __future__ import annotations
 
 import hashlib
+import sqlite3
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -102,6 +103,53 @@ def _seed_cohort_and_append_plan(
     )
 
 
+def _seed_partially_classified_cohort_and_append_plan(archive_root: Path) -> _AppendPlan:
+    """Seed a newer asserted full that temporarily hides the new append."""
+    initialize_active_archive_root(archive_root)
+    session_id = "append-partial-classification-proof"
+    snapshots = _full_snapshots(session_id)
+    source_path = archive_root / "captures" / "append-partial-classification-proof.jsonl"
+    source_path.parent.mkdir()
+    append_payload = f'{{"type":"session_meta","payload":{{"id":"{session_id}"}}}}\n'.encode() + _codex_record(
+        session_id, "append", "a" * 16_384
+    )
+    source_path.write_bytes(snapshots[-1] + append_payload)
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        for index, payload in enumerate(snapshots):
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=payload,
+                source_path=str(source_path),
+                acquired_at_ms=index + 1,
+                revision=RawRevisionEnvelope(
+                    f"codex:{session_id}",
+                    RawRevisionKind.FULL,
+                    f"full-{index}",
+                    index,
+                    authority=(
+                        RawRevisionAuthority.BYTE_PROVEN
+                        if index < len(snapshots) - 1
+                        else RawRevisionAuthority.ASSERTED
+                    ),
+                ),
+            )
+    stat = source_path.stat()
+    return _AppendPlan(
+        path=source_path,
+        source_name="codex",
+        start_offset=len(snapshots[-1]),
+        last_complete_newline=stat.st_size,
+        stat_size=stat.st_size,
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+        payload=append_payload,
+        payload_hash=hashlib.sha256(append_payload).hexdigest(),
+        cursor_fingerprint="full-2",
+        bytes_read=len(append_payload),
+    )
+
+
 def test_watcher_append_uses_durable_replay_metadata_without_historical_full_reads(tmp_path: Path) -> None:
     """An established append cohort replays only its selected full and tail."""
     plan = _seed_cohort_and_append_plan(tmp_path)
@@ -156,16 +204,39 @@ def test_watcher_append_does_not_reclassify_an_established_cohort(tmp_path: Path
     assert result.succeeded == [plan]
 
 
-def test_watcher_append_recovers_incomplete_cohort_via_historical_classification(tmp_path: Path) -> None:
-    """Incomplete metadata retains the classifier fallback instead of skipping authority proof."""
+def test_watcher_append_defers_incomplete_cohort_after_historical_classification(tmp_path: Path) -> None:
+    """Incomplete metadata keeps authority proof and must not advance the append cursor."""
     plan = _seed_cohort_and_append_plan(tmp_path, full_authority=RawRevisionAuthority.ASSERTED)
 
     with append_cohort_memory_counter() as counter:
         result = ingest_append_plans(cast(Any, _owner(tmp_path)), [plan])
 
-    assert result.succeeded == [plan]
+    assert result.succeeded == []
+    assert result.deferred == [plan]
     # The fallback itself returns a replay plan after establishing the full
     # cohort, so both the fast probe and classifier's final plan are observed.
     assert counter.calls_by_site["raw_revision_replay_plan"] == 2
     assert counter.calls_by_site["classify_raw_revision_cohort"] == 1
     assert counter.calls_by_site["historical_full_blob.read_all"] == 3
+
+
+def test_watcher_append_reclassifies_when_nonempty_plan_omits_current_append(tmp_path: Path) -> None:
+    """A newer asserted full must not let the watcher advance an omitted append cursor."""
+    plan = _seed_partially_classified_cohort_and_append_plan(tmp_path)
+
+    with append_cohort_memory_counter() as counter:
+        result = ingest_append_plans(cast(Any, _owner(tmp_path)), [plan])
+
+    assert result.succeeded == []
+    assert result.deferred == [plan]
+    assert counter.calls_by_site["raw_revision_replay_plan"] == 2
+    assert counter.calls_by_site["classify_raw_revision_cohort"] == 1
+    with sqlite3.connect(tmp_path / "source.db") as source, sqlite3.connect(tmp_path / "index.db") as index:
+        assert source.execute("SELECT 1 FROM raw_sessions WHERE revision_kind = 'append'").fetchone() is not None
+        assert (
+            index.execute(
+                "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = ?",
+                ("codex:append-partial-classification-proof",),
+            ).fetchone()
+            is None
+        )


### PR DESCRIPTION
## Summary

Replace repeated historical full-snapshot classification on the established
live-append path with the existing durable revision replay plan. Incomplete or
legacy/crash-interrupted cohorts still take the conservative classifier
fallback; if the current append remains outside the accepted chain, it is
deferred without advancing the cursor.

## Problem

On 2026-07-13, a 46 MiB actively appended Codex JSONL selected by catch-up
every ~16 seconds took 37–38 seconds per 0.1–0.3 MiB append. During one
cycle, anonymous memory rose from roughly 0.4 GiB to 4.2 GiB; the daemon
recorded 6,655 `memory.high` events before it was intentionally stopped. The
production evidence harness identified repeated
`classify_raw_revision_cohort` reads of every retained historical full
snapshot as the dominant avoidable work.

## Solution

`polylogue/sources/live/append_ingest.py` now first derives the accepted chain
from durable raw-revision metadata immediately after recording the
byte-contiguous append witness. It invokes historical full-snapshot
classification whenever that metadata omits the current append. If the
classifier still cannot prove the current raw, the append remains deferred, so
the watcher cannot advance its cursor over unindexed bytes.

The production-route harness distinguishes the normal metadata route from the
fallback. It proves that an established cohort makes zero classifier and
historical-full reads, while incomplete cohorts still invoke classification and
are deferred until their authority proof includes the current append.

Ref polylogue-cnaj

## Verification

- `devtools test tests/integration/test_append_cohort_memory.py` — 4 passed.
- `devtools verify --quick` — all 15 static/generated checks passed.
- A targeted legacy unit selection was also run; two tests that create an
  append without any predecessor baseline deferred before either old or new
  replay path and therefore did not exercise their injected index/crash
  failures. The production-route integration coverage above supplies the
  established and recovery cohort checks for this change.
