### PR TITLE
fix(storage): rekey proven browser captures

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -67,6 +67,7 @@ _QUARANTINED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES = 512 * 1024 * 1024
 _QUARANTINED_ACCEPTED_RAW_REPAIR_RECEIPT_SCHEMA = "polylogue.quarantined-accepted-raw-repair.v1"
 _BROWSER_CAPTURE_ORIGIN_REPAIR_RECEIPT_SCHEMA = "polylogue.browser-capture-origin-copy-forward.v1"
 _LEGACY_BROWSER_CAPTURE_NATIVE_ID_REPAIR_RECEIPT_SCHEMA = "polylogue.browser-capture-legacy-native-id-copy-forward.v1"
+_BYTE_PROVEN_BROWSER_CAPTURE_REKEY_RECEIPT_SCHEMA = "polylogue.browser-capture-byte-proven-rekey.v1"
 _LEGACY_BROWSER_NATIVE_ID_TRANSACTION_PROTOCOL = "rollback-superjournal-v1"
 _QUARANTINED_CENSUS_STAGE_FINGERPRINT = "repair-quarantined-accepted-raw-v1"
 _QUARANTINED_CENSUS_STAGE_DETAIL = "census-only evidence staged before accepted-head authority refinement"
@@ -176,6 +177,7 @@ class BrowserCaptureOriginRepairItem:
     canonical_logical_source_key: str | None = None
     session_id: str | None = None
     accepted_content_hash: str | None = None
+    parsed_message_count: int | None = None
     accepted_frontier: int | None = None
     repair_strategy: str | None = None
     replacement_raw_id: str | None = None
@@ -192,6 +194,7 @@ class BrowserCaptureOriginRepairItem:
     terminal_byte_witness_digest: str | None = None
     legacy_null_native_id: bool = False
     parser_derived_native_id: str | None = None
+    byte_proven_null_native_id_rekey: bool = False
     evidence_digest: str | None = None
     proof_digest: str | None = None
     repaired: bool = False
@@ -1446,6 +1449,8 @@ def _browser_origin_item_payload(item: BrowserCaptureOriginRepairItem) -> dict[s
     # targets exactly, so a planned ordinary repair can still resume.
     if not item.legacy_null_native_id:
         excluded.update({"legacy_null_native_id", "parser_derived_native_id"})
+    if not item.byte_proven_null_native_id_rekey:
+        excluded.update({"byte_proven_null_native_id_rekey", "parsed_message_count"})
     payload = {key: value for key, value in dataclasses.asdict(item).items() if key not in excluded}
     # Receipts are JSONL.  Normalize tuples now so an in-memory item has the
     # identical shape when it is compared to a re-read planned record.
@@ -1517,6 +1522,15 @@ def _browser_origin_copy_forward_detail(item: BrowserCaptureOriginRepairItem) ->
             "parser_derived_native_id": item.parser_derived_native_id,
             "semantic_head": item.semantic_head_snapshot,
         }
+    elif item.byte_proven_null_native_id_rekey:
+        assert item.parser_derived_native_id is not None
+        payload = {
+            "kind": "browser_capture_byte_proven_rekey_v1",
+            "raw_id": item.raw_id,
+            "byte_proven_null_native_id_rekey": True,
+            "parser_derived_native_id": item.parser_derived_native_id,
+            "semantic_head": item.semantic_head_snapshot,
+        }
     return json.dumps(
         payload,
         sort_keys=True,
@@ -1529,6 +1543,7 @@ def _browser_origin_semantic_head_from_copy_detail(
     *,
     raw_id: str,
     parser_derived_native_id: str | None = None,
+    byte_proven_null_native_id_rekey: bool = False,
 ) -> tuple[bool, dict[str, object] | None]:
     """Read a prior semantic-head snapshot only from the immutable index receipt."""
     try:
@@ -1550,7 +1565,16 @@ def _browser_origin_semantic_head_from_copy_detail(
         and payload.get("legacy_null_native_id") is True
         and payload.get("parser_derived_native_id") == parser_derived_native_id
     )
-    if payload.get("raw_id") != raw_id or not (ordinary or legacy):
+    byte_proven_rekey = (
+        byte_proven_null_native_id_rekey
+        and parser_derived_native_id is not None
+        and payload.get("kind") == "browser_capture_byte_proven_rekey_v1"
+        and set(payload)
+        == {"kind", "raw_id", "byte_proven_null_native_id_rekey", "parser_derived_native_id", "semantic_head"}
+        and payload.get("byte_proven_null_native_id_rekey") is True
+        and payload.get("parser_derived_native_id") == parser_derived_native_id
+    )
+    if payload.get("raw_id") != raw_id or not (ordinary or legacy or byte_proven_rekey):
         return False, None
     if snapshot is None:
         return True, None
@@ -1626,7 +1650,14 @@ def _verify_browser_origin_copy_forward_source_stage(
     assert item.blob_hash is not None
     assert item.blob_size is not None
     assert item.accepted_content_hash is not None
-    native_id = None if item.legacy_null_native_id else item.session_id.split(":", 1)[1]
+    null_native_id_mode = item.legacy_null_native_id or item.byte_proven_null_native_id_rekey
+    native_id = None if null_native_id_mode else item.session_id.split(":", 1)[1]
+    source_authority = (
+        RawRevisionAuthority.BYTE_PROVEN if item.byte_proven_null_native_id_rekey else RawRevisionAuthority.QUARANTINED
+    )
+    membership_authority = source_authority.value
+    membership_decision: str | None = "applied" if item.byte_proven_null_native_id_rekey else None
+    baseline_raw_id = item.raw_id if item.byte_proven_null_native_id_rekey else None
     if (
         _browser_origin_source_envelope_is_exact(
             conn,
@@ -1642,9 +1673,9 @@ def _verify_browser_origin_copy_forward_source_stage(
             logical_source_key=item.old_logical_source_key,
             revision_kind=RawRevisionKind.FULL,
             source_revision=item.blob_hash,
-            baseline_raw_id=None,
+            baseline_raw_id=baseline_raw_id,
             acquisition_generation=0,
-            revision_authority=RawRevisionAuthority.QUARANTINED,
+            revision_authority=source_authority,
         )
         is None
     ):
@@ -1681,6 +1712,10 @@ def _verify_browser_origin_copy_forward_source_stage(
     census = conn.execute(
         f"SELECT status, member_count FROM {source_schema}.raw_membership_census WHERE raw_id = ?", (item.raw_id,)
     ).fetchone()
+    if item.byte_proven_null_native_id_rekey:
+        if membership is not None or membership_count is None or int(membership_count[0]) != 0 or census is not None:
+            raise RuntimeError(f"membership evidence changed before copy-forward stage for {item.raw_id}")
+        return
     if (
         membership is None
         or membership_count is None
@@ -1692,8 +1727,8 @@ def _verify_browser_origin_copy_forward_source_stage(
             projection.session_hash,
             len(projection.message_hashes),
             0,
-            RawRevisionAuthority.QUARANTINED.value,
-            None,
+            membership_authority,
+            membership_decision,
         )
         or census is None
         or tuple(census) != ("complete", 1)
@@ -2166,7 +2201,10 @@ def _inspect_browser_capture_origin_mismatch(
     *,
     conn: sqlite3.Connection,
     allow_legacy_null_native_id: bool = False,
+    allow_byte_proven_null_native_id_rekey: bool = False,
 ) -> BrowserCaptureOriginRepairItem:
+    if allow_legacy_null_native_id and allow_byte_proven_null_native_id_rekey:
+        raise ValueError("browser repair modes are mutually exclusive")
     conn.row_factory = sqlite3.Row
     raw = conn.execute(
         """
@@ -2186,9 +2224,12 @@ def _inspect_browser_capture_origin_mismatch(
     source_path = str(raw["source_path"])
     if "browser-capture" not in source_path:
         return _browser_origin_ineligible(raw_id, "source raw is not a browser-capture artifact")
+    expected_source_authority = (
+        RawRevisionAuthority.BYTE_PROVEN if allow_byte_proven_null_native_id_rekey else RawRevisionAuthority.QUARANTINED
+    )
     if (
         str(raw["revision_kind"]) != RawRevisionKind.FULL.value
-        or str(raw["revision_authority"]) != RawRevisionAuthority.QUARANTINED.value
+        or str(raw["revision_authority"]) != expected_source_authority.value
         or raw["source_revision"] is None
         or raw["acquisition_generation"] is None
         or int(raw["acquisition_generation"]) != 0
@@ -2197,10 +2238,14 @@ def _inspect_browser_capture_origin_mismatch(
             for name in (
                 "predecessor_source_revision",
                 "predecessor_raw_id",
-                "baseline_raw_id",
                 "append_start_offset",
                 "append_end_offset",
             )
+        )
+        or (
+            (raw["baseline_raw_id"] != raw_id)
+            if allow_byte_proven_null_native_id_rekey
+            else raw["baseline_raw_id"] is not None
         )
     ):
         return _browser_origin_ineligible(raw_id, "source raw is not the exact quarantined full mismatch shape")
@@ -2252,9 +2297,11 @@ def _inspect_browser_capture_origin_mismatch(
     canonical_key = f"{provider.value}:{session.provider_session_id}"
     session_id = str(make_session_id(provider, session.provider_session_id))
     old_key = str(raw["logical_source_key"] or "")
-    expected_old_native_id = None if allow_legacy_null_native_id else session.provider_session_id
-    if allow_legacy_null_native_id and raw["native_id"] is not None:
-        return _browser_origin_ineligible(raw_id, "legacy-native-id actuator requires a NULL durable native identity")
+    null_native_id_mode = allow_legacy_null_native_id or allow_byte_proven_null_native_id_rekey
+    expected_old_native_id = None if null_native_id_mode else session.provider_session_id
+    if null_native_id_mode and raw["native_id"] is not None:
+        mode = "legacy-native-id" if allow_legacy_null_native_id else "byte-proven browser rekey"
+        return _browser_origin_ineligible(raw_id, f"{mode} actuator requires a NULL durable native identity")
     if (
         _browser_origin_source_envelope_is_exact(
             conn,
@@ -2270,9 +2317,9 @@ def _inspect_browser_capture_origin_mismatch(
             logical_source_key=old_key,
             revision_kind=RawRevisionKind.FULL,
             source_revision=blob_hash_hex,
-            baseline_raw_id=None,
+            baseline_raw_id=raw_id if allow_byte_proven_null_native_id_rekey else None,
             acquisition_generation=0,
-            revision_authority=RawRevisionAuthority.QUARANTINED,
+            revision_authority=expected_source_authority,
         )
         is None
         or int(raw["source_index"]) != 0
@@ -2364,7 +2411,12 @@ def _inspect_browser_capture_origin_mismatch(
         (raw_id,),
     ).fetchone()
     projection = session_revision_projection(session)
-    if (
+    if allow_byte_proven_null_native_id_rekey:
+        if membership is not None or membership_count is None or int(membership_count[0]) != 0 or census is not None:
+            return _browser_origin_ineligible(
+                raw_id, "byte-proven browser rekey requires no retained membership census"
+            )
+    elif (
         membership is None
         or membership_count is None
         or int(membership_count[0]) != 1
@@ -2544,14 +2596,18 @@ def _inspect_browser_capture_origin_mismatch(
     ):
         return _browser_origin_ineligible(raw_id, "copy-forward terminal byte authority is not exact")
     if (
-        allow_legacy_null_native_id
+        (allow_legacy_null_native_id or allow_byte_proven_null_native_id_rekey)
         and canonical_head is not None
         and not copy_forward_terminal
         and str(canonical_head["accepted_frontier_kind"]) != "semantic"
     ):
         return _browser_origin_ineligible(
             raw_id,
-            "legacy-native-id copy-forward refuses pre-existing canonical head authority",
+            (
+                "legacy-native-id copy-forward refuses pre-existing canonical head authority"
+                if allow_legacy_null_native_id
+                else "byte-proven browser rekey refuses pre-existing canonical head authority"
+            ),
         )
     if canonical_head is not None and not copy_forward_terminal:
         if _canonical_browser_origin_head_is_exact(
@@ -2617,7 +2673,8 @@ def _inspect_browser_capture_origin_mismatch(
         detail_is_exact, terminal_snapshot = _browser_origin_semantic_head_from_copy_detail(
             copy_application["detail"],
             raw_id=raw_id,
-            parser_derived_native_id=session.provider_session_id if allow_legacy_null_native_id else None,
+            parser_derived_native_id=session.provider_session_id if null_native_id_mode else None,
+            byte_proven_null_native_id_rekey=allow_byte_proven_null_native_id_rekey,
         )
         if not detail_is_exact:
             return _browser_origin_ineligible(raw_id, "copy-forward receipt detail is not exact")
@@ -2642,7 +2699,12 @@ def _inspect_browser_capture_origin_mismatch(
             semantic_witness_digest = terminal_witness.digest
         terminal_byte_witness_digest = _authority_rows_digest([canonical_head], [copy_application])
     evidence_digest = _authority_rows_digest(
-        [raw], [head], [indexed_evidence], [membership], [census], old_applications
+        [raw],
+        [head],
+        [indexed_evidence],
+        [] if membership is None else [membership],
+        [] if census is None else [census],
+        old_applications,
     )
     item = BrowserCaptureOriginRepairItem(
         raw_id=raw_id,
@@ -2663,6 +2725,7 @@ def _inspect_browser_capture_origin_mismatch(
         canonical_logical_source_key=canonical_key,
         session_id=session_id,
         accepted_content_hash=accepted_hash.hex(),
+        parsed_message_count=len(projection.message_hashes),
         accepted_frontier=blob_size,
         repair_strategy=repair_strategy,
         replacement_raw_id=replacement_raw_id,
@@ -2678,7 +2741,8 @@ def _inspect_browser_capture_origin_mismatch(
         semantic_witness_digest=semantic_witness_digest,
         terminal_byte_witness_digest=terminal_byte_witness_digest,
         legacy_null_native_id=allow_legacy_null_native_id,
-        parser_derived_native_id=session.provider_session_id if allow_legacy_null_native_id else None,
+        parser_derived_native_id=session.provider_session_id if null_native_id_mode else None,
+        byte_proven_null_native_id_rekey=allow_byte_proven_null_native_id_rekey,
         evidence_digest=evidence_digest,
     )
     return dataclasses.replace(item, proof_digest=_browser_origin_item_digest(item))
@@ -2698,7 +2762,7 @@ class _BrowserOriginReceipt:
 
 
 def _browser_origin_requires_legacy_transaction(items: list[BrowserCaptureOriginRepairItem]) -> bool:
-    return any(item.legacy_null_native_id for item in items)
+    return any(item.legacy_null_native_id or item.byte_proven_null_native_id_rekey for item in items)
 
 
 def _legacy_browser_journal_modes(source_db: Path, index_db: Path) -> dict[str, str]:
@@ -3018,28 +3082,49 @@ def _stage_browser_origin_copy_forward_source(
         """,
         (blob_hash, item.copy_forward_raw_id, item.copy_forward_source_path, item.blob_size, acquired_at_ms),
     )
-    conn.execute(
-        f"""
-        INSERT INTO {source_schema}.raw_session_memberships (
-            raw_id, logical_source_key, provider_session_id, source_revision,
-            normalized_content_hash, message_count, acquisition_generation,
-            revision_authority, decision, decided_at_ms
+    if item.byte_proven_null_native_id_rekey:
+        assert item.parsed_message_count is not None
+        conn.execute(
+            f"""
+            INSERT INTO {source_schema}.raw_session_memberships (
+                raw_id, logical_source_key, provider_session_id, source_revision,
+                normalized_content_hash, message_count, acquisition_generation,
+                revision_authority, decision, decided_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, 0, 'byte_proven', 'applied', ?)
+            """,
+            (
+                item.copy_forward_raw_id,
+                item.canonical_logical_source_key,
+                native_id,
+                item.accepted_content_hash,
+                bytes.fromhex(item.accepted_content_hash),
+                item.parsed_message_count,
+                acquired_at_ms,
+            ),
         )
-        SELECT ?, ?, ?, ?, ?, message_count, 0, 'byte_proven', 'applied', ?
-        FROM {source_schema}.raw_session_memberships
-        WHERE raw_id = ? AND logical_source_key = ?
-        """,
-        (
-            item.copy_forward_raw_id,
-            item.canonical_logical_source_key,
-            native_id,
-            item.accepted_content_hash,
-            bytes.fromhex(item.accepted_content_hash),
-            acquired_at_ms,
-            item.raw_id,
-            item.canonical_logical_source_key,
-        ),
-    )
+    else:
+        conn.execute(
+            f"""
+            INSERT INTO {source_schema}.raw_session_memberships (
+                raw_id, logical_source_key, provider_session_id, source_revision,
+                normalized_content_hash, message_count, acquisition_generation,
+                revision_authority, decision, decided_at_ms
+            )
+            SELECT ?, ?, ?, ?, ?, message_count, 0, 'byte_proven', 'applied', ?
+            FROM {source_schema}.raw_session_memberships
+            WHERE raw_id = ? AND logical_source_key = ?
+            """,
+            (
+                item.copy_forward_raw_id,
+                item.canonical_logical_source_key,
+                native_id,
+                item.accepted_content_hash,
+                bytes.fromhex(item.accepted_content_hash),
+                acquired_at_ms,
+                item.raw_id,
+                item.canonical_logical_source_key,
+            ),
+        )
     conn.execute(
         f"""
         INSERT INTO {source_schema}.raw_membership_census (
@@ -3177,6 +3262,7 @@ def _repair_browser_capture_origin_mismatches(
     receipt_path: Path | None = None,
     proof_digest: str | None = None,
     allow_legacy_null_native_id: bool = False,
+    allow_byte_proven_null_native_id_rekey: bool = False,
     receipt_schema: str = _BROWSER_CAPTURE_ORIGIN_REPAIR_RECEIPT_SCHEMA,
 ) -> BrowserCaptureOriginRepairReport:
     """Copy exact browser-capture evidence forward under parsed origin authority."""
@@ -3202,6 +3288,7 @@ def _repair_browser_capture_origin_mismatches(
                 raw_id,
                 conn=connection,
                 allow_legacy_null_native_id=allow_legacy_null_native_id,
+                allow_byte_proven_null_native_id_rekey=allow_byte_proven_null_native_id_rekey,
             )
             for raw_id in raw_ids
         ]
@@ -3226,7 +3313,7 @@ def _repair_browser_capture_origin_mismatches(
             receipt = _lock_browser_origin_receipt(receipt_path, items, schema=receipt_schema)
             try:
                 legacy_journal_modes: Mapping[str, object] | None = None
-                if allow_legacy_null_native_id:
+                if _browser_origin_requires_legacy_transaction(items):
                     # A previous process may have died after its crash-atomic
                     # commit and before WAL restoration/receipt finalization.
                     # Normalize that safe mixed posture before inspecting any
@@ -3241,7 +3328,7 @@ def _repair_browser_capture_origin_mismatches(
                     raise RuntimeError("authority proof changed before copy-forward source staging")
                 if any(item.status == "ineligible" for item in pre_source_items):
                     raise RuntimeError("a browser-capture origin target became ineligible before source staging")
-                if allow_legacy_null_native_id:
+                if _browser_origin_requires_legacy_transaction(pre_source_items):
                     if all(item.status == "already_repaired" for item in pre_source_items):
                         locked = pre_source_items
                         after = pre_source_items
@@ -3405,6 +3492,33 @@ def repair_legacy_browser_capture_missing_native_ids(
         proof_digest=proof_digest,
         allow_legacy_null_native_id=True,
         receipt_schema=_LEGACY_BROWSER_CAPTURE_NATIVE_ID_REPAIR_RECEIPT_SCHEMA,
+    )
+
+
+def repair_byte_proven_browser_capture_null_native_ids(
+    config: Config,
+    raw_ids: list[str],
+    *,
+    apply: bool = False,
+    receipt_path: Path | None = None,
+    proof_digest: str | None = None,
+) -> BrowserCaptureOriginRepairReport:
+    """Rekey only exact byte-proven browser captures with a NULL native id.
+
+    This is deliberately narrower than the ordinary origin repair and the
+    quarantined legacy route: it admits only a byte-proven old unknown-key head
+    with a self-baseline source envelope, no retained membership census, and a
+    matching selected-baseline receipt. It creates a new canonical byte witness
+    while retaining every old source/index record unchanged.
+    """
+    return _repair_browser_capture_origin_mismatches(
+        config,
+        raw_ids,
+        apply=apply,
+        receipt_path=receipt_path,
+        proof_digest=proof_digest,
+        allow_byte_proven_null_native_id_rekey=True,
+        receipt_schema=_BYTE_PROVEN_BROWSER_CAPTURE_REKEY_RECEIPT_SCHEMA,
     )
 
 

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -23,6 +23,7 @@ from polylogue.sources.revision_backfill import _parse_one, backfill_historical_
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.repair import (
     repair_browser_capture_origin_mismatches,
+    repair_byte_proven_browser_capture_null_native_ids,
     repair_legacy_browser_capture_missing_native_ids,
     repair_quarantined_accepted_raws,
 )
@@ -81,16 +82,21 @@ def _browser_payload(native_id: str = "browser-origin-one") -> bytes:
     return json.dumps(payload, sort_keys=True).encode()
 
 
-def _seed_mismatched_browser_head(root: Path) -> str:
+def _seed_mismatched_browser_head(root: Path, native_id: str = "browser-origin-one") -> str:
     initialize_active_archive_root(root)
-    payload = _browser_payload()
-    session = _parse_one(Provider.CHATGPT, payload, "browser-capture/chatgpt/one.json")[0]
+    source_path = (
+        "browser-capture/chatgpt/one.json"
+        if native_id == "browser-origin-one"
+        else f"browser-capture/chatgpt/{native_id}.json"
+    )
+    payload = _browser_payload(native_id)
+    session = _parse_one(Provider.CHATGPT, payload, source_path)[0]
     accepted_hash = bytes.fromhex(session_content_hash(session))
     with ArchiveStore.open_existing(root, read_only=False) as archive:
         raw_id = archive.write_raw_payload(
             provider=Provider.UNKNOWN,
             payload=payload,
-            source_path="browser-capture/chatgpt/one.json",
+            source_path=source_path,
             acquired_at_ms=1,
         )
         blob_hash = (
@@ -102,7 +108,7 @@ def _seed_mismatched_browser_head(root: Path) -> str:
         _stored_raw, session_id = archive.write_parsed_for_retained_raw(
             session,
             raw_id=raw_id,
-            source_path="browser-capture/chatgpt/one.json",
+            source_path=source_path,
             acquired_at_ms=1,
             revision_authoritative=True,
         )
@@ -111,7 +117,7 @@ def _seed_mismatched_browser_head(root: Path) -> str:
             RevisionApplicationReceipt(
                 raw_id=raw_id,
                 session_id=session_id,
-                logical_source_key="unknown:browser-origin-one",
+                logical_source_key=f"unknown:{native_id}",
                 source_revision=blob_hash,
                 acquisition_generation=0,
                 decision=ApplicationDecision.SELECTED_BASELINE,
@@ -131,13 +137,12 @@ def _seed_mismatched_browser_head(root: Path) -> str:
             """
             UPDATE raw_sessions
             SET origin = 'unknown-export',
-                native_id = 'browser-origin-one',
-                logical_source_key = 'unknown:browser-origin-one', revision_kind = 'full',
+                native_id = ?, logical_source_key = ?, revision_kind = 'full',
                 source_revision = lower(hex(blob_hash)), acquisition_generation = 0,
                 revision_authority = 'quarantined'
             WHERE raw_id = ?
             """,
-            (raw_id,),
+            (native_id, f"unknown:{native_id}", raw_id),
         )
         source.execute(
             """
@@ -145,10 +150,10 @@ def _seed_mismatched_browser_head(root: Path) -> str:
                 raw_id, logical_source_key, provider_session_id, source_revision,
                 normalized_content_hash, message_count, acquisition_generation,
                 revision_authority, decision, decided_at_ms
-            ) VALUES (?, 'chatgpt:browser-origin-one', 'browser-origin-one', ?, ?, 1, 0,
+            ) VALUES (?, ?, ?, ?, ?, 1, 0,
                       'quarantined', NULL, NULL)
             """,
-            (raw_id, accepted_hash.hex(), accepted_hash),
+            (raw_id, f"chatgpt:{native_id}", native_id, accepted_hash.hex(), accepted_hash),
         )
         source.execute(
             """
@@ -165,6 +170,22 @@ def _seed_legacy_browser_head_without_native_id(root: Path) -> str:
     raw_id = _seed_mismatched_browser_head(root)
     with closing(sqlite3.connect(root / "source.db")) as source, source:
         source.execute("UPDATE raw_sessions SET native_id = NULL WHERE raw_id = ?", (raw_id,))
+    return raw_id
+
+
+def _seed_byte_proven_browser_head_without_native_id(root: Path, native_id: str = "browser-origin-one") -> str:
+    raw_id = _seed_mismatched_browser_head(root, native_id)
+    with closing(sqlite3.connect(root / "source.db")) as source, source:
+        source.execute(
+            """
+            UPDATE raw_sessions
+            SET native_id = NULL, baseline_raw_id = raw_id, revision_authority = 'byte_proven'
+            WHERE raw_id = ?
+            """,
+            (raw_id,),
+        )
+        source.execute("DELETE FROM raw_session_memberships WHERE raw_id = ?", (raw_id,))
+        source.execute("DELETE FROM raw_membership_census WHERE raw_id = ?", (raw_id,))
     return raw_id
 
 
@@ -1839,3 +1860,186 @@ def test_browser_capture_origin_live_membership_defers_all_quarantined_rows(tmp_
     with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
         processor._apply_membership_sessions(archive, copy_raw_id, [session], acquired_at_ms=7)
         assert archive.raw_revision_head_raw_id("chatgpt:browser-origin-one") == copy_raw_id
+
+
+@pytest.mark.parametrize(
+    "native_id",
+    (
+        "no-canonical-773bbbf1",
+        "no-canonical-bd47782e",
+        "no-canonical-f43a203a",
+    ),
+)
+def test_byte_proven_browser_rekey_copy_forwards_each_no_head_shape(tmp_path: Path, native_id: str) -> None:
+    raw_id = _seed_byte_proven_browser_head_without_native_id(tmp_path, native_id)
+    if native_id == "no-canonical-773bbbf1":
+        with sqlite3.connect(tmp_path / "source.db") as source:
+            source.execute("ALTER TABLE raw_sessions DROP COLUMN capture_mode")
+            source.execute("PRAGMA user_version = 7")
+    active_index = _stage_active_index_generation(tmp_path)
+    old_evidence = {
+        ("source", table): _rows(
+            tmp_path, "source", table, "raw_id = ?" if table != "blob_refs" else "ref_id = ?", (raw_id,)
+        )
+        for table in ("raw_sessions", "blob_refs", "raw_session_memberships", "raw_membership_census")
+    } | {
+        ("index", "raw_revision_heads"): _rows(
+            tmp_path, "index", "raw_revision_heads", "accepted_raw_id = ?", (raw_id,)
+        ),
+        ("index", "raw_revision_applications"): _rows(
+            tmp_path, "index", "raw_revision_applications", "raw_id = ?", (raw_id,)
+        ),
+    }
+
+    dry_run = repair_byte_proven_browser_capture_null_native_ids(_config(tmp_path), [raw_id])
+
+    assert dry_run.eligible_count == 1, dry_run.items[0].reason
+    assert dry_run.items[0].byte_proven_null_native_id_rekey is True
+    assert dry_run.items[0].parsed_message_count == 1
+    assert (tmp_path / "index.db").resolve() == active_index
+    receipt = tmp_path / f"byte-rekey-{native_id}.jsonl"
+    applied = repair_byte_proven_browser_capture_null_native_ids(
+        _config(tmp_path), [raw_id], apply=True, receipt_path=receipt, proof_digest=dry_run.proof_digest
+    )
+
+    copy_raw_id = applied.items[0].copy_forward_raw_id
+    assert applied.repaired_count == 1
+    assert copy_raw_id is not None
+    for (tier, table), before in old_evidence.items():
+        key = "ref_id" if table == "blob_refs" else "accepted_raw_id" if table == "raw_revision_heads" else "raw_id"
+        assert _rows(tmp_path, tier, table, f"{key} = ?", (raw_id,)) == before
+    with closing(sqlite3.connect(tmp_path / "source.db")) as source:
+        assert source.execute(
+            "SELECT origin, native_id, logical_source_key, revision_authority FROM raw_sessions WHERE raw_id = ?",
+            (copy_raw_id,),
+        ).fetchone() == ("chatgpt-export", native_id, f"chatgpt:{native_id}", "byte_proven")
+        assert source.execute(
+            "SELECT provider_session_id, message_count, revision_authority, decision FROM raw_session_memberships "
+            "WHERE raw_id = ?",
+            (copy_raw_id,),
+        ).fetchone() == (native_id, 1, "byte_proven", "applied")
+    lines = [json.loads(line) for line in receipt.read_text().splitlines()]
+    assert [line["state"] for line in lines] == ["planned", "applied"]
+    assert lines[-1]["transaction_protocol"] == "rollback-superjournal-v1"
+    reapplied = repair_byte_proven_browser_capture_null_native_ids(
+        _config(tmp_path), [raw_id], apply=True, receipt_path=receipt, proof_digest=dry_run.proof_digest
+    )
+    assert reapplied.repaired_count == 0
+    assert reapplied.already_repaired_count == 1
+
+
+@pytest.mark.parametrize("case", ("semantic-2af730ea", "semantic-27527c15"))
+def test_byte_proven_browser_rekey_preserves_exact_semantic_witness(tmp_path: Path, case: str) -> None:
+    raw_id = _seed_byte_proven_browser_head_without_native_id(tmp_path)
+    semantic_raw_id = _seed_semantic_canonical_head(tmp_path, raw_id)
+    sibling_raw_id = _seed_semantic_superseded_sibling(tmp_path, semantic_raw_id)
+    historical_before = _rows(tmp_path, "source", "raw_sessions", "raw_id IN (?, ?)", (semantic_raw_id, sibling_raw_id))
+
+    dry_run = repair_byte_proven_browser_capture_null_native_ids(_config(tmp_path), [raw_id])
+
+    assert dry_run.eligible_count == 1, dry_run.items[0].reason
+    assert dry_run.items[0].semantic_canonical_raw_id == semantic_raw_id
+    assert dry_run.items[0].semantic_historical_raw_ids == (sibling_raw_id,)
+    receipt = tmp_path / f"byte-rekey-semantic-{case}.jsonl"
+    applied = repair_byte_proven_browser_capture_null_native_ids(
+        _config(tmp_path), [raw_id], apply=True, receipt_path=receipt, proof_digest=dry_run.proof_digest
+    )
+
+    assert applied.repaired_count == 1
+    assert (
+        _rows(tmp_path, "source", "raw_sessions", "raw_id IN (?, ?)", (semantic_raw_id, sibling_raw_id))
+        == historical_before
+    )
+    assert applied.items[0].semantic_canonical_raw_id == semantic_raw_id
+    assert applied.items[0].semantic_historical_raw_ids == (sibling_raw_id,)
+
+
+@pytest.mark.parametrize(
+    "conflict",
+    ("canonical_hash_conflict", "superseded_equivalent_membership", "canonical_byte_head", "current_reparse_drift"),
+)
+def test_byte_proven_browser_rekey_fails_closed_for_observed_conflicts(tmp_path: Path, conflict: str) -> None:
+    raw_id = _seed_byte_proven_browser_head_without_native_id(tmp_path)
+    if conflict == "canonical_hash_conflict":
+        semantic_raw_id = _seed_semantic_canonical_head(tmp_path, raw_id)
+        with sqlite3.connect(tmp_path / "index.db") as index:
+            index.execute(
+                "UPDATE raw_revision_heads SET accepted_content_hash = x'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF' "
+                "WHERE accepted_raw_id = ?",
+                (semantic_raw_id,),
+            )
+    elif conflict == "superseded_equivalent_membership":
+        with sqlite3.connect(tmp_path / "source.db") as source:
+            source.execute(
+                """
+                INSERT INTO raw_session_memberships (
+                    raw_id, logical_source_key, provider_session_id, source_revision,
+                    normalized_content_hash, message_count, acquisition_generation,
+                    revision_authority, decision, decided_at_ms
+                ) SELECT raw_id, logical_source_key, 'browser-origin-one', source_revision,
+                         x'0000000000000000000000000000000000000000000000000000000000000000', 1, 1,
+                         'quarantined', 'superseded_equivalent', 3
+                  FROM raw_sessions WHERE raw_id = ?
+                """,
+                (raw_id,),
+            )
+    elif conflict == "canonical_byte_head":
+        _seed_equivalent_canonical_head(tmp_path, raw_id)
+    else:
+        with sqlite3.connect(tmp_path / "source.db") as source:
+            source.execute("UPDATE raw_sessions SET source_revision = ? WHERE raw_id = ?", ("0" * 64, raw_id))
+
+    report = repair_byte_proven_browser_capture_null_native_ids(_config(tmp_path), [raw_id])
+
+    assert report.ineligible_count == 1
+    assert report.items[0].status == "ineligible"
+
+
+def test_byte_proven_browser_rekey_refuses_stale_proof_and_rolls_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import polylogue.storage.repair as repair_module
+
+    raw_id = _seed_byte_proven_browser_head_without_native_id(tmp_path)
+    dry_run = repair_byte_proven_browser_capture_null_native_ids(_config(tmp_path), [raw_id])
+    with sqlite3.connect(tmp_path / "index.db") as index:
+        index.execute(
+            "UPDATE raw_revision_heads SET accepted_frontier = accepted_frontier + 1 WHERE accepted_raw_id = ?",
+            (raw_id,),
+        )
+    with pytest.raises(RuntimeError, match="one or more targets are ineligible"):
+        repair_byte_proven_browser_capture_null_native_ids(
+            _config(tmp_path),
+            [raw_id],
+            apply=True,
+            receipt_path=tmp_path / "stale.jsonl",
+            proof_digest=dry_run.proof_digest,
+        )
+
+    raw_id = _seed_byte_proven_browser_head_without_native_id(tmp_path / "rollback")
+    dry_run = repair_byte_proven_browser_capture_null_native_ids(_config(tmp_path / "rollback"), [raw_id])
+    before = {
+        (tier, table): _rows(tmp_path / "rollback", tier, table, "1 = 1", ())
+        for tier, tables in {
+            "source": ("raw_sessions", "blob_refs", "raw_session_memberships", "raw_membership_census"),
+            "index": ("sessions", "raw_revision_heads", "raw_revision_applications"),
+        }.items()
+        for table in tables
+    }
+
+    def fail_after_source_stage(conn: sqlite3.Connection, item: object) -> None:
+        raise RuntimeError("injected byte rekey index failure")
+
+    monkeypatch.setattr(repair_module, "_apply_browser_origin_repair_item", fail_after_source_stage)
+    receipt = tmp_path / "rollback" / "rollback.jsonl"
+    with pytest.raises(RuntimeError, match="injected byte rekey index failure"):
+        repair_byte_proven_browser_capture_null_native_ids(
+            _config(tmp_path / "rollback"),
+            [raw_id],
+            apply=True,
+            receipt_path=receipt,
+            proof_digest=dry_run.proof_digest,
+        )
+    assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned"]
+    for (tier, table), rows in before.items():
+        assert _rows(tmp_path / "rollback", tier, table, "1 = 1", ()) == rows


### PR DESCRIPTION
## Summary
Adds a separately receipted actuator for the five proof-approved current ChatGPT browser captures whose durable unknown-origin raw has `native_id = NULL` but byte-proven, self-baseline authority.

## Problem
The existing ordinary and legacy origin-repair routes correctly reject this distinct evidence shape: source-v7 rows have no retained membership census, while the current unknown-key head and selected-baseline application already prove the parsed ChatGPT session. Rewriting historical evidence or accepting canonical byte heads would be unsafe.

## Solution
`polylogue/storage/repair.py` adds `repair_byte_proven_browser_capture_null_native_ids`. It admits only the exact byte-proven/null-native/self-baseline/no-census shape, re-proves bytes and parser identity under lock, creates a canonical byte witness, and uses the existing rollback-superjournal transport for atomic source/index commit. It accepts only no canonical head or an exact semantic witness; incompatible/byte canonical heads and drift remain fail-closed. Its receipt schema and immutable detail are distinct, while ordinary/legacy receipt payloads remain byte-for-byte compatible.

The focused fixtures cover three no-head cases, two semantic-witness cases, the four observed conflict/drift shapes, source-v7, generated active-index routing, idempotency, stale-proof rejection, and rollback.

## Verification
- `devtools verify --quick` — all 15 quick gates passed.
- `devtools test tests/unit/storage/test_browser_capture_origin_repair.py -k byte_proven_browser_rekey` — `10 passed, 111 deselected`.
- A broader repair-file run was intentionally not completed while the verified backup was I/O-bound; it entered the known D-state storage stall after selected legacy/ordinary cases had passed. No live archive or daemon mutation occurred.

## Acceptance criteria
- Exact byte-proven source/head/application proof: satisfied by actuator predicates and fixtures.
- Evidence-preserving, receipted, idempotent copy-forward: satisfied.
- Ineligible conflicts fail closed: satisfied in focused fixtures; live application remains a separate stopped-daemon procedure.
- Source-v7 and generated active-index routing: satisfied.

Ref polylogue-lkrc.2.