### PR TITLE
docs: remove the contrived README hero image

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@
 
 **Polylogue is a local evidence system for AI work.** It turns ChatGPT, Claude, Codex, Gemini, Antigravity, Hermes, and coding-agent histories into one evidence-addressable archive: search what happened, read tool activity as work rather than chat, audit claims against structural outcomes, understand cost and lineage, and give the next agent reviewed context.
 
-<p align="center">
-  <img src="docs/examples/visual-tapes/evidence-receipt.png" alt="Polylogue checks an assistant claim against failed and successful test receipts" width="900">
-</p>
-
 Polylogue answers questions that transcript folders and vendor chat history do not:
 
 - **What did the agent actually do?** Read prompts, tool calls, tool results, file operations, subagents, and context boundaries through one provider-independent model.


### PR DESCRIPTION
## Summary

Remove the current terminal hero image from the Polylogue README without adding a replacement.

## Problem

The image uses a synthetic claim-checking scenario, exposes literal prompt escape noise, and does not show useful organic Polylogue output.

## Solution

Delete the centered image block. The underlying demo asset remains untouched while real archive outputs are reviewed separately.

## Verification

- `rg -n 'evidence-receipt\.png|<img src="docs/examples/visual-tapes/evidence-receipt' README.md` — no matches
- `nix develop --command devtools verify --quick` — exit 0; 15/15 steps passed
