### PR TITLE
fix(storage): avoid sidecars in schema census

### DIFF
--- a/devtools/archive_schema_fast_forward.py
+++ b/devtools/archive_schema_fast_forward.py
@@ -104,6 +104,19 @@ def _require_no_sidecars(path: Path) -> None:
         raise SchemaFastForwardError(f"SQLite sidecars make clone proof ambiguous: {', '.join(present)}")
 
 
+def _open_immutable_readonly(path: Path) -> sqlite3.Connection:
+    """Open stable archive bytes without creating a WAL shared-memory sidecar.
+
+    Clone proof deliberately rejects a database with a WAL, journal, or SHM
+    sidecar: those bytes are not a complete, stable snapshot.  Check that
+    invariant *before* opening SQLite, then use immutable mode so a census of
+    a sidecar-free WAL-mode archive cannot create a new ``-shm`` file itself.
+    """
+    resolved = path.resolve(strict=True)
+    _require_no_sidecars(resolved)
+    return sqlite3.connect(f"{resolved.as_uri()}?mode=ro&immutable=1", uri=True)
+
+
 def _table_names(conn: sqlite3.Connection) -> tuple[str, ...]:
     return tuple(
         str(row[0])
@@ -122,7 +135,7 @@ def _table_counts(conn: sqlite3.Connection) -> dict[str, int]:
 
 
 def _database_evidence(path: Path) -> DatabaseEvidence:
-    with sqlite3.connect(f"file:{path}?mode=ro", uri=True) as conn:
+    with _open_immutable_readonly(path) as conn:
         _load_vec_if_required(conn)
         return DatabaseEvidence(
             path=str(path),
@@ -246,7 +259,7 @@ def _execute_script(conn: sqlite3.Connection, sql: str) -> None:
 def beads_evidence(path: Path) -> dict[str, int]:
     """Return any Beads origin/path rows; non-empty evidence blocks execution."""
     findings: dict[str, int] = {}
-    with sqlite3.connect(f"file:{path}?mode=ro", uri=True) as conn:
+    with _open_immutable_readonly(path) as conn:
         for table in _table_names(conn):
             columns = {str(row[1]) for row in conn.execute(f'PRAGMA table_info("{table}")')}
             if "origin" in columns:

--- a/tests/unit/devtools/test_archive_schema_fast_forward.py
+++ b/tests/unit/devtools/test_archive_schema_fast_forward.py
@@ -110,6 +110,36 @@ def test_beads_origin_or_path_fails_closed_before_clone(tmp_path: Path) -> None:
         fast_forward_index_clone(source, tmp_path / "clone.db")
 
 
+def test_beads_census_rejects_wal_before_it_can_create_a_shm_sidecar(tmp_path: Path) -> None:
+    """A sidecar-bearing archive must fail before a read-only census opens it.
+
+    ``mode=ro`` alone creates ``-shm`` while a writer's WAL exists.  This is
+    the exact state that used to make prepare reject sidecars it had just
+    introduced itself.  Keep the writer open, remove only its visible SHM
+    pathname, then prove the census neither reconnects nor recreates it.
+    """
+    source = tmp_path / "index-v35.db"
+    writer = sqlite3.connect(source)
+    try:
+        writer.execute("PRAGMA journal_mode = WAL")
+        writer.execute("CREATE TABLE retained (value TEXT)")
+        writer.execute("INSERT INTO retained VALUES ('fixture')")
+        writer.commit()
+        wal = Path(f"{source}-wal")
+        shm = Path(f"{source}-shm")
+        assert wal.exists()
+        shm.unlink(missing_ok=True)
+        assert not shm.exists()
+
+        with pytest.raises(SchemaFastForwardError, match="SQLite sidecars"):
+            beads_evidence(source)
+
+        assert wal.exists()
+        assert not shm.exists()
+    finally:
+        writer.close()
+
+
 def test_embedding_clone_preserves_vectors_and_installs_failure_lifecycle(tmp_path: Path) -> None:
     source = tmp_path / "embeddings-v1.db"
     clone = tmp_path / "embeddings-v2.db"


### PR DESCRIPTION
## Summary

Prevent the v35-to-v36 schema-forward census from creating SQLite WAL shared-memory sidecars.

## Problem

A read-only `mode=ro` connection can create a `-shm` sidecar while an archive WAL exists. The later clone proof then rejected that sidecar, so prepare could fail because its own preflight had mutated filesystem state.

## Solution

Every stable evidence read now first rejects sidecars and then uses SQLite `mode=ro&immutable=1`. The Beads census and structural evidence path share that helper. A WAL regression keeps a writer open, removes the visible `-shm`, and proves census fails closed without recreating it.

## Verification

- `devtools test tests/unit/devtools/test_archive_schema_fast_forward.py` — 8 passed.
- `devtools verify --quick` — exit 0; format, lint, mypy, rendered surfaces, topology, layering, schema roundtrip, and static gates passed.

Ref polylogue-uqj0.