### PR TITLE
fix(actions): read legacy Codex commands without rewriting evidence

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -728,6 +728,49 @@ def _sql_string_literal(value: str) -> str:
     return "'" + value.replace("'", "''") + "'"
 
 
+_LEGACY_EXECUTION_TOOL_NAMES = (
+    "bash",
+    "exec",
+    "exec_command",
+    "functions.exec",
+    "functions.exec_command",
+    "local_shell_call",
+    "run",
+    "shell",
+    "shell_command",
+    "terminal",
+)
+
+
+def _action_command_expression(row_alias: str) -> str:
+    """Return canonical command text without rewriting historical evidence.
+
+    Current parsers persist ``command`` alongside provider-native fields. Older
+    Codex rows may instead carry ``cmd`` or free-form ``arguments``. Restrict
+    those fallbacks to execution tools so unrelated argument strings never
+    become shell commands merely because they share the same JSON key.
+    """
+
+    execution_tools = ", ".join(_sql_string_literal(name) for name in _LEGACY_EXECUTION_TOOL_NAMES)
+    return f"""
+        COALESCE(
+            NULLIF({row_alias}.tool_command, ''),
+            CASE
+                WHEN LOWER(COALESCE({row_alias}.tool_name, '')) IN ({execution_tools}) THEN
+                    COALESCE(
+                        NULLIF(json_extract({row_alias}.tool_input, '$.cmd'), ''),
+                        CASE
+                            WHEN json_type({row_alias}.tool_input, '$.arguments') = 'text'
+                                THEN NULLIF(json_extract({row_alias}.tool_input, '$.arguments'), '')
+                            ELSE NULL
+                        END
+                    )
+                ELSE NULL
+            END
+        )
+    """.strip()
+
+
 _ACTION_FOLLOWUP_ACK_CONDITION = " OR ".join(
     f"followup_text_lower LIKE '%' || {_sql_string_literal(marker)} || '%'" for marker in ACKNOWLEDGMENT_MARKERS
 )
@@ -4580,7 +4623,7 @@ class ArchiveStore:
         handler_expr = (
             "CASE "
             f"WHEN {tool_expr} >= 'mcp__' AND {tool_expr} < 'mcp__\U0010ffff' THEN 'mcp' "
-            "WHEN NULLIF(u.tool_command, '') IS NOT NULL THEN 'shell' "
+            f"WHEN NULLIF({_action_command_expression('u')}, '') IS NOT NULL THEN 'shell' "
             "ELSE COALESCE(NULLIF(u.semantic_type, ''), 'tool_use') "
             "END"
         )
@@ -7223,7 +7266,7 @@ class ArchiveStore:
                 a.tool_result_block_id,
                 a.tool_name,
                 a.semantic_type,
-                a.tool_command,
+                {_action_command_expression("a")} AS tool_command,
                 a.tool_path,
                 m.occurred_at_ms,
                 a.output_text,
@@ -7274,7 +7317,7 @@ class ArchiveStore:
                 a.tool_result_block_id,
                 a.tool_name,
                 a.semantic_type,
-                a.tool_command,
+                {_action_command_expression("a")} AS tool_command,
                 a.tool_path,
                 m.occurred_at_ms,
                 a.output_text,
@@ -7329,7 +7372,7 @@ class ArchiveStore:
                 r.block_id AS tool_result_block_id,
                 u.tool_name,
                 u.semantic_type,
-                u.tool_command,
+                {_action_command_expression("u")} AS tool_command,
                 u.tool_path,
                 m.occurred_at_ms,
                 r.search_text AS output_text,
@@ -7886,7 +7929,7 @@ class ArchiveStore:
                 b.text,
                 b.tool_name,
                 b.semantic_type,
-                b.tool_command,
+                {_action_command_expression("b")} AS tool_command,
                 b.tool_path
             FROM blocks b
             JOIN sessions s ON s.session_id = b.session_id
@@ -9546,7 +9589,7 @@ def _message_field_predicate_clause(message_alias: str, predicate: QueryFieldPre
             """.strip()
         else:
             action_column = {
-                "command": "COALESCE(filter_actions.tool_command, '')",
+                "command": f"COALESCE({_action_command_expression('filter_actions')}, '')",
                 "path": "REPLACE(COALESCE(filter_actions.tool_path, ''), char(92), '/')",
                 "output": "COALESCE(filter_actions.output_text, '')",
             }[field]
@@ -9572,7 +9615,7 @@ def _action_field_predicate_clause(action_alias: str, predicate: QueryFieldPredi
     if field == "time":
         return _time_predicate_clause(_query_unit_time_expression("action", action_alias), predicate)
     if field == "command":
-        return _like_clause(f"COALESCE({action_alias}.tool_command, '')", predicate.values)
+        return _like_clause(f"COALESCE({_action_command_expression(action_alias)}, '')", predicate.values)
     if field == "path":
         return _like_clause(f"REPLACE(COALESCE({action_alias}.tool_path, ''), char(92), '/')", predicate.values)
     if field == "output":
@@ -9599,7 +9642,7 @@ def _action_field_predicate_clause(action_alias: str, predicate: QueryFieldPredi
             f"""
             COALESCE({action_alias}.tool_name, '') || ' ' ||
             COALESCE({action_alias}.semantic_type, '') || ' ' ||
-            COALESCE({action_alias}.tool_command, '') || ' ' ||
+            COALESCE({_action_command_expression(action_alias)}, '') || ' ' ||
             COALESCE({action_alias}.tool_path, '') || ' ' ||
             COALESCE({action_alias}.tool_input, '') || ' ' ||
             COALESCE({action_alias}.output_text, '')
@@ -9621,7 +9664,7 @@ def _file_field_predicate_clause(action_alias: str, predicate: QueryFieldPredica
             REPLACE(COALESCE({action_alias}.tool_path, ''), char(92), '/') || ' ' ||
             COALESCE({action_alias}.tool_name, '') || ' ' ||
             COALESCE({action_alias}.semantic_type, '') || ' ' ||
-            COALESCE({action_alias}.tool_command, '')
+            COALESCE({_action_command_expression(action_alias)}, '')
             """.strip(),
             predicate.values,
         )
@@ -9641,7 +9684,7 @@ def _block_field_predicate_clause(block_alias: str, predicate: QueryFieldPredica
     if field in {"action", "command", "path"}:
         column = {
             "action": f"{block_alias}.semantic_type",
-            "command": f"COALESCE({block_alias}.tool_command, '')",
+            "command": f"COALESCE({_action_command_expression(block_alias)}, '')",
             "path": f"REPLACE(COALESCE({block_alias}.tool_path, ''), char(92), '/')",
         }[field]
         if field == "action":
@@ -10420,7 +10463,7 @@ def _session_filter_clause(
                   AND lower(
                       COALESCE(filter_actions.tool_name, '') || ' ' ||
                       COALESCE(filter_actions.semantic_type, '') || ' ' ||
-                      COALESCE(filter_actions.tool_command, '') || ' ' ||
+                      COALESCE({_action_command_expression("filter_actions")}, '') || ' ' ||
                       COALESCE(filter_actions.tool_path, '') || ' ' ||
                       COALESCE(filter_actions.tool_input, '') || ' ' ||
                       COALESCE(filter_actions.output_text, '')

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -3004,6 +3004,56 @@ class TestBooleanQueryExpression:
             (session_id, "shell", script)
         ]
 
+    def test_legacy_codex_execution_payloads_are_queryable_without_rewrite(
+        self,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        fixtures = (
+            ("legacy-arguments", "exec", {"arguments": "polylogue find repo:polylogue"}),
+            ("legacy-cmd", "exec_command", {"cmd": "polylogue status"}),
+            ("unrelated-arguments", "Task", {"arguments": "polylogue should remain ordinary task input"}),
+        )
+        for session_id, tool_name, tool_input in fixtures:
+            (
+                SessionBuilder(index_db, session_id)
+                .provider("codex")
+                .add_message(
+                    f"message-{session_id}",
+                    role="assistant",
+                    text="tool invocation",
+                    blocks=[
+                        {
+                            "type": "tool_use",
+                            "tool_name": tool_name,
+                            "tool_id": f"tool-{session_id}",
+                            "input": tool_input,
+                        }
+                    ],
+                )
+                .save()
+            )
+
+        action_source = parse_unit_source_expression("actions where command:polylogue")
+        block_source = parse_unit_source_expression("blocks where command:polylogue")
+        assert action_source is not None
+        assert block_source is not None
+        with ArchiveStore.open_existing(index_db.parent) as archive:
+            action_rows = archive.query_actions(action_source.predicate, limit=100)
+            block_rows = archive.query_blocks(block_source.predicate, limit=100)
+
+        assert sorted((row.session_id, row.tool_name, row.tool_command) for row in action_rows) == [
+            ("codex-session:ext-legacy-arguments", "exec", "polylogue find repo:polylogue"),
+            ("codex-session:ext-legacy-cmd", "exec_command", "polylogue status"),
+        ]
+        assert sorted((row.session_id, row.tool_name, row.tool_command) for row in block_rows) == [
+            ("codex-session:ext-legacy-arguments", "exec", "polylogue find repo:polylogue"),
+            ("codex-session:ext-legacy-cmd", "exec_command", "polylogue status"),
+        ]
+
     def test_file_unit_source_parses_terminal_and_exists_forms(self) -> None:
         terminal = parse_unit_source_expression("files where action:file_edit AND path:archive/query")
         assert terminal is not None

--- a/tests/unit/storage/test_no_string_interpolated_sql.py
+++ b/tests/unit/storage/test_no_string_interpolated_sql.py
@@ -58,15 +58,27 @@ _AUDITED_SITES: Final[dict[_AuditedSiteKey, str]] = {
     (
         "polylogue/storage/sqlite/archive_tiers/archive.py",
         "ArchiveStore.query_actions",
-        "d23e920a2a302a20",
+        "37242de27bfb5ed2",
         0,
-    ): "query_actions interpolates _ACTION_FOLLOWUP_RELATION_SQL plus closed predicate/order fragments; user values are bound.",
+    ): "query_actions interpolates _ACTION_FOLLOWUP_RELATION_SQL, a closed command projection, and closed predicate/order fragments; user values are bound.",
     (
         "polylogue/storage/sqlite/archive_tiers/archive.py",
         "ArchiveStore.query_session_actions",
-        "00e73501ef574c76",
+        "57bcf5aec5660000",
         0,
-    ): "query_session_actions interpolates _ACTION_FOLLOWUP_RELATION_SQL, placeholders, and closed order direction; ids are bound.",
+    ): "query_session_actions interpolates _ACTION_FOLLOWUP_RELATION_SQL, a closed command projection, placeholders, and closed order direction; ids are bound.",
+    (
+        "polylogue/storage/sqlite/archive_tiers/archive.py",
+        "ArchiveStore.query_session_action_occurrences",
+        "10dac81780564a24",
+        0,
+    ): "query_session_action_occurrences interpolates a closed command projection, placeholders, and a closed order direction; ids are bound.",
+    (
+        "polylogue/storage/sqlite/archive_tiers/archive.py",
+        "ArchiveStore.query_blocks",
+        "6f5325af0e480c77",
+        0,
+    ): "query_blocks interpolates a closed command projection plus closed predicate/order fragments; user values are bound.",
     (
         "polylogue/storage/sqlite/archive_tiers/archive.py",
         "ArchiveStore.query_runs",


### PR DESCRIPTION
## Summary

Make historical Codex execution actions queryable through the canonical `command` field without mutating stored evidence rows.

## Problem

Older Codex captures store executable text in provider-native `cmd` or string `arguments` fields. Current parsers now also persist `command`, but historical rows cannot be rewritten safely because their serialized payloads participate in content hashes and citation anchors.

## Solution

- add a bounded read-time command expression for known execution tool names
- use it consistently in action/block projections and query predicates
- refuse to promote arbitrary tools’ `arguments` fields into commands
- cover direct legacy storage shapes through the real archive query route

Ref polylogue-1frn.

## Verification

- `nix develop --command devtools test tests/unit/cli/test_query_expression.py::TestBooleanQueryExpression::test_legacy_codex_execution_payloads_are_queryable_without_rewrite` — 1 passed
- pre-push `devtools verify --quick` — 15/15 steps passed in 25.77s
- explicit SQL interpolation audit — this branch’s four changed query methods are audited; the standalone audit remains red only on unrelated sites already present on current master from concurrent storage work
- `git diff --check origin/master...HEAD` — clean

## Anti-vacuity

The regression stores provider-native legacy rows directly, then queries them through `ArchiveStore.query_actions` and `ArchiveStore.query_blocks`. Removing the compatibility expression causes both result sets to lose the historical execution rows.