### PR TITLE
fix(storage): finalize schema clones before evidence

### DIFF
--- a/devtools/archive_schema_fast_forward.py
+++ b/devtools/archive_schema_fast_forward.py
@@ -313,6 +313,32 @@ def reflink_clone(source: Path, destination: Path) -> None:
     _fsync_directory(destination.parent)
 
 
+def _finalize_clone_database(path: Path) -> None:
+    """Checkpoint a completed staging clone before immutable evidence reads.
+
+    The copy-forward transaction can leave a WAL and shared-memory file even
+    though the clone is complete.  They are safe to remove only after the
+    writing connection has closed and a successful truncate checkpoint proves
+    that the database file contains every committed page.
+    """
+    with sqlite3.connect(path) as conn:
+        checkpoint = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        if checkpoint is None or int(checkpoint[0]) != 0:
+            raise SchemaFastForwardError(f"could not checkpoint completed clone {path}: {checkpoint!r}")
+    for suffix in _SQLITE_SIDECARS:
+        sidecar = Path(f"{path}{suffix}")
+        if not sidecar.exists():
+            continue
+        # A non-empty WAL or rollback journal after the completed checkpoint
+        # would carry data the immutable database file does not prove.  SHM is
+        # transient shared state and may remain non-empty after its last close.
+        if suffix != "-shm" and sidecar.stat().st_size:
+            raise SchemaFastForwardError(f"completed clone retains non-empty sidecar: {sidecar}")
+        sidecar.unlink()
+    _fsync_directory(path.parent)
+    _require_no_sidecars(path)
+
+
 def fast_forward_index_clone(source: Path, destination: Path) -> CloneForwardResult:
     """Copy-forward index v35→v36 while preserving rows and all FK declarations."""
     source_before = _database_evidence(source)
@@ -345,6 +371,7 @@ def fast_forward_index_clone(source: Path, destination: Path) -> CloneForwardRes
             quick_check = tuple(str(row[0]) for row in conn.execute("PRAGMA quick_check"))
             if quick_check != ("ok",):
                 raise SchemaFastForwardError(f"index clone quick_check failed: {quick_check!r}")
+        _finalize_clone_database(destination)
     except Exception:
         destination.unlink(missing_ok=True)
         raise
@@ -377,6 +404,7 @@ def fast_forward_embeddings_clone(source: Path, destination: Path) -> CloneForwa
             preserved_fk = all(after_fk.get(table) == declarations for table, declarations in before_fk.items())
             if not preserved_fk or foreign_key_check or quick_check != ("ok",):
                 raise SchemaFastForwardError("embeddings clone integrity contract failed")
+        _finalize_clone_database(destination)
     except Exception:
         destination.unlink(missing_ok=True)
         raise

--- a/tests/unit/devtools/test_archive_schema_fast_forward.py
+++ b/tests/unit/devtools/test_archive_schema_fast_forward.py
@@ -23,11 +23,22 @@ from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.sqlite_vec_extension import try_load_sqlite_vec
 
 
-def _create_v35_index(path: Path) -> None:
+def _clear_wal_sidecars(path: Path) -> None:
+    """Leave a WAL-mode fixture stable enough for clone preflight."""
+    with sqlite3.connect(path) as conn:
+        checkpoint = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        assert checkpoint is not None and checkpoint[0] == 0
+    for suffix in ("-wal", "-shm", "-journal"):
+        Path(f"{path}{suffix}").unlink(missing_ok=True)
+
+
+def _create_v35_index(path: Path, *, wal_mode: bool = False) -> None:
     # The fixture is an actual v35-shaped Origin CHECK schema, not simply a
     # lowered PRAGMA version on current DDL.
     legacy_ddl = INDEX_DDL.replace(", 'beads-issue'", "")
     with sqlite3.connect(path) as conn:
+        if wal_mode:
+            conn.execute("PRAGMA journal_mode = WAL")
         conn.executescript(legacy_ddl)
         conn.execute("PRAGMA user_version = 35")
         conn.execute(
@@ -51,6 +62,8 @@ def _create_v35_index(path: Path) -> None:
             ("chatgpt-export:child", 0, "fixture", "keeps inbound FK declarations honest"),
         )
         conn.commit()
+    if wal_mode:
+        _clear_wal_sidecars(path)
 
 
 def _fk_declarations(path: Path) -> dict[str, tuple[tuple[object, ...], ...]]:
@@ -69,14 +82,16 @@ def _fk_declarations(path: Path) -> dict[str, tuple[tuple[object, ...], ...]]:
 def test_index_clone_copy_forward_preserves_fk_graph_ddl_and_rows(tmp_path: Path) -> None:
     source = tmp_path / "index-v35.db"
     clone = tmp_path / "index-v36.db"
-    _create_v35_index(source)
+    _create_v35_index(source, wal_mode=True)
     before_fk = _fk_declarations(source)
+    _clear_wal_sidecars(source)
 
     result = fast_forward_index_clone(source, clone)
 
     assert result.source.user_version == 35
     assert result.clone.user_version == 36
     assert result.source.table_counts == result.clone.table_counts
+    assert not any(Path(f"{clone}{suffix}").exists() for suffix in ("-wal", "-shm", "-journal"))
     assert _fk_declarations(clone) == before_fk
     with sqlite3.connect(clone) as conn:
         assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
@@ -144,6 +159,7 @@ def test_embedding_clone_preserves_vectors_and_installs_failure_lifecycle(tmp_pa
     source = tmp_path / "embeddings-v1.db"
     clone = tmp_path / "embeddings-v2.db"
     with sqlite3.connect(source) as conn:
+        conn.execute("PRAGMA journal_mode = WAL")
         loaded, error = try_load_sqlite_vec(conn)
         if not loaded:
             pytest.skip(f"sqlite-vec unavailable: {error}")
@@ -157,11 +173,13 @@ def test_embedding_clone_preserves_vectors_and_installs_failure_lifecycle(tmp_pa
         )
         conn.execute("INSERT INTO embedding_status(session_id, origin) VALUES (?, ?)", ("session:1", "chatgpt-export"))
         conn.commit()
+    _clear_wal_sidecars(source)
 
     result = fast_forward_embeddings_clone(source, clone)
 
     assert result.source.user_version == 1
     assert result.clone.user_version == 2
+    assert not any(Path(f"{clone}{suffix}").exists() for suffix in ("-wal", "-shm", "-journal"))
     with sqlite3.connect(clone) as conn:
         loaded, error = try_load_sqlite_vec(conn)
         assert loaded, error


### PR DESCRIPTION
## Summary

Finalize derived schema-forward clones before immutable post-copy evidence reads.

## Problem

A completed WAL-mode clone retained `-wal`/`-shm` sidecars after its transaction. The immutable evidence gate correctly rejected those sidecars, so preparation failed after the costly clone copy had already succeeded.

## Solution

After each index or embeddings clone transaction, checkpoint with `TRUNCATE`, close the writer, reject a remaining non-empty WAL or rollback journal, then remove transient sidecars before immutable evidence. WAL-mode fixtures cover both clone paths.

## Verification

- `devtools test tests/unit/devtools/test_archive_schema_fast_forward.py` — 8 passed.
- Pre-push `devtools verify --quick` — completed before push; quick gate passed.

Ref polylogue-uqj0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clone operations now produce finalized, sidecar-free SQLite databases.
  * Improved reliability of immutable database validation after index and embeddings cloning.
  * Prevented leftover WAL, journal, and shared-memory files from remaining after cloning.

* **Tests**
  * Added coverage for cloning databases created with SQLite WAL mode.
  * Added checks confirming cloned outputs do not retain database sidecar files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->