### PR TITLE
fix(storage): map v7 source revisions by name

### DIFF
--- a/polylogue/storage/sqlite/migrations/source/009_expand_origin_vocabulary.sql
+++ b/polylogue/storage/sqlite/migrations/source/009_expand_origin_vocabulary.sql
@@ -185,7 +185,29 @@ CREATE TABLE history_sidecars (
     content_hash    BLOB NOT NULL CHECK(length(content_hash) = 32)
 ) STRICT;
 
-INSERT INTO raw_sessions SELECT * FROM raw_sessions_v7;
+-- v7 appended ``predecessor_source_revision`` after ``revision_authority``;
+-- the canonical v9 table places it with the other predecessor fields.  Never
+-- copy this durable row positionally: doing so shifts a nullable predecessor
+-- value into the NOT NULL authority column and corrupts the remaining
+-- revision envelope.
+INSERT INTO raw_sessions (
+    raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size,
+    acquired_at_ms, file_mtime_ms, parsed_at_ms, parse_error, validated_at_ms,
+    validation_status, validation_error, validation_drift_count, validation_mode,
+    detection_warnings_json, logical_source_key, revision_kind, source_revision,
+    predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
+    append_start_offset, append_end_offset, acquisition_generation,
+    revision_authority, capture_mode
+)
+SELECT
+    raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size,
+    acquired_at_ms, file_mtime_ms, parsed_at_ms, parse_error, validated_at_ms,
+    validation_status, validation_error, validation_drift_count, validation_mode,
+    detection_warnings_json, logical_source_key, revision_kind, source_revision,
+    predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
+    append_start_offset, append_end_offset, acquisition_generation,
+    revision_authority, capture_mode
+FROM raw_sessions_v7;
 INSERT INTO raw_session_memberships SELECT * FROM raw_session_memberships_v7;
 INSERT INTO raw_membership_census SELECT * FROM raw_membership_census_v7;
 INSERT INTO raw_artifacts SELECT * FROM raw_artifacts_v7;

--- a/tests/unit/storage/test_durable_migrations.py
+++ b/tests/unit/storage/test_durable_migrations.py
@@ -547,6 +547,26 @@ def test_source_tier_v7_expands_origin_checks_with_verified_backup(
         "OR capture_mode IS NULL)),\n",
         "",
     )
+    old_ddl = old_ddl.replace(
+        "    ,source_revision         TEXT\n"
+        "    ,predecessor_source_revision TEXT\n"
+        "    ,predecessor_raw_id      TEXT\n"
+        "    ,baseline_raw_id         TEXT\n"
+        "    ,append_start_offset     INTEGER CHECK(append_start_offset >= 0)\n"
+        "    ,append_end_offset       INTEGER CHECK(append_end_offset > append_start_offset)\n"
+        "    ,acquisition_generation  INTEGER CHECK(acquisition_generation >= 0)\n"
+        "    ,revision_authority      TEXT NOT NULL DEFAULT 'quarantined'\n"
+        "        CHECK(revision_authority IN ('asserted', 'byte_proven', 'quarantined'))\n",
+        "    ,source_revision         TEXT\n"
+        "    ,predecessor_raw_id      TEXT\n"
+        "    ,baseline_raw_id         TEXT\n"
+        "    ,append_start_offset     INTEGER CHECK(append_start_offset >= 0)\n"
+        "    ,append_end_offset       INTEGER CHECK(append_end_offset > append_start_offset)\n"
+        "    ,acquisition_generation  INTEGER CHECK(acquisition_generation >= 0)\n"
+        "    ,revision_authority      TEXT NOT NULL DEFAULT 'quarantined'\n"
+        "        CHECK(revision_authority IN ('asserted', 'byte_proven', 'quarantined'))\n"
+        "    ,predecessor_source_revision TEXT\n",
+    )
     blob_hash, blob_size = BlobStore(workspace_env["archive_root"] / "blob").write_from_bytes(b"before-beads")
     with sqlite3.connect(db_path) as conn:
         conn.executescript(old_ddl)
@@ -554,8 +574,11 @@ def test_source_tier_v7_expands_origin_checks_with_verified_backup(
         conn.execute(
             """
             INSERT INTO raw_sessions (
-                raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size, acquired_at_ms
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size,
+                acquired_at_ms, logical_source_key, revision_kind, source_revision,
+                predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
+                append_start_offset, append_end_offset, acquisition_generation, revision_authority
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 "before-beads",
@@ -566,6 +589,16 @@ def test_source_tier_v7_expands_origin_checks_with_verified_backup(
                 bytes.fromhex(blob_hash),
                 blob_size,
                 1,
+                "codex:session-1",
+                "append",
+                "source-revision-1",
+                "source-revision-0",
+                "raw-predecessor",
+                "raw-baseline",
+                3,
+                7,
+                2,
+                "byte_proven",
             ),
         )
         conn.commit()
@@ -576,7 +609,22 @@ def test_source_tier_v7_expands_origin_checks_with_verified_backup(
         assert result.from_version == 7
         assert result.to_version == SOURCE_SCHEMA_VERSION == 9
         assert result.applied_versions == (8, 9)
-        assert conn.execute("SELECT raw_id FROM raw_sessions WHERE raw_id = 'before-beads'").fetchone()
+        assert conn.execute(
+            """
+            SELECT predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
+                   append_start_offset, append_end_offset, acquisition_generation,
+                   revision_authority
+            FROM raw_sessions WHERE raw_id = 'before-beads'
+            """
+        ).fetchone() == (
+            "source-revision-0",
+            "raw-predecessor",
+            "raw-baseline",
+            3,
+            7,
+            2,
+            "byte_proven",
+        )
         conn.execute(
             """
             INSERT INTO raw_sessions (


### PR DESCRIPTION
## Summary

Map the source v7→v9 raw-session copy-forward by named columns.

## Problem

Migration 009 used `INSERT ... SELECT *` even though v7 appended `predecessor_source_revision` after `revision_authority`, while v9 groups predecessor fields together. The positional copy shifts the nullable predecessor value into the required authority column and aborts the durable upgrade.

## Solution

- Replace the positional `raw_sessions` copy with an explicit full-column projection.
- Model the real v7 column order in the durable-migration regression and assert every moved revision-envelope value survives.

## Verification

- `devtools test tests/unit/storage/test_durable_migrations.py -k source_tier_v7_expands_origin_checks_with_verified_backup` — 1 passed.
- `devtools verify --quick` — 15/15 gates passed.
- Pre-push `devtools verify --quick` — exit 0.

Ref polylogue-25vy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed archive migration handling to preserve revision lineage and authority data when restoring older session records.
  * Prevented migrated records from being corrupted by changes to the session schema.

* **Tests**
  * Added coverage verifying that legacy session records retain their identifiers, offsets, acquisition details, and revision metadata after migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->