### PR TITLE
fix(storage): restore schema snapshots across subvolumes

### DIFF
--- a/devtools/archive_schema_fast_forward.py
+++ b/devtools/archive_schema_fast_forward.py
@@ -460,18 +460,38 @@ def reuse_index_clone(source: Path, staged_clone: Path, destination: Path) -> Cl
 
 
 def atomic_promote(clone: Path, active: Path, rollback: Path) -> dict[str, str]:
-    """Atomically publish one regular prepared clone and retain rollback bytes."""
+    """Atomically publish one prepared clone and retain rollback bytes.
+
+    Prepared clones and rollback storage may be on a different subvolume from
+    the active archive.  ``rename(2)`` cannot cross that boundary, so copy both
+    operands first and perform the only replacement within ``active.parent``.
+    The active path is therefore never absent, even when the staging volume is
+    distinct from the archive volume.
+    """
     if rollback.exists() or clone == active:
         raise SchemaFastForwardError(f"rollback target is unavailable: {rollback}")
     if not clone.exists() or not active.exists():
         raise SchemaFastForwardError("atomic promotion requires both active and prepared clone")
-    os.replace(active, rollback)
+    local_clone = active.with_name(f".{active.name}.schema-forward-{uuid.uuid4().hex}.tmp")
+    published = False
     try:
-        os.replace(clone, active)
+        reflink_clone(clone, local_clone)
+        reflink_clone(active, rollback)
+        os.replace(local_clone, active)
+        published = True
+        _fsync_directory(active.parent)
     except Exception:
-        os.replace(rollback, active)
+        local_clone.unlink(missing_ok=True)
+        if published and rollback.exists():
+            try:
+                _restore_snapshot(rollback, active)
+            except Exception as restore_exc:
+                raise SchemaFastForwardError(
+                    f"promotion failed and rollback could not restore {active}"
+                ) from restore_exc
+        rollback.unlink(missing_ok=True)
         raise
-    _fsync_directory(active.parent)
+    clone.unlink(missing_ok=True)
     return {"kind": "file", "active": str(active), "rollback": str(rollback)}
 
 
@@ -506,16 +526,33 @@ def _promote_index_generation(clone: Path, active_link: Path) -> dict[str, str]:
     }
 
 
-def _restore_promoted(item: dict[str, str], rollback_root: Path) -> None:
+def _restore_promoted(item: dict[str, str]) -> None:
     active = Path(item["active"])
     rollback = Path(item["rollback"])
     if item.get("kind") == "symlink":
         _swap_active_symlink(active, rollback, label="schema-forward-rollback")
         return
-    failed = rollback_root / f"failed-{active.name}"
     if rollback.exists():
-        os.replace(active, failed)
-        os.replace(rollback, active)
+        _restore_snapshot(rollback, active)
+
+
+def _restore_snapshot(snapshot: Path, active: Path) -> None:
+    """Restore retained bytes without assuming snapshot and active share a device."""
+    if not snapshot.exists():
+        raise SchemaFastForwardError(f"rollback snapshot is unavailable: {snapshot}")
+    replacement = active.with_name(f".{active.name}.schema-forward-rollback-{uuid.uuid4().hex}.tmp")
+    try:
+        reflink_clone(snapshot, replacement)
+        # A failed migration may have created WAL sidecars for the bytes being
+        # replaced.  They must not replay against the restored snapshot once
+        # the stopped daemon restarts.
+        for suffix in _SQLITE_SIDECARS:
+            Path(f"{active}{suffix}").unlink(missing_ok=True)
+        os.replace(replacement, active)
+    except Exception:
+        replacement.unlink(missing_ok=True)
+        raise
+    _fsync_directory(active.parent)
 
 
 def plan_clone_forward(
@@ -611,6 +648,7 @@ def activate_prepared_forward(
     require_no_beads_evidence(source, index)
     rollback_root = staging_root / "rollback"
     rollback_root.mkdir(exist_ok=False)
+    snapshots: list[tuple[Path, Path]] = []
     promoted: list[dict[str, str]] = []
     try:
         # Keep exact old durable bytes locally before the runner commits.  The
@@ -619,7 +657,7 @@ def activate_prepared_forward(
         for path in (source, user):
             clone = rollback_root / path.name
             reflink_clone(path, clone)
-            promoted.append({"active": str(path), "rollback": str(clone)})
+            snapshots.append((clone, path))
         with sqlite3.connect(source) as conn:
             migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=backup_manifest)
         with sqlite3.connect(user) as conn:
@@ -629,7 +667,9 @@ def activate_prepared_forward(
         promoted.append(atomic_promote(staging_root / ops.name, ops, rollback_root / ops.name))
     except Exception as exc:
         for item in reversed(promoted):
-            _restore_promoted(item, rollback_root)
+            _restore_promoted(item)
+        for snapshot, active in reversed(snapshots):
+            _restore_snapshot(snapshot, active)
         payload.update({"status": "rolled_back", "activation_error": f"{type(exc).__name__}: {exc}"})
         _write_receipt(receipt_path, payload)
         raise

--- a/tests/unit/devtools/test_archive_schema_fast_forward.py
+++ b/tests/unit/devtools/test_archive_schema_fast_forward.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import errno
+import json
+import os
 import sqlite3
 from pathlib import Path
 
@@ -12,6 +15,7 @@ from devtools.archive_schema_fast_forward import (
     _parser,
     _promote_index_generation,
     _require_receipt_identity,
+    activate_prepared_forward,
     atomic_promote,
     beads_evidence,
     fast_forward_embeddings_clone,
@@ -218,6 +222,104 @@ def test_atomic_promote_keeps_a_named_rollback(tmp_path: Path) -> None:
     assert active.read_text(encoding="utf-8") == "new"
     assert rollback.read_text(encoding="utf-8") == "old"
     assert promoted["rollback"] == str(rollback)
+
+
+def test_atomic_promote_copies_across_subvolumes_before_local_replace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Promotion must not issue a cross-device rename for staging artifacts."""
+    archive = tmp_path / "archive"
+    staging = tmp_path / "staging"
+    archive.mkdir()
+    staging.mkdir()
+    active = archive / "embeddings.db"
+    clone = staging / "prepared-embeddings.db"
+    rollback = staging / "rollback" / "embeddings.db"
+    active.write_text("old", encoding="utf-8")
+    clone.write_text("new", encoding="utf-8")
+    real_replace = os.replace
+    replace_calls: list[tuple[Path, Path]] = []
+
+    def reject_cross_device_replace(source: str | os.PathLike[str], destination: str | os.PathLike[str]) -> None:
+        source_path = Path(source)
+        destination_path = Path(destination)
+        replace_calls.append((source_path, destination_path))
+        if source_path.parent != destination_path.parent:
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", reject_cross_device_replace)
+
+    atomic_promote(clone, active, rollback)
+
+    assert active.read_text(encoding="utf-8") == "new"
+    assert rollback.read_text(encoding="utf-8") == "old"
+    assert not clone.exists()
+    assert all(source.parent == destination.parent for source, destination in replace_calls)
+
+
+def test_activation_failure_restores_durable_snapshots_without_cross_device_rename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pre-migration snapshots are rollback inputs, never promoted entries."""
+    archive = tmp_path / "archive"
+    staging = tmp_path / "staging"
+    archive.mkdir()
+    staging.mkdir()
+    source = archive / "source.db"
+    user = archive / "user.db"
+    for database in (source, user, archive / "index.db", archive / "embeddings.db", archive / "ops.db"):
+        with sqlite3.connect(database) as conn:
+            conn.execute("CREATE TABLE retained (value TEXT)")
+            conn.execute("INSERT INTO retained VALUES ('original')")
+            conn.commit()
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text("{}", encoding="utf-8")
+    receipt = tmp_path / "receipt.json"
+    receipt.write_text(
+        json.dumps(
+            {
+                "schema": "polylogue.archive-schema-fast-forward.v1",
+                "status": "prepared",
+                "archive_root": str(archive),
+                "staging_root": str(staging),
+                "backup_manifest": str(manifest),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("devtools.archive_schema_fast_forward._require_service_stopped", lambda _service: None)
+    monkeypatch.setattr("devtools.archive_schema_fast_forward._require_receipt_identity", lambda *_args: None)
+    monkeypatch.setattr("devtools.archive_schema_fast_forward.require_no_beads_evidence", lambda *_paths: None)
+
+    def fail_after_source_mutation(conn: sqlite3.Connection, tier: ArchiveTier, **_kwargs: object) -> None:
+        assert tier is ArchiveTier.SOURCE
+        conn.execute("CREATE TABLE migration_marker (value TEXT)")
+        conn.commit()
+        raise RuntimeError("synthetic source migration failure")
+
+    monkeypatch.setattr("devtools.archive_schema_fast_forward.migrate_archive_tier", fail_after_source_mutation)
+    real_replace = os.replace
+    replace_calls: list[tuple[Path, Path]] = []
+
+    def reject_cross_device_replace(source_path: str | os.PathLike[str], destination: str | os.PathLike[str]) -> None:
+        source_item = Path(source_path)
+        destination_item = Path(destination)
+        replace_calls.append((source_item, destination_item))
+        if source_item.parent != destination_item.parent:
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        real_replace(source_path, destination)
+
+    monkeypatch.setattr(os, "replace", reject_cross_device_replace)
+
+    with pytest.raises(RuntimeError, match="synthetic source migration failure"):
+        activate_prepared_forward(receipt_path=receipt, backup_manifest=manifest)
+
+    with sqlite3.connect(source) as conn:
+        assert conn.execute("SELECT value FROM retained").fetchall() == [("original",)]
+        assert conn.execute("SELECT name FROM sqlite_master WHERE name='migration_marker'").fetchone() is None
+    assert json.loads(receipt.read_text(encoding="utf-8"))["status"] == "rolled_back"
+    assert all(source_item.parent == destination_item.parent for source_item, destination_item in replace_calls)
 
 
 def test_index_generation_promotion_preserves_active_symlink_protocol(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Make v36 fast-forward activation safe when staging and the live archive are on different subvolumes.

## Problem

Durable source/user rollback snapshots were appended to the promoted-item list. On a migration failure, rollback tried to rename the active archive file into staging and failed with `EXDEV`, leaving recovery incomplete. Derived embeddings/ops promotion had the same cross-device rename assumption.

## Solution

Keep durable snapshots separate from actual promotions. Materialize both staged candidates and rollback copies with `reflink_clone`, then make the only `os.replace` within the active file’s directory. Restore snapshots through the same local-replacement protocol and remove failed WAL sidecars before restart.

Ref polylogue-b08j.

## Verification

- `devtools test tests/unit/devtools/test_archive_schema_fast_forward.py` — 11 passed; includes simulated `EXDEV` for both promotion and migration-failure rollback.
- `devtools verify --quick` — success (format, lint, mypy, generated surfaces, topology/layering/schema checks).