### PR TITLE
fix(storage): localize index generation promotion

### DIFF
--- a/devtools/archive_schema_fast_forward.py
+++ b/devtools/archive_schema_fast_forward.py
@@ -515,9 +515,21 @@ def _promote_index_generation(clone: Path, active_link: Path) -> dict[str, str]:
     generation = generations_root / f"gen-v{INDEX_SCHEMA_VERSION}-schema-forward-{uuid.uuid4().hex}"
     generation.mkdir(mode=0o700)
     target = generation / "index.db"
-    os.replace(clone, target)
-    _fsync_directory(generation)
-    _swap_active_symlink(active_link, target, label="schema-forward")
+    local_clone = generation / f".index.db.schema-forward-{uuid.uuid4().hex}.tmp"
+    try:
+        # The prepared clone lives under staging, which can be a separate
+        # subvolume.  Populate the new generation first, then make the only
+        # file replacement local to that generation before the symlink swap.
+        reflink_clone(clone, local_clone)
+        os.replace(local_clone, target)
+        _fsync_directory(generation)
+        _swap_active_symlink(active_link, target, label="schema-forward")
+    except Exception:
+        local_clone.unlink(missing_ok=True)
+        target.unlink(missing_ok=True)
+        generation.rmdir()
+        raise
+    clone.unlink(missing_ok=True)
     return {
         "kind": "symlink",
         "active": str(active_link),

--- a/tests/unit/devtools/test_archive_schema_fast_forward.py
+++ b/tests/unit/devtools/test_archive_schema_fast_forward.py
@@ -342,6 +342,44 @@ def test_index_generation_promotion_preserves_active_symlink_protocol(tmp_path: 
     assert Path(promoted["generation_target"]).is_relative_to(generations)
 
 
+def test_index_generation_promotion_copies_staging_clone_before_local_replace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A staged index never crosses a device boundary through ``os.replace``."""
+    archive = tmp_path / "archive"
+    staging = tmp_path / "staging"
+    generations = archive / ".index-generations"
+    old_target = generations / "gen-v35" / "index.db"
+    old_target.parent.mkdir(parents=True)
+    staging.mkdir()
+    old_target.write_text("v35", encoding="utf-8")
+    active = archive / "index.db"
+    active.symlink_to(old_target)
+    clone = staging / "prepared-index.db"
+    clone.write_text("v36", encoding="utf-8")
+    real_replace = os.replace
+    replace_calls: list[tuple[Path, Path]] = []
+
+    def reject_cross_device_replace(source: str | os.PathLike[str], destination: str | os.PathLike[str]) -> None:
+        source_path = Path(source)
+        destination_path = Path(destination)
+        replace_calls.append((source_path, destination_path))
+        if source_path.parent != destination_path.parent:
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(os, "replace", reject_cross_device_replace)
+
+    promoted = _promote_index_generation(clone, active)
+
+    assert active.is_symlink()
+    assert active.resolve().read_text(encoding="utf-8") == "v36"
+    assert old_target.read_text(encoding="utf-8") == "v35"
+    assert Path(promoted["rollback"]) == old_target
+    assert not clone.exists()
+    assert all(source.parent == destination.parent for source, destination in replace_calls)
+
+
 def test_activation_receipt_rejects_any_active_tier_identity_drift(tmp_path: Path) -> None:
     database = tmp_path / "source.db"
     with sqlite3.connect(database) as conn:


### PR DESCRIPTION
## Summary

Complete the v36 cross-subvolume publication path for index generations.

## Problem

The durable/regular-file rollback repair removed most staging-to-archive renames, but `_promote_index_generation` still directly renamed the staged v36 index into `/realm/db/.../.index-generations`. Live activation correctly reached that point and failed with `EXDEV`.

## Solution

Copy the proven staging clone into a temporary file inside the new active generation, atomically rename only inside that generation, fsync it, then retain the established symlink swap and rollback target. A failed pre-swap copy removes the unreferenced generation and leaves the active symlink unchanged.

Ref polylogue-b08j.

## Verification

- `devtools test tests/unit/devtools/test_archive_schema_fast_forward.py` — 12 passed, including a simulated `EXDEV` publication path.
- `devtools verify --quick` — success.