### PR TITLE
fix(storage): finalize fast-forward durable WALs

### DIFF
--- a/devtools/archive_schema_fast_forward.py
+++ b/devtools/archive_schema_fast_forward.py
@@ -674,9 +674,22 @@ def activate_prepared_forward(
             migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=backup_manifest)
         with sqlite3.connect(user) as conn:
             migrate_archive_tier(conn, ArchiveTier.USER, backup_manifest=backup_manifest)
+        # Durable migrations can legitimately leave a WAL behind after their
+        # connection closes.  Finalize those files before immutable evidence
+        # reads: their committed pages must be in the database file, not a
+        # transient sidecar.  This remains inside the rollback boundary.
+        for path in (source, user):
+            _finalize_clone_database(path)
         promoted.append(_promote_index_generation(staging_root / index.name, index))
         promoted.append(atomic_promote(staging_root / embeddings.name, embeddings, rollback_root / embeddings.name))
         promoted.append(atomic_promote(staging_root / ops.name, ops, rollback_root / ops.name))
+        versions = {
+            "source": _database_evidence(source).user_version,
+            "user": _database_evidence(user).user_version,
+            "index": _database_evidence(index).user_version,
+            "embeddings": _database_evidence(embeddings).user_version,
+            "ops": _database_evidence(ops).user_version,
+        }
     except Exception as exc:
         for item in reversed(promoted):
             _restore_promoted(item)
@@ -690,13 +703,7 @@ def activate_prepared_forward(
             "status": "activated",
             "activated_at_ms": _now_ms(),
             "promoted": promoted,
-            "versions": {
-                "source": _database_evidence(source).user_version,
-                "user": _database_evidence(user).user_version,
-                "index": _database_evidence(index).user_version,
-                "embeddings": _database_evidence(embeddings).user_version,
-                "ops": _database_evidence(ops).user_version,
-            },
+            "versions": versions,
         }
     )
     _write_receipt(receipt_path, payload)

--- a/tests/unit/devtools/test_archive_schema_fast_forward.py
+++ b/tests/unit/devtools/test_archive_schema_fast_forward.py
@@ -322,6 +322,67 @@ def test_activation_failure_restores_durable_snapshots_without_cross_device_rena
     assert all(source_item.parent == destination_item.parent for source_item, destination_item in replace_calls)
 
 
+def test_activation_final_evidence_failure_is_rolled_back_inside_transaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Post-promotion evidence must not strand an unrecorded activation."""
+    archive = tmp_path / "archive"
+    staging = tmp_path / "staging"
+    archive.mkdir()
+    staging.mkdir()
+    source = archive / "source.db"
+    user = archive / "user.db"
+    for database in (source, user, archive / "index.db", archive / "embeddings.db", archive / "ops.db"):
+        with sqlite3.connect(database) as conn:
+            conn.execute("CREATE TABLE retained (value TEXT)")
+            conn.execute("INSERT INTO retained VALUES ('original')")
+            conn.commit()
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text("{}", encoding="utf-8")
+    receipt = tmp_path / "receipt.json"
+    receipt.write_text(
+        json.dumps(
+            {
+                "schema": "polylogue.archive-schema-fast-forward.v1",
+                "status": "prepared",
+                "archive_root": str(archive),
+                "staging_root": str(staging),
+                "backup_manifest": str(manifest),
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("devtools.archive_schema_fast_forward._require_service_stopped", lambda _service: None)
+    monkeypatch.setattr("devtools.archive_schema_fast_forward._require_receipt_identity", lambda *_args: None)
+    monkeypatch.setattr("devtools.archive_schema_fast_forward.require_no_beads_evidence", lambda *_paths: None)
+    monkeypatch.setattr("devtools.archive_schema_fast_forward.migrate_archive_tier", lambda *_args, **_kwargs: None)
+    finalized: list[Path] = []
+    monkeypatch.setattr(
+        "devtools.archive_schema_fast_forward._finalize_clone_database", lambda path: finalized.append(path)
+    )
+    monkeypatch.setattr(
+        "devtools.archive_schema_fast_forward._promote_index_generation",
+        lambda *_args: {"kind": "file", "active": str(archive / "index.db"), "rollback": "unused"},
+    )
+    monkeypatch.setattr(
+        "devtools.archive_schema_fast_forward.atomic_promote",
+        lambda _clone, active, _rollback: {"kind": "file", "active": str(active), "rollback": "unused"},
+    )
+    monkeypatch.setattr("devtools.archive_schema_fast_forward._restore_promoted", lambda _item: None)
+    monkeypatch.setattr(
+        "devtools.archive_schema_fast_forward._database_evidence",
+        lambda _path: (_ for _ in ()).throw(RuntimeError("synthetic final evidence failure")),
+    )
+
+    with pytest.raises(RuntimeError, match="synthetic final evidence failure"):
+        activate_prepared_forward(receipt_path=receipt, backup_manifest=manifest)
+
+    assert finalized == [source, user]
+    assert json.loads(receipt.read_text(encoding="utf-8"))["status"] == "rolled_back"
+    with sqlite3.connect(source) as conn:
+        assert conn.execute("SELECT value FROM retained").fetchall() == [("original",)]
+
+
 def test_index_generation_promotion_preserves_active_symlink_protocol(tmp_path: Path) -> None:
     archive = tmp_path / "archive"
     generations = archive / ".index-generations"


### PR DESCRIPTION
## Summary

Finalize durable source/user WAL state before immutable post-migration evidence, and keep final evidence inside the activation rollback boundary.

## Problem

The live v35→v36 activation promoted every tier, then final receipt evidence rejected the normal WAL sidecars left by durable migrations. The receipt remained prepared although the archive had changed.

## Solution

Checkpoint the stopped durable tiers after migration; gather final tier evidence before leaving the rollback transaction; and add a regression for a final-evidence exception after promotion.

Ref polylogue-rze2.

## Verification

- `devtools test tests/unit/devtools/test_archive_schema_fast_forward.py` — 13 passed
- `devtools verify --quick` — 15/15 gates passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved archive activation reliability by finalizing migrated databases before final verification.
  - Ensured activation failures roll back cleanly without leaving partially applied changes.
  - Preserved existing database contents when final verification encounters an error.

- **Tests**
  - Added coverage for rollback behavior during final verification failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->