### PR TITLE
fix(storage): copy reused index clones locally

### DIFF
--- a/devtools/archive_schema_fast_forward.py
+++ b/devtools/archive_schema_fast_forward.py
@@ -454,8 +454,19 @@ def reuse_index_clone(source: Path, staged_clone: Path, destination: Path) -> Cl
     if clone_after.table_counts != source_before.table_counts:
         raise SchemaFastForwardError("reused index clone changed structural row counts")
     destination.parent.mkdir(parents=True, exist_ok=True)
-    os.replace(staged_clone, destination)
-    _fsync_directory(destination.parent)
+    local_clone = destination.with_name(f".{destination.name}.schema-forward-{uuid.uuid4().hex}.tmp")
+    try:
+        # A completed clone may live in an archive generation while the new
+        # receipt lives under staging.  Those roots can be separate
+        # subvolumes, so publish a reflinked local copy rather than renaming
+        # across devices.  Retain the independently proven input for a later
+        # retry if this run does not reach activation.
+        reflink_clone(staged_clone, local_clone)
+        os.replace(local_clone, destination)
+        _fsync_directory(destination.parent)
+    except Exception:
+        local_clone.unlink(missing_ok=True)
+        raise
     return CloneForwardResult(source_before, clone_after, True, foreign_key_check)
 
 

--- a/tests/unit/devtools/test_archive_schema_fast_forward.py
+++ b/tests/unit/devtools/test_archive_schema_fast_forward.py
@@ -205,9 +205,44 @@ def test_reuse_index_clone_reproves_v36_staging_before_atomic_move(tmp_path: Pat
 
     assert result.source == expected.source
     assert result.clone == expected.clone
-    assert not staged.exists()
+    assert staged.exists()
     assert destination.exists()
     assert not any(Path(f"{destination}{suffix}").exists() for suffix in ("-wal", "-shm", "-journal"))
+
+
+def test_reuse_index_clone_copies_across_subvolumes_before_local_replace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = tmp_path / "archive"
+    staging = tmp_path / "staging"
+    archive.mkdir()
+    staging.mkdir()
+    source = archive / "index-v35.db"
+    completed = archive / "completed-index-v36.db"
+    destination = staging / "new-run" / "index.db"
+    _create_v35_index(source)
+    fast_forward_index_clone(source, completed)
+    real_replace = os.replace
+    replace_calls: list[tuple[Path, Path]] = []
+
+    def reject_cross_device_replace(
+        source_path: str | os.PathLike[str], destination_path: str | os.PathLike[str]
+    ) -> None:
+        source_item = Path(source_path)
+        destination_item = Path(destination_path)
+        replace_calls.append((source_item, destination_item))
+        if source_item.parent != destination_item.parent:
+            raise OSError(errno.EXDEV, "Invalid cross-device link")
+        real_replace(source_path, destination_path)
+
+    monkeypatch.setattr(os, "replace", reject_cross_device_replace)
+
+    reuse_index_clone(source, completed, destination)
+
+    assert completed.exists()
+    assert destination.exists()
+    assert all(source_item.parent == destination_item.parent for source_item, destination_item in replace_calls)
+    assert not list(destination.parent.glob(f".{destination.name}.schema-forward-*.tmp"))
 
 
 def test_atomic_promote_keeps_a_named_rollback(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Publish a reflinked local copy when a proven v36 index clone is reused across archive and staging subvolumes.

## Problem

The live v36 retry failed safely before receipt creation because `rename` cannot cross the archive→staging subvolume boundary.

## Solution

Copy the proven clone into a temporary file in the destination directory, rename only locally, and retain the source clone for retry.

Ref polylogue-7ufv.

## Verification

- `devtools test tests/unit/devtools/test_archive_schema_fast_forward.py` — 14 passed
- `devtools verify --quick` — 15/15 gates passed