### PR TITLE
fix(browser-capture): grant Private Network Access on CORS preflight

### DIFF
--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -191,6 +191,13 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
         self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
         self.send_header("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Request-ID")
         self.send_header("Access-Control-Max-Age", "600")
+        # Chrome's Private Network Access policy blocks an already-origin-approved
+        # extension fetch to this loopback receiver unless the preflight explicitly
+        # grants it (https://developer.chrome.com/blog/private-network-access-preflight).
+        # Without this the browser reports a bare "Failed to fetch" with no other
+        # signal, so the extension popup's health check hangs forever.
+        if self.headers.get("Access-Control-Request-Private-Network", "").lower() == "true":
+            self.send_header("Access-Control-Allow-Private-Network", "true")
         self.end_headers()
 
     def do_GET(self) -> None:

--- a/tests/unit/browser_capture/test_receiver.py
+++ b/tests/unit/browser_capture/test_receiver.py
@@ -734,6 +734,47 @@ def test_receiver_auth_allows_cors_preflight_without_bearer_token(tmp_path: Path
     assert "X-Request-ID" in allow_headers
 
 
+def test_receiver_preflight_grants_private_network_access_when_requested(tmp_path: Path) -> None:
+    with _running_receiver(tmp_path, auth_token="secret", extra_origins=(_CHATGPT_ORIGIN,)) as (host, port):
+        conn = HTTPConnection(host, port)
+        conn.request(
+            "OPTIONS",
+            "/v1/browser-captures",
+            headers={
+                "Origin": _CHATGPT_ORIGIN,
+                "Access-Control-Request-Headers": "authorization, content-type, x-request-id",
+                "Access-Control-Request-Private-Network": "true",
+            },
+        )
+        response = conn.getresponse()
+        allow_private_network = response.getheader("Access-Control-Allow-Private-Network")
+        response.read()
+        conn.close()
+
+    assert response.status == HTTPStatus.NO_CONTENT
+    assert allow_private_network == "true"
+
+
+def test_receiver_preflight_omits_private_network_header_when_not_requested(tmp_path: Path) -> None:
+    with _running_receiver(tmp_path, auth_token="secret", extra_origins=(_CHATGPT_ORIGIN,)) as (host, port):
+        conn = HTTPConnection(host, port)
+        conn.request(
+            "OPTIONS",
+            "/v1/browser-captures",
+            headers={
+                "Origin": _CHATGPT_ORIGIN,
+                "Access-Control-Request-Headers": "authorization, content-type, x-request-id",
+            },
+        )
+        response = conn.getresponse()
+        allow_private_network = response.getheader("Access-Control-Allow-Private-Network")
+        response.read()
+        conn.close()
+
+    assert response.status == HTTPStatus.NO_CONTENT
+    assert allow_private_network is None
+
+
 def test_receiver_allows_extra_web_origin_only_with_token(tmp_path: Path) -> None:
     with _running_receiver(tmp_path, auth_token="secret", extra_origins=(_CHATGPT_ORIGIN,)) as (host, port):
         conn = HTTPConnection(host, port)


### PR DESCRIPTION
## Summary

The browser extension's popup was stuck on "Checking receiver..." (effectively showing as off) even though the receiver was fully healthy.

## Problem

Chrome's [Private Network Access](https://developer.chrome.com/blog/private-network-access-preflight) policy blocks an already-origin-approved extension fetch to a loopback (`127.0.0.1`) server unless the CORS preflight response explicitly grants it. `curl` doesn't enforce this browser-only security check, so the receiver looked healthy from the shell throughout — the failure was invisible from the daemon side. `chrome.runtime` `fetch()` instead throws a bare `Failed to fetch` with no further signal, which the popup's health check interpreted as "unreachable".

Diagnosed live: `curl -X OPTIONS` with `Access-Control-Request-Private-Network: true` against the running receiver showed the preflight response was missing `Access-Control-Allow-Private-Network: true`.

## Solution

`BrowserCaptureHandler.do_OPTIONS` now echoes `Access-Control-Allow-Private-Network: true` when the preflight explicitly requests it, matching Chrome's documented PNA preflight contract. Origin allow-listing and bearer-token gating are unchanged — this only affects the preflight response for origins already permitted by `_reject_origin`.

## Verification

- `devtools test tests/unit/browser_capture/test_receiver.py -k "private_network or cors_preflight"` — 3 passed.
- `devtools verify --quick` — 15/15 gates passed.
- Live repro against a running daemon instance: preflight `Access-Control-Allow-Private-Network` header absent before the fix, present after (same code path, isolated by the fix commit).

Ref polylogue-jlme.3 (adjacent browser-capture receiver-contract hardening).

## Deployment note

The Nix-packaged daemon needs a rebuild + redeploy to pick this up — a plain `systemctl restart` reruns the already-built package and does not include this source change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved browser-capture compatibility with Chrome’s Private Network Access checks.
  - Updated CORS preflight responses to correctly allow approved private-network requests while preserving existing behavior for standard requests.

- **Tests**
  - Added coverage to verify private-network headers are included only when requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->