### PR TITLE
feat(browser): checkpoint mirror + per-message capture layer

### DIFF
--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -29,7 +29,7 @@
     },
     {
       "matches": ["https://chatgpt.com/*"],
-      "js": ["src/common.js", "src/content/chatgpt.js"],
+      "js": ["src/common.js", "src/content/message_layer.js", "src/content/chatgpt.js"],
       "run_at": "document_start"
     },
     {
@@ -40,7 +40,7 @@
     },
     {
       "matches": ["https://claude.ai/*"],
-      "js": ["src/common.js", "src/content/claude.js"],
+      "js": ["src/common.js", "src/content/message_layer.js", "src/content/claude.js"],
       "run_at": "document_idle"
     },
     {

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -148,13 +148,13 @@ function injectionPlanForUrl(url) {
     if (parsed.hostname === "chatgpt.com" || parsed.hostname.endsWith(".chatgpt.com")) {
       return [
         { files: ["src/content/chatgpt_bridge.js"], world: "MAIN" },
-        { files: ["src/common.js", "src/content/chatgpt.js"] },
+        { files: ["src/common.js", "src/content/message_layer.js", "src/content/chatgpt.js"] },
       ];
     }
     if (parsed.hostname === "claude.ai" || parsed.hostname.endsWith(".claude.ai")) {
       return [
         { files: ["src/content/claude_bridge.js"], world: "MAIN" },
-        { files: ["src/common.js", "src/content/claude.js"] },
+        { files: ["src/common.js", "src/content/message_layer.js", "src/content/claude.js"] },
       ];
     }
     if (

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -74,13 +74,52 @@ async function withExtensionInstanceAttribution(envelope) {
   };
 }
 
+// polylogue-06zm: best-effort mirror of the backfill-ledger checkpoint to the
+// local receiver. IndexedDB is always the fast primary source and the local
+// chrome.storage.local copy (BACKFILL_RECOVERY_CHECKPOINT_KEY, jlme.4) is the
+// first fallback; this receiver mirror only matters when BOTH of those are
+// gone (a browser profile that was fully destroyed/reinstalled, not merely
+// restarted). A mirror failure must never surface as a checkpoint error --
+// see BackfillCoordinator.persistCheckpoint(), which awaits only the
+// checkpoint() callback itself and already tolerates that throwing.
+function mirrorBackfillCheckpointToReceiver(instanceId, checkpoint) {
+  postJson(
+    "/v1/backfill-checkpoint",
+    { extension_instance_id: instanceId, checkpoint },
+    null,
+    PROVIDER_REQUEST_TIMEOUT_MS,
+  ).catch(() => undefined);
+}
+
+async function restoreBackfillCheckpointFromReceiver(store, instanceId) {
+  try {
+    const remote = await getJson(
+      `/v1/backfill-checkpoint?extension_instance_id=${encodeURIComponent(instanceId)}`,
+      PROVIDER_REQUEST_TIMEOUT_MS,
+    );
+    if (remote?.checkpoint) return store.restoreRecoveryCheckpoint(remote.checkpoint);
+  } catch {
+    // No receiver-mirrored checkpoint reachable or available -- fall through
+    // to whatever local state already exists (typically none, the same
+    // empty-ledger outcome as before this fallback existed).
+  }
+  return { restored: 0, reason: "checkpoint_unavailable" };
+}
+
 async function backfillCoordinator() {
   if (!backfillCoordinatorPromise) {
     const candidate = (async () => {
       const store = new IndexedDbBackfillStore();
-      const stored = await chrome.storage.local.get({ [BACKFILL_RECOVERY_CHECKPOINT_KEY]: null });
-      await store.restoreRecoveryCheckpoint(stored[BACKFILL_RECOVERY_CHECKPOINT_KEY]);
       const instanceId = await extensionInstanceId();
+      const stored = await chrome.storage.local.get({ [BACKFILL_RECOVERY_CHECKPOINT_KEY]: null });
+      const localRestore = await store.restoreRecoveryCheckpoint(stored[BACKFILL_RECOVERY_CHECKPOINT_KEY]);
+      if (localRestore.reason === "checkpoint_unavailable") {
+        // Neither IndexedDB nor the local chrome.storage.local mirror had a
+        // usable checkpoint (restoreRecoveryCheckpoint already refuses to
+        // touch a non-empty IndexedDB, so this only ever runs when there is
+        // truly nothing local to lose).
+        await restoreBackfillCheckpointFromReceiver(store, instanceId);
+      }
       return new BackfillCoordinator({
         store,
         adapters: providerAdapters(providerPageFetch, { requirePageContext: true }),
@@ -92,7 +131,10 @@ async function backfillCoordinator() {
           true,
         ),
         receiverPreflight: backfillReceiverPreflight,
-        checkpoint: async (checkpoint) => chrome.storage.local.set({ [BACKFILL_RECOVERY_CHECKPOINT_KEY]: checkpoint }),
+        checkpoint: async (checkpoint) => {
+          await chrome.storage.local.set({ [BACKFILL_RECOVERY_CHECKPOINT_KEY]: checkpoint });
+          mirrorBackfillCheckpointToReceiver(instanceId, checkpoint);
+        },
         alarms: chrome.alarms,
         instanceId,
         receiverContractEpoch: BACKFILL_WORKER_EPOCH,

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -2,6 +2,13 @@
   if (window.__polylogueChatgptCaptureInstalled) return;
   window.__polylogueChatgptCaptureInstalled = true;
 
+  // In-page Layer 1 (polylogue-ys30): capture-status dot + save action mounted
+  // next to each detected message. Reused across every capture trigger below
+  // (badge click, popup, background auto-capture) so the dots always reflect
+  // the most recent capture outcome for the whole session.
+  const MESSAGE_CONTAINER_SELECTOR = '[data-testid^="conversation-turn-"], article, [data-message-author-role]';
+  let messageLayer = null;
+
   const domAdapterName = "chatgpt-dom-v1";
   const nativeAdapterName = "chatgpt-native-v1";
   const nativeCaptureMessage = "polylogue.chatgpt.nativeCapture";
@@ -668,21 +675,33 @@
     const finalEnvelope = envelope || fallbackEnvelope();
     if (!finalEnvelope) return { ok: false, error: "no_turns" };
     const captureResult = await window.polylogueCapture.sendCapture(finalEnvelope, reason);
-    if (!captureResult?.ok) return {
-      ok: false,
-      envelope: finalEnvelope,
-      captureResult,
-      error: captureResult?.error || "capture_rejected",
-      timelineRecorded: true,
-    };
+    if (!captureResult?.ok) {
+      messageLayer?.reportOutcome({ ok: false, turnCount: finalEnvelope.session.turns.length });
+      return {
+        ok: false,
+        envelope: finalEnvelope,
+        captureResult,
+        error: captureResult?.error || "capture_rejected",
+        timelineRecorded: true,
+      };
+    }
     const archiveState = await window.polylogueCapture.refreshArchiveState(
       "chatgpt",
       finalEnvelope.session.provider_session_id
     );
+    messageLayer?.reportOutcome({ ok: true, turnCount: finalEnvelope.session.turns.length });
     return { ok: true, envelope: finalEnvelope, captureResult, archiveState };
   }
 
   window.polylogueCapture.capturePage = capture;
+  if (window.polylogueMessageLayer) {
+    messageLayer = window.polylogueMessageLayer.mount({
+      containerSelector: MESSAGE_CONTAINER_SELECTOR,
+      onSave: () => {
+        capture("message_layer_save").catch(() => undefined);
+      },
+    });
+  }
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     if (message.type !== "polylogue.capturePage") return false;
     capture(message.reason || null).then(sendResponse).catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));

--- a/browser-extension/src/content/claude.js
+++ b/browser-extension/src/content/claude.js
@@ -2,6 +2,13 @@
   if (window.__polylogueClaudeCaptureInstalled) return;
   window.__polylogueClaudeCaptureInstalled = true;
 
+  // In-page Layer 1 (polylogue-ys30): capture-status dot + save action mounted
+  // next to each detected message. Reused across every capture trigger below
+  // (badge click, popup, background auto-capture) so the dots always reflect
+  // the most recent capture outcome for the whole session.
+  const MESSAGE_CONTAINER_SELECTOR = '[data-testid*="message"], [data-message-author-role], article';
+  let messageLayer = null;
+
   const domAdapterName = "claude-ai-dom-v1";
   const nativeAdapterName = "claude-ai-native-v1";
   const nativeCaptureMessage = "polylogue.claude.nativeCapture";
@@ -231,21 +238,33 @@
     const finalEnvelope = envelope || fallbackEnvelope();
     if (!finalEnvelope) return { ok: false, error: "no_turns" };
     const captureResult = await window.polylogueCapture.sendCapture(finalEnvelope, reason);
-    if (!captureResult?.ok) return {
-      ok: false,
-      envelope: finalEnvelope,
-      captureResult,
-      error: captureResult?.error || "capture_rejected",
-      timelineRecorded: true,
-    };
+    if (!captureResult?.ok) {
+      messageLayer?.reportOutcome({ ok: false, turnCount: finalEnvelope.session.turns.length });
+      return {
+        ok: false,
+        envelope: finalEnvelope,
+        captureResult,
+        error: captureResult?.error || "capture_rejected",
+        timelineRecorded: true,
+      };
+    }
     const archiveState = await window.polylogueCapture.refreshArchiveState(
       "claude-ai",
       finalEnvelope.session.provider_session_id
     );
+    messageLayer?.reportOutcome({ ok: true, turnCount: finalEnvelope.session.turns.length });
     return { ok: true, envelope: finalEnvelope, captureResult, archiveState };
   }
 
   window.polylogueCapture.capturePage = capture;
+  if (window.polylogueMessageLayer) {
+    messageLayer = window.polylogueMessageLayer.mount({
+      containerSelector: MESSAGE_CONTAINER_SELECTOR,
+      onSave: () => {
+        capture("message_layer_save").catch(() => undefined);
+      },
+    });
+  }
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     if (message.type !== "polylogue.capturePage") return false;
     capture(message.reason || null).then(sendResponse).catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));

--- a/browser-extension/src/content/message_layer.js
+++ b/browser-extension/src/content/message_layer.js
@@ -1,0 +1,245 @@
+(function () {
+  // In-page Layer 1: a blended per-message capture-status dot + save action.
+  //
+  // Boundary rule (polylogue-yyvg): per-message state blends into the host's
+  // existing message row (this module); cross-conversation intelligence is a
+  // separate floating surface (Layer 2, not this module). This module never
+  // removes or rewrites host DOM/content — it only appends an isolated
+  // Shadow DOM badge next to each detected message container and, at most,
+  // sets `position: relative` on a message container that has no existing
+  // positioning context (a single non-destructive style property, never
+  // touching host classes, text, or listeners).
+  //
+  // The archive's capture unit is a whole session, not a single message —
+  // there is no per-message receiver endpoint. "Save" therefore triggers the
+  // same whole-session capture the popup/auto-capture path already uses, and
+  // this module reflects that outcome onto every currently-mounted badge.
+  // Per-message identity is DOM ordinal position for the current page
+  // lifetime (matching the same ordinal the DOM-fallback capture path
+  // already uses for its provider_turn_id). When the captured turn count and
+  // the mounted node count disagree (branching, streaming, host redesign)
+  // every badge falls back to "unknown" rather than asserting a per-message
+  // status it cannot actually verify — fail closed, never fail wrong.
+
+  const HOST_ATTR = "data-polylogue-message-index";
+  const STATE_ATTR = "data-polylogue-state";
+
+  const STATE_COLORS = {
+    captured: "#14764e",
+    pending: "#9a5b00",
+    failed: "#ad2f2f",
+    unknown: "#6b7280",
+    "not-seen": "#9ca3af",
+  };
+
+  const STATE_LABELS = {
+    captured: "Saved to Polylogue",
+    pending: "Saving to Polylogue…",
+    failed: "Save to Polylogue failed — click to retry",
+    unknown: "Polylogue capture status unknown",
+    "not-seen": "Save to Polylogue",
+  };
+
+  const VALID_STATES = new Set(Object.keys(STATE_COLORS));
+
+  function normalizeState(state) {
+    return VALID_STATES.has(state) ? state : "unknown";
+  }
+
+  // Pure state-derivation, exported for direct unit testing. `priorMap` and
+  // the return value are plain `{ [ordinalIndex]: state }` objects.
+  function deriveStateMap({ nodeCount, priorMap = {}, capture = null, pending = false }) {
+    const next = {};
+    for (let index = 0; index < nodeCount; index += 1) {
+      next[index] = normalizeState(priorMap[index] ?? "not-seen");
+    }
+    if (pending) {
+      for (let index = 0; index < nodeCount; index += 1) next[index] = "pending";
+      return next;
+    }
+    if (capture) {
+      const ok = Boolean(capture.ok);
+      const turnCount = capture.turnCount;
+      if (!ok) {
+        for (let index = 0; index < nodeCount; index += 1) next[index] = "failed";
+        return next;
+      }
+      const correlated = typeof turnCount === "number" && turnCount === nodeCount;
+      for (let index = 0; index < nodeCount; index += 1) next[index] = correlated ? "captured" : "unknown";
+    }
+    return next;
+  }
+
+  function ensurePositioned(node) {
+    try {
+      const view = node.ownerDocument && node.ownerDocument.defaultView;
+      const computed = view && view.getComputedStyle ? view.getComputedStyle(node).position : node.style.position;
+      if (!computed || computed === "static") node.style.position = "relative";
+    } catch {
+      // Reading computed style can throw on a detached/foreign node; leaving
+      // positioning untouched is the safe (native-control-preserving) choice.
+    }
+  }
+
+  function buildBadge({ state, onActivate, doc }) {
+    const host = doc.createElement("span");
+    host.style.cssText =
+      "all:initial;position:absolute;top:4px;right:4px;width:28px;height:28px;" +
+      "pointer-events:auto;z-index:2147483000;display:block;";
+    const shadow = host.attachShadow({ mode: "open" });
+    const style = doc.createElement("style");
+    style.textContent = [
+      ":host{all:initial;}",
+      "button{all:unset;display:inline-flex;align-items:center;justify-content:center;",
+      "width:28px;height:28px;border-radius:999px;cursor:pointer;box-sizing:border-box;}",
+      "button:focus-visible{outline:2px solid #4b8bf5;outline-offset:1px;}",
+      ".dot{width:9px;height:9px;border-radius:999px;background:var(--polylogue-dot-color,#9ca3af);",
+      "box-shadow:0 0 0 1px rgba(0,0,0,0.25);}",
+    ].join("");
+    const button = doc.createElement("button");
+    button.type = "button";
+    button.setAttribute("role", "button");
+    button.tabIndex = 0;
+    const dot = doc.createElement("span");
+    dot.className = "dot";
+    button.appendChild(dot);
+    shadow.appendChild(style);
+    shadow.appendChild(button);
+
+    function activate(event) {
+      event.preventDefault();
+      event.stopPropagation();
+      onActivate();
+    }
+    button.addEventListener("click", activate);
+    button.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") activate(event);
+    });
+
+    const api = {
+      host,
+      button,
+      setState(nextState) {
+        const normalized = normalizeState(nextState);
+        dot.style.setProperty("--polylogue-dot-color", STATE_COLORS[normalized]);
+        button.setAttribute("aria-label", STATE_LABELS[normalized]);
+        button.setAttribute("aria-pressed", normalized === "captured" ? "true" : "false");
+        button.setAttribute("title", STATE_LABELS[normalized]);
+        host.setAttribute(STATE_ATTR, normalized);
+      },
+    };
+    api.setState(state);
+    return api;
+  }
+
+  // Mount the per-message layer under `root` (default: the whole document
+  // element, safe even before <body> exists at document_start). Returns a
+  // handle with `reportPending()` / `reportOutcome()` for the owning content
+  // script to call around its whole-session capture, plus `stop()` for
+  // tests/teardown. Every DOM operation is wrapped so a selector/DOM surprise
+  // never throws into the host page — worst case, no badges mount.
+  function mount({ containerSelector, onSave, doc = document, root = null }) {
+    const mountedRoot = root || doc.documentElement;
+    const mounted = new Map(); // container node -> badge api
+    let nodeOrder = [];
+    let stateMap = {};
+    let pending = false;
+
+    function currentNodes() {
+      try {
+        return [...doc.querySelectorAll(containerSelector)];
+      } catch {
+        return [];
+      }
+    }
+
+    function reconcile() {
+      nodeOrder = currentNodes();
+      for (const [node, badge] of [...mounted.entries()]) {
+        if (!nodeOrder.includes(node)) {
+          try {
+            badge.host.remove();
+          } catch {
+            /* already detached */
+          }
+          mounted.delete(node);
+        }
+      }
+      nodeOrder.forEach((node, index) => {
+        let badge = mounted.get(node);
+        try {
+          if (!badge) {
+            ensurePositioned(node);
+            badge = buildBadge({
+              state: stateMap[index] ?? "not-seen",
+              onActivate: () => {
+                pending = true;
+                stateMap = deriveStateMap({ nodeCount: nodeOrder.length, priorMap: stateMap, pending: true });
+                reconcile();
+                onSave();
+              },
+              doc,
+            });
+            node.appendChild(badge.host);
+            mounted.set(node, badge);
+          }
+          badge.host.setAttribute(HOST_ATTR, String(index));
+          badge.setState(stateMap[index] ?? "not-seen");
+        } catch {
+          // Fail closed: an unsupported/foreign node never breaks the host
+          // page or the rest of the reconciliation pass.
+        }
+      });
+    }
+
+    function reportPending() {
+      pending = true;
+      stateMap = deriveStateMap({ nodeCount: nodeOrder.length, priorMap: stateMap, pending: true });
+      reconcile();
+    }
+
+    function reportOutcome({ ok, turnCount }) {
+      pending = false;
+      stateMap = deriveStateMap({ nodeCount: nodeOrder.length, priorMap: stateMap, capture: { ok, turnCount } });
+      reconcile();
+    }
+
+    let observer = null;
+    if (typeof MutationObserver !== "undefined") {
+      observer = new MutationObserver(() => reconcile());
+      try {
+        observer.observe(mountedRoot, { childList: true, subtree: true });
+      } catch {
+        observer = null;
+      }
+    }
+    reconcile();
+
+    return {
+      reconcile,
+      reportPending,
+      reportOutcome,
+      stop() {
+        if (observer) observer.disconnect();
+        for (const badge of mounted.values()) {
+          try {
+            badge.host.remove();
+          } catch {
+            /* already detached */
+          }
+        }
+        mounted.clear();
+      },
+      isPending: () => pending,
+      debugState: () => ({ ...stateMap }),
+      debugMountedCount: () => mounted.size,
+    };
+  }
+
+  const existing = window.polylogueMessageLayer || {};
+  window.polylogueMessageLayer = {
+    ...existing,
+    deriveStateMap,
+    mount,
+  };
+})();

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -57,10 +57,10 @@ function contentScriptFiles(url) {
   try {
     const parsed = new URL(url || "");
     if (parsed.hostname === "chatgpt.com" || parsed.hostname.endsWith(".chatgpt.com")) {
-      return ["src/common.js", "src/content/chatgpt.js"];
+      return ["src/common.js", "src/content/message_layer.js", "src/content/chatgpt.js"];
     }
     if (parsed.hostname === "claude.ai" || parsed.hostname.endsWith(".claude.ai")) {
-      return ["src/common.js", "src/content/claude.js"];
+      return ["src/common.js", "src/content/message_layer.js", "src/content/claude.js"];
     }
     if (
       parsed.hostname === "grok.com" ||

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -845,7 +845,7 @@ describe("background receiver diagnostics", () => {
     });
     expect(globalThis.chrome.scripting.executeScript).toHaveBeenCalledWith({
       target: { tabId: 42 },
-      files: ["src/common.js", "src/content/chatgpt.js"],
+      files: ["src/common.js", "src/content/message_layer.js", "src/content/chatgpt.js"],
     });
     expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
       type: "polylogue.capturePage",

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -551,8 +551,15 @@ describe("background receiver diagnostics", () => {
       func: expect.any(Function),
       args: [expect.objectContaining({ provider: "chatgpt", operation: "inventory" })],
     })));
-    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
-    expect(fetchCalls[0].url).toContain("/v1/browser-captures/capabilities");
+    // Provider inventory/conversation fetches route through the page bridge
+    // (chrome.scripting.executeScript above), never through this
+    // service-worker `fetch`. The receiver capability preflight and the
+    // best-effort backfill-checkpoint mirror/restore traffic (polylogue-06zm)
+    // are the only legitimate service-worker fetches for this flow.
+    for (const call of fetchCalls) {
+      expect(call.url).toMatch(/\/v1\/(browser-captures\/capabilities|backfill-checkpoint)/);
+    }
+    expect(fetchCalls.filter((call) => String(call.url).includes("/v1/browser-captures/capabilities"))).toHaveLength(1);
     expect(globalThis.chrome.tabs.create).not.toHaveBeenCalled();
     expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
   });
@@ -571,8 +578,9 @@ describe("background receiver diagnostics", () => {
       return responseJson({ durable_ack_fields: ["receiver_request_id", "content_hash"] }, { requestId: "capability-1" });
     });
     await sendRuntimeMessage({ type: "polylogue.backfill.start", provider: "chatgpt", cutoff: "2026-01-01T00:00:00Z" });
-    expect(fetchCalls[0]).toMatchObject({ url: expect.stringContaining("/v1/browser-captures/capabilities") });
-    expect(fetchCalls[0].options.signal).toBeDefined();
+    const capabilityCall = fetchCalls.find((call) => String(call.url).includes("/v1/browser-captures/capabilities"));
+    expect(capabilityCall).toBeDefined();
+    expect(capabilityCall.options.signal).toBeDefined();
   });
 
   it("classifies a reachable receiver missing the capability route as contract-incompatible", async () => {
@@ -604,6 +612,120 @@ describe("background receiver diagnostics", () => {
     alarmListener({ name: "polylogueBackfillWake:recovered-job" });
     await Promise.resolve();
     expect(globalThis.chrome.scripting.executeScript).not.toHaveBeenCalled();
+  });
+
+  it("mirrors every backfill-ledger checkpoint persist to the receiver (polylogue-06zm)", async () => {
+    globalThis.fetch = vi.fn(async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      if (String(url).endsWith("/v1/browser-captures/capabilities")) {
+        return responseJson({ durable_ack_fields: ["receiver_request_id", "content_hash"] });
+      }
+      if (String(url).includes("/v1/backfill-checkpoint")) {
+        return responseJson(
+          { extension_instance_id: "mirrored", stored_at: "2026-01-01T00:00:00Z", bytes_written: 42 },
+          { status: 202 },
+        );
+      }
+      return responseJson({ error: "unexpected_receiver_request" }, { ok: false, status: 500 });
+    });
+
+    await sendRuntimeMessage({ type: "polylogue.backfill.start", provider: "chatgpt", cutoff: "2026-01-01T00:00:00Z" });
+
+    const mirrorCall = fetchCalls.find(
+      (call) => String(call.url).includes("/v1/backfill-checkpoint") && call.options.method === "POST",
+    );
+    expect(mirrorCall).toBeDefined();
+    const body = JSON.parse(mirrorCall.options.body);
+    expect(body.extension_instance_id).toBe(stored.polylogueExtensionInstanceId);
+    expect(body.checkpoint).toMatchObject({ version: 1, jobs: [expect.objectContaining({ provider: "chatgpt" })] });
+    // The local chrome.storage.local copy stays authoritative and is written
+    // regardless of the receiver mirror's reachability -- confirmed here by
+    // the fact the start() call above still returned a running job even
+    // though this fetch mock is a fresh handler with no bearing on local
+    // storage.
+    expect(stored.polylogueBackfillRecoveryCheckpoint).toMatchObject({ version: 1 });
+  });
+
+  it("never lets a receiver mirror failure surface as a checkpoint error", async () => {
+    globalThis.fetch = vi.fn(async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      if (String(url).endsWith("/v1/browser-captures/capabilities")) {
+        return responseJson({ durable_ack_fields: ["receiver_request_id", "content_hash"] });
+      }
+      if (String(url).includes("/v1/backfill-checkpoint")) {
+        throw new Error("synthetic_receiver_unreachable");
+      }
+      return responseJson({ error: "unexpected_receiver_request" }, { ok: false, status: 500 });
+    });
+
+    const started = await sendRuntimeMessage({
+      type: "polylogue.backfill.start",
+      provider: "chatgpt",
+      cutoff: "2026-01-01T00:00:00Z",
+    });
+
+    expect(started.job.recovery_checkpoint_error).toBeNull();
+    expect(started.job.status).toBe("running");
+  });
+
+  it("restores the backfill ledger from the receiver mirror when local checkpoint state is gone", async () => {
+    const remoteCheckpoint = {
+      version: 1,
+      jobs: [{
+        id: "remote-job", provider: "chatgpt", cutoff: "2026-01-01T00:00:00Z", status: "running",
+        inventory_cursor: "5", policy: { leaseMs: 180000, maxDailyRequests: 10 }, execution_generation: 0,
+        learned_cadence_ms: 40000, daily_requests: 2, last_ack: null,
+      }],
+      queue: [],
+      revisions: [],
+    };
+    globalThis.fetch = vi.fn(async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      if (String(url).includes("/v1/backfill-checkpoint")) {
+        return responseJson({
+          extension_instance_id: "remote-instance",
+          checkpoint: remoteCheckpoint,
+          stored_at: "2026-01-01T00:00:00Z",
+        });
+      }
+      return responseJson({ error: "unexpected_receiver_request" }, { ok: false, status: 500 });
+    });
+
+    const status = await sendRuntimeMessage({ type: "polylogue.backfill.status" });
+
+    expect(status.jobs[0]).toMatchObject({
+      id: "remote-job",
+      status: "paused",
+      cooldown_reason: "browser_profile_recovery_required",
+      inventory_cursor: "5",
+    });
+    const restoreCall = fetchCalls.find(
+      (call) => String(call.url).includes("/v1/backfill-checkpoint") && (call.options.method || "GET") === "GET",
+    );
+    expect(restoreCall).toBeDefined();
+  });
+
+  it("does not query the receiver mirror when a local recovery checkpoint already restored jobs", async () => {
+    await loadBackground({
+      polylogueBackfillRecoveryCheckpoint: {
+        version: 1,
+        jobs: [{
+          id: "local-job", provider: "chatgpt", cutoff: "2026-01-01T00:00:00Z", status: "running",
+          inventory_cursor: "3", policy: { leaseMs: 180000, maxDailyRequests: 10 }, execution_generation: 0,
+          learned_cadence_ms: 40000, daily_requests: 1, last_ack: null,
+        }],
+        queue: [],
+        revisions: [],
+      },
+    });
+    globalThis.fetch = vi.fn(async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      return responseJson({ error: "should_not_be_called" }, { ok: false, status: 500 });
+    });
+
+    await sendRuntimeMessage({ type: "polylogue.backfill.status" });
+
+    expect(fetchCalls.some((call) => String(call.url).includes("/v1/backfill-checkpoint") && (call.options.method || "GET") === "GET")).toBe(false);
   });
 
   it("does not reuse unsupported provider subdomains as authenticated transport roots", async () => {

--- a/browser-extension/tests/build.test.js
+++ b/browser-extension/tests/build.test.js
@@ -183,6 +183,16 @@ describe("build.mjs full archive emission", () => {
       if (String(url).endsWith("/v1/browser-captures/capabilities")) {
         return { ok: true, status: 200, headers: { get: (name) => name === "X-Request-ID" ? "packaged-capability" : null }, json: async () => ({ durable_ack_fields: ["receiver_request_id", "content_hash"] }) };
       }
+      if (String(url).includes("/v1/backfill-checkpoint")) {
+        // Best-effort ledger-checkpoint mirror/restore traffic (polylogue-06zm)
+        // is orthogonal to this fixture's receiverPosts accounting below --
+        // it must neither increment that counter nor be hashed as a capture
+        // envelope body.
+        if (options.method === "POST") {
+          return { ok: true, status: 202, headers: { get: () => null }, json: async () => ({ ok: true, extension_instance_id: "packaged-instance", stored_at: new Date().toISOString(), bytes_written: 1 }) };
+        }
+        return { ok: false, status: 404, headers: { get: () => null }, json: async () => ({ ok: false, error: "checkpoint_not_found" }) };
+      }
       const contentHash = createHash("sha256").update(options.body, "utf8").digest("hex");
       receiverPosts += 1;
       body = receiverPosts === 1

--- a/browser-extension/tests/content/message_layer.test.js
+++ b/browser-extension/tests/content/message_layer.test.js
@@ -1,0 +1,290 @@
+/**
+ * Tests for src/content/message_layer.js (polylogue-ys30: in-page Layer 1 —
+ * blended per-message capture-status dot + save action).
+ *
+ * Unlike the chatgpt.test.js/claude.test.js convention of duplicating pure
+ * DOM-detection helpers inline, this suite evaluates the real production
+ * file inside a JSDOM window (the same pattern used by
+ * tests/content/grok.test.js and tests/content/chatgpt_bridge.test.js), so a
+ * regression in the shipped module fails these tests directly.
+ */
+
+import { readFileSync } from "node:fs";
+
+import { JSDOM } from "jsdom";
+import { afterEach, describe, expect, it } from "vitest";
+
+const moduleSource = readFileSync("src/content/message_layer.js", "utf8");
+const openDoms = [];
+
+function freshDom(html = "<!DOCTYPE html><html><body></body></html>") {
+  const dom = new JSDOM(html, { runScripts: "outside-only" });
+  openDoms.push(dom);
+  dom.window.eval(moduleSource);
+  return dom;
+}
+
+afterEach(() => {
+  while (openDoms.length) openDoms.pop().window.close();
+});
+
+describe("deriveStateMap (pure)", () => {
+  it("defaults every index to not-seen with no prior state", () => {
+    const dom = freshDom();
+    const map = dom.window.polylogueMessageLayer.deriveStateMap({ nodeCount: 3 });
+    expect(map).toEqual({ 0: "not-seen", 1: "not-seen", 2: "not-seen" });
+  });
+
+  it("preserves a known-valid prior state and normalizes an invalid one to unknown", () => {
+    const dom = freshDom();
+    const map = dom.window.polylogueMessageLayer.deriveStateMap({
+      nodeCount: 2,
+      priorMap: { 0: "captured", 1: "not-a-real-state" },
+    });
+    expect(map).toEqual({ 0: "captured", 1: "unknown" });
+  });
+
+  it("marks every index pending regardless of prior state", () => {
+    const dom = freshDom();
+    const map = dom.window.polylogueMessageLayer.deriveStateMap({
+      nodeCount: 2,
+      priorMap: { 0: "captured", 1: "failed" },
+      pending: true,
+    });
+    expect(map).toEqual({ 0: "pending", 1: "pending" });
+  });
+
+  it("marks every index captured when the capture turn count matches the DOM node count", () => {
+    const dom = freshDom();
+    const map = dom.window.polylogueMessageLayer.deriveStateMap({
+      nodeCount: 3,
+      capture: { ok: true, turnCount: 3 },
+    });
+    expect(map).toEqual({ 0: "captured", 1: "captured", 2: "captured" });
+  });
+
+  it("falls back to unknown (never a false captured claim) when turn/node counts disagree", () => {
+    const dom = freshDom();
+    const map = dom.window.polylogueMessageLayer.deriveStateMap({
+      nodeCount: 3,
+      capture: { ok: true, turnCount: 2 },
+    });
+    expect(map).toEqual({ 0: "unknown", 1: "unknown", 2: "unknown" });
+  });
+
+  it("marks every index failed on an unsuccessful capture", () => {
+    const dom = freshDom();
+    const map = dom.window.polylogueMessageLayer.deriveStateMap({
+      nodeCount: 2,
+      capture: { ok: false, turnCount: null },
+    });
+    expect(map).toEqual({ 0: "failed", 1: "failed" });
+  });
+});
+
+describe("mount() DOM behavior", () => {
+  it("mounts one shadow-DOM badge per matching container with zero host-node duplication", () => {
+    const dom = freshDom(
+      '<!DOCTYPE html><html><body>' +
+        '<article data-message-author-role="user">Hi</article>' +
+        '<article data-message-author-role="assistant">Hello</article>' +
+        "</body></html>",
+    );
+    const { document } = dom.window;
+    const containers = [...document.querySelectorAll("article")];
+    expect(containers).toHaveLength(2);
+
+    const handle = dom.window.polylogueMessageLayer.mount({
+      containerSelector: "article",
+      onSave: () => {},
+      doc: document,
+    });
+
+    expect(handle.debugMountedCount()).toBe(2);
+    for (const container of containers) {
+      const badges = [...container.children].filter((child) => child.shadowRoot);
+      expect(badges).toHaveLength(1);
+      const button = badges[0].shadowRoot.querySelector("button");
+      expect(button.getAttribute("role")).toBe("button");
+      expect(button.getAttribute("aria-label")).toBe("Save to Polylogue");
+      expect(button.tabIndex).toBe(0);
+    }
+    handle.stop();
+  });
+
+  it("never removes or rewrites existing host content — only appends a badge", () => {
+    const dom = freshDom(
+      '<!DOCTYPE html><html><body>' +
+        '<article data-message-author-role="user"><button class="native-action">Copy</button>Hi</article>' +
+        "</body></html>",
+    );
+    const { document } = dom.window;
+    const before = document.querySelector("article").innerHTML;
+
+    const handle = dom.window.polylogueMessageLayer.mount({
+      containerSelector: "article",
+      onSave: () => {},
+      doc: document,
+    });
+
+    const nativeButton = document.querySelector(".native-action");
+    expect(nativeButton).not.toBeNull();
+    expect(nativeButton.textContent).toBe("Copy");
+    // The badge host is additive: original markup is still a prefix/subset of
+    // the container's content, nothing native was deleted or rewritten.
+    expect(document.querySelector("article").innerHTML.startsWith(before)).toBe(true);
+    handle.stop();
+  });
+
+  it("sets pending on click and reflects a matching captured outcome afterwards", () => {
+    const dom = freshDom(
+      '<!DOCTYPE html><html><body>' +
+        '<article data-message-author-role="user">Hi</article>' +
+        "</body></html>",
+    );
+    const { document } = dom.window;
+    let saveCalls = 0;
+    const handle = dom.window.polylogueMessageLayer.mount({
+      containerSelector: "article",
+      onSave: () => {
+        saveCalls += 1;
+      },
+      doc: document,
+    });
+
+    const container = document.querySelector("article");
+    const badgeHost = [...container.children].find((child) => child.shadowRoot);
+    const button = badgeHost.shadowRoot.querySelector("button");
+    button.dispatchEvent(new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }));
+
+    expect(saveCalls).toBe(1);
+    expect(handle.isPending()).toBe(true);
+    expect(badgeHost.getAttribute("data-polylogue-state")).toBe("pending");
+
+    handle.reportOutcome({ ok: true, turnCount: 1 });
+    expect(handle.isPending()).toBe(false);
+    const badgeAfter = [...document.querySelector("article").children].find((child) => child.shadowRoot);
+    expect(badgeAfter.getAttribute("data-polylogue-state")).toBe("captured");
+    expect(badgeAfter.shadowRoot.querySelector("button").getAttribute("aria-pressed")).toBe("true");
+    handle.stop();
+  });
+
+  it("activates on Enter and Space keydown, not other keys", () => {
+    const dom = freshDom('<!DOCTYPE html><html><body><article>Hi</article></body></html>');
+    const { document } = dom.window;
+    let saveCalls = 0;
+    const handle = dom.window.polylogueMessageLayer.mount({
+      containerSelector: "article",
+      onSave: () => {
+        saveCalls += 1;
+      },
+      doc: document,
+    });
+    const badgeHost = [...document.querySelector("article").children].find((child) => child.shadowRoot);
+    const button = badgeHost.shadowRoot.querySelector("button");
+
+    button.dispatchEvent(new dom.window.KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true }));
+    expect(saveCalls).toBe(0);
+
+    button.dispatchEvent(new dom.window.KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
+    expect(saveCalls).toBe(1);
+
+    button.dispatchEvent(new dom.window.KeyboardEvent("keydown", { key: " ", bubbles: true, cancelable: true }));
+    expect(saveCalls).toBe(2);
+    handle.stop();
+  });
+
+  it("marks failed state on an unsuccessful capture without breaking the badge", () => {
+    const dom = freshDom('<!DOCTYPE html><html><body><article>Hi</article></body></html>');
+    const { document } = dom.window;
+    const handle = dom.window.polylogueMessageLayer.mount({
+      containerSelector: "article",
+      onSave: () => {},
+      doc: document,
+    });
+    handle.reportOutcome({ ok: false, turnCount: null });
+    const badgeHost = [...document.querySelector("article").children].find((child) => child.shadowRoot);
+    expect(badgeHost.getAttribute("data-polylogue-state")).toBe("failed");
+    expect(badgeHost.shadowRoot.querySelector("button").getAttribute("aria-label")).toMatch(/failed/i);
+    handle.stop();
+  });
+
+  it("tracks DOM churn: mounts a badge for a node added after mount and drops it for a removed node", async () => {
+    const dom = freshDom('<!DOCTYPE html><html><body><div id="root"><article>Hi</article></div></body></html>');
+    const { document } = dom.window;
+    const handle = dom.window.polylogueMessageLayer.mount({
+      containerSelector: "article",
+      onSave: () => {},
+      doc: document,
+      root: document.getElementById("root"),
+    });
+    expect(handle.debugMountedCount()).toBe(1);
+
+    const second = document.createElement("article");
+    second.textContent = "New message";
+    document.getElementById("root").appendChild(second);
+
+    await new Promise((resolve) => dom.window.setTimeout(resolve, 0));
+    handle.reconcile();
+    expect(handle.debugMountedCount()).toBe(2);
+
+    document.querySelectorAll("article")[0].remove();
+    handle.reconcile();
+    expect(handle.debugMountedCount()).toBe(1);
+    handle.stop();
+  });
+
+  it("fails closed on an invalid selector: mounts nothing and never throws", () => {
+    const dom = freshDom('<!DOCTYPE html><html><body><article>Hi</article></body></html>');
+    const { document } = dom.window;
+    expect(() => {
+      const handle = dom.window.polylogueMessageLayer.mount({
+        containerSelector: "article[[[not-a-valid-selector",
+        onSave: () => {},
+        doc: document,
+      });
+      expect(handle.debugMountedCount()).toBe(0);
+      handle.stop();
+    }).not.toThrow();
+  });
+
+  it("stop() removes every mounted badge and disconnects the observer", () => {
+    const dom = freshDom(
+      '<!DOCTYPE html><html><body><article>A</article><article>B</article></body></html>',
+    );
+    const { document } = dom.window;
+    const handle = dom.window.polylogueMessageLayer.mount({
+      containerSelector: "article",
+      onSave: () => {},
+      doc: document,
+    });
+    expect(handle.debugMountedCount()).toBe(2);
+    handle.stop();
+    for (const container of document.querySelectorAll("article")) {
+      const badges = [...container.children].filter((child) => child.shadowRoot);
+      expect(badges).toHaveLength(0);
+    }
+  });
+
+  it("establishes a positioning context only when the container has none", () => {
+    const dom = freshDom(
+      '<!DOCTYPE html><html><body>' +
+        '<article style="position:absolute">A</article>' +
+        "<article>B</article>" +
+        "</body></html>",
+    );
+    const { document } = dom.window;
+    const handle = dom.window.polylogueMessageLayer.mount({
+      containerSelector: "article",
+      onSave: () => {},
+      doc: document,
+    });
+    const [positioned, unpositioned] = document.querySelectorAll("article");
+    // Pre-existing positioning is never overwritten.
+    expect(positioned.style.position).toBe("absolute");
+    // A static container gets a non-destructive positioning context so the
+    // badge can be placed without shifting sibling layout.
+    expect(unpositioned.style.position).toBe("relative");
+    handle.stop();
+  });
+});

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -135,12 +135,16 @@ describe("popup capture", () => {
     globalThis.document.getElementById("capture").click();
 
     await vi.waitFor(() => expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledTimes(2));
-    expect(globalThis.chrome.scripting.executeScript).toHaveBeenCalledTimes(2);
+    expect(globalThis.chrome.scripting.executeScript).toHaveBeenCalledTimes(3);
     expect(globalThis.chrome.scripting.executeScript).toHaveBeenNthCalledWith(1, {
       target: { tabId: CHATGPT_TAB.id },
       files: ["src/common.js"],
     });
     expect(globalThis.chrome.scripting.executeScript).toHaveBeenNthCalledWith(2, {
+      target: { tabId: CHATGPT_TAB.id },
+      files: ["src/content/message_layer.js"],
+    });
+    expect(globalThis.chrome.scripting.executeScript).toHaveBeenNthCalledWith(3, {
       target: { tabId: CHATGPT_TAB.id },
       files: ["src/content/chatgpt.js"],
     });

--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -277,8 +277,15 @@ class BrowserBackfillCheckpointRequest(BaseModel):
 
     @field_validator("checkpoint", mode="before")
     @classmethod
-    def coerce_checkpoint(cls, value: object) -> dict[str, object]:
-        return dict(json_document(value))
+    def require_checkpoint_document(cls, value: object) -> dict[str, object]:
+        # This field is the disaster-recovery mirror of the extension's
+        # backfill ledger (polylogue-06zm): a malformed request must be
+        # REJECTED, never silently coerced to {} and persisted as if it were
+        # a legitimate checkpoint -- that would report HTTP 202 success while
+        # overwriting a previously-good stored checkpoint with an empty one.
+        if not is_json_document(value):
+            raise ValueError("checkpoint must be a JSON object")
+        return dict(value)
 
 
 class BrowserBackfillCheckpointRecord(BaseModel):
@@ -290,8 +297,16 @@ class BrowserBackfillCheckpointRecord(BaseModel):
 
     @field_validator("checkpoint", mode="before")
     @classmethod
-    def coerce_checkpoint(cls, value: object) -> dict[str, object]:
-        return dict(json_document(value))
+    def require_checkpoint_document(cls, value: object) -> dict[str, object]:
+        # Same durability rationale as BrowserBackfillCheckpointRequest above:
+        # a checkpoint file on disk that fails to parse as a JSON object is
+        # corrupt, not an empty-but-valid checkpoint. Raising here makes
+        # read_backfill_checkpoint's `except Exception: return None` treat a
+        # corrupt stored file as "no checkpoint found" rather than silently
+        # presenting fabricated empty data as a real one.
+        if not is_json_document(value):
+            raise ValueError("checkpoint must be a JSON object")
+        return dict(value)
 
 
 class BrowserBackfillCheckpointAcceptedPayload(BaseModel):

--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -255,6 +255,67 @@ class BrowserCaptureCapabilitiesPayload(BaseModel):
     )
 
 
+class BrowserBackfillCheckpointRequest(BaseModel):
+    """Extension-submitted backfill-ledger checkpoint mirror (polylogue-06zm).
+
+    The receiver becomes a durable second copy of the extension's IndexedDB
+    backfill ledger (job/queue/revision state, already sanitized of provider
+    credentials by the extension before it ever leaves the browser — see
+    browser-extension/src/backfill/storage.js exportRecoveryCheckpoint), so a
+    browser profile loss that also destroys the extension's local
+    chrome.storage.local mirror still leaves a recoverable checkpoint.
+    IndexedDB remains the fast primary source; this mirror is a fallback.
+
+    The receiver treats ``checkpoint`` as an opaque JSON object: its internal
+    job/queue/revision shape is the extension's concern, matching the browser
+    capture envelope's own "receiver does not reinterpret payload structure"
+    trust boundary (see BrowserCaptureHandler's class docstring).
+    """
+
+    extension_instance_id: str = Field(min_length=1, max_length=128)
+    checkpoint: dict[str, object]
+
+    @field_validator("checkpoint", mode="before")
+    @classmethod
+    def coerce_checkpoint(cls, value: object) -> dict[str, object]:
+        return dict(json_document(value))
+
+
+class BrowserBackfillCheckpointRecord(BaseModel):
+    """Persisted checkpoint envelope, one per extension instance (last write wins)."""
+
+    extension_instance_id: str
+    checkpoint: dict[str, object]
+    stored_at: str
+
+    @field_validator("checkpoint", mode="before")
+    @classmethod
+    def coerce_checkpoint(cls, value: object) -> dict[str, object]:
+        return dict(json_document(value))
+
+
+class BrowserBackfillCheckpointAcceptedPayload(BaseModel):
+    """Response to ``POST /v1/backfill-checkpoint``."""
+
+    ok: Literal[True] = True
+    receiver: Literal["polylogue-browser-capture"] = BROWSER_CAPTURE_RECEIVER
+    schema_version: Literal[1] = BROWSER_CAPTURE_SCHEMA_VERSION
+    extension_instance_id: str
+    stored_at: str
+    bytes_written: int
+
+
+class BrowserBackfillCheckpointPayload(BaseModel):
+    """Response to ``GET /v1/backfill-checkpoint``."""
+
+    ok: Literal[True] = True
+    receiver: Literal["polylogue-browser-capture"] = BROWSER_CAPTURE_RECEIVER
+    schema_version: Literal[1] = BROWSER_CAPTURE_SCHEMA_VERSION
+    extension_instance_id: str
+    checkpoint: dict[str, object]
+    stored_at: str
+
+
 class BrowserCaptureErrorPayload(BaseModel):
     """Safe receiver error payload with no paths or stack traces."""
 
@@ -384,6 +445,10 @@ __all__ = [
     "BROWSER_CAPTURE_RECEIVER",
     "BROWSER_CAPTURE_SCHEMA_VERSION",
     "BROWSER_CAPTURE_TRANSPORT_SOURCE",
+    "BrowserBackfillCheckpointAcceptedPayload",
+    "BrowserBackfillCheckpointPayload",
+    "BrowserBackfillCheckpointRecord",
+    "BrowserBackfillCheckpointRequest",
     "BrowserCaptureAcceptedPayload",
     "BrowserCaptureCapabilitiesPayload",
     "BrowserCaptureArchiveLifecycle",

--- a/polylogue/browser_capture/receiver.py
+++ b/polylogue/browser_capture/receiver.py
@@ -22,6 +22,8 @@ import orjson
 
 from polylogue.browser_capture.models import (
     BROWSER_CAPTURE_EXTENSION_ORIGIN_WILDCARD,
+    BrowserBackfillCheckpointRecord,
+    BrowserBackfillCheckpointRequest,
     BrowserCaptureArchiveLifecycle,
     BrowserCaptureArchiveStatePayload,
     BrowserCaptureEnvelope,
@@ -48,6 +50,10 @@ BROWSER_POST_ENABLED_ENV = "POLYLOGUE_BROWSER_POST_ENABLED"
 
 #: Subdirectory of the capture spool that holds queued post commands.
 POST_COMMAND_QUEUE_DIRNAME = "post-commands"
+
+#: Subdirectory of the capture spool that holds mirrored backfill-ledger
+#: checkpoints (polylogue-06zm). One file per extension_instance_id.
+BACKFILL_CHECKPOINT_DIRNAME = "backfill-checkpoints"
 
 # Backfill scheduling identifies the observer that acquired a snapshot rather
 # than a semantic property of the provider session.  Keep it out of the spool
@@ -868,7 +874,86 @@ def ack_post_command(
     return command
 
 
+# ---- Backfill-ledger checkpoint mirror (polylogue-06zm) --------------------
+#
+# The extension's IndexedDB backfill ledger is the fast primary source; a
+# local chrome.storage.local copy already survives an ordinary profile
+# restart (polylogue-jlme.4). This mirror is the second fallback: a
+# receiver-owned, credential-free copy that outlives BOTH of those when a
+# profile is destructively re-seeded or the extension is fully reinstalled,
+# so recovery has a durable place to look beyond the browser profile itself.
+# One JSON file per extension_instance_id, overwritten on every checkpoint
+# (last write wins) -- the service worker is single-threaded and only ever
+# checkpoints its own ledger, so there is exactly one legitimate writer per
+# instance id at a time. The file-count bound still guards against a buggy
+# or hostile caller minting unbounded distinct instance ids.
+BACKFILL_CHECKPOINT_MAX_FILES = 2_000
+BACKFILL_CHECKPOINT_MAX_BYTES = 200 * 1024 * 1024  # 200 MiB
+
+
+def backfill_checkpoint_root(spool_path: Path | None = None) -> Path:
+    """Return the directory that holds mirrored backfill-ledger checkpoints."""
+    root = spool_path if spool_path is not None else BrowserCaptureReceiverConfig.default().spool_path
+    return root / BACKFILL_CHECKPOINT_DIRNAME
+
+
+def _backfill_checkpoint_path(root: Path, instance_id: str) -> Path:
+    return root / f"{_safe_token(instance_id)}.json"
+
+
+def write_backfill_checkpoint(
+    request: BrowserBackfillCheckpointRequest,
+    *,
+    spool_path: Path | None = None,
+) -> BrowserBackfillCheckpointRecord:
+    """Persist a credential-free backfill-ledger checkpoint mirror.
+
+    Overwrites any prior checkpoint for the same ``extension_instance_id``
+    (last write wins; see module comment above). Guarded by the same write
+    lock and quota-check pattern the capture spool and post-command queue
+    use, so a concurrent write cannot bypass the quota check (TOCTOU).
+    """
+    root = backfill_checkpoint_root(spool_path)
+    with _SPOOL_WRITE_LOCK:
+        target = _backfill_checkpoint_path(root, request.extension_instance_id)
+        if not target.exists():
+            _check_spool_quota(
+                root,
+                max_files=BACKFILL_CHECKPOINT_MAX_FILES,
+                max_bytes=BACKFILL_CHECKPOINT_MAX_BYTES,
+                label="backfill-checkpoint mirror",
+            )
+        record = BrowserBackfillCheckpointRecord(
+            extension_instance_id=request.extension_instance_id,
+            checkpoint=request.checkpoint,
+            stored_at=datetime.now(UTC).isoformat(),
+        )
+        _atomic_write_json(target, record.model_dump(mode="json"))
+    return record
+
+
+def read_backfill_checkpoint(
+    instance_id: str,
+    *,
+    spool_path: Path | None = None,
+) -> BrowserBackfillCheckpointRecord | None:
+    """Return the mirrored checkpoint for an extension instance, if any."""
+    root = backfill_checkpoint_root(spool_path)
+    path = _backfill_checkpoint_path(root, instance_id)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    try:
+        return BrowserBackfillCheckpointRecord.model_validate(payload)
+    except Exception:
+        return None
+
+
 __all__ = [
+    "BACKFILL_CHECKPOINT_DIRNAME",
+    "BACKFILL_CHECKPOINT_MAX_BYTES",
+    "BACKFILL_CHECKPOINT_MAX_FILES",
     "BROWSER_CAPTURE_ALLOW_NO_AUTH_ENV",
     "BROWSER_POST_ENABLED_ENV",
     "POST_COMMAND_QUEUE_DIRNAME",
@@ -879,6 +964,7 @@ __all__ = [
     "BrowserPostCommandStateError",
     "BrowserPostDisabledError",
     "ack_post_command",
+    "backfill_checkpoint_root",
     "browser_post_enabled",
     "capture_artifact_ref",
     "capture_response_id",
@@ -889,7 +975,9 @@ __all__ = [
     "load_or_mint_receiver_token",
     "poll_post_commands",
     "post_command_queue_root",
+    "read_backfill_checkpoint",
     "receiver_status_payload",
     "resolve_receiver_auth_token",
+    "write_backfill_checkpoint",
     "write_capture_envelope",
 ]

--- a/polylogue/browser_capture/route_contracts.py
+++ b/polylogue/browser_capture/route_contracts.py
@@ -20,6 +20,8 @@ BrowserCaptureRouteKind = Literal[
     "post_command_enqueue",
     "post_command_poll",
     "post_command_ack",
+    "backfill_checkpoint_store",
+    "backfill_checkpoint_read",
 ]
 
 
@@ -105,6 +107,28 @@ BROWSER_CAPTURE_ROUTE_CONTRACTS: tuple[BrowserCaptureRouteContract, ...] = (
         "BrowserPostCommandAckRequest",
         "BrowserPostAckPayload | BrowserCaptureErrorPayload",
         "Extension reports the post result (submitted|failed); updates the queued command.",
+    ),
+    BrowserCaptureRouteContract(
+        "POST",
+        "/v1/backfill-checkpoint",
+        "backfill_checkpoint_store",
+        "bearer_if_web_origin",
+        "BrowserBackfillCheckpointRequest",
+        "BrowserBackfillCheckpointAcceptedPayload | BrowserCaptureErrorPayload",
+        (
+            "Mirrors the extension's sanitized backfill-ledger checkpoint (polylogue-06zm); "
+            "IndexedDB remains the fast primary source, this is the profile-loss fallback. "
+            "Overwrites any prior checkpoint for the same extension_instance_id."
+        ),
+    ),
+    BrowserCaptureRouteContract(
+        "GET",
+        "/v1/backfill-checkpoint",
+        "backfill_checkpoint_read",
+        "bearer_if_configured",
+        "extension_instance_id query parameter",
+        "BrowserBackfillCheckpointPayload | BrowserCaptureErrorPayload",
+        "Returns the mirrored checkpoint for an extension instance, or 404 if none was stored.",
     ),
 )
 

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -17,6 +17,9 @@ from pydantic import ValidationError
 
 from polylogue.browser_capture.models import (
     BROWSER_CAPTURE_EXTENSION_ORIGIN_WILDCARD,
+    BrowserBackfillCheckpointAcceptedPayload,
+    BrowserBackfillCheckpointPayload,
+    BrowserBackfillCheckpointRequest,
     BrowserCaptureAcceptedPayload,
     BrowserCaptureCapabilitiesPayload,
     BrowserCaptureEnvelope,
@@ -39,7 +42,9 @@ from polylogue.browser_capture.receiver import (
     enqueue_post_command,
     existing_capture_state,
     poll_post_commands,
+    read_backfill_checkpoint,
     receiver_status_payload,
+    write_backfill_checkpoint,
     write_capture_envelope,
 )
 from polylogue.core.json import dumps_bytes
@@ -247,6 +252,25 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
                 ).model_dump(mode="json", exclude_none=True),
             )
             return
+        if parsed.path == "/v1/backfill-checkpoint":
+            params = parse_qs(parsed.query)
+            instance_id = params.get("extension_instance_id", [""])[0]
+            if not instance_id:
+                self._safe_error(HTTPStatus.BAD_REQUEST, "missing_extension_instance_id")
+                return
+            record = read_backfill_checkpoint(instance_id, spool_path=self.server.config.spool_path)
+            if record is None:
+                self._safe_error(HTTPStatus.NOT_FOUND, "checkpoint_not_found")
+                return
+            self._send_json(
+                HTTPStatus.OK,
+                BrowserBackfillCheckpointPayload(
+                    extension_instance_id=record.extension_instance_id,
+                    checkpoint=record.checkpoint,
+                    stored_at=record.stored_at,
+                ).model_dump(mode="json"),
+            )
+            return
         self._safe_error(HTTPStatus.NOT_FOUND, "not_found")
 
     def do_POST(self) -> None:
@@ -282,6 +306,9 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
         if path.startswith("/v1/post-commands/") and path.endswith("/ack"):
             command_id = path[len("/v1/post-commands/") : -len("/ack")]
             self._post_command_ack(command_id)
+            return
+        if path == "/v1/backfill-checkpoint":
+            self._backfill_checkpoint_store()
             return
         if path != "/v1/browser-captures":
             self._safe_error(HTTPStatus.NOT_FOUND, "not_found")
@@ -414,6 +441,43 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
             HTTPStatus.OK,
             BrowserPostAckPayload(command_id=command.command_id, status=command.status).model_dump(mode="json"),
         )
+
+    def _backfill_checkpoint_store(self) -> None:
+        payload = self._read_json_body()
+        if payload is None:
+            return
+        try:
+            request = BrowserBackfillCheckpointRequest.model_validate(payload)
+        except ValidationError:
+            logger.warning("browser_capture.invalid_backfill_checkpoint", request_id=self._request_id())
+            self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_backfill_checkpoint")
+            return
+        try:
+            record = write_backfill_checkpoint(request, spool_path=self.server.config.spool_path)
+        except SpoolQuotaExceededError as exc:
+            logger.warning(
+                "browser_capture.backfill_checkpoint_quota_exceeded", request_id=self._request_id(), error=str(exc)
+            )
+            self._safe_error(HTTPStatus.TOO_MANY_REQUESTS, "backfill_checkpoint_quota_exceeded")
+            return
+        except OSError as exc:
+            logger.warning(
+                "browser_capture.backfill_checkpoint_write_failed", request_id=self._request_id(), error=repr(exc)
+            )
+            self._safe_error(HTTPStatus.INTERNAL_SERVER_ERROR, "write_failed")
+            return
+        accepted = BrowserBackfillCheckpointAcceptedPayload(
+            extension_instance_id=record.extension_instance_id,
+            stored_at=record.stored_at,
+            bytes_written=len(_json_bytes(record.model_dump(mode="json"))),
+        )
+        logger.debug(
+            "browser_capture.backfill_checkpoint_stored",
+            request_id=self._request_id(),
+            extension_instance_id=record.extension_instance_id,
+            bytes_written=accepted.bytes_written,
+        )
+        self._send_json(HTTPStatus.ACCEPTED, accepted.model_dump(mode="json"))
 
 
 def make_server(

--- a/tests/unit/browser_capture/test_backfill_checkpoint.py
+++ b/tests/unit/browser_capture/test_backfill_checkpoint.py
@@ -21,8 +21,9 @@ from threading import Thread
 from typing import cast
 
 import pytest
+from pydantic import ValidationError
 
-from polylogue.browser_capture.models import BrowserBackfillCheckpointRequest
+from polylogue.browser_capture.models import BrowserBackfillCheckpointRecord, BrowserBackfillCheckpointRequest
 from polylogue.browser_capture.receiver import (
     backfill_checkpoint_root,
     read_backfill_checkpoint,
@@ -66,6 +67,61 @@ def test_write_then_read_round_trips_opaque_checkpoint(tmp_path: Path) -> None:
 
 def test_read_missing_checkpoint_returns_none(tmp_path: Path) -> None:
     assert read_backfill_checkpoint("never-written", spool_path=tmp_path) is None
+
+
+@pytest.mark.parametrize("bad_checkpoint", ["garbage-not-a-dict", None, 42, ["a", "list"]])
+def test_request_rejects_non_dict_checkpoint_instead_of_coercing_to_empty(bad_checkpoint: object) -> None:
+    # Regression for the silent-data-loss hole: a non-dict checkpoint value
+    # must fail validation, not be coerced to {} and accepted.
+    with pytest.raises(ValidationError):
+        BrowserBackfillCheckpointRequest(extension_instance_id="instance-a", checkpoint=bad_checkpoint)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("bad_checkpoint", ["garbage-not-a-dict", None, 42, ["a", "list"]])
+def test_record_rejects_non_dict_checkpoint_instead_of_coercing_to_empty(bad_checkpoint: object) -> None:
+    with pytest.raises(ValidationError):
+        BrowserBackfillCheckpointRecord(
+            extension_instance_id="instance-a",
+            checkpoint=bad_checkpoint,  # type: ignore[arg-type]
+            stored_at="2026-01-01T00:00:00+00:00",
+        )
+
+
+def test_malformed_stored_checkpoint_file_reads_back_as_none_not_fabricated_empty(tmp_path: Path) -> None:
+    # A good checkpoint is written, then the on-disk file is corrupted (as a
+    # bug or disk fault might do). Reading it back must surface "no
+    # checkpoint" rather than a fabricated empty one that looks legitimate.
+    write_backfill_checkpoint(
+        BrowserBackfillCheckpointRequest(extension_instance_id="instance-a", checkpoint=_checkpoint_payload()),
+        spool_path=tmp_path,
+    )
+    target = backfill_checkpoint_root(tmp_path) / "instance-a.json"
+    target.write_text(
+        json.dumps(
+            {
+                "extension_instance_id": "instance-a",
+                "checkpoint": "not-a-dict",
+                "stored_at": "2026-01-01T00:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert read_backfill_checkpoint("instance-a", spool_path=tmp_path) is None
+
+
+def test_write_does_not_overwrite_prior_good_checkpoint_when_new_checkpoint_is_malformed(tmp_path: Path) -> None:
+    write_backfill_checkpoint(
+        BrowserBackfillCheckpointRequest(extension_instance_id="instance-a", checkpoint=_checkpoint_payload(1)),
+        spool_path=tmp_path,
+    )
+
+    with pytest.raises(ValidationError):
+        BrowserBackfillCheckpointRequest(extension_instance_id="instance-a", checkpoint="garbage-not-a-dict")  # type: ignore[arg-type]
+
+    still_good = read_backfill_checkpoint("instance-a", spool_path=tmp_path)
+    assert still_good is not None
+    assert still_good.checkpoint == _checkpoint_payload(1)
 
 
 def test_write_overwrites_prior_checkpoint_for_same_instance_last_write_wins(tmp_path: Path) -> None:
@@ -209,6 +265,37 @@ def test_http_store_rejects_invalid_payload(tmp_path: Path) -> None:
         )  # missing extension_instance_id
     assert status == HTTPStatus.BAD_REQUEST
     assert body["error"] == "invalid_backfill_checkpoint"
+
+
+def test_http_store_rejects_non_dict_checkpoint_and_preserves_prior_good_checkpoint(tmp_path: Path) -> None:
+    # Reviewer-reproduced regression: POSTing
+    # {"extension_instance_id": "instance-a", "checkpoint": "garbage-not-a-dict"}
+    # previously returned HTTP 202 and silently overwrote a good stored
+    # checkpoint with {}. It must now be rejected (400) and leave the prior
+    # good checkpoint untouched.
+    with _running_receiver(tmp_path) as (host, port):
+        status, stored = _request(
+            host,
+            port,
+            "POST",
+            "/v1/backfill-checkpoint",
+            body={"extension_instance_id": "instance-a", "checkpoint": _checkpoint_payload(1)},
+        )
+        assert status == HTTPStatus.ACCEPTED
+
+        status, body = _request(
+            host,
+            port,
+            "POST",
+            "/v1/backfill-checkpoint",
+            body={"extension_instance_id": "instance-a", "checkpoint": "garbage-not-a-dict"},
+        )
+        assert status == HTTPStatus.BAD_REQUEST
+        assert body["error"] == "invalid_backfill_checkpoint"
+
+    preserved = read_backfill_checkpoint("instance-a", spool_path=tmp_path)
+    assert preserved is not None
+    assert preserved.checkpoint == _checkpoint_payload(1)
 
 
 def test_http_store_second_write_overwrites_first_over_the_wire(tmp_path: Path) -> None:

--- a/tests/unit/browser_capture/test_backfill_checkpoint.py
+++ b/tests/unit/browser_capture/test_backfill_checkpoint.py
@@ -1,0 +1,259 @@
+"""Tests for the browser-capture receiver's backfill-ledger checkpoint mirror.
+
+polylogue-06zm: the extension's IndexedDB backfill ledger is the fast
+primary source (already covered by browser-extension/tests/backfill.test.js
+and the PR #2819 recovery-checkpoint work for jlme.3/jlme.4). This receiver
+mirror is the second fallback for when a browser profile loss also destroys
+the extension's local chrome.storage.local copy -- these tests exercise the
+real HTTP route surface end to end (POST store -> GET read), not a mocked
+transport.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http import HTTPStatus
+from http.client import HTTPConnection, HTTPResponse
+from pathlib import Path
+from threading import Thread
+from typing import cast
+
+import pytest
+
+from polylogue.browser_capture.models import BrowserBackfillCheckpointRequest
+from polylogue.browser_capture.receiver import (
+    backfill_checkpoint_root,
+    read_backfill_checkpoint,
+    write_backfill_checkpoint,
+)
+from polylogue.browser_capture.route_contracts import (
+    BROWSER_CAPTURE_ROUTE_CONTRACTS,
+    browser_capture_route_contract_for,
+)
+from polylogue.browser_capture.server import make_server
+
+_EXTENSION_ORIGIN = "chrome-extension://polylogue-test"
+
+
+def _checkpoint_payload(sequence: int = 1) -> dict[str, object]:
+    # Mirrors the shape browser-extension/src/backfill/storage.js
+    # exportRecoveryCheckpoint() produces (opaque to the receiver).
+    return {
+        "version": 1,
+        "sequence": sequence,
+        "jobs": [{"id": "backfill-chatgpt-1", "status": "running", "inventory_cursor": "42"}],
+        "queue": [{"id": "backfill-chatgpt-1:chatgpt:conv-1", "state": "eligible"}],
+        "revisions": [],
+    }
+
+
+# ---- Direct function tests --------------------------------------------------
+
+
+def test_write_then_read_round_trips_opaque_checkpoint(tmp_path: Path) -> None:
+    request = BrowserBackfillCheckpointRequest(extension_instance_id="instance-a", checkpoint=_checkpoint_payload())
+
+    written = write_backfill_checkpoint(request, spool_path=tmp_path)
+    read_back = read_backfill_checkpoint("instance-a", spool_path=tmp_path)
+
+    assert read_back is not None
+    assert read_back.checkpoint == _checkpoint_payload()
+    assert read_back.extension_instance_id == "instance-a"
+    assert read_back.stored_at == written.stored_at
+
+
+def test_read_missing_checkpoint_returns_none(tmp_path: Path) -> None:
+    assert read_backfill_checkpoint("never-written", spool_path=tmp_path) is None
+
+
+def test_write_overwrites_prior_checkpoint_for_same_instance_last_write_wins(tmp_path: Path) -> None:
+    write_backfill_checkpoint(
+        BrowserBackfillCheckpointRequest(extension_instance_id="instance-a", checkpoint=_checkpoint_payload(1)),
+        spool_path=tmp_path,
+    )
+    write_backfill_checkpoint(
+        BrowserBackfillCheckpointRequest(extension_instance_id="instance-a", checkpoint=_checkpoint_payload(2)),
+        spool_path=tmp_path,
+    )
+
+    files = list(backfill_checkpoint_root(tmp_path).glob("*.json"))
+    assert len(files) == 1  # one file per instance id, not one per write
+
+    latest = read_backfill_checkpoint("instance-a", spool_path=tmp_path)
+    assert latest is not None
+    assert latest.checkpoint["sequence"] == 2
+
+
+def test_distinct_instance_ids_get_distinct_checkpoints(tmp_path: Path) -> None:
+    write_backfill_checkpoint(
+        BrowserBackfillCheckpointRequest(extension_instance_id="instance-a", checkpoint=_checkpoint_payload(1)),
+        spool_path=tmp_path,
+    )
+    write_backfill_checkpoint(
+        BrowserBackfillCheckpointRequest(extension_instance_id="instance-b", checkpoint=_checkpoint_payload(2)),
+        spool_path=tmp_path,
+    )
+
+    a = read_backfill_checkpoint("instance-a", spool_path=tmp_path)
+    b = read_backfill_checkpoint("instance-b", spool_path=tmp_path)
+    assert a is not None and a.checkpoint["sequence"] == 1
+    assert b is not None and b.checkpoint["sequence"] == 2
+
+
+def test_write_enforces_quota_before_writing_a_new_instance(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import polylogue.browser_capture.receiver as receiver_mod
+
+    monkeypatch.setattr(receiver_mod, "BACKFILL_CHECKPOINT_MAX_FILES", 1)
+    write_backfill_checkpoint(
+        BrowserBackfillCheckpointRequest(extension_instance_id="instance-a", checkpoint=_checkpoint_payload()),
+        spool_path=tmp_path,
+    )
+
+    with pytest.raises(receiver_mod.SpoolQuotaExceededError):
+        write_backfill_checkpoint(
+            BrowserBackfillCheckpointRequest(extension_instance_id="instance-b", checkpoint=_checkpoint_payload()),
+            spool_path=tmp_path,
+        )
+
+    # Overwriting the ALREADY-present instance never grows the file count, so
+    # it must not be blocked by the same quota that stops a new instance.
+    write_backfill_checkpoint(
+        BrowserBackfillCheckpointRequest(extension_instance_id="instance-a", checkpoint=_checkpoint_payload(9)),
+        spool_path=tmp_path,
+    )
+    refreshed = read_backfill_checkpoint("instance-a", spool_path=tmp_path)
+    assert refreshed is not None and refreshed.checkpoint["sequence"] == 9
+
+
+# ---- HTTP route surface -----------------------------------------------------
+
+
+@contextmanager
+def _running_receiver(tmp_path: Path) -> Iterator[tuple[str, int]]:
+    server = make_server("127.0.0.1", 0, spool_path=tmp_path)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    host, port = cast(tuple[str, int], server.server_address[:2])
+    try:
+        yield host, port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _request(
+    host: str, port: int, method: str, path: str, *, body: object | None = None
+) -> tuple[int, dict[str, object]]:
+    conn = HTTPConnection(host, port)
+    headers = {"Origin": _EXTENSION_ORIGIN}
+    payload: str | None = None
+    if body is not None:
+        payload = json.dumps(body)
+        headers["Content-Type"] = "application/json"
+    conn.request(method, path, body=payload, headers=headers)
+    response: HTTPResponse = conn.getresponse()
+    raw = response.read()
+    conn.close()
+    parsed = json.loads(raw) if raw else {}
+    return response.status, parsed
+
+
+def test_route_contracts_registered() -> None:
+    kinds = {c.kind for c in BROWSER_CAPTURE_ROUTE_CONTRACTS}
+    assert {"backfill_checkpoint_store", "backfill_checkpoint_read"} <= kinds
+    assert browser_capture_route_contract_for("POST", "/v1/backfill-checkpoint") is not None
+    assert browser_capture_route_contract_for("GET", "/v1/backfill-checkpoint") is not None
+
+
+def test_http_store_then_read_full_route(tmp_path: Path) -> None:
+    with _running_receiver(tmp_path) as (host, port):
+        status, stored = _request(
+            host,
+            port,
+            "POST",
+            "/v1/backfill-checkpoint",
+            body={"extension_instance_id": "instance-http", "checkpoint": _checkpoint_payload()},
+        )
+        assert status == HTTPStatus.ACCEPTED
+        assert stored["extension_instance_id"] == "instance-http"
+        assert cast(int, stored["bytes_written"]) > 0
+        assert isinstance(stored["stored_at"], str) and stored["stored_at"]
+
+        status, fetched = _request(host, port, "GET", "/v1/backfill-checkpoint?extension_instance_id=instance-http")
+        assert status == HTTPStatus.OK
+        assert fetched["extension_instance_id"] == "instance-http"
+        assert fetched["checkpoint"] == _checkpoint_payload()
+
+
+def test_http_get_missing_checkpoint_returns_404(tmp_path: Path) -> None:
+    with _running_receiver(tmp_path) as (host, port):
+        status, body = _request(host, port, "GET", "/v1/backfill-checkpoint?extension_instance_id=nope")
+    assert status == HTTPStatus.NOT_FOUND
+    assert body["error"] == "checkpoint_not_found"
+
+
+def test_http_get_without_instance_id_returns_400(tmp_path: Path) -> None:
+    with _running_receiver(tmp_path) as (host, port):
+        status, body = _request(host, port, "GET", "/v1/backfill-checkpoint")
+    assert status == HTTPStatus.BAD_REQUEST
+    assert body["error"] == "missing_extension_instance_id"
+
+
+def test_http_store_rejects_invalid_payload(tmp_path: Path) -> None:
+    with _running_receiver(tmp_path) as (host, port):
+        status, body = _request(
+            host, port, "POST", "/v1/backfill-checkpoint", body={"checkpoint": {"version": 1}}
+        )  # missing extension_instance_id
+    assert status == HTTPStatus.BAD_REQUEST
+    assert body["error"] == "invalid_backfill_checkpoint"
+
+
+def test_http_store_second_write_overwrites_first_over_the_wire(tmp_path: Path) -> None:
+    with _running_receiver(tmp_path) as (host, port):
+        _request(
+            host,
+            port,
+            "POST",
+            "/v1/backfill-checkpoint",
+            body={"extension_instance_id": "instance-http", "checkpoint": _checkpoint_payload(1)},
+        )
+        _request(
+            host,
+            port,
+            "POST",
+            "/v1/backfill-checkpoint",
+            body={"extension_instance_id": "instance-http", "checkpoint": _checkpoint_payload(2)},
+        )
+        status, fetched = _request(host, port, "GET", "/v1/backfill-checkpoint?extension_instance_id=instance-http")
+    assert status == HTTPStatus.OK
+    assert cast(dict[str, object], fetched["checkpoint"])["sequence"] == 2
+
+
+def test_http_store_returns_429_without_writing_when_quota_exceeded(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import polylogue.browser_capture.receiver as receiver_mod
+
+    monkeypatch.setattr(receiver_mod, "BACKFILL_CHECKPOINT_MAX_FILES", 1)
+    write_backfill_checkpoint(
+        BrowserBackfillCheckpointRequest(extension_instance_id="instance-a", checkpoint=_checkpoint_payload()),
+        spool_path=tmp_path,
+    )
+    before = sorted(backfill_checkpoint_root(tmp_path).glob("*.json"))
+
+    with _running_receiver(tmp_path) as (host, port):
+        status, body = _request(
+            host,
+            port,
+            "POST",
+            "/v1/backfill-checkpoint",
+            body={"extension_instance_id": "instance-b", "checkpoint": _checkpoint_payload()},
+        )
+
+    assert status == HTTPStatus.TOO_MANY_REQUESTS
+    assert body["error"] == "backfill_checkpoint_quota_exceeded"
+    after = sorted(backfill_checkpoint_root(tmp_path).glob("*.json"))
+    assert after == before


### PR DESCRIPTION
## Summary

Two coupled pieces of work from the browser-extension cluster:

1. **polylogue-ys30** (in-page Layer 1): a Shadow-DOM capture-status dot + save action blended into each detected ChatGPT/Claude.ai message.
2. **polylogue-06zm** (partial): the local receiver now mirrors the extension's sanitized backfill-ledger checkpoint, giving a second recovery path beyond IndexedDB + the existing `chrome.storage.local` copy from jlme.4.

Everything else in the assigned cluster (jlme.3, jlme.4, jlme.4.1, s8gb, bj5h, wvji, 4g3n, yyvg) was investigated and is reported below — most turned out to be already delivered by merged PRs earlier in this session (#2819, #2823, #2824, and sinnix #1), which the beads' notes hadn't caught up to yet.

## Problem

- **ys30**: the yyvg "ambient two-way surface" redesign's foundational per-message layer had no implementation at all — ChatGPT/Claude.ai messages had no visible per-message capture affordance.
- **06zm**: the existing recovery-checkpoint design (PR #2819) stores its fallback copy in `chrome.storage.local` — the *same browser profile* IndexedDB lives in. A profile that is fully destroyed/reinstalled (not merely restarted) loses both copies together, with no recovery path.

## Solution

**ys30** — `browser-extension/src/content/message_layer.js` (new): a `MutationObserver`-driven module that appends an isolated Shadow DOM badge (dot + button) next to each message container, never touching native DOM/classes/listeners (only a non-destructive `position:relative` fallback when a container has no positioning context). States: `captured` / `pending` / `failed` / `unknown` / `not-seen`. Save re-triggers the existing whole-session `capture()` (there is no per-message receiver endpoint — the archive's capture unit is the session) and every badge reflects the outcome; when the captured turn count and the mounted DOM node count disagree (branching, streaming, redesign) every badge falls back to `unknown` rather than asserting a status it can't verify. Wired into `chatgpt.js`/`claude.js` and all three places the extension injects content scripts (`manifest.json`, `background.js`, `popup.js`).

**06zm** — new `POST`/`GET /v1/backfill-checkpoint` routes on the existing local receiver (`polylogue/browser_capture/{models,receiver,route_contracts,server}.py`), one JSON file per `extension_instance_id`, last-write-wins, same write-lock/quota pattern as the capture spool and post-command queue. The receiver treats the checkpoint body as opaque JSON (same trust boundary as the capture-envelope route). Extension side: `background.js` mirrors every checkpoint persist to the receiver (fire-and-forget, decoupled from the local write so a receiver outage never surfaces as a checkpoint error), and on coordinator construction, if both IndexedDB and the local `chrome.storage.local` copy are empty, falls back to GET-ing the receiver's mirrored checkpoint and restoring from it.

## Acceptance-criteria matrix

| Bead | Status | Evidence |
| --- | --- | --- |
| **polylogue-jlme.3** (stale receiver contract) | **already_done** | Merged PR #2819 (`4c3eb375b`) implements the full preflight/pause/resume contract described in the bead's AC. Verified the merge is on `origin/master` and the code (`ensureReceiverContract`, `receiverAckContractError`, `receiver_contract_incompatible` pause) is present in `browser-extension/src/backfill/coordinator.js`. No new code needed; bead notes were simply stale relative to the merge (written before the PR landed). |
| **polylogue-jlme.4** (ledger preservation across recovery) | **already_done** | Same PR #2819: `exportRecoveryCheckpoint`/`restoreRecoveryCheckpoint` in `storage.js`, `recoveryRequiredItem`/`recoveryCheckpointJob` state repair, `browser_profile_recovery_required` control-path guard in `coordinator.js`. |
| **polylogue-jlme.4.1** (Sinnix restart-vs-reseed) | **already_done** | Sinnix commit `2141c848b` ("preserve private Chrome profiles on restart", `#1`), confirmed on `origin/master` of the sinnix repo — separate-repo scope, out of bounds for this PR, but the work exists and is merged. |
| **polylogue-s8gb** (verify 4 paused oversized captures recover) | **misframed for this delivery model** | The bead's own description says "this Bead does not itself reload the extension, resume the live job, mutate browser profiles, or alter daemon services" — it's an operational live-verification task requiring an authenticated real browser session, not a code change. Its code prerequisites (PR #2823 "bound oversized backfill conversations", PR #2824 "recover bounded backfill captures safely") are confirmed merged on `origin/master`. Recommend the operator or a live-desktop session run the actual verification and record the four retry outcomes directly on the bead. |
| **polylogue-06zm** (receiver-owned durable ledger) | **partial** | AC1 (checkpoint visible via receiver) and AC2/AC3 (a profile loss that also destroys the local `chrome.storage.local` copy can still recover, demonstrating IndexedDB+local-copy are not the only durable source) are satisfied by this PR. AC4 (idempotent duplicate reconnects) is satisfied by the pre-existing `restoreRecoveryCheckpoint` empty-IndexedDB guard. AC5 (integration fixture) is satisfied at the Python HTTP-route level (real server, real POST+GET) and the JS level (background.test.js exercises the full mirror/restore flow against a mocked fetch); a true extension-to-daemon E2E fixture is not attempted (no live browser in this environment). **Explicitly NOT done**: correlating an orphaned checkpoint after a wipe that *also* destroys the extension's own `extension_instance_id` (stored in the same `chrome.storage.local`) — that needs an operator-facing "adopt an orphaned checkpoint" flow, which is real, separate follow-up work, not silently claimed here. |
| **polylogue-ys30** (Layer 1 blended capture dot) | **satisfied** | Full implementation + 15 dedicated tests (real-file JSDOM eval, not duplicated logic) covering mounting/dedup, native-content non-destruction, click/keyboard activation, all 5 states incl. the fail-closed mismatch path, MutationObserver churn, invalid-selector fail-closed, teardown, non-destructive positioning. Known, stated limitation: "zero measured layout shift" and live ChatGPT/Claude.ai selector accuracy are asserted structurally in jsdom, not visually verified against a real browser (none available in this environment). |
| **polylogue-bj5h** (selection→assertion authoring) | **deferred** | Not attempted. Per the operator's explicit guidance for this cluster ("fine to land ys30 solidly... say explicitly which of the four you completed vs deferred"), scope was concentrated on ys30 + 06zm rather than four shallow implementations. |
| **polylogue-wvji** (Layer 2 corner chip/slide-over) | **deferred** | Not attempted, same reasoning as bj5h. This is explicitly the *other* layer from ys30 (cross-conversation intelligence vs. per-message state) and was called out as the layer to defer. |
| **polylogue-4g3n** ("What Polylogue did here" timeline) | **already_done** (for this lane's scope) | Bead notes already record PR #2780 merged, satisfying the local persisted reverse-chron timeline AC. The daemon-queryable mirror is explicitly, correctly deferred in the bead's own notes to the substrate-owned portion ("this browser-extension lane does not modify polylogue/") — confirmed still true, no action needed here. |
| **polylogue-yyvg** (epic) | **not closed** | Epic tracks 12 children, only 5 of which (yyvg itself + bj5h/wvji/ys30/4g3n) were in this cluster; the others (bkff, r2kb, r4no closed; l40k, yqof, yyvg.1-3 open) are out of scope. Not touched. |

## Verification

- `npx vitest run tests/content/message_layer.test.js` — 15/15 passed.
- `npx vitest run` (browser-extension full suite) — 236/236 passed.
- `npm run lint` / `npm run validate` — clean; manifest v0.1.0 valid.
- `devtools test tests/unit/browser_capture/test_backfill_checkpoint.py` — 12/12 passed.
- `devtools test tests/unit/browser_capture/` — 101/101 passed (no regression in existing capture/post-command routes).
- `devtools verify --quick` — 15/15 steps passed (`20260714T002517Z-quick-821673-6e4aee84`): ruff format/check, mypy --strict, render all (grepped for "out of sync": none), topology, layering, closure-matrix, schema roundtrip, manifests, ci-workflows, doc-commands, test-infra-currency, test-clock-hygiene, pytest-timeout-overrides, degrade-loudly.

Per repo policy, GitHub Actions CI is disabled (billing-locked) — the above are the full local verification gates.

## Follow-ups

- polylogue-06zm remains open (partial): the orphaned-checkpoint-after-full-wipe correlation/adopt flow is real, separate work.
- polylogue-s8gb remains open: needs a live operator/desktop session to actually reload the extension and record the four retry outcomes.
- polylogue-bj5h, polylogue-wvji: untouched, ready for a dedicated pass.

Ref polylogue-ys30, polylogue-06zm, polylogue-jlme.3, polylogue-jlme.4, polylogue-jlme.4.1, polylogue-s8gb, polylogue-bj5h, polylogue-wvji, polylogue-4g3n, polylogue-yyvg.

Co-Authored-By: Claude <noreply@anthropic.com>