### PR TITLE
feat(storage): raw-identity evidence packets and duplicate-raw repair

### DIFF
--- a/polylogue/cli/commands/maintenance.py
+++ b/polylogue/cli/commands/maintenance.py
@@ -1812,6 +1812,172 @@ def legacy_browser_capture_missing_native_id_command(
         click.echo(f"Receipt: {report.receipt_path}")
 
 
+@maintenance_group.command("browser-canonical-authority-conflicts")
+@click.option(
+    "--raw-id",
+    "raw_ids",
+    multiple=True,
+    required=True,
+    help="Exact unknown-export raw id a safe rekey refuses (repeatable).",
+)
+@click.option(
+    "--record",
+    "record_blockers",
+    is_flag=True,
+    help="Persist each conflict as a durable, non-injected user.db blocker candidate.",
+)
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+)
+@click.pass_obj
+def browser_canonical_authority_conflicts_command(
+    env: AppEnv,
+    raw_ids: tuple[str, ...],
+    record_blockers: bool,
+    output_format: str,
+) -> None:
+    """Show why a byte-proven-rekey actuator refuses these browser-capture raws.
+
+    Read-only by default: re-runs the ordinary rekey actuator's exact
+    eligibility proof and, for every raw that stays ineligible, re-derives the
+    competing-authority evidence it discards on its own reject path (competing
+    head content hash/frontier kind/decision, any blocking membership row, and
+    -- when both sides are single-session byte-frontier raws -- the first
+    diverging message index). Never selects an authority between the two
+    histories. Pass ``--record`` to additionally persist each conflict as one
+    ``AssertionKind.BLOCKER`` candidate assertion in ``user.db`` (always
+    ``status=candidate``/``inject:false``; an operator must judge it
+    explicitly -- see ``polylogue mark`` / assertion judgment tooling).
+    """
+    del env
+    root = archive_root()
+    config = Config(archive_root=root, render_root=render_root(), sources=[], db_path=root / "index.db")
+    from polylogue.storage.repair import (
+        inspect_browser_canonical_authority_conflicts,
+        record_browser_canonical_authority_conflict_blockers,
+    )
+
+    assertion_ids: tuple[str, ...] = ()
+    try:
+        if record_blockers:
+            report, assertion_ids = record_browser_canonical_authority_conflict_blockers(config, list(raw_ids))
+        else:
+            report = inspect_browser_canonical_authority_conflicts(config, list(raw_ids))
+    except (RuntimeError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    payload: dict[str, Any] = asdict(report)
+    if record_blockers:
+        payload["assertion_ids"] = list(assertion_ids)
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    click.echo(f"requested={report.requested_count} conflicts={report.conflict_count} resolved={report.resolved_count}")
+    for item in report.items:
+        click.echo(
+            f"  {item.raw_id} competing={item.competing_raw_id or 'none'} "
+            f"frontier={item.competing_frontier_kind or 'unavailable'} "
+            f"divergent_message_index={item.divergent_message_index if item.divergent_message_index is not None else 'unavailable'}: "
+            f"{item.divergence_note or item.reason}"
+        )
+    if record_blockers:
+        for assertion_id in assertion_ids:
+            click.echo(f"Blocker: {assertion_id}")
+
+
+@maintenance_group.command("duplicate-raw-identity")
+@click.option(
+    "--pair",
+    "pairs",
+    multiple=True,
+    required=True,
+    metavar="STALE_RAW_ID:CANONICAL_RAW_ID",
+    help="Stale (currently accepted) and canonical (post-fix, dangling) raw id pair (repeatable).",
+)
+@click.option("--apply", "apply_changes", is_flag=True, help="Apply only after every pair passes exact proof.")
+@click.option("--proof-digest", help="Exact aggregate digest emitted by the matching dry-run.")
+@click.option(
+    "--receipt",
+    "receipt_path",
+    type=click.Path(path_type=Path, dir_okay=False),
+    help="Required append-only operator recovery receipt path for --apply.",
+)
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+)
+@click.pass_obj
+def duplicate_raw_identity_command(
+    env: AppEnv,
+    pairs: tuple[str, ...],
+    apply_changes: bool,
+    proof_digest: str | None,
+    receipt_path: Path | None,
+    output_format: str,
+) -> None:
+    """Reconcile a pre-#2729 duplicate raw pair onto its post-fix accepted head.
+
+    PR #2729 aligned new ingests on one deterministic raw-id scheme, but did
+    not retroactively repair raw pairs that already duplicated under the OLD
+    scheme: the accepted head stays bound to the stale raw while its
+    post-fix twin sits orphaned. This actuator proves both raws are
+    byte-identical retained duplicates of one logical session, then
+    repoints the accepted head and session pointer to the canonical raw via
+    the existing revision-application machinery. The stale raw's own row is
+    never mutated or deleted. Apply additionally writes an exclusive,
+    fsynced planned-then-applied operator receipt so the repair is
+    crash-resumable and auditable.
+    """
+    del env
+    if apply_changes and receipt_path is None:
+        raise click.UsageError("--apply requires --receipt PATH")
+    if apply_changes and proof_digest is None:
+        raise click.UsageError("--apply requires --proof-digest from the exact dry-run")
+    parsed_pairs: list[tuple[str, str]] = []
+    for pair in pairs:
+        stale_raw_id, sep, canonical_raw_id = pair.partition(":")
+        if not sep:
+            raise click.UsageError(f"--pair must be STALE_RAW_ID:CANONICAL_RAW_ID, got {pair!r}")
+        parsed_pairs.append((stale_raw_id, canonical_raw_id))
+    root = archive_root()
+    config = Config(archive_root=root, render_root=render_root(), sources=[], db_path=root / "index.db")
+    from polylogue.storage.repair import repair_duplicate_raw_identity
+
+    try:
+        report = repair_duplicate_raw_identity(
+            config,
+            parsed_pairs,
+            apply=apply_changes,
+            receipt_path=receipt_path,
+            proof_digest=proof_digest,
+        )
+    except (RuntimeError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    payload = asdict(report)
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    click.echo(
+        f"{report.mode}: requested={report.requested_count} eligible={report.eligible_count} "
+        f"already_repaired={report.already_repaired_count} repaired={report.repaired_count} "
+        f"ineligible={report.ineligible_count}"
+    )
+    click.echo(f"Proof digest: {report.proof_digest}")
+    for item in report.items:
+        click.echo(
+            f"  {item.stale_raw_id}->{item.canonical_raw_id} {item.status} "
+            f"proof={item.proof_digest or 'unavailable'}: {item.reason}"
+        )
+    if report.receipt_path is not None:
+        click.echo(f"Receipt: {report.receipt_path}")
+
+
 @maintenance_group.command("preview")
 @click.option(
     "--scope",

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -221,6 +221,45 @@ class _SemanticCanonicalWitness:
     digest: str
 
 
+@dataclass(frozen=True, slots=True)
+class BrowserCanonicalAuthorityConflictWitness:
+    """Read-only evidence packet for one unresolved browser-capture authority conflict.
+
+    Built for polylogue-lkrc.3: unlike :class:`BrowserCaptureOriginRepairItem`,
+    which collapses every rejection into a terse ``reason`` string, this packet
+    keeps the competing-head evidence that ``_inspect_browser_capture_origin_mismatch``
+    computes but discards on the ineligible path, so an operator can adjudicate
+    without re-deriving it by hand. Building this packet never mutates state and
+    never chooses an authority -- see ``record_browser_canonical_authority_conflict_blockers``
+    for the separate, explicit step that persists it as a durable candidate blocker.
+    """
+
+    raw_id: str
+    status: str
+    reason: str
+    session_id: str | None = None
+    old_logical_source_key: str | None = None
+    canonical_logical_source_key: str | None = None
+    unknown_raw_content_hash: str | None = None
+    unknown_raw_message_count: int | None = None
+    competing_raw_id: str | None = None
+    competing_content_hash: str | None = None
+    competing_frontier_kind: str | None = None
+    competing_decision: str | None = None
+    competing_message_count: int | None = None
+    divergent_message_index: int | None = None
+    divergence_note: str | None = None
+    evidence_digest: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserCanonicalAuthorityConflictReport:
+    requested_count: int
+    conflict_count: int
+    resolved_count: int
+    items: tuple[BrowserCanonicalAuthorityConflictWitness, ...]
+
+
 def _quarantined_raw_item(raw_id: str, reason: str) -> QuarantinedAcceptedRawRepairItem:
     return QuarantinedAcceptedRawRepairItem(raw_id=raw_id, status="ineligible", reason=reason)
 
@@ -3520,6 +3559,324 @@ def repair_byte_proven_browser_capture_null_native_ids(
         allow_byte_proven_null_native_id_rekey=True,
         receipt_schema=_BYTE_PROVEN_BROWSER_CAPTURE_REKEY_RECEIPT_SCHEMA,
     )
+
+
+def _browser_canonical_authority_conflict_witness(
+    archive_root: Path, conn: sqlite3.Connection, raw_id: str, base_reason: str
+) -> BrowserCanonicalAuthorityConflictWitness:
+    """Re-derive competing-authority evidence for one ineligible byte-proven-rekey raw.
+
+    Kept independent of ``_inspect_browser_capture_origin_mismatch`` (rather than
+    threading extra return fields through it): that function's job is to prove
+    or refuse a repair, and its many early-return branches deliberately discard
+    partial state once refused. This function's only job is to look, so it
+    re-derives the handful of facts a human adjudicator needs and fails soft
+    (``divergence_note`` explains any gap) instead of failing closed.
+    """
+
+    def ineligible(reason: str) -> BrowserCanonicalAuthorityConflictWitness:
+        return BrowserCanonicalAuthorityConflictWitness(
+            raw_id=raw_id, status="ineligible", reason=base_reason, divergence_note=reason
+        )
+
+    raw = conn.execute(
+        """
+        SELECT origin, source_path, blob_hash, blob_size
+        FROM source.raw_sessions WHERE raw_id = ?
+        """,
+        (raw_id,),
+    ).fetchone()
+    if raw is None or str(raw["origin"]) != Origin.UNKNOWN_EXPORT.value:
+        return ineligible("raw is missing or not typed unknown-export; cannot re-derive evidence")
+    source_path = str(raw["source_path"])
+    blob_hash = _bytes_value(raw["blob_hash"])
+    blob_size = int(raw["blob_size"])
+    try:
+        store = BlobStore(archive_root / "blob")
+        payload = store.read_all(blob_hash.hex())
+        if len(payload) != blob_size or hashlib.sha256(payload).digest() != blob_hash:
+            return ineligible("retained blob no longer matches the declared source envelope")
+        decoded = json.loads(payload)
+        provider = detect_provider(decoded)
+        if provider is None or provider is Provider.UNKNOWN:
+            return ineligible("retained envelope has no canonical provider identity")
+        from polylogue.sources.revision_backfill import _parse_one
+
+        sessions = _parse_one(provider, payload, source_path)
+        if len(sessions) != 1:
+            return ineligible(f"retained envelope normalized to {len(sessions)} sessions, expected 1")
+        session = sessions[0]
+        canonical_key = f"{provider.value}:{session.provider_session_id}"
+        session_id = str(make_session_id(provider, session.provider_session_id))
+        accepted_hash = bytes.fromhex(session_content_hash(session))
+        projection = session_revision_projection(session)
+    except Exception as exc:
+        logger.warning(
+            "browser canonical authority conflict evidence build failed",
+            raw_id=raw_id,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+        return ineligible(f"could not re-parse the retained envelope: {type(exc).__name__}")
+
+    head = conn.execute(
+        """
+        SELECT accepted_raw_id, accepted_source_revision, accepted_content_hash, accepted_frontier_kind
+        FROM raw_revision_heads WHERE logical_source_key = ?
+        """,
+        (canonical_key,),
+    ).fetchone()
+    # Deliberately not scoped to ``canonical_key``: the byte-proven-rekey
+    # actuator's precondition rejects on *any* retained membership row for
+    # this raw id (``COUNT(*) ... WHERE raw_id = ?`` with no key filter,
+    # ``_inspect_browser_capture_origin_mismatch``), including a stale row
+    # still keyed under the historical unknown-origin key. Matching that
+    # broader predicate here is what lets this function explain a
+    # ``superseded_equivalent``-shaped conflict instead of reporting a false
+    # "no competing evidence found".
+    membership = conn.execute(
+        """
+        SELECT decision, normalized_content_hash, message_count, logical_source_key
+        FROM source.raw_session_memberships
+        WHERE raw_id = ?
+        ORDER BY logical_source_key
+        LIMIT 1
+        """,
+        (raw_id,),
+    ).fetchone()
+
+    competing_raw_id: str | None = None
+    competing_content_hash: str | None = None
+    competing_frontier_kind: str | None = None
+    competing_decision: str | None = None
+    competing_message_count: int | None = None
+    divergent_message_index: int | None = None
+    divergence_note: str | None = None
+
+    if head is not None:
+        competing_raw_id = str(head["accepted_raw_id"])
+        competing_content_hash = _bytes_value(head["accepted_content_hash"]).hex()
+        competing_frontier_kind = str(head["accepted_frontier_kind"])
+        application = conn.execute(
+            """
+            SELECT decision FROM raw_revision_applications
+            WHERE logical_source_key = ? AND accepted_raw_id = ?
+            ORDER BY decision_id DESC LIMIT 1
+            """,
+            (canonical_key, competing_raw_id),
+        ).fetchone()
+        if application is not None:
+            competing_decision = str(application["decision"])
+        if competing_content_hash == accepted_hash.hex():
+            divergence_note = (
+                "competing head content hash matches; conflict is membership/precondition-shaped, not a hash divergence"
+            )
+        elif competing_frontier_kind == "byte" and competing_raw_id != raw_id:
+            try:
+                competing_source = conn.execute(
+                    "SELECT source_path FROM source.raw_sessions WHERE raw_id = ?", (competing_raw_id,)
+                ).fetchone()
+                competing_source_revision = str(head["accepted_source_revision"])
+                competing_payload = store.read_all(competing_source_revision)
+                competing_provider = detect_provider(json.loads(competing_payload))
+                if competing_provider is not None and competing_source is not None:
+                    competing_sessions = _parse_one(
+                        competing_provider, competing_payload, str(competing_source["source_path"])
+                    )
+                    if len(competing_sessions) == 1:
+                        competing_projection = session_revision_projection(competing_sessions[0])
+                        competing_message_count = len(competing_projection.message_hashes)
+                        divergent_message_index = next(
+                            (
+                                index
+                                for index, (left, right) in enumerate(
+                                    zip(projection.message_hashes, competing_projection.message_hashes, strict=False)
+                                )
+                                if left != right
+                            ),
+                            min(len(projection.message_hashes), len(competing_projection.message_hashes)),
+                        )
+            except Exception as exc:
+                logger.warning(
+                    "browser canonical authority conflict competing-head diff unavailable",
+                    raw_id=raw_id,
+                    competing_raw_id=competing_raw_id,
+                    error_type=type(exc).__name__,
+                    error=str(exc),
+                )
+                divergence_note = (
+                    f"competing head content hash differs; message-level diff unavailable: {type(exc).__name__}"
+                )
+        else:
+            divergence_note = (
+                "competing head content hash differs (semantic frontier; no single-raw message diff available)"
+            )
+    elif membership is not None:
+        divergence_note = (
+            f"no competing byte/semantic head at {canonical_key}; a retained membership row "
+            f"(decision={membership['decision']!r}) blocks the null-membership precondition instead"
+        )
+    else:
+        divergence_note = "no competing head or membership row found; re-run the ordinary rekey actuator"
+
+    packet = {
+        "raw_id": raw_id,
+        "session_id": session_id,
+        "canonical_logical_source_key": canonical_key,
+        "unknown_raw_content_hash": accepted_hash.hex(),
+        "competing_raw_id": competing_raw_id,
+        "competing_content_hash": competing_content_hash,
+        "competing_decision": competing_decision,
+        "divergent_message_index": divergent_message_index,
+    }
+    evidence_digest = hashlib.sha256(json.dumps(packet, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    return BrowserCanonicalAuthorityConflictWitness(
+        raw_id=raw_id,
+        status="ineligible",
+        reason=base_reason,
+        session_id=session_id,
+        old_logical_source_key=f"{Provider.UNKNOWN.value}:{session.provider_session_id}",
+        canonical_logical_source_key=canonical_key,
+        unknown_raw_content_hash=accepted_hash.hex(),
+        unknown_raw_message_count=len(projection.message_hashes),
+        competing_raw_id=competing_raw_id,
+        competing_content_hash=competing_content_hash,
+        competing_frontier_kind=competing_frontier_kind,
+        competing_decision=competing_decision,
+        competing_message_count=competing_message_count,
+        divergent_message_index=divergent_message_index,
+        divergence_note=divergence_note,
+        evidence_digest=evidence_digest,
+    )
+
+
+def inspect_browser_canonical_authority_conflicts(
+    config: Config, raw_ids: list[str]
+) -> BrowserCanonicalAuthorityConflictReport:
+    """Build read-only evidence packets for browser-capture raws a safe rekey refuses.
+
+    Companion to :func:`repair_byte_proven_browser_capture_null_native_ids`
+    (polylogue-lkrc.3): re-runs that actuator's exact eligibility proof for each
+    raw id. A raw that comes back ``eligible``/``already_repaired`` is not a
+    conflict -- the ordinary actuator already owns it -- and is only counted in
+    ``resolved_count``. A raw that stays ``ineligible`` gets an enriched
+    :class:`BrowserCanonicalAuthorityConflictWitness`: the competing canonical
+    head's content hash/frontier kind/decision, any blocking membership row, and
+    -- when both sides are single-session byte-frontier raws -- the first
+    diverging message index.
+
+    Never mutates state and never selects an authority between the two
+    histories; see :func:`record_browser_canonical_authority_conflict_blockers`
+    for the separate, explicit step that persists this as a durable,
+    operator-reviewable candidate blocker in ``user.db``.
+    """
+    if len(set(raw_ids)) != len(raw_ids):
+        raise ValueError("duplicate raw ids are not allowed")
+    if not raw_ids or len(raw_ids) > _QUARANTINED_ACCEPTED_RAW_REPAIR_LIMIT:
+        raise ValueError("raw-id list must contain 1..100 entries")
+    if any(re.fullmatch(r"[0-9a-f]{64}", raw_id) is None for raw_id in raw_ids):
+        raise ValueError("raw ids must be lowercase SHA-256 identifiers")
+    archive_root = _raw_materialization_archive_root(config)
+    source_db = archive_root / "source.db"
+    index_db = archive_root / "index.db"
+    if not source_db.exists() or not index_db.exists():
+        raise RuntimeError("source or index tier is missing")
+
+    items: list[BrowserCanonicalAuthorityConflictWitness] = []
+    resolved_count = 0
+    with closing(sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)) as conn:
+        conn.row_factory = sqlite3.Row
+        conn.execute("ATTACH DATABASE ? AS source", (str(source_db),))
+        for raw_id in raw_ids:
+            base = _inspect_browser_capture_origin_mismatch(
+                archive_root, raw_id, conn=conn, allow_byte_proven_null_native_id_rekey=True
+            )
+            if base.status != "ineligible":
+                resolved_count += 1
+                continue
+            items.append(_browser_canonical_authority_conflict_witness(archive_root, conn, raw_id, base.reason))
+    return BrowserCanonicalAuthorityConflictReport(
+        requested_count=len(raw_ids),
+        conflict_count=len(items),
+        resolved_count=resolved_count,
+        items=tuple(items),
+    )
+
+
+def record_browser_canonical_authority_conflict_blockers(
+    config: Config, raw_ids: list[str], *, now_ms: int | None = None
+) -> tuple[BrowserCanonicalAuthorityConflictReport, tuple[str, ...]]:
+    """Persist each unresolved conflict as a durable, non-injected ``BLOCKER`` candidate.
+
+    This is the explicit, separate step the lkrc.3 design requires: it never
+    picks an authority itself.  Each conflict becomes one
+    ``AssertionKind.BLOCKER`` candidate assertion in ``user.db``, keyed by a
+    deterministic id over the raw id and its evidence digest so re-running the
+    census after new evidence appears creates a new row instead of silently
+    overwriting the old one, while re-running it unchanged is idempotent. Like
+    every other automated writer through ``upsert_assertion``, the row is
+    written ``author_kind="detector"`` and is therefore always forced to
+    ``status=candidate`` with ``inject: false`` -- it can never self-promote to
+    an authoritative, context-injectable claim; an operator must explicitly
+    judge it (mirrors ``upsert_pathology_findings_as_assertions``, #2383).
+    """
+    from polylogue.storage.sqlite.archive_tiers.user_write import (
+        AssertionKind,
+        AssertionStatus,
+        AssertionVisibility,
+        upsert_assertion,
+    )
+
+    report = inspect_browser_canonical_authority_conflicts(config, raw_ids)
+    archive_root = _raw_materialization_archive_root(config)
+    user_db = archive_root / "user.db"
+    if not user_db.exists():
+        raise RuntimeError("user tier is not initialized")
+    timestamp = now_ms if now_ms is not None else int(time.time() * 1000)
+    scope_ref = "insight:browser-canonical-authority-conflict@v1"
+    assertion_ids: list[str] = []
+    conn = sqlite3.connect(user_db)
+    conn.row_factory = sqlite3.Row
+    try:
+        for item in report.items:
+            if item.session_id is None or item.evidence_digest is None:
+                continue
+            assertion_id = hashlib.sha256(
+                f"assertion-blocker-browser-canonical-authority-conflict\0{item.raw_id}\0{item.evidence_digest}".encode()
+            ).hexdigest()
+            envelope = upsert_assertion(
+                conn,
+                assertion_id=f"blocker:{assertion_id}",
+                scope_ref=scope_ref,
+                target_ref=f"session:{item.session_id}",
+                key=f"raw/{item.raw_id}",
+                kind=AssertionKind.BLOCKER,
+                value={
+                    "raw_id": item.raw_id,
+                    "canonical_logical_source_key": item.canonical_logical_source_key,
+                    "unknown_raw_content_hash": item.unknown_raw_content_hash,
+                    "unknown_raw_message_count": item.unknown_raw_message_count,
+                    "competing_raw_id": item.competing_raw_id,
+                    "competing_content_hash": item.competing_content_hash,
+                    "competing_frontier_kind": item.competing_frontier_kind,
+                    "competing_decision": item.competing_decision,
+                    "competing_message_count": item.competing_message_count,
+                    "divergent_message_index": item.divergent_message_index,
+                    "reason": item.reason,
+                },
+                body_text=item.divergence_note or item.reason,
+                author_ref=scope_ref,
+                author_kind="detector",
+                status=AssertionStatus.CANDIDATE,
+                visibility=AssertionVisibility.PRIVATE,
+                context_policy={"inject": False, "promotion_required": True},
+                now_ms=timestamp,
+            )
+            assertion_ids.append(envelope.assertion_id)
+        conn.commit()
+    finally:
+        conn.close()
+    return report, tuple(assertion_ids)
 
 
 def _format_bytes(value: int) -> str:

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -3788,13 +3788,29 @@ def inspect_browser_canonical_authority_conflicts(
         conn.row_factory = sqlite3.Row
         conn.execute("ATTACH DATABASE ? AS source", (str(source_db),))
         for raw_id in raw_ids:
-            base = _inspect_browser_capture_origin_mismatch(
-                archive_root, raw_id, conn=conn, allow_byte_proven_null_native_id_rekey=True
-            )
-            if base.status != "ineligible":
-                resolved_count += 1
-                continue
-            items.append(_browser_canonical_authority_conflict_witness(archive_root, conn, raw_id, base.reason))
+            # Hold one read transaction across the base eligibility proof and
+            # the witness's own re-reads of the same tables (raw_revision_heads,
+            # raw_session_memberships, raw_revision_applications) so both see
+            # one consistent snapshot. Without this, ``base.reason`` (the
+            # eligibility proof) and the witness's competing-head evidence
+            # are independent point-in-time reads on an autocommit
+            # connection -- a concurrent writer landing between the two
+            # calls could make the exported evidence packet describe a
+            # state inconsistent with the reason it's explaining. This is
+            # cheap read-snapshot isolation, not the apply-time CAS/receipt
+            # ceremony: this function never mutates state, so there is
+            # nothing to roll back -- COMMIT just releases the read lock.
+            conn.execute("BEGIN DEFERRED")
+            try:
+                base = _inspect_browser_capture_origin_mismatch(
+                    archive_root, raw_id, conn=conn, allow_byte_proven_null_native_id_rekey=True
+                )
+                if base.status != "ineligible":
+                    resolved_count += 1
+                    continue
+                items.append(_browser_canonical_authority_conflict_witness(archive_root, conn, raw_id, base.reason))
+            finally:
+                conn.execute("COMMIT")
     return BrowserCanonicalAuthorityConflictReport(
         requested_count=len(raw_ids),
         conflict_count=len(items),
@@ -3819,11 +3835,35 @@ def record_browser_canonical_authority_conflict_blockers(
     ``status=candidate`` with ``inject: false`` -- it can never self-promote to
     an authoritative, context-injectable claim; an operator must explicitly
     judge it (mirrors ``upsert_pathology_findings_as_assertions``, #2383).
+
+    Deliberately exempt from this file's apply-flag/proof-digest/receipt
+    ceremony (unlike ``repair_duplicate_raw_identity`` and every other
+    actuator in this module): that ceremony exists because those actuators
+    repoint *authoritative* identity state (``raw_revision_heads``,
+    ``sessions``) where an error is expensive to detect and reverse, so they
+    need a CAS re-proof under an exclusive transaction plus a crash-durable
+    receipt trail. This function never touches authoritative state -- it
+    writes exactly one ``candidate``/non-injected/private assertion, through
+    ``upsert_assertion``'s single write chokepoint, which already refuses to
+    resurrect a judged-terminal row (accepted/rejected/deferred/superseded)
+    back to candidate on a later automated write (see that function's
+    docstring). Concretely: (1) the row can never be read as an authoritative
+    claim (``inject: false``, ``promotion_required: true``); (2) an operator's
+    judgment on a previously-recorded blocker is never silently clobbered by a
+    re-run, even one racing this same function; (3) re-running with unchanged
+    evidence is a no-op (deterministic id), and re-running after new evidence
+    creates a new row rather than mutating the old one. This is the same
+    write-safety posture as every other detector-authored candidate writer in
+    this codebase (``upsert_pathology_findings_as_assertions``,
+    ``digest``-derived ``TRANSFORM_CANDIDATE`` rows) -- none of which carry an
+    apply flag either. Adding one here would be ceremony without a
+    corresponding risk to gate.
     """
     from polylogue.storage.sqlite.archive_tiers.user_write import (
         AssertionKind,
         AssertionStatus,
         AssertionVisibility,
+        read_assertion_envelope,
         upsert_assertion,
     )
 
@@ -3844,9 +3884,22 @@ def record_browser_canonical_authority_conflict_blockers(
             assertion_id = hashlib.sha256(
                 f"assertion-blocker-browser-canonical-authority-conflict\0{item.raw_id}\0{item.evidence_digest}".encode()
             ).hexdigest()
+            full_assertion_id = f"blocker:{assertion_id}"
+            existing = read_assertion_envelope(conn, full_assertion_id)
+            if existing is not None and existing.status != AssertionStatus.CANDIDATE:
+                # Mirror ``upsert_pathology_findings_as_assertions``: once an
+                # operator has judged a blocker (accepted/rejected/deferred/
+                # superseded), a re-run over unchanged evidence must not
+                # overwrite its display fields (value/body_text/evidence_refs
+                # are plain ``ON CONFLICT DO UPDATE`` columns in
+                # ``upsert_assertion`` -- only ``status`` itself is protected
+                # by that function's terminal-judgment chokepoint). Leave the
+                # judged row exactly as the operator left it.
+                assertion_ids.append(existing.assertion_id)
+                continue
             envelope = upsert_assertion(
                 conn,
-                assertion_id=f"blocker:{assertion_id}",
+                assertion_id=full_assertion_id,
                 scope_ref=scope_ref,
                 target_ref=f"session:{item.session_id}",
                 key=f"raw/{item.raw_id}",
@@ -3914,6 +3967,232 @@ class DuplicateRawIdentityRepairReport:
     proof_digest: str
     receipt_path: str | None
     items: tuple[DuplicateRawIdentityRepairItem, ...]
+
+
+def _duplicate_raw_identity_repair_targets(
+    items: list[DuplicateRawIdentityRepairItem],
+) -> list[dict[str, object]]:
+    """Identify each locked target by its requested ``(stale, canonical)`` pair only.
+
+    Deliberately narrower than the quarantined-raw receipt's full-item-proof
+    targets: for that actuator the accepted head is never touched by repair,
+    so a proven item's payload (including its head snapshot) is invariant
+    across "eligible" and "already_repaired" states and can safely anchor the
+    receipt. Here, repair *repoints* the accepted head (a fresh
+    ``decided_at_ms`` lands on every apply), so an item's full payload is NOT
+    invariant across states. Anchoring the receipt to the stable requested
+    identity instead lets a resumed invocation -- which necessarily re-proves
+    the CAS witness via a fresh ``proof_digest``, not a stale one -- validate
+    against the SAME on-disk receipt without a spurious "targets changed"
+    rejection caused only by the head's own repair-induced timestamp change.
+    """
+    return [{"stale_raw_id": item.stale_raw_id, "canonical_raw_id": item.canonical_raw_id} for item in items]
+
+
+@dataclass(slots=True)
+class _LockedDuplicateRawIdentityRepairReceipt:
+    path: Path
+    descriptor: int
+    target_hash: str
+    terminal: bool
+    repair_intent_stale_raw_ids: tuple[str, ...]
+    torn_terminals: tuple[bytes, ...] = ()
+    receipt_terminated: bool = True
+
+    def close(self) -> None:
+        fcntl.flock(self.descriptor, fcntl.LOCK_UN)
+        os.close(self.descriptor)
+
+
+def _validate_duplicate_raw_identity_repair_receipt_records(
+    parsed_receipt: tuple[list[dict[str, object] | bytes], bool],
+    *,
+    targets: list[dict[str, object]],
+    target_hash: str,
+) -> tuple[bool, tuple[str, ...], tuple[bytes, ...], bool]:
+    """Mirror ``_validate_repair_receipt_records`` keyed on ``stale_raw_id``.
+
+    Same planned/applied two-phase JSONL shape and torn-terminal recovery as
+    the quarantined-accepted-raw receipt (see that function's docstring) --
+    ``repair_duplicate_raw_identity`` needs the identical crash/audit
+    guarantees as every other live-archive actuator in this file.
+    """
+    records, terminated = parsed_receipt
+    if not records:
+        raise RuntimeError("existing repair receipt is empty")
+    planned = records[0]
+    if not isinstance(planned, dict):
+        raise RuntimeError("existing repair receipt does not start with valid planned JSON")
+    planned_keys = {"schema", "state", "target_hash", "targets", "repair_intent_stale_raw_ids", "planned_at_ms"}
+    if set(planned) != planned_keys or planned.get("schema") != _DUPLICATE_RAW_IDENTITY_REPAIR_RECEIPT_SCHEMA:
+        raise RuntimeError("existing repair receipt has an invalid planned record schema")
+    if planned.get("state") != "planned":
+        raise RuntimeError("existing repair receipt must start with a planned record")
+    if planned.get("target_hash") != target_hash or planned.get("targets") != targets:
+        raise RuntimeError("existing repair receipt targets do not match the proven repair set")
+    planned_at_ms = planned.get("planned_at_ms")
+    if not isinstance(planned_at_ms, int) or planned_at_ms < 0:
+        raise RuntimeError("existing repair receipt planned timestamp is invalid")
+    stale_raw_ids = tuple(str(target["stale_raw_id"]) for target in targets)
+    intent = planned.get("repair_intent_stale_raw_ids")
+    if not isinstance(intent, list) or any(not isinstance(raw_id, str) for raw_id in intent):
+        raise RuntimeError("existing repair receipt repair intent is invalid")
+    intent_ids = tuple(cast(list[str], intent))
+    if len(set(intent_ids)) != len(intent_ids) or any(raw_id not in stale_raw_ids for raw_id in intent_ids):
+        raise RuntimeError("existing repair receipt repair intent does not match its targets")
+    if len(records) == 1:
+        if not terminated:
+            raise RuntimeError("existing repair receipt has a torn planned record")
+        return False, intent_ids, (), terminated
+    tail = records[1:]
+    applied = tail[-1] if isinstance(tail[-1], dict) else None
+    torn_terminals = (
+        tuple(record for record in tail[:-1] if isinstance(record, bytes))
+        if applied
+        else tuple(record for record in tail if isinstance(record, bytes))
+    )
+    expected_tail_length = len(torn_terminals) + (1 if applied is not None else 0)
+    if len(tail) != expected_tail_length or any(not fragment for fragment in torn_terminals):
+        raise RuntimeError("existing repair receipt has an invalid state transition")
+    if applied is None:
+        return False, intent_ids, torn_terminals, terminated
+    if not terminated:
+        raise RuntimeError("existing repair receipt has an unterminated applied record")
+    recovered = bool(torn_terminals)
+    applied_keys = {
+        "schema",
+        "state",
+        "target_hash",
+        "applied_at_ms",
+        "repaired_stale_raw_ids",
+        "proven_stale_raw_ids",
+    }
+    if recovered:
+        applied_keys |= {"torn_terminals"}
+    if set(applied) != applied_keys or applied.get("schema") != _DUPLICATE_RAW_IDENTITY_REPAIR_RECEIPT_SCHEMA:
+        raise RuntimeError("existing repair receipt has an invalid applied record schema")
+    if applied.get("state") != "applied" or applied.get("target_hash") != target_hash:
+        raise RuntimeError("existing repair receipt has an invalid applied target transition")
+    applied_at_ms = applied.get("applied_at_ms")
+    if not isinstance(applied_at_ms, int) or applied_at_ms < 0:
+        raise RuntimeError("existing repair receipt applied timestamp is invalid")
+    repaired_ids = applied.get("repaired_stale_raw_ids")
+    if (
+        applied.get("proven_stale_raw_ids") != list(stale_raw_ids)
+        or not isinstance(repaired_ids, list)
+        or any(not isinstance(raw_id, str) for raw_id in repaired_ids)
+        or len(set(cast(list[str], repaired_ids))) != len(repaired_ids)
+        or any(raw_id not in intent_ids for raw_id in cast(list[str], repaired_ids))
+    ):
+        raise RuntimeError("existing repair receipt applied ids do not match the planned targets")
+    expected_torn_witnesses = [
+        {"bytes": len(fragment), "sha256": hashlib.sha256(fragment).hexdigest()} for fragment in torn_terminals
+    ]
+    if recovered and applied.get("torn_terminals") != expected_torn_witnesses:
+        raise RuntimeError("existing repair receipt recovery does not match its preserved torn terminal")
+    return True, intent_ids, torn_terminals, terminated
+
+
+def _lock_duplicate_raw_identity_repair_receipt(
+    path: Path,
+    items: list[DuplicateRawIdentityRepairItem],
+) -> _LockedDuplicateRawIdentityRepairReceipt:
+    """Lock one stable receipt inode and create or validate its planned record.
+
+    Same flock(LOCK_EX|LOCK_NB) + O_NOFOLLOW + fsync(file, then parent dir)
+    contract as ``_lock_quarantined_raw_repair_receipt`` -- a concurrent
+    ``--apply`` invocation against the same receipt path fails closed instead
+    of racing a bare ``Path.exists()`` check, and the planned record is
+    durable on disk (not merely in the process) before any mutation begins.
+    """
+    if path.is_symlink():
+        raise RuntimeError("repair receipt path must not be a symbolic link")
+    targets = _duplicate_raw_identity_repair_targets(items)
+    target_hash = hashlib.sha256(json.dumps(targets, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    repair_intent_stale_raw_ids = tuple(item.stale_raw_id for item in items if item.status == "eligible")
+    flags = os.O_RDWR | os.O_CREAT | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags, 0o600)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        os.close(descriptor)
+        raise RuntimeError("operator repair receipt is already locked by another apply") from exc
+    try:
+        opened = os.fstat(descriptor)
+        named = path.stat(follow_symlinks=False)
+        if (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino):
+            raise RuntimeError("operator repair receipt path changed while it was being locked")
+        if opened.st_size:
+            terminal, existing_intent, torn_terminals, terminated = (
+                _validate_duplicate_raw_identity_repair_receipt_records(
+                    _receipt_records(descriptor), targets=targets, target_hash=target_hash
+                )
+            )
+            return _LockedDuplicateRawIdentityRepairReceipt(
+                path,
+                descriptor,
+                target_hash,
+                terminal,
+                existing_intent,
+                torn_terminals,
+                terminated,
+            )
+        planned = {
+            "schema": _DUPLICATE_RAW_IDENTITY_REPAIR_RECEIPT_SCHEMA,
+            "state": "planned",
+            "target_hash": target_hash,
+            "targets": targets,
+            "repair_intent_stale_raw_ids": list(repair_intent_stale_raw_ids),
+            "planned_at_ms": int(time.time() * 1000),
+        }
+        encoded = (json.dumps(planned, sort_keys=True, separators=(",", ":")) + "\n").encode()
+        _write_receipt_all(descriptor, encoded)
+        os.fsync(descriptor)
+        _fsync_parent(path)
+        return _LockedDuplicateRawIdentityRepairReceipt(
+            path, descriptor, target_hash, False, repair_intent_stale_raw_ids
+        )
+    except Exception:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+        raise
+
+
+def _finish_duplicate_raw_identity_repair_receipt(
+    receipt: _LockedDuplicateRawIdentityRepairReceipt,
+    *,
+    items: list[DuplicateRawIdentityRepairItem],
+) -> None:
+    opened = os.fstat(receipt.descriptor)
+    named = receipt.path.stat(follow_symlinks=False)
+    if (opened.st_dev, opened.st_ino) != (named.st_dev, named.st_ino):
+        raise RuntimeError("operator repair receipt path changed before terminal append")
+    os.lseek(receipt.descriptor, 0, os.SEEK_END)
+    preserved_torn_terminals = list(receipt.torn_terminals)
+    if preserved_torn_terminals and not receipt.receipt_terminated:
+        # Make even a complete-JSON prefix permanently distinguishable from a
+        # terminal record after the newline is appended, matching the
+        # quarantined-raw receipt's torn-write recovery contract.
+        _write_receipt_all(receipt.descriptor, b"\xff\n")
+        preserved_torn_terminals[-1] += b"\xff"
+    terminal: dict[str, object] = {
+        "schema": _DUPLICATE_RAW_IDENTITY_REPAIR_RECEIPT_SCHEMA,
+        "state": "applied",
+        "target_hash": receipt.target_hash,
+        "applied_at_ms": int(time.time() * 1000),
+        "repaired_stale_raw_ids": [item.stale_raw_id for item in items if item.repaired],
+        "proven_stale_raw_ids": [item.stale_raw_id for item in items],
+    }
+    if preserved_torn_terminals:
+        terminal["torn_terminals"] = [
+            {"bytes": len(fragment), "sha256": hashlib.sha256(fragment).hexdigest()}
+            for fragment in preserved_torn_terminals
+        ]
+    _write_receipt_all(
+        receipt.descriptor, (json.dumps(terminal, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    )
+    os.fsync(receipt.descriptor)
+    _fsync_parent(receipt.path)
 
 
 def _duplicate_raw_identity_ineligible(
@@ -4204,50 +4483,45 @@ def repair_duplicate_raw_identity(
         raise RuntimeError("apply proof digest does not match the exact dry-run target list")
     if apply:
         assert receipt_path is not None
-        if receipt_path.exists():
-            raise RuntimeError("receipt path already exists; choose a fresh operator receipt path")
         receipt_path.parent.mkdir(parents=True, exist_ok=True)
-        with closing(sqlite3.connect(f"file:{index_db}?mode=rw", uri=True)) as conn:
-            conn.row_factory = sqlite3.Row
-            conn.execute("PRAGMA foreign_keys = ON")
-            conn.execute("ATTACH DATABASE ? AS source", (f"file:{source_db}?mode=ro",))
-            conn.execute("BEGIN IMMEDIATE")
-            try:
-                locked = inspect(conn)
-                locked_digest = hashlib.sha256(
-                    json.dumps([item.proof_digest for item in locked], separators=(",", ":")).encode()
-                ).hexdigest()
-                if locked_digest != proof_digest:
-                    raise RuntimeError("authority proof changed after acquiring the repair transaction")
-                if any(item.status == "ineligible" for item in locked):
-                    raise RuntimeError("a duplicate raw identity target became ineligible")
-                for item in locked:
-                    if item.status == "eligible":
-                        _apply_duplicate_raw_identity_repair(conn, item)
-                after = inspect(conn)
-                if any(item.status != "already_repaired" for item in after):
-                    raise RuntimeError("duplicate raw identity repair did not reach terminal state")
-                conn.commit()
-            except Exception:
-                conn.rollback()
-                raise
-        items = [
-            dataclasses.replace(after_item, repaired=before.status == "eligible")
-            for before, after_item in zip(locked, after, strict=True)
-        ]
-        receipt_path.write_text(
-            json.dumps(
-                {
-                    "schema": _DUPLICATE_RAW_IDENTITY_REPAIR_RECEIPT_SCHEMA,
-                    "state": "applied",
-                    "proof_digest": aggregate,
-                    "items": [dataclasses.asdict(item) for item in items],
-                },
-                sort_keys=True,
-                separators=(",", ":"),
-            )
-            + "\n"
-        )
+        receipt = _lock_duplicate_raw_identity_repair_receipt(receipt_path, items)
+        try:
+            with closing(sqlite3.connect(f"file:{index_db}?mode=rw", uri=True)) as conn:
+                conn.row_factory = sqlite3.Row
+                conn.execute("PRAGMA foreign_keys = ON")
+                conn.execute("ATTACH DATABASE ? AS source", (f"file:{source_db}?mode=ro",))
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    locked = inspect(conn)
+                    locked_digest = hashlib.sha256(
+                        json.dumps([item.proof_digest for item in locked], separators=(",", ":")).encode()
+                    ).hexdigest()
+                    if locked_digest != proof_digest:
+                        raise RuntimeError("authority proof changed after acquiring the repair transaction")
+                    if any(item.status == "ineligible" for item in locked):
+                        raise RuntimeError("a duplicate raw identity target became ineligible")
+                    if receipt.terminal and any(item.status != "already_repaired" for item in locked):
+                        raise RuntimeError("terminal operator receipt disagrees with durable index authority")
+                    if receipt.torn_terminals and any(item.status != "already_repaired" for item in locked):
+                        raise RuntimeError("torn terminal receipt has no matching committed index refinement")
+                    for item in locked:
+                        if item.status == "eligible":
+                            _apply_duplicate_raw_identity_repair(conn, item)
+                    after = inspect(conn)
+                    if any(item.status != "already_repaired" for item in after):
+                        raise RuntimeError("duplicate raw identity repair did not reach terminal state")
+                    conn.commit()
+                except Exception:
+                    conn.rollback()
+                    raise
+            items = [
+                dataclasses.replace(after_item, repaired=before.status == "eligible")
+                for before, after_item in zip(locked, after, strict=True)
+            ]
+            if not receipt.terminal:
+                _finish_duplicate_raw_identity_repair_receipt(receipt, items=items)
+        finally:
+            receipt.close()
     return DuplicateRawIdentityRepairReport(
         mode="apply" if apply else "dry-run",
         requested_count=len(items),

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -3879,6 +3879,388 @@ def record_browser_canonical_authority_conflict_blockers(
     return report, tuple(assertion_ids)
 
 
+# --- polylogue-t0dy: reconcile pre-#2729 duplicate-raw scheme ---
+
+_DUPLICATE_RAW_IDENTITY_REPAIR_RECEIPT_SCHEMA = "polylogue.duplicate-raw-identity-repair.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class DuplicateRawIdentityRepairItem:
+    stale_raw_id: str
+    canonical_raw_id: str
+    status: str
+    reason: str
+    session_id: str | None = None
+    logical_source_key: str | None = None
+    origin: str | None = None
+    source_path: str | None = None
+    accepted_source_revision: str | None = None
+    accepted_content_hash: str | None = None
+    accepted_frontier_kind: str | None = None
+    accepted_frontier: int | None = None
+    accepted_decided_at_ms: int | None = None
+    proof_digest: str | None = None
+    repaired: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class DuplicateRawIdentityRepairReport:
+    mode: str
+    requested_count: int
+    eligible_count: int
+    repaired_count: int
+    already_repaired_count: int
+    ineligible_count: int
+    proof_digest: str
+    receipt_path: str | None
+    items: tuple[DuplicateRawIdentityRepairItem, ...]
+
+
+def _duplicate_raw_identity_ineligible(
+    stale_raw_id: str, canonical_raw_id: str, reason: str
+) -> DuplicateRawIdentityRepairItem:
+    return DuplicateRawIdentityRepairItem(
+        stale_raw_id=stale_raw_id, canonical_raw_id=canonical_raw_id, status="ineligible", reason=reason
+    )
+
+
+def _duplicate_raw_identity_proof_digest(item: DuplicateRawIdentityRepairItem) -> str:
+    payload = {
+        key: value
+        for key, value in dataclasses.asdict(item).items()
+        if key not in {"proof_digest", "reason", "repaired", "status"}
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _inspect_duplicate_raw_identity(
+    conn: sqlite3.Connection, archive_root: Path, stale_raw_id: str, canonical_raw_id: str
+) -> DuplicateRawIdentityRepairItem:
+    """Prove one ``(stale, canonical)`` raw pair is the exact pre-/post-#2729 duplicate shape.
+
+    Both raws must carry byte-identical content; each raw id must equal the
+    deterministic id its own recorded fields predict under its own scheme
+    (``native_id``-inclusive for the stale raw, ``native_id=NULL`` for the
+    canonical raw -- see ``deterministic_raw_session_id``, #2729); the stale
+    raw must be the *current* accepted head and session pointer; and the
+    canonical raw must be a genuinely dangling duplicate -- not itself an
+    accepted head or session pointer anywhere. Read-only; never mutates state.
+    """
+    from polylogue.storage.sqlite.archive_tiers.source_write import deterministic_raw_session_id
+
+    def ineligible(reason: str) -> DuplicateRawIdentityRepairItem:
+        return _duplicate_raw_identity_ineligible(stale_raw_id, canonical_raw_id, reason)
+
+    if stale_raw_id == canonical_raw_id:
+        return ineligible("stale and canonical raw ids must differ")
+    fields = "origin, native_id, source_path, source_index, blob_hash, blob_size"
+    stale = conn.execute(f"SELECT {fields} FROM source.raw_sessions WHERE raw_id = ?", (stale_raw_id,)).fetchone()
+    canonical = conn.execute(
+        f"SELECT {fields} FROM source.raw_sessions WHERE raw_id = ?", (canonical_raw_id,)
+    ).fetchone()
+    if stale is None or canonical is None:
+        return ineligible("one or both raw rows are missing")
+    if stale["native_id"] is None:
+        return ineligible("stale raw must carry the pre-#2729 native_id-inclusive scheme")
+    if canonical["native_id"] is not None:
+        return ineligible("canonical raw must carry the post-#2729 native_id=NULL scheme")
+    identity_fields = ("origin", "source_path", "source_index", "blob_hash", "blob_size")
+    if tuple(stale[name] for name in identity_fields) != tuple(canonical[name] for name in identity_fields):
+        return ineligible("stale and canonical raws do not share identical origin/source_path/blob content")
+    stale_blob_hash = _bytes_value(stale["blob_hash"])
+    blob_size = int(stale["blob_size"])
+    expected_stale_id = deterministic_raw_session_id(
+        str(stale["origin"]),
+        str(stale["source_path"]),
+        int(stale["source_index"]),
+        stale_blob_hash,
+        native_id=str(stale["native_id"]),
+    )
+    expected_canonical_id = deterministic_raw_session_id(
+        str(canonical["origin"]),
+        str(canonical["source_path"]),
+        int(canonical["source_index"]),
+        stale_blob_hash,
+        native_id=None,
+    )
+    if expected_stale_id != stale_raw_id:
+        return ineligible("stale raw id does not match the deterministic pre-#2729 id for its own fields")
+    if expected_canonical_id != canonical_raw_id:
+        return ineligible("canonical raw id does not match the deterministic post-#2729 id for its own fields")
+    try:
+        # BlobStore is content-addressed by ``blob_hash``, and the equality
+        # check above already proved both raws declare the identical hash, so
+        # a single read resolves to the one physical blob file either raw
+        # would read -- there is no separate "canonical blob" to diverge from
+        # it short of a SHA-256 collision. This still proves the retained
+        # bytes genuinely match the declared digest/size rather than trusting
+        # the ``raw_sessions`` columns blindly.
+        store = BlobStore(archive_root / "blob")
+        payload = store.read_all(stale_blob_hash.hex())
+        if len(payload) != blob_size or hashlib.sha256(payload).digest() != stale_blob_hash:
+            return ineligible("retained blob content does not match its declared digest/size")
+    except (OSError, ValueError):
+        return ineligible("retained blob for one or both raws is missing or unreadable")
+
+    stale_head = conn.execute(
+        """
+        SELECT logical_source_key, session_id, accepted_source_revision, accepted_content_hash,
+               accepted_frontier_kind, accepted_frontier, decided_at_ms
+        FROM raw_revision_heads WHERE accepted_raw_id = ?
+        """,
+        (stale_raw_id,),
+    ).fetchone()
+    canonical_head = conn.execute(
+        "SELECT logical_source_key FROM raw_revision_heads WHERE accepted_raw_id = ?", (canonical_raw_id,)
+    ).fetchone()
+
+    if stale_head is None:
+        if canonical_head is not None:
+            head_key = str(canonical_head["logical_source_key"])
+            session = conn.execute(
+                "SELECT session_id, raw_id FROM sessions WHERE raw_id = ?", (canonical_raw_id,)
+            ).fetchone()
+            # An immutable ``raw_revision_applications`` row is append-only and
+            # its ``decision_id`` is a content hash, not a sequence -- ordering
+            # by it to find the "latest" decision for this (raw_id, key) is
+            # meaningless. The stale raw legitimately carries both an old
+            # ``selected_baseline`` receipt (from before repair) and the new
+            # ``superseded`` receipt (from repair); only presence of the
+            # latter proves this exact pair was already repaired.
+            stale_superseded = conn.execute(
+                """
+                SELECT 1 FROM raw_revision_applications
+                WHERE raw_id = ? AND logical_source_key = ? AND decision = ? AND accepted_raw_id = ?
+                """,
+                (stale_raw_id, head_key, ApplicationDecision.SUPERSEDED.value, canonical_raw_id),
+            ).fetchone()
+            if session is not None and stale_superseded is not None:
+                return DuplicateRawIdentityRepairItem(
+                    stale_raw_id=stale_raw_id,
+                    canonical_raw_id=canonical_raw_id,
+                    status="already_repaired",
+                    reason="",
+                    session_id=str(session["session_id"]),
+                    logical_source_key=head_key,
+                )
+        return ineligible("stale raw is not the currently accepted head of any logical source key")
+    if canonical_head is not None:
+        return ineligible("canonical raw is already an accepted head; not a dangling duplicate")
+    session = conn.execute(
+        "SELECT session_id, raw_id FROM sessions WHERE session_id = ?", (stale_head["session_id"],)
+    ).fetchone()
+    if session is None or str(session["raw_id"]) != stale_raw_id:
+        return ineligible("session raw pointer does not match the accepted head")
+    if conn.execute("SELECT 1 FROM sessions WHERE raw_id = ?", (canonical_raw_id,)).fetchone() is not None:
+        return ineligible("canonical raw is already referenced by a different session pointer")
+
+    item = DuplicateRawIdentityRepairItem(
+        stale_raw_id=stale_raw_id,
+        canonical_raw_id=canonical_raw_id,
+        status="eligible",
+        reason="",
+        session_id=str(stale_head["session_id"]),
+        logical_source_key=str(stale_head["logical_source_key"]),
+        origin=str(stale["origin"]),
+        source_path=str(stale["source_path"]),
+        accepted_source_revision=str(stale_head["accepted_source_revision"]),
+        accepted_content_hash=_bytes_value(stale_head["accepted_content_hash"]).hex(),
+        accepted_frontier_kind=str(stale_head["accepted_frontier_kind"]),
+        accepted_frontier=int(stale_head["accepted_frontier"]),
+        accepted_decided_at_ms=int(stale_head["decided_at_ms"]),
+    )
+    return dataclasses.replace(item, proof_digest=_duplicate_raw_identity_proof_digest(item))
+
+
+def _apply_duplicate_raw_identity_repair(conn: sqlite3.Connection, item: DuplicateRawIdentityRepairItem) -> None:
+    from polylogue.storage.sqlite.archive_tiers.revision_application import (
+        RevisionApplicationReceipt,
+        record_revision_application_sync,
+    )
+
+    assert item.session_id is not None
+    assert item.logical_source_key is not None
+    assert item.accepted_source_revision is not None
+    assert item.accepted_content_hash is not None
+    assert item.accepted_frontier_kind is not None
+    assert item.accepted_frontier is not None
+    decided_at_ms = int(time.time() * 1000)
+    accepted_hash = bytes.fromhex(item.accepted_content_hash)
+    # Reuse the ordinary revision-application CAS (rather than a hand-written
+    # ``UPDATE raw_revision_heads``, per the design note): session_id,
+    # accepted_content_hash, accepted_frontier_kind, and accepted_frontier are
+    # all unchanged from the current head (the two raws are byte-identical),
+    # so this is exactly the "equivalent-content" acceptance path -- only
+    # accepted_raw_id repoints, from the stale raw to its canonical twin.
+    record_revision_application_sync(
+        conn,
+        RevisionApplicationReceipt(
+            raw_id=item.canonical_raw_id,
+            session_id=item.session_id,
+            logical_source_key=item.logical_source_key,
+            source_revision=item.accepted_source_revision,
+            acquisition_generation=0,
+            decision=ApplicationDecision.SELECTED_BASELINE,
+            accepted_raw_id=item.canonical_raw_id,
+            accepted_source_revision=item.accepted_source_revision,
+            accepted_content_hash=accepted_hash,
+            accepted_frontier_kind=item.accepted_frontier_kind,
+            accepted_frontier=item.accepted_frontier,
+            baseline_raw_id=item.canonical_raw_id if item.accepted_frontier_kind == "byte" else None,
+            detail=f"duplicate_raw_identity_repair:{item.stale_raw_id}->{item.canonical_raw_id}",
+        ),
+        decided_at_ms=decided_at_ms,
+    )
+    cursor = conn.execute(
+        "UPDATE sessions SET raw_id = ? WHERE session_id = ? AND raw_id = ?",
+        (item.canonical_raw_id, item.session_id, item.stale_raw_id),
+    )
+    if cursor.rowcount != 1:
+        raise RuntimeError(f"session raw pointer CAS failed for {item.stale_raw_id}")
+    record_revision_application_sync(
+        conn,
+        RevisionApplicationReceipt(
+            raw_id=item.stale_raw_id,
+            session_id=item.session_id,
+            logical_source_key=item.logical_source_key,
+            source_revision=item.accepted_source_revision,
+            acquisition_generation=0,
+            decision=ApplicationDecision.SUPERSEDED,
+            accepted_raw_id=item.canonical_raw_id,
+            accepted_source_revision=item.accepted_source_revision,
+            accepted_content_hash=accepted_hash,
+            accepted_frontier_kind=item.accepted_frontier_kind,
+            accepted_frontier=item.accepted_frontier,
+            detail=f"duplicate_raw_identity_supersession:{item.stale_raw_id}",
+        ),
+        decided_at_ms=decided_at_ms,
+    )
+
+
+def repair_duplicate_raw_identity(
+    config: Config,
+    pairs: list[tuple[str, str]],
+    *,
+    apply: bool = False,
+    receipt_path: Path | None = None,
+    proof_digest: str | None = None,
+) -> DuplicateRawIdentityRepairReport:
+    """Repoint an accepted head from a pre-#2729 duplicate raw to its post-fix twin.
+
+    polylogue-t0dy: PR #2729 aligned the one-shot importer and the live daemon
+    watcher on one deterministic raw-id scheme (no ``native_id``) so *new*
+    ingests of a grouped/split-session file converge on one raw row instead of
+    duplicating. It explicitly does not retroactively repair raw pairs that
+    already duplicated under the OLD, native_id-inclusive scheme before that
+    fix landed: the accepted head stays bound to the stale raw, and its
+    post-fix, correctly-keyed twin sits orphaned, so every later daemon
+    catch-up pass over that file hits ``RuntimeError: membership replay cannot
+    retire an unrelated accepted head`` (archive.py).
+
+    Each ``(stale_raw_id, canonical_raw_id)`` pair is proven independently by
+    :func:`_inspect_duplicate_raw_identity`: both raws must be verified
+    byte-identical, each raw id must equal the deterministic id its own fields
+    (and native_id shape) predict, the stale raw must be the CURRENT accepted
+    head/session pointer, and the canonical raw must not already be referenced
+    by any head or session -- a genuinely dangling duplicate, never a
+    competing authority. No durable raw/blob row is ever deleted or mutated in
+    place; the stale raw keeps its bytes and gains an immutable ``superseded``
+    application receipt.
+    """
+    if len(pairs) != len({stale for stale, _ in pairs}) or len(pairs) != len({canonical for _, canonical in pairs}):
+        raise ValueError("duplicate stale or canonical raw ids are not allowed")
+    if not pairs or len(pairs) > _QUARANTINED_ACCEPTED_RAW_REPAIR_LIMIT:
+        raise ValueError("raw-id pair list must contain 1..100 entries")
+    for stale_raw_id, canonical_raw_id in pairs:
+        for raw_id in (stale_raw_id, canonical_raw_id):
+            if re.fullmatch(r"[0-9a-f]{64}", raw_id) is None:
+                raise ValueError("raw ids must be lowercase SHA-256 identifiers")
+    block_reason = offline_maintenance_block_reason(config, active=apply, dry_run=not apply)
+    if block_reason is not None:
+        raise RuntimeError(block_reason)
+    archive_root = _raw_materialization_archive_root(config)
+    source_db = archive_root / "source.db"
+    index_db = archive_root / "index.db"
+    if not source_db.exists() or not index_db.exists():
+        raise RuntimeError("source or index tier is missing")
+
+    def inspect(connection: sqlite3.Connection) -> list[DuplicateRawIdentityRepairItem]:
+        return [
+            _inspect_duplicate_raw_identity(connection, archive_root, stale, canonical) for stale, canonical in pairs
+        ]
+
+    with closing(sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)) as conn:
+        conn.row_factory = sqlite3.Row
+        conn.execute("ATTACH DATABASE ? AS source", (f"file:{source_db}?mode=ro",))
+        items = inspect(conn)
+    aggregate = hashlib.sha256(
+        json.dumps([item.proof_digest for item in items], separators=(",", ":")).encode()
+    ).hexdigest()
+    if apply and any(item.status == "ineligible" for item in items):
+        raise RuntimeError("duplicate raw identity repair refused because one or more targets are ineligible")
+    if apply and receipt_path is None:
+        raise ValueError("apply requires an explicit operator repair receipt path")
+    if apply and proof_digest != aggregate:
+        raise RuntimeError("apply proof digest does not match the exact dry-run target list")
+    if apply:
+        assert receipt_path is not None
+        if receipt_path.exists():
+            raise RuntimeError("receipt path already exists; choose a fresh operator receipt path")
+        receipt_path.parent.mkdir(parents=True, exist_ok=True)
+        with closing(sqlite3.connect(f"file:{index_db}?mode=rw", uri=True)) as conn:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA foreign_keys = ON")
+            conn.execute("ATTACH DATABASE ? AS source", (f"file:{source_db}?mode=ro",))
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                locked = inspect(conn)
+                locked_digest = hashlib.sha256(
+                    json.dumps([item.proof_digest for item in locked], separators=(",", ":")).encode()
+                ).hexdigest()
+                if locked_digest != proof_digest:
+                    raise RuntimeError("authority proof changed after acquiring the repair transaction")
+                if any(item.status == "ineligible" for item in locked):
+                    raise RuntimeError("a duplicate raw identity target became ineligible")
+                for item in locked:
+                    if item.status == "eligible":
+                        _apply_duplicate_raw_identity_repair(conn, item)
+                after = inspect(conn)
+                if any(item.status != "already_repaired" for item in after):
+                    raise RuntimeError("duplicate raw identity repair did not reach terminal state")
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+        items = [
+            dataclasses.replace(after_item, repaired=before.status == "eligible")
+            for before, after_item in zip(locked, after, strict=True)
+        ]
+        receipt_path.write_text(
+            json.dumps(
+                {
+                    "schema": _DUPLICATE_RAW_IDENTITY_REPAIR_RECEIPT_SCHEMA,
+                    "state": "applied",
+                    "proof_digest": aggregate,
+                    "items": [dataclasses.asdict(item) for item in items],
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        )
+    return DuplicateRawIdentityRepairReport(
+        mode="apply" if apply else "dry-run",
+        requested_count=len(items),
+        eligible_count=sum(item.status == "eligible" for item in items),
+        repaired_count=sum(item.repaired for item in items),
+        already_repaired_count=sum(item.status == "already_repaired" for item in items),
+        ineligible_count=sum(item.status == "ineligible" for item in items),
+        proof_digest=aggregate,
+        receipt_path=str(receipt_path) if receipt_path is not None else None,
+        items=tuple(items),
+    )
+
+
 def _format_bytes(value: int) -> str:
     units = ("B", "KiB", "MiB", "GiB", "TiB")
     amount = float(max(value, 0))

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -1491,6 +1491,159 @@ def test_legacy_browser_native_id_repair_cli_is_bounded_and_requires_receipt_pro
     assert "--receipt" in missing_receipt.output
 
 
+def test_browser_canonical_authority_conflicts_cli_is_read_only_by_default(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    del cli_workspace
+    raw_id = "d" * 64
+    dry_run = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "browser-canonical-authority-conflicts",
+            "--raw-id",
+            raw_id,
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert dry_run.exit_code == 0
+    payload = json.loads(dry_run.output)
+    assert payload["requested_count"] == 1
+    assert "assertion_ids" not in payload
+
+    plain = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "browser-canonical-authority-conflicts", "--raw-id", raw_id],
+        catch_exceptions=False,
+    )
+    assert plain.exit_code == 0
+    assert "Blocker:" not in plain.output
+
+
+def test_browser_canonical_authority_conflicts_cli_record_calls_the_recording_path(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    """``--record`` routes through ``record_browser_canonical_authority_conflict_blockers``.
+
+    Exercises the CLI adapter's ``--record`` branch (polylogue-hleq NIT): the
+    JSON payload gains an ``assertion_ids`` key (absent without ``--record``,
+    per the sibling read-only test) and the plain-output loop over
+    ``assertion_ids`` runs without error. A raw id with no resolvable session
+    (this test's fixture) is exactly the shape
+    ``record_browser_canonical_authority_conflict_blockers`` itself declines
+    to persist a blocker for (no ``session_id`` to target), so this proves the
+    CLI calls the recording function and surfaces its real (empty) result
+    rather than fabricating one; the deep persistence/idempotency/judged-row-
+    protection behavior of the recording function itself is covered at the
+    storage layer in ``test_browser_capture_origin_repair.py``.
+    """
+    archive_root = cli_workspace["archive_root"]
+    raw_id = "e" * 64
+    dry_run = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "browser-canonical-authority-conflicts",
+            "--raw-id",
+            raw_id,
+            "--record",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert dry_run.exit_code == 0
+    payload = json.loads(dry_run.output)
+    assert payload["assertion_ids"] == []
+    with sqlite3.connect(archive_root / "user.db") as user_conn:
+        count = user_conn.execute("SELECT COUNT(*) FROM assertions WHERE kind = 'blocker'").fetchone()[0]
+        assert count == 0
+
+    plain = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "browser-canonical-authority-conflicts", "--raw-id", raw_id, "--record"],
+        catch_exceptions=False,
+    )
+    assert plain.exit_code == 0
+    assert "Blocker:" not in plain.output
+
+
+def test_duplicate_raw_identity_cli_dry_run_is_bounded_and_requires_receipt_proof(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    del cli_workspace
+    stale_raw_id = "f" * 64
+    canonical_raw_id = "0" * 64
+    dry_run = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "duplicate-raw-identity",
+            "--pair",
+            f"{stale_raw_id}:{canonical_raw_id}",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert dry_run.exit_code == 0
+    payload = json.loads(dry_run.output)
+    assert payload["mode"] == "dry-run"
+    assert payload["requested_count"] == 1
+    assert payload["ineligible_count"] == 1
+    assert payload["items"][0]["stale_raw_id"] == stale_raw_id
+    assert payload["items"][0]["canonical_raw_id"] == canonical_raw_id
+
+    malformed = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "duplicate-raw-identity", "--pair", "not-a-pair"],
+    )
+    assert malformed.exit_code == 2
+    assert "STALE_RAW_ID:CANONICAL_RAW_ID" in malformed.output
+
+    missing_receipt = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "duplicate-raw-identity",
+            "--pair",
+            f"{stale_raw_id}:{canonical_raw_id}",
+            "--apply",
+        ],
+    )
+    assert missing_receipt.exit_code == 2
+    assert "--receipt" in missing_receipt.output
+    missing_proof = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "duplicate-raw-identity",
+            "--pair",
+            f"{stale_raw_id}:{canonical_raw_id}",
+            "--apply",
+            "--receipt",
+            "repair.jsonl",
+        ],
+    )
+    assert missing_proof.exit_code == 2
+    assert "--proof-digest" in missing_proof.output
+
+
 def test_archive_read_cli_lists_archive_sessions(
     cli_workspace: dict[str, Path],
     cli_runner: CliRunner,

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -273,6 +273,160 @@ def _seed_equivalent_canonical_head(root: Path, mismatched_raw_id: str) -> str:
     return raw_id
 
 
+def _diverging_browser_payload(native_id: str = "browser-origin-one") -> bytes:
+    """A same-shape browser capture whose *content* genuinely differs from ``_browser_payload``.
+
+    Two messages instead of one, and the first message's text differs from
+    ``_browser_payload``'s -- so a competing byte-proven head seeded from
+    this payload has a real, provably-different message-hash sequence rather
+    than the identical content ``_seed_equivalent_canonical_head`` seeds.
+    """
+    payload = {
+        "capture_id": f"chatgpt:{native_id}",
+        "polylogue_capture_kind": "browser_llm_session",
+        "provenance": {
+            "adapter_name": "chatgpt-native-v1",
+            "capture_mode": "snapshot",
+            "captured_at": "2026-07-13T00:00:00Z",
+            "source_url": f"https://chatgpt.com/c/{native_id}",
+        },
+        "raw_provider_payload": {
+            "id": native_id,
+            "title": "Diverging canonical capture",
+            "create_time": 1_700_000_100,
+            "update_time": 1_700_000_200,
+            "current_node": "node-2",
+            "mapping": {
+                "node-1": {
+                    "id": "node-1",
+                    "parent": None,
+                    "children": ["node-2"],
+                    "message": {
+                        "id": "message-1",
+                        "author": {"role": "user"},
+                        "content": {"content_type": "text", "parts": ["diverging text"]},
+                        "create_time": 1_700_000_100,
+                    },
+                },
+                "node-2": {
+                    "id": "node-2",
+                    "parent": "node-1",
+                    "children": [],
+                    "message": {
+                        "id": "message-2",
+                        "author": {"role": "assistant"},
+                        "content": {"content_type": "text", "parts": ["assistant reply"]},
+                        "create_time": 1_700_000_101,
+                    },
+                },
+            },
+            "preserved_padding": "x" * 16_000,
+        },
+        "schema_version": 1,
+        "session": {
+            "provider": "chatgpt",
+            "provider_session_id": native_id,
+            "title": "DOM fallback",
+            "turns": [{"provider_turn_id": "dom-1", "role": "user", "text": "fallback"}],
+        },
+        "source": "browser-extension",
+    }
+    return json.dumps(payload, sort_keys=True).encode()
+
+
+def _seed_diverging_canonical_byte_head(root: Path, mismatched_raw_id: str) -> str:
+    """Seed a competing byte-proven head with genuinely different content.
+
+    Unlike ``_seed_equivalent_canonical_head`` (identical payload, so the
+    competing content hash MATCHES and the witness takes the
+    "not a hash divergence" branch), this seeds a competing head whose
+    content is provably different -- exercising
+    ``_browser_canonical_authority_conflict_witness``'s byte-frontier
+    message-diff branch (the shape of the real production conflict
+    ``88aefc84...``: incompatible canonical byte head diverging from
+    message 0).
+    """
+    payload = _diverging_browser_payload()
+    session = _parse_one(Provider.CHATGPT, payload, "browser-capture/chatgpt/diverging-canonical.json")[0]
+    accepted_hash = bytes.fromhex(session_content_hash(session))
+    projection = session_revision_projection(session)
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CHATGPT,
+            payload=payload,
+            source_path="browser-capture/chatgpt/diverging-canonical.json",
+            acquired_at_ms=3,
+        )
+        blob_hash = (
+            archive._ensure_source_conn()
+            .execute("SELECT hex(blob_hash) FROM raw_sessions WHERE raw_id = ?", (raw_id,))
+            .fetchone()[0]
+            .lower()
+        )
+        _stored_raw, session_id = archive.write_parsed_for_retained_raw(
+            session,
+            raw_id=raw_id,
+            source_path="browser-capture/chatgpt/diverging-canonical.json",
+            acquired_at_ms=3,
+            revision_authoritative=True,
+        )
+        record_revision_application_sync(
+            archive._conn,
+            RevisionApplicationReceipt(
+                raw_id=raw_id,
+                session_id=session_id,
+                logical_source_key="chatgpt:browser-origin-one",
+                source_revision=blob_hash,
+                acquisition_generation=0,
+                decision=ApplicationDecision.SELECTED_BASELINE,
+                accepted_raw_id=raw_id,
+                accepted_source_revision=blob_hash,
+                accepted_content_hash=accepted_hash,
+                accepted_frontier_kind="byte",
+                accepted_frontier=len(payload),
+                baseline_raw_id=raw_id,
+                detail="diverging canonical head",
+            ),
+            decided_at_ms=4,
+        )
+        archive._conn.execute(
+            "UPDATE sessions SET raw_id = ? WHERE session_id = ?",
+            (mismatched_raw_id, session_id),
+        )
+        archive.commit()
+    with closing(sqlite3.connect(root / "source.db")) as source, source:
+        source.execute(
+            """
+            UPDATE raw_sessions
+            SET native_id = 'browser-origin-one', logical_source_key = 'chatgpt:browser-origin-one', revision_kind = 'full',
+                source_revision = lower(hex(blob_hash)), baseline_raw_id = raw_id,
+                acquisition_generation = 0, revision_authority = 'byte_proven'
+            WHERE raw_id = ?
+            """,
+            (raw_id,),
+        )
+        source.execute(
+            """
+            INSERT INTO raw_session_memberships (
+                raw_id, logical_source_key, provider_session_id, source_revision,
+                normalized_content_hash, message_count, acquisition_generation,
+                revision_authority, decision, decided_at_ms
+            ) VALUES (?, 'chatgpt:browser-origin-one', 'browser-origin-one', ?, ?, ?, 0,
+                      'byte_proven', 'applied', 4)
+            """,
+            (raw_id, blob_hash, accepted_hash, len(projection.message_hashes)),
+        )
+        source.execute(
+            """
+            INSERT INTO raw_membership_census (
+                raw_id, parser_fingerprint, status, member_count, censused_at_ms, detail
+            ) VALUES (?, 'canonical-parser', 'complete', 1, 4, 'diverging canonical evidence')
+            """,
+            (raw_id,),
+        )
+    return raw_id
+
+
 def _seed_semantic_canonical_head(root: Path, mismatched_raw_id: str) -> str:
     raw_id = _seed_equivalent_canonical_head(root, mismatched_raw_id)
     with (
@@ -2134,6 +2288,44 @@ def test_inspect_conflicts_matching_hash_is_membership_shaped_not_a_divergence(t
     assert item.divergence_note is not None and "not a hash divergence" in item.divergence_note
 
 
+def test_inspect_conflicts_byte_frontier_message_divergence_evidence(tmp_path: Path) -> None:
+    """The untested byte-frontier competing-head diff path: real message-level divergence.
+
+    Unlike ``test_inspect_conflicts_matching_hash_is_membership_shaped_not_a_divergence``
+    (identical content, "not a hash divergence" branch) and
+    ``test_inspect_conflicts_semantic_hash_divergence_evidence`` (semantic
+    frontier, no message diff computed), this seeds a competing head that is
+    both byte-frontier AND genuinely content-divergent -- the
+    ``elif competing_frontier_kind == "byte" and competing_raw_id != raw_id``
+    branch in ``_browser_canonical_authority_conflict_witness`` that re-reads
+    the competing raw's own retained blob, reparses it, and computes
+    ``divergent_message_index`` by zipping two message-hash projections. This
+    is the shape of the real production conflict this evidence-builder
+    exists to explain (an incompatible canonical byte head diverging from
+    message 0). Deleting or breaking this branch (e.g. reverting to the
+    semantic-frontier "no diff available" note, or leaving
+    ``divergent_message_index`` unset) makes this test fail.
+    """
+    raw_id = _seed_byte_proven_browser_head_without_native_id(tmp_path)
+    competing_raw_id = _seed_diverging_canonical_byte_head(tmp_path, raw_id)
+
+    report = inspect_browser_canonical_authority_conflicts(_config(tmp_path), [raw_id])
+
+    assert report.conflict_count == 1
+    item = report.items[0]
+    assert item.competing_raw_id == competing_raw_id
+    assert item.competing_frontier_kind == "byte"
+    assert item.competing_content_hash is not None
+    assert item.competing_content_hash != item.unknown_raw_content_hash
+    # The competing head's own retained bytes were re-parsed (2 messages),
+    # proving this is a real re-derivation, not a stub/None fallback.
+    assert item.competing_message_count == 2
+    assert item.unknown_raw_message_count == 1
+    assert item.divergent_message_index == 0
+    assert item.divergence_note is None
+    assert item.evidence_digest is not None
+
+
 def test_inspect_conflicts_rejects_duplicate_and_malformed_ids(tmp_path: Path) -> None:
     raw_id = _seed_byte_proven_browser_head_without_native_id(tmp_path)
     with pytest.raises(ValueError, match="duplicate"):
@@ -2187,3 +2379,75 @@ def test_record_conflict_blockers_persists_durable_candidate_assertions(tmp_path
             ("session:chatgpt-export:browser-origin-one",),
         ).fetchone()[0]
         assert count == 1
+
+
+def test_record_conflict_blockers_never_clobbers_an_operator_judged_row(tmp_path: Path) -> None:
+    """A judged blocker (accepted/rejected/deferred/superseded) must survive a re-run.
+
+    Mirrors ``upsert_pathology_findings_as_assertions``'s terminal-judgment
+    chokepoint (37t.15): once an operator has judged a candidate this
+    detector produced, a later automated re-run over the SAME evidence must
+    not resurrect or mutate the judged row's status/value -- only
+    ``upsert_assertion``'s own ON CONFLICT DO UPDATE would otherwise
+    overwrite the display fields (value/body_text/evidence_refs) on every
+    call, since only ``status`` itself is protected by that function's
+    chokepoint. Deleting the ``read_assertion_envelope``/``existing.status``
+    guard in ``record_browser_canonical_authority_conflict_blockers`` makes
+    this test fail: the accepted row's value would silently be overwritten
+    back to the detector's regenerated evidence payload.
+    """
+    from polylogue.storage.sqlite.archive_tiers.user_write import (
+        judge_assertion_candidate,
+        read_assertion_envelope,
+    )
+
+    raw_id = _seed_byte_proven_browser_head_without_native_id(tmp_path)
+    semantic_raw_id = _seed_semantic_canonical_head(tmp_path, raw_id)
+    with sqlite3.connect(tmp_path / "index.db") as index:
+        index.execute(
+            "UPDATE raw_revision_heads SET accepted_content_hash = x'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF' "
+            "WHERE accepted_raw_id = ?",
+            (semantic_raw_id,),
+        )
+
+    _report, assertion_ids = record_browser_canonical_authority_conflict_blockers(_config(tmp_path), [raw_id])
+    assert len(assertion_ids) == 1
+    assertion_ref = assertion_ids[0]
+
+    with closing(sqlite3.connect(tmp_path / "user.db")) as user_conn:
+        judge_assertion_candidate(
+            user_conn,
+            candidate_ref=assertion_ref,
+            decision="accept",
+            reason="operator confirmed this conflict is real",
+        )
+        user_conn.commit()
+        judged = read_assertion_envelope(user_conn, assertion_ref)
+        assert judged is not None
+        assert judged.status.value == "accepted"
+        judged_value = judged.value
+
+    # Re-running the detector over the identical evidence must leave the
+    # judged row's status and value exactly as the operator left it.
+    _report_again, assertion_ids_again = record_browser_canonical_authority_conflict_blockers(
+        _config(tmp_path), [raw_id]
+    )
+    assert assertion_ids_again == assertion_ids
+    with closing(sqlite3.connect(tmp_path / "user.db")) as user_conn:
+        still_judged = read_assertion_envelope(user_conn, assertion_ref)
+        assert still_judged is not None
+        assert still_judged.status.value == "accepted"
+        assert still_judged.value == judged_value
+        # ``judge_assertion_candidate(decision="accept")`` legitimately leaves
+        # TWO ``blocker`` rows for this target: the original candidate
+        # (mutated in place to ``status=accepted`` by ``mark_assertion_status``,
+        # same assertion id as ``assertion_ref``) plus a separate promoted
+        # "resulting assertion" row that ``_promote_candidate_assertion``
+        # inserts under a distinct id. The guard under test only has to leave
+        # the ORIGINAL judged row alone -- it must not grow a THIRD row (which
+        # would mean the re-run resurrected or duplicated the candidate).
+        count = user_conn.execute(
+            "SELECT COUNT(*) FROM assertions WHERE kind = 'blocker' AND target_ref = ?",
+            ("session:chatgpt-export:browser-origin-one",),
+        ).fetchone()[0]
+        assert count == 2

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -22,6 +22,8 @@ from polylogue.sources.live.cursor import CursorStore
 from polylogue.sources.revision_backfill import _parse_one, backfill_historical_revision_evidence
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.repair import (
+    inspect_browser_canonical_authority_conflicts,
+    record_browser_canonical_authority_conflict_blockers,
     repair_browser_capture_origin_mismatches,
     repair_byte_proven_browser_capture_null_native_ids,
     repair_legacy_browser_capture_missing_native_ids,
@@ -2043,3 +2045,145 @@ def test_byte_proven_browser_rekey_refuses_stale_proof_and_rolls_back(
     assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned"]
     for (tier, table), rows in before.items():
         assert _rows(tmp_path / "rollback", tier, table, "1 = 1", ()) == rows
+
+
+# --- polylogue-lkrc.3: evidence packets + durable blockers for unresolved conflicts ---
+
+
+def test_inspect_conflicts_reports_resolved_when_actuator_would_succeed(tmp_path: Path) -> None:
+    """A raw the ordinary rekey actuator can already repair is not a conflict."""
+    raw_id = _seed_byte_proven_browser_head_without_native_id(tmp_path)
+
+    report = inspect_browser_canonical_authority_conflicts(_config(tmp_path), [raw_id])
+
+    assert report.requested_count == 1
+    assert report.resolved_count == 1
+    assert report.conflict_count == 0
+    assert report.items == ()
+
+
+def test_inspect_conflicts_semantic_hash_divergence_evidence(tmp_path: Path) -> None:
+    raw_id = _seed_byte_proven_browser_head_without_native_id(tmp_path)
+    semantic_raw_id = _seed_semantic_canonical_head(tmp_path, raw_id)
+    with sqlite3.connect(tmp_path / "index.db") as index:
+        index.execute(
+            "UPDATE raw_revision_heads SET accepted_content_hash = x'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF' "
+            "WHERE accepted_raw_id = ?",
+            (semantic_raw_id,),
+        )
+
+    report = inspect_browser_canonical_authority_conflicts(_config(tmp_path), [raw_id])
+
+    assert report.conflict_count == 1
+    assert report.resolved_count == 0
+    item = report.items[0]
+    assert item.raw_id == raw_id
+    assert item.session_id == "chatgpt-export:browser-origin-one"
+    assert item.canonical_logical_source_key == "chatgpt:browser-origin-one"
+    assert item.competing_raw_id == semantic_raw_id
+    assert item.competing_content_hash == "ff" * 32
+    assert item.competing_frontier_kind == "semantic"
+    assert item.unknown_raw_content_hash is not None
+    assert item.unknown_raw_content_hash != item.competing_content_hash
+    # Semantic frontiers are not a single retained raw's bytes, so a
+    # message-level diff is deliberately not fabricated for them.
+    assert item.divergent_message_index is None
+    assert item.divergence_note is not None and "semantic frontier" in item.divergence_note
+    assert item.evidence_digest is not None
+
+
+def test_inspect_conflicts_membership_precondition_evidence(tmp_path: Path) -> None:
+    raw_id = _seed_byte_proven_browser_head_without_native_id(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as source:
+        source.execute(
+            """
+            INSERT INTO raw_session_memberships (
+                raw_id, logical_source_key, provider_session_id, source_revision,
+                normalized_content_hash, message_count, acquisition_generation,
+                revision_authority, decision, decided_at_ms
+            ) SELECT raw_id, logical_source_key, 'browser-origin-one', source_revision,
+                     x'0000000000000000000000000000000000000000000000000000000000000000', 1, 1,
+                     'quarantined', 'superseded_equivalent', 3
+              FROM raw_sessions WHERE raw_id = ?
+            """,
+            (raw_id,),
+        )
+
+    report = inspect_browser_canonical_authority_conflicts(_config(tmp_path), [raw_id])
+
+    assert report.conflict_count == 1
+    item = report.items[0]
+    assert item.competing_raw_id is None
+    assert item.divergence_note is not None
+    assert "membership row" in item.divergence_note
+    assert "superseded_equivalent" in item.divergence_note
+
+
+def test_inspect_conflicts_matching_hash_is_membership_shaped_not_a_divergence(tmp_path: Path) -> None:
+    """Equal content hashes mean the actuator's block is precondition-shaped, not authority conflict."""
+    raw_id = _seed_byte_proven_browser_head_without_native_id(tmp_path)
+    canonical_raw_id = _seed_equivalent_canonical_head(tmp_path, raw_id)
+
+    report = inspect_browser_canonical_authority_conflicts(_config(tmp_path), [raw_id])
+
+    assert report.conflict_count == 1
+    item = report.items[0]
+    assert item.competing_raw_id == canonical_raw_id
+    assert item.competing_content_hash == item.unknown_raw_content_hash
+    assert item.divergent_message_index is None
+    assert item.divergence_note is not None and "not a hash divergence" in item.divergence_note
+
+
+def test_inspect_conflicts_rejects_duplicate_and_malformed_ids(tmp_path: Path) -> None:
+    raw_id = _seed_byte_proven_browser_head_without_native_id(tmp_path)
+    with pytest.raises(ValueError, match="duplicate"):
+        inspect_browser_canonical_authority_conflicts(_config(tmp_path), [raw_id, raw_id])
+    with pytest.raises(ValueError, match="lowercase SHA-256"):
+        inspect_browser_canonical_authority_conflicts(_config(tmp_path), ["not-a-raw-id"])
+    with pytest.raises(ValueError, match="1..100 entries"):
+        inspect_browser_canonical_authority_conflicts(_config(tmp_path), [])
+
+
+def test_record_conflict_blockers_persists_durable_candidate_assertions(tmp_path: Path) -> None:
+    from polylogue.storage.sqlite.archive_tiers.user_write import read_assertion_envelope
+
+    raw_id = _seed_byte_proven_browser_head_without_native_id(tmp_path)
+    semantic_raw_id = _seed_semantic_canonical_head(tmp_path, raw_id)
+    with sqlite3.connect(tmp_path / "index.db") as index:
+        index.execute(
+            "UPDATE raw_revision_heads SET accepted_content_hash = x'FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF' "
+            "WHERE accepted_raw_id = ?",
+            (semantic_raw_id,),
+        )
+
+    report, assertion_ids = record_browser_canonical_authority_conflict_blockers(_config(tmp_path), [raw_id])
+
+    assert report.conflict_count == 1
+    assert len(assertion_ids) == 1
+    with closing(sqlite3.connect(tmp_path / "user.db")) as user_conn:
+        user_conn.row_factory = sqlite3.Row
+        envelope = read_assertion_envelope(user_conn, assertion_ids[0])
+        assert envelope is not None
+        assert envelope.kind.value == "blocker"
+        # Automated writers can never self-promote (upsert_assertion's chokepoint,
+        # 37t.15): the row is a candidate awaiting explicit operator judgment even
+        # though this function requested status=candidate/visibility=private itself.
+        assert envelope.status.value == "candidate"
+        assert envelope.context_policy["inject"] is False
+        assert envelope.target_ref == "session:chatgpt-export:browser-origin-one"
+        assert isinstance(envelope.value, dict)
+        assert envelope.value["raw_id"] == raw_id
+        assert envelope.value["competing_raw_id"] == semantic_raw_id
+
+    # Re-running over identical evidence is idempotent: same assertion id, not a
+    # duplicate row.
+    _report_again, assertion_ids_again = record_browser_canonical_authority_conflict_blockers(
+        _config(tmp_path), [raw_id]
+    )
+    assert assertion_ids_again == assertion_ids
+    with closing(sqlite3.connect(tmp_path / "user.db")) as user_conn:
+        count = user_conn.execute(
+            "SELECT COUNT(*) FROM assertions WHERE kind = 'blocker' AND target_ref = ?",
+            ("session:chatgpt-export:browser-origin-one",),
+        ).fetchone()[0]
+        assert count == 1

--- a/tests/unit/storage/test_duplicate_raw_identity_repair.py
+++ b/tests/unit/storage/test_duplicate_raw_identity_repair.py
@@ -324,6 +324,121 @@ def test_apply_refuses_stale_proof_digest(tmp_path: Path) -> None:
         )
 
 
+def test_apply_serializes_one_receipt_inode_against_a_concurrent_apply(tmp_path: Path) -> None:
+    """A second ``--apply`` against the same receipt path must fail closed.
+
+    Exercises ``_lock_duplicate_raw_identity_repair_receipt`` directly: hold
+    its flock open (as a genuinely concurrent apply would), then prove the
+    real ``repair_duplicate_raw_identity`` entrypoint refuses to proceed and
+    never mutates the durable authority underneath the held lock. Deleting
+    the flock acquisition from the receipt lock (regressing to the old bare
+    ``receipt_path.exists()`` TOCTOU check) makes this test fail: the second
+    call would instead race straight into the transaction.
+    """
+    stale_raw_id, canonical_raw_id, _session_id, key = _seed_duplicate_raw_pair(tmp_path)
+    dry_run = repair_duplicate_raw_identity(_config(tmp_path), [(stale_raw_id, canonical_raw_id)])
+    receipt_path = tmp_path / "locked.jsonl"
+    from polylogue.storage import repair as repair_module
+
+    locked = repair_module._lock_duplicate_raw_identity_repair_receipt(receipt_path, list(dry_run.items))
+    try:
+        with pytest.raises(RuntimeError, match="already locked"):
+            repair_duplicate_raw_identity(
+                _config(tmp_path),
+                [(stale_raw_id, canonical_raw_id)],
+                apply=True,
+                receipt_path=receipt_path,
+                proof_digest=dry_run.proof_digest,
+            )
+        with closing(sqlite3.connect(tmp_path / "index.db")) as index_conn:
+            head = index_conn.execute(
+                "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = ?", (key,)
+            ).fetchone()
+            assert head[0] == stale_raw_id
+    finally:
+        locked.close()
+
+
+def test_apply_resumes_planned_receipt_after_a_crash_before_the_terminal_append(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A crash between commit and the terminal receipt append must be resumable and auditable.
+
+    Injects a failure into ``_finish_duplicate_raw_identity_repair_receipt``
+    (the real production function that appends the fsynced ``applied``
+    record) after the index-tier transaction has already committed. The
+    receipt on disk must show only the ``planned`` record -- proving the
+    planned phase is durably written *before* mutation, unlike the old
+    single unlocked ``write_text`` -- and re-invoking apply against the SAME
+    receipt path must resume to a terminal ``applied`` record without
+    re-mutating anything (idempotent recovery), once the operator re-proves
+    current authority with a fresh dry-run digest (the accepted head's own
+    ``decided_at_ms`` legitimately changed under repair, so reusing the
+    original pre-repair digest is correctly refused by the top-level CAS
+    gate -- this mirrors exactly how an operator would recover in practice).
+    Removing the planned-phase write or the crash-safe resume path makes
+    this test fail.
+    """
+    stale_raw_id, canonical_raw_id, _session_id, _key = _seed_duplicate_raw_pair(tmp_path)
+    dry_run = repair_duplicate_raw_identity(_config(tmp_path), [(stale_raw_id, canonical_raw_id)])
+    receipt = tmp_path / "planned-resume.jsonl"
+    from polylogue.storage import repair as repair_module
+
+    original_finish = repair_module._finish_duplicate_raw_identity_repair_receipt
+    monkeypatch.setattr(
+        repair_module,
+        "_finish_duplicate_raw_identity_repair_receipt",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("injected terminal append crash")),
+    )
+    with pytest.raises(RuntimeError, match="terminal append crash"):
+        repair_duplicate_raw_identity(
+            _config(tmp_path),
+            [(stale_raw_id, canonical_raw_id)],
+            apply=True,
+            receipt_path=receipt,
+            proof_digest=dry_run.proof_digest,
+        )
+    assert [json.loads(line)["state"] for line in receipt.read_text().splitlines()] == ["planned"]
+    with closing(sqlite3.connect(tmp_path / "index.db")) as index_conn:
+        session_raw = index_conn.execute("SELECT raw_id FROM sessions WHERE session_id = ?", (_session_id,)).fetchone()
+        assert session_raw[0] == canonical_raw_id
+
+    monkeypatch.setattr(repair_module, "_finish_duplicate_raw_identity_repair_receipt", original_finish)
+    post_crash_dry_run = repair_duplicate_raw_identity(_config(tmp_path), [(stale_raw_id, canonical_raw_id)])
+    assert post_crash_dry_run.already_repaired_count == 1
+    resumed = repair_duplicate_raw_identity(
+        _config(tmp_path),
+        [(stale_raw_id, canonical_raw_id)],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=post_crash_dry_run.proof_digest,
+    )
+    assert resumed.already_repaired_count == 1
+    assert resumed.repaired_count == 0
+    records = [json.loads(line) for line in receipt.read_text().splitlines()]
+    assert [record["state"] for record in records] == ["planned", "applied"]
+    assert records[1]["repaired_stale_raw_ids"] == []
+
+
+def test_receipt_path_must_not_be_a_symlink(tmp_path: Path) -> None:
+    stale_raw_id, canonical_raw_id, _session_id, _key = _seed_duplicate_raw_pair(tmp_path)
+    dry_run = repair_duplicate_raw_identity(_config(tmp_path), [(stale_raw_id, canonical_raw_id)])
+    target = tmp_path / "outside-target.jsonl"
+    receipt = tmp_path / "receipt-symlink.jsonl"
+    receipt.symlink_to(target)
+
+    with pytest.raises(RuntimeError, match="symbolic link"):
+        repair_duplicate_raw_identity(
+            _config(tmp_path),
+            [(stale_raw_id, canonical_raw_id)],
+            apply=True,
+            receipt_path=receipt,
+            proof_digest=dry_run.proof_digest,
+        )
+    assert not target.exists()
+
+
 def test_apply_requires_receipt_path(tmp_path: Path) -> None:
     stale_raw_id, canonical_raw_id, _session_id, _key = _seed_duplicate_raw_pair(tmp_path)
     dry_run = repair_duplicate_raw_identity(_config(tmp_path), [(stale_raw_id, canonical_raw_id)])

--- a/tests/unit/storage/test_duplicate_raw_identity_repair.py
+++ b/tests/unit/storage/test_duplicate_raw_identity_repair.py
@@ -1,0 +1,333 @@
+"""Tests for polylogue-t0dy: reconcile the pre-#2729 duplicate-raw scheme.
+
+PR #2729 aligned the one-shot importer and the live daemon watcher on one
+deterministic raw-id scheme (no ``native_id``) so *new* ingests of a grouped/
+split-session file converge on one raw row. It explicitly does not
+retroactively repair pairs that already duplicated under the OLD,
+native_id-inclusive scheme before that fix landed. ``repair_duplicate_raw_identity``
+is the typed, receipted, CAS-gated actuator that performs that one-time
+reconciliation without hand-writing a raw UPDATE.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.revision_replay import ApplicationDecision
+from polylogue.config import Config
+from polylogue.core.enums import Provider, Role
+from polylogue.pipeline.ids import session_content_hash
+from polylogue.sources.parsers.base_models import ParsedMessage, ParsedSession
+from polylogue.storage.repair import repair_duplicate_raw_identity
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from polylogue.storage.sqlite.archive_tiers.revision_application import (
+    RevisionApplicationReceipt,
+    record_revision_application_sync,
+)
+from polylogue.storage.sqlite.archive_tiers.source_write import deterministic_raw_session_id
+
+
+def _config(root: Path) -> Config:
+    return Config(archive_root=root, render_root=root / "render", sources=[], db_path=root / "index.db")
+
+
+def _session() -> ParsedSession:
+    return ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="carryover-session",
+        messages=[ParsedMessage(provider_message_id="m1", role=Role.USER, text="hello")],
+    )
+
+
+def _seed_duplicate_raw_pair(root: Path, *, legacy_native_id: str = "legacy-native-id-1") -> tuple[str, str, str, str]:
+    """Seed the exact pre-#2729 duplicate shape.
+
+    One raw ("canonical") is written the way the current, post-#2729 daemon
+    watcher writes it: ``native_id`` NULL, deterministic id computed from
+    (origin, source_path, source_index, blob_hash) alone. A second raw
+    ("stale") clones its byte-identical content under the OLD, native_id-
+    inclusive scheme and is the one actually bound as the accepted head/
+    session pointer -- reproducing the exact incongruity #2729 prevents
+    recurring but does not retroactively fix.
+    """
+    initialize_active_archive_root(root)
+    payload = json.dumps({"marker": "duplicate-raw-fixture", "legacy_native_id": legacy_native_id}).encode()
+    source_path = "codex-session/carryover.jsonl"
+    session = _session()
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        canonical_raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX, payload=payload, source_path=source_path, acquired_at_ms=2
+        )
+        source_conn = archive._ensure_source_conn()
+        row = source_conn.execute(
+            """
+            SELECT origin, capture_mode, source_path, source_index, blob_hash, blob_size
+            FROM raw_sessions WHERE raw_id = ?
+            """,
+            (canonical_raw_id,),
+        ).fetchone()
+        origin, capture_mode, stored_source_path, source_index, blob_hash, blob_size = row
+        stale_raw_id = deterministic_raw_session_id(
+            str(origin), str(stored_source_path), int(source_index), bytes(blob_hash), native_id=legacy_native_id
+        )
+        blob_hash_hex = bytes(blob_hash).hex()
+        source_conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, capture_mode, native_id, source_path, source_index,
+                blob_hash, blob_size, acquired_at_ms,
+                revision_kind, source_revision, baseline_raw_id, acquisition_generation, revision_authority
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'full', ?, ?, 0, 'byte_proven')
+            """,
+            (
+                stale_raw_id,
+                origin,
+                capture_mode,
+                legacy_native_id,
+                stored_source_path,
+                source_index,
+                blob_hash,
+                blob_size,
+                1,
+                blob_hash_hex,
+                stale_raw_id,
+            ),
+        )
+        source_conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, 'raw_payload', ?, ?, ?)
+            """,
+            (blob_hash, stale_raw_id, stored_source_path, blob_size, 1),
+        )
+        source_conn.commit()
+        _stored, session_id = archive.write_parsed_for_retained_raw(
+            session,
+            raw_id=stale_raw_id,
+            source_path=source_path,
+            acquired_at_ms=1,
+            revision_authoritative=True,
+        )
+        logical_source_key = "codex:carryover-session"
+        blob_hash_hex = bytes(blob_hash).hex()
+        accepted_hash = bytes.fromhex(session_content_hash(session))
+        record_revision_application_sync(
+            archive._conn,
+            RevisionApplicationReceipt(
+                raw_id=stale_raw_id,
+                session_id=session_id,
+                logical_source_key=logical_source_key,
+                source_revision=blob_hash_hex,
+                acquisition_generation=0,
+                decision=ApplicationDecision.SELECTED_BASELINE,
+                accepted_raw_id=stale_raw_id,
+                accepted_source_revision=blob_hash_hex,
+                accepted_content_hash=accepted_hash,
+                accepted_frontier_kind="byte",
+                accepted_frontier=blob_size,
+                baseline_raw_id=stale_raw_id,
+                detail="pre-#2729 duplicate-raw fixture",
+            ),
+            decided_at_ms=1,
+        )
+        archive.commit()
+    return stale_raw_id, canonical_raw_id, session_id, logical_source_key
+
+
+def _rows(root: Path, tier: str, table: str, where: str, params: tuple[object, ...]) -> list[tuple[object, ...]]:
+    with closing(sqlite3.connect(root / f"{tier}.db")) as conn:
+        return sorted(conn.execute(f"SELECT * FROM {table} WHERE {where}", params).fetchall())
+
+
+def test_dry_run_proves_eligible_pair_without_mutating(tmp_path: Path) -> None:
+    stale_raw_id, canonical_raw_id, session_id, _key = _seed_duplicate_raw_pair(tmp_path)
+    before = {
+        (tier, table): _rows(tmp_path, tier, table, "1 = 1", ())
+        for tier, tables in {
+            "source": ("raw_sessions", "blob_refs"),
+            "index": ("sessions", "raw_revision_heads", "raw_revision_applications"),
+        }.items()
+        for table in tables
+    }
+
+    report = repair_duplicate_raw_identity(_config(tmp_path), [(stale_raw_id, canonical_raw_id)])
+
+    assert report.mode == "dry-run"
+    assert report.requested_count == 1
+    assert report.eligible_count == 1
+    assert report.ineligible_count == 0
+    assert report.repaired_count == 0
+    item = report.items[0]
+    assert item.status == "eligible"
+    assert item.session_id == session_id
+    assert item.logical_source_key == "codex:carryover-session"
+    assert item.proof_digest is not None
+    for key, rows in before.items():
+        assert _rows(tmp_path, *key, "1 = 1", ()) == rows
+
+
+def test_apply_repoints_head_and_session_preserving_stale_raw(tmp_path: Path) -> None:
+    stale_raw_id, canonical_raw_id, session_id, key = _seed_duplicate_raw_pair(tmp_path)
+    stale_before = _rows(tmp_path, "source", "raw_sessions", "raw_id = ?", (stale_raw_id,))
+
+    dry_run = repair_duplicate_raw_identity(_config(tmp_path), [(stale_raw_id, canonical_raw_id)])
+    receipt = tmp_path / "t0dy-repair.json"
+    applied = repair_duplicate_raw_identity(
+        _config(tmp_path),
+        [(stale_raw_id, canonical_raw_id)],
+        apply=True,
+        receipt_path=receipt,
+        proof_digest=dry_run.proof_digest,
+    )
+
+    assert applied.mode == "apply"
+    assert applied.repaired_count == 1
+    assert applied.items[0].repaired is True
+    assert receipt.exists()
+
+    # The stale raw's own row is byte-for-byte unchanged -- durable raw
+    # evidence is never mutated or deleted, only its authority.
+    assert _rows(tmp_path, "source", "raw_sessions", "raw_id = ?", (stale_raw_id,)) == stale_before
+
+    with closing(sqlite3.connect(tmp_path / "index.db")) as index_conn:
+        head = index_conn.execute(
+            "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = ?", (key,)
+        ).fetchone()
+        assert head[0] == canonical_raw_id
+        session_raw = index_conn.execute("SELECT raw_id FROM sessions WHERE session_id = ?", (session_id,)).fetchone()
+        assert session_raw[0] == canonical_raw_id
+        # The stale raw carries BOTH its original ``selected_baseline`` receipt
+        # (from before repair) and the new ``superseded`` receipt (from
+        # repair) -- immutable application receipts are append-only, never
+        # overwritten -- so assert presence of the new one specifically
+        # rather than assuming there is only one row.
+        stale_decisions = {
+            row[0]
+            for row in index_conn.execute(
+                "SELECT decision FROM raw_revision_applications WHERE raw_id = ? AND logical_source_key = ?",
+                (stale_raw_id, key),
+            ).fetchall()
+        }
+        assert stale_decisions == {"selected_baseline", "superseded"}
+        stale_superseded_target = index_conn.execute(
+            "SELECT accepted_raw_id FROM raw_revision_applications "
+            "WHERE raw_id = ? AND logical_source_key = ? AND decision = 'superseded'",
+            (stale_raw_id, key),
+        ).fetchone()
+        assert stale_superseded_target[0] == canonical_raw_id
+        canonical_decision = index_conn.execute(
+            "SELECT decision, accepted_raw_id FROM raw_revision_applications WHERE raw_id = ? AND logical_source_key = ?",
+            (canonical_raw_id, key),
+        ).fetchone()
+        assert canonical_decision == ("selected_baseline", canonical_raw_id)
+
+
+def test_reapply_after_success_is_idempotent_already_repaired(tmp_path: Path) -> None:
+    stale_raw_id, canonical_raw_id, _session_id, _key = _seed_duplicate_raw_pair(tmp_path)
+    dry_run = repair_duplicate_raw_identity(_config(tmp_path), [(stale_raw_id, canonical_raw_id)])
+    repair_duplicate_raw_identity(
+        _config(tmp_path),
+        [(stale_raw_id, canonical_raw_id)],
+        apply=True,
+        receipt_path=tmp_path / "first.json",
+        proof_digest=dry_run.proof_digest,
+    )
+
+    again = repair_duplicate_raw_identity(_config(tmp_path), [(stale_raw_id, canonical_raw_id)])
+
+    assert again.mode == "dry-run"
+    assert again.already_repaired_count == 1
+    assert again.eligible_count == 0
+    assert again.ineligible_count == 0
+    assert again.items[0].status == "already_repaired"
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    ("canonical_already_accepted", "stale_not_accepted", "content_differs", "same_scheme_both_null"),
+)
+def test_fails_closed_for_ineligible_shapes(tmp_path: Path, mutation: str) -> None:
+    stale_raw_id, canonical_raw_id, session_id, key = _seed_duplicate_raw_pair(tmp_path)
+    if mutation == "canonical_already_accepted":
+        with closing(sqlite3.connect(tmp_path / "index.db")) as index_conn, index_conn:
+            index_conn.execute(
+                "INSERT INTO raw_revision_heads (logical_source_key, session_id, accepted_raw_id, "
+                "accepted_source_revision, accepted_content_hash, accepted_frontier_kind, accepted_frontier, "
+                "acquisition_generation, decided_at_ms) "
+                "SELECT 'codex:other-session', session_id, ?, accepted_source_revision, accepted_content_hash, "
+                "accepted_frontier_kind, accepted_frontier, acquisition_generation, decided_at_ms "
+                "FROM raw_revision_heads WHERE logical_source_key = ?",
+                (canonical_raw_id, key),
+            )
+    elif mutation == "stale_not_accepted":
+        with closing(sqlite3.connect(tmp_path / "index.db")) as index_conn, index_conn:
+            index_conn.execute(
+                "UPDATE raw_revision_heads SET accepted_raw_id = ? WHERE logical_source_key = ?",
+                (canonical_raw_id, key),
+            )
+    elif mutation == "content_differs":
+        with closing(sqlite3.connect(tmp_path / "source.db")) as source_conn, source_conn:
+            source_conn.execute(
+                "UPDATE raw_sessions SET blob_size = blob_size + 1 WHERE raw_id = ?", (canonical_raw_id,)
+            )
+    else:
+        with closing(sqlite3.connect(tmp_path / "source.db")) as source_conn, source_conn:
+            source_conn.execute("UPDATE raw_sessions SET native_id = NULL WHERE raw_id = ?", (stale_raw_id,))
+
+    report = repair_duplicate_raw_identity(_config(tmp_path), [(stale_raw_id, canonical_raw_id)])
+
+    assert report.ineligible_count == 1
+    assert report.items[0].status == "ineligible"
+    with pytest.raises(RuntimeError, match="ineligible"):
+        repair_duplicate_raw_identity(
+            _config(tmp_path),
+            [(stale_raw_id, canonical_raw_id)],
+            apply=True,
+            receipt_path=tmp_path / "should-not-write.json",
+            proof_digest=report.proof_digest,
+        )
+
+
+def test_rejects_duplicate_pairs_and_malformed_ids(tmp_path: Path) -> None:
+    stale_raw_id, canonical_raw_id, _session_id, _key = _seed_duplicate_raw_pair(tmp_path)
+    with pytest.raises(ValueError, match="duplicate"):
+        repair_duplicate_raw_identity(
+            _config(tmp_path), [(stale_raw_id, canonical_raw_id), (stale_raw_id, canonical_raw_id)]
+        )
+    with pytest.raises(ValueError, match="lowercase SHA-256"):
+        repair_duplicate_raw_identity(_config(tmp_path), [("not-a-raw-id", canonical_raw_id)])
+    with pytest.raises(ValueError, match="1..100 entries"):
+        repair_duplicate_raw_identity(_config(tmp_path), [])
+
+
+def test_apply_refuses_stale_proof_digest(tmp_path: Path) -> None:
+    stale_raw_id, canonical_raw_id, _session_id, key = _seed_duplicate_raw_pair(tmp_path)
+    dry_run = repair_duplicate_raw_identity(_config(tmp_path), [(stale_raw_id, canonical_raw_id)])
+    with closing(sqlite3.connect(tmp_path / "index.db")) as index_conn, index_conn:
+        index_conn.execute(
+            "UPDATE raw_revision_heads SET decided_at_ms = decided_at_ms + 1 WHERE logical_source_key = ?", (key,)
+        )
+
+    with pytest.raises(RuntimeError, match="proof digest does not match"):
+        repair_duplicate_raw_identity(
+            _config(tmp_path),
+            [(stale_raw_id, canonical_raw_id)],
+            apply=True,
+            receipt_path=tmp_path / "stale-digest.json",
+            proof_digest=dry_run.proof_digest,
+        )
+
+
+def test_apply_requires_receipt_path(tmp_path: Path) -> None:
+    stale_raw_id, canonical_raw_id, _session_id, _key = _seed_duplicate_raw_pair(tmp_path)
+    dry_run = repair_duplicate_raw_identity(_config(tmp_path), [(stale_raw_id, canonical_raw_id)])
+    with pytest.raises(ValueError, match="explicit operator repair receipt path"):
+        repair_duplicate_raw_identity(
+            _config(tmp_path), [(stale_raw_id, canonical_raw_id)], apply=True, proof_digest=dry_run.proof_digest
+        )


### PR DESCRIPTION
## Summary

Two additive, read-mostly repair-substrate capabilities for the raw-identity
repair cluster (polylogue-lkrc, polylogue-lkrc.2, polylogue-lkrc.3,
polylogue-yla8, polylogue-yla8.6, polylogue-t0dy, polylogue-57rp,
polylogue-5k5l.1), plus a follow-up commit closing an adversarial-review
hold (polylogue-hleq):

1. **polylogue-lkrc.3** — structured evidence packets + a durable, operator-
   reviewable blocker for the four browser-capture sessions whose canonical
   ChatGPT authority genuinely conflicts (not just fails a precondition) and
   cannot be safely rekeyed by the existing narrow actuator.
2. **polylogue-t0dy** — a typed, receipted, CAS-gated actuator that reconciles
   the two known live production raw pairs still stuck under the pre-#2729
   duplicate-raw scheme, using the existing revision-application machinery
   rather than a hand-written `raw_revision_heads` UPDATE.

Everything else in the assigned cluster (lkrc, lkrc.2, yla8, yla8.6, 57rp,
5k5l.1) was investigated and found either already resolved by prior merged
PRs in this campaign, or blocked on live-archive execution that this PR
deliberately does not perform (see bead-by-bead notes below and in bead
comments).

## Problem

**lkrc.3**: `repair_byte_proven_browser_capture_null_native_ids` (merged in
PR #2850) already correctly refuses to rekey four browser-capture sessions
whose unknown-export accepted head cannot be safely repointed: two diverge
from a semantic canonical head at different content hashes, one has a
`superseded_equivalent` membership row blocking the null-membership
precondition, and one has production reparse hash drift against an
incompatible canonical byte head
(`test_byte_proven_browser_rekey_fails_closed_for_observed_conflicts`,
already green). But the rejection path only returns a terse
`ineligible_reason` string — the competing-authority evidence
(`_inspect_browser_capture_origin_mismatch`'s internal state) is computed and
then discarded on every early-return branch, so nothing survives for an
operator to adjudicate, and nothing records that the conflict exists once the
inspection call returns (AC1/AC4 of lkrc.3).

**t0dy**: PR #2729 aligned the one-shot importer and the live daemon watcher
on one deterministic raw-id scheme (`native_id=NULL`) so *new* ingests of a
grouped/split-session Claude Code/Codex resume-fork file converge on one raw
row. It explicitly did not retroactively repair raw pairs that already
duplicated under the OLD, native_id-inclusive scheme before that fix landed —
the accepted head stays bound to the stale raw, its post-fix twin sits
orphaned, and every later daemon catch-up pass over that file hits
`RuntimeError: membership replay cannot retire an unrelated accepted head`
(`archive.py:2255`) indefinitely. Two live production files are
known-affected (bead notes name the exact raw ids). t0dy's own design note is
explicit that this needs a typed actuator using the existing
revision-application machinery, not a hand-written raw UPDATE.

## Solution

**`polylogue/storage/repair.py`** (all additive, no existing function
touched):

- `inspect_browser_canonical_authority_conflicts(config, raw_ids)` — read-only,
  re-runs the byte-proven-rekey actuator's exact eligibility proof per raw id.
  A raw that comes back eligible/already_repaired is not a conflict (counted
  in `resolved_count`, not returned). A raw that stays ineligible gets a
  `BrowserCanonicalAuthorityConflictWitness`: competing head content
  hash/frontier kind/decision (queried directly against `raw_revision_heads`/
  `raw_revision_applications`, since the underlying inspector discards this on
  reject), any blocking membership row (queried without a `logical_source_key`
  filter, matching the actuator's own broader `COUNT(*)` precondition), and —
  when both sides are single-session byte-frontier raws — the first diverging
  message index via `session_revision_projection`.
- `record_browser_canonical_authority_conflict_blockers(config, raw_ids)` —
  the separate, explicit persistence step. Each conflict becomes one
  `AssertionKind.BLOCKER` candidate assertion in `user.db` (durable,
  irreplaceable tier), deterministic id over `(raw_id, evidence_digest)` so
  re-running after new evidence creates a new row rather than overwriting,
  unchanged re-runs idempotent. Written through `upsert_assertion`'s
  `author_kind="detector"` chokepoint (mirrors
  `upsert_pathology_findings_as_assertions`, #2383) — always forced to
  `status=candidate`/`inject:false`, can never self-promote to an
  authoritative claim. Neither function authorizes a repair; resolving the
  four conflicts under an explicit operator policy is separately scoped
  follow-up (matches lkrc.3 AC2: "no automatic overwrite based on partial
  equality").

- `repair_duplicate_raw_identity(config, pairs, apply=, receipt_path=,
  proof_digest=)` — the same dry-run/apply/CAS/receipt shape as every other
  actuator in this file. `_inspect_duplicate_raw_identity` proves per pair:
  both raws byte-identical (`origin`/`source_path`/`source_index`/
  `blob_hash`/`blob_size`, plus an actual `BlobStore` read verifying retained
  bytes match the declared digest/size); each raw id equals the deterministic
  id its own fields (and `native_id` shape) predict via
  `deterministic_raw_session_id`; the stale raw is the *current* accepted
  head/session pointer; the canonical raw is a genuinely dangling duplicate
  (not itself referenced by any head or session). `_apply_duplicate_raw_identity_repair`
  reuses `record_revision_application_sync` twice — a `SELECTED_BASELINE`
  receipt for the canonical raw performs the head CAS (session_id/
  content_hash/frontier_kind/frontier are unchanged since the raws are
  byte-identical, so this is exactly the existing "equivalent-content"
  acceptance path, only `accepted_raw_id` repoints), then a `SUPERSEDED`
  receipt on the stale raw records the loss of authority. The stale raw's own
  row is never mutated or deleted.

**Tests**: `tests/unit/storage/test_browser_capture_origin_repair.py` (+6
tests reusing the existing fixture matrix) and new
`tests/unit/storage/test_duplicate_raw_identity_repair.py` (10 tests: dry-run
proof, apply + exact before/after row diff, idempotent reapply, 4-way
ineligible-shape matrix, duplicate/malformed-id rejection, stale-digest
rejection, missing-receipt-path rejection).

## Bead-by-bead disposition

- **polylogue-lkrc.3** — satisfied by this PR (evidence + durable blocker;
  AC3's "if a repair is authorized" is explicitly not exercised — no repair
  is authorized here).
- **polylogue-t0dy** — the actuator this PR adds is the full satisfied scope
  for the *code* portion of t0dy's design. The live one-time census/apply
  against the two named production files is explicitly reserved for the
  operator per this cluster's live-archive-safety constraint (t0dy's own AC5
  requires a verified backup + stopped daemon, which this session does not
  perform).
- **polylogue-lkrc** (parent) — re-verified against current `master`: the four
  "adversarial loop iteration 5" proof gaps named in its notes (capture_mode
  binding, `blob_ref.source_path` binding, `native_id` binding,
  `restore_canonical_head` field coverage) are already present in
  `_browser_origin_source_envelope_is_exact` on current `master` (landed via
  PRs #2843/#2847/#2848/#2850, all merged after the note was written). AC1
  (new captures acquire correct origin) is already covered by
  `test_streaming_sized_browser_capture_json_uses_native_payload_detection`.
  Remaining scope (AC4's dynamic live census reaching zero, or — after this
  PR — an explicit durable blocking state for the four) is live-execution-only.
- **polylogue-lkrc.2** — code already merged (PR #2850); remaining scope is
  purely the parent-run stopped-daemon dry proof/apply/postflight, which is
  live-execution-only and out of this PR's scope.
- **polylogue-yla8** / **polylogue-yla8.6** — both substantially closed via
  already-merged children (yla8.10 closed with live postflight evidence;
  yla8.6's own notes record a completed live repair). No further code gap
  identified beyond what's already merged; final closure is a live-postflight
  confirmation, reserved for the operator.
- **polylogue-57rp** — AC1/AC3 already satisfied (PR #2785). AC2 (exact
  848,460-byte/SHA reproduction) and AC5 (live re-capture convergence)
  inherently require either embedding real recovered production bytes in a
  repo fixture or a live capture — correctly left deferred, not fabricated.
  AC4 (replay-debt counts) was investigated; extending it safely would need a
  materially deeper read of `_raw_materialization_candidate_ids`'s WHERE
  clause than this session's remaining budget allowed, so it is left as
  explicitly deferred rather than guessed at.
- **polylogue-5k5l.1** — its own scope (extension-side authenticated asset
  acquisition) is complete per its notes (PR #2712, live-proven); the one
  remaining item it names is explicitly owned by 57rp, not 5k5l.1.

## Review response (polylogue-hleq)

An adversarial review found two majors and a minor, held pending fixes. All
three are addressed in the follow-up commit on this branch:

- **MAJOR — TOCTOU receipt race**: `repair_duplicate_raw_identity`'s
  apply-mode receipt was a single unlocked `receipt_path.write_text()` call
  issued after the index transaction committed, gated only by a TOCTOU-racy
  `receipt_path.exists()` check — two concurrent `--apply` invocations could
  both pass the check before either wrote. **Fixed**: it now locks one
  receipt inode via the exact same
  `flock(LOCK_EX|LOCK_NB)` + `O_NOFOLLOW` + `fsync(file, then parent dir)`
  contract this codebase already uses for the quarantined-raw-repair receipt
  (`_lock_quarantined_raw_repair_receipt`), with the identical
  planned→applied two-phase JSONL shape and torn-terminal crash recovery. A
  second concurrent `--apply` against the same receipt path now fails closed
  with `RuntimeError: operator repair receipt is already locked by another
  apply` instead of racing into the transaction. New tests: concurrent-apply
  lock contention, crash-before-terminal-append resume, symlink receipt path
  rejection.
- **MAJOR — stale re-read in the byte-frontier witness branch**: the
  `elif competing_frontier_kind == "byte" and competing_raw_id != raw_id`
  branch in `_browser_canonical_authority_conflict_witness` re-read the
  competing raw mid-function on an independent point-in-time SQLite read,
  without re-proving it against the same snapshot the base eligibility proof
  (`base.reason`) used. **Fixed**: `inspect_browser_canonical_authority_conflicts`
  now wraps the base proof and the witness's own re-reads of
  `raw_revision_heads`/`raw_session_memberships`/`raw_revision_applications`
  in one `BEGIN DEFERRED`/`COMMIT` read transaction per raw id, so both see
  one consistent snapshot instead of two independent reads. This is
  read-only isolation, not the apply-time CAS/receipt ceremony — nothing is
  mutated, so `COMMIT` just releases the read lock. New test exercises the
  previously-untested byte-frontier message-divergence-evidence branch
  directly.
- **MINOR — `record_browser_canonical_authority_conflict_blockers` has no
  apply flag/proof-digest/receipt**: investigated and judged genuinely
  exempt from this file's actuator ceremony, not a gap to close with more
  machinery. That ceremony exists because the other actuators repoint
  *authoritative* identity state (`raw_revision_heads`, `sessions`) where an
  error is expensive to detect and reverse. This function never touches
  authoritative state — it writes exactly one `candidate`/non-injected/
  private assertion through `upsert_assertion`'s single write chokepoint
  (mirrors `upsert_pathology_findings_as_assertions`, #2383), which already
  refuses to resurrect a judged-terminal row back to candidate on a later
  automated write. Documented this reasoning directly in the function's
  docstring, and hardened it further: added an explicit
  `read_assertion_envelope`/`existing.status` guard so a re-run over
  unchanged evidence never touches a row an operator has already judged
  (accepted/rejected/deferred/superseded) — the same terminal-judgment
  protection this file's other candidate writers already have. New test
  proves a judged row's status and value survive a re-run untouched.
- **NIT — no CLI wiring**: not blocking, addressed anyway. All three
  functions are now reachable from `polylogue ops maintenance`:
  `browser-canonical-authority-conflicts` (read-only by default, `--record`
  persists blockers) and `duplicate-raw-identity` (dry-run/`--apply` with
  the same `--proof-digest`/`--receipt` contract as the sibling
  `quarantined-accepted-raws`/`browser-capture-origin-mismatches` commands),
  mirroring the existing actuator CLI pattern exactly. 4 new CLI adapter
  tests.

## Verification

```
devtools test tests/unit/storage/test_browser_capture_origin_repair.py \
  tests/unit/storage/test_duplicate_raw_identity_repair.py
  -> 15 pre-existing failures (test_browser_capture_origin_copy_forward_
     mutations_fail_closed[*], reproduced identically on a clean checkout
     with this PR's changes stashed out), 127 passed

devtools test tests/unit/cli/test_archive_maintenance_cli.py -k \
  "browser_canonical_authority_conflicts or duplicate_raw_identity_cli"
  -> 3 passed

devtools test tests/unit/cli/test_archive_maintenance_cli.py (full file)
  -> 5 pre-existing failures (backup/migrate-tier, embedding-orphan-reconcile
     x2, assertion-export x2), reproduced identically with this PR's changes
     stashed out — confirmed unrelated flakiness, not caused by this diff

mypy polylogue/storage/repair.py polylogue/cli/commands/maintenance.py \
  tests/unit/storage/test_browser_capture_origin_repair.py \
  tests/unit/storage/test_duplicate_raw_identity_repair.py \
  tests/unit/cli/test_archive_maintenance_cli.py
  -> Success: no issues found in 5 source files

devtools verify --quick
  -> exit_code 0, all 15 steps green (run twice: once before the review-
     response commit, once after)
```

Not run: the full non-integration suite (`devtools verify --all`) or the live
archive.

## Anti-vacuity

- `test_inspect_conflicts_semantic_hash_divergence_evidence` mutates
  `raw_revision_heads.accepted_content_hash` to a distinct value and asserts
  the returned `competing_content_hash` reflects exactly that mutation;
  reverting to the original terse-reason-only inspector makes the assertion
  fail with `AttributeError`/`None`.
- `test_apply_repoints_head_and_session_preserving_stale_raw` asserts
  `raw_revision_heads.accepted_raw_id` and `sessions.raw_id` both equal
  `canonical_raw_id` after apply, the stale raw's own `raw_sessions` row is
  byte-for-byte unchanged, and the stale raw gained a `superseded` receipt
  naming `canonical_raw_id`; reverting `_apply_duplicate_raw_identity_repair`
  to a no-op makes the head/session assertions fail with the pre-repair
  (stale) raw id.
- `test_fails_closed_for_ineligible_shapes` mutates four different witness
  fields (competing accepted head, wrong accepted raw, content divergence,
  matching native_id schemes) and asserts apply raises before any write.
- `test_apply_serializes_one_receipt_inode_against_a_concurrent_apply`
  holds the real receipt-lock flock open (as a genuinely concurrent apply
  would) and proves a second `repair_duplicate_raw_identity(apply=True, ...)`
  call refuses and never mutates the accepted head; deleting the flock
  acquisition from the receipt lock (regressing to the old bare
  `receipt_path.exists()` TOCTOU check) makes this test fail.
- `test_record_conflict_blockers_never_clobbers_an_operator_judged_row`
  judges a blocker candidate via `judge_assertion_candidate(decision="accept")`,
  then re-runs the detector over identical evidence and asserts the judged
  row's status and value are byte-identical; deleting the
  `read_assertion_envelope`/`existing.status` guard makes this test fail
  (the judged row's value would silently be overwritten back to the
  detector's regenerated evidence payload).

## Live-archive safety

No repair actuator in this PR was run against the live archive at
`/realm/db/polylogue` (or any host archive) — every dry-run and apply call in
this PR's tests targets an isolated `tmp_path` fixture archive. The daemon
was not touched.

Ref polylogue-lkrc
Ref polylogue-lkrc.2
Ref polylogue-lkrc.3
Ref polylogue-t0dy
Ref polylogue-yla8
Ref polylogue-yla8.6
Ref polylogue-57rp
Ref polylogue-5k5l.1
Ref polylogue-hleq

Co-Authored-By: Claude <noreply@anthropic.com>
