### PR TITLE
refactor: consolidate role synonym vocabulary (polylogue-a7xr.7)

### DIFF
--- a/polylogue/archive/message/roles.py
+++ b/polylogue/archive/message/roles.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from typing import TypeAlias
 
-from polylogue.core.enums import Role
+from polylogue.core.enums import ROLE_SYNONYMS, Role
 
 
 def normalize_role(raw: str) -> str:
@@ -15,12 +15,10 @@ def normalize_role(raw: str) -> str:
 
 MessageRoleFilter: TypeAlias = tuple[Role, ...]
 
+# Derive SQL values for role filtering from the single source of truth in core/enums.py.
+# Maps each canonical role to its provider string synonyms for SQL WHERE clause expansion.
 ROLE_SQL_VALUES: dict[Role, tuple[str, ...]] = {
-    Role.USER: ("user", "human"),
-    Role.ASSISTANT: ("assistant", "model", "ai"),
-    Role.SYSTEM: ("system", "developer"),
-    Role.TOOL: ("tool", "function", "tool_use", "tool_result", "progress", "result"),
-    Role.UNKNOWN: ("unknown",),
+    role: tuple(sorted(synonyms)) for role, synonyms in ROLE_SYNONYMS.items()
 }
 
 

--- a/polylogue/core/enums.py
+++ b/polylogue/core/enums.py
@@ -126,15 +126,21 @@ class Role(PolylogueStrEnum):
         if not lowered:
             raise ValueError("Role cannot be empty. Handle missing roles at parse time.")
 
-        if lowered in {"user", "human"}:
-            return cls.USER
-        if lowered in {"assistant", "model", "ai"}:
-            return cls.ASSISTANT
-        if lowered in {"system", "developer"}:
-            return cls.SYSTEM
-        if lowered in {"tool", "function", "tool_use", "tool_result", "progress", "result"}:
-            return cls.TOOL
+        for canonical, synonyms in ROLE_SYNONYMS.items():
+            if lowered in synonyms:
+                return canonical
         return cls.UNKNOWN
+
+
+# Single source of truth for role synonym mapping (canonical -> provider strings).
+# Used by Role.normalize and derived by archive/message/roles.py for SQL filtering.
+ROLE_SYNONYMS: dict[Role, frozenset[str]] = {
+    Role.USER: frozenset(("user", "human")),
+    Role.ASSISTANT: frozenset(("assistant", "model", "ai")),
+    Role.SYSTEM: frozenset(("system", "developer")),
+    Role.TOOL: frozenset(("tool", "function", "tool_use", "tool_result", "progress", "result")),
+    Role.UNKNOWN: frozenset(("unknown",)),
+}
 
 
 class MessageType(PolylogueStrEnum):

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -24,7 +24,7 @@ from polylogue.surfaces.payloads import (
     SurfacePayloadModel,
     build_search_envelope,
     model_json_document,
-    normalize_role,
+    role_label,
 )
 from polylogue.surfaces.payloads import (
     ReaderActionAvailabilityPayload as MCPReaderActionAvailabilityPayload,
@@ -1055,7 +1055,7 @@ __all__ = [
     "model_json_document",
     "neighbor_candidates_payload",
     "logical_session_payload",
-    "normalize_role",
+    "role_label",
     "session_tree_payload",
     "session_topology_payload",
 ]

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -462,7 +462,8 @@ class ToolFamilyComparisonPayload(SurfacePayloadModel):
     caveats: tuple[str, ...] = ()
 
 
-def normalize_role(role: object) -> str:
+def role_label(role: object) -> str:
+    """Convert a role object to its string label for display."""
     if not role:
         return "unknown"
     if isinstance(role, Enum):
@@ -709,7 +710,7 @@ class SessionMessagePayload(SurfacePayloadModel):
         )
         return cls(
             id=str(message.id),
-            role=normalize_role(message.role),
+            role=role_label(message.role),
             text=message.text or "",
             target_ref=target_ref,
             anchor=reader_anchor("message", message.id),
@@ -769,7 +770,7 @@ class SessionMessagePayload(SurfacePayloadModel):
         )
         return cls(
             id=message_id,
-            role=normalize_role(getattr(message, "role", "")),
+            role=role_label(getattr(message, "role", "")),
             text=text,
             target_ref=TargetRefPayload.message(session_id=session_id, message_id=message_id),
             anchor=reader_anchor("message", message_id),
@@ -3622,7 +3623,7 @@ __all__ = [
     "build_query_unit_envelope",
     "decode_search_cursor",
     "model_json_document",
-    "normalize_role",
+    "role_label",
     "reader_anchor",
     "reader_session_actions",
     "reader_message_actions",

--- a/tests/unit/core/test_enums.py
+++ b/tests/unit/core/test_enums.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from polylogue.archive.message.roles import Role
+from polylogue.archive.message.roles import ROLE_SQL_VALUES, Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.core.enums import (
+    ROLE_SYNONYMS,
     BlockType,
     Origin,
     PasteBoundary,
@@ -71,3 +72,30 @@ def test_provider_aliases_still_normalize_during_transition() -> None:
     assert Provider.from_string("openai") is Provider.CHATGPT
     assert Provider.from_string("claude") is Provider.CLAUDE_AI
     assert str(Provider.CODEX) == "codex"
+
+
+def test_role_synonyms_and_sql_values_are_coupled() -> None:
+    """Verify ROLE_SYNONYMS and ROLE_SQL_VALUES stay in sync (coupling test).
+
+    ROLE_SYNONYMS in core/enums.py is the single source of truth for role synonyms.
+    ROLE_SQL_VALUES in archive/message/roles.py is derived from ROLE_SYNONYMS.
+    This test ensures they remain coupled.
+    """
+    # Every canonical role in ROLE_SYNONYMS has corresponding entry in ROLE_SQL_VALUES
+    assert set(ROLE_SYNONYMS.keys()) == set(ROLE_SQL_VALUES.keys())
+
+    # Every synonym in ROLE_SYNONYMS round-trips through Role.normalize
+    for canonical_role, synonyms in ROLE_SYNONYMS.items():
+        for synonym in synonyms:
+            normalized = Role.normalize(synonym)
+            assert normalized is canonical_role, (
+                f"Synonym {synonym!r} normalized to {normalized}, expected {canonical_role}"
+            )
+
+    # ROLE_SQL_VALUES values match ROLE_SYNONYMS (as sorted tuples)
+    for canonical_role, synonyms in ROLE_SYNONYMS.items():
+        sql_values = ROLE_SQL_VALUES[canonical_role]
+        expected_values = tuple(sorted(synonyms))
+        assert sql_values == expected_values, (
+            f"ROLE_SQL_VALUES[{canonical_role}] = {sql_values}, expected {expected_values}"
+        )


### PR DESCRIPTION
## Summary

Consolidate role synonym vocabulary into a single source of truth to prevent divergence between Role.normalize and ROLE_SQL_VALUES. Also rename normalize_role in surfaces/payloads.py to role_label to avoid confusion with the canonicalizing version.

## Problem

Two separate places maintain role synonyms independently:
- `core/enums.py:127-137` — `Role.normalize` maps synonyms→canonical
- `archive/message/roles.py:18-24` — `ROLE_SQL_VALUES` holds the same sets inverted

When a synonym is added (e.g., "progress", "result"), both must be updated by hand or the other silently gets out of sync, causing --role filters to miss rows. Additionally, two unrelated functions named normalize_role create wrong-import failure modes.

## Solution

- Create `ROLE_SYNONYMS: dict[Role, frozenset[str]]` in `core/enums.py` as the single source of truth
- Update `Role.normalize` to iterate through `ROLE_SYNONYMS`
- Derive `ROLE_SQL_VALUES` in `archive/message/roles.py` from `ROLE_SYNONYMS` (~6 lines)
- Rename `normalize_role` in `surfaces/payloads.py` to `role_label` and update all call sites
- Add coupling test to verify every synonym round-trips through `Role.normalize` and `ROLE_SQL_VALUES` stays in sync

## Verification

- All 387 role-related tests pass (`devtools test -k role`)
- All 387 role-related tests pass (pytest-testmon affected selection)
- `devtools verify --quick` passes (format, lint, mypy, render all, layering)
- Coupling test verifies:
  - Every canonical role in `ROLE_SYNONYMS` has corresponding entry in `ROLE_SQL_VALUES`
  - Every synonym round-trips through `Role.normalize` to its canonical role
  - `ROLE_SQL_VALUES` values match `ROLE_SYNONYMS` as sorted tuples

Ref polylogue-a7xr.7.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved recognition of equivalent role names from different providers.
  * Standardized role labels in session messages and archived message views.
  * Improved role-based message filtering by including recognized role alternatives.
* **Bug Fixes**
  * Unknown or empty roles now consistently display as “unknown.”
* **Tests**
  * Added coverage to verify role recognition and filtering remain synchronized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->