### PR TITLE
chore: remove dead session-commit stubs and unused web-construct row

### DIFF
--- a/polylogue/insights/session_commit.py
+++ b/polylogue/insights/session_commit.py
@@ -452,38 +452,6 @@ def build_correlation_result(
 # ── Database operations ─────────────────────────────────────────────────
 
 
-async def persist_session_commits(
-    edges: list[SessionCommitEdge],
-    *,
-    repo_id: int | None = None,
-) -> None:
-    """Persist session_commits to the database (placeholder).
-
-    This is called by the MCP tool after detection. The actual write
-    path is through the Polylogue facade / repository. This function
-    exists as the contract declaration; the inline write in the MCP
-    tool is used for the initial implementation.
-    """
-    del edges, repo_id
-
-
-def session_commit_edge_to_row(
-    edge: SessionCommitEdge,
-    *,
-    repo_id: int | None = None,
-) -> dict[str, object]:
-    """Convert a SessionCommitEdge to a row dict for SQLite insert."""
-    return {
-        "session_id": edge.session_id,
-        "commit_sha": edge.commit_sha,
-        "repo_id": repo_id,
-        "detection_method": edge.detection_method,
-        "confidence": edge.confidence,
-        "file_overlap_count": edge.file_overlap_count,
-        "created_at": datetime.now(timezone.utc).isoformat(),
-    }
-
-
 def correlation_result_to_payload(
     result: SessionCorrelationResult,
 ) -> dict[str, object]:

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -72,33 +72,6 @@ class ArchiveBlockRow:
 
 
 @dataclass(frozen=True, slots=True)
-class ArchiveWebConstructRow:
-    construct_id: str
-    session_id: str
-    message_id: str
-    block_id: str
-    position: int
-    provider: str
-    construct_type: str
-    provider_key: str | None = None
-    title: str | None = None
-    url: str | None = None
-    text: str | None = None
-    source_id: str | None = None
-    group_id: str | None = None
-    group_title: str | None = None
-    query: str | None = None
-    asset_pointer: str | None = None
-    mime_type: str | None = None
-    status: str | None = None
-    task_id: str | None = None
-    task_type: str | None = None
-    rank: int | None = None
-    start_index: int | None = None
-    end_index: int | None = None
-
-
-@dataclass(frozen=True, slots=True)
 class ArchiveAttachmentRow:
     attachment_id: str
     message_id: str | None

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -19,7 +19,7 @@ sanitizer boundaries. Each target has two modes:
 | `fuzz_fts5_escape.py` | `fuzz_fts5_escape` | `polylogue.storage.search.escape_fts5_query` — SQLite FTS5 MATCH escaping. |
 | `fuzz_json_parsers.py` | `fuzz_chatgpt_parser`, `fuzz_codex_parser`, `fuzz_claude_code_parser`, `fuzz_claude_ai_parser`, `fuzz_drive_parser`, `fuzz_antigravity_parser`, `fuzz_browser_capture_parser`, `fuzz_local_agent_parser`, `fuzz_all_parsers` | `polylogue.sources.parsers.*` — provider record dispatch (chatgpt, codex, claude-code/ai, drive/gemini, antigravity, browser_capture, local_agent). |
 | `fuzz_path_sanitizer.py` | `fuzz_path_sanitizer`, `fuzz_name_sanitizer` | `polylogue.core.security.sanitize_path` and filename sanitization. |
-| `fuzz_timestamp.py` | `fuzz_parse_timestamp`, `fuzz_normalize_timestamp`, `fuzz_format_timestamp`, `fuzz_all_timestamps` | `polylogue.lib.timestamps` — ISO/epoch parsing and normalization. |
+| `fuzz_timestamp.py` | `fuzz_parse_timestamp`, `fuzz_normalize_timestamp`, `fuzz_format_timestamp`, `fuzz_all_timestamps` | `polylogue.core.timestamps` — ISO/epoch parsing and normalization. |
 
 Every public target above is asserted to be present and structurally callable
 by `tests/unit/sources/test_fuzz_targets_executable.py`. That test does not


### PR DESCRIPTION
## Summary

Removes three dead/unused symbols confirmed to have zero call sites across the entire codebase:

1. **insights/session_commit.py**:
   - `async persist_session_commits()` — no-op placeholder, never called by any code
   - `session_commit_edge_to_row()` — never called; actual writes done inline in `_write_web_constructs`

2. **storage/sqlite/archive_tiers/write.py**:
   - `ArchiveWebConstructRow` dataclass — never instantiated; function uses plain tuples for INSERT rows

3. **tests/fuzz/README.md**:
   - Fixed stale documentation reference from `polylogue.lib.timestamps` (deleted module) to `polylogue.core.timestamps`

## Verification

- All call sites confirmed absent via `rg` grep:
  - `rg persist_session_commits` → only definition
  - `rg session_commit_edge_to_row` → only definition  
  - `rg ArchiveWebConstructRow` → only class definition
- `devtools verify --quick` ✓ (format, lint, mypy, render, layering, topology, all pass)
- Pre-push hook ✓ (all 15 verification stages passed)
- No behavior change — mechanical cleanup only

Ref polylogue-1a9.