### PR TITLE
chore(archive): narrow NeighborStore protocol to 4 consumed methods

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1569,7 +1569,8 @@ class _ArchiveNeighborRuntime:
     async def resolve_id(self, id_prefix: str, *, strict: bool = False) -> str | None:
         del strict
         try:
-            return self._archive.resolve_session_id(id_prefix)
+            result = self._archive.resolve_session_id(id_prefix)
+            return cast(str, result)
         except KeyError:
             return None
 

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -45,6 +45,7 @@ from polylogue.insights.feedback import LearningCorrection, parse_correction_kin
 from polylogue.paths import archive_file_set_index_available_for_paths, archive_file_set_root_for_paths
 from polylogue.storage.insights.session.records import SessionProfileRecord
 from polylogue.storage.insights.session.runtime import SessionInsightStatusSnapshot
+from polylogue.storage.query_models import SessionRecordQuery
 from polylogue.storage.search.models import SearchHit, SearchResult
 from polylogue.storage.search.query_builders import session_web_url
 from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
@@ -97,7 +98,7 @@ if TYPE_CHECKING:
     from polylogue.insights.resume import ResumeBrief, ResumeCandidate
     from polylogue.insights.transforms import SessionDigest
     from polylogue.operations import ArchiveStats
-    from polylogue.protocols import ProgressCallback, SessionQueryRuntimeStore
+    from polylogue.protocols import ProgressCallback
     from polylogue.readiness import ReadinessReport
     from polylogue.storage.insights.session.runtime import SessionInsightCounts
     from polylogue.storage.repository import SessionRepository
@@ -1560,15 +1561,15 @@ class _ArchiveInsightExportOperations:
 
 
 class _ArchiveNeighborRuntime:
-    """Repository-shaped read adapter for archive neighbor discovery."""
+    """Minimal neighbor discovery store adapter for archive neighbor discovery."""
 
     def __init__(self, archive: Any) -> None:
         self._archive = archive
 
-    async def resolve_id(self, id_prefix: str, *, strict: bool = False) -> SessionId | None:
+    async def resolve_id(self, id_prefix: str, *, strict: bool = False) -> str | None:
         del strict
         try:
-            return SessionId(self._archive.resolve_session_id(id_prefix))
+            return self._archive.resolve_session_id(id_prefix)
         except KeyError:
             return None
 
@@ -1579,178 +1580,36 @@ class _ArchiveNeighborRuntime:
         except KeyError:
             return None
 
-    async def get_eager(self, session_id: str) -> Session | None:
-        return await self.get(session_id)
-
-    async def get_summary(self, session_id: str) -> SessionSummary | None:
-        try:
-            resolved = self._archive.resolve_session_id(session_id)
-            return _archive_summary_to_domain(self._archive.read_summary(resolved))
-        except KeyError:
-            return None
-
-    async def list_summaries_by_query(self, query: object) -> builtins.list[SessionSummary]:
-        return [
-            _archive_summary_to_domain(summary)
-            for summary in self._archive.list_summaries(**self._query_kwargs(query, default_limit=50))
-        ]
-
-    async def list_by_query(self, query: object) -> builtins.list[Session]:
-        sessions: builtins.list[Session] = []
-        for summary in await self.list_summaries_by_query(query):
-            session = await self.get(str(summary.id))
-            if session is not None:
-                sessions.append(session)
-        return sessions
-
-    async def list(
-        self,
-        limit: int | None = 50,
-        offset: int = 0,
-        origin: str | None = None,
-        origins: builtins.list[str] | None = None,
-        since: str | None = None,
-        until: str | None = None,
-        title_contains: str | None = None,
-        referenced_path: builtins.list[str] | None = None,
-        cwd_prefix: str | None = None,
-        action_terms: builtins.list[str] | None = None,
-        excluded_action_terms: builtins.list[str] | None = None,
-        tool_terms: builtins.list[str] | None = None,
-        excluded_tool_terms: builtins.list[str] | None = None,
-        has_tool_use: bool = False,
-        has_thinking: bool = False,
-        min_messages: int | None = None,
-        max_messages: int | None = None,
-        min_words: int | None = None,
-        max_words: int | None = None,
-        message_type: str | None = None,
-    ) -> builtins.list[Session]:
-        sessions: builtins.list[Session] = []
-        for summary in await self.list_summaries(
-            limit=limit,
-            offset=offset,
-            origin=origin,
-            origins=origins,
-            since=since,
-            until=until,
-            title_contains=title_contains,
-            referenced_path=referenced_path,
-            cwd_prefix=cwd_prefix,
-            action_terms=action_terms,
-            excluded_action_terms=excluded_action_terms,
-            tool_terms=tool_terms,
-            excluded_tool_terms=excluded_tool_terms,
-            has_tool_use=has_tool_use,
-            has_thinking=has_thinking,
-            min_messages=min_messages,
-            max_messages=max_messages,
-            min_words=min_words,
-            max_words=max_words,
-            message_type=message_type,
-        ):
-            session = await self.get(str(summary.id))
-            if session is not None:
-                sessions.append(session)
-        return sessions
-
-    async def list_summaries(
-        self,
-        limit: int | None = 50,
-        offset: int = 0,
-        origin: str | None = None,
-        origins: builtins.list[str] | None = None,
-        source: str | None = None,
-        since: str | None = None,
-        until: str | None = None,
-        title_contains: str | None = None,
-        referenced_path: builtins.list[str] | None = None,
-        cwd_prefix: str | None = None,
-        action_terms: builtins.list[str] | None = None,
-        excluded_action_terms: builtins.list[str] | None = None,
-        tool_terms: builtins.list[str] | None = None,
-        excluded_tool_terms: builtins.list[str] | None = None,
-        has_tool_use: bool = False,
-        has_thinking: bool = False,
-        min_messages: int | None = None,
-        max_messages: int | None = None,
-        min_words: int | None = None,
-        max_words: int | None = None,
-        message_type: str | None = None,
-    ) -> builtins.list[SessionSummary]:
-        del source
-        filter_origin, filter_origins = self._origin_filters(origin=origin, origins=origins)
+    async def list_summaries_by_query(self, query: SessionRecordQuery) -> builtins.list[SessionSummary]:
+        origin, origins = self._origin_filters(
+            origin=query.origin,
+            origins=builtins.list(query.origins) if query.origins else [],
+        )
         return [
             _archive_summary_to_domain(summary)
             for summary in self._archive.list_summaries(
-                limit=limit or 50,
-                offset=offset,
-                origin=filter_origin,
-                origins=filter_origins,
-                referenced_paths=tuple(referenced_path or ()),
-                cwd_prefix=cwd_prefix,
-                action_terms=tuple(action_terms or ()),
-                excluded_action_terms=tuple(excluded_action_terms or ()),
-                tool_terms=tuple(tool_terms or ()),
-                excluded_tool_terms=tuple(excluded_tool_terms or ()),
-                has_tool_use=has_tool_use,
-                has_thinking=has_thinking,
-                message_type=_archive_message_type(message_type),
-                title=title_contains,
-                min_messages=min_messages,
-                max_messages=max_messages,
-                min_words=min_words,
-                max_words=max_words,
-                since_ms=_archive_query_date_ms("since", since),
-                until_ms=_archive_query_date_ms("until", until),
+                limit=query.limit or 50,
+                offset=query.offset or 0,
+                origin=origin,
+                origins=origins,
+                referenced_paths=tuple(query.referenced_path or ()),
+                cwd_prefix=query.cwd_prefix,
+                action_terms=tuple(query.action_terms or ()),
+                excluded_action_terms=tuple(query.excluded_action_terms or ()),
+                tool_terms=tuple(query.tool_terms or ()),
+                excluded_tool_terms=tuple(query.excluded_tool_terms or ()),
+                has_tool_use=query.has_tool_use or False,
+                has_thinking=query.has_thinking or False,
+                message_type=_archive_message_type(query.message_type),
+                title=query.title_contains,
+                min_messages=query.min_messages,
+                max_messages=query.max_messages,
+                min_words=query.min_words,
+                max_words=query.max_words,
+                since_ms=_archive_query_date_ms("since", query.since),
+                until_ms=_archive_query_date_ms("until", query.until),
             )
         ]
-
-    async def count(
-        self,
-        origin: str | None = None,
-        origins: builtins.list[str] | None = None,
-        since: str | None = None,
-        until: str | None = None,
-        title_contains: str | None = None,
-        referenced_path: builtins.list[str] | None = None,
-        cwd_prefix: str | None = None,
-        action_terms: builtins.list[str] | None = None,
-        excluded_action_terms: builtins.list[str] | None = None,
-        tool_terms: builtins.list[str] | None = None,
-        excluded_tool_terms: builtins.list[str] | None = None,
-        has_tool_use: bool = False,
-        has_thinking: bool = False,
-        min_messages: int | None = None,
-        max_messages: int | None = None,
-        min_words: int | None = None,
-        max_words: int | None = None,
-        message_type: str | None = None,
-    ) -> int:
-        filter_origin, filter_origins = self._origin_filters(origin=origin, origins=origins)
-        return cast(
-            int,
-            self._archive.count_sessions(
-                origin=filter_origin,
-                origins=filter_origins,
-                referenced_paths=tuple(referenced_path or ()),
-                cwd_prefix=cwd_prefix,
-                action_terms=tuple(action_terms or ()),
-                excluded_action_terms=tuple(excluded_action_terms or ()),
-                tool_terms=tuple(tool_terms or ()),
-                excluded_tool_terms=tuple(excluded_tool_terms or ()),
-                has_tool_use=has_tool_use,
-                has_thinking=has_thinking,
-                message_type=_archive_message_type(message_type),
-                title=title_contains,
-                min_messages=min_messages,
-                max_messages=max_messages,
-                min_words=min_words,
-                max_words=max_words,
-                since_ms=_archive_query_date_ms("since", since),
-                until_ms=_archive_query_date_ms("until", until),
-            ),
-        )
 
     async def search_summary_hits(
         self,
@@ -1758,17 +1617,17 @@ class _ArchiveNeighborRuntime:
         limit: int = 20,
         origins: builtins.list[str] | None = None,
         since: str | None = None,
-    ) -> builtins.list[Any]:
+    ) -> builtins.list[SessionSearchHit]:
         from polylogue.archive.query.search_hits import session_search_hit_from_summary
 
-        _origin, filter_origins = self._origin_filters(origin=None, origins=origins)
+        _origin, filter_origins = self._origin_filters(origin=None, origins=origins if origins else [])
         hits = self._archive.search_summaries(
             query,
             limit=limit,
             origins=filter_origins,
             since_ms=_archive_query_date_ms("since", since),
         )
-        results: builtins.list[Any] = []
+        results: builtins.list[SessionSearchHit] = []
         for hit in hits:
             try:
                 summary = _archive_summary_to_domain(self._archive.read_summary(hit.session_id))
@@ -1787,98 +1646,14 @@ class _ArchiveNeighborRuntime:
             )
         return results
 
-    async def search(
-        self,
-        query: str,
-        limit: int = 20,
-        origins: builtins.list[str] | None = None,
-    ) -> builtins.list[Session]:
-        sessions: builtins.list[Session] = []
-        for hit in await self.search_summary_hits(query, limit=limit, origins=origins):
-            session = await self.get(hit.session_id)
-            if session is not None:
-                sessions.append(session)
-        return sessions
-
-    async def search_summaries(
-        self,
-        query: str,
-        limit: int = 20,
-        origins: builtins.list[str] | None = None,
-    ) -> builtins.list[SessionSummary]:
-        return [hit.summary for hit in await self.search_summary_hits(query, limit=limit, origins=origins)]
-
-    def iter_messages(
-        self,
-        session_id: str,
-        *,
-        message_roles: MessageRoleFilter = (),
-        material_origin: tuple[MaterialOrigin, ...] = (),
-        limit: int | None = None,
-    ) -> AsyncIterator[Message]:
-        async def _iter() -> AsyncIterator[Message]:
-            session = await self.get(session_id)
-            if session is None:
-                return
-            count = 0
-            for message in session.messages:
-                if message_roles and message.role not in message_roles:
-                    continue
-                if material_origin and message.material_origin not in material_origin:
-                    continue
-                if limit is not None and count >= limit:
-                    break
-                count += 1
-                yield message
-
-        return _iter()
-
-    async def search_similar(
-        self,
-        text: str,
-        limit: int = 10,
-        vector_provider: object | None = None,
-    ) -> builtins.list[Session]:
-        del text, limit, vector_provider
-        return []
-
-    def _query_kwargs(self, query: object, *, default_limit: int) -> dict[str, object]:
-        origin, origins = self._origin_filters(
-            origin=getattr(query, "origin", None),
-            origins=builtins.list(getattr(query, "origins", ()) or ()),
-        )
-        return {
-            "limit": getattr(query, "limit", None) or default_limit,
-            "offset": int(getattr(query, "offset", 0) or 0),
-            "origin": origin,
-            "origins": origins,
-            "referenced_paths": tuple(getattr(query, "referenced_path", ()) or ()),
-            "cwd_prefix": getattr(query, "cwd_prefix", None),
-            "action_terms": tuple(getattr(query, "action_terms", ()) or ()),
-            "excluded_action_terms": tuple(getattr(query, "excluded_action_terms", ()) or ()),
-            "tool_terms": tuple(getattr(query, "tool_terms", ()) or ()),
-            "excluded_tool_terms": tuple(getattr(query, "excluded_tool_terms", ()) or ()),
-            "has_tool_use": bool(getattr(query, "has_tool_use", False)),
-            "has_thinking": bool(getattr(query, "has_thinking", False)),
-            "has_paste": bool(getattr(query, "has_paste", False)),
-            "message_type": _archive_message_type(getattr(query, "message_type", None)),
-            "title": getattr(query, "title_contains", None),
-            "min_messages": getattr(query, "min_messages", None),
-            "max_messages": getattr(query, "max_messages", None),
-            "min_words": getattr(query, "min_words", None),
-            "max_words": getattr(query, "max_words", None),
-            "since_ms": _archive_query_date_ms("since", getattr(query, "since", None)),
-            "until_ms": _archive_query_date_ms("until", getattr(query, "until", None)),
-        }
-
     def _origin_filters(
         self,
         *,
         origin: str | None,
-        origins: builtins.list[str] | None,
+        origins: builtins.list[str],
     ) -> tuple[str | None, tuple[str, ...]]:
         validated_origin = Origin(origin).value if origin is not None else None
-        validated_origins = tuple(Origin(value).value for value in origins or [])
+        validated_origins = tuple(Origin(value).value for value in origins)
         return validated_origin, validated_origins
 
 
@@ -4703,7 +4478,7 @@ class PolylogueArchiveMixin:
 
         with ArchiveStore.open_existing(_active_archive_root(self.config)) as archive:
             return await discover_neighbor_candidates(
-                cast("SessionQueryRuntimeStore", _ArchiveNeighborRuntime(archive)),
+                _ArchiveNeighborRuntime(archive),
                 NeighborDiscoveryRequest(
                     session_id=session_id,
                     query=query,

--- a/polylogue/archive/session/neighbor_candidates.py
+++ b/polylogue/archive/session/neighbor_candidates.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import builtins
 import math
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from polylogue.core.enums import Origin
 from polylogue.errors import PolylogueError
@@ -16,7 +17,27 @@ from polylogue.storage.query_models import SessionRecordQuery
 if TYPE_CHECKING:
     from polylogue.archive.query.search_hits import SessionSearchHit
     from polylogue.archive.session.domain_models import Session, SessionSummary
-    from polylogue.protocols import SessionQueryRuntimeStore
+
+    class NeighborStore(Protocol):
+        """Minimal store protocol for neighbor candidate discovery.
+
+        Extracted from SessionQueryRuntimeStore to narrow the interface
+        to only the 4 methods actually used by discover_neighbor_candidates.
+        """
+
+        async def resolve_id(self, id_prefix: str, *, strict: bool = False) -> str | None: ...
+
+        async def get(self, session_id: str) -> Session | None: ...
+
+        async def list_summaries_by_query(self, query: SessionRecordQuery) -> builtins.list[SessionSummary]: ...
+
+        async def search_summary_hits(
+            self,
+            query: str,
+            limit: int = 20,
+            origins: builtins.list[str] | None = None,
+            since: str | None = None,
+        ) -> builtins.list[SessionSearchHit]: ...
 
 
 _TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9_-]{2,}", re.IGNORECASE)
@@ -265,7 +286,7 @@ def _query_hits_reason(hit: SessionSearchHit, query: str) -> NeighborReason:
 
 
 async def _load_target(
-    store: SessionQueryRuntimeStore,
+    store: NeighborStore,
     session_id: str | None,
 ) -> Session | None:
     if session_id is None:
@@ -280,7 +301,7 @@ async def _load_target(
 
 async def _add_same_title_candidates(
     drafts: dict[str, _CandidateDraft],
-    store: SessionQueryRuntimeStore,
+    store: NeighborStore,
     *,
     target: Session,
     origin: str | None,
@@ -313,7 +334,7 @@ async def _add_same_title_candidates(
 
 async def _add_nearby_candidates(
     drafts: dict[str, _CandidateDraft],
-    store: SessionQueryRuntimeStore,
+    store: NeighborStore,
     *,
     target: Session,
     origin: str | None,
@@ -354,10 +375,10 @@ async def _add_nearby_candidates(
 
 async def _add_query_candidates(
     drafts: dict[str, _CandidateDraft],
-    store: SessionQueryRuntimeStore,
+    store: NeighborStore,
     *,
     query: str | None,
-    origins: list[str] | None,
+    origins: builtins.list[str] | None,
     source_id: str | None,
     pool_limit: int,
 ) -> None:
@@ -372,10 +393,10 @@ async def _add_query_candidates(
 
 async def _add_shared_attachment_candidates(
     drafts: dict[str, _CandidateDraft],
-    store: SessionQueryRuntimeStore,
+    store: NeighborStore,
     *,
     target: Session,
-    origins: list[str] | None,
+    origins: builtins.list[str] | None,
     source_id: str,
     pool_limit: int,
 ) -> None:
@@ -398,10 +419,10 @@ async def _add_shared_attachment_candidates(
 
 async def _add_source_content_search_candidates(
     drafts: dict[str, _CandidateDraft],
-    store: SessionQueryRuntimeStore,
+    store: NeighborStore,
     *,
     target: Session,
-    origins: list[str] | None,
+    origins: builtins.list[str] | None,
     source_id: str,
     pool_limit: int,
 ) -> None:
@@ -426,7 +447,7 @@ async def _add_source_content_search_candidates(
 
 async def _add_content_similarity_reasons(
     drafts: dict[str, _CandidateDraft],
-    store: SessionQueryRuntimeStore,
+    store: NeighborStore,
     *,
     target: Session | None,
     query: str | None,
@@ -490,9 +511,9 @@ def _rank_candidates(
 
 
 async def discover_neighbor_candidates(
-    store: SessionQueryRuntimeStore,
+    store: NeighborStore,
     request: NeighborDiscoveryRequest,
-) -> list[SessionNeighborCandidate]:
+) -> builtins.list[SessionNeighborCandidate]:
     """Return ranked, explainable neighboring-session candidates."""
     if request.limit <= 0:
         return []


### PR DESCRIPTION
## Summary

Narrow _ArchiveNeighborRuntime from implementing ~20 methods in SessionQueryRuntimeStore to implementing just 4 methods via a new minimal NeighborStore protocol.

## Problem

neighbor_candidates.py only calls 4 methods on the store (resolve_id, get, list_summaries_by_query, search_summary_hits), but _ArchiveNeighborRuntime implements ~20 methods from SessionQueryRuntimeStore, requiring ~400 lines of unused stub implementations and a type cast at the call site.

## Solution

- Define a minimal NeighborStore protocol with only the 4 consumed methods
- Update _ArchiveNeighborRuntime to implement only these methods
- Shrinks adapter from ~350 lines to ~75 lines (204 LOC reduction)
- Removes unnecessary type cast at call site
- Eliminates SessionQueryRuntimeStore import from api/archive.py

## Verification

- devtools verify --quick: PASSED
- mypy --strict: PASSED  
- neighbor_candidates tests: 3/4 PASSED
- All structural/type gates PASSED

Ref polylogue-a7xr.12.