### PR TITLE
feat(devtools): add read-only real-archive slice screening harness

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -456,6 +456,25 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "demo real-slice-screen",
+        "workspace",
+        "Read-only extraction + privacy screening of a candidate real-archive session slice.",
+        "devtools.proof_world_real_slice",
+        use_when=(
+            "Assembling a candidate real-archive slice for the shared demo proof world "
+            "(polylogue-212.11): pulls sessions read-only via the Polylogue API, flattens them "
+            "to text, and screens for secret/credential and PII-adjacent patterns before any "
+            "operator decides to fold the slice into a shared fixture. Never mutates the source "
+            "archive and never writes into polylogue/scenarios/ on its own."
+        ),
+        examples=(
+            "devtools demo real-slice-screen --archive-root /realm/db/polylogue "
+            "--session claude-code-session:<id>:<agent> --out .agent/scratch/real-slice",
+            "devtools demo real-slice-screen --archive-root /realm/db/polylogue "
+            "--refs-file refs.txt --out .agent/scratch/real-slice",
+        ),
+    ),
+    CommandSpec(
         "workspace dev-loop",
         "workspace",
         "Preflight branch-local daemon, web-shell, and browser-capture development loops.",

--- a/devtools/proof_world_real_slice.py
+++ b/devtools/proof_world_real_slice.py
@@ -1,0 +1,317 @@
+"""Real-archive candidate-slice extraction and privacy screening.
+
+Support for polylogue-212.11 (shared deterministic proof world / Incident
+14:32): the deterministic demo corpus should eventually be extended with a
+*representative slice of real archive data*, not synthetic fixtures alone.
+That extension is deliberately a two-step, human-gated process:
+
+1. This tool runs **read-only** queries against a real Polylogue archive,
+   flattens each candidate session to plain text, and screens that text for
+   secrets/credentials and personal-information patterns. It writes a report
+   plus rendered transcripts to an arbitrary output directory. It never
+   mutates the source archive (``Polylogue.get_session`` opens the archive
+   tiers with ``read_only=True``) and never writes into the product fixture
+   tree (``polylogue/scenarios/``) on its own.
+2. An operator reviews the report and transcripts and decides, session by
+   session, whether the slice is safe to fold into the shared proof-world
+   corpus. Only after that explicit approval should the slice move into a
+   real fixture path.
+
+The screening pass is a best-effort heuristic layer, not a certification.
+"Clean" means "no configured pattern fired" — an operator still has to read
+the transcripts before promoting anything to a shared fixture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Patterns that indicate a live secret/credential shape. Kept intentionally
+# narrow (favor false negatives over drowning the report in noise) — this is
+# a triage aid, not a DLP product.
+_SECRET_PATTERNS: dict[str, re.Pattern[str]] = {
+    "aws_access_key_id": re.compile(r"AKIA[0-9A-Z]{16}"),
+    "generic_credential_assignment": re.compile(
+        r"(?i)\b(api[_-]?key|secret|password|passwd|access[_-]?token)\b\s*[:=]\s*"
+        r"['\"]?[A-Za-z0-9_\-/+=.]{12,}"
+    ),
+    "bearer_token": re.compile(r"(?i)\bBearer\s+[A-Za-z0-9_\-.=]{16,}"),
+    "private_key_block": re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    "openai_style_key": re.compile(r"\bsk-[A-Za-z0-9]{20,}\b"),
+    "slack_token": re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
+    "ssh_public_key": re.compile(r"\bssh-(?:rsa|ed25519) [A-Za-z0-9+/]{20,}"),
+    "jwt_like": re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"),
+}
+
+# Patterns that may indicate personal information. These fire far more often
+# on ordinary dev-work text (localhost IPs, placeholder emails), so callers
+# should read the samples rather than treat any hit as disqualifying.
+_PII_PATTERNS: dict[str, re.Pattern[str]] = {
+    "email": re.compile(r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"),
+    "home_path": re.compile(r"/home/[a-zA-Z0-9_-]+"),
+    "ipv4": re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"),
+}
+
+# Substrings that are conventionally placeholders/loopback addresses, not
+# real personal data. A hit that is fully covered by an allowlisted
+# substring is downgraded but still reported (never silently dropped).
+_ALLOWLIST_SUBSTRINGS: tuple[str, ...] = (
+    "test@example.com",
+    "user@example.com",
+    "127.0.0.1",
+    "0.0.0.0",
+    "255.255.255.255",
+)
+
+_SNIPPET_RADIUS = 40
+_MAX_SAMPLES_PER_PATTERN = 5
+
+
+@dataclass(slots=True)
+class PatternHit:
+    pattern: str
+    kind: str  # "secret" | "pii"
+    count: int
+    samples: list[str] = field(default_factory=list)
+    all_allowlisted: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pattern": self.pattern,
+            "kind": self.kind,
+            "count": self.count,
+            "samples": self.samples,
+            "all_allowlisted": self.all_allowlisted,
+        }
+
+
+@dataclass(slots=True)
+class SessionScreeningResult:
+    session_id: str
+    origin: str
+    title: str | None
+    created_at: str | None
+    message_count: int
+    word_count: int
+    hits: list[PatternHit]
+
+    @property
+    def verdict(self) -> str:
+        secret_hits = [h for h in self.hits if h.kind == "secret"]
+        if secret_hits:
+            return "flagged"
+        pii_hits = [h for h in self.hits if h.kind == "pii" and not h.all_allowlisted]
+        if pii_hits:
+            return "review"
+        return "clean"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "origin": self.origin,
+            "title": self.title,
+            "created_at": self.created_at,
+            "message_count": self.message_count,
+            "word_count": self.word_count,
+            "verdict": self.verdict,
+            "hits": [h.to_dict() for h in self.hits],
+        }
+
+
+def _snippet(text: str, match: re.Match[str]) -> str:
+    start = max(0, match.start() - _SNIPPET_RADIUS)
+    end = min(len(text), match.end() + _SNIPPET_RADIUS)
+    prefix = "…" if start > 0 else ""
+    suffix = "…" if end < len(text) else ""
+    return f"{prefix}{text[start:end]!r}{suffix}"
+
+
+def scan_text(text: str) -> list[PatternHit]:
+    """Run every configured secret/PII pattern over ``text``.
+
+    Returns one :class:`PatternHit` per pattern that matched at least once,
+    each carrying up to ``_MAX_SAMPLES_PER_PATTERN`` truncated samples for
+    human review — never the full match set, to keep the report itself from
+    becoming a leak surface.
+    """
+
+    hits: list[PatternHit] = []
+    for kind, patterns in (("secret", _SECRET_PATTERNS), ("pii", _PII_PATTERNS)):
+        for name, pattern in patterns.items():
+            matches = list(pattern.finditer(text))
+            if not matches:
+                continue
+            samples = [_snippet(text, m) for m in matches[:_MAX_SAMPLES_PER_PATTERN]]
+            all_allowlisted = all(any(allowed in m.group(0) for allowed in _ALLOWLIST_SUBSTRINGS) for m in matches)
+            hits.append(
+                PatternHit(
+                    pattern=name,
+                    kind=kind,
+                    count=len(matches),
+                    samples=samples,
+                    all_allowlisted=all_allowlisted,
+                )
+            )
+    return hits
+
+
+def _flatten_session_text(session: Any) -> str:
+    """Flatten every message's text and structured blocks to one string."""
+
+    parts: list[str] = []
+    for message in session.messages:
+        if message.text:
+            parts.append(message.text)
+        if message.blocks:
+            parts.append(json.dumps(message.blocks, default=str))
+    return "\n".join(parts)
+
+
+async def screen_session(archive_root: Path, session_id: str) -> tuple[SessionScreeningResult, str]:
+    """Load one session read-only and screen it. Returns (result, transcript_text)."""
+
+    from polylogue.api import Polylogue
+
+    async with Polylogue(archive_root=archive_root) as pl:
+        session = await pl.get_session(session_id)
+        if session is None:
+            raise ValueError(f"session not found in archive: {session_id}")
+        text = _flatten_session_text(session)
+        word_count = len(text.split())
+        result = SessionScreeningResult(
+            session_id=str(session.id),
+            origin=str(session.origin),
+            title=session.title,
+            created_at=str(session.created_at) if session.created_at else None,
+            message_count=len(session.messages),
+            word_count=word_count,
+            hits=scan_text(text),
+        )
+        return result, text
+
+
+async def screen_sessions(archive_root: Path, session_ids: list[str]) -> list[tuple[SessionScreeningResult, str]]:
+    return [await screen_session(archive_root, session_id) for session_id in session_ids]
+
+
+def render_report_markdown(results: list[SessionScreeningResult], *, archive_root: Path) -> str:
+    lines = [
+        "# Real-archive candidate slice — privacy screening report",
+        "",
+        f"Archive root: `{archive_root}`",
+        f"Sessions screened: {len(results)}",
+        "",
+        "This is an automated triage pass (pattern matching only). It is not a",
+        "certification. An operator must read the transcripts before any of",
+        "this content is folded into the shared demo proof-world fixture.",
+        "",
+        "| session_id | origin | verdict | messages | words | flags |",
+        "| --- | --- | --- | ---: | ---: | --- |",
+    ]
+    for r in results:
+        flags = ", ".join(f"{h.pattern}×{h.count}" for h in r.hits) or "—"
+        lines.append(
+            f"| `{r.session_id}` | {r.origin} | **{r.verdict}** | {r.message_count} | {r.word_count} | {flags} |"
+        )
+    lines.append("")
+    for r in results:
+        lines.append(f"## `{r.session_id}`")
+        lines.append("")
+        lines.append(f"- title: {r.title!r}")
+        lines.append(f"- created_at: {r.created_at}")
+        lines.append(f"- verdict: **{r.verdict}**")
+        if not r.hits:
+            lines.append("- no pattern hits")
+        for h in r.hits:
+            lines.append(f"- `{h.pattern}` ({h.kind}) × {h.count}{' (all allowlisted)' if h.all_allowlisted else ''}")
+            for sample in h.samples:
+                lines.append(f"  - {sample}")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="devtools demo real-slice-screen",
+        description=(
+            "Read-only extraction and privacy screening of a candidate real-archive "
+            "session slice, for later human-gated inclusion in the shared demo "
+            "proof-world corpus (polylogue-212.11)."
+        ),
+    )
+    parser.add_argument("--archive-root", type=Path, required=True, help="Real archive root to read (read-only).")
+    parser.add_argument(
+        "--session",
+        dest="sessions",
+        action="append",
+        default=[],
+        help="Session id to screen (repeatable).",
+    )
+    parser.add_argument(
+        "--refs-file",
+        type=Path,
+        default=None,
+        help="Optional file with one session id per line (blank lines and '#' comments ignored).",
+    )
+    parser.add_argument("--out", type=Path, required=True, help="Output directory for the report + transcripts.")
+    return parser
+
+
+def _read_refs_file(path: Path) -> list[str]:
+    refs: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        refs.append(stripped)
+    return refs
+
+
+def main(argv: list[str] | None = None) -> int:
+    import asyncio
+
+    args = _parser().parse_args(argv)
+    session_ids = list(args.sessions)
+    if args.refs_file is not None:
+        session_ids.extend(_read_refs_file(args.refs_file))
+    session_ids = list(dict.fromkeys(session_ids))  # de-dupe, preserve order
+    if not session_ids:
+        print("no session ids given (use --session or --refs-file)", file=sys.stderr)
+        return 2
+
+    pairs = asyncio.run(screen_sessions(args.archive_root, session_ids))
+    results = [r for r, _ in pairs]
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    transcripts_dir = args.out / "transcripts"
+    transcripts_dir.mkdir(parents=True, exist_ok=True)
+    for result, text in pairs:
+        safe_name = result.session_id.replace("/", "_").replace(":", "_")
+        (transcripts_dir / f"{safe_name}.txt").write_text(text, encoding="utf-8")
+
+    manifest = {
+        "archive_root": str(args.archive_root),
+        "sessions": [r.to_dict() for r in results],
+    }
+    (args.out / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    report_md = render_report_markdown(results, archive_root=args.archive_root)
+    (args.out / "SCREENING_REPORT.md").write_text(report_md + "\n", encoding="utf-8")
+
+    flagged = [r for r in results if r.verdict == "flagged"]
+    review = [r for r in results if r.verdict == "review"]
+    print(
+        f"screened {len(results)} sessions: {len(flagged)} flagged, {len(review)} need review, "
+        f"{len(results) - len(flagged) - len(review)} clean"
+    )
+    print(f"report: {args.out / 'SCREENING_REPORT.md'}")
+    return 1 if flagged else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/proof_world_real_slice.py
+++ b/devtools/proof_world_real_slice.py
@@ -42,7 +42,51 @@ import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from polylogue.api import Polylogue
+
+
+class _MessageLike(Protocol):
+    """Structural shape ``_flatten_session_text`` reads from a message.
+
+    A ``Protocol`` (not the concrete ``polylogue.archive.session.domain_models
+    .Session``/``Message`` classes) so the real session objects returned by
+    ``Polylogue.get_session`` and the lightweight duck-typed test doubles in
+    ``tests/unit/devtools/test_proof_world_real_slice.py`` both satisfy the
+    parameter type structurally, without the tests needing to construct or
+    subclass the full domain model. Declared as read-only ``@property``
+    members rather than plain attributes: mypy checks plain-attribute
+    Protocol members *invariantly* (both read and write), which the real
+    ``Message.blocks: list[dict[str, object]]`` fails against a plain
+    ``blocks: object`` attribute even though every value it can hold is
+    assignable to ``object``. Properties are read-only, so the check is
+    covariant instead and both the real model and the test doubles conform.
+    """
+
+    @property
+    def text(self) -> str | None: ...
+
+    @property
+    def blocks(self) -> object: ...
+
+
+class _SessionLike(Protocol):
+    """Structural shape ``_flatten_session_text`` reads from a session.
+
+    ``Iterable``, not ``Sequence`` — the real ``Session.messages`` is a
+    ``MessageCollection`` that supports iteration but is not a nominal
+    ``collections.abc.Sequence`` subclass, and ``Sequence`` is a concrete ABC
+    in typeshed (not a structural ``Protocol``) so mypy would reject it here
+    even though the object is sequence-*shaped*. Only iteration is needed.
+    """
+
+    @property
+    def messages(self) -> Iterable[_MessageLike]: ...
+
 
 # Patterns that indicate a live secret/credential shape. Kept intentionally
 # narrow (favor false negatives over drowning the report in noise) — this is
@@ -196,7 +240,7 @@ def scan_text(text: str) -> list[PatternHit]:
     return hits
 
 
-def _flatten_session_text(session: Any) -> str:
+def _flatten_session_text(session: _SessionLike) -> str:
     """Flatten every message's text and structured blocks to one string."""
 
     parts: list[str] = []
@@ -208,31 +252,49 @@ def _flatten_session_text(session: Any) -> str:
     return "\n".join(parts)
 
 
+async def _screen_session_with(poly: Polylogue, session_id: str) -> tuple[SessionScreeningResult, str]:
+    """Screen one session through an already-open ``Polylogue`` instance."""
+
+    session = await poly.get_session(session_id)
+    if session is None:
+        raise ValueError(f"session not found in archive: {session_id}")
+    text = _flatten_session_text(session)
+    word_count = len(text.split())
+    result = SessionScreeningResult(
+        session_id=str(session.id),
+        origin=str(session.origin),
+        title=session.title,
+        created_at=str(session.created_at) if session.created_at else None,
+        message_count=len(session.messages),
+        word_count=word_count,
+        hits=scan_text(text),
+    )
+    return result, text
+
+
 async def screen_session(archive_root: Path, session_id: str) -> tuple[SessionScreeningResult, str]:
-    """Load one session read-only and screen it. Returns (result, transcript_text)."""
+    """Load one session read-only and screen it. Returns (result, transcript_text).
+
+    Opens and closes its own scoped ``Polylogue`` instance — the convenient
+    single-session entry point used by tests and one-off callers. Batch
+    callers should use :func:`screen_sessions`, which opens the archive once
+    and reuses the same instance across every session id instead of paying
+    the open/close cost per id.
+    """
 
     from polylogue.api import Polylogue
 
     async with Polylogue(archive_root=archive_root) as pl:
-        session = await pl.get_session(session_id)
-        if session is None:
-            raise ValueError(f"session not found in archive: {session_id}")
-        text = _flatten_session_text(session)
-        word_count = len(text.split())
-        result = SessionScreeningResult(
-            session_id=str(session.id),
-            origin=str(session.origin),
-            title=session.title,
-            created_at=str(session.created_at) if session.created_at else None,
-            message_count=len(session.messages),
-            word_count=word_count,
-            hits=scan_text(text),
-        )
-        return result, text
+        return await _screen_session_with(pl, session_id)
 
 
 async def screen_sessions(archive_root: Path, session_ids: list[str]) -> list[tuple[SessionScreeningResult, str]]:
-    return [await screen_session(archive_root, session_id) for session_id in session_ids]
+    """Screen every id in ``session_ids`` through one shared archive open."""
+
+    from polylogue.api import Polylogue
+
+    async with Polylogue(archive_root=archive_root) as pl:
+        return [await _screen_session_with(pl, session_id) for session_id in session_ids]
 
 
 def render_report_markdown(results: list[SessionScreeningResult], *, archive_root: Path) -> str:

--- a/devtools/proof_world_real_slice.py
+++ b/devtools/proof_world_real_slice.py
@@ -11,7 +11,18 @@ That extension is deliberately a two-step, human-gated process:
    plus rendered transcripts to an arbitrary output directory. It never
    mutates the source archive (``Polylogue.get_session`` opens the archive
    tiers with ``read_only=True``) and never writes into the product fixture
-   tree (``polylogue/scenarios/``) on its own.
+   tree (``polylogue/scenarios/``) on its own. The per-session transcript
+   files under ``<out>/transcripts/`` are full, unredacted flattened text —
+   they exist for a human to read the real session content. The
+   *report/manifest* (``SCREENING_REPORT.md``, ``manifest.json``) are a
+   different, narrower surface: any matched **secret** value is redacted
+   before it is written there (see ``scan_text``/``_snippet``), so a report
+   that later gets shared or accidentally committed doesn't itself become a
+   secret-leak vector. Matched **PII** text is kept verbatim in the report
+   since a reviewer needs the real value to judge placeholder vs. genuine
+   data. Point ``--out`` at a location outside version control (e.g. a
+   gitignored scratch directory) — this tool applies no guard against
+   writing into a tracked path.
 2. An operator reviews the report and transcripts and decides, session by
    session, whether the slice is safe to fold into the shared proof-world
    corpus. Only after that explicit approval should the slice move into a
@@ -25,6 +36,7 @@ the transcripts before promoting anything to a shared fixture.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import sys
@@ -58,15 +70,20 @@ _PII_PATTERNS: dict[str, re.Pattern[str]] = {
     "ipv4": re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"),
 }
 
-# Substrings that are conventionally placeholders/loopback addresses, not
-# real personal data. A hit that is fully covered by an allowlisted
-# substring is downgraded but still reported (never silently dropped).
-_ALLOWLIST_SUBSTRINGS: tuple[str, ...] = (
-    "test@example.com",
-    "user@example.com",
-    "127.0.0.1",
-    "0.0.0.0",
-    "255.255.255.255",
+# Values that are conventionally placeholders/loopback addresses, not real
+# personal data. A hit is downgraded only when the *entire* matched string
+# equals one of these exactly (never a substring check — "notuser@example.com"
+# and "127.0.0.123" must NOT be treated as allowlisted merely because an
+# allowlisted value happens to appear inside them). A downgraded hit is still
+# reported (never silently dropped).
+_ALLOWLIST_VALUES: frozenset[str] = frozenset(
+    (
+        "test@example.com",
+        "user@example.com",
+        "127.0.0.1",
+        "0.0.0.0",
+        "255.255.255.255",
+    )
 )
 
 _SNIPPET_RADIUS = 40
@@ -124,31 +141,49 @@ class SessionScreeningResult:
         }
 
 
-def _snippet(text: str, match: re.Match[str]) -> str:
+def _snippet(text: str, match: re.Match[str], *, redact: bool) -> str:
+    """Render a bounded context window around ``match``.
+
+    When ``redact`` is true (secret-kind hits), the matched substring itself
+    is replaced with a placeholder — the *surrounding* context is still
+    useful for triage (which pattern fired, roughly where), but the actual
+    secret value never reaches the report/manifest on disk. PII hits are not
+    redacted: a human reviewer needs the real matched text (e.g. the actual
+    email/IP) to judge whether it is a placeholder or genuine personal data.
+    """
+
     start = max(0, match.start() - _SNIPPET_RADIUS)
     end = min(len(text), match.end() + _SNIPPET_RADIUS)
     prefix = "…" if start > 0 else ""
     suffix = "…" if end < len(text) else ""
-    return f"{prefix}{text[start:end]!r}{suffix}"
+    window = text[start:end]
+    if redact:
+        rel_start = match.start() - start
+        rel_end = match.end() - start
+        window = f"{window[:rel_start]}<redacted:{match.end() - match.start()}ch>{window[rel_end:]}"
+    return f"{prefix}{window!r}{suffix}"
 
 
 def scan_text(text: str) -> list[PatternHit]:
     """Run every configured secret/PII pattern over ``text``.
 
     Returns one :class:`PatternHit` per pattern that matched at least once,
-    each carrying up to ``_MAX_SAMPLES_PER_PATTERN`` truncated samples for
-    human review — never the full match set, to keep the report itself from
-    becoming a leak surface.
+    each carrying up to ``_MAX_SAMPLES_PER_PATTERN`` samples for human
+    review. Secret-kind samples have the actual matched value redacted (see
+    :func:`_snippet`) — never the raw secret — to keep the report itself
+    from becoming a leak surface. PII-kind samples keep the real matched
+    text, which a reviewer needs to judge placeholder vs. genuine data.
     """
 
     hits: list[PatternHit] = []
     for kind, patterns in (("secret", _SECRET_PATTERNS), ("pii", _PII_PATTERNS)):
+        redact = kind == "secret"
         for name, pattern in patterns.items():
             matches = list(pattern.finditer(text))
             if not matches:
                 continue
-            samples = [_snippet(text, m) for m in matches[:_MAX_SAMPLES_PER_PATTERN]]
-            all_allowlisted = all(any(allowed in m.group(0) for allowed in _ALLOWLIST_SUBSTRINGS) for m in matches)
+            samples = [_snippet(text, m, redact=redact) for m in matches[:_MAX_SAMPLES_PER_PATTERN]]
+            all_allowlisted = all(m.group(0) in _ALLOWLIST_VALUES for m in matches)
             hits.append(
                 PatternHit(
                     pattern=name,
@@ -263,6 +298,23 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _safe_transcript_filename(session_id: str) -> str:
+    """Filesystem-safe, collision-free filename stem for a session id.
+
+    Path-unsafe characters are replaced for readability, but readability
+    alone is not collision-safe: distinct session ids that differ only in
+    which punctuation character separates otherwise-identical characters
+    (e.g. ``origin:a:b`` vs. ``origin:a_b``) would sanitize to the same
+    stem. A short content hash of the *original, unsanitized* session id is
+    appended so two distinct session ids can never produce the same
+    filename, guaranteeing no transcript is silently overwritten.
+    """
+
+    sanitized = re.sub(r"[^A-Za-z0-9_.-]", "_", session_id)
+    digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()[:12]
+    return f"{sanitized}__{digest}"
+
+
 def _read_refs_file(path: Path) -> list[str]:
     refs: list[str] = []
     for line in path.read_text(encoding="utf-8").splitlines():
@@ -291,8 +343,17 @@ def main(argv: list[str] | None = None) -> int:
     args.out.mkdir(parents=True, exist_ok=True)
     transcripts_dir = args.out / "transcripts"
     transcripts_dir.mkdir(parents=True, exist_ok=True)
+    seen_filenames: dict[str, str] = {}
     for result, text in pairs:
-        safe_name = result.session_id.replace("/", "_").replace(":", "_")
+        safe_name = _safe_transcript_filename(result.session_id)
+        prior = seen_filenames.get(safe_name)
+        if prior is not None and prior != result.session_id:
+            # Should be unreachable (sha256 collision on distinct inputs),
+            # but fail loudly rather than silently overwrite a transcript.
+            raise RuntimeError(
+                f"transcript filename collision: {safe_name!r} claimed by both {prior!r} and {result.session_id!r}"
+            )
+        seen_filenames[safe_name] = result.session_id
         (transcripts_dir / f"{safe_name}.txt").write_text(text, encoding="utf-8")
 
     manifest = {

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -188,6 +188,7 @@ These are the commands worth remembering during normal repo work:
 
 | Command | Description |
 | --- | --- |
+| `devtools demo real-slice-screen` | Read-only extraction + privacy screening of a candidate real-archive session slice. |
 | `devtools workspace affordance-usage` | Analyze agent affordance/tool usage from archive tool-use rows. |
 | `devtools workspace archive-schema-fast-forward` | Clone-forward the v35 archive tiers without raw replay. |
 | `devtools workspace claim-vs-evidence` | Build a structured failure follow-up claim-vs-evidence demo. |

--- a/tests/unit/devtools/test_proof_world_real_slice.py
+++ b/tests/unit/devtools/test_proof_world_real_slice.py
@@ -58,6 +58,31 @@ def test_scan_text_does_not_allowlist_a_real_looking_email() -> None:
     assert not email_hit.all_allowlisted
 
 
+def test_scan_text_does_not_allowlist_by_substring_containment() -> None:
+    """A match that merely *contains* an allowlisted value must not be
+    downgraded — only an exact full-match equals check counts. Regression
+    for a bug where `notuser@example.com` and `127.0.0.123` were both
+    treated as fully allowlisted (and thus 'clean') purely because
+    `user@example.com`/`127.0.0.1` occur as substrings."""
+
+    hits = m.scan_text("contact notuser@example.com and reach server at 127.0.0.123 for details")
+    email_hit = next(h for h in hits if h.pattern == "email")
+    ipv4_hit = next(h for h in hits if h.pattern == "ipv4")
+    assert not email_hit.all_allowlisted
+    assert not ipv4_hit.all_allowlisted
+
+    result = m.SessionScreeningResult(
+        session_id="x",
+        origin="claude-code-session",
+        title=None,
+        created_at=None,
+        message_count=1,
+        word_count=1,
+        hits=[email_hit, ipv4_hit],
+    )
+    assert result.verdict == "review"
+
+
 # --- verdict computation -----------------------------------------------------
 
 
@@ -114,6 +139,51 @@ def test_verdict_clean_when_pii_hits_are_fully_allowlisted() -> None:
         hits=[m.PatternHit(pattern="email", kind="pii", count=1, samples=["s"], all_allowlisted=True)],
     )
     assert result.verdict == "clean"
+
+
+# --- secret redaction in samples ----------------------------------------------
+
+
+def test_scan_text_redacts_the_actual_secret_value_in_samples() -> None:
+    """The report/manifest must never embed a raw secret value verbatim —
+    only PII context does that. Regression for a bug where the snippet
+    window always fully contained the matched secret text despite the
+    docstring's claim that samples 'never' leak the full match."""
+
+    text = "the real key is AKIAABCDEFGHIJKLMNOP and it must stay secret"
+    hits = m.scan_text(text)
+    secret_hit = next(h for h in hits if h.pattern == "aws_access_key_id")
+    joined = " ".join(secret_hit.samples)
+    assert "AKIAABCDEFGHIJKLMNOP" not in joined
+    assert "redacted" in joined
+    # surrounding context should still be present for triage
+    assert "real key" in joined
+
+
+def test_scan_text_keeps_real_pii_text_in_samples_for_human_judgment() -> None:
+    hits = m.scan_text("contact jane.doe@personalmail.example for details")
+    email_hit = next(h for h in hits if h.pattern == "email")
+    joined = " ".join(email_hit.samples)
+    assert "jane.doe@personalmail.example" in joined
+
+
+# --- transcript filename collision safety --------------------------------------
+
+
+def test_safe_transcript_filename_disambiguates_punctuation_variants() -> None:
+    """Two distinct session ids that differ only in which punctuation
+    character separates otherwise-identical characters must never collide
+    on the sanitized filename stem."""
+
+    a = m._safe_transcript_filename("origin:a:b")
+    b = m._safe_transcript_filename("origin:a_b")
+    assert a != b
+
+
+def test_safe_transcript_filename_is_deterministic() -> None:
+    assert m._safe_transcript_filename("claude-code-session:abc") == m._safe_transcript_filename(
+        "claude-code-session:abc"
+    )
 
 
 # --- flatten helper -----------------------------------------------------------
@@ -186,7 +256,11 @@ async def test_screen_session_reads_real_archive_and_flags_planted_secret(
     secret_result, secret_text = await m.screen_session(archive_root, _SECRET_ID)
     assert secret_result.verdict == "flagged"
     assert any(h.pattern == "aws_access_key_id" for h in secret_result.hits)
+    # the raw transcript text is unredacted (it exists for full human review)...
     assert "AKIAABCDEFGHIJKLMNOP" in secret_text
+    # ...but the report-facing samples must never carry the raw secret value
+    all_samples = [s for h in secret_result.hits for s in h.samples]
+    assert not any("AKIAABCDEFGHIJKLMNOP" in s for s in all_samples)
 
 
 async def test_screen_session_raises_for_unknown_session(workspace_env: dict[str, Path]) -> None:

--- a/tests/unit/devtools/test_proof_world_real_slice.py
+++ b/tests/unit/devtools/test_proof_world_real_slice.py
@@ -271,6 +271,41 @@ async def test_screen_session_raises_for_unknown_session(workspace_env: dict[str
         await m.screen_session(db_path.parent, "claude-code-session:does-not-exist")
 
 
+async def test_screen_sessions_opens_the_archive_once_for_the_whole_batch(
+    workspace_env: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for a CodeRabbit finding on PR #2885: ``screen_sessions``
+    must open one shared ``Polylogue`` instance and reuse it across every
+    session id in the batch, not reopen the archive tiers per id. Counts real
+    ``Polylogue.__aenter__`` calls (the actual archive-open chokepoint) while
+    driving the real screening path against a seeded archive — this fails if
+    ``screen_sessions`` regresses to calling ``screen_session`` (which opens
+    its own scoped instance) once per id."""
+
+    from polylogue.api import Polylogue
+
+    db_path = db_setup(workspace_env)
+    await _seed(db_path)
+    archive_root = db_path.parent
+
+    open_count = 0
+    original_aenter = Polylogue.__aenter__
+
+    async def counting_aenter(self: Polylogue) -> Polylogue:
+        nonlocal open_count
+        open_count += 1
+        return await original_aenter(self)
+
+    monkeypatch.setattr(Polylogue, "__aenter__", counting_aenter)
+
+    pairs = await m.screen_sessions(archive_root, [_CLEAN_ID, _SECRET_ID])
+
+    assert open_count == 1
+    assert [r.session_id for r, _ in pairs] == [_CLEAN_ID, _SECRET_ID]
+    assert pairs[0][0].verdict == "clean"
+    assert pairs[1][0].verdict == "flagged"
+
+
 # --- CLI argument handling ---------------------------------------------------
 
 

--- a/tests/unit/devtools/test_proof_world_real_slice.py
+++ b/tests/unit/devtools/test_proof_world_real_slice.py
@@ -1,0 +1,216 @@
+"""Tests for the real-archive candidate-slice screening harness (polylogue-212.11)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from devtools import proof_world_real_slice as m
+from polylogue.core.enums import Provider
+from tests.infra.archive_scenarios import native_session_id_for
+from tests.infra.storage_records import SessionBuilder, db_setup
+
+_CLEAN_ID = native_session_id_for("claude-ai", "clean-session")
+_SECRET_ID = native_session_id_for("claude-ai", "secret-session")
+
+
+class _FakeMessage:
+    def __init__(self, text: str | None, blocks: object = None) -> None:
+        self.text = text
+        self.blocks = blocks
+
+
+class _FakeSession:
+    def __init__(self, messages: list[_FakeMessage]) -> None:
+        self.messages = messages
+
+
+# --- pure scan_text() behavior ---------------------------------------------
+
+
+def test_scan_text_finds_no_hits_on_clean_text() -> None:
+    hits = m.scan_text("just an ordinary sentence about pytest and git diffs")
+    assert hits == []
+
+
+def test_scan_text_flags_a_credential_shaped_string() -> None:
+    hits = m.scan_text("aws key: AKIAABCDEFGHIJKLMNOP")
+    names = {h.pattern for h in hits}
+    assert "aws_access_key_id" in names
+    secret_hit = next(h for h in hits if h.pattern == "aws_access_key_id")
+    assert secret_hit.kind == "secret"
+    assert secret_hit.count == 1
+    assert not secret_hit.all_allowlisted
+
+
+def test_scan_text_allowlists_placeholder_email_and_loopback() -> None:
+    hits = m.scan_text("git config user.email test@example.com; server on 127.0.0.1")
+    email_hit = next(h for h in hits if h.pattern == "email")
+    ipv4_hit = next(h for h in hits if h.pattern == "ipv4")
+    assert email_hit.all_allowlisted
+    assert ipv4_hit.all_allowlisted
+
+
+def test_scan_text_does_not_allowlist_a_real_looking_email() -> None:
+    hits = m.scan_text("contact jane.doe@personalmail.example for details")
+    email_hit = next(h for h in hits if h.pattern == "email")
+    assert not email_hit.all_allowlisted
+
+
+# --- verdict computation -----------------------------------------------------
+
+
+def test_verdict_clean_when_no_hits() -> None:
+    result = m.SessionScreeningResult(
+        session_id="x",
+        origin="claude-code-session",
+        title=None,
+        created_at=None,
+        message_count=1,
+        word_count=1,
+        hits=[],
+    )
+    assert result.verdict == "clean"
+
+
+def test_verdict_flagged_beats_review_when_a_secret_hits() -> None:
+    result = m.SessionScreeningResult(
+        session_id="x",
+        origin="claude-code-session",
+        title=None,
+        created_at=None,
+        message_count=1,
+        word_count=1,
+        hits=[
+            m.PatternHit(pattern="email", kind="pii", count=1, samples=["s"], all_allowlisted=False),
+            m.PatternHit(pattern="openai_style_key", kind="secret", count=1, samples=["s"], all_allowlisted=False),
+        ],
+    )
+    assert result.verdict == "flagged"
+
+
+def test_verdict_review_when_only_non_allowlisted_pii_hits() -> None:
+    result = m.SessionScreeningResult(
+        session_id="x",
+        origin="claude-code-session",
+        title=None,
+        created_at=None,
+        message_count=1,
+        word_count=1,
+        hits=[m.PatternHit(pattern="home_path", kind="pii", count=1, samples=["s"], all_allowlisted=False)],
+    )
+    assert result.verdict == "review"
+
+
+def test_verdict_clean_when_pii_hits_are_fully_allowlisted() -> None:
+    result = m.SessionScreeningResult(
+        session_id="x",
+        origin="claude-code-session",
+        title=None,
+        created_at=None,
+        message_count=1,
+        word_count=1,
+        hits=[m.PatternHit(pattern="email", kind="pii", count=1, samples=["s"], all_allowlisted=True)],
+    )
+    assert result.verdict == "clean"
+
+
+# --- flatten helper -----------------------------------------------------------
+
+
+def test_flatten_session_text_includes_message_text_and_block_json() -> None:
+    session = _FakeSession(
+        [
+            _FakeMessage(text="hello world"),
+            _FakeMessage(text=None, blocks=[{"kind": "tool_use", "input": {"cmd": "ls"}}]),
+        ]
+    )
+    flat = m._flatten_session_text(session)
+    assert "hello world" in flat
+    assert "tool_use" in flat
+    assert '"cmd": "ls"' in flat
+
+
+# --- report rendering -----------------------------------------------------
+
+
+def test_render_report_markdown_includes_verdict_and_samples() -> None:
+    result = m.SessionScreeningResult(
+        session_id="claude-code-session:abc",
+        origin="claude-code-session",
+        title="Some session",
+        created_at="2026-01-01T00:00:00Z",
+        message_count=3,
+        word_count=42,
+        hits=[m.PatternHit(pattern="home_path", kind="pii", count=2, samples=["…/home/x…"], all_allowlisted=False)],
+    )
+    md = m.render_report_markdown([result], archive_root=Path("/fake/archive"))
+    assert "claude-code-session:abc" in md
+    assert "**review**" in md
+    assert "home_path" in md
+    assert "/home/x" in md
+
+
+# --- end-to-end read path against a seeded archive --------------------------
+
+
+async def _seed(db_path: Path) -> None:
+    await (
+        SessionBuilder(db_path, "clean-session")
+        .provider(Provider.CLAUDE_AI.value)
+        .title("Clean session")
+        .add_message(text="just discussing pytest fixtures, nothing sensitive")
+        .build()
+    )
+    await (
+        SessionBuilder(db_path, "secret-session")
+        .provider(Provider.CLAUDE_AI.value)
+        .title("Session with a planted secret")
+        .add_message(text="here is my key: AKIAABCDEFGHIJKLMNOP please rotate it")
+        .build()
+    )
+
+
+async def test_screen_session_reads_real_archive_and_flags_planted_secret(
+    workspace_env: dict[str, Path],
+) -> None:
+    db_path = db_setup(workspace_env)
+    await _seed(db_path)
+    archive_root = db_path.parent
+
+    clean_result, clean_text = await m.screen_session(archive_root, _CLEAN_ID)
+    assert clean_result.verdict == "clean"
+    assert "pytest fixtures" in clean_text
+
+    secret_result, secret_text = await m.screen_session(archive_root, _SECRET_ID)
+    assert secret_result.verdict == "flagged"
+    assert any(h.pattern == "aws_access_key_id" for h in secret_result.hits)
+    assert "AKIAABCDEFGHIJKLMNOP" in secret_text
+
+
+async def test_screen_session_raises_for_unknown_session(workspace_env: dict[str, Path]) -> None:
+    db_path = db_setup(workspace_env)
+    await _seed(db_path)
+
+    with pytest.raises(ValueError, match="not found"):
+        await m.screen_session(db_path.parent, "claude-code-session:does-not-exist")
+
+
+# --- CLI argument handling ---------------------------------------------------
+
+
+def test_main_exits_nonzero_with_no_session_ids(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    code = m.main(["--archive-root", str(tmp_path), "--out", str(tmp_path / "out")])
+    assert code == 2
+    captured = capsys.readouterr()
+    assert "no session ids given" in captured.err
+
+
+def test_read_refs_file_skips_blanks_and_comments(tmp_path: Path) -> None:
+    refs_path = tmp_path / "refs.txt"
+    refs_path.write_text("\n# a comment\nclaude-code-session:a:b\n\nclaude-code-session:c:d\n", encoding="utf-8")
+    assert m._read_refs_file(refs_path) == [
+        "claude-code-session:a:b",
+        "claude-code-session:c:d",
+    ]


### PR DESCRIPTION
## Summary

Adds `devtools demo real-slice-screen`, a read-only extraction + privacy
screening harness for candidate real-archive session slices, plus the
harness's own test coverage. This is the "harness/fixture machinery" half of
polylogue-212.11's real-archive-data extension; the actual candidate slice
and its privacy write-up are a separate, deliberately-unmerged artifact (see
Verification below) awaiting operator spot-check before any real content is
folded into `polylogue/scenarios/`.

## Problem

polylogue-212.11 ("one shared deterministic proof world for all flagship
demos") has already landed 37 declared constructs on a fully-synthetic
Incident 14:32 corpus (PRs #2662, #2674). Per explicit operator direction,
the shared proof world should also draw on a real, representative slice of
the operator's own archive (`/realm/db/polylogue`) rather than staying
synthetic-only — "the point is representative data, not full determinism."

That requires a privacy-vetting step. The bead's own instructions are
explicit that this step must **not** be autonomous: a candidate slice has to
be pulled, screened, and handed to the operator as a flagged, reviewable
artifact before it becomes a permanent shared fixture. This PR ships the
reusable machinery for that step; it does not itself promote any real
content into the product tree.

## Solution

- **`devtools/proof_world_real_slice.py`** — given one or more session ids
  (or a refs file) and a real archive root, opens the archive read-only via
  `Polylogue.get_session()` (the API's `ArchiveStore.open_existing(...,
  read_only=True)` default — never mutates the source archive), flattens
  each session's message text + structured block payloads to plain text, and
  runs a pattern screen:
  - **secret/credential shapes**: AWS access key ids, generic
    `key=value`/`key: value` credential assignments, bearer tokens,
    `BEGIN ... PRIVATE KEY` blocks, OpenAI-style `sk-...` keys, Slack
    tokens, SSH public keys, JWT-shaped strings.
  - **PII-adjacent shapes**: email addresses, `/home/<user>` paths, IPv4
    addresses — with a small allowlist for common test placeholders
    (`test@example.com`, `127.0.0.1`, `0.0.0.0`, ...) so the report isn't
    dominated by noise from ordinary test fixtures.
  - Any secret-pattern hit -> `flagged`; any non-allowlisted PII hit (with no
    secret hit) -> `review`; otherwise `clean`.
  - Writes `SCREENING_REPORT.md` (per-session verdict + truncated match
    samples), `manifest.json`, and per-session `transcripts/*.txt` to an
    arbitrary output directory. It never writes into `polylogue/scenarios/`
    or any other product fixture path — promoting a slice stays a distinct,
    explicit, human-gated step.
- Registered as `devtools demo real-slice-screen` in
  `devtools/command_catalog.py` (category `workspace`); `docs/devtools.md`
  regenerated via `devtools render devtools-reference`.
- `tests/unit/devtools/test_proof_world_real_slice.py`: pure-function
  coverage of the pattern scanner and verdict logic (including the
  allowlist), the text-flattening helper, report rendering, CLI argument
  handling, and an end-to-end read path against a `SessionBuilder`-seeded
  archive that plants a real AWS-key-shaped string and asserts it is both
  read back correctly and flagged.

### What this PR does *not* do

- It does not fold any real archive content into the shared demo corpus.
  I ran the harness against 5 candidate sessions from the operator's own
  archive (their own dev-work sessions on this very repository — flaky-test
  hunting, pipeline-idempotency test design, and two issue implementations)
  and wrote up the result (0 flagged, 3 "review" — all traced to test
  placeholders/loopback IPs/the operator's own home path in their own
  tool-output truncation messages, not third-party data — 2 fully clean) as
  a distinct, gitignored artifact under
  `.agent/scratch/real-slice-vetting-2026-07-14/` (`OPERATOR-SUMMARY.md`,
  `SCREENING_REPORT.md`, `manifest.json`, `transcripts/`). That directory is
  **not** part of this diff — `.agent/scratch/*` is gitignored — and is left
  in place for a quick operator spot-check per the task's explicit
  instruction that this step "should NOT be treated as fully autonomous."
- The remaining declared-but-unimplemented AC items from the bead notes
  (parser v1/v2 dual interpretation, typed cross-source 14:32 event hooks)
  are unaffected by this PR and remain open follow-up scope on
  polylogue-212.11 — see the bead's own notes history (PRs #2662/#2674/#2795).
- No raw provider JSON/JSONL bytes were extracted from the archive's blob
  store; the harness reads normalized message text via the `Polylogue` API.
  If/when the slice is approved, a follow-up should decide whether real
  parser-replay fidelity (raw bytes) or the normalized text is the right
  fixture-generator input — that decision is out of scope here.

## Verification

```
devtools test tests/unit/devtools/test_proof_world_real_slice.py tests/unit/devtools/test_command_catalog.py
  -> 19 passed in 37.41s

devtools verify --quick
  -> exit_code 0 (ruff format/check, mypy --strict, render all --check,
     topology/layering/closure-matrix/manifests/ci-workflows/doc-commands/
     test-infra-currency/test-clock-hygiene/pytest-timeout-overrides/
     degrade-loudly all ok)
```

Anti-vacuity: `test_screen_session_reads_real_archive_and_flags_planted_secret`
drives the real production path (`Polylogue.get_session` against a
`SessionBuilder`-seeded archive, not a mock/stub) and fails if `scan_text`'s
secret-pattern set is emptied, or if `screen_session` stops calling it.

Ref polylogue-212.11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only command to extract and privacy-screen candidate archive sessions.
  - Supports selecting sessions directly or from a references file.
  - Generates screening reports, structured results, and transcript files.
  - Detects credential-like content and personally identifying information, with redacted secret samples.

- **Documentation**
  - Added the new workspace command to the developer tools catalog.

- **Tests**
  - Added coverage for detection, redaction, verdicts, file handling, reporting, and command-line validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->