### PR TITLE
chore(core): consolidate role synonym vocabulary (polylogue-a7xr.7)

### DIFF
--- a/polylogue/archive/message/roles.py
+++ b/polylogue/archive/message/roles.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Sequence
 from typing import TypeAlias
 
-from polylogue.core.enums import Role
+from polylogue.core.enums import ROLE_SYNONYMS, Role
 
 
 def normalize_role(raw: str) -> str:
@@ -15,13 +15,16 @@ def normalize_role(raw: str) -> str:
 
 MessageRoleFilter: TypeAlias = tuple[Role, ...]
 
-ROLE_SQL_VALUES: dict[Role, tuple[str, ...]] = {
-    Role.USER: ("user", "human"),
-    Role.ASSISTANT: ("assistant", "model", "ai"),
-    Role.SYSTEM: ("system", "developer"),
-    Role.TOOL: ("tool", "function", "tool_use", "tool_result", "progress", "result"),
-    Role.UNKNOWN: ("unknown",),
-}
+
+def _build_role_sql_values() -> dict[Role, tuple[str, ...]]:
+    """Derive SQL role filter expansion from the canonical ROLE_SYNONYMS."""
+    result: dict[Role, tuple[str, ...]] = {}
+    for role_name, synonyms in ROLE_SYNONYMS.items():
+        result[Role(role_name)] = tuple(sorted(synonyms))
+    return result
+
+
+ROLE_SQL_VALUES: dict[Role, tuple[str, ...]] = _build_role_sql_values()
 
 
 def _split_role_tokens(value: str) -> tuple[str, ...]:

--- a/polylogue/core/enums.py
+++ b/polylogue/core/enums.py
@@ -110,6 +110,18 @@ class SessionKind(PolylogueStrEnum):
             return cls.STANDARD
 
 
+#: Role synonym vocabulary — single source of truth for role normalization.
+#: Maps each canonical role to its accepted synonyms (case-insensitive).
+#: Used by both Role.normalize() and SQL role-filter expansion.
+ROLE_SYNONYMS: dict[str, frozenset[str]] = {
+    "user": frozenset({"user", "human"}),
+    "assistant": frozenset({"assistant", "model", "ai"}),
+    "system": frozenset({"system", "developer"}),
+    "tool": frozenset({"tool", "function", "tool_use", "tool_result", "progress", "result"}),
+    "unknown": frozenset({"unknown"}),
+}
+
+
 class Role(PolylogueStrEnum):
     """Canonical session roles."""
 
@@ -126,14 +138,9 @@ class Role(PolylogueStrEnum):
         if not lowered:
             raise ValueError("Role cannot be empty. Handle missing roles at parse time.")
 
-        if lowered in {"user", "human"}:
-            return cls.USER
-        if lowered in {"assistant", "model", "ai"}:
-            return cls.ASSISTANT
-        if lowered in {"system", "developer"}:
-            return cls.SYSTEM
-        if lowered in {"tool", "function", "tool_use", "tool_result", "progress", "result"}:
-            return cls.TOOL
+        for role_name, synonyms in ROLE_SYNONYMS.items():
+            if lowered in synonyms:
+                return cls(role_name)
         return cls.UNKNOWN
 
 

--- a/polylogue/mcp/payloads.py
+++ b/polylogue/mcp/payloads.py
@@ -24,7 +24,7 @@ from polylogue.surfaces.payloads import (
     SurfacePayloadModel,
     build_search_envelope,
     model_json_document,
-    normalize_role,
+    role_label,
 )
 from polylogue.surfaces.payloads import (
     ReaderActionAvailabilityPayload as MCPReaderActionAvailabilityPayload,
@@ -1055,7 +1055,7 @@ __all__ = [
     "model_json_document",
     "neighbor_candidates_payload",
     "logical_session_payload",
-    "normalize_role",
+    "role_label",
     "session_tree_payload",
     "session_topology_payload",
 ]

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -463,7 +463,8 @@ class ToolFamilyComparisonPayload(SurfacePayloadModel):
     caveats: tuple[str, ...] = ()
 
 
-def normalize_role(role: object) -> str:
+def role_label(role: object) -> str:
+    """Convert a role enum or string to a normalized label string."""
     if not role:
         return "unknown"
     if isinstance(role, Enum):
@@ -710,7 +711,7 @@ class SessionMessagePayload(SurfacePayloadModel):
         )
         return cls(
             id=str(message.id),
-            role=normalize_role(message.role),
+            role=role_label(message.role),
             text=message.text or "",
             target_ref=target_ref,
             anchor=reader_anchor("message", message.id),
@@ -770,7 +771,7 @@ class SessionMessagePayload(SurfacePayloadModel):
         )
         return cls(
             id=message_id,
-            role=normalize_role(getattr(message, "role", "")),
+            role=role_label(getattr(message, "role", "")),
             text=text,
             target_ref=TargetRefPayload.message(session_id=session_id, message_id=message_id),
             anchor=reader_anchor("message", message_id),
@@ -3623,7 +3624,7 @@ __all__ = [
     "build_query_unit_envelope",
     "decode_search_cursor",
     "model_json_document",
-    "normalize_role",
+    "role_label",
     "reader_anchor",
     "reader_session_actions",
     "reader_message_actions",

--- a/tests/unit/core/test_enums.py
+++ b/tests/unit/core/test_enums.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from polylogue.archive.message.roles import Role
+from polylogue.archive.message.roles import ROLE_SQL_VALUES, Role
 from polylogue.archive.message.types import MessageType
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.core.enums import (
+    ROLE_SYNONYMS,
     BlockType,
     Origin,
     PasteBoundary,
@@ -71,3 +72,32 @@ def test_provider_aliases_still_normalize_during_transition() -> None:
     assert Provider.from_string("openai") is Provider.CHATGPT
     assert Provider.from_string("claude") is Provider.CLAUDE_AI
     assert str(Provider.CODEX) == "codex"
+
+
+def test_role_synonyms_round_trip_through_normalize() -> None:
+    """Coupling test: every synonym in ROLE_SYNONYMS must normalize to the expected canonical role.
+
+    This ensures that ROLE_SYNONYMS (used for SQL filter expansion) and Role.normalize()
+    (used for canonicalization) remain synchronized as a single source of truth.
+    """
+    for role_name, synonyms in ROLE_SYNONYMS.items():
+        expected_role = Role(role_name)
+        for synonym in synonyms:
+            normalized = Role.normalize(synonym)
+            assert normalized == expected_role, (
+                f"Synonym {synonym!r} should normalize to {expected_role!r}, but got {normalized!r}"
+            )
+
+
+def test_role_sql_values_derived_from_role_synonyms() -> None:
+    """Verify that ROLE_SQL_VALUES is correctly derived from ROLE_SYNONYMS.
+
+    ROLE_SQL_VALUES should be generated from ROLE_SYNONYMS and contain all the same mappings.
+    """
+    for role, sql_values in ROLE_SQL_VALUES.items():
+        role_name = role.value
+        assert role_name in ROLE_SYNONYMS, f"Role {role_name!r} not found in ROLE_SYNONYMS"
+        expected_synonyms = ROLE_SYNONYMS[role_name]
+        assert set(sql_values) == expected_synonyms, (
+            f"ROLE_SQL_VALUES[{role!r}] should contain {expected_synonyms!r}, but got {set(sql_values)!r}"
+        )


### PR DESCRIPTION
## Summary

Consolidates role synonym vocabulary from two separate locations into a single source of truth in `ROLE_SYNONYMS`, eliminating duplication and preventing silent filtering bugs from synonym divergence.

## Problem

Two places maintained identical role synonym sets by hand:
- `core/enums.py:127-134` — `Role.normalize()` hardcoded synonym if/in checks
- `archive/message/roles.py:18-24` — `ROLE_SQL_VALUES` inverted mapping for SQL expansion

Adding a synonym to one without the other silently makes `--role` filters miss rows (e.g., "developer", "progress", "result" were evidently hand-added to both). No coupling test prevented divergence.

Bonus: `surfaces/payloads.py:466` and `archive/message/roles.py:11` both export `normalize_role` with different semantics (pass-through vs. canonicalizing), causing wrong-import failure modes.

## Solution

**Files changed:**
- `polylogue/core/enums.py`: Added `ROLE_SYNONYMS: dict[str, frozenset[str]]` single source of truth; refactored `Role.normalize()` to iterate it instead of hardcoded if/in checks
- `polylogue/archive/message/roles.py`: Imported `ROLE_SYNONYMS`; replaced `ROLE_SQL_VALUES` dict with derived `_build_role_sql_values()` builder (~20 lines)
- `polylogue/surfaces/payloads.py`: Renamed `normalize_role()` to `role_label()` (its actual semantics: label formatting, not canonicalization) + updated two call sites + `__all__`
- `polylogue/mcp/payloads.py`: Updated import + `__all__` to use `role_label`
- `tests/unit/core/test_enums.py`: Added coupling tests verifying every synonym round-trips through `Role.normalize()` and that `ROLE_SQL_VALUES` stays synchronized

## Verification

Acceptance criteria:
- One synonym table ✓ (`ROLE_SYNONYMS` in core/enums.py)
- SQL expansion derived ✓ (`_build_role_sql_values()` in archive/message/roles.py)
- Rename done with call sites updated ✓ (payloads.py, mcp/payloads.py)
- Coupling test in place ✓ (test_role_synonyms_round_trip_through_normalize + test_role_sql_values_derived_from_role_synonyms)

Local verification:
```bash
devtools test -k role  # 388 passed in ~2:40
devtools verify --quick  # all gates green (ruff, mypy, render, topology, layering, etc.)
```

Ref polylogue-a7xr.7.