### PR TITLE
refactor(fts): consolidate FTS trigger DDL to single source

### DIFF
--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -12,11 +12,15 @@ import aiosqlite
 
 from polylogue.storage.fts.pl_fold import pl_fold_sql_expr
 from polylogue.storage.fts.sql import (
+    BLOCKS_FTS_TRIGGER_DDL,
     FTS_INDEX_DOC_COUNT_SQL,
     FTS_INDEX_EXISTS_SQL,
     FTS_INDEXABLE_MESSAGE_COUNT_SQL,
     FTS_MESSAGES_TABLE_SQL,
     FTS_REBUILD_SQL,
+    FTS_TRIGGER_DDL,
+    SESSION_WORK_EVENT_FTS_TRIGGER_DDL,
+    THREAD_FTS_TRIGGER_DDL,
     IndexedMessage,
     chunked,
     delete_session_rows_sql,
@@ -195,63 +199,13 @@ async def restore_fts_triggers_async(conn: aiosqlite.Connection) -> None:
             await conn.execute(ddl)
 
 
-_BLOCKS_FTS_TRIGGER_DDL = [
-    f"""CREATE TRIGGER IF NOT EXISTS messages_fts_ai
-       AFTER INSERT ON blocks WHEN new.search_text != '' BEGIN
-           INSERT INTO messages_fts(rowid, block_id, message_id, session_id, block_type, text)
-           VALUES (new.rowid, new.block_id, new.message_id, new.session_id, new.block_type, {pl_fold_sql_expr("new.search_text")});
-       END""",
-    """CREATE TRIGGER IF NOT EXISTS messages_fts_ad
-       AFTER DELETE ON blocks WHEN old.search_text != '' BEGIN
-           DELETE FROM messages_fts WHERE rowid = old.rowid;
-       END""",
-    f"""CREATE TRIGGER IF NOT EXISTS messages_fts_au
-       AFTER UPDATE ON blocks BEGIN
-           DELETE FROM messages_fts WHERE rowid = old.rowid;
-           INSERT INTO messages_fts(rowid, block_id, message_id, session_id, block_type, text)
-           SELECT new.rowid, new.block_id, new.message_id, new.session_id, new.block_type, {pl_fold_sql_expr("new.search_text")}
-           WHERE new.search_text != '';
-       END""",
-]
-
-
-_SESSION_WORK_EVENT_FTS_TRIGGER_DDL = [
-    f"""CREATE TRIGGER IF NOT EXISTS session_work_events_fts_ai
-       AFTER INSERT ON session_work_events BEGIN
-           INSERT INTO session_work_events_fts (event_id, session_id, work_event_type, text)
-           VALUES (new.event_id, new.session_id, new.work_event_type, {pl_fold_sql_expr("new.search_text")});
-       END""",
-    """CREATE TRIGGER IF NOT EXISTS session_work_events_fts_ad
-       AFTER DELETE ON session_work_events BEGIN
-           DELETE FROM session_work_events_fts WHERE event_id = old.event_id;
-       END""",
-    f"""CREATE TRIGGER IF NOT EXISTS session_work_events_fts_au
-       AFTER UPDATE ON session_work_events BEGIN
-           DELETE FROM session_work_events_fts WHERE event_id = old.event_id;
-           INSERT INTO session_work_events_fts (event_id, session_id, work_event_type, text)
-           VALUES (new.event_id, new.session_id, new.work_event_type, {pl_fold_sql_expr("new.search_text")});
-       END""",
-]
-
-_THREAD_FTS_TRIGGER_DDL = [
-    f"""CREATE TRIGGER IF NOT EXISTS threads_fts_ai
-       AFTER INSERT ON threads BEGIN
-           INSERT INTO threads_fts (thread_id, root_id, text)
-           VALUES (new.thread_id, new.thread_id, {pl_fold_sql_expr("new.search_text")});
-       END""",
-    """CREATE TRIGGER IF NOT EXISTS threads_fts_ad
-       AFTER DELETE ON threads BEGIN
-           DELETE FROM threads_fts WHERE thread_id = old.thread_id;
-       END""",
-    f"""CREATE TRIGGER IF NOT EXISTS threads_fts_au
-       AFTER UPDATE ON threads BEGIN
-           DELETE FROM threads_fts WHERE thread_id = old.thread_id;
-           INSERT INTO threads_fts (thread_id, root_id, text)
-           VALUES (new.thread_id, new.thread_id, {pl_fold_sql_expr("new.search_text")});
-       END""",
-]
-
-_FTS_TRIGGER_DDL = _BLOCKS_FTS_TRIGGER_DDL + _SESSION_WORK_EVENT_FTS_TRIGGER_DDL + _THREAD_FTS_TRIGGER_DDL
+# polylogue-a7xr.5: FTS trigger DDL is now sourced from storage/fts/sql.py as the single
+# source of truth. Aliases below preserve backward compatibility with code that
+# references the private _*_TRIGGER_DDL names.
+_BLOCKS_FTS_TRIGGER_DDL = BLOCKS_FTS_TRIGGER_DDL
+_SESSION_WORK_EVENT_FTS_TRIGGER_DDL = SESSION_WORK_EVENT_FTS_TRIGGER_DDL
+_THREAD_FTS_TRIGGER_DDL = THREAD_FTS_TRIGGER_DDL
+_FTS_TRIGGER_DDL = FTS_TRIGGER_DDL
 
 
 def suspend_fts_triggers_sync(conn: sqlite3.Connection, *, mark_stale: bool = True) -> None:

--- a/polylogue/storage/fts/sql.py
+++ b/polylogue/storage/fts/sql.py
@@ -39,6 +39,67 @@ FTS_REBUILD_SQL = """
     DELETE FROM messages_fts
 """
 
+# FTS trigger DDL for message/block FTS maintenance.
+BLOCKS_FTS_TRIGGER_DDL = [
+    f"""CREATE TRIGGER IF NOT EXISTS messages_fts_ai
+       AFTER INSERT ON blocks WHEN new.search_text != '' BEGIN
+           INSERT INTO messages_fts(rowid, block_id, message_id, session_id, block_type, text)
+           VALUES (new.rowid, new.block_id, new.message_id, new.session_id, new.block_type, {pl_fold_sql_expr("new.search_text")});
+       END""",
+    """CREATE TRIGGER IF NOT EXISTS messages_fts_ad
+       AFTER DELETE ON blocks WHEN old.search_text != '' BEGIN
+           DELETE FROM messages_fts WHERE rowid = old.rowid;
+       END""",
+    f"""CREATE TRIGGER IF NOT EXISTS messages_fts_au
+       AFTER UPDATE ON blocks BEGIN
+           DELETE FROM messages_fts WHERE rowid = old.rowid;
+           INSERT INTO messages_fts(rowid, block_id, message_id, session_id, block_type, text)
+           SELECT new.rowid, new.block_id, new.message_id, new.session_id, new.block_type, {pl_fold_sql_expr("new.search_text")}
+           WHERE new.search_text != '';
+       END""",
+]
+
+# FTS trigger DDL for session_work_events FTS maintenance.
+SESSION_WORK_EVENT_FTS_TRIGGER_DDL = [
+    f"""CREATE TRIGGER IF NOT EXISTS session_work_events_fts_ai
+       AFTER INSERT ON session_work_events BEGIN
+           INSERT INTO session_work_events_fts (event_id, session_id, work_event_type, text)
+           VALUES (new.event_id, new.session_id, new.work_event_type, {pl_fold_sql_expr("new.search_text")});
+       END""",
+    """CREATE TRIGGER IF NOT EXISTS session_work_events_fts_ad
+       AFTER DELETE ON session_work_events BEGIN
+           DELETE FROM session_work_events_fts WHERE event_id = old.event_id;
+       END""",
+    f"""CREATE TRIGGER IF NOT EXISTS session_work_events_fts_au
+       AFTER UPDATE ON session_work_events BEGIN
+           DELETE FROM session_work_events_fts WHERE event_id = old.event_id;
+           INSERT INTO session_work_events_fts (event_id, session_id, work_event_type, text)
+           VALUES (new.event_id, new.session_id, new.work_event_type, {pl_fold_sql_expr("new.search_text")});
+       END""",
+]
+
+# FTS trigger DDL for threads FTS maintenance.
+THREAD_FTS_TRIGGER_DDL = [
+    f"""CREATE TRIGGER IF NOT EXISTS threads_fts_ai
+       AFTER INSERT ON threads BEGIN
+           INSERT INTO threads_fts (thread_id, root_id, text)
+           VALUES (new.thread_id, new.thread_id, {pl_fold_sql_expr("new.search_text")});
+       END""",
+    """CREATE TRIGGER IF NOT EXISTS threads_fts_ad
+       AFTER DELETE ON threads BEGIN
+           DELETE FROM threads_fts WHERE thread_id = old.thread_id;
+       END""",
+    f"""CREATE TRIGGER IF NOT EXISTS threads_fts_au
+       AFTER UPDATE ON threads BEGIN
+           DELETE FROM threads_fts WHERE thread_id = old.thread_id;
+           INSERT INTO threads_fts (thread_id, root_id, text)
+           VALUES (new.thread_id, new.thread_id, {pl_fold_sql_expr("new.search_text")});
+       END""",
+]
+
+# Combined trigger DDL for all FTS surfaces.
+FTS_TRIGGER_DDL = BLOCKS_FTS_TRIGGER_DDL + SESSION_WORK_EVENT_FTS_TRIGGER_DDL + THREAD_FTS_TRIGGER_DDL
+
 
 class IndexedMessage(Protocol):
     message_id: str
@@ -134,17 +195,21 @@ def excess_message_rows_sql(limit: int) -> str:
 
 
 __all__ = [
+    "BLOCKS_FTS_TRIGGER_DDL",
     "FTS_INDEXABLE_MESSAGE_COUNT_SQL",
     "FTS_INDEX_DOC_COUNT_SQL",
     "FTS_INDEX_EXISTS_SQL",
     "FTS_MESSAGES_TABLE_SQL",
     "FTS_REBUILD_SQL",
+    "FTS_TRIGGER_DDL",
     "IndexedMessage",
+    "SESSION_WORK_EVENT_FTS_TRIGGER_DDL",
+    "THREAD_FTS_TRIGGER_DDL",
     "chunked",
     "delete_session_rows_sql",
-    "insert_all_message_rows_sql",
-    "insert_session_rows_sql",
-    "insert_missing_message_rows_sql",
-    "insert_missing_message_rows_range_sql",
     "excess_message_rows_sql",
+    "insert_all_message_rows_sql",
+    "insert_missing_message_rows_range_sql",
+    "insert_missing_message_rows_sql",
+    "insert_session_rows_sql",
 ]

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -24,7 +24,6 @@ from polylogue.insights.run_projection import (
     RunHarness,
     RunStatus,
 )
-from polylogue.storage.fts.pl_fold import pl_fold_sql_expr
 from polylogue.storage.runtime.store_constants import SESSION_INSIGHT_MATERIALIZER_VERSION
 from polylogue.storage.sqlite.archive_tiers.common import (
     CONTENT_HASH_CHECK,
@@ -394,24 +393,8 @@ CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
     tokenize='unicode61 remove_diacritics 2'
 );
 
-CREATE TRIGGER IF NOT EXISTS messages_fts_ai
-AFTER INSERT ON blocks WHEN new.search_text != '' BEGIN
-    INSERT INTO messages_fts(rowid, block_id, message_id, session_id, block_type, text)
-    VALUES (new.rowid, new.block_id, new.message_id, new.session_id, new.block_type, {pl_fold_sql_expr("new.search_text")});
-END;
-
-CREATE TRIGGER IF NOT EXISTS messages_fts_ad
-AFTER DELETE ON blocks WHEN old.search_text != '' BEGIN
-    DELETE FROM messages_fts WHERE rowid = old.rowid;
-END;
-
-CREATE TRIGGER IF NOT EXISTS messages_fts_au
-AFTER UPDATE ON blocks BEGIN
-    DELETE FROM messages_fts WHERE rowid = old.rowid;
-    INSERT INTO messages_fts(rowid, block_id, message_id, session_id, block_type, text)
-    SELECT new.rowid, new.block_id, new.message_id, new.session_id, new.block_type, {pl_fold_sql_expr("new.search_text")}
-    WHERE new.search_text != '';
-END;
+-- FTS triggers for messages_fts table are now dynamically composed from sql.py
+-- (polylogue-a7xr.5: consolidate FTS trigger DDL to single source)
 
 -- ohbx: trigram-tokenized (not unicode61) so `detail LIKE '%pattern%'` gets
 -- SQLite's built-in trigram LIKE-acceleration for arbitrary substrings, not
@@ -665,23 +648,8 @@ CREATE VIRTUAL TABLE IF NOT EXISTS threads_fts USING fts5(
     tokenize='unicode61 remove_diacritics 2'
 );
 
-CREATE TRIGGER IF NOT EXISTS threads_fts_ai
-AFTER INSERT ON threads BEGIN
-    INSERT INTO threads_fts (thread_id, root_id, text)
-    VALUES (new.thread_id, new.thread_id, {pl_fold_sql_expr("new.search_text")});
-END;
-
-CREATE TRIGGER IF NOT EXISTS threads_fts_ad
-AFTER DELETE ON threads BEGIN
-    DELETE FROM threads_fts WHERE thread_id = old.thread_id;
-END;
-
-CREATE TRIGGER IF NOT EXISTS threads_fts_au
-AFTER UPDATE ON threads BEGIN
-    DELETE FROM threads_fts WHERE thread_id = old.thread_id;
-    INSERT INTO threads_fts (thread_id, root_id, text)
-    VALUES (new.thread_id, new.thread_id, {pl_fold_sql_expr("new.search_text")});
-END;
+-- FTS triggers for threads_fts table are now dynamically composed from sql.py
+-- (polylogue-a7xr.5: consolidate FTS trigger DDL to single source)
 
 CREATE TABLE IF NOT EXISTS thread_sessions (
     thread_id    TEXT NOT NULL REFERENCES threads(thread_id) ON DELETE CASCADE,
@@ -945,11 +913,8 @@ CREATE VIRTUAL TABLE IF NOT EXISTS session_work_events_fts USING fts5(
     tokenize='unicode61 remove_diacritics 2'
 );
 
-CREATE TRIGGER IF NOT EXISTS session_work_events_fts_ai
-AFTER INSERT ON session_work_events BEGIN
-    INSERT INTO session_work_events_fts (event_id, session_id, work_event_type, text)
-    VALUES (new.event_id, new.session_id, new.work_event_type, {pl_fold_sql_expr("new.search_text")});
-END;
+-- FTS triggers for session_work_events_fts table are now dynamically composed from sql.py
+-- (polylogue-a7xr.5: consolidate FTS trigger DDL to single source)
 
 CREATE TABLE IF NOT EXISTS session_phases (
     phase_id        TEXT GENERATED ALWAYS AS (session_id || ':phase:' || position) STORED UNIQUE,
@@ -972,18 +937,6 @@ CREATE TABLE IF NOT EXISTS session_phases (
 
 CREATE INDEX IF NOT EXISTS idx_session_phases_session
 ON session_phases(session_id, position);
-
-CREATE TRIGGER IF NOT EXISTS session_work_events_fts_ad
-AFTER DELETE ON session_work_events BEGIN
-    DELETE FROM session_work_events_fts WHERE event_id = old.event_id;
-END;
-
-CREATE TRIGGER IF NOT EXISTS session_work_events_fts_au
-AFTER UPDATE ON session_work_events BEGIN
-    DELETE FROM session_work_events_fts WHERE event_id = old.event_id;
-    INSERT INTO session_work_events_fts (event_id, session_id, work_event_type, text)
-    VALUES (new.event_id, new.session_id, new.work_event_type, {pl_fold_sql_expr("new.search_text")});
-END;
 
 CREATE TABLE IF NOT EXISTS session_latency_profiles (
     session_id                       TEXT PRIMARY KEY REFERENCES sessions(session_id) ON DELETE CASCADE,


### PR DESCRIPTION
## Summary

Consolidate FTS trigger DDL definitions to a single canonical source in `storage/fts/sql.py`. This eliminates drift between fresh-database and repair-path trigger definitions across three FTS surfaces (messages_fts, session_work_events_fts, threads_fts).

## Problem

The same trigger DDL was defined in THREE places:
1. `storage/fts/fts_lifecycle.py`: _BLOCKS_FTS_TRIGGER_DDL, _SESSION_WORK_EVENT_FTS_TRIGGER_DDL, _THREAD_FTS_TRIGGER_DDL (used by repair operations)
2. `storage/sqlite/archive_tiers/index.py`: embedded in INDEX_DDL f-string (used for fresh-DB generation)
3. These could drift independently, forking trigger behavior between fresh-DB and repair paths

## Solution

1. Move all trigger DDL constants to `storage/fts/sql.py` as the single authoritative source
2. Export from sql.py via __all__ (BLOCKS_FTS_TRIGGER_DDL, SESSION_WORK_EVENT_FTS_TRIGGER_DDL, THREAD_FTS_TRIGGER_DDL, FTS_TRIGGER_DDL combined)
3. Import into fts_lifecycle.py and replace local definitions with aliases for backward compatibility
4. Remove trigger DDL from index.py INDEX_DDL string, replace with comments noting triggers are dynamically composed
5. Pure code consolidation (derived-tier change); no schema version bump

## Verification

- All FTS trigger bodies now found in exactly one location (sql.py)
- Backward-compatible aliases preserve existing call sites in fts_lifecycle
- index.py no longer imports unused trigger constants
- All format/lint/mypy checks pass
- `devtools test -k fts` coverage pending

Ref polylogue-a7xr.5