### PR TITLE
fix: close Wave 1 post-merge review debt (re4a, iwth, ihwv)

### DIFF
--- a/polylogue/sinex/material_adapter.py
+++ b/polylogue/sinex/material_adapter.py
@@ -47,6 +47,21 @@ def _json_safe(value: object) -> JSONValue:
     return str(value)
 
 
+def _dropped_block_gap(
+    session_id: str, message_index: int, block_position: int, block: dict[str, object]
+) -> FidelityGapInput:
+    raw_type = block.get("type")
+    return FidelityGapInput(
+        scope="block",
+        record_id=f"{session_id}:message[{message_index}]:block[{block_position}]",
+        gap_kind="dropped_block",
+        detail=(
+            f"block type {raw_type!r} is missing or not recognized by BlockType.from_string; "
+            "this block was omitted from the exported material, not silently kept"
+        ),
+    )
+
+
 def _block_input(position: int, block: dict[str, object]) -> BlockInput | None:
     raw_type = block.get("type")
     if raw_type is None:
@@ -94,29 +109,34 @@ def session_material_from_session(session: Session) -> SessionMaterial:
     native_id = native_id_from_session_id(session.id)
     if native_id is None:
         raise ValueError(f"session.id {session.id!r} is not a well-formed 'origin:native_id' session id")
-    messages = tuple(
-        MessageInput(
-            native_id=None,
-            position=index,
-            role=message.role,
-            text=message.text,
-            message_type=message.message_type,
-            material_origin=message.material_origin,
-            occurred_at_ms=_timestamp_ms(message.timestamp),
-            model_name=message.model_name,
-            input_tokens=message.input_tokens,
-            output_tokens=message.output_tokens,
-            cache_read_tokens=message.cache_read_tokens,
-            cache_write_tokens=message.cache_write_tokens,
-            duration_ms=message.duration_ms or None,
-            blocks=tuple(
-                block_input
-                for block_position, raw_block in enumerate(message.blocks)
-                if (block_input := _block_input(block_position, raw_block)) is not None
-            ),
+    dropped_block_gaps: list[FidelityGapInput] = []
+    messages: list[MessageInput] = []
+    for index, message in enumerate(session.messages):
+        blocks: list[BlockInput] = []
+        for block_position, raw_block in enumerate(message.blocks):
+            block_input = _block_input(block_position, raw_block)
+            if block_input is None:
+                dropped_block_gaps.append(_dropped_block_gap(session.id, index, block_position, raw_block))
+                continue
+            blocks.append(block_input)
+        messages.append(
+            MessageInput(
+                native_id=None,
+                position=index,
+                role=message.role,
+                text=message.text,
+                message_type=message.message_type,
+                material_origin=message.material_origin,
+                occurred_at_ms=_timestamp_ms(message.timestamp),
+                model_name=message.model_name,
+                input_tokens=message.input_tokens,
+                output_tokens=message.output_tokens,
+                cache_read_tokens=message.cache_read_tokens,
+                cache_write_tokens=message.cache_write_tokens,
+                duration_ms=message.duration_ms or None,
+                blocks=tuple(blocks),
+            )
         )
-        for index, message in enumerate(session.messages)
-    )
     fidelity_gaps = (
         FidelityGapInput(
             scope="session",
@@ -127,6 +147,7 @@ def session_material_from_session(session: Session) -> SessionMaterial:
                 "or session_events -- see module docstring"
             ),
         ),
+        *dropped_block_gaps,
     )
     return SessionMaterial(
         origin=session.origin,
@@ -141,7 +162,7 @@ def session_material_from_session(session: Session) -> SessionMaterial:
         working_directories=session.working_directories,
         metadata={key: _json_safe(value) for key, value in session.metadata.items()},
         tags=session.tags_m2m,
-        messages=messages,
+        messages=tuple(messages),
         lineage=(),
         usage=(),
         session_events=(),

--- a/polylogue/sinex/obligations.py
+++ b/polylogue/sinex/obligations.py
@@ -192,4 +192,46 @@ def mark_attempt(
     return updated
 
 
-__all__ = ["get_obligation", "list_obligations", "mark_attempt", "record_obligation"]
+def mark_publishing(
+    conn: sqlite3.Connection,
+    obligation: PublicationObligation,
+    *,
+    now_ms: int,
+) -> PublicationObligation:
+    """Mark an obligation as actively in-flight to a transport attempt.
+
+    Distinct from :func:`mark_attempt`: this is the pre-attempt transition,
+    written durably *before* the (possibly slow, possibly crashing) transport
+    call starts, so a crash mid-attempt leaves the row at ``publishing``
+    instead of indistinguishable from a still-untried ``pending`` row. It
+    deliberately does not touch ``attempt_count``/``last_receipt_state``/
+    ``last_error`` -- those describe an attempt's *outcome*, which this call
+    precedes and does not yet know.
+    """
+    conn.execute(
+        """
+        UPDATE sinex_publication_obligations
+        SET status = ?, updated_at_ms = ?
+        WHERE object_id = ? AND protocol_version = ? AND revision_id = ? AND manifest_digest = ?
+        """,
+        (
+            ObligationStatus.PUBLISHING.value,
+            now_ms,
+            obligation.object_id,
+            obligation.protocol_version,
+            obligation.revision_id,
+            obligation.manifest_digest,
+        ),
+    )
+    updated = get_obligation(
+        conn,
+        object_id=obligation.object_id,
+        protocol_version=obligation.protocol_version,
+        revision_id=obligation.revision_id,
+        manifest_digest=obligation.manifest_digest,
+    )
+    assert updated is not None
+    return updated
+
+
+__all__ = ["get_obligation", "list_obligations", "mark_attempt", "mark_publishing", "record_obligation"]

--- a/polylogue/sinex/service.py
+++ b/polylogue/sinex/service.py
@@ -140,6 +140,17 @@ class PublicationService:
         on_confirmed: Callable[[PublicationObligation], None] | None,
     ) -> PublicationObligation:
         assert self.transport is not None  # off mode never reaches here
+        publishing_conn = sqlite3.connect(self.source_db_path, timeout=30.0)
+        publishing_conn.execute("PRAGMA busy_timeout = 30000")
+        try:
+            publishing_conn.execute("BEGIN IMMEDIATE")
+            obligations_store.mark_publishing(publishing_conn, obligation, now_ms=self.clock())
+            publishing_conn.commit()
+        except Exception:
+            publishing_conn.rollback()
+            raise
+        finally:
+            publishing_conn.close()
         receipt = await self.transport.publish_revision(
             request_id=obligation.request_id,
             manifest_bytes=manifest_bytes,

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -4482,46 +4482,49 @@ def repair_duplicate_raw_identity(
     if apply and proof_digest != aggregate:
         raise RuntimeError("apply proof digest does not match the exact dry-run target list")
     if apply:
+        from polylogue.storage.index_generation import RebuildLease
+
         assert receipt_path is not None
         receipt_path.parent.mkdir(parents=True, exist_ok=True)
-        receipt = _lock_duplicate_raw_identity_repair_receipt(receipt_path, items)
-        try:
-            with closing(sqlite3.connect(f"file:{index_db}?mode=rw", uri=True)) as conn:
-                conn.row_factory = sqlite3.Row
-                conn.execute("PRAGMA foreign_keys = ON")
-                conn.execute("ATTACH DATABASE ? AS source", (f"file:{source_db}?mode=ro",))
-                conn.execute("BEGIN IMMEDIATE")
-                try:
-                    locked = inspect(conn)
-                    locked_digest = hashlib.sha256(
-                        json.dumps([item.proof_digest for item in locked], separators=(",", ":")).encode()
-                    ).hexdigest()
-                    if locked_digest != proof_digest:
-                        raise RuntimeError("authority proof changed after acquiring the repair transaction")
-                    if any(item.status == "ineligible" for item in locked):
-                        raise RuntimeError("a duplicate raw identity target became ineligible")
-                    if receipt.terminal and any(item.status != "already_repaired" for item in locked):
-                        raise RuntimeError("terminal operator receipt disagrees with durable index authority")
-                    if receipt.torn_terminals and any(item.status != "already_repaired" for item in locked):
-                        raise RuntimeError("torn terminal receipt has no matching committed index refinement")
-                    for item in locked:
-                        if item.status == "eligible":
-                            _apply_duplicate_raw_identity_repair(conn, item)
-                    after = inspect(conn)
-                    if any(item.status != "already_repaired" for item in after):
-                        raise RuntimeError("duplicate raw identity repair did not reach terminal state")
-                    conn.commit()
-                except Exception:
-                    conn.rollback()
-                    raise
-            items = [
-                dataclasses.replace(after_item, repaired=before.status == "eligible")
-                for before, after_item in zip(locked, after, strict=True)
-            ]
-            if not receipt.terminal:
-                _finish_duplicate_raw_identity_repair_receipt(receipt, items=items)
-        finally:
-            receipt.close()
+        with RebuildLease(archive_root):
+            receipt = _lock_duplicate_raw_identity_repair_receipt(receipt_path, items)
+            try:
+                with closing(sqlite3.connect(f"file:{index_db}?mode=rw", uri=True)) as conn:
+                    conn.row_factory = sqlite3.Row
+                    conn.execute("PRAGMA foreign_keys = ON")
+                    conn.execute("ATTACH DATABASE ? AS source", (f"file:{source_db}?mode=ro",))
+                    conn.execute("BEGIN IMMEDIATE")
+                    try:
+                        locked = inspect(conn)
+                        locked_digest = hashlib.sha256(
+                            json.dumps([item.proof_digest for item in locked], separators=(",", ":")).encode()
+                        ).hexdigest()
+                        if locked_digest != proof_digest:
+                            raise RuntimeError("authority proof changed after acquiring the repair transaction")
+                        if any(item.status == "ineligible" for item in locked):
+                            raise RuntimeError("a duplicate raw identity target became ineligible")
+                        if receipt.terminal and any(item.status != "already_repaired" for item in locked):
+                            raise RuntimeError("terminal operator receipt disagrees with durable index authority")
+                        if receipt.torn_terminals and any(item.status != "already_repaired" for item in locked):
+                            raise RuntimeError("torn terminal receipt has no matching committed index refinement")
+                        for item in locked:
+                            if item.status == "eligible":
+                                _apply_duplicate_raw_identity_repair(conn, item)
+                        after = inspect(conn)
+                        if any(item.status != "already_repaired" for item in after):
+                            raise RuntimeError("duplicate raw identity repair did not reach terminal state")
+                        conn.commit()
+                    except Exception:
+                        conn.rollback()
+                        raise
+                items = [
+                    dataclasses.replace(after_item, repaired=before.status == "eligible")
+                    for before, after_item in zip(locked, after, strict=True)
+                ]
+                if not receipt.terminal:
+                    _finish_duplicate_raw_identity_repair_receipt(receipt, items=items)
+            finally:
+                receipt.close()
     return DuplicateRawIdentityRepairReport(
         mode="apply" if apply else "dry-run",
         requested_count=len(items),

--- a/tests/unit/sinex/test_material_adapter.py
+++ b/tests/unit/sinex/test_material_adapter.py
@@ -64,10 +64,15 @@ def test_adapter_output_round_trips_through_the_real_v1_encoder() -> None:
     assert material.messages[0].text == "hello there"
     assert material.messages[1].blocks[0].block_type.value == "text"
     assert material.messages[1].blocks[1].tool_name == "Bash"
-    # The invalid block type was silently dropped, not raised or mis-mapped.
+    # The invalid block type was dropped, not raised or mis-mapped -- but the
+    # drop itself must be a declared fidelity gap, not silent (polylogue-ihwv).
     assert len(material.messages[1].blocks) == 2
-    assert len(material.fidelity_gaps) == 1
+    assert len(material.fidelity_gaps) == 2
     assert material.fidelity_gaps[0].gap_kind == "omitted_relation"
+    dropped_block_gap = material.fidelity_gaps[1]
+    assert dropped_block_gap.gap_kind == "dropped_block"
+    assert dropped_block_gap.scope == "block"
+    assert dropped_block_gap.record_id == "claude-code-session:s1:message[1]:block[2]"
 
     encoded = encode_session_revision(material, revision_created_at="2026-01-01T00:00:02+00:00")
     assert encoded.manifest.session_id == "claude-code-session:s1"

--- a/tests/unit/sinex/test_obligations.py
+++ b/tests/unit/sinex/test_obligations.py
@@ -13,7 +13,13 @@ from pathlib import Path
 import pytest
 
 from polylogue.sinex.models import ObligationStatus, PublicationMode, ReceiptState
-from polylogue.sinex.obligations import get_obligation, list_obligations, mark_attempt, record_obligation
+from polylogue.sinex.obligations import (
+    get_obligation,
+    list_obligations,
+    mark_attempt,
+    mark_publishing,
+    record_obligation,
+)
 
 
 def _conn(source_db_path: Path) -> sqlite3.Connection:
@@ -132,6 +138,53 @@ def test_mark_attempt_increments_count_and_sets_retired_only_on_terminal_status(
         assert after_confirmed.retired_at_ms == 3000
         assert after_confirmed.status is ObligationStatus.CONFIRMED
         assert after_confirmed.last_receipt_state is ReceiptState.PERSISTED_CONFIRMED
+    finally:
+        conn.close()
+
+
+def test_mark_publishing_transitions_status_without_incrementing_attempt_count(
+    workspace_env: dict[str, Path],
+) -> None:
+    """The pre-attempt marker (polylogue-ihwv) is distinct from mark_attempt.
+
+    It durably records "a transport call is in flight" so a crash between
+    this write and the attempt's resolution leaves the row at ``publishing``
+    -- observably different from a still-untried ``pending`` row -- but it
+    must not touch attempt_count/receipt/error, which describe an outcome
+    this call precedes and does not yet know.
+    """
+    source_db = workspace_env["archive_root"] / "source.db"
+    conn = _conn(source_db)
+    try:
+        obligation = record_obligation(
+            conn,
+            object_id="claude-code-session:s1",
+            protocol_version="polylogue.material-protocol/v1",
+            revision_id="rev-1",
+            manifest_digest="digest-1",
+            mode=PublicationMode.PRIMARY,
+            now_ms=1000,
+        )
+        conn.commit()
+
+        publishing = mark_publishing(conn, obligation, now_ms=1500)
+        conn.commit()
+        assert publishing.status is ObligationStatus.PUBLISHING
+        assert publishing.attempt_count == 0
+        assert publishing.retired_at_ms is None
+        assert publishing.updated_at_ms == 1500
+
+        after_confirmed = mark_attempt(
+            conn,
+            publishing,
+            status=ObligationStatus.CONFIRMED,
+            receipt_state=ReceiptState.PERSISTED_CONFIRMED,
+            error=None,
+            now_ms=2000,
+        )
+        conn.commit()
+        assert after_confirmed.attempt_count == 1
+        assert after_confirmed.status is ObligationStatus.CONFIRMED
     finally:
         conn.close()
 

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -3014,6 +3014,14 @@ def test_full_ingest_skips_durably_excised_content_without_aborting_batch(
     through to the generic ``except Exception`` branch (or removing the
     pre-write ``is_blob_hash_excised`` gate entirely) makes this fail: either
     the whole batch call raises, or the excised content gets a fresh raw_id.
+
+    The streaming threshold is patched down (matching the pattern used
+    elsewhere in this file, e.g. ``test_full_ingest_reports_heartbeat_stage_events``)
+    so both fixture files route through ``blob_store.write_from_path`` /
+    ``archive.write_raw_blob_ref`` -> ``write_source_raw_session_blob_ref``,
+    the same code path a real >8MB capture takes -- not the small-payload
+    ``write_raw_payload`` -> ``write_source_raw_session`` gate, which is a
+    different call site (polylogue-re4a).
     """
     from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
     from polylogue.storage.sqlite.archive_tiers.source_write import (
@@ -3059,6 +3067,13 @@ def test_full_ingest_skips_durably_excised_content_without_aborting_batch(
         lambda _path, fallback_provider: (fallback_provider, True),
     )
     monkeypatch.setattr("polylogue.sources.live.batch.parse_stream_payload", lambda *_args, **_kwargs: sessions)
+
+    # Force both fixture files through the streaming blob-ref write path
+    # (>= this threshold uses blob_store.write_from_path + write_raw_blob_ref,
+    # never populating raw_payloads) rather than the small-payload
+    # write_raw_payload path -- see polylogue-re4a.
+    monkeypatch.setattr("polylogue.sources.live.batch._STREAMING_FULL_INGEST_BYTES", 1)
+    monkeypatch.setattr("polylogue.sources.live.batch_support._STREAMING_FULL_INGEST_BYTES", 1)
 
     archive_results: list[_ArchiveFullWriteResult] = []
     original_full_write = processor._ingest_full_records_archive

--- a/tests/unit/storage/test_browser_capture_origin_repair.py
+++ b/tests/unit/storage/test_browser_capture_origin_repair.py
@@ -2426,11 +2426,25 @@ def test_record_conflict_blockers_never_clobbers_an_operator_judged_row(tmp_path
         assert judged is not None
         assert judged.status.value == "accepted"
         judged_value = judged.value
+        judged_updated_at_ms = judged.updated_at_ms
 
     # Re-running the detector over the identical evidence must leave the
-    # judged row's status and value exactly as the operator left it.
+    # judged row's status and value exactly as the operator left it. Passing
+    # a distinct now_ms is the genuine negative control: value/status are
+    # deterministically identical across both runs regardless of whether the
+    # guard fires (same evidence -> same computed value, and
+    # upsert_assertion's own terminal-judgment chokepoint separately protects
+    # status), so those two fields alone cannot distinguish "guard
+    # short-circuited before writing" from "guard removed, wrote anyway".
+    # updated_at_ms can: upsert_assertion's ON CONFLICT always sets
+    # updated_at_ms = excluded.updated_at_ms unconditionally, so if the guard
+    # in record_browser_canonical_authority_conflict_blockers were removed
+    # (or its read_assertion_envelope check bypassed), this second call would
+    # still invoke upsert_assertion for the judged row and updated_at_ms
+    # would move to the new now_ms -- an observable difference the guard
+    # must prevent entirely by never calling upsert_assertion at all.
     _report_again, assertion_ids_again = record_browser_canonical_authority_conflict_blockers(
-        _config(tmp_path), [raw_id]
+        _config(tmp_path), [raw_id], now_ms=judged_updated_at_ms + 999_000
     )
     assert assertion_ids_again == assertion_ids
     with closing(sqlite3.connect(tmp_path / "user.db")) as user_conn:
@@ -2438,6 +2452,7 @@ def test_record_conflict_blockers_never_clobbers_an_operator_judged_row(tmp_path
         assert still_judged is not None
         assert still_judged.status.value == "accepted"
         assert still_judged.value == judged_value
+        assert still_judged.updated_at_ms == judged_updated_at_ms
         # ``judge_assertion_candidate(decision="accept")`` legitimately leaves
         # TWO ``blocker`` rows for this target: the original candidate
         # (mutated in place to ``status=accepted`` by ``mark_assertion_status``,


### PR DESCRIPTION
## Summary

Closes three small pieces of independent-reviewer-flagged residual debt from Wave 1's merged clusters (excision #2875, raw-identity #2877, sinex evidence mode #2873). Done directly, without a separate implementer/reviewer Workflow round, per operator instruction.

## Problem

Each item is a real gap an independent adversarial reviewer found in an already-merged PR:

- **polylogue-re4a**: the excision-bypass regression test routed through the pre-existing small-payload gate, never touching the new streaming blob-ref gate it claimed to prove.
- **polylogue-iwth**: (1) the operator-judgment-guard test asserted only fields that are deterministically identical whether or not the guard fires, so it would pass even with the guard removed; (2) `repair_duplicate_raw_identity`'s apply path skipped `RebuildLease`, unlike its sibling actuators.
- **polylogue-ihwv**: sinex_mode's own fix was independently re-verified correct (existing targeted tests green); two residual nits: `material_adapter.py` silently dropped unrecognized blocks without declaring a fidelity gap, and `ObligationStatus.PUBLISHING` was declared but never written.

## Solution

- `tests/unit/sources/test_live_batch_support.py`: patch `_STREAMING_FULL_INGEST_BYTES` down to 1 (existing pattern in this file) so the excised/normal fixtures route through the blob-ref write path. Verified as a genuine anti-vacuity check with an in-memory `mock.patch` on `is_blob_hash_excised` (not a file edit to the production gate — the auto-mode classifier correctly blocked that as a security-weakening action).
- `tests/unit/storage/test_browser_capture_origin_repair.py` + `polylogue/storage/repair.py`: added an `updated_at_ms`-unchanged assertion — the one field `upsert_assertion`'s `ON CONFLICT` always moves regardless of the guard, so it's the only observable proof the guard short-circuited before writing. Verified as a genuine negative control with an in-memory mock (side_effect returning `None` only for the guard's own read, real behavior otherwise) — bypassing the guard moves `updated_at_ms` as predicted. Wrapped `repair_duplicate_raw_identity`'s apply block in `RebuildLease(archive_root)`.
- `polylogue/sinex/material_adapter.py` + test: `session_material_from_session` now emits a `FidelityGapInput(gap_kind="dropped_block")` per dropped block. Extended the existing fixture's assertions (it already had a `"not-a-real-block-type"` block commented "must be dropped, not raise").
- `polylogue/sinex/obligations.py` + `service.py` + test: added `mark_publishing()`, a pre-attempt transition distinct from `mark_attempt` (no attempt_count/receipt outcome yet). `PublicationService._attempt` now durably marks the obligation `PUBLISHING` immediately before the transport call, in its own short transaction, so a crash mid-attempt is now observably distinguishable from a never-tried `pending` row — consistent with `pending()`/`lag()` already including `PUBLISHING` in their filters.

## Verification

- `devtools test tests/unit/sources/test_live_batch_support.py -k test_full_ingest_skips_durably_excised_content_without_aborting_batch` — 1 passed
- `devtools test tests/unit/storage/test_browser_capture_origin_repair.py -k test_record_conflict_blockers_never_clobbers_an_operator_judged_row` — 1 passed
- `devtools test tests/unit/storage/test_duplicate_raw_identity_repair.py` — 13 passed
- `devtools test tests/unit/sinex/` — 25 passed
- `devtools verify --quick` — exit 0, all 16 steps green

Ref polylogue-re4a. Ref polylogue-iwth. Ref polylogue-ihwv.