### PR TITLE
fix(browser): normalize rich-composer prompt verification

### DIFF
--- a/browser-extension/src/launch/chatgpt_launch.js
+++ b/browser-extension/src/launch/chatgpt_launch.js
@@ -114,7 +114,7 @@ export async function executeChatGptLaunchInPage(job, attachments) {
   composer.dispatchEvent(new InputEvent("input", { bubbles: true, cancelable: true, inputType: "deleteContent" }));
   if (!document.execCommand("insertText", false, job.prompt)) throw new Error("protocol_prompt_insert_failed");
   const expectedPromptPrefix = normalizedText(job.prompt).slice(0, 120);
-  if (!normalizedText(textOf(composer)).includes(expectedPromptPrefix)) {
+  if (!normalizedText(textOf(composer)).startsWith(expectedPromptPrefix)) {
     throw new Error("protocol_prompt_verification_failed");
   }
 

--- a/browser-extension/src/launch/chatgpt_launch.js
+++ b/browser-extension/src/launch/chatgpt_launch.js
@@ -23,6 +23,7 @@ export async function executeChatGptLaunchInPage(job, attachments) {
   const requiredEffort = "Pro";
   const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
   const textOf = (node) => String(node?.innerText || node?.textContent || "").trim();
+  const normalizedText = (value) => String(value || "").replace(/\s+/g, " ").trim();
   const waitFor = async (predicate, timeoutMs, label) => {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
@@ -112,7 +113,10 @@ export async function executeChatGptLaunchInPage(job, attachments) {
   composer.replaceChildren();
   composer.dispatchEvent(new InputEvent("input", { bubbles: true, cancelable: true, inputType: "deleteContent" }));
   if (!document.execCommand("insertText", false, job.prompt)) throw new Error("protocol_prompt_insert_failed");
-  if (!textOf(composer).includes(job.prompt.trim().slice(0, 80))) throw new Error("protocol_prompt_verification_failed");
+  const expectedPromptPrefix = normalizedText(job.prompt).slice(0, 120);
+  if (!normalizedText(textOf(composer)).includes(expectedPromptPrefix)) {
+    throw new Error("protocol_prompt_verification_failed");
+  }
 
   // Re-read the mode after upload/composer work: React can rerender the mode
   // switch independently, and this is the final fail-closed submit boundary.

--- a/browser-extension/tests/chatgpt_launch.test.js
+++ b/browser-extension/tests/chatgpt_launch.test.js
@@ -128,7 +128,7 @@ describe("ChatGPT Sol Pro launch adapter", () => {
       <button class="composer-submit-button-color">Send</button>
     `, "https://chatgpt.com/");
     document.execCommand = vi.fn((_command, _ui, value) => {
-      document.querySelector("#prompt-textarea").textContent = value;
+      document.querySelector("#prompt-textarea").textContent = value.replaceAll("\n", "\n\n\n");
       return true;
     });
     document.querySelector(".composer-submit-button-color").addEventListener("click", () => {
@@ -145,7 +145,7 @@ describe("ChatGPT Sol Pro launch adapter", () => {
     });
 
     await expect(executeChatGptLaunchInPage({
-      prompt: "Produce a durable result.",
+      prompt: "# Mission: Produce a durable result.\n\nExplain the work directly and attach the handoff.",
       mode: "chat",
       model_slug: "gpt-5-6-pro",
       model_label: "GPT-5.6 Sol",


### PR DESCRIPTION
## Summary

Accept mission-first Sol Pro prompts after ChatGPT ProseMirror expands paragraph whitespace, while retaining the fail-closed content verification immediately before submission.

## Problem

The first v2 priority-queue launch inserted its complete prompt and attachment correctly, but ProseMirror projected each Markdown paragraph break as additional blank lines. The adapter compared an exact raw prefix and paused the job with `protocol_prompt_verification_failed` before submission.

## Solution

Normalize whitespace on both the expected bounded prefix and the live composer text. The check still proves that the beginning of the intended prompt is present and remains inside the final Chat / GPT-5.6 Sol / Pro boundary. The production-route test now simulates rich-composer paragraph expansion.

## Verification

- `npm test -- --run tests/chatgpt_launch.test.js` — 9 passed.
- `npm run lint` — clean.
- `devtools verify --quick` — 16/16 steps passed (`20260715T221832Z-quick-1939440-da63fe66`).
- Live pre-fix receipt: job `sol-burst-query-discovery` paused before submission while the composer contained the full 5,102-character prompt with expanded paragraph whitespace.

Ref `polylogue-yyvg.5`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt insertion verification by handling repeated whitespace and line breaks more reliably.
  * Increased verification coverage for longer, multi-paragraph prompts.

* **Tests**
  * Updated submission checks to reflect formatting changes applied to multiline prompt text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->