### PR TITLE
fix(storage): make raw replay batches component-aware

### DIFF
--- a/docs/plans/layering.yaml
+++ b/docs/plans/layering.yaml
@@ -31,7 +31,7 @@ writer_modules:
           interruption: atomic
       entrypoints:
         [apply_raw_membership_classification, apply_raw_revision_replay, classify_raw_revision_cohort,
-        delete_sessions, replace_raw_membership_census,
+        delete_sessions, release_provisional_full_revisions, replace_raw_membership_census,
         write_parsed_for_retained_raw, write_parsed_for_retained_raw_result, write_raw_and_parsed,
         write_raw_and_parsed_result, write_raw_blob_and_parsed, write_raw_blob_and_parsed_result]
       twin_write_contract: raw-membership-classification

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -630,9 +630,29 @@ def _drain_raw_materialization_once(*, limit: int = _RAW_MATERIALIZATION_CONVERG
         result = repair_raw_materialization(config, dry_run=False, raw_artifact_limit=limit)
     finally:
         _close_raw_materialization_fts(config.archive_root / "index.db")
+    _emit_raw_materialization_pass(result)
     if not result.success:
         logger.warning("raw materialization: bounded convergence incomplete: %s", result.detail)
     return result.repaired_count
+
+
+def _emit_raw_materialization_pass(result: Any) -> None:
+    """Persist the conserved plan outcomes for one bounded daemon pass."""
+    outcomes = tuple(getattr(result, "plan_outcomes", ()))
+    from polylogue.daemon.events import emit_daemon_event
+
+    metrics = dict(getattr(result, "metrics", {}))
+    emit_daemon_event(
+        "raw_materialization_pass",
+        payload={
+            "pass_id": f"raw-materialization:{os.urandom(16).hex()}",
+            "success": bool(result.success),
+            "repaired_count": int(result.repaired_count),
+            "detail": str(result.detail),
+            "metrics": metrics,
+            "plan_outcomes": [outcome.to_dict() for outcome in outcomes],
+        },
+    )
 
 
 def _close_raw_materialization_fts(index_db: Path) -> None:

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -12,7 +12,12 @@ from io import BytesIO
 from pathlib import Path
 from types import TracebackType
 
-from polylogue.archive.revision_authority import BYTE_AUTHORITY_CENSUS_DETAIL
+from polylogue.archive.revision_authority import (
+    BYTE_AUTHORITY_CENSUS_DETAIL,
+    RawRevisionAuthority,
+    RawRevisionEnvelope,
+    RawRevisionKind,
+)
 from polylogue.archive.session_revision_membership import MembershipRevision, classify_membership_revisions
 from polylogue.core.enums import Provider
 from polylogue.pipeline.ids import session_revision_projection
@@ -58,6 +63,8 @@ def backfill_historical_revision_evidence(
     quarantined = 0
     adoption_deferred = 0
     logical_keys: set[str] = set()
+    membership_candidates: dict[str, set[str]] = {}
+    provisional_full_raw_ids: dict[str, set[str]] = {}
     archive_context = (
         ArchiveStore.open_owned_inactive_generation(
             archive_root,
@@ -102,7 +109,7 @@ def backfill_historical_revision_evidence(
                         quarantined += 1
                         continue
                     try:
-                        sessions, _payload_bytes = _parse_retained_raw(archive, raw_id)
+                        sessions, _payload_bytes, revision_kind = _parse_retained_raw(archive, raw_id)
                     except Exception as exc:
                         archive.replace_raw_membership_census(
                             raw_id,
@@ -115,12 +122,30 @@ def backfill_historical_revision_evidence(
                         continue
                     classified += int(len(sessions) == 1)
                     spill.add(raw_id, sessions, payload_bytes=_payload_bytes)
-                    archive.replace_raw_membership_census(
-                        raw_id,
-                        sessions,
-                        parser_fingerprint="revision-membership-v1",
-                        censused_at_ms=0,
-                    )
+                    if len(sessions) == 1 and revision_kind is RawRevisionKind.UNKNOWN:
+                        session = sessions[0]
+                        logical_key = f"{session.source_name.value}:{session.provider_session_id}"
+                        archive.bind_raw_revision(
+                            raw_id,
+                            RawRevisionEnvelope(
+                                logical_source_key=logical_key,
+                                kind=RawRevisionKind.FULL,
+                                source_revision=raw_id,
+                                acquisition_generation=0,
+                                authority=RawRevisionAuthority.QUARANTINED,
+                            ),
+                        )
+                        provisional_full_raw_ids.setdefault(logical_key, set()).add(raw_id)
+                    elif revision_kind is RawRevisionKind.UNKNOWN:
+                        archive.replace_raw_membership_census(
+                            raw_id,
+                            sessions,
+                            parser_fingerprint="revision-membership-v1",
+                            censused_at_ms=0,
+                        )
+                        for session in sessions:
+                            logical_key = f"{session.source_name.value}:{session.provider_session_id}"
+                            membership_candidates.setdefault(logical_key, set()).add(raw_id)
                 if census_selection is None:
                     break
                 expanded, _keys = archive.expand_raw_membership_selection(list(census_selection))
@@ -130,12 +155,32 @@ def backfill_historical_revision_evidence(
 
         _unclassified, selected_keys = archive.raw_revision_rebuild_selection(selected_raw_ids)
         logical_keys.update(selected_keys)
-        _selected_membership_raws, membership_keys = archive.expand_raw_membership_selection(selected_raw_ids)
+        _selected_membership_raws, selected_membership_keys = archive.expand_raw_membership_selection(selected_raw_ids)
+        membership_keys = set(selected_membership_keys)
 
         replayed = 0
+        byte_replayed_keys: set[str] = set()
         for logical_key in sorted(logical_keys):
             plan = archive.classify_raw_revision_cohort(logical_key)
             if not plan.accepted_raw_ids:
+                # Complete snapshots that are not a unique byte-prefix chain
+                # still carry semantic evidence. Move only that full-only
+                # cohort to membership governance and let parsed-content
+                # prefix rules decide it; append chains remain byte-governed.
+                for raw_id in archive.convertible_full_revision_raw_ids(logical_key):
+                    sessions, _payload_bytes = spill.for_raw(raw_id)
+                    if len(sessions) != 1:
+                        raise RuntimeError(f"full revision {raw_id} no longer parses to one session")
+                    archive.replace_raw_membership_census(
+                        raw_id,
+                        sessions,
+                        parser_fingerprint="revision-membership-v1",
+                        censused_at_ms=0,
+                        detail="historical non-prefix full revision governance",
+                        retire_full_revision_governance=True,
+                    )
+                    membership_candidates.setdefault(logical_key, set()).add(raw_id)
+                membership_keys.add(logical_key)
                 continue
             parsed_by_raw_id: dict[str, ParsedSession] = {}
             retained_bytes = 0
@@ -150,19 +195,25 @@ def backfill_historical_revision_evidence(
             accepted_sessions = [parsed_by_raw_id[raw_id] for raw_id in plan.accepted_raw_ids]
             if not archive.raw_revision_replay_adoptable(accepted_sessions):
                 archive.defer_raw_revision_adoption(plan.logical_source_key, plan.accepted_raw_ids, accepted_sessions)
+                provisional_raw_ids = provisional_full_raw_ids.get(logical_key, set())
+                plan_raw_ids = {application.raw_id for application in plan.applications}
+                if plan_raw_ids and plan_raw_ids <= provisional_raw_ids:
+                    archive.release_provisional_full_revisions(sorted(plan_raw_ids))
                 adoption_deferred += len(plan.accepted_raw_ids)
                 continue
             archive.apply_raw_revision_replay(plan, parsed_by_raw_id, acquired_at_ms=0)
             replayed += 1
+            byte_replayed_keys.add(logical_key)
 
-        for logical_key in membership_keys:
-            if logical_key in logical_keys:
+        for logical_key in sorted(membership_keys):
+            if logical_key in byte_replayed_keys:
                 continue
             member_sessions: dict[str, ParsedSession] = {}
             revisions: list[MembershipRevision] = []
             projections = {}
             retained_bytes = 0
             candidate_raw_ids = set(archive.raw_membership_rebuild_raw_ids(logical_key))
+            candidate_raw_ids.update(membership_candidates.get(logical_key, ()))
             for raw_id, session, payload_bytes in spill.for_logical_key(logical_key):
                 if raw_id not in candidate_raw_ids:
                     continue
@@ -197,9 +248,9 @@ def backfill_historical_revision_evidence(
     return RevisionBackfillResult(scanned, classified, replayed, quarantined, adoption_deferred)
 
 
-def _parse_retained_raw(archive: ArchiveStore, raw_id: str) -> tuple[list[ParsedSession], int]:
-    provider, payload, source_path, _kind = archive.raw_revision_material(raw_id)
-    return _parse_one(provider, payload, source_path), len(payload)
+def _parse_retained_raw(archive: ArchiveStore, raw_id: str) -> tuple[list[ParsedSession], int, RawRevisionKind]:
+    provider, payload, source_path, kind = archive.raw_revision_material(raw_id)
+    return _parse_one(provider, payload, source_path), len(payload), kind
 
 
 class _ParsedSessionSpill:

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -14,6 +14,7 @@ from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import closing, contextmanager, suppress
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
 from typing import cast
 
@@ -4561,6 +4562,7 @@ class RawMaterializationCandidates:
     raw_blob_bytes: dict[str, int] = field(default_factory=dict)
     raw_origins: dict[str, str] = field(default_factory=dict)
     raw_source_paths: dict[str, str] = field(default_factory=dict)
+    raw_acquired_at_ms: dict[str, int] = field(default_factory=dict)
     missing_blob_source_available: int = 0
     missing_blob_source_missing: int = 0
     adoption_deferred: int = 0
@@ -4579,6 +4581,34 @@ class RawMaterializationCandidates:
     @property
     def max_blob_bytes(self) -> int:
         return max((self.raw_blob_bytes.get(raw_id, 0) for raw_id in self.raw_ids), default=0)
+
+
+class RawReplayPlanStatus(StrEnum):
+    EXECUTED = "executed"
+    RETRYABLE = "retryable"
+    DEFERRED = "deferred"
+    TERMINAL = "terminal"
+    REJECTED_STALE = "rejected_stale"
+
+
+@dataclass(frozen=True, slots=True)
+class RawReplayPlanOutcome:
+    plan_id: str
+    input_raw_ids: tuple[str, ...]
+    status: RawReplayPlanStatus
+    reason: str
+    next_action: str
+
+    def to_dict(self) -> JSONDocument:
+        return json_document(
+            {
+                "plan_id": self.plan_id,
+                "input_raw_ids": list(self.input_raw_ids),
+                "status": self.status.value,
+                "reason": self.reason,
+                "next_action": self.next_action,
+            }
+        )
 
 
 def _raw_materialization_origin_from_provider(provider: str | None) -> str | None:
@@ -4632,6 +4662,7 @@ def _raw_materialization_candidate_ids(
     raw_blob_bytes: dict[str, int] = {}
     raw_origins: dict[str, str] = {}
     raw_source_paths: dict[str, str] = {}
+    raw_acquired_at_ms: dict[str, int] = {}
     missing_blobs = 0
     missing_blob_source_available = 0
     missing_blob_source_missing = 0
@@ -4662,7 +4693,8 @@ def _raw_materialization_candidate_ids(
             params.extend((normalized_root, f"{normalized_root}/%"))
         rows = conn.execute(
             f"""
-            SELECT r.raw_id, r.origin, r.native_id, r.source_path, r.blob_hash, r.blob_size, r.parsed_at_ms,
+            SELECT r.raw_id, r.origin, r.native_id, r.source_path, r.blob_hash, r.blob_size,
+                   r.acquired_at_ms, r.parsed_at_ms,
                    r.parse_error,
                    EXISTS (
                        SELECT 1
@@ -4790,6 +4822,7 @@ def _raw_materialization_candidate_ids(
                 raw_ids.append(raw_id)
                 raw_origins[raw_id] = str(row["origin"] or "")
                 raw_source_paths[raw_id] = str(row["source_path"] or "")
+                raw_acquired_at_ms[raw_id] = int(row["acquired_at_ms"] or 0)
                 blob_size = row["blob_size"]
                 if isinstance(blob_size, int):
                     raw_blob_bytes[raw_id] = blob_size
@@ -4821,6 +4854,7 @@ def _raw_materialization_candidate_ids(
         raw_blob_bytes=raw_blob_bytes,
         raw_origins=raw_origins,
         raw_source_paths=raw_source_paths,
+        raw_acquired_at_ms=raw_acquired_at_ms,
         missing_blob_source_available=missing_blob_source_available,
         missing_blob_source_missing=missing_blob_source_missing,
         adoption_deferred=adoption_deferred,
@@ -4848,12 +4882,196 @@ def _raw_materialization_retryable_missing_blob_error(parse_error: object) -> bo
     )
 
 
-def _raw_materialization_total_bytes(candidates: RawMaterializationCandidates, raw_ids: list[str]) -> int:
-    return sum(candidates.raw_blob_bytes.get(raw_id, 0) for raw_id in raw_ids)
+def _raw_materialization_ordered_components(
+    candidates: RawMaterializationCandidates,
+    *,
+    archive_root: Path,
+) -> list[tuple[str, ...]]:
+    """Order complete components fairly without splitting authority cohorts."""
+    candidate_ids = set(candidates.raw_ids)
+    source_components = candidates.authority_components or tuple((raw_id,) for raw_id in candidates.raw_ids)
+    components = [component for component in source_components if candidate_ids.intersection(component)]
+    last_attempts = _raw_replay_plan_last_attempts(archive_root)
+
+    def candidate_order(raw_id: str) -> tuple[int, int, str]:
+        if raw_id in candidates.raw_acquired_at_ms:
+            return (0, candidates.raw_acquired_at_ms[raw_id], raw_id)
+        return (1, candidates.raw_blob_bytes.get(raw_id, 0), raw_id)
+
+    return sorted(
+        components,
+        key=lambda component: (
+            _raw_replay_plan_id(component) in last_attempts,
+            last_attempts.get(_raw_replay_plan_id(component), 0),
+            min(candidate_order(raw_id) for raw_id in component if raw_id in candidate_ids),
+            component,
+        ),
+    )
 
 
-def _raw_materialization_max_bytes(candidates: RawMaterializationCandidates, raw_ids: list[str]) -> int:
-    return max((candidates.raw_blob_bytes.get(raw_id, 0) for raw_id in raw_ids), default=0)
+def _raw_materialization_component_seed(
+    candidates: RawMaterializationCandidates,
+    component: tuple[str, ...],
+) -> str:
+    candidate_ids = set(candidates.raw_ids)
+    return min(
+        (raw_id for raw_id in component if raw_id in candidate_ids),
+        key=lambda raw_id: (
+            (0, candidates.raw_acquired_at_ms[raw_id], raw_id)
+            if raw_id in candidates.raw_acquired_at_ms
+            else (1, candidates.raw_blob_bytes.get(raw_id, 0), raw_id)
+        ),
+    )
+
+
+def _raw_materialization_component_blob_bytes(candidates: RawMaterializationCandidates, raw_id: str) -> int:
+    return candidates.expanded_blob_bytes.get(raw_id, candidates.raw_blob_bytes.get(raw_id, 0))
+
+
+def _raw_replay_plan_id(component: tuple[str, ...]) -> str:
+    digest = hashlib.sha256()
+    digest.update(b"polylogue.raw-replay-plan.v1\0")
+    for raw_id in sorted(component):
+        digest.update(raw_id.encode("utf-8"))
+        digest.update(b"\0")
+    return f"raw-replay:{digest.hexdigest()}"
+
+
+def _raw_replay_plan_last_attempts(archive_root: Path) -> dict[str, int]:
+    """Read disposable daemon receipts to rotate retryable plans fairly."""
+    ops_db = archive_root / "ops.db"
+    if not ops_db.is_file():
+        return {}
+    try:
+        with closing(sqlite3.connect(f"file:{ops_db}?mode=ro", uri=True)) as conn:
+            exists = conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='daemon_events'").fetchone()
+            if exists is None:
+                return {}
+            rows = conn.execute(
+                """
+                SELECT json_extract(outcome.value, '$.plan_id'), MAX(event.id)
+                FROM daemon_events AS event,
+                     json_each(event.payload_json, '$.plan_outcomes') AS outcome
+                WHERE event.kind = 'raw_materialization_pass'
+                  AND json_valid(event.payload_json)
+                  AND json_extract(outcome.value, '$.plan_id') IS NOT NULL
+                GROUP BY json_extract(outcome.value, '$.plan_id')
+                """
+            )
+            return {str(row[0]): int(row[1]) for row in rows}
+    except sqlite3.Error:
+        logger.warning("raw replay: failed to read prior plan attempts", exc_info=True)
+        return {}
+
+
+def _raw_replay_plan_outcome(
+    conn: sqlite3.Connection,
+    component: tuple[str, ...],
+    *,
+    remaining: RawMaterializationCandidates,
+) -> RawReplayPlanOutcome:
+    """Conserve one selected component into an explicit post-pass state."""
+    plan_id = _raw_replay_plan_id(component)
+    remaining_ids = set(remaining.expanded_raw_ids) | set(remaining.raw_ids)
+    if remaining_ids.intersection(component):
+        return RawReplayPlanOutcome(
+            plan_id,
+            component,
+            RawReplayPlanStatus.RETRYABLE,
+            "authority component remains executable after this pass",
+            "retry the same plan after the current writer pass",
+        )
+
+    placeholders = ",".join("?" for _ in component)
+    deferred = conn.execute(
+        f"""
+            SELECT 1
+            FROM index_tier.raw_revision_applications
+            WHERE raw_id IN ({placeholders}) AND decision = 'deferred'
+            UNION ALL
+            SELECT 1
+            FROM raw_session_memberships
+            WHERE raw_id IN ({placeholders}) AND decision = 'deferred'
+            LIMIT 1
+            """,
+        (*component, *component),
+    ).fetchone()
+    if deferred is not None:
+        return RawReplayPlanOutcome(
+            plan_id,
+            component,
+            RawReplayPlanStatus.DEFERRED,
+            "authority comparison produced a durable deferred decision",
+            "resolve the recorded authority conflict before retry",
+        )
+    terminal = conn.execute(
+        f"""
+            SELECT 1
+            FROM index_tier.raw_revision_applications
+            WHERE raw_id IN ({placeholders}) AND decision = 'ambiguous'
+            UNION ALL
+            SELECT 1
+            FROM raw_session_memberships
+            WHERE raw_id IN ({placeholders}) AND decision = 'ambiguous'
+            UNION ALL
+            SELECT 1
+            FROM raw_sessions
+            WHERE raw_id IN ({placeholders})
+              AND parse_error IS NOT NULL
+              AND parse_error != ?
+            UNION ALL
+            SELECT 1
+            FROM raw_membership_census
+            WHERE raw_id IN ({placeholders}) AND status = 'failed'
+            LIMIT 1
+            """,
+        (*component, *component, *component, _TRANSIENT_LOCK_PARSE_ERROR, *component),
+    ).fetchone()
+    if terminal is not None:
+        return RawReplayPlanOutcome(
+            plan_id,
+            component,
+            RawReplayPlanStatus.TERMINAL,
+            "component ended in explicit ambiguous or parse-terminal authority state",
+            "inspect durable authority debt; do not replay without new evidence",
+        )
+    executed = conn.execute(
+        f"""
+            SELECT COUNT(*) = ?
+            FROM raw_sessions
+            WHERE raw_id IN ({placeholders}) AND parsed_at_ms IS NOT NULL
+            """,
+        (len(component), *component),
+    ).fetchone()
+    if executed is not None and bool(executed[0]):
+        return RawReplayPlanOutcome(
+            plan_id,
+            component,
+            RawReplayPlanStatus.EXECUTED,
+            "every retained raw in the selected component reached a terminal parse/application receipt",
+            "none",
+        )
+    return RawReplayPlanOutcome(
+        plan_id,
+        component,
+        RawReplayPlanStatus.REJECTED_STALE,
+        "selected component disappeared without an executable or durable terminal outcome",
+        "stop automatic convergence and investigate outcome conservation",
+    )
+
+
+def _raw_replay_plan_outcomes(
+    archive_root: Path,
+    components: Sequence[tuple[str, ...]],
+    *,
+    remaining: RawMaterializationCandidates,
+) -> tuple[RawReplayPlanOutcome, ...]:
+    if not components:
+        return ()
+    with closing(sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True)) as conn:
+        conn.row_factory = sqlite3.Row
+        conn.execute("ATTACH DATABASE ? AS index_tier", (str(archive_root / "index.db"),))
+        return tuple(_raw_replay_plan_outcome(conn, component, remaining=remaining) for component in components)
 
 
 def _raw_materialization_bucket_summary(
@@ -5321,19 +5539,21 @@ class RepairResult:
     success: bool
     detail: str = ""
     metrics: dict[str, float] = field(default_factory=dict)
+    plan_outcomes: tuple[RawReplayPlanOutcome, ...] = ()
 
     def to_dict(self) -> JSONDocument:
-        return json_document(
-            {
-                "name": self.name,
-                "category": self.category.value,
-                "destructive": self.destructive,
-                "repaired_count": self.repaired_count,
-                "success": self.success,
-                "detail": self.detail,
-                "metrics": dict(self.metrics),
-            }
-        )
+        payload: dict[str, object] = {
+            "name": self.name,
+            "category": self.category.value,
+            "destructive": self.destructive,
+            "repaired_count": self.repaired_count,
+            "success": self.success,
+            "detail": self.detail,
+            "metrics": dict(self.metrics),
+        }
+        if self.plan_outcomes:
+            payload["plan_outcomes"] = [outcome.to_dict() for outcome in self.plan_outcomes]
+        return json_document(payload)
 
 
 # ---------------------------------------------------------------------------
@@ -5530,6 +5750,7 @@ def _internal_derived_repair_result(
     success: bool,
     detail: str,
     metrics: dict[str, float] | None = None,
+    plan_outcomes: tuple[RawReplayPlanOutcome, ...] = (),
 ) -> RepairResult:
     return RepairResult(
         name=name,
@@ -5539,6 +5760,7 @@ def _internal_derived_repair_result(
         success=success,
         detail=detail,
         metrics=dict(metrics or {}),
+        plan_outcomes=plan_outcomes,
     )
 
 
@@ -6152,16 +6374,49 @@ def repair_raw_materialization(
         source_root=source_root,
     )
     candidate_raw_ids = candidates.raw_ids
-    raw_ids = list(candidate_raw_ids)
-    if raw_artifact_limit is not None:
-        raw_ids = sorted(raw_ids, key=lambda raw_id: (candidates.raw_blob_bytes.get(raw_id, 0), raw_id))
-        raw_ids = raw_ids[:raw_artifact_limit]
+    archive_root = _raw_materialization_archive_root(config)
+    ordered_components = _raw_materialization_ordered_components(candidates, archive_root=archive_root)
+    all_blocked_components = [
+        component
+        for component in ordered_components
+        if sum(_raw_materialization_component_blob_bytes(candidates, member) for member in component)
+        > RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
+    ]
+    all_blocked_component_raw_ids = {raw_id for component in all_blocked_components for raw_id in component}
+    selected_components = (
+        ordered_components[:raw_artifact_limit] if raw_artifact_limit is not None else ordered_components
+    )
+    blocked_components = [
+        component for component in selected_components if all_blocked_component_raw_ids.intersection(component)
+    ]
+    blocked_component_raw_ids = {raw_id for component in blocked_components for raw_id in component}
+    blocked_plan_outcomes = tuple(
+        RawReplayPlanOutcome(
+            _raw_replay_plan_id(component),
+            component,
+            RawReplayPlanStatus.RETRYABLE,
+            "authority component exceeds the bounded replay resource envelope",
+            "retry the same plan after streaming/resource admission is available",
+        )
+        for component in blocked_components
+    )
+    executable_components = [
+        component for component in selected_components if not blocked_component_raw_ids.intersection(component)
+    ]
+    raw_ids = [_raw_materialization_component_seed(candidates, component) for component in executable_components]
+    selected_component_raw_ids = {raw_id for component in selected_components for raw_id in component}
+    selected_candidate_raw_ids = selected_component_raw_ids.intersection(candidate_raw_ids)
     missing_blobs = candidates.missing_blobs
-    selected_total_bytes = _raw_materialization_total_bytes(candidates, raw_ids)
-    selected_max_bytes = _raw_materialization_max_bytes(candidates, raw_ids)
+    selected_total_bytes = sum(
+        _raw_materialization_component_blob_bytes(candidates, raw_id) for raw_id in selected_component_raw_ids
+    )
+    selected_max_bytes = max(
+        (_raw_materialization_component_blob_bytes(candidates, raw_id) for raw_id in selected_component_raw_ids),
+        default=0,
+    )
     metrics = {
         "raw_materialization_candidate_count": float(len(candidate_raw_ids)),
-        "raw_materialization_selected_count": float(len(raw_ids)),
+        "raw_materialization_selected_count": float(len(selected_candidate_raw_ids)),
         "raw_materialization_missing_blob_count": float(missing_blobs),
         "raw_materialization_missing_blob_source_available_count": float(candidates.missing_blob_source_available),
         "raw_materialization_missing_blob_source_missing_count": float(candidates.missing_blob_source_missing),
@@ -6178,10 +6433,18 @@ def repair_raw_materialization(
     }
     if raw_artifact_limit is not None:
         metrics["raw_materialization_limit"] = float(raw_artifact_limit)
+        metrics["raw_materialization_selected_component_count"] = float(len(selected_components))
+    metrics["raw_materialization_before_component_count"] = float(len(ordered_components))
+    metrics["raw_materialization_selected_executable_component_count"] = float(len(executable_components))
+    metrics["raw_materialization_selected_blocked_component_count"] = float(len(blocked_components))
+    if all_blocked_component_raw_ids:
+        metrics["raw_materialization_resource_blocked_count"] = float(len(all_blocked_component_raw_ids))
+        metrics["raw_materialization_execute_blob_limit_bytes"] = float(RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES)
+    diagnostic_component_raw_ids = selected_component_raw_ids | all_blocked_component_raw_ids
     oversized_candidate_raw_ids = [
         raw_id
-        for raw_id in raw_ids
-        if candidates.raw_blob_bytes.get(raw_id, 0) > RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
+        for raw_id in diagnostic_component_raw_ids
+        if _raw_materialization_component_blob_bytes(candidates, raw_id) > RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
     ]
     oversized_stream_safe_raw_ids = [
         raw_id for raw_id in oversized_candidate_raw_ids if _raw_materialization_stream_safe(candidates, raw_id)
@@ -6191,11 +6454,14 @@ def repair_raw_materialization(
     oversized_raw_ids = oversized_candidate_raw_ids
     if oversized_raw_ids:
         metrics["raw_materialization_oversized_count"] = float(len(oversized_raw_ids))
-        metrics["raw_materialization_resource_blocked_count"] = float(len(oversized_raw_ids))
+        metrics["raw_materialization_resource_blocked_count"] = max(
+            metrics.get("raw_materialization_resource_blocked_count", 0.0),
+            float(len(oversized_raw_ids)),
+        )
         metrics["raw_materialization_execute_blob_limit_bytes"] = float(RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES)
     if oversized_stream_safe_raw_ids:
         metrics["raw_materialization_stream_oversized_count"] = float(len(oversized_stream_safe_raw_ids))
-    if not raw_ids:
+    if not candidate_raw_ids:
         detail = "Executable raw replay converged"
         if (
             candidates.authority_quarantined
@@ -6236,8 +6502,22 @@ def repair_raw_materialization(
             metrics=metrics,
         )
     if dry_run:
+        plan_outcomes = (
+            tuple(
+                RawReplayPlanOutcome(
+                    _raw_replay_plan_id(component),
+                    component,
+                    RawReplayPlanStatus.RETRYABLE,
+                    "dry-run census selected this executable authority component",
+                    "execute through the typed raw-materialization writer",
+                )
+                for component in executable_components
+            )
+            + blocked_plan_outcomes
+        )
         detail = (
-            f"Would: classify and replay {len(raw_ids):,} selected raw row(s) through per-session revision authority; "
+            f"Would: classify and replay {len(executable_components):,} selected authority component(s) "
+            "through per-session revision authority; "
             f"selected raw payload bytes total={_format_bytes(selected_total_bytes)}, "
             f"largest={_format_bytes(selected_max_bytes)}"
         )
@@ -6253,51 +6533,74 @@ def repair_raw_materialization(
         if oversized_stream_safe_raw_ids:
             detail += f"; {len(oversized_stream_safe_raw_ids):,} oversized stream-record raw rows are stream-capable"
         return _internal_derived_repair_result(
-            "raw_materialization", repaired_count=0, success=False, detail=detail, metrics=metrics
+            "raw_materialization",
+            repaired_count=0,
+            success=False,
+            detail=detail,
+            metrics=metrics,
+            plan_outcomes=plan_outcomes,
         )
 
     from polylogue.sources.revision_backfill import (
         RawRevisionReplayResourceBlockedError,
+        RevisionBackfillResult,
         backfill_historical_revision_evidence,
     )
 
-    archive_root = _raw_materialization_archive_root(config)
-    blocked_component_raw_ids = {
-        raw_id
-        for component in candidates.authority_components
-        if sum(candidates.expanded_blob_bytes.get(member, 0) for member in component)
-        > RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
-        for raw_id in component
-    }
-    if blocked_component_raw_ids:
-        metrics["raw_materialization_resource_blocked_count"] = float(len(blocked_component_raw_ids))
-    executable_raw_ids = [raw_id for raw_id in raw_ids if raw_id not in blocked_component_raw_ids]
+    executable_raw_ids = raw_ids
     metrics["raw_materialization_executed_count"] = float(len(executable_raw_ids))
-    if executable_raw_ids:
+    replay_parts: list[RevisionBackfillResult] = []
+    execution_outcomes: list[RawReplayPlanOutcome] = []
+    for component, raw_id in zip(executable_components, executable_raw_ids, strict=True):
         try:
-            replay = backfill_historical_revision_evidence(
+            part = backfill_historical_revision_evidence(
                 archive_root,
-                selected_raw_ids=executable_raw_ids,
+                selected_raw_ids=[raw_id],
                 max_payload_bytes=RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES,
             )
         except RawRevisionReplayResourceBlockedError as exc:
-            metrics["raw_materialization_resource_blocked_count"] = float(len(exc.raw_ids))
-            metrics["raw_materialization_executed_count"] = 0.0
-            return _internal_derived_repair_result(
-                "raw_materialization",
-                repaired_count=0,
-                success=False,
-                detail=(
-                    f"Raw materialization blocked: {len(exc.raw_ids):,} expanded-cohort raw row(s), "
-                    f"aggregate {_format_bytes(exc.total_bytes)}, exceed execution limit "
-                    f"{_format_bytes(exc.limit_bytes)}"
-                ),
-                metrics=metrics,
+            metrics["raw_materialization_resource_blocked_count"] = max(
+                metrics.get("raw_materialization_resource_blocked_count", 0.0), float(len(exc.raw_ids))
             )
-    else:
-        from polylogue.sources.revision_backfill import RevisionBackfillResult
+            execution_outcomes.append(
+                RawReplayPlanOutcome(
+                    _raw_replay_plan_id(component),
+                    component,
+                    RawReplayPlanStatus.RETRYABLE,
+                    "expanded authority component exceeded the bounded replay resource envelope",
+                    "retry the same plan after streaming/resource admission is available",
+                )
+            )
+            continue
+        except Exception as exc:
+            logger.exception("raw replay plan %s failed", _raw_replay_plan_id(component))
+            execution_outcomes.append(
+                RawReplayPlanOutcome(
+                    _raw_replay_plan_id(component),
+                    component,
+                    RawReplayPlanStatus.RETRYABLE,
+                    f"component execution raised {type(exc).__name__}: {exc}",
+                    "retry this plan after independent components have received a turn",
+                )
+            )
+            continue
+        replay_parts.append(part)
+        current = _raw_materialization_candidate_ids(
+            config,
+            raw_artifact_id=raw_artifact_id,
+            provider=provider,
+            source_family=source_family,
+            source_root=source_root,
+        )
+        execution_outcomes.extend(_raw_replay_plan_outcomes(archive_root, [component], remaining=current))
 
-        replay = RevisionBackfillResult(scanned=0, classified_full=0, replayed_logical_sources=0, quarantined=0)
+    replay = RevisionBackfillResult(
+        scanned=sum(part.scanned for part in replay_parts),
+        classified_full=sum(part.classified_full for part in replay_parts),
+        replayed_logical_sources=sum(part.replayed_logical_sources for part in replay_parts),
+        quarantined=sum(part.quarantined for part in replay_parts),
+        adoption_deferred=sum(part.adoption_deferred for part in replay_parts),
+    )
     remaining = _raw_materialization_candidate_ids(
         config,
         raw_artifact_id=raw_artifact_id,
@@ -6321,12 +6624,22 @@ def repair_raw_materialization(
             "raw_materialization_remaining_byte_authority_pending_count": float(remaining.byte_authority_pending),
         }
     )
+    plan_outcomes = tuple(execution_outcomes) + blocked_plan_outcomes
+    for status in RawReplayPlanStatus:
+        metrics[f"raw_materialization_plan_{status.value}_count"] = float(
+            sum(outcome.status is status for outcome in plan_outcomes)
+        )
+    metrics["raw_materialization_plan_outcome_count"] = float(len(plan_outcomes))
+    metrics["raw_materialization_plan_conservation_error_count"] = float(
+        sum(outcome.status is RawReplayPlanStatus.REJECTED_STALE for outcome in plan_outcomes)
+    )
     success = (
         not remaining.raw_ids
         and remaining.missing_blobs == 0
         and replay.adoption_deferred == 0
         and remaining.adoption_deferred == 0
         and remaining.byte_authority_pending == 0
+        and not any(outcome.status is RawReplayPlanStatus.REJECTED_STALE for outcome in plan_outcomes)
         and (
             raw_artifact_id is None
             or (
@@ -6358,14 +6671,20 @@ def repair_raw_materialization(
             f"{remaining.byte_authority_quarantined:,} append authority quarantine(s), "
             f"{remaining.byte_authority_pending:,} append fragment(s) pending adjudication"
         )
-    if oversized_raw_ids:
+    expanded_component_blocked = any(len(component) > 1 for component in all_blocked_components)
+    if all_blocked_component_raw_ids and expanded_component_blocked:
+        detail += (
+            f"; {len(all_blocked_component_raw_ids):,} raw row(s) belong to authority components whose aggregate "
+            f"payload exceeds {_format_bytes(RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES)}"
+        )
+    elif oversized_raw_ids:
         detail += (
             f"; {len(oversized_raw_ids):,} non-stream-safe raw row(s) exceed execution limit "
             f"{_format_bytes(RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES)}"
         )
-    elif blocked_component_raw_ids:
+    elif all_blocked_component_raw_ids:
         detail += (
-            f"; {len(blocked_component_raw_ids):,} raw row(s) belong to authority components whose aggregate "
+            f"; {len(all_blocked_component_raw_ids):,} raw row(s) belong to authority components whose aggregate "
             f"payload exceeds {_format_bytes(RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES)}"
         )
     if remaining.missing_blobs:
@@ -6378,6 +6697,7 @@ def repair_raw_materialization(
         success=success,
         detail=detail,
         metrics=metrics,
+        plan_outcomes=plan_outcomes,
     )
 
 

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1641,6 +1641,37 @@ class ArchiveStore:
     def bind_raw_revision(self, raw_id: str, revision: RawRevisionEnvelope) -> None:
         bind_source_raw_revision(self._ensure_source_conn(), raw_id, revision)
 
+    def release_provisional_full_revisions(self, raw_ids: Sequence[str]) -> None:
+        """Undo census-time bindings when index authority rejects adoption.
+
+        Only backfill-created full envelopes use ``source_revision=raw_id``;
+        asserted/live envelopes and append authority cannot match this guard.
+        """
+        if not raw_ids:
+            return
+        placeholders = ",".join("?" for _ in raw_ids)
+        conn = self._ensure_source_conn()
+        with conn:
+            conn.execute(
+                f"""
+                UPDATE raw_sessions
+                SET logical_source_key = NULL,
+                    revision_kind = 'unknown',
+                    source_revision = NULL,
+                    predecessor_source_revision = NULL,
+                    predecessor_raw_id = NULL,
+                    baseline_raw_id = NULL,
+                    append_start_offset = NULL,
+                    append_end_offset = NULL,
+                    acquisition_generation = NULL,
+                    revision_authority = 'quarantined'
+                WHERE raw_id IN ({placeholders})
+                  AND revision_kind = 'full'
+                  AND source_revision = raw_id
+                """,
+                tuple(raw_ids),
+            )
+
     def raw_full_revision_generation(self, logical_source_key: str) -> int:
         """Allocate the next generation from durable, authoritative evidence."""
         row = (
@@ -2235,8 +2266,17 @@ class ArchiveStore:
             keys = {
                 str(row[0])
                 for row in conn.execute(
-                    f"SELECT DISTINCT logical_source_key FROM raw_session_memberships WHERE raw_id IN ({placeholders})",
-                    tuple(selected),
+                    f"""
+                    SELECT logical_source_key
+                    FROM raw_session_memberships
+                    WHERE raw_id IN ({placeholders})
+                    UNION
+                    SELECT logical_source_key
+                    FROM raw_sessions
+                    WHERE raw_id IN ({placeholders})
+                      AND logical_source_key IS NOT NULL
+                    """,
+                    (*selected, *selected),
                 )
             }
             before = len(selected)
@@ -2245,9 +2285,16 @@ class ArchiveStore:
                 selected.update(
                     str(row[0])
                     for row in conn.execute(
-                        f"SELECT DISTINCT raw_id FROM raw_session_memberships "
-                        f"WHERE logical_source_key IN ({key_marks})",
-                        tuple(keys),
+                        f"""
+                        SELECT raw_id
+                        FROM raw_session_memberships
+                        WHERE logical_source_key IN ({key_marks})
+                        UNION
+                        SELECT raw_id
+                        FROM raw_sessions
+                        WHERE logical_source_key IN ({key_marks})
+                        """,
+                        (*keys, *keys),
                     )
                 )
             changed = len(selected) != before
@@ -2258,8 +2305,17 @@ class ArchiveStore:
             sorted(
                 str(row[0])
                 for row in conn.execute(
-                    f"SELECT DISTINCT logical_source_key FROM raw_session_memberships WHERE raw_id IN ({placeholders})",
-                    tuple(selected),
+                    f"""
+                    SELECT logical_source_key
+                    FROM raw_session_memberships
+                    WHERE raw_id IN ({placeholders})
+                    UNION
+                    SELECT logical_source_key
+                    FROM raw_sessions
+                    WHERE raw_id IN ({placeholders})
+                      AND logical_source_key IS NOT NULL
+                    """,
+                    (*selected, *selected),
                 )
             )
         )

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -562,6 +562,83 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
     }
 
 
+def test_raw_materialization_pass_emits_conserved_plan_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    events: list[tuple[str, dict[str, object]]] = []
+    outcome = SimpleNamespace(
+        status=SimpleNamespace(value="executed"),
+        plan_id="raw-replay:stable",
+        reason="applied",
+        to_dict=lambda: {
+            "plan_id": "raw-replay:stable",
+            "input_raw_ids": ["raw-a"],
+            "status": "executed",
+            "reason": "applied",
+            "next_action": "none",
+        },
+    )
+    monkeypatch.setattr(
+        "polylogue.daemon.events.emit_daemon_event",
+        lambda kind, *, payload: events.append((kind, payload)),
+    )
+    monkeypatch.setattr(os, "urandom", lambda _size: b"x" * 16)
+
+    daemon_cli._emit_raw_materialization_pass(
+        SimpleNamespace(
+            success=True,
+            repaired_count=1,
+            detail="done",
+            metrics={
+                "raw_materialization_candidate_count": 1.0,
+                "raw_materialization_remaining_candidate_count": 0.0,
+            },
+            plan_outcomes=(outcome,),
+        )
+    )
+
+    assert events == [
+        (
+            "raw_materialization_pass",
+            {
+                "pass_id": f"raw-materialization:{(b'x' * 16).hex()}",
+                "success": True,
+                "repaired_count": 1,
+                "detail": "done",
+                "metrics": {
+                    "raw_materialization_candidate_count": 1.0,
+                    "raw_materialization_remaining_candidate_count": 0.0,
+                },
+                "plan_outcomes": [outcome.to_dict()],
+            },
+        )
+    ]
+
+
+def test_raw_materialization_pass_emits_zero_work_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    events: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        "polylogue.daemon.events.emit_daemon_event",
+        lambda kind, *, payload: events.append((kind, payload)),
+    )
+    monkeypatch.setattr(os, "urandom", lambda _size: b"z" * 16)
+
+    daemon_cli._emit_raw_materialization_pass(
+        SimpleNamespace(
+            success=True,
+            repaired_count=0,
+            detail="Executable raw replay converged",
+            metrics={"raw_materialization_candidate_count": 0.0},
+            plan_outcomes=(),
+        )
+    )
+
+    assert events[0][1]["success"] is True
+    assert events[0][1]["plan_outcomes"] == []
+
+
 def test_raw_materialization_closes_fts_on_cancellation(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -705,12 +782,16 @@ def test_periodic_raw_materialization_convergence_treats_sqlite_lock_as_retry(
         sleep_calls += 1
         raise asyncio.CancelledError
 
-    async def fake_to_thread(_func: object, *_args: object, **_kwargs: object) -> object:
+    async def fake_run_sync(_actor: str, _func: object, *_args: object, **_kwargs: object) -> object:
         raise sqlite3.OperationalError("database is locked")
 
+    monkeypatch.setattr(
+        daemon_cli,
+        "daemon_write_coordinator",
+        lambda: SimpleNamespace(run_sync=fake_run_sync),
+    )
     with (
         patch("asyncio.sleep", side_effect=fake_sleep),
-        patch("asyncio.to_thread", side_effect=fake_to_thread),
         patch.object(daemon_cli.logger, "info") as info,
         patch.object(daemon_cli.logger, "warning") as warning,
         pytest.raises(asyncio.CancelledError),
@@ -729,13 +810,17 @@ def test_periodic_raw_materialization_convergence_waits_for_catch_up_complete(
 
     calls: list[str] = []
 
-    async def fake_to_thread(_func: object, *_args: object, **_kwargs: object) -> object:
+    async def fake_run_sync(_actor: str, _func: object, *_args: object, **_kwargs: object) -> object:
         calls.append("drain")
         raise asyncio.CancelledError
 
     async def exercise() -> None:
         catch_up_complete = asyncio.Event()
-        monkeypatch.setattr(asyncio, "to_thread", fake_to_thread)
+        monkeypatch.setattr(
+            daemon_cli,
+            "daemon_write_coordinator",
+            lambda: SimpleNamespace(run_sync=fake_run_sync),
+        )
         task = asyncio.create_task(
             daemon_cli._periodic_raw_materialization_convergence_after(catch_up_complete=catch_up_complete)
         )

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.archive.revision_authority import RawRevisionKind
 from polylogue.core.enums import Provider
 from polylogue.sources.decoders import _iter_json_stream
 from polylogue.sources.dispatch import parse_payload
@@ -158,6 +159,45 @@ def test_historical_backfill_selects_prefix_newest_independent_of_acquisition_or
         )
     with sqlite3.connect(tmp_path / "index.db") as conn:
         assert conn.execute("SELECT message_count, raw_id FROM sessions").fetchone() == (2, newest_raw_id)
+
+
+def test_incremental_target_expands_new_logical_key_across_source_paths(tmp_path: Path) -> None:
+    """A newly parsed path must not split an already-known byte cohort."""
+    initialize_active_archive_root(tmp_path)
+    baseline = (
+        b'{"type":"session_meta","payload":{"id":"shared","timestamp":"2026-07-15T00:00:00Z"}}\n'
+        b'{"type":"response_item","payload":{"type":"message","role":"user","content":'
+        b'[{"type":"input_text","text":"old"}]}}\n'
+    )
+    newest = baseline + (
+        b'{"type":"response_item","payload":{"type":"message","role":"assistant","content":'
+        b'[{"type":"output_text","text":"new"}]}}\n'
+    )
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        old_raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=baseline,
+            source_path="first/shared.jsonl",
+            acquired_at_ms=1,
+        )
+    assert backfill_historical_revision_evidence(tmp_path, selected_raw_ids=[old_raw_id]).replayed_logical_sources == 1
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        new_raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=newest,
+            source_path="moved/shared.jsonl",
+            acquired_at_ms=2,
+        )
+
+    result = backfill_historical_revision_evidence(tmp_path, selected_raw_ids=[new_raw_id])
+
+    assert result.scanned == 2
+    assert result.replayed_logical_sources == 1
+    with sqlite3.connect(tmp_path / "index.db") as conn:
+        assert conn.execute("SELECT native_id, message_count, raw_id FROM sessions").fetchall() == [
+            ("shared", 2, new_raw_id)
+        ]
 
 
 def test_backfill_resumes_after_index_receipt_commits_before_source_terminal(
@@ -417,7 +457,7 @@ def test_targeted_rebuild_expands_same_session_across_source_paths_only(
     original_parse = revision_backfill._parse_retained_raw
     opened: list[str] = []
 
-    def observed_parse(archive: ArchiveStore, raw_id: str) -> tuple[list[ParsedSession], int]:
+    def observed_parse(archive: ArchiveStore, raw_id: str) -> tuple[list[ParsedSession], int, RawRevisionKind]:
         opened.append(raw_id)
         return original_parse(archive, raw_id)
 

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -253,6 +254,9 @@ def test_raw_materialization_preview_counts_replayable_rows_without_erasing_miss
         "raw_materialization_byte_authority_fragment_count": 0.0,
         "raw_materialization_byte_authority_pending_count": 0.0,
         "raw_materialization_byte_authority_quarantined_count": 0.0,
+        "raw_materialization_before_component_count": 1.0,
+        "raw_materialization_selected_executable_component_count": 1.0,
+        "raw_materialization_selected_blocked_component_count": 0.0,
     }
     assert "per-session revision authority" in result.detail
     assert "selected raw payload bytes total=" in result.detail
@@ -1903,8 +1907,12 @@ def test_raw_materialization_blocks_aggregate_sub_limit_cohort_before_blob_open(
         lambda *_args, **_kwargs: pytest.fail("aggregate cohort limit must be checked before blob open"),
     )
     result = repair_mod.repair_raw_materialization(_config(tmp_path), raw_artifact_limit=1)
+    repeated = repair_mod.repair_raw_materialization(_config(tmp_path), raw_artifact_limit=1)
     assert result.success is False
     assert result.metrics["raw_materialization_resource_blocked_count"] == 2.0
+    assert len(result.plan_outcomes) == 1
+    assert result.plan_outcomes[0].status.value == "retryable"
+    assert result.plan_outcomes[0].plan_id == repeated.plan_outcomes[0].plan_id
     assert "aggregate payload exceeds 1.0 GiB" in result.detail
 
 
@@ -1949,6 +1957,157 @@ def test_raw_materialization_processes_independent_components_across_bounded_pas
         repaired_per_pass.append(result.repaired_count)
     assert repaired_per_pass == [5, 5, 5, 5, 5]
     assert repair_mod.repair_raw_materialization(config, raw_artifact_limit=5).success is True
+
+
+def test_raw_materialization_receipts_rotate_retryable_plan_behind_unattempted_work(tmp_path: Path) -> None:
+    """A retryable oldest component must not monopolize a bounded daemon slot."""
+    from polylogue.core.enums import Provider
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_ids = [
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=(
+                    f'{{"type":"session_meta","payload":{{"id":"session-{index}",'
+                    '"timestamp":"2026-07-15T00:00:00Z"}}}}\n'
+                ).encode(),
+                source_path=f"session-{index}.jsonl",
+                acquired_at_ms=index + 1,
+            )
+            for index in range(3)
+        ]
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute(
+            "UPDATE raw_sessions SET blob_size = ? WHERE raw_id = ?",
+            (repair_mod.RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES + 1, raw_ids[0]),
+        )
+        conn.commit()
+
+    first = repair_mod.repair_raw_materialization(_config(tmp_path), raw_artifact_limit=1)
+    assert first.plan_outcomes[0].status.value == "retryable"
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        conn.execute(
+            "INSERT INTO daemon_events(ts_ms, kind, payload_json) VALUES (1, 'raw_materialization_pass', ?)",
+            (json.dumps({"plan_outcomes": [outcome.to_dict() for outcome in first.plan_outcomes]}),),
+        )
+        conn.commit()
+
+    second = repair_mod.repair_raw_materialization(_config(tmp_path), raw_artifact_limit=1)
+    assert second.repaired_count == 1
+    assert second.plan_outcomes[0].input_raw_ids == (raw_ids[1],)
+
+
+def test_raw_materialization_isolates_failed_component_and_continues_batch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One runtime failure must produce a receipt without starving peers."""
+    from polylogue.core.enums import Provider
+    from polylogue.sources import revision_backfill
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_ids = [
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=f'{{"type":"session_meta","payload":{{"id":"session-{index}"}}}}\n'.encode(),
+                source_path=f"session-{index}.jsonl",
+                acquired_at_ms=index + 1,
+            )
+            for index in range(3)
+        ]
+
+    original = revision_backfill.backfill_historical_revision_evidence
+
+    def fail_oldest(*args: Any, selected_raw_ids: list[str] | None = None, **kwargs: Any) -> Any:
+        if selected_raw_ids == [raw_ids[0]]:
+            raise RuntimeError("injected component failure")
+        return original(*args, selected_raw_ids=selected_raw_ids, **kwargs)
+
+    monkeypatch.setattr(revision_backfill, "backfill_historical_revision_evidence", fail_oldest)
+    result = repair_mod.repair_raw_materialization(_config(tmp_path), raw_artifact_limit=3)
+
+    assert result.repaired_count == 2
+    assert [outcome.status.value for outcome in result.plan_outcomes].count("retryable") == 1
+    assert [outcome.status.value for outcome in result.plan_outcomes].count("executed") == 2
+
+
+def test_raw_materialization_batch_limit_counts_authority_components(tmp_path: Path) -> None:
+    """One revision-heavy source must not consume the whole daemon batch."""
+    from polylogue.core.enums import Provider
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(tmp_path)
+    session_meta = b'{"type":"session_meta","payload":{"id":"shared-session","timestamp":"2026-07-15T00:00:00Z"}}\n'
+    shared_raw_ids: list[str] = []
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        for revision in range(5):
+            messages = b"".join(
+                (
+                    b'{"type":"response_item","payload":{"type":"message",'
+                    b'"role":"user","content":[{"type":"input_text","text":"revision-'
+                    + str(index).encode()
+                    + b'"}]}}\n'
+                )
+                for index in range(revision + 1)
+            )
+            shared_raw_ids.append(
+                archive.write_raw_payload(
+                    provider=Provider.CODEX,
+                    payload=session_meta + messages,
+                    source_path="shared-session.jsonl",
+                    acquired_at_ms=revision + 1,
+                )
+            )
+        independent_raw_ids = [
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=(
+                    f'{{"type":"session_meta","payload":{{"id":"independent-{index}",'
+                    '"timestamp":"2026-07-15T00:00:00Z"}}}}\n'
+                ).encode(),
+                source_path=f"independent-{index}.jsonl",
+                acquired_at_ms=100 + index,
+            )
+            for index in range(4)
+        ]
+
+    # The previous scheduler sorted individual raws by size before applying
+    # the batch limit. Force that old ordering deterministically: the fixed
+    # scheduler must still select three complete, oldest-first components.
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_conn.executemany(
+            "UPDATE raw_sessions SET blob_size = ? WHERE raw_id = ?",
+            [
+                *((index + 1, raw_id) for index, raw_id in enumerate(shared_raw_ids)),
+                *((100 + index, raw_id) for index, raw_id in enumerate(independent_raw_ids)),
+            ],
+        )
+        source_conn.commit()
+
+    config = _config(tmp_path)
+    before = repair_mod.raw_materialization_replay_backlog(config)
+    assert before["candidate_count"] == 9
+    assert before["authority_component_count"] == 5
+
+    preview = repair_mod.repair_raw_materialization(config, dry_run=True, raw_artifact_limit=3)
+    first = repair_mod.repair_raw_materialization(config, raw_artifact_limit=3)
+    after = repair_mod.raw_materialization_replay_backlog(config)
+
+    assert first.repaired_count == 3, (first.detail, first.metrics, after)
+    assert first.metrics["raw_materialization_selected_component_count"] == 3.0
+    assert first.metrics["raw_materialization_plan_outcome_count"] == 3.0
+    assert first.metrics["raw_materialization_plan_executed_count"] == 3.0
+    assert {outcome.plan_id for outcome in first.plan_outcomes} == {
+        outcome.plan_id for outcome in preview.plan_outcomes
+    }
+    assert {outcome.status.value for outcome in first.plan_outcomes} == {"executed"}
+    assert after["candidate_count"] == 2
 
 
 def test_raw_materialization_quarantines_parse_failures_without_legacy_parser(


### PR DESCRIPTION
## Summary

Makes bounded raw materialization schedule complete authority components rather than individual raw rows, classifies historical single-session snapshots into revision authority, isolates failures per selected component, and emits typed selected-attempt receipts. Ref `polylogue-hjpx`.

## Problem

A production-shaped reproduction with five revisions of one Codex session plus four independent raws produced nine candidates in five authority components. The old raw-row limit repeatedly selected several cheap rows from the same component; classification scanned them but yielded zero replayed logical sources, leaving the same executable backlog forever. The live July 15 preflight showed the same failure class at archive scale while the daemon processed two sources per pass and the candidate count grew.

## Solution

- Bind uncensused single-session historical raws as provisional full revisions, then use byte-prefix authority when possible and semantic membership authority for divergent full snapshots.
- Expand components transitively through source path, membership keys, and raw-revision logical keys, including newly discovered moved-path history.
- Apply the batch limit to complete components; blocked and executable work share the same budget.
- Rotate previously attempted retryable components behind never-attempted work using disposable daemon receipts.
- Execute independent components separately so a resource/runtime failure receives a retryable receipt without starving peers.
- Add stable selected-attempt IDs and typed outcomes to `RepairResult`, plus zero-work and nonzero daemon pass receipts.

This is the execution foundation, not closure of the full P0. Immutable pre-execution census and full before/after conservation remain `polylogue-hjpx.1`; the sanitized July-15-scale proof remains `polylogue-hjpx.2`. The umbrella stays open. No live archive mutation was authorized or performed.

## Acceptance matrix

- Reproduction and non-progress cause: satisfied.
- Complete-component batching and finite happy-path drain: satisfied for known components.
- Retry/resource/runtime isolation and fairness: satisfied for selected-attempt scheduling.
- Immutable full-census plan conservation, authority witnesses, durable rejected-stale blocker, and two-census fixed point: deferred to `polylogue-hjpx.1`.
- July-15-shape resource/convergence proof: deferred to `polylogue-hjpx.2`.
- Live apply gate: intentionally untouched; `polylogue-yla8` remains refused pending verified backup and explicit authorization.

## Verification

- `devtools test tests/unit/sources/test_revision_backfill.py -k 'incremental_target_expands_new_logical_key_across_source_paths or targeted_rebuild_expands_same_session_across_source_paths_only'` — 2 passed.
- `devtools test tests/unit/storage/test_repair.py -k 'isolates_failed_component or receipts_rotate_retryable_plan or batch_limit_counts_authority_components or blocks_aggregate_sub_limit_cohort'` — 4 passed.
- `devtools test -k raw_materialization` — 79 passed before the final per-component isolation refactor; the changed isolation path then passed the focused four-test command above.
- `devtools verify --quick` — all 16 steps passed; run `20260715T222101Z-quick-1942203-bab135b4`.
- Full `devtools verify` was not completed: a fresh-worktree testmon seed expanded to the full corpus, accumulated inherited failures, consumed ~17.5 GB peak memory plus ~9.3 GB swap and ~11 GB writes, then stalled at 94%. Tracked as `polylogue-b054.1.1`.
- `devtools test -k raw_authority` has one inherited clean-`origin/master` failure, tracked as `polylogue-lkrc.4`.

## Adversarial review notes

- Iteration 1 found cross-path component splitting, retry starvation, split blocked/executable budgets, and an invalid one-pass fixed-point claim. The first three were fixed with regressions; the fixed-point claim was removed and specified under `polylogue-hjpx.1`.
- Iteration 2 found that complete immutable census/conservation, durable rejection, authority witnesses, and scale proof still exceed this phase. Those are not claimed here and are captured in `polylogue-hjpx.1`/`.2`. It also found whole-batch exception starvation; this phase now isolates and receipts each selected component independently.
