### PR TITLE
fix(browser): reconcile accepted ambiguous submissions

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -2107,8 +2107,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       const result = await postJson(`/v1/launch-jobs/${encodeURIComponent(message.job_id)}/control`, {
         action: message.action,
         inspection_receipt: message.inspection_receipt || null,
+        conversation_id: message.conversation_id || null,
+        conversation_url: message.conversation_url || null,
       });
-      if (["resume", "retry", "launch_now", "confirm_no_conversation"].includes(message.action)) {
+      if (["resume", "retry", "launch_now", "confirm_no_conversation", "confirm_existing_conversation"].includes(message.action)) {
         void pollLaunchJobs();
       }
       sendResponse({ ok: true, job: result.job });

--- a/browser-extension/src/popup.html
+++ b/browser-extension/src/popup.html
@@ -402,6 +402,7 @@
           <button id="launch-pause"><span class="button-label">Pause</span><span class="button-status"></span></button>
           <button id="launch-resume"><span class="button-label">Resume</span><span class="button-status"></span></button>
           <button id="launch-retry"><span class="button-label">Retry</span><span class="button-status"></span></button>
+          <button id="launch-confirm-existing" disabled><span class="button-label">Confirmed submitted</span><span class="button-status"></span></button>
           <button id="launch-confirm-absent" disabled><span class="button-label">Confirmed absent</span><span class="button-status"></span></button>
           <button id="launch-cancel"><span class="button-label">Cancel</span><span class="button-status"></span></button>
           <button id="launch-inspect"><span class="button-label">Inspect chat</span><span class="button-status"></span></button>

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -447,7 +447,7 @@ function renderLaunch(jobs, { launchEnabled = false, ownerInstanceId = null } = 
     for (const id of ["launch-phase", "launch-cadence", "launch-owner", "launch-last"]) {
       document.getElementById(id).textContent = "--";
     }
-    for (const id of ["launch-poll", "launch-now", "launch-pause", "launch-resume", "launch-retry", "launch-confirm-absent", "launch-cancel", "launch-inspect"]) {
+    for (const id of ["launch-poll", "launch-now", "launch-pause", "launch-resume", "launch-retry", "launch-confirm-existing", "launch-confirm-absent", "launch-cancel", "launch-inspect"]) {
       document.getElementById(id).disabled = true;
     }
     return;
@@ -471,6 +471,8 @@ function renderLaunch(jobs, { launchEnabled = false, ownerInstanceId = null } = 
     || !["paused", "cooldown", "failed"].includes(job.status);
   document.getElementById("launch-retry").disabled = protectedCircuit
     || !["paused", "cooldown", "failed"].includes(job.status);
+  document.getElementById("launch-confirm-existing").disabled = job.status !== "submission_unknown"
+    || (!job.tab_id && !job.conversation_url);
   document.getElementById("launch-confirm-absent").disabled = job.status !== "submission_unknown";
   document.getElementById("launch-cancel").disabled = ["completed", "cancelled"].includes(job.status);
   document.getElementById("launch-inspect").disabled = !job.tab_id && !job.conversation_url;
@@ -821,6 +823,42 @@ document.getElementById("launch-inspect")?.addEventListener("click", async () =>
   } else if (selectedLaunchJob?.conversation_url) {
     await chrome.tabs.create({ url: selectedLaunchJob.conversation_url, active: true });
   }
+});
+
+function exactChatGptConversation(url) {
+  try {
+    const parsed = new URL(url);
+    const parts = parsed.pathname.split("/").filter(Boolean);
+    if (parsed.protocol !== "https:" || parsed.hostname !== "chatgpt.com" || parts.length !== 2 || parts[0] !== "c") {
+      return null;
+    }
+    return { conversation_id: parts[1], conversation_url: parsed.href };
+  } catch {
+    return null;
+  }
+}
+
+document.getElementById("launch-confirm-existing")?.addEventListener("click", async () => {
+  if (!selectedLaunchJobId || selectedLaunchJob?.status !== "submission_unknown") return;
+  const tab = selectedLaunchJob.tab_id ? await chrome.tabs.get(selectedLaunchJob.tab_id) : null;
+  const conversation = exactChatGptConversation(tab?.url || selectedLaunchJob.conversation_url || "");
+  if (!conversation) {
+    await withAction("launch-confirm-existing", async () => {
+      throw new Error("The inspected tab is not an exact ChatGPT conversation URL");
+    });
+    return;
+  }
+  if (!globalThis.confirm(`Confirm that this job submitted conversation ${conversation.conversation_id}.`)) return;
+  await withAction("launch-confirm-existing", async () => {
+    await chrome.runtime.sendMessage({
+      type: "polylogue.launch.control",
+      job_id: selectedLaunchJobId,
+      action: "confirm_existing_conversation",
+      inspection_receipt: "operator inspected the retained launch tab and confirmed the matching ChatGPT conversation exists",
+      ...conversation,
+    });
+    await refreshLaunches();
+  }, { busy: "Recording…", ok: "Submitted" });
 });
 
 document.getElementById("launch-confirm-absent")?.addEventListener("click", async () => {

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -68,6 +68,7 @@ function installDom() {
       <button id="launch-pause"><span class="button-status"></span></button>
       <button id="launch-resume"><span class="button-status"></span></button>
       <button id="launch-retry"><span class="button-status"></span></button>
+      <button id="launch-confirm-existing"><span class="button-status"></span></button>
       <button id="launch-confirm-absent"><span class="button-status"></span></button>
       <button id="launch-cancel"><span class="button-status"></span></button>
       <button id="launch-inspect"><span class="button-status"></span></button>
@@ -121,6 +122,7 @@ function installChromeMock(storagePatch = {}, tabs = [CHATGPT_TAB], sendMessage 
     },
     tabs: {
       create: vi.fn(async (details) => ({ id: 99, ...details })),
+      get: vi.fn(async (tabId) => tabs.find((tab) => tab.id === tabId) || { id: tabId }),
       update: vi.fn(async (tabId, details) => ({ id: tabId, ...details })),
       query: vi.fn(async () => tabs),
       sendMessage: vi.fn(async () => {
@@ -383,12 +385,24 @@ describe("popup capture", () => {
       }
       return { ok: true, job: { ...job, status: "queued" } };
     });
+    chrome.tabs.get.mockResolvedValue({ id: 42, url: "https://chatgpt.com/c/conversation-from-unknown" });
 
     await vi.waitFor(() => expect(document.getElementById("launch-status").textContent).toBe("submission_unknown"));
     expect(document.getElementById("launch-retry").disabled).toBe(true);
+    expect(document.getElementById("launch-confirm-existing").disabled).toBe(false);
     expect(document.getElementById("launch-confirm-absent").disabled).toBe(false);
     document.getElementById("launch-inspect").click();
     await vi.waitFor(() => expect(chrome.tabs.update).toHaveBeenCalledWith(42, { active: true }));
+
+    document.getElementById("launch-confirm-existing").click();
+    await vi.waitFor(() => expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
+      type: "polylogue.launch.control",
+      job_id: "launch-unknown",
+      action: "confirm_existing_conversation",
+      inspection_receipt: "operator inspected the retained launch tab and confirmed the matching ChatGPT conversation exists",
+      conversation_id: "conversation-from-unknown",
+      conversation_url: "https://chatgpt.com/c/conversation-from-unknown",
+    }));
 
     document.getElementById("launch-confirm-absent").click();
     await vi.waitFor(() => expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({
@@ -405,7 +419,7 @@ describe("popup capture", () => {
       return { ok: true };
     });
     await vi.waitFor(() => expect(document.getElementById("launch-status").textContent).toBe("idle"));
-    for (const id of ["launch-poll", "launch-now", "launch-pause", "launch-resume", "launch-retry", "launch-confirm-absent", "launch-cancel", "launch-inspect"]) {
+    for (const id of ["launch-poll", "launch-now", "launch-pause", "launch-resume", "launch-retry", "launch-confirm-existing", "launch-confirm-absent", "launch-cancel", "launch-inspect"]) {
       expect(document.getElementById(id).disabled).toBe(true);
     }
 

--- a/polylogue/browser_capture/launch_jobs.py
+++ b/polylogue/browser_capture/launch_jobs.py
@@ -277,7 +277,7 @@ def _latest_submitted_at(jobs: list[BrowserLaunchJob]) -> datetime | None:
         _parse(event.at)
         for job in jobs
         for event in job.events
-        if event.kind == "submitted" and _parse(event.at) is not None
+        if event.kind in {"submitted", "operator_confirm_existing_conversation"} and _parse(event.at) is not None
     ]
     return max((value for value in timestamps if value is not None), default=None)
 
@@ -514,6 +514,17 @@ def control_launch_job(
         job.last_error = None
         job.cooldown_reason = None
         job.manual_priority = True
+    elif request.action == "confirm_existing_conversation":
+        if job.status != "submission_unknown":
+            raise BrowserLaunchConflictError(f"cannot confirm existing conversation for launch job in {job.status}")
+        job.status = "submitted"
+        job.phase = "operator_confirmed_existing_conversation"
+        job.conversation_id = request.conversation_id
+        job.conversation_url = request.conversation_url
+        job.attempts += 1
+        job.last_error = None
+        job.cooldown_reason = None
+        job.manual_priority = False
     else:
         if job.status not in {"paused", "failed", "cooldown"}:
             raise BrowserLaunchConflictError(f"cannot {request.action} launch job in {job.status}")

--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Literal
+from urllib.parse import urlsplit
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -463,6 +464,7 @@ BrowserLaunchControlAction = Literal[
     "retry",
     "launch_now",
     "confirm_no_conversation",
+    "confirm_existing_conversation",
 ]
 BrowserLaunchOutcome = Literal[
     "progress",
@@ -634,11 +636,26 @@ class BrowserLaunchJobUpdateRequest(BaseModel):
 class BrowserLaunchJobControlRequest(BaseModel):
     action: BrowserLaunchControlAction
     inspection_receipt: str | None = Field(default=None, min_length=1, max_length=2_000)
+    conversation_id: str | None = Field(default=None, min_length=1, max_length=200)
+    conversation_url: str | None = Field(default=None, min_length=1, max_length=2_048)
 
     @model_validator(mode="after")
     def require_inspection_receipt(self) -> BrowserLaunchJobControlRequest:
-        if self.action == "confirm_no_conversation" and not self.inspection_receipt:
-            raise ValueError("confirm_no_conversation requires an inspection receipt")
+        if self.action in {"confirm_no_conversation", "confirm_existing_conversation"} and not self.inspection_receipt:
+            raise ValueError(f"{self.action} requires an inspection receipt")
+        if self.action == "confirm_existing_conversation":
+            if not self.conversation_id or not self.conversation_url:
+                raise ValueError("confirm_existing_conversation requires a conversation id and URL")
+            parsed = urlsplit(self.conversation_url)
+            path_parts = [part for part in parsed.path.split("/") if part]
+            if (
+                parsed.scheme != "https"
+                or parsed.hostname != "chatgpt.com"
+                or len(path_parts) != 2
+                or path_parts[0] != "c"
+                or path_parts[1] != self.conversation_id
+            ):
+                raise ValueError("confirmed conversation must be an exact ChatGPT conversation URL matching its id")
         return self
 
 

--- a/polylogue/browser_capture/route_contracts.py
+++ b/polylogue/browser_capture/route_contracts.py
@@ -179,7 +179,7 @@ BROWSER_CAPTURE_ROUTE_CONTRACTS: tuple[BrowserCaptureRouteContract, ...] = (
         "bearer_if_web_origin",
         "BrowserLaunchJobControlRequest",
         "BrowserLaunchJobEnqueuedPayload | BrowserCaptureErrorPayload",
-        "Operator pause/resume/cancel/retry; terminal completion cannot be reopened.",
+        "Operator pause/resume/cancel/retry and ambiguous-submit reconciliation; terminal completion cannot be reopened.",
     ),
     BrowserCaptureRouteContract(
         "POST",

--- a/tests/unit/browser_capture/test_launch_jobs.py
+++ b/tests/unit/browser_capture/test_launch_jobs.py
@@ -12,7 +12,7 @@ from http.client import HTTPConnection, HTTPResponse
 from io import BytesIO
 from pathlib import Path
 from threading import Thread
-from typing import cast
+from typing import Literal, cast
 
 import pytest
 from click.testing import CliRunner
@@ -69,12 +69,18 @@ def _http(host: str, port: int, method: str, path: str, body: object | None = No
     return conn.getresponse()
 
 
-def _request(*, not_before: str | None = None) -> BrowserLaunchJobRequest:
+def _request(
+    *,
+    not_before: str | None = None,
+    job_id: str | None = None,
+    cadence_minutes: Literal[1, 5, 15, 30, 60] = 1,
+) -> BrowserLaunchJobRequest:
     return BrowserLaunchJobRequest(
         job_title="Implement the durable Sol Pro launch queue",
         scope_prompt="Implement the receiver queue described by the relevant Bead.",
-        cadence_minutes=1,
+        cadence_minutes=cadence_minutes,
         not_before=not_before,
+        job_id=job_id,
         attachments=[
             BrowserLaunchAttachmentInput(
                 name="context.tar.gz",
@@ -367,6 +373,67 @@ def test_unknown_submit_is_quarantined_until_operator_confirms_absence(tmp_path:
     assert requeued.manual_priority is True
     assert requeued.events[-1].kind == "operator_confirm_no_conversation"
     assert requeued.events[-1].detail == "operator inspected ChatGPT and found no matching conversation"
+
+
+def test_unknown_submit_can_be_reconciled_to_an_existing_conversation(tmp_path: Path) -> None:
+    job = enqueue_launch_job(_request(), spool_path=tmp_path)
+    next_job = enqueue_launch_job(
+        _request(job_id="launch-after-reconciliation", cadence_minutes=15),
+        spool_path=tmp_path,
+    )
+    claim_due_launch_job("owner", spool_path=tmp_path)
+    update_launch_job(
+        job.job_id,
+        BrowserLaunchJobUpdateRequest(
+            owner_instance_id="owner",
+            outcome="submission_unknown",
+            phase="unknown_submit_outcome",
+            detail="provider accepted submit before the execution channel ended",
+            tab_id=42,
+        ),
+        spool_path=tmp_path,
+    )
+
+    with pytest.raises(ValueError, match="conversation id and URL"):
+        BrowserLaunchJobControlRequest(
+            action="confirm_existing_conversation",
+            inspection_receipt="inspected retained tab",
+        )
+    with pytest.raises(ValueError, match="matching its id"):
+        BrowserLaunchJobControlRequest(
+            action="confirm_existing_conversation",
+            inspection_receipt="inspected retained tab",
+            conversation_id="conversation-1",
+            conversation_url="https://chatgpt.com/c/different-conversation",
+        )
+
+    reconciled = control_launch_job(
+        job.job_id,
+        BrowserLaunchJobControlRequest(
+            action="confirm_existing_conversation",
+            inspection_receipt="operator inspected retained tab and found the matching conversation",
+            conversation_id="conversation-1",
+            conversation_url="https://chatgpt.com/c/conversation-1",
+        ),
+        spool_path=tmp_path,
+    ) or pytest.fail("missing job")
+
+    assert reconciled.status == "submitted"
+    assert reconciled.phase == "operator_confirmed_existing_conversation"
+    assert reconciled.conversation_id == "conversation-1"
+    assert reconciled.conversation_url == "https://chatgpt.com/c/conversation-1"
+    assert reconciled.attempts == 1
+    assert reconciled.last_error is None
+    assert reconciled.lease_owner is None
+    assert reconciled.events[-1].kind == "operator_confirm_existing_conversation"
+    adopted = claim_due_launch_job("monitor", spool_path=tmp_path) or pytest.fail("monitor did not adopt job")
+    assert adopted.job_id == job.job_id
+    assert adopted.status == "submitted"
+    assert adopted.lease_owner == "monitor"
+    assert claim_due_launch_job("other", spool_path=tmp_path) is None
+    delayed = next(item for item in list_launch_jobs(spool_path=tmp_path) if item.job_id == next_job.job_id)
+    assert delayed.status == "cooldown"
+    assert delayed.cooldown_reason == "cadence"
 
 
 def test_non_owner_update_and_invalid_terminal_control_fail_closed(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Add a receiver-authoritative operator transition that records an already-created ChatGPT conversation after an ambiguous submit acknowledgement, and expose it in the extension queue UI.

## Problem

ChatGPT can accept a launch while the page simultaneously reports a transient rate-limit signal. The queue then entered `submission_unknown`, but operators could only confirm that no conversation existed and permit a retry. When the conversation did exist, there was no safe durable transition, creating duplicate-launch risk and failing to advance the cadence clock.

## Solution

- Require an exact `https://chatgpt.com/c/<id>` URL, matching conversation ID, and inspection receipt for confirmed submission.
- Transition only `submission_unknown` jobs to `submitted`, preserving the retained tab and making monitoring adoptable.
- Count operator-confirmed submissions as cadence receipts so the next launch cannot run early.
- Add a `Confirmed submitted` queue control that inspects the retained tab and forwards its exact identity.

## Verification

- `npm test -- --run tests/popup.test.js`: 30 passed.
- `devtools test tests/unit/browser_capture/test_launch_jobs.py -k unknown_submit`: 2 passed, 13 deselected.
- `npm run lint`: clean.
- `devtools verify --quick`: 16/16 steps green (`20260715T222840Z-quick-1948433-9855c54f`).
- Pre-push `devtools verify --quick`: 16/16 steps green (`20260715T223603Z-quick-1953836-7a2f6d07`).