### PR TITLE
fix(browser): make launch orchestration advisory

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1230,6 +1230,19 @@ async function monitorSubmittedLaunch(job, ownerInstanceId) {
     });
     return;
   }
+  if (inspection?.soft_warning) {
+    if (job.phase !== "provider_soft_warning") {
+      await updateLaunchJob(job.job_id, ownerInstanceId, {
+        outcome: "soft_warning",
+        phase: "provider_soft_warning",
+        detail: "provider conversation-access warning visible; submitted chat may still continue",
+        tab_id: job.tab_id,
+        conversation_id: inspection.conversation_id,
+        conversation_url: inspection.conversation_url,
+      });
+    }
+    return;
+  }
   if (inspection?.rate_limited) {
     await updateLaunchJob(job.job_id, ownerInstanceId, {
       outcome: "rate_limited",
@@ -1251,6 +1264,16 @@ async function monitorSubmittedLaunch(job, ownerInstanceId) {
       conversation_url: inspection.conversation_url,
     });
     return;
+  }
+  if ((inspection?.busy || inspection?.assistant_turns) && job.phase !== "provider_running") {
+    await updateLaunchJob(job.job_id, ownerInstanceId, {
+      outcome: "progress",
+      phase: "provider_running",
+      detail: "provider accepted the submitted chat without a visible circuit",
+      tab_id: job.tab_id,
+      conversation_id: inspection.conversation_id,
+      conversation_url: inspection.conversation_url,
+    });
   }
   if (inspection?.busy || !inspection?.assistant_turns) return;
   if (!inspection.handoff_name) {
@@ -1291,16 +1314,16 @@ async function monitorSubmittedLaunch(job, ownerInstanceId) {
       });
       return;
     }
-    const accepted = await postJson(`/v1/launch-jobs/${encodeURIComponent(job.job_id)}/handoff`, {
-      owner_instance_id: ownerInstanceId,
-      name: inspection.handoff_name,
-      content_base64: handoff.inline_base64,
-    });
+    // captureTab already sent these exact bytes through the ordinary capture
+    // envelope used for every user- or queue-created conversation. The
+    // receiver correlates that canonical artifact to the launch job; never
+    // repost or store assistant output through a launch-only side channel.
     await appendCaptureLog({
       ok: true,
-      reason: "sol_pro_handoff_validated",
+      reason: "sol_pro_handoff_captured",
       job_id: job.job_id,
-      artifact_ref: accepted.job?.handoff_artifact_ref || null,
+      provider_attachment_id: handoff.provider_attachment_id || null,
+      artifact_ref: captured?.captureResult?.artifact_ref || null,
     });
   } catch (error) {
     const classified = classifyLaunchFailure(error, error?.retryAfterSeconds || null);

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1241,7 +1241,6 @@ async function monitorSubmittedLaunch(job, ownerInstanceId) {
         conversation_url: inspection.conversation_url,
       });
     }
-    return;
   }
   if (inspection?.rate_limited) {
     await updateLaunchJob(job.job_id, ownerInstanceId, {
@@ -1265,7 +1264,7 @@ async function monitorSubmittedLaunch(job, ownerInstanceId) {
     });
     return;
   }
-  if ((inspection?.busy || inspection?.assistant_turns) && job.phase !== "provider_running") {
+  if (!inspection?.soft_warning && (inspection?.busy || inspection?.assistant_turns) && job.phase !== "provider_running") {
     await updateLaunchJob(job.job_id, ownerInstanceId, {
       outcome: "progress",
       phase: "provider_running",

--- a/browser-extension/src/launch/chatgpt_launch.js
+++ b/browser-extension/src/launch/chatgpt_launch.js
@@ -189,6 +189,7 @@ export async function executeChatGptLaunchInPage(job, attachments) {
 export function inspectChatGptLaunchPage() {
   const textOf = (node) => String(node?.innerText || node?.textContent || "");
   const text = textOf(document.body);
+  const softWarning = /temporarily limited access to your conversations to protect your data/i.test(text);
   const busy = [...document.querySelectorAll("button")].some((button) =>
     /pro thinking|stop generating|stop responding|stop answering/i.test(
       button.getAttribute("aria-label") || textOf(button),
@@ -209,7 +210,8 @@ export function inspectChatGptLaunchPage() {
     assistant_turns: assistantTurns.length,
     handoff_name: handoffNode ? handoffName : null,
     handoff_href: handoffNode?.href || null,
-    rate_limited: /too many requests|rate.?limit/i.test(text),
-    safety_lock: /temporarily blocked|unusual activity|access to conversations/i.test(text),
+    soft_warning: softWarning,
+    rate_limited: !softWarning && /too many requests|rate.?limit/i.test(text),
+    safety_lock: !softWarning && /temporarily blocked|unusual activity|access to conversations/i.test(text),
   };
 }

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -455,7 +455,13 @@ function renderLaunch(jobs, { launchEnabled = false, ownerInstanceId = null } = 
   statusNode.textContent = launchEnabled ? job.status : `${job.status} · disabled`;
   document.getElementById("launch-phase").textContent = job.phase || job.status;
   const due = job.next_attempt_at ? new Date(job.next_attempt_at).toLocaleTimeString() : "now";
-  document.getElementById("launch-cadence").textContent = `${job.cadence_minutes}m · ${job.cooldown_reason || due}`;
+  const remainingMinutes = job.next_attempt_at
+    ? Math.max(0, Math.ceil((Date.parse(job.next_attempt_at) - Date.now()) / 60_000))
+    : 0;
+  const cooldown = job.cooldown_reason
+    ? `${job.cooldown_reason} until ${due}${remainingMinutes ? ` (~${remainingMinutes}m)` : ""}`
+    : `due ${due}`;
+  document.getElementById("launch-cadence").textContent = `${job.cadence_minutes}m cadence · ${cooldown}`;
   document.getElementById("launch-owner").textContent = job.lease_owner
     ? (job.lease_owner === ownerInstanceId ? "this extension" : "another extension")
     : "unclaimed";

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -1506,6 +1506,7 @@ describe("Sol Pro launch worker", () => {
       return [{ result: {
         busy: false,
         assistant_turns: 1,
+        soft_warning: true,
         handoff_name: "polylogue-sol-pro-launch-handoff.zip",
         conversation_id: "conversation-1",
         conversation_url: "https://chatgpt.com/c/conversation-1",

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -1403,6 +1403,7 @@ describe("Sol Pro launch worker", () => {
   });
 
   it.each([
+    ["soft warning", { soft_warning: true }, "soft_warning", "provider_soft_warning"],
     ["rate limit", { rate_limited: true }, "rate_limited", "provider_rate_limit"],
     ["safety lock", { safety_lock: true }, "safety_locked", "provider_safety_lock"],
   ])("delegates %s backoff duration to the receiver", async (_label, inspection, outcome, phase) => {
@@ -1428,6 +1429,7 @@ describe("Sol Pro launch worker", () => {
       assistant_turns: 0,
       conversation_id: "conversation-1",
       conversation_url: "https://chatgpt.com/c/conversation-1",
+      soft_warning: false,
       rate_limited: false,
       safety_lock: false,
       ...inspection,
@@ -1441,7 +1443,46 @@ describe("Sol Pro launch worker", () => {
     expect(event).not.toHaveProperty("retry_after_seconds");
   });
 
-  it("completes only after authenticated capture returns the exact handoff bytes", async () => {
+  it("records a clean provider-running observation", async () => {
+    const job = {
+      job_id: "launch-provider-running",
+      status: "submitted",
+      phase: "submitted",
+      lease_owner: "launch-executor-test",
+      tab_id: 42,
+      conversation_id: "conversation-1",
+      conversation_url: "https://chatgpt.com/c/conversation-1",
+    };
+    globalThis.fetch = vi.fn(async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      const path = String(url);
+      if (path.includes("claim_by=")) return responseJson({ jobs: [] });
+      if (path.endsWith("/v1/launch-jobs")) return responseJson({ jobs: [job] });
+      if (path.endsWith("/events")) return responseJson({ job: { ...job, phase: "provider_running" } });
+      return responseJson({ error: "unexpected_receiver_request" }, { ok: false, status: 500 });
+    });
+    chrome.scripting.executeScript.mockResolvedValue([{ result: {
+      busy: true,
+      assistant_turns: 0,
+      conversation_id: "conversation-1",
+      conversation_url: "https://chatgpt.com/c/conversation-1",
+      soft_warning: false,
+      rate_limited: false,
+      safety_lock: false,
+    } }]);
+
+    await sendRuntimeMessage({ type: "polylogue.launch.configure", launchEnabled: true });
+
+    await vi.waitFor(() => expect(fetchCalls.some((call) => String(call.url).endsWith("/events"))).toBe(true));
+    const event = JSON.parse(fetchCalls.find((call) => String(call.url).endsWith("/events")).options.body);
+    expect(event).toMatchObject({
+      outcome: "progress",
+      phase: "provider_running",
+      detail: expect.stringContaining("accepted"),
+    });
+  });
+
+  it("reuses canonical capture for a launched chat handoff", async () => {
     const zipBase64 = btoa("PK synthetic handoff");
     const job = {
       job_id: "launch-complete",
@@ -1458,9 +1499,6 @@ describe("Sol Pro launch worker", () => {
       if (path.includes("claim_by=")) return responseJson({ jobs: [] });
       if (path.endsWith("/v1/launch-jobs")) return responseJson({ jobs: [job] });
       if (path.endsWith("/events")) return responseJson({ job });
-      if (path.endsWith("/handoff")) {
-        return responseJson({ job: { ...job, status: "completed", handoff_artifact_ref: "launch-jobs/result.zip" } });
-      }
       return responseJson({ error: "unexpected_receiver_request" }, { ok: false, status: 500 });
     });
     chrome.scripting.executeScript.mockImplementation(async (details) => {
@@ -1483,24 +1521,24 @@ describe("Sol Pro launch worker", () => {
           attachments: [{ name: "polylogue-sol-pro-launch-handoff.zip", inline_base64: zipBase64 }],
         },
       },
-      captureResult: { ok: true, provider: "chatgpt", provider_session_id: "conversation-1" },
+      captureResult: {
+        ok: true,
+        provider: "chatgpt",
+        provider_session_id: "conversation-1",
+        artifact_ref: "chatgpt/conversation-1.json",
+      },
       archiveState: { captured: true, state: "archived" },
     });
 
     await sendRuntimeMessage({ type: "polylogue.launch.configure", launchEnabled: true });
 
-    await vi.waitFor(() => expect(fetchCalls.some((call) => String(call.url).endsWith("/handoff"))).toBe(true));
+    await vi.waitFor(() => expect(chrome.tabs.sendMessage).toHaveBeenCalled());
     expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
       type: "polylogue.capturePage",
       reason: "launch_job_handoff",
       capture_context: { launch_job_id: "launch-complete" },
     });
-    const handoffCall = fetchCalls.find((call) => String(call.url).endsWith("/handoff"));
-    expect(JSON.parse(handoffCall.options.body)).toEqual({
-      owner_instance_id: "launch-executor-test",
-      name: "polylogue-sol-pro-launch-handoff.zip",
-      content_base64: zipBase64,
-    });
+    expect(fetchCalls.some((call) => String(call.url).endsWith("/handoff"))).toBe(false);
   });
 
   it("lets the owning extension close a cancelled background run", async () => {

--- a/browser-extension/tests/chatgpt_launch.test.js
+++ b/browser-extension/tests/chatgpt_launch.test.js
@@ -190,7 +190,20 @@ describe("ChatGPT Sol Pro launch adapter", () => {
 
   it("keeps ordinary rate limits distinct from provider safety locks", () => {
     installPage('<section data-testid="conversation-turn-2">Too many requests; rate limit reached</section>');
-    expect(inspectChatGptLaunchPage()).toMatchObject({ rate_limited: true, safety_lock: false });
+    expect(inspectChatGptLaunchPage()).toMatchObject({ soft_warning: false, rate_limited: true, safety_lock: false });
+  });
+
+  it("classifies the conversation-access anti-abuse banner as a soft warning", () => {
+    installPage(`<section data-testid="conversation-turn-2">
+      Too many requests. You’re making requests too quickly.
+      We’ve temporarily limited access to your conversations to protect your data.
+      Please wait a few minutes before trying again.
+    </section>`);
+    expect(inspectChatGptLaunchPage()).toMatchObject({
+      soft_warning: true,
+      rate_limited: false,
+      safety_lock: false,
+    });
   });
 
   it("treats the current Pro stop-answering control as a busy run", () => {

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -336,7 +336,7 @@ describe("popup capture", () => {
 
     await vi.waitFor(() => expect(document.getElementById("launch-status").textContent).toBe("cooldown"));
     expect(document.getElementById("launch-job").selectedOptions[0].textContent).toContain("#3 launch-1");
-    expect(document.getElementById("launch-cadence").textContent).toContain("5m · rate_limited");
+    expect(document.getElementById("launch-cadence").textContent).toContain("5m cadence · rate_limited until");
     expect(document.getElementById("launch-owner").textContent).toBe("another extension");
     expect(document.getElementById("launch-last").textContent).toContain("provider_http_429");
     expect(document.getElementById("launch-resume").disabled).toBe(true);

--- a/polylogue/browser_capture/launch_jobs.py
+++ b/polylogue/browser_capture/launch_jobs.py
@@ -18,15 +18,15 @@ from functools import wraps
 from io import BytesIO
 from pathlib import Path, PurePosixPath
 from threading import RLock
-from typing import Any, TypeVar, cast
+from typing import Any, Literal, TypeVar, cast
 from uuid import uuid4
 
 import orjson
 
 from polylogue.browser_capture.models import (
+    BrowserCaptureEnvelope,
     BrowserLaunchAttachment,
     BrowserLaunchEvent,
-    BrowserLaunchHandoffRequest,
     BrowserLaunchJob,
     BrowserLaunchJobControlRequest,
     BrowserLaunchJobRequest,
@@ -174,10 +174,63 @@ def _backoff_with_jitter(job: BrowserLaunchJob, base_seconds: int, *, cap_second
     return int(exponential + int(exponential * 0.1 * seed / 255))
 
 
-def _event(job: BrowserLaunchJob, kind: str, *, detail: str | None = None, owner: str | None = None) -> None:
+def _provider_backoff_with_jitter(
+    job: BrowserLaunchJob, base_seconds: int, *, circuit_streak: int, cap_seconds: int
+) -> int:
+    exponential = min(cap_seconds, base_seconds * (2 ** min(max(circuit_streak - 1, 0), 5)))
+    seed = hashlib.sha256(f"{job.job_id}:{circuit_streak}:{job.cooldown_reason}".encode()).digest()[0]
+    return int(exponential + int(exponential * 0.1 * seed / 255))
+
+
+def _provider_circuit_streak(jobs: list[BrowserLaunchJob]) -> int:
+    signals = sorted(
+        (
+            parsed,
+            event.kind,
+            event.phase,
+        )
+        for job in jobs
+        for event in job.events
+        if (parsed := _parse(event.at)) is not None
+        if event.kind in {"soft_warning", "rate_limited", "safety_locked", "completed"}
+        or (event.kind == "progress" and event.phase == "provider_running")
+    )
+    streak = 0
+    for _at, kind, phase in signals:
+        if kind == "completed" or (kind == "progress" and phase == "provider_running"):
+            streak = 0
+        else:
+            streak += 1
+    return streak
+
+
+def _event(
+    job: BrowserLaunchJob,
+    kind: str,
+    *,
+    detail: str | None = None,
+    owner: str | None = None,
+    phase: str | None = None,
+    provider_state: Literal["accepted", "soft_warning", "hard_rate_limit", "safety_lock"] | None = None,
+    provider_circuit_streak: int | None = None,
+    backoff_seconds: int | None = None,
+    backoff_source: Literal["receiver_adaptive", "provider_retry_after"] | None = None,
+) -> None:
     job.events = [
         *job.events,
-        BrowserLaunchEvent(event_id=uuid4().hex, at=_iso(_now()), kind=kind, detail=detail, owner_instance_id=owner),
+        BrowserLaunchEvent(
+            event_id=uuid4().hex,
+            at=_iso(_now()),
+            kind=kind,
+            detail=detail,
+            owner_instance_id=owner,
+            phase=phase,
+            provider_state=provider_state,
+            provider_circuit_streak=provider_circuit_streak,
+            backoff_seconds=backoff_seconds,
+            backoff_source=backoff_source,
+            cadence_minutes=job.cadence_minutes,
+        ),
     ][-LAUNCH_EVENT_LIMIT:]
 
 
@@ -331,7 +384,7 @@ def claim_due_launch_job(
         _write_job(root, job)
         return job
 
-    global_cooldown_until = max(
+    hard_cooldown_until = max(
         (
             parsed
             for job in jobs
@@ -340,7 +393,22 @@ def claim_due_launch_job(
         ),
         default=None,
     )
-    if global_cooldown_until is not None and global_cooldown_until > now:
+    if hard_cooldown_until is not None and hard_cooldown_until > now:
+        return None
+    soft_cooldown_until = max(
+        (
+            parsed
+            for job in jobs
+            if job.cooldown_reason == "soft_warning"
+            if (parsed := _parse(job.next_attempt_at)) is not None
+        ),
+        default=None,
+    )
+    manual_override_ready = any(
+        job.manual_priority and job.status in {"queued", "cooldown"} and (_parse(job.not_before) or now) <= now
+        for job in jobs
+    )
+    if soft_cooldown_until is not None and soft_cooldown_until > now and not manual_override_ready:
         return None
 
     latest_submitted = _latest_submitted_at(jobs)
@@ -402,13 +470,19 @@ def update_launch_job(
     job.conversation_url = update.conversation_url or job.conversation_url
     job.handoff_attachment_id = update.handoff_attachment_id or job.handoff_attachment_id
     job.retry_after_seconds = update.retry_after_seconds
-    _event(job, update.outcome, detail=update.detail, owner=update.owner_instance_id)
+    provider_state: Literal["accepted", "soft_warning", "hard_rate_limit", "safety_lock"] | None = None
+    provider_circuit_streak: int | None = None
+    backoff_seconds: int | None = None
+    backoff_source: Literal["receiver_adaptive", "provider_retry_after"] | None = None
 
     if update.outcome == "progress":
         if job.status == "submitted":
             job.lease_expires_at = _iso(now + timedelta(hours=6))
             job.cooldown_reason = None
             job.last_error = None
+            if update.phase == "provider_running":
+                provider_state = "accepted"
+                provider_circuit_streak = 0
         elif update.phase == "submit_intent":
             job.status = "submitting"
             job.lease_expires_at = _iso(now + timedelta(hours=6))
@@ -432,19 +506,43 @@ def update_launch_job(
         job.last_error = update.detail or update.outcome
         job.lease_owner = None
         job.lease_expires_at = None
-    elif update.outcome in {"rate_limited", "safety_locked", "network_error"}:
-        job.attempts += 1
-        if update.outcome == "safety_locked":
-            default_delay = _backoff_with_jitter(job, 3600, cap_seconds=8 * 3600)
-        elif update.outcome == "rate_limited":
-            default_delay = _backoff_with_jitter(job, 900, cap_seconds=4 * 3600)
-        else:
+    elif update.outcome in {"soft_warning", "rate_limited", "safety_locked", "network_error"}:
+        # A provider observation after a successful submit is telemetry about
+        # that same attempt, not another dispatch attempt.
+        if not was_submitted:
+            job.attempts += 1
+        if update.outcome == "network_error":
             default_delay = _backoff_with_jitter(job, 60, cap_seconds=1800)
+        else:
+            provider_circuit_streak = _provider_circuit_streak(list_launch_jobs(spool_path=spool_path)) + 1
+            if update.outcome == "soft_warning":
+                provider_state = "soft_warning"
+                base_seconds, cap_seconds = 900, 4 * 3600
+            elif update.outcome == "rate_limited":
+                provider_state = "hard_rate_limit"
+                base_seconds, cap_seconds = 1800, 8 * 3600
+            else:
+                provider_state = "safety_lock"
+                base_seconds, cap_seconds = 3600, 12 * 3600
+            default_delay = _provider_backoff_with_jitter(
+                job,
+                base_seconds,
+                circuit_streak=provider_circuit_streak,
+                cap_seconds=cap_seconds,
+            )
         delay = update.retry_after_seconds or default_delay
+        backoff_seconds = delay
+        backoff_source = "provider_retry_after" if update.retry_after_seconds is not None else "receiver_adaptive"
         job.cooldown_reason = update.outcome
         job.last_error = update.detail or update.outcome
         job.next_attempt_at = _iso(now + timedelta(seconds=delay))
-        if was_submitted and update.outcome in {"rate_limited", "safety_locked"}:
+        if was_submitted and update.outcome == "soft_warning":
+            # The conversation may still run despite this advisory provider
+            # banner. Keep its durable identity monitored, never resubmit it,
+            # and use the warning only to pace later automatic launches.
+            job.status = "submitted"
+            job.lease_expires_at = _iso(now + timedelta(hours=6))
+        elif was_submitted and update.outcome in {"rate_limited", "safety_locked"}:
             # The provider may already have accepted the conversation. Never
             # turn a post-submit safety/rate response into an automatic new
             # conversation; pause this job while its circuit protects all
@@ -464,6 +562,17 @@ def update_launch_job(
         job.last_error = update.detail or update.outcome
         job.lease_owner = None
         job.lease_expires_at = None
+    _event(
+        job,
+        update.outcome,
+        detail=update.detail,
+        owner=update.owner_instance_id,
+        phase=update.phase,
+        provider_state=provider_state,
+        provider_circuit_streak=provider_circuit_streak,
+        backoff_seconds=backoff_seconds,
+        backoff_source=backoff_source,
+    )
     _write_job(root, job)
     return job
 
@@ -629,34 +738,83 @@ def _validate_handoff_zip(content: bytes, *, expected_prompt_profile: str) -> in
 
 
 @_serialized
-def accept_launch_handoff(
-    job_id: str,
-    request: BrowserLaunchHandoffRequest,
+def reconcile_launch_handoff_capture(
+    envelope: BrowserCaptureEnvelope,
+    artifact_ref: str,
     *,
     spool_path: Path | None = None,
 ) -> BrowserLaunchJob | None:
+    """Complete a launch job from its ordinary canonical capture artifact.
+
+    Assistant files are acquired by the provider-neutral browser capture path
+    for every conversation.  A launch job contributes only a correlation id;
+    it must not create a second file transport or a second copy of the result.
+    """
+
+    raw_job_id = envelope.provider_meta.get("launch_job_id")
+    if not isinstance(raw_job_id, str) or not raw_job_id:
+        return None
     root = launch_job_root(spool_path)
-    job = _read_job(_job_path(root, job_id))
+    job = _read_job(_job_path(root, raw_job_id))
     if job is None:
         return None
-    if job.lease_owner != request.owner_instance_id:
-        raise BrowserLaunchLeaseError("launch job lease owner mismatch")
-    if job.status != "submitted":
-        raise BrowserLaunchConflictError(f"cannot accept handoff for launch job in {job.status}")
+    if job.status == "completed":
+        return job
+    if job.status not in {"submitted", "paused"}:
+        return None
+    if job.conversation_id != envelope.session.provider_session_id or envelope.session.provider.value != "chatgpt":
+        return None
+    attachment = next(
+        (item for item in envelope.session.attachments if item.name == LAUNCH_HANDOFF_NAME),
+        None,
+    )
+    if attachment is None:
+        return None
+    encoded = attachment.inline_base64 or attachment.content_base64 or attachment.data
+    if not encoded:
+        return None
     try:
-        content = base64.b64decode(request.content_base64, validate=True)
-    except (binascii.Error, ValueError) as exc:
-        raise BrowserLaunchHandoffError("handoff content is not valid base64") from exc
+        content = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError):
+        error = BrowserLaunchHandoffError("handoff content is not valid base64")
+        job.status = "paused"
+        job.phase = "handoff_invalid"
+        job.updated_at = _iso(_now())
+        job.last_error = str(error)
+        job.lease_owner = None
+        job.lease_expires_at = None
+        _event(job, "protocol_mismatch", detail=str(error), phase="handoff_invalid")
+        _write_job(root, job)
+        return job
     if len(content) > LAUNCH_HANDOFF_MAX_BYTES:
-        raise BrowserLaunchQuotaError("launch handoff byte quota exceeded")
-    file_count = _validate_handoff_zip(content, expected_prompt_profile=job.prompt_profile)
-    path = _job_dir(root, job_id) / "handoff" / LAUNCH_HANDOFF_NAME
-    _atomic_write(path, content)
+        quota_error = BrowserLaunchQuotaError("launch handoff byte quota exceeded")
+        job.status = "paused"
+        job.phase = "handoff_invalid"
+        job.updated_at = _iso(_now())
+        job.last_error = str(quota_error)
+        job.lease_owner = None
+        job.lease_expires_at = None
+        _event(job, "protocol_mismatch", detail=str(quota_error), phase="handoff_invalid")
+        _write_job(root, job)
+        return job
+    try:
+        file_count = _validate_handoff_zip(content, expected_prompt_profile=job.prompt_profile)
+    except BrowserLaunchHandoffError as exc:
+        job.status = "paused"
+        job.phase = "handoff_invalid"
+        job.updated_at = _iso(_now())
+        job.last_error = str(exc)
+        job.lease_owner = None
+        job.lease_expires_at = None
+        _event(job, "protocol_mismatch", detail=str(exc), phase="handoff_invalid")
+        _write_job(root, job)
+        return job
     now = _now()
     job.status = "completed"
     job.phase = "handoff_validated"
     job.updated_at = _iso(now)
-    job.handoff_artifact_ref = path.relative_to(root.parent).as_posix()
+    job.handoff_artifact_ref = artifact_ref
+    job.handoff_attachment_id = attachment.provider_attachment_id
     job.handoff_sha256 = hashlib.sha256(content).hexdigest()
     job.handoff_size_bytes = len(content)
     job.handoff_file_count = file_count
@@ -664,7 +822,14 @@ def accept_launch_handoff(
     job.lease_owner = None
     job.lease_expires_at = None
     job.last_error = None
-    _event(job, "completed", detail=f"validated {file_count} handoff files", owner=request.owner_instance_id)
+    _event(
+        job,
+        "completed",
+        detail=f"validated {file_count} handoff files in canonical capture {artifact_ref}",
+        phase="handoff_validated",
+        provider_state="accepted",
+        provider_circuit_streak=0,
+    )
     _write_job(root, job)
     return job
 
@@ -675,12 +840,12 @@ __all__ = [
     "BrowserLaunchLeaseError",
     "BrowserLaunchQuotaError",
     "BrowserLaunchStateError",
-    "accept_launch_handoff",
     "claim_due_launch_job",
     "control_launch_job",
     "enqueue_launch_job",
     "launch_job_root",
     "list_launch_jobs",
     "read_launch_attachment",
+    "reconcile_launch_handoff_capture",
     "update_launch_job",
 ]

--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -470,6 +470,7 @@ BrowserLaunchOutcome = Literal[
     "progress",
     "submitted",
     "submission_unknown",
+    "soft_warning",
     "rate_limited",
     "safety_locked",
     "auth_challenge",
@@ -557,6 +558,12 @@ class BrowserLaunchEvent(BaseModel):
     kind: str
     detail: str | None = None
     owner_instance_id: str | None = None
+    phase: str | None = None
+    provider_state: Literal["accepted", "soft_warning", "hard_rate_limit", "safety_lock"] | None = None
+    provider_circuit_streak: int | None = Field(default=None, ge=0)
+    backoff_seconds: int | None = Field(default=None, ge=1)
+    backoff_source: Literal["receiver_adaptive", "provider_retry_after"] | None = None
+    cadence_minutes: BrowserLaunchCadenceMinutes | None = None
 
 
 class BrowserLaunchJob(BaseModel):
@@ -659,21 +666,6 @@ class BrowserLaunchJobControlRequest(BaseModel):
         return self
 
 
-class BrowserLaunchHandoffRequest(BaseModel):
-    """Exact cohesive ZIP acquired from the provider page by the lease owner."""
-
-    owner_instance_id: str = Field(min_length=1, max_length=200)
-    name: Literal["polylogue-sol-pro-launch-handoff.zip"]
-    content_base64: str
-
-
-class BrowserLaunchHandoffAcceptedPayload(BaseModel):
-    ok: Literal[True] = True
-    receiver: Literal["polylogue-browser-capture"] = BROWSER_CAPTURE_RECEIVER
-    schema_version: Literal[1] = BROWSER_CAPTURE_SCHEMA_VERSION
-    job: BrowserLaunchJob
-
-
 def looks_like_browser_capture(payload: object) -> bool:
     """Return whether a payload is a browser-capture envelope."""
     if not isinstance(payload, dict):
@@ -720,8 +712,6 @@ __all__ = [
     "BrowserLaunchJobListPayload",
     "BrowserLaunchJobRequest",
     "BrowserLaunchJobUpdateRequest",
-    "BrowserLaunchHandoffAcceptedPayload",
-    "BrowserLaunchHandoffRequest",
     "BrowserLaunchOutcome",
     "BrowserLaunchStatus",
     "BrowserPostAckPayload",

--- a/polylogue/browser_capture/route_contracts.py
+++ b/polylogue/browser_capture/route_contracts.py
@@ -181,15 +181,6 @@ BROWSER_CAPTURE_ROUTE_CONTRACTS: tuple[BrowserCaptureRouteContract, ...] = (
         "BrowserLaunchJobEnqueuedPayload | BrowserCaptureErrorPayload",
         "Operator pause/resume/cancel/retry and ambiguous-submit reconciliation; terminal completion cannot be reopened.",
     ),
-    BrowserCaptureRouteContract(
-        "POST",
-        "/v1/launch-jobs/{job_id}/handoff",
-        "launch_job_handoff",
-        "bearer_if_web_origin",
-        "BrowserLaunchHandoffRequest",
-        "BrowserLaunchHandoffAcceptedPayload | BrowserCaptureErrorPayload",
-        "Stores and checksum-validates the cohesive ZIP before marking the job complete.",
-    ),
 )
 
 

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -17,16 +17,15 @@ from pydantic import ValidationError
 
 from polylogue.browser_capture.launch_jobs import (
     BrowserLaunchConflictError,
-    BrowserLaunchHandoffError,
     BrowserLaunchLeaseError,
     BrowserLaunchQuotaError,
     BrowserLaunchStateError,
-    accept_launch_handoff,
     claim_due_launch_job,
     control_launch_job,
     enqueue_launch_job,
     list_launch_jobs,
     read_launch_attachment,
+    reconcile_launch_handoff_capture,
     update_launch_job,
 )
 from polylogue.browser_capture.models import (
@@ -38,8 +37,6 @@ from polylogue.browser_capture.models import (
     BrowserCaptureCapabilitiesPayload,
     BrowserCaptureEnvelope,
     BrowserCaptureErrorPayload,
-    BrowserLaunchHandoffAcceptedPayload,
-    BrowserLaunchHandoffRequest,
     BrowserLaunchJobControlRequest,
     BrowserLaunchJobEnqueuedPayload,
     BrowserLaunchJobListPayload,
@@ -392,10 +389,6 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
             job_id = path[len("/v1/launch-jobs/") : -len("/control")]
             self._launch_job_control(job_id)
             return
-        if path.startswith("/v1/launch-jobs/") and path.endswith("/handoff"):
-            job_id = path[len("/v1/launch-jobs/") : -len("/handoff")]
-            self._launch_job_handoff(job_id)
-            return
         if path == "/v1/backfill-checkpoint":
             self._backfill_checkpoint_store()
             return
@@ -425,6 +418,20 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
             logger.warning("browser_capture.write_failed", request_id=self._request_id(), error=repr(exc))
             self._safe_error(HTTPStatus.INTERNAL_SERVER_ERROR, "write_failed")
             return
+        try:
+            reconcile_launch_handoff_capture(
+                envelope,
+                result.artifact_ref,
+                spool_path=self.server.config.spool_path,
+            )
+        except (OSError, BrowserLaunchStateError) as exc:
+            # The canonical conversation capture is already durable. Launch
+            # projection failure must not reject or duplicate that capture.
+            logger.warning(
+                "browser_capture.launch_reconcile_failed",
+                request_id=self._request_id(),
+                error=repr(exc),
+            )
         logger.debug(
             "browser_capture.capture_accepted",
             request_id=self._request_id(),
@@ -569,38 +576,6 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
             self._safe_error(HTTPStatus.NOT_FOUND, "unknown_launch_job")
             return
         self._send_json(HTTPStatus.OK, BrowserLaunchJobEnqueuedPayload(job=job).model_dump(mode="json"))
-
-    def _launch_job_handoff(self, job_id: str) -> None:
-        payload = self._read_json_body()
-        if payload is None:
-            return
-        try:
-            request = BrowserLaunchHandoffRequest.model_validate(payload)
-            job = accept_launch_handoff(job_id, request, spool_path=self.server.config.spool_path)
-        except ValidationError:
-            self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_launch_handoff")
-            return
-        except BrowserLaunchLeaseError:
-            self._safe_error(HTTPStatus.CONFLICT, "launch_lease_owner_mismatch")
-            return
-        except BrowserLaunchConflictError:
-            self._safe_error(HTTPStatus.CONFLICT, "invalid_launch_job_state")
-            return
-        except BrowserLaunchQuotaError:
-            self._safe_error(HTTPStatus.TOO_MANY_REQUESTS, "launch_handoff_quota_exceeded")
-            return
-        except BrowserLaunchHandoffError as exc:
-            logger.warning("browser_capture.launch_handoff_invalid", request_id=self._request_id(), error=str(exc))
-            self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_launch_handoff_archive")
-            return
-        except (OSError, BrowserLaunchStateError) as exc:
-            logger.warning("browser_capture.launch_handoff_failed", request_id=self._request_id(), error=repr(exc))
-            self._safe_error(HTTPStatus.INTERNAL_SERVER_ERROR, "write_failed")
-            return
-        if job is None:
-            self._safe_error(HTTPStatus.NOT_FOUND, "unknown_launch_job")
-            return
-        self._send_json(HTTPStatus.OK, BrowserLaunchHandoffAcceptedPayload(job=job).model_dump(mode="json"))
 
     def _post_command_ack(self, command_id: str) -> None:
         payload = self._read_json_body()

--- a/tests/unit/browser_capture/test_launch_jobs.py
+++ b/tests/unit/browser_capture/test_launch_jobs.py
@@ -19,19 +19,18 @@ from click.testing import CliRunner
 
 from polylogue.browser_capture.launch_jobs import (
     BrowserLaunchConflictError,
-    BrowserLaunchHandoffError,
     BrowserLaunchLeaseError,
-    accept_launch_handoff,
     claim_due_launch_job,
     control_launch_job,
     enqueue_launch_job,
     list_launch_jobs,
     read_launch_attachment,
+    reconcile_launch_handoff_capture,
     update_launch_job,
 )
 from polylogue.browser_capture.models import (
+    BrowserCaptureEnvelope,
     BrowserLaunchAttachmentInput,
-    BrowserLaunchHandoffRequest,
     BrowserLaunchJobControlRequest,
     BrowserLaunchJobRequest,
     BrowserLaunchJobUpdateRequest,
@@ -123,6 +122,39 @@ def _handoff_zip(
         for name, content in files.items():
             archive.writestr(name, content)
     return buffer.getvalue()
+
+
+def _handoff_capture(
+    job_id: str,
+    content: bytes,
+    *,
+    conversation_id: str = "conversation-1",
+) -> BrowserCaptureEnvelope:
+    return BrowserCaptureEnvelope.model_validate(
+        {
+            "provenance": {
+                "source_url": f"https://chatgpt.com/c/{conversation_id}",
+                "captured_at": "2026-07-16T00:00:00+00:00",
+                "extension_instance_id": "capture-instance",
+                "adapter_name": "chatgpt-native",
+            },
+            "provider_meta": {"launch_job_id": job_id},
+            "session": {
+                "provider": "chatgpt",
+                "provider_session_id": conversation_id,
+                "turns": [{"provider_turn_id": "turn-1", "role": "assistant", "text": "Done."}],
+                "attachments": [
+                    {
+                        "provider_attachment_id": "file-handoff",
+                        "message_provider_id": "turn-1",
+                        "name": "polylogue-sol-pro-launch-handoff.zip",
+                        "mime_type": "application/zip",
+                        "inline_base64": base64.b64encode(content).decode(),
+                    }
+                ],
+            },
+        }
+    )
 
 
 def test_enqueue_copies_and_hash_verifies_attachment(tmp_path: Path) -> None:
@@ -359,6 +391,115 @@ def test_post_submit_rate_limit_uses_receiver_exponential_backoff(tmp_path: Path
     assert retry_at < frozen_clock.now() + timedelta(minutes=33)
 
 
+def test_soft_warning_streak_escalates_across_jobs_and_acceptance_resets(
+    tmp_path: Path, frozen_clock: FrozenClock
+) -> None:
+    jobs = [
+        enqueue_launch_job(_request(job_id=job_id), spool_path=tmp_path)
+        for job_id in ("warning-one", "warning-two", "accepted", "warning-after-acceptance")
+    ]
+
+    def submit(job_id: str, owner: str) -> None:
+        claimed = claim_due_launch_job(owner, spool_path=tmp_path) or pytest.fail("not claimed")
+        assert claimed.job_id == job_id
+        update_launch_job(
+            job_id,
+            BrowserLaunchJobUpdateRequest(owner_instance_id=owner, outcome="submitted", phase="submitted"),
+            spool_path=tmp_path,
+        )
+
+    submit(jobs[0].job_id, "one")
+    first = update_launch_job(
+        jobs[0].job_id,
+        BrowserLaunchJobUpdateRequest(
+            owner_instance_id="one",
+            outcome="soft_warning",
+            phase="provider_soft_warning",
+        ),
+        spool_path=tmp_path,
+    ) or pytest.fail("missing first warning")
+    first_event = first.events[-1]
+    assert first.status == "submitted"
+    assert first.attempts == 1
+    assert first_event.provider_state == "soft_warning"
+    assert first_event.provider_circuit_streak == 1
+    assert first_event.backoff_source == "receiver_adaptive"
+    assert 900 <= (first_event.backoff_seconds or 0) < 990
+
+    frozen_clock.advance(1_000)
+    submit(jobs[1].job_id, "two")
+    second = update_launch_job(
+        jobs[1].job_id,
+        BrowserLaunchJobUpdateRequest(
+            owner_instance_id="two",
+            outcome="soft_warning",
+            phase="provider_soft_warning",
+        ),
+        spool_path=tmp_path,
+    ) or pytest.fail("missing second warning")
+    second_event = second.events[-1]
+    assert second_event.provider_circuit_streak == 2
+    assert 1_800 <= (second_event.backoff_seconds or 0) < 1_980
+
+    frozen_clock.advance(2_000)
+    submit(jobs[2].job_id, "accepted")
+    accepted = update_launch_job(
+        jobs[2].job_id,
+        BrowserLaunchJobUpdateRequest(
+            owner_instance_id="accepted",
+            outcome="progress",
+            phase="provider_running",
+        ),
+        spool_path=tmp_path,
+    ) or pytest.fail("missing accepted observation")
+    assert accepted.events[-1].provider_state == "accepted"
+    assert accepted.events[-1].provider_circuit_streak == 0
+
+    frozen_clock.advance(61)
+    submit(jobs[3].job_id, "after")
+    after = update_launch_job(
+        jobs[3].job_id,
+        BrowserLaunchJobUpdateRequest(
+            owner_instance_id="after",
+            outcome="soft_warning",
+            phase="provider_soft_warning",
+        ),
+        spool_path=tmp_path,
+    ) or pytest.fail("missing warning after acceptance")
+    assert after.events[-1].provider_circuit_streak == 1
+    assert 900 <= (after.events[-1].backoff_seconds or 0) < 990
+
+
+def test_manual_priority_can_bypass_soft_warning_circuit(
+    tmp_path: Path,
+) -> None:
+    warned = enqueue_launch_job(_request(job_id="soft-warning"), spool_path=tmp_path)
+    manual = enqueue_launch_job(_request(job_id="manual"), spool_path=tmp_path)
+    claim_due_launch_job("one", spool_path=tmp_path)
+    update_launch_job(
+        warned.job_id,
+        BrowserLaunchJobUpdateRequest(owner_instance_id="one", outcome="submitted", phase="submitted"),
+        spool_path=tmp_path,
+    )
+    update_launch_job(
+        warned.job_id,
+        BrowserLaunchJobUpdateRequest(
+            owner_instance_id="one",
+            outcome="soft_warning",
+            phase="provider_soft_warning",
+        ),
+        spool_path=tmp_path,
+    )
+
+    control_launch_job(
+        manual.job_id,
+        BrowserLaunchJobControlRequest(action="launch_now"),
+        spool_path=tmp_path,
+    )
+    claimed = claim_due_launch_job("two", spool_path=tmp_path) or pytest.fail("manual job not claimed")
+    assert claimed.job_id == manual.job_id
+
+
 def test_unknown_submit_is_quarantined_until_operator_confirms_absence(tmp_path: Path) -> None:
     job = enqueue_launch_job(_request(), spool_path=tmp_path)
     enqueue_launch_job(_request(), spool_path=tmp_path)
@@ -483,16 +624,18 @@ def test_non_owner_update_and_invalid_terminal_control_fail_closed(tmp_path: Pat
         )
     update_launch_job(
         job.job_id,
-        BrowserLaunchJobUpdateRequest(owner_instance_id="owner", outcome="submitted", phase="submitted"),
+        BrowserLaunchJobUpdateRequest(
+            owner_instance_id="owner",
+            outcome="submitted",
+            phase="submitted",
+            conversation_id="conversation-1",
+            conversation_url="https://chatgpt.com/c/conversation-1",
+        ),
         spool_path=tmp_path,
     )
-    completed = accept_launch_handoff(
-        job.job_id,
-        BrowserLaunchHandoffRequest(
-            owner_instance_id="owner",
-            name="polylogue-sol-pro-launch-handoff.zip",
-            content_base64=base64.b64encode(_handoff_zip()).decode(),
-        ),
+    completed = reconcile_launch_handoff_capture(
+        _handoff_capture(job.job_id, _handoff_zip()),
+        "chatgpt/conversation-1.json",
         spool_path=tmp_path,
     ) or pytest.fail("missing job")
     assert completed.status == "completed"
@@ -504,54 +647,63 @@ def test_non_owner_update_and_invalid_terminal_control_fail_closed(tmp_path: Pat
         )
 
 
-def test_handoff_completion_requires_locally_validated_cohesive_zip(tmp_path: Path) -> None:
-    job = enqueue_launch_job(_request(), spool_path=tmp_path)
-    claim_due_launch_job("owner", spool_path=tmp_path)
+def test_handoff_completion_reconciles_the_canonical_capture_artifact(tmp_path: Path) -> None:
+    for index, (content, expected_error) in enumerate(
+        (
+            (_handoff_zip(corrupt_checksum=True), "checksum mismatch"),
+            (_handoff_zip(prompt_profile=None), "prompt profile mismatch"),
+            (_handoff_zip(prompt_profile="polylogue-sol-pro-worker-wrong"), "prompt profile mismatch"),
+        )
+    ):
+        invalid_spool = tmp_path / f"invalid-{index}"
+        invalid = enqueue_launch_job(_request(job_id=f"invalid-{index}"), spool_path=invalid_spool)
+        claim_due_launch_job(f"invalid-owner-{index}", spool_path=invalid_spool)
+        update_launch_job(
+            invalid.job_id,
+            BrowserLaunchJobUpdateRequest(
+                owner_instance_id=f"invalid-owner-{index}",
+                outcome="submitted",
+                phase="submitted",
+                conversation_id="conversation-1",
+                conversation_url="https://chatgpt.com/c/conversation-1",
+            ),
+            spool_path=invalid_spool,
+        )
+        rejected = reconcile_launch_handoff_capture(
+            _handoff_capture(invalid.job_id, content),
+            "chatgpt/conversation-1.json",
+            spool_path=invalid_spool,
+        ) or pytest.fail("missing invalid job")
+        assert rejected.status == "paused"
+        assert rejected.phase == "handoff_invalid"
+        assert expected_error in (rejected.last_error or "")
+
+    valid_spool = tmp_path / "valid"
+    job = enqueue_launch_job(_request(job_id="valid-handoff"), spool_path=valid_spool)
+    claim_due_launch_job("owner", spool_path=valid_spool)
     update_launch_job(
         job.job_id,
-        BrowserLaunchJobUpdateRequest(owner_instance_id="owner", outcome="submitted", phase="submitted"),
-        spool_path=tmp_path,
-    )
-
-    with pytest.raises(BrowserLaunchHandoffError, match="checksum mismatch"):
-        accept_launch_handoff(
-            job.job_id,
-            BrowserLaunchHandoffRequest(
-                owner_instance_id="owner",
-                name="polylogue-sol-pro-launch-handoff.zip",
-                content_base64=base64.b64encode(_handoff_zip(corrupt_checksum=True)).decode(),
-            ),
-            spool_path=tmp_path,
-        )
-
-    for profile in (None, "polylogue-sol-pro-worker-wrong"):
-        with pytest.raises(BrowserLaunchHandoffError, match="prompt profile mismatch"):
-            accept_launch_handoff(
-                job.job_id,
-                BrowserLaunchHandoffRequest(
-                    owner_instance_id="owner",
-                    name="polylogue-sol-pro-launch-handoff.zip",
-                    content_base64=base64.b64encode(_handoff_zip(prompt_profile=profile)).decode(),
-                ),
-                spool_path=tmp_path,
-            )
-
-    content = _handoff_zip()
-    completed = accept_launch_handoff(
-        job.job_id,
-        BrowserLaunchHandoffRequest(
+        BrowserLaunchJobUpdateRequest(
             owner_instance_id="owner",
-            name="polylogue-sol-pro-launch-handoff.zip",
-            content_base64=base64.b64encode(content).decode(),
+            outcome="submitted",
+            phase="submitted",
+            conversation_id="conversation-1",
+            conversation_url="https://chatgpt.com/c/conversation-1",
         ),
-        spool_path=tmp_path,
+        spool_path=valid_spool,
+    )
+    content = _handoff_zip()
+    completed = reconcile_launch_handoff_capture(
+        _handoff_capture(job.job_id, content),
+        "chatgpt/conversation-1.json",
+        spool_path=valid_spool,
     ) or pytest.fail("missing job")
     assert completed.status == "completed"
     assert completed.phase == "handoff_validated"
     assert completed.handoff_sha256 == hashlib.sha256(content).hexdigest()
     assert completed.handoff_file_count == 7
-    assert completed.handoff_artifact_ref is not None
-    assert (tmp_path / completed.handoff_artifact_ref).read_bytes() == content
+    assert completed.handoff_artifact_ref == "chatgpt/conversation-1.json"
+    assert completed.handoff_attachment_id == "file-handoff"
 
 
 def test_future_job_is_not_claimed_early(tmp_path: Path, frozen_clock: FrozenClock) -> None:
@@ -634,22 +786,25 @@ def test_receiver_routes_enqueue_claim_and_serve_hash_pinned_inputs(tmp_path: Pa
             port,
             "POST",
             f"/v1/launch-jobs/{job_id}/events",
-            {"owner_instance_id": "live-browser", "outcome": "submitted", "phase": "submitted"},
+            {
+                "owner_instance_id": "live-browser",
+                "outcome": "submitted",
+                "phase": "submitted",
+                "conversation_id": "conversation-1",
+                "conversation_url": "https://chatgpt.com/c/conversation-1",
+            },
         )
         submitted.read()
         handoff_content = _handoff_zip()
-        handoff = _http(
+        capture = _http(
             host,
             port,
             "POST",
-            f"/v1/launch-jobs/{job_id}/handoff",
-            {
-                "owner_instance_id": "live-browser",
-                "name": "polylogue-sol-pro-launch-handoff.zip",
-                "content_base64": base64.b64encode(handoff_content).decode(),
-            },
+            "/v1/browser-captures",
+            _handoff_capture(job_id, handoff_content).model_dump(mode="json", exclude_none=True),
         )
-        handoff_body = json.loads(handoff.read())
+        capture_body = json.loads(capture.read())
+        completed_body = json.loads(_http(host, port, "GET", "/v1/launch-jobs").read())
 
     assert created.status == HTTPStatus.ACCEPTED
     assert claimed.status == HTTPStatus.OK
@@ -658,9 +813,12 @@ def test_receiver_routes_enqueue_claim_and_serve_hash_pinned_inputs(tmp_path: Pa
     assert attachment_response.status == HTTPStatus.OK
     assert attachment_response.getheader("Content-Disposition") == 'attachment; filename="context.tar.gz"'
     assert attachment_bytes == b"project context"
-    assert handoff.status == HTTPStatus.OK
-    assert handoff_body["job"]["status"] == "completed"
-    assert handoff_body["job"]["handoff_sha256"] == hashlib.sha256(handoff_content).hexdigest()
+    assert capture.status == HTTPStatus.ACCEPTED
+    completed_job = next(job for job in completed_body["jobs"] if job["job_id"] == job_id)
+    assert completed_job["status"] == "completed"
+    assert completed_job["handoff_sha256"] == hashlib.sha256(handoff_content).hexdigest()
+    assert completed_job["handoff_artifact_ref"] == capture_body["artifact_ref"]
+    assert not (tmp_path / "launch-jobs" / job_id / "handoff").exists()
 
 
 def test_receiver_reports_corrupt_launch_state_instead_of_hiding_it(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Treat ChatGPT's conversation-access banner as a soft anti-abuse warning and keep launch orchestration subordinate to the canonical browser-capture pipeline. Submitted chats remain monitored, receiver-owned pacing becomes observable and adaptive, manual priority may bypass only the soft circuit, and completed handoffs reconcile from the ordinary captured conversation artifact instead of a launch-only byte transport.

## Problem

A live GPT-5.6 Sol Pro chat continued doing substantial work after ChatGPT displayed “temporarily limited access to your conversations to protect your data.” The monitor classified that post-submit banner as a hard rate limit and paused the job. Separately, the launch completion path took an assistant ZIP already acquired by ordinary ChatGPT capture, reposted its base64 bytes to `/v1/launch-jobs/{id}/handoff`, and stored a second copy. That made automatically launched conversations a special archival silo even though Polylogue must capture the same assistant outputs for user-created chats.

## Solution

- Distinguish the exact conversation-access warning from hard HTTP/rate and safety circuits.
- Preserve the submitted job and six-hour monitor lease; use the warning only to pace later automatic launches.
- Record provider state, cross-job circuit streak, cadence, chosen backoff, and whether Retry-After or receiver policy supplied it.
- Start soft automatic pacing at 15 minutes, escalate repeated warnings across jobs, and reset the streak on accepted/running or completed evidence.
- Allow an explicit manual-priority job through a soft warning, while hard rate/safety circuits remain non-bypassable.
- Improve popup cooldown text with cadence, deadline, and remaining time.
- Reconcile a valid handoff by `launch_job_id`, exact conversation identity, canonical capture artifact ref, and provider attachment id.
- Remove the launch-only handoff request model, route contract, HTTP handler, browser repost, and duplicate ZIP copy. Invalid handoffs pause the launch projection without rejecting the already-durable conversation capture.

Ref polylogue-yyvg.5. Also advances the capture-time asset requirement in polylogue-5k5l without creating a second acquisition path.

## Verification

- `devtools test tests/unit/browser_capture/test_launch_jobs.py` — `18 passed`
- `npm test -- --run tests/chatgpt_launch.test.js tests/background.test.js tests/popup.test.js` — `102 passed`
- `npm run lint` — passed
- `devtools verify --quick` — all 16 gates passed
- pre-push `devtools verify --quick` — all 16 gates passed

A fresh-worktree `devtools verify --seed-testmon --skip-slow` run was stopped at 22% after recording 3,512 passes and 20 failures in unrelated existing CLI, MCP, storage, daemon, snapshot, and query surfaces. The complete partial JSON report was inspected; none of the failures touched browser capture or launch code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer handling for temporary provider access warnings without misclassifying them as hard rate limits.
  - Improved launch progress reporting while the provider is processing requests.
  - Added adaptive retry pacing for repeated provider warnings and failures.
  - Handoff completion now uses the standard browser capture flow for more reliable artifact tracking.

- **Improvements**
  - Launch cadence messages now show cooldown reasons, due times, and estimated minutes remaining.
  - Manual launch actions can bypass temporary warning-based delays when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->