### PR TITLE
fix(browser): reconcile launches from ordinary capture

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -990,7 +990,7 @@ async function cleanupBackfillTransportTab(alarmName) {
   }
 }
 
-async function captureTab(tab, reason = "background", expectedConversation = null, captureContext = null) {
+async function captureTab(tab, reason = "background", expectedConversation = null) {
   if (expectedConversation && tab?.id && chrome.tabs?.get) {
     const currentTab = await chrome.tabs.get(tab.id);
     const currentUrl = currentTab?.url || currentTab?.pendingUrl || "";
@@ -1018,7 +1018,6 @@ async function captureTab(tab, reason = "background", expectedConversation = nul
     const captureMessage = {
       type: "polylogue.capturePage",
       reason,
-      ...(captureContext ? { capture_context: captureContext } : {}),
     };
     const resultWithTimeout = await withTimeout(
       chrome.tabs.sendMessage(tab.id, captureMessage),
@@ -1296,9 +1295,7 @@ async function monitorSubmittedLaunch(job, ownerInstanceId) {
       conversation_url: inspection.conversation_url,
       handoff_attachment_id: inspection.handoff_name,
     });
-    const captured = await captureTab(await chrome.tabs.get(job.tab_id), "launch_job_handoff", null, {
-      launch_job_id: job.job_id,
-    });
+    const captured = await captureTab(await chrome.tabs.get(job.tab_id), "launch_job_handoff");
     const handoff = captured?.envelope?.session?.attachments?.find(
       (attachment) => attachment.name === inspection.handoff_name && attachment.inline_base64,
     );

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -626,7 +626,7 @@
     });
   }
 
-  async function capture(reason = null, captureContext = null) {
+  async function capture(reason = null) {
     const nativePayload = latestNativePayload() || (await fetchNativePayloadOnDemand());
     let assetAcquisition = null;
     if (nativePayload) {
@@ -674,16 +674,6 @@
     };
     const finalEnvelope = envelope || fallbackEnvelope();
     if (!finalEnvelope) return { ok: false, error: "no_turns" };
-    const launchJobId = typeof captureContext?.launch_job_id === "string"
-      ? captureContext.launch_job_id.slice(0, 160)
-      : null;
-    if (launchJobId) {
-      finalEnvelope.provider_meta = { ...(finalEnvelope.provider_meta || {}), launch_job_id: launchJobId };
-      finalEnvelope.session.provider_meta = {
-        ...(finalEnvelope.session.provider_meta || {}),
-        launch_job_id: launchJobId,
-      };
-    }
     const captureResult = await window.polylogueCapture.sendCapture(finalEnvelope, reason);
     if (!captureResult?.ok) {
       messageLayer?.reportOutcome({ ok: false, turnCount: finalEnvelope.session.turns.length });
@@ -714,7 +704,7 @@
   }
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     if (message.type !== "polylogue.capturePage") return false;
-    capture(message.reason || null, message.capture_context || null)
+    capture(message.reason || null)
       .then(sendResponse)
       .catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));
     return true;

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -1537,7 +1537,6 @@ describe("Sol Pro launch worker", () => {
     expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
       type: "polylogue.capturePage",
       reason: "launch_job_handoff",
-      capture_context: { launch_job_id: "launch-complete" },
     });
     expect(fetchCalls.some((call) => String(call.url).endsWith("/handoff"))).toBe(false);
   });

--- a/browser-extension/tests/content/chatgpt_bridge.test.js
+++ b/browser-extension/tests/content/chatgpt_bridge.test.js
@@ -373,25 +373,6 @@ describe("ChatGPT authenticated interpreter bridge response contract", () => {
 });
 
 describe("ChatGPT authenticated asset capture envelope", () => {
-  it("links a launch-job completion capture back to its durable job", async () => {
-    const harness = installFullCapture(syntheticEndpointAdapter());
-    const captureListener = harness.runtimeListeners[0];
-    const result = await new Promise((resolve) => {
-      const accepted = captureListener({
-        type: "polylogue.capturePage",
-        reason: "launch_job_completed",
-        capture_context: { launch_job_id: "launch-job-1" },
-      }, {}, resolve);
-      expect(accepted).toBe(true);
-    });
-
-    expect(result.ok).toBe(true);
-    expect(result.envelope.provider_meta.launch_job_id).toBe("launch-job-1");
-    expect(result.envelope.session.provider_meta.launch_job_id).toBe("launch-job-1");
-    const [captureMessage] = harness.runtimeMessages.filter((message) => message.type === "polylogue.capture");
-    expect(captureMessage.envelope.session.provider_meta.launch_job_id).toBe("launch-job-1");
-  });
-
   it("records stable attachment identity, bytes, size, and SHA receipt across repeat capture", async () => {
     const adapter = syntheticEndpointAdapter();
     const harness = installFullCapture(adapter);

--- a/polylogue/browser_capture/launch_jobs.py
+++ b/polylogue/browser_capture/launch_jobs.py
@@ -747,17 +747,20 @@ def reconcile_launch_handoff_capture(
     """Complete a launch job from its ordinary canonical capture artifact.
 
     Assistant files are acquired by the provider-neutral browser capture path
-    for every conversation.  A launch job contributes only a correlation id;
-    it must not create a second file transport or a second copy of the result.
+    for every conversation. The receiver correlates the provider-native
+    conversation identity already recorded at submit time; capture must not
+    carry launch-only metadata or create a second file transport/copy.
     """
 
-    raw_job_id = envelope.provider_meta.get("launch_job_id")
-    if not isinstance(raw_job_id, str) or not raw_job_id:
-        return None
     root = launch_job_root(spool_path)
-    job = _read_job(_job_path(root, raw_job_id))
-    if job is None:
+    matches = [
+        job
+        for job in list_launch_jobs(spool_path=spool_path)
+        if job.conversation_id == envelope.session.provider_session_id
+    ]
+    if len(matches) != 1:
         return None
+    job = matches[0]
     if job.status == "completed":
         return job
     if job.status not in {"submitted", "paused"}:

--- a/tests/unit/browser_capture/test_launch_jobs.py
+++ b/tests/unit/browser_capture/test_launch_jobs.py
@@ -125,7 +125,6 @@ def _handoff_zip(
 
 
 def _handoff_capture(
-    job_id: str,
     content: bytes,
     *,
     conversation_id: str = "conversation-1",
@@ -138,7 +137,6 @@ def _handoff_capture(
                 "extension_instance_id": "capture-instance",
                 "adapter_name": "chatgpt-native",
             },
-            "provider_meta": {"launch_job_id": job_id},
             "session": {
                 "provider": "chatgpt",
                 "provider_session_id": conversation_id,
@@ -634,7 +632,7 @@ def test_non_owner_update_and_invalid_terminal_control_fail_closed(tmp_path: Pat
         spool_path=tmp_path,
     )
     completed = reconcile_launch_handoff_capture(
-        _handoff_capture(job.job_id, _handoff_zip()),
+        _handoff_capture(_handoff_zip()),
         "chatgpt/conversation-1.json",
         spool_path=tmp_path,
     ) or pytest.fail("missing job")
@@ -670,7 +668,7 @@ def test_handoff_completion_reconciles_the_canonical_capture_artifact(tmp_path: 
             spool_path=invalid_spool,
         )
         rejected = reconcile_launch_handoff_capture(
-            _handoff_capture(invalid.job_id, content),
+            _handoff_capture(content),
             "chatgpt/conversation-1.json",
             spool_path=invalid_spool,
         ) or pytest.fail("missing invalid job")
@@ -694,7 +692,7 @@ def test_handoff_completion_reconciles_the_canonical_capture_artifact(tmp_path: 
     )
     content = _handoff_zip()
     completed = reconcile_launch_handoff_capture(
-        _handoff_capture(job.job_id, content),
+        _handoff_capture(content),
         "chatgpt/conversation-1.json",
         spool_path=valid_spool,
     ) or pytest.fail("missing job")
@@ -801,7 +799,7 @@ def test_receiver_routes_enqueue_claim_and_serve_hash_pinned_inputs(tmp_path: Pa
             port,
             "POST",
             "/v1/browser-captures",
-            _handoff_capture(job_id, handoff_content).model_dump(mode="json", exclude_none=True),
+            _handoff_capture(handoff_content).model_dump(mode="json", exclude_none=True),
         )
         capture_body = json.loads(capture.read())
         completed_body = json.loads(_http(host, port, "GET", "/v1/launch-jobs").read())


### PR DESCRIPTION
## Summary

Make launch-job completion a projection of ordinary ChatGPT capture, including reopened and backfilled conversations. The receiver correlates the exact provider-native conversation id recorded at submit time; the extension no longer adds any launch-only capture context or envelope metadata.

## Problem

PR #2918 removed the duplicate handoff byte endpoint and made the canonical capture artifact authoritative, but the capture still needed a `launch_job_id` injected by the active launch monitor. If that background tab closed and the same conversation was later reopened, synced, or backfilled, Polylogue captured the assistant ZIP correctly yet could leave the launch receipt unresolved. That contradicted the extension invariant that user-created and automatically launched conversations share one capture path.

## Solution

- Match exactly one launch job by its recorded ChatGPT `conversation_id` when an ordinary capture arrives.
- Fail closed when no job or multiple jobs match.
- Remove `capture_context` from the background capture message.
- Remove launch-job metadata mutation from the ChatGPT content adapter.
- Keep normal capture and authenticated asset acquisition unchanged for every conversation source.
- Exercise receiver reconciliation with an envelope containing no launch metadata and retain the real extension asset-capture coverage.

Ref polylogue-yyvg.5 and polylogue-5k5l.

## Verification

- `devtools test tests/unit/browser_capture/test_launch_jobs.py` — `18 passed`
- `npm test -- --run tests/chatgpt_launch.test.js tests/background.test.js tests/popup.test.js tests/content/chatgpt_bridge.test.js` — `115 passed`
- `npm run lint` — passed
- `devtools verify --quick` — all 16 gates passed
- pre-push `devtools verify --quick` — all 16 gates passed
