### PR TITLE
fix(browser): recover fresh launch completion capture (#2920)

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1208,8 +1208,95 @@ async function waitForTabComplete(tabId, timeoutMs = 30000) {
   throw new Error("protocol_chatgpt_tab_load_timeout");
 }
 
+function exactChatGptConversation(url) {
+  try {
+    const parsed = new URL(url);
+    const parts = parsed.pathname.split("/").filter(Boolean);
+    if (parsed.protocol !== "https:" || parsed.hostname !== "chatgpt.com" || parts.length !== 2 || parts[0] !== "c") {
+      return null;
+    }
+    return { conversation_id: parts[1], conversation_url: parsed.href };
+  } catch {
+    return null;
+  }
+}
+
+async function monitoringTabForLaunch(job, ownerInstanceId) {
+  const expected = exactChatGptConversation(job.conversation_url || "");
+  if (!expected || (job.conversation_id && expected.conversation_id !== job.conversation_id)) {
+    await updateLaunchJob(job.job_id, ownerInstanceId, {
+      outcome: "protocol_mismatch",
+      phase: "monitoring",
+      detail: "submitted launch has no exact recoverable ChatGPT conversation URL",
+      tab_id: job.tab_id || null,
+      conversation_id: job.conversation_id || null,
+      conversation_url: job.conversation_url || null,
+    });
+    return null;
+  }
+
+  let currentTab = null;
+  if (job.tab_id) {
+    try {
+      currentTab = await chrome.tabs.get(job.tab_id);
+    } catch {
+      currentTab = null;
+    }
+  }
+  const currentConversation = exactChatGptConversation(currentTab?.url || "");
+  if (currentTab?.id && currentConversation?.conversation_id === expected.conversation_id) {
+    return currentTab;
+  }
+
+  const existingTabs = await chrome.tabs.query({});
+  const existingTab = existingTabs.find((tab) =>
+    exactChatGptConversation(tab.url || "")?.conversation_id === expected.conversation_id
+  );
+  if (existingTab?.id) {
+    await updateLaunchJob(job.job_id, ownerInstanceId, {
+      outcome: "progress",
+      phase: "monitoring_recovered",
+      detail: "re-associated submitted launch with an existing background conversation tab",
+      tab_id: existingTab.id,
+      conversation_id: expected.conversation_id,
+      conversation_url: expected.conversation_url,
+    });
+    return existingTab;
+  }
+
+  // The submission boundary is already behind us. Reopen only the known
+  // conversation URL; never return to the composer or resubmit the prompt.
+  const reopenedTab = await chrome.tabs.create({ url: expected.conversation_url, active: false });
+  if (!reopenedTab?.id) throw new Error("protocol_background_tab_create_failed");
+  const loadedTab = await waitForTabComplete(reopenedTab.id);
+  await updateLaunchJob(job.job_id, ownerInstanceId, {
+    outcome: "progress",
+    phase: "monitoring_recovered",
+    detail: "reopened submitted conversation in a background tab after the original tab disappeared",
+    tab_id: loadedTab.id,
+    conversation_id: expected.conversation_id,
+    conversation_url: expected.conversation_url,
+  });
+  return loadedTab;
+}
+
 async function monitorSubmittedLaunch(job, ownerInstanceId) {
-  if (!job.tab_id) return;
+  let monitoringTab;
+  try {
+    monitoringTab = await monitoringTabForLaunch(job, ownerInstanceId);
+  } catch (error) {
+    const classified = classifyLaunchFailure(error);
+    await updateLaunchJob(job.job_id, ownerInstanceId, {
+      ...classified,
+      phase: "monitoring",
+      tab_id: job.tab_id || null,
+      conversation_id: job.conversation_id || null,
+      conversation_url: job.conversation_url || null,
+    });
+    return;
+  }
+  if (!monitoringTab?.id) return;
+  job = { ...job, tab_id: monitoringTab.id };
   let inspection;
   try {
     const [{ result }] = await chrome.scripting.executeScript({
@@ -1295,7 +1382,7 @@ async function monitorSubmittedLaunch(job, ownerInstanceId) {
       conversation_url: inspection.conversation_url,
       handoff_attachment_id: inspection.handoff_name,
     });
-    const captured = await captureTab(await chrome.tabs.get(job.tab_id), "launch_job_handoff");
+    const captured = await captureTab(monitoringTab, "launch_job_handoff");
     const handoff = captured?.envelope?.session?.attachments?.find(
       (attachment) => attachment.name === inspection.handoff_name && attachment.inline_base64,
     );

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -627,7 +627,12 @@
   }
 
   async function capture(reason = null) {
-    const nativePayload = latestNativePayload() || (await fetchNativePayloadOnDemand());
+    // Intercepted responses are only a bootstrap/fallback cache. A long-running
+    // conversation can grow substantially after the response observed at page
+    // load, so every explicit capture first asks ChatGPT for current native
+    // detail with cache: "no-store". Falling back preserves degraded/offline
+    // capture without allowing an old response to outrank fresh provider state.
+    const nativePayload = (await fetchNativePayloadOnDemand()) || latestNativePayload();
     let assetAcquisition = null;
     if (nativePayload) {
       try {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -1416,6 +1416,7 @@ describe("Sol Pro launch worker", () => {
       conversation_id: "conversation-1",
       conversation_url: "https://chatgpt.com/c/conversation-1",
     };
+    tabs[0] = { ...tabs[0], url: job.conversation_url, status: "complete" };
     globalThis.fetch = vi.fn(async (url, options = {}) => {
       fetchCalls.push({ url, options });
       const path = String(url);
@@ -1453,6 +1454,7 @@ describe("Sol Pro launch worker", () => {
       conversation_id: "conversation-1",
       conversation_url: "https://chatgpt.com/c/conversation-1",
     };
+    tabs[0] = { ...tabs[0], url: job.conversation_url, status: "complete" };
     globalThis.fetch = vi.fn(async (url, options = {}) => {
       fetchCalls.push({ url, options });
       const path = String(url);
@@ -1493,6 +1495,7 @@ describe("Sol Pro launch worker", () => {
       conversation_id: "conversation-1",
       conversation_url: "https://chatgpt.com/c/conversation-1",
     };
+    tabs[0] = { ...tabs[0], url: job.conversation_url, status: "complete" };
     globalThis.fetch = vi.fn(async (url, options = {}) => {
       fetchCalls.push({ url, options });
       const path = String(url);
@@ -1539,6 +1542,105 @@ describe("Sol Pro launch worker", () => {
       reason: "launch_job_handoff",
     });
     expect(fetchCalls.some((call) => String(call.url).endsWith("/handoff"))).toBe(false);
+  });
+
+  it("reopens a submitted conversation in the background after its tab was closed", async () => {
+    const job = {
+      job_id: "launch-reopen-closed",
+      status: "submitted",
+      phase: "provider_running",
+      lease_owner: "launch-executor-test",
+      tab_id: 42,
+      conversation_id: "conversation-1",
+      conversation_url: "https://chatgpt.com/c/conversation-1",
+    };
+    tabs = [];
+    globalThis.fetch = vi.fn(async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      const path = String(url);
+      if (path.includes("claim_by=")) return responseJson({ jobs: [] });
+      if (path.endsWith("/v1/launch-jobs")) return responseJson({ jobs: [job] });
+      if (path.endsWith("/events")) return responseJson({ job });
+      return responseJson({ error: "unexpected_receiver_request" }, { ok: false, status: 500 });
+    });
+    chrome.tabs.create.mockImplementation(async (details) => {
+      const tab = { id: 99, url: details.url, status: "complete", active: details.active };
+      tabs.push(tab);
+      return tab;
+    });
+    chrome.scripting.executeScript.mockResolvedValue([{ result: {
+      busy: true,
+      assistant_turns: 0,
+      conversation_id: "conversation-1",
+      conversation_url: job.conversation_url,
+      soft_warning: false,
+      rate_limited: false,
+      safety_lock: false,
+    } }]);
+
+    await sendRuntimeMessage({ type: "polylogue.launch.configure", launchEnabled: true });
+
+    await vi.waitFor(() => expect(chrome.tabs.create).toHaveBeenCalledWith({
+      url: job.conversation_url,
+      active: false,
+    }));
+    await vi.waitFor(() => expect(chrome.scripting.executeScript).toHaveBeenCalledWith(expect.objectContaining({
+      target: { tabId: 99 },
+    })));
+    const eventBodies = fetchCalls
+      .filter((call) => String(call.url).endsWith("/events"))
+      .map((call) => JSON.parse(call.options.body));
+    expect(eventBodies).toContainEqual(expect.objectContaining({
+      outcome: "progress",
+      phase: "monitoring_recovered",
+      tab_id: 99,
+      conversation_id: "conversation-1",
+    }));
+  });
+
+  it("does not monitor a reused tab id after it navigated to another conversation", async () => {
+    const job = {
+      job_id: "launch-reopen-navigated",
+      status: "submitted",
+      phase: "provider_running",
+      lease_owner: "launch-executor-test",
+      tab_id: 42,
+      conversation_id: "conversation-1",
+      conversation_url: "https://chatgpt.com/c/conversation-1",
+    };
+    tabs[0] = { id: 42, url: "https://chatgpt.com/c/different-conversation", status: "complete" };
+    globalThis.fetch = vi.fn(async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      const path = String(url);
+      if (path.includes("claim_by=")) return responseJson({ jobs: [] });
+      if (path.endsWith("/v1/launch-jobs")) return responseJson({ jobs: [job] });
+      if (path.endsWith("/events")) return responseJson({ job });
+      return responseJson({ error: "unexpected_receiver_request" }, { ok: false, status: 500 });
+    });
+    chrome.tabs.create.mockImplementation(async (details) => {
+      const tab = { id: 99, url: details.url, status: "complete", active: details.active };
+      tabs.push(tab);
+      return tab;
+    });
+    chrome.scripting.executeScript.mockResolvedValue([{ result: {
+      busy: true,
+      assistant_turns: 0,
+      conversation_id: "conversation-1",
+      conversation_url: job.conversation_url,
+      soft_warning: false,
+      rate_limited: false,
+      safety_lock: false,
+    } }]);
+
+    await sendRuntimeMessage({ type: "polylogue.launch.configure", launchEnabled: true });
+
+    await vi.waitFor(() => expect(chrome.scripting.executeScript).toHaveBeenCalledWith(expect.objectContaining({
+      target: { tabId: 99 },
+    })));
+    expect(chrome.scripting.executeScript).not.toHaveBeenCalledWith(expect.objectContaining({
+      target: { tabId: 42 },
+    }));
+    expect(chrome.tabs.remove).not.toHaveBeenCalledWith(42);
   });
 
   it("lets the owning extension close a cancelled background run", async () => {

--- a/browser-extension/tests/content/chatgpt_bridge.test.js
+++ b/browser-extension/tests/content/chatgpt_bridge.test.js
@@ -373,6 +373,55 @@ describe("ChatGPT authenticated interpreter bridge response contract", () => {
 });
 
 describe("ChatGPT authenticated asset capture envelope", () => {
+  it("prefers fresh native detail over an intercepted page-load payload", async () => {
+    const adapter = syntheticEndpointAdapter();
+    const harness = installFullCapture(adapter);
+    const stalePayload = {
+      ...conversationPayload(),
+      title: "Stale page-load title",
+      update_time: 1781366401,
+      current_node: "stale-node",
+      mapping: {
+        "stale-node": {
+          id: "stale-node",
+          parent: null,
+          children: [],
+          message: {
+            id: "stale-message",
+            author: { role: "user" },
+            create_time: 1781366401,
+            content: { content_type: "text", parts: ["opening prompt only"] },
+            metadata: { model_slug: "gpt-test" },
+          },
+        },
+      },
+    };
+    harness.dom.window.dispatchEvent(
+      new harness.dom.window.MessageEvent("message", {
+        source: harness.dom.window,
+        origin: harness.dom.window.location.origin,
+        data: {
+          type: "polylogue.chatgpt.nativeCapture",
+          capture: {
+            ok: true,
+            status: 200,
+            contentType: "application/json",
+            url: "https://chatgpt.com/backend-api/conversation/conversation-1",
+            body: JSON.stringify(stalePayload),
+          },
+        },
+      }),
+    );
+
+    const result = await harness.dom.window.polylogueCapture.capturePage();
+
+    expect(result.envelope.session.title).toBe("Authenticated capture fixture");
+    expect(result.envelope.session.turns[0].provider_turn_id).toBe("assistant-message-1");
+    expect(
+      adapter.calls.filter((call) => call.url.pathname === "/backend-api/conversation/conversation-1"),
+    ).toHaveLength(1);
+  });
+
   it("records stable attachment identity, bytes, size, and SHA receipt across repeat capture", async () => {
     const adapter = syntheticEndpointAdapter();
     const harness = installFullCapture(adapter);


### PR DESCRIPTION
## Summary

Make long-running ChatGPT capture fresh at the moment of capture and recover submitted Sol Pro monitoring after its original background tab disappears.

## Problem

The ChatGPT content adapter preferred an intercepted page-load response over a fresh native-detail request. A conversation captured at submission could therefore remain opening-prompt-only after the provider produced many more turns and output assets. Submitted launch monitoring also retained a numeric tab id; closing that tab produced repeated `No tab with id` failures even though the durable conversation URL was known.

## Solution

- Fetch current native conversation detail with `cache: no-store` before consulting intercepted fallback payloads.
- Resolve monitoring by exact ChatGPT conversation identity.
- Reuse an already-open exact conversation tab, or reopen the known `/c/<id>` URL inactive when the original tab is gone.
- Never cross the submit boundary during recovery: no composer route, prompt refill, or resubmission.
- Reject a reused tab id when it now points at another conversation.

This is a focused slice of `polylogue-3v1`; recurring inventory/push-driven freshness for ordinary non-launch conversations remains open.

## Verification

- `npm test -- tests/content/chatgpt_bridge.test.js tests/background.test.js` — 78 passed.
- `npm run lint` — ESLint clean.
- `devtools verify --quick` — 16/16 steps succeeded, exit 0 (`20260716T004225Z-quick-2084075-6ae93a16`).
- Pre-push quick gate — 16/16 steps succeeded, exit 0 (`20260716T004441Z-quick-2085574-57e5a437`).

Anti-vacuity: the native-detail regression seeds a stale intercepted payload and fails if cached-first selection returns; the monitoring regressions remove or navigate the production tab and fail if monitoring still targets the old id instead of reopening the exact durable conversation URL.

Ref polylogue-3v1.
