### PR TITLE
fix(browser): adopt stranded completion monitors

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1212,7 +1212,13 @@ function exactChatGptConversation(url) {
   try {
     const parsed = new URL(url);
     const parts = parsed.pathname.split("/").filter(Boolean);
-    if (parsed.protocol !== "https:" || parsed.hostname !== "chatgpt.com" || parts.length !== 2 || parts[0] !== "c") {
+    if (
+      parsed.origin !== "https://chatgpt.com" ||
+      parsed.search ||
+      parsed.hash ||
+      parts.length !== 2 ||
+      parts[0] !== "c"
+    ) {
       return null;
     }
     return { conversation_id: parts[1], conversation_url: parsed.href };
@@ -1360,7 +1366,17 @@ async function monitorSubmittedLaunch(job, ownerInstanceId) {
       conversation_url: inspection.conversation_url,
     });
   }
-  if (inspection?.busy || !inspection?.assistant_turns) return;
+  if (inspection?.busy || !inspection?.assistant_turns) {
+    await updateLaunchJob(job.job_id, ownerInstanceId, {
+      outcome: "progress",
+      phase: "monitoring_heartbeat",
+      detail: "renewed exact-conversation completion monitor",
+      tab_id: job.tab_id,
+      conversation_id: inspection.conversation_id,
+      conversation_url: inspection.conversation_url,
+    });
+    return;
+  }
   if (!inspection.handoff_name) {
     await updateLaunchJob(job.job_id, ownerInstanceId, {
       outcome: "protocol_mismatch",

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1535,8 +1535,7 @@ async function pollLaunchJobsOnce() {
       await chrome.tabs.remove(job.tab_id).catch(() => undefined);
     } else if (
       job.status === "submitted" &&
-      job.lease_owner === ownerInstanceId &&
-      (!job.next_attempt_at || Date.parse(job.next_attempt_at) <= Date.now())
+      job.lease_owner === ownerInstanceId
     ) {
       await monitorSubmittedLaunch(job, ownerInstanceId);
     } else if (job.status === "submitting" && job.lease_owner === ownerInstanceId) {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -1476,12 +1476,19 @@ describe("Sol Pro launch worker", () => {
     await sendRuntimeMessage({ type: "polylogue.launch.configure", launchEnabled: true });
 
     await vi.waitFor(() => expect(fetchCalls.some((call) => String(call.url).endsWith("/events"))).toBe(true));
-    const event = JSON.parse(fetchCalls.find((call) => String(call.url).endsWith("/events")).options.body);
-    expect(event).toMatchObject({
+    await vi.waitFor(() => expect(fetchCalls.filter((call) => String(call.url).endsWith("/events")).length).toBeGreaterThan(1));
+    const events = fetchCalls
+      .filter((call) => String(call.url).endsWith("/events"))
+      .map((call) => JSON.parse(call.options.body));
+    expect(events).toContainEqual(expect.objectContaining({
       outcome: "progress",
       phase: "provider_running",
       detail: expect.stringContaining("accepted"),
-    });
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      outcome: "progress",
+      phase: "monitoring_heartbeat",
+    }));
   });
 
   it("reuses canonical capture for a launched chat handoff", async () => {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -1491,6 +1491,7 @@ describe("Sol Pro launch worker", () => {
       status: "submitted",
       phase: "submitted",
       lease_owner: "launch-executor-test",
+      next_attempt_at: "2099-01-01T00:00:00Z",
       tab_id: 42,
       conversation_id: "conversation-1",
       conversation_url: "https://chatgpt.com/c/conversation-1",

--- a/polylogue/browser_capture/launch_jobs.py
+++ b/polylogue/browser_capture/launch_jobs.py
@@ -19,7 +19,6 @@ from io import BytesIO
 from pathlib import Path, PurePosixPath
 from threading import RLock
 from typing import Any, Literal, TypeVar, cast
-from urllib.parse import urlsplit
 from uuid import uuid4
 
 import orjson
@@ -340,8 +339,7 @@ def _latest_submitted_at(jobs: list[BrowserLaunchJob]) -> datetime | None:
 def _has_exact_conversation_identity(job: BrowserLaunchJob) -> bool:
     if not job.conversation_id or not job.conversation_url:
         return False
-    parsed = urlsplit(job.conversation_url)
-    return parsed.scheme == "https" and parsed.hostname == "chatgpt.com" and parsed.path == f"/c/{job.conversation_id}"
+    return job.conversation_url == f"https://chatgpt.com/c/{job.conversation_id}"
 
 
 def _monitorable_submitted_job(job: BrowserLaunchJob) -> bool:
@@ -354,6 +352,16 @@ def _monitorable_submitted_job(job: BrowserLaunchJob) -> bool:
         "rate_limited",
         "safety_locked",
     }
+
+
+def _monitor_lease_deadline(job: BrowserLaunchJob) -> datetime | None:
+    """Bound legacy long leases by their last receiver-visible heartbeat."""
+    if job.lease_owner is None:
+        return None
+    declared = _parse(job.lease_expires_at)
+    updated = _parse(job.updated_at)
+    heartbeat_deadline = updated + timedelta(seconds=LAUNCH_MONITOR_LEASE_SECONDS) if updated is not None else None
+    return min((value for value in (declared, heartbeat_deadline) if value is not None), default=None)
 
 
 @_serialized
@@ -391,10 +399,13 @@ def claim_due_launch_job(
             _event(job, "lease_expired")
             _write_job(root, job)
 
-    for job in jobs:
-        if not _monitorable_submitted_job(job):
-            continue
-        expiry = _parse(job.lease_expires_at)
+    epoch = datetime.min.replace(tzinfo=UTC)
+    monitorable_jobs = sorted(
+        (job for job in jobs if _monitorable_submitted_job(job)),
+        key=lambda job: (_monitor_lease_deadline(job) or epoch, _parse(job.created_at) or epoch, job.job_id),
+    )
+    for job in monitorable_jobs:
+        expiry = _monitor_lease_deadline(job)
         if expiry is not None and expiry > now:
             continue
         recovered_warning = job.status == "paused"
@@ -495,7 +506,9 @@ def update_launch_job(
         raise BrowserLaunchLeaseError("launch job lease owner mismatch")
     now = _now()
     was_submitted = job.status == "submitted"
-    job.phase = update.phase
+    monitor_heartbeat = was_submitted and update.outcome == "progress" and update.phase == "monitoring_heartbeat"
+    if not monitor_heartbeat:
+        job.phase = update.phase
     job.updated_at = _iso(now)
     job.tab_id = update.tab_id if update.tab_id is not None else job.tab_id
     job.conversation_id = update.conversation_id or job.conversation_id
@@ -510,8 +523,9 @@ def update_launch_job(
     if update.outcome == "progress":
         if job.status == "submitted":
             job.lease_expires_at = _iso(now + timedelta(seconds=LAUNCH_MONITOR_LEASE_SECONDS))
-            job.cooldown_reason = None
-            job.last_error = None
+            if not monitor_heartbeat:
+                job.cooldown_reason = None
+                job.last_error = None
             if update.phase == "provider_running":
                 provider_state = "accepted"
                 provider_circuit_streak = 0
@@ -568,13 +582,19 @@ def update_launch_job(
         job.cooldown_reason = update.outcome
         job.last_error = update.detail or update.outcome
         job.next_attempt_at = _iso(now + timedelta(seconds=delay))
-        if was_submitted:
+        if was_submitted and _has_exact_conversation_identity(job):
             # A provider banner after the submit boundary is telemetry for the
             # known conversation, not evidence that it stopped. Keep checking
             # that exact identity and never turn the warning into a resubmit;
             # the circuit still paces later automatic launches independently.
             job.status = "submitted"
             job.lease_expires_at = _iso(now + timedelta(seconds=LAUNCH_MONITOR_LEASE_SECONDS))
+        elif was_submitted:
+            job.status = "submission_unknown"
+            job.cooldown_reason = "submission_unknown"
+            job.last_error = "post-submit provider state has no exact recoverable conversation identity"
+            job.lease_owner = None
+            job.lease_expires_at = None
         else:
             job.status = "cooldown"
             job.lease_owner = None

--- a/polylogue/browser_capture/launch_jobs.py
+++ b/polylogue/browser_capture/launch_jobs.py
@@ -19,6 +19,7 @@ from io import BytesIO
 from pathlib import Path, PurePosixPath
 from threading import RLock
 from typing import Any, Literal, TypeVar, cast
+from urllib.parse import urlsplit
 from uuid import uuid4
 
 import orjson
@@ -45,6 +46,7 @@ LAUNCH_ATTACHMENT_MAX_BYTES = 16 * 1024 * 1024
 LAUNCH_JOB_MAX_ATTACHMENT_BYTES = 16 * 1024 * 1024
 LAUNCH_EVENT_LIMIT = 200
 LAUNCH_LEASE_SECONDS = 180
+LAUNCH_MONITOR_LEASE_SECONDS = 120
 LAUNCH_HANDOFF_MAX_BYTES = 64 * 1024 * 1024
 LAUNCH_HANDOFF_MAX_UNCOMPRESSED_BYTES = 128 * 1024 * 1024
 LAUNCH_HANDOFF_MAX_FILES = 2_000
@@ -335,6 +337,25 @@ def _latest_submitted_at(jobs: list[BrowserLaunchJob]) -> datetime | None:
     return max((value for value in timestamps if value is not None), default=None)
 
 
+def _has_exact_conversation_identity(job: BrowserLaunchJob) -> bool:
+    if not job.conversation_id or not job.conversation_url:
+        return False
+    parsed = urlsplit(job.conversation_url)
+    return parsed.scheme == "https" and parsed.hostname == "chatgpt.com" and parsed.path == f"/c/{job.conversation_id}"
+
+
+def _monitorable_submitted_job(job: BrowserLaunchJob) -> bool:
+    if not _has_exact_conversation_identity(job):
+        return False
+    if job.status == "submitted":
+        return True
+    return job.status == "paused" and job.cooldown_reason in {
+        "soft_warning",
+        "rate_limited",
+        "safety_locked",
+    }
+
+
 @_serialized
 def claim_due_launch_job(
     owner_instance_id: str,
@@ -371,16 +392,27 @@ def claim_due_launch_job(
             _write_job(root, job)
 
     for job in jobs:
-        if job.status != "submitted":
+        if not _monitorable_submitted_job(job):
             continue
         expiry = _parse(job.lease_expires_at)
         if expiry is not None and expiry > now:
             continue
+        recovered_warning = job.status == "paused"
+        job.status = "submitted"
         job.lease_owner = owner_instance_id
         job.executor_instance_id = owner_instance_id
-        job.lease_expires_at = _iso(now + timedelta(hours=6))
+        job.lease_expires_at = _iso(now + timedelta(seconds=LAUNCH_MONITOR_LEASE_SECONDS))
         job.updated_at = _iso(now)
-        _event(job, "monitor_adopted", owner=owner_instance_id)
+        _event(
+            job,
+            "monitor_adopted",
+            detail=(
+                "resumed completion monitoring for a legacy post-submit provider warning"
+                if recovered_warning
+                else "adopted expired completion-monitor lease"
+            ),
+            owner=owner_instance_id,
+        )
         _write_job(root, job)
         return job
 
@@ -477,7 +509,7 @@ def update_launch_job(
 
     if update.outcome == "progress":
         if job.status == "submitted":
-            job.lease_expires_at = _iso(now + timedelta(hours=6))
+            job.lease_expires_at = _iso(now + timedelta(seconds=LAUNCH_MONITOR_LEASE_SECONDS))
             job.cooldown_reason = None
             job.last_error = None
             if update.phase == "provider_running":
@@ -493,7 +525,7 @@ def update_launch_job(
         job.status = "submitted"
         job.attempts += 1
         job.last_error = None
-        job.lease_expires_at = _iso(now + timedelta(hours=6))
+        job.lease_expires_at = _iso(now + timedelta(seconds=LAUNCH_MONITOR_LEASE_SECONDS))
     elif update.outcome == "submission_unknown":
         job.status = "submission_unknown"
         job.cooldown_reason = "submission_unknown"
@@ -536,23 +568,13 @@ def update_launch_job(
         job.cooldown_reason = update.outcome
         job.last_error = update.detail or update.outcome
         job.next_attempt_at = _iso(now + timedelta(seconds=delay))
-        if was_submitted and update.outcome == "soft_warning":
-            # The conversation may still run despite this advisory provider
-            # banner. Keep its durable identity monitored, never resubmit it,
-            # and use the warning only to pace later automatic launches.
+        if was_submitted:
+            # A provider banner after the submit boundary is telemetry for the
+            # known conversation, not evidence that it stopped. Keep checking
+            # that exact identity and never turn the warning into a resubmit;
+            # the circuit still paces later automatic launches independently.
             job.status = "submitted"
-            job.lease_expires_at = _iso(now + timedelta(hours=6))
-        elif was_submitted and update.outcome in {"rate_limited", "safety_locked"}:
-            # The provider may already have accepted the conversation. Never
-            # turn a post-submit safety/rate response into an automatic new
-            # conversation; pause this job while its circuit protects all
-            # subsequent submissions.
-            job.status = "paused"
-            job.lease_owner = None
-            job.lease_expires_at = None
-        elif was_submitted:
-            job.status = "submitted"
-            job.lease_expires_at = _iso(now + timedelta(hours=6))
+            job.lease_expires_at = _iso(now + timedelta(seconds=LAUNCH_MONITOR_LEASE_SECONDS))
         else:
             job.status = "cooldown"
             job.lease_owner = None

--- a/tests/unit/browser_capture/test_launch_jobs.py
+++ b/tests/unit/browser_capture/test_launch_jobs.py
@@ -230,6 +230,36 @@ def test_submitted_chats_continue_in_parallel_at_configured_cadence(tmp_path: Pa
     assert list_launch_jobs(spool_path=tmp_path)[-1].status == "submitted"
 
 
+def test_completion_monitor_lease_is_short_and_adoptable_after_extension_restart(
+    tmp_path: Path, frozen_clock: FrozenClock
+) -> None:
+    job = enqueue_launch_job(_request(), spool_path=tmp_path)
+    claim_due_launch_job("old-extension", spool_path=tmp_path)
+    submitted = update_launch_job(
+        job.job_id,
+        BrowserLaunchJobUpdateRequest(
+            owner_instance_id="old-extension",
+            outcome="submitted",
+            phase="submitted",
+            conversation_id="conversation-1",
+            conversation_url="https://chatgpt.com/c/conversation-1",
+        ),
+        spool_path=tmp_path,
+    ) or pytest.fail("missing submitted job")
+
+    expiry = datetime.fromisoformat(submitted.lease_expires_at or "")
+    assert frozen_clock.now() + timedelta(seconds=119) <= expiry
+    assert expiry <= frozen_clock.now() + timedelta(seconds=121)
+    assert claim_due_launch_job("new-extension", spool_path=tmp_path) is None
+
+    frozen_clock.advance(121)
+    adopted = claim_due_launch_job("new-extension", spool_path=tmp_path) or pytest.fail("monitor not adopted")
+    assert adopted.job_id == job.job_id
+    assert adopted.status == "submitted"
+    assert adopted.lease_owner == "new-extension"
+    assert adopted.events[-1].kind == "monitor_adopted"
+
+
 def test_launch_now_prioritizes_out_of_order_without_bypassing_provider_circuit(
     tmp_path: Path, frozen_clock: FrozenClock
 ) -> None:
@@ -340,7 +370,13 @@ def test_post_submit_provider_circuit_never_auto_launches_duplicate_conversation
     claim_due_launch_job("owner", spool_path=tmp_path)
     update_launch_job(
         job.job_id,
-        BrowserLaunchJobUpdateRequest(owner_instance_id="owner", outcome="submitted", phase="submitted"),
+        BrowserLaunchJobUpdateRequest(
+            owner_instance_id="owner",
+            outcome="submitted",
+            phase="submitted",
+            conversation_id="conversation-1",
+            conversation_url="https://chatgpt.com/c/conversation-1",
+        ),
         spool_path=tmp_path,
     )
     blocked = update_launch_job(
@@ -354,13 +390,14 @@ def test_post_submit_provider_circuit_never_auto_launches_duplicate_conversation
         spool_path=tmp_path,
     ) or pytest.fail("missing job")
 
-    assert blocked.status == "paused"
-    assert blocked.conversation_url is None
+    assert blocked.status == "submitted"
+    assert blocked.conversation_url == "https://chatgpt.com/c/conversation-1"
     assert claim_due_launch_job("other", spool_path=tmp_path) is None
-    frozen_clock.advance(3601)
-    next_job = claim_due_launch_job("other", spool_path=tmp_path) or pytest.fail("next job not claimed")
-    assert next_job.job_id != blocked.job_id
-    assert list_launch_jobs(spool_path=tmp_path)[-1].status == "paused"
+    frozen_clock.advance(121)
+    adopted = claim_due_launch_job("other", spool_path=tmp_path) or pytest.fail("monitor not adopted")
+    assert adopted.job_id == blocked.job_id
+    assert adopted.lease_owner == "other"
+    assert all(item.status != "leased" for item in list_launch_jobs(spool_path=tmp_path))
 
 
 def test_post_submit_rate_limit_uses_receiver_exponential_backoff(tmp_path: Path, frozen_clock: FrozenClock) -> None:
@@ -383,10 +420,42 @@ def test_post_submit_rate_limit_uses_receiver_exponential_backoff(tmp_path: Path
     ) or pytest.fail("missing job")
 
     retry_at = datetime.fromisoformat(blocked.next_attempt_at)
-    assert blocked.status == "paused"
+    assert blocked.status == "submitted"
     assert blocked.retry_after_seconds is None
     assert frozen_clock.now() + timedelta(minutes=30) <= retry_at
     assert retry_at < frozen_clock.now() + timedelta(minutes=33)
+
+
+def test_legacy_paused_provider_warning_is_resumed_only_for_exact_conversation(tmp_path: Path) -> None:
+    job = enqueue_launch_job(_request(), spool_path=tmp_path)
+    claim_due_launch_job("old-extension", spool_path=tmp_path)
+    update_launch_job(
+        job.job_id,
+        BrowserLaunchJobUpdateRequest(
+            owner_instance_id="old-extension",
+            outcome="submitted",
+            phase="submitted",
+            conversation_id="conversation-1",
+            conversation_url="https://chatgpt.com/c/conversation-1",
+        ),
+        spool_path=tmp_path,
+    )
+    job_path = tmp_path / "launch-jobs" / job.job_id / "job.json"
+    legacy = json.loads(job_path.read_text(encoding="utf-8"))
+    legacy.update(
+        status="paused",
+        phase="provider_safety_lock",
+        cooldown_reason="safety_locked",
+        lease_owner=None,
+        lease_expires_at=None,
+    )
+    job_path.write_text(json.dumps(legacy), encoding="utf-8")
+
+    adopted = claim_due_launch_job("new-extension", spool_path=tmp_path) or pytest.fail("legacy monitor not adopted")
+    assert adopted.status == "submitted"
+    assert adopted.lease_owner == "new-extension"
+    assert adopted.events[-1].kind == "monitor_adopted"
+    assert "legacy post-submit provider warning" in (adopted.events[-1].detail or "")
 
 
 def test_soft_warning_streak_escalates_across_jobs_and_acceptance_resets(

--- a/tests/unit/browser_capture/test_launch_jobs.py
+++ b/tests/unit/browser_capture/test_launch_jobs.py
@@ -260,6 +260,46 @@ def test_completion_monitor_lease_is_short_and_adoptable_after_extension_restart
     assert adopted.events[-1].kind == "monitor_adopted"
 
 
+def test_adopted_monitor_heartbeats_let_one_worker_recover_every_stranded_job(
+    tmp_path: Path, frozen_clock: FrozenClock
+) -> None:
+    jobs = [enqueue_launch_job(_request(job_id=f"stranded-{index}"), spool_path=tmp_path) for index in range(3)]
+    for index, job in enumerate(jobs):
+        control_launch_job(job.job_id, BrowserLaunchJobControlRequest(action="launch_now"), spool_path=tmp_path)
+        claimed = claim_due_launch_job(f"old-extension-{index}", spool_path=tmp_path) or pytest.fail("not claimed")
+        assert claimed.job_id == job.job_id
+        update_launch_job(
+            job.job_id,
+            BrowserLaunchJobUpdateRequest(
+                owner_instance_id=f"old-extension-{index}",
+                outcome="submitted",
+                phase="submitted",
+                conversation_id=f"conversation-{index}",
+                conversation_url=f"https://chatgpt.com/c/conversation-{index}",
+            ),
+            spool_path=tmp_path,
+        )
+
+    frozen_clock.advance(121)
+    adopted_ids: set[str] = set()
+    for _index in range(3):
+        adopted = claim_due_launch_job("new-extension", spool_path=tmp_path) or pytest.fail("monitor not adopted")
+        adopted_ids.add(adopted.job_id)
+        heartbeat = update_launch_job(
+            adopted.job_id,
+            BrowserLaunchJobUpdateRequest(
+                owner_instance_id="new-extension",
+                outcome="progress",
+                phase="monitoring_heartbeat",
+            ),
+            spool_path=tmp_path,
+        ) or pytest.fail("heartbeat failed")
+        assert heartbeat.phase != "monitoring_heartbeat"
+        frozen_clock.advance(60)
+
+    assert adopted_ids == {job.job_id for job in jobs}
+
+
 def test_launch_now_prioritizes_out_of_order_without_bypassing_provider_circuit(
     tmp_path: Path, frozen_clock: FrozenClock
 ) -> None:
@@ -405,7 +445,13 @@ def test_post_submit_rate_limit_uses_receiver_exponential_backoff(tmp_path: Path
     claim_due_launch_job("owner", spool_path=tmp_path)
     update_launch_job(
         job.job_id,
-        BrowserLaunchJobUpdateRequest(owner_instance_id="owner", outcome="submitted", phase="submitted"),
+        BrowserLaunchJobUpdateRequest(
+            owner_instance_id="owner",
+            outcome="submitted",
+            phase="submitted",
+            conversation_id="conversation-1",
+            conversation_url="https://chatgpt.com/c/conversation-1",
+        ),
         spool_path=tmp_path,
     )
 
@@ -458,6 +504,64 @@ def test_legacy_paused_provider_warning_is_resumed_only_for_exact_conversation(t
     assert "legacy post-submit provider warning" in (adopted.events[-1].detail or "")
 
 
+@pytest.mark.parametrize(
+    ("conversation_id", "conversation_url"),
+    (
+        (None, None),
+        ("conversation-1", "https://chatgpt.com/c/different"),
+        ("conversation-1", "https://chatgpt.com:443/c/conversation-1"),
+        ("conversation-1", "https://chatgpt.com/c/conversation-1?temporary-chat=true"),
+        ("conversation-1", "https://chatgpt.com/c/conversation-1#result"),
+    ),
+)
+def test_legacy_warning_monitor_rejects_noncanonical_conversation_identity(
+    tmp_path: Path, conversation_id: str | None, conversation_url: str | None
+) -> None:
+    job = enqueue_launch_job(_request(), spool_path=tmp_path)
+    job_path = tmp_path / "launch-jobs" / job.job_id / "job.json"
+    legacy = json.loads(job_path.read_text(encoding="utf-8"))
+    legacy.update(
+        status="paused",
+        phase="provider_soft_warning",
+        cooldown_reason="soft_warning",
+        conversation_id=conversation_id,
+        conversation_url=conversation_url,
+        lease_owner=None,
+        lease_expires_at=None,
+    )
+    job_path.write_text(json.dumps(legacy), encoding="utf-8")
+
+    assert claim_due_launch_job("new-extension", spool_path=tmp_path) is None
+    stored = list_launch_jobs(spool_path=tmp_path)[0]
+    assert stored.status == "paused"
+    assert stored.lease_owner is None
+
+
+def test_post_submit_warning_without_exact_identity_is_quarantined(tmp_path: Path) -> None:
+    job = enqueue_launch_job(_request(), spool_path=tmp_path)
+    claim_due_launch_job("owner", spool_path=tmp_path)
+    update_launch_job(
+        job.job_id,
+        BrowserLaunchJobUpdateRequest(owner_instance_id="owner", outcome="submitted", phase="submitted"),
+        spool_path=tmp_path,
+    )
+
+    quarantined = update_launch_job(
+        job.job_id,
+        BrowserLaunchJobUpdateRequest(
+            owner_instance_id="owner",
+            outcome="soft_warning",
+            phase="provider_soft_warning",
+        ),
+        spool_path=tmp_path,
+    ) or pytest.fail("missing job")
+
+    assert quarantined.status == "submission_unknown"
+    assert quarantined.cooldown_reason == "submission_unknown"
+    assert quarantined.lease_owner is None
+    assert quarantined.lease_expires_at is None
+
+
 def test_soft_warning_streak_escalates_across_jobs_and_acceptance_resets(
     tmp_path: Path, frozen_clock: FrozenClock
 ) -> None:
@@ -471,9 +575,33 @@ def test_soft_warning_streak_escalates_across_jobs_and_acceptance_resets(
         assert claimed.job_id == job_id
         update_launch_job(
             job_id,
-            BrowserLaunchJobUpdateRequest(owner_instance_id=owner, outcome="submitted", phase="submitted"),
+            BrowserLaunchJobUpdateRequest(
+                owner_instance_id=owner,
+                outcome="submitted",
+                phase="submitted",
+                conversation_id=job_id,
+                conversation_url=f"https://chatgpt.com/c/{job_id}",
+            ),
             spool_path=tmp_path,
         )
+
+    def renew_due_monitors(job_ids: set[str]) -> None:
+        remaining = set(job_ids)
+        while remaining:
+            adopted = claim_due_launch_job("replacement-monitor", spool_path=tmp_path) or pytest.fail(
+                "monitor not adopted"
+            )
+            assert adopted.job_id in remaining
+            remaining.remove(adopted.job_id)
+            update_launch_job(
+                adopted.job_id,
+                BrowserLaunchJobUpdateRequest(
+                    owner_instance_id="replacement-monitor",
+                    outcome="progress",
+                    phase="monitoring_heartbeat",
+                ),
+                spool_path=tmp_path,
+            )
 
     submit(jobs[0].job_id, "one")
     first = update_launch_job(
@@ -494,6 +622,7 @@ def test_soft_warning_streak_escalates_across_jobs_and_acceptance_resets(
     assert 900 <= (first_event.backoff_seconds or 0) < 990
 
     frozen_clock.advance(1_000)
+    renew_due_monitors({jobs[0].job_id})
     submit(jobs[1].job_id, "two")
     second = update_launch_job(
         jobs[1].job_id,
@@ -509,6 +638,7 @@ def test_soft_warning_streak_escalates_across_jobs_and_acceptance_resets(
     assert 1_800 <= (second_event.backoff_seconds or 0) < 1_980
 
     frozen_clock.advance(2_000)
+    renew_due_monitors({jobs[0].job_id, jobs[1].job_id})
     submit(jobs[2].job_id, "accepted")
     accepted = update_launch_job(
         jobs[2].job_id,
@@ -545,7 +675,13 @@ def test_manual_priority_can_bypass_soft_warning_circuit(
     claim_due_launch_job("one", spool_path=tmp_path)
     update_launch_job(
         warned.job_id,
-        BrowserLaunchJobUpdateRequest(owner_instance_id="one", outcome="submitted", phase="submitted"),
+        BrowserLaunchJobUpdateRequest(
+            owner_instance_id="one",
+            outcome="submitted",
+            phase="submitted",
+            conversation_id="warning-conversation",
+            conversation_url="https://chatgpt.com/c/warning-conversation",
+        ),
         spool_path=tmp_path,
     )
     update_launch_job(


### PR DESCRIPTION
## Summary

Make completion monitoring recover quickly across extension reloads, browser
profiles, and stale executor identities without ever resubmitting a known
conversation.

## Problem

Live evidence from the Sol Pro batch showed that most conversations were
captured before their assistant output appeared and were never revisited.
Submitted jobs retained six-hour leases owned by a transient browser-session
executor; another extension instance could not adopt them after reload. Launch
cooldown timestamps also suppressed monitoring of already-running
conversations, and post-submit provider banners paused some conversations that
continued to completion.

## Solution

- Use a 120-second completion-monitor lease distinct from the long pre-submit
  intent lease.
- Adopt expired exact-conversation monitors across extension instances.
- Automatically recover legacy warning-paused jobs only when their ChatGPT
  conversation identity is exact.
- Keep post-submit provider warning/rate/safety observations advisory for that
  known conversation while preserving the global circuit for later launches.
- Monitor submitted chats independently of `next_attempt_at`, which remains
  new-launch pacing state.

The submission boundary remains quarantined: monitoring only reopens the exact
`/c/<id>` URL and never returns to the composer or resubmits.

Ref polylogue-yyvg.5.

## Verification

- `devtools test tests/unit/browser_capture/test_launch_jobs.py` — 20 passed
- `npm test -- tests/background.test.js` — 64 passed
- `npm run lint` — clean
- `devtools verify --quick` — 16/16 gates, run
  `20260716T010050Z-quick-2095860-9bb34409`
- pre-push `devtools verify --quick` — 16/16 gates, run
  `20260716T010249Z-quick-2097162-9a33f9c0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved launch-job monitoring so submitted jobs are monitored immediately when assigned to the active extension.
  * Strengthened recovery after extension restarts by allowing eligible monitoring leases to be adopted promptly.
  * Improved handling of rate limits, provider warnings, and network issues while preserving submitted jobs for monitoring.
  * Added safeguards to resume paused jobs only when their conversation identity matches exactly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->