### PR TITLE
fix(lineage): compose sibling variants canonically

### DIFF
--- a/polylogue/storage/runtime/store_constants.py
+++ b/polylogue/storage/runtime/store_constants.py
@@ -9,8 +9,15 @@ SESSION_INFERENCE_FAMILY = "heuristic_session_semantics"
 SESSION_ENRICHMENT_VERSION = 1
 SESSION_ENRICHMENT_FAMILY = "scored_session_enrichment"
 
+# Iterative lineage composition uses this only as a runaway backstop; cycle
+# detection is the primary guard. Keep sync-writer and async-reader composition
+# aligned so a valid deep branch cannot be normalized differently on write and
+# read merely because one path stopped walking ancestors earlier.
+LINEAGE_ITERATIVE_DEPTH_LIMIT = 1024
+
 
 __all__ = [
+    "LINEAGE_ITERATIVE_DEPTH_LIMIT",
     "SESSION_EVENT_MATERIALIZER_VERSION",
     "SESSION_ENRICHMENT_FAMILY",
     "SESSION_ENRICHMENT_VERSION",

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -3225,12 +3225,12 @@ def _own_db_signatures(conn: sqlite3.Connection, session_id: str) -> list[tuple[
     per ingest batch and invalidated whenever those rows change."""
     own_rows = conn.execute(
         """
-        SELECT m.message_id, m.position, m.role,
+        SELECT m.message_id, m.position, m.variant_index, m.role,
                b.block_type, b.text, b.tool_name, b.tool_input
         FROM messages m
         LEFT JOIN blocks b ON b.session_id = m.session_id AND b.message_id = m.message_id
-        WHERE m.session_id = ? AND m.variant_index = 0
-        ORDER BY m.position, b.position
+        WHERE m.session_id = ?
+        ORDER BY m.position, m.variant_index, b.position
         """,
         (session_id,),
     ).fetchall()
@@ -3243,7 +3243,7 @@ def _own_db_signatures(conn: sqlite3.Connection, session_id: str) -> list[tuple[
         if cur_id is not None:
             own.append((cur_id, _message_signature_from_blocks(cur_role, cur_blocks)))
 
-    for message_id, _position, role, block_type, text, tool_name, tool_input in own_rows:
+    for message_id, _position, _variant_index, role, block_type, text, tool_name, tool_input in own_rows:
         if message_id != cur_id:
             flush()
             cur_id = message_id
@@ -3330,11 +3330,18 @@ def _composed_db_signatures(
         _depth=_depth + 1,
     )
     prefix: list[tuple[str, str]] = []
+    found = False
     for entry in parent_composed:
         prefix.append(entry)
         if entry[0] == branch_point_message_id:
+            found = True
             break
-    composed = prefix + own
+    # A branch point that no longer exists in the composed parent is not a
+    # license to inherit a nearby or entire prefix.  The synchronous and async
+    # read paths both expose only the child's owned tail in this state; keep the
+    # writer-side alignment stream identical so a later re-ingest cannot turn a
+    # dangling edge into a fabricated complete lineage.
+    composed = (prefix if found else []) + own
     if composed_cache is not None:
         composed_cache[session_id] = composed
     return composed

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -50,6 +50,7 @@ from polylogue.storage.runtime import (
     LINEAGE_TRUNCATION_DEPTH_LIMIT,
     LineageTruncationReason,
 )
+from polylogue.storage.runtime.store_constants import LINEAGE_ITERATIVE_DEPTH_LIMIT
 from polylogue.storage.search.query_support import normalize_fts5_query
 from polylogue.storage.sqlite.archive_tiers import archive_tiers_specs
 from polylogue.storage.sqlite.archive_tiers.session_annotations_write import (
@@ -3171,7 +3172,11 @@ def _message_blocks(message: ParsedMessage) -> Sequence[ParsedContentBlock]:
 
 _SIG_FIELD_SEP = "\x1f"
 _SIG_BLOCK_SEP = "\x1e"
+# The synchronous envelope reader below is recursive, so retain its conservative
+# Python-stack guard. Writer-side signature composition is iterative and shares
+# the async reader's much larger runaway backstop.
 _MAX_LINEAGE_DEPTH = 64
+_MAX_WRITER_LINEAGE_DEPTH = LINEAGE_ITERATIVE_DEPTH_LIMIT
 
 
 def _canonical_json(value: object) -> str:
@@ -3271,8 +3276,9 @@ def _composed_db_signatures(
     _depth: int = 0,
 ) -> list[tuple[str, str]]:
     """Return ``[(message_id, signature), ...]`` for ``session_id``'s composed
-    transcript (its inherited prefix + own tail), recursively resolving any
-    prefix-sharing lineage edge. Mirrors the read-side composition.
+    transcript (its inherited prefix + own tail). Walk the lineage iteratively
+    and compose root-to-leaf, mirroring the async read path without inheriting
+    the synchronous envelope reader's Python-stack limit.
 
     When ``cache`` is supplied, each session's OWN signatures are memoized by
     ``session_id`` for the life of one ingest batch. When ``composed_cache`` is
@@ -3291,59 +3297,77 @@ def _composed_db_signatures(
             return _composed_db_signatures(conn, session_id, cache=cache, composed_cache=composed_cache, _depth=_depth)
         finally:
             conn.execute("ROLLBACK")
-    if composed_cache is not None:
-        composed = composed_cache.get(session_id)
-        if composed is not None:
-            return composed
-    own = cache.get(session_id) if cache is not None else None
-    if own is None:
-        own = _own_db_signatures(conn, session_id)
-        if cache is not None:
-            cache[session_id] = own
 
-    if _depth >= _MAX_LINEAGE_DEPTH:
-        if composed_cache is not None:
-            composed_cache[session_id] = own
+    def own_signatures(target_session_id: str) -> list[tuple[str, str]]:
+        own = cache.get(target_session_id) if cache is not None else None
+        if own is None:
+            own = _own_db_signatures(conn, target_session_id)
+            if cache is not None:
+                cache[target_session_id] = own
         return own
-    edge = conn.execute(
-        """
-        SELECT resolved_dst_session_id, branch_point_message_id
-        FROM session_links
-        WHERE src_session_id = ?
-          AND inheritance = 'prefix-sharing'
-          AND resolved_dst_session_id IS NOT NULL
-          AND branch_point_message_id IS NOT NULL
-        LIMIT 1
-        """,
-        (session_id,),
-    ).fetchone()
-    if edge is None:
+
+    # Collect (child, branch point, child-owned rows) leaf-first, then compose
+    # from the oldest reached ancestor down. A visited set is the real cycle
+    # guard; the shared depth limit only bounds malformed acyclic chains.
+    chain: list[tuple[str, str, list[tuple[str, str]]]] = []
+    visited = {session_id}
+    cursor_session_id = session_id
+    composed: list[tuple[str, str]] | None = None
+    remaining_depth = max(0, _MAX_WRITER_LINEAGE_DEPTH - _depth)
+    for _ in range(remaining_depth):
         if composed_cache is not None:
-            composed_cache[session_id] = own
-        return own
-    parent_id, branch_point_message_id = edge
-    parent_composed = _composed_db_signatures(
-        conn,
-        str(parent_id),
-        cache=cache,
-        composed_cache=composed_cache,
-        _depth=_depth + 1,
-    )
-    prefix: list[tuple[str, str]] = []
-    found = False
-    for entry in parent_composed:
-        prefix.append(entry)
-        if entry[0] == branch_point_message_id:
-            found = True
+            cached_composed = composed_cache.get(cursor_session_id)
+            if cached_composed is not None:
+                composed = cached_composed
+                break
+        own = own_signatures(cursor_session_id)
+        edge = conn.execute(
+            """
+            SELECT resolved_dst_session_id, branch_point_message_id
+            FROM session_links
+            WHERE src_session_id = ?
+              AND inheritance = 'prefix-sharing'
+              AND resolved_dst_session_id IS NOT NULL
+              AND branch_point_message_id IS NOT NULL
+            LIMIT 1
+            """,
+            (cursor_session_id,),
+        ).fetchone()
+        if edge is None:
+            composed = own
+            if composed_cache is not None:
+                composed_cache[cursor_session_id] = composed
             break
-    # A branch point that no longer exists in the composed parent is not a
-    # license to inherit a nearby or entire prefix.  The synchronous and async
-    # read paths both expose only the child's owned tail in this state; keep the
-    # writer-side alignment stream identical so a later re-ingest cannot turn a
-    # dangling edge into a fabricated complete lineage.
-    composed = (prefix if found else []) + own
-    if composed_cache is not None:
-        composed_cache[session_id] = composed
+        parent_id, branch_point_message_id = str(edge[0]), str(edge[1])
+        if parent_id in visited:
+            composed = own
+            if composed_cache is not None:
+                composed_cache[cursor_session_id] = composed
+            break
+        chain.append((cursor_session_id, branch_point_message_id, own))
+        visited.add(parent_id)
+        cursor_session_id = parent_id
+    if composed is None:
+        # The runaway guard was exhausted. Match the async reader: start with
+        # the oldest reached session's own rows, then compose the retained
+        # descendant chain. Ancestors beyond the common cutoff are omitted.
+        composed = own_signatures(cursor_session_id)
+        if composed_cache is not None:
+            composed_cache[cursor_session_id] = composed
+
+    for child_session_id, branch_point_message_id, own in reversed(chain):
+        prefix: list[tuple[str, str]] = []
+        found = False
+        for entry in composed:
+            prefix.append(entry)
+            if entry[0] == branch_point_message_id:
+                found = True
+                break
+        # A genuinely missing branch point is not a license to inherit a nearby
+        # or entire prefix. This matches the async reader's dangling-edge rule.
+        composed = (prefix if found else []) + own
+        if composed_cache is not None:
+            composed_cache[child_session_id] = composed
     return composed
 
 

--- a/polylogue/storage/sqlite/queries/message_query_reads.py
+++ b/polylogue/storage/sqlite/queries/message_query_reads.py
@@ -17,6 +17,7 @@ from polylogue.storage.runtime import (
     LineageCompleteness,
     MessageRecord,
 )
+from polylogue.storage.runtime.store_constants import LINEAGE_ITERATIVE_DEPTH_LIMIT
 from polylogue.storage.sqlite.queries.mappers import _row_to_message
 
 logger = get_logger(__name__)
@@ -67,7 +68,7 @@ async def _resolve_session_id(conn: aiosqlite.Connection, session_id: str) -> st
 # Cycle/runaway guard only. Composition is iterative (not recursive), so this is
 # NOT a Python-stack limit — a deep acompact/fork chain composes fine. Kept large
 # so realistic lineages never truncate; a `visited` set is the real cycle guard.
-_MAX_LINEAGE_DEPTH = 1024
+_MAX_LINEAGE_DEPTH = LINEAGE_ITERATIVE_DEPTH_LIMIT
 
 
 async def _prefix_sharing_edge(conn: aiosqlite.Connection, session_id: str) -> tuple[str, str] | None:

--- a/tests/property/test_write_path_state_machine.py
+++ b/tests/property/test_write_path_state_machine.py
@@ -64,6 +64,7 @@ class WritePathStateMachine(RuleBasedStateMachine):
         self._pending_children: dict[str, tuple[str, list[str], int, list[str]]] = {}
         self._next_session = 0
         self._next_text = 0
+        self._next_fresh_version = 1
         self._deletion_done = False
 
     @initialize()
@@ -356,7 +357,9 @@ class WritePathStateMachine(RuleBasedStateMachine):
         return text
 
     def _fresh_timestamp(self) -> str:
-        return f"2027-01-{1 + (self._next_text % 27):02d}T00:00:00Z"
+        timestamp = f"2027-01-01T00:00:{self._next_fresh_version:02d}Z"
+        self._next_fresh_version += 1
+        return timestamp
 
     def _message_texts(self, session_id: str) -> list[str]:
         return self._texts_from_envelope(read_archive_session_envelope(self._conn, session_id))

--- a/tests/property/test_write_path_state_machine.py
+++ b/tests/property/test_write_path_state_machine.py
@@ -11,6 +11,7 @@ import asyncio
 import sqlite3
 import tempfile
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import aiosqlite
@@ -357,7 +358,7 @@ class WritePathStateMachine(RuleBasedStateMachine):
         return text
 
     def _fresh_timestamp(self) -> str:
-        timestamp = f"2027-01-01T00:00:{self._next_fresh_version:02d}Z"
+        timestamp = (datetime(2027, 1, 1, tzinfo=UTC) + timedelta(seconds=self._next_fresh_version)).isoformat()
         self._next_fresh_version += 1
         return timestamp
 

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -3017,12 +3017,12 @@ def test_own_db_signatures_uses_session_scoped_block_lookup(tmp_path: Path) -> N
     plan_rows = conn.execute(
         """
         EXPLAIN QUERY PLAN
-        SELECT m.message_id, m.position, m.role,
+        SELECT m.message_id, m.position, m.variant_index, m.role,
                b.block_type, b.text, b.tool_name, b.tool_input
         FROM messages m
         LEFT JOIN blocks b ON b.session_id = m.session_id AND b.message_id = m.message_id
-        WHERE m.session_id = ? AND m.variant_index = 0
-        ORDER BY m.position, b.position
+        WHERE m.session_id = ?
+        ORDER BY m.position, m.variant_index, b.position
         """,
         ("session:planner",),
     ).fetchall()

--- a/tests/unit/storage/test_lineage_normalization.py
+++ b/tests/unit/storage/test_lineage_normalization.py
@@ -1664,6 +1664,72 @@ def test_sync_report_incomplete_at_depth_limit(tmp_path: Path) -> None:
     conn.close()
 
 
+def test_writer_composes_beyond_recursive_reader_depth(tmp_path: Path) -> None:
+    """A valid branch point beyond the sync reader's stack guard stays valid.
+
+    The writer and async reader are iterative and share a larger runaway limit.
+    If writer composition accidentally reuses the sync reader's 64-level guard,
+    the later descendants cannot see the root branch point and become
+    spawned-fresh with a duplicated root message.
+    """
+    db = tmp_path / "index.db"
+    conn = _connect(db)
+    provider_session_id = "deep-root"
+    root_id = write_parsed_session_to_archive(
+        conn,
+        ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id=provider_session_id,
+            title="deep root",
+            messages=[_msg("root-0", Role.USER, "root message", 0)],
+        ),
+    )
+
+    leaf: ParsedSession | None = None
+    leaf_id: str | None = None
+    for level in range(_MAX_LINEAGE_DEPTH + 2):
+        child_provider_id = f"deep-level-{level}"
+        leaf = ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id=child_provider_id,
+            title=child_provider_id,
+            parent_session_provider_id=provider_session_id,
+            branch_type=BranchType.FORK,
+            updated_at=f"2027-01-01T00:{level // 60:02d}:{level % 60:02d}Z",
+            messages=[
+                _msg("root-0", Role.USER, "root message", 0),
+                _msg(f"tail-{level}", Role.ASSISTANT, f"level {level} tail", 1),
+            ],
+        )
+        leaf_id = write_parsed_session_to_archive(conn, leaf)
+        provider_session_id = child_provider_id
+
+    assert leaf is not None
+    assert leaf_id is not None
+    link = conn.execute(
+        "SELECT inheritance, branch_point_message_id FROM session_links WHERE src_session_id = ?",
+        (leaf_id,),
+    ).fetchone()
+    assert tuple(link) == ("prefix-sharing", f"{root_id}:root-0")
+    assert conn.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", (leaf_id,)).fetchone()[0] == 1
+
+    # Full replacement/re-ingest exercises writer alignment again rather than
+    # merely preserving the link produced on the first write.
+    write_parsed_session_to_archive(
+        conn,
+        leaf.model_copy(update={"updated_at": "2027-01-01T00:59:59Z"}),
+    )
+    link = conn.execute(
+        "SELECT inheritance, branch_point_message_id FROM session_links WHERE src_session_id = ?",
+        (leaf_id,),
+    ).fetchone()
+    assert tuple(link) == ("prefix-sharing", f"{root_id}:root-0")
+    assert conn.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", (leaf_id,)).fetchone()[0] == 1
+    conn.close()
+
+    assert asyncio.run(_read_texts(db, leaf_id)) == ["root message", f"level {_MAX_LINEAGE_DEPTH + 1} tail"]
+
+
 def test_async_reports_incomplete_at_its_own_depth_limit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """4ts.6, async twin: get_messages_with_lineage_completeness is ITERATIVE
     (not recursive), so it has its own, much larger _MAX_LINEAGE_DEPTH (1024)

--- a/tests/unit/storage/test_lineage_normalization.py
+++ b/tests/unit/storage/test_lineage_normalization.py
@@ -527,6 +527,65 @@ def test_missing_variant_branch_point_keeps_only_owned_child_tail(tmp_path: Path
     conn.close()
 
 
+def test_reingest_after_dangling_ancestor_does_not_fabricate_a_prefix(tmp_path: Path) -> None:
+    """Writer-side alignment must use the same dangling-cut bound as readers."""
+    db = tmp_path / "index.db"
+    conn = _connect(db)
+    root = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="root",
+        messages=[
+            _msg("r0", Role.USER, "root prompt", 0),
+            _msg("r1", Role.ASSISTANT, "root reply", 1),
+        ],
+    )
+    root_id = write_parsed_session_to_archive(conn, root)
+    parent = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="parent",
+        parent_session_provider_id="root",
+        branch_type=BranchType.FORK,
+        messages=[
+            _msg("p0", Role.USER, "root prompt", 0),
+            _msg("p1", Role.ASSISTANT, "root reply", 1),
+            _msg("p2", Role.USER, "parent tail", 2),
+        ],
+    )
+    parent_id = write_parsed_session_to_archive(conn, parent)
+    conn.execute("DELETE FROM messages WHERE message_id = ?", (f"{root_id}:r1",))
+    conn.commit()
+
+    child = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="child",
+        parent_session_provider_id="parent",
+        branch_type=BranchType.FORK,
+        messages=[
+            _msg("c0", Role.USER, "root prompt", 0),
+            _msg("c1", Role.ASSISTANT, "root reply", 1),
+            _msg("c2", Role.USER, "parent tail", 2),
+            _msg("c3", Role.ASSISTANT, "child tail", 3),
+        ],
+    )
+    child_id = write_parsed_session_to_archive(conn, child)
+
+    # The parent's branch cut is absent.  It contributes only its owned tail
+    # to signature alignment, so the child's full replay is preserved rather
+    # than deduplicating a surviving but semantically incomplete root prefix.
+    link = conn.execute(
+        "SELECT resolved_dst_session_id, branch_point_message_id, inheritance "
+        "FROM session_links WHERE src_session_id = ?",
+        (child_id,),
+    ).fetchone()
+    assert tuple(link) == (parent_id, None, "spawned-fresh")
+    physical = conn.execute(
+        "SELECT native_id FROM messages WHERE session_id = ? ORDER BY position, variant_index",
+        (child_id,),
+    ).fetchall()
+    assert [row[0] for row in physical] == ["c0", "c1", "c2", "c3"]
+    conn.close()
+
+
 def test_stale_immediate_parent_branch_point_repairs_to_composed_ancestor(tmp_path: Path) -> None:
     db = tmp_path / "index.db"
     conn = _connect(db)

--- a/tests/unit/storage/test_lineage_normalization.py
+++ b/tests/unit/storage/test_lineage_normalization.py
@@ -53,13 +53,13 @@ def _connect(path: Path) -> sqlite3.Connection:
     return conn
 
 
-def _msg(pid: str, role: Role, text: str, position: int) -> ParsedMessage:
+def _msg(pid: str, role: Role, text: str, position: int, *, variant_index: int = 0) -> ParsedMessage:
     return ParsedMessage(
         provider_message_id=pid,
         role=role,
         text=text,
         position=position,
-        variant_index=0,
+        variant_index=variant_index,
         is_active_path=True,
         is_active_leaf=False,
         blocks=[ParsedContentBlock(type=BlockType.TEXT, text=text)],
@@ -382,6 +382,149 @@ def test_child_before_parent_is_reextracted_on_resolution(tmp_path: Path) -> Non
     conn.close()
     composed = asyncio.run(_read_texts(db, child_id))
     assert composed == ["hello", "hi there", "child diverges here", "child reply"]
+
+
+@pytest.mark.parametrize("child_first", [False, True], ids=["parent-first", "child-first"])
+def test_variant_prefix_lineage_converges_across_order_and_parent_replacement(
+    tmp_path: Path, child_first: bool
+) -> None:
+    """The production write/read routes agree on every sibling variant.
+
+    This is the deterministic reduction of the state-machine order failure:
+    parent-first and child-first ingestion must leave the same child tail,
+    resolved link, and composed transcript.  Replacing the parent then proves
+    the child composes the latest accepted sibling values rather than retaining
+    a duplicate child-owned variant.
+    """
+    db = tmp_path / "index.db"
+    conn = _connect(db)
+    parent = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="parent",
+        updated_at="2027-01-01T00:00:01Z",
+        messages=[
+            _msg("p0", Role.USER, "root", 0),
+            _msg("p1", Role.ASSISTANT, "primary v1", 1),
+            _msg("p1-alt", Role.ASSISTANT, "sibling v1", 1, variant_index=1),
+        ],
+    )
+    child = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="child",
+        parent_session_provider_id="parent",
+        branch_type=BranchType.FORK,
+        updated_at="2027-01-01T00:00:02Z",
+        messages=[
+            _msg("c0", Role.USER, "root", 0),
+            _msg("c1", Role.ASSISTANT, "primary v1", 1),
+            _msg("c1-alt", Role.ASSISTANT, "sibling v1", 1, variant_index=1),
+            _msg("c2", Role.USER, "child tail", 2),
+        ],
+    )
+
+    if child_first:
+        child_id = write_parsed_session_to_archive(conn, child)
+        parent_id = write_parsed_session_to_archive(conn, parent)
+    else:
+        parent_id = write_parsed_session_to_archive(conn, parent)
+        child_id = write_parsed_session_to_archive(conn, child)
+
+    physical = conn.execute(
+        "SELECT native_id, position, variant_index FROM messages WHERE session_id = ? ORDER BY position, variant_index",
+        (child_id,),
+    ).fetchall()
+    assert [tuple(row) for row in physical] == [("c2", 2, 0)]
+    link = conn.execute(
+        "SELECT resolved_dst_session_id, branch_point_message_id, inheritance, status "
+        "FROM session_links WHERE src_session_id = ?",
+        (child_id,),
+    ).fetchone()
+    assert tuple(link) == (parent_id, f"{parent_id}:p1-alt", "prefix-sharing", None)
+    assert asyncio.run(_read_texts(db, child_id)) == ["root", "primary v1", "sibling v1", "child tail"]
+
+    replacement = parent.model_copy(
+        update={
+            "updated_at": "2027-01-01T00:00:03Z",
+            "messages": [
+                _msg("p0", Role.USER, "root", 0),
+                _msg("p1", Role.ASSISTANT, "primary v2", 1),
+                _msg("p1-alt", Role.ASSISTANT, "sibling v2", 1, variant_index=1),
+            ],
+        }
+    )
+    write_parsed_session_to_archive(conn, replacement)
+
+    assert asyncio.run(_read_texts(db, child_id)) == ["root", "primary v2", "sibling v2", "child tail"]
+    assert (
+        conn.execute(
+            "SELECT native_id, position, variant_index FROM messages WHERE session_id = ? ORDER BY position, variant_index",
+            (child_id,),
+        ).fetchall()
+        == physical
+    )
+    assert (
+        conn.execute(
+            "SELECT resolved_dst_session_id, branch_point_message_id, inheritance, status "
+            "FROM session_links WHERE src_session_id = ?",
+            (child_id,),
+        ).fetchone()
+        == link
+    )
+    conn.close()
+
+
+def test_missing_variant_branch_point_keeps_only_owned_child_tail(tmp_path: Path) -> None:
+    """A full parent replacement may not substitute a shorter sibling prefix."""
+    db = tmp_path / "index.db"
+    conn = _connect(db)
+    parent = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="parent",
+        updated_at="2027-01-01T00:00:01Z",
+        messages=[
+            _msg("p0", Role.USER, "root", 0),
+            _msg("p1", Role.ASSISTANT, "primary", 1),
+            _msg("p1-alt", Role.ASSISTANT, "branch cut", 1, variant_index=1),
+        ],
+    )
+    parent_id = write_parsed_session_to_archive(conn, parent)
+    child = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="child",
+        parent_session_provider_id="parent",
+        branch_type=BranchType.FORK,
+        updated_at="2027-01-01T00:00:02Z",
+        messages=[
+            _msg("c0", Role.USER, "root", 0),
+            _msg("c1", Role.ASSISTANT, "primary", 1),
+            _msg("c1-alt", Role.ASSISTANT, "branch cut", 1, variant_index=1),
+            _msg("c2", Role.USER, "child tail", 2),
+        ],
+    )
+    child_id = write_parsed_session_to_archive(conn, child)
+
+    write_parsed_session_to_archive(
+        conn,
+        parent.model_copy(
+            update={
+                "updated_at": "2027-01-01T00:00:03Z",
+                "messages": [
+                    _msg("p0", Role.USER, "root", 0),
+                    _msg("p1", Role.ASSISTANT, "primary", 1),
+                ],
+            }
+        ),
+    )
+
+    link = conn.execute(
+        "SELECT branch_point_message_id, inheritance, status FROM session_links WHERE src_session_id = ?", (child_id,)
+    ).fetchone()
+    assert tuple(link) == (f"{parent_id}:p1-alt", "prefix-sharing", None)
+    envelope = read_archive_session_envelope(conn, child_id)
+    assert [message.blocks[0].text for message in envelope.messages] == ["child tail"]
+    assert envelope.lineage_complete is False
+    assert envelope.lineage_truncation_reason == "dangling_branch_point"
+    conn.close()
 
 
 def test_stale_immediate_parent_branch_point_repairs_to_composed_ancestor(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Make write-side lineage signatures use the same canonical sibling-variant order
as composed reads, and prevent a missing branch point from fabricating an
inherited prefix during later ingestion. Add production-route regressions for
parent/child order, replacement, missing sibling cuts, and dangling-ancestor
reingest.

## Problem

Writer-side prefix alignment considered only variant zero while composed reads
include all sibling variants. This made physical child tails depend on ingest
order and could retain a duplicated sibling. Separately, a missing branch point
caused writer alignment to inherit the accumulated parent prefix even though
readers correctly expose only the child's bounded tail.

## Solution

- Order writer signatures by `(position, variant_index, block position)` and
  include every sibling variant.
- Treat an absent branch point as no inherited writer-side prefix.
- Exercise the real SQLite writer, physical rows and links, async composed
  reader, parent replacement, dangling cuts, and child reingest.
- Generate replacement timestamps with monotonic real datetime arithmetic so
  the state machine cannot accidentally model fresh writes as stale after 59
  updates.

Ref polylogue-866e. Ref polylogue-t8t. The supplied t8t continuity package was
not applied because it implemented only two of seven routes and introduced a
competing scenario seam.

## Acceptance status

- Satisfied for this slice: canonical sibling ordering and parent-first versus
  child-first convergence; bounded behavior when a direct branch cut is
  missing; no fabricated prefix on dangling-ancestor reingest.
- Still open under polylogue-866e: persisted semantic cut witnesses,
  crash/rollback fault injection, exhaustive saved examples, and complete
  nested-ancestor completeness propagation.
- No polylogue-t8t acceptance criterion is claimed.

## Verification

- Focused lineage/property/storage run after coordinator review — 28 passed,
  1 inherited property failure.
- Baseline `origin/master` property run — 1 failed with three distinct
  counterexamples; this branch removes the two sibling-replacement failures but
  retains the pre-existing nested dangling-completeness counterexample.
- `devtools test -k 'session_links or composed'` — 11 passed.
- Dangling-ancestor deterministic regression — passed.
- `devtools verify --quick` — 16/16 checks passed, run
  `20260716T014100Z-quick-2135389-bff17c2f`.
- Pre-push quick gate — 16/16 checks passed, run
  `20260716T014141Z-quick-2136224-5f98b796`.

Anti-vacuity: restoring the primary-only signature query leaves the sibling in
the child tail; removing the missing-cut guard fabricates a prefix and drops
part of the child's physical replay. Both mutations fail production-route
regressions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript lineage composition for messages with multiple variants.
  * Prevented incomplete or dangling lineage branches from producing fabricated inherited content.
  * Added safeguards for very deep lineage chains and preserved correct behavior during replacement and re-ingestion.

* **Tests**
  * Expanded coverage for variant-aware lineage, deep compositions, and query behavior.
  * Improved timestamp generation for more reliable state-based testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->