### PR TITLE
fix(sources): admit complete live bundle census

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -1755,6 +1755,9 @@ class LiveBatchProcessor:
                             source_raw_id,
                             sessions,
                             acquired_at_ms=acquired_at_ms,
+                            # This raw passed artifact taxonomy and produced a complete
+                            # multi-session census; admit only this caller-owned candidate.
+                            allow_current_complete_raw=True,
                         )
                     if raw_authority_complete:
                         result.raw_ids[record.raw_id] = record_raw_id

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -3099,52 +3099,70 @@ def test_full_ingest_skips_durably_excised_content_without_aborting_batch(
         assert all("excised.jsonl" not in str(row[0]) for row in rows)
 
 
-def test_live_multi_session_divergence_reopens_raw_authority(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    root = tmp_path / "sessions"
+def test_live_multi_session_divergence_reopens_raw_authority(tmp_path: Path) -> None:
+    root = tmp_path / "inbox"
     root.mkdir()
-    first = root / "first.jsonl"
-    second = root / "second.jsonl"
-    first.write_bytes(b'{"first":true}\n')
-    second.write_bytes(b'{"second":true}\n')
+    first = root / "first.json"
+    second = root / "second.json"
+
+    def conversation(native_id: str, *texts: str) -> dict[str, object]:
+        mapping: dict[str, object] = {
+            "root": {
+                "id": "root",
+                "message": None,
+                "parent": None,
+                "children": [f"{native_id}-node-0"],
+            }
+        }
+        for index, text in enumerate(texts):
+            node_id = f"{native_id}-node-{index}"
+            next_node = f"{native_id}-node-{index + 1}" if index + 1 < len(texts) else None
+            mapping[node_id] = {
+                "id": node_id,
+                "parent": "root" if index == 0 else f"{native_id}-node-{index - 1}",
+                "children": [] if next_node is None else [next_node],
+                "message": {
+                    "id": f"{native_id}-message-{index}",
+                    "author": {"role": "user"},
+                    "create_time": 1_780_000_000.0 + index,
+                    "content": {"content_type": "text", "parts": [text]},
+                    "metadata": {},
+                },
+            }
+        return {
+            "id": native_id,
+            "title": native_id,
+            "current_node": f"{native_id}-node-{len(texts) - 1}",
+            "mapping": mapping,
+        }
+
+    first.write_text(
+        json.dumps([conversation("shared", "base", "left"), conversation("safe-1", "one")]),
+        encoding="utf-8",
+    )
+    second.write_text(
+        json.dumps([conversation("shared", "base", "right"), conversation("safe-2", "two")]),
+        encoding="utf-8",
+    )
     index_db = tmp_path / "index.db"
     processor = LiveBatchProcessor(
         cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db))),
-        (WatchSource(name="codex", root=root),),
+        (WatchSource(name="inbox", root=root, suffixes=(".json",)),),
         cursor=CursorStore(index_db),
         parser_fingerprint="test-parser",
     )
 
-    def session(native_id: str, *texts: str) -> ParsedSession:
-        return ParsedSession(
-            source_name=Provider.CODEX,
-            provider_session_id=native_id,
-            messages=[
-                ParsedMessage(provider_message_id=f"{native_id}-{index}", role=Role.USER, text=text)
-                for index, text in enumerate(texts)
-            ],
-        )
+    # This is a real ChatGPT export bundle, not a JSONL shape authorized by a
+    # monkeypatch. Keep the taxonomy assertion next to the route assertion so
+    # the test cannot pass after accidentally becoming a non-session fixture.
+    assert _parse_path_as_session_artifact(first, provider=Provider.CHATGPT) is True
+    first_result = processor._ingest_full_paths_sync([first], source_name="inbox")
+    assert first_result.succeeded == [first]
+    assert first_result.failed == []
+    assert first_result.raw_source_names[first] == Provider.CHATGPT.value
+    accepted_raw_id = first_result.raw_fingerprints[first]
 
-    parsed_batches = iter(
-        [
-            [session("shared", "base", "left"), session("safe-1", "one")],
-            [session("shared", "base", "right"), session("safe-2", "two")],
-            [session("shared", "base", "left"), session("safe-1", "one")],
-        ]
-    )
-    monkeypatch.setattr(
-        "polylogue.sources.live.batch._jsonl_provider_and_session_artifact",
-        lambda _path, fallback_provider: (fallback_provider, True),
-    )
-    monkeypatch.setattr(
-        "polylogue.sources.live.batch.parse_stream_payload",
-        lambda *_args, **_kwargs: next(parsed_batches),
-    )
-
-    assert processor._ingest_full_paths_sync([first], source_name="codex").failed == []
-    second_result = processor._ingest_full_paths_sync([second], source_name="codex")
+    second_result = processor._ingest_full_paths_sync([second], source_name="inbox")
     assert second_result.failed == [second]
     assert second_result.succeeded == []
     with sqlite3.connect(tmp_path / "source.db") as conn:
@@ -3152,6 +3170,19 @@ def test_live_multi_session_divergence_reopens_raw_authority(
             2,
         )
         assert conn.execute("SELECT COUNT(*) FROM raw_sessions WHERE parsed_at_ms IS NULL").fetchone() == (2,)
+        assert conn.execute("SELECT COUNT(*) FROM raw_sessions WHERE parse_error IS NOT NULL").fetchone() == (0,)
+        assert conn.execute(
+            """
+            SELECT r.source_path, m.decision, m.revision_authority
+            FROM raw_session_memberships AS m
+            JOIN raw_sessions AS r USING (raw_id)
+            WHERE m.logical_source_key = 'chatgpt:shared'
+            ORDER BY r.source_path
+            """
+        ).fetchall() == [
+            (str(first), "ambiguous", "quarantined"),
+            (str(second), "ambiguous", "quarantined"),
+        ]
     with sqlite3.connect(index_db) as conn:
         # The first accepted branch remains queryable; the later divergence is
         # nonterminal debt and has no deletion authority.
@@ -3160,6 +3191,42 @@ def test_live_multi_session_divergence_reopens_raw_authority(
             ("safe-2",),
             ("shared",),
         }
+        assert conn.execute(
+            "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = 'chatgpt:shared'"
+        ).fetchone() == (accepted_raw_id,)
+        assert conn.execute(
+            """
+            SELECT b.search_text
+            FROM sessions AS s
+            JOIN messages AS m USING (session_id)
+            JOIN blocks AS b USING (message_id)
+            WHERE s.native_id = 'shared'
+            ORDER BY m.position, b.position
+            """
+        ).fetchall() == [("base",), ("left",)]
+
+    retry_result = processor._ingest_full_paths_sync([first], source_name="inbox")
+
+    assert retry_result.succeeded == [first]
+    assert retry_result.failed == []
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute(
+            """
+            SELECT r.source_path, m.decision, m.revision_authority,
+                   r.parsed_at_ms IS NOT NULL, r.parse_error
+            FROM raw_session_memberships AS m
+            JOIN raw_sessions AS r USING (raw_id)
+            WHERE m.logical_source_key = 'chatgpt:shared'
+            ORDER BY r.source_path
+            """
+        ).fetchall() == [
+            (str(first), "applied", "byte_proven", 1, None),
+            (str(second), "ambiguous", "quarantined", 0, None),
+        ]
+    with sqlite3.connect(index_db) as conn:
+        assert conn.execute(
+            "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = 'chatgpt:shared'"
+        ).fetchone() == (accepted_raw_id,)
 
 
 def test_single_session_full_terminally_supersedes_older_membership_prefix(


### PR DESCRIPTION
## Summary

Admit a caller-owned, complete multi-session raw census through the existing
strict authority gate after real artifact taxonomy and parsing. Replace the
mocked regression with real ChatGPT export bundles covering divergence,
quarantine, retained accepted content, and retry.

## Problem

The live multi-session path completed taxonomy, parsing, and membership census
but did not tell the strict raw-authority query that its current candidate was
complete. The first valid bundle could therefore be rejected before its raw
membership became accepted authority. The previous regression mocked both
artifact classification and parsing, so it could pass without exercising the
production dependency that failed.

## Solution

- Pass `allow_current_complete_raw=True` only from the live multi-session path
  after its complete census is available.
- Use actual ChatGPT export bundles in the regression and assert taxonomy,
  parser dispatch, source/index persistence, ambiguity debt, preserved
  accepted head/content, and matching retry.
- Keep the strict authority implementation unchanged; the caller admits only
  its own validated raw candidate.

Ref polylogue-hjpx.1. This is a narrow repair, not completion of its immutable
census/conservation program.

## Acceptance status

- Satisfied: the reproduced live multi-session admission defect and its real
  taxonomy/parser/storage/retry route.
- Deferred under polylogue-hjpx.1: immutable pre-parse census, durable
  conservation ledger, interruption handling, rejected-stale state, and full
  two-pass fixed-point proof.

## Verification

- `devtools test tests/unit/sources/test_live_batch_support.py -k live_multi_session_divergence_reopens_raw_authority` — 1 passed, 63 deselected.
- `devtools test -k raw_authority` — 2 passed, 16,090 deselected.
- `devtools verify --quick` — 16/16 checks passed.
- Pre-push quick gate — 16/16 checks passed.
- Broader `test_live_batch_support.py` classification: 54 passed, 10 failed in
  unrelated generic detection, append, bootstrap/observability, and explicitly
  single-session paths; this PR does not alter those routes.

Anti-vacuity: removing the new admission flag restores the empty-candidate
failure before the first success assertion. Breaking the bundle mapping shape
fails the adjacent real taxonomy assertion.

