### PR TITLE
fix(capture): recover replaced browser snapshots

### DIFF
--- a/polylogue/archive/session_revision_membership.py
+++ b/polylogue/archive/session_revision_membership.py
@@ -120,7 +120,11 @@ def _browser_snapshot_dominates(older: MembershipRevision, newer: MembershipRevi
     if older_time is None or newer_time is None:
         return False
     if older.browser_snapshot_fidelity == "dom" and newer.browser_snapshot_fidelity == "native":
-        return _frontier(newer.projection) >= _frontier(older.projection)
+        older_frontier = _frontier(older.projection)
+        newer_frontier = _frontier(newer.projection)
+        return all(
+            newer_count >= older_count for older_count, newer_count in zip(older_frontier, newer_frontier, strict=True)
+        )
     if older.browser_snapshot_fidelity != newer.browser_snapshot_fidelity:
         return False
     identities_preserved = (

--- a/polylogue/archive/session_revision_membership.py
+++ b/polylogue/archive/session_revision_membership.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 from polylogue.core.timestamps import parse_timestamp
 from polylogue.pipeline.ids import SessionRevisionProjection
@@ -13,6 +14,10 @@ class MembershipRevision:
     raw_id: str
     projection: SessionRevisionProjection
     provider_updated_at: str | None = None
+    observed_at_ms: int | None = None
+    browser_snapshot_fidelity: Literal["dom", "native"] | None = None
+    provider_message_ids: frozenset[str] = frozenset()
+    provider_attachment_ids: frozenset[str] = frozenset()
 
 
 @dataclass(frozen=True, slots=True)
@@ -62,15 +67,78 @@ def classify_membership_revisions(revisions: list[MembershipRevision]) -> Member
         not _strictly_dominates(older.projection, newer.projection)
         for older, newer in zip(representatives, representatives[1:], strict=False)
     ):
-        return MembershipClassification(
-            (),
-            tuple(sorted(equivalents)),
-            tuple(sorted(item.raw_id for item in representatives)),
-        )
+        browser_order = _provider_ordered_browser_snapshots(representatives)
+        if browser_order is None:
+            return MembershipClassification(
+                (),
+                tuple(sorted(equivalents)),
+                tuple(sorted(item.raw_id for item in representatives)),
+            )
+        representatives = browser_order
     return MembershipClassification(
         tuple(item.raw_id for item in representatives),
         tuple(sorted(equivalents)),
         (),
+    )
+
+
+def _provider_ordered_browser_snapshots(
+    revisions: list[MembershipRevision],
+) -> list[MembershipRevision] | None:
+    """Order compatible mutable browser snapshots by provider authority.
+
+    Browser-native payloads are complete snapshots, not append logs.  ChatGPT
+    can move an already-present context/tool node when later work appears, and
+    can complete text in place under the same provider message id.  A strict
+    serialized-content prefix therefore rejects ordinary provider progress.
+    Provider timestamps may resolve that progress only when stable message and
+    attachment identities are preserved.  DOM-to-native is the sole fidelity
+    upgrade and may use different synthetic ids; a native-to-DOM downgrade is
+    never selected.
+    """
+
+    if not revisions or any(item.browser_snapshot_fidelity is None for item in revisions):
+        return None
+    timestamped: list[tuple[int, float, int, str, MembershipRevision]] = []
+    for item in revisions:
+        parsed = parse_timestamp(item.provider_updated_at)
+        if parsed is None:
+            return None
+        fidelity_rank = 1 if item.browser_snapshot_fidelity == "native" else 0
+        timestamped.append((fidelity_rank, parsed.timestamp(), item.observed_at_ms or -1, item.raw_id, item))
+    timestamped.sort(key=lambda entry: entry[:4])
+    ordered = [entry[4] for entry in timestamped]
+    for older, newer in zip(ordered, ordered[1:], strict=False):
+        if not _browser_snapshot_dominates(older, newer):
+            return None
+    return ordered
+
+
+def _browser_snapshot_dominates(older: MembershipRevision, newer: MembershipRevision) -> bool:
+    older_time = parse_timestamp(older.provider_updated_at)
+    newer_time = parse_timestamp(newer.provider_updated_at)
+    if older_time is None or newer_time is None:
+        return False
+    if older.browser_snapshot_fidelity == "dom" and newer.browser_snapshot_fidelity == "native":
+        return _frontier(newer.projection) >= _frontier(older.projection)
+    if older.browser_snapshot_fidelity != newer.browser_snapshot_fidelity:
+        return False
+    identities_preserved = (
+        bool(older.provider_message_ids)
+        and older.provider_message_ids <= newer.provider_message_ids
+        and older.provider_attachment_ids <= newer.provider_attachment_ids
+    )
+    if not identities_preserved:
+        return False
+    if newer_time.timestamp() > older_time.timestamp():
+        return True
+    return (
+        newer_time.timestamp() == older_time.timestamp()
+        and older.observed_at_ms is not None
+        and newer.observed_at_ms is not None
+        and newer.observed_at_ms > older.observed_at_ms
+        and older.projection.message_hashes == newer.projection.message_hashes
+        and older.projection.event_hashes == newer.projection.event_hashes
     )
 
 

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -789,7 +789,7 @@ class LiveBatchProcessor:
                     st_ino=stat.st_ino,
                     mtime_ns=stat.st_mtime_ns,
                 )
-            self._cursor.mark_failed(path)
+            self._cursor.mark_failed(path, failed_stat=stat)
         except sqlite3.OperationalError as exc:
             if not is_transient_sqlite_lock(exc):
                 raise

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -18,6 +18,11 @@ from json import loads as json_loads
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypeVar, cast
 
+from polylogue.archive.ingest_flags import (
+    COMPACT_BROWSER_CAPTURE_INGEST_FLAG,
+    DOM_FALLBACK_INGEST_FLAG,
+    NATIVE_BROWSER_CAPTURE_INGEST_FLAG,
+)
 from polylogue.archive.revision_authority import (
     RawRevisionAuthority,
     RawRevisionEnvelope,
@@ -1877,7 +1882,31 @@ class LiveBatchProcessor:
                 projection = session_revision_projection(matches[0])
                 member_sessions[member_raw_id] = matches[0]
                 projections[member_raw_id] = projection
-                revisions.append(MembershipRevision(member_raw_id, projection, matches[0].updated_at))
+                retained_session = matches[0]
+                browser_snapshot_fidelity: Literal["dom", "native"] | None = None
+                if NATIVE_BROWSER_CAPTURE_INGEST_FLAG in retained_session.ingest_flags or (
+                    COMPACT_BROWSER_CAPTURE_INGEST_FLAG in retained_session.ingest_flags
+                ):
+                    browser_snapshot_fidelity = "native"
+                elif DOM_FALLBACK_INGEST_FLAG in retained_session.ingest_flags:
+                    browser_snapshot_fidelity = "dom"
+                revisions.append(
+                    MembershipRevision(
+                        member_raw_id,
+                        projection,
+                        retained_session.updated_at,
+                        observed_at_ms=archive.raw_revision_acquired_at_ms(member_raw_id),
+                        browser_snapshot_fidelity=browser_snapshot_fidelity,
+                        provider_message_ids=frozenset(
+                            message.provider_message_id
+                            for message in retained_session.messages
+                            if message.provider_message_id is not None
+                        ),
+                        provider_attachment_ids=frozenset(
+                            attachment.provider_attachment_id for attachment in retained_session.attachments
+                        ),
+                    )
+                )
             classification = classify_membership_revisions(revisions)
             membership_session_id = archive.apply_raw_membership_classification(
                 logical_source_key,

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -8,6 +8,7 @@ comparison rather than relying on file size alone.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import threading
 import uuid
@@ -1034,7 +1035,7 @@ class CursorStore:
             )
         )
 
-    def mark_failed(self, path: Path) -> None:
+    def mark_failed(self, path: Path, *, failed_stat: os.stat_result | None = None) -> None:
         """Increment failure count and set exponential backoff.
 
         Read-modify-write against ``failure_count`` happens inside one
@@ -1072,9 +1073,19 @@ class CursorStore:
             failures = record.failure_count + 1
             now = datetime.now(UTC).isoformat()
             if failures >= _MAX_CURSOR_FAILURES_BEFORE_EXCLUDE:
+                # Successful cursors intentionally retain the last accepted
+                # observation while an updated file is merely in backoff.  At
+                # quarantine, however, bind exclusion to the exact failed
+                # observation.  Otherwise the watcher mistakes the unchanged
+                # poison file for a replacement and immediately revives it.
+                observed = failed_stat
                 return replace(
                     record,
                     updated_at=now,
+                    byte_size=observed.st_size if observed is not None else record.byte_size,
+                    st_dev=observed.st_dev if observed is not None else record.st_dev,
+                    st_ino=observed.st_ino if observed is not None else record.st_ino,
+                    mtime_ns=observed.st_mtime_ns if observed is not None else record.mtime_ns,
                     failure_count=failures,
                     next_retry_at=None,
                     excluded=True,

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -1124,6 +1124,42 @@ class CursorStore:
 
         self._read_modify_write_cursor_record(path, mutate)
 
+    def revive_replaced_exclusion(
+        self,
+        path: Path,
+        *,
+        byte_size: int,
+        st_dev: int,
+        st_ino: int,
+        mtime_ns: int,
+    ) -> None:
+        """Clear a path quarantine only after the observed file was replaced.
+
+        Exclusion belongs to the exact failed file observation, not forever to
+        its pathname.  Keep the prior cursor observation intact so the caller
+        still routes the replacement through full acquisition.
+        """
+
+        def mutate(current: CursorRecord | None) -> CursorRecord | None:
+            if current is None or not current.excluded:
+                return None
+            if (
+                current.byte_size,
+                current.st_dev,
+                current.st_ino,
+                current.mtime_ns,
+            ) == (byte_size, st_dev, st_ino, mtime_ns):
+                return None
+            return replace(
+                current,
+                updated_at=datetime.now(UTC).isoformat(),
+                failure_count=0,
+                next_retry_at=None,
+                excluded=False,
+            )
+
+        self._read_modify_write_cursor_record(path, mutate)
+
     def reset_failures(self, path: Path) -> None:
         """Clear failure count and backoff after a successful parse."""
 

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -633,7 +633,21 @@ class LiveWatcher:
             cursor = self._cursor.get_record(path)
             return cursor is not None and size > cursor.byte_offset
         if cursor.excluded:
-            return False
+            if (
+                cursor.byte_size,
+                cursor.st_dev,
+                cursor.st_ino,
+                cursor.mtime_ns,
+            ) == (size, stat.st_dev, stat.st_ino, stat.st_mtime_ns):
+                return False
+            self._cursor.revive_replaced_exclusion(
+                path,
+                byte_size=size,
+                st_dev=stat.st_dev,
+                st_ino=stat.st_ino,
+                mtime_ns=stat.st_mtime_ns,
+            )
+            return True
         if cursor.failure_count == 0 and cursor.content_fingerprint is None and cursor.next_retry_at is not None:
             if not _retry_due(cursor.next_retry_at):
                 return False

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2359,6 +2359,20 @@ class ArchiveStore:
         )
         return tuple(str(row[0]) for row in rows)
 
+    def raw_revision_acquired_at_ms(self, raw_id: str) -> int:
+        """Return the durable acquisition order for one retained raw revision."""
+        row = (
+            self._ensure_source_conn()
+            .execute(
+                "SELECT acquired_at_ms FROM raw_sessions WHERE raw_id = ?",
+                (raw_id,),
+            )
+            .fetchone()
+        )
+        if row is None:
+            raise KeyError(f"unknown raw revision {raw_id}")
+        return int(row[0])
+
     def raw_membership_rebuild_raw_ids(self, logical_source_key: str) -> tuple[str, ...]:
         """Return census candidates excluding quarantined full rows with another authority key."""
         rows = (

--- a/tests/unit/archive/test_session_revision_membership.py
+++ b/tests/unit/archive/test_session_revision_membership.py
@@ -156,6 +156,38 @@ def test_browser_native_snapshot_refuses_later_revision_that_loses_message_ident
     assert result.ambiguous_raw_ids == ("raw-new", "raw-old")
 
 
+def test_browser_native_upgrade_refuses_any_shrinking_frontier_dimension() -> None:
+    older = _revision("raw-old", "prompt")
+    older_projection = older.projection.__class__(
+        session_hash=b"o" * 32,
+        message_hashes=older.projection.message_hashes,
+        event_hashes=older.projection.event_hashes,
+        attachment_hashes=frozenset({b"attachment"}),
+    )
+    newer = _revision("raw-new", "prompt", "answer")
+    revisions = [
+        MembershipRevision(
+            older.raw_id,
+            older_projection,
+            "2026-01-01T00:00:00Z",
+            observed_at_ms=1,
+            browser_snapshot_fidelity="dom",
+        ),
+        MembershipRevision(
+            newer.raw_id,
+            newer.projection,
+            "2026-01-01T00:01:00Z",
+            observed_at_ms=2,
+            browser_snapshot_fidelity="native",
+        ),
+    ]
+
+    result = classify_membership_revisions(revisions)
+
+    assert result.accepted_raw_ids == ()
+    assert result.ambiguous_raw_ids == ("raw-new", "raw-old")
+
+
 def test_browser_snapshot_accepts_later_attachment_enrichment_without_provider_update() -> None:
     older = _revision("raw-old", "prompt", "answer")
     newer = _revision("raw-new", "prompt", "answer")

--- a/tests/unit/archive/test_session_revision_membership.py
+++ b/tests/unit/archive/test_session_revision_membership.py
@@ -100,3 +100,93 @@ def test_metadata_revisions_with_equal_provider_time_are_ambiguous() -> None:
 
     assert result.accepted_raw_ids == ()
     assert result.ambiguous_raw_ids == ("raw-a", "raw-b")
+
+
+def test_browser_native_snapshot_accepts_later_provider_revision_when_messages_reorder() -> None:
+    older = _revision("raw-old", "prompt", "attachment context")
+    newer = _revision("raw-new", "prompt", "tool result", "attachment context")
+    older = MembershipRevision(
+        older.raw_id,
+        older.projection,
+        "2026-01-01T00:00:00Z",
+        observed_at_ms=1,
+        browser_snapshot_fidelity="native",
+        provider_message_ids=frozenset({"prompt", "attachment"}),
+    )
+    newer = MembershipRevision(
+        newer.raw_id,
+        newer.projection,
+        "2026-01-01T00:01:00Z",
+        observed_at_ms=2,
+        browser_snapshot_fidelity="native",
+        provider_message_ids=frozenset({"prompt", "tool", "attachment"}),
+    )
+
+    result = classify_membership_revisions([newer, older])
+
+    assert result.accepted_raw_ids == ("raw-old", "raw-new")
+    assert result.ambiguous_raw_ids == ()
+
+
+def test_browser_native_snapshot_refuses_later_revision_that_loses_message_identity() -> None:
+    older = _revision("raw-old", "prompt", "left")
+    newer = _revision("raw-new", "prompt", "right")
+    revisions = [
+        MembershipRevision(
+            older.raw_id,
+            older.projection,
+            "2026-01-01T00:00:00Z",
+            observed_at_ms=1,
+            browser_snapshot_fidelity="native",
+            provider_message_ids=frozenset({"prompt", "left"}),
+        ),
+        MembershipRevision(
+            newer.raw_id,
+            newer.projection,
+            "2026-01-01T00:01:00Z",
+            observed_at_ms=2,
+            browser_snapshot_fidelity="native",
+            provider_message_ids=frozenset({"prompt", "right"}),
+        ),
+    ]
+
+    result = classify_membership_revisions(revisions)
+
+    assert result.accepted_raw_ids == ()
+    assert result.ambiguous_raw_ids == ("raw-new", "raw-old")
+
+
+def test_browser_snapshot_accepts_later_attachment_enrichment_without_provider_update() -> None:
+    older = _revision("raw-old", "prompt", "answer")
+    newer = _revision("raw-new", "prompt", "answer")
+    newer_projection = newer.projection.__class__(
+        session_hash=b"n" * 32,
+        message_hashes=newer.projection.message_hashes,
+        event_hashes=newer.projection.event_hashes,
+        attachment_hashes=frozenset({b"attachment-v2"}),
+    )
+    revisions = [
+        MembershipRevision(
+            older.raw_id,
+            older.projection,
+            "2026-01-01T00:01:00Z",
+            observed_at_ms=1,
+            browser_snapshot_fidelity="native",
+            provider_message_ids=frozenset({"prompt", "answer"}),
+            provider_attachment_ids=frozenset({"asset"}),
+        ),
+        MembershipRevision(
+            newer.raw_id,
+            newer_projection,
+            "2026-01-01T00:01:00Z",
+            observed_at_ms=2,
+            browser_snapshot_fidelity="native",
+            provider_message_ids=frozenset({"prompt", "answer"}),
+            provider_attachment_ids=frozenset({"asset"}),
+        ),
+    ]
+
+    result = classify_membership_revisions(revisions)
+
+    assert result.accepted_raw_ids == ("raw-old", "raw-new")
+    assert result.ambiguous_raw_ids == ()

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -1194,6 +1194,86 @@ async def test_browser_capture_replacement_advances_membership_head_and_acquires
         await archive.close()
 
 
+@pytest.mark.asyncio
+async def test_browser_capture_provider_timestamp_advances_reordered_native_snapshot(tmp_path: Path) -> None:
+    """Provider-native snapshots may insert work before an existing context node."""
+    from polylogue.api import Polylogue
+
+    root = tmp_path / "browser-capture"
+    root.mkdir()
+    path = root / "capture.json"
+
+    def capture(turns: list[dict[str, object]], *, updated_at: str) -> dict[str, object]:
+        return {
+            "polylogue_capture_kind": "browser_llm_session",
+            "schema_version": 1,
+            "capture_id": "chatgpt:provider-ordered-replacement",
+            "provenance": {
+                "source_url": "https://chatgpt.com/c/provider-ordered-replacement",
+                "captured_at": updated_at,
+                "adapter_name": "chatgpt-native-v1",
+                "capture_mode": "snapshot",
+            },
+            "session": {
+                "provider": "chatgpt",
+                "provider_session_id": "provider-ordered-replacement",
+                "title": "Provider ordered replacement",
+                "updated_at": updated_at,
+                "turns": turns,
+                "provider_meta": {"capture_fidelity": "native_compact"},
+            },
+            "raw_provider_payload": {
+                "polylogue_bridge_projection": "chatgpt-native-compact-v1",
+                "mapping": {},
+            },
+        }
+
+    prompt = {"provider_turn_id": "prompt", "role": "user", "text": "do work", "ordinal": 0}
+    context = {
+        "provider_turn_id": "attachment-context",
+        "role": "user",
+        "text": "The user provided an attachment",
+        "ordinal": 1,
+    }
+    tool = {"provider_turn_id": "tool", "role": "assistant", "text": "tool output", "ordinal": 1}
+    path.write_text(json.dumps(capture([prompt, context], updated_at="2026-07-16T00:00:00Z")), encoding="utf-8")
+    archive = Polylogue(archive_root=tmp_path / "archive")
+    processor = LiveBatchProcessor(
+        archive,
+        (WatchSource(name="browser-capture", root=root, suffixes=(".json",)),),
+        cursor=CursorStore(archive.backend.db_path),
+        parser_fingerprint="test-parser",
+    )
+
+    try:
+        first = await processor.ingest_files([path], emit_event=False)
+        path.write_text(
+            json.dumps(capture([prompt, tool, context], updated_at="2026-07-16T00:01:00Z")),
+            encoding="utf-8",
+        )
+        second = await processor.ingest_files([path], emit_event=False)
+
+        with sqlite3.connect(archive.archive_root / "index.db") as conn:
+            row = conn.execute(
+                "SELECT message_count, title FROM sessions WHERE session_id = ?",
+                ("chatgpt-export:provider-ordered-replacement",),
+            ).fetchone()
+        with sqlite3.connect(archive.archive_root / "source.db") as conn:
+            decisions = conn.execute(
+                """
+                SELECT decision FROM raw_session_memberships
+                WHERE logical_source_key = 'chatgpt:provider-ordered-replacement'
+                ORDER BY acquisition_generation
+                """
+            ).fetchall()
+
+        assert first.succeeded_file_count == second.succeeded_file_count == 1
+        assert row == (3, "Provider ordered replacement")
+        assert {decision for (decision,) in decisions} == {"superseded_prefix", "applied"}
+    finally:
+        await archive.close()
+
+
 def test_jsonl_stream_retains_append_plan(tmp_path: Path) -> None:
     root = tmp_path / "sessions"
     root.mkdir()

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -535,6 +535,39 @@ def test_cursor_mark_failed_quarantines_repeated_failures(tmp_path: Path) -> Non
     assert store.list_failed_with_retry() == []
 
 
+def test_cursor_quarantine_binds_to_failed_replacement_observation(tmp_path: Path) -> None:
+    store = CursorStore(tmp_path / "live.sqlite")
+    path = tmp_path / "capture.json"
+    path.write_text('{"accepted":true}', encoding="utf-8")
+    accepted = path.stat()
+    store.set(
+        path,
+        accepted.st_size,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+        content_fingerprint="accepted",
+        st_dev=accepted.st_dev,
+        st_ino=accepted.st_ino,
+        mtime_ns=accepted.st_mtime_ns,
+    )
+
+    replacement = tmp_path / "replacement.json"
+    replacement.write_text('{"malformed":', encoding="utf-8")
+    replacement.replace(path)
+    failed = path.stat()
+    for _ in range(5):
+        store.mark_failed(path, failed_stat=failed)
+
+    record = store.get_record(path)
+    assert record is not None
+    assert record.excluded is True
+    assert (record.byte_size, record.st_dev, record.st_ino, record.mtime_ns) == (
+        failed.st_size,
+        failed.st_dev,
+        failed.st_ino,
+        failed.st_mtime_ns,
+    )
+
+
 def test_cursor_round_trips_freshness_metadata(tmp_path: Path) -> None:
     store = CursorStore(tmp_path / "live.sqlite")
     p = tmp_path / "session.jsonl"

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -912,6 +912,39 @@ def test_parser_version_change_needs_work_without_prefingerprint_read(
     assert watcher._needs_work(f) is True
 
 
+def test_replaced_excluded_file_is_revived_without_retrying_unchanged_poison(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    path = root / "capture.json"
+    path.write_text('{"broken":true}', encoding="utf-8")
+    watcher, _parse_sources = _make_watcher(tmp_path, root)
+    stat = path.stat()
+    watcher._cursor.set(
+        path,
+        stat.st_size,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+        content_fingerprint="broken",
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+        failure_count=5,
+        excluded=True,
+    )
+
+    assert watcher._needs_work(path) is False
+
+    replacement = root / "replacement.json"
+    replacement.write_text('{"valid":"new capture"}', encoding="utf-8")
+    replacement.replace(path)
+
+    assert watcher._needs_work(path) is True
+    revived = watcher._cursor.get_record(path)
+    assert revived is not None
+    assert revived.excluded is False
+    assert revived.failure_count == 0
+    assert revived.next_retry_at is None
+
+
 def test_full_cursor_uses_batch_raw_fingerprint_without_db_lookup(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Recover browser captures after transient parse quarantine and accept later provider-authoritative browser snapshots without weakening divergent-branch protection.

## Problem

The 27-session Sol Pro production census found current extension files parsing to 2,551 messages while the index exposed 205. Twenty-two cursor paths were excluded after five transient failures and never reconsidered after atomic replacement. Separately, mutable provider-native snapshots were quarantined because stable context/tool messages can reorder and output attachments can become available without serialized strict-prefix growth.

## Solution

- Bind cursor exclusion to the exact failed stat/inode observation and revive only a changed replacement.
- Carry browser capture fidelity, stable provider message/attachment identities, provider update time, and durable acquisition order into membership classification.
- Accept compatible provider progress, DOM-to-native upgrades, and later attachment-only enrichment.
- Preserve ambiguity for identity loss, same-time transcript divergence, native-to-DOM downgrade, and ordinary non-browser revision branches.
- Add production-route watcher, membership, reverse/divergence, and browser replacement regressions.

Ref polylogue-3v1.

## Verification

- `devtools test tests/unit/archive/test_session_revision_membership.py tests/unit/sources/test_live_batch_support.py::test_browser_capture_replacement_advances_membership_head_and_acquires_attachment tests/unit/sources/test_live_batch_support.py::test_browser_capture_provider_timestamp_advances_reordered_native_snapshot tests/unit/sources/test_live_watcher.py::test_cursor_mark_failed_quarantines_repeated_failures tests/unit/sources/test_live_watcher.py::test_replaced_excluded_file_is_revived_without_retrying_unchanged_poison`
  - 12 passed
- `devtools verify --quick`
  - exit 0, run `20260716T090428Z-quick-53371-e8ba2806`
- pre-push `devtools verify --quick`
  - exit 0, run `20260716T090710Z-quick-56296-18a04001`
- Default affected-test verification could not run in the fresh worktree because its testmon database was not seeded; the exact impacted production routes were run explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved browser snapshot handling, including native and DOM fidelity, message identity, and attachment preservation.
  * Browser captures are now ordered more reliably when provider timestamps and content changes indicate a newer revision.
  * Replaced files previously excluded after ingestion failures are automatically retried, while unchanged files remain skipped.
  * Added durable acquisition-time lookup for retained revisions.

* **Bug Fixes**
  * Prevented valid reordered or attachment-enriched browser snapshots from being incorrectly rejected.
  * Preserved safeguards against revisions that lose message identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->