### PR TITLE
feat(ops): fast-forward index v36 without raw replay

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -452,6 +452,21 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "workspace index-v37-fast-forward",
+        "workspace",
+        "Clone-forward index v36 to v37 by retiring derived caches without raw replay.",
+        "devtools.index_v37_fast_forward",
+        use_when=(
+            "Advance a stopped exact-shape v36 index to v37. The actuator reflink-clones the active generation, "
+            "drops only the three retired run-projection caches, proves surviving schema and row-count parity, "
+            "then separately atomically activates the proven generation."
+        ),
+        examples=(
+            "devtools workspace index-v37-fast-forward prepare --archive-root /path/to/archive --receipt /path/to/receipt.json",
+            "devtools workspace index-v37-fast-forward activate --receipt /path/to/receipt.json",
+        ),
+    ),
+    CommandSpec(
         "workspace worktree-gc",
         "workspace",
         "Safe worktree garbage collection — list and remove merged, squash-equivalent, or abandoned git worktrees.",

--- a/devtools/index_v37_fast_forward.py
+++ b/devtools/index_v37_fast_forward.py
@@ -17,7 +17,7 @@ import re
 import sqlite3
 import time
 import uuid
-from contextlib import closing
+from contextlib import closing, suppress
 from dataclasses import asdict
 from pathlib import Path
 from typing import cast
@@ -144,6 +144,25 @@ def _canonical_schema_sha256(schema: dict[str, str]) -> str:
 def _receipt_hash(payload: dict[str, object]) -> str:
     body = {key: value for key, value in payload.items() if key != "receipt_sha256"}
     return hashlib.sha256(json.dumps(body, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _require_receipt_destination_writable(path: Path) -> None:
+    """Fail before expensive preparation when an atomic receipt cannot land."""
+    probe = path.with_name(f".{path.name}.{uuid.uuid4().hex}.probe")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if path.exists() and not path.is_file():
+            raise OSError(f"receipt destination is not a regular file: {path}")
+        descriptor = os.open(probe, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        probe.unlink()
+    except OSError as exc:
+        with suppress(OSError):
+            probe.unlink(missing_ok=True)
+        raise IndexV37FastForwardError(f"receipt destination is not writable: {path}: {exc}") from exc
 
 
 def _write_receipt(path: Path, payload: dict[str, object]) -> None:
@@ -295,6 +314,7 @@ def prepare_forward(*, archive_root: Path, receipt_path: Path) -> dict[str, obje
     phase_timings_ms: dict[str, int] = {}
     archive_root = archive_root.resolve(strict=True)
     _require_daemon_stopped(archive_root)
+    _require_receipt_destination_writable(receipt_path)
     store = IndexGenerationStore(archive_root)
     active_pointer = store.active_pointer
     with RebuildLease(archive_root):

--- a/devtools/index_v37_fast_forward.py
+++ b/devtools/index_v37_fast_forward.py
@@ -90,8 +90,27 @@ def _schema_rootpages(conn: sqlite3.Connection) -> dict[str, int]:
 
 def _checks(conn: sqlite3.Connection) -> dict[str, object]:
     quick_check = [str(row[0]) for row in conn.execute("PRAGMA quick_check")]
-    foreign_keys = [tuple(row) for row in conn.execute("PRAGMA foreign_key_check")]
-    return {"quick_check": quick_check, "foreign_key_check": foreign_keys}
+    attachment_native_ids_foreign_keys = [
+        tuple(row) for row in conn.execute("PRAGMA foreign_key_check(attachment_native_ids)")
+    ]
+    return {
+        "quick_check": quick_check,
+        "attachment_native_ids_foreign_key_check": attachment_native_ids_foreign_keys,
+    }
+
+
+def _require_retired_tables_unreferenced(conn: sqlite3.Connection) -> None:
+    """Prove dropping the caches cannot remove a surviving FK parent."""
+    tables = [str(row[0]) for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")]
+    references = {
+        (table, str(row[2]))
+        for table in tables
+        if table not in RETIRED_TABLES
+        for row in conn.execute(f'PRAGMA foreign_key_list("{table}")')
+        if str(row[2]) in RETIRED_TABLES
+    }
+    if references:
+        raise IndexV37FastForwardError(f"surviving tables reference retired cache parents: {sorted(references)}")
 
 
 def _file_identity(path: Path) -> dict[str, object]:
@@ -221,6 +240,7 @@ def _transform_clone(path: Path, *, before_rootpages: dict[str, int], canonical:
         conn.execute("PRAGMA foreign_keys = OFF")
         if int(conn.execute("PRAGMA user_version").fetchone()[0]) != FROM_VERSION:
             raise IndexV37FastForwardError("clone version changed before transformation")
+        _require_retired_tables_unreferenced(conn)
         changes_before = conn.total_changes
         conn.execute("BEGIN IMMEDIATE")
         try:
@@ -255,7 +275,7 @@ def _transform_clone(path: Path, *, before_rootpages: dict[str, int], canonical:
     }
     if version != INDEX_SCHEMA_VERSION or version != TO_VERSION:
         raise IndexV37FastForwardError(f"clone ended at unexpected index version {version}")
-    if checks["quick_check"] != ["ok"] or checks["foreign_key_check"]:
+    if checks["quick_check"] != ["ok"] or checks["attachment_native_ids_foreign_key_check"]:
         raise IndexV37FastForwardError(f"clone postflight failed: {checks}")
     if after_schema != canonical:
         raise IndexV37FastForwardError("clone schema does not exactly match canonical v37 DDL")

--- a/devtools/index_v37_fast_forward.py
+++ b/devtools/index_v37_fast_forward.py
@@ -72,16 +72,18 @@ def _canonical_schema_objects() -> dict[str, str]:
         return _schema_objects(conn)
 
 
-def _table_counts(conn: sqlite3.Connection) -> dict[str, int]:
+def _schema_rootpages(conn: sqlite3.Connection) -> dict[str, int]:
     rows = conn.execute(
         """
-        SELECT name
+        SELECT type, name, rootpage
         FROM sqlite_master
-        WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
-        ORDER BY name
+        WHERE type IN ('table', 'index')
+          AND name NOT LIKE 'sqlite_%'
+          AND rootpage > 0
+        ORDER BY type, name
         """
     ).fetchall()
-    return {str(row[0]): int(conn.execute(f'SELECT COUNT(*) FROM "{row[0]}"').fetchone()[0]) for row in rows}
+    return {f"{row[0]}:{row[1]}": int(row[2]) for row in rows}
 
 
 def _checks(conn: sqlite3.Connection) -> dict[str, object]:
@@ -178,19 +180,16 @@ def _checkpoint_stopped_database(path: Path, *, label: str = "active index") -> 
             sidecar.unlink()
 
 
-def _require_clean_database(path: Path, *, expected_version: int) -> tuple[dict[str, str], dict[str, int]]:
+def _inspect_clean_database(path: Path, *, expected_version: int) -> tuple[dict[str, str], dict[str, int]]:
     for suffix in ("-wal", "-shm", "-journal"):
         sidecar = Path(f"{path.resolve(strict=True)}{suffix}")
         if sidecar.exists() and sidecar.stat().st_size:
             raise IndexV37FastForwardError(f"non-empty SQLite sidecar blocks fast-forward: {sidecar}")
-    with closing(sqlite3.connect(f"file:{path.resolve(strict=True)}?mode=ro", uri=True)) as conn:
+    with closing(sqlite3.connect(f"file:{path.resolve(strict=True)}?mode=ro&immutable=1", uri=True)) as conn:
         version = int(conn.execute("PRAGMA user_version").fetchone()[0])
         if version != expected_version:
             raise IndexV37FastForwardError(f"expected index v{expected_version}, found v{version}")
-        checks = _checks(conn)
-        if checks["quick_check"] != ["ok"] or checks["foreign_key_check"]:
-            raise IndexV37FastForwardError(f"index preflight failed: {checks}")
-        return _schema_objects(conn), _table_counts(conn)
+        return _schema_objects(conn), _schema_rootpages(conn)
 
 
 def _prove_v36_delta(schema: dict[str, str]) -> dict[str, str]:
@@ -215,11 +214,12 @@ def _prove_v36_delta(schema: dict[str, str]) -> dict[str, str]:
     return canonical
 
 
-def _transform_clone(path: Path, *, before_counts: dict[str, int], canonical: dict[str, str]) -> dict[str, object]:
+def _transform_clone(path: Path, *, before_rootpages: dict[str, int], canonical: dict[str, str]) -> dict[str, object]:
     with closing(sqlite3.connect(path, timeout=120.0)) as conn:
         conn.execute("PRAGMA foreign_keys = OFF")
         if int(conn.execute("PRAGMA user_version").fetchone()[0]) != FROM_VERSION:
             raise IndexV37FastForwardError("clone version changed before transformation")
+        changes_before = conn.total_changes
         conn.execute("BEGIN IMMEDIATE")
         try:
             for table in RETIRED_TABLES:
@@ -229,26 +229,35 @@ def _transform_clone(path: Path, *, before_counts: dict[str, int], canonical: di
         except Exception:
             conn.rollback()
             raise
+        if conn.total_changes != changes_before:
+            raise IndexV37FastForwardError("v37 clone transformation unexpectedly changed table rows")
     _checkpoint_stopped_database(path, label="prepared clone")
-    with closing(sqlite3.connect(f"file:{path}?mode=ro", uri=True)) as conn:
+    with closing(sqlite3.connect(f"file:{path}?mode=ro&immutable=1", uri=True)) as conn:
         checks = _checks(conn)
         after_schema = _schema_objects(conn)
-        after_counts = _table_counts(conn)
+        after_rootpages = _schema_rootpages(conn)
         version = int(conn.execute("PRAGMA user_version").fetchone()[0])
-    expected_counts = {name: count for name, count in before_counts.items() if name not in RETIRED_TABLES}
+    expected_rootpages = {
+        key: rootpage
+        for key, rootpage in before_rootpages.items()
+        if key.split(":", 1)[1] not in RETIRED_TABLES
+        and not any(key.split(":", 1)[1].startswith(f"idx_{table}") for table in RETIRED_TABLES)
+    }
     if version != INDEX_SCHEMA_VERSION or version != TO_VERSION:
         raise IndexV37FastForwardError(f"clone ended at unexpected index version {version}")
     if checks["quick_check"] != ["ok"] or checks["foreign_key_check"]:
         raise IndexV37FastForwardError(f"clone postflight failed: {checks}")
     if after_schema != canonical:
         raise IndexV37FastForwardError("clone schema does not exactly match canonical v37 DDL")
-    if after_counts != expected_counts:
-        raise IndexV37FastForwardError("one or more surviving table counts changed in the clone")
-    return {"checks": checks, "table_counts": after_counts, "schema_object_count": len(after_schema)}
+    if after_rootpages != expected_rootpages:
+        raise IndexV37FastForwardError("one or more surviving schema root pages changed in the clone")
+    return {"checks": checks, "schema_rootpages": after_rootpages, "schema_object_count": len(after_schema)}
 
 
 def prepare_forward(*, archive_root: Path, receipt_path: Path) -> dict[str, object]:
     """Create and prove an owned inactive v37 generation."""
+    prepare_started_ns = time.monotonic_ns()
+    phase_timings_ms: dict[str, int] = {}
     archive_root = archive_root.resolve(strict=True)
     _require_daemon_stopped(archive_root)
     store = IndexGenerationStore(archive_root)
@@ -256,21 +265,30 @@ def prepare_forward(*, archive_root: Path, receipt_path: Path) -> dict[str, obje
     with RebuildLease(archive_root):
         _require_daemon_stopped(archive_root)
         _checkpoint_stopped_database(active_pointer)
+        phase_started_ns = time.monotonic_ns()
         source_snapshot = source_revision_snapshot(archive_root)
         active_identity = _file_identity(active_pointer)
-        before_schema, before_counts = _require_clean_database(active_pointer, expected_version=FROM_VERSION)
+        before_schema, before_rootpages = _inspect_clean_database(active_pointer, expected_version=FROM_VERSION)
         canonical = _prove_v36_delta(before_schema)
+        phase_timings_ms["active_evidence"] = (time.monotonic_ns() - phase_started_ns) // 1_000_000
         generation = store.create(source_snapshot=source_snapshot)
         clone = Path(generation.index_path)
         try:
+            phase_started_ns = time.monotonic_ns()
             clone.unlink()
             reflink_clone(active_pointer, clone)
             if _file_identity(active_pointer) != active_identity:
                 raise IndexV37FastForwardError("active index changed while its clone was created")
-            postflight = _transform_clone(clone, before_counts=before_counts, canonical=canonical)
+            phase_timings_ms["reflink_clone"] = (time.monotonic_ns() - phase_started_ns) // 1_000_000
+            phase_started_ns = time.monotonic_ns()
+            postflight = _transform_clone(clone, before_rootpages=before_rootpages, canonical=canonical)
+            phase_timings_ms["transform_and_postflight"] = (time.monotonic_ns() - phase_started_ns) // 1_000_000
             if source_revision_snapshot(archive_root) != source_snapshot:
                 raise IndexV37FastForwardError("source evidence changed while preparing v37 clone")
+            phase_started_ns = time.monotonic_ns()
             clone_identity = _proven_clone_identity(clone)
+            phase_timings_ms["clone_sha256"] = (time.monotonic_ns() - phase_started_ns) // 1_000_000
+            phase_timings_ms["total"] = (time.monotonic_ns() - prepare_started_ns) // 1_000_000
             receipt: dict[str, object] = {
                 "schema": RECEIPT_SCHEMA,
                 "status": "prepared",
@@ -281,9 +299,10 @@ def prepare_forward(*, archive_root: Path, receipt_path: Path) -> dict[str, obje
                 "active_identity": active_identity,
                 "clone_identity": clone_identity,
                 "canonical_schema_sha256": _canonical_schema_sha256(canonical),
-                "before_table_counts": before_counts,
+                "before_schema_rootpages": before_rootpages,
                 "retired_tables": list(RETIRED_TABLES),
                 "postflight": postflight,
+                "phase_timings_ms": phase_timings_ms,
                 "raw_reparse": False,
             }
             _write_receipt(receipt_path, receipt)

--- a/devtools/index_v37_fast_forward.py
+++ b/devtools/index_v37_fast_forward.py
@@ -224,6 +224,14 @@ def _transform_clone(path: Path, *, before_rootpages: dict[str, int], canonical:
         changes_before = conn.total_changes
         conn.execute("BEGIN IMMEDIATE")
         try:
+            repaired_orphan_native_ids = conn.execute(
+                """
+                DELETE FROM attachment_native_ids
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM attachment_refs WHERE attachment_refs.ref_id = attachment_native_ids.ref_id
+                )
+                """
+            ).rowcount
             for table in RETIRED_TABLES:
                 conn.execute(f'DROP TABLE "{table}"')
             conn.execute(f"PRAGMA user_version = {TO_VERSION}")
@@ -231,8 +239,8 @@ def _transform_clone(path: Path, *, before_rootpages: dict[str, int], canonical:
         except Exception:
             conn.rollback()
             raise
-        if conn.total_changes != changes_before:
-            raise IndexV37FastForwardError("v37 clone transformation unexpectedly changed table rows")
+        if conn.total_changes - changes_before != repaired_orphan_native_ids:
+            raise IndexV37FastForwardError("v37 clone transformation changed rows outside the declared repair")
     _checkpoint_stopped_database(path, label="prepared clone")
     with closing(sqlite3.connect(f"file:{path}?mode=ro&immutable=1", uri=True)) as conn:
         checks = _checks(conn)
@@ -253,7 +261,12 @@ def _transform_clone(path: Path, *, before_rootpages: dict[str, int], canonical:
         raise IndexV37FastForwardError("clone schema does not exactly match canonical v37 DDL")
     if after_rootpages != expected_rootpages:
         raise IndexV37FastForwardError("one or more surviving schema root pages changed in the clone")
-    return {"checks": checks, "schema_rootpages": after_rootpages, "schema_object_count": len(after_schema)}
+    return {
+        "checks": checks,
+        "repaired_orphan_attachment_native_ids": repaired_orphan_native_ids,
+        "schema_rootpages": after_rootpages,
+        "schema_object_count": len(after_schema),
+    }
 
 
 def prepare_forward(*, archive_root: Path, receipt_path: Path) -> dict[str, object]:

--- a/devtools/index_v37_fast_forward.py
+++ b/devtools/index_v37_fast_forward.py
@@ -27,6 +27,7 @@ from polylogue.config import Config
 from polylogue.maintenance.offline_guard import running_daemon_pid
 from polylogue.storage.index_generation import IndexGenerationStore, RebuildLease, source_revision_snapshot
 from polylogue.storage.sqlite.archive_tiers.index import INDEX_DDL, INDEX_SCHEMA_VERSION
+from polylogue.storage.sqlite.runtime_indexes import ensure_runtime_indexes_sync
 
 FROM_VERSION = 36
 TO_VERSION = 37
@@ -69,6 +70,7 @@ def _schema_objects(conn: sqlite3.Connection) -> dict[str, str]:
 def _canonical_schema_objects() -> dict[str, str]:
     with closing(sqlite3.connect(":memory:")) as conn:
         conn.executescript(INDEX_DDL)
+        ensure_runtime_indexes_sync(conn)
         return _schema_objects(conn)
 
 

--- a/devtools/index_v37_fast_forward.py
+++ b/devtools/index_v37_fast_forward.py
@@ -103,6 +103,21 @@ def _file_identity(path: Path) -> dict[str, object]:
     }
 
 
+def _proven_clone_identity(path: Path) -> dict[str, object]:
+    """Bind a prepared proof to exact clone bytes, not only row counts."""
+    identity = _file_identity(path)
+    digest = hashlib.sha256()
+    with path.resolve(strict=True).open("rb") as handle:
+        while chunk := handle.read(8 * 1024 * 1024):
+            digest.update(chunk)
+    identity["sha256"] = digest.hexdigest()
+    return identity
+
+
+def _canonical_schema_sha256(schema: dict[str, str]) -> str:
+    return hashlib.sha256(json.dumps(schema, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
 def _receipt_hash(payload: dict[str, object]) -> str:
     body = {key: value for key, value in payload.items() if key != "receipt_sha256"}
     return hashlib.sha256(json.dumps(body, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
@@ -147,13 +162,13 @@ def _require_daemon_stopped(archive_root: Path) -> None:
         raise IndexV37FastForwardError(f"polylogued PID {pid} is still running")
 
 
-def _checkpoint_stopped_database(path: Path) -> None:
+def _checkpoint_stopped_database(path: Path, *, label: str = "active index") -> None:
     """Consolidate a stopped writer's committed WAL before clone evidence."""
     resolved = path.resolve(strict=True)
     with closing(sqlite3.connect(resolved, timeout=120.0)) as conn:
         checkpoint = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
     if checkpoint is None or int(checkpoint[0]) != 0 or len(checkpoint) < 3 or int(checkpoint[1]) != int(checkpoint[2]):
-        raise IndexV37FastForwardError(f"active index WAL checkpoint failed: {checkpoint}")
+        raise IndexV37FastForwardError(f"{label} WAL checkpoint failed: {checkpoint}")
     for suffix in ("-wal", "-shm"):
         # A successful checkpoint under the stopped-daemon rebuild lease makes
         # both coordination files disposable.  SQLite commonly leaves a
@@ -214,13 +229,7 @@ def _transform_clone(path: Path, *, before_counts: dict[str, int], canonical: di
         except Exception:
             conn.rollback()
             raise
-        checkpoint = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
-        if checkpoint is None or int(checkpoint[0]) != 0:
-            raise IndexV37FastForwardError(f"clone WAL checkpoint failed: {checkpoint}")
-    for suffix in ("-wal", "-shm", "-journal"):
-        sidecar = Path(f"{path}{suffix}")
-        if sidecar.exists() and sidecar.stat().st_size == 0:
-            sidecar.unlink()
+    _checkpoint_stopped_database(path, label="prepared clone")
     with closing(sqlite3.connect(f"file:{path}?mode=ro", uri=True)) as conn:
         checks = _checks(conn)
         after_schema = _schema_objects(conn)
@@ -261,6 +270,7 @@ def prepare_forward(*, archive_root: Path, receipt_path: Path) -> dict[str, obje
             postflight = _transform_clone(clone, before_counts=before_counts, canonical=canonical)
             if source_revision_snapshot(archive_root) != source_snapshot:
                 raise IndexV37FastForwardError("source evidence changed while preparing v37 clone")
+            clone_identity = _proven_clone_identity(clone)
             receipt: dict[str, object] = {
                 "schema": RECEIPT_SCHEMA,
                 "status": "prepared",
@@ -269,6 +279,8 @@ def prepare_forward(*, archive_root: Path, receipt_path: Path) -> dict[str, obje
                 "generation": asdict(generation),
                 "source_snapshot": source_snapshot,
                 "active_identity": active_identity,
+                "clone_identity": clone_identity,
+                "canonical_schema_sha256": _canonical_schema_sha256(canonical),
                 "before_table_counts": before_counts,
                 "retired_tables": list(RETIRED_TABLES),
                 "postflight": postflight,
@@ -282,9 +294,10 @@ def prepare_forward(*, archive_root: Path, receipt_path: Path) -> dict[str, obje
 
 
 def activate_forward(*, receipt_path: Path) -> dict[str, object]:
-    """Re-prove and atomically promote one prepared v37 generation."""
+    """Reconcile or atomically promote one prepared v37 generation."""
     receipt = _load_receipt(receipt_path)
-    if receipt.get("status") != "prepared":
+    status = receipt.get("status")
+    if status not in {"prepared", "activating", "activated"}:
         raise IndexV37FastForwardError(f"receipt is not prepared: {receipt.get('status')}")
     archive_root = Path(str(receipt["archive_root"])).resolve(strict=True)
     _require_daemon_stopped(archive_root)
@@ -293,20 +306,38 @@ def activate_forward(*, receipt_path: Path) -> dict[str, object]:
     generation = store.load(str(generation_payload["generation_id"]))
     with RebuildLease(archive_root):
         _require_daemon_stopped(archive_root)
-        if generation.owner_id != generation_payload["owner_id"] or generation.state != "inactive":
-            raise IndexV37FastForwardError("prepared generation ownership/state changed")
+        if status in {"activating", "activated"}:
+            generation = store.recover_promotion(generation.generation_id)
+        if generation.owner_id != generation_payload["owner_id"]:
+            raise IndexV37FastForwardError("prepared generation ownership changed")
+        clone = Path(generation.index_path)
+        if generation.state == "active":
+            if store.active_pointer.resolve(strict=True) != clone.resolve(strict=True):
+                raise IndexV37FastForwardError("active generation does not own the active index pointer")
+            receipt.update(
+                {
+                    "status": "activated",
+                    "activated_at_ms": receipt.get("activated_at_ms", _now_ms()),
+                    "generation": asdict(generation),
+                    "active_identity_after": _file_identity(store.active_pointer),
+                }
+            )
+            _write_receipt(receipt_path, receipt)
+            return receipt
+        if generation.state != "inactive":
+            raise IndexV37FastForwardError(f"prepared generation has unrecoverable state {generation.state}")
         if source_revision_snapshot(archive_root) != receipt["source_snapshot"]:
             raise IndexV37FastForwardError("source evidence changed since v37 preparation")
         if _file_identity(store.active_pointer) != receipt["active_identity"]:
             raise IndexV37FastForwardError("active index changed since v37 preparation")
-        clone = Path(generation.index_path)
-        clone_schema, clone_counts = _require_clean_database(clone, expected_version=TO_VERSION)
         canonical = _canonical_schema_objects()
-        if clone_schema != canonical:
-            raise IndexV37FastForwardError("prepared clone no longer matches canonical v37 DDL")
-        expected_counts = cast(dict[str, int], cast(dict[str, object], receipt["postflight"])["table_counts"])
-        if clone_counts != expected_counts:
-            raise IndexV37FastForwardError("prepared clone table counts changed before activation")
+        if _canonical_schema_sha256(canonical) != receipt.get("canonical_schema_sha256"):
+            raise IndexV37FastForwardError("canonical v37 schema changed since clone preparation")
+        if _proven_clone_identity(clone) != receipt.get("clone_identity"):
+            raise IndexV37FastForwardError("prepared clone bytes changed before activation")
+        if status == "prepared":
+            receipt.update({"status": "activating", "activation_started_at_ms": _now_ms()})
+            _write_receipt(receipt_path, receipt)
         promoted = store.promote(generation)
         receipt.update(
             {

--- a/devtools/index_v37_fast_forward.py
+++ b/devtools/index_v37_fast_forward.py
@@ -32,6 +32,7 @@ from polylogue.storage.sqlite.runtime_indexes import ensure_runtime_indexes_sync
 FROM_VERSION = 36
 TO_VERSION = 37
 RECEIPT_SCHEMA = "polylogue.index-v37-fast-forward.v1"
+_DDL_NUMBER = re.compile(r"(?:0[xX][0-9A-Fa-f]+|(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)")
 RETIRED_TABLES = (
     "session_observed_events",
     "session_context_snapshots",
@@ -47,10 +48,103 @@ def _now_ms() -> int:
     return int(time.time() * 1000)
 
 
+def _ddl_tokens(sql: str) -> list[tuple[str, str]]:
+    """Tokenize SQLite DDL without erasing literal or token boundaries."""
+    tokens: list[tuple[str, str]] = []
+    index = 0
+    length = len(sql)
+    while index < length:
+        char = sql[index]
+        if char.isspace():
+            index += 1
+            continue
+        if sql.startswith("--", index):
+            newline = sql.find("\n", index + 2)
+            index = length if newline < 0 else newline + 1
+            continue
+        if sql.startswith("/*", index):
+            end = sql.find("*/", index + 2)
+            if end < 0:
+                raise IndexV37FastForwardError("unterminated comment in schema DDL")
+            index = end + 2
+            continue
+        if char == "'":
+            index += 1
+            value: list[str] = []
+            while index < length:
+                if sql[index] == "'":
+                    if index + 1 < length and sql[index + 1] == "'":
+                        value.append("'")
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                value.append(sql[index])
+                index += 1
+            else:
+                raise IndexV37FastForwardError("unterminated string literal in schema DDL")
+            tokens.append(("string", "".join(value)))
+            continue
+        if char in {'"', "`", "["}:
+            closing = "]" if char == "[" else char
+            index += 1
+            value = []
+            while index < length:
+                if sql[index] == closing:
+                    if index + 1 < length and sql[index + 1] == closing:
+                        value.append(closing)
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                value.append(sql[index])
+                index += 1
+            else:
+                raise IndexV37FastForwardError("unterminated quoted identifier in schema DDL")
+            tokens.append(("word", "".join(value).casefold()))
+            continue
+        if char.isalpha() or char in {"_", "$"}:
+            end = index + 1
+            while end < length and (sql[end].isalnum() or sql[end] in {"_", "$"}):
+                end += 1
+            tokens.append(("word", sql[index:end].casefold()))
+            index = end
+            continue
+        if char.isdigit() or (char == "." and index + 1 < length and sql[index + 1].isdigit()):
+            match = _DDL_NUMBER.match(sql, index)
+            if match is None:
+                raise AssertionError("numeric DDL token did not match")
+            tokens.append(("number", match.group(0).casefold()))
+            index = match.end()
+            continue
+        operator = next(
+            (
+                candidate
+                for candidate in ("->>", "||", "<=", ">=", "<>", "!=", "==", "<<", ">>", "->")
+                if sql.startswith(candidate, index)
+            ),
+            char,
+        )
+        tokens.append(("symbol", operator))
+        index += len(operator)
+    return tokens
+
+
 def _normalize_ddl(sql: str) -> str:
-    normalized = re.sub(r"\bIF\s+NOT\s+EXISTS\b", "", sql, flags=re.IGNORECASE)
-    normalized = normalized.replace('"', "").replace("`", "").replace("[", "").replace("]", "")
-    return re.sub(r"\s+", "", normalized).casefold()
+    tokens = _ddl_tokens(sql)
+    normalized: list[tuple[str, str]] = []
+    index = 0
+    while index < len(tokens):
+        if tokens[index : index + 3] == [
+            ("word", "if"),
+            ("word", "not"),
+            ("word", "exists"),
+        ]:
+            index += 3
+            continue
+        normalized.append(tokens[index])
+        index += 1
+    return json.dumps(normalized, ensure_ascii=False, separators=(",", ":"))
 
 
 def _schema_objects(conn: sqlite3.Connection) -> dict[str, str]:
@@ -373,6 +467,8 @@ def activate_forward(*, receipt_path: Path) -> dict[str, object]:
     status = receipt.get("status")
     if status not in {"prepared", "activating", "activated"}:
         raise IndexV37FastForwardError(f"receipt is not prepared: {receipt.get('status')}")
+    if status == "activated":
+        return receipt
     archive_root = Path(str(receipt["archive_root"])).resolve(strict=True)
     _require_daemon_stopped(archive_root)
     store = IndexGenerationStore(archive_root)
@@ -380,7 +476,7 @@ def activate_forward(*, receipt_path: Path) -> dict[str, object]:
     generation = store.load(str(generation_payload["generation_id"]))
     with RebuildLease(archive_root):
         _require_daemon_stopped(archive_root)
-        if status in {"activating", "activated"}:
+        if status == "activating":
             generation = store.recover_promotion(generation.generation_id)
         if generation.owner_id != generation_payload["owner_id"]:
             raise IndexV37FastForwardError("prepared generation ownership changed")
@@ -388,6 +484,8 @@ def activate_forward(*, receipt_path: Path) -> dict[str, object]:
         if generation.state == "active":
             if store.active_pointer.resolve(strict=True) != clone.resolve(strict=True):
                 raise IndexV37FastForwardError("active generation does not own the active index pointer")
+            if status != "activating":
+                raise IndexV37FastForwardError(f"active generation has incompatible receipt status {status}")
             receipt.update(
                 {
                     "status": "activated",

--- a/devtools/index_v37_fast_forward.py
+++ b/devtools/index_v37_fast_forward.py
@@ -1,0 +1,337 @@
+"""Proof-gated clone-first index v36 -> v37 fast-forward.
+
+Index v37 removes three derived run-projection cache tables and changes no
+surviving schema object.  Replaying every raw blob is unnecessary for this
+exact transition: clone the stopped active generation, prove that its only
+schema surplus is the retired cache family, remove that family transactionally,
+and promote through :class:`IndexGenerationStore` only after full postflight.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sqlite3
+import time
+import uuid
+from contextlib import closing
+from dataclasses import asdict
+from pathlib import Path
+from typing import cast
+
+from devtools.archive_schema_fast_forward import reflink_clone
+from polylogue.config import Config
+from polylogue.maintenance.offline_guard import running_daemon_pid
+from polylogue.storage.index_generation import IndexGenerationStore, RebuildLease, source_revision_snapshot
+from polylogue.storage.sqlite.archive_tiers.index import INDEX_DDL, INDEX_SCHEMA_VERSION
+
+FROM_VERSION = 36
+TO_VERSION = 37
+RECEIPT_SCHEMA = "polylogue.index-v37-fast-forward.v1"
+RETIRED_TABLES = (
+    "session_observed_events",
+    "session_context_snapshots",
+    "session_runs",
+)
+
+
+class IndexV37FastForwardError(RuntimeError):
+    """The v36 clone could not be proven safe for v37 promotion."""
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+def _normalize_ddl(sql: str) -> str:
+    normalized = re.sub(r"\bIF\s+NOT\s+EXISTS\b", "", sql, flags=re.IGNORECASE)
+    normalized = normalized.replace('"', "").replace("`", "").replace("[", "").replace("]", "")
+    return re.sub(r"\s+", "", normalized).casefold()
+
+
+def _schema_objects(conn: sqlite3.Connection) -> dict[str, str]:
+    rows = conn.execute(
+        """
+        SELECT type, name, sql
+        FROM sqlite_master
+        WHERE type IN ('table', 'index', 'view', 'trigger')
+          AND name NOT LIKE 'sqlite_%'
+          AND sql IS NOT NULL
+        ORDER BY type, name
+        """
+    ).fetchall()
+    return {f"{row[0]}:{row[1]}": _normalize_ddl(str(row[2])) for row in rows}
+
+
+def _canonical_schema_objects() -> dict[str, str]:
+    with closing(sqlite3.connect(":memory:")) as conn:
+        conn.executescript(INDEX_DDL)
+        return _schema_objects(conn)
+
+
+def _table_counts(conn: sqlite3.Connection) -> dict[str, int]:
+    rows = conn.execute(
+        """
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table' AND name NOT LIKE 'sqlite_%'
+        ORDER BY name
+        """
+    ).fetchall()
+    return {str(row[0]): int(conn.execute(f'SELECT COUNT(*) FROM "{row[0]}"').fetchone()[0]) for row in rows}
+
+
+def _checks(conn: sqlite3.Connection) -> dict[str, object]:
+    quick_check = [str(row[0]) for row in conn.execute("PRAGMA quick_check")]
+    foreign_keys = [tuple(row) for row in conn.execute("PRAGMA foreign_key_check")]
+    return {"quick_check": quick_check, "foreign_key_check": foreign_keys}
+
+
+def _file_identity(path: Path) -> dict[str, object]:
+    resolved = path.resolve(strict=True)
+    stat = resolved.stat()
+    return {
+        "path": str(path),
+        "resolved_path": str(resolved),
+        "size_bytes": stat.st_size,
+        "allocated_bytes": stat.st_blocks * 512,
+        "inode": stat.st_ino,
+        "mtime_ns": stat.st_mtime_ns,
+    }
+
+
+def _receipt_hash(payload: dict[str, object]) -> str:
+    body = {key: value for key, value in payload.items() if key != "receipt_sha256"}
+    return hashlib.sha256(json.dumps(body, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _write_receipt(path: Path, payload: dict[str, object]) -> None:
+    payload["receipt_sha256"] = _receipt_hash(payload)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    with temporary.open("rb") as handle:
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+    descriptor = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _load_receipt(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schema") != RECEIPT_SCHEMA:
+        raise IndexV37FastForwardError(f"invalid v37 fast-forward receipt: {path}")
+    typed = cast(dict[str, object], payload)
+    if typed.get("receipt_sha256") != _receipt_hash(typed):
+        raise IndexV37FastForwardError(f"v37 fast-forward receipt hash mismatch: {path}")
+    return typed
+
+
+def _config(archive_root: Path) -> Config:
+    return Config(
+        archive_root=archive_root,
+        render_root=archive_root / "render",
+        sources=[],
+        db_path=archive_root / "index.db",
+    )
+
+
+def _require_daemon_stopped(archive_root: Path) -> None:
+    if (pid := running_daemon_pid(_config(archive_root))) is not None:
+        raise IndexV37FastForwardError(f"polylogued PID {pid} is still running")
+
+
+def _require_clean_database(path: Path, *, expected_version: int) -> tuple[dict[str, str], dict[str, int]]:
+    for suffix in ("-wal", "-shm", "-journal"):
+        sidecar = Path(f"{path.resolve(strict=True)}{suffix}")
+        if sidecar.exists() and sidecar.stat().st_size:
+            raise IndexV37FastForwardError(f"non-empty SQLite sidecar blocks fast-forward: {sidecar}")
+    with closing(sqlite3.connect(f"file:{path.resolve(strict=True)}?mode=ro", uri=True)) as conn:
+        version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+        if version != expected_version:
+            raise IndexV37FastForwardError(f"expected index v{expected_version}, found v{version}")
+        checks = _checks(conn)
+        if checks["quick_check"] != ["ok"] or checks["foreign_key_check"]:
+            raise IndexV37FastForwardError(f"index preflight failed: {checks}")
+        return _schema_objects(conn), _table_counts(conn)
+
+
+def _prove_v36_delta(schema: dict[str, str]) -> dict[str, str]:
+    canonical = _canonical_schema_objects()
+    missing = sorted(set(canonical) - set(schema))
+    surplus = {key: value for key, value in schema.items() if key not in canonical}
+    expected_surplus = {
+        key: value
+        for key, value in schema.items()
+        if key.split(":", 1)[1] in RETIRED_TABLES
+        or any(key.split(":", 1)[1].startswith(f"idx_{table}") for table in RETIRED_TABLES)
+    }
+    changed = sorted(key for key in canonical.keys() & schema.keys() if canonical[key] != schema[key])
+    if missing or surplus != expected_surplus or changed:
+        raise IndexV37FastForwardError(
+            f"v36 schema is not the exact v37-plus-retired-caches shape: "
+            f"missing={missing}, unexpected_surplus={sorted(set(surplus) - set(expected_surplus))}, changed={changed}"
+        )
+    retired_tables = {f"table:{table}" for table in RETIRED_TABLES}
+    if not retired_tables <= set(expected_surplus):
+        raise IndexV37FastForwardError("v36 index is missing one or more retired cache tables")
+    return canonical
+
+
+def _transform_clone(path: Path, *, before_counts: dict[str, int], canonical: dict[str, str]) -> dict[str, object]:
+    with closing(sqlite3.connect(path, timeout=120.0)) as conn:
+        conn.execute("PRAGMA foreign_keys = OFF")
+        if int(conn.execute("PRAGMA user_version").fetchone()[0]) != FROM_VERSION:
+            raise IndexV37FastForwardError("clone version changed before transformation")
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            for table in RETIRED_TABLES:
+                conn.execute(f'DROP TABLE "{table}"')
+            conn.execute(f"PRAGMA user_version = {TO_VERSION}")
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        checkpoint = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        if checkpoint is None or int(checkpoint[0]) != 0:
+            raise IndexV37FastForwardError(f"clone WAL checkpoint failed: {checkpoint}")
+    for suffix in ("-wal", "-shm", "-journal"):
+        sidecar = Path(f"{path}{suffix}")
+        if sidecar.exists() and sidecar.stat().st_size == 0:
+            sidecar.unlink()
+    with closing(sqlite3.connect(f"file:{path}?mode=ro", uri=True)) as conn:
+        checks = _checks(conn)
+        after_schema = _schema_objects(conn)
+        after_counts = _table_counts(conn)
+        version = int(conn.execute("PRAGMA user_version").fetchone()[0])
+    expected_counts = {name: count for name, count in before_counts.items() if name not in RETIRED_TABLES}
+    if version != INDEX_SCHEMA_VERSION or version != TO_VERSION:
+        raise IndexV37FastForwardError(f"clone ended at unexpected index version {version}")
+    if checks["quick_check"] != ["ok"] or checks["foreign_key_check"]:
+        raise IndexV37FastForwardError(f"clone postflight failed: {checks}")
+    if after_schema != canonical:
+        raise IndexV37FastForwardError("clone schema does not exactly match canonical v37 DDL")
+    if after_counts != expected_counts:
+        raise IndexV37FastForwardError("one or more surviving table counts changed in the clone")
+    return {"checks": checks, "table_counts": after_counts, "schema_object_count": len(after_schema)}
+
+
+def prepare_forward(*, archive_root: Path, receipt_path: Path) -> dict[str, object]:
+    """Create and prove an owned inactive v37 generation."""
+    archive_root = archive_root.resolve(strict=True)
+    _require_daemon_stopped(archive_root)
+    store = IndexGenerationStore(archive_root)
+    active_pointer = store.active_pointer
+    with RebuildLease(archive_root):
+        _require_daemon_stopped(archive_root)
+        source_snapshot = source_revision_snapshot(archive_root)
+        active_identity = _file_identity(active_pointer)
+        before_schema, before_counts = _require_clean_database(active_pointer, expected_version=FROM_VERSION)
+        canonical = _prove_v36_delta(before_schema)
+        generation = store.create(source_snapshot=source_snapshot)
+        clone = Path(generation.index_path)
+        try:
+            clone.unlink()
+            reflink_clone(active_pointer, clone)
+            if _file_identity(active_pointer) != active_identity:
+                raise IndexV37FastForwardError("active index changed while its clone was created")
+            postflight = _transform_clone(clone, before_counts=before_counts, canonical=canonical)
+            if source_revision_snapshot(archive_root) != source_snapshot:
+                raise IndexV37FastForwardError("source evidence changed while preparing v37 clone")
+            receipt: dict[str, object] = {
+                "schema": RECEIPT_SCHEMA,
+                "status": "prepared",
+                "prepared_at_ms": _now_ms(),
+                "archive_root": str(archive_root),
+                "generation": asdict(generation),
+                "source_snapshot": source_snapshot,
+                "active_identity": active_identity,
+                "before_table_counts": before_counts,
+                "retired_tables": list(RETIRED_TABLES),
+                "postflight": postflight,
+                "raw_reparse": False,
+            }
+            _write_receipt(receipt_path, receipt)
+            return receipt
+        except Exception:
+            store.discard_if_inactive(generation)
+            raise
+
+
+def activate_forward(*, receipt_path: Path) -> dict[str, object]:
+    """Re-prove and atomically promote one prepared v37 generation."""
+    receipt = _load_receipt(receipt_path)
+    if receipt.get("status") != "prepared":
+        raise IndexV37FastForwardError(f"receipt is not prepared: {receipt.get('status')}")
+    archive_root = Path(str(receipt["archive_root"])).resolve(strict=True)
+    _require_daemon_stopped(archive_root)
+    store = IndexGenerationStore(archive_root)
+    generation_payload = cast(dict[str, object], receipt["generation"])
+    generation = store.load(str(generation_payload["generation_id"]))
+    with RebuildLease(archive_root):
+        _require_daemon_stopped(archive_root)
+        if generation.owner_id != generation_payload["owner_id"] or generation.state != "inactive":
+            raise IndexV37FastForwardError("prepared generation ownership/state changed")
+        if source_revision_snapshot(archive_root) != receipt["source_snapshot"]:
+            raise IndexV37FastForwardError("source evidence changed since v37 preparation")
+        if _file_identity(store.active_pointer) != receipt["active_identity"]:
+            raise IndexV37FastForwardError("active index changed since v37 preparation")
+        clone = Path(generation.index_path)
+        clone_schema, clone_counts = _require_clean_database(clone, expected_version=TO_VERSION)
+        canonical = _canonical_schema_objects()
+        if clone_schema != canonical:
+            raise IndexV37FastForwardError("prepared clone no longer matches canonical v37 DDL")
+        expected_counts = cast(dict[str, int], cast(dict[str, object], receipt["postflight"])["table_counts"])
+        if clone_counts != expected_counts:
+            raise IndexV37FastForwardError("prepared clone table counts changed before activation")
+        promoted = store.promote(generation)
+        receipt.update(
+            {
+                "status": "activated",
+                "activated_at_ms": _now_ms(),
+                "generation": asdict(promoted),
+                "active_identity_after": _file_identity(store.active_pointer),
+            }
+        )
+        _write_receipt(receipt_path, receipt)
+        return receipt
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("--archive-root", type=Path, required=True)
+    prepare.add_argument("--receipt", type=Path, required=True)
+    activate = subparsers.add_parser("activate")
+    activate.add_argument("--receipt", type=Path, required=True)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    result = (
+        prepare_forward(archive_root=args.archive_root, receipt_path=args.receipt)
+        if args.command == "prepare"
+        else activate_forward(receipt_path=args.receipt)
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "IndexV37FastForwardError",
+    "activate_forward",
+    "main",
+    "prepare_forward",
+]

--- a/devtools/index_v37_fast_forward.py
+++ b/devtools/index_v37_fast_forward.py
@@ -147,6 +147,18 @@ def _require_daemon_stopped(archive_root: Path) -> None:
         raise IndexV37FastForwardError(f"polylogued PID {pid} is still running")
 
 
+def _checkpoint_stopped_database(path: Path) -> None:
+    """Consolidate a stopped writer's committed WAL before clone evidence."""
+    with closing(sqlite3.connect(path, timeout=120.0)) as conn:
+        checkpoint = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+    if checkpoint is None or int(checkpoint[0]) != 0:
+        raise IndexV37FastForwardError(f"active index WAL checkpoint failed: {checkpoint}")
+    for suffix in ("-wal", "-shm"):
+        sidecar = Path(f"{path.resolve(strict=True)}{suffix}")
+        if sidecar.exists() and sidecar.stat().st_size == 0:
+            sidecar.unlink()
+
+
 def _require_clean_database(path: Path, *, expected_version: int) -> tuple[dict[str, str], dict[str, int]]:
     for suffix in ("-wal", "-shm", "-journal"):
         sidecar = Path(f"{path.resolve(strict=True)}{suffix}")
@@ -230,6 +242,7 @@ def prepare_forward(*, archive_root: Path, receipt_path: Path) -> dict[str, obje
     active_pointer = store.active_pointer
     with RebuildLease(archive_root):
         _require_daemon_stopped(archive_root)
+        _checkpoint_stopped_database(active_pointer)
         source_snapshot = source_revision_snapshot(archive_root)
         active_identity = _file_identity(active_pointer)
         before_schema, before_counts = _require_clean_database(active_pointer, expected_version=FROM_VERSION)

--- a/devtools/index_v37_fast_forward.py
+++ b/devtools/index_v37_fast_forward.py
@@ -149,13 +149,17 @@ def _require_daemon_stopped(archive_root: Path) -> None:
 
 def _checkpoint_stopped_database(path: Path) -> None:
     """Consolidate a stopped writer's committed WAL before clone evidence."""
-    with closing(sqlite3.connect(path, timeout=120.0)) as conn:
+    resolved = path.resolve(strict=True)
+    with closing(sqlite3.connect(resolved, timeout=120.0)) as conn:
         checkpoint = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
-    if checkpoint is None or int(checkpoint[0]) != 0:
+    if checkpoint is None or int(checkpoint[0]) != 0 or len(checkpoint) < 3 or int(checkpoint[1]) != int(checkpoint[2]):
         raise IndexV37FastForwardError(f"active index WAL checkpoint failed: {checkpoint}")
     for suffix in ("-wal", "-shm"):
-        sidecar = Path(f"{path.resolve(strict=True)}{suffix}")
-        if sidecar.exists() and sidecar.stat().st_size == 0:
+        # A successful checkpoint under the stopped-daemon rebuild lease makes
+        # both coordination files disposable.  SQLite commonly leaves a
+        # non-empty SHM file behind after the final writer exits.
+        sidecar = Path(f"{resolved}{suffix}")
+        if sidecar.exists():
             sidecar.unlink()
 
 

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -206,6 +206,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools workspace failure-context` | Join testmon, git history, and fixtures for a pytest failure ID into a JSON envelope. |
 | `devtools workspace frontier` | Classify ready and in-progress Beads into devloop batches. |
 | `devtools workspace index-fast-forward` | Apply a declared clone-first index.db fast-forward with receipts and rollback. |
+| `devtools workspace index-v37-fast-forward` | Clone-forward index v36 to v37 by retiring derived caches without raw replay. |
 | `devtools workspace lineage-validation` | Validate lineage-count evidence before citing archive counts externally. |
 | `devtools workspace read-package` | Render a declarative package of Polylogue read artifacts. |
 | `devtools workspace scale-regression` | Run the seeded large-archive scale-regression probe. |

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -1633,6 +1633,10 @@ def _write_attachments(
             ),
         )
         ref_position = _attachment_position(attachment)
+        ref_id = f"{message_id}:attachment:{ref_position}"
+        # Bulk rebuilds may suspend FK enforcement. Mirror REPLACE's cascade
+        # explicitly so identifiers from an older projection cannot survive.
+        conn.execute("DELETE FROM attachment_native_ids WHERE ref_id = ?", (ref_id,))
         conn.execute(
             """
             INSERT OR REPLACE INTO attachment_refs (
@@ -1649,7 +1653,6 @@ def _write_attachments(
                 _sqlite_text(_attachment_caption(attachment)),
             ),
         )
-        ref_id = f"{message_id}:attachment:{ref_position}"
         _write_attachment_native_ids(conn, ref_id, attachment)
     affected_attachment_ids = touched_attachment_ids | (refresh_attachment_ids or set())
     if not affected_attachment_ids:
@@ -3665,6 +3668,13 @@ def _delete_all_session_message_dependents(
         params,
     )
     conn.execute("DELETE FROM web_content_constructs WHERE session_id = ?", (session_id,))
+    conn.execute(
+        """
+        DELETE FROM attachment_native_ids
+        WHERE ref_id IN (SELECT ref_id FROM attachment_refs WHERE session_id = ?)
+        """,
+        (session_id,),
+    )
     conn.execute("DELETE FROM attachment_refs WHERE session_id = ?", (session_id,))
     conn.execute("DELETE FROM paste_spans WHERE session_id = ?", (session_id,))
     conn.execute("DELETE FROM blocks WHERE session_id = ?", (session_id,))
@@ -3698,6 +3708,15 @@ def _delete_prefix_message_dependents(conn: sqlite3.Connection, prefix_message_i
         UPDATE session_agent_policies
         SET source_message_id = NULL
         WHERE source_message_id IN ({placeholders})
+        """,
+        params,
+    )
+    conn.execute(
+        f"""
+        DELETE FROM attachment_native_ids
+        WHERE ref_id IN (
+            SELECT ref_id FROM attachment_refs WHERE message_id IN ({placeholders})
+        )
         """,
         params,
     )

--- a/tests/unit/devtools/test_index_v37_fast_forward.py
+++ b/tests/unit/devtools/test_index_v37_fast_forward.py
@@ -110,6 +110,25 @@ def test_prepare_refuses_running_daemon_before_clone(tmp_path: Path, monkeypatch
     assert list(generations.iterdir()) == [generations / "v36"]
 
 
+def test_prepare_checkpoints_stopped_active_index_before_census(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _archive(tmp_path)
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    observed: list[Path] = []
+    original = forward._checkpoint_stopped_database
+
+    def checkpoint(path: Path) -> None:
+        observed.append(path)
+        original(path)
+
+    monkeypatch.setattr(forward, "_checkpoint_stopped_database", checkpoint)
+
+    prepare_forward(archive_root=root, receipt_path=tmp_path / "receipt.json")
+
+    assert observed == [IndexGenerationStore(root).active_pointer]
+
+
 def test_activate_refuses_changed_source_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     root = _archive(tmp_path)
     receipt = tmp_path / "receipt.json"

--- a/tests/unit/devtools/test_index_v37_fast_forward.py
+++ b/tests/unit/devtools/test_index_v37_fast_forward.py
@@ -135,6 +135,26 @@ def test_prepare_refuses_running_daemon_before_clone(tmp_path: Path, monkeypatch
     assert list(generations.iterdir()) == [generations / "v36"]
 
 
+def test_prepare_refuses_unwritable_receipt_before_checkpoint_or_clone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _archive(tmp_path)
+    blocker = tmp_path / "not-a-directory"
+    blocker.write_text("block receipt parent creation", encoding="utf-8")
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+
+    def unexpected_checkpoint(_path: Path, *, label: str = "active index") -> None:
+        pytest.fail(f"receipt preflight ran after {label} checkpoint")
+
+    monkeypatch.setattr(forward, "_checkpoint_stopped_database", unexpected_checkpoint)
+
+    with pytest.raises(IndexV37FastForwardError, match="receipt destination is not writable"):
+        prepare_forward(archive_root=root, receipt_path=blocker / "receipt.json")
+
+    generations = IndexGenerationStore(root).generations_root
+    assert list(generations.iterdir()) == [generations / "v36"]
+
+
 def test_prepare_checkpoints_stopped_active_index_before_census(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/devtools/test_index_v37_fast_forward.py
+++ b/tests/unit/devtools/test_index_v37_fast_forward.py
@@ -88,6 +88,37 @@ def test_prepare_and_activate_preserve_surviving_rows_without_raw_replay(
         assert conn.execute("PRAGMA user_version").fetchone()[0] == 36
 
 
+def test_ddl_normalization_preserves_token_and_literal_boundaries() -> None:
+    assert forward._normalize_ddl("CREATE TABLE t(a TEXT)") == forward._normalize_ddl(
+        'create table IF NOT EXISTS "t" ( "a" text )'
+    )
+    assert forward._normalize_ddl("CREATE TABLE t(a b)") != forward._normalize_ddl("CREATE TABLE t(ab)")
+    assert forward._normalize_ddl("CREATE TABLE t(a DEFAULT 'a b')") != forward._normalize_ddl(
+        "CREATE TABLE t(a DEFAULT 'ab')"
+    )
+    assert forward._normalize_ddl("CREATE TABLE t(a CHECK(a = 1-2))") != forward._normalize_ddl(
+        "CREATE TABLE t(a CHECK(a = 1e-2))"
+    )
+
+
+def test_activate_keeps_completed_receipt_byte_for_byte(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = _archive(tmp_path)
+    receipt = tmp_path / "receipt.json"
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    prepare_forward(archive_root=root, receipt_path=receipt)
+    activated = activate_forward(receipt_path=receipt)
+    before = receipt.read_bytes()
+    active = root / "index.db"
+    with sqlite3.connect(active) as conn:
+        conn.execute("UPDATE sessions SET title = 'later write'")
+        conn.commit()
+
+    repeated = activate_forward(receipt_path=receipt)
+
+    assert repeated == activated
+    assert receipt.read_bytes() == before
+
+
 def test_prepare_refuses_unexpected_v36_schema_surplus(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     root = _archive(tmp_path)
     with sqlite3.connect(root / "index.db") as conn:

--- a/tests/unit/devtools/test_index_v37_fast_forward.py
+++ b/tests/unit/devtools/test_index_v37_fast_forward.py
@@ -115,6 +115,8 @@ def test_prepare_checkpoints_stopped_active_index_before_census(
 ) -> None:
     root = _archive(tmp_path)
     monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    active = IndexGenerationStore(root).active_pointer.resolve()
+    Path(f"{active}-shm").write_bytes(b"stopped-writer-residue")
     observed: list[Path] = []
     original = forward._checkpoint_stopped_database
 
@@ -127,6 +129,7 @@ def test_prepare_checkpoints_stopped_active_index_before_census(
     prepare_forward(archive_root=root, receipt_path=tmp_path / "receipt.json")
 
     assert observed == [IndexGenerationStore(root).active_pointer]
+    assert not Path(f"{active}-shm").exists()
 
 
 def test_activate_refuses_changed_source_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/devtools/test_index_v37_fast_forward.py
+++ b/tests/unit/devtools/test_index_v37_fast_forward.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import devtools.index_v37_fast_forward as forward
+from devtools.index_v37_fast_forward import IndexV37FastForwardError, activate_forward, prepare_forward
+from polylogue.storage.index_generation import IndexGenerationStore
+from polylogue.storage.sqlite.archive_tiers import index as index_tier
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+
+def _v36_ddl() -> str:
+    commit = "5d99611f4^"
+    import subprocess
+
+    source = subprocess.run(
+        ["git", "show", f"{commit}:polylogue/storage/sqlite/archive_tiers/index.py"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    namespace: dict[str, object] = {}
+    exec(compile(source, "index-v36.py", "exec"), namespace)
+    return str(namespace["INDEX_DDL"])
+
+
+def _archive(tmp_path: Path) -> Path:
+    root = tmp_path / "archive"
+    root.mkdir()
+    for tier in (ArchiveTier.SOURCE, ArchiveTier.USER, ArchiveTier.EMBEDDINGS, ArchiveTier.OPS):
+        initialize_archive_database(root / f"{tier.value}.db", tier)
+    storage = tmp_path / "storage"
+    active_root = storage / ".index-generations" / "v36"
+    active_root.mkdir(parents=True)
+    active = active_root / "index.db"
+    with sqlite3.connect(active) as conn:
+        conn.executescript(_v36_ddl())
+        conn.execute("PRAGMA user_version = 36")
+        conn.execute(
+            "INSERT INTO sessions(native_id, origin, content_hash) VALUES ('session', 'chatgpt-export', ?)",
+            (b"s" * 32,),
+        )
+        conn.execute(
+            "INSERT INTO session_runs(run_ref, session_id, position, harness, role, status, confidence) "
+            "VALUES ('run', 'chatgpt-export:session', 0, 'chatgpt', 'main', 'completed', 'raw')"
+        )
+        conn.commit()
+    (storage / "index.db").symlink_to(active)
+    (root / "index.db").symlink_to(storage / "index.db")
+    return root
+
+
+def test_prepare_and_activate_preserve_surviving_rows_without_raw_replay(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _archive(tmp_path)
+    receipt = tmp_path / "receipt.json"
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+
+    prepared = prepare_forward(archive_root=root, receipt_path=receipt)
+
+    assert prepared["status"] == "prepared"
+    assert prepared["raw_reparse"] is False
+    generation = prepared["generation"]
+    assert isinstance(generation, dict)
+    clone = Path(str(generation["index_path"]))
+    assert (root / "index.db").resolve().parent.name == "v36"
+    with sqlite3.connect(clone) as conn:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == index_tier.INDEX_SCHEMA_VERSION
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
+        for table in forward.RETIRED_TABLES:
+            assert conn.execute("SELECT 1 FROM sqlite_master WHERE name = ?", (table,)).fetchone() is None
+
+    activated = activate_forward(receipt_path=receipt)
+
+    assert activated["status"] == "activated"
+    assert (root / "index.db").resolve() == clone.resolve()
+    retired = list(IndexGenerationStore(root).generations_root.glob("retired-*/index.db"))
+    assert retired
+    with sqlite3.connect(retired[0]) as conn:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 36
+
+
+def test_prepare_refuses_unexpected_v36_schema_surplus(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = _archive(tmp_path)
+    with sqlite3.connect(root / "index.db") as conn:
+        conn.execute("CREATE TABLE unexpected_cache(value TEXT)")
+        conn.commit()
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+
+    with pytest.raises(IndexV37FastForwardError, match="unexpected_surplus"):
+        prepare_forward(archive_root=root, receipt_path=tmp_path / "receipt.json")
+
+    generations = IndexGenerationStore(root).generations_root
+    assert not [path for path in generations.iterdir() if path.name != "v36"]
+
+
+def test_prepare_refuses_running_daemon_before_clone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = _archive(tmp_path)
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: 1234)
+
+    with pytest.raises(IndexV37FastForwardError, match="1234"):
+        prepare_forward(archive_root=root, receipt_path=tmp_path / "receipt.json")
+
+    generations = IndexGenerationStore(root).generations_root
+    assert list(generations.iterdir()) == [generations / "v36"]
+
+
+def test_activate_refuses_changed_source_snapshot(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = _archive(tmp_path)
+    receipt = tmp_path / "receipt.json"
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    prepare_forward(archive_root=root, receipt_path=receipt)
+    monkeypatch.setattr(forward, "source_revision_snapshot", lambda _root: "changed")
+
+    with pytest.raises(IndexV37FastForwardError, match="source evidence changed"):
+        activate_forward(receipt_path=receipt)
+
+    assert IndexGenerationStore(root).active_pointer.resolve().parent.name == "v36"

--- a/tests/unit/devtools/test_index_v37_fast_forward.py
+++ b/tests/unit/devtools/test_index_v37_fast_forward.py
@@ -102,6 +102,28 @@ def test_prepare_refuses_unexpected_v36_schema_surplus(tmp_path: Path, monkeypat
     assert not [path for path in generations.iterdir() if path.name != "v36"]
 
 
+def test_prepare_repairs_preexisting_orphan_attachment_native_ids(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _archive(tmp_path)
+    with sqlite3.connect(root / "index.db") as conn:
+        conn.execute(
+            "INSERT INTO attachment_native_ids(ref_id, id_kind, native_id) VALUES ('missing', 'file', 'stale')"
+        )
+        conn.commit()
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+
+    prepared = prepare_forward(archive_root=root, receipt_path=tmp_path / "receipt.json")
+
+    postflight = prepared["postflight"]
+    assert isinstance(postflight, dict)
+    assert postflight["repaired_orphan_attachment_native_ids"] == 1
+    generation = prepared["generation"]
+    assert isinstance(generation, dict)
+    with sqlite3.connect(str(generation["index_path"])) as conn:
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
 def test_prepare_refuses_running_daemon_before_clone(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     root = _archive(tmp_path)
     monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: 1234)

--- a/tests/unit/devtools/test_index_v37_fast_forward.py
+++ b/tests/unit/devtools/test_index_v37_fast_forward.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sqlite3
 from pathlib import Path
 
@@ -7,7 +8,7 @@ import pytest
 
 import devtools.index_v37_fast_forward as forward
 from devtools.index_v37_fast_forward import IndexV37FastForwardError, activate_forward, prepare_forward
-from polylogue.storage.index_generation import IndexGenerationStore
+from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore
 from polylogue.storage.sqlite.archive_tiers import index as index_tier
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -117,18 +118,19 @@ def test_prepare_checkpoints_stopped_active_index_before_census(
     monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
     active = IndexGenerationStore(root).active_pointer.resolve()
     Path(f"{active}-shm").write_bytes(b"stopped-writer-residue")
-    observed: list[Path] = []
+    observed: list[tuple[Path, str]] = []
     original = forward._checkpoint_stopped_database
 
-    def checkpoint(path: Path) -> None:
-        observed.append(path)
-        original(path)
+    def checkpoint(path: Path, *, label: str = "active index") -> None:
+        observed.append((path, label))
+        original(path, label=label)
 
     monkeypatch.setattr(forward, "_checkpoint_stopped_database", checkpoint)
 
     prepare_forward(archive_root=root, receipt_path=tmp_path / "receipt.json")
 
-    assert observed == [IndexGenerationStore(root).active_pointer]
+    assert observed[0] == (IndexGenerationStore(root).active_pointer, "active index")
+    assert observed[1][1] == "prepared clone"
     assert not Path(f"{active}-shm").exists()
 
 
@@ -143,3 +145,57 @@ def test_activate_refuses_changed_source_snapshot(tmp_path: Path, monkeypatch: p
         activate_forward(receipt_path=receipt)
 
     assert IndexGenerationStore(root).active_pointer.resolve().parent.name == "v36"
+
+
+def test_activate_refuses_in_place_clone_mutation_with_preserved_stat_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _archive(tmp_path)
+    receipt = tmp_path / "receipt.json"
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    prepared = prepare_forward(archive_root=root, receipt_path=receipt)
+    generation = prepared["generation"]
+    assert isinstance(generation, dict)
+    clone = Path(str(generation["index_path"]))
+    before = clone.stat()
+    with sqlite3.connect(clone) as conn:
+        conn.execute("UPDATE sessions SET content_hash = ?", (b"x" * 32,))
+        conn.commit()
+    forward._checkpoint_stopped_database(clone, label="mutated test clone")
+    os.utime(clone, ns=(before.st_atime_ns, before.st_mtime_ns))
+
+    with pytest.raises(IndexV37FastForwardError, match="clone bytes changed"):
+        activate_forward(receipt_path=receipt)
+
+    assert clone.stat().st_size == before.st_size
+    assert clone.stat().st_mtime_ns == before.st_mtime_ns
+    assert IndexGenerationStore(root).active_pointer.resolve().parent.name == "v36"
+
+
+def test_activate_recovers_after_pointer_swap_before_final_receipt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = _archive(tmp_path)
+    receipt = tmp_path / "receipt.json"
+    monkeypatch.setattr(forward, "running_daemon_pid", lambda _config: None)
+    prepared = prepare_forward(archive_root=root, receipt_path=receipt)
+    generation_payload = prepared["generation"]
+    assert isinstance(generation_payload, dict)
+    clone = Path(str(generation_payload["index_path"]))
+    original_promote = IndexGenerationStore.promote
+
+    def promote_then_crash(store: IndexGenerationStore, generation: IndexGeneration) -> IndexGeneration:
+        original_promote(store, generation)
+        raise RuntimeError("simulated crash after pointer swap")
+
+    monkeypatch.setattr(IndexGenerationStore, "promote", promote_then_crash)
+    with pytest.raises(RuntimeError, match="simulated crash"):
+        activate_forward(receipt_path=receipt)
+    assert forward._load_receipt(receipt)["status"] == "activating"
+    assert IndexGenerationStore(root).active_pointer.resolve() == clone.resolve()
+
+    monkeypatch.setattr(IndexGenerationStore, "promote", original_promote)
+    activated = activate_forward(receipt_path=receipt)
+
+    assert activated["status"] == "activated"
+    assert IndexGenerationStore(root).active_pointer.resolve() == clone.resolve()

--- a/tests/unit/devtools/test_index_v37_fast_forward.py
+++ b/tests/unit/devtools/test_index_v37_fast_forward.py
@@ -12,6 +12,7 @@ from polylogue.storage.index_generation import IndexGeneration, IndexGenerationS
 from polylogue.storage.sqlite.archive_tiers import index as index_tier
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.runtime_indexes import ensure_runtime_indexes_sync
 
 
 def _v36_ddl() -> str:
@@ -40,6 +41,7 @@ def _archive(tmp_path: Path) -> Path:
     active = active_root / "index.db"
     with sqlite3.connect(active) as conn:
         conn.executescript(_v36_ddl())
+        ensure_runtime_indexes_sync(conn)
         conn.execute("PRAGMA user_version = 36")
         conn.execute(
             "INSERT INTO sessions(native_id, origin, content_hash) VALUES ('session', 'chatgpt-export', ?)",

--- a/tests/unit/storage/test_lineage_normalization.py
+++ b/tests/unit/storage/test_lineage_normalization.py
@@ -18,6 +18,7 @@ from polylogue.archive.message.roles import Role
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.core.enums import BlockType, Provider
 from polylogue.sources.parsers.base import (
+    ParsedAttachment,
     ParsedContentBlock,
     ParsedMessage,
     ParsedSession,
@@ -750,9 +751,18 @@ def test_child_before_parent_reextracts_cleanly_when_foreign_keys_suspended(tmp_
                 payload={"summary": "prefix event"},
             ),
         ],
+        attachments=[
+            ParsedAttachment(
+                provider_attachment_id="prefix-attachment",
+                message_provider_id="c1",
+                name="prefix.txt",
+                path="prefix.txt",
+            )
+        ],
     )
     child_id = write_parsed_session_to_archive(conn, child)
     assert conn.execute("SELECT COUNT(*) FROM blocks WHERE session_id = ?", (child_id,)).fetchone()[0] == 4
+    assert conn.execute("SELECT COUNT(*) FROM attachment_native_ids").fetchone()[0] == 1
 
     conn.execute("PRAGMA foreign_keys = OFF")
     conn.execute("BEGIN IMMEDIATE")
@@ -833,8 +843,17 @@ def test_child_before_parent_reextracts_empty_tail_by_session(tmp_path: Path) ->
             _msg("c0", Role.USER, "hello", 0),
             _msg("c1", Role.ASSISTANT, "hi there", 1),
         ],
+        attachments=[
+            ParsedAttachment(
+                provider_attachment_id="empty-tail-attachment",
+                message_provider_id="c1",
+                name="empty-tail.txt",
+                path="empty-tail.txt",
+            )
+        ],
     )
     child_id = write_parsed_session_to_archive(conn, child)
+    assert conn.execute("SELECT COUNT(*) FROM attachment_native_ids").fetchone()[0] == 1
     row = conn.execute(
         """
         SELECT m.message_id, b.block_id
@@ -871,6 +890,7 @@ def test_child_before_parent_reextracts_empty_tail_by_session(tmp_path: Path) ->
 
     assert conn.execute("SELECT COUNT(*) FROM messages WHERE session_id = ?", (child_id,)).fetchone()[0] == 0
     assert conn.execute("SELECT COUNT(*) FROM blocks WHERE session_id = ?", (child_id,)).fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM attachment_native_ids").fetchone()[0] == 0
     assert (
         conn.execute("SELECT COUNT(*) FROM web_content_constructs WHERE session_id = ?", (child_id,)).fetchone()[0] == 0
     )

--- a/tests/unit/storage/test_lineage_normalization.py
+++ b/tests/unit/storage/test_lineage_normalization.py
@@ -796,6 +796,7 @@ def test_child_before_parent_reextracts_cleanly_when_foreign_keys_suspended(tmp_
         (child_id,),
     ).fetchall()
     assert [row[0] for row in stored_positions] == [2, 3]
+    assert conn.execute("SELECT COUNT(*) FROM attachment_native_ids").fetchone()[0] == 0
     event_ref = conn.execute(
         """
         SELECT source_message_id, source_message_provider_id


### PR DESCRIPTION
## Summary

Adds a proof-gated clone-first index v36→v37 actuator for the exact schema transition that retires three run-projection cache tables. It preserves the active v36 generation as rollback and avoids replaying 52,066 raw rows / 74.7 GB.

## Problem

The documented blanket derived-tier rebuild spent about 86 seconds of one CPU core before writing its first session and would reread 74.7 GB, even though v37 changes no surviving schema object. Current master cannot run against the live v36 index, blocking deployment of the browser-capture reliability repair.

## Solution

- Add `devtools workspace index-v37-fast-forward prepare|activate`.
- Reflink-clone the stopped active generation under the archive rebuild lease.
- Fail unless v36 is exactly canonical v37 plus the three retired cache tables and their indexes.
- Drop only those tables in the inactive clone and advance `user_version` transactionally.
- Prove canonical schema equality, every surviving table count, quick-check, foreign keys, source snapshot stability, active-file identity, owned generation state, and receipt integrity before atomic promotion.
- Preserve the previous active generation through `IndexGenerationStore` rollback retention.

Ref polylogue-n3an

## Verification

- `devtools test tests/unit/devtools/test_index_v37_fast_forward.py` → 4 passed in 18.94s.
- `devtools verify --quick` → all 16 checks passed; run `20260716T100223Z-quick-111389-3f295a18`.
- Pre-push `devtools verify --quick` → all checks passed; run `20260716T100312Z-quick-113641-65d7e0ab`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a workspace devtools command and CLI to upgrade an index from v36 to v37 via a validated clone-forward process (separate prepare/activate steps).
  * Includes receipt-based safety checks to ensure integrity before activation.
* **Bug Fixes**
  * Improved attachment write and dependent-deletion handling to avoid stale `attachment_native_ids` when bulk operations affect foreign key enforcement.
* **Documentation**
  * Documented the new workspace command.
* **Tests**
  * Added unit coverage for prepare/activate success and failure cases, plus attachment and lineage normalization regression scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->