### PR TITLE
feat(agent): add external campaign prompt portfolios

### DIFF
--- a/.agent/handoffs/README.md
+++ b/.agent/handoffs/README.md
@@ -20,5 +20,6 @@ references and were retired instead.
 | `polylogue-readme-positioning-2026-07-14/` | 2026-07-14 | README/positioning draft work — see `START-HERE-polylogue.md` |
 | `polylogue-session-snapshot-2026-07-08/` | 2026-07-08 | A single captured ChatGPT session (html/md/messages.json/router-stream.js) used as an analysis fixture |
 | `polylogue-sol-pro-2026-07-15/` | 2026-07-15/16 | 28 Sol/Pro launch-dispatch deliverables (design+patches), currently the only surviving copy of that output — see its own `README.md` and `polylogue-3v1` for the capture-gap status |
+| `external-agent-campaigns/` | 2026-07-16 onward | Reusable, provider-independent campaign input/result layout plus paste-ready ChatGPT Pro portfolios. This is repository-side orchestration material, not extension/product state. |
 
 For the Gemini/AI Studio equivalent, see `/realm/inbox/handoffs/polylogue-gemini-2026-07-16/` (outside this repo — not yet unified here, tracked separately).

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/README.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/README.md
@@ -1,0 +1,24 @@
+# GPT Pro wave — 2026-07-16
+
+Prepared input portfolio for manual-first, automation-ready dispatch after the
+test-harness foundation is merged and a fresh Lynchpin Chisel project-state
+archive is generated.
+
+Workloads:
+
+- `testdiet/`: 16 staged implementation-draft lanes over the Test Suite Diet;
+- `beads/`: high-fit implementation clusters selected from current Beads;
+- `analysis/`: custom cross-cutting audits and adjudication;
+- `deep-research/`: source-cited external research tied to concrete decisions.
+
+Every prompt begins with a literal `Title: "..."`, declares a readable job and
+exact unique output filename, and requires a substantive answer plus a verified
+package. The same project-state attachment may be reused across jobs only while
+its snapshot identity remains authoritative.
+
+Do not launch the Test Diet implementation prompts until the foundation mission
+below has landed, the project-state archive has been regenerated, and the job's
+dependency state in `campaign.json` is satisfied.
+
+The active local test-harness agent should receive
+[`test-harness-agent-foundation-mission.md`](test-harness-agent-foundation-mission.md).

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/README.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/README.md
@@ -1,0 +1,4 @@
+# Custom analysis portfolio
+
+Eight analysis/adjudication jobs suited to broad source and Beads inspection.
+They produce decision inputs, not speculative implementation patches.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/01-bead-overlap-contradictions.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/01-bead-overlap-contradictions.md
@@ -1,0 +1,13 @@
+Title: "[analysis 01] Bead overlap and contradiction audit"
+
+Job ID: `analysis-01`
+Result ZIP: `analysis-01-bead-overlap-contradictions-r01.zip`
+
+Audit all open/in-progress Polylogue Beads by current source area, intended
+authority, dependency, and acceptance semantics. Find duplicate owners,
+contradictory product decisions, stale descriptions superseded by notes,
+parallel registries/protocols, false blockers, and clusters that should share
+one branch versus remain separate. Prioritize P0/P1 and active write hotspots.
+Return a source-validated graph-change proposal and execution clusters, but do
+not mutate Beads. Every proposed merge/supersede/dependency change needs exact
+evidence and an explanation of information that must be preserved.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/02-campaign-effectiveness.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/02-campaign-effectiveness.md
@@ -1,0 +1,14 @@
+Title: "[analysis 02] External-agent campaign effectiveness postmortem"
+
+Job ID: `analysis-02`
+Result ZIP: `analysis-02-campaign-effectiveness-r01.zip`
+
+Reconstruct the full recent GPT Pro campaign from canonical Polylogue sessions,
+handoff corpora, package ledgers, Beads, git, worktrees, PRs, and corrections.
+Measure the honest funnel from submitted conversation through terminal turn,
+asset acquisition, validation, triage, incorporated work, local repair,
+verification, PR, merge, and Bead closure. Relate prompt/mission shape, package
+size/content, iterations, failures, and timing to yield without claiming
+causality the data cannot support. Produce concrete prompt, routing, repair,
+cadence, and integration improvements plus the telemetry schema needed for the
+next campaign.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/03-active-diff-ac-review.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/03-active-diff-ac-review.md
@@ -1,0 +1,13 @@
+Title: "[analysis 03] Adversarial AC review of active large diffs"
+
+Job ID: `analysis-03`
+Result ZIP: `analysis-03-active-diff-ac-review-r01.zip`
+
+Review every currently active substantial Polylogue branch/worktree/PR against
+its complete owning Beads and current master. Build a per-AC matrix, trace every
+claim to changed production routes and tests, identify uncommitted/stranded
+value, overlaps, stale-base conflicts, invented parallel mechanisms, vacuous
+tests, missing generated surfaces, and unsafe merge ordering. This mission is
+an adversarial audit by definition; do not merely summarize diffs. Return
+repair prompts/actions per branch and an integration order, but do not claim
+checks ran or recommend wholesale application without source evidence.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/04-surface-semantic-matrix.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/04-surface-semantic-matrix.md
@@ -1,0 +1,13 @@
+Title: "[analysis 04] Cross-surface semantic parity matrix"
+
+Job ID: `analysis-04`
+Result ZIP: `analysis-04-surface-semantic-matrix-r01.zip`
+
+Map CLI, Python API, repository/operations, daemon HTTP, MCP, and browser
+capture/status surfaces to the semantic facts and mutation authorities they
+expose. For each repeated concept, identify the substrate owner, projection
+differences, origin/provider vocabulary, identity, absence/error/provenance,
+pagination, and authorization semantics. Find real divergence and duplication,
+distinguish legitimate presentation differences, and propose a prioritized
+parity-test/refactor plan tied to owning Beads. Do not propose one giant surface
+abstraction or rely on names alone; trace actual call paths.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/05-duplicate-authority-census.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/05-duplicate-authority-census.md
@@ -1,0 +1,13 @@
+Title: "[analysis 05] Definition-to-production duplicate-authority census"
+
+Job ID: `analysis-05`
+Result ZIP: `analysis-05-duplicate-authority-census-r01.zip`
+
+Find concepts defined in two or more registries, schemas, generated catalogs,
+enums, routes, tool declarations, config maps, fixtures, or docs where more than
+one copy influences production. Trace writers, generators, validators, and
+consumers, then classify canonical authority, projection, compatibility copy,
+dead duplicate, or unresolved collision. Prioritize duplicates that cause drift
+or broad edit cost. Return a ranked consolidation portfolio with exact deletion
+gates and tests that exercise the real consumer; do not equate textual
+duplication with semantic duplicate authority.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/06-fixture-portfolio.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/06-fixture-portfolio.md
@@ -1,0 +1,14 @@
+Title: "[analysis 06] Compact synthetic fixture portfolio design"
+
+Job ID: `analysis-06`
+Result ZIP: `analysis-06-fixture-portfolio-r01.zip`
+
+Design a small composable portfolio of privacy-safe synthetic workloads that
+activates Polylogue's highest-risk cross-module laws: provider ambiguity,
+authoredness, attachments/assets, lineage, action joins, convergence debt,
+rebuild equivalence, query composition/cardinality, evidence absence and
+provenance, temporal edges, and scale/selectivity. Reuse the current workload
+profile/identity/canary substrate rather than defining another generator.
+Specify planted independent facts, combinable variants, minimization, stable
+identities, expected resource tiers, and which existing fixtures can migrate.
+Return a decision-ready design and exact source integration map, not code.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/07-cold-start-review.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/07-cold-start-review.md
@@ -1,0 +1,13 @@
+Title: "[analysis 07] Cold-start agent usability review"
+
+Job ID: `analysis-07`
+Result ZIP: `analysis-07-cold-start-review-r01.zip`
+
+Act as a capable but cold-start coding agent encountering Polylogue only through
+the attached repository. Attempt to derive install, architecture, devloop,
+query/API/MCP usage, testing, schema rules, browser capture, Beads, and release
+workflow from the actual docs and scripts. Record wrong turns, contradictions,
+missing executable examples, stale generated references, hidden prerequisites,
+and high cognitive-load hubs. Cross-check claims against source. Return an
+ordered legibility/manual repair plan and exact falsifiable cold-start tasks;
+do not rewrite the README based on taste alone.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/08-capture-timing-completeness.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/briefs/08-capture-timing-completeness.md
@@ -1,0 +1,16 @@
+Title: "[analysis 08] Browser-capture timing and completion evidence audit"
+
+Job ID: `analysis-08`
+Result ZIP: `analysis-08-capture-timing-completeness-r01.zip`
+
+Audit the full ChatGPT browser-capture path—from page bridge/network payload,
+DOM/lifecycle observation, receiver spool/acquisition, raw source evidence,
+parser normalization, index columns, semantic timing/profile, and public
+queries—for generation start/progress/terminal state, reasoning duration,
+message duration, model/effort, attachments, and assistant-produced assets.
+Use actual captured fixture shapes, including `reasoning_start_time`,
+`reasoning_end_time`, and `finished_duration_sec`. Distinguish already captured
+raw evidence, projection loss, genuinely transient UI/stream state, and
+unsupported claims such as relabeling wall duration as model compute. Return a
+field-by-field completeness matrix and implementation/test plan tied to current
+Beads.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/campaign.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/campaign.json
@@ -1,0 +1,17 @@
+{
+  "schema_version":1,
+  "campaign_id":"gpt-pro-wave-2026-07-16",
+  "workload_id":"analysis",
+  "prompt_profile":"polylogue-chatgpt-pro-analysis-v3",
+  "prompt_contract":"../../contracts/chatgpt-pro-analysis.md",
+  "jobs":[
+    {"id":"analysis-01","slug":"bead-overlap-contradictions","title":"Bead overlap and contradiction audit","brief":"briefs/01-bead-overlap-contradictions.md","prompt":"prompts/01-bead-overlap-contradictions.md","result_prefix":"analysis-01-bead-overlap-contradictions","depends_on":[]},
+    {"id":"analysis-02","slug":"campaign-effectiveness","title":"External-agent campaign effectiveness postmortem","brief":"briefs/02-campaign-effectiveness.md","prompt":"prompts/02-campaign-effectiveness.md","result_prefix":"analysis-02-campaign-effectiveness","depends_on":[]},
+    {"id":"analysis-03","slug":"active-diff-ac-review","title":"Adversarial AC review of active large diffs","brief":"briefs/03-active-diff-ac-review.md","prompt":"prompts/03-active-diff-ac-review.md","result_prefix":"analysis-03-active-diff-ac-review","depends_on":[]},
+    {"id":"analysis-04","slug":"surface-semantic-matrix","title":"Cross-surface semantic parity matrix","brief":"briefs/04-surface-semantic-matrix.md","prompt":"prompts/04-surface-semantic-matrix.md","result_prefix":"analysis-04-surface-semantic-matrix","depends_on":[]},
+    {"id":"analysis-05","slug":"duplicate-authority-census","title":"Definition-to-production duplicate-authority census","brief":"briefs/05-duplicate-authority-census.md","prompt":"prompts/05-duplicate-authority-census.md","result_prefix":"analysis-05-duplicate-authority-census","depends_on":[]},
+    {"id":"analysis-06","slug":"fixture-portfolio","title":"Compact synthetic fixture portfolio design","brief":"briefs/06-fixture-portfolio.md","prompt":"prompts/06-fixture-portfolio.md","result_prefix":"analysis-06-fixture-portfolio","depends_on":[]},
+    {"id":"analysis-07","slug":"cold-start-review","title":"Cold-start agent usability review","brief":"briefs/07-cold-start-review.md","prompt":"prompts/07-cold-start-review.md","result_prefix":"analysis-07-cold-start-review","depends_on":[]},
+    {"id":"analysis-08","slug":"capture-timing-completeness","title":"Browser-capture timing and completion evidence audit","brief":"briefs/08-capture-timing-completeness.md","prompt":"prompts/08-capture-timing-completeness.md","result_prefix":"analysis-08-capture-timing-completeness","depends_on":[]}
+  ]
+}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/01-bead-overlap-contradictions.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/01-bead-overlap-contradictions.md
@@ -1,0 +1,60 @@
+Title: "[analysis 01] Bead overlap and contradiction audit"
+
+Job ID: `analysis-01`
+Result ZIP: `analysis-01-bead-overlap-contradictions-r01.zip`
+
+Audit all open/in-progress Polylogue Beads by current source area, intended
+authority, dependency, and acceptance semantics. Find duplicate owners,
+contradictory product decisions, stale descriptions superseded by notes,
+parallel registries/protocols, false blockers, and clusters that should share
+one branch versus remain separate. Prioritize P0/P1 and active write hotspots.
+Return a source-validated graph-change proposal and execution clusters, but do
+not mutate Beads. Every proposed merge/supersede/dependency change needs exact
+evidence and an explanation of information that must be preserved.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro analysis worker. A recent, complete
+Polylogue project-state archive will be attached. Retrieve and inspect it
+broadly; attachment size alone is not a reason to ignore evidence. This prompt
+defines the question. The snapshot's current source, repository instructions,
+complete relevant Beads records, and cited history are the evidence authority,
+in that order when older plans drift.
+
+## Working contract
+
+- Investigate the actual source and tracker state before recommending changes.
+- Separate observed facts, source-supported inference, unresolved uncertainty,
+  and recommendation. Quote paths/symbols/Bead ids precisely but do not fill the
+  report with copied source.
+- Adjudicate contradictions and duplicates; do not create a parallel product
+  model or generic architecture merely to make the report look complete.
+- Translate findings into decision-ready actions: exact owning areas, ordering,
+  acceptance criteria, falsification evidence, and what a local implementer
+  should verify.
+- Do not claim live browser, daemon, archive, deployment, or test evidence you
+  cannot access.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`. It must
+contain `REPORT.md`, `EVIDENCE.md`, `DECISIONS.md`, and `NEXT-ACTIONS.md`.
+Include compact machine-readable tables as JSON/CSV only when they add genuine
+integration value. Do not copy the input archive into the result. Attach the
+finished ZIP to the conversation through a working user-clickable link; files
+left only in an internal temporary directory are not delivered.
+
+Reopen and validate the ZIP, then report its SHA-256, size, and members. The
+final chat answer must itself explain the important conclusions and decisions,
+limitations, missing evidence, and the likely value of another iteration before
+linking the package.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, preserve sound findings, resolve the
+highest-value remaining uncertainty, and regenerate a complete package
+revision. On an explicit **adversarial review** request, try to falsify the
+prior report: seek contrary source/history evidence, unsupported certainty,
+missed stakeholders/call sites, duplicate or incompatible designs, weak
+acceptance criteria, and recommendations that do not survive current code.
+Repair legitimate findings, regenerate the cohesive package, and report the
+delta, residual disputes, and expected value of another pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/02-campaign-effectiveness.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/02-campaign-effectiveness.md
@@ -1,0 +1,61 @@
+Title: "[analysis 02] External-agent campaign effectiveness postmortem"
+
+Job ID: `analysis-02`
+Result ZIP: `analysis-02-campaign-effectiveness-r01.zip`
+
+Reconstruct the full recent GPT Pro campaign from canonical Polylogue sessions,
+handoff corpora, package ledgers, Beads, git, worktrees, PRs, and corrections.
+Measure the honest funnel from submitted conversation through terminal turn,
+asset acquisition, validation, triage, incorporated work, local repair,
+verification, PR, merge, and Bead closure. Relate prompt/mission shape, package
+size/content, iterations, failures, and timing to yield without claiming
+causality the data cannot support. Produce concrete prompt, routing, repair,
+cadence, and integration improvements plus the telemetry schema needed for the
+next campaign.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro analysis worker. A recent, complete
+Polylogue project-state archive will be attached. Retrieve and inspect it
+broadly; attachment size alone is not a reason to ignore evidence. This prompt
+defines the question. The snapshot's current source, repository instructions,
+complete relevant Beads records, and cited history are the evidence authority,
+in that order when older plans drift.
+
+## Working contract
+
+- Investigate the actual source and tracker state before recommending changes.
+- Separate observed facts, source-supported inference, unresolved uncertainty,
+  and recommendation. Quote paths/symbols/Bead ids precisely but do not fill the
+  report with copied source.
+- Adjudicate contradictions and duplicates; do not create a parallel product
+  model or generic architecture merely to make the report look complete.
+- Translate findings into decision-ready actions: exact owning areas, ordering,
+  acceptance criteria, falsification evidence, and what a local implementer
+  should verify.
+- Do not claim live browser, daemon, archive, deployment, or test evidence you
+  cannot access.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`. It must
+contain `REPORT.md`, `EVIDENCE.md`, `DECISIONS.md`, and `NEXT-ACTIONS.md`.
+Include compact machine-readable tables as JSON/CSV only when they add genuine
+integration value. Do not copy the input archive into the result. Attach the
+finished ZIP to the conversation through a working user-clickable link; files
+left only in an internal temporary directory are not delivered.
+
+Reopen and validate the ZIP, then report its SHA-256, size, and members. The
+final chat answer must itself explain the important conclusions and decisions,
+limitations, missing evidence, and the likely value of another iteration before
+linking the package.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, preserve sound findings, resolve the
+highest-value remaining uncertainty, and regenerate a complete package
+revision. On an explicit **adversarial review** request, try to falsify the
+prior report: seek contrary source/history evidence, unsupported certainty,
+missed stakeholders/call sites, duplicate or incompatible designs, weak
+acceptance criteria, and recommendations that do not survive current code.
+Repair legitimate findings, regenerate the cohesive package, and report the
+delta, residual disputes, and expected value of another pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/03-active-diff-ac-review.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/03-active-diff-ac-review.md
@@ -1,0 +1,60 @@
+Title: "[analysis 03] Adversarial AC review of active large diffs"
+
+Job ID: `analysis-03`
+Result ZIP: `analysis-03-active-diff-ac-review-r01.zip`
+
+Review every currently active substantial Polylogue branch/worktree/PR against
+its complete owning Beads and current master. Build a per-AC matrix, trace every
+claim to changed production routes and tests, identify uncommitted/stranded
+value, overlaps, stale-base conflicts, invented parallel mechanisms, vacuous
+tests, missing generated surfaces, and unsafe merge ordering. This mission is
+an adversarial audit by definition; do not merely summarize diffs. Return
+repair prompts/actions per branch and an integration order, but do not claim
+checks ran or recommend wholesale application without source evidence.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro analysis worker. A recent, complete
+Polylogue project-state archive will be attached. Retrieve and inspect it
+broadly; attachment size alone is not a reason to ignore evidence. This prompt
+defines the question. The snapshot's current source, repository instructions,
+complete relevant Beads records, and cited history are the evidence authority,
+in that order when older plans drift.
+
+## Working contract
+
+- Investigate the actual source and tracker state before recommending changes.
+- Separate observed facts, source-supported inference, unresolved uncertainty,
+  and recommendation. Quote paths/symbols/Bead ids precisely but do not fill the
+  report with copied source.
+- Adjudicate contradictions and duplicates; do not create a parallel product
+  model or generic architecture merely to make the report look complete.
+- Translate findings into decision-ready actions: exact owning areas, ordering,
+  acceptance criteria, falsification evidence, and what a local implementer
+  should verify.
+- Do not claim live browser, daemon, archive, deployment, or test evidence you
+  cannot access.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`. It must
+contain `REPORT.md`, `EVIDENCE.md`, `DECISIONS.md`, and `NEXT-ACTIONS.md`.
+Include compact machine-readable tables as JSON/CSV only when they add genuine
+integration value. Do not copy the input archive into the result. Attach the
+finished ZIP to the conversation through a working user-clickable link; files
+left only in an internal temporary directory are not delivered.
+
+Reopen and validate the ZIP, then report its SHA-256, size, and members. The
+final chat answer must itself explain the important conclusions and decisions,
+limitations, missing evidence, and the likely value of another iteration before
+linking the package.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, preserve sound findings, resolve the
+highest-value remaining uncertainty, and regenerate a complete package
+revision. On an explicit **adversarial review** request, try to falsify the
+prior report: seek contrary source/history evidence, unsupported certainty,
+missed stakeholders/call sites, duplicate or incompatible designs, weak
+acceptance criteria, and recommendations that do not survive current code.
+Repair legitimate findings, regenerate the cohesive package, and report the
+delta, residual disputes, and expected value of another pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/04-surface-semantic-matrix.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/04-surface-semantic-matrix.md
@@ -1,0 +1,60 @@
+Title: "[analysis 04] Cross-surface semantic parity matrix"
+
+Job ID: `analysis-04`
+Result ZIP: `analysis-04-surface-semantic-matrix-r01.zip`
+
+Map CLI, Python API, repository/operations, daemon HTTP, MCP, and browser
+capture/status surfaces to the semantic facts and mutation authorities they
+expose. For each repeated concept, identify the substrate owner, projection
+differences, origin/provider vocabulary, identity, absence/error/provenance,
+pagination, and authorization semantics. Find real divergence and duplication,
+distinguish legitimate presentation differences, and propose a prioritized
+parity-test/refactor plan tied to owning Beads. Do not propose one giant surface
+abstraction or rely on names alone; trace actual call paths.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro analysis worker. A recent, complete
+Polylogue project-state archive will be attached. Retrieve and inspect it
+broadly; attachment size alone is not a reason to ignore evidence. This prompt
+defines the question. The snapshot's current source, repository instructions,
+complete relevant Beads records, and cited history are the evidence authority,
+in that order when older plans drift.
+
+## Working contract
+
+- Investigate the actual source and tracker state before recommending changes.
+- Separate observed facts, source-supported inference, unresolved uncertainty,
+  and recommendation. Quote paths/symbols/Bead ids precisely but do not fill the
+  report with copied source.
+- Adjudicate contradictions and duplicates; do not create a parallel product
+  model or generic architecture merely to make the report look complete.
+- Translate findings into decision-ready actions: exact owning areas, ordering,
+  acceptance criteria, falsification evidence, and what a local implementer
+  should verify.
+- Do not claim live browser, daemon, archive, deployment, or test evidence you
+  cannot access.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`. It must
+contain `REPORT.md`, `EVIDENCE.md`, `DECISIONS.md`, and `NEXT-ACTIONS.md`.
+Include compact machine-readable tables as JSON/CSV only when they add genuine
+integration value. Do not copy the input archive into the result. Attach the
+finished ZIP to the conversation through a working user-clickable link; files
+left only in an internal temporary directory are not delivered.
+
+Reopen and validate the ZIP, then report its SHA-256, size, and members. The
+final chat answer must itself explain the important conclusions and decisions,
+limitations, missing evidence, and the likely value of another iteration before
+linking the package.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, preserve sound findings, resolve the
+highest-value remaining uncertainty, and regenerate a complete package
+revision. On an explicit **adversarial review** request, try to falsify the
+prior report: seek contrary source/history evidence, unsupported certainty,
+missed stakeholders/call sites, duplicate or incompatible designs, weak
+acceptance criteria, and recommendations that do not survive current code.
+Repair legitimate findings, regenerate the cohesive package, and report the
+delta, residual disputes, and expected value of another pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/05-duplicate-authority-census.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/05-duplicate-authority-census.md
@@ -1,0 +1,60 @@
+Title: "[analysis 05] Definition-to-production duplicate-authority census"
+
+Job ID: `analysis-05`
+Result ZIP: `analysis-05-duplicate-authority-census-r01.zip`
+
+Find concepts defined in two or more registries, schemas, generated catalogs,
+enums, routes, tool declarations, config maps, fixtures, or docs where more than
+one copy influences production. Trace writers, generators, validators, and
+consumers, then classify canonical authority, projection, compatibility copy,
+dead duplicate, or unresolved collision. Prioritize duplicates that cause drift
+or broad edit cost. Return a ranked consolidation portfolio with exact deletion
+gates and tests that exercise the real consumer; do not equate textual
+duplication with semantic duplicate authority.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro analysis worker. A recent, complete
+Polylogue project-state archive will be attached. Retrieve and inspect it
+broadly; attachment size alone is not a reason to ignore evidence. This prompt
+defines the question. The snapshot's current source, repository instructions,
+complete relevant Beads records, and cited history are the evidence authority,
+in that order when older plans drift.
+
+## Working contract
+
+- Investigate the actual source and tracker state before recommending changes.
+- Separate observed facts, source-supported inference, unresolved uncertainty,
+  and recommendation. Quote paths/symbols/Bead ids precisely but do not fill the
+  report with copied source.
+- Adjudicate contradictions and duplicates; do not create a parallel product
+  model or generic architecture merely to make the report look complete.
+- Translate findings into decision-ready actions: exact owning areas, ordering,
+  acceptance criteria, falsification evidence, and what a local implementer
+  should verify.
+- Do not claim live browser, daemon, archive, deployment, or test evidence you
+  cannot access.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`. It must
+contain `REPORT.md`, `EVIDENCE.md`, `DECISIONS.md`, and `NEXT-ACTIONS.md`.
+Include compact machine-readable tables as JSON/CSV only when they add genuine
+integration value. Do not copy the input archive into the result. Attach the
+finished ZIP to the conversation through a working user-clickable link; files
+left only in an internal temporary directory are not delivered.
+
+Reopen and validate the ZIP, then report its SHA-256, size, and members. The
+final chat answer must itself explain the important conclusions and decisions,
+limitations, missing evidence, and the likely value of another iteration before
+linking the package.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, preserve sound findings, resolve the
+highest-value remaining uncertainty, and regenerate a complete package
+revision. On an explicit **adversarial review** request, try to falsify the
+prior report: seek contrary source/history evidence, unsupported certainty,
+missed stakeholders/call sites, duplicate or incompatible designs, weak
+acceptance criteria, and recommendations that do not survive current code.
+Repair legitimate findings, regenerate the cohesive package, and report the
+delta, residual disputes, and expected value of another pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/06-fixture-portfolio.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/06-fixture-portfolio.md
@@ -1,0 +1,61 @@
+Title: "[analysis 06] Compact synthetic fixture portfolio design"
+
+Job ID: `analysis-06`
+Result ZIP: `analysis-06-fixture-portfolio-r01.zip`
+
+Design a small composable portfolio of privacy-safe synthetic workloads that
+activates Polylogue's highest-risk cross-module laws: provider ambiguity,
+authoredness, attachments/assets, lineage, action joins, convergence debt,
+rebuild equivalence, query composition/cardinality, evidence absence and
+provenance, temporal edges, and scale/selectivity. Reuse the current workload
+profile/identity/canary substrate rather than defining another generator.
+Specify planted independent facts, combinable variants, minimization, stable
+identities, expected resource tiers, and which existing fixtures can migrate.
+Return a decision-ready design and exact source integration map, not code.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro analysis worker. A recent, complete
+Polylogue project-state archive will be attached. Retrieve and inspect it
+broadly; attachment size alone is not a reason to ignore evidence. This prompt
+defines the question. The snapshot's current source, repository instructions,
+complete relevant Beads records, and cited history are the evidence authority,
+in that order when older plans drift.
+
+## Working contract
+
+- Investigate the actual source and tracker state before recommending changes.
+- Separate observed facts, source-supported inference, unresolved uncertainty,
+  and recommendation. Quote paths/symbols/Bead ids precisely but do not fill the
+  report with copied source.
+- Adjudicate contradictions and duplicates; do not create a parallel product
+  model or generic architecture merely to make the report look complete.
+- Translate findings into decision-ready actions: exact owning areas, ordering,
+  acceptance criteria, falsification evidence, and what a local implementer
+  should verify.
+- Do not claim live browser, daemon, archive, deployment, or test evidence you
+  cannot access.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`. It must
+contain `REPORT.md`, `EVIDENCE.md`, `DECISIONS.md`, and `NEXT-ACTIONS.md`.
+Include compact machine-readable tables as JSON/CSV only when they add genuine
+integration value. Do not copy the input archive into the result. Attach the
+finished ZIP to the conversation through a working user-clickable link; files
+left only in an internal temporary directory are not delivered.
+
+Reopen and validate the ZIP, then report its SHA-256, size, and members. The
+final chat answer must itself explain the important conclusions and decisions,
+limitations, missing evidence, and the likely value of another iteration before
+linking the package.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, preserve sound findings, resolve the
+highest-value remaining uncertainty, and regenerate a complete package
+revision. On an explicit **adversarial review** request, try to falsify the
+prior report: seek contrary source/history evidence, unsupported certainty,
+missed stakeholders/call sites, duplicate or incompatible designs, weak
+acceptance criteria, and recommendations that do not survive current code.
+Repair legitimate findings, regenerate the cohesive package, and report the
+delta, residual disputes, and expected value of another pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/07-cold-start-review.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/07-cold-start-review.md
@@ -1,0 +1,60 @@
+Title: "[analysis 07] Cold-start agent usability review"
+
+Job ID: `analysis-07`
+Result ZIP: `analysis-07-cold-start-review-r01.zip`
+
+Act as a capable but cold-start coding agent encountering Polylogue only through
+the attached repository. Attempt to derive install, architecture, devloop,
+query/API/MCP usage, testing, schema rules, browser capture, Beads, and release
+workflow from the actual docs and scripts. Record wrong turns, contradictions,
+missing executable examples, stale generated references, hidden prerequisites,
+and high cognitive-load hubs. Cross-check claims against source. Return an
+ordered legibility/manual repair plan and exact falsifiable cold-start tasks;
+do not rewrite the README based on taste alone.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro analysis worker. A recent, complete
+Polylogue project-state archive will be attached. Retrieve and inspect it
+broadly; attachment size alone is not a reason to ignore evidence. This prompt
+defines the question. The snapshot's current source, repository instructions,
+complete relevant Beads records, and cited history are the evidence authority,
+in that order when older plans drift.
+
+## Working contract
+
+- Investigate the actual source and tracker state before recommending changes.
+- Separate observed facts, source-supported inference, unresolved uncertainty,
+  and recommendation. Quote paths/symbols/Bead ids precisely but do not fill the
+  report with copied source.
+- Adjudicate contradictions and duplicates; do not create a parallel product
+  model or generic architecture merely to make the report look complete.
+- Translate findings into decision-ready actions: exact owning areas, ordering,
+  acceptance criteria, falsification evidence, and what a local implementer
+  should verify.
+- Do not claim live browser, daemon, archive, deployment, or test evidence you
+  cannot access.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`. It must
+contain `REPORT.md`, `EVIDENCE.md`, `DECISIONS.md`, and `NEXT-ACTIONS.md`.
+Include compact machine-readable tables as JSON/CSV only when they add genuine
+integration value. Do not copy the input archive into the result. Attach the
+finished ZIP to the conversation through a working user-clickable link; files
+left only in an internal temporary directory are not delivered.
+
+Reopen and validate the ZIP, then report its SHA-256, size, and members. The
+final chat answer must itself explain the important conclusions and decisions,
+limitations, missing evidence, and the likely value of another iteration before
+linking the package.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, preserve sound findings, resolve the
+highest-value remaining uncertainty, and regenerate a complete package
+revision. On an explicit **adversarial review** request, try to falsify the
+prior report: seek contrary source/history evidence, unsupported certainty,
+missed stakeholders/call sites, duplicate or incompatible designs, weak
+acceptance criteria, and recommendations that do not survive current code.
+Repair legitimate findings, regenerate the cohesive package, and report the
+delta, residual disputes, and expected value of another pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/08-capture-timing-completeness.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/prompts/08-capture-timing-completeness.md
@@ -1,0 +1,63 @@
+Title: "[analysis 08] Browser-capture timing and completion evidence audit"
+
+Job ID: `analysis-08`
+Result ZIP: `analysis-08-capture-timing-completeness-r01.zip`
+
+Audit the full ChatGPT browser-capture path—from page bridge/network payload,
+DOM/lifecycle observation, receiver spool/acquisition, raw source evidence,
+parser normalization, index columns, semantic timing/profile, and public
+queries—for generation start/progress/terminal state, reasoning duration,
+message duration, model/effort, attachments, and assistant-produced assets.
+Use actual captured fixture shapes, including `reasoning_start_time`,
+`reasoning_end_time`, and `finished_duration_sec`. Distinguish already captured
+raw evidence, projection loss, genuinely transient UI/stream state, and
+unsupported claims such as relabeling wall duration as model compute. Return a
+field-by-field completeness matrix and implementation/test plan tied to current
+Beads.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro analysis worker. A recent, complete
+Polylogue project-state archive will be attached. Retrieve and inspect it
+broadly; attachment size alone is not a reason to ignore evidence. This prompt
+defines the question. The snapshot's current source, repository instructions,
+complete relevant Beads records, and cited history are the evidence authority,
+in that order when older plans drift.
+
+## Working contract
+
+- Investigate the actual source and tracker state before recommending changes.
+- Separate observed facts, source-supported inference, unresolved uncertainty,
+  and recommendation. Quote paths/symbols/Bead ids precisely but do not fill the
+  report with copied source.
+- Adjudicate contradictions and duplicates; do not create a parallel product
+  model or generic architecture merely to make the report look complete.
+- Translate findings into decision-ready actions: exact owning areas, ordering,
+  acceptance criteria, falsification evidence, and what a local implementer
+  should verify.
+- Do not claim live browser, daemon, archive, deployment, or test evidence you
+  cannot access.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`. It must
+contain `REPORT.md`, `EVIDENCE.md`, `DECISIONS.md`, and `NEXT-ACTIONS.md`.
+Include compact machine-readable tables as JSON/CSV only when they add genuine
+integration value. Do not copy the input archive into the result. Attach the
+finished ZIP to the conversation through a working user-clickable link; files
+left only in an internal temporary directory are not delivered.
+
+Reopen and validate the ZIP, then report its SHA-256, size, and members. The
+final chat answer must itself explain the important conclusions and decisions,
+limitations, missing evidence, and the likely value of another iteration before
+linking the package.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, preserve sound findings, resolve the
+highest-value remaining uncertainty, and regenerate a complete package
+revision. On an explicit **adversarial review** request, try to falsify the
+prior report: seek contrary source/history evidence, unsupported certainty,
+missed stakeholders/call sites, duplicate or incompatible designs, weak
+acceptance criteria, and recommendations that do not survive current code.
+Repair legitimate findings, regenerate the cohesive package, and report the
+delta, residual disputes, and expected value of another pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/README.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/README.md
@@ -1,0 +1,4 @@
+# Results
+
+Use the campaign-standard immutable attempt layout. Analysis revisions from the
+same chat receive new attempt/package revision IDs and supersedes links.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/index.json
@@ -1,0 +1,1 @@
+{"schema_version":1,"campaign_id":"gpt-pro-wave-2026-07-16","workload_id":"analysis","attempts":[]}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/README.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/README.md
@@ -1,0 +1,5 @@
+# Beads implementation portfolio
+
+Ten high-fit implementation portfolios derived from current Beads. These are
+independent of the Test Diet prompts, though the same fresh Chisel project-state
+attachment can be reused. Read each prompt's dependencies before dispatch.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/01-config-closure.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/01-config-closure.md
@@ -1,0 +1,18 @@
+Title: "[beads 01] Configuration precedence closure"
+
+Job ID: `beads-01`
+Result ZIP: `beads-01-config-closure-r01.zip`
+Primary Beads: `polylogue-9gh1`, `polylogue-fd2s`, `polylogue-cxlk`; treat
+`polylogue-uu8r` as a separately partitioned migration unless current source
+proves the write footprint is cohesive.
+
+## Mission
+
+Close the actual configuration precedence/merge slice across config files,
+environment, explicit arguments, runtime inventory, archive tier roots, and
+diagnostics. Read every later note and current call site. Implement one typed
+authority and migrate the relevant consumers rather than adding another
+normalization wrapper. Preserve provider/runtime-specific direct-environment
+behavior only where it is a real boundary, and make conflicting/split roots
+fail honestly. Include real-route tests through at least the config facade and
+daemon/CLI consumer paths plus a precise residual matrix for `uu8r`.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/02-mcp-algebra-contract.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/02-mcp-algebra-contract.md
@@ -1,0 +1,18 @@
+Title: "[beads 02] MCP algebra contract and equivalence map"
+
+Job ID: `beads-02`
+Result ZIP: `beads-02-mcp-algebra-contract-r01.zip`
+Primary Beads: `polylogue-t46.8`, especially contract/map child
+`polylogue-t46.8.1`, plus `polylogue-s1kr`.
+
+## Mission
+
+Resolve and implement the shared MCP tool algebra contract that can replace
+hand-authored surface repetition without erasing distinct authorization,
+ObjectRef, schema, or workflow semantics. Inventory all current registered
+tools, contracts, generated Python parity expectations, and operation/query
+owners. Produce the smallest executable descriptor/adapter kernel plus an
+equivalence map that proves discovery names, input/output schemas, role gates,
+and behavior remain stable. Do not migrate every tool in this job unless the
+current Beads explicitly authorize it; leave exact disjoint migration groups
+for jobs 03 and 04.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/03-mcp-read-migration.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/03-mcp-read-migration.md
@@ -1,0 +1,16 @@
+Title: "[beads 03] MCP read-surface algebra migration"
+
+Job ID: `beads-03`
+Result ZIP: `beads-03-mcp-read-migration-r01.zip`
+Dependency: the accepted algebra/equivalence kernel from `beads-02`.
+
+## Mission
+
+Migrate the disjoint MCP read/search/insight/topology/timeline tool families
+onto the accepted shared algebra. Preserve exact discovery names, schemas,
+role gates, ObjectRef semantics, query behavior, pagination, and error/absence
+contracts. Remove superseded per-tool glue in the same patch rather than
+keeping two authorities. Update the generated Python parity matrix and MCP
+tool/contract fixtures required by current source. Prove representative tools
+through the real MCP registration and operations route, not by testing the
+descriptor in isolation.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/04-mcp-context-migration.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/04-mcp-context-migration.md
@@ -1,0 +1,16 @@
+Title: "[beads 04] MCP context and assertion algebra migration"
+
+Job ID: `beads-04`
+Result ZIP: `beads-04-mcp-context-migration-r01.zip`
+Dependency: the accepted algebra/equivalence kernel from `beads-02`.
+
+## Mission
+
+Migrate the MCP context/recall/assertion/correction/maintenance tool families
+onto the accepted algebra while preserving their materially different write,
+trust, injection-policy, authorization, and audit contracts. Keep candidate
+agent-authored material distinct from operator judgment and preserve immutable
+annotation schema/batch provenance. Delete superseded glue, update discovery
+and tool contracts, and exercise real user-tier writes and readback through the
+MCP surface. Do not collapse destructive/maintenance authorization into a
+generic handler.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/05-semantic-transcript.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/05-semantic-transcript.md
@@ -1,0 +1,16 @@
+Title: "[beads 05] Semantic transcript rendering"
+
+Job ID: `beads-05`
+Result ZIP: `beads-05-semantic-transcript-r01.zip`
+Primary Beads: `polylogue-ap7.1`, `polylogue-395j`.
+
+## Mission
+
+Implement a semantic transcript rendering slice that presents messages,
+thinking, tools/results, attachments, lineage, authoredness, and status in a
+readable form without losing machine identity or inventing prose-derived
+semantics. Reuse the canonical composed session tree and existing projection
+vocabulary. Ensure CLI/read/API or the exact stable surfaces named by the Beads
+share one semantic renderer with presentation-specific framing at the leaf.
+Cover mixed protocol/context rows, errors, variants, inherited prefixes, and
+attachments through real fixtures. Remove superseded renderer duplication.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/06-agent-manual-install.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/06-agent-manual-install.md
@@ -1,0 +1,17 @@
+Title: "[beads 06] Executable agent manual and install kit"
+
+Job ID: `beads-06`
+Result ZIP: `beads-06-agent-manual-install-r01.zip`
+Primary Beads: `polylogue-3gd.2`, `polylogue-3gd.3`.
+
+## Mission
+
+Build the executable cold-start agent manual and installation kit from current
+packaging, CLI, MCP, daemon, config, demo, and Nix/cloud contracts. A new agent
+must be able to identify the right install path, seed or import privacy-safe
+data, verify the daemon/archive, connect MCP, run representative queries, and
+diagnose failure without tribal knowledge. Prefer checked commands and
+generated/reference-backed excerpts over another narrative copy. Add automated
+doc-command/install-contract checks available in the snapshot. Mark NixOS/live
+service verification honestly for local follow-up; do not claim browser or
+deployment access.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/07-provider-negative-space.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/07-provider-negative-space.md
@@ -1,0 +1,16 @@
+Title: "[beads 07] Provider contradiction and negative-space fixtures"
+
+Job ID: `beads-07`
+Result ZIP: `beads-07-provider-negative-space-r01.zip`
+Primary Bead: `polylogue-yeq.2`.
+
+## Mission
+
+Implement the strongest authorized provider contradiction/negative-space
+mining slice. From actual detectors, parsers, schemas, and fixture gaps, build
+privacy-safe near-miss/ambiguous payloads that prove tightest-valid detector
+selection and honest unknown/absent semantics. Include examples where a looser
+provider would claim another provider's shape, where optional fields are
+missing, and where structured evidence contradicts prose. Drive the real
+dispatch/lowering/parser route and produce reusable fixture design plus tests;
+do not create a synthetic provider catalog or infer correctness from filename.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/08-origin-spec-migration.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/08-origin-spec-migration.md
@@ -1,0 +1,17 @@
+Title: "[beads 08] OriginSpec source-family migration"
+
+Job ID: `beads-08`
+Result ZIP: `beads-08-origin-spec-migration-r01.zip`
+Primary Bead: `polylogue-2qx.1.2`; launch only after the OriginSpec kernel is
+present in the attached snapshot.
+
+## Mission
+
+Migrate one cohesive set of source families onto the landed OriginSpec kernel,
+partitioned by actual detector/parser/fixture write footprints. Preserve
+non-injective provider-to-origin behavior, strictness/tightness ordering,
+parser fingerprint, raw and normalized fixture authority, fidelity notes, and
+deterministic ambiguity. Remove migrated parallel declarations and update real
+dispatch/validation consumers. If all families overlap through one hotspot,
+deliver one carefully ordered patch rather than pretending the work is
+parallel; otherwise identify clean follow-up family slices.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/09-declaration-spec-migration.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/09-declaration-spec-migration.md
@@ -1,0 +1,17 @@
+Title: "[beads 09] DeclarationSpec family migration"
+
+Job ID: `beads-09`
+Result ZIP: `beads-09-declaration-spec-migration-r01.zip`
+Primary Bead: `polylogue-o21.3`; launch only after the DeclarationSpec kernel
+is present in the attached snapshot.
+
+## Mission
+
+Migrate a coherent declaration family onto the landed DeclarationSpec
+authority, preserving its public/generated/validation semantics and removing
+the old duplicated registry in the same patch. Trace every writer and consumer
+before choosing the family boundary. Exercise real generation/discovery and
+runtime consumers so the new descriptor cannot authorize itself through a
+self-referential test. Report remaining families, shared hotspots, ordering,
+and any declaration whose semantics do not fit the kernel rather than forcing
+it into a false abstraction.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/10-campaign-orchestrator.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/briefs/10-campaign-orchestrator.md
@@ -1,0 +1,22 @@
+Title: "[beads 10] External-agent campaign orchestrator"
+
+Job ID: `beads-10`
+Result ZIP: `beads-10-campaign-orchestrator-r01.zip`
+Primary Bead: `polylogue-yyvg.6`.
+
+## Mission
+
+Implement a replaceable repository-side orchestrator over generic browser
+action and canonical Polylogue capture primitives. It owns campaign/job/
+attempt/package-revision identities, prompt and attachment manifests, queue and
+backoff policy, same-chat iteration, immutable acquisition, triage, worktree/
+agent/PR integration receipts, and the full acquired-to-Bead-closed funnel.
+It must not add campaign/work-package concepts to the browser extension,
+receiver transport, or product UI.
+
+Use the campaign layout in `.agent/handoffs/external-agent-campaigns/` as input
+and result convention. Create/reply only through the generic action API and
+observe responses/assets only through canonical Polylogue evidence. Include a
+deterministic current-campaign fixture that fails on omitted conversations,
+turns, assets, retries, packages, or integration outcomes. Do not grant browser
+surfaces Git/Beads mutation authority.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/campaign.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/campaign.json
@@ -1,0 +1,19 @@
+{
+  "schema_version":1,
+  "campaign_id":"gpt-pro-wave-2026-07-16",
+  "workload_id":"beads",
+  "prompt_profile":"polylogue-chatgpt-pro-implementation-v3",
+  "prompt_contract":"../../contracts/chatgpt-pro-implementation.md",
+  "jobs":[
+    {"id":"beads-01","slug":"config-closure","title":"Configuration precedence closure","brief":"briefs/01-config-closure.md","prompt":"prompts/01-config-closure.md","result_prefix":"beads-01-config-closure","depends_on":[]},
+    {"id":"beads-02","slug":"mcp-algebra-contract","title":"MCP algebra contract and equivalence map","brief":"briefs/02-mcp-algebra-contract.md","prompt":"prompts/02-mcp-algebra-contract.md","result_prefix":"beads-02-mcp-algebra-contract","depends_on":[]},
+    {"id":"beads-03","slug":"mcp-read-migration","title":"MCP read-surface algebra migration","brief":"briefs/03-mcp-read-migration.md","prompt":"prompts/03-mcp-read-migration.md","result_prefix":"beads-03-mcp-read-migration","depends_on":["beads-02"]},
+    {"id":"beads-04","slug":"mcp-context-migration","title":"MCP context and assertion algebra migration","brief":"briefs/04-mcp-context-migration.md","prompt":"prompts/04-mcp-context-migration.md","result_prefix":"beads-04-mcp-context-migration","depends_on":["beads-02"]},
+    {"id":"beads-05","slug":"semantic-transcript","title":"Semantic transcript rendering","brief":"briefs/05-semantic-transcript.md","prompt":"prompts/05-semantic-transcript.md","result_prefix":"beads-05-semantic-transcript","depends_on":[]},
+    {"id":"beads-06","slug":"agent-manual-install","title":"Executable agent manual and install kit","brief":"briefs/06-agent-manual-install.md","prompt":"prompts/06-agent-manual-install.md","result_prefix":"beads-06-agent-manual-install","depends_on":[]},
+    {"id":"beads-07","slug":"provider-negative-space","title":"Provider contradiction and negative-space fixtures","brief":"briefs/07-provider-negative-space.md","prompt":"prompts/07-provider-negative-space.md","result_prefix":"beads-07-provider-negative-space","depends_on":[]},
+    {"id":"beads-08","slug":"origin-spec-migration","title":"OriginSpec source-family migration","brief":"briefs/08-origin-spec-migration.md","prompt":"prompts/08-origin-spec-migration.md","result_prefix":"beads-08-origin-spec-migration","depends_on":["OriginSpec kernel landed"]},
+    {"id":"beads-09","slug":"declaration-spec-migration","title":"DeclarationSpec family migration","brief":"briefs/09-declaration-spec-migration.md","prompt":"prompts/09-declaration-spec-migration.md","result_prefix":"beads-09-declaration-spec-migration","depends_on":["DeclarationSpec kernel landed"]},
+    {"id":"beads-10","slug":"campaign-orchestrator","title":"External-agent campaign orchestrator","brief":"briefs/10-campaign-orchestrator.md","prompt":"prompts/10-campaign-orchestrator.md","result_prefix":"beads-10-campaign-orchestrator","depends_on":["generic browser action and canonical capture contracts stable"]}
+  ]
+}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/01-config-closure.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/01-config-closure.md
@@ -1,0 +1,101 @@
+Title: "[beads 01] Configuration precedence closure"
+
+Job ID: `beads-01`
+Result ZIP: `beads-01-config-closure-r01.zip`
+Primary Beads: `polylogue-9gh1`, `polylogue-fd2s`, `polylogue-cxlk`; treat
+`polylogue-uu8r` as a separately partitioned migration unless current source
+proves the write footprint is cohesive.
+
+## Mission
+
+Close the actual configuration precedence/merge slice across config files,
+environment, explicit arguments, runtime inventory, archive tier roots, and
+diagnostics. Read every later note and current call site. Implement one typed
+authority and migrate the relevant consumers rather than adding another
+normalization wrapper. Preserve provider/runtime-specific direct-environment
+behavior only where it is a real boundary, and make conflicting/split roots
+fail honestly. Include real-route tests through at least the config facade and
+daemon/CLI consumer paths plus a precise residual matrix for `uu8r`.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/02-mcp-algebra-contract.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/02-mcp-algebra-contract.md
@@ -1,0 +1,101 @@
+Title: "[beads 02] MCP algebra contract and equivalence map"
+
+Job ID: `beads-02`
+Result ZIP: `beads-02-mcp-algebra-contract-r01.zip`
+Primary Beads: `polylogue-t46.8`, especially contract/map child
+`polylogue-t46.8.1`, plus `polylogue-s1kr`.
+
+## Mission
+
+Resolve and implement the shared MCP tool algebra contract that can replace
+hand-authored surface repetition without erasing distinct authorization,
+ObjectRef, schema, or workflow semantics. Inventory all current registered
+tools, contracts, generated Python parity expectations, and operation/query
+owners. Produce the smallest executable descriptor/adapter kernel plus an
+equivalence map that proves discovery names, input/output schemas, role gates,
+and behavior remain stable. Do not migrate every tool in this job unless the
+current Beads explicitly authorize it; leave exact disjoint migration groups
+for jobs 03 and 04.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/03-mcp-read-migration.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/03-mcp-read-migration.md
@@ -1,0 +1,99 @@
+Title: "[beads 03] MCP read-surface algebra migration"
+
+Job ID: `beads-03`
+Result ZIP: `beads-03-mcp-read-migration-r01.zip`
+Dependency: the accepted algebra/equivalence kernel from `beads-02`.
+
+## Mission
+
+Migrate the disjoint MCP read/search/insight/topology/timeline tool families
+onto the accepted shared algebra. Preserve exact discovery names, schemas,
+role gates, ObjectRef semantics, query behavior, pagination, and error/absence
+contracts. Remove superseded per-tool glue in the same patch rather than
+keeping two authorities. Update the generated Python parity matrix and MCP
+tool/contract fixtures required by current source. Prove representative tools
+through the real MCP registration and operations route, not by testing the
+descriptor in isolation.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/04-mcp-context-migration.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/04-mcp-context-migration.md
@@ -1,0 +1,99 @@
+Title: "[beads 04] MCP context and assertion algebra migration"
+
+Job ID: `beads-04`
+Result ZIP: `beads-04-mcp-context-migration-r01.zip`
+Dependency: the accepted algebra/equivalence kernel from `beads-02`.
+
+## Mission
+
+Migrate the MCP context/recall/assertion/correction/maintenance tool families
+onto the accepted algebra while preserving their materially different write,
+trust, injection-policy, authorization, and audit contracts. Keep candidate
+agent-authored material distinct from operator judgment and preserve immutable
+annotation schema/batch provenance. Delete superseded glue, update discovery
+and tool contracts, and exercise real user-tier writes and readback through the
+MCP surface. Do not collapse destructive/maintenance authorization into a
+generic handler.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/05-semantic-transcript.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/05-semantic-transcript.md
@@ -1,0 +1,99 @@
+Title: "[beads 05] Semantic transcript rendering"
+
+Job ID: `beads-05`
+Result ZIP: `beads-05-semantic-transcript-r01.zip`
+Primary Beads: `polylogue-ap7.1`, `polylogue-395j`.
+
+## Mission
+
+Implement a semantic transcript rendering slice that presents messages,
+thinking, tools/results, attachments, lineage, authoredness, and status in a
+readable form without losing machine identity or inventing prose-derived
+semantics. Reuse the canonical composed session tree and existing projection
+vocabulary. Ensure CLI/read/API or the exact stable surfaces named by the Beads
+share one semantic renderer with presentation-specific framing at the leaf.
+Cover mixed protocol/context rows, errors, variants, inherited prefixes, and
+attachments through real fixtures. Remove superseded renderer duplication.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/06-agent-manual-install.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/06-agent-manual-install.md
@@ -1,0 +1,100 @@
+Title: "[beads 06] Executable agent manual and install kit"
+
+Job ID: `beads-06`
+Result ZIP: `beads-06-agent-manual-install-r01.zip`
+Primary Beads: `polylogue-3gd.2`, `polylogue-3gd.3`.
+
+## Mission
+
+Build the executable cold-start agent manual and installation kit from current
+packaging, CLI, MCP, daemon, config, demo, and Nix/cloud contracts. A new agent
+must be able to identify the right install path, seed or import privacy-safe
+data, verify the daemon/archive, connect MCP, run representative queries, and
+diagnose failure without tribal knowledge. Prefer checked commands and
+generated/reference-backed excerpts over another narrative copy. Add automated
+doc-command/install-contract checks available in the snapshot. Mark NixOS/live
+service verification honestly for local follow-up; do not claim browser or
+deployment access.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/07-provider-negative-space.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/07-provider-negative-space.md
@@ -1,0 +1,99 @@
+Title: "[beads 07] Provider contradiction and negative-space fixtures"
+
+Job ID: `beads-07`
+Result ZIP: `beads-07-provider-negative-space-r01.zip`
+Primary Bead: `polylogue-yeq.2`.
+
+## Mission
+
+Implement the strongest authorized provider contradiction/negative-space
+mining slice. From actual detectors, parsers, schemas, and fixture gaps, build
+privacy-safe near-miss/ambiguous payloads that prove tightest-valid detector
+selection and honest unknown/absent semantics. Include examples where a looser
+provider would claim another provider's shape, where optional fields are
+missing, and where structured evidence contradicts prose. Drive the real
+dispatch/lowering/parser route and produce reusable fixture design plus tests;
+do not create a synthetic provider catalog or infer correctness from filename.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/08-origin-spec-migration.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/08-origin-spec-migration.md
@@ -1,0 +1,100 @@
+Title: "[beads 08] OriginSpec source-family migration"
+
+Job ID: `beads-08`
+Result ZIP: `beads-08-origin-spec-migration-r01.zip`
+Primary Bead: `polylogue-2qx.1.2`; launch only after the OriginSpec kernel is
+present in the attached snapshot.
+
+## Mission
+
+Migrate one cohesive set of source families onto the landed OriginSpec kernel,
+partitioned by actual detector/parser/fixture write footprints. Preserve
+non-injective provider-to-origin behavior, strictness/tightness ordering,
+parser fingerprint, raw and normalized fixture authority, fidelity notes, and
+deterministic ambiguity. Remove migrated parallel declarations and update real
+dispatch/validation consumers. If all families overlap through one hotspot,
+deliver one carefully ordered patch rather than pretending the work is
+parallel; otherwise identify clean follow-up family slices.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/09-declaration-spec-migration.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/09-declaration-spec-migration.md
@@ -1,0 +1,100 @@
+Title: "[beads 09] DeclarationSpec family migration"
+
+Job ID: `beads-09`
+Result ZIP: `beads-09-declaration-spec-migration-r01.zip`
+Primary Bead: `polylogue-o21.3`; launch only after the DeclarationSpec kernel
+is present in the attached snapshot.
+
+## Mission
+
+Migrate a coherent declaration family onto the landed DeclarationSpec
+authority, preserving its public/generated/validation semantics and removing
+the old duplicated registry in the same patch. Trace every writer and consumer
+before choosing the family boundary. Exercise real generation/discovery and
+runtime consumers so the new descriptor cannot authorize itself through a
+self-referential test. Report remaining families, shared hotspots, ordering,
+and any declaration whose semantics do not fit the kernel rather than forcing
+it into a false abstraction.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/10-campaign-orchestrator.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/prompts/10-campaign-orchestrator.md
@@ -1,0 +1,105 @@
+Title: "[beads 10] External-agent campaign orchestrator"
+
+Job ID: `beads-10`
+Result ZIP: `beads-10-campaign-orchestrator-r01.zip`
+Primary Bead: `polylogue-yyvg.6`.
+
+## Mission
+
+Implement a replaceable repository-side orchestrator over generic browser
+action and canonical Polylogue capture primitives. It owns campaign/job/
+attempt/package-revision identities, prompt and attachment manifests, queue and
+backoff policy, same-chat iteration, immutable acquisition, triage, worktree/
+agent/PR integration receipts, and the full acquired-to-Bead-closed funnel.
+It must not add campaign/work-package concepts to the browser extension,
+receiver transport, or product UI.
+
+Use the campaign layout in `.agent/handoffs/external-agent-campaigns/` as input
+and result convention. Create/reply only through the generic action API and
+observe responses/assets only through canonical Polylogue evidence. Include a
+deterministic current-campaign fixture that fails on omitted conversations,
+turns, assets, retries, packages, or integration outcomes. Do not grant browser
+surfaces Git/Beads mutation authority.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/README.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/README.md
@@ -1,0 +1,4 @@
+# Results
+
+Use the standard `results/<job-id>/<attempt-id>/{result.json,raw/,extracted/,integration/}`
+layout documented at the campaign root. Do not overwrite retries or revisions.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/index.json
@@ -1,0 +1,1 @@
+{"schema_version":1,"campaign_id":"gpt-pro-wave-2026-07-16","workload_id":"beads","attempts":[]}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/README.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/README.md
@@ -1,0 +1,4 @@
+# Deep Research portfolio
+
+Seven source-cited decision memos. Use ChatGPT Deep Research. These prompts ask
+for standards/policy/empirical evidence mapped to Polylogue decisions, not code.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/01-mv3-provider-automation.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/01-mv3-provider-automation.md
@@ -1,0 +1,14 @@
+Title: "[research 01] MV3 lifecycle and provider automation policy"
+
+Job ID: `deep-research-01`
+Result ZIP: `deep-research-01-mv3-provider-automation-r01.zip`
+
+Research current Chrome Manifest V3 service-worker, offscreen document,
+background tab/window, alarms, notifications, downloads, storage, and lifecycle
+constraints for a reliable authenticated local extension conduit. Separately
+research official OpenAI/ChatGPT and Anthropic/Claude terms, automation/rate
+limits, safety warnings, and supported user-like interaction boundaries.
+Resolve what can run without visible tabs, what needs a page context, how state
+survives suspension, and how Polylogue should distinguish transport backoff
+from campaign policy. Map findings to extension/receiver action and capture
+Beads; do not recommend evasion or abuse.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/02-sqlite-cancellation.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/02-sqlite-cancellation.md
@@ -1,0 +1,13 @@
+Title: "[research 02] Cancellable resumable SQLite reads"
+
+Job ID: `deep-research-02`
+Result ZIP: `deep-research-02-sqlite-cancellation-r01.zip`
+
+Research current SQLite and Python sqlite3/aiosqlite mechanisms for bounding,
+interrupting, and resuming expensive read-only queries: progress handlers,
+interrupt, deadlines, statement lifecycle, transactions/snapshots, keyset
+pagination, materialized intermediate state, temp resources, and concurrency
+with one writer. Compare semantic guarantees and failure/cleanup behavior.
+Produce a decision matrix for Polylogue's query DSL/daemon/API, including which
+operations can be losslessly resumed and what receipts/work counters can be
+observed without duplicating the query algorithm.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/03-test-selection-mutation.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/03-test-selection-mutation.md
@@ -1,0 +1,13 @@
+Title: "[research 03] Regression selection and incremental mutation certification"
+
+Job ID: `deep-research-03`
+Result ZIP: `deep-research-03-test-selection-mutation-r01.zip`
+
+Research state-of-practice and primary literature/tools for regression-test
+selection, test-impact analysis, per-test coverage contexts, dynamic dependency
+graphs, mutation testing, incremental mutation, flaky/hang attribution, and
+test-suite minimization in large Python/pytest systems. Focus on independent
+certification of survivor tests and safe dominance-based deletion rather than
+coverage percentages. Map concrete options onto Polylogue's pytest-testmon,
+xdist, mutmut, devtools, and receipt model, including false-negative risks and
+an empirical evaluation design.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/04-agent-observability-provenance.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/04-agent-observability-provenance.md
@@ -1,0 +1,13 @@
+Title: "[research 04] MCP, GenAI telemetry, and provenance interoperability"
+
+Job ID: `deep-research-04`
+Result ZIP: `deep-research-04-agent-observability-provenance-r01.zip`
+
+Research the latest MCP Tasks/resources/prompts/sampling/elicitation and
+authorization specifications, OpenTelemetry GenAI semantic conventions, W3C
+PROV, CloudEvents, and related agent/run/artifact lineage standards. Determine
+which identities and receipts could interoperate with Polylogue ObjectRefs,
+assertions, tool actions, topology, capture observations, and external campaign
+ledgers without importing campaign-specific vocabulary into the product.
+Produce a compatibility/translation matrix, gaps, versioning risks, and small
+recommended seams rather than a standards-shaped rewrite.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/05-attachment-provenance.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/05-attachment-provenance.md
@@ -1,0 +1,13 @@
+Title: "[research 05] Attachment acquisition and archival provenance"
+
+Job ID: `deep-research-05`
+Result ZIP: `deep-research-05-attachment-provenance-r01.zip`
+
+Research current archival, digital-preservation, HTTP/content-addressing, RO-
+Crate/BagIt/OCFL, PREMIS, provenance, and software-supply-chain practices
+relevant to acquiring ephemeral AI-chat attachments and generated files.
+Address provider IDs/URLs, expiring authorization, byte hashes, MIME/name,
+download attempts, partial/range transfer, duplicates, container manifests,
+custody paths, privacy, and repair/reacquisition. Map the smallest useful
+semantics to Polylogue source/blob/attachment evidence and campaign result
+ledgers; distinguish preservation requirements from overengineered packaging.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/06-browser-capture-lifecycle.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/06-browser-capture-lifecycle.md
@@ -1,0 +1,15 @@
+Title: "[research 06] Browser-native AI generation lifecycle evidence"
+
+Job ID: `deep-research-06`
+Result ZIP: `deep-research-06-browser-capture-lifecycle-r01.zip`
+
+Research public/officially documented browser and web-platform techniques for
+capturing authenticated AI conversation state and generation lifecycle from a
+user-installed extension: fetch/XHR/SSE/stream interception constraints,
+service workers, Performance APIs, DOM mutation, navigation/BFCache, background
+tabs, notifications, downloads, and privacy/security boundaries. Assess what
+can reliably establish submit, first progress, reasoning start/end, terminal
+turn, asset-visible, and download completion without scraping display prose.
+Map evidence levels and failure modes to Polylogue's raw observation and
+normalization design; do not rely on undocumented provider internals as stable
+contracts.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/07-ai-artifact-supply-chain.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/07-ai-artifact-supply-chain.md
@@ -1,0 +1,13 @@
+Title: "[research 07] AI-generated artifact supply-chain receipts"
+
+Job ID: `deep-research-07`
+Result ZIP: `deep-research-07-ai-artifact-supply-chain-r01.zip`
+
+Research practical provenance and supply-chain models for AI-generated code,
+patches, analysis packages, and iterative repairs: SLSA/in-toto attestations,
+SBOM concepts, reproducible archives, prompt/snapshot/model identities,
+content hashes, supersedes lineage, verification/integration receipts, and
+privacy boundaries. Focus on a lightweight local campaign ledger that can
+prove which package became which commit/PR/Bead outcome without pretending the
+browser model verified execution. Recommend a minimal schema and threat model,
+clearly separating generic Polylogue evidence from private orchestration state.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/campaign.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/campaign.json
@@ -1,0 +1,16 @@
+{
+  "schema_version":1,
+  "campaign_id":"gpt-pro-wave-2026-07-16",
+  "workload_id":"deep-research",
+  "prompt_profile":"polylogue-chatgpt-deep-research-v3",
+  "prompt_contract":"../../contracts/chatgpt-deep-research.md",
+  "jobs":[
+    {"id":"deep-research-01","slug":"mv3-provider-automation","title":"MV3 lifecycle and provider automation policy","brief":"briefs/01-mv3-provider-automation.md","prompt":"prompts/01-mv3-provider-automation.md","result_prefix":"deep-research-01-mv3-provider-automation","depends_on":[]},
+    {"id":"deep-research-02","slug":"sqlite-cancellation","title":"Cancellable resumable SQLite reads","brief":"briefs/02-sqlite-cancellation.md","prompt":"prompts/02-sqlite-cancellation.md","result_prefix":"deep-research-02-sqlite-cancellation","depends_on":[]},
+    {"id":"deep-research-03","slug":"test-selection-mutation","title":"Regression selection and incremental mutation certification","brief":"briefs/03-test-selection-mutation.md","prompt":"prompts/03-test-selection-mutation.md","result_prefix":"deep-research-03-test-selection-mutation","depends_on":[]},
+    {"id":"deep-research-04","slug":"agent-observability-provenance","title":"MCP, GenAI telemetry, and provenance interoperability","brief":"briefs/04-agent-observability-provenance.md","prompt":"prompts/04-agent-observability-provenance.md","result_prefix":"deep-research-04-agent-observability-provenance","depends_on":[]},
+    {"id":"deep-research-05","slug":"attachment-provenance","title":"Attachment acquisition and archival provenance","brief":"briefs/05-attachment-provenance.md","prompt":"prompts/05-attachment-provenance.md","result_prefix":"deep-research-05-attachment-provenance","depends_on":[]},
+    {"id":"deep-research-06","slug":"browser-capture-lifecycle","title":"Browser-native AI generation lifecycle evidence","brief":"briefs/06-browser-capture-lifecycle.md","prompt":"prompts/06-browser-capture-lifecycle.md","result_prefix":"deep-research-06-browser-capture-lifecycle","depends_on":[]},
+    {"id":"deep-research-07","slug":"ai-artifact-supply-chain","title":"AI-generated artifact supply-chain receipts","brief":"briefs/07-ai-artifact-supply-chain.md","prompt":"prompts/07-ai-artifact-supply-chain.md","result_prefix":"deep-research-07-ai-artifact-supply-chain","depends_on":[]}
+  ]
+}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/01-mv3-provider-automation.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/01-mv3-provider-automation.md
@@ -1,0 +1,47 @@
+Title: "[research 01] MV3 lifecycle and provider automation policy"
+
+Job ID: `deep-research-01`
+Result ZIP: `deep-research-01-mv3-provider-automation-r01.zip`
+
+Research current Chrome Manifest V3 service-worker, offscreen document,
+background tab/window, alarms, notifications, downloads, storage, and lifecycle
+constraints for a reliable authenticated local extension conduit. Separately
+research official OpenAI/ChatGPT and Anthropic/Claude terms, automation/rate
+limits, safety warnings, and supported user-like interaction boundaries.
+Resolve what can run without visible tabs, what needs a page context, how state
+survives suspension, and how Polylogue should distinguish transport backoff
+from campaign policy. Map findings to extension/receiver action and capture
+Beads; do not recommend evasion or abuse.
+
+## Research contract
+
+Use Deep Research, not ordinary implementation mode. Prefer current primary and
+official sources; record direct URLs, publication/update dates, access date,
+and the exact claim each source supports. Distinguish standards, documented
+provider policy, measured behavior, informed inference, and proposal. Search
+for counterevidence and incompatible constraints rather than writing a survey
+that merely confirms the mission premise.
+
+A current Polylogue project-state archive may be attached for product context.
+Inspect relevant source and Beads so the research resolves concrete project
+decisions, but do not return speculative patches. Map each conclusion to the
+named Polylogue decision/Bead, state what should change, what should not change,
+and what local experiment would falsify the recommendation.
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
+`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
+`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
+finished ZIP through a working user-clickable conversation link; an internal
+temporary path alone is not delivery. Reopen and validate the ZIP, report
+SHA-256/size/members, and provide a substantive direct answer covering
+conclusions, rationale, limitations, missing evidence, and the likely value of
+another iteration before the exact package link.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, extend the strongest unresolved research
+branch and regenerate the complete package. On an explicit **adversarial
+review** request, try to falsify the prior memo with counterevidence, later or
+more authoritative sources, incompatible policies/standards, hidden product
+assumptions, and experiments that would overturn its recommendations. Repair
+legitimate findings, regenerate the cohesive package, and report what changed,
+what remains uncertain, and whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/02-sqlite-cancellation.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/02-sqlite-cancellation.md
@@ -1,0 +1,46 @@
+Title: "[research 02] Cancellable resumable SQLite reads"
+
+Job ID: `deep-research-02`
+Result ZIP: `deep-research-02-sqlite-cancellation-r01.zip`
+
+Research current SQLite and Python sqlite3/aiosqlite mechanisms for bounding,
+interrupting, and resuming expensive read-only queries: progress handlers,
+interrupt, deadlines, statement lifecycle, transactions/snapshots, keyset
+pagination, materialized intermediate state, temp resources, and concurrency
+with one writer. Compare semantic guarantees and failure/cleanup behavior.
+Produce a decision matrix for Polylogue's query DSL/daemon/API, including which
+operations can be losslessly resumed and what receipts/work counters can be
+observed without duplicating the query algorithm.
+
+## Research contract
+
+Use Deep Research, not ordinary implementation mode. Prefer current primary and
+official sources; record direct URLs, publication/update dates, access date,
+and the exact claim each source supports. Distinguish standards, documented
+provider policy, measured behavior, informed inference, and proposal. Search
+for counterevidence and incompatible constraints rather than writing a survey
+that merely confirms the mission premise.
+
+A current Polylogue project-state archive may be attached for product context.
+Inspect relevant source and Beads so the research resolves concrete project
+decisions, but do not return speculative patches. Map each conclusion to the
+named Polylogue decision/Bead, state what should change, what should not change,
+and what local experiment would falsify the recommendation.
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
+`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
+`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
+finished ZIP through a working user-clickable conversation link; an internal
+temporary path alone is not delivery. Reopen and validate the ZIP, report
+SHA-256/size/members, and provide a substantive direct answer covering
+conclusions, rationale, limitations, missing evidence, and the likely value of
+another iteration before the exact package link.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, extend the strongest unresolved research
+branch and regenerate the complete package. On an explicit **adversarial
+review** request, try to falsify the prior memo with counterevidence, later or
+more authoritative sources, incompatible policies/standards, hidden product
+assumptions, and experiments that would overturn its recommendations. Repair
+legitimate findings, regenerate the cohesive package, and report what changed,
+what remains uncertain, and whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/03-test-selection-mutation.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/03-test-selection-mutation.md
@@ -1,0 +1,46 @@
+Title: "[research 03] Regression selection and incremental mutation certification"
+
+Job ID: `deep-research-03`
+Result ZIP: `deep-research-03-test-selection-mutation-r01.zip`
+
+Research state-of-practice and primary literature/tools for regression-test
+selection, test-impact analysis, per-test coverage contexts, dynamic dependency
+graphs, mutation testing, incremental mutation, flaky/hang attribution, and
+test-suite minimization in large Python/pytest systems. Focus on independent
+certification of survivor tests and safe dominance-based deletion rather than
+coverage percentages. Map concrete options onto Polylogue's pytest-testmon,
+xdist, mutmut, devtools, and receipt model, including false-negative risks and
+an empirical evaluation design.
+
+## Research contract
+
+Use Deep Research, not ordinary implementation mode. Prefer current primary and
+official sources; record direct URLs, publication/update dates, access date,
+and the exact claim each source supports. Distinguish standards, documented
+provider policy, measured behavior, informed inference, and proposal. Search
+for counterevidence and incompatible constraints rather than writing a survey
+that merely confirms the mission premise.
+
+A current Polylogue project-state archive may be attached for product context.
+Inspect relevant source and Beads so the research resolves concrete project
+decisions, but do not return speculative patches. Map each conclusion to the
+named Polylogue decision/Bead, state what should change, what should not change,
+and what local experiment would falsify the recommendation.
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
+`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
+`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
+finished ZIP through a working user-clickable conversation link; an internal
+temporary path alone is not delivery. Reopen and validate the ZIP, report
+SHA-256/size/members, and provide a substantive direct answer covering
+conclusions, rationale, limitations, missing evidence, and the likely value of
+another iteration before the exact package link.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, extend the strongest unresolved research
+branch and regenerate the complete package. On an explicit **adversarial
+review** request, try to falsify the prior memo with counterevidence, later or
+more authoritative sources, incompatible policies/standards, hidden product
+assumptions, and experiments that would overturn its recommendations. Repair
+legitimate findings, regenerate the cohesive package, and report what changed,
+what remains uncertain, and whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/04-agent-observability-provenance.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/04-agent-observability-provenance.md
@@ -1,0 +1,46 @@
+Title: "[research 04] MCP, GenAI telemetry, and provenance interoperability"
+
+Job ID: `deep-research-04`
+Result ZIP: `deep-research-04-agent-observability-provenance-r01.zip`
+
+Research the latest MCP Tasks/resources/prompts/sampling/elicitation and
+authorization specifications, OpenTelemetry GenAI semantic conventions, W3C
+PROV, CloudEvents, and related agent/run/artifact lineage standards. Determine
+which identities and receipts could interoperate with Polylogue ObjectRefs,
+assertions, tool actions, topology, capture observations, and external campaign
+ledgers without importing campaign-specific vocabulary into the product.
+Produce a compatibility/translation matrix, gaps, versioning risks, and small
+recommended seams rather than a standards-shaped rewrite.
+
+## Research contract
+
+Use Deep Research, not ordinary implementation mode. Prefer current primary and
+official sources; record direct URLs, publication/update dates, access date,
+and the exact claim each source supports. Distinguish standards, documented
+provider policy, measured behavior, informed inference, and proposal. Search
+for counterevidence and incompatible constraints rather than writing a survey
+that merely confirms the mission premise.
+
+A current Polylogue project-state archive may be attached for product context.
+Inspect relevant source and Beads so the research resolves concrete project
+decisions, but do not return speculative patches. Map each conclusion to the
+named Polylogue decision/Bead, state what should change, what should not change,
+and what local experiment would falsify the recommendation.
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
+`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
+`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
+finished ZIP through a working user-clickable conversation link; an internal
+temporary path alone is not delivery. Reopen and validate the ZIP, report
+SHA-256/size/members, and provide a substantive direct answer covering
+conclusions, rationale, limitations, missing evidence, and the likely value of
+another iteration before the exact package link.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, extend the strongest unresolved research
+branch and regenerate the complete package. On an explicit **adversarial
+review** request, try to falsify the prior memo with counterevidence, later or
+more authoritative sources, incompatible policies/standards, hidden product
+assumptions, and experiments that would overturn its recommendations. Repair
+legitimate findings, regenerate the cohesive package, and report what changed,
+what remains uncertain, and whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/05-attachment-provenance.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/05-attachment-provenance.md
@@ -1,0 +1,46 @@
+Title: "[research 05] Attachment acquisition and archival provenance"
+
+Job ID: `deep-research-05`
+Result ZIP: `deep-research-05-attachment-provenance-r01.zip`
+
+Research current archival, digital-preservation, HTTP/content-addressing, RO-
+Crate/BagIt/OCFL, PREMIS, provenance, and software-supply-chain practices
+relevant to acquiring ephemeral AI-chat attachments and generated files.
+Address provider IDs/URLs, expiring authorization, byte hashes, MIME/name,
+download attempts, partial/range transfer, duplicates, container manifests,
+custody paths, privacy, and repair/reacquisition. Map the smallest useful
+semantics to Polylogue source/blob/attachment evidence and campaign result
+ledgers; distinguish preservation requirements from overengineered packaging.
+
+## Research contract
+
+Use Deep Research, not ordinary implementation mode. Prefer current primary and
+official sources; record direct URLs, publication/update dates, access date,
+and the exact claim each source supports. Distinguish standards, documented
+provider policy, measured behavior, informed inference, and proposal. Search
+for counterevidence and incompatible constraints rather than writing a survey
+that merely confirms the mission premise.
+
+A current Polylogue project-state archive may be attached for product context.
+Inspect relevant source and Beads so the research resolves concrete project
+decisions, but do not return speculative patches. Map each conclusion to the
+named Polylogue decision/Bead, state what should change, what should not change,
+and what local experiment would falsify the recommendation.
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
+`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
+`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
+finished ZIP through a working user-clickable conversation link; an internal
+temporary path alone is not delivery. Reopen and validate the ZIP, report
+SHA-256/size/members, and provide a substantive direct answer covering
+conclusions, rationale, limitations, missing evidence, and the likely value of
+another iteration before the exact package link.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, extend the strongest unresolved research
+branch and regenerate the complete package. On an explicit **adversarial
+review** request, try to falsify the prior memo with counterevidence, later or
+more authoritative sources, incompatible policies/standards, hidden product
+assumptions, and experiments that would overturn its recommendations. Repair
+legitimate findings, regenerate the cohesive package, and report what changed,
+what remains uncertain, and whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/06-browser-capture-lifecycle.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/06-browser-capture-lifecycle.md
@@ -1,0 +1,48 @@
+Title: "[research 06] Browser-native AI generation lifecycle evidence"
+
+Job ID: `deep-research-06`
+Result ZIP: `deep-research-06-browser-capture-lifecycle-r01.zip`
+
+Research public/officially documented browser and web-platform techniques for
+capturing authenticated AI conversation state and generation lifecycle from a
+user-installed extension: fetch/XHR/SSE/stream interception constraints,
+service workers, Performance APIs, DOM mutation, navigation/BFCache, background
+tabs, notifications, downloads, and privacy/security boundaries. Assess what
+can reliably establish submit, first progress, reasoning start/end, terminal
+turn, asset-visible, and download completion without scraping display prose.
+Map evidence levels and failure modes to Polylogue's raw observation and
+normalization design; do not rely on undocumented provider internals as stable
+contracts.
+
+## Research contract
+
+Use Deep Research, not ordinary implementation mode. Prefer current primary and
+official sources; record direct URLs, publication/update dates, access date,
+and the exact claim each source supports. Distinguish standards, documented
+provider policy, measured behavior, informed inference, and proposal. Search
+for counterevidence and incompatible constraints rather than writing a survey
+that merely confirms the mission premise.
+
+A current Polylogue project-state archive may be attached for product context.
+Inspect relevant source and Beads so the research resolves concrete project
+decisions, but do not return speculative patches. Map each conclusion to the
+named Polylogue decision/Bead, state what should change, what should not change,
+and what local experiment would falsify the recommendation.
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
+`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
+`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
+finished ZIP through a working user-clickable conversation link; an internal
+temporary path alone is not delivery. Reopen and validate the ZIP, report
+SHA-256/size/members, and provide a substantive direct answer covering
+conclusions, rationale, limitations, missing evidence, and the likely value of
+another iteration before the exact package link.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, extend the strongest unresolved research
+branch and regenerate the complete package. On an explicit **adversarial
+review** request, try to falsify the prior memo with counterevidence, later or
+more authoritative sources, incompatible policies/standards, hidden product
+assumptions, and experiments that would overturn its recommendations. Repair
+legitimate findings, regenerate the cohesive package, and report what changed,
+what remains uncertain, and whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/07-ai-artifact-supply-chain.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/07-ai-artifact-supply-chain.md
@@ -1,0 +1,46 @@
+Title: "[research 07] AI-generated artifact supply-chain receipts"
+
+Job ID: `deep-research-07`
+Result ZIP: `deep-research-07-ai-artifact-supply-chain-r01.zip`
+
+Research practical provenance and supply-chain models for AI-generated code,
+patches, analysis packages, and iterative repairs: SLSA/in-toto attestations,
+SBOM concepts, reproducible archives, prompt/snapshot/model identities,
+content hashes, supersedes lineage, verification/integration receipts, and
+privacy boundaries. Focus on a lightweight local campaign ledger that can
+prove which package became which commit/PR/Bead outcome without pretending the
+browser model verified execution. Recommend a minimal schema and threat model,
+clearly separating generic Polylogue evidence from private orchestration state.
+
+## Research contract
+
+Use Deep Research, not ordinary implementation mode. Prefer current primary and
+official sources; record direct URLs, publication/update dates, access date,
+and the exact claim each source supports. Distinguish standards, documented
+provider policy, measured behavior, informed inference, and proposal. Search
+for counterevidence and incompatible constraints rather than writing a survey
+that merely confirms the mission premise.
+
+A current Polylogue project-state archive may be attached for product context.
+Inspect relevant source and Beads so the research resolves concrete project
+decisions, but do not return speculative patches. Map each conclusion to the
+named Polylogue decision/Bead, state what should change, what should not change,
+and what local experiment would falsify the recommendation.
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
+`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
+`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
+finished ZIP through a working user-clickable conversation link; an internal
+temporary path alone is not delivery. Reopen and validate the ZIP, report
+SHA-256/size/members, and provide a substantive direct answer covering
+conclusions, rationale, limitations, missing evidence, and the likely value of
+another iteration before the exact package link.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, extend the strongest unresolved research
+branch and regenerate the complete package. On an explicit **adversarial
+review** request, try to falsify the prior memo with counterevidence, later or
+more authoritative sources, incompatible policies/standards, hidden product
+assumptions, and experiments that would overturn its recommendations. Repair
+legitimate findings, regenerate the cohesive package, and report what changed,
+what remains uncertain, and whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/results/README.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/results/README.md
@@ -1,0 +1,4 @@
+# Results
+
+Store each cited decision-memo package under the campaign-standard immutable
+attempt path. Preserve source-ledger revisions and supersedes lineage.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/results/index.json
@@ -1,0 +1,1 @@
+{"schema_version":1,"campaign_id":"gpt-pro-wave-2026-07-16","workload_id":"deep-research","attempts":[]}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/test-harness-agent-foundation-mission.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/test-harness-agent-foundation-mission.md
@@ -1,0 +1,58 @@
+# Revised mission for the active test-harness agent
+
+You now own the local foundation that makes the external Test Suite Diet
+fan-out safe and useful. Preserve and finish the substantial workload-profile
+implementation already committed on your current branch; do not restart it or
+turn this into a planning-only pass.
+
+Your verified end state is a merged, current-master foundation on which 16
+browser-hosted GPT Pro workers can independently draft subsystem survivor laws
+without inventing shared fixtures, identities, receipts, or architecture.
+
+## Scope
+
+1. Finish the current workload/profile branch as a coherent production slice:
+   deterministic privacy-classified package/archive workload profiles,
+   correlated variants, named scale/selectivity tiers, stable
+   workload/profile/build/archive identity, and the intended structural
+   canaries. Reconcile every current Bead acceptance criterion and later note;
+   do not treat the scratch Diet documents as authority over source or Beads.
+2. Complete the shared Test Diet foundation that must have one local owner:
+   fail-closed seeded-artifact/cache publication, atomic publication,
+   validation before the build-complete guard, immutable per-test clones, and
+   independently planted expected facts for the smallest realized canary.
+   Reuse the workload and receipt identities you just landed. Do not create a
+   Diet-specific generator, semantic profile, receipt vocabulary, or test
+   framework.
+3. Provide the concrete post-merge reconciliation evidence needed for fan-out:
+   the authoritative merged commit(s), actual canary/workload/receipt symbols,
+   exact stable production/test entry points external agents should reuse, and
+   any unresolved product decisions or shared write hotspots. Promote or
+   archive the currently ignored Testsuite Diet control corpus before removing
+   this worktree; do not let the only copy disappear.
+4. Harden only the existing thin Diet runner prerequisites needed for later
+   local integration: validate the reconciliation receipt against the current
+   head and use the attested launcher/job-control path for timeout/interruption.
+   Do not build a new scheduler or launch the external portfolio yourself.
+
+## Boundaries
+
+- Do not perform the 16 subsystem jobs, authorize broad test deletion, or
+  certify your own survivor tests by temporary mutation.
+- Do not change product semantics merely to make a test easier. Escalate a
+  genuine authority/security/lineage contract decision with exact evidence.
+- Commit every verified logical chunk. Keep the current feature work backed up;
+  rebase/branch only when required by the repository workflow, never by
+  discarding committed work.
+- You own real local verification: focused production-route tests, anti-vacuity
+  reasoning, `devtools verify --quick`, and the broader harness/dependency gate
+  warranted by the foundation. Browser GPT Pro workers will not be allowed to
+  claim these checks for you.
+
+## Completion report
+
+Return: commits/PR/merge state; per-Bead AC matrix; exact files and public
+routes; focused and broad command outputs; canary/receipt identity map; known
+hotspots and safe parallel partitions; residual blockers; and the final path
+to the durable Testsuite Diet corpus. A green-looking patch that remains only
+in this worktree is not complete.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/README.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/README.md
@@ -1,0 +1,21 @@
+# Test Diet implementation portfolio
+
+Sixteen external drafting lanes to launch only after the local foundation
+mission lands and the attached Chisel project-state archive is regenerated.
+
+The jobs are deliberately broader than individual tests and narrower than the
+whole suite. Each owns one behavioral responsibility. They may draft survivor
+tests and necessary production seams, but they may only *propose* deletion;
+local independent mutation/dominance certification authorizes subtraction.
+
+Suggested manual launch order:
+
+1. First parallel wave: 01, 02, 03, 06, 08–12, 13–16.
+2. After reviewing dependencies: 04 after 02+03; 05 after 01; 07 after 01+06.
+3. Use same-chat iteration for concrete repair requests. Ask for adversarial
+   review only after a plausible first package exists.
+
+The same fresh project-state archive may be attached to all jobs. The prompts
+carry enough Test Diet law/mission detail that the ignored scratch directory
+does not need to be uploaded separately, though uploading it is harmless and
+potentially useful when available.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/01-query-algebra-cardinality.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/01-query-algebra-cardinality.md
@@ -1,0 +1,26 @@
+Title: "[testdiet 01] Query algebra and cardinality survivor"
+
+Job ID: `testdiet-01`
+Result ZIP: `testdiet-01-query-algebra-cardinality-r01.zip`
+
+## Mission
+
+Implement a strong real-route survivor law for Polylogue query algebra and
+relational cardinality. Starting from the current realized structural canary in
+the attached snapshot, plant an independent expected fact set and exercise
+public expressions through parsing, lowering, SQL/repository execution, and
+stable public read/action routes. Prove membership, count, partition,
+pagination, and preview/apply agreement; include duplicate/join shapes that
+would expose lost or multiplied rows.
+
+The oracle must be computed from planted input facts, never by asking the
+production query path for its own expected output. Include a representative
+anti-vacuity mutation such as dropping a predicate, changing `DISTINCT`, moving
+selection after a join, or making selection global-first, and explain the
+specific wrong result the survivor must detect.
+
+Inspect all current query tests and helpers in the affected cluster. Preserve
+unique parser diagnostics, security, and compatibility obligations. Propose
+dominated layer-local/mock-forwarding tests for later certification, but do not
+delete them. Avoid redesigning the query language or inventing a Test Diet
+query framework.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/02-convergence-liveness.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/02-convergence-liveness.md
@@ -1,0 +1,25 @@
+Title: "[testdiet 02] Convergence restart and debt liveness"
+
+Job ID: `testdiet-02`
+Result ZIP: `testdiet-02-convergence-liveness-r01.zip`
+
+## Mission
+
+Implement a survivor law for daemon convergence across interruption, restart,
+retryable debt, and eventual quiescence. Use the current active-growing or
+partial-convergence workload variant and real `DaemonConverger`/ops debt/write
+routes. Demonstrate that bounded work may defer honestly, durable debt survives
+process restart, retries address the intended session/stage without replaying
+unrelated acquisition, and repeated convergence reaches the same terminal
+facts without duplication.
+
+Prefer deterministic barriers/failpoints or existing injected clock/executor
+seams over sleeps. If one minimal production trace seam is genuinely needed,
+make it report the real stage/debt lifecycle rather than mirror the algorithm
+inside tests. The independent oracle should cover debt identity, retry count,
+terminal state, materialized facts, and cleanup.
+
+Name a mutation such as dropping the debt write, consuming debt before stage
+success, skipping the retry path, or re-resolving the wrong source, and show
+why the survivor fails. Propose dominated restart/example tests but do not
+delete them. Do not build a new convergence state machine or corpus generator.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/03-rebuild-equivalence.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/03-rebuild-equivalence.md
@@ -1,0 +1,25 @@
+Title: "[testdiet 03] Incremental and rebuild equivalence"
+
+Job ID: `testdiet-03`
+Result ZIP: `testdiet-03-rebuild-equivalence-r01.zip`
+
+## Mission
+
+Implement an incremental-versus-rebuild equivalence survivor over Polylogue's
+actual durable source evidence and rebuildable index route. Replay one realized
+workload identity through incremental ingest/update/reprocess and through a
+fresh index rebuild, then compare independently selected public facts:
+session/message/block identity and active path, attachments, lineage, search,
+materialized insight outputs, and absence/unknown semantics relevant to the
+chosen canary.
+
+Keep user-tier overlays outside content/workload identity and prove they are
+preserved or deliberately rejoined rather than folded into raw content hashes.
+The expected fact set must originate from planted input facts and declared
+transform invariants, not from serializing one production result and comparing
+it to another.
+
+Name an omitted-rebuild-stage or stale-dependent-row mutation that the test
+must kill. Respect durable-versus-derived schema rules and the sole-writer
+architecture. Propose duplicated rebuild/example checks for later
+certification, but do not remove them or invent another rebuild harness.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/04-derived-freshness.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/04-derived-freshness.md
@@ -1,0 +1,27 @@
+Title: "[testdiet 04] Monotonic derived freshness"
+
+Job ID: `testdiet-04`
+Result ZIP: `testdiet-04-derived-freshness-r01.zip`
+Dependency: integrate only after `testdiet-02` and `testdiet-03` foundations are
+adjudicated.
+
+## Mission
+
+Implement a survivor law that derived Polylogue facts never silently move
+backward relative to their content and recipe/generation authority. Cover the
+current FTS, insight, and—where the source contract makes it meaningful—
+embedding catch-up identities through ingest, reprocess, recipe change,
+restart, and rebuild. A reader must see a current generation, an explicit
+pending/degraded state, or an honest absence; never a stale value presented as
+current.
+
+First discover the canonical identity already supplied by current source and
+Beads. Do not invent a Diet-specific freshness token. Reuse the convergence
+and rebuild survivor mechanisms produced by the prerequisite lanes when
+possible. Include varied arrival orders and an independent expected freshness
+relation.
+
+Name a mutation that ignores recipe identity, retains a stale materialization,
+or marks debt complete early. If the product contract for one derived tier is
+still genuinely undecided, implement the decided tiers and return a precise
+blocker/decision matrix for the remainder rather than choosing policy yourself.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/05-query-bounds-progress.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/05-query-bounds-progress.md
@@ -1,0 +1,25 @@
+Title: "[testdiet 05] Bounded query work, cancellation, and cleanup"
+
+Job ID: `testdiet-05`
+Result ZIP: `testdiet-05-query-bounds-progress-r01.zip`
+Dependency: integrate after the query algebra survivor in `testdiet-01`.
+
+## Mission
+
+Implement the strongest currently authorized slice of bounded and
+interruptible query work. Reuse the exact-selection facts from the query
+survivor and exercise irrelevant-growth equivalence, selected-work scaling,
+lossless pagination/addressability, cancellation/deadline propagation, truthful
+progress, and cleanup through real SQLite/repository/public routes.
+
+Use an existing work/progress counter if current source provides one. Add a
+minimal production observation seam only if it measures actual SQLite/runner
+work and has at least the concrete consumer in this survivor; do not duplicate
+the query algorithm in a test counter. Prefer deterministic cancellation over
+wall-clock flakiness.
+
+Name work-amplification, ignored-cancellation, depth-limit, leaked temporary
+state, or double-counted-progress mutations and the expected failure. Read the
+current product decision for oversized results and cancellation; implement no
+semantics that remain undecided. Propose slow/redundant examples for later
+certification without deleting them.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/06-evidence-provenance.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/06-evidence-provenance.md
@@ -1,0 +1,25 @@
+Title: "[testdiet 06] Evidence monotonicity and provenance conservation"
+
+Job ID: `testdiet-06`
+Result ZIP: `testdiet-06-evidence-provenance-r01.zip`
+
+## Mission
+
+Implement survivor laws for Polylogue evidence monotonicity and quantitative
+provenance conservation. Across the current source/index/user evidence models,
+prove that adding stronger evidence can refine or supersede a claim without
+silently reducing supported information; aggregations conserve totals across
+disjoint sources; unknown/absent/unsupported never becomes numeric zero; and
+every public value retains the evidence/provenance needed to explain it.
+
+Use the smallest current source vocabulary and ObjectRef/EvidenceRef mechanisms
+already present. Do not create a second evidence lattice or a test-only
+registry. Build independent planted facts that include missing, contradictory,
+duplicate, and differently authoritative observations and vary ordering and
+grouping.
+
+Name mutations such as dropping one source, double-counting a duplicate,
+strengthening provenance without evidence, or coercing unknown to zero. Cover
+the stable production readers directly; defer surfaces under explicit rewrite
+only with a transfer-of-obligation note. Propose dominated arithmetic/local
+model tests, but keep unique compatibility and error witnesses.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/07-public-fact-parity.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/07-public-fact-parity.md
@@ -1,0 +1,25 @@
+Title: "[testdiet 07] One public fact algebra across stable surfaces"
+
+Job ID: `testdiet-07`
+Result ZIP: `testdiet-07-public-fact-parity-r01.zip`
+Dependencies: `testdiet-01` query facts and `testdiet-06` provenance facts.
+
+## Mission
+
+Implement cross-surface survivor tests proving that one selected semantic fact
+set projects consistently through Polylogue's stable CLI, Python API,
+operations/repository, daemon HTTP, and applicable MCP routes. Compare meaning,
+identity, absence/error semantics, origin vocabulary, counts, and provenance—not
+byte-for-byte formatting. Route-specific presentation may differ only where an
+explicit public contract says so.
+
+Reuse the independent fact fixtures from prerequisite lanes instead of
+creating another seeded database or expected-output catalog. Exercise real
+surface adapters and their shared substrate. Identify MCP/web areas currently
+owned by rewrites and transfer their obligations precisely rather than
+strengthening obsolete implementation.
+
+Name a surface-disagreement mutation such as bypassing origin projection,
+dropping a filter, coercing absence, or reading a stale model. Propose
+mock-forwarding and snapshot tests dominated by the survivor, but do not delete
+them. Do not centralize presentation logic that is legitimately surface-local.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/08-chatgpt-normalization.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/08-chatgpt-normalization.md
@@ -1,0 +1,25 @@
+Title: "[testdiet 08] ChatGPT capture and export normalization laws"
+
+Job ID: `testdiet-08`
+Result ZIP: `testdiet-08-chatgpt-normalization-r01.zip`
+
+## Mission
+
+Implement provider-family normalization survivors for ChatGPT exports and
+native browser-capture payloads. Use real, privacy-safe wire fixtures and the
+actual detect/lower/parse routes. Prove tight detector selection, active-path
+and variant identity, role/material-origin, content blocks including reasoning,
+attachments and assistant-produced assets, timestamps/durations, model effort,
+status/end-turn, and full-fidelity-versus-fallback replacement semantics.
+
+Pay particular attention to native metadata spellings actually present in
+current fixtures (`reasoning_start_time`, `reasoning_end_time`,
+`finished_duration_sec`, and any legacy duration field) and to provider tree
+nodes that duplicate metadata. Normalize one semantic duration once without
+double counting. Preserve raw fields even when their semantic meaning remains
+explicitly provider-reported rather than model-compute time.
+
+Name detector-order, authoredness, active-branch, duration-loss, or missing
+asset mutations the survivors must kill. Do not make browser capture a special
+campaign protocol or infer semantic facts from prose/UI labels when structured
+provider data exists.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/09-claude-code-normalization.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/09-claude-code-normalization.md
@@ -1,0 +1,23 @@
+Title: "[testdiet 09] Claude Code normalization laws"
+
+Job ID: `testdiet-09`
+Result ZIP: `testdiet-09-claude-code-normalization-r01.zip`
+
+## Mission
+
+Implement provider-family normalization survivors for Claude Code session
+JSONL, including streaming/multi-GiB lowering where relevant. Prove message and
+block identity, parent/subagent/resume topology, operator command versus runtime
+protocol/context versus human-authored material, thinking/output/tool-use and
+tool-result pairing, structured error/exit outcomes, token/cache usage, model
+identity, timestamps, and replayed-prefix lineage behavior.
+
+Use real privacy-safe wire-shape fixtures and current dispatch/parser routes.
+Vary protocol rows, missing/late tool results, subagent parent arrival, and
+compaction/resume forms while retaining exact historical witnesses for unique
+wire compatibility. Expected facts must be independent of the parser output.
+
+Name authoredness, detector, topology, tool pairing, or streaming-boundary
+mutations. Preserve narrow compatibility regressions that cannot honestly be
+generalized. Do not build another Claude event model or treat every `role=user`
+row as authored user material.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/10-claude-web-normalization.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/10-claude-web-normalization.md
@@ -1,0 +1,24 @@
+Title: "[testdiet 10] Claude web normalization laws"
+
+Job ID: `testdiet-10`
+Result ZIP: `testdiet-10-claude-web-normalization-r01.zip`
+
+## Mission
+
+Implement provider-family normalization survivors for Claude web exports and
+authenticated browser-capture payloads. Prove conversation/message identity,
+edits/variants/branches where represented, model and thinking configuration,
+content block types, artifacts/attachments, timestamps/status, and
+full-native-versus-fallback capture fidelity through real detector/lower/parser
+routes.
+
+Use structured provider evidence and privacy-safe fixtures, including ambiguous
+shapes that might otherwise be claimed by a looser detector. Plant independent
+expected facts and vary missing optional metadata, reordered records, edited
+turns, and attachment-only enrichment. Preserve raw evidence when semantics are
+unknown rather than guessing from display text.
+
+Name detector-order, branch loss, thinking metadata loss, or attachment
+replacement mutations. Keep unique compatibility/diagnostic witnesses and only
+propose dominated local parser snapshots. Do not couple the parser to current
+DOM selectors or create a second browser conversation identity.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/11-codex-normalization.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/11-codex-normalization.md
@@ -1,0 +1,23 @@
+Title: "[testdiet 11] Codex session normalization laws"
+
+Job ID: `testdiet-11`
+Result ZIP: `testdiet-11-codex-normalization-r01.zip`
+
+## Mission
+
+Implement provider-family normalization survivors for Codex session records.
+Prove tight detection, session/message/block identity, user-authored material
+versus developer/runtime context, reasoning and visible assistant output,
+function/tool calls and outcomes, approvals, token accounting including cached
+input semantics, model/effort, timestamps/durations, branches/compaction, and
+terminal/interrupted states through the real parser route.
+
+Build independent expected facts from privacy-safe wire fixtures and vary
+missing optional fields, multiple tool calls, failed results, cached-token
+mixes, compaction/replay, and interrupted turns. Retain exact provider-specific
+witnesses where no honest generalization exists.
+
+Name mutations that double-count cached input, lose reasoning/output identity,
+misclassify runtime context as authored input, or pair the wrong tool result.
+Propose dominated narrow snapshots but do not delete them. Do not infer tool
+failures from prose when structured outcome fields exist.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/12-gemini-drive-normalization.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/12-gemini-drive-normalization.md
@@ -1,0 +1,24 @@
+Title: "[testdiet 12] Gemini and AI Studio Drive normalization laws"
+
+Job ID: `testdiet-12`
+Result ZIP: `testdiet-12-gemini-drive-normalization-r01.zip`
+
+## Mission
+
+Implement provider-family normalization survivors for Gemini CLI/session data
+and AI Studio/Drive exports while respecting their distinct wire forms and the
+non-injective provider-to-origin mapping. Prove tight detection, conversation
+and turn identity, author/material origin, model configuration, thought/output
+and tool blocks, file/Drive artifacts, timestamps, usage, status, and nested
+Drive-like lowering through real dispatch/parser routes.
+
+Use privacy-safe structured fixtures with intentionally ambiguous and nested
+shapes. Plant expected facts independently and vary missing metadata, reordered
+records, tool failures, multiple files, and provider tokens that collapse to
+the same public origin. Do not use a naive provider-to-origin rename as the
+oracle.
+
+Name detector-order, identity-collapse, authoredness, artifact-loss, or
+thought/tool outcome mutations. Preserve unique wire-compatibility cases and
+propose only genuinely dominated local tests. Do not generalize AI Studio's
+attachment-token limitation into a ChatGPT or product-wide rule.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/13-output-injection-safety.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/13-output-injection-safety.md
@@ -1,0 +1,25 @@
+Title: "[testdiet 13] Output and schema injection safety"
+
+Job ID: `testdiet-13`
+Result ZIP: `testdiet-13-output-injection-safety-r01.zip`
+
+## Mission
+
+Implement production-route safety survivors for attacker-controlled provider,
+schema, annotation, saved-query, and generated-output tokens crossing
+Polylogue's CLI, JSON, HTTP, MCP, rendered docs/schema, and archive paths.
+Prove that values remain data rather than becoming SQL, shell, path, markup,
+terminal-control, or schema/code authority; outputs remain parseable; and
+invalid identifiers fail through the intended typed boundary.
+
+Start from actual ingress and output call sites, not a synthetic bad-string
+catalog. Build a compact malicious-token corpus covering quotes, separators,
+Unicode confusables/control characters, traversal, terminal escapes, markup,
+SQL-shaped strings, and oversized values where boundedness is contractual.
+Exercise real serializers/renderers/storage parameterization and independent
+parse/readback or side-effect oracles.
+
+Name a parameterization, escaping, path-normalization, schema-enum, or output
+framing mutation. Retain narrow security diagnostics even when other examples
+are dominated. Do not build a second sanitizer registry or claim general
+security from string-absence assertions.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/14-config-path-coherence.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/14-config-path-coherence.md
@@ -1,0 +1,24 @@
+Title: "[testdiet 14] Configuration composition and path coherence"
+
+Job ID: `testdiet-14`
+Result ZIP: `testdiet-14-config-path-coherence-r01.zip`
+
+## Mission
+
+Implement survivor laws for Polylogue's real five-layer configuration
+composition and archive/tier/runtime path coherence. Prove precedence and merge
+semantics across defaults, files, environment, explicit inputs, and runtime
+inventory; ensure independently configured tier roots either compose as an
+authorized archive or fail closed with actionable diagnostics; and verify that
+CLI/API/daemon/browser receiver observe the same effective authority.
+
+Use temporary real files/environment and the actual config/service factories.
+Vary missing, empty, conflicting, relative, symlinked, and split-root values,
+including cloud-lane overrides. Expected effective configuration must be
+computed from the declared precedence contract, not by calling production
+resolution twice.
+
+Name a reversed-precedence, shallow-overwrite, environment-bypass, or split
+path mutation. Read current Beads before choosing any still-unsettled policy;
+implement the decided slice and surface exact blockers. Propose dominated
+getter/forwarding tests, not unique diagnostic or privacy-boundary tests.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/15-temporal-equivalence.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/15-temporal-equivalence.md
@@ -1,0 +1,23 @@
+Title: "[testdiet 15] Equivalent-instant temporal behavior"
+
+Job ID: `testdiet-15`
+Result ZIP: `testdiet-15-temporal-equivalence-r01.zip`
+
+## Mission
+
+Implement temporal survivor laws proving that equivalent instants and declared
+provider timestamps produce consistent Polylogue behavior across parsing,
+filtering/query ranges, ordering, freshness, durations, receipts, and public
+rendering. Use existing frozen-clock and temporal strategy infrastructure.
+
+Vary timezone offsets, DST folds/gaps, leap-day/month/year boundaries,
+subsecond precision, naive/aware provider inputs, absent timestamps, equal
+instants with different representations, and start/end inclusivity. Preserve
+the semantic distinction between provider-reported durations, observed wall
+time, and inferred message gaps; never relabel one as model compute time.
+
+The oracle should normalize through an independent standard instant model and
+explicit interval rules, not production helpers under test. Name a timezone
+strip, local-time comparison, inclusive-boundary, precision truncation, or
+duration-unit mutation. Keep exact unique provider wire witnesses and propose
+only dominated repetitive boundary examples.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/16-inventory-authority.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/briefs/16-inventory-authority.md
@@ -1,0 +1,25 @@
+Title: "[testdiet 16] Executable inventory and test-selection authority"
+
+Job ID: `testdiet-16`
+Result ZIP: `testdiet-16-inventory-authority-r01.zip`
+
+## Mission
+
+Adjudicate and implement the residual production-backed authority for
+Polylogue's executable inventories, generated verification catalogs, testmon
+selection evidence, and isolated/xdist receipts after reading what the merged
+test-harness foundation already supplies. Remove no behavior based merely on a
+catalog claiming zero consumers.
+
+Trace every candidate inventory/catalog to its real writer and consumers.
+Where a static list duplicates executable registration or source discovery,
+replace its verification role with a direct production-route law or retire the
+adapter in the patch only when current source proves zero independent behavior.
+For test selection/xdist, consume the existing real mutation and repeated
+isolation receipts; do not recreate a wrapper-mock proof or another hang
+harness.
+
+Name a missing registration/consumer, stale generated inventory, real-mutation
+selection, or cross-worker artifact-attribution mutation. Preserve useful
+diagnostics and publication surfaces. Clearly separate changes safe to apply
+now from exact deletion candidates that still require local certification.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/campaign.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/campaign.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "campaign_id": "gpt-pro-wave-2026-07-16",
+  "workload_id": "testdiet",
+  "prompt_profile": "polylogue-chatgpt-pro-implementation-v3",
+  "prompt_contract": "../../contracts/chatgpt-pro-implementation.md",
+  "snapshot_gate": "Regenerate the Lynchpin Chisel project-state attachment after the local test-harness foundation is merged.",
+  "jobs": [
+    {"id":"testdiet-01","slug":"query-algebra-cardinality","title":"Query algebra and cardinality survivor","brief":"briefs/01-query-algebra-cardinality.md","prompt":"prompts/01-query-algebra-cardinality.md","result_prefix":"testdiet-01-query-algebra-cardinality","depends_on":["foundation"]},
+    {"id":"testdiet-02","slug":"convergence-liveness","title":"Convergence restart and debt liveness","brief":"briefs/02-convergence-liveness.md","prompt":"prompts/02-convergence-liveness.md","result_prefix":"testdiet-02-convergence-liveness","depends_on":["foundation"]},
+    {"id":"testdiet-03","slug":"rebuild-equivalence","title":"Incremental and rebuild equivalence","brief":"briefs/03-rebuild-equivalence.md","prompt":"prompts/03-rebuild-equivalence.md","result_prefix":"testdiet-03-rebuild-equivalence","depends_on":["foundation"]},
+    {"id":"testdiet-04","slug":"derived-freshness","title":"Monotonic derived freshness","brief":"briefs/04-derived-freshness.md","prompt":"prompts/04-derived-freshness.md","result_prefix":"testdiet-04-derived-freshness","depends_on":["testdiet-02","testdiet-03"]},
+    {"id":"testdiet-05","slug":"query-bounds-progress","title":"Bounded query work, cancellation, and cleanup","brief":"briefs/05-query-bounds-progress.md","prompt":"prompts/05-query-bounds-progress.md","result_prefix":"testdiet-05-query-bounds-progress","depends_on":["testdiet-01"]},
+    {"id":"testdiet-06","slug":"evidence-provenance","title":"Evidence monotonicity and provenance conservation","brief":"briefs/06-evidence-provenance.md","prompt":"prompts/06-evidence-provenance.md","result_prefix":"testdiet-06-evidence-provenance","depends_on":["foundation"]},
+    {"id":"testdiet-07","slug":"public-fact-parity","title":"One public fact algebra across stable surfaces","brief":"briefs/07-public-fact-parity.md","prompt":"prompts/07-public-fact-parity.md","result_prefix":"testdiet-07-public-fact-parity","depends_on":["testdiet-01","testdiet-06"]},
+    {"id":"testdiet-08","slug":"chatgpt-normalization","title":"ChatGPT capture and export normalization laws","brief":"briefs/08-chatgpt-normalization.md","prompt":"prompts/08-chatgpt-normalization.md","result_prefix":"testdiet-08-chatgpt-normalization","depends_on":["foundation"]},
+    {"id":"testdiet-09","slug":"claude-code-normalization","title":"Claude Code normalization laws","brief":"briefs/09-claude-code-normalization.md","prompt":"prompts/09-claude-code-normalization.md","result_prefix":"testdiet-09-claude-code-normalization","depends_on":["foundation"]},
+    {"id":"testdiet-10","slug":"claude-web-normalization","title":"Claude web normalization laws","brief":"briefs/10-claude-web-normalization.md","prompt":"prompts/10-claude-web-normalization.md","result_prefix":"testdiet-10-claude-web-normalization","depends_on":["foundation"]},
+    {"id":"testdiet-11","slug":"codex-normalization","title":"Codex session normalization laws","brief":"briefs/11-codex-normalization.md","prompt":"prompts/11-codex-normalization.md","result_prefix":"testdiet-11-codex-normalization","depends_on":["foundation"]},
+    {"id":"testdiet-12","slug":"gemini-drive-normalization","title":"Gemini and AI Studio Drive normalization laws","brief":"briefs/12-gemini-drive-normalization.md","prompt":"prompts/12-gemini-drive-normalization.md","result_prefix":"testdiet-12-gemini-drive-normalization","depends_on":["foundation"]},
+    {"id":"testdiet-13","slug":"output-injection-safety","title":"Output and schema injection safety","brief":"briefs/13-output-injection-safety.md","prompt":"prompts/13-output-injection-safety.md","result_prefix":"testdiet-13-output-injection-safety","depends_on":["foundation"]},
+    {"id":"testdiet-14","slug":"config-path-coherence","title":"Configuration composition and path coherence","brief":"briefs/14-config-path-coherence.md","prompt":"prompts/14-config-path-coherence.md","result_prefix":"testdiet-14-config-path-coherence","depends_on":["foundation"]},
+    {"id":"testdiet-15","slug":"temporal-equivalence","title":"Equivalent-instant temporal behavior","brief":"briefs/15-temporal-equivalence.md","prompt":"prompts/15-temporal-equivalence.md","result_prefix":"testdiet-15-temporal-equivalence","depends_on":["foundation"]},
+    {"id":"testdiet-16","slug":"inventory-authority","title":"Executable inventory and test-selection authority","brief":"briefs/16-inventory-authority.md","prompt":"prompts/16-inventory-authority.md","result_prefix":"testdiet-16-inventory-authority","depends_on":["foundation"]}
+  ]
+}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/01-query-algebra-cardinality.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/01-query-algebra-cardinality.md
@@ -1,0 +1,109 @@
+Title: "[testdiet 01] Query algebra and cardinality survivor"
+
+Job ID: `testdiet-01`
+Result ZIP: `testdiet-01-query-algebra-cardinality-r01.zip`
+
+## Mission
+
+Implement a strong real-route survivor law for Polylogue query algebra and
+relational cardinality. Starting from the current realized structural canary in
+the attached snapshot, plant an independent expected fact set and exercise
+public expressions through parsing, lowering, SQL/repository execution, and
+stable public read/action routes. Prove membership, count, partition,
+pagination, and preview/apply agreement; include duplicate/join shapes that
+would expose lost or multiplied rows.
+
+The oracle must be computed from planted input facts, never by asking the
+production query path for its own expected output. Include a representative
+anti-vacuity mutation such as dropping a predicate, changing `DISTINCT`, moving
+selection after a join, or making selection global-first, and explain the
+specific wrong result the survivor must detect.
+
+Inspect all current query tests and helpers in the affected cluster. Preserve
+unique parser diagnostics, security, and compatibility obligations. Propose
+dominated layer-local/mock-forwarding tests for later certification, but do not
+delete them. Avoid redesigning the query language or inventing a Test Diet
+query framework.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/02-convergence-liveness.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/02-convergence-liveness.md
@@ -1,0 +1,108 @@
+Title: "[testdiet 02] Convergence restart and debt liveness"
+
+Job ID: `testdiet-02`
+Result ZIP: `testdiet-02-convergence-liveness-r01.zip`
+
+## Mission
+
+Implement a survivor law for daemon convergence across interruption, restart,
+retryable debt, and eventual quiescence. Use the current active-growing or
+partial-convergence workload variant and real `DaemonConverger`/ops debt/write
+routes. Demonstrate that bounded work may defer honestly, durable debt survives
+process restart, retries address the intended session/stage without replaying
+unrelated acquisition, and repeated convergence reaches the same terminal
+facts without duplication.
+
+Prefer deterministic barriers/failpoints or existing injected clock/executor
+seams over sleeps. If one minimal production trace seam is genuinely needed,
+make it report the real stage/debt lifecycle rather than mirror the algorithm
+inside tests. The independent oracle should cover debt identity, retry count,
+terminal state, materialized facts, and cleanup.
+
+Name a mutation such as dropping the debt write, consuming debt before stage
+success, skipping the retry path, or re-resolving the wrong source, and show
+why the survivor fails. Propose dominated restart/example tests but do not
+delete them. Do not build a new convergence state machine or corpus generator.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/03-rebuild-equivalence.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/03-rebuild-equivalence.md
@@ -1,0 +1,108 @@
+Title: "[testdiet 03] Incremental and rebuild equivalence"
+
+Job ID: `testdiet-03`
+Result ZIP: `testdiet-03-rebuild-equivalence-r01.zip`
+
+## Mission
+
+Implement an incremental-versus-rebuild equivalence survivor over Polylogue's
+actual durable source evidence and rebuildable index route. Replay one realized
+workload identity through incremental ingest/update/reprocess and through a
+fresh index rebuild, then compare independently selected public facts:
+session/message/block identity and active path, attachments, lineage, search,
+materialized insight outputs, and absence/unknown semantics relevant to the
+chosen canary.
+
+Keep user-tier overlays outside content/workload identity and prove they are
+preserved or deliberately rejoined rather than folded into raw content hashes.
+The expected fact set must originate from planted input facts and declared
+transform invariants, not from serializing one production result and comparing
+it to another.
+
+Name an omitted-rebuild-stage or stale-dependent-row mutation that the test
+must kill. Respect durable-versus-derived schema rules and the sole-writer
+architecture. Propose duplicated rebuild/example checks for later
+certification, but do not remove them or invent another rebuild harness.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/04-derived-freshness.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/04-derived-freshness.md
@@ -1,0 +1,110 @@
+Title: "[testdiet 04] Monotonic derived freshness"
+
+Job ID: `testdiet-04`
+Result ZIP: `testdiet-04-derived-freshness-r01.zip`
+Dependency: integrate only after `testdiet-02` and `testdiet-03` foundations are
+adjudicated.
+
+## Mission
+
+Implement a survivor law that derived Polylogue facts never silently move
+backward relative to their content and recipe/generation authority. Cover the
+current FTS, insight, and—where the source contract makes it meaningful—
+embedding catch-up identities through ingest, reprocess, recipe change,
+restart, and rebuild. A reader must see a current generation, an explicit
+pending/degraded state, or an honest absence; never a stale value presented as
+current.
+
+First discover the canonical identity already supplied by current source and
+Beads. Do not invent a Diet-specific freshness token. Reuse the convergence
+and rebuild survivor mechanisms produced by the prerequisite lanes when
+possible. Include varied arrival orders and an independent expected freshness
+relation.
+
+Name a mutation that ignores recipe identity, retains a stale materialization,
+or marks debt complete early. If the product contract for one derived tier is
+still genuinely undecided, implement the decided tiers and return a precise
+blocker/decision matrix for the remainder rather than choosing policy yourself.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/05-query-bounds-progress.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/05-query-bounds-progress.md
@@ -1,0 +1,108 @@
+Title: "[testdiet 05] Bounded query work, cancellation, and cleanup"
+
+Job ID: `testdiet-05`
+Result ZIP: `testdiet-05-query-bounds-progress-r01.zip`
+Dependency: integrate after the query algebra survivor in `testdiet-01`.
+
+## Mission
+
+Implement the strongest currently authorized slice of bounded and
+interruptible query work. Reuse the exact-selection facts from the query
+survivor and exercise irrelevant-growth equivalence, selected-work scaling,
+lossless pagination/addressability, cancellation/deadline propagation, truthful
+progress, and cleanup through real SQLite/repository/public routes.
+
+Use an existing work/progress counter if current source provides one. Add a
+minimal production observation seam only if it measures actual SQLite/runner
+work and has at least the concrete consumer in this survivor; do not duplicate
+the query algorithm in a test counter. Prefer deterministic cancellation over
+wall-clock flakiness.
+
+Name work-amplification, ignored-cancellation, depth-limit, leaked temporary
+state, or double-counted-progress mutations and the expected failure. Read the
+current product decision for oversized results and cancellation; implement no
+semantics that remain undecided. Propose slow/redundant examples for later
+certification without deleting them.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/06-evidence-provenance.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/06-evidence-provenance.md
@@ -1,0 +1,108 @@
+Title: "[testdiet 06] Evidence monotonicity and provenance conservation"
+
+Job ID: `testdiet-06`
+Result ZIP: `testdiet-06-evidence-provenance-r01.zip`
+
+## Mission
+
+Implement survivor laws for Polylogue evidence monotonicity and quantitative
+provenance conservation. Across the current source/index/user evidence models,
+prove that adding stronger evidence can refine or supersede a claim without
+silently reducing supported information; aggregations conserve totals across
+disjoint sources; unknown/absent/unsupported never becomes numeric zero; and
+every public value retains the evidence/provenance needed to explain it.
+
+Use the smallest current source vocabulary and ObjectRef/EvidenceRef mechanisms
+already present. Do not create a second evidence lattice or a test-only
+registry. Build independent planted facts that include missing, contradictory,
+duplicate, and differently authoritative observations and vary ordering and
+grouping.
+
+Name mutations such as dropping one source, double-counting a duplicate,
+strengthening provenance without evidence, or coercing unknown to zero. Cover
+the stable production readers directly; defer surfaces under explicit rewrite
+only with a transfer-of-obligation note. Propose dominated arithmetic/local
+model tests, but keep unique compatibility and error witnesses.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/07-public-fact-parity.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/07-public-fact-parity.md
@@ -1,0 +1,108 @@
+Title: "[testdiet 07] One public fact algebra across stable surfaces"
+
+Job ID: `testdiet-07`
+Result ZIP: `testdiet-07-public-fact-parity-r01.zip`
+Dependencies: `testdiet-01` query facts and `testdiet-06` provenance facts.
+
+## Mission
+
+Implement cross-surface survivor tests proving that one selected semantic fact
+set projects consistently through Polylogue's stable CLI, Python API,
+operations/repository, daemon HTTP, and applicable MCP routes. Compare meaning,
+identity, absence/error semantics, origin vocabulary, counts, and provenance—not
+byte-for-byte formatting. Route-specific presentation may differ only where an
+explicit public contract says so.
+
+Reuse the independent fact fixtures from prerequisite lanes instead of
+creating another seeded database or expected-output catalog. Exercise real
+surface adapters and their shared substrate. Identify MCP/web areas currently
+owned by rewrites and transfer their obligations precisely rather than
+strengthening obsolete implementation.
+
+Name a surface-disagreement mutation such as bypassing origin projection,
+dropping a filter, coercing absence, or reading a stale model. Propose
+mock-forwarding and snapshot tests dominated by the survivor, but do not delete
+them. Do not centralize presentation logic that is legitimately surface-local.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/08-chatgpt-normalization.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/08-chatgpt-normalization.md
@@ -1,0 +1,108 @@
+Title: "[testdiet 08] ChatGPT capture and export normalization laws"
+
+Job ID: `testdiet-08`
+Result ZIP: `testdiet-08-chatgpt-normalization-r01.zip`
+
+## Mission
+
+Implement provider-family normalization survivors for ChatGPT exports and
+native browser-capture payloads. Use real, privacy-safe wire fixtures and the
+actual detect/lower/parse routes. Prove tight detector selection, active-path
+and variant identity, role/material-origin, content blocks including reasoning,
+attachments and assistant-produced assets, timestamps/durations, model effort,
+status/end-turn, and full-fidelity-versus-fallback replacement semantics.
+
+Pay particular attention to native metadata spellings actually present in
+current fixtures (`reasoning_start_time`, `reasoning_end_time`,
+`finished_duration_sec`, and any legacy duration field) and to provider tree
+nodes that duplicate metadata. Normalize one semantic duration once without
+double counting. Preserve raw fields even when their semantic meaning remains
+explicitly provider-reported rather than model-compute time.
+
+Name detector-order, authoredness, active-branch, duration-loss, or missing
+asset mutations the survivors must kill. Do not make browser capture a special
+campaign protocol or infer semantic facts from prose/UI labels when structured
+provider data exists.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/09-claude-code-normalization.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/09-claude-code-normalization.md
@@ -1,0 +1,106 @@
+Title: "[testdiet 09] Claude Code normalization laws"
+
+Job ID: `testdiet-09`
+Result ZIP: `testdiet-09-claude-code-normalization-r01.zip`
+
+## Mission
+
+Implement provider-family normalization survivors for Claude Code session
+JSONL, including streaming/multi-GiB lowering where relevant. Prove message and
+block identity, parent/subagent/resume topology, operator command versus runtime
+protocol/context versus human-authored material, thinking/output/tool-use and
+tool-result pairing, structured error/exit outcomes, token/cache usage, model
+identity, timestamps, and replayed-prefix lineage behavior.
+
+Use real privacy-safe wire-shape fixtures and current dispatch/parser routes.
+Vary protocol rows, missing/late tool results, subagent parent arrival, and
+compaction/resume forms while retaining exact historical witnesses for unique
+wire compatibility. Expected facts must be independent of the parser output.
+
+Name authoredness, detector, topology, tool pairing, or streaming-boundary
+mutations. Preserve narrow compatibility regressions that cannot honestly be
+generalized. Do not build another Claude event model or treat every `role=user`
+row as authored user material.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/10-claude-web-normalization.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/10-claude-web-normalization.md
@@ -1,0 +1,107 @@
+Title: "[testdiet 10] Claude web normalization laws"
+
+Job ID: `testdiet-10`
+Result ZIP: `testdiet-10-claude-web-normalization-r01.zip`
+
+## Mission
+
+Implement provider-family normalization survivors for Claude web exports and
+authenticated browser-capture payloads. Prove conversation/message identity,
+edits/variants/branches where represented, model and thinking configuration,
+content block types, artifacts/attachments, timestamps/status, and
+full-native-versus-fallback capture fidelity through real detector/lower/parser
+routes.
+
+Use structured provider evidence and privacy-safe fixtures, including ambiguous
+shapes that might otherwise be claimed by a looser detector. Plant independent
+expected facts and vary missing optional metadata, reordered records, edited
+turns, and attachment-only enrichment. Preserve raw evidence when semantics are
+unknown rather than guessing from display text.
+
+Name detector-order, branch loss, thinking metadata loss, or attachment
+replacement mutations. Keep unique compatibility/diagnostic witnesses and only
+propose dominated local parser snapshots. Do not couple the parser to current
+DOM selectors or create a second browser conversation identity.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/11-codex-normalization.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/11-codex-normalization.md
@@ -1,0 +1,106 @@
+Title: "[testdiet 11] Codex session normalization laws"
+
+Job ID: `testdiet-11`
+Result ZIP: `testdiet-11-codex-normalization-r01.zip`
+
+## Mission
+
+Implement provider-family normalization survivors for Codex session records.
+Prove tight detection, session/message/block identity, user-authored material
+versus developer/runtime context, reasoning and visible assistant output,
+function/tool calls and outcomes, approvals, token accounting including cached
+input semantics, model/effort, timestamps/durations, branches/compaction, and
+terminal/interrupted states through the real parser route.
+
+Build independent expected facts from privacy-safe wire fixtures and vary
+missing optional fields, multiple tool calls, failed results, cached-token
+mixes, compaction/replay, and interrupted turns. Retain exact provider-specific
+witnesses where no honest generalization exists.
+
+Name mutations that double-count cached input, lose reasoning/output identity,
+misclassify runtime context as authored input, or pair the wrong tool result.
+Propose dominated narrow snapshots but do not delete them. Do not infer tool
+failures from prose when structured outcome fields exist.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/12-gemini-drive-normalization.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/12-gemini-drive-normalization.md
@@ -1,0 +1,107 @@
+Title: "[testdiet 12] Gemini and AI Studio Drive normalization laws"
+
+Job ID: `testdiet-12`
+Result ZIP: `testdiet-12-gemini-drive-normalization-r01.zip`
+
+## Mission
+
+Implement provider-family normalization survivors for Gemini CLI/session data
+and AI Studio/Drive exports while respecting their distinct wire forms and the
+non-injective provider-to-origin mapping. Prove tight detection, conversation
+and turn identity, author/material origin, model configuration, thought/output
+and tool blocks, file/Drive artifacts, timestamps, usage, status, and nested
+Drive-like lowering through real dispatch/parser routes.
+
+Use privacy-safe structured fixtures with intentionally ambiguous and nested
+shapes. Plant expected facts independently and vary missing metadata, reordered
+records, tool failures, multiple files, and provider tokens that collapse to
+the same public origin. Do not use a naive provider-to-origin rename as the
+oracle.
+
+Name detector-order, identity-collapse, authoredness, artifact-loss, or
+thought/tool outcome mutations. Preserve unique wire-compatibility cases and
+propose only genuinely dominated local tests. Do not generalize AI Studio's
+attachment-token limitation into a ChatGPT or product-wide rule.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/13-output-injection-safety.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/13-output-injection-safety.md
@@ -1,0 +1,108 @@
+Title: "[testdiet 13] Output and schema injection safety"
+
+Job ID: `testdiet-13`
+Result ZIP: `testdiet-13-output-injection-safety-r01.zip`
+
+## Mission
+
+Implement production-route safety survivors for attacker-controlled provider,
+schema, annotation, saved-query, and generated-output tokens crossing
+Polylogue's CLI, JSON, HTTP, MCP, rendered docs/schema, and archive paths.
+Prove that values remain data rather than becoming SQL, shell, path, markup,
+terminal-control, or schema/code authority; outputs remain parseable; and
+invalid identifiers fail through the intended typed boundary.
+
+Start from actual ingress and output call sites, not a synthetic bad-string
+catalog. Build a compact malicious-token corpus covering quotes, separators,
+Unicode confusables/control characters, traversal, terminal escapes, markup,
+SQL-shaped strings, and oversized values where boundedness is contractual.
+Exercise real serializers/renderers/storage parameterization and independent
+parse/readback or side-effect oracles.
+
+Name a parameterization, escaping, path-normalization, schema-enum, or output
+framing mutation. Retain narrow security diagnostics even when other examples
+are dominated. Do not build a second sanitizer registry or claim general
+security from string-absence assertions.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/14-config-path-coherence.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/14-config-path-coherence.md
@@ -1,0 +1,107 @@
+Title: "[testdiet 14] Configuration composition and path coherence"
+
+Job ID: `testdiet-14`
+Result ZIP: `testdiet-14-config-path-coherence-r01.zip`
+
+## Mission
+
+Implement survivor laws for Polylogue's real five-layer configuration
+composition and archive/tier/runtime path coherence. Prove precedence and merge
+semantics across defaults, files, environment, explicit inputs, and runtime
+inventory; ensure independently configured tier roots either compose as an
+authorized archive or fail closed with actionable diagnostics; and verify that
+CLI/API/daemon/browser receiver observe the same effective authority.
+
+Use temporary real files/environment and the actual config/service factories.
+Vary missing, empty, conflicting, relative, symlinked, and split-root values,
+including cloud-lane overrides. Expected effective configuration must be
+computed from the declared precedence contract, not by calling production
+resolution twice.
+
+Name a reversed-precedence, shallow-overwrite, environment-bypass, or split
+path mutation. Read current Beads before choosing any still-unsettled policy;
+implement the decided slice and surface exact blockers. Propose dominated
+getter/forwarding tests, not unique diagnostic or privacy-boundary tests.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/15-temporal-equivalence.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/15-temporal-equivalence.md
@@ -1,0 +1,106 @@
+Title: "[testdiet 15] Equivalent-instant temporal behavior"
+
+Job ID: `testdiet-15`
+Result ZIP: `testdiet-15-temporal-equivalence-r01.zip`
+
+## Mission
+
+Implement temporal survivor laws proving that equivalent instants and declared
+provider timestamps produce consistent Polylogue behavior across parsing,
+filtering/query ranges, ordering, freshness, durations, receipts, and public
+rendering. Use existing frozen-clock and temporal strategy infrastructure.
+
+Vary timezone offsets, DST folds/gaps, leap-day/month/year boundaries,
+subsecond precision, naive/aware provider inputs, absent timestamps, equal
+instants with different representations, and start/end inclusivity. Preserve
+the semantic distinction between provider-reported durations, observed wall
+time, and inferred message gaps; never relabel one as model compute time.
+
+The oracle should normalize through an independent standard instant model and
+explicit interval rules, not production helpers under test. Name a timezone
+strip, local-time comparison, inclusive-boundary, precision truncation, or
+duration-unit mutation. Keep exact unique provider wire witnesses and propose
+only dominated repetitive boundary examples.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/16-inventory-authority.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/prompts/16-inventory-authority.md
@@ -1,0 +1,108 @@
+Title: "[testdiet 16] Executable inventory and test-selection authority"
+
+Job ID: `testdiet-16`
+Result ZIP: `testdiet-16-inventory-authority-r01.zip`
+
+## Mission
+
+Adjudicate and implement the residual production-backed authority for
+Polylogue's executable inventories, generated verification catalogs, testmon
+selection evidence, and isolated/xdist receipts after reading what the merged
+test-harness foundation already supplies. Remove no behavior based merely on a
+catalog claiming zero consumers.
+
+Trace every candidate inventory/catalog to its real writer and consumers.
+Where a static list duplicates executable registration or source discovery,
+replace its verification role with a direct production-route law or retire the
+adapter in the patch only when current source proves zero independent behavior.
+For test selection/xdist, consume the existing real mutation and repeated
+isolation receipts; do not recreate a wrapper-mock proof or another hang
+harness.
+
+Name a missing registration/consumer, stale generated inventory, real-mutation
+selection, or cross-worker artifact-attribution mutation. Preserve useful
+diagnostics and publication surfaces. Clearly separate changes safe to apply
+now from exact deletion candidates that still require local certification.
+
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/README.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/README.md
@@ -1,0 +1,10 @@
+# Results
+
+Create `results/<job-id>/<attempt-id>/result.json` when a chat is launched or
+imported. Store every downloaded/captured package under `raw/` by its declared
+filename plus SHA-256; never overwrite a prior revision. `result.json` records
+provider conversation/turn, prompt hash, snapshot identity, package hash,
+validation, triage, iteration/supersedes lineage, and integration receipts.
+
+The initial empty ledger is `index.json`. It is not execution state until an
+orchestrator or operator writes evidence-backed entries.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/index.json
@@ -1,0 +1,1 @@
+{"schema_version":1,"campaign_id":"gpt-pro-wave-2026-07-16","workload_id":"testdiet","attempts":[]}

--- a/.agent/handoffs/external-agent-campaigns/README.md
+++ b/.agent/handoffs/external-agent-campaigns/README.md
@@ -1,0 +1,77 @@
+# External-agent campaign workspace
+
+This directory is the repository-side, provider-independent home for external
+agent campaign inputs and returned artifacts. It is local orchestration data,
+not a Polylogue product protocol and not browser-extension state.
+
+Each campaign run is a self-contained directory with one or more workload
+subdirectories. A workload has:
+
+- `campaign.json`: stable campaign, workload, job, dependency, prompt, and
+  expected-result identities;
+- `briefs/`: concise job-specific source material;
+- `prompts/`: fully rendered prompts ready to paste or submit;
+- `results/index.json`: the append-only reconciliation ledger for returned
+  attempts and artifacts;
+- `results/README.md`: the on-disk result convention.
+
+The prompt renderer combines a workload's brief with the named shared contract:
+
+```bash
+python .agent/handoffs/external-agent-campaigns/render_prompts.py \
+  .agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet
+```
+
+Use `--check` at a publication boundary. The rendered prompt is the dispatch
+artifact; a launcher never needs to understand prompt fragments.
+
+## Stable identities
+
+- Campaign: a dated, readable execution portfolio, for example
+  `gpt-pro-wave-2026-07-16`.
+- Workload: a reusable problem family within the campaign, for example
+  `testdiet` or `deep-research`.
+- Job: `<workload>-NN`, with a fixed two-digit number and readable slug.
+- Attempt: `aNN`; a retry or same-chat repair is a new attempt, not an
+  overwrite.
+- Package revision: `rNN`; the exact output filename is declared in the job.
+
+An orchestrator may add provider conversation IDs, Polylogue ObjectRefs,
+content hashes, Beads, worktrees, agents, PRs, and merge outcomes to
+`results/index.json`. It must not infer completion from a filename alone.
+
+## Result path
+
+Returned material is stored as:
+
+```text
+results/<job-id>/<attempt-id>/
+  result.json
+  raw/                 # immutable downloaded/captured provider artifacts
+  extracted/           # deterministic extraction of raw packages
+  integration/         # local adjudication, worktree, test, PR receipts
+```
+
+`raw/` is hash-addressed evidence. `extracted/` can be rebuilt. `integration/`
+records what Polylogue maintainers actually accepted and verified. Large or
+private artifacts stay outside Git when policy requires it; `result.json`
+then records the absolute custody path and checksum rather than pretending the
+file is absent.
+
+Machine-readable shapes are documented by `schemas/campaign.schema.json` and
+`schemas/result.schema.json`. `campaign.json` is dispatch intent and should
+remain stable after launch. Per-attempt `result.json` is immutable evidence.
+`results/index.json` is a rebuildable reconciliation projection across those
+receipts.
+
+## Attachment policy
+
+For ChatGPT Pro, attachment bytes are not assumed to consume the active prompt
+context. Attach all relevant authorized evidence, including a complete Chisel
+project-state archive, and provide navigation instructions. Do not remove
+useful evidence merely because it is large. Reduce inputs only for a real
+provider upload/retrieval limit, privacy boundary, or irrelevance.
+
+Generated result packages must not copy the supplied repository/state archive
+back into their output. They contain only new analysis, patches, tests,
+evidence, and explanation.

--- a/.agent/handoffs/external-agent-campaigns/contracts/chatgpt-deep-research.md
+++ b/.agent/handoffs/external-agent-campaigns/contracts/chatgpt-deep-research.md
@@ -1,0 +1,32 @@
+## Research contract
+
+Use Deep Research, not ordinary implementation mode. Prefer current primary and
+official sources; record direct URLs, publication/update dates, access date,
+and the exact claim each source supports. Distinguish standards, documented
+provider policy, measured behavior, informed inference, and proposal. Search
+for counterevidence and incompatible constraints rather than writing a survey
+that merely confirms the mission premise.
+
+A current Polylogue project-state archive may be attached for product context.
+Inspect relevant source and Beads so the research resolves concrete project
+decisions, but do not return speculative patches. Map each conclusion to the
+named Polylogue decision/Bead, state what should change, what should not change,
+and what local experiment would falsify the recommendation.
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
+`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
+`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
+finished ZIP through a working user-clickable conversation link; an internal
+temporary path alone is not delivery. Reopen and validate the ZIP, report
+SHA-256/size/members, and provide a substantive direct answer covering
+conclusions, rationale, limitations, missing evidence, and the likely value of
+another iteration before the exact package link.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, extend the strongest unresolved research
+branch and regenerate the complete package. On an explicit **adversarial
+review** request, try to falsify the prior memo with counterevidence, later or
+more authoritative sources, incompatible policies/standards, hidden product
+assumptions, and experiments that would overturn its recommendations. Repair
+legitimate findings, regenerate the cohesive package, and report what changed,
+what remains uncertain, and whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/contracts/chatgpt-pro-analysis.md
+++ b/.agent/handoffs/external-agent-campaigns/contracts/chatgpt-pro-analysis.md
@@ -1,0 +1,46 @@
+## Context and authority
+
+You are a long-running ChatGPT Pro analysis worker. A recent, complete
+Polylogue project-state archive will be attached. Retrieve and inspect it
+broadly; attachment size alone is not a reason to ignore evidence. This prompt
+defines the question. The snapshot's current source, repository instructions,
+complete relevant Beads records, and cited history are the evidence authority,
+in that order when older plans drift.
+
+## Working contract
+
+- Investigate the actual source and tracker state before recommending changes.
+- Separate observed facts, source-supported inference, unresolved uncertainty,
+  and recommendation. Quote paths/symbols/Bead ids precisely but do not fill the
+  report with copied source.
+- Adjudicate contradictions and duplicates; do not create a parallel product
+  model or generic architecture merely to make the report look complete.
+- Translate findings into decision-ready actions: exact owning areas, ordering,
+  acceptance criteria, falsification evidence, and what a local implementer
+  should verify.
+- Do not claim live browser, daemon, archive, deployment, or test evidence you
+  cannot access.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top under `/mnt/data/`. It must
+contain `REPORT.md`, `EVIDENCE.md`, `DECISIONS.md`, and `NEXT-ACTIONS.md`.
+Include compact machine-readable tables as JSON/CSV only when they add genuine
+integration value. Do not copy the input archive into the result. Attach the
+finished ZIP to the conversation through a working user-clickable link; files
+left only in an internal temporary directory are not delivered.
+
+Reopen and validate the ZIP, then report its SHA-256, size, and members. The
+final chat answer must itself explain the important conclusions and decisions,
+limitations, missing evidence, and the likely value of another iteration before
+linking the package.
+
+Do not perform an adversarial review unless explicitly requested. On an
+ordinary **iterate/continue** request, preserve sound findings, resolve the
+highest-value remaining uncertainty, and regenerate a complete package
+revision. On an explicit **adversarial review** request, try to falsify the
+prior report: seek contrary source/history evidence, unsupported certainty,
+missed stakeholders/call sites, duplicate or incompatible designs, weak
+acceptance criteria, and recommendations that do not survive current code.
+Repair legitimate findings, regenerate the cohesive package, and report the
+delta, residual disputes, and expected value of another pass.

--- a/.agent/handoffs/external-agent-campaigns/contracts/chatgpt-pro-implementation.md
+++ b/.agent/handoffs/external-agent-campaigns/contracts/chatgpt-pro-implementation.md
@@ -1,0 +1,82 @@
+## Context and authority
+
+You are a long-running ChatGPT Pro engineering worker. A recent Polylogue
+project-state archive will be attached. Retrieve and inspect it broadly; do not
+assume attachment bytes consume your active prompt context. The attached
+snapshot is the code authority. This prompt defines your mission. Repository
+instructions and complete relevant Beads records define constraints and intent;
+later Beads notes may supersede older descriptions. Current source wins when a
+stale plan names paths or APIs that no longer exist.
+
+Start by reporting the snapshot commit/branch/dirty-patch identity you found and
+the source, tests, Beads, and history you inspected. Follow dependencies beyond
+the obvious files when they affect the production route. Do not invent an API,
+test helper, product contract, or parallel framework to make the task easy.
+
+## Working contract
+
+- Produce the largest internally coherent implementation draft that fits the
+  mission. Prefer one real end-to-end behavior over disconnected scaffolding.
+- Preserve Polylogue's substrate-first architecture and existing typed
+  interfaces. Small production seams are allowed only when real production
+  behavior needs observation or control.
+- Write concrete production changes and real-route tests. A test must name the
+  production dependency it exercises and the representative implementation
+  mutation/removal that should make it fail.
+- Do not delete existing tests or helpers. Identify proposed dominated
+  deletions separately for independent local certification.
+- Use your container and run meaningful self-contained checks when possible.
+  Never claim access to the operator's live daemon, browser, archive, secrets,
+  NixOS deployment, or current worktree. Mark those checks `unverified`.
+- If the full scope is unsafe, complete the strongest coherent subset and make
+  the remaining decisions and exact continuation steps explicit. Do not return
+  placeholders, ellipses, pseudocode presented as code, or a generic plan in
+  place of implementation.
+
+## Deliverable
+
+Create the exact `Result ZIP` named near the top of this prompt under
+`/mnt/data/`. Do not include the supplied repository/project-state archive or
+other copied inputs in the result. The finished ZIP must be attached to the
+conversation through a working, user-clickable download link. Work left only
+in an internal shell directory, temporary notebook, scattered sandbox files,
+or prose is not delivered.
+
+The ZIP must contain:
+
+- `HANDOFF.md`: mission, snapshot identity, inspected evidence, mechanism,
+  decisions, changed files, acceptance matrix, apply order, risks, and exact
+  verification performed/remaining;
+- `PATCH.diff`: one apply-ready unified diff against the named snapshot;
+- `TESTS.md`: test design, production dependencies, anti-vacuity mutation,
+  commands, and honest execution results;
+- `EVIDENCE.md`: relevant source/Bead/history findings and any contradictions;
+- `FILES/`: complete replacements only where they materially disambiguate the
+  patch; omit it when unnecessary.
+
+Before answering, reopen the ZIP, list and validate its members, compute its
+SHA-256 and byte size, and confirm that `PATCH.diff` has no placeholders or
+copied source snapshot. Your final chat response must begin with a substantive
+operator-readable report of what you did and why. It must also state important
+limitations, missing or unverified work, and how much additional value another
+iteration could plausibly add—distinguishing a small repair from a substantial
+second pass. Then report verification and risks and give a prominent working
+link to the exact `/mnt/data/` ZIP. A bare download receipt is not acceptable.
+
+## Continuation protocol
+
+Do not perform a separate adversarial review unless the user explicitly asks
+for one. If the user asks to **iterate** or **continue**, preserve valid prior
+work, perform the highest-value remaining implementation/research pass, and
+publish a new cohesive package revision with the same complete structure—not a
+loose supplemental patch. Explain exactly what changed, what improved, what
+still remains, and whether another iteration is likely to pay off.
+
+If the user explicitly asks for an **adversarial review**, attack your prior
+result against the original mission and current attached authority: search for
+unsupported claims, invented or stale APIs, missing call sites, composition
+failures, unsafe assumptions, vacuous tests, patch/apply defects, incomplete
+acceptance criteria, and evidence that would falsify the design. Preserve work
+that survives. Then repair every legitimate finding you can, regenerate the
+entire cohesive package as the next revision, and report findings, repairs,
+remaining disputes, and the value of another adversarial/implementation pass.

--- a/.agent/handoffs/external-agent-campaigns/render_prompts.py
+++ b/.agent/handoffs/external-agent-campaigns/render_prompts.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Render complete external-agent prompts from campaign briefs and contracts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def render_workload(workload: Path, *, check: bool) -> list[str]:
+    manifest_path = workload / "campaign.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    contract_path = workload / manifest["prompt_contract"]
+    contract = contract_path.read_text(encoding="utf-8").strip()
+    errors: list[str] = []
+
+    job_ids: set[str] = set()
+    result_prefixes: set[str] = set()
+    for job in manifest["jobs"]:
+        job_id = job["id"]
+        if job_id in job_ids:
+            errors.append(f"{manifest_path}: duplicate job id {job_id}")
+        job_ids.add(job_id)
+        result_prefix = job["result_prefix"]
+        if result_prefix in result_prefixes:
+            errors.append(f"{manifest_path}: duplicate result prefix {result_prefix}")
+        result_prefixes.add(result_prefix)
+        brief_path = workload / job["brief"]
+        prompt_path = workload / job["prompt"]
+        brief = brief_path.read_text(encoding="utf-8").strip()
+        if not brief.startswith('Title: "'):
+            errors.append(f"{brief_path}: first line must be a literal Title")
+            continue
+        expected_zip = f"Result ZIP: `{result_prefix}-r01.zip`"
+        if expected_zip not in brief:
+            errors.append(f"{brief_path}: expected {expected_zip}")
+            continue
+        rendered = f"{brief}\n\n{contract}\n"
+        if check:
+            if not prompt_path.exists():
+                errors.append(f"{prompt_path}: missing rendered prompt")
+            elif prompt_path.read_text(encoding="utf-8") != rendered:
+                errors.append(f"{prompt_path}: rendered prompt is stale")
+        else:
+            prompt_path.parent.mkdir(parents=True, exist_ok=True)
+            prompt_path.write_text(rendered, encoding="utf-8")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("workloads", nargs="+", type=Path)
+    parser.add_argument("--check", action="store_true")
+    args = parser.parse_args()
+
+    errors: list[str] = []
+    for workload in args.workloads:
+        errors.extend(render_workload(workload, check=args.check))
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agent/handoffs/external-agent-campaigns/schemas/campaign.schema.json
+++ b/.agent/handoffs/external-agent-campaigns/schemas/campaign.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "polylogue.external-agent-campaign.v1",
+  "type": "object",
+  "required": ["schema_version", "campaign_id", "workload_id", "prompt_profile", "prompt_contract", "jobs"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "campaign_id": {"type": "string", "minLength": 1},
+    "workload_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+    "prompt_profile": {"type": "string", "minLength": 1},
+    "prompt_contract": {"type": "string", "minLength": 1},
+    "snapshot_gate": {"type": "string"},
+    "jobs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "slug", "title", "brief", "prompt", "result_prefix", "depends_on"],
+        "properties": {
+          "id": {"type": "string", "pattern": "^[a-z0-9-]+-[0-9]{2}$"},
+          "slug": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+          "title": {"type": "string", "minLength": 1},
+          "brief": {"type": "string", "pattern": "^briefs/[0-9]{2}-.*\\.md$"},
+          "prompt": {"type": "string", "pattern": "^prompts/[0-9]{2}-.*\\.md$"},
+          "result_prefix": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
+          "depends_on": {"type": "array", "items": {"type": "string"}}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/.agent/handoffs/external-agent-campaigns/schemas/result.schema.json
+++ b/.agent/handoffs/external-agent-campaigns/schemas/result.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "polylogue.external-agent-result.v1",
+  "type": "object",
+  "required": ["schema_version", "campaign_id", "workload_id", "job_id", "attempt_id", "state", "prompt_sha256", "artifacts"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "campaign_id": {"type": "string"},
+    "workload_id": {"type": "string"},
+    "job_id": {"type": "string"},
+    "attempt_id": {"type": "string", "pattern": "^a[0-9]{2}$"},
+    "package_revision": {"type": ["string", "null"], "pattern": "^r[0-9]{2}$"},
+    "state": {"enum": ["prepared", "submitted", "running", "terminal", "acquired", "validated", "triaged", "integrating", "verified", "published", "rejected", "blocked"]},
+    "provider": {"type": ["string", "null"]},
+    "provider_conversation_id": {"type": ["string", "null"]},
+    "provider_turn_id": {"type": ["string", "null"]},
+    "polylogue_session_ref": {"type": ["string", "null"]},
+    "prompt_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "snapshot_identity": {"type": ["string", "null"]},
+    "supersedes_attempt_id": {"type": ["string", "null"]},
+    "artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["filename", "sha256", "size_bytes", "custody_path"],
+        "properties": {
+          "filename": {"type": "string"},
+          "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+          "size_bytes": {"type": "integer", "minimum": 0},
+          "custody_path": {"type": "string"},
+          "polylogue_attachment_ref": {"type": ["string", "null"]}
+        },
+        "additionalProperties": false
+      }
+    },
+    "triage": {"type": ["string", "null"]},
+    "beads": {"type": "array", "items": {"type": "string"}},
+    "worktree": {"type": ["string", "null"]},
+    "agent_handle": {"type": ["string", "null"]},
+    "commits": {"type": "array", "items": {"type": "string"}},
+    "pull_request": {"type": ["string", "null"]},
+    "verification_receipts": {"type": "array", "items": {"type": "string"}},
+    "notes": {"type": "string"}
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

Add a reusable repository-side external-agent campaign layout and a prepared 41-job ChatGPT Pro portfolio: 16 Test Diet implementation drafts, 10 Beads implementation clusters, 8 analysis/adjudication jobs, and 7 Deep Research memos.

## Problem

The recent browser-agent campaign had no stable input/result directory convention, unique job/package identities, or reusable prompt continuation contract. Manual launches and downloads therefore made later capture reconciliation, iteration, and integration unnecessarily difficult. The Test Suite Diet also needed a fan-out portfolio that begins only after one local foundation owner lands shared workload, canary, cache, and receipt semantics.

## Solution

- Add machine-readable campaign/result schemas and a deterministic brief-to-prompt renderer.
- Define immutable job/attempt/package-revision and result custody conventions outside extension/product models.
- Add fully rendered prompts with literal readable titles, unique result filenames, complete evidence attachment policy, cohesive user-accessible packages, substantive direct reports, iteration-value reporting, and opt-in adversarial review behavior.
- Add the revised local test-harness foundation mission and dependency-aware Test Diet launch order.
- Include the browser-capture timing audit and ChatGPT normalization lane so native reasoning timestamps/durations are treated as raw evidence rather than lost behind export-only assumptions.

Ref polylogue-yyvg.6.

## Verification

- `python .agent/handoffs/external-agent-campaigns/render_prompts.py --check <all four workload directories>` — all 41 prompts current.
- JSON Schema Draft 2020-12 validation — all four `campaign.json` manifests valid.
- `python -m py_compile .agent/handoffs/external-agent-campaigns/render_prompts.py` — success.
- `devtools verify --quick` — 16/16 steps passed; run `20260716T144707Z-quick-563627-14aca90c`.
- Pre-push `devtools verify --quick` — 16/16 steps passed in 27.99s; run `20260716T145019Z-quick-566629-d45849d1`.
