### PR TITLE
fix(agent): make deep research responses conversation-native

### DIFF
--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/README.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/README.md
@@ -1,4 +1,6 @@
 # Deep Research portfolio
 
 Seven source-cited decision memos. Use ChatGPT Deep Research. These prompts ask
-for standards/policy/empirical evidence mapped to Polylogue decisions, not code.
+for standards/policy/empirical evidence mapped to Polylogue decisions, not code
+or generated files. Completed responses are acquired through Polylogue as
+Markdown and named by the orchestrator.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/01-mv3-provider-automation.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/01-mv3-provider-automation.md
@@ -1,7 +1,6 @@
 Title: "[research 01] MV3 lifecycle and provider automation policy"
 
 Job ID: `deep-research-01`
-Result ZIP: `deep-research-01-mv3-provider-automation-r01.zip`
 
 Research current Chrome Manifest V3 service-worker, offscreen document,
 background tab/window, alarms, notifications, downloads, storage, and lifecycle

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/02-sqlite-cancellation.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/02-sqlite-cancellation.md
@@ -1,7 +1,6 @@
 Title: "[research 02] Cancellable resumable SQLite reads"
 
 Job ID: `deep-research-02`
-Result ZIP: `deep-research-02-sqlite-cancellation-r01.zip`
 
 Research current SQLite and Python sqlite3/aiosqlite mechanisms for bounding,
 interrupting, and resuming expensive read-only queries: progress handlers,

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/03-test-selection-mutation.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/03-test-selection-mutation.md
@@ -1,7 +1,6 @@
 Title: "[research 03] Regression selection and incremental mutation certification"
 
 Job ID: `deep-research-03`
-Result ZIP: `deep-research-03-test-selection-mutation-r01.zip`
 
 Research state-of-practice and primary literature/tools for regression-test
 selection, test-impact analysis, per-test coverage contexts, dynamic dependency

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/04-agent-observability-provenance.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/04-agent-observability-provenance.md
@@ -1,7 +1,6 @@
 Title: "[research 04] MCP, GenAI telemetry, and provenance interoperability"
 
 Job ID: `deep-research-04`
-Result ZIP: `deep-research-04-agent-observability-provenance-r01.zip`
 
 Research the latest MCP Tasks/resources/prompts/sampling/elicitation and
 authorization specifications, OpenTelemetry GenAI semantic conventions, W3C

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/05-attachment-provenance.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/05-attachment-provenance.md
@@ -1,7 +1,6 @@
 Title: "[research 05] Attachment acquisition and archival provenance"
 
 Job ID: `deep-research-05`
-Result ZIP: `deep-research-05-attachment-provenance-r01.zip`
 
 Research current archival, digital-preservation, HTTP/content-addressing, RO-
 Crate/BagIt/OCFL, PREMIS, provenance, and software-supply-chain practices

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/06-browser-capture-lifecycle.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/06-browser-capture-lifecycle.md
@@ -1,7 +1,6 @@
 Title: "[research 06] Browser-native AI generation lifecycle evidence"
 
 Job ID: `deep-research-06`
-Result ZIP: `deep-research-06-browser-capture-lifecycle-r01.zip`
 
 Research public/officially documented browser and web-platform techniques for
 capturing authenticated AI conversation state and generation lifecycle from a

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/07-ai-artifact-supply-chain.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/briefs/07-ai-artifact-supply-chain.md
@@ -1,7 +1,6 @@
 Title: "[research 07] AI-generated artifact supply-chain receipts"
 
 Job ID: `deep-research-07`
-Result ZIP: `deep-research-07-ai-artifact-supply-chain-r01.zip`
 
 Research practical provenance and supply-chain models for AI-generated code,
 patches, analysis packages, and iterative repairs: SLSA/in-toto attestations,

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/campaign.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/campaign.json
@@ -4,6 +4,7 @@
   "workload_id":"deep-research",
   "prompt_profile":"polylogue-chatgpt-deep-research-v3",
   "prompt_contract":"../../contracts/chatgpt-deep-research.md",
+  "result_kind":"conversation_markdown",
   "jobs":[
     {"id":"deep-research-01","slug":"mv3-provider-automation","title":"MV3 lifecycle and provider automation policy","brief":"briefs/01-mv3-provider-automation.md","prompt":"prompts/01-mv3-provider-automation.md","result_prefix":"deep-research-01-mv3-provider-automation","depends_on":[]},
     {"id":"deep-research-02","slug":"sqlite-cancellation","title":"Cancellable resumable SQLite reads","brief":"briefs/02-sqlite-cancellation.md","prompt":"prompts/02-sqlite-cancellation.md","result_prefix":"deep-research-02-sqlite-cancellation","depends_on":[]},

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/01-mv3-provider-automation.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/01-mv3-provider-automation.md
@@ -1,7 +1,6 @@
 Title: "[research 01] MV3 lifecycle and provider automation policy"
 
 Job ID: `deep-research-01`
-Result ZIP: `deep-research-01-mv3-provider-automation-r01.zip`
 
 Research current Chrome Manifest V3 service-worker, offscreen document,
 background tab/window, alarms, notifications, downloads, storage, and lifecycle
@@ -28,20 +27,17 @@ decisions, but do not return speculative patches. Map each conclusion to the
 named Polylogue decision/Bead, state what should change, what should not change,
 and what local experiment would falsify the recommendation.
 
-Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
-`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
-`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
-finished ZIP through a working user-clickable conversation link; an internal
-temporary path alone is not delivery. Reopen and validate the ZIP, report
-SHA-256/size/members, and provide a substantive direct answer covering
-conclusions, rationale, limitations, missing evidence, and the likely value of
-another iteration before the exact package link.
+Present a substantive, self-contained research report with conclusions,
+rationale, source-by-source support, counterevidence, limitations, missing
+evidence, Polylogue decision mappings, and the likely value of another
+iteration. It must remain useful to a reader who has not opened the attached
+project-state archive.
 
 Do not perform an adversarial review unless explicitly requested. On an
 ordinary **iterate/continue** request, extend the strongest unresolved research
-branch and regenerate the complete package. On an explicit **adversarial
+branch and return a revised complete report. On an explicit **adversarial
 review** request, try to falsify the prior memo with counterevidence, later or
 more authoritative sources, incompatible policies/standards, hidden product
 assumptions, and experiments that would overturn its recommendations. Repair
-legitimate findings, regenerate the cohesive package, and report what changed,
-what remains uncertain, and whether another pass is worthwhile.
+legitimate findings and report what changed, what remains uncertain, and
+whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/02-sqlite-cancellation.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/02-sqlite-cancellation.md
@@ -1,7 +1,6 @@
 Title: "[research 02] Cancellable resumable SQLite reads"
 
 Job ID: `deep-research-02`
-Result ZIP: `deep-research-02-sqlite-cancellation-r01.zip`
 
 Research current SQLite and Python sqlite3/aiosqlite mechanisms for bounding,
 interrupting, and resuming expensive read-only queries: progress handlers,
@@ -27,20 +26,17 @@ decisions, but do not return speculative patches. Map each conclusion to the
 named Polylogue decision/Bead, state what should change, what should not change,
 and what local experiment would falsify the recommendation.
 
-Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
-`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
-`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
-finished ZIP through a working user-clickable conversation link; an internal
-temporary path alone is not delivery. Reopen and validate the ZIP, report
-SHA-256/size/members, and provide a substantive direct answer covering
-conclusions, rationale, limitations, missing evidence, and the likely value of
-another iteration before the exact package link.
+Present a substantive, self-contained research report with conclusions,
+rationale, source-by-source support, counterevidence, limitations, missing
+evidence, Polylogue decision mappings, and the likely value of another
+iteration. It must remain useful to a reader who has not opened the attached
+project-state archive.
 
 Do not perform an adversarial review unless explicitly requested. On an
 ordinary **iterate/continue** request, extend the strongest unresolved research
-branch and regenerate the complete package. On an explicit **adversarial
+branch and return a revised complete report. On an explicit **adversarial
 review** request, try to falsify the prior memo with counterevidence, later or
 more authoritative sources, incompatible policies/standards, hidden product
 assumptions, and experiments that would overturn its recommendations. Repair
-legitimate findings, regenerate the cohesive package, and report what changed,
-what remains uncertain, and whether another pass is worthwhile.
+legitimate findings and report what changed, what remains uncertain, and
+whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/03-test-selection-mutation.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/03-test-selection-mutation.md
@@ -1,7 +1,6 @@
 Title: "[research 03] Regression selection and incremental mutation certification"
 
 Job ID: `deep-research-03`
-Result ZIP: `deep-research-03-test-selection-mutation-r01.zip`
 
 Research state-of-practice and primary literature/tools for regression-test
 selection, test-impact analysis, per-test coverage contexts, dynamic dependency
@@ -27,20 +26,17 @@ decisions, but do not return speculative patches. Map each conclusion to the
 named Polylogue decision/Bead, state what should change, what should not change,
 and what local experiment would falsify the recommendation.
 
-Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
-`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
-`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
-finished ZIP through a working user-clickable conversation link; an internal
-temporary path alone is not delivery. Reopen and validate the ZIP, report
-SHA-256/size/members, and provide a substantive direct answer covering
-conclusions, rationale, limitations, missing evidence, and the likely value of
-another iteration before the exact package link.
+Present a substantive, self-contained research report with conclusions,
+rationale, source-by-source support, counterevidence, limitations, missing
+evidence, Polylogue decision mappings, and the likely value of another
+iteration. It must remain useful to a reader who has not opened the attached
+project-state archive.
 
 Do not perform an adversarial review unless explicitly requested. On an
 ordinary **iterate/continue** request, extend the strongest unresolved research
-branch and regenerate the complete package. On an explicit **adversarial
+branch and return a revised complete report. On an explicit **adversarial
 review** request, try to falsify the prior memo with counterevidence, later or
 more authoritative sources, incompatible policies/standards, hidden product
 assumptions, and experiments that would overturn its recommendations. Repair
-legitimate findings, regenerate the cohesive package, and report what changed,
-what remains uncertain, and whether another pass is worthwhile.
+legitimate findings and report what changed, what remains uncertain, and
+whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/04-agent-observability-provenance.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/04-agent-observability-provenance.md
@@ -1,7 +1,6 @@
 Title: "[research 04] MCP, GenAI telemetry, and provenance interoperability"
 
 Job ID: `deep-research-04`
-Result ZIP: `deep-research-04-agent-observability-provenance-r01.zip`
 
 Research the latest MCP Tasks/resources/prompts/sampling/elicitation and
 authorization specifications, OpenTelemetry GenAI semantic conventions, W3C
@@ -27,20 +26,17 @@ decisions, but do not return speculative patches. Map each conclusion to the
 named Polylogue decision/Bead, state what should change, what should not change,
 and what local experiment would falsify the recommendation.
 
-Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
-`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
-`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
-finished ZIP through a working user-clickable conversation link; an internal
-temporary path alone is not delivery. Reopen and validate the ZIP, report
-SHA-256/size/members, and provide a substantive direct answer covering
-conclusions, rationale, limitations, missing evidence, and the likely value of
-another iteration before the exact package link.
+Present a substantive, self-contained research report with conclusions,
+rationale, source-by-source support, counterevidence, limitations, missing
+evidence, Polylogue decision mappings, and the likely value of another
+iteration. It must remain useful to a reader who has not opened the attached
+project-state archive.
 
 Do not perform an adversarial review unless explicitly requested. On an
 ordinary **iterate/continue** request, extend the strongest unresolved research
-branch and regenerate the complete package. On an explicit **adversarial
+branch and return a revised complete report. On an explicit **adversarial
 review** request, try to falsify the prior memo with counterevidence, later or
 more authoritative sources, incompatible policies/standards, hidden product
 assumptions, and experiments that would overturn its recommendations. Repair
-legitimate findings, regenerate the cohesive package, and report what changed,
-what remains uncertain, and whether another pass is worthwhile.
+legitimate findings and report what changed, what remains uncertain, and
+whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/05-attachment-provenance.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/05-attachment-provenance.md
@@ -1,7 +1,6 @@
 Title: "[research 05] Attachment acquisition and archival provenance"
 
 Job ID: `deep-research-05`
-Result ZIP: `deep-research-05-attachment-provenance-r01.zip`
 
 Research current archival, digital-preservation, HTTP/content-addressing, RO-
 Crate/BagIt/OCFL, PREMIS, provenance, and software-supply-chain practices
@@ -27,20 +26,17 @@ decisions, but do not return speculative patches. Map each conclusion to the
 named Polylogue decision/Bead, state what should change, what should not change,
 and what local experiment would falsify the recommendation.
 
-Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
-`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
-`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
-finished ZIP through a working user-clickable conversation link; an internal
-temporary path alone is not delivery. Reopen and validate the ZIP, report
-SHA-256/size/members, and provide a substantive direct answer covering
-conclusions, rationale, limitations, missing evidence, and the likely value of
-another iteration before the exact package link.
+Present a substantive, self-contained research report with conclusions,
+rationale, source-by-source support, counterevidence, limitations, missing
+evidence, Polylogue decision mappings, and the likely value of another
+iteration. It must remain useful to a reader who has not opened the attached
+project-state archive.
 
 Do not perform an adversarial review unless explicitly requested. On an
 ordinary **iterate/continue** request, extend the strongest unresolved research
-branch and regenerate the complete package. On an explicit **adversarial
+branch and return a revised complete report. On an explicit **adversarial
 review** request, try to falsify the prior memo with counterevidence, later or
 more authoritative sources, incompatible policies/standards, hidden product
 assumptions, and experiments that would overturn its recommendations. Repair
-legitimate findings, regenerate the cohesive package, and report what changed,
-what remains uncertain, and whether another pass is worthwhile.
+legitimate findings and report what changed, what remains uncertain, and
+whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/06-browser-capture-lifecycle.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/06-browser-capture-lifecycle.md
@@ -1,7 +1,6 @@
 Title: "[research 06] Browser-native AI generation lifecycle evidence"
 
 Job ID: `deep-research-06`
-Result ZIP: `deep-research-06-browser-capture-lifecycle-r01.zip`
 
 Research public/officially documented browser and web-platform techniques for
 capturing authenticated AI conversation state and generation lifecycle from a
@@ -29,20 +28,17 @@ decisions, but do not return speculative patches. Map each conclusion to the
 named Polylogue decision/Bead, state what should change, what should not change,
 and what local experiment would falsify the recommendation.
 
-Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
-`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
-`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
-finished ZIP through a working user-clickable conversation link; an internal
-temporary path alone is not delivery. Reopen and validate the ZIP, report
-SHA-256/size/members, and provide a substantive direct answer covering
-conclusions, rationale, limitations, missing evidence, and the likely value of
-another iteration before the exact package link.
+Present a substantive, self-contained research report with conclusions,
+rationale, source-by-source support, counterevidence, limitations, missing
+evidence, Polylogue decision mappings, and the likely value of another
+iteration. It must remain useful to a reader who has not opened the attached
+project-state archive.
 
 Do not perform an adversarial review unless explicitly requested. On an
 ordinary **iterate/continue** request, extend the strongest unresolved research
-branch and regenerate the complete package. On an explicit **adversarial
+branch and return a revised complete report. On an explicit **adversarial
 review** request, try to falsify the prior memo with counterevidence, later or
 more authoritative sources, incompatible policies/standards, hidden product
 assumptions, and experiments that would overturn its recommendations. Repair
-legitimate findings, regenerate the cohesive package, and report what changed,
-what remains uncertain, and whether another pass is worthwhile.
+legitimate findings and report what changed, what remains uncertain, and
+whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/07-ai-artifact-supply-chain.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/prompts/07-ai-artifact-supply-chain.md
@@ -1,7 +1,6 @@
 Title: "[research 07] AI-generated artifact supply-chain receipts"
 
 Job ID: `deep-research-07`
-Result ZIP: `deep-research-07-ai-artifact-supply-chain-r01.zip`
 
 Research practical provenance and supply-chain models for AI-generated code,
 patches, analysis packages, and iterative repairs: SLSA/in-toto attestations,
@@ -27,20 +26,17 @@ decisions, but do not return speculative patches. Map each conclusion to the
 named Polylogue decision/Bead, state what should change, what should not change,
 and what local experiment would falsify the recommendation.
 
-Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
-`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
-`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
-finished ZIP through a working user-clickable conversation link; an internal
-temporary path alone is not delivery. Reopen and validate the ZIP, report
-SHA-256/size/members, and provide a substantive direct answer covering
-conclusions, rationale, limitations, missing evidence, and the likely value of
-another iteration before the exact package link.
+Present a substantive, self-contained research report with conclusions,
+rationale, source-by-source support, counterevidence, limitations, missing
+evidence, Polylogue decision mappings, and the likely value of another
+iteration. It must remain useful to a reader who has not opened the attached
+project-state archive.
 
 Do not perform an adversarial review unless explicitly requested. On an
 ordinary **iterate/continue** request, extend the strongest unresolved research
-branch and regenerate the complete package. On an explicit **adversarial
+branch and return a revised complete report. On an explicit **adversarial
 review** request, try to falsify the prior memo with counterevidence, later or
 more authoritative sources, incompatible policies/standards, hidden product
 assumptions, and experiments that would overturn its recommendations. Repair
-legitimate findings, regenerate the cohesive package, and report what changed,
-what remains uncertain, and whether another pass is worthwhile.
+legitimate findings and report what changed, what remains uncertain, and
+whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/results/README.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/results/README.md
@@ -1,4 +1,7 @@
 # Results
 
-Store each cited decision-memo package under the campaign-standard immutable
-attempt path. Preserve source-ledger revisions and supersedes lineage.
+Acquire each completed research response from Polylogue as Markdown under the
+campaign-standard immutable attempt path. The orchestrator assigns the stable
+local filename and records the Polylogue session/turn reference, content hash,
+and supersedes lineage; the research prompt does not impose storage or
+packaging instructions.

--- a/.agent/handoffs/external-agent-campaigns/README.md
+++ b/.agent/handoffs/external-agent-campaigns/README.md
@@ -34,11 +34,13 @@ artifact; a launcher never needs to understand prompt fragments.
 - Job: `<workload>-NN`, with a fixed two-digit number and readable slug.
 - Attempt: `aNN`; a retry or same-chat repair is a new attempt, not an
   overwrite.
-- Package revision: `rNN`; the exact output filename is declared in the job.
+- Package revision: `rNN` for workloads whose executor returns a package.
 
 An orchestrator may add provider conversation IDs, Polylogue ObjectRefs,
 content hashes, Beads, worktrees, agents, PRs, and merge outcomes to
-`results/index.json`. It must not infer completion from a filename alone.
+`results/index.json`. It assigns stable local filenames to conversation-native
+artifacts such as Deep Research responses and must not infer completion from a
+filename alone.
 
 ## Result path
 

--- a/.agent/handoffs/external-agent-campaigns/contracts/chatgpt-deep-research.md
+++ b/.agent/handoffs/external-agent-campaigns/contracts/chatgpt-deep-research.md
@@ -13,20 +13,17 @@ decisions, but do not return speculative patches. Map each conclusion to the
 named Polylogue decision/Bead, state what should change, what should not change,
 and what local experiment would falsify the recommendation.
 
-Create the exact `Result ZIP` named near the top under `/mnt/data/`, containing
-`DECISION-MEMO.md`, `SOURCE-LEDGER.md`, `COUNTEREVIDENCE.md`, and
-`POLYLOGUE-MAPPING.md`. Do not copy attached project inputs into it. Attach the
-finished ZIP through a working user-clickable conversation link; an internal
-temporary path alone is not delivery. Reopen and validate the ZIP, report
-SHA-256/size/members, and provide a substantive direct answer covering
-conclusions, rationale, limitations, missing evidence, and the likely value of
-another iteration before the exact package link.
+Present a substantive, self-contained research report with conclusions,
+rationale, source-by-source support, counterevidence, limitations, missing
+evidence, Polylogue decision mappings, and the likely value of another
+iteration. It must remain useful to a reader who has not opened the attached
+project-state archive.
 
 Do not perform an adversarial review unless explicitly requested. On an
 ordinary **iterate/continue** request, extend the strongest unresolved research
-branch and regenerate the complete package. On an explicit **adversarial
+branch and return a revised complete report. On an explicit **adversarial
 review** request, try to falsify the prior memo with counterevidence, later or
 more authoritative sources, incompatible policies/standards, hidden product
 assumptions, and experiments that would overturn its recommendations. Repair
-legitimate findings, regenerate the cohesive package, and report what changed,
-what remains uncertain, and whether another pass is worthwhile.
+legitimate findings and report what changed, what remains uncertain, and
+whether another pass is worthwhile.

--- a/.agent/handoffs/external-agent-campaigns/render_prompts.py
+++ b/.agent/handoffs/external-agent-campaigns/render_prompts.py
@@ -14,6 +14,7 @@ def render_workload(workload: Path, *, check: bool) -> list[str]:
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     contract_path = workload / manifest["prompt_contract"]
     contract = contract_path.read_text(encoding="utf-8").strip()
+    result_kind = manifest.get("result_kind", "package")
     errors: list[str] = []
 
     job_ids: set[str] = set()
@@ -33,9 +34,13 @@ def render_workload(workload: Path, *, check: bool) -> list[str]:
         if not brief.startswith('Title: "'):
             errors.append(f"{brief_path}: first line must be a literal Title")
             continue
-        expected_zip = f"Result ZIP: `{result_prefix}-r01.zip`"
-        if expected_zip not in brief:
-            errors.append(f"{brief_path}: expected {expected_zip}")
+        if result_kind == "package":
+            expected_zip = f"Result ZIP: `{result_prefix}-r01.zip`"
+            if expected_zip not in brief:
+                errors.append(f"{brief_path}: expected {expected_zip}")
+                continue
+        elif result_kind != "conversation_markdown":
+            errors.append(f"{manifest_path}: unsupported result kind {result_kind}")
             continue
         rendered = f"{brief}\n\n{contract}\n"
         if check:

--- a/.agent/handoffs/external-agent-campaigns/schemas/campaign.schema.json
+++ b/.agent/handoffs/external-agent-campaigns/schemas/campaign.schema.json
@@ -9,6 +9,7 @@
     "workload_id": {"type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$"},
     "prompt_profile": {"type": "string", "minLength": 1},
     "prompt_contract": {"type": "string", "minLength": 1},
+    "result_kind": {"enum": ["package", "conversation_markdown"]},
     "snapshot_gate": {"type": "string"},
     "jobs": {
       "type": "array",


### PR DESCRIPTION
## Summary

Remove generated-file and ZIP requirements from every Deep Research prompt. The research response itself is the canonical external-agent artifact; local orchestration acquires it from Polylogue as Markdown and assigns stable custody names.

## Problem

The initial campaign contract treated Deep Research like an implementation handoff and required a fixed ZIP. That adds irrelevant work to the research agent and conflicts with the actual acquisition path: Polylogue captures the conversation-native report, while the private orchestrator owns storage identity.

## Solution

- make the seven research briefs and rendered prompts request only a substantive research report;
- add a manifest-level `conversation_markdown` result kind so prompt validation does not require a ZIP declaration;
- document stable local naming and Polylogue turn acquisition only in orchestration-side result conventions;
- retain package validation as the default for implementation and analysis workloads.

## Verification

- `python .agent/handoffs/external-agent-campaigns/render_prompts.py --check <all four workload paths>` — exit 0
- `python -m py_compile .agent/handoffs/external-agent-campaigns/render_prompts.py` — exit 0
- `git diff --check` — exit 0
- pre-push `devtools verify --quick` — 16/16 steps passed, exit 0
