### PR TITLE
feat(browser): preserve ChatGPT generation lifecycle evidence

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1549,7 +1549,7 @@ async function captureProviderConversation(
   provider,
   providerSessionId,
   reason,
-  { deferReceiver = false, nativePayload = null } = {},
+  { deferReceiver = false, nativePayload = null, generationObservations = [] } = {},
 ) {
   if (provider !== "chatgpt") throw new Error(`exact_provider_capture_unsupported:${provider}`);
   if (!/^[A-Za-z0-9_-]{1,256}$/.test(String(providerSessionId || ""))) {
@@ -1565,6 +1565,7 @@ async function captureProviderConversation(
         providerSessionId,
         deferReceiver,
         nativePayload,
+        generationObservations,
       }),
       CAPTURE_MESSAGE_TIMEOUT_MS,
       "capture_message",
@@ -1592,6 +1593,7 @@ async function scheduleCaptureFreshness({
   reason,
   delayMs = 0,
   providerUpdatedAt = null,
+  generationObservations = [],
 }) {
   if (provider !== "chatgpt" || !/^[A-Za-z0-9_-]{1,256}$/.test(String(nativeId || ""))) {
     return { scheduled: false, reason: "unsupported_or_invalid_identity" };
@@ -1605,6 +1607,7 @@ async function scheduleCaptureFreshness({
       nowMs: Date.now(),
       delayMs,
       providerUpdatedAt,
+      generationObservations,
     }));
   });
   const entry = queue.entries[`${provider}:${nativeId}`];
@@ -1652,6 +1655,7 @@ async function processCaptureFreshnessQueueOnce() {
       claim.provider,
       claim.native_id,
       "freshness_convergence",
+      { generationObservations: claim.generation_observations || [] },
     );
     needsFollowUp = chatGptCaptureNeedsFollowUp(result.envelope);
     retryDelayMs = needsFollowUp ? runningPollDelayMs(claim.running_poll_count || 0) : 0;
@@ -2650,8 +2654,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           provider,
           nativeId,
           reason: message.reason || "provider_page_hint",
-          delayMs: Math.max(0, Math.min(5 * 60_000, Number(message.delay_ms) || 5_000)),
+          delayMs: Math.max(
+            0,
+            Math.min(5 * 60_000, Number.isFinite(Number(message.delay_ms)) ? Number(message.delay_ms) : 5_000),
+          ),
           providerUpdatedAt: message.provider_updated_at || null,
+          generationObservations: Array.isArray(message.generation_observations)
+            ? message.generation_observations
+            : [],
         })),
       });
       return;

--- a/browser-extension/src/capture/freshness.js
+++ b/browser-extension/src/capture/freshness.js
@@ -28,17 +28,24 @@ export function scheduleFreshnessHint(queueValue, {
   nowMs,
   delayMs = 0,
   providerUpdatedAt = null,
+  generationObservations = [],
 }) {
   const queue = normalizeFreshnessQueue(queueValue);
   const key = entryKey(provider, nativeId);
   const previous = queue.entries[key] || null;
   const requestedAt = nowMs + Math.max(0, delayMs);
+  const observationsById = new Map(
+    [...(previous?.generation_observations || []), ...generationObservations]
+      .filter((observation) => observation?.observation_id)
+      .map((observation) => [observation.observation_id, observation]),
+  );
   const entry = {
     key,
     provider,
     native_id: nativeId,
     reasons: [...new Set([...(previous?.reasons || []), reason].filter(Boolean))].slice(-8),
     provider_updated_at: providerUpdatedAt || previous?.provider_updated_at || null,
+    generation_observations: [...observationsById.values()].slice(-64),
     generation: (previous?.generation || 0) + 1,
     hinted_at: new Date(nowMs).toISOString(),
     first_hinted_at: previous?.first_hinted_at || new Date(nowMs).toISOString(),

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -19,6 +19,9 @@
   const nativeFetchResponses = new Map();
   const nativeAttemptDiagnostics = [];
   const freshnessHintTimers = new Map();
+  const pendingFreshnessObservations = new Map();
+  const lifecycleObservationHistory = new Map();
+  const lifecycleRuntime = new Map();
   let domFreshnessScanTimer = null;
   let lastDomFreshnessSignature = null;
 
@@ -39,12 +42,31 @@
     return marker >= 0 && parts[marker + 1] ? parts[marker + 1] : null;
   }
 
-  function queueFreshnessHint(reason, nativeId = conversationIdFromUrl(), delayMs = 5000, providerUpdatedAt = null) {
+  function queueFreshnessHint(
+    reason,
+    nativeId = conversationIdFromUrl(),
+    delayMs = 5000,
+    providerUpdatedAt = null,
+    generationObservation = null,
+  ) {
     if (!nativeId || !/^[A-Za-z0-9_-]{1,256}$/.test(nativeId)) return;
+    if (generationObservation) {
+      const pending = pendingFreshnessObservations.get(nativeId) || [];
+      const byId = new Map(pending.map((observation) => [observation.observation_id, observation]));
+      byId.set(generationObservation.observation_id, generationObservation);
+      pendingFreshnessObservations.set(nativeId, [...byId.values()].slice(-24));
+
+      const history = lifecycleObservationHistory.get(nativeId) || [];
+      const historyById = new Map(history.map((observation) => [observation.observation_id, observation]));
+      historyById.set(generationObservation.observation_id, generationObservation);
+      lifecycleObservationHistory.set(nativeId, [...historyById.values()].slice(-64));
+    }
     const existingTimer = freshnessHintTimers.get(nativeId);
     if (existingTimer) clearTimeout(existingTimer);
     const timer = setTimeout(() => {
       freshnessHintTimers.delete(nativeId);
+      const observations = pendingFreshnessObservations.get(nativeId) || [];
+      pendingFreshnessObservations.delete(nativeId);
       chrome.runtime.sendMessage({
         type: "polylogue.captureFreshnessHint",
         provider: "chatgpt",
@@ -52,9 +74,125 @@
         provider_updated_at: providerUpdatedAt,
         reason,
         delay_ms: delayMs,
+        generation_observations: observations,
       }).catch(() => undefined);
     }, 750);
     freshnessHintTimers.set(nativeId, timer);
+  }
+
+  function displayedElapsedMs(label) {
+    const text = String(label || "").replace(/\s+/g, " ").trim();
+    if (!/^Worked for\b/i.test(text)) return null;
+    const hours = Number(text.match(/\b(\d+)\s*h\b/i)?.[1] || 0);
+    const minutes = Number(text.match(/\b(\d+)\s*m\b/i)?.[1] || 0);
+    const seconds = Number(text.match(/\b(\d+)\s*s\b/i)?.[1] || 0);
+    if (![hours, minutes, seconds].every(Number.isFinite) || hours + minutes + seconds === 0) return null;
+    return ((hours * 60 + minutes) * 60 + seconds) * 1000;
+  }
+
+  function lifecycleTurnIdentity(node) {
+    return node?.getAttribute?.("data-turn-id")
+      || node?.getAttribute?.("data-message-id")
+      || node?.getAttribute?.("data-testid")
+      || null;
+  }
+
+  function completedDurationControl() {
+    const turns = [...document.querySelectorAll(MESSAGE_CONTAINER_SELECTOR)].reverse();
+    for (const turn of turns) {
+      const role = turn.getAttribute("data-turn") || turn.getAttribute("data-message-author-role") || "";
+      if (role && role !== "assistant") continue;
+      for (const button of turn.querySelectorAll("button")) {
+        const label = String(button.innerText || button.textContent || "").replace(/\s+/g, " ").trim();
+        if (/^Worked for\b/i.test(label)) return { turn, label };
+      }
+    }
+    return null;
+  }
+
+  function observeGenerationLifecycle(trigger) {
+    const nativeId = conversationIdFromUrl();
+    if (!nativeId) return null;
+    const nowMs = Date.now();
+    const previous = lifecycleRuntime.get(nativeId) || {};
+    const stopButton = document.querySelector(
+      '[data-testid="stop-button"], button[aria-label="Stop generating"], button[aria-label="Stop streaming"]',
+    );
+    const completed = completedDurationControl();
+    let observation = null;
+    let next = previous;
+
+    if (stopButton) {
+      const stopTurnId = lifecycleTurnIdentity(stopButton.closest(MESSAGE_CONTAINER_SELECTOR));
+      const completedKey = completed
+        ? `${lifecycleTurnIdentity(completed.turn) || "active"}:${completed.label}`
+        : null;
+      const startedAtMs = previous.started_at_ms || nowMs;
+      const state = previous.running ? "in_progress" : "started";
+      if (state === "started" || nowMs - (previous.last_progress_at_ms || 0) >= 30_000) {
+        observation = {
+          observation_id: `${nativeId}:${stopTurnId || "active"}:${state}:${state === "started" ? startedAtMs : Math.floor(nowMs / 30_000)}`,
+          state,
+          observed_at: new Date(nowMs).toISOString(),
+          evidence_source: "dom_control",
+          fidelity: "observed",
+          duration_semantics: "dom_observed_wall",
+          turn_provider_id: stopTurnId,
+          wall_elapsed_ms: Math.max(0, nowMs - startedAtMs),
+          trigger,
+        };
+      }
+      next = {
+        ...previous,
+        running: true,
+        started_at_ms: startedAtMs,
+        last_progress_at_ms: observation ? nowMs : previous.last_progress_at_ms,
+        turn_provider_id: stopTurnId || previous.turn_provider_id,
+        baseline_completed_key: previous.running ? previous.baseline_completed_key : completedKey,
+      };
+    } else if (completed || previous.running) {
+      const completedKey = completed
+        ? `${lifecycleTurnIdentity(completed.turn) || "active"}:${completed.label}`
+        : null;
+      const effectiveCompleted = previous.running
+        && completedKey
+        && completedKey === previous.baseline_completed_key
+        ? null
+        : completed;
+      const turn = effectiveCompleted?.turn || null;
+      const label = effectiveCompleted?.label || null;
+      const turnId = lifecycleTurnIdentity(turn) || previous.turn_provider_id || "active";
+      const elapsedMs = displayedElapsedMs(label);
+      const terminalKey = `${turnId}:${label || "stop_disappeared"}`;
+      if (previous.terminal_key !== terminalKey) {
+        observation = {
+          observation_id: `${nativeId}:${turnId}:completed:${window.polylogueCapture.fnv1a(terminalKey)}`,
+          state: "completed",
+          observed_at: new Date(nowMs).toISOString(),
+          evidence_source: effectiveCompleted ? "dom_duration_control" : "dom_control_transition",
+          fidelity: effectiveCompleted ? "observed" : "inferred",
+          duration_semantics: effectiveCompleted ? "provider_ui_elapsed" : "dom_observed_wall",
+          turn_provider_id: turnId === "active" ? null : turnId,
+          displayed_elapsed_ms: elapsedMs,
+          wall_elapsed_ms: previous.started_at_ms ? Math.max(0, nowMs - previous.started_at_ms) : null,
+          raw_label: label,
+          trigger,
+        };
+      }
+      next = { ...previous, running: false, terminal_key: terminalKey, turn_provider_id: turnId };
+    }
+
+    lifecycleRuntime.set(nativeId, next);
+    if (observation) {
+      queueFreshnessHint(
+        `generation_${observation.state}`,
+        nativeId,
+        observation.state === "completed" ? 0 : 1000,
+        null,
+        observation,
+      );
+    }
+    return observation;
   }
 
   function nativeCaptureIdentity(capture) {
@@ -654,7 +792,12 @@
     return { attachments, outcome };
   }
 
-  function buildNativeEnvelope(payload, assetAcquisition = null, requestedConversationId = null) {
+  function buildNativeEnvelope(
+    payload,
+    assetAcquisition = null,
+    requestedConversationId = null,
+    generationObservations = [],
+  ) {
     const turns = collectNativeTurns(payload);
     if (!turns.length) return null;
     return window.polylogueCapture.buildEnvelope({
@@ -673,7 +816,8 @@
         mapping_node_count: payload.mapping ? Object.keys(payload.mapping).length : 0,
         is_temporary: payload.is_temporary === true,
         session_kind: payload.is_temporary === true ? "temporary" : null,
-        asset_acquisition: assetAcquisition ? assetAcquisition.outcome : null
+        asset_acquisition: assetAcquisition ? assetAcquisition.outcome : null,
+        generation_observations: generationObservations,
       },
       rawProviderPayload: payload,
       attachments: assetAcquisition ? assetAcquisition.attachments : []
@@ -685,6 +829,7 @@
     requestedConversationId = null,
     deferReceiver = false,
     nativePayloadOverride = null,
+    generationObservationsOverride = [],
   ) {
     // Intercepted responses are only a bootstrap/fallback cache. A long-running
     // conversation can grow substantially after the response observed at page
@@ -735,7 +880,29 @@
         };
       }
     }
-    const envelope = nativePayload ? buildNativeEnvelope(nativePayload, assetAcquisition, requestedConversationId) : null;
+    const nativeId = String(
+      nativePayload?.conversation_id
+      || nativePayload?.id
+      || requestedConversationId
+      || conversationIdFromUrl()
+      || "",
+    );
+    const generationObservations = [
+      ...(lifecycleObservationHistory.get(nativeId) || []),
+      ...(Array.isArray(generationObservationsOverride) ? generationObservationsOverride : []),
+    ].reduce((byId, observation) => {
+      if (observation?.observation_id) byId.set(observation.observation_id, observation);
+      return byId;
+    }, new Map());
+    const normalizedGenerationObservations = [...generationObservations.values()].slice(-64);
+    const envelope = nativePayload
+      ? buildNativeEnvelope(
+        nativePayload,
+        assetAcquisition,
+        requestedConversationId,
+        normalizedGenerationObservations,
+      )
+      : null;
     const fallbackEnvelope = () => {
       const turns = collectTurns();
       if (!turns.length) return null;
@@ -745,7 +912,8 @@
         turns,
         providerMeta: {
           capture_fidelity: "dom_degraded",
-          native_attempts: nativeAttemptDiagnostics.slice(-6)
+          native_attempts: nativeAttemptDiagnostics.slice(-6),
+          generation_observations: normalizedGenerationObservations,
         }
       });
     };
@@ -793,14 +961,18 @@
       })
       .join("|");
     lastDomFreshnessSignature = domFreshnessSignature();
+    observeGenerationLifecycle("initial_scan");
     const freshnessObserver = new MutationObserver(() => {
       if (domFreshnessScanTimer) clearTimeout(domFreshnessScanTimer);
       domFreshnessScanTimer = setTimeout(() => {
         domFreshnessScanTimer = null;
+        const lifecycleObservation = observeGenerationLifecycle("dom_mutation");
         const signature = domFreshnessSignature();
         if (!signature || signature === lastDomFreshnessSignature) return;
         lastDomFreshnessSignature = signature;
-        queueFreshnessHint("provider_dom_changed", conversationIdFromUrl(), 5000);
+        if (!lifecycleObservation) {
+          queueFreshnessHint("provider_dom_changed", conversationIdFromUrl(), 5000);
+        }
       }, 750);
     });
     freshnessObserver.observe(document.documentElement, {
@@ -816,6 +988,7 @@
       message.providerSessionId || null,
       message.deferReceiver === true,
       message.nativePayload ?? null,
+      message.generationObservations ?? [],
     )
       .then(sendResponse)
       .catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -1016,6 +1016,34 @@ describe("background receiver diagnostics", () => {
     expect(freshnessAlarms.at(-1)[1]).toEqual({ when: 101_000 });
   });
 
+  it("persists terminal lifecycle evidence with an immediate freshness deadline", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(100_000);
+    const observation = {
+      observation_id: "terminal:turn-2",
+      state: "completed",
+      observed_at: "2026-07-16T01:26:30Z",
+      displayed_elapsed_ms: 5_190_000,
+    };
+
+    await sendRuntimeMessage({
+      type: "polylogue.captureFreshnessHint",
+      provider: "chatgpt",
+      provider_session_id: "terminal-conversation",
+      reason: "generation_completed",
+      delay_ms: 0,
+      generation_observations: [observation],
+    });
+
+    expect(stored.polylogueCaptureFreshnessQueue.entries["chatgpt:terminal-conversation"])
+      .toMatchObject({
+        next_attempt_at_ms: 100_000,
+        generation_observations: [observation],
+      });
+    const freshnessAlarms = globalThis.chrome.alarms.create.mock.calls
+      .filter(([name]) => name === "polylogueCaptureFreshnessWake");
+    expect(freshnessAlarms.at(-1)[1]).toEqual({ when: 101_000 });
+  });
+
   it("serializes concurrent captures without losing either ledger or timeline entry", async () => {
     globalThis.fetch = vi.fn(async (_url, options) => {
       const session = JSON.parse(options.body).session;

--- a/browser-extension/tests/capture_freshness.test.js
+++ b/browser-extension/tests/capture_freshness.test.js
@@ -39,6 +39,31 @@ describe("capture freshness queue", () => {
     expect(entry.provider_updated_at).toBe("2026-07-16T00:00:00Z");
   });
 
+  it("retains deduplicated lifecycle observations until the exact capture claim completes", () => {
+    const started = {
+      observation_id: "conversation-1:turn-2:started:1000",
+      state: "started",
+      observed_at: "2026-07-16T00:00:00Z",
+    };
+    const completed = {
+      observation_id: "conversation-1:turn-2:completed:worked-for",
+      state: "completed",
+      observed_at: "2026-07-16T01:26:30Z",
+    };
+    const first = hint(null, "conversation-1", 1000, { generationObservations: [started] });
+    const repeated = hint(first, "conversation-1", 2000, {
+      delayMs: 0,
+      generationObservations: [started, completed],
+    });
+
+    expect(repeated.entries["chatgpt:conversation-1"].generation_observations).toEqual([
+      started,
+      completed,
+    ]);
+    expect(claimDueFreshness(repeated, { nowMs: 2000, owner: "one", leaseMs: 5000 }).claim)
+      .toMatchObject({ generation_observations: [started, completed] });
+  });
+
   it("leases one due identity and recovers an expired lease", () => {
     let queue = hint(null, "later", 1000, { delayMs: 10_000 });
     queue = hint(queue, "due", 1000, { delayMs: 0 });

--- a/browser-extension/tests/content/chatgpt_bridge.test.js
+++ b/browser-extension/tests/content/chatgpt_bridge.test.js
@@ -461,6 +461,107 @@ describe("ChatGPT authenticated asset capture envelope", () => {
     ]);
   });
 
+  it("captures typed live generation start and terminal UI timing before native reconciliation", async () => {
+    const harness = installFullCapture(syntheticEndpointAdapter());
+    const turn = harness.dom.window.document.createElement("section");
+    turn.setAttribute("data-testid", "conversation-turn-2");
+    turn.setAttribute("data-turn", "assistant");
+    turn.setAttribute("data-turn-id", "assistant-turn-2");
+    const stop = harness.dom.window.document.createElement("button");
+    stop.setAttribute("data-testid", "stop-button");
+    stop.textContent = "Stop";
+    turn.appendChild(stop);
+    harness.dom.window.document.body.appendChild(turn);
+
+    await new Promise((resolve) => harness.dom.window.setTimeout(resolve, 1600));
+    const started = harness.runtimeMessages.find((message) =>
+      message.type === "polylogue.captureFreshnessHint"
+      && message.generation_observations?.some((observation) => observation.state === "started")
+    );
+    expect(started).toMatchObject({
+      reason: "generation_started",
+      provider_session_id: "conversation-1",
+      delay_ms: 1000,
+      generation_observations: [{
+        state: "started",
+        evidence_source: "dom_control",
+        fidelity: "observed",
+        duration_semantics: "dom_observed_wall",
+        turn_provider_id: "assistant-turn-2",
+      }],
+    });
+
+    stop.remove();
+    const workedFor = harness.dom.window.document.createElement("button");
+    workedFor.textContent = "Worked for 86m 30s";
+    turn.appendChild(workedFor);
+
+    await new Promise((resolve) => harness.dom.window.setTimeout(resolve, 1600));
+    const completed = harness.runtimeMessages.findLast((message) =>
+      message.type === "polylogue.captureFreshnessHint"
+      && message.generation_observations?.some((observation) => observation.state === "completed")
+    );
+    expect(completed).toMatchObject({
+      reason: "generation_completed",
+      delay_ms: 0,
+      generation_observations: [{
+        state: "completed",
+        evidence_source: "dom_duration_control",
+        fidelity: "observed",
+        duration_semantics: "provider_ui_elapsed",
+        displayed_elapsed_ms: 5_190_000,
+        raw_label: "Worked for 86m 30s",
+        turn_provider_id: "assistant-turn-2",
+      }],
+    });
+  });
+
+  it("does not attribute an older Worked-for control to a newly completed turn", async () => {
+    const harness = installFullCapture(syntheticEndpointAdapter());
+    const priorTurn = harness.dom.window.document.createElement("section");
+    priorTurn.setAttribute("data-testid", "conversation-turn-2");
+    priorTurn.setAttribute("data-turn", "assistant");
+    priorTurn.setAttribute("data-turn-id", "prior-assistant-turn");
+    const priorWorkedFor = harness.dom.window.document.createElement("button");
+    priorWorkedFor.textContent = "Worked for 4m 10s";
+    priorTurn.appendChild(priorWorkedFor);
+    harness.dom.window.document.body.appendChild(priorTurn);
+
+    const activeTurn = harness.dom.window.document.createElement("section");
+    activeTurn.setAttribute("data-testid", "conversation-turn-4");
+    activeTurn.setAttribute("data-turn", "assistant");
+    activeTurn.setAttribute("data-turn-id", "active-assistant-turn");
+    const stop = harness.dom.window.document.createElement("button");
+    stop.setAttribute("data-testid", "stop-button");
+    activeTurn.appendChild(stop);
+    harness.dom.window.document.body.appendChild(activeTurn);
+
+    await new Promise((resolve) => harness.dom.window.setTimeout(resolve, 1600));
+    stop.remove();
+    activeTurn.appendChild(harness.dom.window.document.createTextNode("Finished"));
+    await new Promise((resolve) => harness.dom.window.setTimeout(resolve, 1600));
+
+    const completed = harness.runtimeMessages.findLast((message) =>
+      message.type === "polylogue.captureFreshnessHint"
+      && message.generation_observations?.some((observation) =>
+        observation.state === "completed"
+        && observation.turn_provider_id === "active-assistant-turn"
+      )
+    );
+    expect(completed).toMatchObject({
+      reason: "generation_completed",
+      generation_observations: [{
+        state: "completed",
+        evidence_source: "dom_control_transition",
+        fidelity: "inferred",
+        duration_semantics: "dom_observed_wall",
+        turn_provider_id: "active-assistant-turn",
+        displayed_elapsed_ms: null,
+        raw_label: null,
+      }],
+    });
+  });
+
   it("reuses supplied native detail without a second conversation read", async () => {
     const adapter = syntheticEndpointAdapter();
     const harness = installFullCapture(adapter, { url: "https://chatgpt.com/" });
@@ -480,6 +581,28 @@ describe("ChatGPT authenticated asset capture envelope", () => {
       adapter.calls.filter((call) => call.url.pathname === "/backend-api/conversation/conversation-1"),
     ).toHaveLength(0);
     expect(result.envelope.session.attachments).toHaveLength(1);
+  });
+
+  it("carries background-observed lifecycle evidence into the exact native envelope", async () => {
+    const harness = installFullCapture(syntheticEndpointAdapter(), { url: "https://chatgpt.com/" });
+    const observation = {
+      observation_id: "conversation-1:assistant-turn-2:completed:worked-for",
+      state: "completed",
+      observed_at: "2026-07-16T01:26:30Z",
+      evidence_source: "dom_duration_control",
+      fidelity: "observed",
+      displayed_elapsed_ms: 5_190_000,
+    };
+
+    const result = await harness.sendRuntimeMessage({
+      type: "polylogue.capturePage",
+      reason: "freshness_convergence",
+      providerSessionId: "conversation-1",
+      nativePayload: conversationPayload(),
+      generationObservations: [observation],
+    });
+
+    expect(result.envelope.session.provider_meta.generation_observations).toEqual([observation]);
   });
 
   it("prefers fresh native detail over an intercepted page-load payload", async () => {

--- a/polylogue/sources/parsers/browser_capture.py
+++ b/polylogue/sources/parsers/browser_capture.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import binascii
+import math
 from collections.abc import Mapping
 from typing import TypeGuard
 
@@ -20,6 +21,7 @@ from polylogue.browser_capture.models import (
     looks_like_browser_capture,
 )
 from polylogue.core.enums import Provider, SessionKind
+from polylogue.core.timestamps import parse_timestamp
 from polylogue.sources.parsers.base_models import (
     ParsedAttachment,
     ParsedMessage,
@@ -231,8 +233,113 @@ def _capture_interruption_session_events(envelope: BrowserCaptureEnvelope) -> li
     ]
 
 
+def _non_negative_milliseconds(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric < 0:
+        return None
+    return round(numeric)
+
+
+def _bounded_string(value: object, *, max_length: int) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized or len(normalized) > max_length:
+        return None
+    return normalized
+
+
+def _capture_generation_session_events(envelope: BrowserCaptureEnvelope) -> list[ParsedSessionEvent]:
+    """Project typed, bounded live lifecycle observations from the extension.
+
+    These observations describe what the browser actually exposed while a
+    generation was running. They intentionally remain distinct from the
+    provider-native terminal event emitted by the ChatGPT parser: DOM wall
+    time and the provider's reported reasoning duration are different
+    measurements, and retaining both makes their provenance queryable.
+    """
+
+    raw_observations: list[object] = []
+    for provider_meta in (envelope.provider_meta, envelope.session.provider_meta):
+        candidate = provider_meta.get("generation_observations")
+        if isinstance(candidate, list):
+            raw_observations.extend(candidate)
+
+    events: list[ParsedSessionEvent] = []
+    seen_observation_ids: set[str] = set()
+    for raw_observation in raw_observations:
+        if not isinstance(raw_observation, Mapping):
+            continue
+        observation_id = _bounded_string(raw_observation.get("observation_id"), max_length=512)
+        state = _bounded_string(raw_observation.get("state"), max_length=32)
+        observed_at = _bounded_string(raw_observation.get("observed_at"), max_length=80)
+        evidence_source = _bounded_string(raw_observation.get("evidence_source"), max_length=80)
+        fidelity = _bounded_string(raw_observation.get("fidelity"), max_length=32)
+        duration_semantics = _bounded_string(raw_observation.get("duration_semantics"), max_length=80)
+        if (
+            observation_id is None
+            or observation_id in seen_observation_ids
+            or state not in {"started", "in_progress", "completed"}
+            or observed_at is None
+            or parse_timestamp(observed_at) is None
+            or evidence_source is None
+            or fidelity not in {"observed", "inferred"}
+            or duration_semantics is None
+        ):
+            continue
+
+        payload: dict[str, object] = {
+            "observation_id": observation_id,
+            "state": state,
+            "evidence_source": evidence_source,
+            "fidelity": fidelity,
+            "duration_semantics": duration_semantics,
+        }
+        malformed_duration = False
+        for key in ("displayed_elapsed_ms", "wall_elapsed_ms"):
+            raw_duration = raw_observation.get(key)
+            if raw_duration is None:
+                continue
+            duration = _non_negative_milliseconds(raw_duration)
+            if duration is None:
+                malformed_duration = True
+                break
+            payload[key] = duration
+        if malformed_duration:
+            continue
+        for key, max_length in (("raw_label", 512), ("trigger", 80)):
+            raw_value = raw_observation.get(key)
+            if raw_value is None:
+                continue
+            value = _bounded_string(raw_value, max_length=max_length)
+            if value is None:
+                continue
+            payload[key] = value
+
+        turn_provider_id = _bounded_string(raw_observation.get("turn_provider_id"), max_length=256)
+        events.append(
+            ParsedSessionEvent(
+                event_type="generation_lifecycle",
+                timestamp=observed_at,
+                source_message_provider_id=turn_provider_id,
+                payload=payload,
+            )
+        )
+        seen_observation_ids.add(observation_id)
+    return events
+
+
+def _capture_session_events(envelope: BrowserCaptureEnvelope) -> list[ParsedSessionEvent]:
+    return [
+        *_capture_interruption_session_events(envelope),
+        *_capture_generation_session_events(envelope),
+    ]
+
+
 def _merge_envelope_session_events(parsed: ParsedSession, envelope: BrowserCaptureEnvelope) -> ParsedSession:
-    events = _capture_interruption_session_events(envelope)
+    events = _capture_session_events(envelope)
     if not events:
         return parsed
     return parsed.model_copy(update={"session_events": [*parsed.session_events, *events]})
@@ -326,7 +433,7 @@ def parse(payload: object, fallback_id: str) -> ParsedSession:
         messages=messages,
         active_leaf_message_provider_id=active_leaf_message_provider_id,
         attachments=attachments,
-        session_events=_capture_interruption_session_events(envelope),
+        session_events=_capture_session_events(envelope),
         ingest_flags=[
             *dict.fromkeys(
                 [

--- a/polylogue/sources/parsers/chatgpt.py
+++ b/polylogue/sources/parsers/chatgpt.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 from collections.abc import Mapping
+from dataclasses import dataclass
 
 from polylogue.archive.message.artifacts import classify_material_origin, classify_text_message_type
 from polylogue.archive.message.roles import Role
@@ -10,9 +12,26 @@ from polylogue.archive.message.types import MessageType
 from polylogue.core.enums import BlockType, Provider, SessionKind, WebConstructType
 from polylogue.core.timestamps import parse_timestamp
 
-from .base import ParsedAttachment, ParsedContentBlock, ParsedMessage, ParsedSession, ParsedWebConstruct
+from .base import (
+    ParsedAttachment,
+    ParsedContentBlock,
+    ParsedMessage,
+    ParsedSession,
+    ParsedSessionEvent,
+    ParsedWebConstruct,
+)
 
 SHARED_CONVERSATION_INDEX_INGEST_FLAG = "capture:chatgpt-shared-index-shell"
+
+
+@dataclass(frozen=True)
+class _GenerationTiming:
+    message_provider_id: str
+    elapsed_duration_ms: int
+    started_at_ms: int | None
+    ended_at_ms: int | None
+    event_timestamp: str | None
+    fidelity: str
 
 
 def _coerce_float(value: object) -> float | None:
@@ -30,6 +49,101 @@ def _coerce_float(value: object) -> float | None:
         if parsed is not None:
             return parsed.timestamp()
     return None
+
+
+def _non_negative_finite_float(value: object) -> float | None:
+    parsed = _coerce_float(value)
+    if parsed is None or not math.isfinite(parsed) or parsed < 0:
+        return None
+    return parsed
+
+
+def _generation_branch_key(mapping: Mapping[str, object], node_id: str) -> str:
+    """Return the first assistant-side node below the nearest user ancestor.
+
+    ChatGPT repeats run-wide reasoning metadata across thought, tool, recap,
+    and final-answer nodes. Grouping by this branch root deduplicates those
+    copies while preserving regenerated alternatives beneath the same user
+    message as distinct generations.
+    """
+
+    current_id = node_id
+    seen: set[str] = set()
+    while current_id not in seen:
+        seen.add(current_id)
+        current = mapping.get(current_id)
+        if not isinstance(current, Mapping):
+            break
+        parent_raw = current.get("parent")
+        if not isinstance(parent_raw, str) or not parent_raw:
+            break
+        parent = mapping.get(parent_raw)
+        if not isinstance(parent, Mapping):
+            break
+        parent_message = parent.get("message")
+        parent_author = parent_message.get("author") if isinstance(parent_message, Mapping) else None
+        parent_role = parent_author.get("role") if isinstance(parent_author, Mapping) else None
+        if parent_role == "user":
+            return current_id
+        current_id = parent_raw
+    return current_id
+
+
+def _extract_generation_timings(mapping: Mapping[str, object]) -> list[_GenerationTiming]:
+    """Select one authoritative lifecycle timing per ChatGPT generation.
+
+    Native conversation payloads commonly copy ``reasoning_start_time`` and
+    ``finished_duration_sec`` onto many nodes. A complete ``reasoning_recap``
+    is preferred over those partial copies; otherwise the best complete node
+    on the same assistant branch owns the timing. Provider-finished duration
+    is authoritative, with a valid start/end delta as the derived fallback.
+    """
+
+    candidates: dict[str, list[tuple[tuple[int, int, int, int], _GenerationTiming]]] = {}
+    for position, (node_id, raw_node) in enumerate(mapping.items()):
+        if not isinstance(raw_node, Mapping):
+            continue
+        raw_message = raw_node.get("message")
+        if not isinstance(raw_message, Mapping):
+            continue
+        raw_metadata = raw_message.get("metadata")
+        if not isinstance(raw_metadata, Mapping):
+            continue
+
+        start_sec = _non_negative_finite_float(raw_metadata.get("reasoning_start_time"))
+        end_sec = _non_negative_finite_float(raw_metadata.get("reasoning_end_time"))
+        finished_sec = _non_negative_finite_float(raw_metadata.get("finished_duration_sec"))
+        if finished_sec is not None:
+            elapsed_ms = round(finished_sec * 1000)
+            fidelity = "exact"
+        elif start_sec is not None and end_sec is not None and end_sec >= start_sec:
+            elapsed_ms = round((end_sec - start_sec) * 1000)
+            fidelity = "derived"
+        else:
+            continue
+
+        content = raw_message.get("content")
+        content_type = content.get("content_type") if isinstance(content, Mapping) else None
+        message_id_raw = raw_message.get("id") or raw_node.get("id") or node_id
+        message_id = str(message_id_raw)
+        timing = _GenerationTiming(
+            message_provider_id=message_id,
+            elapsed_duration_ms=elapsed_ms,
+            started_at_ms=round(start_sec * 1000) if start_sec is not None else None,
+            ended_at_ms=round(end_sec * 1000) if end_sec is not None else None,
+            event_timestamp=str(end_sec) if end_sec is not None else None,
+            fidelity=fidelity,
+        )
+        score = (
+            int(content_type == "reasoning_recap"),
+            int(start_sec is not None and end_sec is not None),
+            int(raw_message.get("end_turn") is True),
+            position,
+        )
+        branch_key = _generation_branch_key(mapping, str(node_id))
+        candidates.setdefault(branch_key, []).append((score, timing))
+
+    return [max(branch_candidates, key=lambda item: item[0])[1] for branch_candidates in candidates.values()]
 
 
 def _string_value(payload: Mapping[str, object], *keys: str) -> str | None:
@@ -667,6 +781,35 @@ def parse(payload: Mapping[str, object], fallback_id: str) -> ParsedSession:
     current_node = payload.get("current_node")
     current_node = current_node if isinstance(current_node, str) else None
     messages, attachments = extract_messages_from_mapping(mapping, current_node)
+    generation_timings = _extract_generation_timings(mapping)
+    timing_by_message_id = {timing.message_provider_id: timing for timing in generation_timings}
+    if timing_by_message_id:
+        messages = [
+            message.model_copy(
+                update={"duration_ms": timing_by_message_id[message.provider_message_id].elapsed_duration_ms}
+            )
+            if message.provider_message_id in timing_by_message_id
+            else message
+            for message in messages
+        ]
+    session_events = [
+        ParsedSessionEvent(
+            event_type="generation_lifecycle",
+            timestamp=timing.event_timestamp,
+            source_message_provider_id=timing.message_provider_id,
+            payload={
+                "state": "completed",
+                "evidence_source": "provider_native",
+                "fidelity": timing.fidelity,
+                "duration_semantics": "provider_reported_elapsed",
+                "elapsed_duration_ms": timing.elapsed_duration_ms,
+                **({"started_at_ms": timing.started_at_ms} if timing.started_at_ms is not None else {}),
+                **({"ended_at_ms": timing.ended_at_ms} if timing.ended_at_ms is not None else {}),
+            },
+        )
+        for timing in generation_timings
+    ]
+    duration_values = [message.duration_ms for message in messages if message.duration_ms is not None]
     title = payload.get("title") or payload.get("name") or fallback_id
     conv_id = payload.get("id") or payload.get("uuid") or payload.get("conversation_id")
     ingest_flags: list[str] = []
@@ -696,5 +839,7 @@ def parse(payload: Mapping[str, object], fallback_id: str) -> ParsedSession:
             None,
         ),
         attachments=attachments,
+        session_events=session_events,
+        reported_duration_ms=sum(duration_values) if duration_values else None,
         ingest_flags=ingest_flags,
     )

--- a/tests/unit/sources/test_browser_capture.py
+++ b/tests/unit/sources/test_browser_capture.py
@@ -271,6 +271,115 @@ def test_browser_capture_raw_chatgpt_payload_matches_direct_import_identity() ->
     )
 
 
+def test_browser_capture_preserves_live_and_native_generation_measurements() -> None:
+    payload = _capture_payload()
+    session_payload = payload["session"]
+    assert isinstance(session_payload, dict)
+    session_payload["provider_meta"] = {
+        "generation_observations": [
+            {
+                "observation_id": "conv-123:a1:started:1",
+                "state": "started",
+                "observed_at": "2026-07-16T00:00:00Z",
+                "evidence_source": "dom_control",
+                "fidelity": "observed",
+                "duration_semantics": "dom_observed_wall",
+                "turn_provider_id": "native-a1",
+                "wall_elapsed_ms": 0,
+                "trigger": "initial_scan",
+            },
+            {
+                "observation_id": "conv-123:a1:completed:worked-for",
+                "state": "completed",
+                "observed_at": "2026-07-16T01:26:30Z",
+                "evidence_source": "dom_duration_control",
+                "fidelity": "observed",
+                "duration_semantics": "provider_ui_elapsed",
+                "turn_provider_id": "native-a1",
+                "displayed_elapsed_ms": 5_190_000,
+                "raw_label": "Worked for 86m 30s",
+                "trigger": "dom_mutation",
+            },
+        ]
+    }
+    payload["raw_provider_payload"] = {
+        "conversation_id": "conv-123",
+        "title": "Native ChatGPT title",
+        "current_node": "assistant-node",
+        "mapping": {
+            "user-node": {
+                "id": "user-node",
+                "parent": None,
+                "children": ["assistant-node"],
+                "message": {
+                    "id": "native-u1",
+                    "author": {"role": "user"},
+                    "content": {"content_type": "text", "parts": ["Do the work"]},
+                    "metadata": {},
+                },
+            },
+            "assistant-node": {
+                "id": "assistant-node",
+                "parent": "user-node",
+                "children": [],
+                "message": {
+                    "id": "native-a1",
+                    "author": {"role": "assistant"},
+                    "content": {"content_type": "reasoning_recap", "parts": ["Done"]},
+                    "metadata": {
+                        "reasoning_start_time": 1784164541.690012,
+                        "reasoning_end_time": 1784169732.588194,
+                        "finished_duration_sec": 5190,
+                    },
+                },
+            },
+        },
+    }
+
+    parsed = parse_payload(Provider.CHATGPT, payload, "fallback")[0]
+    lifecycle = [event for event in parsed.session_events if event.event_type == "generation_lifecycle"]
+
+    assert [event.payload["evidence_source"] for event in lifecycle] == [
+        "provider_native",
+        "dom_control",
+        "dom_duration_control",
+    ]
+    assert lifecycle[0].payload["elapsed_duration_ms"] == 5_190_000
+    assert lifecycle[1].payload["wall_elapsed_ms"] == 0
+    assert lifecycle[2].payload["displayed_elapsed_ms"] == 5_190_000
+    assert parsed.reported_duration_ms == 5_190_000
+
+
+def test_browser_capture_rejects_malformed_or_duplicate_generation_observations() -> None:
+    payload = _capture_payload()
+    session_payload = payload["session"]
+    assert isinstance(session_payload, dict)
+    valid = {
+        "observation_id": "conv-123:a1:started:1",
+        "state": "started",
+        "observed_at": "2026-07-16T00:00:00Z",
+        "evidence_source": "dom_control",
+        "fidelity": "observed",
+        "duration_semantics": "dom_observed_wall",
+        "wall_elapsed_ms": 0,
+    }
+    session_payload["provider_meta"] = {
+        "generation_observations": [
+            valid,
+            valid,
+            {**valid, "observation_id": "negative", "wall_elapsed_ms": -1},
+            {**valid, "observation_id": "bad-time", "observed_at": "not-a-timestamp"},
+            {**valid, "observation_id": "bad-state", "state": "thinking-ish"},
+        ]
+    }
+
+    parsed = parse_payload(Provider.CHATGPT, payload, "fallback")[0]
+    lifecycle = [event for event in parsed.session_events if event.event_type == "generation_lifecycle"]
+
+    assert len(lifecycle) == 1
+    assert lifecycle[0].payload["observation_id"] == valid["observation_id"]
+
+
 def test_browser_capture_raw_chatgpt_without_id_uses_envelope_session_id() -> None:
     payload = _capture_payload()
     payload["raw_provider_payload"] = {

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -1061,6 +1061,80 @@ def test_chatgpt_archive_contract_fields() -> None:
     assert active.duration_ms == 2500
 
 
+def test_chatgpt_generation_timing_uses_one_authoritative_reasoning_owner() -> None:
+    """Repeated run-wide metadata must not multiply one Pro generation."""
+    nodes = [
+        _branch_node("u1", "user", "Do the work", parent=None, children=["thought"]),
+        _branch_node("thought", "assistant", "working", parent="u1", children=["recap"]),
+        _branch_node("recap", "assistant", "reasoning summary", parent="thought", children=["answer"]),
+        _branch_node("answer", "assistant", "substantive answer", parent="recap", children=[]),
+    ]
+    nodes[1]["message"]["content"]["content_type"] = "thoughts"
+    nodes[1]["message"]["metadata"] = {"reasoning_start_time": 1784164544.946}
+    nodes[2]["message"]["content"]["content_type"] = "reasoning_recap"
+    nodes[2]["message"]["metadata"] = {
+        "reasoning_start_time": 1784164541.690012,
+        "reasoning_end_time": 1784169732.588194,
+        "finished_duration_sec": 5190,
+    }
+    nodes[3]["message"]["metadata"] = {
+        "reasoning_start_time": 1784164544.946,
+        "finished_duration_sec": 5190,
+    }
+    payload = {
+        "id": "pro-generation",
+        "title": "Long Pro generation",
+        "mapping": {node["id"]: node for node in nodes},
+        "current_node": "answer",
+    }
+
+    session = chatgpt_parse(payload, "fallback-id")
+    by_id = {message.provider_message_id: message for message in session.messages}
+    lifecycle = [event for event in session.session_events if event.event_type == "generation_lifecycle"]
+
+    assert by_id["recap"].duration_ms == 5_190_000
+    assert by_id["thought"].duration_ms is None
+    assert by_id["answer"].duration_ms is None
+    assert session.reported_duration_ms == 5_190_000
+    assert len(lifecycle) == 1
+    assert lifecycle[0].source_message_provider_id == "recap"
+    assert lifecycle[0].payload == {
+        "state": "completed",
+        "evidence_source": "provider_native",
+        "fidelity": "exact",
+        "duration_semantics": "provider_reported_elapsed",
+        "elapsed_duration_ms": 5_190_000,
+        "started_at_ms": 1_784_164_541_690,
+        "ended_at_ms": 1_784_169_732_588,
+    }
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected_duration_ms"),
+    [
+        ({"reasoning_start_time": 10.0, "reasoning_end_time": 12.25}, 2250),
+        ({"reasoning_start_time": 12.0, "reasoning_end_time": 10.0}, None),
+        ({"finished_duration_sec": -3}, None),
+        ({"finished_duration_sec": "pending"}, None),
+    ],
+)
+def test_chatgpt_generation_timing_fallback_rejects_malformed_values(
+    metadata: dict[str, object], expected_duration_ms: int | None
+) -> None:
+    node = _branch_node("recap", "assistant", "summary", parent=None, children=[])
+    node["message"]["content"]["content_type"] = "reasoning_recap"
+    node["message"]["metadata"] = metadata
+
+    session = chatgpt_parse(
+        {"id": "timing-edge", "mapping": {"recap": node}, "current_node": "recap"},
+        "fallback-id",
+    )
+
+    assert session.messages[0].duration_ms == expected_duration_ms
+    assert session.reported_duration_ms == expected_duration_ms
+    assert len(session.session_events) == (1 if expected_duration_ms is not None else 0)
+
+
 # ---------------------------------------------------------------------------
 # #1744 — non-`parts` content is preserved (code interpreter, execution output)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Preserve ChatGPT generation lifecycle timing across provider-native parsing, live DOM observation, freshness convergence, and browser-capture normalization. Native provider elapsed time and lower-fidelity browser wall-time observations remain distinct, typed evidence.

## Problem

Real ChatGPT Pro captures already contain `reasoning_start_time`, `reasoning_end_time`, and `finished_duration_sec`, but the parser ignored them. The extension also reduced live generation changes to generic freshness hints, losing the visible start/terminal state and “Worked for …” duration before exact recapture. Repeated native metadata across reasoning tree nodes would double-count elapsed time if mapped naïvely.

## Solution

- Select one authoritative native timing owner per assistant generation branch, preferring complete reasoning recaps and safely falling back to a valid start/end delta.
- Detect live start, bounded progress, and completion observations from ChatGPT controls without deriving timing from answer prose.
- Persist observations through the canonical freshness queue and extension-owned exact provider refetch, including completed chats whose visible tab is later closed.
- Project DOM observations as typed session events alongside the provider-native terminal event, preserving evidence source, fidelity, and duration semantics.
- Reject malformed, negative, unbounded, or duplicate lifecycle observations and avoid attributing an older “Worked for …” control to a newer turn.

Ref polylogue-3v1.2.

## Verification

- `devtools verify --seed-testmon --skip-slow`: 15,923 passed, 1 skipped; all 16 static/generated/schema gates passed.
- `devtools test tests/unit/sources/test_parsers_chatgpt.py`: 95 passed.
- `devtools test tests/unit/sources/test_browser_capture.py`: 35 passed.
- `cd browser-extension && npm test`: 290 passed across 15 files.
- `cd browser-extension && npm run lint`: ESLint passed.
- A real stored capture for conversation `6a5830bc-…` now projects exactly one provider-native lifecycle event with `reported_duration_ms=5190000`, rather than zero or repeated duration.