### PR TITLE
fix(insights): apply heavy-session degraded path on incremental refresh

### DIFF
--- a/polylogue/storage/insights/session/refresh.py
+++ b/polylogue/storage/insights/session/refresh.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 import aiosqlite
 
 from polylogue.core.memory import release_process_memory
+from polylogue.storage.insights.session import rebuild as _rebuild
 from polylogue.storage.insights.session.aggregates import (
     profile_provider_day,
     refresh_async_provider_day_aggregates,
@@ -244,6 +245,47 @@ async def _apply_session_insight_session_update_async(
             (session_id,),
         )
     ).fetchone()
+    if str(session_id) in await _rebuild._heavy_session_ids_async(conn, [session_id]):
+        # Heavy sessions must never be hydrated on the incremental path: use
+        # the same bounded/degraded bundle as rebuild, with the same
+        # logical_session_id=session_id argument, so the stored profile is
+        # byte-identical whichever materializer last touched the session
+        # (polylogue-61zb: refresh/rebuild profile flip-flop).
+        thread_root_id = await thread_root_id_async(conn, session_id)
+        record_bundle = await _rebuild.build_large_session_insight_record_bundle_async(
+            conn,
+            session_id,
+            logical_session_id=session_id,
+        )
+        await replace_session_profile(conn, record_bundle.profile_record, transaction_depth)
+        await replace_session_latency_profile(conn, record_bundle.latency_profile_record, transaction_depth)
+        await replace_session_work_events(
+            conn,
+            session_id,
+            record_bundle.work_event_records,
+            transaction_depth,
+        )
+        await replace_session_phases(
+            conn,
+            session_id,
+            record_bundle.phase_records,
+            transaction_depth,
+        )
+        affected_groups = {
+            group
+            for group in (
+                profile_provider_day(_row_to_session_profile_record(old_profile_record))
+                if old_profile_record
+                else None,
+                profile_provider_day(record_bundle.profile_record),
+            )
+            if group is not None
+        }
+        return _SessionInsightRefreshUpdate(
+            counts=SessionInsightCounts(profiles=1, work_events=0, phases=0),
+            thread_root_id=thread_root_id,
+            affected_groups=affected_groups,
+        )
     batch = await load_async_batch(conn, [session_id])
     hydrated = hydrate_sessions(batch)
     if not hydrated:
@@ -461,6 +503,7 @@ async def _apply_session_insight_session_updates_async(
     chunk_observations: list[SessionInsightRefreshChunkObservation] = []
     session_id_list = list(session_ids)
     message_counts = await _load_message_counts_async(conn, session_id_list)
+    heavy_session_ids = await _rebuild._heavy_session_ids_async(conn, session_id_list)
     session_chunks = _chunk_session_ids_by_message_budget(
         session_id_list,
         message_counts=message_counts,
@@ -470,18 +513,45 @@ async def _apply_session_insight_session_updates_async(
 
     for chunk in session_chunks:
         chunk_started = time.perf_counter()
+        # Same split as rebuild: heavy sessions get the bounded/degraded
+        # bundle and are never hydrated, so the stored profile is identical
+        # whichever materializer last touched the session (polylogue-61zb).
+        chunk_degraded_ids = tuple(session_id for session_id in chunk.session_ids if session_id in heavy_session_ids)
+        chunk_full_ids = tuple(session_id for session_id in chunk.session_ids if session_id not in heavy_session_ids)
+        if chunk.max_estimated_session_messages >= _rebuild._SESSION_INSIGHT_DEGRADED_MESSAGE_THRESHOLD:
+            chunk_degraded_ids = chunk.session_ids
+            chunk_full_ids = ()
         load_started = time.perf_counter()
         old_profile_records = await _load_existing_session_profile_records_async(conn, chunk.session_ids)
-        batch = await load_async_batch(conn, chunk.session_ids)
+        batch = await load_async_batch(conn, chunk_full_ids) if chunk_full_ids else None
         root_ids_by_session = await thread_root_ids_async(conn, chunk.session_ids)
         load_elapsed_ms = round((time.perf_counter() - load_started) * 1000.0, 1)
         hydrate_started = time.perf_counter()
-        hydrated_by_id = {str(session.id): session for session in hydrate_sessions(batch)}
+        hydrated_by_id = {str(session.id): session for session in hydrate_sessions(batch)} if batch is not None else {}
         hydrate_elapsed_ms = round((time.perf_counter() - hydrate_started) * 1000.0, 1)
 
         build_started = time.perf_counter()
         record_bundles: list[SessionInsightRecordBundle] = []
-        for session_id in chunk.session_ids:
+        for session_id in chunk_degraded_ids:
+            record_bundle = await _rebuild.build_large_session_insight_record_bundle_async(
+                conn,
+                session_id,
+                logical_session_id=session_id,
+            )
+            record_bundles.append(record_bundle)
+            counts.add(profiles=1)
+            affected_groups.update(
+                group
+                for group in (
+                    profile_provider_day(old_profile_records.get(session_id)),
+                    profile_provider_day(record_bundle.profile_record),
+                )
+                if group is not None
+            )
+            root_id = root_ids_by_session.get(session_id)
+            if root_id is not None:
+                thread_root_ids.add(root_id)
+        for session_id in chunk_full_ids:
             old_profile_record = old_profile_records.get(session_id)
             hydrated_session = hydrated_by_id.get(session_id)
             if hydrated_session is None:
@@ -492,7 +562,7 @@ async def _apply_session_insight_session_updates_async(
 
             record_bundle = build_session_insight_records(
                 hydrated_session,
-                compaction_count=batch.compaction_counts_by_session.get(session_id),
+                compaction_count=batch.compaction_counts_by_session.get(session_id) if batch is not None else None,
                 logical_session_id=root_ids_by_session.get(session_id),
             )
             record_bundles.append(record_bundle)
@@ -552,9 +622,14 @@ async def _apply_session_insight_session_updates_async(
         )
 
         hydrated_ids: set[str] = set()
+        degraded_id_set = set(chunk_degraded_ids)
         for bundle in record_bundles:
             bundle_conv_id = str(bundle.profile_record.session_id)
             hydrated_ids.add(bundle_conv_id)
+            if bundle_conv_id in degraded_id_set:
+                # Rebuild leaves session_repos untouched for degraded
+                # sessions (observations need hydration); mirror it.
+                continue
             bundle_observations = tuple(obs for obs in bundle.repo_observations if isinstance(obs, RepoObservation))
             await refresh_session_repos(conn, bundle_conv_id, bundle_observations)
         # Sessions dropped from this chunk still need observation cleanup.

--- a/tests/unit/storage/test_session_insight_refresh.py
+++ b/tests/unit/storage/test_session_insight_refresh.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import json
 import sqlite3
 import time
+from collections.abc import Sequence
 from pathlib import Path
 
 import aiosqlite
 import pytest
 
 import polylogue.storage.insights.session.rebuild as rebuild_mod
+import polylogue.storage.insights.session.refresh as refresh_mod
 from polylogue.daemon import cli as daemon_cli
 from polylogue.operations.archive_debt import archive_debt_list
 from polylogue.storage.insights.session.aggregates import refresh_async_provider_day_aggregates
@@ -21,6 +23,7 @@ from polylogue.storage.insights.session.rebuild import (
 from polylogue.storage.insights.session.refresh import (
     _apply_session_insight_session_updates_async,
     _refresh_thread_roots_async,
+    refresh_session_insights_for_session_async,
 )
 from polylogue.storage.insights.session.repair_assessment import assess_session_insight_repairs
 from polylogue.storage.runtime import SESSION_INSIGHT_MATERIALIZER_VERSION
@@ -1627,3 +1630,181 @@ async def test_refresh_async_provider_day_aggregates_batches_multiple_groups(
         ("chatgpt-export", "2026-04-02", 2),
         ("claude-ai-export", "2026-04-03", 1),
     ]
+
+
+def _seed_heavy_session(db_path: Path, native: str, *, origin: str = "codex-session") -> str:
+    """Store a small real session, then inflate its counters past the (monkeypatched) heavy threshold."""
+    session_id = _sid(native, origin)
+    with open_connection(db_path) as conn:
+        store_records(
+            session=make_session(native, source_name="codex", title="Heavy refresh parity"),
+            messages=[
+                make_message(f"{native}:msg-1", native, text="first prompt"),
+                make_message(f"{native}:msg-2", native, role="assistant", text="answer"),
+            ],
+            attachments=[],
+            conn=conn,
+        )
+        conn.execute(
+            """
+            UPDATE sessions
+            SET message_count = ?, word_count = ?, tool_use_count = ?, thinking_count = ?
+            WHERE session_id = ?
+            """,
+            (50, 1234, 7, 3, session_id),
+        )
+        conn.commit()
+    return session_id
+
+
+@pytest.mark.asyncio
+async def test_refresh_single_session_heavy_uses_bounded_degraded_profile(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Production dependency: refresh_session_insights_for_session_async must
+    branch heavy sessions into rebuild's bounded bundle. Removing the heavy
+    check in _apply_session_insight_session_update_async makes this fail (the
+    patched load_async_batch raises, and workflow_shape reverts to full analysis)."""
+    db_path = tmp_path / "refresh-heavy-single.db"
+    session_id = _seed_heavy_session(db_path, "conv-refresh-heavy-single")
+
+    monkeypatch.setattr(rebuild_mod, "_SESSION_INSIGHT_DEGRADED_MESSAGE_THRESHOLD", 10)
+
+    async def fail_full_load(_conn: object, _session_ids: object) -> object:
+        raise AssertionError("heavy-session refresh single path must not hydrate the full session")
+
+    monkeypatch.setattr(refresh_mod, "load_async_batch", fail_full_load)
+    async with aiosqlite.connect(db_path) as async_conn:
+        async_conn.row_factory = sqlite3.Row
+        counts = await refresh_session_insights_for_session_async(async_conn, session_id)
+        profile = await (
+            await async_conn.execute(
+                "SELECT * FROM session_profiles WHERE session_id = ?",
+                (session_id,),
+            )
+        ).fetchone()
+        work_events_row = await (
+            await async_conn.execute(
+                "SELECT COUNT(*) FROM session_work_events WHERE session_id = ?",
+                (session_id,),
+            )
+        ).fetchone()
+
+    assert counts.profiles == 1
+    assert counts.work_events == 0
+    assert counts.phases == 0
+    assert profile is not None
+    assert profile["workflow_shape"] == "bounded_large_session"
+    assert profile["message_count"] == 50
+    assert "large_session_bounded" in profile["inference_payload_json"]
+    assert work_events_row is not None and work_events_row[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_refresh_bulk_heavy_uses_bounded_degraded_profile_and_keeps_light_full(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The bulk refresh path (ordinary ingest tick) must degrade heavy sessions
+    without hydrating them while still fully analyzing light sessions in the
+    same call. A tool-count-heavy session has a small message count, so it
+    genuinely shares a chunk with light sessions (message-heavy sessions
+    always chunk alone under the message budget). Dropping the heavy split in
+    _apply_session_insight_session_updates_async fails this test."""
+    db_path = tmp_path / "refresh-heavy-bulk.db"
+    heavy_id = _seed_heavy_session(db_path, "conv-refresh-heavy-bulk")
+    light_native = "conv-refresh-light-bulk"
+    light_id = _sid(light_native, "codex-session")
+    with open_connection(db_path) as conn:
+        store_records(
+            session=make_session(light_native, source_name="codex", title="Light bulk refresh"),
+            messages=[
+                make_message(f"{light_native}:msg-1", light_native, text="hello"),
+                make_message(f"{light_native}:msg-2", light_native, role="assistant", text="world"),
+            ],
+            attachments=[],
+            conn=conn,
+        )
+        conn.commit()
+
+    monkeypatch.setattr(rebuild_mod, "_SESSION_INSIGHT_DEGRADED_TOOL_THRESHOLD", 5)
+
+    real_load = rebuild_mod.load_async_batch
+
+    async def guarded_load(
+        conn: aiosqlite.Connection,
+        session_ids: Sequence[str],
+    ) -> rebuild_mod.SessionInsightArchiveBatch:
+        assert heavy_id not in {str(session_id) for session_id in session_ids}, (
+            "heavy session must not reach hydration on the bulk refresh path"
+        )
+        return await real_load(conn, session_ids)
+
+    monkeypatch.setattr(refresh_mod, "load_async_batch", guarded_load)
+    async with aiosqlite.connect(db_path) as async_conn:
+        async_conn.row_factory = sqlite3.Row
+        update = await _apply_session_insight_session_updates_async(
+            async_conn,
+            [heavy_id, light_id],
+            transaction_depth=0,
+        )
+        rows = {
+            str(row["session_id"]): row
+            for row in await (
+                await async_conn.execute(
+                    "SELECT * FROM session_profiles WHERE session_id IN (?, ?)",
+                    (heavy_id, light_id),
+                )
+            ).fetchall()
+        }
+
+    assert update.counts.profiles == 2
+    assert rows[heavy_id]["workflow_shape"] == "bounded_large_session"
+    assert rows[light_id]["workflow_shape"] != "bounded_large_session"
+
+
+@pytest.mark.asyncio
+async def test_heavy_session_profile_agrees_between_refresh_and_rebuild(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """polylogue-61zb acceptance: a heavy session's stored profile must be the
+    same degraded shape whether the incremental refresh or a convergence
+    rebuild materialized it last — no flip-flopping."""
+    db_path = tmp_path / "refresh-rebuild-parity.db"
+    session_id = _seed_heavy_session(db_path, "conv-refresh-parity")
+
+    monkeypatch.setattr(rebuild_mod, "_SESSION_INSIGHT_DEGRADED_MESSAGE_THRESHOLD", 10)
+
+    volatile_columns = {"materialized_at"}
+
+    async def profile_snapshot(async_conn: aiosqlite.Connection) -> dict[str, object]:
+        row = await (
+            await async_conn.execute(
+                "SELECT * FROM session_profiles WHERE session_id = ?",
+                (session_id,),
+            )
+        ).fetchone()
+        assert row is not None
+        columns: list[str] = row.keys()
+        return {key: row[key] for key in columns if key not in volatile_columns}
+
+    async with aiosqlite.connect(db_path) as async_conn:
+        async_conn.row_factory = sqlite3.Row
+        await refresh_session_insights_for_session_async(async_conn, session_id)
+        await async_conn.commit()
+        refreshed = await profile_snapshot(async_conn)
+
+        await rebuild_mod.rebuild_session_insights_async(async_conn, session_ids=[session_id])
+        await async_conn.commit()
+        rebuilt = await profile_snapshot(async_conn)
+
+        # And back again: refresh after rebuild must not flip the shape.
+        await refresh_session_insights_for_session_async(async_conn, session_id)
+        await async_conn.commit()
+        refreshed_again = await profile_snapshot(async_conn)
+
+    assert refreshed["workflow_shape"] == "bounded_large_session"
+    assert refreshed == rebuilt
+    assert refreshed_again == rebuilt


### PR DESCRIPTION
## Summary

`refresh.py` — the incremental insight materializer running on every ordinary
ingest tick — now branches heavy sessions into the same bounded/degraded
profile path that `rebuild.py` has enforced since #1314, ending the
refresh/rebuild profile flip-flop and restoring the RSS safety valve on the
path most likely to touch a growing heavy session.

Ref polylogue-61zb (P1, discovered-from dogfood-2).

## Problem

`rebuild.py` defines heavy-session thresholds (message/word/tool-count) and a
bounded materialization (`build_large_session_insight_record_bundle_*`)
specifically so huge sessions are never fully hydrated. `refresh.py`, wired
into `pipeline/run_stages.py` and `daemon/cli.py` on every ingest tick, had
zero heavy handling (grep: no match for heavy/degraded/bounded across the
file). Two live consequences documented on the bead: the memory valve was
defeated exactly where a growing heavy session gets touched first, and
`session_profiles` visibly flip-flopped between full-analysis and
`bounded_large_session` shapes depending on which materializer last ran —
a same-input-different-output violation.

## Solution

- **Single-session path** (`_apply_session_insight_session_update_async`):
  heavy detection up front via rebuild's `_heavy_session_ids_async`; degraded
  bundle built with the same `logical_session_id=session_id` argument rebuild
  uses, so the stored row is identical whichever materializer wrote it; the
  archive batch is never loaded.
- **Bulk path** (`_apply_session_insight_session_updates_async`): chunks split
  into degraded/full id sets exactly like rebuild's, including the
  whole-chunk message-threshold fallback; degraded ids skip hydration and
  leave `session_repos` untouched (parity with rebuild); light co-tenants of
  a tool-count-heavy session keep full analysis.
- Heavy helpers referenced through the rebuild module object so the existing
  threshold-monkeypatch test pattern governs both materializers.

## Verification

- `devtools test tests/unit/storage/test_session_insight_refresh.py` → **28 passed**, including three new tests:
  - single-path anti-hydration: patched `load_async_batch` raises if the heavy branch is removed;
  - bulk mixed-chunk: a tool-count-heavy session (small message count — the shape that genuinely shares a chunk in production) is degraded while its light chunk-mate keeps full analysis; a hydration guard asserts the heavy id never reaches `load_async_batch`;
  - the acceptance law: refresh → rebuild → refresh yields an identical profile row (modulo `materialized_at`) with `workflow_shape=bounded_large_session` throughout.
- Dependents: `devtools test tests/unit/pipeline/test_run_stages_runtime.py tests/unit/pipeline/test_ingest_batch.py` → passed.
- `devtools verify --quick` → exit 0.

Anti-vacuity: deleting the heavy check in either path fails the corresponding
test (AssertionError from the patched loader / hydration guard), and reverting
`logical_session_id=session_id` to the thread root fails the parity law.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ