### PR TITLE
fix(storage): admit parser-drift membership replay (#2957)

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2665,22 +2665,27 @@ class ArchiveStore:
             with self._conn:
                 existing_head = self._conn.execute(
                     """
-                    SELECT accepted_raw_id, accepted_content_hash, accepted_frontier_kind
+                    SELECT accepted_raw_id, accepted_content_hash, accepted_frontier_kind, session_id
                     FROM raw_revision_heads WHERE logical_source_key = ?
                     """,
                     (logical_source_key,),
                 ).fetchone()
                 if existing_head is not None:
                     existing_raw_id = str(existing_head[0])
-                    existing_projection = projections_by_raw_id.get(existing_raw_id)
                     classified_raw_ids = {
                         *classification.accepted_raw_ids,
                         *classification.equivalent_raw_ids,
                     }
+                    persisted_session = self._conn.execute(
+                        "SELECT raw_id, content_hash FROM sessions WHERE session_id = ?",
+                        (str(existing_head[3]),),
+                    ).fetchone()
                     if (
-                        existing_projection is None
-                        or existing_raw_id not in classified_raw_ids
-                        or bytes(existing_head[1]) != existing_projection.session_hash
+                        existing_raw_id not in classified_raw_ids
+                        or persisted_session is None
+                        or str(persisted_session[0]) != existing_raw_id
+                        or not isinstance(persisted_session[1], bytes)
+                        or bytes(existing_head[1]) != bytes(persisted_session[1])
                     ):
                         raise RuntimeError("membership replay cannot retire an unrelated accepted head")
                     existing_is_byte_governed = conn.execute(

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -19,8 +19,9 @@ from polylogue.archive.revision_authority import (
     RawRevisionEnvelope,
     RawRevisionKind,
 )
+from polylogue.archive.session_revision_membership import MembershipClassification
 from polylogue.core.enums import Provider
-from polylogue.pipeline.ids import session_content_hash
+from polylogue.pipeline.ids import session_content_hash, session_revision_projection
 from polylogue.sources.dispatch import parse_payload
 from polylogue.sources.live import LiveWatcher, WatchSource
 from polylogue.sources.live.append_ingest import ingest_append_plans
@@ -39,6 +40,7 @@ from polylogue.sources.live.cursor import CursorStore
 from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers import archive as archive_tier_module
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.embeddings import EMBEDDINGS_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.index import INDEX_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.source import SOURCE_SCHEMA_VERSION
@@ -3329,6 +3331,94 @@ def test_live_multi_session_divergence_reopens_raw_authority(tmp_path: Path) -> 
         assert conn.execute(
             "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = 'chatgpt:shared'"
         ).fetchone() == (accepted_raw_id,)
+
+
+def test_live_membership_reprocesses_parser_drift_without_retiring_unrelated_head(tmp_path: Path) -> None:
+    """A current parse of the accepted raw is authority, even after parser drift.
+
+    This reproduces the July 16 live failure: an older browser snapshot was
+    accepted under an earlier parser, then byte-equivalent current snapshots
+    reparsed both the accepted raw and the new raw to the same new projection.
+    The accepted index head remains the CAS witness; its old content hash must
+    not be mistaken for an unrelated raw head.
+    """
+    root = tmp_path / "inbox"
+    root.mkdir()
+    snapshot = root / "snapshot.json"
+    payload: list[dict[str, object]] = [
+        {
+            "id": "parser-drift",
+            "title": "current title",
+            "current_node": "node",
+            "mapping": {
+                "node": {
+                    "id": "node",
+                    "parent": None,
+                    "children": [],
+                    "message": {
+                        "id": "message",
+                        "author": {"role": "user"},
+                        "create_time": 1_780_000_000.0,
+                        "content": {"content_type": "text", "parts": ["retained evidence"]},
+                        "metadata": {},
+                    },
+                }
+            },
+        }
+    ]
+    snapshot.write_text(json.dumps(payload), encoding="utf-8")
+    current_session = parse_payload(Provider.CHATGPT, payload, "snapshot")[0]
+    legacy_session = current_session.model_copy(update={"title": "legacy parser title"})
+    legacy_projection = session_revision_projection(legacy_session)
+    current_projection = session_revision_projection(current_session)
+    assert legacy_projection.session_hash != current_projection.session_hash
+
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        legacy_raw_id = archive.write_raw_payload(
+            provider=Provider.CHATGPT,
+            payload=snapshot.read_bytes(),
+            source_path=str(snapshot),
+            acquired_at_ms=1,
+        )
+        archive.replace_raw_membership_census(
+            legacy_raw_id,
+            [legacy_session],
+            parser_fingerprint="legacy-parser",
+            censused_at_ms=1,
+        )
+        archive.apply_raw_membership_classification(
+            "chatgpt:parser-drift",
+            MembershipClassification((legacy_raw_id,), (), ()),
+            {legacy_raw_id: legacy_session},
+            {legacy_raw_id: legacy_projection},
+            acquired_at_ms=1,
+        )
+
+    # Byte-level formatting changes create a new retained raw while preserving
+    # the provider session. The live route reparses the accepted raw too.
+    snapshot.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=tmp_path / "index.db"))),
+        (WatchSource(name="inbox", root=root, suffixes=(".json",)),),
+        cursor=CursorStore(tmp_path / "index.db"),
+        parser_fingerprint="current-parser",
+    )
+
+    result = processor._ingest_full_paths_sync([snapshot], source_name="inbox")
+
+    assert result.succeeded == [snapshot]
+    assert result.failed == []
+    with sqlite3.connect(tmp_path / "index.db") as conn:
+        stored = conn.execute(
+            "SELECT content_hash FROM sessions WHERE session_id = 'chatgpt-export:parser-drift'"
+        ).fetchone()
+        assert stored is not None
+        assert stored != (legacy_projection.session_hash,)
+        head = conn.execute(
+            "SELECT accepted_content_hash FROM raw_revision_heads WHERE logical_source_key = 'chatgpt:parser-drift'"
+        ).fetchone()
+        assert head == stored
 
 
 def test_single_session_full_terminally_supersedes_older_membership_prefix(


### PR DESCRIPTION
## Summary

Allows retained membership cohorts to reprocess safely when a parser upgrade
changes the semantic projection of the already-accepted raw. The existing
accepted head remains the compare-and-swap witness, and unrelated or ambiguous
heads still fail closed.

## Problem

The live daemon rejected at least fourteen current ChatGPT browser captures
with `membership replay cannot retire an unrelated accepted head`. Read-only
inspection showed the accepted raw and new raw reparse to the same current
projection, while the stored head retained the older parser's content hash.
The writer compared that historical hash to the current projection and
misclassified normal parser drift as an unrelated authority change.

## Solution

- Validate the accepted head against the persisted indexed session and raw ID.
- Continue requiring that raw ID in the accepted/equivalent authority cohort.
- Add a production-route regression that seeds a legacy parser projection,
  reparses byte-equivalent retained evidence through `LiveBatchProcessor`, and
  proves the head/session advance together.
- Preserve divergent-branch, quarantined-head, and byte-governance rejection.

Ref `polylogue-lkrc.4`.
Ref `polylogue-lkrc`.

## Verification

- `devtools test tests/unit/sources/test_live_batch_support.py -k
  'membership_reprocesses_parser_drift or
  live_multi_session_divergence_reopens_raw_authority'` — 2 passed.
- `devtools test tests/unit/storage/test_browser_capture_origin_repair.py -k
  'live_membership_ignores_quarantined_conflict or
  live_membership_defers_all_quarantined_rows'` — 2 passed.
- `devtools verify --quick` — 16/16 steps passed; run
  `20260716T193300Z-quick-919643-3de25328`.

The historical test path
`tests/unit/storage/test_no_string_interpolated_sql.py` no longer exists on
current master; the quick gate's static and schema checks passed.
