### PR TITLE
fix(cli): report failed status components as explicit unknown entries

### DIFF
--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -1856,6 +1856,25 @@ def _show_direct_json(
     env.ui.console.print(json.dumps(output, indent=2, default=str))
 
 
+def _component_computation_failure(component: str, exc: Exception, *, scope: str = "archive") -> dict[str, Any]:
+    """Explicit unknown-state entry for a component whose readiness computation failed.
+
+    A component that cannot be computed must stay visible as unknown; silently
+    omitting it is indistinguishable from not-applicable (polylogue-feqr).
+    """
+    from polylogue.readiness.capability import CapabilityReadinessState, ComponentReadiness
+
+    return dict(
+        ComponentReadiness(
+            component=component,
+            scope=scope,
+            state=CapabilityReadinessState.UNKNOWN,
+            summary=f"status computation failed: {type(exc).__name__}: {exc}",
+            caveats=("component readiness could not be computed; unknown is not healthy",),
+        ).to_dict()
+    )
+
+
 def _direct_status_ok(component_readiness: dict[str, Any]) -> bool:
     """Return direct-fallback health without penalizing intentionally unknown probes."""
 
@@ -1910,19 +1929,19 @@ def _direct_component_readiness(
                         repair_hint=_ARCHIVE_COMPONENT_REPAIR_HINTS.get(component),
                     )
                     components[readiness.component] = readiness.to_dict()
-        except Exception:
-            pass
+        except Exception as exc:
+            components["archive_surfaces"] = _component_computation_failure("archive_surfaces", exc)
     try:
         raw_component = _direct_raw_materialization_component(raw_materialization_readiness)
         components[raw_component["component"]] = raw_component
-    except Exception:
-        pass
+    except Exception as exc:
+        components["raw_materialization"] = _component_computation_failure("raw_materialization", exc)
     if raw_frontier_integrity is not None:
         try:
             frontier_component = _direct_raw_frontier_integrity_component(raw_frontier_integrity)
             components[frontier_component["component"]] = frontier_component
-        except Exception:
-            pass
+        except Exception as exc:
+            components["raw_frontier_integrity"] = _component_computation_failure("raw_frontier_integrity", exc)
     try:
         from polylogue.readiness.capability import component_from_embedding_payload
         from polylogue.storage.embeddings.status_payload import embedding_status_payload
@@ -1930,18 +1949,18 @@ def _direct_component_readiness(
         embedding_payload = embedding_status_payload(env, include_retrieval_bands=False)
         embedding = component_from_embedding_payload(embedding_payload)
         components[embedding.component] = embedding.to_dict()
-    except Exception:
-        pass
+    except Exception as exc:
+        components["embeddings"] = _component_computation_failure("embeddings", exc)
     try:
         assertions = _direct_assertion_component(active_root)
         components[assertions["component"]] = assertions
-    except Exception:
-        pass
+    except Exception as exc:
+        components["assertions"] = _component_computation_failure("assertions", exc)
     try:
         transforms = _direct_transform_component(archive_readiness)
         components[transforms["component"]] = transforms
-    except Exception:
-        pass
+    except Exception as exc:
+        components["transforms"] = _component_computation_failure("transforms", exc)
     return components
 
 

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -1871,6 +1871,7 @@ def _component_computation_failure(component: str, exc: Exception, *, scope: str
             state=CapabilityReadinessState.UNKNOWN,
             summary=f"status computation failed: {type(exc).__name__}: {exc}",
             caveats=("component readiness could not be computed; unknown is not healthy",),
+            metadata={"computation_failed": True},
         ).to_dict()
     )
 
@@ -1892,6 +1893,15 @@ def _direct_status_ok(component_readiness: dict[str, Any]) -> bool:
     for component, readiness in component_readiness.items():
         if not isinstance(readiness, dict):
             continue
+        metadata = readiness.get("metadata")
+        if (
+            component in required_known_components | required_missing_components
+            and isinstance(metadata, dict)
+            and metadata.get("computation_failed")
+        ):
+            # A required component whose readiness could not even be computed
+            # must not read as healthy (polylogue-feqr review follow-up).
+            return False
         state = str(readiness.get("state") or "unknown")
         if state in hard_failure_states:
             return False
@@ -1950,17 +1960,17 @@ def _direct_component_readiness(
         embedding = component_from_embedding_payload(embedding_payload)
         components[embedding.component] = embedding.to_dict()
     except Exception as exc:
-        components["embeddings"] = _component_computation_failure("embeddings", exc)
+        components["embeddings"] = _component_computation_failure("embeddings", exc, scope="semantic")
     try:
         assertions = _direct_assertion_component(active_root)
         components[assertions["component"]] = assertions
     except Exception as exc:
-        components["assertions"] = _component_computation_failure("assertions", exc)
+        components["assertions"] = _component_computation_failure("assertions", exc, scope="user")
     try:
         transforms = _direct_transform_component(archive_readiness)
         components[transforms["component"]] = transforms
     except Exception as exc:
-        components["transforms"] = _component_computation_failure("transforms", exc)
+        components["transforms"] = _component_computation_failure("transforms", exc, scope="session-analysis")
     return components
 
 

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -842,6 +842,32 @@ class TestNoArchiveStatus:
         assert readiness["caveats"] == []
         assert readiness["repair_hint"] == "polylogue ops embed backfill --yes --max-sessions 10"
 
+    def test_direct_status_json_reports_failed_component_as_unknown(self, tmp_path: Path) -> None:
+        """A component whose readiness computation raises must appear as an
+        explicit unknown entry, never silently vanish from the payload
+        (polylogue-feqr). Reverting the except-pass fix makes the 'embeddings'
+        key absent and this test fail."""
+        env = _make_app_env()
+        db_anchor = tmp_path / "index.db"
+        initialize_archive_database(db_anchor, ArchiveTier.INDEX)
+
+        with (
+            patch("polylogue.paths.db_path", return_value=db_anchor),
+            patch("polylogue.paths.archive_root", return_value=tmp_path),
+            patch(
+                "polylogue.storage.embeddings.status_payload.embedding_status_payload",
+                side_effect=RuntimeError("embedding tier unreadable"),
+            ),
+        ):
+            _show_direct_json(env, include_archive_readiness=True)
+
+        payload = json.loads(_combined_calls(env))
+        readiness = payload["component_readiness"]["embeddings"]
+        assert readiness["component"] == "embeddings"
+        assert readiness["state"] == "unknown"
+        assert "RuntimeError" in readiness["summary"]
+        assert "embedding tier unreadable" in readiness["summary"]
+
     def test_direct_status_json_maps_archive_surface_component_readiness(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary
Failed status-component computations now produce explicit `state=unknown` entries instead of silently vanishing from the payload. Ref polylogue-feqr (found by the xnws narration pilot).

## Problem
Six `except Exception: pass` sites in `_direct_component_readiness` made a failed component indistinguishable from not-applicable — a direct loud-degradation violation on the status surface itself.

## Solution
`_component_computation_failure` helper (reuses the existing `ComponentReadiness`/`CapabilityReadinessState.UNKNOWN` vocabulary — no new tokens); each block inserts it under its statically-known component name (`archive_surfaces` sentinel, `raw_materialization`, `raw_frontier_integrity`, `embeddings`, `assertions`, `transforms`). The `_direct_status_ok` claim guard already treats `unknown` correctly.

## Verification
`devtools test tests/unit/cli/test_status.py` → 61 passed, including a new test forcing an embeddings failure through the real `_show_direct_json` route and asserting the unknown entry (reverting the fix → key absent → test fails). `devtools verify --quick` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ