### PR TITLE
feat(devtools): add raw authority scale proof runner

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -557,6 +557,20 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "workspace raw-authority-scale-proof",
+        "workspace",
+        "Run bounded raw-authority replay to a two-census fixed point.",
+        "devtools.raw_authority_scale_proof",
+        use_when=(
+            "Generate a receipt-backed raw-authority scenario before a live replay gate. "
+            "Use explicit July-15-shaped component/raw arguments for the contained scale run."
+        ),
+        examples=(
+            "devtools workspace raw-authority-scale-proof --json",
+            "devtools workspace raw-authority-scale-proof --components 10163 --raws 15264 --pass-limit 64 --keep --json",
+        ),
+    ),
+    CommandSpec(
         "workspace temporal-read-profile",
         "workspace",
         "Measure read --view temporal phase timings on the active archive.",

--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -1,0 +1,191 @@
+"""Run a receipt-backed bounded raw-authority fixed-point scenario.
+
+The default is deliberately small enough for local verification.  The caller
+may supply the July-15 component/raw cardinalities for a long, contained run;
+the JSON receipt records the exact requested shape rather than presenting a
+small projection as production evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import resource
+import shutil
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TextIO, cast
+
+from polylogue.config import Config
+from polylogue.core.enums import Provider
+from polylogue.scenarios.workload import (
+    WorkloadPhaseObservation,
+    WorkloadReceipt,
+    WorkloadRunStatus,
+    raw_authority_fixed_point_spec,
+)
+from polylogue.schemas.workload_tiers import WorkloadScaleTier
+from polylogue.storage import repair
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+@dataclass(frozen=True, slots=True)
+class RawAuthorityScalePass:
+    number: int
+    candidate_count: int
+    repaired_count: int
+    executable_component_count: int
+    fixed_point: bool
+    wall_ms: int
+    peak_rss_bytes: int
+
+
+def _payload(native_id: str, revision: int) -> bytes:
+    records = [f'{{"type":"session_meta","payload":{{"id":"{native_id}","timestamp":"2026-07-15T00:00:00Z"}}}}\n']
+    records.extend(
+        f'{{"type":"response_item","payload":{{"type":"message","id":"{native_id}-{index}","role":"user","content":[{{"type":"input_text","text":"revision-{index}"}}]}}}}\n'
+        for index in range(revision + 1)
+    )
+    return "".join(records).encode()
+
+
+def _rss_bytes() -> int:
+    # Linux ru_maxrss is KiB; this repository's supported development host is Linux.
+    return int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss) * 1024
+
+
+def run_raw_authority_scale_proof(
+    workdir: Path,
+    *,
+    components: int = 16,
+    raws: int = 24,
+    pass_limit: int = 4,
+    keep: bool = False,
+) -> dict[str, object]:
+    """Exercise real authority census/replay and emit a stable receipt payload."""
+    if components < 1 or raws < components or pass_limit < 1:
+        raise ValueError("require components >= 1, raws >= components, and pass_limit >= 1")
+    root = workdir.expanduser().resolve() / "raw-authority-scale-proof"
+    if root.exists():
+        shutil.rmtree(root)
+    initialize_active_archive_root(root)
+    revision_counts = [1] * components
+    for index in range(raws - components):
+        revision_counts[index % components] += 1
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        acquired_at_ms = 0
+        for component, revisions in enumerate(revision_counts):
+            native_id = f"scale-{component:05d}"
+            for revision in range(revisions):
+                archive.write_raw_payload(
+                    provider=Provider.CODEX,
+                    payload=_payload(native_id, revision),
+                    source_path=f"/synthetic/raw-authority/{native_id}.jsonl",
+                    acquired_at_ms=acquired_at_ms,
+                )
+                acquired_at_ms += 1
+    config = Config(archive_root=root, render_root=root, sources=[], db_path=root / "index.db")
+    pass_receipts: list[RawAuthorityScalePass] = []
+    fixed_point_digests: list[str] = []
+    for number in range(1, (components * 3) + 4):
+        started = time.perf_counter()
+        result = repair.repair_raw_materialization(config, raw_artifact_limit=pass_limit)
+        wall_ms = int((time.perf_counter() - started) * 1000)
+        metrics = result.metrics
+        candidate_count = int(metrics.get("raw_materialization_candidate_count", 0))
+        executable_components = int(metrics.get("raw_materialization_selected_executable_component_count", 0))
+        fixed_point = bool(metrics.get("raw_materialization_census_fixed_point", 0))
+        pass_receipts.append(
+            RawAuthorityScalePass(
+                number,
+                candidate_count,
+                result.repaired_count,
+                executable_components,
+                fixed_point,
+                wall_ms,
+                _rss_bytes(),
+            )
+        )
+        digest = result.census_receipt.residual_digest if result.census_receipt is not None else "unavailable"
+        if candidate_count == 0:
+            fixed_point_digests.append(digest)
+            if len(fixed_point_digests) == 2 and fixed_point_digests[-1] == fixed_point_digests[-2]:
+                break
+    else:
+        raise RuntimeError("raw-authority scale proof did not reach two matching quiescent passes")
+    profile_id = f"workload-profile:synthetic-raw-authority:{components}:{raws}"
+    archive_id = f"raw-authority-scale:{hashlib.sha256(str(root).encode()).hexdigest()}"
+    spec = raw_authority_fixed_point_spec(
+        profile_id=profile_id,
+        archive_id=archive_id,
+        scale_tier=WorkloadScaleTier.CI_ACTIVATION,
+    )
+    total_wall_ms = sum(item.wall_ms for item in pass_receipts)
+    peak_rss = max(item.peak_rss_bytes for item in pass_receipts)
+    receipt = WorkloadReceipt.from_observations(
+        spec=spec,
+        status=WorkloadRunStatus.SUCCEEDED,
+        build_id="git:local",
+        runtime_id=f"python:{platform.python_version()}",
+        archive_id=archive_id,
+        generation_id=None,
+        frame_id=None,
+        phases=(
+            WorkloadPhaseObservation(name="generate"),
+            WorkloadPhaseObservation(name="acquire"),
+            WorkloadPhaseObservation(name="census", wall_ms=total_wall_ms, peak_rss_bytes=peak_rss),
+            WorkloadPhaseObservation(name="replay", wall_ms=total_wall_ms, peak_rss_bytes=peak_rss),
+            WorkloadPhaseObservation(name="postflight"),
+            WorkloadPhaseObservation(name="quiescent", cleanup_complete=not keep, quiescent=True),
+        ),
+        cleanup_complete=not keep,
+        notes=(
+            f"requested_components={components}",
+            f"requested_raws={raws}",
+            "This receipt is a generated projection; only an explicit July-15-sized invocation is production-shaped evidence.",
+        ),
+    )
+    payload: dict[str, object] = {
+        "archive_root": str(root),
+        "requested_shape": {"components": components, "raws": raws, "pass_limit": pass_limit},
+        "passes": [asdict(item) for item in pass_receipts],
+        "fixed_point_digests": fixed_point_digests,
+        "receipt": receipt.to_payload(),
+    }
+    (root / "raw-authority-scale-receipt.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    if not keep:
+        shutil.rmtree(root)
+    return payload
+
+
+def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workdir", type=Path, default=Path(".cache") / "raw-authority-scale-proof")
+    parser.add_argument("--components", type=int, default=16)
+    parser.add_argument("--raws", type=int, default=24)
+    parser.add_argument("--pass-limit", type=int, default=4)
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    payload = run_raw_authority_scale_proof(
+        args.workdir, components=args.components, raws=args.raws, pass_limit=args.pass_limit, keep=args.keep
+    )
+    out = stdout
+    if out is None:
+        import sys
+
+        out = sys.stdout
+    receipt = cast(dict[str, object], payload["receipt"])
+    print(json.dumps(payload, indent=2, sort_keys=True) if args.json else receipt["receipt_id"], file=out)
+    return 0
+
+
+__all__ = ["main", "run_raw_authority_scale_proof"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -206,6 +206,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools workspace index-fast-forward` | Apply a declared clone-first index.db fast-forward with receipts and rollback. |
 | `devtools workspace index-v37-fast-forward` | Clone-forward index v36 to v37 by retiring derived caches without raw replay. |
 | `devtools workspace lineage-validation` | Validate lineage-count evidence before citing archive counts externally. |
+| `devtools workspace raw-authority-scale-proof` | Run bounded raw-authority replay to a two-census fixed point. |
 | `devtools workspace read-package` | Render a declarative package of Polylogue read artifacts. |
 | `devtools workspace scale-regression` | Run the seeded large-archive scale-regression probe. |
 | `devtools workspace tasks` | Record and query local agent task execution history. |

--- a/polylogue/scenarios/workload.py
+++ b/polylogue/scenarios/workload.py
@@ -612,6 +612,34 @@ def partial_convergence_canary_spec(
     )
 
 
+def raw_authority_fixed_point_spec(
+    *,
+    profile_id: str,
+    archive_id: str,
+    scale_tier: WorkloadScaleTier = WorkloadScaleTier.CI_ACTIVATION,
+) -> WorkloadEnvelopeSpec:
+    """Declare the bounded raw-authority census and replay fixed-point route.
+
+    This is intentionally an envelope over the shared schema-derived corpus,
+    rather than another synthetic archive format.  A production-shaped run
+    binds its revision skew, component closure, and cursor/head conflict
+    distributions to the same profile and receipt as the input corpus.
+    """
+    return _schema_profile_canary_spec(
+        workload_id="canary:raw-authority-fixed-point",
+        profile_id=profile_id,
+        archive_id=archive_id,
+        phases=("generate", "acquire", "census", "replay", "postflight", "quiescent"),
+        distribution_refs=(
+            "archive.raw_revision_shapes",
+            "archive.authority_component_sizes",
+            "operations.cursor_lag",
+            "operations.convergence_debt",
+        ),
+        scale_tier=scale_tier,
+    )
+
+
 def _identity(namespace: str, payload: JSONDocument) -> str:
     encoded = json.dumps(
         payload,
@@ -640,6 +668,7 @@ __all__ = [
     "exact_session_actions_canary_spec",
     "lineage_replay_canary_spec",
     "partial_convergence_canary_spec",
+    "raw_authority_fixed_point_spec",
     "tool_pairing_canary_spec",
     "watcher_append_cohort_canary_spec",
 ]

--- a/tests/unit/devtools/test_raw_authority_scale_proof.py
+++ b/tests/unit/devtools/test_raw_authority_scale_proof.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from devtools.raw_authority_scale_proof import run_raw_authority_scale_proof
+
+
+def test_raw_authority_scale_proof_reaches_two_matching_quiescent_censuses(tmp_path: Path) -> None:
+    payload = run_raw_authority_scale_proof(tmp_path, components=3, raws=5, pass_limit=2)
+
+    assert payload["requested_shape"] == {"components": 3, "raws": 5, "pass_limit": 2}
+    digests = cast(list[str], payload["fixed_point_digests"])
+    passes = cast(list[dict[str, object]], payload["passes"])
+    receipt = cast(dict[str, object], payload["receipt"])
+    assert len(digests) == 2
+    assert digests[0] == digests[1]
+    assert passes[-1]["candidate_count"] == 0
+    assert receipt["status"] == "succeeded"

--- a/tests/unit/scenarios/test_workload_receipts.py
+++ b/tests/unit/scenarios/test_workload_receipts.py
@@ -18,6 +18,7 @@ from polylogue.scenarios.workload import (
     WorkloadRunStatus,
     evaluate_budgets,
     exact_session_actions_canary_spec,
+    raw_authority_fixed_point_spec,
 )
 from polylogue.schemas.workload_tiers import WorkloadScaleTier, WorkloadSelectivityTier
 
@@ -197,3 +198,21 @@ def test_exact_session_actions_canary_uses_shared_tier_and_receipt_contract() ->
     assert passing.budget_results[0].verdict is BudgetVerdict.PASS
     assert exceeded.budget_results[0].verdict is BudgetVerdict.EXCEEDED
     assert exceeded.spec.semantic_result == "complete"
+
+
+def test_raw_authority_fixed_point_canary_uses_shared_corpus_identity() -> None:
+    spec = raw_authority_fixed_point_spec(
+        profile_id="workload-profile:sha256:raw-authority",
+        archive_id="seeded-archive:sha256:raw-authority",
+        scale_tier=WorkloadScaleTier.ARCHIVE_1X,
+    )
+
+    assert spec.workload_id == "canary:raw-authority-fixed-point"
+    assert spec.inputs[0].scale_tier == WorkloadScaleTier.ARCHIVE_1X.value
+    assert spec.inputs[0].distribution_refs == (
+        "archive.raw_revision_shapes",
+        "archive.authority_component_sizes",
+        "operations.cursor_lag",
+        "operations.convergence_debt",
+    )
+    assert spec.phases == ("generate", "acquire", "census", "replay", "postflight", "quiescent")


### PR DESCRIPTION
## Summary

Add a shared-workload, receipt-backed runner for bounded raw-authority census and replay to a two-census fixed point.

## Problem

The raw-authority repair path had unit-scale scheduling proofs but no executable scenario that records requested corpus shape, every bounded pass, and a durable fixed-point witness.

## Solution

- Declare the raw-authority fixed-point workload through the shared schema/profile receipt substrate.
- Add `devtools workspace raw-authority-scale-proof`, which initializes a real split-tier archive, generates deterministic revision-shaped retained raws, executes bounded repair passes, and records two matching quiescent residual digests.
- Emit a JSON receipt that records the requested component/raw shape and explicitly distinguishes the small default projection from a full July-15-sized invocation.

## Verification

- `devtools test tests/unit/devtools/test_raw_authority_scale_proof.py tests/unit/scenarios/test_workload_receipts.py` — 7 passed.
- Manual smoke: `python -m devtools.raw_authority_scale_proof --workdir /realm/tmp/raw-authority-proof-smoke --components 3 --raws 5 --pass-limit 2 --keep --json` — three bounded work passes followed by two matching quiescent residual digests.
- `devtools verify --quick` — static/generated gates passed.

Ref polylogue-hjpx.2.