### PR TITLE
fix(schemas): bound journal replay transactions

### DIFF
--- a/polylogue/schemas/generation/cluster_collection.py
+++ b/polylogue/schemas/generation/cluster_collection.py
@@ -105,6 +105,10 @@ def collect_cluster_analysis(
         for unit in observed_units:
             observe_summary(unit)
             journal.append_unit(unit, retain_cluster_payload=False)
+        # The following phases replay the journal repeatedly. Commit its final
+        # ingest batch first so reads do not repeatedly traverse one enormous
+        # writer WAL instead of the checkpointable journal database.
+        journal.flush()
 
     coarse_clusters: list[_ClusterAccumulator] = []
     ordered_summaries: Iterable[tuple[object, _ProfileSummary]]

--- a/polylogue/schemas/generation/observation_journal.py
+++ b/polylogue/schemas/generation/observation_journal.py
@@ -28,6 +28,8 @@ _JOURNAL_FORMAT = 1
 _DEFAULT_STALE_AGE_S = 24 * 60 * 60
 _ROOT_MODE = 0o700
 _FILE_MODE = 0o600
+_COMMIT_UNIT_LIMIT = 1_024
+_COMMIT_PAYLOAD_BYTES_LIMIT = 32 * 1024 * 1024
 _DISTINCT_UNIT_COLUMNS = frozenset({"bundle_scope", "exact_structure_id", "profile_family_id"})
 DistinctUnitColumn = Literal["bundle_scope", "exact_structure_id", "profile_family_id"]
 _SCOPE_KEY_SQL = (
@@ -161,7 +163,28 @@ class ObservationJournal:
         self.path = path
         self._connection = connection
         self._closed = False
+        self._pending_unit_count = 0
+        self._pending_payload_bytes = 0
         self._previous_signal_handlers: dict[signal.Signals, object] = {}
+
+    def _record_pending_write(self, payload_bytes: int = 0) -> None:
+        """Bound one private WAL transaction without changing observations.
+
+        The journal is only a run-scoped staging spool: nothing becomes a
+        generated package until the enclosing generation returns successfully.
+        Committing batches therefore changes neither output atomicity nor
+        evidence semantics, but prevents a full archive from becoming one
+        uncheckpointable WAL transaction.
+        """
+        self._pending_payload_bytes += payload_bytes
+        if self._pending_unit_count >= _COMMIT_UNIT_LIMIT or self._pending_payload_bytes >= _COMMIT_PAYLOAD_BYTES_LIMIT:
+            self.flush()
+
+    def flush(self) -> None:
+        """Commit pending private journal evidence before a replay phase."""
+        self._connection.commit()
+        self._pending_unit_count = 0
+        self._pending_payload_bytes = 0
 
     def _handle_termination(self, signum: int, frame: FrameType | None) -> NoReturn:
         """Turn ordinary termination into stack unwinding through ``__exit__``."""
@@ -281,7 +304,7 @@ class ObservationJournal:
 
                 CREATE INDEX units_artifact_kind_idx ON units(artifact_kind, unit_id);
                 CREATE INDEX units_bundle_scope_idx ON units(bundle_scope, unit_id);
-                CREATE INDEX units_profile_family_idx ON units(profile_family_id, unit_id);
+                CREATE INDEX units_profile_family_idx ON units(profile_family_id, artifact_kind, unit_id);
                 CREATE INDEX units_package_family_idx ON units(package_family_id, package_selected, artifact_kind, unit_id);
                 CREATE INDEX profile_summaries_family_idx
                     ON profile_summaries(profile_family_id, artifact_kind, profile_tokens_json);
@@ -299,6 +322,17 @@ class ObservationJournal:
 
     def append_unit(self, unit: SchemaUnit, *, retain_cluster_payload: bool = True) -> int:
         """Append one canonical unit and its independently replayable samples."""
+        cluster_payload_json = _canonical_json(unit.cluster_payload if retain_cluster_payload else {})
+        profile_tokens_json = _canonical_json(list(unit.profile_tokens))
+        sample_payload_bytes = 0
+
+        def sample_rows() -> Iterator[tuple[int, bytes]]:
+            nonlocal sample_payload_bytes
+            for position, sample in enumerate(unit.schema_samples):
+                sample_json = _canonical_json(sample)
+                sample_payload_bytes += len(sample_json)
+                yield position, sample_json
+
         cursor = self._connection.execute(
             """
             INSERT INTO units(
@@ -308,7 +342,7 @@ class ObservationJournal:
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
-                _canonical_json(unit.cluster_payload if retain_cluster_payload else {}),
+                cluster_payload_json,
                 unit.artifact_kind,
                 unit.session_id,
                 unit.raw_id,
@@ -316,7 +350,7 @@ class ObservationJournal:
                 unit.bundle_scope,
                 unit.observed_at,
                 unit.exact_structure_id,
-                _canonical_json(list(unit.profile_tokens)),
+                profile_tokens_json,
                 len(unit.schema_samples),
             ),
         )
@@ -325,8 +359,10 @@ class ObservationJournal:
         unit_id = cursor.lastrowid
         self._connection.executemany(
             "INSERT INTO samples(unit_id, position, sample_json) VALUES (?, ?, ?)",
-            ((unit_id, position, _canonical_json(sample)) for position, sample in enumerate(unit.schema_samples)),
+            ((unit_id, position, sample_json) for position, sample_json in sample_rows()),
         )
+        self._pending_unit_count += 1
+        self._record_pending_write(len(cluster_payload_json) + len(profile_tokens_json) + sample_payload_bytes)
         return unit_id
 
     def record_terminal(
@@ -345,6 +381,9 @@ class ObservationJournal:
             VALUES (?, ?, ?, ?, ?)
             """,
             (raw_id, status, artifact_kind, source_path, reason),
+        )
+        self._record_pending_write(
+            sum(len(value.encode("utf-8")) for value in (raw_id, artifact_kind, source_path, reason) if value)
         )
 
     def observe_profile_summary(self, unit: SchemaUnit, *, dominant_keys: Sequence[str]) -> None:
@@ -387,6 +426,9 @@ class ObservationJournal:
                     profile_tokens_json,
                 ),
             )
+        self._record_pending_write(
+            len(profile_tokens_json) + sum(len(key.encode("utf-8")) for key in dominant_keys[:20])
+        )
 
     def iter_profile_summaries(self) -> Iterator[_ProfileSummary]:
         """Replay exact summaries in deterministic clustering priority order."""
@@ -783,7 +825,7 @@ class ObservationJournal:
         joined_query = (
             "SELECT units.*, samples.position AS replay_position, "
             "samples.sample_json AS replay_sample_json "
-            "FROM samples CROSS JOIN units ON units.unit_id = samples.unit_id "
+            "FROM units JOIN samples ON samples.unit_id = units.unit_id "
             f"WHERE {where} ORDER BY samples.unit_id, samples.position"
         )
         current_row: sqlite3.Row | None = None
@@ -1005,7 +1047,7 @@ class ObservationJournal:
             return
         self._closed = True
         try:
-            self._connection.commit()
+            self.flush()
         finally:
             try:
                 self._connection.close()

--- a/tests/unit/core/test_schema_observation_journal.py
+++ b/tests/unit/core/test_schema_observation_journal.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import signal
+import sqlite3
 import stat
 import subprocess
 import sys
@@ -242,6 +243,57 @@ def test_journal_replays_lone_surrogate_provider_values_without_utf8_failure(tmp
     with ObservationJournal.create(root=tmp_path / "journals") as journal:
         journal.append_unit(unit)
         assert list(journal.iter_units()) == [unit]
+
+
+def test_journal_flushes_private_ingest_before_replay(tmp_path: Path) -> None:
+    """A long generation may observe indefinitely without making one giant WAL."""
+    root = tmp_path / "journals"
+    with ObservationJournal.create(root=root) as journal:
+        journal.append_unit(_unit())
+        journal.flush()
+
+        with sqlite3.connect(journal.path) as reader:
+            assert reader.execute("SELECT COUNT(*) FROM units").fetchone() == (1,)
+            assert reader.execute("SELECT COUNT(*) FROM samples").fetchone() == (2,)
+
+
+def test_selective_membership_replay_uses_units_before_samples(tmp_path: Path) -> None:
+    """Package replay must not scan every sample before applying its package filter."""
+    with ObservationJournal.create(root=tmp_path / "journals") as journal:
+        for index in range(32):
+            unit_id = journal.append_unit(
+                SchemaUnit(
+                    cluster_payload={},
+                    schema_samples=[{"index": index}],
+                    artifact_kind="session_record_stream",
+                    exact_structure_id=f"shape-{index}",
+                    profile_tokens=("field:index",),
+                ),
+                retain_cluster_payload=False,
+            )
+            journal.assign_profile_family(unit_id, "selected" if index == 0 else "other")
+            journal.assign_package_family(unit_id, "selected" if index == 0 else "other")
+        journal.flush()
+
+        where, parameters = journal._membership_where(
+            profile_family_id="selected",
+            package_family_id="selected",
+            artifact_kind="session_record_stream",
+        )
+        plan = [
+            str(row[-1])
+            for row in journal._connection.execute(
+                "EXPLAIN QUERY PLAN "
+                "SELECT units.*, samples.position, samples.sample_json "
+                "FROM units JOIN samples ON samples.unit_id = units.unit_id "
+                f"WHERE {where} ORDER BY samples.unit_id, samples.position",
+                parameters,
+            )
+        ]
+
+        assert any("SEARCH units USING INDEX units_package_family_idx" in detail for detail in plan)
+        assert any("SEARCH samples USING PRIMARY KEY (unit_id=?)" in detail for detail in plan)
+        assert list(journal.memberships(package_family_id="selected"))[0].unit.schema_samples == [{"index": 0}]
 
 
 def test_journal_cleanup_runs_for_exceptions(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Bounds private observation-journal transactions and makes membership replay
apply selective unit filters before reading samples.

## Problem

A live full-corpus Codex regeneration accumulated a 41.7 GiB SQLite WAL because
journal ingest committed only at close. After ingest, package/schema replay
continued at roughly 1.48 GiB of physical reads per 30 seconds. Its SQL forced
`samples` to be the outer relation, so package/profile predicates could not
narrow work before sample replay.

## Solution

- Commit bounded private journal batches and explicitly flush after ingest,
  before any replay phase. Generated artifacts are still published only after
  successful generation; this changes spool durability, not output semantics.
- Start membership replay at filtered `units`, then join `samples`; retain
  indexes aligned with profile/package and artifact filters.
- Add behavioral coverage for committed private replay visibility and an
  `EXPLAIN QUERY PLAN` contract proving a selective package lookup uses units
  then the per-unit samples primary key.

Ref polylogue-1xc.14.1.1.

## Verification

- `devtools test tests/unit/core/test_schema_observation_journal.py tests/unit/core/test_schema_generation.py` — 46 passed.
- `devtools verify --quick` — all 16 checks passed.
- Pre-push quick baseline — all checks passed.
