### PR TITLE
feat(devtools): guard and meter raw authority proofs

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -557,6 +557,20 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "workspace raw-authority-scale-proof",
+        "workspace",
+        "Run bounded raw-authority replay to a two-census fixed point.",
+        "devtools.raw_authority_scale_proof",
+        use_when=(
+            "Generate a receipt-backed raw-authority scenario before a live replay gate. "
+            "Use explicit July-15-shaped component/raw arguments for the contained scale run."
+        ),
+        examples=(
+            "devtools workspace raw-authority-scale-proof --json",
+            "devtools workspace raw-authority-scale-proof --components 10163 --raws 15264 --pass-limit 64 --keep --json",
+        ),
+    ),
+    CommandSpec(
         "workspace temporal-read-profile",
         "workspace",
         "Measure read --view temporal phase timings on the active archive.",

--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -1,0 +1,191 @@
+"""Run a receipt-backed bounded raw-authority fixed-point scenario.
+
+The default is deliberately small enough for local verification.  The caller
+may supply the July-15 component/raw cardinalities for a long, contained run;
+the JSON receipt records the exact requested shape rather than presenting a
+small projection as production evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import resource
+import shutil
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TextIO, cast
+
+from polylogue.config import Config
+from polylogue.core.enums import Provider
+from polylogue.scenarios.workload import (
+    WorkloadPhaseObservation,
+    WorkloadReceipt,
+    WorkloadRunStatus,
+    raw_authority_fixed_point_spec,
+)
+from polylogue.schemas.workload_tiers import WorkloadScaleTier
+from polylogue.storage import repair
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+@dataclass(frozen=True, slots=True)
+class RawAuthorityScalePass:
+    number: int
+    candidate_count: int
+    repaired_count: int
+    executable_component_count: int
+    fixed_point: bool
+    wall_ms: int
+    peak_rss_bytes: int
+
+
+def _payload(native_id: str, revision: int) -> bytes:
+    records = [f'{{"type":"session_meta","payload":{{"id":"{native_id}","timestamp":"2026-07-15T00:00:00Z"}}}}\n']
+    records.extend(
+        f'{{"type":"response_item","payload":{{"type":"message","id":"{native_id}-{index}","role":"user","content":[{{"type":"input_text","text":"revision-{index}"}}]}}}}\n'
+        for index in range(revision + 1)
+    )
+    return "".join(records).encode()
+
+
+def _rss_bytes() -> int:
+    # Linux ru_maxrss is KiB; this repository's supported development host is Linux.
+    return int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss) * 1024
+
+
+def run_raw_authority_scale_proof(
+    workdir: Path,
+    *,
+    components: int = 16,
+    raws: int = 24,
+    pass_limit: int = 4,
+    keep: bool = False,
+) -> dict[str, object]:
+    """Exercise real authority census/replay and emit a stable receipt payload."""
+    if components < 1 or raws < components or pass_limit < 1:
+        raise ValueError("require components >= 1, raws >= components, and pass_limit >= 1")
+    root = workdir.expanduser().resolve() / "raw-authority-scale-proof"
+    if root.exists():
+        shutil.rmtree(root)
+    initialize_active_archive_root(root)
+    revision_counts = [1] * components
+    for index in range(raws - components):
+        revision_counts[index % components] += 1
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        acquired_at_ms = 0
+        for component, revisions in enumerate(revision_counts):
+            native_id = f"scale-{component:05d}"
+            for revision in range(revisions):
+                archive.write_raw_payload(
+                    provider=Provider.CODEX,
+                    payload=_payload(native_id, revision),
+                    source_path=f"/synthetic/raw-authority/{native_id}.jsonl",
+                    acquired_at_ms=acquired_at_ms,
+                )
+                acquired_at_ms += 1
+    config = Config(archive_root=root, render_root=root, sources=[], db_path=root / "index.db")
+    pass_receipts: list[RawAuthorityScalePass] = []
+    fixed_point_digests: list[str] = []
+    for number in range(1, (components * 3) + 4):
+        started = time.perf_counter()
+        result = repair.repair_raw_materialization(config, raw_artifact_limit=pass_limit)
+        wall_ms = int((time.perf_counter() - started) * 1000)
+        metrics = result.metrics
+        candidate_count = int(metrics.get("raw_materialization_candidate_count", 0))
+        executable_components = int(metrics.get("raw_materialization_selected_executable_component_count", 0))
+        fixed_point = bool(metrics.get("raw_materialization_census_fixed_point", 0))
+        pass_receipts.append(
+            RawAuthorityScalePass(
+                number,
+                candidate_count,
+                result.repaired_count,
+                executable_components,
+                fixed_point,
+                wall_ms,
+                _rss_bytes(),
+            )
+        )
+        digest = result.census_receipt.residual_digest if result.census_receipt is not None else "unavailable"
+        if candidate_count == 0:
+            fixed_point_digests.append(digest)
+            if len(fixed_point_digests) == 2 and fixed_point_digests[-1] == fixed_point_digests[-2]:
+                break
+    else:
+        raise RuntimeError("raw-authority scale proof did not reach two matching quiescent passes")
+    profile_id = f"workload-profile:synthetic-raw-authority:{components}:{raws}"
+    archive_id = f"raw-authority-scale:{hashlib.sha256(str(root).encode()).hexdigest()}"
+    spec = raw_authority_fixed_point_spec(
+        profile_id=profile_id,
+        archive_id=archive_id,
+        scale_tier=WorkloadScaleTier.CI_ACTIVATION,
+    )
+    total_wall_ms = sum(item.wall_ms for item in pass_receipts)
+    peak_rss = max(item.peak_rss_bytes for item in pass_receipts)
+    receipt = WorkloadReceipt.from_observations(
+        spec=spec,
+        status=WorkloadRunStatus.SUCCEEDED,
+        build_id="git:local",
+        runtime_id=f"python:{platform.python_version()}",
+        archive_id=archive_id,
+        generation_id=None,
+        frame_id=None,
+        phases=(
+            WorkloadPhaseObservation(name="generate"),
+            WorkloadPhaseObservation(name="acquire"),
+            WorkloadPhaseObservation(name="census", wall_ms=total_wall_ms, peak_rss_bytes=peak_rss),
+            WorkloadPhaseObservation(name="replay", wall_ms=total_wall_ms, peak_rss_bytes=peak_rss),
+            WorkloadPhaseObservation(name="postflight"),
+            WorkloadPhaseObservation(name="quiescent", cleanup_complete=not keep, quiescent=True),
+        ),
+        cleanup_complete=not keep,
+        notes=(
+            f"requested_components={components}",
+            f"requested_raws={raws}",
+            "This receipt is a generated projection; only an explicit July-15-sized invocation is production-shaped evidence.",
+        ),
+    )
+    payload: dict[str, object] = {
+        "archive_root": str(root),
+        "requested_shape": {"components": components, "raws": raws, "pass_limit": pass_limit},
+        "passes": [asdict(item) for item in pass_receipts],
+        "fixed_point_digests": fixed_point_digests,
+        "receipt": receipt.to_payload(),
+    }
+    (root / "raw-authority-scale-receipt.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    if not keep:
+        shutil.rmtree(root)
+    return payload
+
+
+def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workdir", type=Path, default=Path(".cache") / "raw-authority-scale-proof")
+    parser.add_argument("--components", type=int, default=16)
+    parser.add_argument("--raws", type=int, default=24)
+    parser.add_argument("--pass-limit", type=int, default=4)
+    parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    payload = run_raw_authority_scale_proof(
+        args.workdir, components=args.components, raws=args.raws, pass_limit=args.pass_limit, keep=args.keep
+    )
+    out = stdout
+    if out is None:
+        import sys
+
+        out = sys.stdout
+    receipt = cast(dict[str, object], payload["receipt"])
+    print(json.dumps(payload, indent=2, sort_keys=True) if args.json else receipt["receipt_id"], file=out)
+    return 0
+
+
+__all__ = ["main", "run_raw_authority_scale_proof"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -9,8 +9,10 @@ small projection as production evidence.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import hashlib
 import json
+import os
 import platform
 import resource
 import shutil
@@ -44,6 +46,25 @@ class RawAuthorityScalePass:
     fixed_point: bool
     wall_ms: int
     peak_rss_bytes: int
+    peak_pss_bytes: int | None
+    peak_swap_bytes: int | None
+    cpu_ms: int | None
+    read_io_bytes: int | None
+    write_io_bytes: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class ProcessSample:
+    """Boundary sample for the runner process, using kernel-owned counters."""
+
+    rss_bytes: int
+    pss_bytes: int | None
+    swap_bytes: int | None
+    cpu_ms: int | None
+    read_io_bytes: int | None
+    write_io_bytes: int | None
+    io_full_avg10: float | None
+    memory_full_avg10: float | None
 
 
 def _payload(native_id: str, revision: int) -> bytes:
@@ -60,6 +81,72 @@ def _rss_bytes() -> int:
     return int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss) * 1024
 
 
+def _proc_kb(path: Path, keys: set[str]) -> dict[str, int]:
+    values: dict[str, int] = {}
+    with contextlib.suppress(OSError):
+        for line in path.read_text().splitlines():
+            key, separator, raw = line.partition(":")
+            if separator and key in keys:
+                with contextlib.suppress(ValueError, IndexError):
+                    values[key] = int(raw.split()[0])
+    return values
+
+
+def _pressure_full_avg10(kind: str) -> float | None:
+    with contextlib.suppress(OSError, ValueError):
+        for line in Path(f"/proc/pressure/{kind}").read_text().splitlines():
+            fields = line.split()
+            if not fields or fields[0] != "full":
+                continue
+            for field in fields[1:]:
+                key, _, raw = field.partition("=")
+                if key == "avg10":
+                    return float(raw)
+    return None
+
+
+def _process_sample() -> ProcessSample:
+    pid = os.getpid()
+    status = _proc_kb(Path(f"/proc/{pid}/status"), {"VmRSS", "VmSwap"})
+    smaps = _proc_kb(Path(f"/proc/{pid}/smaps_rollup"), {"Pss", "SwapPss"})
+    process_io = _proc_kb(Path(f"/proc/{pid}/io"), {"read_bytes", "write_bytes"})
+    usage = resource.getrusage(resource.RUSAGE_SELF)
+    return ProcessSample(
+        rss_bytes=int(status.get("VmRSS", 0)) * 1024,
+        pss_bytes=smaps.get("Pss", 0) * 1024 if "Pss" in smaps else None,
+        swap_bytes=smaps.get("SwapPss", 0) * 1024 if "SwapPss" in smaps else None,
+        cpu_ms=round((usage.ru_utime + usage.ru_stime) * 1000),
+        read_io_bytes=process_io.get("read_bytes"),
+        write_io_bytes=process_io.get("write_bytes"),
+        io_full_avg10=_pressure_full_avg10("io"),
+        memory_full_avg10=_pressure_full_avg10("memory"),
+    )
+
+
+def _delta(after: int | None, before: int | None) -> int | None:
+    if after is None or before is None:
+        return None
+    return max(0, after - before)
+
+
+def _assert_admission(
+    sample: ProcessSample, *, max_io_full_avg10: float | None, max_memory_full_avg10: float | None
+) -> None:
+    if max_io_full_avg10 is not None and (value := sample.io_full_avg10) is not None and value > max_io_full_avg10:
+        raise RuntimeError(
+            f"I/O pressure gate refused raw-authority scale proof: full avg10={value:.2f} > {max_io_full_avg10:.2f}"
+        )
+    if (
+        max_memory_full_avg10 is not None
+        and (value := sample.memory_full_avg10) is not None
+        and value > max_memory_full_avg10
+    ):
+        raise RuntimeError(
+            "memory pressure gate refused raw-authority scale proof: "
+            f"full avg10={value:.2f} > {max_memory_full_avg10:.2f}"
+        )
+
+
 def run_raw_authority_scale_proof(
     workdir: Path,
     *,
@@ -67,10 +154,18 @@ def run_raw_authority_scale_proof(
     raws: int = 24,
     pass_limit: int = 4,
     keep: bool = False,
+    max_io_full_avg10: float | None = 2.0,
+    max_memory_full_avg10: float | None = 2.0,
 ) -> dict[str, object]:
     """Exercise real authority census/replay and emit a stable receipt payload."""
     if components < 1 or raws < components or pass_limit < 1:
         raise ValueError("require components >= 1, raws >= components, and pass_limit >= 1")
+    admission_sample = _process_sample()
+    _assert_admission(
+        admission_sample,
+        max_io_full_avg10=max_io_full_avg10,
+        max_memory_full_avg10=max_memory_full_avg10,
+    )
     root = workdir.expanduser().resolve() / "raw-authority-scale-proof"
     if root.exists():
         shutil.rmtree(root)
@@ -107,9 +202,11 @@ def run_raw_authority_scale_proof(
     pass_receipts: list[RawAuthorityScalePass] = []
     fixed_point_digests: list[str] = []
     for number in range(1, (components * 3) + 4):
+        before = _process_sample()
         started = time.perf_counter()
         result = repair.repair_raw_materialization(config, raw_artifact_limit=pass_limit)
         wall_ms = int((time.perf_counter() - started) * 1000)
+        after = _process_sample()
         metrics = result.metrics
         candidate_count = int(metrics.get("raw_materialization_candidate_count", 0))
         executable_components = int(metrics.get("raw_materialization_selected_executable_component_count", 0))
@@ -122,7 +219,16 @@ def run_raw_authority_scale_proof(
                 executable_components,
                 fixed_point,
                 wall_ms,
-                _rss_bytes(),
+                max(_rss_bytes(), before.rss_bytes, after.rss_bytes),
+                max(value for value in (before.pss_bytes, after.pss_bytes) if value is not None)
+                if before.pss_bytes is not None or after.pss_bytes is not None
+                else None,
+                max(value for value in (before.swap_bytes, after.swap_bytes) if value is not None)
+                if before.swap_bytes is not None or after.swap_bytes is not None
+                else None,
+                _delta(after.cpu_ms, before.cpu_ms),
+                _delta(after.read_io_bytes, before.read_io_bytes),
+                _delta(after.write_io_bytes, before.write_io_bytes),
             )
         )
         digest = result.census_receipt.residual_digest if result.census_receipt is not None else "unavailable"
@@ -141,6 +247,11 @@ def run_raw_authority_scale_proof(
     )
     total_wall_ms = sum(item.wall_ms for item in pass_receipts)
     peak_rss = max(item.peak_rss_bytes for item in pass_receipts)
+    peak_pss = max((item.peak_pss_bytes for item in pass_receipts if item.peak_pss_bytes is not None), default=None)
+    peak_swap = max((item.peak_swap_bytes for item in pass_receipts if item.peak_swap_bytes is not None), default=None)
+    total_cpu_ms = sum(item.cpu_ms or 0 for item in pass_receipts)
+    total_read_io = sum(item.read_io_bytes or 0 for item in pass_receipts)
+    total_write_io = sum(item.write_io_bytes or 0 for item in pass_receipts)
     receipt = WorkloadReceipt.from_observations(
         spec=spec,
         status=WorkloadRunStatus.SUCCEEDED,
@@ -152,8 +263,26 @@ def run_raw_authority_scale_proof(
         phases=(
             WorkloadPhaseObservation(name="generate"),
             WorkloadPhaseObservation(name="acquire"),
-            WorkloadPhaseObservation(name="census", wall_ms=total_wall_ms, peak_rss_bytes=peak_rss),
-            WorkloadPhaseObservation(name="replay", wall_ms=total_wall_ms, peak_rss_bytes=peak_rss),
+            WorkloadPhaseObservation(
+                name="census",
+                wall_ms=total_wall_ms,
+                cpu_ms=total_cpu_ms,
+                peak_rss_bytes=peak_rss,
+                peak_pss_bytes=peak_pss,
+                swap_bytes=peak_swap,
+                read_io_bytes=total_read_io,
+                write_io_bytes=total_write_io,
+            ),
+            WorkloadPhaseObservation(
+                name="replay",
+                wall_ms=total_wall_ms,
+                cpu_ms=total_cpu_ms,
+                peak_rss_bytes=peak_rss,
+                peak_pss_bytes=peak_pss,
+                swap_bytes=peak_swap,
+                read_io_bytes=total_read_io,
+                write_io_bytes=total_write_io,
+            ),
             WorkloadPhaseObservation(name="postflight"),
             WorkloadPhaseObservation(name="quiescent", cleanup_complete=not keep, quiescent=True),
         ),
@@ -167,6 +296,7 @@ def run_raw_authority_scale_proof(
     report: dict[str, object] = {
         "archive_root": str(root),
         "requested_shape": {"components": components, "raws": raws, "pass_limit": pass_limit},
+        "admission_sample": asdict(admission_sample),
         "passes": [asdict(item) for item in pass_receipts],
         "fixed_point_digests": fixed_point_digests,
         "receipt": receipt.to_payload(),
@@ -184,10 +314,21 @@ def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
     parser.add_argument("--raws", type=int, default=24)
     parser.add_argument("--pass-limit", type=int, default=4)
     parser.add_argument("--keep", action="store_true")
+    parser.add_argument("--max-io-full-avg10", type=float, default=2.0)
+    parser.add_argument("--max-memory-full-avg10", type=float, default=2.0)
+    parser.add_argument("--allow-contended-host", action="store_true")
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args(argv)
+    pressure_limit = None if args.allow_contended_host else args.max_io_full_avg10
+    memory_limit = None if args.allow_contended_host else args.max_memory_full_avg10
     payload = run_raw_authority_scale_proof(
-        args.workdir, components=args.components, raws=args.raws, pass_limit=args.pass_limit, keep=args.keep
+        args.workdir,
+        components=args.components,
+        raws=args.raws,
+        pass_limit=args.pass_limit,
+        keep=args.keep,
+        max_io_full_avg10=pressure_limit,
+        max_memory_full_avg10=memory_limit,
     )
     out = stdout
     if out is None:

--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -21,6 +21,7 @@ from typing import TextIO, cast
 
 from polylogue.config import Config
 from polylogue.core.enums import Provider
+from polylogue.core.sources import origin_from_provider
 from polylogue.scenarios.workload import (
     WorkloadPhaseObservation,
     WorkloadReceipt,
@@ -31,6 +32,7 @@ from polylogue.schemas.workload_tiers import WorkloadScaleTier
 from polylogue.storage import repair
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw_session
 
 
 @dataclass(frozen=True, slots=True)
@@ -77,17 +79,30 @@ def run_raw_authority_scale_proof(
     for index in range(raws - components):
         revision_counts[index % components] += 1
     with ArchiveStore.open_existing(root, read_only=False) as archive:
+        publisher = archive._blob_publisher
+        if publisher is None:
+            raise RuntimeError("raw-authority scale proof requires a writable blob publisher")
+        source_conn = archive._ensure_source_conn()
         acquired_at_ms = 0
-        for component, revisions in enumerate(revision_counts):
-            native_id = f"scale-{component:05d}"
-            for revision in range(revisions):
-                archive.write_raw_payload(
-                    provider=Provider.CODEX,
-                    payload=_payload(native_id, revision),
-                    source_path=f"/synthetic/raw-authority/{native_id}.jsonl",
-                    acquired_at_ms=acquired_at_ms,
-                )
-                acquired_at_ms += 1
+        with source_conn:
+            for component, revisions in enumerate(revision_counts):
+                native_id = f"scale-{component:05d}"
+                for revision in range(revisions):
+                    payload = _payload(native_id, revision)
+                    blob_hash, _blob_size = publisher.write_from_bytes(payload)
+                    write_source_raw_session(
+                        source_conn,
+                        origin=origin_from_provider(Provider.CODEX),
+                        capture_mode=Provider.CODEX,
+                        source_path=f"/synthetic/raw-authority/{native_id}.jsonl",
+                        source_index=revision,
+                        payload=payload,
+                        acquired_at_ms=acquired_at_ms,
+                        blob_publication_receipt_id=publisher.receipt_id(blob_hash),
+                        manage_transaction=False,
+                    )
+                    acquired_at_ms += 1
+        publisher.flush()
     config = Config(archive_root=root, render_root=root, sources=[], db_path=root / "index.db")
     pass_receipts: list[RawAuthorityScalePass] = []
     fixed_point_digests: list[str] = []
@@ -149,17 +164,17 @@ def run_raw_authority_scale_proof(
             "This receipt is a generated projection; only an explicit July-15-sized invocation is production-shaped evidence.",
         ),
     )
-    payload: dict[str, object] = {
+    report: dict[str, object] = {
         "archive_root": str(root),
         "requested_shape": {"components": components, "raws": raws, "pass_limit": pass_limit},
         "passes": [asdict(item) for item in pass_receipts],
         "fixed_point_digests": fixed_point_digests,
         "receipt": receipt.to_payload(),
     }
-    (root / "raw-authority-scale-receipt.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    (root / "raw-authority-scale-receipt.json").write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
     if not keep:
         shutil.rmtree(root)
-    return payload
+    return report
 
 
 def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:

--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -40,6 +40,7 @@ from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw
 @dataclass(frozen=True, slots=True)
 class RawAuthorityScalePass:
     number: int
+    mode: str
     candidate_count: int
     repaired_count: int
     executable_component_count: int
@@ -147,6 +148,77 @@ def _assert_admission(
         )
 
 
+def _generated_archive_id(rows: list[tuple[str, int, str]]) -> str:
+    """Bind the receipt to corpus content rather than its temporary directory."""
+    manifest = {
+        "format": "raw-authority-scale-proof-v1",
+        "rows": [
+            {"blob_hash": blob_hash, "native_id": native_id, "revision": revision}
+            for native_id, revision, blob_hash in rows
+        ],
+    }
+    encoded = json.dumps(manifest, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+    return f"raw-authority-scale:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _record_repair_pass(
+    *,
+    number: int,
+    mode: str,
+    config: Config,
+    pass_limit: int,
+) -> tuple[RawAuthorityScalePass, str]:
+    """Run one real repair/census pass and reject incomplete evidence."""
+    before = _process_sample()
+    started = time.perf_counter()
+    result = repair.repair_raw_materialization(
+        config,
+        raw_artifact_limit=pass_limit,
+        dry_run=mode == "dry_run",
+    )
+    wall_ms = int((time.perf_counter() - started) * 1000)
+    after = _process_sample()
+    metrics = result.metrics
+    candidate_value = metrics.get("raw_materialization_candidate_count")
+    if (
+        not isinstance(candidate_value, int | float)
+        or isinstance(candidate_value, bool)
+        or not float(candidate_value).is_integer()
+        or candidate_value < 0
+    ):
+        raise RuntimeError(
+            "raw-authority scale proof requires a non-negative integral raw-materialization candidate count"
+        )
+    if result.census_receipt is None:
+        raise RuntimeError("raw-authority scale proof requires a census receipt for every replay pass")
+    receipt = result.census_receipt
+    expected_modes = {"apply", "census"} if mode == "apply" else {"dry_run"}
+    if receipt.mode not in expected_modes:
+        raise RuntimeError(f"raw-authority scale proof expected {mode} census evidence, received {receipt.mode}")
+    return (
+        RawAuthorityScalePass(
+            number=number,
+            mode=receipt.mode,
+            candidate_count=int(candidate_value),
+            repaired_count=result.repaired_count,
+            executable_component_count=int(metrics.get("raw_materialization_selected_executable_component_count", 0)),
+            fixed_point=receipt.fixed_point,
+            wall_ms=wall_ms,
+            peak_rss_bytes=max(_rss_bytes(), before.rss_bytes, after.rss_bytes),
+            peak_pss_bytes=max(value for value in (before.pss_bytes, after.pss_bytes) if value is not None)
+            if before.pss_bytes is not None or after.pss_bytes is not None
+            else None,
+            peak_swap_bytes=max(value for value in (before.swap_bytes, after.swap_bytes) if value is not None)
+            if before.swap_bytes is not None or after.swap_bytes is not None
+            else None,
+            cpu_ms=_delta(after.cpu_ms, before.cpu_ms),
+            read_io_bytes=_delta(after.read_io_bytes, before.read_io_bytes),
+            write_io_bytes=_delta(after.write_io_bytes, before.write_io_bytes),
+        ),
+        receipt.residual_digest,
+    )
+
+
 def run_raw_authority_scale_proof(
     workdir: Path,
     *,
@@ -178,68 +250,58 @@ def run_raw_authority_scale_proof(
         if publisher is None:
             raise RuntimeError("raw-authority scale proof requires a writable blob publisher")
         source_conn = archive._ensure_source_conn()
+        generated_rows: list[tuple[str, int, str]] = []
+        for component, revisions in enumerate(revision_counts):
+            native_id = f"scale-{component:05d}"
+            for revision in range(revisions):
+                blob_hash, _blob_size = publisher.write_from_bytes(_payload(native_id, revision))
+                generated_rows.append((native_id, revision, blob_hash))
+        publisher.flush()
         acquired_at_ms = 0
         with source_conn:
-            for component, revisions in enumerate(revision_counts):
-                native_id = f"scale-{component:05d}"
-                for revision in range(revisions):
-                    payload = _payload(native_id, revision)
-                    blob_hash, _blob_size = publisher.write_from_bytes(payload)
-                    write_source_raw_session(
-                        source_conn,
-                        origin=origin_from_provider(Provider.CODEX),
-                        capture_mode=Provider.CODEX,
-                        source_path=f"/synthetic/raw-authority/{native_id}.jsonl",
-                        source_index=revision,
-                        payload=payload,
-                        acquired_at_ms=acquired_at_ms,
-                        blob_publication_receipt_id=publisher.receipt_id(blob_hash),
-                        manage_transaction=False,
-                    )
-                    acquired_at_ms += 1
-        publisher.flush()
+            for native_id, revision, blob_hash in generated_rows:
+                write_source_raw_session(
+                    source_conn,
+                    origin=origin_from_provider(Provider.CODEX),
+                    capture_mode=Provider.CODEX,
+                    source_path=f"/synthetic/raw-authority/{native_id}.jsonl",
+                    source_index=revision,
+                    payload=_payload(native_id, revision),
+                    acquired_at_ms=acquired_at_ms,
+                    blob_publication_receipt_id=publisher.receipt_id(blob_hash),
+                    manage_transaction=False,
+                )
+                acquired_at_ms += 1
+    archive_id = _generated_archive_id(generated_rows)
     config = Config(archive_root=root, render_root=root, sources=[], db_path=root / "index.db")
     pass_receipts: list[RawAuthorityScalePass] = []
-    fixed_point_digests: list[str] = []
     for number in range(1, (components * 3) + 4):
-        before = _process_sample()
-        started = time.perf_counter()
-        result = repair.repair_raw_materialization(config, raw_artifact_limit=pass_limit)
-        wall_ms = int((time.perf_counter() - started) * 1000)
-        after = _process_sample()
-        metrics = result.metrics
-        candidate_count = int(metrics.get("raw_materialization_candidate_count", 0))
-        executable_components = int(metrics.get("raw_materialization_selected_executable_component_count", 0))
-        fixed_point = bool(metrics.get("raw_materialization_census_fixed_point", 0))
-        pass_receipts.append(
-            RawAuthorityScalePass(
-                number,
-                candidate_count,
-                result.repaired_count,
-                executable_components,
-                fixed_point,
-                wall_ms,
-                max(_rss_bytes(), before.rss_bytes, after.rss_bytes),
-                max(value for value in (before.pss_bytes, after.pss_bytes) if value is not None)
-                if before.pss_bytes is not None or after.pss_bytes is not None
-                else None,
-                max(value for value in (before.swap_bytes, after.swap_bytes) if value is not None)
-                if before.swap_bytes is not None or after.swap_bytes is not None
-                else None,
-                _delta(after.cpu_ms, before.cpu_ms),
-                _delta(after.read_io_bytes, before.read_io_bytes),
-                _delta(after.write_io_bytes, before.write_io_bytes),
-            )
+        pass_receipt, _digest = _record_repair_pass(
+            number=number,
+            mode="apply",
+            config=config,
+            pass_limit=pass_limit,
         )
-        digest = result.census_receipt.residual_digest if result.census_receipt is not None else "unavailable"
-        if candidate_count == 0:
-            fixed_point_digests.append(digest)
-            if len(fixed_point_digests) == 2 and fixed_point_digests[-1] == fixed_point_digests[-2]:
-                break
+        pass_receipts.append(pass_receipt)
+        if pass_receipt.candidate_count == 0:
+            break
     else:
-        raise RuntimeError("raw-authority scale proof did not reach two matching quiescent passes")
+        raise RuntimeError("raw-authority scale proof did not drain bounded apply passes")
+    fixed_point_digests: list[str] = []
+    for _ in range(2):
+        pass_receipt, digest = _record_repair_pass(
+            number=len(pass_receipts) + 1,
+            mode="dry_run",
+            config=config,
+            pass_limit=pass_limit,
+        )
+        if pass_receipt.candidate_count != 0:
+            raise RuntimeError("raw-authority scale proof lost quiescence during fixed-point confirmation")
+        pass_receipts.append(pass_receipt)
+        fixed_point_digests.append(digest)
+    if fixed_point_digests[0] != fixed_point_digests[1] or not pass_receipts[-1].fixed_point:
+        raise RuntimeError("raw-authority scale proof did not reach two matching quiescent fixed-point censuses")
     profile_id = f"workload-profile:synthetic-raw-authority:{components}:{raws}"
-    archive_id = f"raw-authority-scale:{hashlib.sha256(str(root).encode()).hexdigest()}"
     spec = raw_authority_fixed_point_spec(
         profile_id=profile_id,
         archive_id=archive_id,
@@ -263,16 +325,7 @@ def run_raw_authority_scale_proof(
         phases=(
             WorkloadPhaseObservation(name="generate"),
             WorkloadPhaseObservation(name="acquire"),
-            WorkloadPhaseObservation(
-                name="census",
-                wall_ms=total_wall_ms,
-                cpu_ms=total_cpu_ms,
-                peak_rss_bytes=peak_rss,
-                peak_pss_bytes=peak_pss,
-                swap_bytes=peak_swap,
-                read_io_bytes=total_read_io,
-                write_io_bytes=total_write_io,
-            ),
+            WorkloadPhaseObservation(name="census"),
             WorkloadPhaseObservation(
                 name="replay",
                 wall_ms=total_wall_ms,
@@ -290,6 +343,7 @@ def run_raw_authority_scale_proof(
         notes=(
             f"requested_components={components}",
             f"requested_raws={raws}",
+            "repair_raw_materialization combines census and replay; its measured resource totals are recorded once on replay.",
             "This receipt is a generated projection; only an explicit July-15-sized invocation is production-shaped evidence.",
         ),
     )

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -206,6 +206,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools workspace index-fast-forward` | Apply a declared clone-first index.db fast-forward with receipts and rollback. |
 | `devtools workspace index-v37-fast-forward` | Clone-forward index v36 to v37 by retiring derived caches without raw replay. |
 | `devtools workspace lineage-validation` | Validate lineage-count evidence before citing archive counts externally. |
+| `devtools workspace raw-authority-scale-proof` | Run bounded raw-authority replay to a two-census fixed point. |
 | `devtools workspace read-package` | Render a declarative package of Polylogue read artifacts. |
 | `devtools workspace scale-regression` | Run the seeded large-archive scale-regression probe. |
 | `devtools workspace tasks` | Record and query local agent task execution history. |

--- a/polylogue/scenarios/workload.py
+++ b/polylogue/scenarios/workload.py
@@ -612,6 +612,34 @@ def partial_convergence_canary_spec(
     )
 
 
+def raw_authority_fixed_point_spec(
+    *,
+    profile_id: str,
+    archive_id: str,
+    scale_tier: WorkloadScaleTier = WorkloadScaleTier.CI_ACTIVATION,
+) -> WorkloadEnvelopeSpec:
+    """Declare the bounded raw-authority census and replay fixed-point route.
+
+    This is intentionally an envelope over the shared schema-derived corpus,
+    rather than another synthetic archive format.  A production-shaped run
+    binds its revision skew, component closure, and cursor/head conflict
+    distributions to the same profile and receipt as the input corpus.
+    """
+    return _schema_profile_canary_spec(
+        workload_id="canary:raw-authority-fixed-point",
+        profile_id=profile_id,
+        archive_id=archive_id,
+        phases=("generate", "acquire", "census", "replay", "postflight", "quiescent"),
+        distribution_refs=(
+            "archive.raw_revision_shapes",
+            "archive.authority_component_sizes",
+            "operations.cursor_lag",
+            "operations.convergence_debt",
+        ),
+        scale_tier=scale_tier,
+    )
+
+
 def _identity(namespace: str, payload: JSONDocument) -> str:
     encoded = json.dumps(
         payload,
@@ -640,6 +668,7 @@ __all__ = [
     "exact_session_actions_canary_spec",
     "lineage_replay_canary_spec",
     "partial_convergence_canary_spec",
+    "raw_authority_fixed_point_spec",
     "tool_pairing_canary_spec",
     "watcher_append_cohort_canary_spec",
 ]

--- a/tests/unit/devtools/test_raw_authority_scale_proof.py
+++ b/tests/unit/devtools/test_raw_authority_scale_proof.py
@@ -3,11 +3,20 @@ from __future__ import annotations
 from pathlib import Path
 from typing import cast
 
-from devtools.raw_authority_scale_proof import run_raw_authority_scale_proof
+import pytest
+
+from devtools.raw_authority_scale_proof import ProcessSample, run_raw_authority_scale_proof
 
 
 def test_raw_authority_scale_proof_reaches_two_matching_quiescent_censuses(tmp_path: Path) -> None:
-    payload = run_raw_authority_scale_proof(tmp_path, components=3, raws=5, pass_limit=2)
+    payload = run_raw_authority_scale_proof(
+        tmp_path,
+        components=3,
+        raws=5,
+        pass_limit=2,
+        max_io_full_avg10=None,
+        max_memory_full_avg10=None,
+    )
 
     assert payload["requested_shape"] == {"components": 3, "raws": 5, "pass_limit": 2}
     digests = cast(list[str], payload["fixed_point_digests"])
@@ -16,4 +25,25 @@ def test_raw_authority_scale_proof_reaches_two_matching_quiescent_censuses(tmp_p
     assert len(digests) == 2
     assert digests[0] == digests[1]
     assert passes[-1]["candidate_count"] == 0
+    assert all(isinstance(item["peak_rss_bytes"], int) and item["peak_rss_bytes"] > 0 for item in passes)
+    assert "admission_sample" in payload
     assert receipt["status"] == "succeeded"
+
+
+def test_raw_authority_scale_proof_refuses_a_contended_host(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        "devtools.raw_authority_scale_proof._process_sample",
+        lambda: ProcessSample(
+            rss_bytes=1,
+            pss_bytes=1,
+            swap_bytes=0,
+            cpu_ms=0,
+            read_io_bytes=0,
+            write_io_bytes=0,
+            io_full_avg10=2.1,
+            memory_full_avg10=0.0,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="I/O pressure gate"):
+        run_raw_authority_scale_proof(tmp_path, max_io_full_avg10=2.0)

--- a/tests/unit/devtools/test_raw_authority_scale_proof.py
+++ b/tests/unit/devtools/test_raw_authority_scale_proof.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from devtools.raw_authority_scale_proof import run_raw_authority_scale_proof
+
+
+def test_raw_authority_scale_proof_reaches_two_matching_quiescent_censuses(tmp_path: Path) -> None:
+    payload = run_raw_authority_scale_proof(tmp_path, components=3, raws=5, pass_limit=2)
+
+    assert payload["requested_shape"] == {"components": 3, "raws": 5, "pass_limit": 2}
+    digests = cast(list[str], payload["fixed_point_digests"])
+    passes = cast(list[dict[str, object]], payload["passes"])
+    receipt = cast(dict[str, object], payload["receipt"])
+    assert len(digests) == 2
+    assert digests[0] == digests[1]
+    assert passes[-1]["candidate_count"] == 0
+    assert receipt["status"] == "succeeded"

--- a/tests/unit/devtools/test_raw_authority_scale_proof.py
+++ b/tests/unit/devtools/test_raw_authority_scale_proof.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 from typing import cast
 
@@ -22,12 +23,18 @@ def test_raw_authority_scale_proof_reaches_two_matching_quiescent_censuses(tmp_p
     digests = cast(list[str], payload["fixed_point_digests"])
     passes = cast(list[dict[str, object]], payload["passes"])
     receipt = cast(dict[str, object], payload["receipt"])
+    phases = cast(list[dict[str, object]], receipt["phases"])
     assert len(digests) == 2
     assert digests[0] == digests[1]
     assert passes[-1]["candidate_count"] == 0
+    assert passes[-2]["mode"] == "dry_run"
+    assert passes[-1]["mode"] == "dry_run"
+    assert passes[-1]["fixed_point"] is True
     assert all(isinstance(item["peak_rss_bytes"], int) and item["peak_rss_bytes"] > 0 for item in passes)
     assert "admission_sample" in payload
     assert receipt["status"] == "succeeded"
+    assert isinstance(phases[3]["wall_ms"], int | float) and phases[3]["wall_ms"] > 0
+    assert "wall_ms" not in phases[2]
 
 
 def test_raw_authority_scale_proof_refuses_a_contended_host(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -47,3 +54,31 @@ def test_raw_authority_scale_proof_refuses_a_contended_host(monkeypatch: pytest.
 
     with pytest.raises(RuntimeError, match="I/O pressure gate"):
         run_raw_authority_scale_proof(tmp_path, max_io_full_avg10=2.0)
+
+
+def test_raw_authority_scale_proof_consumes_reservations_and_has_stable_corpus_identity(tmp_path: Path) -> None:
+    first = run_raw_authority_scale_proof(
+        tmp_path / "first",
+        components=3,
+        raws=5,
+        pass_limit=2,
+        keep=True,
+        max_io_full_avg10=None,
+        max_memory_full_avg10=None,
+    )
+    second = run_raw_authority_scale_proof(
+        tmp_path / "second",
+        components=3,
+        raws=5,
+        pass_limit=2,
+        keep=True,
+        max_io_full_avg10=None,
+        max_memory_full_avg10=None,
+    )
+
+    first_root = Path(cast(str, first["archive_root"]))
+    with sqlite3.connect(first_root / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM blob_publication_reservations").fetchone() == (0,)
+    first_receipt = cast(dict[str, object], first["receipt"])
+    second_receipt = cast(dict[str, object], second["receipt"])
+    assert first_receipt["archive_id"] == second_receipt["archive_id"]

--- a/tests/unit/scenarios/test_workload_receipts.py
+++ b/tests/unit/scenarios/test_workload_receipts.py
@@ -18,6 +18,7 @@ from polylogue.scenarios.workload import (
     WorkloadRunStatus,
     evaluate_budgets,
     exact_session_actions_canary_spec,
+    raw_authority_fixed_point_spec,
 )
 from polylogue.schemas.workload_tiers import WorkloadScaleTier, WorkloadSelectivityTier
 
@@ -197,3 +198,21 @@ def test_exact_session_actions_canary_uses_shared_tier_and_receipt_contract() ->
     assert passing.budget_results[0].verdict is BudgetVerdict.PASS
     assert exceeded.budget_results[0].verdict is BudgetVerdict.EXCEEDED
     assert exceeded.spec.semantic_result == "complete"
+
+
+def test_raw_authority_fixed_point_canary_uses_shared_corpus_identity() -> None:
+    spec = raw_authority_fixed_point_spec(
+        profile_id="workload-profile:sha256:raw-authority",
+        archive_id="seeded-archive:sha256:raw-authority",
+        scale_tier=WorkloadScaleTier.ARCHIVE_1X,
+    )
+
+    assert spec.workload_id == "canary:raw-authority-fixed-point"
+    assert spec.inputs[0].scale_tier == WorkloadScaleTier.ARCHIVE_1X.value
+    assert spec.inputs[0].distribution_refs == (
+        "archive.raw_revision_shapes",
+        "archive.authority_component_sizes",
+        "operations.cursor_lag",
+        "operations.convergence_debt",
+    )
+    assert spec.phases == ("generate", "acquire", "census", "replay", "postflight", "quiescent")


### PR DESCRIPTION
## Summary

Make the raw-authority scale scenario safe to schedule on a shared host and make its resource evidence usable for the July-shape fixed-point gate.

## Problem

The first cardinality run used the one-row archive writer for every synthetic raw. That writer correctly flushes and commits ordinary acquisitions, but at 15,264 rows it turned scenario generation into an I/O storm before authority replay could be measured. The original receipt also reported only `ru_maxrss`, which cannot distinguish process memory, swap, or the workload’s own I/O.

## Solution

The runner now uses the source writer’s documented bulk transaction contract: it writes each payload to the existing blob publisher, inserts source rows in one transaction with `manage_transaction=False`, then flushes once. It samples kernel-owned process RSS/PSS/swap, CPU, and read/write I/O counters around each replay pass and includes measured values in its receipt. It refuses to start when host I/O or memory full-stall pressure is above a conservative threshold; `--allow-contended-host` is an explicit operator override for intentionally contended experiments.

Replay semantics and the production archive writer remain unchanged.

## Verification

- `devtools test tests/unit/devtools/test_raw_authority_scale_proof.py` — `2 passed`
- `devtools verify --quick` — format, lint, strict mypy, generated-surface, topology, layering, schema, and policy gates passed.

## Remaining evidence

The full July-shape run remains deliberately pending until host I/O pressure falls below admission. This PR supplies the safe, measurable runner; it does not claim the full-scale result.
