### PR TITLE
fix(schemas): batch large journal units

### DIFF
--- a/polylogue/schemas/generation/observation_journal.py
+++ b/polylogue/schemas/generation/observation_journal.py
@@ -30,6 +30,8 @@ _ROOT_MODE = 0o700
 _FILE_MODE = 0o600
 _COMMIT_UNIT_LIMIT = 1_024
 _COMMIT_PAYLOAD_BYTES_LIMIT = 32 * 1024 * 1024
+_SAMPLE_INSERT_BATCH_ROWS = 512
+_SAMPLE_INSERT_BATCH_BYTES = 1024 * 1024
 _DISTINCT_UNIT_COLUMNS = frozenset({"bundle_scope", "exact_structure_id", "profile_family_id"})
 DistinctUnitColumn = Literal["bundle_scope", "exact_structure_id", "profile_family_id"]
 _SCOPE_KEY_SQL = (
@@ -324,15 +326,6 @@ class ObservationJournal:
         """Append one canonical unit and its independently replayable samples."""
         cluster_payload_json = _canonical_json(unit.cluster_payload if retain_cluster_payload else {})
         profile_tokens_json = _canonical_json(list(unit.profile_tokens))
-        sample_payload_bytes = 0
-
-        def sample_rows() -> Iterator[tuple[int, bytes]]:
-            nonlocal sample_payload_bytes
-            for position, sample in enumerate(unit.schema_samples):
-                sample_json = _canonical_json(sample)
-                sample_payload_bytes += len(sample_json)
-                yield position, sample_json
-
         cursor = self._connection.execute(
             """
             INSERT INTO units(
@@ -357,12 +350,31 @@ class ObservationJournal:
         if cursor.lastrowid is None:
             raise RuntimeError("Observation journal did not return a unit identity")
         unit_id = cursor.lastrowid
-        self._connection.executemany(
-            "INSERT INTO samples(unit_id, position, sample_json) VALUES (?, ?, ?)",
-            ((unit_id, position, sample_json) for position, sample_json in sample_rows()),
-        )
+
+        sample_rows: list[tuple[int, bytes]] = []
+        sample_payload_bytes = 0
+
+        def write_sample_batch() -> None:
+            nonlocal sample_payload_bytes
+            if not sample_rows:
+                return
+            self._connection.executemany(
+                "INSERT INTO samples(unit_id, position, sample_json) VALUES (?, ?, ?)",
+                ((unit_id, position, sample_json) for position, sample_json in sample_rows),
+            )
+            self._record_pending_write(sample_payload_bytes)
+            sample_rows.clear()
+            sample_payload_bytes = 0
+
+        for position, sample in enumerate(unit.schema_samples):
+            sample_json = _canonical_json(sample)
+            sample_rows.append((position, sample_json))
+            sample_payload_bytes += len(sample_json)
+            if len(sample_rows) >= _SAMPLE_INSERT_BATCH_ROWS or sample_payload_bytes >= _SAMPLE_INSERT_BATCH_BYTES:
+                write_sample_batch()
+        write_sample_batch()
         self._pending_unit_count += 1
-        self._record_pending_write(len(cluster_payload_json) + len(profile_tokens_json) + sample_payload_bytes)
+        self._record_pending_write(len(cluster_payload_json) + len(profile_tokens_json))
         return unit_id
 
     def record_terminal(

--- a/tests/unit/core/test_schema_observation_journal.py
+++ b/tests/unit/core/test_schema_observation_journal.py
@@ -257,6 +257,23 @@ def test_journal_flushes_private_ingest_before_replay(tmp_path: Path) -> None:
             assert reader.execute("SELECT COUNT(*) FROM samples").fetchone() == (2,)
 
 
+def test_large_single_unit_commits_sample_batches_before_unit_finishes(tmp_path: Path) -> None:
+    """One transcript cannot turn the complete private WAL budget into one transaction."""
+    unit = SchemaUnit(
+        cluster_payload={},
+        schema_samples=[{"payload": "x" * (1024 * 1024)} for _ in range(33)],
+        artifact_kind="session_record_stream",
+        exact_structure_id="large-stream",
+        profile_tokens=("field:payload",),
+    )
+    with ObservationJournal.create(root=tmp_path / "journals") as journal:
+        journal.append_unit(unit)
+
+        with sqlite3.connect(journal.path) as reader:
+            committed_samples = reader.execute("SELECT COUNT(*) FROM samples").fetchone()[0]
+        assert 0 < committed_samples < len(unit.schema_samples)
+
+
 def test_selective_membership_replay_uses_units_before_samples(tmp_path: Path) -> None:
     """Package replay must not scan every sample before applying its package filter."""
     with ObservationJournal.create(root=tmp_path / "journals") as journal:


### PR DESCRIPTION
## Summary

Batches sample insertion inside one schema observation unit so an unusually
large Codex transcript cannot create one multi-gigabyte private WAL
transaction.

## Problem

Live Codex regeneration established that an individual `SchemaUnit` can carry
223,710 samples. The prior transaction repair committed between units, but only
after all samples in a unit had been inserted; that still allowed one giant
unit to exceed the intended journal transaction window.

## Solution

Insert sample rows in bounded row/byte batches and account each completed batch
toward the existing private transaction budget. No sample, schema observation,
or generated output is dropped; incomplete journals remain private staging and
are removed on interruption.

Ref polylogue-1xc.14.1.1.

## Verification

- `devtools test tests/unit/core/test_schema_observation_journal.py` — 15 passed.
- `devtools verify --quick` — all checks passed.
- Pre-push quick baseline — passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large observation journals by committing sample data in manageable batches during ingestion.
  * Reduced the risk of delayed writes and excessive memory usage when processing units with many large samples.

* **Tests**
  * Added regression coverage confirming that large sample sets are committed incrementally before ingestion completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->