### PR TITLE
fix(extension): stop replacing operator-owned transport tabs

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -47,6 +47,7 @@ const BACKFILL_PAGE_REQUEST_TIMEOUT_MS = 58000;
 const BACKFILL_TRANSPORT_TAB_TTL_MS = 5 * 60 * 1000;
 const BACKFILL_TRANSPORT_CLEANUP_PREFIX = "polylogueBackfillTransportCleanup";
 const PROVIDER_TRANSPORT_SESSION_PREFIX = "polylogueProviderTransportTab";
+const PROVIDER_TRANSPORT_OPERATOR_TAKEN_SESSION_PREFIX = "polylogueProviderTransportOperatorTaken";
 const recentBackgroundCaptures = new Map();
 const recentActiveTabStateChecks = new Map();
 let backfillCoordinatorPromise = null;
@@ -1397,30 +1398,57 @@ function providerTransportSessionKey(provider) {
   return `${PROVIDER_TRANSPORT_SESSION_PREFIX}:${provider}`;
 }
 
+function providerTransportOperatorTakenSessionKey(provider) {
+  return `${PROVIDER_TRANSPORT_OPERATOR_TAKEN_SESSION_PREFIX}:${provider}`;
+}
+
 async function forgetProviderTransport(provider, tabId = null) {
   const key = providerTransportSessionKey(provider);
-  const stored = await chrome.storage.session.get({ [key]: null });
-  if (tabId === null || stored[key] === tabId) await chrome.storage.session.remove(key);
+  const operatorTakenKey = providerTransportOperatorTakenSessionKey(provider);
+  const stored = await chrome.storage.session.get({ [key]: null, [operatorTakenKey]: null });
+  if (tabId === null || stored[key] === tabId) {
+    await chrome.storage.session.remove([key, operatorTakenKey]);
+  }
+}
+
+async function markProviderTransportOperatorTaken(provider, tabId) {
+  const key = providerTransportSessionKey(provider);
+  const operatorTakenKey = providerTransportOperatorTakenSessionKey(provider);
+  await chrome.storage.session.set({ [key]: tabId, [operatorTakenKey]: tabId });
+}
+
+function operatorTakenProviderTransportError() {
+  const error = new Error("provider_transport_operator_taken");
+  error.code = "provider_transport_operator_taken";
+  return error;
 }
 
 async function acquireProviderTab(provider) {
   const key = providerTransportSessionKey(provider);
-  const stored = await chrome.storage.session.get({ [key]: null });
+  const operatorTakenKey = providerTransportOperatorTakenSessionKey(provider);
+  const stored = await chrome.storage.session.get({ [key]: null, [operatorTakenKey]: null });
   const storedTabId = stored[key];
   if (Number.isInteger(storedTabId)) {
     const existing = await chrome.tabs.get(storedTabId).catch(() => null);
-    if (
-      existing
-      && existing.active !== true
-      && providerForUrl(existing.url || existing.pendingUrl) === provider
-    ) {
-      return {
-        tab: existing,
-        owned: true,
-        cleanupAlarm: `${BACKFILL_TRANSPORT_CLEANUP_PREFIX}:${provider}:${storedTabId}`,
-      };
+    if (!existing) {
+      await forgetProviderTransport(provider, storedTabId);
+    } else {
+      if (stored[operatorTakenKey] === storedTabId) throw operatorTakenProviderTransportError();
+      if (existing.active === true) {
+        // A previously background-owned tab has become an operator surface. It
+        // must never be repurposed, closed, or replaced behind their back.
+        await markProviderTransportOperatorTaken(provider, storedTabId);
+        throw operatorTakenProviderTransportError();
+      }
+      if (providerForUrl(existing.url || existing.pendingUrl) === provider) {
+        return {
+          tab: existing,
+          owned: true,
+          cleanupAlarm: `${BACKFILL_TRANSPORT_CLEANUP_PREFIX}:${provider}:${storedTabId}`,
+        };
+      }
+      await forgetProviderTransport(provider, storedTabId);
     }
-    await forgetProviderTransport(provider, storedTabId);
   }
   const url = provider === "chatgpt" ? "https://chatgpt.com/" : "https://claude.ai/";
   const created = await chrome.tabs.create({ url, active: false });
@@ -1561,8 +1589,19 @@ async function cleanupBackfillTransportTab(alarmName) {
   const provider = parts[1];
   const tabId = Number.parseInt(parts[2] || "", 10);
   if (!provider || !Number.isInteger(tabId)) return;
+  const operatorTakenKey = providerTransportOperatorTakenSessionKey(provider);
+  const stored = await chrome.storage.session.get({ [operatorTakenKey]: null });
+  if (stored[operatorTakenKey] === tabId) {
+    await chrome.alarms.clear(alarmName);
+    return;
+  }
   try {
     const tab = await chrome.tabs.get(tabId);
+    if (tab?.active === true) {
+      await markProviderTransportOperatorTaken(provider, tabId);
+      await chrome.alarms.clear(alarmName);
+      return;
+    }
     if (providerForUrl(tab?.url || tab?.pendingUrl) === provider) await chrome.tabs.remove(tabId);
   } catch {
     // The operator or browser already closed the inactive transport tab.
@@ -2627,6 +2666,13 @@ chrome.tabs?.onUpdated?.addListener((tabId, changeInfo, tab) => {
       await captureTab(resolvedTab, "tab_updated");
     }
   })();
+});
+
+chrome.tabs?.onRemoved?.addListener((tabId) => {
+  void Promise.all([
+    forgetProviderTransport("chatgpt", tabId),
+    forgetProviderTransport("claude-ai", tabId),
+  ]);
 });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -5,6 +5,7 @@ let messageListener;
 let installedListener;
 let activatedListener;
 let updatedListener;
+let removedListener;
 let alarmListener;
 let stored;
 let sessionStored;
@@ -21,6 +22,7 @@ function installChromeMock(storagePatch = {}) {
   installedListener = null;
   activatedListener = null;
   updatedListener = null;
+  removedListener = null;
   alarmListener = null;
   fetchCalls = [];
   sessionStored = {};
@@ -117,6 +119,11 @@ function installChromeMock(storagePatch = {}) {
       onUpdated: {
         addListener: vi.fn((fn) => {
           updatedListener = fn;
+        }),
+      },
+      onRemoved: {
+        addListener: vi.fn((fn) => {
+          removedListener = fn;
         }),
       },
       query: vi.fn(async () => tabs),
@@ -690,6 +697,33 @@ describe("background receiver diagnostics", () => {
     expect(chatGptTabs).toHaveLength(1);
     expect(globalThis.chrome.tabs.create).toHaveBeenCalledWith({ url: "https://chatgpt.com/", active: false });
     expect(globalThis.chrome.scripting.executeScript.mock.calls.every(([details]) => details.target.tabId === 99)).toBe(true);
+  });
+
+  it("does not replace a provider transport tab once the operator activates it", async () => {
+    await loadBackground();
+    const transportKey = "polylogueProviderTransportTab:chatgpt";
+    const takenKey = "polylogueProviderTransportOperatorTaken:chatgpt";
+    tabs = [{ id: 99, url: "https://chatgpt.com/", active: true, status: "complete" }];
+    sessionStored = { [transportKey]: 99 };
+
+    alarmListener({ name: "polylogueBackfillTransportCleanup:chatgpt:99" });
+    await vi.waitFor(() => expect(sessionStored[takenKey]).toBe(99));
+    expect(globalThis.chrome.tabs.remove).not.toHaveBeenCalledWith(99);
+
+    const started = await sendRuntimeMessage({
+      type: "polylogue.backfill.start",
+      provider: "chatgpt",
+      cutoff: "2026-01-01T00:00:00Z",
+    });
+
+    expect(started.ok).toBe(true);
+    await vi.waitFor(() => expect(globalThis.chrome.tabs.get).toHaveBeenCalledWith(99));
+    expect(globalThis.chrome.tabs.create.mock.calls.filter(([request]) => request.url === "https://chatgpt.com/")).toHaveLength(0);
+
+    tabs = [];
+    removedListener(99);
+    await vi.waitFor(() => expect(sessionStored[transportKey]).toBeUndefined());
+    expect(sessionStored[takenKey]).toBeUndefined();
   });
 
   it("retries coordinator initialization after recovery storage fails once", async () => {


### PR DESCRIPTION
## Summary

Preserve an extension-created provider transport tab once an operator activates it, preventing automatic ChatGPT root-tab replacement loops.

## Problem

The automatic freshness sweep runs through an inactive authenticated ChatGPT tab. Its five-minute cleanup and active-tab rejection previously forgot that tab, so later work created a replacement root tab. Activating the newest empty tab could therefore lead to unbounded visible tab churn.

## Solution

Track an operator-taken transport tab in session storage. It is neither reused nor closed; freshness work receives a typed unavailable result until Chrome reports the tab closed. The existing inactive transport cleanup remains unchanged.

## Verification

- `npm test -- --run tests/background.test.js` — 75 passed
- `npm run lint -- --quiet` — passed

Ref polylogue-yyvg.7