### PR TITLE
fix(schemas): classify evidence sidecars before decoding

### DIFF
--- a/polylogue/archive/raw_payload/decode.py
+++ b/polylogue/archive/raw_payload/decode.py
@@ -23,6 +23,24 @@ WireFormat = Literal["json", "jsonl"]
 JSONRecord: TypeAlias = JSONDocument
 
 
+def _decode_provider_utf8(raw: bytes) -> str:
+    """Decode provider bytes while preserving UTF-8-encoded surrogate code units.
+
+    Some historical exports contain a lone UTF-16 surrogate encoded directly
+    as its three-byte UTF-8 sequence. This is invalid Unicode scalar UTF-8,
+    so ``orjson`` correctly rejects it, but Python can preserve the original
+    code unit with ``surrogatepass``. Arbitrary malformed byte sequences still
+    raise and retain the ordinary malformed-JSONL behavior.
+    """
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError as error:
+        try:
+            return raw.decode("utf-8", errors="surrogatepass")
+        except UnicodeDecodeError:
+            raise error from None
+
+
 def _load_json_record(line: str) -> JSONValue:
     try:
         return loads(line)
@@ -32,6 +50,19 @@ def _load_json_record(line: str) -> JSONValue:
         import json
 
         return cast("JSONValue", json.loads(line))
+
+
+def _load_raw_json(raw: bytes | str) -> JSONValue:
+    """Parse a JSON document, retaining recoverable provider surrogates."""
+    try:
+        return loads(raw)
+    except (orjson.JSONDecodeError, ValueError) as error:
+        if not isinstance(raw, bytes):
+            raise
+        try:
+            return _load_json_record(_decode_provider_utf8(raw))
+        except (orjson.JSONDecodeError, ValueError, UnicodeDecodeError):
+            raise error from None
 
 
 @dataclass(frozen=True)
@@ -66,7 +97,7 @@ def _decode_jsonl_payload(
         for raw_line in stream:
             line_number += 1
             try:
-                line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
+                line = _decode_provider_utf8(raw_line) if isinstance(raw_line, bytes) else raw_line
             except UnicodeDecodeError as exc:
                 malformed_lines += 1
                 if malformed_detail is None:
@@ -118,7 +149,7 @@ def _sample_jsonl_payload_with_detail(
         for raw_line in stream:
             line_number += 1
             try:
-                line = raw_line.decode("utf-8") if isinstance(raw_line, bytes) else raw_line
+                line = _decode_provider_utf8(raw_line) if isinstance(raw_line, bytes) else raw_line
             except UnicodeDecodeError as exc:
                 malformed_lines += 1
                 if malformed_detail is None:
@@ -188,7 +219,7 @@ def _decode_raw_payload(
                 pass
         raw_bytes = raw_content.read_bytes()
         try:
-            return loads(raw_bytes), "json", 0, None
+            return _load_raw_json(raw_bytes), "json", 0, None
         except (orjson.JSONDecodeError, ValueError) as exc:
             try:
                 payload, malformed_lines, malformed_detail = _decode_jsonl_payload(
@@ -213,7 +244,7 @@ def _decode_raw_payload(
         except (UnicodeDecodeError, ValueError):
             pass
     try:
-        return loads(raw), "json", 0, None
+        return _load_raw_json(raw), "json", 0, None
     except (orjson.JSONDecodeError, ValueError) as exc:
         try:
             payload, malformed_lines, malformed_detail = _decode_jsonl_payload(

--- a/polylogue/schemas/sampling_db.py
+++ b/polylogue/schemas/sampling_db.py
@@ -12,6 +12,7 @@ from typing import Literal, TypeAlias, overload
 import ijson
 from ijson.common import ObjectBuilder
 
+from polylogue.archive.artifact_taxonomy import classify_artifact_path
 from polylogue.archive.raw_payload import extract_record_samples_from_raw_content
 from polylogue.archive.raw_payload.decode import RawPayloadEnvelope
 from polylogue.core.enums import Origin, Provider
@@ -281,6 +282,20 @@ def _iter_schema_units_from_db(
                 break
             for row in batch:
                 raw_content = blob_store.blob_path(_blob_hash_hex(row.blob_hash))
+
+                path_classification = classify_artifact_path(
+                    row.source_path,
+                    provider=row.provider_token or source_name,
+                )
+                if path_classification is not None and not path_classification.schema_eligible:
+                    _record_terminal(
+                        terminal_recorder,
+                        row,
+                        status="intentionally_excluded",
+                        reason=f"artifact_taxonomy:{path_classification.reason}",
+                        artifact_kind=path_classification.kind.value,
+                    )
+                    continue
 
                 if row.validation_status == "failed":
                     _record_terminal(

--- a/tests/unit/core/test_raw_payload_decode.py
+++ b/tests/unit/core/test_raw_payload_decode.py
@@ -33,6 +33,21 @@ def test_sample_jsonl_payload_accepts_lone_surrogates_via_stdlib_fallback(tmp_pa
     assert any(sample.get("text") == "broken \udce2 surrogate" for sample in dict_samples)
 
 
+def test_raw_json_payload_preserves_utf8_encoded_lone_surrogates(tmp_path: Path) -> None:
+    """Historical provider bytes may encode a lone UTF-16 surrogate directly."""
+    path = tmp_path / "surrogate.json"
+    path.write_bytes(b'{"text":"broken \xed\xa0\x80 provider value"}')
+
+    envelope = build_raw_payload_envelope(
+        path,
+        source_path=str(path),
+        fallback_provider="hermes",
+    )
+
+    payload = _as_dict(envelope.payload)
+    assert payload["text"] == "broken \ud800 provider value"
+
+
 def test_build_raw_payload_envelope_reports_first_bad_jsonl_line(tmp_path: Path) -> None:
     path = tmp_path / "broken.jsonl"
     path.write_text('{"ok": 1}\n{"broken": \n{"ok": 2}\n', encoding="utf-8")

--- a/tests/unit/core/test_sampling.py
+++ b/tests/unit/core/test_sampling.py
@@ -391,6 +391,37 @@ class TestLoadSamplesFromDb:
             bad_raw_id: "payload_decode_failed",
         }
 
+    def test_schema_observation_excludes_hermes_sqlite_evidence_before_json_decode(self, tmp_path: Path) -> None:
+        db = _archive_index_db(tmp_path)
+        raw_id = _insert_raw_session(
+            db_path=db,
+            origin="hermes-session",
+            source_path="/tmp/hermes/verification_evidence.db",
+            raw_content=b"SQLite format 3\x00\x10\x00\x02\x02",
+        )
+        outcomes: list[dict[str, object]] = []
+
+        units = list(
+            iter_schema_units(
+                "hermes",
+                db_path=db,
+                full_corpus=True,
+                terminal_recorder=lambda **outcome: outcomes.append(outcome),
+            )
+        )
+
+        assert all(unit.raw_id != raw_id for unit in units)
+        target_outcomes = [outcome for outcome in outcomes if outcome["raw_id"] == raw_id]
+        assert target_outcomes == [
+            {
+                "raw_id": raw_id,
+                "status": "intentionally_excluded",
+                "artifact_kind": "metadata_document",
+                "source_path": "/tmp/hermes/verification_evidence.db",
+                "reason": "artifact_taxonomy:Hermes SQLite evidence sidecar",
+            }
+        ]
+
 
 class TestLoadSamplesFromSessions:
     def test_nonexistent_dir_returns_empty(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Classify known Hermes SQLite evidence sidecars before raw decoding, and retain valid recoverable UTF-8-encoded surrogates in historical JSON/JSONL exports.

## Problem

Two `verification_evidence.db` artifacts entered the generic JSON decoder during full-corpus Hermes schema inference. They are SQLite files, not malformed JSON or a UTF-8 character, so the prior failure message obscured their true type and did not provide a typed terminal outcome.

## Solution

The sampling source now consults artifact taxonomy before payload decoding and records a typed `intentionally_excluded` terminal result for non-schema artifacts. Raw payload decoding uses `surrogatepass` only for recoverable UTF-8-encoded surrogate code units; arbitrary malformed bytes still fail normally. Focused tests exercise both contracts.

Ref polylogue-1xc.14.1.1.

## Verification

- `devtools test tests/unit/core/test_raw_payload_decode.py tests/unit/core/test_sampling.py` — 42 passed.
- `devtools lab schema generate --provider hermes --cluster --full-corpus --json` — successful; 188 included units and no decoder stderr.
- Direct full-archive terminal receipt — two `metadata_document` sidecars intentionally excluded; two unsupported template artifacts and one provider mismatch remain explicitly represented.
- `devtools verify --quick` — success.
- Pre-push quick baseline — success.