### PR TITLE
fix(daemon): bound raw maintenance admission

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -69,7 +69,9 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 _CONVERGENCE_DEBT_RETRY_INTERVAL_SECONDS = 60
 _RAW_MATERIALIZATION_CONVERGENCE_INTERVAL_SECONDS = 30
-_RAW_MATERIALIZATION_CONVERGENCE_BATCH_LIMIT = 25
+_RAW_MATERIALIZATION_CONVERGENCE_BATCH_LIMIT = 1
+_RAW_MATERIALIZATION_DAEMON_BLOB_LIMIT_BYTES = 64 * 1024 * 1024
+_RAW_MATERIALIZATION_LIVE_SPOOL_BACKOFF_SECONDS = 60
 
 
 async def _run_startup_fts_readiness(coordinator: DaemonWriteCoordinator) -> None:
@@ -507,6 +509,10 @@ async def _periodic_raw_materialization_convergence_after(
     if catch_up_complete is not None:
         await catch_up_complete.wait()
     while True:
+        if _browser_capture_spool_has_pending_files():
+            logger.info("raw materialization: yielding to pending browser-capture spool files")
+            await asyncio.sleep(_RAW_MATERIALIZATION_LIVE_SPOOL_BACKOFF_SECONDS)
+            continue
         try:
             materialized = await daemon_write_coordinator().run_sync(
                 "maintenance.raw_materialization",
@@ -630,7 +636,12 @@ def _drain_raw_materialization_once(*, limit: int = _RAW_MATERIALIZATION_CONVERG
 
     recover_interrupted_raw_authority_frontier(config)
     try:
-        result = repair_raw_materialization(config, dry_run=False, raw_artifact_limit=limit)
+        result = repair_raw_materialization(
+            config,
+            dry_run=False,
+            raw_artifact_limit=limit,
+            max_payload_bytes=_RAW_MATERIALIZATION_DAEMON_BLOB_LIMIT_BYTES,
+        )
     finally:
         _close_raw_materialization_fts(config.archive_root / "index.db")
     _emit_raw_materialization_pass(result)
@@ -638,6 +649,42 @@ def _drain_raw_materialization_once(*, limit: int = _RAW_MATERIALIZATION_CONVERG
     if not result.success:
         logger.warning("raw materialization: bounded convergence incomplete: %s", result.detail)
     return result.repaired_count + frontier_repaired
+
+
+def _browser_capture_spool_has_pending_files() -> bool:
+    """Whether live browser evidence is awaiting its normal ingest route."""
+    from polylogue.paths import browser_capture_spool_root
+    from polylogue.sources.live.batch import fingerprint_file
+    from polylogue.sources.live.cursor import CursorStore
+    from polylogue.sources.live.watcher import _PARSER_FINGERPRINT
+
+    spool = browser_capture_spool_root()
+    if not spool.exists():
+        return False
+    cursor_store = CursorStore(_active_index_db_path())
+    for path in spool.rglob("*.json"):
+        try:
+            stat = path.stat()
+        except FileNotFoundError:
+            continue
+        cursor = cursor_store.get_record(path)
+        if cursor is None or cursor.excluded or cursor.failure_count:
+            return True
+        if (
+            cursor.parser_fingerprint != _PARSER_FINGERPRINT
+            or cursor.byte_size != stat.st_size
+            or cursor.st_dev != stat.st_dev
+            or cursor.st_ino != stat.st_ino
+            or cursor.mtime_ns != stat.st_mtime_ns
+            or cursor.content_fingerprint is None
+        ):
+            try:
+                fingerprint, _last_newline = fingerprint_file(path)
+            except OSError:
+                return True
+            if fingerprint != cursor.content_fingerprint:
+                return True
+    return False
 
 
 def _converge_raw_authority_frontier(config: Any, *, limit: int) -> int:

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -65,7 +65,17 @@ class RawRevisionReplayResourceBlockedError(RuntimeError):
         super().__init__(f"{len(raw_ids)} raw revision(s) total {total_bytes} bytes exceed replay limit {limit_bytes}")
 
 
-def uncensused_historical_revision_raw_ids(archive_root: Path, raw_ids: list[str]) -> tuple[str, ...]:
+def _resource_blocked_parser_fingerprint(max_payload_bytes: int) -> str:
+    """Return the durable admission identity for one bounded census envelope."""
+    return f"revision-membership-v1:resource-blocked:{max_payload_bytes}"
+
+
+def uncensused_historical_revision_raw_ids(
+    archive_root: Path,
+    raw_ids: list[str],
+    *,
+    max_payload_bytes: int | None = None,
+) -> tuple[str, ...]:
     """Return inputs whose current parser identity has not been persisted.
 
     The dedicated receipt proves that the current parser actually observed
@@ -76,6 +86,9 @@ def uncensused_historical_revision_raw_ids(archive_root: Path, raw_ids: list[str
     if not raw_ids:
         return ()
     placeholders = ",".join("?" for _ in raw_ids)
+    resource_blocked_fingerprint = (
+        _resource_blocked_parser_fingerprint(max_payload_bytes) if max_payload_bytes is not None else None
+    )
     with sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True) as conn:
         rows = conn.execute(
             f"""
@@ -88,11 +101,56 @@ def uncensused_historical_revision_raw_ids(archive_root: Path, raw_ids: list[str
                   AND c.status = 'complete',
                   0
               )
+              AND NOT COALESCE(
+                  c.parser_fingerprint = ?
+                  AND c.status = 'failed',
+                  0
+              )
             ORDER BY r.raw_id
             """,
-            raw_ids,
+            [*raw_ids, resource_blocked_fingerprint],
         ).fetchall()
     return tuple(str(row[0]) for row in rows)
+
+
+def record_resource_blocked_revision_census(
+    archive_root: Path,
+    raw_ids: tuple[str, ...],
+    *,
+    max_payload_bytes: int,
+    total_payload_bytes: int,
+) -> None:
+    """Persist a non-terminal no-retry receipt for immutable oversized bytes.
+
+    ``failed`` is deliberately truthful: the current parser has not inspected
+    the payload.  The fingerprint binds that fact to the exact admission
+    envelope, so increasing the envelope (or changing the parser identity)
+    re-admits the raw without a timer-driven retry storm.
+    """
+    if not raw_ids:
+        return
+    fingerprint = _resource_blocked_parser_fingerprint(max_payload_bytes)
+    detail = (
+        "current parser census deferred before blob open: "
+        f"component payload {total_payload_bytes} exceeds envelope {max_payload_bytes}"
+    )
+    with sqlite3.connect(archive_root / "source.db") as conn, conn:
+        for raw_id in raw_ids:
+            conn.execute(
+                """
+                INSERT INTO raw_authority_parser_census (
+                    raw_id, parser_fingerprint, status, logical_keys_json,
+                    detail, censused_at_ms
+                ) VALUES (?, ?, 'failed', '[]', ?, 0)
+                ON CONFLICT(raw_id) DO UPDATE SET
+                    parser_fingerprint = excluded.parser_fingerprint,
+                    status = excluded.status,
+                    logical_keys_json = excluded.logical_keys_json,
+                    detail = excluded.detail,
+                    censused_at_ms = excluded.censused_at_ms
+                """,
+                (raw_id, fingerprint, detail),
+            )
 
 
 def _record_raw_authority_parser_census(archive_root: Path, raw_ids: tuple[str, ...]) -> None:
@@ -539,5 +597,7 @@ __all__ = [
     "RevisionCensusResult",
     "backfill_historical_revision_evidence",
     "census_historical_revision_evidence",
+    "record_resource_blocked_revision_census",
+    "uncensused_historical_revision_raw_ids",
     "parse_retained_raw_sessions",
 ]

--- a/polylogue/storage/raw_authority.py
+++ b/polylogue/storage/raw_authority.py
@@ -677,6 +677,40 @@ def raw_replay_plan_last_attempts(archive_root: Path) -> dict[str, int]:
         }
 
 
+def raw_replay_plan_deferred_for_envelope(archive_root: Path, *, max_payload_bytes: int) -> set[str]:
+    """Return unchanged plans already deferred for this exact resource envelope.
+
+    Plan identity includes the raw and index preconditions.  A changed source
+    component therefore gets a new plan id and is immediately eligible; only
+    the same immutable plan is held out of periodic maintenance.
+    """
+    source_db = archive_root / "source.db"
+    if not source_db.is_file():
+        return set()
+    reason = f"resource-envelope:{max_payload_bytes}"
+    with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as conn:
+        exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='raw_authority_census_plans'"
+        ).fetchone()
+        if exists is None:
+            return set()
+        return {
+            str(row[0])
+            for row in conn.execute(
+                """
+                SELECT cp.plan_id
+                FROM raw_authority_census_plans AS cp
+                JOIN raw_authority_censuses AS c ON c.census_id = cp.census_id
+                WHERE cp.selected = 1
+                  AND cp.outcome_status = 'deferred'
+                  AND cp.reason = ?
+                  AND c.lifecycle_status IN ('completed', 'interrupted')
+                """,
+                (reason,),
+            )
+        }
+
+
 def unresolved_raw_authority_blockers(archive_root: Path) -> int:
     source_db = archive_root / "source.db"
     if not source_db.is_file():
@@ -1618,6 +1652,7 @@ __all__ = [
     "raw_authority_census_query_handle",
     "raw_authority_detail_query_handle",
     "raw_replay_plan_last_attempts",
+    "raw_replay_plan_deferred_for_envelope",
     "recover_interrupted_raw_authority_censuses",
     "read_raw_authority_census",
     "read_raw_authority_detail",

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -62,6 +62,7 @@ from polylogue.storage.raw_authority import (
     build_raw_replay_plans,
     finalize_raw_authority_census,
     raw_replay_application_receipt,
+    raw_replay_plan_deferred_for_envelope,
     raw_replay_plan_last_attempts,
     record_raw_authority_census,
     record_raw_replay_outcome,
@@ -5456,9 +5457,12 @@ def repair_raw_materialization(
     source_family: str | None = None,
     source_root: Path | None = None,
     raw_artifact_limit: int | None = None,
+    max_payload_bytes: int = RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES,
     progress_callback: ProgressCallback | None = None,
 ) -> RepairResult:
     """Converge retained raws through typed per-session revision authority."""
+    if max_payload_bytes < 1:
+        raise ValueError("max_payload_bytes must be positive")
     archive_root = _raw_materialization_archive_root(config)
     recovered_censuses = recover_interrupted_raw_authority_censuses(archive_root)
     for recovered_census_id, recovered_scope in recovered_censuses:
@@ -5502,7 +5506,9 @@ def repair_raw_materialization(
     )
 
     relevant_raw_ids = list(candidates.expanded_raw_ids or tuple(candidates.raw_ids))
-    uncensused_raw_ids = set(uncensused_historical_revision_raw_ids(archive_root, relevant_raw_ids))
+    uncensused_raw_ids = set(
+        uncensused_historical_revision_raw_ids(archive_root, relevant_raw_ids, max_payload_bytes=max_payload_bytes)
+    )
     census_failed_raw_ids: set[str] = set()
     census_resource_blocked_raw_ids: set[str] = set()
     census_component_limit = (
@@ -5524,7 +5530,7 @@ def repair_raw_materialization(
                 census_historical_revision_evidence(
                     archive_root,
                     selected_raw_ids=[seed],
-                    max_payload_bytes=RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES,
+                    max_payload_bytes=max_payload_bytes,
                 )
             except RawRevisionReplayResourceBlockedError as exc:
                 logger.warning(
@@ -5533,6 +5539,14 @@ def repair_raw_materialization(
                     exc,
                 )
                 census_resource_blocked_raw_ids.update(component)
+                from polylogue.sources.revision_backfill import record_resource_blocked_revision_census
+
+                record_resource_blocked_revision_census(
+                    archive_root,
+                    tuple(sorted(uncensused_raw_ids.intersection(component))),
+                    max_payload_bytes=max_payload_bytes,
+                    total_payload_bytes=exc.total_bytes,
+                )
             except Exception:
                 logger.exception("raw authority census failed for component containing %s", seed)
                 census_failed_raw_ids.update(component)
@@ -5544,7 +5558,9 @@ def repair_raw_materialization(
             source_root=source_root,
         )
         relevant_raw_ids = list(candidates.expanded_raw_ids or tuple(candidates.raw_ids))
-        uncensused_raw_ids = set(uncensused_historical_revision_raw_ids(archive_root, relevant_raw_ids))
+        uncensused_raw_ids = set(
+            uncensused_historical_revision_raw_ids(archive_root, relevant_raw_ids, max_payload_bytes=max_payload_bytes)
+        )
     census_pending_raw_ids = tuple(sorted(uncensused_raw_ids | census_failed_raw_ids))
     if census_pending_raw_ids:
         residual = _raw_authority_residual(candidates, census_pending_raw_ids=census_pending_raw_ids)
@@ -5583,14 +5599,11 @@ def repair_raw_materialization(
         )
         if census_resource_blocked_raw_ids:
             metrics["raw_materialization_resource_blocked_count"] = float(len(census_resource_blocked_raw_ids))
-            metrics["raw_materialization_execute_blob_limit_bytes"] = float(
-                RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
-            )
+            metrics["raw_materialization_execute_blob_limit_bytes"] = float(max_payload_bytes)
             oversized = {
                 raw_id
                 for raw_id in census_resource_blocked_raw_ids
-                if _raw_materialization_component_blob_bytes(candidates, raw_id)
-                > RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
+                if _raw_materialization_component_blob_bytes(candidates, raw_id) > max_payload_bytes
             }
             if oversized:
                 metrics["raw_materialization_oversized_count"] = float(len(oversized))
@@ -5606,7 +5619,7 @@ def repair_raw_materialization(
         if census_resource_blocked_raw_ids:
             detail += (
                 f"; {len(census_resource_blocked_raw_ids):,} raw(s) belong to authority components whose "
-                f"aggregate payload exceeds {_format_bytes(RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES)}"
+                f"aggregate payload exceeds {_format_bytes(max_payload_bytes)}"
             )
         return _internal_derived_repair_result(
             "raw_materialization",
@@ -5624,12 +5637,16 @@ def repair_raw_materialization(
         component
         for component in ordered_components
         if sum(_raw_materialization_component_blob_bytes(candidates, member) for member in component)
-        > RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
+        > max_payload_bytes
     ]
     all_blocked_component_raw_ids = {raw_id for component in all_blocked_components for raw_id in component}
     selected_components = (
         ordered_components[:raw_artifact_limit] if raw_artifact_limit is not None else ordered_components
     )
+    deferred_plan_ids = raw_replay_plan_deferred_for_envelope(archive_root, max_payload_bytes=max_payload_bytes)
+    selected_components = [
+        component for component in selected_components if plan_by_component[component].plan_id not in deferred_plan_ids
+    ]
     blocked_components = [
         component for component in selected_components if all_blocked_component_raw_ids.intersection(component)
     ]
@@ -5638,9 +5655,9 @@ def repair_raw_materialization(
         RawReplayPlanOutcome(
             plan_by_component[component].plan_id,
             component,
-            RawReplayPlanStatus.RETRYABLE,
-            "authority component exceeds the bounded replay resource envelope",
-            "retry the same plan after streaming/resource admission is available",
+            RawReplayPlanStatus.DEFERRED,
+            f"resource-envelope:{max_payload_bytes}",
+            "retry only after a larger resource envelope or changed source/index preconditions",
         )
         for component in blocked_components
     )
@@ -5675,12 +5692,12 @@ def repair_raw_materialization(
     metrics["raw_materialization_selected_blocked_component_count"] = float(len(blocked_components))
     if all_blocked_component_raw_ids:
         metrics["raw_materialization_resource_blocked_count"] = float(len(all_blocked_component_raw_ids))
-        metrics["raw_materialization_execute_blob_limit_bytes"] = float(RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES)
+        metrics["raw_materialization_execute_blob_limit_bytes"] = float(max_payload_bytes)
     diagnostic_component_raw_ids = selected_component_raw_ids | all_blocked_component_raw_ids
     oversized_candidate_raw_ids = [
         raw_id
         for raw_id in diagnostic_component_raw_ids
-        if _raw_materialization_component_blob_bytes(candidates, raw_id) > RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES
+        if _raw_materialization_component_blob_bytes(candidates, raw_id) > max_payload_bytes
     ]
     oversized_stream_safe_raw_ids = [
         raw_id for raw_id in oversized_candidate_raw_ids if _raw_materialization_stream_safe(candidates, raw_id)
@@ -5692,9 +5709,23 @@ def repair_raw_materialization(
             metrics.get("raw_materialization_resource_blocked_count", 0.0),
             float(len(oversized_raw_ids)),
         )
-        metrics["raw_materialization_execute_blob_limit_bytes"] = float(RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES)
+        metrics["raw_materialization_execute_blob_limit_bytes"] = float(max_payload_bytes)
     if oversized_stream_safe_raw_ids:
         metrics["raw_materialization_stream_oversized_count"] = float(len(oversized_stream_safe_raw_ids))
+    if deferred_plan_ids:
+        metrics["raw_materialization_deferred_plan_count"] = float(len(deferred_plan_ids))
+    if not selected_components and deferred_plan_ids:
+        return _internal_derived_repair_result(
+            "raw_materialization",
+            repaired_count=0,
+            success=True,
+            detail=(
+                "Raw materialization has no newly admissible authority components; "
+                f"{len(deferred_plan_ids):,} unchanged plan(s) remain deferred for "
+                f"the {_format_bytes(max_payload_bytes)} envelope"
+            ),
+            metrics=metrics,
+        )
     selected_plan_ids = {plan_by_component[component].plan_id for component in selected_components}
     executable_plan_ids = {
         plan_by_component[component].plan_id
@@ -5883,7 +5914,7 @@ def repair_raw_materialization(
             part = backfill_historical_revision_evidence(
                 archive_root,
                 selected_raw_ids=[raw_id],
-                max_payload_bytes=RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES,
+                max_payload_bytes=max_payload_bytes,
             )
         except RawRevisionReplayResourceBlockedError as exc:
             metrics["raw_materialization_resource_blocked_count"] = max(
@@ -5892,9 +5923,9 @@ def repair_raw_materialization(
             outcome = RawReplayPlanOutcome(
                 plan.plan_id,
                 component,
-                RawReplayPlanStatus.RETRYABLE,
-                "expanded authority component exceeded the bounded replay resource envelope",
-                "retry the same plan after streaming/resource admission is available",
+                RawReplayPlanStatus.DEFERRED,
+                f"resource-envelope:{max_payload_bytes}",
+                "retry only after a larger resource envelope or changed source/index preconditions",
             )
             record_raw_replay_outcome(archive_root, census_receipt.census_id, outcome)
             execution_outcomes.append(outcome)

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -543,12 +543,19 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
         calls["restore_sample_size"] = sample_size
         return FakeRestoreResult()
 
-    def fake_repair_raw_materialization(config: Config, *, dry_run: bool, raw_artifact_limit: int) -> FakeResult:
+    def fake_repair_raw_materialization(
+        config: Config,
+        *,
+        dry_run: bool,
+        raw_artifact_limit: int,
+        max_payload_bytes: int,
+    ) -> FakeResult:
         order.append("materialize")
         calls["archive_root"] = config.archive_root
         calls["render_root"] = config.render_root
         calls["dry_run"] = dry_run
         calls["raw_artifact_limit"] = raw_artifact_limit
+        calls["max_payload_bytes"] = max_payload_bytes
         return FakeResult()
 
     def fake_recover(config: Config) -> tuple[str, ...]:
@@ -586,6 +593,7 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
         "render_root": tmp_path / "render",
         "dry_run": False,
         "raw_artifact_limit": 11,
+        "max_payload_bytes": daemon_cli._RAW_MATERIALIZATION_DAEMON_BLOB_LIMIT_BYTES,
         "recover_archive_root": tmp_path / "archive",
         "frontier_archive_root": tmp_path / "archive",
         "frontier_limit": 8,
@@ -955,6 +963,24 @@ def test_periodic_raw_materialization_convergence_waits_for_catch_up_complete(
     asyncio.run(exercise())
 
     assert calls == ["drain"]
+
+
+def test_periodic_raw_materialization_yields_to_pending_browser_capture_spool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polylogue.daemon import cli as daemon_cli
+
+    async def fake_sleep(seconds: float) -> None:
+        assert seconds == daemon_cli._RAW_MATERIALIZATION_LIVE_SPOOL_BACKOFF_SECONDS
+        raise asyncio.CancelledError
+
+    async def fail_run_sync(*_args: object, **_kwargs: object) -> object:
+        pytest.fail("raw maintenance must not acquire the writer ahead of pending browser capture")
+
+    monkeypatch.setattr(daemon_cli, "_browser_capture_spool_has_pending_files", lambda: True)
+    monkeypatch.setattr(daemon_cli, "daemon_write_coordinator", lambda: SimpleNamespace(run_sync=fail_run_sync))
+    with patch("asyncio.sleep", side_effect=fake_sleep), pytest.raises(asyncio.CancelledError):
+        asyncio.run(daemon_cli._periodic_raw_materialization_convergence())
 
 
 def test_periodic_session_insight_convergence_waits_for_catch_up_complete(

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -1647,14 +1647,27 @@ def test_raw_materialization_blocks_oversized_actual_replay(
     monkeypatch.setattr("polylogue.pipeline.services.parsing.ParsingService", UnexpectedParsingService)
 
     result = repair_mod.repair_raw_materialization(config, dry_run=False)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        first_census_count = int(conn.execute("SELECT COUNT(*) FROM raw_authority_censuses").fetchone()[0])
+        parser_fingerprint = str(
+            conn.execute(
+                "SELECT parser_fingerprint FROM raw_authority_parser_census WHERE raw_id = ?", (raw_id,)
+            ).fetchone()[0]
+        )
+    repeated = repair_mod.repair_raw_materialization(config, dry_run=False)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        repeated_census_count = int(conn.execute("SELECT COUNT(*) FROM raw_authority_censuses").fetchone()[0])
 
     assert result.success is False
     assert result.repaired_count == 0
-    assert "planning paused" in result.detail
+    assert "replay candidate(s) remain" in result.detail
     assert result.metrics["raw_materialization_oversized_count"] == 1.0
     assert result.metrics["raw_materialization_resource_blocked_count"] == 1.0
     assert result.metrics["raw_materialization_executed_count"] == 0.0
     assert result.metrics["raw_materialization_execute_blob_limit_bytes"] == float(1024 * 1024 * 1024)
+    assert parser_fingerprint.endswith(":resource-blocked:1073741824")
+    assert repeated.success is True
+    assert repeated_census_count == first_census_count
 
 
 def test_raw_materialization_classifies_oversized_stream_record_replay(
@@ -1831,8 +1844,10 @@ def test_raw_materialization_blocks_aggregate_sub_limit_cohort_before_blob_open(
     assert result.success is False
     assert result.metrics["raw_materialization_resource_blocked_count"] == 2.0
     assert len(result.plan_outcomes) == 1
-    assert result.plan_outcomes[0].status.value == "retryable"
-    assert result.plan_outcomes[0].plan_id == repeated.plan_outcomes[0].plan_id
+    assert result.plan_outcomes[0].status.value == "deferred"
+    assert repeated.success is True
+    assert repeated.plan_outcomes == ()
+    assert "unchanged plan(s) remain deferred" in repeated.detail
     assert "aggregate payload exceeds 1.0 GiB" in result.detail
 
 
@@ -1920,7 +1935,7 @@ def test_raw_materialization_durable_ledger_survives_ops_reset_for_fairness(
     )
 
     first = repair_mod.repair_raw_materialization(_config(tmp_path), raw_artifact_limit=1)
-    assert first.plan_outcomes[0].status.value == "retryable"
+    assert first.plan_outcomes[0].status.value == "deferred"
     (tmp_path / "ops.db").unlink()
 
     second = repair_mod.repair_raw_materialization(_config(tmp_path), raw_artifact_limit=1)


### PR DESCRIPTION
## Summary
Bounds periodic raw-authority maintenance so it cannot repeatedly monopolize
Polylogue's single writer while browser capture is waiting.

## Problem
The daemon was admitting up to 25 raw-authority components every 30 seconds,
each with a 1 GiB resource envelope. Unchanged resource-blocked cohorts were
re-censused indefinitely, leaving fresh browser-capture receiver files spooled
without source-tier ingestion.

## Solution
- Persist resource-blocked parser census receipts keyed by the exact byte
envelope; the raw remains explicitly non-complete but is not re-admitted under
that same envelope.
- Persist matching replay plans as `deferred` and skip only unchanged plan
identities. New source evidence, changed index preconditions, a parser change,
or a larger envelope re-admit the work.
- Use a daemon-only 64 MiB / one-component maintenance quantum.
- Yield raw maintenance before writer admission while cursor evidence shows
browser-capture spool files still need live ingestion.

## Verification
- `devtools test tests/unit/storage/test_repair.py -k raw_materialization`
  — 33 passed.
- `devtools test tests/unit/daemon/test_daemon_cli.py -k raw_materialization`
  — 12 passed.
- `devtools verify --quick` — exit 0; format, lint, mypy, generated surfaces,
  schema roundtrip, layering, and policy checks passed.

Ref polylogue-hjpx
