### PR TITLE
fix(extension): reconcile terminal captures before fetch

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -2014,7 +2014,17 @@ async function ensureCaptureFreshnessAlarms() {
 async function captureSupportedTabs(reason) {
   if (!chrome.tabs?.query) return;
   const tabs = await chrome.tabs.query({});
-  await Promise.allSettled(tabs.map((tab) => captureTab(tab, reason)));
+  // Explicit operator sync may recapture an open conversation.  Automatic
+  // lifecycle events must reconcile with the receiver first: `spooled_only`
+  // means the receiver already accepted a capture and is converging it, not
+  // that the extension should re-fetch authenticated provider data.  This is
+  // deliberately durable across service-worker restarts, unlike the in-memory
+  // background-capture throttle.
+  if (reason === "popup_sync_open_tabs") {
+    await Promise.allSettled(tabs.map((tab) => captureTab(tab, reason)));
+    return;
+  }
+  await Promise.allSettled(tabs.map((tab) => refreshActiveTabArchiveState(tab, reason)));
 }
 
 function bytesToBase64(bytes) {
@@ -2672,10 +2682,7 @@ chrome.runtime.onStartup?.addListener(() => {
 chrome.tabs?.onActivated?.addListener((activeInfo) => {
   void (async () => {
     const tab = await chrome.tabs.get(activeInfo.tabId);
-    const archiveState = await refreshActiveTabArchiveState(tab, "tab_activated");
-    if (archiveState && !["missing", "receiver_error", "not_conversation"].includes(archiveState)) {
-      await captureTab(tab, "tab_activated");
-    }
+    await refreshActiveTabArchiveState(tab, "tab_activated");
   })();
 });
 
@@ -2683,10 +2690,7 @@ chrome.tabs?.onUpdated?.addListener((tabId, changeInfo, tab) => {
   if (changeInfo?.status !== "complete" && !changeInfo?.url) return;
   void (async () => {
     const resolvedTab = tab?.id ? tab : await chrome.tabs.get(tabId);
-    const archiveState = await refreshActiveTabArchiveState(resolvedTab, "tab_updated");
-    if (archiveState && !["missing", "receiver_error", "not_conversation"].includes(archiveState)) {
-      await captureTab(resolvedTab, "tab_updated");
-    }
+    await refreshActiveTabArchiveState(resolvedTab, "tab_updated");
   })();
 });
 

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -616,18 +616,22 @@ describe("background receiver diagnostics", () => {
     expect(stored.polylogueState).toMatchObject({ online: true, error: "no_turns" });
   });
 
-  it("automatically captures existing conversation tabs on extension update", async () => {
+  it("reconciles existing conversation tabs on extension update without recapturing", async () => {
     expect(installedListener).toBeTypeOf("function");
     tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-installed", title: "ChatGPT" }];
-    globalThis.fetch = vi.fn(async () => responseJson({ ok: true, active: true }));
+    globalThis.fetch = vi.fn(async () => responseJson({
+      provider: "chatgpt",
+      provider_session_id: "conv-installed",
+      state: "spooled_only",
+      captured: true,
+    }));
 
     installedListener();
 
-    await vi.waitFor(() => expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
-      type: "polylogue.capturePage",
-      reason: "extension_installed_or_updated",
-    }));
-    expect(globalThis.chrome.scripting.executeScript).toHaveBeenCalled();
+    await vi.waitFor(() => expect(stored.polylogueSessionLedger["chatgpt:conv-installed"]?.archive_state)
+      .toMatchObject({ state: "spooled_only" }));
+    expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
+    expect(globalThis.chrome.scripting.executeScript).not.toHaveBeenCalled();
   });
 
   it("routes backfill inventory through an existing provider page without creating a tab", async () => {
@@ -1616,7 +1620,7 @@ describe("background receiver diagnostics", () => {
     expect(timeline[0]).toMatchObject({ reason: "auto_capture_missing", detail: "spooled_only" });
   });
 
-  it("does not hand a throttled archive-state refresh to automatic capture", async () => {
+  it("does not recapture an already-safe conversation on activation", async () => {
     tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-throttle", title: "ChatGPT" }];
     globalThis.fetch = vi.fn(async () => responseJson({
       provider: "chatgpt",
@@ -1626,13 +1630,35 @@ describe("background receiver diagnostics", () => {
     }));
 
     activatedListener({ tabId: 42 });
-    await vi.waitFor(() => expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(stored.polylogueState?.archive_state?.state).toBe("archived"));
     activatedListener({ tabId: 42 });
     await new Promise((resolve) => globalThis.setTimeout(resolve, 20));
 
-    expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledTimes(1);
+    expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
     expect((stored.polylogueConversationTimeline?.["chatgpt:conv-throttle"] || [])
       .some((event) => event.detail === "background_capture_throttled")).toBe(false);
+  });
+
+  it("captures a missing conversation once during automatic reconciliation", async () => {
+    tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-missing-on-start", title: "ChatGPT" }];
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).includes("/v1/archive-state")) {
+        return responseJson({
+          provider: "chatgpt",
+          provider_session_id: "conv-missing-on-start",
+          state: "missing",
+          captured: false,
+        });
+      }
+      return responseJson({ error: "unexpected" }, { ok: false, status: 500 });
+    });
+
+    installedListener();
+
+    await vi.waitFor(() => expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      type: "polylogue.capturePage",
+      reason: "auto_capture_missing",
+    }));
   });
 
   it("keeps the earliest freshness deadline when a later hint is queued", async () => {


### PR DESCRIPTION
## Summary
Stops the installed extension from re-fetching provider conversation data for conversations the receiver already accepted or archived.

## Problem
Live Chrome evidence showed `fetchNativePayloadFromContentScript` repeatedly retrieving a completed Sol-Pro conversation and two attachments every few seconds. Startup, tab activation, and tab-update paths directly captured terminal conversations; service-worker restarts reset their in-memory throttle and amplified receiver faults into authenticated ChatGPT traffic.

## Solution
Automatic lifecycle paths now reconcile each tab against receiver archive state. Only a `missing` state triggers automatic capture; `spooled_only` and archived states remain receiver-owned convergence. Explicit popup sync remains an operator-requested direct capture. Focused tests cover terminal startup/activation non-recapture and missing-state capture.

Ref polylogue-yyvg.6.1.

## Verification
- `npm test -- --run tests/background.test.js` — 76 passed.
- `npm run lint` — passed.
- `devtools verify --quick` — 16/16 steps passed.
- `npm test` — 314 passed; one inherited failure in `tests/build.test.js > executes the packaged service worker fixture without foreground tab activation`, reproduced unchanged on current `master`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate background captures when activating, updating, or synchronizing open conversation tabs.
  * Improved archive-state reconciliation during extension updates and tab events.
  * Ensured missing conversations are automatically captured only once.
  * Prevented unnecessary capture messages and throttling events when conversations are already archived.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->