### PR TITLE
fix(extension): add automatic capture circuit breaker

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -549,7 +549,7 @@ function hostnameForUrl(url) {
 
 async function ambientSettings(hostname = "") {
   const stored = await chrome.storage.local.get({
-    [AMBIENT_SETTINGS_KEY]: { enabled: true, disabled_sites: {} },
+    [AMBIENT_SETTINGS_KEY]: { enabled: true, automatic_capture_enabled: true, disabled_sites: {} },
   });
   const raw = stored[AMBIENT_SETTINGS_KEY] && typeof stored[AMBIENT_SETTINGS_KEY] === "object"
     ? stored[AMBIENT_SETTINGS_KEY]
@@ -557,13 +557,14 @@ async function ambientSettings(hostname = "") {
   const disabledSites = raw.disabled_sites && typeof raw.disabled_sites === "object" ? raw.disabled_sites : {};
   return {
     enabled: raw.enabled !== false,
+    automatic_capture_enabled: raw.automatic_capture_enabled !== false,
     disabled_sites: disabledSites,
     site: hostname || null,
     site_enabled: hostname ? disabledSites[hostname] !== true : true,
   };
 }
 
-async function saveAmbientSettings({ enabled = null, hostname = "", siteEnabled = null } = {}) {
+async function saveAmbientSettings({ enabled = null, automaticCaptureEnabled = null, hostname = "", siteEnabled = null } = {}) {
   const current = await ambientSettings(hostname);
   const disabledSites = { ...current.disabled_sites };
   if (hostname && siteEnabled !== null) {
@@ -572,10 +573,17 @@ async function saveAmbientSettings({ enabled = null, hostname = "", siteEnabled 
   }
   const next = {
     enabled: enabled === null ? current.enabled : Boolean(enabled),
+    automatic_capture_enabled: automaticCaptureEnabled === null
+      ? current.automatic_capture_enabled
+      : Boolean(automaticCaptureEnabled),
     disabled_sites: disabledSites,
   };
   await chrome.storage.local.set({ [AMBIENT_SETTINGS_KEY]: next });
   return ambientSettings(hostname);
+}
+
+async function automaticCaptureEnabled() {
+  return (await ambientSettings()).automatic_capture_enabled;
 }
 
 function sessionKey(provider, providerSessionId) {
@@ -1651,6 +1659,9 @@ async function captureTab(tab, reason = "background", expectedConversation = nul
     || !conversationIdForUrl(conversationUrl)
     || !injectionPlanForUrl(conversationUrl).length
   ) return null;
+  if (reason !== "popup_sync_open_tabs" && !(await automaticCaptureEnabled())) {
+    return { ok: false, skipped: true, reason: "automatic_capture_paused" };
+  }
   const now = Date.now();
   const lastCaptureAt = recentBackgroundCaptures.get(tab.id) || 0;
   if (
@@ -1854,6 +1865,10 @@ async function scheduleNextCaptureFreshnessWake(queueValue = null) {
 }
 
 async function processCaptureFreshnessQueueOnce() {
+  if (!(await automaticCaptureEnabled())) {
+    await chrome.alarms?.clear?.(CAPTURE_FRESHNESS_ALARM);
+    return { processed: 0, paused: true };
+  }
   const owner = await extensionInstanceId();
   const now = Date.now();
   const { queue, claim } = await serializeStorageMutation(async () => {
@@ -1943,6 +1958,9 @@ function processCaptureFreshnessQueue() {
 }
 
 async function runCaptureFreshnessSweep() {
+  if (!(await automaticCaptureEnabled())) {
+    return { skipped: true, reason: "automatic_capture_paused" };
+  }
   const now = Date.now();
   let queue = await storedCaptureFreshnessQueue();
   if (queue.sweep_not_before_ms > now) return { skipped: true, reason: "sweep_backoff" };
@@ -2722,9 +2740,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       const url = sender.tab?.url || sender.tab?.pendingUrl || message.url || "";
       const settings = await saveAmbientSettings({
         enabled: message.enabled ?? null,
+        automaticCaptureEnabled: message.automatic_capture_enabled ?? null,
         hostname: message.hostname || hostnameForUrl(url),
         siteEnabled: message.site_enabled ?? null,
       });
+      if (settings.automatic_capture_enabled) await ensureCaptureFreshnessAlarms();
+      else await chrome.alarms?.clear?.(CAPTURE_FRESHNESS_ALARM);
       sendResponse({ ok: true, ambient: settings });
       return;
     }

--- a/browser-extension/src/popup.html
+++ b/browser-extension/src/popup.html
@@ -350,6 +350,11 @@
           <label for="ambient-site-enabled">Show it on this site</label>
           <input id="ambient-site-enabled" type="checkbox">
         </div>
+        <div class="switch-row">
+          <label for="automatic-capture-enabled">Automatic capture and provider refresh</label>
+          <input id="automatic-capture-enabled" type="checkbox">
+        </div>
+        <p class="section-note">Pause this only to stop automatic provider traffic during an incident. Explicit capture remains available.</p>
         <p id="assertion-status" class="section-note">Text selections can form a local assertion candidate. Save remains disabled until the authenticated receiver advertises an assertion route.</p>
       </section>
 

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -454,6 +454,7 @@ function ambientFallback(raw, tabUrl) {
   try { hostname = new URL(tabUrl || "").hostname; } catch { hostname = ""; }
   return {
     enabled: settings.enabled !== false,
+    automatic_capture_enabled: settings.automatic_capture_enabled !== false,
     disabled_sites: disabledSites,
     site: hostname || null,
     site_enabled: hostname ? disabledSites[hostname] !== true : true,
@@ -464,12 +465,14 @@ function renderAmbient(ambient, tabUrl = "", assertions = null) {
   const enabledNode = document.getElementById("ambient-enabled");
   const siteNode = document.getElementById("ambient-site-enabled");
   const siteLabel = document.getElementById("ambient-site");
+  const automaticCaptureNode = document.getElementById("automatic-capture-enabled");
   const assertionNode = document.getElementById("assertion-status");
   if (enabledNode) enabledNode.checked = ambient?.enabled !== false;
   if (siteNode) {
     siteNode.checked = ambient?.site_enabled !== false;
     siteNode.disabled = !providerFromUrl(tabUrl) || providerFromUrl(tabUrl) === "unknown";
   }
+  if (automaticCaptureNode) automaticCaptureNode.checked = ambient?.automatic_capture_enabled !== false;
   if (siteLabel) siteLabel.textContent = ambient?.site || hostLabel(tabUrl || "") || "Current site";
   if (assertionNode) {
     assertionNode.textContent = assertions?.persistence_supported
@@ -715,6 +718,14 @@ document.getElementById("ambient-site-enabled")?.addEventListener("change", asyn
     type: "polylogue.ambient.configure",
     url: tab?.url || "",
     site_enabled: Boolean(event.target.checked),
+  });
+  await render();
+});
+
+document.getElementById("automatic-capture-enabled")?.addEventListener("change", async (event) => {
+  await chrome.runtime.sendMessage({
+    type: "polylogue.ambient.configure",
+    automatic_capture_enabled: Boolean(event.target.checked),
   });
   await render();
 });

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -1661,6 +1661,27 @@ describe("background receiver diagnostics", () => {
     }));
   });
 
+  it("does not fetch a missing conversation while automatic capture is paused", async () => {
+    tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-paused", title: "ChatGPT" }];
+    await sendRuntimeMessage({
+      type: "polylogue.ambient.configure",
+      automatic_capture_enabled: false,
+    });
+    globalThis.fetch = vi.fn(async () => responseJson({
+      provider: "chatgpt",
+      provider_session_id: "conv-paused",
+      state: "missing",
+      captured: false,
+    }));
+
+    installedListener();
+
+    await vi.waitFor(() => expect(stored.polylogueSessionLedger["chatgpt:conv-paused"]?.archive_state)
+      .toMatchObject({ state: "missing" }));
+    expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
+    expect(globalThis.chrome.alarms.clear).toHaveBeenCalledWith("polylogueCaptureFreshnessWake");
+  });
+
   it("keeps the earliest freshness deadline when a later hint is queued", async () => {
     vi.spyOn(Date, "now").mockReturnValue(100_000);
     await sendRuntimeMessage({
@@ -2320,12 +2341,31 @@ describe("ambient capture status", () => {
 
     expect(response).toMatchObject({
       ok: true,
-      ambient: { enabled: true, site_enabled: false, site: "chatgpt.com" },
+      ambient: { enabled: true, automatic_capture_enabled: true, site_enabled: false, site: "chatgpt.com" },
     });
     expect(stored.polylogueAmbientSettings).toEqual({
       enabled: true,
+      automatic_capture_enabled: true,
       disabled_sites: { "chatgpt.com": true },
     });
+  });
+
+  it("persists a global automatic-capture circuit breaker and clears its wake", async () => {
+    const response = await sendRuntimeMessage({
+      type: "polylogue.ambient.configure",
+      automatic_capture_enabled: false,
+    });
+
+    expect(response).toMatchObject({
+      ok: true,
+      ambient: { enabled: true, automatic_capture_enabled: false },
+    });
+    expect(stored.polylogueAmbientSettings).toEqual({
+      enabled: true,
+      automatic_capture_enabled: false,
+      disabled_sites: {},
+    });
+    expect(globalThis.chrome.alarms.clear).toHaveBeenCalledWith("polylogueCaptureFreshnessWake");
   });
 });
 

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -85,6 +85,7 @@ function installDom() {
       <div id="open-tabs"></div>
       <input id="ambient-enabled" type="checkbox" />
       <input id="ambient-site-enabled" type="checkbox" />
+      <input id="automatic-capture-enabled" type="checkbox" />
       <span id="ambient-site"></span>
       <span id="assertion-status"></span>
       <div id="debug-panel" hidden><div id="debug-log"></div></div>
@@ -161,6 +162,24 @@ describe("popup capture", () => {
       expect(markup).not.toContain(`id="${id}"`);
     }
     expect(markup).toContain("Capture, freshness checks, open-tab convergence, and receiver health run automatically.");
+  });
+
+  it("exposes a persisted automatic-capture circuit breaker", async () => {
+    await loadPopup({}, [CHATGPT_TAB], async (message) => {
+      if (message.type === "polylogue.ambient.configure") {
+        return { ok: true, ambient: { enabled: true, automatic_capture_enabled: false, site_enabled: true } };
+      }
+      return { ok: true };
+    });
+
+    const control = document.getElementById("automatic-capture-enabled");
+    control.checked = false;
+    control.dispatchEvent(new globalThis.window.Event("change"));
+
+    await vi.waitFor(() => expect(globalThis.chrome.runtime.sendMessage).toHaveBeenCalledWith({
+      type: "polylogue.ambient.configure",
+      automatic_capture_enabled: false,
+    }));
   });
 
   it("starts in the manifest classic-script load order without a global redeclaration", () => {


### PR DESCRIPTION
## Summary
Adds a persisted, reversible extension control that stops automatic provider capture and freshness traffic during an incident.

## Problem
The prior incident required uninstalling the unpacked extension because the existing ambient toggle only hid UI. Automatic capture/freshness paths could still issue provider requests and a pending freshness alarm could revive work after a receiver fault.

## Solution
The popup now exposes an Automatic capture and provider refresh breaker. It persists across worker restarts, gates automatic tab capture and freshness queues before provider traffic, clears the capture-freshness alarm while paused, and re-arms convergence on resume. Explicit popup sync remains available.

Ref polylogue-yyvg.6.1.

## Verification
- `npm test -- --run tests/background.test.js tests/popup.test.js` — 105 passed.
- `npm run lint` — passed.
- `devtools verify --quick` — 16/16 passed.
- `npm test` — 317 passed; the pre-existing packaged-worker fixture failure reproduced unchanged.