### PR TITLE
fix(extension): recapture providers without freshness signals

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -2328,6 +2328,16 @@ function archiveProviderForUrl(url) {
   return null;
 }
 
+// ChatGPT emits durable freshness hints and has a bounded sweep queue, so an
+// already-archived ChatGPT conversation can remain receiver-owned until that
+// path reports a change.  Claude and Grok have no equivalent convergence
+// signal yet: suppressing their ordinary lifecycle capture would leave later
+// turns permanently stale.  Keep that distinction explicit rather than
+// treating every provider's `archived` state as equally terminal.
+function hasReceiverFreshnessConvergence(provider) {
+  return provider === "chatgpt";
+}
+
 function conversationIdForUrl(url) {
   try {
     const parsed = new URL(url || "");
@@ -2427,6 +2437,22 @@ async function refreshActiveTabArchiveState(tab, reason = "tab_state", allowReco
             providerSessionId,
             event: "held_with_reason",
             reason: "auto_capture_missing",
+            detail: captureResult?.reason || "capture_not_available",
+            tabId: tab?.id || null,
+          });
+        }
+      } else if (state.state === "archived" && !hasReceiverFreshnessConvergence(provider)) {
+        const captureResult = await captureTab(tab, "auto_capture_unconverged_provider", {
+          provider,
+          providerSessionId,
+          url,
+        });
+        if (!captureResult || captureResult.skipped) {
+          await appendConversationTimeline({
+            provider,
+            providerSessionId,
+            event: "held_with_reason",
+            reason: "auto_capture_unconverged_provider",
             detail: captureResult?.reason || "capture_not_available",
             tabId: tab?.id || null,
           });

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -1639,6 +1639,24 @@ describe("background receiver diagnostics", () => {
       .some((event) => event.detail === "background_capture_throttled")).toBe(false);
   });
 
+  it("recaptures an archived Claude conversation until that provider has freshness convergence", async () => {
+    tabs = [{ id: 42, url: "https://claude.ai/chat/claude-freshness", title: "Claude" }];
+    globalThis.fetch = vi.fn(async () => responseJson({
+      provider: "claude-ai",
+      provider_session_id: "claude-freshness",
+      state: "archived",
+      captured: true,
+    }));
+
+    activatedListener({ tabId: 42 });
+
+    await vi.waitFor(() => expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledWith(42, {
+      type: "polylogue.capturePage",
+      reason: "auto_capture_unconverged_provider",
+    }));
+    expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("captures a missing conversation once during automatic reconciliation", async () => {
     tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-missing-on-start", title: "ChatGPT" }];
     globalThis.fetch = vi.fn(async (url) => {


### PR DESCRIPTION
## Summary

Restores lifecycle recapture for archived providers that lack a receiver-side freshness signal, without reopening the ChatGPT terminal-capture loop.

## Problem

The archived-state reconciliation rule applied to Claude and Grok even though they lack ChatGPT's freshness convergence route, risking permanently stale later turns.

## Solution

Make freshness convergence an explicit provider capability. Archived Claude/Grok conversations use the existing automatic, throttled capture path; ChatGPT remains receiver-owned after archival.

Ref polylogue-yyvg.6.1.

## Verification

- `npm test -- --run tests/background.test.js` — 79 passed.
- `npm run lint` — passed.
- `npm run validate` — manifest valid.
