### PR TITLE
fix(test): bind pytest workers to active worktree

### DIFF
--- a/devtools/run_tests.py
+++ b/devtools/run_tests.py
@@ -53,6 +53,8 @@ def _managed_env() -> dict[str, str]:
     env, _policy = apply_managed_pytest_runtime_policy(os.environ)
     env["POLYLOGUE_ROOT"] = str(ROOT)
     env["POLYLOGUE_REPO_ROOT"] = str(ROOT)
+    inherited_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = str(ROOT) if not inherited_pythonpath else f"{ROOT}{os.pathsep}{inherited_pythonpath}"
     env["PYTHONPYCACHEPREFIX"] = str(ROOT / ".cache" / "pycache")
     env["POLYLOGUE_PYTEST_EVENTS_PATH"] = str(ROOT / PYTEST_EVENTS_PATH)
     env["POLYLOGUE_PYTEST_SELECTION_PATH"] = str(ROOT / PYTEST_SELECTION_PATH)

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -1720,6 +1720,8 @@ def _subprocess_env() -> dict[str, str]:
     env = normalize_pytest_basetemp_env(os.environ)
     env["POLYLOGUE_ROOT"] = str(ROOT)
     env["POLYLOGUE_REPO_ROOT"] = str(ROOT)
+    inherited_pythonpath = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = str(ROOT) if not inherited_pythonpath else f"{ROOT}{os.pathsep}{inherited_pythonpath}"
     env["PYTHONPYCACHEPREFIX"] = str(ROOT / ".cache" / "pycache")
     TESTMON_DATA.parent.mkdir(parents=True, exist_ok=True)
     env["TESTMON_DATAFILE"] = str(TESTMON_DATA)

--- a/tests/unit/devtools/test_run_tests.py
+++ b/tests/unit/devtools/test_run_tests.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -111,6 +112,7 @@ def test_managed_env_sets_repo_roots() -> None:
     assert env["POLYLOGUE_ROOT"] == str(run_tests.ROOT)
     assert env["POLYLOGUE_REPO_ROOT"] == str(run_tests.ROOT)
     assert env["PYTHONPYCACHEPREFIX"] == str(run_tests.ROOT / ".cache" / "pycache")
+    assert env["PYTHONPATH"].split(os.pathsep)[0] == str(run_tests.ROOT)
     assert env["POLYLOGUE_PYTEST_EVENTS_PATH"] == str(run_tests.ROOT / PYTEST_EVENTS_PATH)
     assert env["POLYLOGUE_PYTEST_SELECTION_PATH"] == str(run_tests.ROOT / PYTEST_SELECTION_PATH)
     assert env["POLYLOGUE_PYTEST_SUMMARY_PATH"] == str(run_tests.ROOT / PYTEST_SUMMARY_PATH)

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -987,6 +987,7 @@ def test_run_forces_subprocesses_to_current_checkout(monkeypatch: pytest.MonkeyP
     monkeypatch.setenv("POLYLOGUE_ROOT", "/stale/main")
     monkeypatch.setenv("POLYLOGUE_REPO_ROOT", "/stale/main")
     monkeypatch.setenv("PYTHONPYCACHEPREFIX", "/stale/main/.cache/pycache")
+    monkeypatch.setenv("PYTHONPATH", "/stale/main")
     completed = subprocess.CompletedProcess(args=["devtools"], returncode=0, stdout="", stderr="")
 
     with patch("devtools.verify.subprocess.run", return_value=completed) as run:
@@ -997,6 +998,7 @@ def test_run_forces_subprocesses_to_current_checkout(monkeypatch: pytest.MonkeyP
     assert env["POLYLOGUE_ROOT"] == str(ROOT)
     assert env["POLYLOGUE_REPO_ROOT"] == str(ROOT)
     assert env["PYTHONPYCACHEPREFIX"] == str(ROOT / ".cache" / "pycache")
+    assert env["PYTHONPATH"].split(os.pathsep)[0] == str(ROOT)
     assert env["POLYLOGUE_PYTEST_EVENTS_PATH"] == str(Path.cwd() / PYTEST_EVENTS_PATH)
 
 


### PR DESCRIPTION
## Summary

Ensure managed pytest workers import code from the active worktree.

## Problem

An editable environment could resolve `devtools` from the main checkout while xdist collected tests from a worktree, creating mixed-revision imports and false harness failures.

## Solution

Prepend the active checkout to `PYTHONPATH` in both verification and focused-test managed environments, with regression assertions.

## Verification

- `devtools test tests/unit/devtools/test_verify.py tests/unit/devtools/test_run_tests.py` — 92 passed.
- Corrected xdist testmon collect-only probe — 16,077 tests collected in 27.06s, no mixed-revision import error.
- Pre-push `devtools verify --quick` passed.

Ref polylogue-b054.1.1.5.