### PR TITLE
perf(backup): reuse verified scratch blob hashes

### DIFF
--- a/polylogue/daemon/backup.py
+++ b/polylogue/daemon/backup.py
@@ -19,6 +19,7 @@ import sqlite3
 import stat
 import tempfile
 import time
+from collections.abc import Mapping
 from contextlib import AbstractContextManager, closing, nullcontext
 from datetime import datetime, timezone
 from pathlib import Path
@@ -136,7 +137,11 @@ def _reject_sqlite_sidecars(path: Path) -> None:
             raise RuntimeError(f"backup tier has an unbound SQLite sidecar: {sidecar}")
 
 
-def _backup_artifact_inventory(backup_root: Path) -> list[dict[str, object]]:
+def _backup_artifact_inventory(
+    backup_root: Path,
+    *,
+    verified_file_hashes: Mapping[str, tuple[int, str]] | None = None,
+) -> list[dict[str, object]]:
     _require_real_backup_directory(backup_root, label="backup root")
     rows: list[dict[str, object]] = []
     for candidate in sorted(backup_root.rglob("*")):
@@ -151,12 +156,15 @@ def _backup_artifact_inventory(backup_root: Path) -> list[dict[str, object]]:
         if candidate.name.endswith(_SQLITE_SIDECAR_SUFFIXES):
             raise RuntimeError(f"backup contains an unbound SQLite sidecar: {candidate}")
         _require_regular_backup_artifact(candidate, backup_root=backup_root, label="backup artifact")
+        verified = (verified_file_hashes or {}).get(str(relative))
+        if verified is not None and verified[0] != metadata.st_size:
+            raise RuntimeError(f"verified backup artifact changed while receipt evidence was built: {candidate}")
         rows.append(
             {
                 "path": str(relative),
                 "type": "file",
                 "size_bytes": metadata.st_size,
-                "sha256": _sha256_file(candidate),
+                "sha256": verified[1] if verified is not None else _sha256_file(candidate),
             }
         )
     return rows
@@ -759,12 +767,15 @@ def _verify_archive_file_set_backup(path: Path) -> dict[str, object]:
         restored_blob_paths = _regular_backup_blob_files(restored)
         restored_blob_count = len(restored_blob_paths)
         restored_hashes: dict[str, int] = {}
+        verified_blob_file_hashes: dict[str, tuple[int, str]] = {}
         hashes_valid = True
         for blob_path in restored_blob_paths:
             blob_hash = blob_path.parent.name + blob_path.name
             payload = blob_path.read_bytes()
             restored_hashes[blob_hash] = len(payload)
-            hashes_valid = hashes_valid and hashlib.sha256(payload).hexdigest() == blob_hash
+            payload_hash = hashlib.sha256(payload).hexdigest()
+            hashes_valid = hashes_valid and payload_hash == blob_hash
+            verified_blob_file_hashes[str(blob_path.relative_to(restored))] = (len(payload), payload_hash)
         blobs_ok = (
             restored_blob_count == blob_count
             and len(expected_blobs) == blob_count
@@ -785,7 +796,7 @@ def _verify_archive_file_set_backup(path: Path) -> dict[str, object]:
             and source_blobs_resolved
             and index_attachment_blobs_resolved
         )
-        receipt_evidence = _receipt_evidence(restored) if ok else None
+        receipt_evidence = _receipt_evidence(restored, verified_file_hashes=verified_blob_file_hashes) if ok else None
         return {
             "ok": ok,
             "mode": "archive_file_set",
@@ -907,9 +918,13 @@ def _inventory_file_evidence(
     }
 
 
-def _receipt_evidence(backup_root: Path) -> dict[str, object]:
+def _receipt_evidence(
+    backup_root: Path,
+    *,
+    verified_file_hashes: Mapping[str, tuple[int, str]] | None = None,
+) -> dict[str, object]:
     _require_real_backup_directory(backup_root, label="backup root")
-    artifact_inventory = _backup_artifact_inventory(backup_root)
+    artifact_inventory = _backup_artifact_inventory(backup_root, verified_file_hashes=verified_file_hashes)
     file_evidence = {str(item["path"]): item for item in artifact_inventory if item.get("type") == "file"}
     manifest_path = backup_root / "manifest.json"
     _require_regular_backup_artifact(manifest_path, backup_root=backup_root, label="backup manifest")

--- a/tests/infra/backup_read_counter.py
+++ b/tests/infra/backup_read_counter.py
@@ -1,0 +1,62 @@
+"""Measurement harness for archive-backup verification I/O.
+
+The production verifier intentionally has two distinct roots while it works:
+the immutable backup itself and a temporary scratch restore.  Keeping those
+reads separate lets regression scenarios distinguish the restore proof from
+post-proof receipt construction.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import patch
+
+
+@dataclass
+class BackupVerificationReadCounter:
+    """Count blob bytes read by verifier operation and physical root."""
+
+    bytes_by_site: Counter[str] = field(default_factory=Counter)
+    calls_by_site: Counter[str] = field(default_factory=Counter)
+
+    def record(self, site: str, path: Path) -> None:
+        if "blob" not in path.parts:
+            return
+        size = path.stat().st_size
+        self.calls_by_site[site] += 1
+        self.bytes_by_site[site] += size
+
+
+def _root_name(path: Path) -> str:
+    return "scratch" if any(part.startswith("polylogue-backup-verify-") for part in path.parts) else "backup"
+
+
+@contextmanager
+def backup_verification_read_counter() -> Iterator[BackupVerificationReadCounter]:
+    """Measure blob reads performed by one real backup verification pass."""
+    from polylogue.daemon import backup as backup_mod
+
+    counter = BackupVerificationReadCounter()
+    real_sha256_file = backup_mod._sha256_file
+    real_read_bytes = Path.read_bytes
+
+    def counted_sha256_file(path: Path) -> str:
+        counter.record(f"sha256_file:{_root_name(path)}", path)
+        return real_sha256_file(path)
+
+    def counted_read_bytes(path: Path) -> bytes:
+        counter.record(f"read_bytes:{_root_name(path)}", path)
+        return real_read_bytes(path)
+
+    with (
+        patch.object(backup_mod, "_sha256_file", counted_sha256_file),
+        patch.object(Path, "read_bytes", counted_read_bytes),
+    ):
+        yield counter
+
+
+__all__ = ["BackupVerificationReadCounter", "backup_verification_read_counter"]

--- a/tests/integration/test_backup_verification_read_amplification.py
+++ b/tests/integration/test_backup_verification_read_amplification.py
@@ -1,0 +1,75 @@
+"""Measured regression scenario for backup verification read amplification."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.daemon import backup as backup_mod
+from polylogue.daemon.backup import backup_archive
+from polylogue.storage.blob_store import BlobStore
+from tests.infra.backup_read_counter import backup_verification_read_counter
+from tests.infra.storage_records import db_setup
+
+
+def _seed_referenced_blob(archive_root: Path, *, raw_id: str, payload: bytes) -> None:
+    blob_hash, _ = BlobStore(archive_root / "blob").write_from_bytes(payload)
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash,
+                blob_size, acquired_at_ms, validation_status
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                raw_id,
+                "chatgpt-export",
+                raw_id,
+                f"/tmp/{raw_id}.json",
+                0,
+                bytes.fromhex(blob_hash),
+                len(payload),
+                1,
+                "passed",
+            ),
+        )
+        conn.execute(
+            "INSERT INTO blob_refs VALUES (?, ?, ?, ?, ?, ?)",
+            (bytes.fromhex(blob_hash), raw_id, "raw_payload", f"/tmp/{raw_id}.json", len(payload), 1),
+        )
+
+
+def test_verified_backup_avoids_rehashing_scratch_blobs_after_validation(
+    workspace_env: dict[str, Path], tmp_path: Path
+) -> None:
+    """Pin the two required proof reads: scratch validation and original stability.
+
+    Three deliberately unequal blobs ensure the measurement is byte-accurate,
+    not merely a call-count artefact.  This scenario is intentionally a
+    characterization.  Receipt construction must reuse the hash just obtained
+    from the scratch payload rather than rereading every scratch blob.
+    """
+    db_setup(workspace_env)
+    archive_root = workspace_env["archive_root"]
+    payloads = (b"a" * 17, b"b" * 1031, b"c" * 16_385)
+    for index, payload in enumerate(payloads):
+        _seed_referenced_blob(archive_root, raw_id=f"raw-{index}", payload=payload)
+    total_blob_bytes = sum(map(len, payloads))
+
+    result = backup_archive(output_dir=tmp_path / "backups", verify=False)
+    assert result.ok
+
+    with backup_verification_read_counter() as counter:
+        backup_mod._verify_backup_result(result)
+
+    assert result.ok
+    assert result.verified
+    assert counter.calls_by_site == {
+        "read_bytes:scratch": len(payloads),
+        "sha256_file:backup": len(payloads),
+    }
+    assert counter.bytes_by_site == {
+        "read_bytes:scratch": total_blob_bytes,
+        "sha256_file:backup": total_blob_bytes,
+    }


### PR DESCRIPTION
## Summary

Eliminates one redundant full read of every scratch-restored blob during a verified archive backup, while retaining both the scratch restore validation and the original-backup stability check.

## Problem

A completed full-evidence migration backup contained 64,837 blobs and incurred a high-I/O verification phase. Static tracing and a real three-blob harness showed that each blob was read three times after copying: the scratch payload validation, scratch receipt inventory hashing, and original-backup receipt inventory hashing.

Ref polylogue-swgh.

## Solution

`_verify_archive_file_set_backup` now carries the size and SHA-256 acquired while validating each scratch payload into `_receipt_evidence`. The artifact inventory accepts that narrowly scoped verified evidence, still checks the observed file size, and continues to hash all other artifacts. `_write_successful_verification_receipt` still independently inventories the original backup and compares it to the scratch evidence before signing; this preserves the post-scratch mutation guard.

The new integration harness counts real verifier blob reads by operation/root. With three unequal referenced blobs it proves the remaining required reads are:

| Site | Before | After |
| --- | ---: | ---: |
| scratch payload validation | 1x | 1x |
| scratch receipt inventory | 1x | 0x |
| original stability inventory | 1x | 1x |

## What I decided not to change

The scratch `copytree` restore remains: it is the isolation proof that the backup is restorable. The original-backup inventory remains: it detects mutation between scratch verification and receipt signing. Neither was implicated as redundant by the harness.

## Verification

- `devtools test tests/integration/test_backup_verification_read_amplification.py tests/unit/daemon/test_backup.py` — 24 passed.
- `devtools verify --quick` — format, lint, mypy, generated surfaces, topology, layering, schema roundtrip, manifests, documentation, and test-infrastructure gates passed.
- Pre-push reran the quick baseline successfully.
