### PR TITLE
perf(watcher): defer unchanged incomplete tails

### DIFF
--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -717,6 +717,14 @@ class LiveWatcher:
                 final_stat.st_ctime_ns,
             ) != (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns)
         if size > cursor.byte_offset:
+            # A previous incomplete-tail probe recorded this exact filesystem
+            # state.  The next useful observation is a write notification (or
+            # a periodic scan that sees different stat evidence), not another
+            # probe of the same unfinished record.  In particular, a single
+            # oversized JSONL record must not make the 15-second safety scan
+            # reread its first 64 MiB forever.
+            if _cursor_stat_matches(cursor, stat):
+                return False
             return not self._defer_incomplete_jsonl_append(path, stat=stat, cursor=cursor)
         if cursor.content_fingerprint is None:
             return True
@@ -755,8 +763,10 @@ class LiveWatcher:
             return True
         if b"\n" in payload:
             return False
-        if bytes_to_probe < remaining_bytes:
-            return False
+        # The bounded probe can prove that no complete record begins at the
+        # cursor, even when the unfinished record exceeds the probe budget.
+        # Record this observed state so unchanged periodic catch-up scans skip
+        # it; a subsequent append changes stat evidence and reopens the probe.
         record_deferred_append_cursor(
             self._cursor,
             path,

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1118,12 +1118,12 @@ def test_append_plan_reads_only_completed_tail(tmp_path: Path) -> None:
     assert append_plan.last_complete_newline == len(original) + len(b'{"b":2}\n')
 
 
-def test_large_incomplete_jsonl_append_still_needs_work(tmp_path: Path) -> None:
+def test_large_incomplete_jsonl_append_defers_until_the_file_changes(tmp_path: Path) -> None:
     root = tmp_path / "src"
     root.mkdir()
     f = root / "session.jsonl"
     original = b'{"a":1}\n'
-    f.write_bytes(original + (b"x" * (live_watcher._INCOMPLETE_APPEND_PROBE_BYTES + 1)))
+    f.write_bytes(original)
     watcher, _parse_sources = _make_watcher(tmp_path, root)
     stat = f.stat()
     watcher._cursor.set(
@@ -1142,11 +1142,16 @@ def test_large_incomplete_jsonl_append_still_needs_work(tmp_path: Path) -> None:
         st_ino=stat.st_ino,
         mtime_ns=stat.st_mtime_ns,
     )
+    f.write_bytes(original + (b"x" * (live_watcher._INCOMPLETE_APPEND_PROBE_BYTES + 1)))
 
-    assert watcher._needs_work(f) is True
+    # The first bounded probe observes no newline and records the unfinished
+    # tail.  Repeating the same periodic scan must then be a stat-only skip.
+    assert watcher._needs_work(f) is False
     record = watcher._cursor.get_record(f)
     assert record is not None
-    assert record.byte_size == len(original)
+    assert record.byte_size == f.stat().st_size
+    assert record.byte_offset == len(original)
+    assert watcher._needs_work(f) is False
 
 
 def test_last_complete_newline_from_tail_reads_only_final_chunk(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Avoid repeated bounded reads of an unchanged, incomplete live-session tail.

## Problem

The daemon's 15-second catch-up safety scan repeatedly re-probed two oversized
Codex JSONL tails that had no completed newline. Each pass reread up to 64 MiB,
then scheduled the same files again despite no new filesystem evidence.

## Solution

Persist the observed filesystem state after a bounded incomplete-tail probe,
including when the unfinished record exceeds the probe limit. The watcher now
skips that exact state and resumes probing when a later stat change proves that
new bytes arrived.

## Verification

- `devtools test tests/unit/sources/test_live_watcher.py -k 'large_incomplete_jsonl_append_defers_until_the_file_changes or incomplete_append_event_defers_without_ingest_until_newline or partial_trailing_line_keeps_cursor_at_last_newline'` — 3 passed.
- `devtools verify --quick` — 16/16 checks passed.
