### PR TITLE
fix(extension): skip browser polling before pairing

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -2304,6 +2304,12 @@ async function dispatchBrowserAction(action, ownerInstanceId) {
 }
 
 async function pollBrowserActionsOnce() {
+  // Browser-action polling is autonomous work.  An unpaired profile has no
+  // trusted receiver identity, so it must remain entirely local instead of
+  // turning the wake alarm into recurring unauthenticated receiver traffic.
+  if (!(await storedReceiverPairing())?.receiver_id) {
+    return { actions: [], skipped: true, reason: "receiver_unpaired" };
+  }
   const ownerInstanceId = await browserActionExecutorId();
   const claimed = await getJson(`/v1/browser-actions?claim_by=${encodeURIComponent(ownerInstanceId)}`)
     .catch(() => ({ actions: [] }));

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -2195,11 +2195,33 @@ describe("capture retry queue", () => {
   });
 });
 
-describe("provider-neutral browser action worker", () => {
+describe("browser action polling", () => {
   beforeEach(async () => {
     vi.restoreAllMocks();
     vi.useRealTimers();
     await loadBackground();
+  });
+
+  it("keeps an unpaired alarm wake entirely local", async () => {
+    expect(alarmListener).toBeTypeOf("function");
+
+    alarmListener({ name: "polylogueBrowserActionWake" });
+
+    await vi.waitFor(() => expect(fetchCalls).toHaveLength(0));
+  });
+});
+
+describe("provider-neutral browser action worker", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    await loadBackground({
+      polylogueReceiverPairing: {
+        state: "online",
+        receiver_id: "rx-action-test",
+        api_schema: "polylogue-browser-capture/v1",
+      },
+    });
   });
 
   it("submits in an inactive provider tab and records an owner-bound exact receipt", async () => {
@@ -2224,6 +2246,9 @@ describe("provider-neutral browser action worker", () => {
     const updates = [];
     globalThis.fetch = vi.fn(async (url, options = {}) => {
       fetchCalls.push({ url, options });
+      if (String(url).endsWith("/v1/status")) {
+        return responseJson({ ok: true, receiver_id: "rx-action-test", api_schema: "polylogue-browser-capture/v1" });
+      }
       if (String(url).includes("/v1/browser-actions?claim_by=")) {
         if (claimed) return responseJson({ actions: [] });
         claimed = true;
@@ -2295,6 +2320,9 @@ describe("provider-neutral browser action worker", () => {
     });
     const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval").mockImplementation(() => undefined);
     globalThis.fetch = vi.fn(async (url, options = {}) => {
+      if (String(url).endsWith("/v1/status")) {
+        return responseJson({ ok: true, receiver_id: "rx-action-test", api_schema: "polylogue-browser-capture/v1" });
+      }
       if (String(url).includes("/v1/browser-actions?claim_by=")) {
         if (claimed) return responseJson({ actions: [] });
         claimed = true;
@@ -2357,6 +2385,9 @@ describe("provider-neutral browser action worker", () => {
     const updates = [];
     let claimed = false;
     globalThis.fetch = vi.fn(async (url, options = {}) => {
+      if (String(url).endsWith("/v1/status")) {
+        return responseJson({ ok: true, receiver_id: "rx-action-test", api_schema: "polylogue-browser-capture/v1" });
+      }
       if (String(url).includes("/v1/browser-actions?claim_by=")) {
         if (claimed) return responseJson({ actions: [] });
         claimed = true;
@@ -2403,6 +2434,9 @@ describe("provider-neutral browser action worker", () => {
     let claimed = false;
     let cancelled = false;
     globalThis.fetch = vi.fn(async (url, options = {}) => {
+      if (String(url).endsWith("/v1/status")) {
+        return responseJson({ ok: true, receiver_id: "rx-action-test", api_schema: "polylogue-browser-capture/v1" });
+      }
       if (String(url).includes("/v1/browser-actions?claim_by=")) {
         if (claimed) return responseJson({ actions: [] });
         claimed = true;


### PR DESCRIPTION
## Summary

Prevent the browser extension from making receiver-authenticated action-poll requests until it has a receiver pairing.

## Problem

An unpacked extension with automatic capture disabled and no receiver pairing still created the browser-action alarm and attempted polling. Those requests generated avoidable rejected-token telemetry and made the receiver appear unhealthy.

## Solution

Gate `pollBrowserActionsOnce()` on persisted receiver pairing, returning a local skipped result before any receiver request. Preserve paired provider-action behavior and add a focused regression test that proves an unpaired alarm wake makes no fetch.

## Verification

- `npm test -- --run tests/background.test.js` — 82 passed
- `npm run lint` — passed
- `npm run validate` — passed
- pre-push `devtools verify --quick` — passed

Ref polylogue-yyvg.4