### PR TITLE
perf(watcher): back off periodic reconciliation

### DIFF
--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -52,7 +52,12 @@ _PARSER_FINGERPRINT = "live-batched-v2"
 _CATCH_UP_MAX_BATCH_FILES = 50
 _CATCH_UP_MAX_BATCH_BYTES = 64 * 1024 * 1024
 _INCOMPLETE_APPEND_PROBE_BYTES = 64 * 1024 * 1024
+# Filesystem notifications are the real-time delivery path.  This sweep is a
+# recovery mechanism for notifications missed while the daemon was unavailable
+# or a watch backend was briefly unhealthy.  Keeping it at the watch cadence
+# made a large, otherwise-idle archive continuously rescan itself.
 _PERIODIC_CATCH_UP_INTERVAL_S = 15.0
+_PERIODIC_CATCH_UP_MAX_INTERVAL_S = 15.0 * 60.0
 INBOX_SOURCE_SUFFIXES = (".jsonl", ".zip", ".json", ".ndjson", ".db", ".sqlite", ".sqlite3")
 
 
@@ -284,8 +289,9 @@ class LiveWatcher:
         self._cancel_periodic_catch_up()
 
     async def _periodic_catch_up(self, roots: list[Path]) -> None:
+        delay_s = _PERIODIC_CATCH_UP_INTERVAL_S
         while not self._stop.is_set():
-            await asyncio.sleep(_PERIODIC_CATCH_UP_INTERVAL_S)
+            await asyncio.sleep(delay_s)
             if self._stop.is_set():
                 return
             try:
@@ -294,6 +300,11 @@ class LiveWatcher:
                 if not _is_database_locked(exc):
                     raise
                 logger.warning("live.watcher: archive busy during periodic catch-up; will retry")
+            # A periodic pass is deliberately a low-duty-cycle safety net.
+            # Event-driven batches and explicit failed-file retry wakeups keep
+            # normal writes and known failures prompt; repeatedly walking every
+            # source tree does neither.
+            delay_s = min(delay_s * 2, _PERIODIC_CATCH_UP_MAX_INTERVAL_S)
 
     def _cancel_periodic_catch_up(self) -> None:
         task = self._periodic_catch_up_task

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -2278,6 +2278,35 @@ def test_periodic_catch_up_drains_missed_browser_capture_event(
     asyncio.run(_drive())
 
 
+def test_periodic_catch_up_backs_off_after_each_reconciliation_pass(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    watcher, _parse_sources = _make_watcher(tmp_path, root)
+    monkeypatch.setattr(live_watcher, "_PERIODIC_CATCH_UP_INTERVAL_S", 0.01)
+    monkeypatch.setattr(live_watcher, "_PERIODIC_CATCH_UP_MAX_INTERVAL_S", 0.04)
+    delays: list[float] = []
+    passes = 0
+
+    async def fake_sleep(delay_s: float) -> None:
+        delays.append(delay_s)
+
+    async def fake_catch_up(_roots: list[Path]) -> None:
+        nonlocal passes
+        passes += 1
+        if passes == 3:
+            watcher.stop()
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    watcher._catch_up = fake_catch_up  # type: ignore[assignment,method-assign]
+
+    asyncio.run(watcher._periodic_catch_up([root]))
+
+    assert delays == [0.01, 0.02, 0.04]
+
+
 def test_end_to_end_deletion_does_not_ingest(tmp_path: Path) -> None:
     root = tmp_path / "src"
     root.mkdir()


### PR DESCRIPTION
## Summary

Turn the live watcher’s whole-tree reconciliation into an exponentially backing-off recovery sweep instead of a permanent 15-second hot loop.

## Problem

Live evidence showed an otherwise-idle archive walking 16,070 source files every 15 seconds. Each prefilter took roughly two minutes, so the daemon was spending most of its life rescanning files even though ordinary changes already arrive through filesystem events.

## Solution

Keep the first recovery pass prompt, then double subsequent periodic-reconciliation delays up to fifteen minutes. Filesystem events and the explicit failed-file retry scheduler remain the prompt paths for ordinary writes and known failures.

## Verification

- `devtools test tests/unit/sources/test_live_watcher.py -k "periodic_catch_up_drains_missed_browser_capture_event or periodic_catch_up_backs_off_after_each_reconciliation_pass or large_incomplete_jsonl_append_defers_until_the_file_changes"` — 3 passed
- `devtools verify --quick` — passed (16 checks)

Ref polylogue-20d.6