### PR TITLE
perf(watcher): prune runtime dependency trees

### DIFF
--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -115,6 +115,7 @@ class WatchSource:
     name: str
     root: Path
     suffixes: tuple[str, ...] = (".jsonl",)
+    ignored_dir_names: frozenset[str] = frozenset({".git", "__pycache__", "node_modules", "venv", ".venv"})
 
     def exists(self) -> bool:
         return self.root.exists()
@@ -122,6 +123,10 @@ class WatchSource:
     def accepts(self, path: Path) -> bool:
         name = path.name.lower()
         return any(name.endswith(suffix) for suffix in self.suffixes)
+
+    def ignores_directory(self, path: Path) -> bool:
+        """Return whether a subtree cannot contain a live source artifact."""
+        return path.name in self.ignored_dir_names
 
 
 @dataclass(frozen=True, slots=True)
@@ -403,8 +408,14 @@ class LiveWatcher:
                 continue
             if source.name == "hooks":
                 continue
-            for suffix in source.suffixes:
-                for path in source.root.rglob(f"*{suffix}"):
+            for directory, dirnames, filenames in os.walk(source.root, followlinks=False):
+                dirnames[:] = [
+                    dirname for dirname in dirnames if not source.ignores_directory(Path(directory) / dirname)
+                ]
+                for filename in filenames:
+                    path = Path(directory) / filename
+                    if not source.accepts(path):
+                        continue
                     try:
                         stat = path.stat()
                     except FileNotFoundError:
@@ -415,7 +426,7 @@ class LiveWatcher:
                         CandidateSourceFile(
                             path=path,
                             source_name=source.name,
-                            suffix=suffix,
+                            suffix=path.suffix,
                             stat=stat,
                         )
                     )

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -2045,6 +2045,22 @@ def test_catch_up_recurses_like_live_watch(tmp_path: Path) -> None:
     assert parse_sources.await_count == 1
 
 
+def test_catch_up_prunes_runtime_dependency_trees(tmp_path: Path) -> None:
+    root = tmp_path / "src"
+    root.mkdir()
+    session = root / "sessions" / "session.jsonl"
+    session.parent.mkdir()
+    session.write_text('{"a":1}\n')
+    dependency = root / "venv" / "lib" / "site-packages" / "generated.jsonl"
+    dependency.parent.mkdir(parents=True)
+    dependency.write_text('{"not":"a session"}\n')
+    watcher, parse_sources = _make_watcher(tmp_path, root)
+
+    asyncio.run(watcher._catch_up([root]))
+
+    assert parse_sources.await_count == 1
+
+
 def test_catch_up_handles_empty_roots(tmp_path: Path) -> None:
     root = tmp_path / "src"
     root.mkdir()


### PR DESCRIPTION
## Summary

Prune runtime dependency subtrees from live-source discovery before candidate planning.

## Problem

The live daemon spent about two minutes planning a 16,070-path reconciliation. Live cursor evidence showed Hermes virtual-environment files had been admitted as JSON sources, producing thousands of irrelevant candidates and retry records.

## Solution

Use a prunable directory walk rather than suffix-specific `rglob` passes. `WatchSource` now centrally identifies dependency trees that cannot contain live source artifacts, so those subtrees are never walked or statted.

## Verification

- `devtools test tests/unit/sources/test_live_watcher.py -k "catch_up_recurses_like_live_watch or catch_up_prunes_runtime_dependency_trees or periodic_catch_up_drains_missed_browser_capture_event or periodic_catch_up_backs_off_after_each_reconciliation_pass"` — 4 passed
- `mypy polylogue/sources/live/watcher.py tests/unit/sources/test_live_watcher.py` — passed
- `devtools verify --quick` — passed

Ref polylogue-20d.6