### PR TITLE
fix(test): restore seed baseline readiness contracts

### DIFF
--- a/docs/examples/demo-tour/report.json
+++ b/docs/examples/demo-tour/report.json
@@ -276,7 +276,7 @@
         "construct_id": "error_terminal_state_rows",
         "label": "Error terminal-state rows",
         "minimum": 1,
-        "observed": 2,
+        "observed": 1,
         "ok": true
       },
       {
@@ -616,7 +616,7 @@
         "construct_id": "error_terminal_state_rows",
         "label": "Error terminal-state rows",
         "minimum": 1,
-        "observed": 2,
+        "observed": 1,
         "ok": true
       },
       {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -635,9 +635,18 @@ def empty_archive_template(
     tmp_path_factory: pytest.TempPathFactory,
     worker_id: str,
 ) -> Path:
-    """Build the empty five-tier archive once per pytest run, shared read-only."""
+    """Build a census-complete empty archive once per pytest run.
+
+    A complete five-tier layout alone is no longer sufficient to claim raw
+    materialization readiness: the raw-authority frontier must have a
+    completed census too.  The shared fixture represents a usable empty
+    archive, so establish that real durable state through the production
+    census route before sharing clones with CLI and insight tests.
+    """
     import fcntl
 
+    from polylogue.config import Config
+    from polylogue.storage.raw_reconciler import inspect_raw_authority_frontier
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
     worker_base = tmp_path_factory.getbasetemp()
@@ -656,6 +665,14 @@ def empty_archive_template(
         try:
             with ArchiveStore(building):
                 pass
+            inspect_raw_authority_frontier(
+                Config(
+                    archive_root=building,
+                    render_root=building / "render",
+                    sources=[],
+                    db_path=building / "index.db",
+                )
+            )
             building.replace(template)
             ready.touch()
         finally:

--- a/tests/infra/workload_artifacts.py
+++ b/tests/infra/workload_artifacts.py
@@ -22,7 +22,7 @@ from collections.abc import Iterable, Iterator
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
-from polylogue.config import Source
+from polylogue.config import Config, Source
 from polylogue.pipeline.services.archive_ingest import parse_sources_archive
 from polylogue.scenarios import CorpusSpec
 from polylogue.scenarios.workload import (
@@ -34,6 +34,8 @@ from polylogue.scenarios.workload import (
 )
 from polylogue.schemas.synthetic import SyntheticCorpus
 from polylogue.schemas.synthetic.models import SyntheticArtifactFacts
+from polylogue.storage.archive_readiness import raw_materialization_readiness_snapshot, raw_materialization_ready
+from polylogue.storage.raw_reconciler import inspect_raw_authority_frontier
 
 _ARTIFACT_PROTOCOL_VERSION = 1
 _CACHE_ROOT = Path("/realm/tmp/polylogue-seeded-artifacts")
@@ -42,6 +44,8 @@ _RECIPE_PATHS = (
     Path("polylogue/schemas/synthetic/core.py"),
     Path("polylogue/pipeline/services/archive_ingest.py"),
     Path("polylogue/storage/sqlite/archive_tiers/bootstrap.py"),
+    Path("polylogue/storage/raw_reconciler.py"),
+    Path("polylogue/storage/archive_readiness.py"),
 )
 _ARCHIVE_DB_NAMES = ("source.db", "index.db", "user.db", "ops.db", "embeddings.db")
 
@@ -193,7 +197,16 @@ def _archive_build_spec(
                 profile_id=profile_id,
             ),
         ),
-        phases=("generate", "acquire", "parse", "materialize", "index", "validate", "publish"),
+        phases=(
+            "generate",
+            "acquire",
+            "parse",
+            "materialize",
+            "index",
+            "raw_authority_frontier",
+            "validate",
+            "publish",
+        ),
     )
 
 
@@ -292,6 +305,13 @@ def _validate_facts(root: Path, facts: tuple[SyntheticArtifactFacts, ...]) -> No
             raise RuntimeError(f"missing planted tool action for {fact.expected_session_id}")
 
 
+def _validate_frontier_convergence(root: Path) -> None:
+    """Require a published artifact to be query-ready, not merely ingested."""
+    readiness = raw_materialization_readiness_snapshot(root)
+    if not raw_materialization_ready(readiness):
+        raise RuntimeError("seeded archive is missing completed raw-authority frontier convergence")
+
+
 def _read_manifest(path: Path) -> SeededArchiveManifest:
     payload = json.loads(path.read_text(encoding="utf-8"))
     facts = tuple(SyntheticArtifactFacts(**item) for item in payload.pop("facts"))
@@ -313,6 +333,7 @@ def _validate_artifact(root: Path, key: SeededArchiveKey) -> SeededArchiveArtifa
                 return None
         _sqlite_integrity(root)
         _validate_facts(root, manifest.facts)
+        _validate_frontier_convergence(root)
     except (OSError, RuntimeError, TypeError, ValueError, json.JSONDecodeError, sqlite3.Error):
         return None
     return SeededArchiveArtifact(root=root, manifest=manifest)
@@ -369,9 +390,18 @@ def build_seeded_archive(
             ]
             with _configured_archive_root(staging):
                 asyncio.run(parse_sources_archive(staging, sources))
+            inspect_raw_authority_frontier(
+                Config(
+                    archive_root=staging,
+                    render_root=staging / "render",
+                    sources=[],
+                    db_path=staging / "index.db",
+                )
+            )
             facts = tuple(item.facts for written in written_batches for item in written.batch.artifacts)
             _sqlite_integrity(staging)
             _validate_facts(staging, facts)
+            _validate_frontier_convergence(staging)
             archive_id = f"archive:seeded:{final_root.name}"
             profile_id = _profile_id(key)
             receipt = WorkloadReceipt.from_observations(
@@ -388,6 +418,7 @@ def build_seeded_archive(
                     WorkloadPhaseObservation(name="parse"),
                     WorkloadPhaseObservation(name="materialize"),
                     WorkloadPhaseObservation(name="index"),
+                    WorkloadPhaseObservation(name="raw_authority_frontier"),
                     WorkloadPhaseObservation(name="validate"),
                     WorkloadPhaseObservation(name="publish", cleanup_complete=True, quiescent=True),
                 ),

--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -25,13 +25,13 @@
               "session_id": "claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>"
             },
             {
+              "session_id": "chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>"
+            },
+            {
               "session_id": "claude-code-session:3eb13b90-4668-4257-bdd6-<HASH>"
             },
             {
-              "session_id": "chatgpt-export:402913ec-9ef2-493e-b0ac-<HASH>"
-            },
-            {
-              "session_id": "chatgpt-export:8a476a87-e49d-481d-91d8-<HASH>"
+              "session_id": "chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>"
             }
           ]
         },
@@ -50,7 +50,7 @@
           "total_cost_usd": 0.0,
           "cost_is_estimated": true,
           "tokens": {
-            "input_tokens": 174,
+            "input_tokens": 198,
             "output_tokens": 0,
             "cache_read_tokens": 0,
             "cache_write_tokens": 0
@@ -73,22 +73,25 @@
         "wallclock_span": {
           "earliest_first_message_at": "<TIMESTAMP>",
           "latest_last_message_at": "<TIMESTAMP>",
-          "span_ms": 80251994107,
+          "span_ms": 89015964354,
           "summed_wall_duration_ms": <HASH>,
           "evidence_refs": [
             {
-              "session_id": "chatgpt-export:402913ec-9ef2-493e-b0ac-<HASH>"
+              "session_id": "chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>"
+            },
+            {
+              "session_id": "chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>"
             }
           ]
         },
         "wallclock_distribution_s": {
           "count": 4,
-          "total": 150690970.11,
+          "total": 138057653.592,
           "minimum": 240.0,
           "p50": 360.0,
-          "p90": 80251994.107,
-          "maximum": 80251994.107,
-          "mean": 37672742.5275
+          "p90": 73354075.265,
+          "maximum": 73354075.265,
+          "mean": 34514413.398
         },
         "pathologies": {
           "status": "clean",
@@ -131,24 +134,27 @@
               "session_id": "claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>"
             },
             {
+              "session_id": "chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>"
+            },
+            {
               "session_id": "claude-code-session:3eb13b90-4668-4257-bdd6-<HASH>"
             },
             {
-              "session_id": "chatgpt-export:402913ec-9ef2-493e-b0ac-<HASH>"
-            },
-            {
-              "session_id": "chatgpt-export:8a476a87-e49d-481d-91d8-<HASH>"
+              "session_id": "chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>"
             }
           ]
         },
         "wallclock_span": {
           "earliest_first_message_at": "<TIMESTAMP>",
           "latest_last_message_at": "<TIMESTAMP>",
-          "span_ms": 80251994107,
+          "span_ms": 89015964354,
           "summed_wall_duration_ms": <HASH>,
           "evidence_refs": [
             {
-              "session_id": "chatgpt-export:402913ec-9ef2-493e-b0ac-<HASH>"
+              "session_id": "chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>"
+            },
+            {
+              "session_id": "chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>"
             }
           ]
         },
@@ -156,7 +162,7 @@
           "total_cost_usd": 0.0,
           "cost_is_estimated": true,
           "tokens": {
-            "input_tokens": 174,
+            "input_tokens": 198,
             "output_tokens": 0,
             "cache_read_tokens": 0,
             "cache_write_tokens": 0
@@ -214,7 +220,7 @@
 # name: test_json_analyze_snapshot
   '''
   {
-    "avg_messages_per_session": 5.0,
+    "avg_messages_per_session": 6.0,
     "db_size_bytes": <SIZE_BYTES>,
     "embedded_messages": 0,
     "embedded_sessions": 0,
@@ -225,11 +231,11 @@
     "embedding_oldest_at": null,
     "embedding_readiness_status": "none",
     "material_origins": {
-      "assistant_authored": 4,
-      "human_authored": 6
+      "assistant_authored": 5,
+      "human_authored": 7
     },
     "message_types": {
-      "message": 10
+      "message": 12
     },
     "messages_missing_embedding_provenance": 0,
     "mode": "stats",
@@ -242,12 +248,12 @@
     "query": null,
     "retrieval_ready": false,
     "role_counts": {
-      "assistant": 4,
-      "user": 6
+      "assistant": 5,
+      "user": 7
     },
     "stale_embedding_messages": 0,
     "total_attachments": 0,
-    "total_messages": 10,
+    "total_messages": 12,
     "total_sessions": 2
   }
   
@@ -390,7 +396,7 @@
     "omitted_facet_counts": {},
     "time_range": null,
     "total_sessions": 2,
-    "total_messages": 10,
+    "total_messages": 12,
     "scoped": {
       "origins": {
         "chatgpt-export": 2
@@ -404,7 +410,7 @@
       "has_flags": {},
       "omitted": {},
       "total_sessions": 2,
-      "total_messages": 10
+      "total_messages": 12
     },
     "global": {
       "origins": {
@@ -419,7 +425,7 @@
       "has_flags": {},
       "omitted": {},
       "total_sessions": 2,
-      "total_messages": 10
+      "total_messages": 12
     },
     "idf": {
       "origins": {
@@ -449,21 +455,21 @@
             "state": "enabled"
           }
         },
-        "anchor": "session-chatgpt-export-402913ec-9ef2-493e-b0ac-<HASH>",
+        "anchor": "session-chatgpt-export-22af711f-1b62-4a9d-b536-<HASH>",
         "created_at": "<TIMESTAMP>",
-        "id": "chatgpt-export:402913ec-9ef2-493e-b0ac-<HASH>",
-        "message_count": 5,
+        "id": "chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>",
+        "message_count": 7,
         "origin": "chatgpt-export",
         "tags": [],
         "target_ref": {
-          "identity_key": "session:chatgpt-export:402913ec-9ef2-493e-b0ac-<HASH>",
-          "session_id": "chatgpt-export:402913ec-9ef2-493e-b0ac-<HASH>",
-          "target_id": "chatgpt-export:402913ec-9ef2-493e-b0ac-<HASH>",
+          "identity_key": "session:chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>",
+          "session_id": "chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>",
+          "target_id": "chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>",
           "target_type": "session"
         },
-        "title": "corpus-01",
+        "title": "seed-00-01",
         "updated_at": "<TIMESTAMP>",
-        "words": 90
+        "words": 203
       },
       {
         "actions": {
@@ -480,21 +486,21 @@
             "state": "enabled"
           }
         },
-        "anchor": "session-chatgpt-export-8a476a87-e49d-481d-91d8-<HASH>",
+        "anchor": "session-chatgpt-export-4991ab9b-ebc2-426f-af34-<HASH>",
         "created_at": "<TIMESTAMP>",
-        "id": "chatgpt-export:8a476a87-e49d-481d-91d8-<HASH>",
+        "id": "chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>",
         "message_count": 5,
         "origin": "chatgpt-export",
         "tags": [],
         "target_ref": {
-          "identity_key": "session:chatgpt-export:8a476a87-e49d-481d-91d8-<HASH>",
-          "session_id": "chatgpt-export:8a476a87-e49d-481d-91d8-<HASH>",
-          "target_id": "chatgpt-export:8a476a87-e49d-481d-91d8-<HASH>",
+          "identity_key": "session:chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>",
+          "session_id": "chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>",
+          "target_id": "chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>",
           "target_type": "session"
         },
-        "title": "corpus-00",
+        "title": "seed-00-00",
         "updated_at": "<TIMESTAMP>",
-        "words": 164
+        "words": 190
       }
     ],
     "limit": 20,
@@ -523,7 +529,7 @@
     "config_exists": false,
     "config_path": "<PATH>",
     "sessions": 2,
-    "messages": 10,
+    "messages": 12,
     "raw_records": 2,
     "next_action": "polylogue init",
     "component_readiness": {
@@ -972,8 +978,8 @@
         "path": "<PATH>",
         "exists": true,
         "size_bytes": <SIZE_BYTES>,
-        "expected_user_version": 12,
-        "user_version": 12,
+        "expected_user_version": 13,
+        "user_version": 13,
         "version_status": "ok",
         "table_counts": {
           "raw_sessions": 2,
@@ -1001,8 +1007,8 @@
         "version_status": "ok",
         "table_counts": {
           "sessions": 2,
-          "messages": 10,
-          "blocks": 27,
+          "messages": 12,
+          "blocks": 44,
           "session_profiles": 0,
           "session_work_events": 0,
           "session_phases": 0,
@@ -1194,7 +1200,50 @@
         "raw_parse_failed": 0,
         "parsed_without_index_session": 0
       },
-      "source_family_counts": {}
+      "source_family_counts": {},
+      "raw_authority_census": {
+        "census_id": "census:1:<HASH>:<HASH>",
+        "sequence_no": 1,
+        "inventory_digest": "<HASH>",
+        "residual_digest": "<HASH>",
+        "plan_count": 0,
+        "post_inventory_digest": "<HASH>",
+        "post_residual_digest": "<HASH>",
+        "post_plan_count": 0,
+        "executable_plan_count": 0,
+        "residual_plan_count": 0,
+        "predecessor_census_id": null,
+        "mode": "dry_run",
+        "lifecycle_status": "completed",
+        "quiescent": true,
+        "fixed_point": false,
+        "completed_at_ms": <HASH>,
+        "pending_census_count": 0,
+        "query_handle": "polylogue:/<PATH>:1:<HASH>:<HASH>/0"
+      },
+      "raw_authority_frontier": {
+        "census_id": "census:1:<HASH>:<HASH>",
+        "sequence_no": 1,
+        "inventory_digest": "<HASH>",
+        "plan_inventory_digest": "<HASH>",
+        "residual_digest": "<HASH>",
+        "plan_count": 0,
+        "executable_plan_count": 0,
+        "residual_plan_count": 0,
+        "state_counts": {},
+        "blocking_count": 0,
+        "lifecycle_status": "completed",
+        "completed_at_ms": <HASH>,
+        "query_handle": "polylogue:/<PATH>:1:<HASH>:<HASH>/0"
+      },
+      "raw_authority_frontier_blocking_count": 0,
+      "raw_authority_frontier_remediation_refs": [],
+      "raw_authority_blocker_count": 0,
+      "raw_authority_pending_census_count": 0,
+      "raw_authority_ledger_counts": {
+        "unresolved_blockers": 0,
+        "pending_censuses": 0
+      }
     },
     "raw_frontier_integrity": {
       "available": true,
@@ -1262,12 +1311,12 @@
   - **Sessions:** 4 analyzed / 4 matched
   - **Origins:** chatgpt-export (2), claude-code-session (2)
   - **Total cost:** $0.00 _(estimated)_
-  - **Tokens:** in 174, out 0, cache-read 0, cache-write 0
+  - **Tokens:** in 198, out 0, cache-read 0, cache-write 0
   
   ## Distributions
   
   - Cost per session (USD): no signal
-  - Wall time per session: n=4 total=1.50691e+<DURATION> min=240 p50=360 p90=8.0252e+07 max=8.0252e+07 mean=3.76727e+07
+  - Wall time per session: n=4 total=1.38058e+<DURATION> min=240 p50=360 p90=7.33541e+07 max=7.33541e+07 mean=3.45144e+07
   
   ## Failure-mode pathologies
   
@@ -1293,9 +1342,9 @@
   | Field | Value |
   | --- | --- |
   | session_count | 4 |
-  | wallclock_span | span_ms=80251994107, summed_wall_ms=<HASH> |
+  | wallclock_span | span_ms=89015964354, summed_wall_ms=<HASH> |
   | estimated_cost_usd | $0.000000 (estimated) |
-  | token_lanes | input=174, output=0, cache_read=0, cache_write=0 |
+  | token_lanes | input=198, output=0, cache_read=0, cache_write=0 |
   | top_expensive_session | no_signal: no session in scope carries a positive cost figure |
   | repos_touched | (none) |
   | subagent_branch_count | 0 |
@@ -1307,8 +1356,8 @@
   
   | Field | Evidence refs |
   | --- | --- |
-  | session_count | claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>, claude-code-session:3eb13b90-4668-4257-bdd6-<HASH>, chatgpt-export:402913ec-9ef2-493e-b0ac-<HASH>, chatgpt-export:8a476a87-e49d-481d-91d8-<HASH> |
-  | wallclock_span | chatgpt-export:402913ec-9ef2-493e-b0ac-<HASH> |
+  | session_count | claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>, chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>, claude-code-session:3eb13b90-4668-4257-bdd6-<HASH>, chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH> |
+  | wallclock_span | chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>, chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH> |
   | estimated_cost | claude-code-session:e6b3c944-cb32-4e35-b922-<HASH> |
   | top_expensive_session | claude-code-session:e6b3c944-cb32-4e35-b922-<HASH> |
   | subagent_branch_count | claude-code-session:e6b3c944-cb32-4e35-b922-<HASH> |
@@ -1329,10 +1378,10 @@
   sessions: analyzed=4 matched=4
   origins: chatgpt-export=2, claude-code-session=2
   total_cost: $0.00 (estimated)
-  tokens: in=174 out=0 cache_read=0 cache_write=0
+  tokens: in=198 out=0 cache_read=0 cache_write=0
   cost_per_session_usd: no signal
-  wall_per_session_s: n=4 total=1.50691e+<DURATION> min=240 p50=360 p90=8.0252e+07 max=8.0252e+07 mean=3.76727e+07
-  wallclock_span_ms: 80251994107
+  wall_per_session_s: n=4 total=1.38058e+<DURATION> min=240 p50=360 p90=7.33541e+07 max=7.33541e+07 mean=3.45144e+07
+  wallclock_span_ms: 89015964354
   pathologies: clean (detectors ran; no pathology found)
   context_loss: clean (detectors ran; no pathology found)
   
@@ -1343,9 +1392,9 @@
   Postmortem bundle
     scope: matched=4, analyzed=4
     sessions: 4
-    wallclock: span_ms=80251994107 summed_wall_ms=<HASH> (<TIMESTAMP> -> <TIMESTAMP>)
+    wallclock: span_ms=89015964354 summed_wall_ms=<HASH> (<TIMESTAMP> -> <TIMESTAMP>)
     cost: $0.000000 (estimated)
-      tokens: input=174 output=0 cache_read=0 cache_write=0
+      tokens: input=198 output=0 cache_read=0 cache_write=0
     top_expensive_session: no_signal (no session in scope carries a positive cost figure)
     repos_touched: (none)
     subagent_branch_count: 0
@@ -1353,8 +1402,8 @@
     wasted_loop: clean (no pathology found)
     failure_mode: clean (no pathology found)
     evidence:
-      session_count: claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>, claude-code-session:3eb13b90-4668-4257-bdd6-<HASH>, chatgpt-export:402913ec-9ef2-493e-b0ac-<HASH>, chatgpt-export:8a476a87-e49d-481d-91d8-<HASH>
-      wallclock_span: chatgpt-export:402913ec-9ef2-493e-b0ac-<HASH>
+      session_count: claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>, chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>, claude-code-session:3eb13b90-4668-4257-bdd6-<HASH>, chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>
+      wallclock_span: chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>, chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>
       estimated_cost: claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>
       top_expensive_session: claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>
       subagent_branch_count: claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>
@@ -1364,24 +1413,24 @@
 # name: test_plain_analyze_snapshot
   '''
   Sessions: 2
-  Messages: 10
+  Messages: 12
   Attachments: 0
   Origins: 1
-  Average messages: 5.0
+  Average messages: 6.0
   
   '''
 # ---
 # name: test_plain_read_all_origin_filter_snapshot
   '''
-  chatgpt-export:402913ec-  <TIMESTAMP>  chatgpt-export            corpus-01 (5 msgs)
-  chatgpt-export:8a476a87-  <TIMESTAMP>  chatgpt-export            corpus-00 (5 msgs)
+  chatgpt-export:22af711f-  <TIMESTAMP>  chatgpt-export            seed-00-01 (7 msgs)
+  chatgpt-export:4991ab9b-  <TIMESTAMP>  chatgpt-export            seed-00-00 (5 msgs)
   
   '''
 # ---
 # name: test_plain_read_all_snapshot
   '''
-  chatgpt-export:402913ec-  <TIMESTAMP>  chatgpt-export            corpus-01 (5 msgs)
-  chatgpt-export:8a476a87-  <TIMESTAMP>  chatgpt-export            corpus-00 (5 msgs)
+  chatgpt-export:22af711f-  <TIMESTAMP>  chatgpt-export            seed-00-01 (7 msgs)
+  chatgpt-export:4991ab9b-  <TIMESTAMP>  chatgpt-export            seed-00-00 (5 msgs)
   
   '''
 # ---

--- a/tests/unit/cli/test_insights.py
+++ b/tests/unit/cli/test_insights.py
@@ -465,7 +465,7 @@ def test_insights_status_json(cli_workspace: CliWorkspace) -> None:
 
     assert result.exit_code == 0
     payload = extract_json_result(result.output)
-    assert payload["aggregate_verdict"] == "ready"
+    assert payload["aggregate_verdict"] == "degraded"
     insights = {item["insight_name"]: item for item in json_object_list(payload["insights"])}
     assert set(insights) >= {
         "session_profiles",
@@ -475,7 +475,8 @@ def test_insights_status_json(cli_workspace: CliWorkspace) -> None:
         "session_tag_rollups",
         "archive_coverage",
     }
-    assert insights["session_profiles"]["verdict"] == "ready"
+    assert insights["session_profiles"]["verdict"] == "degraded"
+    assert json_int(insights["session_profiles"]["degraded_count"]) == 2
     assert json_int(insights["session_work_events"]["row_count"]) >= 1
 
 
@@ -516,8 +517,8 @@ def test_insights_status_plain(cli_workspace: CliWorkspace) -> None:
     result = runner.invoke(cli, ["ops", "insights", "status", "--insight", "profiles"], catch_exceptions=False)
 
     assert result.exit_code == 0
-    assert "Insight Readiness: ready" in result.output
-    assert "session_profiles: ready" in result.output
+    assert "Insight Readiness: degraded" in result.output
+    assert "session_profiles: degraded" in result.output
 
 
 def test_insights_audit_json(cli_workspace: CliWorkspace) -> None:

--- a/tests/unit/cli/test_plain_cli_snapshots.py
+++ b/tests/unit/cli/test_plain_cli_snapshots.py
@@ -432,7 +432,10 @@ def test_analyze_facets_include_deferred_materializes_expensive_families(
     assert payload["family_status"]["repos"]["canonicalization"].startswith("prefer repo_name")
     assert payload["role_counts"]
     assert payload["material_origins"]
-    assert payload["message_types"] == {"message": 10}
+    # The named ``cli-chatgpt`` workload is deliberately generated through
+    # the schema-backed production route; its deterministic seed currently
+    # realizes 12 message blocks across its two sessions.
+    assert payload["message_types"] == {"message": 12}
 
 
 def test_analyze_facets_default_marks_detail_families_deferred_not_authoritative(

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -73,6 +73,16 @@ def _healthy_raw_frontier_integrity() -> dict[str, Any]:
     }
 
 
+def _completed_raw_materialization_readiness() -> dict[str, Any]:
+    """Minimal raw-readiness evidence that can honestly support a green claim."""
+    return {
+        "available": True,
+        "total": 0,
+        "affected_total": 0,
+        "raw_authority_frontier": {"lifecycle_status": "completed"},
+    }
+
+
 def _fresh_status_snapshot(frozen_clock: FrozenClock) -> dict[str, object]:
     return {
         "state": "fresh",
@@ -1133,7 +1143,7 @@ class TestNoArchiveStatus:
             patch("polylogue.cli.commands.status._archive_readiness_status", return_value=archive_readiness),
             patch(
                 monkeypatch_target,
-                return_value={"available": True, "total": 0, "affected_total": 0},
+                return_value=_completed_raw_materialization_readiness(),
             ),
             patch("polylogue.storage.embeddings.status_payload.embedding_status_payload", side_effect=RuntimeError),
         ):
@@ -1179,7 +1189,7 @@ class TestNoArchiveStatus:
             patch("polylogue.cli.commands.status._archive_readiness_status", return_value=archive_readiness),
             patch(
                 "polylogue.storage.archive_readiness.raw_materialization_readiness_snapshot",
-                return_value={"available": True, "total": 0, "affected_total": 0},
+                return_value=_completed_raw_materialization_readiness(),
             ),
             patch("polylogue.storage.embeddings.status_payload.embedding_status_payload", side_effect=RuntimeError),
         ):
@@ -1265,7 +1275,7 @@ class TestNoArchiveStatus:
             patch("polylogue.cli.commands.status._archive_readiness_status", return_value=archive_readiness),
             patch(
                 "polylogue.storage.archive_readiness.raw_materialization_readiness_snapshot",
-                return_value={"available": True, "total": 0, "affected_total": 0},
+                return_value=_completed_raw_materialization_readiness(),
             ),
             patch("polylogue.storage.embeddings.status_payload.embedding_status_payload", side_effect=RuntimeError),
         ):
@@ -1305,7 +1315,7 @@ class TestNoArchiveStatus:
             patch("polylogue.paths.archive_root", return_value=tmp_path),
             patch(
                 "polylogue.storage.archive_readiness.raw_materialization_readiness_snapshot",
-                return_value={"available": True, "total": 0, "affected_total": 0},
+                return_value=_completed_raw_materialization_readiness(),
             ),
             patch("polylogue.storage.embeddings.status_payload.embedding_status_payload", side_effect=RuntimeError),
         ):
@@ -1336,7 +1346,7 @@ class TestNoArchiveStatus:
             "raw_frontier_integrity": {"state": "ready", "summary": "ready"},
             "search": {"state": "ready", "summary": "ready"},
         }
-        raw_materialization_readiness = {"available": True, "total": 0, "affected_total": 0}
+        raw_materialization_readiness = _completed_raw_materialization_readiness()
         raw_frontier_integrity = {"overall_status": "healthy"}
 
         for unavailable_workload in (

--- a/tests/unit/core/test_claim_guard.py
+++ b/tests/unit/core/test_claim_guard.py
@@ -205,7 +205,11 @@ def test_raw_materialization_ready_agrees_with_archived_devloop_classification()
     """
     for totals in _FIXED_ARCHIVE_STATES:
         devloop_state = _devloop_status_raw_materialization_state(totals)
-        payload = {"available": True, **totals}
+        payload = {
+            "available": True,
+            "raw_authority_frontier": {"lifecycle_status": "completed"},
+            **totals,
+        }
         product_ready = raw_materialization_ready(payload)
         assert product_ready == (devloop_state == "ready"), (
             f"parity mismatch for {totals}: devloop_state={devloop_state!r} product_ready={product_ready!r}"

--- a/tests/unit/core/test_insight_readiness.py
+++ b/tests/unit/core/test_insight_readiness.py
@@ -68,9 +68,10 @@ async def test_insight_readiness_report_marks_rebuilt_insights_ready(cli_workspa
     archive = Polylogue(archive_root=cli_workspace["archive_root"], db_path=db_path)
     report = await archive.insight_readiness_report()
 
-    # The sparse seed now materializes a complete deterministic insight set;
-    # missing rich workflow events do not make the rebuilt read model degraded.
-    assert report.aggregate_verdict == "ready"
+    # The sparse seed deliberately lacks the evidence needed for a fully
+    # grounded profile. Rebuild is complete, but readiness must surface its
+    # fallback rather than falsely claiming a ready insight.
+    assert report.aggregate_verdict == "degraded"
     assert {insight.insight_name for insight in report.insights} >= {
         "session_profiles",
         "session_work_events",
@@ -80,9 +81,9 @@ async def test_insight_readiness_report_marks_rebuilt_insights_ready(cli_workspa
         "archive_coverage",
     }
     profile = _entry_by_name(report, "session_profiles")
-    assert profile.verdict == "ready"
-    assert profile.degraded_count == 0
-    assert profile.fallback_reason_counts == {}
+    assert profile.verdict == "degraded"
+    assert profile.degraded_count == 1
+    assert profile.fallback_reason_counts
     assert profile.row_count == 1
     assert profile.origin_coverage[0].origin == "codex-session"
     assert profile.version_coverage[0].versions[str(SESSION_INSIGHT_MATERIALIZER_VERSION)] == 1

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -1379,6 +1379,13 @@ def test_build_daemon_status_detects_broken_append_head_blocks_converged(tmp_pat
         patch("polylogue.daemon.status.archive_root", return_value=tmp_path),
         patch("polylogue.daemon.status._active_status_db_path", return_value=tmp_path / "index.db"),
         patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
+        patch(
+            "polylogue.daemon.status._raw_materialization_readiness_info",
+            return_value=status_module.RawMaterializationReadiness(
+                available=True,
+                raw_authority_frontier={"lifecycle_status": "completed"},
+            ),
+        ),
     ):
         status = build_daemon_status(sources=())
 
@@ -1466,7 +1473,10 @@ def test_daemon_and_direct_claim_guard_share_mixed_frontier_summary(tmp_path: Pa
         archive_schema_ready=True,
         present_tiers=["source", "index", "embeddings", "user", "ops"],
     )
-    raw_readiness = status_module.RawMaterializationReadiness(available=True)
+    raw_readiness = status_module.RawMaterializationReadiness(
+        available=True,
+        raw_authority_frontier={"lifecycle_status": "completed"},
+    )
     daemon_guard = status_module._daemon_claim_guard(
         archive_storage=storage,
         raw_materialization_readiness=raw_readiness,

--- a/tests/unit/infra/test_workload_artifacts.py
+++ b/tests/unit/infra/test_workload_artifacts.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.storage.archive_readiness import raw_materialization_readiness_snapshot, raw_materialization_ready
 from tests.infra.workload_artifacts import build_seeded_archive, clone_seeded_archive
 
 
@@ -22,6 +23,10 @@ def test_seeded_archive_publishes_valid_immutable_real_pipeline_artifact(tmp_pat
     assert len(first.facts) == 64
     assert first.facts[0].expected_session_id == "codex-session:c03-target"
     assert first.root.joinpath("index.db").exists()
+    assert raw_materialization_ready(raw_materialization_readiness_snapshot(first.root))
+    phases = first.manifest.receipt["phases"]
+    assert isinstance(phases, list)
+    assert any(isinstance(phase, dict) and phase.get("name") == "raw_authority_frontier" for phase in phases)
     assert not (first.root.stat().st_mode & os.W_OK)
 
 


### PR DESCRIPTION
## Summary

Reconciles the current seed baseline with the intentional raw-authority frontier and named workload contracts.

## Problem

The first post-witness clean 8-worker seed was resource-clean but had 25 deterministic failures: stale fixtures described an empty archive as ready, CLI snapshots still encoded the superseded corpus, and sparse insight fixtures expected a falsely-ready state.

## Solution

The real workload build now materializes and validates the raw-authority frontier before publication; fixture readiness payloads explicitly carry a completed frontier when testing healthy state; degraded fallback expectations are honest; and the intentionally changed workload-driven snapshots and demo evidence are reconciled.

## Verification

- `devtools test tests/unit/infra/test_workload_artifacts.py` — 4 passed
- `devtools test tests/unit/cli/test_plain_cli_snapshots.py` — 22 passed
- `devtools test tests/unit/devtools/test_verify_demo_tour_freshness.py` — 6 passed
- `POLYLOGUE_PYTEST_WORKERS=3 devtools test ...` focused readiness/workload cluster — 36 passed
- `devtools verify --quick` — 16/16 steps passed

Ref polylogue-b054.1.1.6