### PR TITLE
fix(receiver): identify rejected browser requests

### DIFF
--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -209,8 +209,14 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
             return False
         if _check_token(dict(self.headers), config):
             return False
+        # The daemon normally uses the lazy stdlib logger, whose plain handler
+        # does not render structured kwargs.  Keep this rejection forensic
+        # without emitting credentials or arbitrary request headers.
         logger.warning(
-            "browser_capture.token_rejected", request_id=self._request_id(), origin=self.headers.get("Origin")
+            "browser_capture.token_rejected request_id=%s path=%s origin=%s",
+            self._request_id(),
+            urlparse(self.path).path,
+            self.headers.get("Origin") or "-",
         )
         self._safe_error(HTTPStatus.UNAUTHORIZED, "unauthorized")
         return True


### PR DESCRIPTION
## Summary

Make browser-capture token rejections diagnostically attributable in the daemon’s ordinary lazy logging mode.

## Problem

The receiver attached request ID and Origin as structured logging fields, but the daemon’s default stdlib logger does not render those fields. Repeated unauthenticated calls therefore could not be traced to a route or extension origin.

## Solution

Render only the safe request identity directly in the rejection event: request ID, route path, and Origin. Tokens and arbitrary headers remain excluded.

## Verification

- `devtools test tests/unit/browser_capture/test_receiver.py -k "auth or token"` — 11 passed