### PR TITLE
perf(watcher): sparsify recovery reconciliation

### DIFF
--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -56,8 +56,8 @@ _INCOMPLETE_APPEND_PROBE_BYTES = 64 * 1024 * 1024
 # recovery mechanism for notifications missed while the daemon was unavailable
 # or a watch backend was briefly unhealthy.  Keeping it at the watch cadence
 # made a large, otherwise-idle archive continuously rescan itself.
-_PERIODIC_CATCH_UP_INTERVAL_S = 15.0
-_PERIODIC_CATCH_UP_MAX_INTERVAL_S = 15.0 * 60.0
+_PERIODIC_CATCH_UP_INTERVAL_S = 5.0 * 60.0
+_PERIODIC_CATCH_UP_MAX_INTERVAL_S = 60.0 * 60.0
 INBOX_SOURCE_SUFFIXES = (".jsonl", ".zip", ".json", ".ndjson", ".db", ".sqlite", ".sqlite3")
 
 


### PR DESCRIPTION
## Summary

Make periodic full-source reconciliation a deliberately sparse missed-event recovery path rather than a near-watch-frequency archive census.

## Problem

Live evidence for `polylogue-20d.6` showed startup catch-up scanning roughly 15,000 candidate paths and taking about two minutes before selecting three active inputs. The native watcher and failed-file retry already provide prompt paths; repeating the expensive full scan after 15 seconds creates avoidable I/O pressure.

## Solution

Start periodic reconciliation five minutes after the mandatory startup catch-up and exponentially back off to one hour. This preserves recovery from missed filesystem events while keeping steady-state capture on the native watcher and explicit retry paths.

Ref polylogue-20d.6.

## Verification

- `devtools test tests/unit/sources/test_live_watcher.py -k 'periodic_catch_up_drains_missed_browser_capture_event or periodic_catch_up_backs_off_after_each_reconciliation_pass'` — 2 passed\n- `devtools verify --quick` — success (pre-push hook)