### PR TITLE
fix(schemas): bound default synthetic payload tails

### DIFF
--- a/docs/plans/demo-corpus-construct-audit.md
+++ b/docs/plans/demo-corpus-construct-audit.md
@@ -17,7 +17,7 @@ This datasheet is generated from the deterministic demo family registry, the dec
 | --- | ---: |
 | Sessions | 15 |
 | Messages | 62 indexed |
-| Blocks | 106 |
+| Blocks | 105 |
 | Session profiles | 15 |
 | Origins | aistudio-drive, chatgpt-export, claude-ai-export, claude-code-session, codex-session |
 | Run rows | 15 |

--- a/polylogue/schemas/synthetic/build_batch.py
+++ b/polylogue/schemas/synthetic/build_batch.py
@@ -34,6 +34,7 @@ class _SyntheticBatchContext(Protocol):
     workload_profile: SchemaRecord | None
     _active_profile_tokens: tuple[str, ...]
     _active_record_bucket: tuple[str, str] | None
+    _max_synthetic_string_length: int | None
     _relation_solver: RelationConstraintSolver
     _semantic_gen: SemanticValueGenerator | None
 
@@ -470,7 +471,10 @@ def generate_batch(
     generated_message_counts: list[int] = []
     selected_variants: Counter[str] = Counter()
     for index in range(count):
-        self._relation_solver = RelationConstraintSolver(self.schema)
+        self._relation_solver = RelationConstraintSolver(
+            self.schema,
+            max_string_length=self._max_synthetic_string_length,
+        )
         self._semantic_gen = None
         selected_variant = self._select_structural_variant(profile_rng)
         if selected_variant is not None:

--- a/polylogue/schemas/synthetic/core.py
+++ b/polylogue/schemas/synthetic/core.py
@@ -31,6 +31,10 @@ if TYPE_CHECKING:
     from polylogue.schemas.synthetic.demo_themes import SessionTheme
 
 
+_DEFAULT_MAX_ARRAY_ITEMS = 32
+_DEFAULT_MAX_STRING_LENGTH = 4_096
+
+
 class SyntheticCorpus:
     """Generate synthetic provider data from annotated schemas."""
 
@@ -43,17 +47,25 @@ class SyntheticCorpus:
         package_version: str = "default",
         element_kind: str | None = None,
         workload_profile: SchemaRecord | None = None,
+        max_array_items: int | None = _DEFAULT_MAX_ARRAY_ITEMS,
+        max_string_length: int | None = _DEFAULT_MAX_STRING_LENGTH,
     ) -> None:
+        if max_array_items is not None and max_array_items < 1:
+            raise ValueError("max_array_items must be positive or None")
+        if max_string_length is not None and max_string_length < 1:
+            raise ValueError("max_string_length must be positive or None")
         self.schema = schema
         self.wire_format = wire_format
         self.provider = provider
         self.package_version = package_version
         self.element_kind = element_kind
         self.workload_profile = workload_profile
+        self._max_array_items = max_array_items
+        self._max_synthetic_string_length = max_string_length
         self._active_profile_tokens: tuple[str, ...] = ()
         self._active_record_bucket: tuple[str, str] | None = None
         self._generation_state = SyntheticGenerationState(
-            relation_solver=RelationConstraintSolver(schema),
+            relation_solver=RelationConstraintSolver(schema, max_string_length=max_string_length),
             semantic_generator=None,
         )
 
@@ -64,6 +76,8 @@ class SyntheticCorpus:
         *,
         version: str = "default",
         element_kind: str | None = None,
+        max_array_items: int | None = _DEFAULT_MAX_ARRAY_ITEMS,
+        max_string_length: int | None = _DEFAULT_MAX_STRING_LENGTH,
     ) -> SyntheticCorpus:
         selection = select_synthetic_schema(
             provider,
@@ -72,10 +86,20 @@ class SyntheticCorpus:
             registry_factory=lambda: SchemaRegistry(),
             canonical_provider_resolver=canonical_schema_provider,
         )
-        return cls.from_selection(selection)
+        return cls.from_selection(
+            selection,
+            max_array_items=max_array_items,
+            max_string_length=max_string_length,
+        )
 
     @classmethod
-    def from_selection(cls, selection: SyntheticSchemaSelection) -> SyntheticCorpus:
+    def from_selection(
+        cls,
+        selection: SyntheticSchemaSelection,
+        *,
+        max_array_items: int | None = _DEFAULT_MAX_ARRAY_ITEMS,
+        max_string_length: int | None = _DEFAULT_MAX_STRING_LENGTH,
+    ) -> SyntheticCorpus:
         return cls(
             selection.schema,
             selection.wire_format,
@@ -83,6 +107,8 @@ class SyntheticCorpus:
             package_version=selection.package_version,
             element_kind=selection.element_kind,
             workload_profile=selection.workload_profile,
+            max_array_items=max_array_items,
+            max_string_length=max_string_length,
         )
 
     def _select_structural_variant(self, rng: random.Random) -> str | None:

--- a/polylogue/schemas/synthetic/relation_solver_runtime.py
+++ b/polylogue/schemas/synthetic/relation_solver_runtime.py
@@ -17,6 +17,11 @@ if TYPE_CHECKING:
     )
 
 
+# Default synthetic generation remains compact; explicit scale workloads are
+# responsible for exercising retained multi-megabyte archive payload tails.
+_DEFAULT_MAX_STRING_LENGTH = 4_096
+
+
 @dataclass(frozen=True)
 class _ForeignKeyAnnotation:
     source: str
@@ -227,6 +232,7 @@ class RelationConstraintSolverRuntimeMixin:
 
         target = int(rng.gauss(constraint.avg_length, constraint.stddev))
         target = max(constraint.min_length, min(constraint.max_length, target))
+        target = min(target, _DEFAULT_MAX_STRING_LENGTH)
 
         if len(base_text) == 0:
             return base_text

--- a/polylogue/schemas/synthetic/relation_solver_runtime.py
+++ b/polylogue/schemas/synthetic/relation_solver_runtime.py
@@ -17,11 +17,6 @@ if TYPE_CHECKING:
     )
 
 
-# Default synthetic generation remains compact; explicit scale workloads are
-# responsible for exercising retained multi-megabyte archive payload tails.
-_DEFAULT_MAX_STRING_LENGTH = 4_096
-
-
 @dataclass(frozen=True)
 class _ForeignKeyAnnotation:
     source: str
@@ -146,6 +141,7 @@ class RelationConstraintSolverRuntimeMixin:
     _time_delta_cls: type[TimeDeltaConstraint]
     _mutual_exclusion_cls: type[MutualExclusionGroup]
     _string_length_cls: type[StringLengthConstraint]
+    _max_synthetic_string_length: int | None
 
     def _parse_foreign_keys(self, schema: SchemaRecord) -> None:
         for annotation in _foreign_key_annotations(schema):
@@ -232,7 +228,9 @@ class RelationConstraintSolverRuntimeMixin:
 
         target = int(rng.gauss(constraint.avg_length, constraint.stddev))
         target = max(constraint.min_length, min(constraint.max_length, target))
-        target = min(target, _DEFAULT_MAX_STRING_LENGTH)
+        limit = self._max_synthetic_string_length
+        if limit is not None:
+            target = min(target, limit)
 
         if len(base_text) == 0:
             return base_text

--- a/polylogue/schemas/synthetic/relations.py
+++ b/polylogue/schemas/synthetic/relations.py
@@ -88,7 +88,7 @@ class RelationConstraintSolver(RelationConstraintSolverRuntimeMixin):
     consistency.
     """
 
-    def __init__(self, schema: SchemaRecord) -> None:
+    def __init__(self, schema: SchemaRecord, *, max_string_length: int | None = None) -> None:
         self.fk_graph = ForeignKeyGraph()
         self.time_deltas: list[TimeDeltaConstraint] = []
         self.mutual_exclusions: list[MutualExclusionGroup] = []
@@ -96,6 +96,7 @@ class RelationConstraintSolver(RelationConstraintSolverRuntimeMixin):
         self._time_delta_cls = TimeDeltaConstraint
         self._mutual_exclusion_cls = MutualExclusionGroup
         self._string_length_cls = StringLengthConstraint
+        self._max_synthetic_string_length = max_string_length
 
         self._parse_foreign_keys(schema)
         self._parse_time_deltas(schema)

--- a/polylogue/schemas/synthetic/runtime.py
+++ b/polylogue/schemas/synthetic/runtime.py
@@ -19,6 +19,11 @@ if TYPE_CHECKING:
 
 SyntheticRecord: TypeAlias = dict[str, JSONValue]
 
+# Inferred schemas retain archive extrema for analysis and scale-tier planning,
+# but this default generator also powers property tests and ordinary seeded
+# artifacts. Sampling a huge nested archive tail there must stay bounded.
+_DEFAULT_MAX_ARRAY_ITEMS = 32
+
 
 class _SyntheticRuntimeContext(Protocol):
     wire_format: WireFormat
@@ -389,6 +394,7 @@ def _generate_array(
         n_items = rng.randint(bounded_lo, bounded_hi)
     else:
         n_items = rng.randint(1, 3)
+    n_items = min(n_items, _DEFAULT_MAX_ARRAY_ITEMS)
 
     item_type = item_schema.get("type")
     item_allows_null = item_type == "null" or (

--- a/polylogue/schemas/synthetic/runtime.py
+++ b/polylogue/schemas/synthetic/runtime.py
@@ -19,11 +19,6 @@ if TYPE_CHECKING:
 
 SyntheticRecord: TypeAlias = dict[str, JSONValue]
 
-# Inferred schemas retain archive extrema for analysis and scale-tier planning,
-# but this default generator also powers property tests and ordinary seeded
-# artifacts. Sampling a huge nested archive tail there must stay bounded.
-_DEFAULT_MAX_ARRAY_ITEMS = 32
-
 
 class _SyntheticRuntimeContext(Protocol):
     wire_format: WireFormat
@@ -31,6 +26,7 @@ class _SyntheticRuntimeContext(Protocol):
     _relation_solver: RelationConstraintSolver
     _active_profile_tokens: tuple[str, ...]
     _active_record_bucket: tuple[str, str] | None
+    _max_array_items: int | None
 
     def _generate_from_schema(
         self,
@@ -394,7 +390,8 @@ def _generate_array(
         n_items = rng.randint(bounded_lo, bounded_hi)
     else:
         n_items = rng.randint(1, 3)
-    n_items = min(n_items, _DEFAULT_MAX_ARRAY_ITEMS)
+    if self._max_array_items is not None:
+        n_items = min(n_items, self._max_array_items)
 
     item_type = item_schema.get("type")
     item_allows_null = item_type == "null" or (

--- a/tests/unit/core/test_schema_workload_profiles.py
+++ b/tests/unit/core/test_schema_workload_profiles.py
@@ -220,10 +220,43 @@ def test_synthetic_generation_bounds_inferred_tail_payloads() -> None:
     corpus = SyntheticCorpus(schema, WireFormat(encoding="json"), "test")
 
     generated = cast(dict[str, JSONValue], corpus._generate_from_schema(schema, random.Random(7)))
-    items = cast(list[str], generated["items"])
+    items = cast(list[JSONValue], generated["items"])
+    generated_strings = [item for item in items if isinstance(item, str)]
 
     assert len(items) == 32
-    assert all(4_000 <= len(item) <= 4_096 for item in items)
+    assert generated_strings
+    assert max(map(len, generated_strings)) <= 4_096
+
+
+def test_synthetic_generation_can_explicitly_preserve_tail_limits() -> None:
+    array_schema: JSONDocument = {
+        "type": "array",
+        "items": {"type": "integer"},
+        "x-polylogue-array-lengths": [2_500, 2_500],
+    }
+    string_schema: JSONDocument = {
+        "type": "object",
+        "properties": {"body": {"type": "string"}},
+        "x-polylogue-string-lengths": [{"path": "$.body", "min": 8_192, "max": 8_192, "avg": 8_192, "stddev": 0}],
+    }
+    unbounded_array = SyntheticCorpus(
+        array_schema,
+        WireFormat(encoding="json"),
+        "test",
+        max_array_items=None,
+    )
+    unbounded_string = SyntheticCorpus(
+        string_schema,
+        WireFormat(encoding="json"),
+        "test",
+        max_string_length=None,
+    )
+
+    items = cast(list[JSONValue], unbounded_array._generate_from_schema(array_schema, random.Random(7)))
+    record = cast(dict[str, JSONValue], unbounded_string._generate_from_schema(string_schema, random.Random(7)))
+
+    assert len(items) == 2_500
+    assert 8_190 <= len(cast(str, record["body"])) <= 8_192
 
 
 def test_registry_roundtrips_separate_workload_profile_artifact(tmp_path: Path) -> None:

--- a/tests/unit/core/test_schema_workload_profiles.py
+++ b/tests/unit/core/test_schema_workload_profiles.py
@@ -203,6 +203,29 @@ def test_annotations_drive_synthetic_numeric_and_array_distributions() -> None:
     assert max(lengths) >= 19
 
 
+def test_synthetic_generation_bounds_inferred_tail_payloads() -> None:
+    schema: JSONDocument = {
+        "type": "object",
+        "properties": {
+            "items": {
+                "type": "array",
+                "items": {"type": "string"},
+                "x-polylogue-array-lengths": [2_500, 2_500],
+            }
+        },
+        "x-polylogue-string-lengths": [
+            {"path": "$.items[*]", "min": 1_000_000, "max": 1_000_000, "avg": 1_000_000, "stddev": 0}
+        ],
+    }
+    corpus = SyntheticCorpus(schema, WireFormat(encoding="json"), "test")
+
+    generated = cast(dict[str, JSONValue], corpus._generate_from_schema(schema, random.Random(7)))
+    items = cast(list[str], generated["items"])
+
+    assert len(items) == 32
+    assert all(4_000 <= len(item) <= 4_096 for item in items)
+
+
 def test_registry_roundtrips_separate_workload_profile_artifact(tmp_path: Path) -> None:
     registry = SchemaRegistry(storage_root=tmp_path / "schemas")
     package = SchemaVersionPackage(


### PR DESCRIPTION
## Summary

Bounds ordinary schema-driven synthetic generation while preserving inferred archive tail evidence for explicit scale workloads.

## Problem

The first post-baseline 8-worker seed passed 15,904 tests but one Gemini property workload sampled schema extrema such as 2,502 nested parts and multi-megabyte strings. It exceeded the 120-second timeout and Hypothesis correctly rejected the timeout-induced replay as flaky.

## Solution

Default arrays cap at 32 elements and generated strings at 4 KiB. The inferred maxima remain in schema annotations; scale-tier workloads remain the place to exercise those tails. A regression constructs the pathological shape and proves bounded output.

## Verification

- `POLYLOGUE_PYTEST_WORKERS=3 devtools test tests/unit/core/test_schema_workload_profiles.py tests/unit/sources/test_source_laws.py::test_parse_payload_bundle_cardinality_contract[gemini-bundle]` — 20 passed
- `devtools verify --quick` — 16/16 steps passed

Ref polylogue-b054.1.1.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Synthetic data generation now limits arrays to 32 items and generated strings to 4,096 characters, improving predictability and preventing excessively large outputs.
  * Corrected the documented demo archive coverage count for blocks from 106 to 105.

* **Tests**
  * Added coverage verifying that generated arrays and strings respect the new size limits and configured constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->