### PR TITLE
fix(watcher): rebase remounted cursor observations

### DIFF
--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -72,6 +72,14 @@ def cursor_ctime_ns(authority: str | None) -> int | None:
     return int(authority.rsplit(":", 1)[1])
 
 
+def cursor_tail_hash(authority: str | None) -> str | None:
+    """Return the bounded tail digest embedded in cursor authority."""
+    if cursor_prefix_hash(authority) is None:
+        return None
+    assert authority is not None
+    return authority.split(":")[2]
+
+
 def _archive_blob_exists(archive_root: Path, blob_hash_hex: str) -> bool:
     """Return whether a content-addressed archive blob is present on disk."""
     normalized = blob_hash_hex.lower()

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -1047,39 +1047,6 @@ class CursorStore:
             )
         )
 
-    def rebase_authoritative_observation(
-        self,
-        path: Path,
-        *,
-        expected: CursorRecord,
-        stat: os.stat_result,
-        tail_hash: str,
-    ) -> bool:
-        """Adopt a new stat observation after proving the accepted prefix.
-
-        A filesystem remount can change ``st_dev`` while leaving the inode,
-        bytes, and timestamps intact.  The watcher verifies the whole accepted
-        prefix in that situation.  Persisting the new observation is essential:
-        without it every later restart repeats the same proof for every file.
-        The compare-and-replace mutation refuses to overwrite a concurrent
-        append or ingest cursor update.
-        """
-
-        return bool(
-            self.rebase_authoritative_observations(
-                (
-                    CursorObservationRebase(
-                        path=path,
-                        expected=expected,
-                        st_dev=stat.st_dev,
-                        st_ino=stat.st_ino,
-                        mtime_ns=stat.st_mtime_ns,
-                        tail_hash=tail_hash,
-                    ),
-                )
-            )
-        )
-
     def rebase_authoritative_observations(self, rebases: Iterable[CursorObservationRebase]) -> int:
         """Persist a catch-up batch of already-proved observation rebases.
 

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -77,6 +77,18 @@ class CursorRecord:
 
 
 @dataclass(frozen=True, slots=True)
+class CursorObservationRebase:
+    """A proved-safe replacement for a cursor's filesystem observation."""
+
+    path: Path
+    expected: CursorRecord
+    st_dev: int
+    st_ino: int
+    mtime_ns: int
+    tail_hash: str
+
+
+@dataclass(frozen=True, slots=True)
 class LiveIngestAttempt:
     """Durable live-ingest attempt snapshot for in-flight diagnostics."""
 
@@ -1035,6 +1047,76 @@ class CursorStore:
             )
         )
 
+    def rebase_authoritative_observation(
+        self,
+        path: Path,
+        *,
+        expected: CursorRecord,
+        stat: os.stat_result,
+        tail_hash: str,
+    ) -> bool:
+        """Adopt a new stat observation after proving the accepted prefix.
+
+        A filesystem remount can change ``st_dev`` while leaving the inode,
+        bytes, and timestamps intact.  The watcher verifies the whole accepted
+        prefix in that situation.  Persisting the new observation is essential:
+        without it every later restart repeats the same proof for every file.
+        The compare-and-replace mutation refuses to overwrite a concurrent
+        append or ingest cursor update.
+        """
+
+        return bool(
+            self.rebase_authoritative_observations(
+                (
+                    CursorObservationRebase(
+                        path=path,
+                        expected=expected,
+                        st_dev=stat.st_dev,
+                        st_ino=stat.st_ino,
+                        mtime_ns=stat.st_mtime_ns,
+                        tail_hash=tail_hash,
+                    ),
+                )
+            )
+        )
+
+    def rebase_authoritative_observations(self, rebases: Iterable[CursorObservationRebase]) -> int:
+        """Persist a catch-up batch of already-proved observation rebases.
+
+        The catch-up planner can prove thousands of stable files after a
+        remount.  Use one ops-tier transaction so that retiring that legacy
+        device identity does not itself become a long-lived SQLite write storm.
+        """
+
+        unique = {rebase.path: rebase for rebase in rebases}
+        if not unique:
+            return 0
+        updated = 0
+
+        def write() -> None:
+            nonlocal updated
+            with self._connect_ops() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                for rebase in unique.values():
+                    current = self._get_record_on_conn(conn, rebase.path)
+                    if current != rebase.expected:
+                        continue
+                    self._write_cursor_record_on_conn(
+                        conn,
+                        replace(
+                            current,
+                            updated_at=datetime.now(UTC).isoformat(),
+                            tail_hash=rebase.tail_hash,
+                            st_dev=rebase.st_dev,
+                            st_ino=rebase.st_ino,
+                            mtime_ns=rebase.mtime_ns,
+                        ),
+                    )
+                    updated += 1
+
+        best_effort_cursor_write("archive ops cursor observation rebase", write)
+        return updated
+
     def mark_failed(self, path: Path, *, failed_stat: os.stat_result | None = None) -> None:
         """Increment failure count and set exponential backoff.
 
@@ -1327,6 +1409,7 @@ class CursorStore:
 
 
 __all__ = [
+    "CursorObservationRebase",
     "CursorRecord",
     "CursorStore",
     "LiveConvergenceDebt",

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -34,12 +34,13 @@ from polylogue.sources.live.batch_support import (
     _archive_blob_exists,
     cursor_ctime_ns,
     cursor_prefix_hash,
+    cursor_tail_hash,
     encode_cursor_hash_authority,
     sha256_range_from_path,
     tail_hash_and_last_complete_newline_from_path,
     tail_hash_from_path,
 )
-from polylogue.sources.live.cursor import CursorRecord, CursorStore
+from polylogue.sources.live.cursor import CursorObservationRebase, CursorRecord, CursorStore
 from polylogue.sources.live.deferred_cursor import record_deferred_append_cursor
 from polylogue.sources.live.metrics import LiveBatchMetrics
 from polylogue.sources.sqlite_snapshot import is_sqlite_path, sqlite_database_for_sidecar, sqlite_source_revision
@@ -437,6 +438,7 @@ class LiveWatcher:
             return CatchUpPlan(candidates=(), needed=(), skipped_file_count=0, needed_bytes=0)
         cursor_records = self._cursor.get_records(candidate.path for candidate in candidates)
         needed: list[Path] = []
+        rebases: list[CursorObservationRebase] = []
         skipped = 0
         needed_bytes = 0
         for candidate in candidates:
@@ -446,11 +448,14 @@ class LiveWatcher:
                 candidate.path,
                 stat=candidate.stat,
                 cursor=cursor_records.get(candidate.path),
+                rebase_queue=rebases,
             ):
                 needed.append(candidate.path)
                 needed_bytes += candidate.stat.st_size
             else:
                 skipped += 1
+        if rebases:
+            self._cursor.rebase_authoritative_observations(rebases)
         return CatchUpPlan(
             candidates=candidates,
             needed=tuple(needed),
@@ -664,7 +669,14 @@ class LiveWatcher:
         cursor = self._cursor.get_record(path)
         return self._needs_work_from_state(path, stat=stat, cursor=cursor)
 
-    def _needs_work_from_state(self, path: Path, *, stat: os.stat_result, cursor: CursorRecord | None) -> bool:
+    def _needs_work_from_state(
+        self,
+        path: Path,
+        *,
+        stat: os.stat_result,
+        cursor: CursorRecord | None,
+        rebase_queue: list[CursorObservationRebase] | None = None,
+    ) -> bool:
         size = stat.st_size
         if cursor is None:
             if not self._reconcile_archived_cursor(path, stat=stat):
@@ -731,13 +743,31 @@ class LiveWatcher:
                 final_stat = path.stat()
             except (EOFError, OSError):
                 return True
-            return current_prefix_hash != prefix_hash or (
+            observation_changed = (
                 final_stat.st_dev,
                 final_stat.st_ino,
                 final_stat.st_size,
                 final_stat.st_mtime_ns,
                 final_stat.st_ctime_ns,
             ) != (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns, stat.st_ctime_ns)
+            if current_prefix_hash != prefix_hash or observation_changed:
+                return True
+            tail_hash = cursor_tail_hash(cursor.tail_hash)
+            if tail_hash is None:
+                return True
+            rebase = CursorObservationRebase(
+                path=path,
+                expected=cursor,
+                st_dev=final_stat.st_dev,
+                st_ino=final_stat.st_ino,
+                mtime_ns=final_stat.st_mtime_ns,
+                tail_hash=encode_cursor_hash_authority(prefix_hash, tail_hash, ctime_ns=final_stat.st_ctime_ns),
+            )
+            if rebase_queue is None:
+                self._cursor.rebase_authoritative_observations((rebase,))
+            else:
+                rebase_queue.append(rebase)
+            return False
         if size > cursor.byte_offset:
             # A previous incomplete-tail probe recorded this exact filesystem
             # state.  The next useful observation is a write notification (or

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -32,7 +32,10 @@ from polylogue.sources.live.batch import (
     _FullIngestResult,
     last_complete_newline_from_tail,
 )
-from polylogue.sources.live.batch_support import encode_cursor_hash_authority
+from polylogue.sources.live.batch_support import (
+    encode_cursor_hash_authority,
+    tail_hash_from_path,
+)
 from polylogue.sources.live.cursor import CursorRecord, CursorStore
 from polylogue.sources.live.metrics import LiveBatchMetrics
 from polylogue.sources.sqlite_snapshot import sqlite_source_revision
@@ -1984,6 +1987,78 @@ def test_catch_up_skips_already_processed(tmp_path: Path) -> None:
     parse_sources.reset_mock()
 
     asyncio.run(watcher._catch_up([root]))
+    assert parse_sources.await_count == 0
+
+
+def test_catch_up_rebases_device_drift_after_one_prefix_proof(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A remount must not make every later restart rehash stable history."""
+    root = tmp_path / "src"
+    root.mkdir()
+    path = root / "session.jsonl"
+    payload = b'{"a":1}\n'
+    path.write_bytes(payload)
+    watcher, parse_sources = _make_watcher(tmp_path, root)
+    stat = path.stat()
+    prefix_hash = sha256(payload).hexdigest()
+    tail_hash, _ = tail_hash_from_path(path, len(payload))
+    watcher._cursor.set(
+        path,
+        len(payload),
+        byte_offset=len(payload),
+        last_complete_newline=len(payload),
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+        content_fingerprint=prefix_hash,
+        tail_hash=encode_cursor_hash_authority(
+            prefix_hash,
+            tail_hash,
+            ctime_ns=stat.st_ctime_ns,
+        ),
+        source_name="test",
+        st_dev=stat.st_dev + 1,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+    )
+
+    calls = 0
+    rebase_batches = 0
+    real_hash = cast(Callable[..., tuple[str, int]], live_watcher.__dict__["sha256_range_from_path"])
+    real_rebase = watcher._cursor.rebase_authoritative_observations
+
+    def counted_hash(
+        source: Path,
+        *,
+        start_offset: int,
+        end_offset: int,
+        chunk_size: int = 64 * 1024,
+    ) -> tuple[str, int]:
+        nonlocal calls
+        calls += 1
+        return real_hash(
+            source,
+            start_offset=start_offset,
+            end_offset=end_offset,
+            chunk_size=chunk_size,
+        )
+
+    monkeypatch.setattr(live_watcher, "sha256_range_from_path", counted_hash)
+
+    def counted_rebase(rebases: Iterable[object]) -> int:
+        nonlocal rebase_batches
+        rebase_batches += 1
+        return real_rebase(cast(Iterable[Any], rebases))
+
+    monkeypatch.setattr(watcher._cursor, "rebase_authoritative_observations", counted_rebase)
+
+    asyncio.run(watcher._catch_up([root]))
+    rebased = watcher._cursor.get_record(path)
+    assert calls == 1
+    assert rebase_batches == 1
+    assert parse_sources.await_count == 0
+    assert rebased is not None
+    assert rebased.st_dev == stat.st_dev
+
+    asyncio.run(watcher._catch_up([root]))
+    assert calls == 1
     assert parse_sources.await_count == 0
 
 


### PR DESCRIPTION
## Summary

Repair the live watcher so a filesystem remount causes at most one full-prefix proof per authoritative cursor, followed by a persistent fast-path observation.

## Problem

Live evidence found a changed filesystem device id on 14,145 of 15,473 catch-up candidates. Their inode, size, mtime, ctime, and accepted prefix all remained valid, but the watcher re-hashed every prefix on every restart because it never adopted the proven post-remount observation. One startup prefilter held the daemon writer for 168.5 seconds and previously made service restart exceed its 90-second stop timeout.

## Solution

- Add a compare-and-replace cursor-observation rebase that preserves content authority and adopts the current filesystem observation only after the full accepted prefix proves equal.
- Batch all catch-up rebases in one ops-tier transaction, avoiding a second SQLite write storm during remount recovery.
- Add a regression route proving one hash and one batch rebase on first catch-up, then zero hashes and no ingestion on the next catch-up.

### Evidence

| Scenario | Before | After |
| --- | --- | --- |
| Remounted authoritative cursor | Full prefix proof every catch-up | One proof, then rebased fast skip |
| Catch-up cursor writes | One transaction per rebase would be required | One transaction for the catch-up batch |

What I did not change: ordinary same-size content rewrites still require full-prefix proof; this remains the integrity boundary.

Ref polylogue-20d.6.

## Verification

- `devtools test tests/unit/sources/test_live_watcher.py` — 82 passed
- `devtools verify --quick` — success
- Pre-push `devtools verify --quick` — success

Note: `tests/integration/test_live_read_amplification.py::TestRestartedCursorReconcile::test_missing_cursor_reconciles_archived_prefix_for_append` fails unchanged on current master; it is outside this diff and reproduced independently.