### PR TITLE
test(cli): refresh named workload snapshots

### DIFF
--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -25,13 +25,13 @@
               "session_id": "claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>"
             },
             {
-              "session_id": "chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>"
+              "session_id": "chatgpt-export:88ffbd40-3b72-486d-92fa-<HASH>"
             },
             {
               "session_id": "claude-code-session:3eb13b90-4668-4257-bdd6-<HASH>"
             },
             {
-              "session_id": "chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>"
+              "session_id": "chatgpt-export:c3b290d0-8edd-4fcd-9e52-<HASH>"
             }
           ]
         },
@@ -50,7 +50,7 @@
           "total_cost_usd": 0.0,
           "cost_is_estimated": true,
           "tokens": {
-            "input_tokens": 198,
+            "input_tokens": 231,
             "output_tokens": 0,
             "cache_read_tokens": 0,
             "cache_write_tokens": 0
@@ -73,25 +73,22 @@
         "wallclock_span": {
           "earliest_first_message_at": "<TIMESTAMP>",
           "latest_last_message_at": "<TIMESTAMP>",
-          "span_ms": 89015964354,
+          "span_ms": 84831612311,
           "summed_wall_duration_ms": <HASH>,
           "evidence_refs": [
             {
-              "session_id": "chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>"
-            },
-            {
-              "session_id": "chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>"
+              "session_id": "chatgpt-export:88ffbd40-3b72-486d-92fa-<HASH>"
             }
           ]
         },
         "wallclock_distribution_s": {
           "count": 4,
-          "total": 138057653.592,
+          "total": 160083156.106,
           "minimum": 240.0,
           "p50": 360.0,
-          "p90": 73354075.265,
-          "maximum": 73354075.265,
-          "mean": 34514413.398
+          "p90": 84831612.311,
+          "maximum": 84831612.311,
+          "mean": 40020789.0265
         },
         "pathologies": {
           "status": "clean",
@@ -134,27 +131,24 @@
               "session_id": "claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>"
             },
             {
-              "session_id": "chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>"
+              "session_id": "chatgpt-export:88ffbd40-3b72-486d-92fa-<HASH>"
             },
             {
               "session_id": "claude-code-session:3eb13b90-4668-4257-bdd6-<HASH>"
             },
             {
-              "session_id": "chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>"
+              "session_id": "chatgpt-export:c3b290d0-8edd-4fcd-9e52-<HASH>"
             }
           ]
         },
         "wallclock_span": {
           "earliest_first_message_at": "<TIMESTAMP>",
           "latest_last_message_at": "<TIMESTAMP>",
-          "span_ms": 89015964354,
+          "span_ms": 84831612311,
           "summed_wall_duration_ms": <HASH>,
           "evidence_refs": [
             {
-              "session_id": "chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>"
-            },
-            {
-              "session_id": "chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>"
+              "session_id": "chatgpt-export:88ffbd40-3b72-486d-92fa-<HASH>"
             }
           ]
         },
@@ -162,7 +156,7 @@
           "total_cost_usd": 0.0,
           "cost_is_estimated": true,
           "tokens": {
-            "input_tokens": 198,
+            "input_tokens": 231,
             "output_tokens": 0,
             "cache_read_tokens": 0,
             "cache_write_tokens": 0
@@ -220,7 +214,7 @@
 # name: test_json_analyze_snapshot
   '''
   {
-    "avg_messages_per_session": 6.0,
+    "avg_messages_per_session": 7.5,
     "db_size_bytes": <SIZE_BYTES>,
     "embedded_messages": 0,
     "embedded_sessions": 0,
@@ -231,11 +225,11 @@
     "embedding_oldest_at": null,
     "embedding_readiness_status": "none",
     "material_origins": {
-      "assistant_authored": 5,
-      "human_authored": 7
+      "assistant_authored": 7,
+      "human_authored": 8
     },
     "message_types": {
-      "message": 12
+      "message": 15
     },
     "messages_missing_embedding_provenance": 0,
     "mode": "stats",
@@ -248,12 +242,12 @@
     "query": null,
     "retrieval_ready": false,
     "role_counts": {
-      "assistant": 5,
-      "user": 7
+      "assistant": 7,
+      "user": 8
     },
     "stale_embedding_messages": 0,
     "total_attachments": 0,
-    "total_messages": 12,
+    "total_messages": 15,
     "total_sessions": 2
   }
   
@@ -396,7 +390,7 @@
     "omitted_facet_counts": {},
     "time_range": null,
     "total_sessions": 2,
-    "total_messages": 12,
+    "total_messages": 15,
     "scoped": {
       "origins": {
         "chatgpt-export": 2
@@ -410,7 +404,7 @@
       "has_flags": {},
       "omitted": {},
       "total_sessions": 2,
-      "total_messages": 12
+      "total_messages": 15
     },
     "global": {
       "origins": {
@@ -425,7 +419,7 @@
       "has_flags": {},
       "omitted": {},
       "total_sessions": 2,
-      "total_messages": 12
+      "total_messages": 15
     },
     "idf": {
       "origins": {
@@ -455,21 +449,21 @@
             "state": "enabled"
           }
         },
-        "anchor": "session-chatgpt-export-22af711f-1b62-4a9d-b536-<HASH>",
+        "anchor": "session-chatgpt-export-88ffbd40-3b72-486d-92fa-<HASH>",
         "created_at": "<TIMESTAMP>",
-        "id": "chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>",
-        "message_count": 7,
+        "id": "chatgpt-export:88ffbd40-3b72-486d-92fa-<HASH>",
+        "message_count": 10,
         "origin": "chatgpt-export",
         "tags": [],
         "target_ref": {
-          "identity_key": "session:chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>",
-          "session_id": "chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>",
-          "target_id": "chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>",
+          "identity_key": "session:chatgpt-export:88ffbd40-3b72-486d-92fa-<HASH>",
+          "session_id": "chatgpt-export:88ffbd40-3b72-486d-92fa-<HASH>",
+          "target_id": "chatgpt-export:88ffbd40-3b72-486d-92fa-<HASH>",
           "target_type": "session"
         },
         "title": "seed-00-01",
         "updated_at": "<TIMESTAMP>",
-        "words": 203
+        "words": 420
       },
       {
         "actions": {
@@ -486,21 +480,21 @@
             "state": "enabled"
           }
         },
-        "anchor": "session-chatgpt-export-4991ab9b-ebc2-426f-af34-<HASH>",
+        "anchor": "session-chatgpt-export-c3b290d0-8edd-4fcd-9e52-<HASH>",
         "created_at": "<TIMESTAMP>",
-        "id": "chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>",
+        "id": "chatgpt-export:c3b290d0-8edd-4fcd-9e52-<HASH>",
         "message_count": 5,
         "origin": "chatgpt-export",
         "tags": [],
         "target_ref": {
-          "identity_key": "session:chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>",
-          "session_id": "chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>",
-          "target_id": "chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>",
+          "identity_key": "session:chatgpt-export:c3b290d0-8edd-4fcd-9e52-<HASH>",
+          "session_id": "chatgpt-export:c3b290d0-8edd-4fcd-9e52-<HASH>",
+          "target_id": "chatgpt-export:c3b290d0-8edd-4fcd-9e52-<HASH>",
           "target_type": "session"
         },
         "title": "seed-00-00",
         "updated_at": "<TIMESTAMP>",
-        "words": 190
+        "words": 195
       }
     ],
     "limit": 20,
@@ -529,7 +523,7 @@
     "config_exists": false,
     "config_path": "<PATH>",
     "sessions": 2,
-    "messages": 12,
+    "messages": 15,
     "raw_records": 2,
     "next_action": "polylogue init",
     "component_readiness": {
@@ -1007,8 +1001,8 @@
         "version_status": "ok",
         "table_counts": {
           "sessions": 2,
-          "messages": 12,
-          "blocks": 44,
+          "messages": 15,
+          "blocks": 68,
           "session_profiles": 0,
           "session_work_events": 0,
           "session_phases": 0,
@@ -1311,12 +1305,12 @@
   - **Sessions:** 4 analyzed / 4 matched
   - **Origins:** chatgpt-export (2), claude-code-session (2)
   - **Total cost:** $0.00 _(estimated)_
-  - **Tokens:** in 198, out 0, cache-read 0, cache-write 0
+  - **Tokens:** in 231, out 0, cache-read 0, cache-write 0
   
   ## Distributions
   
   - Cost per session (USD): no signal
-  - Wall time per session: n=4 total=1.38058e+<DURATION> min=240 p50=360 p90=7.33541e+07 max=7.33541e+07 mean=3.45144e+07
+  - Wall time per session: n=4 total=1.60083e+<DURATION> min=240 p50=360 p90=8.48316e+07 max=8.48316e+07 mean=4.00208e+07
   
   ## Failure-mode pathologies
   
@@ -1342,9 +1336,9 @@
   | Field | Value |
   | --- | --- |
   | session_count | 4 |
-  | wallclock_span | span_ms=89015964354, summed_wall_ms=<HASH> |
+  | wallclock_span | span_ms=84831612311, summed_wall_ms=<HASH> |
   | estimated_cost_usd | $0.000000 (estimated) |
-  | token_lanes | input=198, output=0, cache_read=0, cache_write=0 |
+  | token_lanes | input=231, output=0, cache_read=0, cache_write=0 |
   | top_expensive_session | no_signal: no session in scope carries a positive cost figure |
   | repos_touched | (none) |
   | subagent_branch_count | 0 |
@@ -1356,8 +1350,8 @@
   
   | Field | Evidence refs |
   | --- | --- |
-  | session_count | claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>, chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>, claude-code-session:3eb13b90-4668-4257-bdd6-<HASH>, chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH> |
-  | wallclock_span | chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>, chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH> |
+  | session_count | claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>, chatgpt-export:88ffbd40-3b72-486d-92fa-<HASH>, claude-code-session:3eb13b90-4668-4257-bdd6-<HASH>, chatgpt-export:c3b290d0-8edd-4fcd-9e52-<HASH> |
+  | wallclock_span | chatgpt-export:88ffbd40-3b72-486d-92fa-<HASH> |
   | estimated_cost | claude-code-session:e6b3c944-cb32-4e35-b922-<HASH> |
   | top_expensive_session | claude-code-session:e6b3c944-cb32-4e35-b922-<HASH> |
   | subagent_branch_count | claude-code-session:e6b3c944-cb32-4e35-b922-<HASH> |
@@ -1378,10 +1372,10 @@
   sessions: analyzed=4 matched=4
   origins: chatgpt-export=2, claude-code-session=2
   total_cost: $0.00 (estimated)
-  tokens: in=198 out=0 cache_read=0 cache_write=0
+  tokens: in=231 out=0 cache_read=0 cache_write=0
   cost_per_session_usd: no signal
-  wall_per_session_s: n=4 total=1.38058e+<DURATION> min=240 p50=360 p90=7.33541e+07 max=7.33541e+07 mean=3.45144e+07
-  wallclock_span_ms: 89015964354
+  wall_per_session_s: n=4 total=1.60083e+<DURATION> min=240 p50=360 p90=8.48316e+07 max=8.48316e+07 mean=4.00208e+07
+  wallclock_span_ms: 84831612311
   pathologies: clean (detectors ran; no pathology found)
   context_loss: clean (detectors ran; no pathology found)
   
@@ -1392,9 +1386,9 @@
   Postmortem bundle
     scope: matched=4, analyzed=4
     sessions: 4
-    wallclock: span_ms=89015964354 summed_wall_ms=<HASH> (<TIMESTAMP> -> <TIMESTAMP>)
+    wallclock: span_ms=84831612311 summed_wall_ms=<HASH> (<TIMESTAMP> -> <TIMESTAMP>)
     cost: $0.000000 (estimated)
-      tokens: input=198 output=0 cache_read=0 cache_write=0
+      tokens: input=231 output=0 cache_read=0 cache_write=0
     top_expensive_session: no_signal (no session in scope carries a positive cost figure)
     repos_touched: (none)
     subagent_branch_count: 0
@@ -1402,8 +1396,8 @@
     wasted_loop: clean (no pathology found)
     failure_mode: clean (no pathology found)
     evidence:
-      session_count: claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>, chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>, claude-code-session:3eb13b90-4668-4257-bdd6-<HASH>, chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>
-      wallclock_span: chatgpt-export:22af711f-1b62-4a9d-b536-<HASH>, chatgpt-export:4991ab9b-ebc2-426f-af34-<HASH>
+      session_count: claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>, chatgpt-export:88ffbd40-3b72-486d-92fa-<HASH>, claude-code-session:3eb13b90-4668-4257-bdd6-<HASH>, chatgpt-export:c3b290d0-8edd-4fcd-9e52-<HASH>
+      wallclock_span: chatgpt-export:88ffbd40-3b72-486d-92fa-<HASH>
       estimated_cost: claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>
       top_expensive_session: claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>
       subagent_branch_count: claude-code-session:e6b3c944-cb32-4e35-b922-<HASH>
@@ -1413,24 +1407,24 @@
 # name: test_plain_analyze_snapshot
   '''
   Sessions: 2
-  Messages: 12
+  Messages: 15
   Attachments: 0
   Origins: 1
-  Average messages: 6.0
+  Average messages: 7.5
   
   '''
 # ---
 # name: test_plain_read_all_origin_filter_snapshot
   '''
-  chatgpt-export:22af711f-  <TIMESTAMP>  chatgpt-export            seed-00-01 (7 msgs)
-  chatgpt-export:4991ab9b-  <TIMESTAMP>  chatgpt-export            seed-00-00 (5 msgs)
+  chatgpt-export:88ffbd40-  <TIMESTAMP>  chatgpt-export            seed-00-01 (10 msgs)
+  chatgpt-export:c3b290d0-  <TIMESTAMP>  chatgpt-export            seed-00-00 (5 msgs)
   
   '''
 # ---
 # name: test_plain_read_all_snapshot
   '''
-  chatgpt-export:22af711f-  <TIMESTAMP>  chatgpt-export            seed-00-01 (7 msgs)
-  chatgpt-export:4991ab9b-  <TIMESTAMP>  chatgpt-export            seed-00-00 (5 msgs)
+  chatgpt-export:88ffbd40-  <TIMESTAMP>  chatgpt-export            seed-00-01 (10 msgs)
+  chatgpt-export:c3b290d0-  <TIMESTAMP>  chatgpt-export            seed-00-00 (5 msgs)
   
   '''
 # ---

--- a/tests/unit/cli/test_plain_cli_snapshots.py
+++ b/tests/unit/cli/test_plain_cli_snapshots.py
@@ -434,8 +434,8 @@ def test_analyze_facets_include_deferred_materializes_expensive_families(
     assert payload["material_origins"]
     # The named ``cli-chatgpt`` workload is deliberately generated through
     # the schema-backed production route; its deterministic seed currently
-    # realizes 12 message blocks across its two sessions.
-    assert payload["message_types"] == {"message": 12}
+    # realizes 15 message blocks across its two sessions.
+    assert payload["message_types"] == {"message": 15}
 
 
 def test_analyze_facets_default_marks_detail_families_deferred_not_authoritative(


### PR DESCRIPTION
## Summary

Refreshes deterministic CLI snapshots for the named schema-backed `cli-chatgpt` workload.

## Problem

The compact default synthetic-generation policy intentionally changes this fixed-seed workload's realized corpus from 12 to 15 messages. Fourteen production-route CLI snapshots and one explicit aggregate expectation were therefore stale; fresh-process byte hashes proved this is deterministic, not a cross-process instability.

## Solution

Regenerate `test_plain_cli_snapshots.ambr` through the real CLI fixture and align the explicit `message_types` aggregate assertion with the 15-message corpus. No product behavior changed.

## Verification

- `POLYLOGUE_PYTEST_WORKERS=3 devtools test tests/unit/cli/test_plain_cli_snapshots.py` → 22 passed
- `devtools verify --quick` → 16/16 checks succeeded

Ref polylogue-b054.1.1.6.
