### PR TITLE
fix(extension): skip unauthenticated receiver probes

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -876,6 +876,19 @@ async function checkReceiverHealth({ allowCanonicalRecovery = true } = {}) {
   const settings = await receiverSettings();
   const pairingBefore = await storedReceiverPairing();
 
+  // A fresh extension profile has no authority to probe an authenticated
+  // receiver. Keep that unpaired state local: repeatedly sending an empty
+  // request only creates receiver-side auth noise and cannot establish trust.
+  if (!settings.authToken) {
+    return {
+      ok: true,
+      status: "unauthorized",
+      detail: "receiver_auth_missing",
+      endpoint: settings.baseUrl,
+      pairing: pairingBefore,
+    };
+  }
+
   async function classifyProbe(endpoint, probe, recoveredFrom = null) {
     const body = probe.body;
     if (!body || typeof body !== "object") {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -2725,12 +2725,15 @@ describe("receiver health probe", () => {
     expect(stored.polylogueCaptureQueue).toEqual(queue);
   });
 
-  it("reports the receiver as reachable but unauthorized when no valid token is configured", async () => {
+  it("keeps a missing receiver token local without probing the receiver", async () => {
+    await loadBackground({ receiverAuthToken: "" });
     globalThis.fetch = vi.fn(async () => responseJson({ ok: false, error: "unauthorized" }));
 
     const response = await sendRuntimeMessage({ type: "polylogue.checkReceiverHealth" });
 
-    expect(response).toMatchObject({ ok: true, status: "unauthorized", detail: "unauthorized" });
+    expect(response).toMatchObject({ ok: true, status: "unauthorized", detail: "receiver_auth_missing" });
+    expect(response.receiver_request_id).toBeUndefined();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   it("reports the receiver as unreachable when the fetch itself fails", async () => {


### PR DESCRIPTION
## Summary

A fresh, unpaired extension profile now reports that its receiver token is
required without issuing an unauthenticated status request.

## Problem

The receiver is intentionally deny-by-default. A profile without a stored
bearer token cannot establish trust by polling it, yet every automatic health
refresh sent another request that the receiver correctly rejected. This
produced misleading auth-noise logs while the extension still had no path to
pair automatically. Ref polylogue-jlme.5.

## Solution

`checkReceiverHealth` now returns the established `unauthorized` UI state
locally when no token is stored, with detail `receiver_auth_missing`. A stored
but invalid token still performs the real probe and reports a real 401,
preserving receiver diagnostics. The regression test proves the no-token path
never calls `fetch`.

## Verification

- `cd browser-extension && npm test -- --run tests/background.test.js` — 82
  passed.
- `cd browser-extension && npm run lint` — passed.
- `cd browser-extension && npm run validate` — manifest valid.
- `devtools verify --quick` — passed.
- pre-push quick baseline — passed.
