### PR TITLE
fix(daemon): bound periodic status snapshots

### DIFF
--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -1961,8 +1961,18 @@ def _raw_frontier_integrity_info(
     return RawFrontierIntegrity.model_validate(projection.to_dict())
 
 
-def _raw_replay_backlog_info() -> dict[str, object]:
-    """Return weighted raw source-to-index replay backlog for daemon status."""
+def _raw_replay_backlog_info(*, include: bool = True) -> dict[str, object]:
+    """Return weighted raw replay backlog only for an explicitly rich read."""
+    if not include:
+        return {
+            "available": False,
+            "reason": "excluded_from_bounded_status_snapshot",
+            "candidate_count": 0,
+            "total_blob_bytes": 0,
+            "top_raw_rows": [],
+            "origin_summary": [],
+            "source_path_summary": [],
+        }
     try:
         from polylogue.config import Config
         from polylogue.paths import render_root
@@ -1989,6 +1999,7 @@ def build_daemon_status(
     browser_capture_enabled: bool | None = None,
     browser_capture_spool_path: Path | None = None,
     include_expensive_health: bool = False,
+    include_raw_replay_backlog: bool = True,
 ) -> DaemonStatus:
     """Build a typed DaemonStatus from durable component state."""
     watch_sources = sources if sources is not None else default_sources()
@@ -2008,7 +2019,7 @@ def build_daemon_status(
     freshness = _insight_freshness_info()
     raw_materialization_readiness = _raw_materialization_readiness_info()
     raw_frontier_integrity = _raw_frontier_integrity_info(raw_materialization_readiness)
-    raw_replay_backlog = _raw_replay_backlog_info()
+    raw_replay_backlog = _raw_replay_backlog_info(include=include_raw_replay_backlog)
     materialization_ready = storage_info.archive_materialization_ready and raw_materialization_ready(
         raw_materialization_readiness
     )
@@ -2195,6 +2206,7 @@ def daemon_status_payload(
     browser_capture_enabled: bool | None = None,
     browser_capture_spool_path: Path | None = None,
     include_browser_capture_spool_path: bool = False,
+    include_raw_replay_backlog: bool = True,
 ) -> JSONDocument:
     """Return the local daemon component status payload (backward-compat dict)."""
     watch_sources = sources if sources is not None else default_sources()
@@ -2219,6 +2231,7 @@ def daemon_status_payload(
         sources=sources,
         browser_capture_enabled=browser_capture_enabled,
         browser_capture_spool_path=browser_capture_spool_path,
+        include_raw_replay_backlog=include_raw_replay_backlog,
     )
     archive_debt = _archive_debt_status_summary()
 

--- a/polylogue/daemon/status_snapshot.py
+++ b/polylogue/daemon/status_snapshot.py
@@ -319,7 +319,11 @@ def refresh_status_snapshot(*, payload: JSONDocument | None = None, rich: bool =
                 if rich:
                     from polylogue.daemon.status import daemon_status_payload
 
-                    payload = daemon_status_payload()
+                    # Raw replay selection expands authority cohorts and is a
+                    # diagnostic operation, not a bounded health projection.
+                    # Running it in the periodic snapshot can strand a
+                    # default-executor worker through process shutdown.
+                    payload = daemon_status_payload(include_raw_replay_backlog=False)
                 else:
                     payload = _minimal_status_payload()
         except Exception as exc:

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -318,7 +318,7 @@ def test_status_snapshot_refresh_default_builds_rich_payload(monkeypatch: pytest
 
     snapshot = refresh_status_snapshot()
 
-    assert build.call_count == 1
+    build.assert_called_once_with(include_raw_replay_backlog=False)
     assert snapshot.payload["checked_at"] == "rich"
     assert snapshot.payload["raw_materialization_readiness"] == {"total": 2}
 
@@ -574,7 +574,7 @@ def test_daemon_status_marks_raw_materialization_debt_not_ready(
     )
     monkeypatch.setattr(
         "polylogue.daemon.status._raw_replay_backlog_info",
-        lambda: {
+        lambda *, include=True: {
             "available": True,
             "execution_blocked": True,
             "execution_block_reason": "raw source-to-index replay is disabled pending revision authority",


### PR DESCRIPTION
## Summary

Keep the daemon's periodic status snapshot bounded by excluding the
diagnostic raw replay cohort expansion.

## Problem

The periodic snapshot ran raw replay backlog selection in a default-executor
thread. On the live archive, that authority-cohort expansion continued after
SIGTERM, so Python waited for the thread until systemd reached its 90-second
shutdown deadline. The signal handler, watcher cancellation, and lifecycle
markers had all completed within one second; this detached read was the actual
exit blocker. Ref polylogue-20d.6.

## Solution

Detailed replay backlog remains available to explicit rich status reads. The
periodic snapshot asks for the bounded form instead, which retains raw
materialization readiness and frontier integrity while rendering the detailed
replay inventory explicitly unavailable rather than empty.

## Verification

- `devtools test tests/unit/daemon/test_daemon_status.py` — 54 passed.
- `devtools verify --quick` — passed.
- pre-push quick baseline — passed.
