### PR TITLE
fix(test): reset degraded ingestion state

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -408,12 +408,22 @@ def _clear_polylogue_env(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     _reclaim_passing_test_tmp_path: None,
+    request: pytest.FixtureRequest,
 ) -> None:
     # Close any cached SQLite connections to prevent WAL sidecar corruption
     # when tests create/move/delete temp database files.
     from polylogue.storage.sqlite.connection import _clear_connection_cache
 
     _clear_connection_cache()
+
+    # The daemon's structural-fault gate is intentionally process-local in
+    # production, but tests simulate that fault routinely.  Reset it on both
+    # sides of every test so a simulated mismatch cannot silently turn a later
+    # live-ingest or demo test into an all-skipped batch.
+    from polylogue.core.degraded import clear_degraded
+
+    clear_degraded()
+    request.addfinalizer(clear_degraded)
 
     # Clear search runtime state to prevent monkeypatched package-level search
     # adapters and cached results from leaking across tests.


### PR DESCRIPTION
## Summary

Resets the process-local degraded ingestion gate between every test.

## Problem

A fresh 8-worker seed passed once then failed nine unrelated live-ingest and demo tests with zero successful files. The exact cluster passed alone under 3 and 8 workers. The production degraded gate was the remaining process singleton not cleared by the global test fixture; package-local reset fixtures left full-suite order dependence.

## Solution

Clear degraded state before each test and register matching fixture teardown. The production daemon behavior is unchanged; this limits test-only simulated structural faults to the test that creates them.

## Verification

- POLYLOGUE_PYTEST_WORKERS=8 devtools test selected daemon-convergence and demo cluster: 10 passed
- devtools verify --quick: 16/16 checks succeeded

Ref polylogue-b054.1.1.9.