### PR TITLE
fix(status): bound periodic readiness classification

### DIFF
--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -1936,7 +1936,7 @@ def _component_from_live_ingest(summary: LiveIngestAttemptSummary) -> ComponentR
     )
 
 
-def _raw_materialization_readiness_info() -> RawMaterializationReadiness:
+def _raw_materialization_readiness_info(*, classify_gaps: bool = True) -> RawMaterializationReadiness:
     """Summarize acquired-but-not-materialized raw evidence for readiness.
 
     This is intentionally cheaper than the full archive-debt endpoint: daemon
@@ -1944,7 +1944,11 @@ def _raw_materialization_readiness_info() -> RawMaterializationReadiness:
     not silently diverge, but normal status reads must not open raw blobs or run
     the exact classifier over large archives.
     """
-    payload = raw_materialization_readiness_snapshot(archive_root())
+    payload = (
+        raw_materialization_readiness_snapshot(archive_root())
+        if classify_gaps
+        else raw_materialization_readiness_snapshot(archive_root(), classify_gaps=False)
+    )
     return RawMaterializationReadiness.model_validate(payload)
 
 
@@ -2000,6 +2004,7 @@ def build_daemon_status(
     browser_capture_spool_path: Path | None = None,
     include_expensive_health: bool = False,
     include_raw_replay_backlog: bool = True,
+    include_exact_raw_materialization_readiness: bool = True,
 ) -> DaemonStatus:
     """Build a typed DaemonStatus from durable component state."""
     watch_sources = sources if sources is not None else default_sources()
@@ -2017,7 +2022,9 @@ def build_daemon_status(
     storage_info = _archive_storage_info()
     fts = _fts_readiness_info()
     freshness = _insight_freshness_info()
-    raw_materialization_readiness = _raw_materialization_readiness_info()
+    raw_materialization_readiness = _raw_materialization_readiness_info(
+        classify_gaps=include_exact_raw_materialization_readiness
+    )
     raw_frontier_integrity = _raw_frontier_integrity_info(raw_materialization_readiness)
     raw_replay_backlog = _raw_replay_backlog_info(include=include_raw_replay_backlog)
     materialization_ready = storage_info.archive_materialization_ready and raw_materialization_ready(
@@ -2207,6 +2214,7 @@ def daemon_status_payload(
     browser_capture_spool_path: Path | None = None,
     include_browser_capture_spool_path: bool = False,
     include_raw_replay_backlog: bool = True,
+    include_exact_raw_materialization_readiness: bool = True,
 ) -> JSONDocument:
     """Return the local daemon component status payload (backward-compat dict)."""
     watch_sources = sources if sources is not None else default_sources()
@@ -2232,6 +2240,7 @@ def daemon_status_payload(
         browser_capture_enabled=browser_capture_enabled,
         browser_capture_spool_path=browser_capture_spool_path,
         include_raw_replay_backlog=include_raw_replay_backlog,
+        include_exact_raw_materialization_readiness=include_exact_raw_materialization_readiness,
     )
     archive_debt = _archive_debt_status_summary()
 

--- a/polylogue/daemon/status_snapshot.py
+++ b/polylogue/daemon/status_snapshot.py
@@ -323,7 +323,10 @@ def refresh_status_snapshot(*, payload: JSONDocument | None = None, rich: bool =
                     # diagnostic operation, not a bounded health projection.
                     # Running it in the periodic snapshot can strand a
                     # default-executor worker through process shutdown.
-                    payload = daemon_status_payload(include_raw_replay_backlog=False)
+                    payload = daemon_status_payload(
+                        include_raw_replay_backlog=False,
+                        include_exact_raw_materialization_readiness=False,
+                    )
                 else:
                     payload = _minimal_status_payload()
         except Exception as exc:

--- a/polylogue/storage/archive_readiness.py
+++ b/polylogue/storage/archive_readiness.py
@@ -112,14 +112,17 @@ def raw_materialization_ready(readiness: Mapping[str, Any] | object | None) -> b
     return all(_read_int(readiness, key) == 0 for key in blocking_keys)
 
 
-def raw_materialization_readiness_snapshot(active_archive: Path) -> dict[str, object]:
+def raw_materialization_readiness_snapshot(
+    active_archive: Path,
+    *,
+    classify_gaps: bool = True,
+) -> dict[str, object]:
     """Return compact raw→index materialization readiness for an archive root.
 
-    This function is used by status/readiness surfaces and must stay cheap on
-    large archives. It classifies only cheap structural explanations for
-    raw-id join gaps: rows already materialized by provider/source aliases and
-    parsed sidecar/metadata artifacts. Remaining gaps are daemon convergence
-    input, not an operator maintenance workflow.
+    Exact classification may inspect every raw-id gap and is therefore reserved
+    for explicit diagnostic reads. ``classify_gaps=False`` keeps the aggregate
+    counters and durable authority state but marks all unclassified gaps as
+    unchecked, which is the bounded periodic-status contract.
     """
     source_db = active_archive / "source.db"
     index_db = active_archive / "index.db"
@@ -131,7 +134,6 @@ def raw_materialization_readiness_snapshot(active_archive: Path) -> dict[str, ob
             conn.execute("ATTACH DATABASE ? AS source", (str(source_db),))
             raw_columns = _table_columns(conn, "source", "raw_sessions")
             session_columns = _table_columns(conn, "main", "sessions")
-            raw_select_columns = _raw_gap_select_columns(raw_columns)
             row = conn.execute(
                 """
                 WITH raw_rows AS (
@@ -192,34 +194,38 @@ def raw_materialization_readiness_snapshot(active_archive: Path) -> dict[str, ob
                 LIMIT 16
                 """
             ).fetchall()
-            gap_rows = conn.execute(
-                f"""
-                WITH raw_rows AS (
-                    SELECT
-                        {raw_select_columns},
-                        EXISTS (
-                            SELECT 1
-                            FROM main.sessions s
-                            WHERE s.raw_id = r.raw_id
-                        ) AS is_materialized
-                    FROM source.raw_sessions r
-                    WHERE COALESCE(r.validation_status, '') != 'skipped'
+            classified_counts: Counter[str] = Counter()
+            parse_failed_origins: set[str] = set()
+            if classify_gaps:
+                raw_select_columns = _raw_gap_select_columns(raw_columns)
+                gap_rows = conn.execute(
+                    f"""
+                    WITH raw_rows AS (
+                        SELECT
+                            {raw_select_columns},
+                            EXISTS (
+                                SELECT 1
+                                FROM main.sessions s
+                                WHERE s.raw_id = r.raw_id
+                            ) AS is_materialized
+                        FROM source.raw_sessions r
+                        WHERE COALESCE(r.validation_status, '') != 'skipped'
+                    )
+                    SELECT *
+                    FROM raw_rows
+                    WHERE NOT is_materialized
+                    """,
+                ).fetchall()
+                classified_counts, parse_failed_origins = _classify_raw_gap_rows(
+                    conn,
+                    active_archive,
+                    gap_rows,
+                    raw_columns=raw_columns,
+                    session_columns=session_columns,
+                    has_revision_applications=bool(_table_columns(conn, "main", "raw_revision_applications")),
+                    has_membership_census=bool(_table_columns(conn, "source", "raw_membership_census")),
+                    has_session_memberships=bool(_table_columns(conn, "source", "raw_session_memberships")),
                 )
-                SELECT *
-                FROM raw_rows
-                WHERE NOT is_materialized
-                """,
-            ).fetchall()
-            classified_counts, parse_failed_origins = _classify_raw_gap_rows(
-                conn,
-                active_archive,
-                gap_rows,
-                raw_columns=raw_columns,
-                session_columns=session_columns,
-                has_revision_applications=bool(_table_columns(conn, "main", "raw_revision_applications")),
-                has_membership_census=bool(_table_columns(conn, "source", "raw_membership_census")),
-                has_session_memberships=bool(_table_columns(conn, "source", "raw_session_memberships")),
-            )
             adoption_deferred_count = 0
             if _table_columns(conn, "main", "raw_revision_applications"):
                 adoption_deferred_count = int(
@@ -390,7 +396,7 @@ def raw_materialization_readiness_snapshot(active_archive: Path) -> dict[str, ob
     critical = actionable
     affected_actionable = parse_failed
     unchecked = max(total - classified - affected_actionable - adoption_deferred_count, 0)
-    classification = "cheap_projection" if classified or adoption_deferred_count else "not_run"
+    classification = "cheap_projection" if classify_gaps and (classified or adoption_deferred_count) else "not_run"
     raw_id_join_gap_count = unchecked
     category_counts: dict[str, int] = {
         "raw_id_join_gap": raw_id_join_gap_count,

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -318,7 +318,10 @@ def test_status_snapshot_refresh_default_builds_rich_payload(monkeypatch: pytest
 
     snapshot = refresh_status_snapshot()
 
-    build.assert_called_once_with(include_raw_replay_backlog=False)
+    build.assert_called_once_with(
+        include_raw_replay_backlog=False,
+        include_exact_raw_materialization_readiness=False,
+    )
     assert snapshot.payload["checked_at"] == "rich"
     assert snapshot.payload["raw_materialization_readiness"] == {"total": 2}
 

--- a/tests/unit/storage/test_archive_readiness.py
+++ b/tests/unit/storage/test_archive_readiness.py
@@ -5,6 +5,8 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import cast
 
+import pytest
+
 from polylogue.archive.revision_authority import BYTE_AUTHORITY_CENSUS_DETAIL
 from polylogue.storage.archive_readiness import raw_materialization_readiness_snapshot, raw_materialization_ready
 from polylogue.storage.raw_authority import (
@@ -118,7 +120,10 @@ def test_readiness_uses_frontier_postflight_not_preapply_scope(tmp_path: Path) -
     assert raw_materialization_ready(snapshot) is True
 
 
-def test_raw_materialization_snapshot_classifies_durable_authority_gaps(tmp_path: Path) -> None:
+def test_raw_materialization_snapshot_classifies_durable_authority_gaps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     source_db = tmp_path / "source.db"
     index_db = tmp_path / "index.db"
     with sqlite3.connect(source_db) as conn:
@@ -215,6 +220,17 @@ def test_raw_materialization_snapshot_classifies_durable_authority_gaps(tmp_path
         "revision-application-terminal": 1,
         "adoption_deferred": 1,
     }
+
+    def fail_if_classified(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("bounded readiness must not classify individual raw gaps")
+
+    monkeypatch.setattr("polylogue.storage.archive_readiness._classify_raw_gap_rows", fail_if_classified)
+    aggregate = raw_materialization_readiness_snapshot(tmp_path, classify_gaps=False)
+
+    assert aggregate["classification"] == "not_run"
+    assert aggregate["classified"] == 0
+    assert aggregate["unchecked"] == 9
+    assert aggregate["actionable"] == 0
 
 
 def test_raw_materialization_snapshot_reads_append_census_writer_contract(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Make periodic daemon status snapshots avoid per-row raw materialization gap
classification.

## Problem

The live snapshot worker still called the exact raw materialization readiness
classifier. Its alias and authority checks traversed roughly 49,649 raw-id
gaps, so the status API repeatedly fell back to its minimal `refreshing`
payload even after the replay-backlog repair. The worker also remained a
shutdown risk because it used the default executor.

## Solution

The readiness projection now supports a bounded aggregate mode. It keeps
durable counts, lost-evidence checks, and authority-frontier state, but does
not materialize or classify individual gaps; those remain explicitly
unchecked. Periodic snapshots request this mode. Explicit rich status reads
retain exact classification.

## Verification

- `devtools test tests/unit/storage/test_archive_readiness.py
  tests/unit/daemon/test_daemon_status.py` — 71 passed.
- `devtools verify --quick` — passed.
- pre-push quick baseline — passed.

Ref polylogue-20d.6.
