### PR TITLE
fix(status): omit archive debt from periodic snapshots

### DIFF
--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -2215,6 +2215,7 @@ def daemon_status_payload(
     include_browser_capture_spool_path: bool = False,
     include_raw_replay_backlog: bool = True,
     include_exact_raw_materialization_readiness: bool = True,
+    include_archive_debt: bool = True,
 ) -> JSONDocument:
     """Return the local daemon component status payload (backward-compat dict)."""
     watch_sources = sources if sources is not None else default_sources()
@@ -2242,7 +2243,7 @@ def daemon_status_payload(
         include_raw_replay_backlog=include_raw_replay_backlog,
         include_exact_raw_materialization_readiness=include_exact_raw_materialization_readiness,
     )
-    archive_debt = _archive_debt_status_summary()
+    archive_debt = _archive_debt_status_summary() if include_archive_debt else _excluded_archive_debt_status_summary()
 
     return json_document(
         {
@@ -2321,6 +2322,17 @@ def _archive_debt_status_summary() -> dict[str, object]:
         "available": True,
         "rows": [row.model_dump(mode="json", exclude_none=True) for row in payload.rows],
         "totals": payload.totals.model_dump(mode="json"),
+    }
+
+
+def _excluded_archive_debt_status_summary() -> dict[str, object]:
+    """Describe the diagnostic debt endpoint without recomputing it."""
+    return {
+        "endpoint": "/api/archive-debt",
+        "available": False,
+        "reason": "excluded_from_bounded_status_snapshot",
+        "rows": [],
+        "totals": {},
     }
 
 

--- a/polylogue/daemon/status_snapshot.py
+++ b/polylogue/daemon/status_snapshot.py
@@ -326,6 +326,7 @@ def refresh_status_snapshot(*, payload: JSONDocument | None = None, rich: bool =
                     payload = daemon_status_payload(
                         include_raw_replay_backlog=False,
                         include_exact_raw_materialization_readiness=False,
+                        include_archive_debt=False,
                     )
                 else:
                     payload = _minimal_status_payload()

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -321,6 +321,7 @@ def test_status_snapshot_refresh_default_builds_rich_payload(monkeypatch: pytest
     build.assert_called_once_with(
         include_raw_replay_backlog=False,
         include_exact_raw_materialization_readiness=False,
+        include_archive_debt=False,
     )
     assert snapshot.payload["checked_at"] == "rich"
     assert snapshot.payload["raw_materialization_readiness"] == {"total": 2}


### PR DESCRIPTION
## Summary

Keep archive-debt recomputation out of the periodic daemon status snapshot.

## Problem

After bounding replay and raw-gap classification, the live snapshot worker was
still entering `archive_debt_list`, which recalculates embedding debt. That
diagnostic work delayed the next snapshot and could again leave a default
executor worker active at shutdown.

## Solution

Periodic snapshots now expose the archive-debt endpoint with an explicit
excluded status instead of recalculating it. Direct status and archive-debt
reads retain the complete diagnostic report.

## Verification

- `devtools test tests/unit/daemon/test_daemon_status.py` — 54 passed.
- `devtools verify --quick` — passed.
- pre-push quick baseline — passed.

Ref polylogue-20d.6.
