### PR TITLE
feat(schemas): emit bounded generation progress receipts

### DIFF
--- a/devtools/schema_generate.py
+++ b/devtools/schema_generate.py
@@ -3,14 +3,56 @@
 from __future__ import annotations
 
 import argparse
+import json
+import resource
+import sqlite3
 import sys
 from pathlib import Path
 
 from polylogue.cli.shared.schema_command_support import build_schema_privacy_config
 from polylogue.cli.shared.schema_rendering import render_schema_generate_result
 from polylogue.config import get_config
+from polylogue.core.json import JSONDocument
 from polylogue.schemas.operator.models import SchemaInferRequest
 from polylogue.schemas.operator.workflow import infer_schema
+
+
+def _process_resources() -> JSONDocument:
+    """Return aggregate process evidence without inspecting payload contents."""
+    metrics: JSONDocument = {}
+    try:
+        for line in Path("/proc/self/smaps_rollup").read_text(encoding="ascii").splitlines():
+            key, separator, raw_value = line.partition(":")
+            if separator and key in {"Pss", "Pss_Anon", "Pss_File", "SwapPss"}:
+                metrics[f"{key.lower()}_kb"] = int(raw_value.split()[0])
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        for line in Path("/proc/self/io").read_text(encoding="ascii").splitlines():
+            key, separator, raw_value = line.partition(":")
+            if separator and key in {"rchar", "wchar", "read_bytes", "write_bytes"}:
+                metrics[key] = int(raw_value.strip())
+    except (OSError, ValueError):
+        pass
+    metrics["max_rss_bytes"] = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss * 1024
+    return metrics
+
+
+def _source_input_summary(index_path: Path) -> JSONDocument:
+    """Count the source-tier input without opening raw payloads."""
+    source_path = index_path.with_name("source.db")
+    if not source_path.exists():
+        return {"source_db_bytes": None, "raw_row_count": None, "raw_blob_bytes": None}
+    try:
+        with sqlite3.connect(f"file:{source_path}?mode=ro", uri=True) as connection:
+            row = connection.execute("SELECT COUNT(*), COALESCE(SUM(blob_size), 0) FROM raw_sessions").fetchone()
+        return {
+            "source_db_bytes": source_path.stat().st_size,
+            "raw_row_count": int(row[0]) if row is not None else 0,
+            "raw_blob_bytes": int(row[1]) if row is not None else 0,
+        }
+    except (OSError, sqlite3.Error):
+        return {"source_db_bytes": None, "raw_row_count": None, "raw_blob_bytes": None}
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -36,12 +78,23 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Bypass all sample caps for full-corpus schema generation.",
     )
+    parser.add_argument("--progress", action="store_true", help="Emit aggregate phase progress to stderr.")
+    parser.add_argument(
+        "--receipt", type=Path, default=None, help="Write an aggregate-only generation receipt as JSON."
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
+    progress_events: list[JSONDocument] = []
+
+    def on_progress(_phase: str, payload: JSONDocument) -> None:
+        event = {**payload, "process": _process_resources()}
+        progress_events.append(event)
+        if args.progress:
+            print(f"schema-generate: {json.dumps(event, sort_keys=True)}", file=sys.stderr, flush=True)
 
     try:
         privacy_config = build_schema_privacy_config(
@@ -56,6 +109,7 @@ def main(argv: list[str] | None = None) -> int:
                 privacy_config=privacy_config,
                 cluster=bool(args.cluster),
                 full_corpus=bool(args.full_corpus),
+                progress_callback=on_progress if args.progress or args.receipt is not None else None,
             )
         )
     except ValueError as exc:
@@ -63,6 +117,28 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     generation = result.generation
+    if args.receipt is not None:
+        archive_path = get_config().db_path
+        try:
+            archive_size_bytes = archive_path.stat().st_size
+        except OSError:
+            archive_size_bytes = None
+        receipt = {
+            "version": 1,
+            "provider": str(args.provider),
+            "full_corpus": bool(args.full_corpus),
+            "max_samples": args.max_samples,
+            "input": {"index_size_bytes": archive_size_bytes, **_source_input_summary(archive_path)},
+            "generation": generation.phase_receipt,
+            "progress_events": progress_events,
+            "process_final": _process_resources(),
+            "resume": {
+                "status": "restart_from_acquisition",
+                "reason": "the private observation journal is intentionally removed after interruption",
+            },
+        }
+        args.receipt.parent.mkdir(parents=True, exist_ok=True)
+        args.receipt.write_text(json.dumps(receipt, sort_keys=True, indent=2) + "\n", encoding="utf-8")
     if not generation.success:
         print(f"schema-generate: {generation.error or 'Schema generation failed'}", file=sys.stderr)
         return 1

--- a/polylogue/schemas/generation/cluster_collection.py
+++ b/polylogue/schemas/generation/cluster_collection.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
 
+from polylogue.core.json import JSONDocument
 from polylogue.schemas.generation.cluster_support import (
     _artifact_priority,
     _cluster_profile_tokens,
@@ -36,6 +37,7 @@ def _collect_cluster_accumulators(
     max_samples: int | None,
     full_corpus: bool = False,
     journal: ObservationJournal | None = None,
+    progress_callback: Callable[[JSONDocument], None] | None = None,
 ) -> tuple[dict[str, _ClusterAccumulator], Sequence[_UnitMembership], int, dict[str, int]]:
     result = collect_cluster_analysis(
         provider,
@@ -43,6 +45,7 @@ def _collect_cluster_accumulators(
         max_samples=max_samples,
         full_corpus=full_corpus,
         journal=journal,
+        progress_callback=progress_callback,
     )
     return result.clusters, result.memberships, result.sample_count, result.artifact_counts
 
@@ -54,6 +57,7 @@ def collect_cluster_analysis(
     max_samples: int | None,
     full_corpus: bool = False,
     journal: ObservationJournal | None = None,
+    progress_callback: Callable[[JSONDocument], None] | None = None,
 ) -> ClusterCollectionResult:
     from polylogue.schemas.sampling import iter_schema_units
 
@@ -102,13 +106,32 @@ def collect_cluster_analysis(
         for unit in retained_units:
             observe_summary(unit)
     else:
+        observed_unit_count = 0
         for unit in observed_units:
             observe_summary(unit)
             journal.append_unit(unit, retain_cluster_payload=False)
+            observed_unit_count += 1
+            if progress_callback is not None and observed_unit_count % 128 == 0:
+                progress_callback(
+                    {
+                        "unit_count": observed_unit_count,
+                        "sample_count": total_schema_samples,
+                        "journal": {"unit_count": journal.unit_count, "sample_count": journal.sample_count},
+                    }
+                )
         # The following phases replay the journal repeatedly. Commit its final
         # ingest batch first so reads do not repeatedly traverse one enormous
         # writer WAL instead of the checkpointable journal database.
         journal.flush()
+        if progress_callback is not None:
+            progress_callback(
+                {
+                    "unit_count": observed_unit_count,
+                    "sample_count": total_schema_samples,
+                    "journal": {"unit_count": journal.unit_count, "sample_count": journal.sample_count},
+                    "complete": True,
+                }
+            )
 
     coarse_clusters: list[_ClusterAccumulator] = []
     ordered_summaries: Iterable[tuple[object, _ProfileSummary]]

--- a/polylogue/schemas/generation/models.py
+++ b/polylogue/schemas/generation/models.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeAlias
 
 from polylogue.core.json import JSONDocument
 from polylogue.schemas.observation import SchemaUnit
@@ -14,6 +14,9 @@ from polylogue.schemas.registry import ClusterManifest
 
 if TYPE_CHECKING:
     from polylogue.schemas.redaction_report import SchemaReport
+
+
+GenerationProgressCallback: TypeAlias = Callable[[str, JSONDocument], None]
 
 
 @dataclass
@@ -30,6 +33,7 @@ class GenerationResult:
     cluster_count: int = 0
     package_count: int = 0
     artifact_counts: dict[str, int] = field(default_factory=dict)
+    phase_receipt: JSONDocument = field(default_factory=dict)
 
     @property
     def success(self) -> bool:

--- a/polylogue/schemas/generation/provider_bundle.py
+++ b/polylogue/schemas/generation/provider_bundle.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 from polylogue.core.enums import Provider
+from polylogue.core.json import JSONDocument, JSONValue, json_document
 from polylogue.paths import db_path as index_db_path
 from polylogue.schemas.generation.cluster_collection import (
     _collect_cluster_accumulators,
@@ -13,7 +15,7 @@ from polylogue.schemas.generation.cluster_support import (
     _cluster_profile_tokens,
     _cluster_sort_key,
 )
-from polylogue.schemas.generation.models import GenerationResult, _ProviderBundle
+from polylogue.schemas.generation.models import GenerationProgressCallback, GenerationResult, _ProviderBundle
 from polylogue.schemas.generation.observation_journal import ObservationJournal, recover_stale_journals
 from polylogue.schemas.generation.packages import (
     _build_package_candidates,
@@ -26,6 +28,18 @@ from polylogue.schemas.generation.support import GENSON_AVAILABLE
 from polylogue.schemas.observation import PROVIDERS, ProviderConfig, resolve_provider_config
 from polylogue.schemas.privacy_config import SchemaPrivacyConfig
 from polylogue.schemas.registry import ClusterManifest, SchemaCluster
+
+
+def _journal_storage_bytes(journal: ObservationJournal) -> dict[str, int]:
+    """Return aggregate private-spool sizes without exposing observation data."""
+    path = journal.path
+    wal_path = path.with_name(f"{path.name}-wal")
+    shm_path = path.with_name(f"{path.name}-shm")
+    return {
+        "db_bytes": path.stat().st_size if path.exists() else 0,
+        "wal_bytes": wal_path.stat().st_size if wal_path.exists() else 0,
+        "shm_bytes": shm_path.stat().st_size if shm_path.exists() else 0,
+    }
 
 
 def build_provider_error_bundle(
@@ -58,6 +72,7 @@ def _build_provider_bundle(
     max_samples: int | None,
     privacy_config: SchemaPrivacyConfig | None,
     full_corpus: bool = False,
+    progress_callback: GenerationProgressCallback | None = None,
 ) -> _ProviderBundle:
     """Generate all inferred schema versions plus the default result for a provider."""
     provider_token = Provider.from_string(provider)
@@ -76,29 +91,88 @@ def _build_provider_bundle(
 
     config: ProviderConfig = resolve_provider_config(provider_token)
 
+    phase_receipt: JSONDocument = {"version": 1, "status": "running", "phases": []}
+
+    def report(phase: str, state: str, **details: JSONValue) -> None:
+        payload = json_document({"phase": phase, "state": state, **details})
+        if progress_callback is not None:
+            progress_callback(phase, payload)
+
+    def complete_phase(phase: str, started_ns: int, journal: ObservationJournal, **details: JSONValue) -> None:
+        phase_payload = json_document(
+            {
+                "name": phase,
+                "elapsed_ms": round((time.monotonic_ns() - started_ns) / 1_000_000, 3),
+                "journal": _journal_storage_bytes(journal),
+                **details,
+            }
+        )
+        phases = phase_receipt["phases"]
+        assert isinstance(phases, list)
+        phases.append(phase_payload)
+        report(phase, "completed", **phase_payload)
+
     try:
         recover_stale_journals(minimum_age_s=0)
         with ObservationJournal.create(forbidden_roots=(db_path.parent,)) as journal:
+            observe_started_ns = time.monotonic_ns()
+            report("observe_and_cluster", "started")
+
+            def observe_progress(details: JSONDocument) -> None:
+                elapsed_ms = round((time.monotonic_ns() - observe_started_ns) / 1_000_000, 3)
+                unit_count = details.get("unit_count")
+                units_per_s = (
+                    round(int(unit_count) / max(elapsed_ms / 1_000, 0.001), 3) if isinstance(unit_count, int) else None
+                )
+                report(
+                    "observe_and_cluster",
+                    "progress",
+                    elapsed_ms=elapsed_ms,
+                    units_per_s=units_per_s,
+                    estimated_total_units=None,
+                    estimate_status="source_total_unavailable",
+                    **details,
+                )
+
             clusters, memberships, sample_count, artifact_counts = _collect_cluster_accumulators(
                 provider,
                 db_path=db_path,
                 max_samples=max_samples,
                 full_corpus=full_corpus,
                 journal=journal,
+                progress_callback=observe_progress,
+            )
+            complete_phase(
+                "observe_and_cluster",
+                observe_started_ns,
+                journal,
+                cluster_count=len(clusters),
+                unit_count=journal.unit_count,
+                sample_count=sample_count,
             )
             if not clusters:
-                return build_provider_error_bundle(
+                bundle = build_provider_error_bundle(
                     str(provider_token),
                     error="No samples found",
                 )
+                bundle.result.phase_receipt = {**phase_receipt, "status": "empty"}
+                return bundle
+            package_started_ns = time.monotonic_ns()
+            report("assemble_packages", "started")
             packages, orphan_adjunct_counts = _build_package_candidates(
                 str(provider_token),
                 memberships=memberships,
                 clusters=clusters,
                 journal=journal,
             )
+            complete_phase(
+                "assemble_packages",
+                package_started_ns,
+                journal,
+                package_count=len(packages),
+            )
             if not packages:
-                return build_provider_error_bundle(
+                bundle = build_provider_error_bundle(
                     str(provider_token),
                     error="No anchor-backed schema packages found",
                     sample_count=sample_count,
@@ -134,9 +208,13 @@ def _build_provider_bundle(
                         artifact_counts=artifact_counts,
                     ),
                 )
+                bundle.result.phase_receipt = {**phase_receipt, "status": "empty"}
+                return bundle
             observation_outcomes = journal.terminal_summary()
             if observation_outcomes.get("total") == 0:
                 observation_outcomes = {}
+            catalog_started_ns = time.monotonic_ns()
+            report("build_catalog", "started")
             catalog_artifacts = build_provider_catalog_artifacts(
                 provider_token=provider_token,
                 config=config,
@@ -151,18 +229,28 @@ def _build_provider_bundle(
                 observation_outcomes=observation_outcomes,
                 journal=journal,
             )
-            return build_success_provider_bundle(
+            complete_phase(
+                "build_catalog",
+                catalog_started_ns,
+                journal,
+                package_count=len(catalog_artifacts.catalog.packages),
+            )
+            bundle = build_success_provider_bundle(
                 provider_token=provider_token,
                 sample_count=sample_count,
                 clusters=clusters,
                 artifact_counts=artifact_counts,
                 catalog_artifacts=catalog_artifacts,
             )
+            bundle.result.phase_receipt = {**phase_receipt, "status": "succeeded"}
+            return bundle
     except Exception as e:
-        return build_provider_error_bundle(
+        bundle = build_provider_error_bundle(
             str(provider_token),
             error=str(e),
         )
+        bundle.result.phase_receipt = {**phase_receipt, "status": "failed", "error": str(e)}
+        return bundle
 
 
 __all__ = ["_build_provider_bundle"]

--- a/polylogue/schemas/generation/workflow.py
+++ b/polylogue/schemas/generation/workflow.py
@@ -10,7 +10,7 @@ from polylogue.schemas.generation.archive_workload_profile import (
     build_archive_workload_profile,
     write_archive_workload_profile,
 )
-from polylogue.schemas.generation.models import GenerationResult, _ProviderBundle
+from polylogue.schemas.generation.models import GenerationProgressCallback, GenerationResult, _ProviderBundle
 from polylogue.schemas.generation.provider_bundle import _build_provider_bundle
 from polylogue.schemas.generation.schema_builder import generate_schema_from_samples
 from polylogue.schemas.observation import PROVIDERS
@@ -58,6 +58,7 @@ def generate_provider_schema(
     max_samples: int | None = None,
     privacy_config: SchemaPrivacyConfig | None = None,
     full_corpus: bool = False,
+    progress_callback: GenerationProgressCallback | None = None,
 ) -> GenerationResult:
     """Generate the default inferred schema for a provider."""
     return _build_provider_bundle(
@@ -66,6 +67,7 @@ def generate_provider_schema(
         max_samples=max_samples,
         privacy_config=privacy_config,
         full_corpus=full_corpus,
+        progress_callback=progress_callback,
     ).result
 
 

--- a/polylogue/schemas/operator/inference.py
+++ b/polylogue/schemas/operator/inference.py
@@ -111,6 +111,7 @@ def infer_schema(request: SchemaInferRequest) -> SchemaInferResult:
         max_samples=request.max_samples,
         privacy_config=_privacy_config(request.privacy_config),
         full_corpus=request.full_corpus,
+        progress_callback=request.progress_callback,
     )
     package_version = result.default_version or "default"
     registry = _typed_registry()

--- a/polylogue/schemas/operator/models.py
+++ b/polylogue/schemas/operator/models.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TypeAlias, TypeGuard
 
 from polylogue.scenarios import CorpusScenario, CorpusSpec
-from polylogue.schemas.generation.models import GenerationResult
+from polylogue.schemas.generation.models import GenerationProgressCallback, GenerationResult
 from polylogue.schemas.packages import SchemaPackageCatalog, SchemaResolution, SchemaVersionPackage
 from polylogue.schemas.tooling_registry import ClusterManifest, SchemaDiff
 from polylogue.schemas.validation.models import ArtifactCoverageReport
@@ -76,6 +76,7 @@ class SchemaInferRequest:
     cluster: bool = False
     cluster_sample_limit: int = 500
     full_corpus: bool = False
+    progress_callback: GenerationProgressCallback | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/infra/schema_inference_memory_probe.py
+++ b/tests/infra/schema_inference_memory_probe.py
@@ -6,8 +6,12 @@ import argparse
 import json
 import os
 import sys
+import time
 import tracemalloc
+from collections import defaultdict
+from collections.abc import Iterable, Iterator
 from pathlib import Path
+from typing import cast
 
 
 def _payload(index: int) -> bytes:
@@ -46,6 +50,39 @@ def _codex_payload(record_count: int) -> bytes:
     ).encode("utf-8")
 
 
+def _process_io_counters() -> dict[str, int | None]:
+    """Return Linux process I/O counters without guessing from wall time."""
+    counters: dict[str, int | None] = {
+        "rchar": None,
+        "wchar": None,
+        "read_bytes": None,
+        "write_bytes": None,
+    }
+    try:
+        for line in Path("/proc/self/io").read_text(encoding="ascii").splitlines():
+            key, separator, raw_value = line.partition(":")
+            if separator and key in counters:
+                counters[key] = int(raw_value.strip())
+    except (OSError, ValueError):
+        pass
+    return counters
+
+
+def _journal_storage_bytes(journal_root: Path) -> dict[str, int]:
+    """Keep journal database and WAL growth separately observable."""
+    totals = {"journal_db_bytes": 0, "journal_wal_bytes": 0, "journal_shm_bytes": 0}
+    for path in journal_root.glob("run-*.sqlite3*"):
+        if not path.is_file():
+            continue
+        if path.name.endswith("-wal"):
+            totals["journal_wal_bytes"] += path.stat().st_size
+        elif path.name.endswith("-shm"):
+            totals["journal_shm_bytes"] += path.stat().st_size
+        else:
+            totals["journal_db_bytes"] += path.stat().st_size
+    return totals
+
+
 def _resource_snapshot(*, phase: str, journal_root: Path) -> dict[str, int | str | None]:
     smaps: dict[str, int] = {}
     try:
@@ -56,16 +93,19 @@ def _resource_snapshot(*, phase: str, journal_root: Path) -> dict[str, int | str
     except (OSError, ValueError, IndexError):
         pass
     current, peak = tracemalloc.get_traced_memory()
-    journal_bytes = sum(path.stat().st_size for path in journal_root.glob("run-*.sqlite3*") if path.is_file())
+    journal_storage = _journal_storage_bytes(journal_root)
     return {
         "phase": phase,
+        "monotonic_ns": time.monotonic_ns(),
         "pss_kb": smaps.get("Pss"),
         "anon_pss_kb": smaps.get("Pss_Anon"),
         "file_pss_kb": smaps.get("Pss_File"),
         "swap_pss_kb": smaps.get("SwapPss"),
         "tracemalloc_current_bytes": current,
         "tracemalloc_peak_bytes": peak,
-        "journal_bytes": journal_bytes,
+        "journal_bytes": sum(journal_storage.values()),
+        **journal_storage,
+        **_process_io_counters(),
     }
 
 
@@ -85,7 +125,7 @@ def main(argv: list[str] | None = None) -> int:
     os.environ["XDG_STATE_HOME"] = str(archive_root.parent / "state")
 
     from polylogue.core.enums import Provider
-    from polylogue.schemas.generation import provider_bundle
+    from polylogue.schemas.generation import observation_journal, provider_bundle
     from polylogue.schemas.generation.workflow import generate_provider_schema
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
@@ -106,6 +146,7 @@ def main(argv: list[str] | None = None) -> int:
 
     journal_root = Path(os.environ["XDG_CACHE_HOME"]) / "polylogue" / "schema-observation-journals"
     snapshots: list[dict[str, int | str | None]] = []
+    method_metrics: dict[str, dict[str, int]] = defaultdict(lambda: {"calls": 0, "wall_ns": 0, "yielded": 0})
     tracemalloc.start()
     snapshots.append(_resource_snapshot(phase="before-provider-bundle", journal_root=journal_root))
     for name in ("_collect_cluster_accumulators", "_build_package_candidates", "build_provider_catalog_artifacts"):
@@ -120,6 +161,39 @@ def main(argv: list[str] | None = None) -> int:
             return result
 
         setattr(provider_bundle, name, wrapped)
+
+    def wrap_journal_method(name: str, *, iterable: bool = False) -> None:
+        original = getattr(observation_journal.ObservationJournal, name)
+
+        def wrapped(self: object, *call_args: object, **call_kwargs: object) -> object:
+            started_ns = time.monotonic_ns()
+            result = original(self, *call_args, **call_kwargs)
+            if not iterable:
+                metric = method_metrics[name]
+                metric["calls"] += 1
+                metric["wall_ns"] += time.monotonic_ns() - started_ns
+                return result
+
+            def measured() -> Iterator[object]:
+                yielded = 0
+                try:
+                    for item in cast(Iterable[object], result):
+                        yielded += 1
+                        yield item
+                finally:
+                    metric = method_metrics[name]
+                    metric["calls"] += 1
+                    metric["yielded"] += yielded
+                    metric["wall_ns"] += time.monotonic_ns() - started_ns
+
+            return measured()
+
+        setattr(observation_journal.ObservationJournal, name, wrapped)
+
+    for method_name in ("append_unit", "flush", "assign_canonical_package_families"):
+        wrap_journal_method(method_name)
+    for method_name in ("_iter_joined_memberships", "iter_distinct_membership_values"):
+        wrap_journal_method(method_name, iterable=True)
     try:
         result = generate_provider_schema(
             args.provider,
@@ -136,8 +210,10 @@ def main(argv: list[str] | None = None) -> int:
                 "error": result.error,
                 "sample_count": result.sample_count,
                 "cluster_count": result.cluster_count,
+                "phase_receipt": result.phase_receipt,
                 "journal_remaining": sorted(path.name for path in journal_root.glob("run-*.sqlite3*")),
                 "phases": snapshots,
+                "journal_method_metrics": dict(method_metrics),
             },
             sort_keys=True,
         ),

--- a/tests/unit/core/test_schema_generation.py
+++ b/tests/unit/core/test_schema_generation.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
+from polylogue.core.json import JSONDocument
 from polylogue.schemas.generation.cluster_collection import _collect_cluster_accumulators
 from polylogue.schemas.generation.models import _ProviderBundle
 from polylogue.schemas.generation.observation_journal import ObservationJournal
@@ -62,9 +63,34 @@ class TestProviderSchemaGeneration:
         assert success.success
         assert success.provider == "test"
         assert success.sample_count == 10
-
         failure = GenerationResult(provider="test", schema=None, sample_count=0, error="no data")
         assert not failure.success
+
+
+def test_generation_records_aggregate_phase_receipt(seeded_archive_writable: SeededArchiveClone) -> None:
+    events: list[JSONDocument] = []
+    result = generate_provider_schema(
+        "chatgpt",
+        db_path=seeded_archive_writable.root / "index.db",
+        max_samples=10,
+        progress_callback=lambda _phase, payload: events.append(payload),
+    )
+
+    if result.sample_count == 0:
+        pytest.skip("seeded archive has no chatgpt samples")
+    assert result.success
+    assert result.phase_receipt["status"] == "succeeded"
+    phases = result.phase_receipt["phases"]
+    assert isinstance(phases, list)
+    assert {item["name"] for item in phases if isinstance(item, dict)} == {
+        "observe_and_cluster",
+        "assemble_packages",
+        "build_catalog",
+    }
+    assert {item["state"] for item in events} >= {"started", "completed", "progress"}
+    progress = next(item for item in events if item["state"] == "progress")
+    assert progress["estimate_status"] == "source_total_unavailable"
+    assert isinstance(progress["units_per_s"], float)
 
 
 def test_catalog_selection_preserves_latest_without_defaulting_to_rare_family() -> None:

--- a/tests/unit/core/test_schema_observation_journal.py
+++ b/tests/unit/core/test_schema_observation_journal.py
@@ -39,6 +39,7 @@ class _InferenceProbeResult:
     peak_rss_bytes: int
     peak_journal_bytes: int
     phase_snapshots: tuple[dict[str, object], ...]
+    journal_method_metrics: dict[str, dict[str, int]]
     receipt: WorkloadReceipt
 
 
@@ -102,9 +103,12 @@ def _run_inference_probe(
         assert process.returncode == 0, stderr
         payload = json.loads(stdout)
         assert payload["success"] is True
+        assert payload["phase_receipt"]["status"] == "succeeded"
         assert payload["journal_remaining"] == []
         phase_snapshots = tuple(item for item in payload["phases"] if isinstance(item, dict))
         assert phase_snapshots
+        journal_method_metrics = payload["journal_method_metrics"]
+        assert isinstance(journal_method_metrics, dict)
         wall_ms = (time.perf_counter() - started) * 1_000
         spec = WorkloadEnvelopeSpec(
             workload_id="canary:schema-inference-memory-scaling",
@@ -156,6 +160,11 @@ def _run_inference_probe(
             peak_rss_bytes=peak_rss_bytes,
             peak_journal_bytes=peak_journal_bytes,
             phase_snapshots=phase_snapshots,
+            journal_method_metrics={
+                str(name): {str(key): int(value) for key, value in metric.items()}
+                for name, metric in journal_method_metrics.items()
+                if isinstance(metric, dict)
+            },
             receipt=receipt,
         )
     finally:
@@ -537,6 +546,15 @@ def test_full_generation_10x_scales_counts_without_10x_python_memory(tmp_path: P
         "after-build_provider_catalog_artifacts",
         "after-provider-bundle",
     }
+    assert all(
+        {"monotonic_ns", "rchar", "wchar", "read_bytes", "write_bytes", "journal_db_bytes", "journal_wal_bytes"}
+        <= snapshot.keys()
+        for snapshot in one_x.phase_snapshots
+    )
+    assert one_x.journal_method_metrics["append_unit"]["calls"] == 32
+    assert ten_x.journal_method_metrics["append_unit"]["calls"] == 320
+    assert one_x.journal_method_metrics["flush"]["calls"] >= 1
+    assert one_x.journal_method_metrics["assign_canonical_package_families"]["calls"] == 1
     assert ten_x.peak_rss_bytes <= one_x.peak_rss_bytes + 96 * 1024 * 1024
     assert one_x.receipt.spec.inputs[0].scale_tier == WorkloadScaleTier.ARCHIVE_1X.value
     assert ten_x.receipt.spec.inputs[0].scale_tier == WorkloadScaleTier.ARCHIVE_10X.value

--- a/tests/unit/devtools/test_schema_lab_commands.py
+++ b/tests/unit/devtools/test_schema_lab_commands.py
@@ -197,6 +197,60 @@ def test_schema_generate_forwards_generation_request(
     assert "Generated schema package set for chatgpt" in capsys.readouterr().out
 
 
+def test_schema_generate_writes_aggregate_progress_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fake_get_config() -> _ConfigStub:
+        return _ConfigStub(db_path=tmp_path / "archive.db")
+
+    def fake_infer(request: SchemaInferRequest) -> SchemaInferResult:
+        assert request.progress_callback is not None
+        request.progress_callback(
+            "observe_and_cluster",
+            {
+                "phase": "observe_and_cluster",
+                "state": "progress",
+                "unit_count": 128,
+                "units_per_s": 32.0,
+            },
+        )
+        return SchemaInferResult(
+            generation=GenerationResult(
+                provider=request.provider,
+                schema={"type": "object"},
+                sample_count=2,
+                phase_receipt={"version": 1, "status": "succeeded", "phases": []},
+            )
+        )
+
+    receipt_path = tmp_path / "receipt.json"
+    monkeypatch.setattr(schema_generate, "get_config", fake_get_config)
+    monkeypatch.setattr(schema_generate, "infer_schema", fake_infer)
+
+    assert schema_generate.main(["--provider", "chatgpt", "--progress", "--receipt", str(receipt_path)]) == 0
+
+    receipt = json.loads(receipt_path.read_text())
+    assert receipt["generation"]["status"] == "succeeded"
+    assert len(receipt["progress_events"]) == 1
+    event = receipt["progress_events"][0]
+    assert event["phase"] == "observe_and_cluster"
+    assert event["state"] == "progress"
+    assert event["unit_count"] == 128
+    assert event["units_per_s"] == 32.0
+    assert "max_rss_bytes" in event["process"]
+    assert receipt["input"] == {
+        "index_size_bytes": None,
+        "source_db_bytes": None,
+        "raw_row_count": None,
+        "raw_blob_bytes": None,
+    }
+    assert "max_rss_bytes" in receipt["process_final"]
+    assert receipt["resume"]["status"] == "restart_from_acquisition"
+    assert "observe_and_cluster" in capsys.readouterr().err
+
+
 def test_schema_generate_cluster_without_manifest_fails(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Adds aggregate-only phase progress and durable receipts to full-corpus schema generation, with direct journal-operation and phase-I/O evidence in the existing subprocess probe.

## Problem

An archive-scale Codex inference run performed unexpectedly large reads/writes without a single receipt tying input scale, journal growth, phase boundaries, process resources, and restart semantics together. This made admission of other resource-sensitive jobs unsafe and obscured whether the remaining cost was I/O replay or CPU work. Ref polylogue-3jlg.

## Solution

- Thread an optional generation progress callback through the operator and generation layers.
- Emit `observe_and_cluster`, `assemble_packages`, and `build_catalog` phase receipts with journal DB/WAL/SHM sizes and bounded observation rate.
- Add `devtools/schema_generate.py --progress --receipt PATH`; its aggregate receipt includes source-tier row/blob counts, index size, PSS/I/O snapshots, final peak RSS, and the explicit safe `restart_from_acquisition` contract after private journal cleanup.
- Extend the real subprocess scaling probe to record method-level journal calls/yields/wall time and phase-local process I/O, rather than inferring attribution from wall-clock duration.

A fresh 128-stream / 32,768-sample Codex-shaped run completed in 6.3s. Its receipt shows a 5.31 MiB journal WAL, ~148 KiB physical reads, and catalog construction as the elapsed-time dominant phase; this rejects the stale hypothesis that post-repair catalog replay is still primarily I/O amplification.

## Verification

- `devtools test tests/unit/core/test_schema_generation.py::test_generation_records_aggregate_phase_receipt tests/unit/core/test_schema_observation_journal.py::test_full_generation_10x_scales_counts_without_10x_python_memory tests/unit/devtools/test_schema_lab_commands.py::test_schema_generate_forwards_generation_request tests/unit/devtools/test_schema_lab_commands.py::test_schema_generate_writes_aggregate_progress_receipt` — 3 passed, 1 fixture-data skip.
- `devtools verify --quick` — all 16 static/generated/layering/schema gates passed.
- `POLYLOGUE_ARCHIVE_ROOT=/realm/tmp/polylogue-3jlg-probe/archive … python devtools/schema_generate.py --provider codex --full-corpus --progress --receipt /realm/tmp/polylogue-3jlg-cli/receipt.json` — succeeded; durable aggregate receipt recorded without raw payload content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional progress reporting for schema generation, including phase status, unit counts, and processing rates.
  * Added aggregate JSON receipts containing generation outcomes, phase details, resource metrics, and archive information.
  * Added `--progress` and `--receipt` options to the schema generation command.
  * Generation results now report clearer phase states for successful, empty, and failed workflows.

* **Tests**
  * Expanded coverage for progress events, receipts, phase outcomes, and resource-scaling metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->