### PR TITLE
feat(repair): capture raw-authority scale profiles

### DIFF
--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -21,7 +21,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import TextIO, cast
 
-from polylogue.config import Config
+from polylogue.config import Config, get_config
 from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.scenarios.workload import (
@@ -371,8 +371,20 @@ def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
     parser.add_argument("--max-io-full-avg10", type=float, default=2.0)
     parser.add_argument("--max-memory-full-avg10", type=float, default=2.0)
     parser.add_argument("--allow-contended-host", action="store_true")
+    parser.add_argument(
+        "--capture-profile",
+        type=Path,
+        default=None,
+        help="Write a read-only aggregate frontier profile for a private-free synthetic scenario, then exit.",
+    )
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args(argv)
+    if args.capture_profile is not None:
+        profile = repair.raw_materialization_scale_profile(get_config())
+        args.capture_profile.parent.mkdir(parents=True, exist_ok=True)
+        args.capture_profile.write_text(json.dumps(profile, indent=2, sort_keys=True) + "\n")
+        print(json.dumps(profile, indent=2, sort_keys=True) if args.json else args.capture_profile, file=stdout)
+        return 0
     pressure_limit = None if args.allow_contended_host else args.max_io_full_avg10
     memory_limit = None if args.allow_contended_host else args.max_memory_full_avg10
     payload = run_raw_authority_scale_proof(

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -4311,6 +4311,14 @@ def _histogram(values: Sequence[int], *, field: str) -> list[dict[str, int]]:
     return [{field: upper_bound, "count": count} for upper_bound, count in sorted(buckets.items())]
 
 
+def _backlog_count(backlog: Mapping[str, object], field: str) -> int:
+    """Read a bounded numeric backlog field without trusting an untyped dict."""
+    value = backlog.get(field)
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    raise RuntimeError(f"raw materialization backlog returned a non-integral {field!r}: {value!r}")
+
+
 def raw_materialization_scale_profile(config: Config) -> dict[str, object]:
     """Return a private-free authority-frontier shape for synthetic proof input.
 
@@ -4330,23 +4338,23 @@ def raw_materialization_scale_profile(config: Config) -> dict[str, object]:
     return {
         "available": True,
         "format": "raw-authority-scale-profile-v1",
-        "candidate_count": int(backlog["candidate_count"]),
-        "expanded_candidate_count": int(backlog["expanded_candidate_count"]),
-        "authority_component_count": int(backlog["authority_component_count"]),
-        "executable_authority_component_count": int(backlog["executable_authority_component_count"]),
-        "blocked_authority_component_count": int(backlog["blocked_authority_component_count"]),
-        "total_blob_bytes": int(backlog["total_blob_bytes"]),
-        "expanded_total_blob_bytes": int(backlog["expanded_total_blob_bytes"]),
+        "candidate_count": _backlog_count(backlog, "candidate_count"),
+        "expanded_candidate_count": _backlog_count(backlog, "expanded_candidate_count"),
+        "authority_component_count": _backlog_count(backlog, "authority_component_count"),
+        "executable_authority_component_count": _backlog_count(backlog, "executable_authority_component_count"),
+        "blocked_authority_component_count": _backlog_count(backlog, "blocked_authority_component_count"),
+        "total_blob_bytes": _backlog_count(backlog, "total_blob_bytes"),
+        "expanded_total_blob_bytes": _backlog_count(backlog, "expanded_total_blob_bytes"),
         "component_raw_count_histogram": _histogram(component_raw_counts, field="upper_bound_raw_count"),
         "component_blob_bytes_histogram": _histogram(component_blob_bytes, field="upper_bound_blob_bytes"),
         "residual_state_counts": {
-            "missing_blob_count": int(backlog["missing_blob_count"]),
-            "authority_quarantined_count": int(backlog["authority_quarantined_count"]),
-            "byte_authority_fragment_count": int(backlog["byte_authority_fragment_count"]),
-            "byte_authority_quarantined_count": int(backlog["byte_authority_quarantined_count"]),
-            "byte_authority_pending_count": int(backlog["byte_authority_pending_count"]),
-            "adoption_deferred_count": int(backlog["adoption_deferred_count"]),
-            "blocked_candidate_count": int(backlog["blocked_candidate_count"]),
+            "missing_blob_count": _backlog_count(backlog, "missing_blob_count"),
+            "authority_quarantined_count": _backlog_count(backlog, "authority_quarantined_count"),
+            "byte_authority_fragment_count": _backlog_count(backlog, "byte_authority_fragment_count"),
+            "byte_authority_quarantined_count": _backlog_count(backlog, "byte_authority_quarantined_count"),
+            "byte_authority_pending_count": _backlog_count(backlog, "byte_authority_pending_count"),
+            "adoption_deferred_count": _backlog_count(backlog, "adoption_deferred_count"),
+            "blocked_candidate_count": _backlog_count(backlog, "blocked_candidate_count"),
         },
     }
 

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -4300,6 +4300,57 @@ def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> di
     }
 
 
+def _histogram(values: Sequence[int], *, field: str) -> list[dict[str, int]]:
+    """Summarize numeric frontier shape without retaining identifying rows."""
+    buckets: dict[int, int] = {}
+    for value in values:
+        upper_bound = 1
+        while upper_bound < max(value, 1):
+            upper_bound *= 2
+        buckets[upper_bound] = buckets.get(upper_bound, 0) + 1
+    return [{field: upper_bound, "count": count} for upper_bound, count in sorted(buckets.items())]
+
+
+def raw_materialization_scale_profile(config: Config) -> dict[str, object]:
+    """Return a private-free authority-frontier shape for synthetic proof input.
+
+    The profile deliberately exposes counts and distributions only.  It is safe
+    to retain with a synthetic workload receipt because it never includes raw
+    ids, source paths, blob hashes, or payload-derived fields.
+    """
+    backlog = raw_materialization_replay_backlog(config, limit=0)
+    if not bool(backlog["available"]):
+        return {"available": False, "reason": backlog["reason"]}
+    candidates = _raw_materialization_candidate_ids(config)
+    component_raw_counts = [len(component) for component in candidates.authority_components]
+    component_blob_bytes = [
+        sum(_raw_materialization_component_blob_bytes(candidates, raw_id) for raw_id in component)
+        for component in candidates.authority_components
+    ]
+    return {
+        "available": True,
+        "format": "raw-authority-scale-profile-v1",
+        "candidate_count": int(backlog["candidate_count"]),
+        "expanded_candidate_count": int(backlog["expanded_candidate_count"]),
+        "authority_component_count": int(backlog["authority_component_count"]),
+        "executable_authority_component_count": int(backlog["executable_authority_component_count"]),
+        "blocked_authority_component_count": int(backlog["blocked_authority_component_count"]),
+        "total_blob_bytes": int(backlog["total_blob_bytes"]),
+        "expanded_total_blob_bytes": int(backlog["expanded_total_blob_bytes"]),
+        "component_raw_count_histogram": _histogram(component_raw_counts, field="upper_bound_raw_count"),
+        "component_blob_bytes_histogram": _histogram(component_blob_bytes, field="upper_bound_blob_bytes"),
+        "residual_state_counts": {
+            "missing_blob_count": int(backlog["missing_blob_count"]),
+            "authority_quarantined_count": int(backlog["authority_quarantined_count"]),
+            "byte_authority_fragment_count": int(backlog["byte_authority_fragment_count"]),
+            "byte_authority_quarantined_count": int(backlog["byte_authority_quarantined_count"]),
+            "byte_authority_pending_count": int(backlog["byte_authority_pending_count"]),
+            "adoption_deferred_count": int(backlog["adoption_deferred_count"]),
+            "blocked_candidate_count": int(backlog["blocked_candidate_count"]),
+        },
+    }
+
+
 def _raw_materialized_by_source_path_native(conn: sqlite3.Connection, row: sqlite3.Row) -> bool:
     origin = str(row["origin"] or "")
     if not origin:
@@ -6302,6 +6353,7 @@ __all__ = [
     "preview_message_type_backfill",
     "preview_session_insights",
     "raw_materialization_replay_backlog",
+    "raw_materialization_scale_profile",
     "repair_empty_sessions",
     "repair_message_type_backfill",
     "repair_orphaned_attachments",

--- a/tests/unit/devtools/test_raw_authority_scale_proof.py
+++ b/tests/unit/devtools/test_raw_authority_scale_proof.py
@@ -7,6 +7,11 @@ from typing import cast
 import pytest
 
 from devtools.raw_authority_scale_proof import ProcessSample, run_raw_authority_scale_proof
+from polylogue.config import Config
+from polylogue.core.enums import Provider
+from polylogue.storage import repair
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 
 
 def test_raw_authority_scale_proof_reaches_two_matching_quiescent_censuses(tmp_path: Path) -> None:
@@ -82,3 +87,27 @@ def test_raw_authority_scale_proof_consumes_reservations_and_has_stable_corpus_i
     first_receipt = cast(dict[str, object], first["receipt"])
     second_receipt = cast(dict[str, object], second["receipt"])
     assert first_receipt["archive_id"] == second_receipt["archive_id"]
+
+
+def test_raw_authority_scale_profile_is_aggregate_only(tmp_path: Path) -> None:
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b'{"type":"session_meta","payload":{"id":"private-native-id"}}\n',
+            source_path="/private/source/session.jsonl",
+            acquired_at_ms=1,
+        )
+
+    profile = repair.raw_materialization_scale_profile(
+        Config(archive_root=tmp_path, render_root=tmp_path, sources=[], db_path=tmp_path / "index.db")
+    )
+
+    assert profile["available"] is True
+    assert profile["candidate_count"] == 1
+    assert profile["expanded_candidate_count"] == 1
+    assert profile["authority_component_count"] == 1
+    assert profile["component_raw_count_histogram"] == [{"upper_bound_raw_count": 1, "count": 1}]
+    serialized = str(profile)
+    assert "private-native-id" not in serialized
+    assert "/private/source/session.jsonl" not in serialized


### PR DESCRIPTION
## Summary

Adds a read-only aggregate frontier profile as the first missing prerequisite for the July-15-shaped raw-authority scale proof.

## Problem

The existing proof runner could vary only component/raw cardinality. It always generated tiny fixed JSONL inputs, so it could not represent or verify the production preflight's byte envelope, expanded-candidate topology, or residual cohorts. A scheduler-shaped run was therefore incorrectly easy to overinterpret as a full-scale proof. Ref polylogue-hjpx.2.

## Solution

- Add `raw_materialization_scale_profile`, which derives aggregate candidate/component/byte distributions and typed residual counts from the real raw-authority selector.
- Expose `devtools workspace raw-authority-scale-proof --capture-profile PATH` as a read-only capture path for the private-free synthetic scenario manifest.
- Exclude raw IDs, paths, hashes, and payload-derived content by construction; the regression test seeds private identifiers and asserts they cannot appear in the profile.
- Validate numeric values at the untyped diagnostic boundary rather than coercing unexpected values.

This is deliberately not a claim that the current runner has completed the full proof. The next phase uses this profile to construct bounded, actual-byte synthetic inputs and execute them only after PSI admission.

## Verification

- `devtools test tests/unit/devtools/test_raw_authority_scale_proof.py` — 4 passed.
- `devtools verify --quick` — all 16 static/generated/layering/schema gates passed.
- A live 3-component runner admission attempt was refused at I/O PSI full avg10 12.11 > 2.00; no contended-host override was used.
