### PR TITLE
test(lineage): cover nested dangling rollback

### DIFF
--- a/tests/unit/storage/test_lineage_normalization.py
+++ b/tests/unit/storage/test_lineage_normalization.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import sqlite3
+from collections.abc import Callable
 from pathlib import Path
 
 import aiosqlite
@@ -584,6 +585,202 @@ def test_reingest_after_dangling_ancestor_does_not_fabricate_a_prefix(tmp_path: 
         (child_id,),
     ).fetchall()
     assert [row[0] for row in physical] == ["c0", "c1", "c2", "c3"]
+    conn.close()
+
+
+def test_nested_dangling_ancestor_keeps_only_reachable_tails(tmp_path: Path) -> None:
+    """A dangling cut propagates through descendants without substituting a prefix.
+
+    The child has a valid branch point in its immediate parent, but that parent
+    itself inherits through a now-missing root branch point.  The real composed
+    read route must preserve the reachable parent and child tails, mark the
+    complete lineage as incomplete, and leave both physical tails and links
+    intact for a later authoritative re-ingest to repair.
+    """
+    db = tmp_path / "index.db"
+    conn = _connect(db)
+    root = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="root",
+        messages=[
+            _msg("r0", Role.USER, "root prompt", 0),
+            _msg("r1", Role.ASSISTANT, "root reply", 1),
+        ],
+    )
+    root_id = write_parsed_session_to_archive(conn, root)
+    parent = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="parent",
+        parent_session_provider_id="root",
+        branch_type=BranchType.FORK,
+        messages=[
+            _msg("p0", Role.USER, "root prompt", 0),
+            _msg("p1", Role.ASSISTANT, "root reply", 1),
+            _msg("p2", Role.USER, "parent tail", 2),
+        ],
+    )
+    parent_id = write_parsed_session_to_archive(conn, parent)
+    child = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="child",
+        parent_session_provider_id="parent",
+        branch_type=BranchType.FORK,
+        messages=[
+            _msg("c0", Role.USER, "root prompt", 0),
+            _msg("c1", Role.ASSISTANT, "root reply", 1),
+            _msg("c2", Role.USER, "parent tail", 2),
+            _msg("c3", Role.ASSISTANT, "child tail", 3),
+        ],
+    )
+    child_id = write_parsed_session_to_archive(conn, child)
+
+    before_physical = conn.execute(
+        "SELECT session_id, native_id, position, variant_index FROM messages "
+        "WHERE session_id IN (?, ?) ORDER BY session_id, position, variant_index",
+        (parent_id, child_id),
+    ).fetchall()
+    before_links = conn.execute(
+        "SELECT src_session_id, resolved_dst_session_id, branch_point_message_id, inheritance, status "
+        "FROM session_links WHERE src_session_id IN (?, ?) ORDER BY src_session_id",
+        (parent_id, child_id),
+    ).fetchall()
+
+    # This is the failure shape: the parent edge still resolves to the root
+    # session, but its branch-point message disappeared.  Do not rewrite a
+    # resolved edge as 'unresolved': the typed degradation belongs on the
+    # composed read result while its known relation remains queryable.
+    conn.execute("DELETE FROM messages WHERE message_id = ?", (f"{root_id}:r1",))
+    conn.commit()
+
+    envelope = read_archive_session_envelope(conn, child_id)
+    assert [message.blocks[0].text for message in envelope.messages] == ["parent tail", "child tail"]
+    assert envelope.lineage_complete is False
+    assert envelope.lineage_truncation_reason == "dangling_branch_point"
+    assert (
+        conn.execute(
+            "SELECT session_id, native_id, position, variant_index FROM messages "
+            "WHERE session_id IN (?, ?) ORDER BY session_id, position, variant_index",
+            (parent_id, child_id),
+        ).fetchall()
+        == before_physical
+    )
+    assert (
+        conn.execute(
+            "SELECT src_session_id, resolved_dst_session_id, branch_point_message_id, inheritance, status "
+            "FROM session_links WHERE src_session_id IN (?, ?) ORDER BY src_session_id",
+            (parent_id, child_id),
+        ).fetchall()
+        == before_links
+    )
+    conn.close()
+
+
+def test_full_replace_graph_failure_rolls_back_then_retries_idempotently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The full writer transaction cannot expose replacement/link mixed state.
+
+    Inject after the real graph-resolution phase, where replacement rows, link
+    resolution, stale-cut repair, and projections have all had a chance to
+    mutate.  The failed replacement must leave the earlier physical rows,
+    relation row, and composed read exactly intact; the same input can then be
+    retried repeatedly with one converged state.
+    """
+    db = tmp_path / "index.db"
+    conn = _connect(db)
+    parent = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="parent",
+        updated_at="2027-01-01T00:00:01Z",
+        messages=[
+            _msg("p0", Role.USER, "root", 0),
+            _msg("p1", Role.ASSISTANT, "parent v1", 1),
+        ],
+    )
+    parent_id = write_parsed_session_to_archive(conn, parent)
+    child = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="child",
+        parent_session_provider_id="parent",
+        branch_type=BranchType.FORK,
+        messages=[
+            _msg("c0", Role.USER, "root", 0),
+            _msg("c1", Role.ASSISTANT, "parent v1", 1),
+            _msg("c2", Role.USER, "child tail", 2),
+        ],
+    )
+    child_id = write_parsed_session_to_archive(conn, child)
+
+    def _state() -> tuple[list[tuple[object, ...]], tuple[object, ...], list[str | None], bool, str | None]:
+        physical = [
+            tuple(row)
+            for row in conn.execute(
+                "SELECT session_id, native_id, position, variant_index FROM messages "
+                "WHERE session_id IN (?, ?) ORDER BY session_id, position, variant_index",
+                (parent_id, child_id),
+            ).fetchall()
+        ]
+        link = tuple(
+            conn.execute(
+                "SELECT resolved_dst_session_id, branch_point_message_id, inheritance, status "
+                "FROM session_links WHERE src_session_id = ?",
+                (child_id,),
+            ).fetchone()
+        )
+        envelope = read_archive_session_envelope(conn, child_id)
+        return (
+            physical,
+            link,
+            [message.blocks[0].text for message in envelope.messages],
+            envelope.lineage_complete,
+            envelope.lineage_truncation_reason,
+        )
+
+    before = _state()
+    replacement = parent.model_copy(
+        update={
+            "updated_at": "2027-01-01T00:00:02Z",
+            "messages": [
+                _msg("p0", Role.USER, "root", 0),
+                _msg("p1", Role.ASSISTANT, "parent v2", 1),
+            ],
+        }
+    )
+    real_resolve = _write_module._resolve_session_graph
+    fired = {"count": 0}
+
+    def _fail_after_graph_resolution(
+        conn_inner: sqlite3.Connection,
+        session_id: str,
+        native_id: str,
+        origin: str,
+        *,
+        cache: dict[str, list[tuple[str, str]]] | None = None,
+        add_timing: Callable[[str, float], None] | None = None,
+    ) -> None:
+        real_resolve(
+            conn_inner,
+            session_id,
+            native_id,
+            origin,
+            cache=cache,
+            add_timing=add_timing,
+        )
+        fired["count"] += 1
+        raise RuntimeError("fault after graph resolution")
+
+    monkeypatch.setattr(_write_module, "_resolve_session_graph", _fail_after_graph_resolution)
+    with pytest.raises(RuntimeError, match="fault after graph resolution"):
+        write_parsed_session_to_archive(conn, replacement)
+    assert fired["count"] == 1, "fault injection did not reach graph resolution"
+    assert _state() == before
+
+    monkeypatch.setattr(_write_module, "_resolve_session_graph", real_resolve)
+    write_parsed_session_to_archive(conn, replacement)
+    after_retry = _state()
+    assert after_retry[2:] == (["root", "parent v2", "child tail"], True, None)
+    write_parsed_session_to_archive(conn, replacement)
+    assert _state() == after_retry
     conn.close()
 
 


### PR DESCRIPTION
## Summary

Adds deterministic production-route lineage regressions for nested dangling ancestry and failure after full-replace graph resolution.

## Problem

The existing lineage suite covered direct dangling cuts and caller-owned rollback, but not a descendant inheriting through a parent whose own branch point disappeared, nor an exception after real graph resolution.

## Solution

The new tests assert physical message rows, resolved link rows, composed transcript, typed completeness, atomic rollback, and repeated-retry convergence through `write_parsed_session_to_archive`. A resolved relation remains resolved when only its historical branch-point message is absent; the typed degraded state is `LineageCompleteness(dangling_branch_point)`.

Ref polylogue-866e.

## Verification

- `devtools test tests/unit/storage/test_lineage_normalization.py -k "nested_dangling or full_replace_graph_failure"` — 2 passed.
- `POLYLOGUE_HYPOTHESIS_REUSE_FAILURES=1 devtools test tests/property/test_write_path_state_machine.py` — 3 passed.
- `devtools test -k session_links` — 5 passed.
- `devtools test -k composed` — 6 passed.
- `devtools verify --seed-testmon --skip-slow` — 15,933 recorded, zero failures.
- `POLYLOGUE_PYTEST_WORKERS=0 devtools verify` — passed. The default parallel repeat hit the separately tracked xdist collection-divergence pathology before tests ran.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lineage handling when ancestor branch points are missing, preserving reachable message history while accurately marking incomplete lineage.
  * Ensured failed full-replacement writes roll back completely, allowing safe retries without data corruption or duplicate changes.

* **Tests**
  * Added regression coverage for dangling lineage branches, transactional rollback, and idempotent repeated writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->