### PR TITLE
perf(repair): batch raw authority profile graph

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -3631,6 +3631,17 @@ def _raw_materialization_candidate_ids(
     with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as conn:
         conn.row_factory = sqlite3.Row
         conn.execute("ATTACH DATABASE ? AS index_tier", (str(index_db),))
+        materialized_aliases = {
+            (str(row[0]), str(row[1]))
+            for row in conn.execute(
+                """
+                SELECT DISTINCT s.origin, s.native_id
+                FROM index_tier.sessions AS s
+                JOIN raw_sessions AS existing_raw ON existing_raw.raw_id = s.raw_id
+                WHERE s.native_id IS NOT NULL
+                """
+            )
+        }
         params: list[object] = []
         raw_filter = ""
         if raw_artifact_id is not None:
@@ -3776,7 +3787,7 @@ def _raw_materialization_candidate_ids(
                 continue
             if row["parse_error"] and not _raw_materialization_retryable_missing_blob_error(row["parse_error"]):
                 continue
-            if _raw_materialized_by_source_path_native(conn, row):
+            if _raw_materialized_by_source_path_native(materialized_aliases, row):
                 continue
             if _raw_materialization_parsed_non_session_artifact(archive_root, row):
                 continue
@@ -4188,7 +4199,12 @@ def _unavailable_raw_materialization_backlog(reason: str) -> dict[str, object]:
     }
 
 
-def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> dict[str, object]:
+def raw_materialization_replay_backlog(
+    config: Config,
+    *,
+    limit: int = 10,
+    _candidates: RawMaterializationCandidates | None = None,
+) -> dict[str, object]:
     """Return a read-only weighted backlog for raw source-to-index replay.
 
     The report uses the same candidate selector as ``repair_raw_materialization``
@@ -4207,7 +4223,7 @@ def raw_materialization_replay_backlog(config: Config, *, limit: int = 10) -> di
         ).fetchone()
     if source_ready is None:
         return _unavailable_raw_materialization_backlog("source_tier_uninitialized")
-    candidates = _raw_materialization_candidate_ids(config)
+    candidates = _candidates or _raw_materialization_candidate_ids(config)
     raw_ids_by_size = sorted(
         candidates.raw_ids,
         key=lambda raw_id: (-candidates.raw_blob_bytes.get(raw_id, 0), raw_id),
@@ -4326,10 +4342,10 @@ def raw_materialization_scale_profile(config: Config) -> dict[str, object]:
     to retain with a synthetic workload receipt because it never includes raw
     ids, source paths, blob hashes, or payload-derived fields.
     """
-    backlog = raw_materialization_replay_backlog(config, limit=0)
+    candidates = _raw_materialization_candidate_ids(config)
+    backlog = raw_materialization_replay_backlog(config, limit=0, _candidates=candidates)
     if not bool(backlog["available"]):
         return {"available": False, "reason": backlog["reason"]}
-    candidates = _raw_materialization_candidate_ids(config)
     component_raw_counts = [len(component) for component in candidates.authority_components]
     component_blob_bytes = [
         sum(_raw_materialization_component_blob_bytes(candidates, raw_id) for raw_id in component)
@@ -4359,23 +4375,12 @@ def raw_materialization_scale_profile(config: Config) -> dict[str, object]:
     }
 
 
-def _raw_materialized_by_source_path_native(conn: sqlite3.Connection, row: sqlite3.Row) -> bool:
+def _raw_materialized_by_source_path_native(materialized_aliases: set[tuple[str, str]], row: sqlite3.Row) -> bool:
     origin = str(row["origin"] or "")
     if not origin:
         return False
     for native_id in _source_path_native_id_candidates(str(row["source_path"] or "")):
-        existing = conn.execute(
-            """
-            SELECT 1
-            FROM index_tier.sessions AS s
-            JOIN raw_sessions AS existing_raw ON existing_raw.raw_id = s.raw_id
-            WHERE s.origin = ?
-              AND s.native_id = ?
-            LIMIT 1
-            """,
-            (origin, native_id),
-        ).fetchone()
-        if existing is not None:
+        if (origin, native_id) in materialized_aliases:
             return True
     return False
 

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2332,17 +2332,67 @@ class ArchiveStore:
         conn: sqlite3.Connection,
         raw_ids: list[str],
     ) -> tuple[tuple[str, ...], ...]:
-        """Partition scheduling hints into transitive authority components."""
-        components: list[set[str]] = []
-        for raw_id in dict.fromkeys(raw_ids):
-            expanded, _keys = ArchiveStore.expand_raw_membership_selection_sync(conn, [raw_id])
-            component = set(expanded)
-            overlapping = [existing for existing in components if existing & component]
-            for existing in overlapping:
-                component.update(existing)
-                components.remove(existing)
-            components.append(component)
-        return tuple(tuple(sorted(component)) for component in sorted(components, key=lambda item: min(item)))
+        """Partition scheduling hints with one bulk authority-graph snapshot.
+
+        Re-expanding every direct candidate separately turns a large backlog
+        into thousands of overlapping recursive SQL walks.  Source paths and
+        logical membership keys are both undirected authority edges, so build
+        their connected components once and project only components containing
+        a scheduling hint.
+        """
+        hints = tuple(dict.fromkeys(raw_ids))
+        if not hints:
+            return ()
+
+        parent: dict[str, str] = {}
+
+        def find(raw_id: str) -> str:
+            root = parent.setdefault(raw_id, raw_id)
+            while root != parent[root]:
+                parent[root] = parent[parent[root]]
+                root = parent[root]
+            while raw_id != root:
+                next_raw_id = parent[raw_id]
+                parent[raw_id] = root
+                raw_id = next_raw_id
+            return root
+
+        def join(left: str, right: str) -> None:
+            left_root = find(left)
+            right_root = find(right)
+            if left_root != right_root:
+                parent[right_root] = left_root
+
+        by_path: dict[str, str] = {}
+        by_key: dict[str, str] = {}
+        for raw_id, source_path, logical_source_key in conn.execute(
+            "SELECT raw_id, source_path, logical_source_key FROM raw_sessions"
+        ):
+            raw_text = str(raw_id)
+            find(raw_text)
+            path = str(source_path or "")
+            if path:
+                prior = by_path.setdefault(path, raw_text)
+                join(prior, raw_text)
+            if logical_source_key is not None:
+                key = str(logical_source_key)
+                prior = by_key.setdefault(key, raw_text)
+                join(prior, raw_text)
+        for raw_id, logical_source_key in conn.execute(
+            "SELECT raw_id, logical_source_key FROM raw_session_memberships"
+        ):
+            raw_text = str(raw_id)
+            find(raw_text)
+            key = str(logical_source_key)
+            prior = by_key.setdefault(key, raw_text)
+            join(prior, raw_text)
+
+        members: dict[str, list[str]] = {}
+        for raw_id in parent:
+            members.setdefault(find(raw_id), []).append(raw_id)
+        selected_roots = {find(raw_id) for raw_id in hints if raw_id in parent}
+        components = [tuple(sorted(members[root])) for root in selected_roots]
+        return tuple(sorted(components, key=lambda component: component[0]))
 
     def raw_membership_selection_components(self, raw_ids: list[str]) -> tuple[tuple[str, ...], ...]:
         return self.raw_membership_selection_components_sync(self._ensure_source_conn(), raw_ids)

--- a/tests/unit/devtools/test_raw_authority_scale_proof.py
+++ b/tests/unit/devtools/test_raw_authority_scale_proof.py
@@ -123,6 +123,34 @@ def test_raw_authority_scale_profile_is_aggregate_only(tmp_path: Path) -> None:
     assert "/private/source/session.jsonl" not in serialized
 
 
+def test_raw_authority_scale_profile_selects_candidates_once(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        for index in range(3):
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=f'{{"type":"session_meta","payload":{{"id":"profile-{index}"}}}}\n'.encode(),
+                source_path=f"/private/source/profile-{index}.jsonl",
+                acquired_at_ms=index,
+            )
+
+    original = repair._raw_materialization_candidate_ids
+    calls = 0
+
+    def counted(config: Config) -> repair.RawMaterializationCandidates:
+        nonlocal calls
+        calls += 1
+        return original(config)
+
+    monkeypatch.setattr(repair, "_raw_materialization_candidate_ids", counted)
+    profile = repair.raw_materialization_scale_profile(
+        Config(archive_root=tmp_path, render_root=tmp_path, sources=[], db_path=tmp_path / "index.db")
+    )
+
+    assert profile["candidate_count"] == 3
+    assert calls == 1
+
+
 def test_raw_authority_scale_proof_generates_exact_scenario_bytes_and_expansion(tmp_path: Path) -> None:
     scenario = RawAuthorityScaleScenario(
         components=2,


### PR DESCRIPTION
## Summary

Makes raw-authority scale-profile capture a bounded bulk read rather than an overlapping per-candidate expansion.

## Problem

The read-only operational preflight exceeded its 20-second bound on the active archive. It selected candidates twice, looked up materialized aliases per row, and recursively expanded authority components once per candidate.

## Solution

- Reuses one candidate snapshot for backlog and profile projection.
- Loads materialized source aliases in one set-based query.
- Builds source-path and logical-key authority components from one bulk graph snapshot.

Ref polylogue-hjpx.3 and polylogue-hjpx.2.

## Evidence

The exact live profile that previously exceeded 20 seconds completed in 3.4 seconds with polylogued active: 41,230 direct candidates, 46,759 expanded candidates, and 36,181 components. The run was read-only.

## Verification

- devtools test tests/unit/devtools/test_raw_authority_scale_proof.py tests/unit/storage/test_repair.py -k raw_materialization or raw_authority_scale_profile — 35 passed.
- devtools verify --quick — all static/generated gates passed.