### PR TITLE
fix(devtools): stream large authority components

### DIFF
--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -429,6 +429,11 @@ def run_raw_authority_scale_proof(
                                     )
                             acquired_at_ms += 1
                     pending_rows.clear()
+                    # Publication atomically moves prepared blobs.  Continue
+                    # the prefix chain from the now-stable final blob rather
+                    # than the moved temporary path, so large components can
+                    # flush without retaining thousands of prepared blobs.
+                    previous = publisher.blob_path(blob_hash)
             if pending_rows:
                 publisher.flush()
                 with source_conn:


### PR DESCRIPTION
## Summary

Makes the scale corpus generator safe for authority components larger than its blob-publication batch.

## Problem

A full current-shape preparation exposed that publishing midway through a prefix chain moved the predecessor temporary blob, while deferring all publication retained an unbounded number of prepared blobs.

## Solution

After every bounded publication flush, the next revision uses the stable published blob as its prefix source.

Ref polylogue-hjpx.2.

## Verification

- devtools test tests/unit/devtools/test_raw_authority_scale_proof.py — 6 passed.
- ruff format and ruff check passed.
- Pre-push quick verification completed before publication.