### PR TITLE
test(daemon): prove convergence restart recovery

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -864,7 +864,13 @@ def _drain_session_insights_once(*, limit: int = _SESSION_INSIGHT_CONVERGENCE_BA
 
 
 def _drain_convergence_debt_once(db: Path, *, limit: int = 100) -> int:
-    """Retry due derived convergence debt without rereading source payloads."""
+    """Retry due derived convergence debt without rereading source payloads.
+
+    Debt identity is stage-scoped. A retry therefore runs only the recorded
+    stage for the recorded subject and updates that same ops-ledger row on a
+    further deferral/failure. The legacy ``convergence`` stage remains an
+    all-stage fallback for older generic rows.
+    """
     from polylogue.daemon.convergence import DaemonConverger
     from polylogue.daemon.convergence_stages import make_default_convergence_stages
     from polylogue.sources.live.cursor import CursorStore
@@ -878,60 +884,109 @@ def _drain_convergence_debt_once(db: Path, *, limit: int = 100) -> int:
     ]
     if not due_debt:
         return 0
-    session_ids = tuple(dict.fromkeys(debt.subject_id for debt in due_debt if debt.subject_type == "session_id"))
-    paths = tuple(dict.fromkeys([Path(debt.subject_id) for debt in due_debt if debt.subject_type == "source_path"]))
+
     fts_surfaces = tuple(dict.fromkeys(debt.subject_id for debt in due_debt if debt.subject_type == "fts_surface"))
-    if not paths and not session_ids and not fts_surfaces:
-        return 0
     fts_surface_results = _drain_fts_surface_debt(db, fts_surfaces)
-    converger = DaemonConverger(stages=make_default_convergence_stages(db), max_workers=2)
-    path_states, _path_timings = converger.converge_batch(paths)
-    session_states, _session_timings = converger.converge_sessions(session_ids)
+
+    subject_states: dict[tuple[str, str, str], object] = {}
+    retryable_debt = tuple(debt for debt in due_debt if debt.subject_type in {"source_path", "session_id"})
+    if retryable_debt:
+        default_stages = make_default_convergence_stages(db)
+        stages_by_name = {stage.name: stage for stage in default_stages}
+        for stage_name in dict.fromkeys(debt.stage for debt in retryable_debt):
+            selected_stages = (
+                default_stages
+                if stage_name == "convergence"
+                else (stages_by_name[stage_name],)
+                if stage_name in stages_by_name
+                else ()
+            )
+            if not selected_stages:
+                continue
+            stage_debt = tuple(debt for debt in retryable_debt if debt.stage == stage_name)
+            paths = tuple(
+                dict.fromkeys(Path(debt.subject_id) for debt in stage_debt if debt.subject_type == "source_path")
+            )
+            session_ids = tuple(
+                dict.fromkeys(debt.subject_id for debt in stage_debt if debt.subject_type == "session_id")
+            )
+            converger = DaemonConverger(stages=selected_stages, max_workers=2)
+            path_states, _path_timings = converger.converge_batch(paths)
+            session_states, _session_timings = converger.converge_sessions(session_ids)
+            subject_states.update(
+                ((stage_name, "source_path", str(path)), state) for path, state in path_states.items()
+            )
+            subject_states.update(
+                ((stage_name, "session_id", session_id), state) for session_id, state in session_states.items()
+            )
+
     retried = 0
     for debt in due_debt:
-        subject_states: list[object | None]
-        if debt.subject_type == "session_id":
-            subject_states = [session_states.get(debt.subject_id)]
-        elif debt.subject_type == "fts_surface":
+        retried += 1
+        if debt.subject_type == "fts_surface":
             if fts_surface_results.get(debt.subject_id) is True:
-                cursor.clear_convergence_debt(subject_type=debt.subject_type, subject_id=debt.subject_id)
-                retried += 1
+                cursor.clear_convergence_debt(
+                    stage=debt.stage,
+                    subject_type=debt.subject_type,
+                    subject_id=debt.subject_id,
+                )
                 continue
-            cursor.clear_convergence_debt(subject_type=debt.subject_type, subject_id=debt.subject_id)
             cursor.record_convergence_debt(
                 stage=debt.stage,
                 subject_type=debt.subject_type,
                 subject_id=debt.subject_id,
                 error="FTS freshness convergence did not converge",
+                materializer_version=debt.materializer_version,
             )
-            retried += 1
             continue
-        else:
-            subject_states = [path_states.get(Path(debt.subject_id))]
-        converged = all(state is not None and bool(getattr(state, "converged", False)) for state in subject_states)
-        if converged:
-            cursor.clear_convergence_debt(subject_type=debt.subject_type, subject_id=debt.subject_id)
-            retried += 1
+
+        state = subject_states.get((debt.stage, debt.subject_type, debt.subject_id))
+        if state is None:
+            cursor.record_convergence_debt(
+                stage=debt.stage,
+                subject_type=debt.subject_type,
+                subject_id=debt.subject_id,
+                error=f"convergence retry stage unavailable: {debt.stage}",
+                materializer_version=debt.materializer_version,
+            )
             continue
-        failed_stages: tuple[str, ...] = ()
-        last_error: object = None
-        for state in subject_states:
-            stages = getattr(state, "stages", {}) if state is not None else {}
-            last_error = getattr(state, "last_error", None) if state is not None else None
-            failed_stages = _failed_convergence_stage_names(stages)
-            if failed_stages:
-                break
-        if not failed_stages:
-            failed_stages = ("convergence",)
-        cursor.clear_convergence_debt(subject_type=debt.subject_type, subject_id=debt.subject_id)
+        if bool(getattr(state, "converged", False)):
+            cursor.clear_convergence_debt(
+                stage=debt.stage,
+                subject_type=debt.subject_type,
+                subject_id=debt.subject_id,
+            )
+            continue
+
+        last_error = getattr(state, "last_error", None)
+        retry_error = last_error if isinstance(last_error, str) and last_error else "retry did not converge"
+        if debt.stage != "convergence":
+            cursor.record_convergence_debt(
+                stage=debt.stage,
+                subject_type=debt.subject_type,
+                subject_id=debt.subject_id,
+                error=retry_error,
+                materializer_version=debt.materializer_version,
+            )
+            continue
+
+        # Generic rows predate stage-scoped retry identity. Preserve the old
+        # migration behavior by replacing only that generic row with the exact
+        # stages that remain pending; other stage rows for the subject survive.
+        failed_stages = _failed_convergence_stage_names(getattr(state, "stages", {})) or ("convergence",)
+        cursor.clear_convergence_debt(
+            stage=debt.stage,
+            subject_type=debt.subject_type,
+            subject_id=debt.subject_id,
+        )
         for stage in failed_stages:
             cursor.record_convergence_debt(
                 stage=stage,
                 subject_type=debt.subject_type,
                 subject_id=debt.subject_id,
-                error=last_error if isinstance(last_error, str) and last_error else "retry did not converge",
+                error=retry_error,
+                materializer_version=debt.materializer_version,
             )
-        retried += 1
     return retried
 
 

--- a/tests/infra/convergence_harness.py
+++ b/tests/infra/convergence_harness.py
@@ -1,0 +1,396 @@
+"""Real-SQLite fixtures and independent facts for convergence survivor tests.
+
+This module adapts the production archive writers, daemon stages, and ops
+ledger. It deliberately owns no alternate convergence state machine.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+import polylogue.daemon.convergence_stages as convergence_stages
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
+from polylogue.scenarios import WorkloadEnvelopeSpec, partial_convergence_canary_spec
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+from polylogue.storage.sqlite.connection import open_connection
+
+SqlValue = str | int | float | bytes | None
+FactRow = tuple[SqlValue, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PartialConvergenceArchive:
+    root: Path
+    index_db: Path
+    source_db: Path
+    ops_db: Path
+    target_source: Path
+    unrelated_source: Path
+    target_session_id: str
+    unrelated_session_id: str
+    workload_spec: WorkloadEnvelopeSpec
+
+    def make_target_quiet(self) -> None:
+        truncate_sparse(self.target_source, 1_024)
+
+
+@dataclass(frozen=True, slots=True)
+class DebtLedgerRow:
+    debt_id: str
+    stage: str
+    subject_type: str
+    subject_id: str
+    status: str
+    attempts: int
+    last_error: str | None
+    next_retry_at: str | None
+    materializer_version: str | None
+    created_at_ms: int
+    updated_at_ms: int
+
+
+@dataclass(frozen=True, slots=True)
+class SessionMaterializationFacts:
+    """Stable terminal facts, excluding attempt-time materialization stamps."""
+
+    profile: FactRow | None
+    materializations: tuple[FactRow, ...]
+    work_events: tuple[FactRow, ...]
+    phases: tuple[FactRow, ...]
+    threads: tuple[FactRow, ...]
+    thread_sessions: tuple[FactRow, ...]
+    table_counts: tuple[tuple[str, int], ...]
+
+
+def seed_partial_convergence_archive(root: Path, *, target_hot: bool) -> PartialConvergenceArchive:
+    """Seed the current partial-convergence workload through typed archive writes."""
+    root.mkdir(parents=True, exist_ok=True)
+    index_db = root / "index.db"
+    source_db = root / "source.db"
+    ops_db = root / "ops.db"
+    target_source = root / "profile-growing-codex.jsonl"
+    unrelated_source = root / "unrelated-codex.jsonl"
+    target_size = convergence_stages._HOT_INSIGHT_SOURCE_BYTES + 1 if target_hot else 1_024
+    truncate_sparse(target_source, target_size)
+    truncate_sparse(unrelated_source, 1_024)
+
+    with open_connection(index_db) as conn:
+        target_session_id = _seed_raw_source_session(
+            conn,
+            session_id="convergence-survivor",
+            source_path=target_source,
+        )
+        unrelated_session_id = _seed_raw_source_session(
+            conn,
+            session_id="convergence-unrelated",
+            source_path=unrelated_source,
+        )
+        conn.commit()
+
+    return PartialConvergenceArchive(
+        root=root,
+        index_db=index_db,
+        source_db=source_db,
+        ops_db=ops_db,
+        target_source=target_source,
+        unrelated_source=unrelated_source,
+        target_session_id=target_session_id,
+        unrelated_session_id=unrelated_session_id,
+        workload_spec=partial_convergence_canary_spec(
+            profile_id="workload-profile:testdiet-02-partial-convergence",
+            archive_id="archive:testdiet-02-partial-convergence",
+        ),
+    )
+
+
+def truncate_sparse(path: Path, size: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as handle:
+        handle.truncate(size)
+
+
+def debt_ledger_row(
+    ops_db: Path,
+    *,
+    stage: str,
+    subject_type: str,
+    subject_id: str,
+) -> DebtLedgerRow | None:
+    with sqlite3.connect(ops_db) as conn:
+        row = conn.execute(
+            """
+            SELECT debt_id, stage, target_type, target_id, status, attempts,
+                   last_error, next_retry_at, materializer_version,
+                   created_at_ms, updated_at_ms
+            FROM convergence_debt
+            WHERE stage = ? AND target_type = ? AND target_id = ?
+            """,
+            (stage, subject_type, subject_id),
+        ).fetchone()
+    if row is None:
+        return None
+    return DebtLedgerRow(
+        debt_id=str(row[0]),
+        stage=str(row[1]),
+        subject_type=str(row[2]),
+        subject_id=str(row[3]),
+        status=str(row[4]),
+        attempts=int(row[5]),
+        last_error=None if row[6] is None else str(row[6]),
+        next_retry_at=None if row[7] is None else str(row[7]),
+        materializer_version=None if row[8] is None else str(row[8]),
+        created_at_ms=int(row[9]),
+        updated_at_ms=int(row[10]),
+    )
+
+
+def set_debt_retry_at(
+    ops_db: Path,
+    *,
+    stage: str,
+    subject_type: str,
+    subject_id: str,
+    retry_at: str,
+) -> None:
+    with sqlite3.connect(ops_db) as conn:
+        cursor = conn.execute(
+            """
+            UPDATE convergence_debt
+            SET next_retry_at = ?
+            WHERE stage = ? AND target_type = ? AND target_id = ?
+            """,
+            (retry_at, stage, subject_type, subject_id),
+        )
+        conn.commit()
+    if cursor.rowcount != 1:
+        raise AssertionError(f"expected one convergence debt row, updated {cursor.rowcount}")
+
+
+def make_messages_fts_stale(index_db: Path, *, session_id: str) -> int:
+    """Delete only this session's real FTS rows to create unrelated stage debt."""
+    with sqlite3.connect(index_db) as conn:
+        row_ids = [
+            int(row[0])
+            for row in conn.execute(
+                "SELECT rowid FROM blocks WHERE session_id = ? ORDER BY rowid",
+                (session_id,),
+            ).fetchall()
+        ]
+        conn.executemany("DELETE FROM messages_fts WHERE rowid = ?", ((row_id,) for row_id in row_ids))
+        conn.commit()
+    if not row_ids:
+        raise AssertionError(f"session {session_id!r} has no indexed blocks")
+    return len(row_ids)
+
+
+def messages_fts_match_count(index_db: Path, query: str) -> int:
+    with sqlite3.connect(index_db) as conn:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM messages_fts WHERE messages_fts MATCH ?",
+            (query,),
+        ).fetchone()
+    return 0 if row is None else int(row[0])
+
+
+def raw_authority_facts(source_db: Path) -> tuple[FactRow, ...]:
+    with sqlite3.connect(source_db) as conn:
+        rows = conn.execute(
+            """
+            SELECT raw_id, origin, native_id, source_path, hex(blob_hash),
+                   blob_size, acquired_at_ms
+            FROM raw_sessions
+            ORDER BY raw_id
+            """
+        ).fetchall()
+    return _fact_rows(rows)
+
+
+def session_materialization_facts(index_db: Path, *, session_id: str) -> SessionMaterializationFacts:
+    with sqlite3.connect(index_db) as conn:
+        profile_row = conn.execute(
+            """
+            SELECT session_id, logical_session_id, materializer_version,
+                   source_updated_at, source_sort_key, input_high_water_mark,
+                   input_high_water_mark_source, input_row_count, source_name,
+                   title, message_count, work_event_count, phase_count,
+                   word_count, tool_use_count, thinking_count, total_cost_usd,
+                   total_duration_ms, workflow_shape, terminal_state,
+                   total_input_tokens, total_output_tokens,
+                   evidence_payload_json, inference_payload_json,
+                   enrichment_payload_json
+            FROM session_profiles
+            WHERE session_id = ?
+            """,
+            (session_id,),
+        ).fetchone()
+        materializations = conn.execute(
+            """
+            SELECT insight_type, session_id, materializer_version,
+                   source_updated_at_ms, source_sort_key_ms,
+                   input_high_water_mark_ms, input_high_water_mark_source,
+                   input_row_count
+            FROM insight_materialization
+            WHERE session_id = ?
+            ORDER BY insight_type
+            """,
+            (session_id,),
+        ).fetchall()
+        work_events = conn.execute(
+            """
+            SELECT session_id, position, work_event_type, summary, confidence,
+                   start_index, end_index, started_at_ms, ended_at_ms,
+                   duration_ms, file_paths_json, tools_used_json,
+                   input_high_water_mark, input_high_water_mark_source,
+                   evidence_json, inference_json, search_text
+            FROM session_work_events
+            WHERE session_id = ?
+            ORDER BY position
+            """,
+            (session_id,),
+        ).fetchall()
+        phases = conn.execute(
+            """
+            SELECT session_id, position, start_index, end_index,
+                   started_at_ms, ended_at_ms, duration_ms,
+                   tool_counts_json, word_count,
+                   input_high_water_mark, input_high_water_mark_source,
+                   evidence_json, inference_json, search_text
+            FROM session_phases
+            WHERE session_id = ?
+            ORDER BY position
+            """,
+            (session_id,),
+        ).fetchall()
+        threads = conn.execute(
+            """
+            SELECT t.thread_id, t.dominant_repo_id, t.materializer_version,
+                   t.source_updated_at, t.input_high_water_mark,
+                   t.input_high_water_mark_source, t.input_row_count,
+                   t.start_time, t.end_time, t.dominant_repo,
+                   t.session_ids_json, t.session_count, t.depth, t.branch_count,
+                   t.total_messages, t.total_cost_usd, t.wall_duration_ms,
+                   t.work_event_breakdown_json, t.payload_json, t.search_text
+            FROM threads AS t
+            JOIN thread_sessions AS ts ON ts.thread_id = t.thread_id
+            WHERE ts.session_id = ?
+            ORDER BY t.thread_id
+            """,
+            (session_id,),
+        ).fetchall()
+        thread_sessions = conn.execute(
+            """
+            SELECT thread_id, session_id, position
+            FROM thread_sessions
+            WHERE session_id = ?
+            ORDER BY thread_id, position
+            """,
+            (session_id,),
+        ).fetchall()
+        count_tables = (
+            "sessions",
+            "messages",
+            "blocks",
+            "session_profiles",
+            "insight_materialization",
+            "session_work_events",
+            "session_phases",
+            "threads",
+            "thread_sessions",
+        )
+        table_counts = tuple(
+            (table, int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])) for table in count_tables
+        )
+    return SessionMaterializationFacts(
+        profile=None if profile_row is None else cast(FactRow, tuple(profile_row)),
+        materializations=_fact_rows(materializations),
+        work_events=_fact_rows(work_events),
+        phases=_fact_rows(phases),
+        threads=_fact_rows(threads),
+        thread_sessions=_fact_rows(thread_sessions),
+        table_counts=table_counts,
+    )
+
+
+def _seed_raw_source_session(conn: sqlite3.Connection, *, session_id: str, source_path: Path) -> str:
+    raw_id = f"raw-{session_id}"
+    source_db = _main_db_path(conn).with_name("source.db")
+    with sqlite3.connect(source_db) as source_conn:
+        initialize_archive_tier(source_conn, ArchiveTier.SOURCE)
+        source_conn.execute(
+            """
+            INSERT OR REPLACE INTO raw_sessions (
+                raw_id, origin, native_id, source_path, blob_hash, blob_size,
+                acquired_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                raw_id,
+                "codex-session",
+                session_id,
+                str(source_path),
+                hashlib.sha256(f"raw:{session_id}".encode()).digest(),
+                source_path.stat().st_size,
+                1_769_000_000_000,
+            ),
+        )
+        source_conn.commit()
+    return write_parsed_session_to_archive(
+        conn,
+        ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id=session_id,
+            title=session_id,
+            created_at="2026-05-24T01:00:00+00:00",
+            updated_at="2026-05-24T01:00:00+00:00",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="msg-1",
+                    role=Role.normalize("user"),
+                    text=f"Message for {session_id}",
+                    position=0,
+                    blocks=[
+                        ParsedContentBlock(
+                            type=BlockType.TEXT,
+                            text=f"Message for {session_id}",
+                        )
+                    ],
+                )
+            ],
+        ),
+        raw_id=raw_id,
+        content_hash=hashlib.sha256(f"session:{session_id}".encode()).hexdigest(),
+    )
+
+
+def _main_db_path(conn: sqlite3.Connection) -> Path:
+    row = conn.execute("PRAGMA database_list").fetchone()
+    if row is None or not row[2]:
+        raise AssertionError("archive index connection has no main database path")
+    return Path(str(row[2]))
+
+
+def _fact_rows(rows: list[tuple[object, ...]]) -> tuple[FactRow, ...]:
+    return tuple(cast(FactRow, tuple(row)) for row in rows)
+
+
+__all__ = [
+    "DebtLedgerRow",
+    "PartialConvergenceArchive",
+    "SessionMaterializationFacts",
+    "debt_ledger_row",
+    "make_messages_fts_stale",
+    "messages_fts_match_count",
+    "raw_authority_facts",
+    "seed_partial_convergence_archive",
+    "session_materialization_facts",
+    "set_debt_retry_at",
+    "truncate_sparse",
+]

--- a/tests/unit/daemon/test_convergence_restart_law.py
+++ b/tests/unit/daemon/test_convergence_restart_law.py
@@ -1,0 +1,346 @@
+"""Survivor law for convergence interruption, restart, retry, and quiescence."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from polylogue.daemon.convergence import DaemonConverger, StageState
+from polylogue.daemon.convergence_debt_status import convergence_debt_summary_info
+from polylogue.daemon.convergence_stages import make_fts_stage, make_insights_stage
+from polylogue.scenarios import WorkloadPhaseObservation, WorkloadReceipt, WorkloadRunStatus
+from polylogue.sources.live.convergence_debt import convergence_debt_from_states
+from polylogue.sources.live.convergence_outcome import record_convergence_outcome
+from polylogue.sources.live.cursor import CursorStore
+from tests.infra.convergence_harness import (
+    debt_ledger_row,
+    make_messages_fts_stale,
+    messages_fts_match_count,
+    raw_authority_facts,
+    seed_partial_convergence_archive,
+    session_materialization_facts,
+    set_debt_retry_at,
+)
+
+_DUE_RETRY_AT = "1970-01-01T00:00:00+00:00"
+_NOT_DUE_RETRY_AT = "9999-01-01T00:00:00+00:00"
+_FUTURE_MTIME = 4_102_444_800
+
+
+def _run_retry_in_fresh_process(index_db: Path) -> int:
+    """Execute the production debt drain across a genuine interpreter restart."""
+    repo_root = Path(__file__).resolve().parents[3]
+    env = os.environ.copy()
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = str(repo_root) if not existing_pythonpath else f"{repo_root}{os.pathsep}{existing_pythonpath}"
+    script = (
+        "from pathlib import Path\n"
+        "from polylogue.daemon.cli import _drain_convergence_debt_once\n"
+        f"print('RETRIED=' + str(_drain_convergence_debt_once(Path({str(index_db)!r}))))\n"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert completed.returncode == 0, (
+        f"fresh-process convergence retry failed\nstdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )
+    for line in reversed(completed.stdout.splitlines()):
+        if line.startswith("RETRIED="):
+            return int(line.removeprefix("RETRIED="))
+    raise AssertionError(f"fresh-process convergence retry emitted no result marker: {completed.stdout!r}")
+
+
+@pytest.mark.contract
+@pytest.mark.timeout(90)
+def test_convergence_debt_survives_restart_and_reaches_one_terminal_fact_set(tmp_path: Path) -> None:
+    """The real daemon route preserves exact debt until its own stage succeeds.
+
+    Production dependencies exercised: the typed archive writer, source-to-session
+    resolver, ``DaemonConverger`` false-means-pending contract, insights and FTS
+    stage implementations, ``CursorStore`` ops.db ledger, public debt status,
+    and ``_drain_convergence_debt_once`` in fresh Python processes.
+
+    Anti-vacuity mutations: deleting debt before stage success loses the hot
+    retry row; deleting/recreating it changes ``debt_id`` or resets attempts;
+    ignoring ``debt.stage`` repairs the deliberately stale FTS rows during an
+    insights retry; skipping retry leaves the profile absent; resolving the
+    wrong source materializes the unrelated session.
+    """
+    recovered = seed_partial_convergence_archive(tmp_path / "recovered", target_hot=True)
+    os.utime(recovered.target_source, (_FUTURE_MTIME, _FUTURE_MTIME))
+    raw_facts_before = raw_authority_facts(recovered.source_db)
+
+    # Bounded work is allowed to defer, but the exact stage/session obligation
+    # must be written durably before this process ends.
+    insights = make_insights_stage(recovered.index_db)
+    initial_states, _timings = DaemonConverger((insights,)).converge_batch((recovered.target_source,))
+    initial_state = initial_states[recovered.target_source]
+    assert initial_state.stages == {"insights": StageState.PENDING}
+    assert initial_state.last_error == "insights deferred until source quiet"
+    record_convergence_outcome(
+        CursorStore(recovered.index_db),
+        recovered.target_source,
+        convergence_debt_from_states((recovered.target_source,), initial_states),
+        archive_root=recovered.root,
+    )
+
+    initial_insights_debt = debt_ledger_row(
+        recovered.ops_db,
+        stage="insights",
+        subject_type="session_id",
+        subject_id=recovered.target_session_id,
+    )
+    assert initial_insights_debt is not None
+    assert initial_insights_debt.status == "deferred"
+    assert initial_insights_debt.attempts == 1
+    assert convergence_debt_summary_info(recovered.index_db).failed_count == 0
+    assert (
+        session_materialization_facts(
+            recovered.index_db,
+            session_id=recovered.target_session_id,
+        ).profile
+        is None
+    )
+
+    # Add unrelated real FTS debt for the same session. Its future deadline is
+    # a deterministic barrier: an insights retry must not execute, consume, or
+    # rewrite this other stage's obligation.
+    deleted_fts_rows = make_messages_fts_stale(
+        recovered.index_db,
+        session_id=recovered.target_session_id,
+    )
+    fts = make_fts_stage(recovered.index_db)
+    assert fts.check_sessions is not None
+    assert fts.check_sessions((recovered.target_session_id,)) == {recovered.target_session_id}
+    cursor = CursorStore(recovered.index_db)
+    cursor.record_convergence_debt(
+        stage="fts",
+        subject_type="session_id",
+        subject_id=recovered.target_session_id,
+        error="deliberate unrelated FTS backlog",
+    )
+    set_debt_retry_at(
+        recovered.ops_db,
+        stage="fts",
+        subject_type="session_id",
+        subject_id=recovered.target_session_id,
+        retry_at=_NOT_DUE_RETRY_AT,
+    )
+    unrelated_fts_debt = debt_ledger_row(
+        recovered.ops_db,
+        stage="fts",
+        subject_type="session_id",
+        subject_id=recovered.target_session_id,
+    )
+    assert unrelated_fts_debt is not None
+    assert unrelated_fts_debt.status == "failed"
+    assert messages_fts_match_count(recovered.index_db, "Message") == 1
+
+    status_with_fts_debt = convergence_debt_summary_info(recovered.index_db)
+    assert status_with_fts_debt.failed_count == 1
+    assert status_with_fts_debt.retry_due_count == 0
+    assert [(item.stage, item.failed_count) for item in status_with_fts_debt.stage_summaries] == [("fts", 1)]
+
+    # First restart: the source is still hot. Retrying must update the same
+    # insights row in place and leave both FTS materialization and FTS debt
+    # untouched.
+    set_debt_retry_at(
+        recovered.ops_db,
+        stage="insights",
+        subject_type="session_id",
+        subject_id=recovered.target_session_id,
+        retry_at=_DUE_RETRY_AT,
+    )
+    due_insights_debt = debt_ledger_row(
+        recovered.ops_db,
+        stage="insights",
+        subject_type="session_id",
+        subject_id=recovered.target_session_id,
+    )
+    assert due_insights_debt is not None
+    assert _run_retry_in_fresh_process(recovered.index_db) == 1
+
+    deferred_again = debt_ledger_row(
+        recovered.ops_db,
+        stage="insights",
+        subject_type="session_id",
+        subject_id=recovered.target_session_id,
+    )
+    assert deferred_again is not None
+    assert deferred_again.debt_id == due_insights_debt.debt_id
+    assert deferred_again.created_at_ms == due_insights_debt.created_at_ms
+    assert deferred_again.attempts == 2
+    assert deferred_again.status == "deferred"
+    assert (
+        debt_ledger_row(
+            recovered.ops_db,
+            stage="fts",
+            subject_type="session_id",
+            subject_id=recovered.target_session_id,
+        )
+        == unrelated_fts_debt
+    )
+    assert fts.check_sessions((recovered.target_session_id,)) == {recovered.target_session_id}
+    assert messages_fts_match_count(recovered.index_db, "Message") == 1
+    assert raw_authority_facts(recovered.source_db) == raw_facts_before
+    assert (
+        session_materialization_facts(
+            recovered.index_db,
+            session_id=recovered.target_session_id,
+        ).profile
+        is None
+    )
+    assert (
+        session_materialization_facts(
+            recovered.index_db,
+            session_id=recovered.unrelated_session_id,
+        ).profile
+        is None
+    )
+
+    # Second restart: after the source becomes quiet, only the recorded
+    # insights stage may complete and consume only its exact debt row.
+    recovered.make_target_quiet()
+    set_debt_retry_at(
+        recovered.ops_db,
+        stage="insights",
+        subject_type="session_id",
+        subject_id=recovered.target_session_id,
+        retry_at=_DUE_RETRY_AT,
+    )
+    assert _run_retry_in_fresh_process(recovered.index_db) == 1
+    assert (
+        debt_ledger_row(
+            recovered.ops_db,
+            stage="insights",
+            subject_type="session_id",
+            subject_id=recovered.target_session_id,
+        )
+        is None
+    )
+    assert (
+        debt_ledger_row(
+            recovered.ops_db,
+            stage="fts",
+            subject_type="session_id",
+            subject_id=recovered.target_session_id,
+        )
+        == unrelated_fts_debt
+    )
+    assert fts.check_sessions((recovered.target_session_id,)) == {recovered.target_session_id}
+    recovered_terminal_facts = session_materialization_facts(
+        recovered.index_db,
+        session_id=recovered.target_session_id,
+    )
+    assert recovered_terminal_facts.profile is not None
+    assert (
+        session_materialization_facts(
+            recovered.index_db,
+            session_id=recovered.unrelated_session_id,
+        ).profile
+        is None
+    )
+    assert raw_authority_facts(recovered.source_db) == raw_facts_before
+
+    # The independent FTS obligation is due only now. Its own retry repairs the
+    # missing rows without replaying or duplicating insights materialization.
+    set_debt_retry_at(
+        recovered.ops_db,
+        stage="fts",
+        subject_type="session_id",
+        subject_id=recovered.target_session_id,
+        retry_at=_DUE_RETRY_AT,
+    )
+    assert _run_retry_in_fresh_process(recovered.index_db) == 1
+    assert (
+        debt_ledger_row(
+            recovered.ops_db,
+            stage="fts",
+            subject_type="session_id",
+            subject_id=recovered.target_session_id,
+        )
+        is None
+    )
+    assert fts.check_sessions((recovered.target_session_id,)) == set()
+    assert messages_fts_match_count(recovered.index_db, "Message") == deleted_fts_rows + 1
+    assert (
+        session_materialization_facts(
+            recovered.index_db,
+            session_id=recovered.target_session_id,
+        )
+        == recovered_terminal_facts
+    )
+
+    # Repeated convergence is a no-op at quiescence and public status agrees
+    # with the durable ledger rather than hiding a residual row.
+    assert _run_retry_in_fresh_process(recovered.index_db) == 0
+    assert CursorStore(recovered.index_db).list_convergence_debt(limit=20) == []
+    quiescent_status = convergence_debt_summary_info(recovered.index_db)
+    assert quiescent_status.failed_count == 0
+    assert quiescent_status.retry_due_count == 0
+    assert (
+        session_materialization_facts(
+            recovered.index_db,
+            session_id=recovered.target_session_id,
+        )
+        == recovered_terminal_facts
+    )
+    assert raw_authority_facts(recovered.source_db) == raw_facts_before
+
+    # Independent terminal oracle: an uninterrupted quiet archive reaches the
+    # same stable profile/receipt/event/thread facts and leaves the unrelated
+    # session untouched.
+    baseline = seed_partial_convergence_archive(tmp_path / "baseline", target_hot=False)
+    baseline_states, _baseline_timings = DaemonConverger((make_insights_stage(baseline.index_db),)).converge_batch(
+        (baseline.target_source,)
+    )
+    assert baseline_states[baseline.target_source].converged
+    baseline_terminal_facts = session_materialization_facts(
+        baseline.index_db,
+        session_id=baseline.target_session_id,
+    )
+    assert baseline_terminal_facts == recovered_terminal_facts
+    assert (
+        session_materialization_facts(
+            baseline.index_db,
+            session_id=baseline.unrelated_session_id,
+        ).profile
+        is None
+    )
+
+    receipt = WorkloadReceipt.from_observations(
+        spec=recovered.workload_spec,
+        status=WorkloadRunStatus.SUCCEEDED,
+        build_id="git:f654480cadb7cc4c194704e24dfd483199547b35",
+        runtime_id="pytest:fresh-python-process-retries",
+        archive_id="archive:testdiet-02-partial-convergence",
+        generation_id="typed-archive-writer:testdiet-02",
+        frame_id=None,
+        phases=(
+            WorkloadPhaseObservation(name="generate"),
+            WorkloadPhaseObservation(name="ingest"),
+            WorkloadPhaseObservation(name="observe-debt", progress_completed=0, progress_total=1),
+            WorkloadPhaseObservation(name="converge", progress_completed=1, progress_total=1),
+            WorkloadPhaseObservation(name="query"),
+            WorkloadPhaseObservation(name="quiescent", cleanup_complete=True, quiescent=True),
+        ),
+        evidence_refs=(
+            f"ops-debt:{due_insights_debt.debt_id}",
+            f"session:{recovered.target_session_id}",
+        ),
+        cleanup_complete=True,
+    )
+    assert receipt.spec.workload_id == "canary:partial-convergence-drain"
+    assert receipt.status is WorkloadRunStatus.SUCCEEDED
+    assert receipt.cleanup_complete is True
+    assert receipt.phases[-1].quiescent is True


### PR DESCRIPTION
## Summary

Admits the validated Test Diet convergence-restart handoff as a current-master production survivor law.

## Problem

Convergence debt, interrupted stage work, fresh-process retry, and steady-state idempotence lacked one integrated proof.

## Solution

Add a production harness and survivor law that seeds partial convergence, crosses fresh-process retry boundaries, checks FTS/insight debt and terminal facts, then proves quiescent no-op behavior.

## Verification

- `devtools test tests/unit/daemon/test_convergence_restart_law.py` — passed.
- `devtools test tests/unit/daemon/test_daemon_convergence.py tests/unit/daemon/test_convergence_stages.py tests/unit/daemon/test_convergence_final_state.py tests/unit/daemon/test_convergence_restart_law.py` — 54 passed.
- Focused ruff, strict mypy, and pre-push `devtools verify --quick` passed.

Ref Test Diet handoff `testdiet-02`.