### PR TITLE
fix(devtools): stream large authority components

### DIFF
--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -648,8 +648,13 @@ def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
         import sys
 
         out = sys.stdout
-    receipt = cast(dict[str, object], payload["receipt"])
-    print(json.dumps(payload, indent=2, sort_keys=True) if args.json else receipt["receipt_id"], file=out)
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True), file=out)
+    elif args.prepare_only:
+        print(payload["archive_root"], file=out)
+    else:
+        receipt = cast(dict[str, object], payload["receipt"])
+        print(receipt["receipt_id"], file=out)
     return 0
 
 

--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -429,6 +429,11 @@ def run_raw_authority_scale_proof(
                                     )
                             acquired_at_ms += 1
                     pending_rows.clear()
+                    # Publication atomically moves prepared blobs.  Continue
+                    # the prefix chain from the now-stable final blob rather
+                    # than the moved temporary path, so large components can
+                    # flush without retaining thousands of prepared blobs.
+                    previous = publisher.blob_path(blob_hash)
             if pending_rows:
                 publisher.flush()
                 with source_conn:

--- a/tests/unit/devtools/test_raw_authority_scale_proof.py
+++ b/tests/unit/devtools/test_raw_authority_scale_proof.py
@@ -177,3 +177,30 @@ def test_raw_authority_scale_proof_generates_exact_scenario_bytes_and_expansion(
     assert achieved["authority_component_count"] == 2
     assert achieved["expanded_total_blob_bytes"] == 8192
     assert payload["prepared_only"] is True
+
+
+def test_raw_authority_scale_proof_keeps_prefix_chain_across_blob_flushes(tmp_path: Path) -> None:
+    """A component larger than the publisher batch must continue from its blob."""
+    scenario = RawAuthorityScaleScenario(
+        components=1,
+        direct_candidates=129,
+        expanded_candidates=129,
+        total_payload_bytes=2_200_000,
+    )
+
+    payload = run_raw_authority_scale_proof(
+        tmp_path,
+        scenario=scenario,
+        pass_limit=2,
+        keep=True,
+        prepare_only=True,
+        max_io_full_avg10=None,
+        max_memory_full_avg10=None,
+    )
+
+    root = Path(cast(str, payload["archive_root"]))
+    with sqlite3.connect(root / "source.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM raw_sessions").fetchone() == (129,)
+    achieved = cast(dict[str, object], payload["achieved_shape"])
+    assert achieved["authority_component_count"] == 1
+    assert achieved["expanded_candidate_count"] == 129


### PR DESCRIPTION
## Summary

Make raw-authority scale-corpus generation safe for large authority components, with a regression that crosses the blob publisher batch boundary.

## Problem

The exact current-shape preflight reached a component larger than the publisher batch. Publishing atomically moves prepared blobs, leaving the next prefix revision pointed at a vanished temporary path.

## Solution

Continue each prefix chain from the stable published blob after each batch flush. Exercise a 129-member component and make the prepare-only command return its archive root rather than requiring a replay receipt.

Ref polylogue-hjpx.2.

## Verification

-  — 7 passed.
- 2 files already formatted — passed.
- All checks passed! — passed.
- Pre-push {
  "timestamp": "2026-07-17T12:16:21.747045+00:00",
  "git_head": "2bab8f79de95181cf8b5629e27019b11ec9a05fe",
  "tier": "quick",
  "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
  "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0",
  "steps": [
    {
      "name": "ruff format",
      "duration_s": 0.01,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/01-ruff-format"
    },
    {
      "name": "ruff check",
      "duration_s": 0.01,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/02-ruff-check"
    },
    {
      "name": "mypy",
      "duration_s": 0.57,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/03-mypy"
    },
    {
      "name": "render all",
      "duration_s": 7.72,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/04-render-all"
    },
    {
      "name": "verify topology",
      "duration_s": 0.42,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/05-verify-topology"
    },
    {
      "name": "verify layering",
      "duration_s": 4.41,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/06-verify-layering"
    },
    {
      "name": "verify closure-matrix",
      "duration_s": 0.27,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/07-verify-closure-matrix"
    },
    {
      "name": "lab schema roundtrip",
      "duration_s": 1.11,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/08-lab-schema-roundtrip"
    },
    {
      "name": "verify manifests",
      "duration_s": 1.74,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/09-verify-manifests"
    },
    {
      "name": "verify ci-workflows",
      "duration_s": 0.32,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/10-verify-ci-workflows"
    },
    {
      "name": "verify doc-commands",
      "duration_s": 2.5,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/11-verify-doc-commands"
    },
    {
      "name": "verify docs-coverage",
      "duration_s": 2.44,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/12-verify-docs-coverage"
    },
    {
      "name": "verify test-infra-currency",
      "duration_s": 0.33,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/13-verify-test-infra-currency"
    },
    {
      "name": "verify test-clock-hygiene",
      "duration_s": 2.0,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/14-verify-test-clock-hygiene"
    },
    {
      "name": "verify pytest-timeout-overrides",
      "duration_s": 3.56,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/15-verify-pytest-timeout-overrides"
    },
    {
      "name": "verify degrade-loudly",
      "duration_s": 1.08,
      "exit": 0,
      "run_id": "20260717T121552Z-quick-2274866-4ef0bdc0",
      "artifact_dir": ".cache/verify/runs/20260717T121552Z-quick-2274866-4ef0bdc0/steps/16-verify-degrade-loudly"
    }
  ],
  "total_duration_s": 28.78,
  "exit_code": 0
} — passed.