### PR TITLE
feat(devtools): preserve raw authority cohort shape

### DIFF
--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -139,9 +139,13 @@ class RawAuthorityScaleScenario:
                 raw_count = item.get("component_raw_count")
                 direct_candidate_count = item.get("direct_candidate_count")
                 component_count = item.get("component_count")
-                if any(
-                    not isinstance(value, int) or isinstance(value, bool)
-                    for value in (raw_count, direct_candidate_count, component_count)
+                if (
+                    not isinstance(raw_count, int)
+                    or isinstance(raw_count, bool)
+                    or not isinstance(direct_candidate_count, int)
+                    or isinstance(direct_candidate_count, bool)
+                    or not isinstance(component_count, int)
+                    or isinstance(component_count, bool)
                 ):
                     raise ValueError("scenario profile component cohort values must be integral")
                 parsed_cohorts.append((raw_count, direct_candidate_count, component_count))

--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -78,6 +78,7 @@ class RawAuthorityScaleScenario:
     direct_candidates: int
     expanded_candidates: int
     total_payload_bytes: int
+    component_cohorts: tuple[tuple[int, int, int], ...] | None = None
 
     def __post_init__(self) -> None:
         if self.components < 1:
@@ -88,6 +89,32 @@ class RawAuthorityScaleScenario:
             raise ValueError("scenario expanded candidates cannot be smaller than direct candidates")
         if self.total_payload_bytes < self.expanded_candidates * 256:
             raise ValueError("scenario payload budget is too small for valid JSONL evidence")
+        if self.component_cohorts is not None:
+            if not self.component_cohorts:
+                raise ValueError("scenario component cohorts cannot be empty")
+            if any(
+                raw_count < 1 or direct_candidate_count < 1 or direct_candidate_count > raw_count or component_count < 1
+                for raw_count, direct_candidate_count, component_count in self.component_cohorts
+            ):
+                raise ValueError("scenario component cohorts must contain positive valid counts")
+            if (
+                sum(component_count for _raw_count, _direct_count, component_count in self.component_cohorts)
+                != self.components
+            ):
+                raise ValueError("scenario component cohorts disagree with component count")
+            if (
+                sum(raw_count * component_count for raw_count, _direct_count, component_count in self.component_cohorts)
+                != self.expanded_candidates
+            ):
+                raise ValueError("scenario component cohorts disagree with expanded candidate count")
+            if (
+                sum(
+                    direct_candidate_count * component_count
+                    for _raw_count, direct_candidate_count, component_count in self.component_cohorts
+                )
+                != self.direct_candidates
+            ):
+                raise ValueError("scenario component cohorts disagree with direct candidate count")
 
     @classmethod
     def from_profile(cls, profile: object) -> RawAuthorityScaleScenario:
@@ -100,11 +127,32 @@ class RawAuthorityScaleScenario:
                 raise ValueError(f"scenario profile has no integral {field}")
             return value
 
+        cohort_payload = profile.get("component_cohort_distribution")
+        cohorts: tuple[tuple[int, int, int], ...] | None = None
+        if cohort_payload is not None:
+            if not isinstance(cohort_payload, list):
+                raise ValueError("scenario profile component cohorts must be a list")
+            parsed_cohorts: list[tuple[int, int, int]] = []
+            for item in cohort_payload:
+                if not isinstance(item, dict):
+                    raise ValueError("scenario profile component cohort must be an object")
+                raw_count = item.get("component_raw_count")
+                direct_candidate_count = item.get("direct_candidate_count")
+                component_count = item.get("component_count")
+                if any(
+                    not isinstance(value, int) or isinstance(value, bool)
+                    for value in (raw_count, direct_candidate_count, component_count)
+                ):
+                    raise ValueError("scenario profile component cohort values must be integral")
+                parsed_cohorts.append((raw_count, direct_candidate_count, component_count))
+            cohorts = tuple(parsed_cohorts)
+
         return cls(
             components=count("authority_component_count"),
             direct_candidates=count("candidate_count"),
             expanded_candidates=count("expanded_candidate_count"),
             total_payload_bytes=count("expanded_total_blob_bytes"),
+            component_cohorts=cohorts,
         )
 
 
@@ -140,6 +188,12 @@ def _component_counts(total: int, *, components: int) -> list[int]:
 
 def _component_authority_shape(scenario: RawAuthorityScaleScenario) -> list[tuple[int, int]]:
     """Return direct-candidate and pre-materialized sibling counts per component."""
+    if scenario.component_cohorts is not None:
+        return [
+            (direct_candidate_count, raw_count - direct_candidate_count)
+            for raw_count, direct_candidate_count, component_count in scenario.component_cohorts
+            for _ in range(component_count)
+        ]
     direct = _component_counts(scenario.direct_candidates, components=scenario.components)
     siblings = _component_counts(
         scenario.expanded_candidates - scenario.direct_candidates,
@@ -150,7 +204,10 @@ def _component_authority_shape(scenario: RawAuthorityScaleScenario) -> list[tupl
 
 def _row_sizes(scenario: RawAuthorityScaleScenario, component_counts: list[int]) -> list[list[int]]:
     """Give every standalone raw a valid evidence budget, then spread the remainder."""
-    minimum_rows = [[256 * (revision + 1) for revision in range(count)] for count in component_counts]
+    minimum_rows = [
+        [256 * (revision + 1) for revision in range(count)] if scenario.component_cohorts is None else [256] * count
+        for count in component_counts
+    ]
     remaining = scenario.total_payload_bytes - sum(sum(rows) for rows in minimum_rows)
     if remaining < 0:
         raise ValueError("scenario payload budget cannot preserve the requested revision topology")
@@ -245,6 +302,27 @@ def _generated_archive_id(rows: list[tuple[str, int, str]]) -> str:
     }
     encoded = json.dumps(manifest, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
     return f"raw-authority-scale:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _requested_shape(scenario: RawAuthorityScaleScenario, *, pass_limit: int) -> dict[str, object]:
+    """Serialize the scenario without exposing an implementation-only null field."""
+    payload: dict[str, object] = {
+        "components": scenario.components,
+        "direct_candidates": scenario.direct_candidates,
+        "expanded_candidates": scenario.expanded_candidates,
+        "total_payload_bytes": scenario.total_payload_bytes,
+        "pass_limit": pass_limit,
+    }
+    if scenario.component_cohorts is not None:
+        payload["component_cohort_distribution"] = [
+            {
+                "component_raw_count": raw_count,
+                "direct_candidate_count": direct_candidate_count,
+                "component_count": component_count,
+            }
+            for raw_count, direct_candidate_count, component_count in scenario.component_cohorts
+        ]
+    return payload
 
 
 def _record_repair_pass(
@@ -377,7 +455,7 @@ def run_raw_authority_scale_proof(
                         native_id=session_native_id,
                         revision=member,
                         target_size=row_size,
-                        previous=previous,
+                        previous=previous if scenario.component_cohorts is None else None,
                     )
                     blob_hash, blob_size = publisher.write_from_path(payload_path)
                     payload_path.unlink()
@@ -483,7 +561,7 @@ def run_raw_authority_scale_proof(
     if prepare_only:
         prepared_report: dict[str, object] = {
             "archive_root": str(root),
-            "requested_shape": {**asdict(scenario), "pass_limit": pass_limit},
+            "requested_shape": _requested_shape(scenario, pass_limit=pass_limit),
             "achieved_shape": achieved_shape,
             "admission_sample": asdict(admission_sample),
             "prepared_only": True,
@@ -494,6 +572,10 @@ def run_raw_authority_scale_proof(
         if not keep:
             shutil.rmtree(root)
         return prepared_report
+    if scenario.component_cohorts is not None:
+        raise ValueError(
+            "an exact cohort scenario is preparation-only until its terminal/deferred outcome variants are implemented"
+        )
     if scenario.expanded_candidates != scenario.direct_candidates:
         raise ValueError(
             "an expanded-authority scenario requires explicit terminal/deferred cohort outcomes; "
@@ -579,7 +661,7 @@ def run_raw_authority_scale_proof(
     )
     report: dict[str, object] = {
         "archive_root": str(root),
-        "requested_shape": {**asdict(scenario), "pass_limit": pass_limit},
+        "requested_shape": _requested_shape(scenario, pass_limit=pass_limit),
         "achieved_shape": achieved_shape,
         "admission_sample": asdict(admission_sample),
         "passes": [asdict(item) for item in pass_receipts],

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -4347,6 +4347,11 @@ def raw_materialization_scale_profile(config: Config) -> dict[str, object]:
     if not bool(backlog["available"]):
         return {"available": False, "reason": backlog["reason"]}
     component_raw_counts = [len(component) for component in candidates.authority_components]
+    candidate_ids = set(candidates.raw_ids)
+    component_cohorts: dict[tuple[int, int], int] = {}
+    for component in candidates.authority_components:
+        key = (len(component), len(candidate_ids.intersection(component)))
+        component_cohorts[key] = component_cohorts.get(key, 0) + 1
     component_blob_bytes = [
         sum(_raw_materialization_component_blob_bytes(candidates, raw_id) for raw_id in component)
         for component in candidates.authority_components
@@ -4362,6 +4367,14 @@ def raw_materialization_scale_profile(config: Config) -> dict[str, object]:
         "total_blob_bytes": _backlog_count(backlog, "total_blob_bytes"),
         "expanded_total_blob_bytes": _backlog_count(backlog, "expanded_total_blob_bytes"),
         "component_raw_count_histogram": _histogram(component_raw_counts, field="upper_bound_raw_count"),
+        "component_cohort_distribution": [
+            {
+                "component_raw_count": raw_count,
+                "direct_candidate_count": direct_candidate_count,
+                "component_count": count,
+            }
+            for (raw_count, direct_candidate_count), count in sorted(component_cohorts.items())
+        ],
         "component_blob_bytes_histogram": _histogram(component_blob_bytes, field="upper_bound_blob_bytes"),
         "residual_state_counts": {
             "missing_blob_count": _backlog_count(backlog, "missing_blob_count"),

--- a/tests/unit/devtools/test_raw_authority_scale_proof.py
+++ b/tests/unit/devtools/test_raw_authority_scale_proof.py
@@ -118,6 +118,9 @@ def test_raw_authority_scale_profile_is_aggregate_only(tmp_path: Path) -> None:
     assert profile["expanded_candidate_count"] == 1
     assert profile["authority_component_count"] == 1
     assert profile["component_raw_count_histogram"] == [{"upper_bound_raw_count": 1, "count": 1}]
+    assert profile["component_cohort_distribution"] == [
+        {"component_raw_count": 1, "direct_candidate_count": 1, "component_count": 1}
+    ]
     serialized = str(profile)
     assert "private-native-id" not in serialized
     assert "/private/source/session.jsonl" not in serialized
@@ -204,3 +207,28 @@ def test_raw_authority_scale_proof_keeps_prefix_chain_across_blob_flushes(tmp_pa
     achieved = cast(dict[str, object], payload["achieved_shape"])
     assert achieved["authority_component_count"] == 1
     assert achieved["expanded_candidate_count"] == 129
+
+
+def test_raw_authority_scale_proof_preserves_exact_private_free_component_cohorts(tmp_path: Path) -> None:
+    scenario = RawAuthorityScaleScenario(
+        components=2,
+        direct_candidates=2,
+        expanded_candidates=4,
+        total_payload_bytes=4096,
+        component_cohorts=((1, 1, 1), (3, 1, 1)),
+    )
+
+    payload = run_raw_authority_scale_proof(
+        tmp_path,
+        scenario=scenario,
+        keep=True,
+        prepare_only=True,
+        max_io_full_avg10=None,
+        max_memory_full_avg10=None,
+    )
+
+    achieved = cast(dict[str, object], payload["achieved_shape"])
+    assert achieved["component_cohort_distribution"] == [
+        {"component_raw_count": 1, "direct_candidate_count": 1, "component_count": 1},
+        {"component_raw_count": 3, "direct_candidate_count": 1, "component_count": 1},
+    ]


### PR DESCRIPTION
## Summary

Preserve the aggregate authority-cohort topology in the private-free raw replay scale profile and its synthetic preflight.

## Problem

The prior scale proof matched only totals. It round-robined raw members across components, erasing the live frontier's giant authority cohorts and therefore not exercising the relevant scheduler/blob-publication shape.

## Solution

Record compressed component-raw-count, direct-candidate-count, and frequency cohorts without identifiers, paths, hashes, or content. Generate those exact component cardinalities for preparation, while explicitly reserving cohort scenarios with terminal/deferred siblings for the forthcoming outcome-conservation proof.

Ref polylogue-hjpx.2.

## Verification

- `mypy devtools/raw_authority_scale_proof.py` — passed.
- `devtools test tests/unit/devtools/test_raw_authority_scale_proof.py` — 8 passed.
- Pre-push `devtools verify --quick` — all quick-gate steps passed.
