### PR TITLE
fix(devtools): preserve cohort direct candidates

### DIFF
--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -453,10 +453,15 @@ def run_raw_authority_scale_proof(
                 previous: Path | None = None
                 for member, (row_size, terminalized) in enumerate(zip(row_sizes, row_kinds, strict=True)):
                     source_label = f"scale-{component:05d}-member-{member:05d}"
+                    row_native_id = (
+                        session_native_id
+                        if scenario.component_cohorts is None
+                        else f"{session_native_id}-member-{member:05d}"
+                    )
                     payload_path = temporary_root / f"{source_label}.jsonl"
                     _write_payload(
                         payload_path,
-                        native_id=session_native_id,
+                        native_id=row_native_id,
                         revision=member,
                         target_size=row_size,
                         previous=previous if scenario.component_cohorts is None else None,
@@ -465,7 +470,7 @@ def run_raw_authority_scale_proof(
                     payload_path.unlink()
                     previous = publisher.blob_path(blob_hash)
                     source_path = component_source_path
-                    pending_rows.append((session_native_id, source_path, blob_hash, blob_size, terminalized, component))
+                    pending_rows.append((row_native_id, source_path, blob_hash, blob_size, terminalized, component))
                     generated_rows.append((source_label, member, blob_hash))
                     if len(pending_rows) < 128:
                         continue

--- a/tests/unit/devtools/test_raw_authority_scale_proof.py
+++ b/tests/unit/devtools/test_raw_authority_scale_proof.py
@@ -212,10 +212,10 @@ def test_raw_authority_scale_proof_keeps_prefix_chain_across_blob_flushes(tmp_pa
 def test_raw_authority_scale_proof_preserves_exact_private_free_component_cohorts(tmp_path: Path) -> None:
     scenario = RawAuthorityScaleScenario(
         components=2,
-        direct_candidates=2,
+        direct_candidates=3,
         expanded_candidates=4,
         total_payload_bytes=4096,
-        component_cohorts=((1, 1, 1), (3, 1, 1)),
+        component_cohorts=((1, 1, 1), (3, 2, 1)),
     )
 
     payload = run_raw_authority_scale_proof(
@@ -230,5 +230,5 @@ def test_raw_authority_scale_proof_preserves_exact_private_free_component_cohort
     achieved = cast(dict[str, object], payload["achieved_shape"])
     assert achieved["component_cohort_distribution"] == [
         {"component_raw_count": 1, "direct_candidate_count": 1, "component_count": 1},
-        {"component_raw_count": 3, "direct_candidate_count": 1, "component_count": 1},
+        {"component_raw_count": 3, "direct_candidate_count": 2, "component_count": 1},
     ]


### PR DESCRIPTION
## Summary

Prevent exact raw-authority scale preflights from collapsing multiple direct candidates within one authority cohort.

## Problem

All synthetic members in a cohort had the same native id. The archive correctly deduplicated those direct candidates, so an otherwise exact topology receipt did not preserve its requested candidate counts.

## Solution

Use distinct synthetic native ids for direct members while retaining the shared source path that defines their authority component. The focused regression now covers a cohort with two direct candidates and one terminal sibling.

Ref polylogue-hjpx.2.

## Verification

- mypy devtools/raw_authority_scale_proof.py — passed.
- devtools test tests/unit/devtools/test_raw_authority_scale_proof.py — 8 passed.
- Pre-push devtools verify --quick — all quick-gate steps passed.
