### PR TITLE
docs(campaign): record testdiet query admission

### DIFF
--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/index.json
@@ -12,7 +12,7 @@
    "checked_at": "2026-07-17T10:55:34+00:00",
    "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
    "problems": [],
-   "status": "blocked",
+   "status": "integrated_merged",
    "members": [
     "EVIDENCE.md",
     "HANDOFF.md",
@@ -24,7 +24,8 @@
    "apply_detail": "patch applies cleanly",
    "attempt_id": "a01",
    "package_revision": "r01",
-   "state": "blocked"
+   "state": "integrated_merged",
+   "integration": "production defect reconciled against current master and admitted as PR #3022 / d1c08af640a07b27c3fb04185e34f4fda2f814ec; native-Codex corpus proves selector-only root CLI membership and total preserve the compiled boolean predicate"
   },
   {
    "job": "testdiet-02",

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-01/a01/result.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-01/a01/result.json
@@ -5,7 +5,7 @@
   "job_id": "testdiet-01",
   "attempt_id": "a01",
   "package_revision": "r01",
-  "state": "blocked",
+  "state": "integrated_merged",
   "provider": "chatgpt-pro",
   "provider_conversation_id": null,
   "provider_turn_id": null,
@@ -22,12 +22,20 @@
       "polylogue_attachment_ref": null
     }
   ],
-  "triage": "package validation completed; dispatch deliberately blocked by missing foundation receipt",
-  "beads": [],
-  "worktree": null,
+  "triage": "reconciled against current master after the query-law substrate landed; the package's root CLI boolean-predicate forwarding defect remained real and its focused production hunk applied cleanly",
+  "beads": [
+    "polylogue-yeq.3"
+  ],
+  "worktree": "feature/fix/cli-boolean-predicate",
   "agent_handle": null,
-  "commits": [],
-  "pull_request": null,
-  "verification_receipts": [],
-  "notes": "valid draft package; blocked pending foundation-receipt.json and fresh foundation snapshot"
+  "commits": [
+    "3f43c3e95fda95e073b5b84bc8f4907e75209a55",
+    "d1c08af640a07b27c3fb04185e34f4fda2f814ec"
+  ],
+  "pull_request": "https://github.com/Sinity/polylogue/pull/3022",
+  "verification_receipts": [
+    "devtools test tests/unit/cli/test_query_composition_laws.py tests/unit/cli/test_query_exec_laws.py: 86 passed",
+    "devtools verify --quick: 16 checks passed"
+  ],
+  "notes": "Admitted as a narrow production fix only. The added native-Codex corpus law exercises public Click root execution and fails if the final list_summaries call stops forwarding filter_kwargs: selector membership broadens from the two matching sessions to every archive session. The larger cross-surface/cancellation/workload-receipt scope remains open in polylogue-yeq.3."
 }


### PR DESCRIPTION
## Summary

Record the current-master reconciliation and merged delivery of the original Test Diet query-algebra package.

## Problem

The durable campaign receipt still described `testdiet-01/a01` as blocked despite its remaining production defect having been admitted and merged.

## Solution

Update only that attempt receipt and the matching index record with PR #3022, commit identities, focused verification, and the remaining `polylogue-yeq.3` scope.

## Verification

- `jq empty` on both changed JSON documents.
- `git diff --check`.
- Push hook: `devtools verify --quick`.

Ref polylogue-yeq.3.