### PR TITLE
docs(campaign): reconcile MCP read handoff

### DIFF
--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/beads-03/a01/result.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/beads-03/a01/result.json
@@ -5,7 +5,7 @@
   "job_id": "beads-03",
   "attempt_id": "a01",
   "package_revision": "r01",
-  "state": "validated",
+  "state": "subsumed_foundation_retained",
   "provider": "chatgpt-pro",
   "provider_conversation_id": null,
   "provider_turn_id": null,
@@ -22,12 +22,19 @@
       "polylogue_attachment_ref": null
     }
   ],
-  "triage": "locally inspected and checksum-validated",
-  "beads": [],
+  "triage": "current-master reconciliation found the core MCP declaration/registration implementation landed independently as PR #3004; the package no longer applies because it overlaps that implementation",
+  "beads": [
+    "polylogue-t46.8",
+    "polylogue-t46.8.2"
+  ],
   "worktree": null,
   "agent_handle": null,
-  "commits": [],
-  "pull_request": null,
-  "verification_receipts": [],
-  "notes": "valid package; preserved pending current-master reconciliation"
+  "commits": [
+    "ed44be18f"
+  ],
+  "pull_request": "https://github.com/Sinity/polylogue/pull/3004",
+  "verification_receipts": [
+    "fresh origin/master at 47fe1cb: both beads-02 and beads-03 apply checks conflict on existing declaration, adapter, renderer, generated-equivalence, and registration paths"
+  ],
+  "notes": "Retained as a positive design and proof input: it describes per-family read migration, no-wrapper FastMCP registration, compatibility witnesses, and representative query/ObjectRef/topology/timeline production routes. Current source already provides the shared declaration substrate. It must not be misrepresented as completing default-surface collapse, semantic tool retirement, shared bounded transaction adoption, URI resources/prompts, cold-model discovery, or incident-scale cancellation/cleanup; those remain polylogue-t46.8.2 scope."
 }

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/index.json
@@ -51,7 +51,7 @@
    "checked_at": "2026-07-17T10:55:16+00:00",
    "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
    "problems": [],
-   "status": "triaged",
+  "status": "subsumed_foundation_retained",
    "members": [
     "EVIDENCE.md",
     "HANDOFF.md",
@@ -63,7 +63,8 @@
    "apply_detail": "patch applies cleanly",
    "attempt_id": "a01",
    "package_revision": "r01",
-   "state": "validated"
+  "state": "subsumed_foundation_retained",
+  "integration": "Current-master reconciliation at 47fe1cb found the MCP-specific declaration/registration implementation already landed in PR #3004 / ed44be18f. Both this patch and the recovered beads-02 prerequisite now conflict on the same registry, adapters, generated equivalence, and server registration paths. Retain the package's read-family equivalence and representative production-route tests as implementation input for polylogue-t46.8.2; it does not complete the required 10-15 tool default-profile collapse or read-tool retirement."
   },
   {
    "job": "beads-04",


### PR DESCRIPTION
## Summary

Record the current-master reconciliation of the GPT Pro MCP read-migration package.

## Problem

The package remained merely triaged although its declaration/registration implementation now conflicts with the independently landed MCP foundation.

## Solution

Record the conflict evidence, retain its read-migration/equivalence material for `polylogue-t46.8.2`, and explicitly preserve the larger unfinished MCP-redesign scope.

## Verification

- Current `origin/master` at `47fe1cb`: both recovered `beads-02` and `beads-03` patches conflict on existing declaration/adapter/renderer/registration paths.
- `jq empty` for both receipt documents.
- `git diff --check`.
- Push hook: `devtools verify --quick`.

Ref polylogue-t46.8.2.