### PR TITLE
docs(campaign): reconcile MCP context handoff

### DIFF
--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/beads-04/a01/result.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/beads-04/a01/result.json
@@ -5,7 +5,7 @@
   "job_id": "beads-04",
   "attempt_id": "a01",
   "package_revision": "r01",
-  "state": "validated",
+  "state": "subsumed_foundation_retained",
   "provider": "chatgpt-pro",
   "provider_conversation_id": null,
   "provider_turn_id": null,
@@ -22,12 +22,19 @@
       "polylogue_attachment_ref": null
     }
   ],
-  "triage": "locally inspected and checksum-validated",
-  "beads": [],
+  "triage": "current-master reconciliation found the MCP declaration/registration foundation landed independently as PR #3004; the package's provisional kernel now conflicts with that implementation",
+  "beads": [
+    "polylogue-t46.8.3",
+    "polylogue-t46.9"
+  ],
   "worktree": null,
   "agent_handle": null,
-  "commits": [],
-  "pull_request": null,
-  "verification_receipts": [],
-  "notes": "valid package; preserved pending current-master reconciliation"
+  "commits": [
+    "ed44be18f"
+  ],
+  "pull_request": "https://github.com/Sinity/polylogue/pull/3004",
+  "verification_receipts": [
+    "fresh origin/master at 66cee5e: beads-04 apply check conflicts on existing declaration, adapter, server registration, and generated-surface paths"
+  ],
+  "notes": "Retained as a positive design/proof input for polylogue-t46.8.3: it inventories 41 context/assertion/personal-state/correction/judgment/maintenance tools; distinguishes candidate material from operator judgment; preserves immutable annotation provenance; and supplies negative role/injection and real user-tier lifecycle tests. Its boolean confirmation proposal remains only an interim compatibility idea; preview-bound authorization and receipts belong to polylogue-t46.9."
 }

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/index.json
@@ -75,7 +75,7 @@
    "checked_at": "2026-07-17T10:55:25+00:00",
    "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
    "problems": [],
-   "status": "triaged",
+  "status": "subsumed_foundation_retained",
    "members": [
     "EVIDENCE.md",
     "HANDOFF.md",
@@ -87,7 +87,8 @@
    "apply_detail": "patch applies cleanly",
    "attempt_id": "a01",
    "package_revision": "r01",
-   "state": "validated"
+  "state": "subsumed_foundation_retained",
+  "integration": "Current-master reconciliation at 66cee5e found the provisional MCP declaration/registration implementation already landed in PR #3004 / ed44be18f. This patch conflicts on the existing registry, adapters, server-family registration, and generated surfaces. Retain its 41-family trust/provenance/role lifecycle evidence for polylogue-t46.8.3; it does not complete tool retirement, URI/prompt surfaces, cold-model proof, telemetry, or t46.9 authorization receipts."
   }
  ]
 }


### PR DESCRIPTION
## Summary

Record the current-master reconciliation of the GPT Pro MCP context/privileged-family package.

## Problem

The package remained only triaged despite its provisional declaration kernel now conflicting with the independently landed MCP foundation.

## Solution

Record the conflict evidence and preserve its 41-family trust, provenance, lifecycle, role, and negative-test material for `polylogue-t46.8.3` and `polylogue-t46.9`.

## Verification

- Current `origin/master` at `66cee5e`: patch conflicts on existing declaration, adapters, registrations, and generated paths.
- `jq empty` and `git diff --check`.
- Push hook: `devtools verify --quick`.

Ref polylogue-t46.8.3.