### PR TITLE
docs(campaign): adjudicate analysis handoffs

### DIFF
--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/analysis-01/a01/result.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/analysis-01/a01/result.json
@@ -5,7 +5,7 @@
   "job_id": "analysis-01",
   "attempt_id": "a01",
   "package_revision": "r01",
-  "state": "acquired",
+  "state": "adjudicated_mixed_snapshot",
   "provider": "chatgpt-pro",
   "provider_conversation_id": null,
   "provider_turn_id": null,
@@ -29,5 +29,5 @@
   "commits": [],
   "pull_request": null,
   "verification_receipts": [],
-  "notes": "analysis retained for current-source adjudication"
+  "notes": "Current-master adjudication retained status/query/raw-chain/synchronization evidence but rejected stale ownership proposals, especially superseding polylogue-t46.9; no source patch admitted."
 }

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/analysis-02/a01/result.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/analysis-02/a01/result.json
@@ -5,7 +5,7 @@
   "job_id": "analysis-02",
   "attempt_id": "a01",
   "package_revision": "r01",
-  "state": "acquired",
+  "state": "integrated_campaign_contract",
   "provider": "chatgpt-pro",
   "provider_conversation_id": null,
   "provider_turn_id": null,
@@ -29,5 +29,5 @@
   "commits": [],
   "pull_request": null,
   "verification_receipts": [],
-  "notes": "analysis retained for current-source adjudication"
+  "notes": "Admitted to polylogue-yyvg.6: distinct funnel identities, immutable event receipts, mission shape, custody, and generic product-boundary requirements; no campaign ontology enters product code."
 }

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/analysis-03/a01/result.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/analysis-03/a01/result.json
@@ -5,7 +5,7 @@
   "job_id": "analysis-03",
   "attempt_id": "a01",
   "package_revision": "r01",
-  "state": "acquired",
+  "state": "adjudicated_forensic_snapshot",
   "provider": "chatgpt-pro",
   "provider_conversation_id": null,
   "provider_turn_id": null,
@@ -29,5 +29,5 @@
   "commits": [],
   "pull_request": null,
   "verification_receipts": [],
-  "notes": "analysis retained for current-master review"
+  "notes": "Useful as historical branch/closure forensics only; its proposed baseline and stale-branch actions are superseded by current master and current Bead authority."
 }

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/analysis-04/a01/result.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/analysis-04/a01/result.json
@@ -5,7 +5,7 @@
   "job_id": "analysis-04",
   "attempt_id": "a01",
   "package_revision": "r01",
-  "state": "acquired",
+  "state": "adjudicated_current_owner_map",
   "provider": "chatgpt-pro",
   "provider_conversation_id": null,
   "provider_turn_id": null,
@@ -29,5 +29,5 @@
   "commits": [],
   "pull_request": null,
   "verification_receipts": [],
-  "notes": "analysis retained for Bead adjudication"
+  "notes": "Current-compatible surface semantics map to existing owners: z9gh.9.1 query transaction, 2qx origin boundary, cuxz.2 absence/provenance, t46.9/kwsb.2/71ey mutation execution, t46.8.2 MCP retirement, and s1kr operation parity; no parallel surface model admitted."
 }

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/analysis-05/a01/result.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/analysis-05/a01/result.json
@@ -5,7 +5,7 @@
   "job_id": "analysis-05",
   "attempt_id": "a01",
   "package_revision": "r01",
-  "state": "acquired",
+  "state": "integrated_bead_evidence",
   "provider": "chatgpt-pro",
   "provider_conversation_id": null,
   "provider_turn_id": null,
@@ -29,5 +29,5 @@
   "commits": [],
   "pull_request": null,
   "verification_receipts": [],
-  "notes": "analysis retained for Bead adjudication"
+  "notes": "Admitted execution-grade proof refinements to 71ey, fd2s, mhx.7, and s1kr; query recipe and MCP-declaration findings map to z9gh.3/t46.8 without a second registry."
 }

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/index.json
@@ -10,7 +10,7 @@
    "sha256": "833d16be7bd83ba6000c069b112a0b0a2436f3f324fc7938051149982fe3e74a",
    "bytes": 101167,
    "checked_at": "2026-07-17T10:55:00+00:00",
-   "status": "acquired_analysis",
+   "status": "adjudicated_mixed_snapshot",
    "members": [
     "REPORT.md",
     "EVIDENCE.md",
@@ -21,7 +21,7 @@
     "EXECUTION-CLUSTERS.csv",
     "AUDIT-STATS.json"
    ],
-   "integration": "read and retained; decisions require current-source adjudication",
+   "integration": "current-master adjudication retained status/query/raw-chain/synchronization evidence but rejected stale ownership proposals, especially superseding t46.9; no source patch admitted",
    "attempt_id": "a01",
    "package_revision": "r01",
    "state": "acquired"
@@ -33,8 +33,8 @@
    "sha256": "3170b3999b062f5b0ee6c048661c55478dd65f72c9f952f2ebf6d9a218de0039",
    "bytes": 31570,
    "checked_at": "2026-07-17T10:55:00+00:00",
-   "status": "acquired_analysis",
-   "integration": "read and retained; campaign evidence is snapshot-relative",
+   "status": "integrated_campaign_contract",
+   "integration": "admitted to polylogue-yyvg.6: distinct funnel identities, immutable event receipts, mission shape, custody, and generic product-boundary requirements; no campaign ontology enters product code",
    "attempt_id": "a01",
    "package_revision": "r01",
    "state": "acquired"
@@ -46,8 +46,8 @@
    "sha256": "7e60be9d8f14dc7aac6e00635a0cf9ed098f94f36ad98347e1f4f2b26bb3b7b4",
    "bytes": 30429,
    "checked_at": "2026-07-17T10:55:00+00:00",
-   "status": "acquired_analysis",
-   "integration": "read and retained; active-diff claims require current-master review",
+   "status": "adjudicated_forensic_snapshot",
+   "integration": "useful as historical branch/closure forensics only; its proposed baseline and stale-branch actions are superseded by current master and current Bead authority",
    "attempt_id": "a01",
    "package_revision": "r01",
    "state": "acquired"
@@ -59,8 +59,8 @@
    "sha256": "01e51ca0f2f122fa1484ed9a17b0e0f279876d3a71ca1524d8167b148b8b07f2",
    "bytes": 31672,
    "checked_at": "2026-07-17T10:55:00+00:00",
-   "status": "acquired_analysis",
-   "integration": "read and retained; concrete surface-fork findings feed current Beads",
+   "status": "adjudicated_current_owner_map",
+   "integration": "current-compatible surface semantics map to existing owners: z9gh.9.1 query transaction, 2qx origin boundary, cuxz.2 absence/provenance, t46.9/kwsb.2/71ey mutation execution, t46.8.2 MCP retirement, and s1kr operation parity; no parallel surface model admitted",
    "attempt_id": "a01",
    "package_revision": "r01",
    "state": "acquired"
@@ -72,8 +72,8 @@
    "sha256": "e8b470b89cbea09279016f282a09683facf96b90ff7c587de9480ce896ec3271",
    "bytes": 23488,
    "checked_at": "2026-07-17T10:55:00+00:00",
-   "status": "acquired_analysis",
-   "integration": "read and retained; concrete collisions feed current Beads",
+   "status": "integrated_bead_evidence",
+   "integration": "admitted execution-grade proof refinements to 71ey, fd2s, mhx.7, and s1kr; query recipe and MCP-declaration findings map to z9gh.3/t46.8 without a second registry",
    "attempt_id": "a01",
    "package_revision": "r01",
    "state": "acquired"


### PR DESCRIPTION
## Summary

Record the current-master disposition of all five GPT Pro analysis handoffs.

## Solution

Distinguish campaign-contract and Bead evidence admissions from snapshot-era forensic material, and record the current authoritative owners for each surviving finding.

## Verification

- `jq empty` for the amended index.
- `git diff --check`.
- Push hook: `devtools verify --quick`.

No product architecture is changed by this receipt update.