### PR TITLE
fix(repair): fail closed on plan conservation drift

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -6138,6 +6138,7 @@ def repair_raw_materialization(
         and replay.adoption_deferred == 0
         and remaining.adoption_deferred == 0
         and remaining.byte_authority_pending == 0
+        and conservation_error_count == 0
         and not any(outcome.status is RawReplayPlanStatus.REJECTED_STALE for outcome in plan_outcomes)
         and (
             raw_artifact_id is None

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -17,6 +17,7 @@ from polylogue.storage.blob_publication import ArchiveBlobPublisher
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.insights.session.repair_assessment import assess_session_insight_repairs
 from polylogue.storage.insights.session.runtime import SessionInsightCounts, SessionInsightStatusSnapshot
+from polylogue.storage.raw_authority import RawReplayPlan, RawReplayPlanOutcome
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
@@ -1998,9 +1999,13 @@ def test_raw_materialization_fails_closed_on_plan_conservation_mismatch(
 
     original = repair_mod._raw_replay_conservation_metrics
 
-    def corrupt_outcome_algebra(*args: object, **kwargs: object) -> tuple[int, int, int]:
-        plans, carried_forward, _errors = original(*args, **kwargs)
-        return plans, carried_forward, 1
+    def corrupt_outcome_algebra(
+        plans: Sequence[RawReplayPlan],
+        selected_plan_ids: set[str],
+        outcomes: Sequence[RawReplayPlanOutcome],
+    ) -> tuple[int, int, int]:
+        plan_count, carried_forward, _errors = original(plans, selected_plan_ids, outcomes)
+        return plan_count, carried_forward, 1
 
     monkeypatch.setattr(repair_mod, "_raw_replay_conservation_metrics", corrupt_outcome_algebra)
     result = repair_mod.repair_raw_materialization(_config(tmp_path))

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -1979,6 +1979,37 @@ def test_raw_materialization_isolates_failed_component_and_continues_batch(
     assert [outcome.status.value for outcome in result.plan_outcomes].count("executed") == 2
 
 
+def test_raw_materialization_fails_closed_on_plan_conservation_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The success flag must not conceal a mutated before/after plan algebra."""
+    from polylogue.core.enums import Provider
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b'{"type":"session_meta","payload":{"id":"conservation"}}\n',
+            source_path="conservation.jsonl",
+            acquired_at_ms=1,
+        )
+
+    original = repair_mod._raw_replay_conservation_metrics
+
+    def corrupt_outcome_algebra(*args: object, **kwargs: object) -> tuple[int, int, int]:
+        plans, carried_forward, _errors = original(*args, **kwargs)
+        return plans, carried_forward, 1
+
+    monkeypatch.setattr(repair_mod, "_raw_replay_conservation_metrics", corrupt_outcome_algebra)
+    result = repair_mod.repair_raw_materialization(_config(tmp_path))
+
+    assert result.repaired_count == 1
+    assert result.metrics["raw_materialization_plan_conservation_error_count"] == 1.0
+    assert result.success is False
+
+
 def test_raw_materialization_batch_limit_counts_authority_components(tmp_path: Path) -> None:
     """One revision-heavy source must not consume the whole daemon batch."""
     from polylogue.core.enums import Provider


### PR DESCRIPTION
## Summary

Reject raw materialization success when its before/after replay-plan conservation algebra reports an error.

## Problem

The reconciler exposed a nonzero conservation metric but could still report success, concealing a corrupted immutable-plan accounting pass.

## Solution

Make conservation error count a required success condition. The focused mutation corrupts the conservation computation after the real repair route has executed and proves the result fails closed.

Ref polylogue-hjpx.2.

## Verification

- Focused storage mutation test passed.
- Mypy for the mutation test passed.
- Pre-push quick verification passed.