### PR TITLE
docs(campaign): reconcile recovered MCP foundation

### DIFF
--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/beads-02/a01/result.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/beads-02/a01/result.json
@@ -5,7 +5,7 @@
   "job_id": "beads-02",
   "attempt_id": "a01",
   "package_revision": "r01",
-  "state": "verified",
+  "state": "subsumed_foundation_retained",
   "provider": "chatgpt-pro",
   "provider_conversation_id": null,
   "provider_turn_id": null,
@@ -22,14 +22,19 @@
       "polylogue_attachment_ref": null
     }
   ],
-  "triage": "locally inspected and checksum-validated",
-  "beads": [],
+  "triage": "current-master reconciliation found the recovered standalone diff is the same MCP declaration/registration foundation that PR #3004 landed; it no longer applies because it overlaps that implementation",
+  "beads": [
+    "polylogue-t46.8",
+    "polylogue-t46.8.2"
+  ],
   "worktree": null,
   "agent_handle": null,
   "commits": [
     "ed44be18f448c31f9fa5b9289c75da7eee99b131"
   ],
   "pull_request": "https://github.com/Sinity/polylogue/pull/3004",
-  "verification_receipts": [],
-  "notes": "incomplete package; its bounded MCP foundation was integrated as PR #3004"
+  "verification_receipts": [
+    "fresh origin/master at e673da994: recovered beads-02 diff conflicts on existing declaration, adapter, generated-equivalence, and registration paths already supplied by PR #3004"
+  ],
+  "notes": "The missing cohesive package remains a delivery limitation, but the standalone diff is retained as positive historical/proof input. Its declaration/registration foundation is materially subsumed by PR #3004 / ed44be18f. Do not repeat the obsolete kernel or claim it completed the requested 10-15 tool default surface, semantic read-tool retirement, cold-model discovery, URI resources/prompts, or bounded shared transaction adoption; those remain under polylogue-t46.8.2."
 }

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/index.json
@@ -29,7 +29,7 @@
    "bytes": 781283,
    "checked_at": "2026-07-17T10:56:00+00:00",
    "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
-   "status": "recovered_incomplete_package",
+   "status": "subsumed_foundation_retained",
    "patch_applies": true,
    "problems": [
     "missing required HANDOFF.md",
@@ -37,10 +37,10 @@
     "missing required EVIDENCE.md",
     "no provider result ZIP or verified conversation export"
    ],
-   "integration": "MCP algebra foundation candidate; must be reconciled with beads-03/04 on current master",
+   "integration": "Current-master reconciliation found the recovered standalone diff is the same declaration/registration foundation now landed in PR #3004 / ed44be18f. It conflicts on the existing registry, adapters, generated equivalence, and server registration paths. Retain it as historical/proof input to polylogue-t46.8.2; it does not complete default-profile collapse, read-tool retirement, or bounded transaction adoption.",
    "attempt_id": "a01",
    "package_revision": "r01",
-   "state": "verified"
+   "state": "subsumed_foundation_retained"
   },
   {
    "job": "beads-03",


### PR DESCRIPTION
## Summary

Closes the remaining ambiguous recovered GPT Pro handoff record.

## Problem

The standalone beads-02 MCP diff still said it required future reconciliation, although current master already contains its declaration/registration foundation through PR #3004.

## Solution

Records the exact current-master supersession, preserves the diff as historical/proof input, and points its remaining scope at `polylogue-t46.8.2`.

## Verification

- `jq -e` on the campaign index and attempt receipt: passed
- `git diff --check`: passed
- pre-push `devtools verify --quick`: passed

Ref polylogue-t46.8.2.