### PR TITLE
docs(campaign): record Test Diet 06 admission

### DIFF
--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/index.json
@@ -156,15 +156,14 @@
    "bytes": 153265,
    "checked_at": "2026-07-17T15:16:00+00:00",
    "snapshot": "b9052e09103502017c0f510ecc699aac395de23c",
-   "status": "candidate_requires_kernel_rebase",
-   "state": "candidate_requires_kernel_rebase",
+   "status": "integrated_merged",
+   "state": "integrated_merged",
    "patch_paths": 18,
    "problems": [
     "the provider did not produce the mandated cohesive result ZIP",
-    "the patch does not apply to current master only because generated topology files drift",
-    "its local FactFamilySpec must be rebased onto the existing o21.1 DeclarationSpec contract rather than introducing a second declaration kernel"
+    "the received patch required generated-topology refresh and a small shared-declaration-kernel rebase before admission"
    ],
-   "integration": "Positive implementation/design input admitted to polylogue-cuxz.2: preserve the three production canaries and composition laws, but rebase the core onto the shared declaration kernel before source admission."
+   "integration": "admitted as PR #3033 / efadb404ebe70ec91f03ffcb7eaf0de7956ece4d after FactFamilySpec was projected through the shared DeclarationRegistry; three real owner-route canaries landed while broader EvidenceValue family migration remains open"
   }
  ]
 }

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-06/r01/receipt.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-06/r01/receipt.json
@@ -4,7 +4,7 @@
   "workload_id": "testdiet",
   "job_id": "testdiet-06",
   "package_revision": "r01",
-  "state": "candidate_requires_kernel_rebase",
+  "state": "integrated_merged",
   "provider": "chatgpt-pro",
   "prompt_sha256": "5a863e2954c70000d9afc2b2c491bbc4578bcf8cb23fdf31633e10c3a979d804",
   "snapshot_identity": "b9052e09103502017c0f510ecc699aac395de23c",
@@ -17,8 +17,13 @@
   "validation": [
     "the patch targets an ancestor of current master",
     "the patch contains 18 paths and three real owner-route canaries",
-    "current-master application stops only at generated topology artifacts",
-    "the source candidate introduces a local FactFamilySpec and must instead consume the o21.1 DeclarationSpec kernel"
+    "current-master reconciliation refreshed generated topology artifacts",
+    "FactFamilySpec was rebased to project through the shared DeclarationRegistry rather than creating a second registry",
+    "focused owner-route suite: 172 passed",
+    "devtools verify --quick passed"
   ],
-  "admission": "Positive source/design material is retained for polylogue-cuxz.2. Its exact-token/unknown-price, stale-last-good-status, and excluded-source-byte-lag canaries are accepted as the first kernel-rebased slice; no source code is admitted before that rebase."
+  "bead": "polylogue-cuxz.2",
+  "merge_commit": "efadb404ebe70ec91f03ffcb7eaf0de7956ece4d",
+  "pull_request": "https://github.com/Sinity/polylogue/pull/3033",
+  "admission": "The candidate is admitted as the first kernel-rebased EvidenceValue production slice. Exact-token/unknown-price, stale-last-good-status, and excluded-source-byte-lag canaries are now on master. Broad family/surface migration remains explicitly open under the parent EvidenceValue program."
 }


### PR DESCRIPTION
## Summary

Updates the durable Test Diet 06 receipt after its evidence/provenance implementation merged.

## Problem

The original intake correctly recorded that the standalone patch required a declaration-kernel rebase, but it would remain falsely pending after PR #3033.

## Solution

Records the shared-kernel rebase, focused 172-test result, quick gate, and authoritative merge identity while retaining the missing original ZIP as honest provenance.

## Verification

- `jq -e` on campaign index and receipt: passed
- `git diff --check`: passed
- pre-push `devtools verify --quick`: passed

Ref polylogue-cuxz.2.