### PR TITLE
perf(devtools): bound raw authority corpus generation

### DIFF
--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -350,7 +350,13 @@ def _row_sizes(
     sizes: list[list[int]] = []
     for minimums, target in zip(minimum_rows, target_component_bytes, strict=True):
         rows = list(minimums)
-        rows[-1] += target - sum(rows)
+        extra_bytes = target - sum(rows)
+        if _uses_independent_component_members(scenario):
+            extra_per_member, remainder = divmod(extra_bytes, len(rows))
+            for member in range(len(rows)):
+                rows[member] += extra_per_member + (1 if member < remainder else 0)
+        else:
+            rows[-1] += extra_bytes
         sizes.append(rows)
     return sizes
 
@@ -570,6 +576,17 @@ def run_raw_authority_scale_proof(
         max_io_full_avg10=max_io_full_avg10,
         max_memory_full_avg10=max_memory_full_avg10,
     )
+    generation_samples = [admission_sample]
+
+    def check_generation_pressure() -> None:
+        sample = _process_sample()
+        _assert_admission(
+            sample,
+            max_io_full_avg10=max_io_full_avg10,
+            max_memory_full_avg10=max_memory_full_avg10,
+        )
+        generation_samples.append(sample)
+
     root = workdir.expanduser().resolve() / "raw-authority-scale-proof"
     if root.exists():
         shutil.rmtree(root)
@@ -623,6 +640,7 @@ def run_raw_authority_scale_proof(
                     if len(pending_rows) < 128:
                         continue
                     publisher.flush()
+                    check_generation_pressure()
                     with source_conn:
                         for (
                             row_native_id,
@@ -668,6 +686,7 @@ def run_raw_authority_scale_proof(
                                     )
                             acquired_at_ms += 1
                     pending_rows.clear()
+                    check_generation_pressure()
                     # Publication atomically moves prepared blobs.  Continue
                     # the prefix chain from the now-stable final blob rather
                     # than the moved temporary path, so large components can
@@ -675,6 +694,7 @@ def run_raw_authority_scale_proof(
                     previous = publisher.blob_path(blob_hash)
             if pending_rows:
                 publisher.flush()
+                check_generation_pressure()
                 with source_conn:
                     for (
                         row_native_id,
@@ -717,6 +737,7 @@ def run_raw_authority_scale_proof(
                                     ),
                                 )
                         acquired_at_ms += 1
+                check_generation_pressure()
         staging.rmdir()
     archive_id = _generated_archive_id(generated_rows)
     config = Config(archive_root=root, render_root=root, sources=[], db_path=root / "index.db")
@@ -727,6 +748,7 @@ def run_raw_authority_scale_proof(
             "requested_shape": _requested_shape(scenario, pass_limit=pass_limit),
             "achieved_shape": achieved_shape,
             "admission_sample": asdict(admission_sample),
+            "generation_samples": [asdict(sample) for sample in generation_samples],
             "prepared_only": True,
         }
         (root / "raw-authority-scale-preflight.json").write_text(
@@ -823,6 +845,7 @@ def run_raw_authority_scale_proof(
         "requested_shape": _requested_shape(scenario, pass_limit=pass_limit),
         "achieved_shape": achieved_shape,
         "admission_sample": asdict(admission_sample),
+        "generation_samples": [asdict(sample) for sample in generation_samples],
         "passes": [asdict(item) for item in pass_receipts],
         "fixed_point_digests": fixed_point_digests,
         "receipt": receipt.to_payload(),

--- a/tests/unit/devtools/test_raw_authority_scale_proof.py
+++ b/tests/unit/devtools/test_raw_authority_scale_proof.py
@@ -47,6 +47,7 @@ def test_raw_authority_scale_proof_reaches_two_matching_quiescent_censuses(tmp_p
     assert passes[-1]["fixed_point"] is True
     assert all(isinstance(item["peak_rss_bytes"], int) and item["peak_rss_bytes"] > 0 for item in passes)
     assert "admission_sample" in payload
+    assert len(cast(list[object], payload["generation_samples"])) >= 2
     assert receipt["status"] == "succeeded"
     assert isinstance(phases[3]["wall_ms"], int | float) and phases[3]["wall_ms"] > 0
     assert "wall_ms" not in phases[2]
@@ -69,6 +70,27 @@ def test_raw_authority_scale_proof_refuses_a_contended_host(monkeypatch: pytest.
 
     with pytest.raises(RuntimeError, match="I/O pressure gate"):
         run_raw_authority_scale_proof(tmp_path, max_io_full_avg10=2.0)
+
+
+def test_raw_authority_scale_proof_rechecks_pressure_during_generation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    samples = iter(
+        (
+            ProcessSample(1, 1, 0, 0, 0, 0, 0.0, 0.0),
+            ProcessSample(1, 1, 0, 0, 0, 0, 2.1, 0.0),
+        )
+    )
+    monkeypatch.setattr("devtools.raw_authority_scale_proof._process_sample", lambda: next(samples))
+
+    with pytest.raises(RuntimeError, match="I/O pressure gate"):
+        run_raw_authority_scale_proof(
+            tmp_path,
+            components=1,
+            raws=1,
+            prepare_only=True,
+            max_io_full_avg10=2.0,
+        )
 
 
 def test_raw_authority_scale_proof_consumes_reservations_and_has_stable_corpus_identity(tmp_path: Path) -> None:
@@ -313,3 +335,8 @@ def test_raw_authority_scale_proof_preserves_private_free_joint_byte_cohorts(tmp
     assert requested["component_byte_cohort_distribution"] == expected
     assert achieved["component_byte_cohort_distribution"] == expected
     assert achieved["expanded_total_blob_bytes"] == 6_000
+    root = Path(cast(str, payload["archive_root"]))
+    with sqlite3.connect(root / "source.db") as conn:
+        largest_blob = conn.execute("SELECT MAX(blob_size) FROM raw_sessions").fetchone()
+    assert largest_blob is not None
+    assert int(largest_blob[0]) < 4_096


### PR DESCRIPTION
## Summary

Makes large raw-authority synthetic corpus preparation bounded and observable during generation.

## Problem

Explicit byte cohorts preserved a component total by placing all excess into the final raw. For a multi-thousand-member component this produced one synthetic multi-gigabyte blob, and the runner sampled pressure only before generation.

## Solution

Distribute explicit-cohort byte budget across independent raw members, recheck I/O and memory pressure after every 128-row publication batch, and retain generation samples in both preparation and full-run receipts.

Ref polylogue-hjpx.2.

## Verification

- `devtools test tests/unit/devtools/test_raw_authority_scale_proof.py` — 11 passed.
- `devtools verify --quick` — format, lint, mypy, generated-surface and policy checks passed.
