### PR TITLE
feat(campaign): reconcile result projections (#3039)

### DIFF
--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/README.md
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/README.md
@@ -28,11 +28,16 @@ Launch gating and result intake are mechanical, not prose:
   foundation merges, write `foundation-receipt.json`
   (`{"merged_commit": "<sha>", "verified_at": "<iso8601>"}`) at this
   directory's root.
-- `./triage-package.py <result.zip> --workload W --job J --snapshot <commit>
-  [--record]` validates an incoming package (identity, required members,
-  placeholder scan, `git apply --check` in a throwaway worktree) and appends
-  the attempt record to the workload's `results/index.json`. It never runs a
-  package's own test commands — that happens later in a reviewed lane.
+- `./triage-package.py <result.zip> --workload W --job J --attempt aNN
+  --package-revision rNN --prompt-sha256 <hash> --snapshot <commit> --write`
+  validates an incoming package (identity, required members, placeholder scan,
+  `git apply --check` in a throwaway worktree), preserves it in canonical raw
+  custody, and writes one immutable attempt receipt. It then rebuilds the
+  index from receipts. It never runs a package's own test commands — that
+  happens later in a reviewed lane.
+- `python ../reconcile_results.py . --check` is the required post-intake
+  integrity gate: it rejects a missing, ambiguous, stale, or second-outcome
+  projection rather than silently trusting the index.
 - `testdiet/owning-beads.json` maps each testdiet job to the Beads records
   owning its durable product contracts (persisted by PR #2947); paste the
   job's line into the dispatch chat with the prompt. `check-dispatch.py`

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/analysis/results/index.json
@@ -1,82 +1,77 @@
 {
- "schema_version": 1,
- "campaign_id": "gpt-pro-wave-2026-07-16",
- "workload_id": "analysis",
- "attempts": [
-  {
-   "job": "analysis-01",
-   "workload": "analysis",
-   "zip": "analysis-01-bead-overlap-contradictions-r01.zip",
-   "sha256": "833d16be7bd83ba6000c069b112a0b0a2436f3f324fc7938051149982fe3e74a",
-   "bytes": 101167,
-   "checked_at": "2026-07-17T10:55:00+00:00",
-   "status": "adjudicated_mixed_snapshot",
-   "members": [
-    "REPORT.md",
-    "EVIDENCE.md",
-    "DECISIONS.md",
-    "NEXT-ACTIONS.md",
-    "ACTIVE-CENSUS.csv",
-    "GRAPH-CHANGES.csv",
-    "EXECUTION-CLUSTERS.csv",
-    "AUDIT-STATS.json"
-   ],
-   "integration": "current-master adjudication retained status/query/raw-chain/synchronization evidence but rejected stale ownership proposals, especially superseding t46.9; no source patch admitted",
-   "attempt_id": "a01",
-   "package_revision": "r01",
-   "state": "adjudicated_mixed_snapshot"
-  },
-  {
-   "job": "analysis-02",
-   "workload": "analysis",
-   "zip": "analysis-02-campaign-effectiveness-r01.zip",
-   "sha256": "3170b3999b062f5b0ee6c048661c55478dd65f72c9f952f2ebf6d9a218de0039",
-   "bytes": 31570,
-   "checked_at": "2026-07-17T10:55:00+00:00",
-   "status": "integrated_campaign_contract",
-   "integration": "admitted to polylogue-yyvg.6: distinct funnel identities, immutable event receipts, mission shape, custody, and generic product-boundary requirements; no campaign ontology enters product code",
-   "attempt_id": "a01",
-   "package_revision": "r01",
-   "state": "integrated_campaign_contract"
-  },
-  {
-   "job": "analysis-03",
-   "workload": "analysis",
-   "zip": "analysis-03-active-diff-ac-review-r01.zip",
-   "sha256": "7e60be9d8f14dc7aac6e00635a0cf9ed098f94f36ad98347e1f4f2b26bb3b7b4",
-   "bytes": 30429,
-   "checked_at": "2026-07-17T10:55:00+00:00",
-   "status": "adjudicated_forensic_snapshot",
-   "integration": "useful as historical branch/closure forensics only; its proposed baseline and stale-branch actions are superseded by current master and current Bead authority",
-   "attempt_id": "a01",
-   "package_revision": "r01",
-   "state": "adjudicated_forensic_snapshot"
-  },
-  {
-   "job": "analysis-04",
-   "workload": "analysis",
-   "zip": "analysis-04-surface-semantic-matrix-r01.zip",
-   "sha256": "01e51ca0f2f122fa1484ed9a17b0e0f279876d3a71ca1524d8167b148b8b07f2",
-   "bytes": 31672,
-   "checked_at": "2026-07-17T10:55:00+00:00",
-   "status": "adjudicated_current_owner_map",
-   "integration": "current-compatible surface semantics map to existing owners: z9gh.9.1 query transaction, 2qx origin boundary, cuxz.2 absence/provenance, t46.9/kwsb.2/71ey mutation execution, t46.8.2 MCP retirement, and s1kr operation parity; no parallel surface model admitted",
-   "attempt_id": "a01",
-   "package_revision": "r01",
-   "state": "adjudicated_current_owner_map"
-  },
-  {
-   "job": "analysis-05",
-   "workload": "analysis",
-   "zip": "analysis-05-duplicate-authority-census-r01.zip",
-   "sha256": "e8b470b89cbea09279016f282a09683facf96b90ff7c587de9480ce896ec3271",
-   "bytes": 23488,
-   "checked_at": "2026-07-17T10:55:00+00:00",
-   "status": "integrated_bead_evidence",
-   "integration": "admitted execution-grade proof refinements to 71ey, fd2s, mhx.7, and s1kr; query recipe and MCP-declaration findings map to z9gh.3/t46.8 without a second registry",
-   "attempt_id": "a01",
-   "package_revision": "r01",
-   "state": "integrated_bead_evidence"
-  }
- ]
+  "schema_version": 1,
+  "campaign_id": "gpt-pro-wave-2026-07-16",
+  "workload_id": "analysis",
+  "attempts": [
+    {
+      "job": "analysis-01",
+      "workload": "analysis",
+      "zip": "analysis-01-bead-overlap-contradictions-r01.zip",
+      "sha256": "833d16be7bd83ba6000c069b112a0b0a2436f3f324fc7938051149982fe3e74a",
+      "bytes": 101167,
+      "checked_at": "2026-07-17T10:55:00+00:00",
+      "members": [
+        "REPORT.md",
+        "EVIDENCE.md",
+        "DECISIONS.md",
+        "NEXT-ACTIONS.md",
+        "ACTIVE-CENSUS.csv",
+        "GRAPH-CHANGES.csv",
+        "EXECUTION-CLUSTERS.csv",
+        "AUDIT-STATS.json"
+      ],
+      "integration": "current-master adjudication retained status/query/raw-chain/synchronization evidence but rejected stale ownership proposals, especially superseding t46.9; no source patch admitted",
+      "attempt_id": "a01",
+      "package_revision": "r01",
+      "state": "adjudicated_mixed_snapshot"
+    },
+    {
+      "job": "analysis-02",
+      "workload": "analysis",
+      "zip": "analysis-02-campaign-effectiveness-r01.zip",
+      "sha256": "3170b3999b062f5b0ee6c048661c55478dd65f72c9f952f2ebf6d9a218de0039",
+      "bytes": 31570,
+      "checked_at": "2026-07-17T10:55:00+00:00",
+      "integration": "admitted to polylogue-yyvg.6: distinct funnel identities, immutable event receipts, mission shape, custody, and generic product-boundary requirements; no campaign ontology enters product code",
+      "attempt_id": "a01",
+      "package_revision": "r01",
+      "state": "integrated_campaign_contract"
+    },
+    {
+      "job": "analysis-03",
+      "workload": "analysis",
+      "zip": "analysis-03-active-diff-ac-review-r01.zip",
+      "sha256": "7e60be9d8f14dc7aac6e00635a0cf9ed098f94f36ad98347e1f4f2b26bb3b7b4",
+      "bytes": 30429,
+      "checked_at": "2026-07-17T10:55:00+00:00",
+      "integration": "useful as historical branch/closure forensics only; its proposed baseline and stale-branch actions are superseded by current master and current Bead authority",
+      "attempt_id": "a01",
+      "package_revision": "r01",
+      "state": "adjudicated_forensic_snapshot"
+    },
+    {
+      "job": "analysis-04",
+      "workload": "analysis",
+      "zip": "analysis-04-surface-semantic-matrix-r01.zip",
+      "sha256": "01e51ca0f2f122fa1484ed9a17b0e0f279876d3a71ca1524d8167b148b8b07f2",
+      "bytes": 31672,
+      "checked_at": "2026-07-17T10:55:00+00:00",
+      "integration": "current-compatible surface semantics map to existing owners: z9gh.9.1 query transaction, 2qx origin boundary, cuxz.2 absence/provenance, t46.9/kwsb.2/71ey mutation execution, t46.8.2 MCP retirement, and s1kr operation parity; no parallel surface model admitted",
+      "attempt_id": "a01",
+      "package_revision": "r01",
+      "state": "adjudicated_current_owner_map"
+    },
+    {
+      "job": "analysis-05",
+      "workload": "analysis",
+      "zip": "analysis-05-duplicate-authority-census-r01.zip",
+      "sha256": "e8b470b89cbea09279016f282a09683facf96b90ff7c587de9480ce896ec3271",
+      "bytes": 23488,
+      "checked_at": "2026-07-17T10:55:00+00:00",
+      "integration": "admitted execution-grade proof refinements to 71ey, fd2s, mhx.7, and s1kr; query recipe and MCP-declaration findings map to z9gh.3/t46.8 without a second registry",
+      "attempt_id": "a01",
+      "package_revision": "r01",
+      "state": "integrated_bead_evidence"
+    }
+  ]
 }

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/index.json
@@ -1,94 +1,90 @@
 {
- "schema_version": 1,
- "campaign_id": "gpt-pro-wave-2026-07-16",
- "workload_id": "beads",
- "attempts": [
-  {
-   "job": "beads-01",
-   "workload": "beads",
-   "zip": "polylogue-config-closure.zip",
-   "sha256": "dcef7122d477232585c6169d5306d5dc30ce9924ab86dda92915c95c2c4dcd26",
-   "bytes": 35210095,
-   "checked_at": "2026-07-17T10:55:00+00:00",
-   "status": "rejected_incomplete",
-   "problems": [
-    "zero-byte patch",
-    "copied 162 MB repository snapshot",
-    "remote verification lacks project dependencies"
-   ],
-   "integration": "raw package retained; no implementation is authorized from it",
-   "attempt_id": "a01",
-   "package_revision": "r01",
-   "state": "rejected"
-  },
-  {
-   "job": "beads-02",
-   "workload": "beads",
-   "artifact": "PATCH.diff",
-   "sha256": "59d40d9e39f4cd97b35ef7c3e47f9efa9a0153c4766e091a7609091ba4397592",
-   "bytes": 781283,
-   "checked_at": "2026-07-17T10:56:00+00:00",
-   "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
-   "status": "subsumed_foundation_retained",
-   "patch_applies": true,
-   "problems": [
-    "missing required HANDOFF.md",
-    "missing required TESTS.md",
-    "missing required EVIDENCE.md",
-    "no provider result ZIP or verified conversation export"
-   ],
-   "integration": "Current-master reconciliation found the recovered standalone diff is the same declaration/registration foundation now landed in PR #3004 / ed44be18f. It conflicts on the existing registry, adapters, generated equivalence, and server registration paths. Retain it as historical/proof input to polylogue-t46.8.2; it does not complete default-profile collapse, read-tool retirement, or bounded transaction adoption.",
-   "attempt_id": "a01",
-   "package_revision": "r01",
-   "state": "subsumed_foundation_retained"
-  },
-  {
-   "job": "beads-03",
-   "workload": "beads",
-   "zip": "beads-03-mcp-read-migration-r01.zip",
-   "sha256": "195e7f898c298c29a39006247e2836e981b51549ce92ba46a43db938c4365830",
-   "bytes": 76818,
-   "checked_at": "2026-07-17T10:55:16+00:00",
-   "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
-   "problems": [],
-  "status": "subsumed_foundation_retained",
-   "members": [
-    "EVIDENCE.md",
-    "HANDOFF.md",
-    "PATCH.diff",
-    "TESTS.md"
-   ],
-   "patch_lines": 20870,
-   "patch_applies": true,
-   "apply_detail": "patch applies cleanly",
-   "attempt_id": "a01",
-   "package_revision": "r01",
-  "state": "subsumed_foundation_retained",
-  "integration": "Current-master reconciliation at 47fe1cb found the MCP-specific declaration/registration implementation already landed in PR #3004 / ed44be18f. Both this patch and the recovered beads-02 prerequisite now conflict on the same registry, adapters, generated equivalence, and server registration paths. Retain the package's read-family equivalence and representative production-route tests as implementation input for polylogue-t46.8.2; it does not complete the required 10-15 tool default-profile collapse or read-tool retirement."
-  },
-  {
-   "job": "beads-04",
-   "workload": "beads",
-   "zip": "beads-04-mcp-context-migration-r01.zip",
-   "sha256": "fe1c8a99a89372da83db8068ec97fa2bec671302248696bd99e6d907de13d8a9",
-   "bytes": 40602,
-   "checked_at": "2026-07-17T10:55:25+00:00",
-   "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
-   "problems": [],
-  "status": "subsumed_foundation_retained",
-   "members": [
-    "EVIDENCE.md",
-    "HANDOFF.md",
-    "PATCH.diff",
-    "TESTS.md"
-   ],
-   "patch_lines": 4143,
-   "patch_applies": true,
-   "apply_detail": "patch applies cleanly",
-   "attempt_id": "a01",
-   "package_revision": "r01",
-  "state": "subsumed_foundation_retained",
-  "integration": "Current-master reconciliation at 66cee5e found the provisional MCP declaration/registration implementation already landed in PR #3004 / ed44be18f. This patch conflicts on the existing registry, adapters, server-family registration, and generated surfaces. Retain its 41-family trust/provenance/role lifecycle evidence for polylogue-t46.8.3; it does not complete tool retirement, URI/prompt surfaces, cold-model proof, telemetry, or t46.9 authorization receipts."
-  }
- ]
+  "schema_version": 1,
+  "campaign_id": "gpt-pro-wave-2026-07-16",
+  "workload_id": "beads",
+  "attempts": [
+    {
+      "job": "beads-01",
+      "workload": "beads",
+      "zip": "polylogue-config-closure.zip",
+      "sha256": "dcef7122d477232585c6169d5306d5dc30ce9924ab86dda92915c95c2c4dcd26",
+      "bytes": 35210095,
+      "checked_at": "2026-07-17T10:55:00+00:00",
+      "problems": [
+        "zero-byte patch",
+        "copied 162 MB repository snapshot",
+        "remote verification lacks project dependencies"
+      ],
+      "integration": "raw package retained; no implementation is authorized from it",
+      "attempt_id": "a01",
+      "package_revision": "r01",
+      "state": "rejected"
+    },
+    {
+      "job": "beads-02",
+      "workload": "beads",
+      "artifact": "PATCH.diff",
+      "sha256": "59d40d9e39f4cd97b35ef7c3e47f9efa9a0153c4766e091a7609091ba4397592",
+      "bytes": 781283,
+      "checked_at": "2026-07-17T10:56:00+00:00",
+      "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
+      "patch_applies": true,
+      "problems": [
+        "missing required HANDOFF.md",
+        "missing required TESTS.md",
+        "missing required EVIDENCE.md",
+        "no provider result ZIP or verified conversation export"
+      ],
+      "integration": "Current-master reconciliation found the recovered standalone diff is the same declaration/registration foundation now landed in PR #3004 / ed44be18f. It conflicts on the existing registry, adapters, generated equivalence, and server registration paths. Retain it as historical/proof input to polylogue-t46.8.2; it does not complete default-profile collapse, read-tool retirement, or bounded transaction adoption.",
+      "attempt_id": "a01",
+      "package_revision": "r01",
+      "state": "subsumed_foundation_retained"
+    },
+    {
+      "job": "beads-03",
+      "workload": "beads",
+      "zip": "beads-03-mcp-read-migration-r01.zip",
+      "sha256": "195e7f898c298c29a39006247e2836e981b51549ce92ba46a43db938c4365830",
+      "bytes": 76818,
+      "checked_at": "2026-07-17T10:55:16+00:00",
+      "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
+      "problems": [],
+      "members": [
+        "EVIDENCE.md",
+        "HANDOFF.md",
+        "PATCH.diff",
+        "TESTS.md"
+      ],
+      "patch_lines": 20870,
+      "patch_applies": true,
+      "apply_detail": "patch applies cleanly",
+      "attempt_id": "a01",
+      "package_revision": "r01",
+      "state": "subsumed_foundation_retained",
+      "integration": "Current-master reconciliation at 47fe1cb found the MCP-specific declaration/registration implementation already landed in PR #3004 / ed44be18f. Both this patch and the recovered beads-02 prerequisite now conflict on the same registry, adapters, generated equivalence, and server registration paths. Retain the package's read-family equivalence and representative production-route tests as implementation input for polylogue-t46.8.2; it does not complete the required 10-15 tool default-profile collapse or read-tool retirement."
+    },
+    {
+      "job": "beads-04",
+      "workload": "beads",
+      "zip": "beads-04-mcp-context-migration-r01.zip",
+      "sha256": "fe1c8a99a89372da83db8068ec97fa2bec671302248696bd99e6d907de13d8a9",
+      "bytes": 40602,
+      "checked_at": "2026-07-17T10:55:25+00:00",
+      "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
+      "problems": [],
+      "members": [
+        "EVIDENCE.md",
+        "HANDOFF.md",
+        "PATCH.diff",
+        "TESTS.md"
+      ],
+      "patch_lines": 4143,
+      "patch_applies": true,
+      "apply_detail": "patch applies cleanly",
+      "attempt_id": "a01",
+      "package_revision": "r01",
+      "state": "subsumed_foundation_retained",
+      "integration": "Current-master reconciliation at 66cee5e found the provisional MCP declaration/registration implementation already landed in PR #3004 / ed44be18f. This patch conflicts on the existing registry, adapters, server-family registration, and generated surfaces. Retain its 41-family trust/provenance/role lifecycle evidence for polylogue-t46.8.3; it does not complete tool retirement, URI/prompt surfaces, cold-model proof, telemetry, or t46.9 authorization receipts."
+    }
+  ]
 }

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/deep-research/results/index.json
@@ -1,1 +1,6 @@
-{"schema_version":1,"campaign_id":"gpt-pro-wave-2026-07-16","workload_id":"deep-research","attempts":[]}
+{
+  "schema_version": 1,
+  "campaign_id": "gpt-pro-wave-2026-07-16",
+  "workload_id": "deep-research",
+  "attempts": []
+}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/index.json
@@ -1,169 +1,172 @@
 {
- "schema_version": 1,
- "campaign_id": "gpt-pro-wave-2026-07-16",
- "workload_id": "testdiet",
- "attempts": [
-  {
-   "job": "testdiet-01",
-   "workload": "testdiet",
-   "zip": "testdiet-01-query-algebra-cardinality-r01.zip",
-   "sha256": "365cb58bf6e1135bc210b62ae422fb5009825cd3f505db0c3adcb41ccd00d2e5",
-   "bytes": 21998,
-   "checked_at": "2026-07-17T10:55:34+00:00",
-   "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
-   "problems": [],
-   "status": "integrated_merged",
-   "members": [
-    "EVIDENCE.md",
-    "HANDOFF.md",
-    "PATCH.diff",
-    "TESTS.md"
-   ],
-   "patch_lines": 786,
-   "patch_applies": true,
-   "apply_detail": "patch applies cleanly",
-   "attempt_id": "a01",
-   "package_revision": "r01",
-   "state": "integrated_merged",
-   "integration": "production defect reconciled against current master and admitted as PR #3022 / d1c08af640a07b27c3fb04185e34f4fda2f814ec; native-Codex corpus proves selector-only root CLI membership and total preserve the compiled boolean predicate"
-  },
-  {
-   "job": "testdiet-02",
-   "workload": "testdiet",
-   "zip": "testdiet-02-convergence-liveness-r01.zip",
-   "sha256": "57d52025be0554c45d482073e776b82f77d368127bc6000ef872a894d26fbcb6",
-   "bytes": 22637,
-   "checked_at": "2026-07-17T10:55:43+00:00",
-   "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
-   "problems": [],
-   "status": "integrated_merged",
-   "members": [
-    "EVIDENCE.md",
-    "HANDOFF.md",
-    "PATCH.diff",
-    "TESTS.md"
-   ],
-   "patch_lines": 917,
-   "patch_applies": true,
-   "apply_detail": "patch applies cleanly",
-   "attempt_id": "a01",
-   "package_revision": "r01",
-   "state": "integrated_merged",
-   "integration": "admitted after current-master reconciliation as PR #3014 / 76ad3e1379bde4829650392e459cd4804abb721d; real restart/debt recovery proof landed, while the missing live FTS-debt feeder remains explicit residual scope"
-  },
-  {
-   "job": "testdiet-04",
-   "workload": "testdiet",
-   "revision": "r02",
-   "zip": "testdiet-04/r02/raw.zip",
-   "sha256": "225ad872667e579b0d0b0975ff0f463f9e54acd5a07d29825084a93eae79b2b3",
-   "bytes": 6294,
-   "checked_at": "2026-07-17T14:01:00+00:00",
-   "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
-   "status": "evidence_only_no_candidate",
-   "members": [
-    "derived_freshness_solution/README.md",
-    "derived_freshness_solution/candidate-index.json",
-    "derived_freshness_solution/changed-paths.txt",
-    "derived_freshness_solution/input-identities.json",
-    "derived_freshness_solution/manifest.json",
-    "derived_freshness_solution/requirements/04-derived-freshness.md",
-    "derived_freshness_solution/selection.json",
-    "derived_freshness_solution/solution.patch",
-    "derived_freshness_solution/validation/archive-verification.json"
-   ],
-   "patch_lines": 0,
-   "problems": [
-    "solution.patch is zero bytes",
-    "selected_candidate is null",
-    "changed_paths is empty"
-   ],
-   "integration": "ZIP CRC and manifest checked. Retained as delivery/freshness evidence only; it authorizes no implementation or Bead closure."
-  },
-  {
-   "job": "testdiet-01",
-   "workload": "testdiet",
-   "revision": "r02",
-   "zip": "testdiet-01/r02/raw.zip",
-   "sha256": "557ba43a9f77783ed0e7644eb7dd4c9f6a07e4c416ac6a16c4aae096f2cc3fa8",
-   "bytes": 23470,
-   "checked_at": "2026-07-17T12:21:00+00:00",
-   "snapshot": "b9052e09103502017c0f510ecc699aac395de23c",
-   "status": "integrated_merged",
-   "state": "integrated_merged",
-   "members": ["EVIDENCE.md", "HANDOFF.md", "PATCH.diff", "TESTS.md"],
-   "patch_lines": 923,
-   "integration": "admitted after current-master reconciliation as PR #3019 / d42cc1497ee91fded8c46313a46e18733f9084ee; native Codex action-cardinality survivor is a query-law seed, not closure of the broad cross-surface/cancellation/receipt scope"
-  },
-  {
-   "job": "testdiet-05",
-   "workload": "testdiet",
-   "revision": "r01",
-   "zip": "testdiet-05/r01/raw.zip",
-   "sha256": "cad064d3c0c4cdfa3c221adf6a7a1000ce59dccf84a8b9944003bfd8c21350f4",
-   "bytes": 33668,
-   "checked_at": "2026-07-17T14:01:00+00:00",
-   "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
-   "status": "integrated_merged",
-   "state": "integrated_merged",
-   "members": ["EVIDENCE.md", "HANDOFF.md", "PATCH.diff", "TESTS.md"],
-   "integration": "admitted after current-master reconciliation as PR #3012 / 876358610ebd8c7532d3d6865df6bc5fc01712b1; bounded aggregate execution is proven, while shared resumable query transaction scope remains open"
-  },
-  {
-   "job": "testdiet-02",
-   "workload": "testdiet",
-   "revision": "r02",
-   "artifact": "testdiet-02/r02/raw/polylogue-convergence-liveness-handoff.zip",
-   "sha256": "079eedeefb6fcf830c023b1700692ed5b080fe3186dcf466067cb2684f1724e7",
-   "bytes": 8059,
-   "checked_at": "2026-07-17T15:16:00+00:00",
-   "snapshot": "b9052e09103502017c0f510ecc699aac395de23c",
-   "status": "rejected_validation_failed",
-   "state": "rejected_validation_failed",
-   "problems": [
-    "release status declares INCOMPLETE/FAIL",
-    "base commit is unknown and changed_files is empty",
-    "bundle contains no PATCH.diff or production payload",
-    "finalizer failed to locate the required repository baseline"
-   ],
-   "integration": "Retained as honest failed-delivery evidence only. It authorizes neither code admission nor Bead closure; the independently verified r01 admission remains PR #3014."
-  },
-  {
-   "job": "testdiet-05",
-   "workload": "testdiet",
-   "revision": "r02",
-   "artifact": "testdiet-05/r02/raw/query-bounds-deliverables.tar.gz",
-   "sha256": "e0954c7f5002ad41d9af4eeb644437f8229f61b680070cff7d01e01f5962456a",
-   "bytes": 1863,
-   "checked_at": "2026-07-17T15:16:00+00:00",
-   "snapshot": "b9052e09103502017c0f510ecc699aac395de23c",
-   "status": "rejected_validation_failed",
-   "state": "rejected_validation_failed",
-   "problems": [
-    "STATUS is PARTIAL",
-    "no reconstructed Git worktree was found",
-    "no patch or changed-file payload exists",
-    "no executable test transcript exists"
-   ],
-   "integration": "Retained as honest failed-delivery evidence only. It authorizes neither code admission nor Bead closure; the independently verified r01 admission remains PR #3012."
-  },
-  {
-   "job": "testdiet-06",
-   "workload": "testdiet",
-   "revision": "r01",
-   "artifact": "testdiet-06/r01/raw/PATCH.diff",
-   "sha256": "2b48fb36707e0310fe734618794ef0faadeb41ac02d627b7d4a33f8a622fbe62",
-   "bytes": 153265,
-   "checked_at": "2026-07-17T15:16:00+00:00",
-   "snapshot": "b9052e09103502017c0f510ecc699aac395de23c",
-   "status": "integrated_merged",
-   "state": "integrated_merged",
-   "patch_paths": 18,
-   "problems": [
-    "the provider did not produce the mandated cohesive result ZIP",
-    "the received patch required generated-topology refresh and a small shared-declaration-kernel rebase before admission"
-   ],
-   "integration": "admitted as PR #3033 / efadb404ebe70ec91f03ffcb7eaf0de7956ece4d after FactFamilySpec was projected through the shared DeclarationRegistry; three real owner-route canaries landed while broader EvidenceValue family migration remains open"
-  }
- ]
+  "schema_version": 1,
+  "campaign_id": "gpt-pro-wave-2026-07-16",
+  "workload_id": "testdiet",
+  "attempts": [
+    {
+      "job": "testdiet-01",
+      "workload": "testdiet",
+      "zip": "testdiet-01-query-algebra-cardinality-r01.zip",
+      "sha256": "365cb58bf6e1135bc210b62ae422fb5009825cd3f505db0c3adcb41ccd00d2e5",
+      "bytes": 21998,
+      "checked_at": "2026-07-17T10:55:34+00:00",
+      "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
+      "problems": [],
+      "members": [
+        "EVIDENCE.md",
+        "HANDOFF.md",
+        "PATCH.diff",
+        "TESTS.md"
+      ],
+      "patch_lines": 786,
+      "patch_applies": true,
+      "apply_detail": "patch applies cleanly",
+      "attempt_id": "a01",
+      "package_revision": "r01",
+      "state": "integrated_merged",
+      "integration": "production defect reconciled against current master and admitted as PR #3022 / d1c08af640a07b27c3fb04185e34f4fda2f814ec; native-Codex corpus proves selector-only root CLI membership and total preserve the compiled boolean predicate"
+    },
+    {
+      "job": "testdiet-02",
+      "workload": "testdiet",
+      "zip": "testdiet-02-convergence-liveness-r01.zip",
+      "sha256": "57d52025be0554c45d482073e776b82f77d368127bc6000ef872a894d26fbcb6",
+      "bytes": 22637,
+      "checked_at": "2026-07-17T10:55:43+00:00",
+      "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
+      "problems": [],
+      "members": [
+        "EVIDENCE.md",
+        "HANDOFF.md",
+        "PATCH.diff",
+        "TESTS.md"
+      ],
+      "patch_lines": 917,
+      "patch_applies": true,
+      "apply_detail": "patch applies cleanly",
+      "attempt_id": "a01",
+      "package_revision": "r01",
+      "state": "integrated_merged",
+      "integration": "admitted after current-master reconciliation as PR #3014 / 76ad3e1379bde4829650392e459cd4804abb721d; real restart/debt recovery proof landed, while the missing live FTS-debt feeder remains explicit residual scope"
+    },
+    {
+      "job": "testdiet-01",
+      "workload": "testdiet",
+      "zip": "testdiet-01/r02/raw.zip",
+      "sha256": "557ba43a9f77783ed0e7644eb7dd4c9f6a07e4c416ac6a16c4aae096f2cc3fa8",
+      "bytes": 23470,
+      "checked_at": "2026-07-17T12:21:00+00:00",
+      "snapshot": "b9052e09103502017c0f510ecc699aac395de23c",
+      "state": "integrated_merged",
+      "members": [
+        "EVIDENCE.md",
+        "HANDOFF.md",
+        "PATCH.diff",
+        "TESTS.md"
+      ],
+      "patch_lines": 923,
+      "integration": "admitted after current-master reconciliation as PR #3019 / d42cc1497ee91fded8c46313a46e18733f9084ee; native Codex action-cardinality survivor is a query-law seed, not closure of the broad cross-surface/cancellation/receipt scope",
+      "package_revision": "r02"
+    },
+    {
+      "job": "testdiet-02",
+      "workload": "testdiet",
+      "artifact": "testdiet-02/r02/raw/polylogue-convergence-liveness-handoff.zip",
+      "sha256": "079eedeefb6fcf830c023b1700692ed5b080fe3186dcf466067cb2684f1724e7",
+      "bytes": 8059,
+      "checked_at": "2026-07-17T15:16:00+00:00",
+      "snapshot": "b9052e09103502017c0f510ecc699aac395de23c",
+      "state": "rejected_validation_failed",
+      "problems": [
+        "release status declares INCOMPLETE/FAIL",
+        "base commit is unknown and changed_files is empty",
+        "bundle contains no PATCH.diff or production payload",
+        "finalizer failed to locate the required repository baseline"
+      ],
+      "integration": "Retained as honest failed-delivery evidence only. It authorizes neither code admission nor Bead closure; the independently verified r01 admission remains PR #3014.",
+      "package_revision": "r02"
+    },
+    {
+      "job": "testdiet-04",
+      "workload": "testdiet",
+      "zip": "testdiet-04/r02/raw.zip",
+      "sha256": "225ad872667e579b0d0b0975ff0f463f9e54acd5a07d29825084a93eae79b2b3",
+      "bytes": 6294,
+      "checked_at": "2026-07-17T14:01:00+00:00",
+      "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
+      "members": [
+        "derived_freshness_solution/README.md",
+        "derived_freshness_solution/candidate-index.json",
+        "derived_freshness_solution/changed-paths.txt",
+        "derived_freshness_solution/input-identities.json",
+        "derived_freshness_solution/manifest.json",
+        "derived_freshness_solution/requirements/04-derived-freshness.md",
+        "derived_freshness_solution/selection.json",
+        "derived_freshness_solution/solution.patch",
+        "derived_freshness_solution/validation/archive-verification.json"
+      ],
+      "patch_lines": 0,
+      "problems": [
+        "solution.patch is zero bytes",
+        "selected_candidate is null",
+        "changed_paths is empty"
+      ],
+      "integration": "ZIP CRC and manifest checked. Retained as delivery/freshness evidence only; it authorizes no implementation or Bead closure.",
+      "package_revision": "r02",
+      "state": "evidence_only_no_candidate"
+    },
+    {
+      "job": "testdiet-05",
+      "workload": "testdiet",
+      "zip": "testdiet-05/r01/raw.zip",
+      "sha256": "cad064d3c0c4cdfa3c221adf6a7a1000ce59dccf84a8b9944003bfd8c21350f4",
+      "bytes": 33668,
+      "checked_at": "2026-07-17T14:01:00+00:00",
+      "snapshot": "f654480cadb7cc4c194704e24dfd483199547b35",
+      "state": "integrated_merged",
+      "members": [
+        "EVIDENCE.md",
+        "HANDOFF.md",
+        "PATCH.diff",
+        "TESTS.md"
+      ],
+      "integration": "admitted after current-master reconciliation as PR #3012 / 876358610ebd8c7532d3d6865df6bc5fc01712b1; bounded aggregate execution is proven, while shared resumable query transaction scope remains open",
+      "package_revision": "r01"
+    },
+    {
+      "job": "testdiet-05",
+      "workload": "testdiet",
+      "artifact": "testdiet-05/r02/raw/query-bounds-deliverables.tar.gz",
+      "sha256": "e0954c7f5002ad41d9af4eeb644437f8229f61b680070cff7d01e01f5962456a",
+      "bytes": 1863,
+      "checked_at": "2026-07-17T15:16:00+00:00",
+      "snapshot": "b9052e09103502017c0f510ecc699aac395de23c",
+      "state": "rejected_validation_failed",
+      "problems": [
+        "STATUS is PARTIAL",
+        "no reconstructed Git worktree was found",
+        "no patch or changed-file payload exists",
+        "no executable test transcript exists"
+      ],
+      "integration": "Retained as honest failed-delivery evidence only. It authorizes neither code admission nor Bead closure; the independently verified r01 admission remains PR #3012.",
+      "package_revision": "r02"
+    },
+    {
+      "job": "testdiet-06",
+      "workload": "testdiet",
+      "artifact": "testdiet-06/r01/raw/PATCH.diff",
+      "sha256": "2b48fb36707e0310fe734618794ef0faadeb41ac02d627b7d4a33f8a622fbe62",
+      "bytes": 153265,
+      "checked_at": "2026-07-17T15:16:00+00:00",
+      "snapshot": "b9052e09103502017c0f510ecc699aac395de23c",
+      "state": "integrated_merged",
+      "patch_paths": 18,
+      "problems": [
+        "the provider did not produce the mandated cohesive result ZIP",
+        "the received patch required generated-topology refresh and a small shared-declaration-kernel rebase before admission"
+      ],
+      "integration": "admitted as PR #3033 / efadb404ebe70ec91f03ffcb7eaf0de7956ece4d after FactFamilySpec was projected through the shared DeclarationRegistry; three real owner-route canaries landed while broader EvidenceValue family migration remains open",
+      "package_revision": "r01"
+    }
+  ]
 }

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/triage-package.py
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/triage-package.py
@@ -33,6 +33,7 @@ import argparse
 import hashlib
 import json
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -110,9 +111,20 @@ def main() -> int:
     parser.add_argument("zip_path", type=Path)
     parser.add_argument("--workload", required=True)
     parser.add_argument("--job", required=True)
+    parser.add_argument("--attempt", required=True, help="immutable attempt id (aNN)")
+    parser.add_argument("--package-revision", required=True, help="immutable package revision (rNN)")
+    parser.add_argument("--prompt-sha256", required=True, help="64-character hash of the dispatched prompt")
     parser.add_argument("--snapshot", help="commit the package claims to target (from its HANDOFF.md)")
-    parser.add_argument("--record", action="store_true", help="append attempt record to results/index.json")
+    parser.add_argument(
+        "--write", action="store_true", help="preserve immutable raw custody and write the result receipt"
+    )
     args = parser.parse_args()
+    if not re.fullmatch(r"a[0-9]{2}", args.attempt):
+        raise SystemExit("error: --attempt must be aNN")
+    if not re.fullmatch(r"r[0-9]{2}", args.package_revision):
+        raise SystemExit("error: --package-revision must be rNN")
+    if not re.fullmatch(r"[0-9a-f]{64}", args.prompt_sha256):
+        raise SystemExit("error: --prompt-sha256 must be a lowercase SHA-256")
 
     zp: Path = args.zip_path
     if not zp.exists():
@@ -128,63 +140,117 @@ def main() -> int:
         "checked_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
         "snapshot": args.snapshot,
         "problems": [],
-        "status": "triaged",
+        "state": "triaged",
     }
 
     try:
         zf = zipfile.ZipFile(zp)
     except zipfile.BadZipFile:
         record["problems"].append("not a valid ZIP")
-        record["status"] = "rejected"
-        print(json.dumps(record, indent=2))
-        return 2
+        record["state"] = "rejected"
+        zf = None
 
-    names = zf.namelist()
-    basenames = {_member_basename(n) for n in names if not n.endswith("/")}
-    record["members"] = sorted(names)
+    if zf is not None:
+        names = zf.namelist()
+        basenames = {_member_basename(n) for n in names if not n.endswith("/")}
+        record["members"] = sorted(names)
 
-    for required in sorted(REQUIRED_MEMBERS - basenames):
-        record["problems"].append(f"missing required member {required}")
-    for n in names:
-        info = zf.getinfo(n)
-        if n.lower().endswith(".zip"):
-            record["problems"].append(f"nested archive in package: {n} (copied inputs are forbidden)")
-        if info.file_size > HUGE_MEMBER_BYTES:
-            record["problems"].append(f"oversized member {n} ({info.file_size} bytes)")
+        for required in sorted(REQUIRED_MEMBERS - basenames):
+            record["problems"].append(f"missing required member {required}")
+        for n in names:
+            info = zf.getinfo(n)
+            if n.lower().endswith(".zip"):
+                record["problems"].append(f"nested archive in package: {n} (copied inputs are forbidden)")
+            if info.file_size > HUGE_MEMBER_BYTES:
+                record["problems"].append(f"oversized member {n} ({info.file_size} bytes)")
 
-    patch_names = [n for n in names if _member_basename(n) == "PATCH.diff"]
-    if patch_names:
-        patch_text = zf.read(patch_names[0]).decode("utf-8", errors="replace")
-        if not patch_text.strip():
-            record["problems"].append("PATCH.diff is empty")
-        elif "+++ " not in patch_text:
-            record["problems"].append("PATCH.diff has no unified-diff hunks")
-        hits = sorted({pat.pattern for pat in PLACEHOLDER_PATTERNS if pat.search(patch_text)})
-        if hits:
-            record["problems"].append(f"placeholder markers in PATCH.diff: {hits}")
-        record["patch_lines"] = patch_text.count("\n")
-        if args.snapshot and not record["problems"]:
-            ok, detail = apply_check(_repo_root(), args.snapshot, patch_text)
-            record["patch_applies"] = ok
-            record["apply_detail"] = detail
-            if not ok:
-                record["problems"].append(f"apply-check failed: {detail[:200]}")
-        elif not args.snapshot:
-            record["patch_applies"] = None
-            record["problems"].append("no --snapshot given: apply-check skipped (get the commit from HANDOFF.md)")
+        patch_names = [n for n in names if _member_basename(n) == "PATCH.diff"]
+        if patch_names:
+            patch_text = zf.read(patch_names[0]).decode("utf-8", errors="replace")
+            if not patch_text.strip():
+                record["problems"].append("PATCH.diff is empty")
+            elif "+++ " not in patch_text:
+                record["problems"].append("PATCH.diff has no unified-diff hunks")
+            hits = sorted({pat.pattern for pat in PLACEHOLDER_PATTERNS if pat.search(patch_text)})
+            if hits:
+                record["problems"].append(f"placeholder markers in PATCH.diff: {hits}")
+            record["patch_lines"] = patch_text.count("\n")
+            if args.snapshot and not record["problems"]:
+                ok, detail = apply_check(_repo_root(), args.snapshot, patch_text)
+                record["patch_applies"] = ok
+                record["apply_detail"] = detail
+                if not ok:
+                    record["problems"].append(f"apply-check failed: {detail[:200]}")
+            elif not args.snapshot:
+                record["patch_applies"] = None
+                record["problems"].append("no --snapshot given: apply-check skipped (get the commit from HANDOFF.md)")
 
     if any(p.startswith(("missing required member", "not a valid", "PATCH.diff is empty")) for p in record["problems"]):
-        record["status"] = "rejected"
+        record["state"] = "rejected"
 
     print(json.dumps(record, indent=2))
 
-    if args.record:
-        index_path = WAVE_ROOT / args.workload / "results" / "index.json"
-        index = json.loads(index_path.read_text())
-        index.setdefault("attempts", []).append(record)
-        index_path.write_text(json.dumps(index, indent=1) + "\n")
-        print(f"recorded attempt in {index_path}", file=sys.stderr)
-    return 0 if record["status"] == "triaged" and not record["problems"] else 2
+    if args.write:
+        receipt_path = WAVE_ROOT / args.workload / "results" / args.job / args.attempt / "result.json"
+        raw_dir = receipt_path.parent / "raw"
+        if receipt_path.exists():
+            raise SystemExit(f"error: immutable receipt already exists: {receipt_path}")
+        raw_dir.mkdir(parents=True, exist_ok=True)
+        custody = raw_dir / zp.name
+        if custody.exists():
+            raise SystemExit(f"error: immutable raw artifact already exists: {custody}")
+        shutil.copy2(zp, custody)
+        receipt = {
+            "schema_version": 1,
+            "campaign_id": _load_campaign_id(args.workload),
+            "workload_id": args.workload,
+            "job_id": args.job,
+            "attempt_id": args.attempt,
+            "package_revision": args.package_revision,
+            "state": record["state"],
+            "provider": None,
+            "provider_conversation_id": None,
+            "provider_turn_id": None,
+            "polylogue_session_ref": None,
+            "prompt_sha256": args.prompt_sha256,
+            "snapshot_identity": args.snapshot,
+            "supersedes_attempt_id": None,
+            "artifacts": [
+                {
+                    "filename": zp.name,
+                    "sha256": record["sha256"],
+                    "size_bytes": record["bytes"],
+                    "custody_path": str(custody.relative_to(WAVE_ROOT)),
+                    "polylogue_attachment_ref": None,
+                }
+            ],
+            "triage": "; ".join(record["problems"]) if record["problems"] else record.get("apply_detail", "validated"),
+            "beads": [],
+            "worktree": None,
+            "agent_handle": None,
+            "commits": [],
+            "pull_request": None,
+            "verification_receipts": [],
+            "notes": "created by triage-package.py; later integration evidence belongs in a new immutable receipt revision",
+        }
+        receipt_path.write_text(json.dumps(receipt, indent=2) + "\n")
+        reconcile = subprocess.run(
+            [sys.executable, str(WAVE_ROOT.parent / "reconcile_results.py"), str(WAVE_ROOT), "--write"],
+            capture_output=True,
+            text=True,
+        )
+        if reconcile.returncode:
+            raise SystemExit(f"error: receipt was written but index materialization failed: {reconcile.stderr.strip()}")
+        print(f"wrote immutable receipt {receipt_path} and rebuilt indexes", file=sys.stderr)
+    return 0 if record["state"] == "triaged" and not record["problems"] else 2
+
+
+def _load_campaign_id(workload: str) -> str:
+    campaign = json.loads((WAVE_ROOT / workload / "campaign.json").read_text())
+    campaign_id = campaign.get("campaign_id")
+    if not isinstance(campaign_id, str) or not campaign_id:
+        raise SystemExit(f"error: {workload}/campaign.json has no campaign_id")
+    return campaign_id
 
 
 if __name__ == "__main__":

--- a/.agent/handoffs/external-agent-campaigns/README.md
+++ b/.agent/handoffs/external-agent-campaigns/README.md
@@ -11,8 +11,8 @@ subdirectories. A workload has:
   expected-result identities;
 - `briefs/`: concise job-specific source material;
 - `prompts/`: fully rendered prompts ready to paste or submit;
-- `results/index.json`: the append-only reconciliation ledger for returned
-  attempts and artifacts;
+- `results/index.json`: a rebuildable query projection of immutable returned
+  attempt/package receipts;
 - `results/README.md`: the on-disk result convention.
 
 The prompt renderer combines a workload's brief with the named shared contract:
@@ -64,7 +64,21 @@ Machine-readable shapes are documented by `schemas/campaign.schema.json` and
 `schemas/result.schema.json`. `campaign.json` is dispatch intent and should
 remain stable after launch. Per-attempt `result.json` is immutable evidence.
 `results/index.json` is a rebuildable reconciliation projection across those
-receipts.
+receipts. Its sole outcome field is `state`; it must never carry a second
+`status` field or independently adjudicate an artifact. Rebuild and verify it
+with:
+
+```bash
+python .agent/handoffs/external-agent-campaigns/reconcile_results.py \
+  .agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave --check
+python .agent/handoffs/external-agent-campaigns/reconcile_results.py \
+  .agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave --write
+```
+
+`result.json` is the immutable attempt form (`aNN`). `receipt.json` is the
+immutable package-revision form (`rNN`) for a revision without a separate
+provider attempt. The reconciler accepts both explicitly, rejects ambiguous
+identity mappings, and never rewrites either receipt.
 
 ## Attachment policy
 

--- a/.agent/handoffs/external-agent-campaigns/reconcile_results.py
+++ b/.agent/handoffs/external-agent-campaigns/reconcile_results.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Materialize and verify campaign result indexes from immutable receipts.
+
+``results/index.json`` is a rebuildable query projection.  The authoritative
+outcome is written once in either an attempt ``result.json`` or a package
+revision ``receipt.json``.  This command deliberately never writes receipts.
+
+Usage::
+
+    reconcile_results.py <wave-root> --check
+    reconcile_results.py <wave-root> --write
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+class ReconciliationError(ValueError):
+    """A projection cannot be trusted or rebuilt without operator judgment."""
+
+
+@dataclass(frozen=True)
+class Receipt:
+    path: Path
+    workload: str
+    job: str
+    attempt: str | None
+    revision: str | None
+    state: str
+    payload: dict[str, Any]
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        if self.attempt is not None:
+            return (self.job, "attempt", self.attempt)
+        assert self.revision is not None
+        return (self.job, "revision", self.revision)
+
+
+@dataclass(frozen=True)
+class WorkloadPlan:
+    index_path: Path
+    rendered: str
+    errors: tuple[str, ...]
+    unrebuildable: bool
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        raise ReconciliationError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ReconciliationError(f"expected an object in {path}")
+    return value
+
+
+def require_text(payload: dict[str, Any], field: str, path: Path) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value:
+        raise ReconciliationError(f"{path}: missing non-empty {field}")
+    return value
+
+
+def discover_receipts(workload_root: Path, campaign_id: str, workload: str) -> list[Receipt]:
+    results = workload_root / "results"
+    receipts: list[Receipt] = []
+    for path in sorted(results.glob("*/*/result.json")):
+        payload = load_json(path)
+        job, attempt = path.parts[-3:-1]
+        if not attempt.startswith("a"):
+            raise ReconciliationError(f"{path}: result.json must live below an aNN attempt directory")
+        _validate_common(payload, path, campaign_id, workload, job)
+        if require_text(payload, "attempt_id", path) != attempt:
+            raise ReconciliationError(f"{path}: attempt_id does not match its directory")
+        revision = payload.get("package_revision")
+        if revision is not None and (not isinstance(revision, str) or not revision.startswith("r")):
+            raise ReconciliationError(f"{path}: package_revision must be rNN or null")
+        receipts.append(Receipt(path, workload, job, attempt, revision, require_text(payload, "state", path), payload))
+    for path in sorted(results.glob("*/*/receipt.json")):
+        payload = load_json(path)
+        job, revision = path.parts[-3:-1]
+        if not revision.startswith("r"):
+            raise ReconciliationError(f"{path}: receipt.json must live below an rNN revision directory")
+        _validate_common(payload, path, campaign_id, workload, job)
+        if require_text(payload, "package_revision", path) != revision:
+            raise ReconciliationError(f"{path}: package_revision does not match its directory")
+        if "attempt_id" in payload:
+            raise ReconciliationError(f"{path}: revision receipt must not carry attempt_id; use result.json")
+        receipts.append(Receipt(path, workload, job, None, revision, require_text(payload, "state", path), payload))
+    keys = [receipt.key for receipt in receipts]
+    if len(keys) != len(set(keys)):
+        duplicates = sorted(key for key in set(keys) if keys.count(key) > 1)
+        raise ReconciliationError(f"{workload_root}: duplicate immutable receipt identities: {duplicates}")
+    return receipts
+
+
+def _validate_common(payload: dict[str, Any], path: Path, campaign_id: str, workload: str, job: str) -> None:
+    if require_text(payload, "campaign_id", path) != campaign_id:
+        raise ReconciliationError(f"{path}: campaign_id does not match wave")
+    if require_text(payload, "workload_id", path) != workload:
+        raise ReconciliationError(f"{path}: workload_id does not match directory")
+    if require_text(payload, "job_id", path) != job:
+        raise ReconciliationError(f"{path}: job_id does not match directory")
+
+
+def index_key(entry: dict[str, Any], path: Path) -> tuple[str, str, str]:
+    job = entry.get("job")
+    if not isinstance(job, str) or not job:
+        raise ReconciliationError(f"{path}: index entry has no job")
+    attempt = entry.get("attempt_id")
+    revision = entry.get("package_revision")
+    legacy_revision = entry.get("revision")
+    if revision is not None and legacy_revision is not None and revision != legacy_revision:
+        raise ReconciliationError(f"{path}: index entry {job} has conflicting revision identifiers")
+    if revision is None:
+        revision = legacy_revision
+    if isinstance(attempt, str) and attempt:
+        return (job, "attempt", attempt)
+    if isinstance(revision, str) and revision:
+        return (job, "revision", revision)
+    raise ReconciliationError(f"{path}: index entry {job} needs exactly one of attempt_id or package_revision")
+
+
+def projection_entry(receipt: Receipt) -> dict[str, Any]:
+    payload = receipt.payload
+    artifact: dict[str, Any] | None = None
+    artifacts = payload.get("artifacts")
+    if isinstance(artifacts, list) and len(artifacts) == 1 and isinstance(artifacts[0], dict):
+        artifact = artifacts[0]
+    elif isinstance(payload.get("artifact"), dict):
+        artifact = payload["artifact"]
+    entry: dict[str, Any] = {"job": receipt.job, "workload": receipt.workload, "state": receipt.state}
+    if receipt.attempt is not None:
+        entry["attempt_id"] = receipt.attempt
+    else:
+        entry["package_revision"] = receipt.revision
+    if receipt.attempt is not None and receipt.revision is not None:
+        entry["package_revision"] = receipt.revision
+    if artifact is not None:
+        entry.update(
+            {
+                "artifact": artifact.get("filename"),
+                "sha256": artifact.get("sha256"),
+                "bytes": artifact.get("size_bytes"),
+            }
+        )
+    return {key: value for key, value in entry.items() if value is not None}
+
+
+def plan_workload(workload_root: Path) -> WorkloadPlan:
+    campaign = load_json(workload_root / "campaign.json")
+    campaign_id = require_text(campaign, "campaign_id", workload_root / "campaign.json")
+    workload = require_text(campaign, "workload_id", workload_root / "campaign.json")
+    index_path = workload_root / "results" / "index.json"
+    index = load_json(index_path)
+    if index.get("campaign_id") != campaign_id or index.get("workload_id") != workload:
+        raise ReconciliationError(f"{index_path}: campaign/workload identity does not match campaign.json")
+    attempts = index.get("attempts")
+    if not isinstance(attempts, list):
+        raise ReconciliationError(f"{index_path}: attempts must be an array")
+    receipts = discover_receipts(workload_root, campaign_id, workload)
+    receipt_by_key = {receipt.key: receipt for receipt in receipts}
+    entry_by_key: dict[tuple[str, str, str], dict[str, Any]] = {}
+    errors: list[str] = []
+    unrebuildable = False
+    for entry in attempts:
+        if not isinstance(entry, dict):
+            errors.append(f"{index_path}: index contains a non-object entry")
+            unrebuildable = True
+            continue
+        if entry.get("workload") != workload:
+            errors.append(f"{index_path}: index entry workload does not match {workload}")
+            continue
+        try:
+            key = index_key(entry, index_path)
+        except ReconciliationError as exc:
+            errors.append(str(exc))
+            unrebuildable = True
+            continue
+        if key in entry_by_key:
+            errors.append(f"{index_path}: duplicate projection identity {key}")
+            unrebuildable = True
+        else:
+            entry_by_key[key] = entry
+    for key, entry in entry_by_key.items():
+        receipt = receipt_by_key.get(key)
+        if receipt is None:
+            errors.append(f"{index_path}: projection {key} has no immutable receipt")
+            unrebuildable = True
+            continue
+        if "status" in entry:
+            errors.append(f"{index_path}: projection {key} has forbidden legacy status field")
+        if "revision" in entry:
+            errors.append(f"{index_path}: projection {key} has forbidden legacy revision field")
+        if key[1] == "attempt" and entry.get("package_revision") != receipt.revision:
+            errors.append(
+                f"{index_path}: projection {key} package_revision {entry.get('package_revision')!r} "
+                f"does not equal receipt package_revision {receipt.revision!r}"
+            )
+        if entry.get("state") != receipt.state:
+            errors.append(
+                f"{index_path}: projection {key} state {entry.get('state')!r} "
+                f"does not equal receipt state {receipt.state!r}"
+            )
+    for key in receipt_by_key:
+        if key not in entry_by_key:
+            errors.append(f"{index_path}: immutable receipt {key} has no projection")
+    materialized: list[dict[str, Any]] = []
+    for receipt in receipts:
+        entry = entry_by_key.get(receipt.key)
+        if entry is None:
+            materialized.append(projection_entry(receipt))
+            continue
+        projected = dict(entry)
+        projected.pop("status", None)
+        legacy_revision = projected.pop("revision", None)
+        if "package_revision" not in projected and legacy_revision is not None:
+            projected["package_revision"] = legacy_revision
+        projected["state"] = receipt.state
+        materialized.append(projected)
+    updated = dict(index)
+    updated["attempts"] = materialized
+    rendered = json.dumps(updated, indent=2) + "\n"
+    if not errors and index_path.read_text() != rendered:
+        errors.append(f"{index_path}: projection is not in canonical receipt order/format")
+    return WorkloadPlan(index_path, rendered, tuple(errors), unrebuildable)
+
+
+def atomic_write(path: Path, content: str) -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as handle:
+        handle.write(content)
+        temporary = Path(handle.name)
+    try:
+        os.replace(temporary, path)
+    except BaseException:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def workload_roots(wave_root: Path) -> list[Path]:
+    roots = sorted(path.parent for path in wave_root.glob("*/campaign.json"))
+    if not roots:
+        raise ReconciliationError(f"{wave_root}: no workload campaign.json files found")
+    return roots
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("wave_root", type=Path)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--check", action="store_true", help="fail on any projection drift (default)")
+    mode.add_argument("--write", action="store_true", help="rebuild indexes only; immutable receipts are never changed")
+    args = parser.parse_args()
+    try:
+        plans = [plan_workload(root) for root in workload_roots(args.wave_root)]
+    except ReconciliationError as exc:
+        plans = []
+        problems = [str(exc)]
+    else:
+        problems = [problem for plan in plans for problem in plan.errors]
+        if args.write and not any(plan.unrebuildable for plan in plans):
+            for plan in plans:
+                atomic_write(plan.index_path, plan.rendered)
+            problems = []
+    if problems:
+        print("receipt/index reconciliation failed:", file=sys.stderr)
+        print("\n".join(f"- {problem}" for problem in problems), file=sys.stderr)
+        return 2
+    print(f"receipt/index reconciliation {'materialized' if args.write else 'verified'} for {args.wave_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agent/handoffs/external-agent-campaigns/schemas/result.schema.json
+++ b/.agent/handoffs/external-agent-campaigns/schemas/result.schema.json
@@ -10,7 +10,7 @@
     "job_id": {"type": "string"},
     "attempt_id": {"type": "string", "pattern": "^a[0-9]{2}$"},
     "package_revision": {"type": ["string", "null"], "pattern": "^r[0-9]{2}$"},
-    "state": {"enum": ["prepared", "submitted", "running", "terminal", "acquired", "validated", "triaged", "integrating", "verified", "published", "rejected", "blocked"]},
+    "state": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$"},
     "provider": {"type": ["string", "null"]},
     "provider_conversation_id": {"type": ["string", "null"]},
     "provider_turn_id": {"type": ["string", "null"]},

--- a/tests/unit/devtools/test_campaign_receipt_reconciliation.py
+++ b/tests/unit/devtools/test_campaign_receipt_reconciliation.py
@@ -1,0 +1,132 @@
+"""The external campaign index is an auditable projection, never a second ledger."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CAMPAIGNS = REPO_ROOT / ".agent" / "handoffs" / "external-agent-campaigns"
+WAVE = CAMPAIGNS / "2026-07-16-gpt-pro-wave"
+RECONCILE = CAMPAIGNS / "reconcile_results.py"
+TRIAGE = WAVE / "triage-package.py"
+
+
+def run_reconcile(wave: Path, *flags: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(RECONCILE), str(wave), *flags],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_live_campaign_projection_matches_immutable_receipts() -> None:
+    result = run_reconcile(WAVE, "--check")
+    assert result.returncode == 0, result.stderr
+
+
+def test_materializer_repairs_projection_without_mutating_receipt(tmp_path: Path) -> None:
+    wave = tmp_path / "wave"
+    shutil.copytree(WAVE, wave)
+    receipt = wave / "analysis" / "results" / "analysis-01" / "a01" / "result.json"
+    before = receipt.read_bytes()
+    index_path = wave / "analysis" / "results" / "index.json"
+    index = json.loads(index_path.read_text())
+    index["attempts"][0]["state"] = "acquired"
+    index["attempts"][0]["status"] = "also_acquired"
+    index_path.write_text(json.dumps(index) + "\n")
+
+    stale = run_reconcile(wave, "--check")
+    assert stale.returncode == 2
+    assert "does not equal receipt state" in stale.stderr
+    assert "forbidden legacy status field" in stale.stderr
+
+    materialized = run_reconcile(wave, "--write")
+    assert materialized.returncode == 0, materialized.stderr
+    assert receipt.read_bytes() == before
+    assert "status" not in json.loads(index_path.read_text())["attempts"][0]
+    assert run_reconcile(wave, "--check").returncode == 0
+
+
+def test_receipt_mutation_and_ambiguous_mapping_fail_closed(tmp_path: Path) -> None:
+    wave = tmp_path / "wave"
+    shutil.copytree(WAVE, wave)
+    receipt_path = wave / "analysis" / "results" / "analysis-01" / "a01" / "result.json"
+    receipt = json.loads(receipt_path.read_text())
+    receipt["state"] = "tampered"
+    receipt_path.write_text(json.dumps(receipt) + "\n")
+    changed_receipt = run_reconcile(wave, "--check")
+    assert changed_receipt.returncode == 2
+    assert "does not equal receipt state" in changed_receipt.stderr
+
+    index_path = wave / "analysis" / "results" / "index.json"
+    index = json.loads(index_path.read_text())
+    index["attempts"].append(dict(index["attempts"][0]))
+    index_path.write_text(json.dumps(index) + "\n")
+    ambiguous = run_reconcile(wave, "--write")
+    assert ambiguous.returncode == 2
+    assert "duplicate projection identity" in ambiguous.stderr
+
+
+def test_triage_publishes_immutable_receipt_before_reprojecting(tmp_path: Path) -> None:
+    campaign_root = tmp_path / "campaigns"
+    wave = campaign_root / "wave"
+    wave.mkdir(parents=True)
+    shutil.copy2(RECONCILE, campaign_root / "reconcile_results.py")
+    triage = wave / "triage-package.py"
+    shutil.copy2(TRIAGE, triage)
+    workload = wave / "sample"
+    (workload / "results").mkdir(parents=True)
+    (workload / "campaign.json").write_text(json.dumps({"campaign_id": "sample-wave", "workload_id": "sample"}))
+    (workload / "results" / "index.json").write_text(
+        json.dumps({"schema_version": 1, "campaign_id": "sample-wave", "workload_id": "sample", "attempts": []})
+    )
+    package = tmp_path / "sample.zip"
+    with zipfile.ZipFile(package, "w") as archive:
+        archive.writestr("HANDOFF.md", "handoff")
+        archive.writestr("TESTS.md", "tests")
+        archive.writestr("EVIDENCE.md", "evidence")
+        archive.writestr("PATCH.diff", "--- a/x\n+++ b/x\n@@ -0,0 +1 @@\n+new\n")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(triage),
+            str(package),
+            "--workload",
+            "sample",
+            "--job",
+            "sample-01",
+            "--attempt",
+            "a01",
+            "--package-revision",
+            "r01",
+            "--prompt-sha256",
+            "a" * 64,
+            "--write",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2  # no snapshot is an explicitly recorded validation gap
+    receipt = workload / "results" / "sample-01" / "a01" / "result.json"
+    assert receipt.exists()
+    assert json.loads(receipt.read_text())["state"] == "triaged"
+    projection = json.loads((workload / "results" / "index.json").read_text())
+    assert projection["attempts"] == [
+        {
+            "job": "sample-01",
+            "workload": "sample",
+            "attempt_id": "a01",
+            "package_revision": "r01",
+            "state": "triaged",
+            "artifact": "sample.zip",
+            "sha256": json.loads(receipt.read_text())["artifacts"][0]["sha256"],
+            "bytes": package.stat().st_size,
+        }
+    ]


### PR DESCRIPTION
## Summary

Make external-agent result indexes a receipt-derived projection rather than a second, manually editable outcome ledger.

## Problem

PR #3028 updated immutable analysis receipts but the index retained stale state values. A later manual patch was needed before state-oriented intake queries became truthful. The prior intake command also appended directly to the index.

## Solution

- add a generic reconciler for every workload, including explicit attempt and package-revision receipt forms;
- reject missing, duplicate, stale, or second-outcome projections;
- atomically replace each validated index only, never an immutable receipt;
- make package triage preserve raw custody and write an immutable attempt receipt before materializing the index;
- rebuild all current wave indexes to the single state field.

## Verification

- Focused campaign receipt reconciliation: 4 passed; exercises live projection, index-state mutation, receipt mutation, duplicate identity, and end-to-end triage publication.
- Quick verification gate: passed.
- Campaign reconciliation check: verified all workload projections.

Ref polylogue-yyvg.6.