### PR TITLE
perf(devtools): publish independent authority raws directly

### DIFF
--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -257,6 +257,14 @@ def _write_payload(path: Path, *, native_id: str, revision: int, target_size: in
             remaining -= amount
 
 
+def _independent_payload(*, native_id: str, target_size: int) -> bytes:
+    """Build one bounded standalone JSONL raw without a disk staging file."""
+    header = f'{{"type":"session_meta","payload":{{"id":"{native_id}","timestamp":"2026-07-15T00:00:00Z"}}}}\n'.encode()
+    if target_size < len(header):
+        raise ValueError("scenario payload allocation cannot preserve valid JSONL evidence")
+    return header + (b" " * (target_size - len(header)))
+
+
 def _component_counts(total: int, *, components: int) -> list[int]:
     counts = [0] * components
     for index in range(total):
@@ -623,16 +631,21 @@ def run_raw_authority_scale_proof(
                         if not _uses_independent_component_members(scenario)
                         else f"{session_native_id}-member-{member:05d}"
                     )
-                    payload_path = temporary_root / f"{source_label}.jsonl"
-                    _write_payload(
-                        payload_path,
-                        native_id=row_native_id,
-                        revision=member,
-                        target_size=row_size,
-                        previous=previous if not _uses_independent_component_members(scenario) else None,
-                    )
-                    blob_hash, blob_size = publisher.write_from_path(payload_path)
-                    payload_path.unlink()
+                    if _uses_independent_component_members(scenario):
+                        blob_hash, blob_size = publisher.write_from_bytes(
+                            _independent_payload(native_id=row_native_id, target_size=row_size)
+                        )
+                    else:
+                        payload_path = temporary_root / f"{source_label}.jsonl"
+                        _write_payload(
+                            payload_path,
+                            native_id=row_native_id,
+                            revision=member,
+                            target_size=row_size,
+                            previous=previous,
+                        )
+                        blob_hash, blob_size = publisher.write_from_path(payload_path)
+                        payload_path.unlink()
                     previous = publisher.blob_path(blob_hash)
                     source_path = component_source_path
                     pending_rows.append((row_native_id, source_path, blob_hash, blob_size, terminalized, component))

--- a/tests/unit/devtools/test_raw_authority_scale_proof.py
+++ b/tests/unit/devtools/test_raw_authority_scale_proof.py
@@ -14,6 +14,7 @@ from devtools.raw_authority_scale_proof import (
 from polylogue.config import Config
 from polylogue.core.enums import Provider
 from polylogue.storage import repair
+from polylogue.storage.blob_publication import ArchiveBlobPublisher
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 
@@ -340,3 +341,31 @@ def test_raw_authority_scale_proof_preserves_private_free_joint_byte_cohorts(tmp
         largest_blob = conn.execute("SELECT MAX(blob_size) FROM raw_sessions").fetchone()
     assert largest_blob is not None
     assert int(largest_blob[0]) < 4_096
+
+
+def test_explicit_cohorts_publish_bounded_payloads_without_disk_staging(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    scenario = RawAuthorityScaleScenario(
+        components=1,
+        direct_candidates=2,
+        expanded_candidates=2,
+        total_payload_bytes=2_048,
+        component_cohorts=((2, 2, 1),),
+        component_byte_cohorts=((2, 2, 2048, 1),),
+    )
+
+    def reject_staged_publication(*_args: object, **_kwargs: object) -> tuple[str, int]:
+        raise AssertionError("explicit cohorts must publish bytes without a staged payload path")
+
+    monkeypatch.setattr(ArchiveBlobPublisher, "write_from_path", reject_staged_publication)
+    payload = run_raw_authority_scale_proof(
+        tmp_path,
+        scenario=scenario,
+        prepare_only=True,
+        max_io_full_avg10=None,
+        max_memory_full_avg10=None,
+    )
+
+    achieved = cast(dict[str, object], payload["achieved_shape"])
+    assert achieved["expanded_total_blob_bytes"] == 2_048


### PR DESCRIPTION
## Summary

Eliminates duplicate disk staging for the independent synthetic raws used by production-shaped authority cohorts.

## Problem

Even after bounded byte distribution, explicit cohorts wrote every standalone payload to a temporary file before the blob publisher copied it into publication staging. The current profile has tens of thousands of such small members.

## Solution

Build bounded standalone JSONL payloads in memory and use the publisher’s byte API for independent cohorts. Prefix-sharing cohorts preserve their existing streamed temporary-file path because each revision needs the previous raw’s bytes.

Ref polylogue-hjpx.2.

## Verification

- `devtools test tests/unit/devtools/test_raw_authority_scale_proof.py` — 12 passed.
- `devtools verify --quick` — format, lint, mypy, generated-surface and policy checks passed.
