### PR TITLE
docs(campaign): record semantic transcript revisions (#3041)

### DIFF
--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/beads-05/r01/receipt.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/beads-05/r01/receipt.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "campaign_id": "gpt-pro-wave-2026-07-16",
+  "workload_id": "beads",
+  "job_id": "beads-05",
+  "package_revision": "r01",
+  "state": "superseded_by_revision",
+  "provider": "chatgpt-pro",
+  "snapshot_identity": "f654480cadb7cc4c194704e24dfd483199547b35",
+  "artifact": {
+    "filename": "beads-05-semantic-transcript-r01.zip",
+    "sha256": "9014fa0efeed77fa51cae7b7e901a5e411ba362f7b5510e870aa93e6f7a862db",
+    "size_bytes": 59165,
+    "custody_path": "/realm/inbox/download/beads-05-semantic-transcript-r01.zip"
+  },
+  "validation": [
+    "ZIP member listing confirms HANDOFF.md, PATCH.diff, TESTS.md, and EVIDENCE.md",
+    "PATCH.diff contains 7,126 lines across semantic transcript, storage, CLI, and web-reader routes",
+    "the declared snapshot is f654480cadb7cc4c194704e24dfd483199547b35",
+    "the ZIP does not attest a provider turn, capture reference, or exact dispatched-prompt hash; those fields remain unknown rather than inferred from the current campaign prompt"
+  ],
+  "admission": "The revision is retained as positive design and test evidence, but it is superseded by the cohesive r02 revision. Its intended ordered semantic transcript, structural tool pairing, bounded lineage/attachment provenance, and compact empty-thinking behaviour were admitted from r02 after current-master reconciliation as PR #3016. Do not apply this older broad patch on top of the merged implementation."
+}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/beads-05/r02/receipt.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/beads-05/r02/receipt.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "campaign_id": "gpt-pro-wave-2026-07-16",
+  "workload_id": "beads",
+  "job_id": "beads-05",
+  "package_revision": "r02",
+  "state": "integrated_merged",
+  "provider": "chatgpt-pro",
+  "snapshot_identity": "f654480cadb7cc4c194704e24dfd483199547b35",
+  "artifact": {
+    "filename": "beads-05-semantic-transcript-r01(1).zip",
+    "sha256": "f5cb4b9126df7f7694b7a2a03270ce633d0a7bdb5064a4445975064bac9e57a7",
+    "size_bytes": 69996,
+    "custody_path": "/realm/inbox/download/beads-05-semantic-transcript-r01(1).zip"
+  },
+  "validation": [
+    "ZIP member listing confirms HANDOFF.md, PATCH.diff, TESTS.md, and EVIDENCE.md",
+    "PATCH.diff contains 7,265 lines including generated topology artifacts",
+    "current-master reconciliation added the missing result-before-use ordering fixture before admission",
+    "focused renderer, CLI, reader, lineage, and ChatGPT parser route suite: 232 passed",
+    "Ruff, strict Mypy, and devtools verify --quick passed before merge",
+    "the ZIP does not attest a provider turn, capture reference, or exact dispatched-prompt hash; those fields remain unknown rather than inferred from the current campaign prompt"
+  ],
+  "bead": "polylogue-ap7.1",
+  "related_bead": "polylogue-395j",
+  "merge_commit": "fc770dbd9a16227037a51a6882dc5cca9ef4eda1",
+  "pull_request": "https://github.com/Sinity/polylogue/pull/3016",
+  "admission": "The r02 semantic-transcript.v1 slice is merged. It supplies the shared ordered semantic stream for CLI and web reader, explicit fallback coverage for normalized families/origins, structural result pairing, bounded lineage/attachment provenance, recipient-addressed ChatGPT tool preservation, and compact typed empty-thinking notices. The requested live private-export manual visual inspection remains deliberately open on the owning Beads."
+}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/beads/results/index.json
@@ -85,6 +85,24 @@
       "package_revision": "r01",
       "state": "subsumed_foundation_retained",
       "integration": "Current-master reconciliation at 66cee5e found the provisional MCP declaration/registration implementation already landed in PR #3004 / ed44be18f. This patch conflicts on the existing registry, adapters, server-family registration, and generated surfaces. Retain its 41-family trust/provenance/role lifecycle evidence for polylogue-t46.8.3; it does not complete tool retirement, URI/prompt surfaces, cold-model proof, telemetry, or t46.9 authorization receipts."
+    },
+    {
+      "job": "beads-05",
+      "workload": "beads",
+      "state": "superseded_by_revision",
+      "package_revision": "r01",
+      "artifact": "beads-05-semantic-transcript-r01.zip",
+      "sha256": "9014fa0efeed77fa51cae7b7e901a5e411ba362f7b5510e870aa93e6f7a862db",
+      "bytes": 59165
+    },
+    {
+      "job": "beads-05",
+      "workload": "beads",
+      "state": "integrated_merged",
+      "package_revision": "r02",
+      "artifact": "beads-05-semantic-transcript-r01(1).zip",
+      "sha256": "f5cb4b9126df7f7694b7a2a03270ce633d0a7bdb5064a4445975064bac9e57a7",
+      "bytes": 69996
     }
   ]
 }


### PR DESCRIPTION
## Summary

Record the two recovered beads-05 semantic-transcript revisions as immutable campaign receipts.

## Problem

The raw ZIPs had informed PR #3016 and the owner Beads, but the campaign index did not preserve their revision-level identity, hash, custody, disposition, or the distinction between the older broad draft and the merged successor.

## Solution

- add exact r01 and r02 package-revision receipts;
- mark r01 superseded by the integrated successor;
- attach r02 to PR #3016 and its merge commit;
- preserve unavailable provider-turn and prompt provenance as unknown;
- regenerate the Beads workload projection through the receipt materializer.

## Verification

- Campaign reconciliation check: verified all workloads.
- Focused campaign receipt suite: 4 passed.
- Quick verification gate: passed.

Ref polylogue-ap7.1 and polylogue-395j.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added receipts documenting campaign results, validation details, artifacts, and revision status.
  - Recorded a superseded attempt and its replacement integrated revision.
  - Added artifact checksums, sizes, custody paths, and verification outcomes.
  - Linked the merged result to its related work and pull request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->