### PR TITLE
fix(repair): retain receipts for resource-deferred replay (#3043)

### DIFF
--- a/devtools/raw_authority_scale_proof.py
+++ b/devtools/raw_authority_scale_proof.py
@@ -45,6 +45,7 @@ class RawAuthorityScalePass:
     number: int
     mode: str
     candidate_count: int
+    executable_candidate_count: int
     repaired_count: int
     executable_component_count: int
     fixed_point: bool
@@ -492,6 +493,7 @@ def _record_repair_pass(
     mode: str,
     config: Config,
     pass_limit: int,
+    max_payload_bytes: int,
 ) -> tuple[RawAuthorityScalePass, str]:
     """Run one real repair/census pass and reject incomplete evidence."""
     before = _process_sample()
@@ -499,12 +501,14 @@ def _record_repair_pass(
     result = repair.repair_raw_materialization(
         config,
         raw_artifact_limit=pass_limit,
+        max_payload_bytes=max_payload_bytes,
         dry_run=mode == "dry_run",
     )
     wall_ms = int((time.perf_counter() - started) * 1000)
     after = _process_sample()
     metrics = result.metrics
     candidate_value = metrics.get("raw_materialization_candidate_count")
+    executable_candidate_value = metrics.get("raw_materialization_executable_candidate_count", candidate_value)
     if (
         not isinstance(candidate_value, int | float)
         or isinstance(candidate_value, bool)
@@ -514,6 +518,14 @@ def _record_repair_pass(
         raise RuntimeError(
             "raw-authority scale proof requires a non-negative integral raw-materialization candidate count"
         )
+    if (
+        not isinstance(executable_candidate_value, int | float)
+        or isinstance(executable_candidate_value, bool)
+        or not float(executable_candidate_value).is_integer()
+        or executable_candidate_value < 0
+        or executable_candidate_value > candidate_value
+    ):
+        raise RuntimeError("raw-authority scale proof requires a bounded integral executable-candidate count")
     if result.census_receipt is None:
         raise RuntimeError("raw-authority scale proof requires a census receipt for every replay pass")
     receipt = result.census_receipt
@@ -525,6 +537,7 @@ def _record_repair_pass(
             number=number,
             mode=receipt.mode,
             candidate_count=int(candidate_value),
+            executable_candidate_count=int(executable_candidate_value),
             repaired_count=result.repaired_count,
             executable_component_count=int(metrics.get("raw_materialization_selected_executable_component_count", 0)),
             fixed_point=receipt.fixed_point,
@@ -557,12 +570,15 @@ def run_raw_authority_scale_proof(
     pass_limit: int = 4,
     keep: bool = False,
     prepare_only: bool = False,
+    max_payload_bytes: int = repair.RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES,
     max_io_full_avg10: float | None = 2.0,
     max_memory_full_avg10: float | None = 2.0,
 ) -> dict[str, object]:
     """Exercise real authority census/replay and emit a stable receipt payload."""
     if pass_limit < 1:
         raise ValueError("pass_limit must be positive")
+    if max_payload_bytes < 1:
+        raise ValueError("max_payload_bytes must be positive")
     if scenario is None:
         if components < 1 or raws < components:
             raise ValueError("require components >= 1 and raws >= components")
@@ -782,9 +798,10 @@ def run_raw_authority_scale_proof(
             mode="apply",
             config=config,
             pass_limit=pass_limit,
+            max_payload_bytes=max_payload_bytes,
         )
         pass_receipts.append(pass_receipt)
-        if pass_receipt.candidate_count == 0:
+        if pass_receipt.executable_candidate_count == 0:
             break
     else:
         raise RuntimeError("raw-authority scale proof did not drain bounded apply passes")
@@ -795,8 +812,9 @@ def run_raw_authority_scale_proof(
             mode="dry_run",
             config=config,
             pass_limit=pass_limit,
+            max_payload_bytes=max_payload_bytes,
         )
-        if pass_receipt.candidate_count != 0:
+        if pass_receipt.executable_candidate_count != 0:
             raise RuntimeError("raw-authority scale proof lost quiescence during fixed-point confirmation")
         pass_receipts.append(pass_receipt)
         fixed_point_digests.append(digest)
@@ -849,6 +867,7 @@ def run_raw_authority_scale_proof(
             f"requested_direct_candidates={scenario.direct_candidates}",
             f"requested_expanded_candidates={scenario.expanded_candidates}",
             f"requested_payload_bytes={scenario.total_payload_bytes}",
+            f"resource_envelope_bytes={max_payload_bytes}",
             "repair_raw_materialization combines census and replay; its measured resource totals are recorded once on replay.",
             "This receipt is a generated projection; only an explicit July-15-sized invocation is production-shaped evidence.",
         ),
@@ -881,6 +900,12 @@ def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
         help="Read an aggregate scale profile produced by --capture-profile and generate that synthetic shape.",
     )
     parser.add_argument("--pass-limit", type=int, default=4)
+    parser.add_argument(
+        "--max-payload-bytes",
+        type=int,
+        default=repair.RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES,
+        help="Bound each authority component replay; deferred components remain typed residual debt.",
+    )
     parser.add_argument("--keep", action="store_true")
     parser.add_argument(
         "--prepare-only",
@@ -917,6 +942,7 @@ def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
         pass_limit=args.pass_limit,
         keep=args.keep,
         prepare_only=args.prepare_only,
+        max_payload_bytes=args.max_payload_bytes,
         max_io_full_avg10=pressure_limit,
         max_memory_full_avg10=memory_limit,
     )

--- a/polylogue/storage/raw_authority.py
+++ b/polylogue/storage/raw_authority.py
@@ -1202,6 +1202,27 @@ def _raw_authority_census_receipt(conn: sqlite3.Connection, census_id: str) -> R
     )
 
 
+def latest_raw_authority_census_receipt(
+    archive_root: Path,
+    *,
+    scope: Mapping[str, object],
+) -> RawAuthorityCensusReceipt | None:
+    """Return the newest completed receipt for one exact scope without another ledger row."""
+    scope_json = _canonical_json(scope)
+    with closing(sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True)) as conn:
+        row = conn.execute(
+            """
+            SELECT census_id
+            FROM raw_authority_censuses
+            WHERE lifecycle_status = 'completed' AND scope_json = ?
+            ORDER BY sequence_no DESC
+            LIMIT 1
+            """,
+            (scope_json,),
+        ).fetchone()
+        return _raw_authority_census_receipt(conn, str(row[0])) if row is not None else None
+
+
 def finalize_raw_authority_census(
     archive_root: Path,
     census_id: str,
@@ -1648,6 +1669,7 @@ __all__ = [
     "build_raw_replay_plan",
     "build_raw_replay_plans",
     "finalize_raw_authority_census",
+    "latest_raw_authority_census_receipt",
     "raw_replay_application_receipt",
     "raw_authority_census_query_handle",
     "raw_authority_detail_query_handle",

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -61,6 +61,7 @@ from polylogue.storage.raw_authority import (
     RawReplayPlanStatus,
     build_raw_replay_plans,
     finalize_raw_authority_census,
+    latest_raw_authority_census_receipt,
     raw_replay_application_receipt,
     raw_replay_plan_deferred_for_envelope,
     raw_replay_plan_last_attempts,
@@ -5702,6 +5703,13 @@ def repair_raw_materialization(
             }
         )
         if census_resource_blocked_raw_ids:
+            resource_blocked_candidate_raw_ids = set(candidates.raw_ids).intersection(census_resource_blocked_raw_ids)
+            metrics["raw_materialization_executable_candidate_count"] = float(
+                len(set(candidates.raw_ids) - resource_blocked_candidate_raw_ids)
+            )
+            metrics["raw_materialization_resource_blocked_candidate_count"] = float(
+                len(resource_blocked_candidate_raw_ids)
+            )
             metrics["raw_materialization_resource_blocked_count"] = float(len(census_resource_blocked_raw_ids))
             metrics["raw_materialization_execute_blob_limit_bytes"] = float(max_payload_bytes)
             oversized = {
@@ -5744,6 +5752,7 @@ def repair_raw_materialization(
         > max_payload_bytes
     ]
     all_blocked_component_raw_ids = {raw_id for component in all_blocked_components for raw_id in component}
+    resource_blocked_candidate_raw_ids = set(candidate_raw_ids).intersection(all_blocked_component_raw_ids)
     selected_components = (
         ordered_components[:raw_artifact_limit] if raw_artifact_limit is not None else ordered_components
     )
@@ -5795,6 +5804,10 @@ def repair_raw_materialization(
     metrics["raw_materialization_selected_executable_component_count"] = float(len(executable_components))
     metrics["raw_materialization_selected_blocked_component_count"] = float(len(blocked_components))
     if all_blocked_component_raw_ids:
+        metrics["raw_materialization_executable_candidate_count"] = float(
+            len(set(candidate_raw_ids) - resource_blocked_candidate_raw_ids)
+        )
+        metrics["raw_materialization_resource_blocked_candidate_count"] = float(len(resource_blocked_candidate_raw_ids))
         metrics["raw_materialization_resource_blocked_count"] = float(len(all_blocked_component_raw_ids))
         metrics["raw_materialization_execute_blob_limit_bytes"] = float(max_payload_bytes)
     diagnostic_component_raw_ids = selected_component_raw_ids | all_blocked_component_raw_ids
@@ -5818,7 +5831,17 @@ def repair_raw_materialization(
         metrics["raw_materialization_stream_oversized_count"] = float(len(oversized_stream_safe_raw_ids))
     if deferred_plan_ids:
         metrics["raw_materialization_deferred_plan_count"] = float(len(deferred_plan_ids))
-    if not selected_components and deferred_plan_ids:
+    scope = _raw_authority_scope(
+        raw_artifact_id=raw_artifact_id,
+        provider=provider,
+        source_family=source_family,
+        source_root=source_root,
+        raw_artifact_limit=raw_artifact_limit,
+    )
+    if not dry_run and not selected_components and deferred_plan_ids:
+        retained_census_receipt = latest_raw_authority_census_receipt(archive_root, scope=scope)
+        if retained_census_receipt is None:
+            raise RuntimeError("resource-deferred raw replay lacks a completed durable census receipt")
         return _internal_derived_repair_result(
             "raw_materialization",
             repaired_count=0,
@@ -5829,6 +5852,7 @@ def repair_raw_materialization(
                 f"the {_format_bytes(max_payload_bytes)} envelope"
             ),
             metrics=metrics,
+            census_receipt=retained_census_receipt,
         )
     selected_plan_ids = {plan_by_component[component].plan_id for component in selected_components}
     executable_plan_ids = {
@@ -5849,13 +5873,7 @@ def repair_raw_materialization(
         executable_plan_ids=executable_plan_ids,
         mode="dry_run" if dry_run else "apply",
         quiescent=True,
-        scope=_raw_authority_scope(
-            raw_artifact_id=raw_artifact_id,
-            provider=provider,
-            source_family=source_family,
-            source_root=source_root,
-            raw_artifact_limit=raw_artifact_limit,
-        ),
+        scope=scope,
         residual=residual,
     )
     metrics["raw_materialization_census_sequence"] = float(census_receipt.sequence_no)

--- a/tests/unit/devtools/test_raw_authority_scale_proof.py
+++ b/tests/unit/devtools/test_raw_authority_scale_proof.py
@@ -292,6 +292,36 @@ def test_raw_authority_scale_proof_converges_with_explicit_deferred_cohort(tmp_p
     assert digests[0] == digests[1]
 
 
+def test_raw_authority_scale_proof_reaches_fixed_point_with_resource_deferred_residual(tmp_path: Path) -> None:
+    """A bounded envelope may leave durable debt without preventing quiescence."""
+    scenario = RawAuthorityScaleScenario(
+        components=2,
+        direct_candidates=3,
+        expanded_candidates=4,
+        total_payload_bytes=10_000,
+        component_cohorts=((1, 1, 1), (3, 2, 1)),
+        component_byte_cohorts=((1, 1, 2_048, 1), (3, 2, 8_192, 1)),
+    )
+
+    payload = run_raw_authority_scale_proof(
+        tmp_path,
+        scenario=scenario,
+        pass_limit=2,
+        keep=True,
+        max_payload_bytes=4_096,
+        max_io_full_avg10=None,
+        max_memory_full_avg10=None,
+    )
+
+    passes = cast(list[dict[str, object]], payload["passes"])
+    assert passes[-1]["candidate_count"] == 2
+    assert passes[-1]["executable_candidate_count"] == 0
+    assert any(item["executable_candidate_count"] == 1 for item in passes)
+    assert all(item["executable_candidate_count"] == 0 for item in passes[-3:])
+    digests = cast(list[str], payload["fixed_point_digests"])
+    assert digests[0] == digests[1]
+
+
 def test_raw_authority_scale_proof_preserves_private_free_joint_byte_cohorts(tmp_path: Path) -> None:
     expected = [
         {


### PR DESCRIPTION
## Summary

Makes the raw-authority fixed-point proof distinguish executable replay work
from resource-deferred residual debt.

## Problem

An envelope-blocked component could remain as a valid, typed residual while
all executable components were complete. The runner demanded zero total
candidates, and the repeated no-op apply route supplied no census receipt,
so neither route could prove quiescence honestly.

## Solution

- Expose the latest completed census receipt for an exact repair scope.
- Preserve that receipt on repeated all-deferred apply passes without adding
  duplicate ledger rows.
- Publish executable/resource-blocked candidate counts only when a resource
  block exists.
- Drive the scale proof's drain and quiescent checks by executable candidates,
  with the resource envelope recorded in its receipt.
- Add a regression scenario containing one executable component and one
  envelope-deferred residual component.

## Acceptance matrix

- Resource-deferred residual remains durable and visible: satisfied.
- Repeated all-deferred apply does not append a ledger row: satisfied.
- Two dry-run censuses can prove a matching fixed point with zero executable
  candidates: satisfied.
- Ordinary unblocked metrics remain unchanged: satisfied.

## Verification

- `devtools test tests/unit/devtools/test_raw_authority_scale_proof.py`
  — 13 passed.
- `devtools test tests/unit/storage/test_repair.py -k raw_materialization`
  — 35 passed, 17 deselected.
- `devtools verify --quick` — success through all 16 managed steps.

Ref polylogue-hjpx.2
