### PR TITLE
docs(campaign): record Test Diet admissions

### DIFF
--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/index.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/index.json
@@ -177,6 +177,15 @@
       "package_revision": "r02"
     },
     {
+      "job": "testdiet-03",
+      "workload": "testdiet",
+      "state": "integrated_merged",
+      "package_revision": "r02",
+      "artifact": "testdiet-03-rebuild-equivalence-r01.zip",
+      "sha256": "c3843babc8fc0126401e471c9eaee1db26ad5ccdcabf0e1697d01157e591e47e",
+      "bytes": 26025
+    },
+    {
       "job": "testdiet-04",
       "workload": "testdiet",
       "zip": "testdiet-04/r02/raw.zip",
@@ -257,6 +266,60 @@
       ],
       "integration": "admitted as PR #3033 / efadb404ebe70ec91f03ffcb7eaf0de7956ece4d after FactFamilySpec was projected through the shared DeclarationRegistry; three real owner-route canaries landed while broader EvidenceValue family migration remains open",
       "package_revision": "r01"
+    },
+    {
+      "job": "testdiet-07",
+      "workload": "testdiet",
+      "state": "integrated_merged",
+      "package_revision": "r02",
+      "artifact": "testdiet-07-public-fact-parity-r01.zip",
+      "sha256": "95e7bbdfa984daca703160d154a36c39e01e35c23643debf60180b6b9962acbd",
+      "bytes": 24694
+    },
+    {
+      "job": "testdiet-08",
+      "workload": "testdiet",
+      "state": "integrated_merged",
+      "package_revision": "r02",
+      "artifact": "testdiet-08-chatgpt-normalization-r01.zip",
+      "sha256": "602019b069c47f9490ed31953a8cfd2bf1201d6ea6c14176a827155c8e6f9f66",
+      "bytes": 25012
+    },
+    {
+      "job": "testdiet-09",
+      "workload": "testdiet",
+      "state": "integrated_merged",
+      "package_revision": "r02",
+      "artifact": "testdiet-09-claude-code-normalization-r01.zip",
+      "sha256": "ff1220a65cfa3e882d4887e257a68cfadd34e686f77042fd6a35058912646047",
+      "bytes": 25182
+    },
+    {
+      "job": "testdiet-10",
+      "workload": "testdiet",
+      "state": "integrated_merged",
+      "package_revision": "r02",
+      "artifact": "testdiet-10-claude-web-normalization-r01.zip",
+      "sha256": "b73e7d46d640dcfbf9a3feec7842ee4ed029e19ef7fe36b49413ef98bffdb91f",
+      "bytes": 32845
+    },
+    {
+      "job": "testdiet-12",
+      "workload": "testdiet",
+      "state": "integrated_merged",
+      "package_revision": "r02",
+      "artifact": "testdiet-12-gemini-drive-normalization-r01.zip",
+      "sha256": "5d3b0e9e8f6813ef28690dfa3889822f86c6fd156033d6c12c936eed77133e3e",
+      "bytes": 32474
+    },
+    {
+      "job": "testdiet-15",
+      "workload": "testdiet",
+      "state": "integrated_merged",
+      "package_revision": "r02",
+      "artifact": "testdiet-15-temporal-equivalence-r01.zip",
+      "sha256": "693fa6b09b9d69d6662a576ed1195ef9ea0836ab0a796a8241d826165b92b5b5",
+      "bytes": 24864
     }
   ]
 }

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-03/r02/receipt.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-03/r02/receipt.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "campaign_id": "gpt-pro-wave-2026-07-16",
+  "workload_id": "testdiet",
+  "job_id": "testdiet-03",
+  "package_revision": "r02",
+  "state": "integrated_merged",
+  "artifact": {"filename": "testdiet-03-rebuild-equivalence-r01.zip", "sha256": "c3843babc8fc0126401e471c9eaee1db26ad5ccdcabf0e1697d01157e591e47e", "size_bytes": 26025, "custody_path": "testdiet/results/testdiet-03/a01/raw/testdiet-03-rebuild-equivalence-r01.zip"},
+  "local_adjudication": "Current-master reconciliation admitted the thread refresh ordering repair and exact incremental/rebuild survivor.",
+  "beads": ["polylogue-9rw0", "polylogue-b5l", "polylogue-b5l.1"],
+  "merge_commit": "1d3145afa5f07a8f90ffceefc33ba425c877a8ad",
+  "pull_request": "https://github.com/Sinity/polylogue/pull/3044",
+  "verification": "Focused new-law set and devtools verify --quick passed.",
+  "scope": "Root/child ordering equivalence survivor; broader resumable rebuild protocol remains open."
+}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-07/r02/receipt.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-07/r02/receipt.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "campaign_id": "gpt-pro-wave-2026-07-16",
+  "workload_id": "testdiet",
+  "job_id": "testdiet-07",
+  "package_revision": "r02",
+  "state": "integrated_merged",
+  "artifact": {"filename": "testdiet-07-public-fact-parity-r01.zip", "sha256": "95e7bbdfa984daca703160d154a36c39e01e35c23643debf60180b6b9962acbd", "size_bytes": 24694, "custody_path": "testdiet/results/testdiet-07/a01/raw/testdiet-07-public-fact-parity-r01.zip"},
+  "local_adjudication": "Archive provenance now reaches repository, façade, CLI, and daemon profile projections under one real-route parity survivor.",
+  "beads": ["polylogue-yeq.3", "polylogue-4p1"],
+  "merge_commit": "1d3145afa5f07a8f90ffceefc33ba425c877a8ad",
+  "pull_request": "https://github.com/Sinity/polylogue/pull/3044",
+  "verification": "Focused new-law set and devtools verify --quick passed.",
+  "scope": "Session-profile parity slice only; broad query/projection/render program remains open."
+}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-08/r02/receipt.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-08/r02/receipt.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "campaign_id": "gpt-pro-wave-2026-07-16",
+  "workload_id": "testdiet",
+  "job_id": "testdiet-08",
+  "package_revision": "r02",
+  "state": "integrated_merged",
+  "artifact": {"filename": "testdiet-08-chatgpt-normalization-r01.zip", "sha256": "602019b069c47f9490ed31953a8cfd2bf1201d6ea6c14176a827155c8e6f9f66", "size_bytes": 25012, "custody_path": "testdiet/results/testdiet-08/a01/raw/testdiet-08-chatgpt-normalization-r01.zip"},
+  "local_adjudication": "Current ChatGPT parser now preserves native timing, model effort, branch identity, browser-native preference, and exact raw replacement under real-route laws.",
+  "beads": ["polylogue-2qx", "polylogue-2qx.1"],
+  "merge_commit": "1d3145afa5f07a8f90ffceefc33ba425c877a8ad",
+  "pull_request": "https://github.com/Sinity/polylogue/pull/3044",
+  "verification": "Focused new-law set and devtools verify --quick passed.",
+  "scope": "ChatGPT normalization slice; OriginSpec remains the wider declaration program."
+}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-09/r02/receipt.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-09/r02/receipt.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "campaign_id": "gpt-pro-wave-2026-07-16",
+  "workload_id": "testdiet",
+  "job_id": "testdiet-09",
+  "package_revision": "r02",
+  "state": "integrated_merged",
+  "artifact": {"filename": "testdiet-09-claude-code-normalization-r01.zip", "sha256": "ff1220a65cfa3e882d4887e257a68cfadd34e686f77042fd6a35058912646047", "size_bytes": 25182, "custody_path": "testdiet/results/testdiet-09/a01/raw/testdiet-09-claude-code-normalization-r01.zip"},
+  "local_adjudication": "Current Claude Code dispatch/parser reconciliation admits authoredness, streaming identity, background completion, and lineage law coverage.",
+  "beads": ["polylogue-2qx", "polylogue-2qx.1", "polylogue-866e", "polylogue-4ts.3"],
+  "merge_commit": "1d3145afa5f07a8f90ffceefc33ba425c877a8ad",
+  "pull_request": "https://github.com/Sinity/polylogue/pull/3044",
+  "verification": "Focused new-law set and devtools verify --quick passed.",
+  "scope": "Provider normalization witnesses; lineage-write P0 remains separately in progress."
+}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-10/r02/receipt.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-10/r02/receipt.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "campaign_id": "gpt-pro-wave-2026-07-16",
+  "workload_id": "testdiet",
+  "job_id": "testdiet-10",
+  "package_revision": "r02",
+  "state": "integrated_merged",
+  "artifact": {"filename": "testdiet-10-claude-web-normalization-r01.zip", "sha256": "b73e7d46d640dcfbf9a3feec7842ee4ed029e19ef7fe36b49413ef98bffdb91f", "size_bytes": 32845, "custody_path": "testdiet/results/testdiet-10/a01/raw/testdiet-10-claude-web-normalization-r01.zip"},
+  "local_adjudication": "Direct exports, native browser envelopes, and degraded DOM fallback now share Claude evidence normalization while retaining native identity and fidelity.",
+  "beads": ["polylogue-2qx", "polylogue-2qx.1"],
+  "merge_commit": "1d3145afa5f07a8f90ffceefc33ba425c877a8ad",
+  "pull_request": "https://github.com/Sinity/polylogue/pull/3044",
+  "verification": "Focused new-law set and devtools verify --quick passed.",
+  "scope": "Claude web normalization slice; live authenticated capture remains unverified."
+}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-12/r02/receipt.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-12/r02/receipt.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "campaign_id": "gpt-pro-wave-2026-07-16",
+  "workload_id": "testdiet",
+  "job_id": "testdiet-12",
+  "package_revision": "r02",
+  "state": "integrated_merged",
+  "artifact": {"filename": "testdiet-12-gemini-drive-normalization-r01.zip", "sha256": "5d3b0e9e8f6813ef28690dfa3889822f86c6fd156033d6c12c936eed77133e3e", "size_bytes": 32474, "custody_path": "testdiet/results/testdiet-12/a01/raw/testdiet-12-gemini-drive-normalization-r01.zip"},
+  "local_adjudication": "Tight Drive detection, recursive lowering, Gemini/Drive typed facts, and Gemini CLI normalization are admitted through real parser routes.",
+  "beads": ["polylogue-2qx", "polylogue-2qx.1"],
+  "merge_commit": "1d3145afa5f07a8f90ffceefc33ba425c877a8ad",
+  "pull_request": "https://github.com/Sinity/polylogue/pull/3044",
+  "verification": "Focused new-law set and devtools verify --quick passed.",
+  "scope": "Gemini/Drive normalization slice; full provider declaration work remains open."
+}

--- a/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-15/r02/receipt.json
+++ b/.agent/handoffs/external-agent-campaigns/2026-07-16-gpt-pro-wave/testdiet/results/testdiet-15/r02/receipt.json
@@ -1,0 +1,15 @@
+{
+  "schema_version": 1,
+  "campaign_id": "gpt-pro-wave-2026-07-16",
+  "workload_id": "testdiet",
+  "job_id": "testdiet-15",
+  "package_revision": "r02",
+  "state": "integrated_merged",
+  "artifact": {"filename": "testdiet-15-temporal-equivalence-r01.zip", "sha256": "693fa6b09b9d69d6662a576ed1195ef9ea0836ab0a796a8241d826165b92b5b5", "size_bytes": 24864, "custody_path": "testdiet/results/testdiet-15/a01/raw/testdiet-15-temporal-equivalence-r01.zip"},
+  "local_adjudication": "Canonical UTC public instants, normalized bounds, and explicit inferred event-gap semantics were reconciled with the current freshness test seam.",
+  "beads": ["polylogue-896y"],
+  "merge_commit": "1d3145afa5f07a8f90ffceefc33ba425c877a8ad",
+  "pull_request": "https://github.com/Sinity/polylogue/pull/3044",
+  "verification": "238 temporal/affected-route tests and devtools verify --quick passed.",
+  "scope": "Temporal public-surface equivalence slice; broader time-authority audit remains open."
+}


### PR DESCRIPTION
Summary

Records immutable post-merge campaign receipts for the seven Test Diet packages admitted in PR #3044.

Problem

The initial a01 receipts intentionally contain only package triage. Without separate post-merge receipts, the campaign index cannot distinguish a checked package from a merged implementation.

Solution

Adds r02 receipts for TD03, TD07–TD10, TD12, and TD15, all pointing to PR #3044 and its merge commit.

Verification

- reconcile_results.py wave --write: passed.
- .agent/scripts/bd-graph-lint: passed.

Beads: polylogue-9rw0, polylogue-yeq.3, polylogue-2qx, polylogue-866e, polylogue-896y.