### PR TITLE
build: allowlist sdist contents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,19 @@ polylogue-mcp = "polylogue.mcp.cli:main"
 [tool.hatch.build.targets.wheel]
 packages = ["polylogue", "devtools"]
 
+[tool.hatch.build.targets.sdist]
+only-include = [
+  "polylogue",
+  "devtools",
+  "packaging",
+  "tests",
+  "docs",
+  "README.md",
+  "CHANGELOG.md",
+  "LICENSE",
+  "uv.lock",
+]
+
 [tool.hatch.build.hooks.custom]
 path = "packaging/hatch_build.py"
 


### PR DESCRIPTION
## Summary
Explicit sdist allowlist so source distributions stop sweeping untracked runtime state.

## Problem
`uv build` from a working checkout produced a 324MB sdist: hatchling's default sdist includes the whole project dir, which swept 287MB of live `.beads/` Dolt data and 254MB of `.agent/` campaign artifacts (incl. gitignored files). 0.3.0 release artifacts were about to ship this way.

## Solution
`[tool.hatch.build.targets.sdist] only-include`: `polylogue`, `devtools`, `packaging`, `tests`, `docs`, README/CHANGELOG/LICENSE/uv.lock. Custom build hook unaffected.

## Verification
`uv build`: sdist 324MB → 7.5MB, 2,455 files, top-level entries exactly the allowlist + PKG-INFO, zero `.agent/`/`.beads/` paths; wheel builds from the new sdist with `_build_info` embedded. Repo CI currently disabled (account billing lock) — local verification only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ