### PR TITLE
fix(storage): resolve managed archive index identity

### DIFF
--- a/polylogue/cli/commands/debt.py
+++ b/polylogue/cli/commands/debt.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import click
 
 from polylogue.operations.archive_debt import archive_debt_list
-from polylogue.paths import active_index_db_path
+from polylogue.paths import archive_root
 from polylogue.surfaces.payloads import ArchiveDebtListPayload
 
 _DEBT_KINDS = ("archive-tier", "assertion-candidate", "convergence", "embedding", "fts", "raw-materialization")
@@ -53,10 +53,10 @@ def debt_list_command(
     output_format: str,
 ) -> None:
     """List archive debt across assertions, tiers, raw ingest, convergence, embedding, and FTS signals."""
-    archive_root = active_index_db_path().parent
+    configured_root = archive_root()
     selected_statuses = statuses or _DEFAULT_DEBT_STATUSES
     payload = archive_debt_list(
-        archive_root=archive_root,
+        archive_root=configured_root,
         kinds=kinds,
         statuses=selected_statuses,
         only_actionable=only_actionable,

--- a/polylogue/cli/commands/maintenance/_rebuild_index.py
+++ b/polylogue/cli/commands/maintenance/_rebuild_index.py
@@ -15,6 +15,7 @@ import click
 from polylogue.config import Config
 from polylogue.logging import configure_logging
 from polylogue.paths import archive_root, render_root
+from polylogue.storage.archive_identity import ArchiveLocation
 
 
 def _count_source_raw_sessions(root: Path) -> int:
@@ -28,7 +29,7 @@ def _count_source_raw_sessions(root: Path) -> int:
 
 def _missing_index_raw_ids(root: Path) -> list[str]:
     source_db = root / "source.db"
-    index_db = root / "index.db"
+    index_db = ArchiveLocation.resolve(root).active_index_path
     if not source_db.exists() or not index_db.exists():
         return []
     with contextlib.closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True, timeout=10.0)) as conn:
@@ -96,7 +97,7 @@ def _rebuild_index_selection_plan(
     limit: int,
 ) -> dict[str, object]:
     source_db = root / "source.db"
-    index_db = root / "index.db"
+    index_db = ArchiveLocation.resolve(root).active_index_path
     if not source_db.exists():
         return {
             "archive_root": str(root),
@@ -334,6 +335,7 @@ def rebuild_index_command(
         raise click.BadParameter("plan limit must be positive", param_hint="--plan-limit")
 
     root = archive_root()
+    location = ArchiveLocation.resolve(root)
     raw_count = _count_source_raw_sessions(root)
     if raw_count == 0:
         payload = {
@@ -415,7 +417,12 @@ def rebuild_index_command(
 
     generation_store = IndexGenerationStore(root)
     with RebuildLease(root):
-        active_config = Config(archive_root=root, render_root=render_root(), sources=[], db_path=root / "index.db")
+        active_config = Config(
+            archive_root=root,
+            render_root=render_root(),
+            sources=[],
+            db_path=location.active_index_path,
+        )
         daemon_pid = running_daemon_pid(active_config)
         if daemon_pid is not None:
             raise click.ClickException(f"offline rebuild refused while polylogued PID {daemon_pid} is running")

--- a/polylogue/cli/commands/maintenance/_rebuild_index.py
+++ b/polylogue/cli/commands/maintenance/_rebuild_index.py
@@ -298,6 +298,19 @@ def _rebuild_index_selection_plan(
 )
 @click.option("--plan-limit", type=int, default=10, show_default=True, help="Rows to include in --plan top_rows.")
 @click.option(
+    "--operation-id",
+    type=str,
+    default=None,
+    help="Resume the retained candidate generation for this rebuild operation.",
+)
+@click.option(
+    "--raw-batch-size",
+    type=int,
+    default=500,
+    show_default=True,
+    help="Maximum source rows scheduled by this invocation; rerun with --operation-id to continue.",
+)
+@click.option(
     "--output-format",
     "output_format",
     type=click.Choice(["plain", "json"]),
@@ -312,6 +325,8 @@ def rebuild_index_command(
     max_blob_mb: float | None,
     plan_only: bool,
     plan_limit: int,
+    operation_id: str | None,
+    raw_batch_size: int,
     output_format: str,
     no_promote: bool,
 ) -> None:
@@ -333,6 +348,10 @@ def rebuild_index_command(
         raise click.UsageError("--max-blob-mb requires --only-missing or --raw-id")
     if plan_limit <= 0:
         raise click.BadParameter("plan limit must be positive", param_hint="--plan-limit")
+    if raw_batch_size <= 0:
+        raise click.BadParameter("raw batch size must be positive", param_hint="--raw-batch-size")
+    if operation_id is not None and (raw_ids or only_missing or max_blob_mb is not None or plan_only):
+        raise click.UsageError("--operation-id only resumes an unfiltered full-source rebuild")
 
     root = archive_root()
     location = ArchiveLocation.resolve(root)
@@ -427,19 +446,48 @@ def rebuild_index_command(
         if daemon_pid is not None:
             raise click.ClickException(f"offline rebuild refused while polylogued PID {daemon_pid} is running")
         raw_count = _count_source_raw_sessions(root)
-        selected_raw_ids = (
-            list(dict.fromkeys(raw_ids))
-            if raw_ids
-            else _missing_index_raw_ids(root)
-            if only_missing
-            else _all_index_rebuild_raw_ids(root)
-        )
-        unfiltered_selected_raw_count = len(selected_raw_ids)
-        selected_raw_ids = _filter_raw_ids_by_max_blob_size(root, selected_raw_ids, max_blob_mb)
-        selected_raw_count = len(selected_raw_ids)
-        skipped_by_blob_limit_count = unfiltered_selected_raw_count - selected_raw_count
-        source_snapshot = source_revision_snapshot(root)
-        generation = generation_store.create(source_snapshot=source_snapshot)
+        resumable_full_source = not raw_ids and not only_missing and max_blob_mb is None
+        transaction = None
+        page: tuple[tuple[str, int], ...] = ()
+        if resumable_full_source:
+            transaction = (
+                generation_store.load_transaction(operation_id)
+                if operation_id is not None
+                else generation_store.create_transaction(source_snapshot=source_revision_snapshot(root))
+            )
+            if transaction.status in {"promoted", "stale"}:
+                raise click.ClickException(
+                    f"rebuild operation {transaction.operation_id} is {transaction.status}; start a new operation"
+                )
+            if source_revision_snapshot(root) != transaction.source_snapshot:
+                generation_store.checkpoint_transaction(
+                    transaction,
+                    status="stale",
+                    error="source evidence changed since this rebuild was planned",
+                )
+                raise click.ClickException(
+                    f"rebuild operation {transaction.operation_id} is stale because source evidence changed"
+                )
+            generation = generation_store.load(transaction.generation_id)
+            if generation.owner_id != transaction.generation_owner_id or generation.state != "inactive":
+                raise click.ClickException(f"rebuild operation {transaction.operation_id} lost its inactive candidate")
+            page = generation_store.next_raw_page(transaction, limit=raw_batch_size)
+            selected_raw_ids = [raw_id for raw_id, _acquired_at_ms in page]
+            selected_raw_count = len(selected_raw_ids)
+            skipped_by_blob_limit_count = 0
+        else:
+            selected_raw_ids = (
+                list(dict.fromkeys(raw_ids))
+                if raw_ids
+                else _missing_index_raw_ids(root)
+                if only_missing
+                else _all_index_rebuild_raw_ids(root)
+            )
+            unfiltered_selected_raw_count = len(selected_raw_ids)
+            selected_raw_ids = _filter_raw_ids_by_max_blob_size(root, selected_raw_ids, max_blob_mb)
+            selected_raw_count = len(selected_raw_ids)
+            skipped_by_blob_limit_count = unfiltered_selected_raw_count - selected_raw_count
+            generation = generation_store.create(source_snapshot=source_revision_snapshot(root))
         try:
             generation_root = Path(generation.index_path).parent
             config = Config(
@@ -452,13 +500,50 @@ def rebuild_index_command(
                 rebuild_index_from_source(
                     config,
                     raw_ids=selected_raw_ids,
-                    raw_batch_size=500,
+                    raw_batch_size=raw_batch_size,
                     ingest_workers=None,
                     materialize=True,
                     progress_callback=None,
                     owned_inactive_generation=(generation.generation_id, generation.owner_id),
                 )
             )
+            if transaction is not None and selected_raw_ids:
+                if source_revision_snapshot(root) != transaction.source_snapshot:
+                    generation_store.checkpoint_transaction(
+                        transaction,
+                        status="stale",
+                        error="source evidence changed during this bounded rebuild pass",
+                    )
+                    raise click.ClickException(
+                        f"rebuild operation {transaction.operation_id} is stale because source evidence changed"
+                    )
+                last_raw_id, last_acquired_at_ms = page[-1]
+                transaction = generation_store.checkpoint_transaction(
+                    transaction,
+                    status="paused",
+                    last_acquired_at_ms=last_acquired_at_ms,
+                    last_raw_id=last_raw_id,
+                    processed_raw_count=transaction.processed_raw_count + len(selected_raw_ids),
+                )
+                payload = {
+                    "archive_root": str(root),
+                    "raw_session_count": raw_count,
+                    "selected_raw_count": selected_raw_count,
+                    "skipped_by_blob_limit_count": 0,
+                    "status": "paused",
+                    "materialized": False,
+                    "generation": asdict(generation),
+                    "transaction": asdict(transaction),
+                    **result,
+                }
+                if output_format == "json":
+                    click.echo(json.dumps(payload, indent=2, sort_keys=True))
+                else:
+                    click.echo(f"Rebuild operation: {transaction.operation_id}")
+                    click.echo(f"Scheduled:         {selected_raw_count:,} raw row(s)")
+                    click.echo(f"Paused cursor:     {transaction.cursor or 'start'}")
+                    click.echo("Resume with --operation-id after this bounded pass.")
+                return
             from polylogue.storage.repair import repair_session_insights
 
             insight_result = repair_session_insights(
@@ -488,9 +573,22 @@ def rebuild_index_command(
                 )
             if not no_promote:
                 generation = generation_store.promote(generation)
+            if transaction is not None:
+                transaction = generation_store.checkpoint_transaction(
+                    transaction,
+                    status="promoted" if not no_promote else "ready-to-promote",
+                )
         except Exception:
-            with contextlib.suppress(Exception):
-                generation_store.discard_if_inactive(generation)
+            if transaction is not None:
+                with contextlib.suppress(Exception):
+                    generation_store.checkpoint_transaction(
+                        transaction,
+                        status="failed",
+                        error="bounded rebuild pass failed; candidate retained for diagnosis or explicit recovery",
+                    )
+            else:
+                with contextlib.suppress(Exception):
+                    generation_store.discard_if_inactive(generation)
             raise
     payload = {
         "archive_root": str(root),
@@ -502,6 +600,7 @@ def rebuild_index_command(
         "materialization": insight_result.to_dict(),
         "generation": asdict(generation),
         "readiness": readiness,
+        "transaction": asdict(transaction) if transaction is not None else None,
         **result,
     }
     if output_format == "json":

--- a/polylogue/cli/commands/maintenance/_rebuild_index.py
+++ b/polylogue/cli/commands/maintenance/_rebuild_index.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import json
 import sqlite3
+import time
 from dataclasses import asdict
 from pathlib import Path
 from typing import Any, cast
@@ -311,6 +312,18 @@ def _rebuild_index_selection_plan(
     help="Maximum source rows scheduled by this invocation; rerun with --operation-id to continue.",
 )
 @click.option(
+    "--pass-byte-budget-mb",
+    type=float,
+    default=None,
+    help="Aggregate raw bytes scheduled per resumable pass; never excludes later source rows.",
+)
+@click.option(
+    "--pass-deadline-seconds",
+    type=float,
+    default=None,
+    help="Wall-clock deadline for one resumable pass; expiry defers remaining source rows.",
+)
+@click.option(
     "--output-format",
     "output_format",
     type=click.Choice(["plain", "json"]),
@@ -327,6 +340,8 @@ def rebuild_index_command(
     plan_limit: int,
     operation_id: str | None,
     raw_batch_size: int,
+    pass_byte_budget_mb: float | None,
+    pass_deadline_seconds: float | None,
     output_format: str,
     no_promote: bool,
 ) -> None:
@@ -350,6 +365,10 @@ def rebuild_index_command(
         raise click.BadParameter("plan limit must be positive", param_hint="--plan-limit")
     if raw_batch_size <= 0:
         raise click.BadParameter("raw batch size must be positive", param_hint="--raw-batch-size")
+    if pass_byte_budget_mb is not None and pass_byte_budget_mb <= 0:
+        raise click.BadParameter("pass byte budget must be positive", param_hint="--pass-byte-budget-mb")
+    if pass_deadline_seconds is not None and pass_deadline_seconds <= 0:
+        raise click.BadParameter("pass deadline must be positive", param_hint="--pass-deadline-seconds")
     if operation_id is not None and (raw_ids or only_missing or max_blob_mb is not None or plan_only):
         raise click.UsageError("--operation-id only resumes an unfiltered full-source rebuild")
 
@@ -371,18 +390,18 @@ def rebuild_index_command(
             click.echo(f"Archive root: {root}")
             click.echo("No source.db raw_sessions rows found.")
         return
-    selected_raw_ids = (
-        list(dict.fromkeys(raw_ids))
-        if raw_ids
-        else _missing_index_raw_ids(root)
-        if only_missing
-        else _all_index_rebuild_raw_ids(root)
-    )
-    unfiltered_selected_raw_count = len(selected_raw_ids)
-    selected_raw_ids = _filter_raw_ids_by_max_blob_size(root, selected_raw_ids, max_blob_mb)
-    selected_raw_count = len(selected_raw_ids)
-    skipped_by_blob_limit_count = unfiltered_selected_raw_count - selected_raw_count
     if plan_only:
+        selected_raw_ids = (
+            list(dict.fromkeys(raw_ids))
+            if raw_ids
+            else _missing_index_raw_ids(root)
+            if only_missing
+            else _all_index_rebuild_raw_ids(root)
+        )
+        unfiltered_selected_raw_count = len(selected_raw_ids)
+        selected_raw_ids = _filter_raw_ids_by_max_blob_size(root, selected_raw_ids, max_blob_mb)
+        selected_raw_count = len(selected_raw_ids)
+        skipped_by_blob_limit_count = unfiltered_selected_raw_count - selected_raw_count
         payload = _rebuild_index_selection_plan(
             root,
             selected_raw_ids=selected_raw_ids,
@@ -448,13 +467,24 @@ def rebuild_index_command(
         raw_count = _count_source_raw_sessions(root)
         resumable_full_source = not raw_ids and not only_missing and max_blob_mb is None
         transaction = None
-        page: tuple[tuple[str, int], ...] = ()
+        page = None
+        pass_started_at_ms = int(time.time() * 1000)
         if resumable_full_source:
             transaction = (
                 generation_store.load_transaction(operation_id)
                 if operation_id is not None
-                else generation_store.create_transaction(source_snapshot=source_revision_snapshot(root))
+                else generation_store.create_transaction(
+                    source_snapshot=source_revision_snapshot(root),
+                    pass_byte_budget=(
+                        int(pass_byte_budget_mb * 1024 * 1024) if pass_byte_budget_mb is not None else None
+                    ),
+                    pass_deadline_ms=(int(pass_deadline_seconds * 1000) if pass_deadline_seconds is not None else None),
+                )
             )
+            if operation_id is not None and (pass_byte_budget_mb is not None or pass_deadline_seconds is not None):
+                raise click.UsageError(
+                    "resumed rebuild budgets are durable; omit pass budget options with --operation-id"
+                )
             if transaction.status in {"promoted", "stale"}:
                 raise click.ClickException(
                     f"rebuild operation {transaction.operation_id} is {transaction.status}; start a new operation"
@@ -472,7 +502,7 @@ def rebuild_index_command(
             if generation.owner_id != transaction.generation_owner_id or generation.state != "inactive":
                 raise click.ClickException(f"rebuild operation {transaction.operation_id} lost its inactive candidate")
             page = generation_store.next_raw_page(transaction, limit=raw_batch_size)
-            selected_raw_ids = [raw_id for raw_id, _acquired_at_ms in page]
+            selected_raw_ids = [raw_id for raw_id, _acquired_at_ms, _blob_size in page.rows]
             selected_raw_count = len(selected_raw_ids)
             skipped_by_blob_limit_count = 0
         else:
@@ -488,6 +518,7 @@ def rebuild_index_command(
             selected_raw_count = len(selected_raw_ids)
             skipped_by_blob_limit_count = unfiltered_selected_raw_count - selected_raw_count
             generation = generation_store.create(source_snapshot=source_revision_snapshot(root))
+        source_drifted = False
         try:
             generation_root = Path(generation.index_path).parent
             config = Config(
@@ -509,41 +540,52 @@ def rebuild_index_command(
             )
             if transaction is not None and selected_raw_ids:
                 if source_revision_snapshot(root) != transaction.source_snapshot:
-                    generation_store.checkpoint_transaction(
+                    transaction = generation_store.checkpoint_transaction(
                         transaction,
                         status="stale",
                         error="source evidence changed during this bounded rebuild pass",
                     )
+                    source_drifted = True
                     raise click.ClickException(
                         f"rebuild operation {transaction.operation_id} is stale because source evidence changed"
                     )
-                last_raw_id, last_acquired_at_ms = page[-1]
+                assert page is not None
+                last_raw_id, last_acquired_at_ms, _blob_size = page.rows[-1]
+                elapsed_ms = int(time.time() * 1000) - pass_started_at_ms
+                deadline_expired = (
+                    transaction.pass_deadline_ms is not None and elapsed_ms >= transaction.pass_deadline_ms
+                )
+                status = "deferred" if page.deferred_reason == "byte-budget" or deadline_expired else "paused"
+                if deadline_expired:
+                    status = "deferred"
                 transaction = generation_store.checkpoint_transaction(
                     transaction,
-                    status="paused",
+                    status=status,
                     last_acquired_at_ms=last_acquired_at_ms,
                     last_raw_id=last_raw_id,
                     processed_raw_count=transaction.processed_raw_count + len(selected_raw_ids),
+                    processed_blob_bytes=transaction.processed_blob_bytes + sum(row[2] for row in page.rows),
                 )
-                payload = {
-                    "archive_root": str(root),
-                    "raw_session_count": raw_count,
-                    "selected_raw_count": selected_raw_count,
-                    "skipped_by_blob_limit_count": 0,
-                    "status": "paused",
-                    "materialized": False,
-                    "generation": asdict(generation),
-                    "transaction": asdict(transaction),
-                    **result,
-                }
-                if output_format == "json":
-                    click.echo(json.dumps(payload, indent=2, sort_keys=True))
-                else:
-                    click.echo(f"Rebuild operation: {transaction.operation_id}")
-                    click.echo(f"Scheduled:         {selected_raw_count:,} raw row(s)")
-                    click.echo(f"Paused cursor:     {transaction.cursor or 'start'}")
-                    click.echo("Resume with --operation-id after this bounded pass.")
-                return
+                if page.has_more or deadline_expired:
+                    payload = {
+                        "archive_root": str(root),
+                        "raw_session_count": raw_count,
+                        "selected_raw_count": selected_raw_count,
+                        "skipped_by_blob_limit_count": 0,
+                        "status": status,
+                        "materialized": False,
+                        "generation": asdict(generation),
+                        "transaction": asdict(transaction),
+                        **result,
+                    }
+                    if output_format == "json":
+                        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+                    else:
+                        click.echo(f"Rebuild operation: {transaction.operation_id}")
+                        click.echo(f"Scheduled:         {selected_raw_count:,} raw row(s)")
+                        click.echo(f"Paused cursor:     {transaction.cursor or 'start'}")
+                        click.echo("Resume with --operation-id after this bounded pass.")
+                    return
             from polylogue.storage.repair import repair_session_insights
 
             insight_result = repair_session_insights(
@@ -555,6 +597,13 @@ def rebuild_index_command(
             if not insight_result.success:
                 raise click.ClickException(f"session insight materialization failed: {insight_result.detail}")
             if source_revision_snapshot(root) != generation.source_snapshot:
+                if transaction is not None:
+                    transaction = generation_store.checkpoint_transaction(
+                        transaction,
+                        status="stale",
+                        error="source evidence changed before terminal readiness",
+                    )
+                    source_drifted = True
                 raise click.ClickException(f"source evidence changed while rebuilding {generation.generation_id}")
             readiness = _archive_readiness_status(generation_root)
             if not readiness.get("checked") or int(readiness.get("blocked_surface_count", 1)) != 0:
@@ -571,15 +620,17 @@ def rebuild_index_command(
                 raise click.ClickException(
                     f"inactive generation {generation.generation_id} is not exact-ready; {detail}"
                 )
-            if not no_promote:
-                generation = generation_store.promote(generation)
             if transaction is not None:
                 transaction = generation_store.checkpoint_transaction(
                     transaction,
-                    status="promoted" if not no_promote else "ready-to-promote",
+                    status="ready",
                 )
+            if not no_promote:
+                generation = generation_store.promote(generation)
+                if transaction is not None:
+                    transaction = generation_store.checkpoint_transaction(transaction, status="promoted")
         except Exception:
-            if transaction is not None:
+            if transaction is not None and not source_drifted:
                 with contextlib.suppress(Exception):
                     generation_store.checkpoint_transaction(
                         transaction,

--- a/polylogue/cli/commands/paths.py
+++ b/polylogue/cli/commands/paths.py
@@ -36,21 +36,22 @@ def paths_command(output_format: str) -> None:
     blob store root, and whether any bind mounts are detected.
     """
     from polylogue.paths import (
-        active_index_db_path,
         archive_root,
         blob_store_root,
         config_home,
         data_home,
     )
+    from polylogue.storage.archive_identity import ArchiveLocation
 
-    archive = archive_root().resolve()
-    active_db = active_index_db_path().resolve()
+    location = ArchiveLocation.resolve(archive_root())
+    archive = location.configured_root.resolve()
+    active_db = location.active_index.resolved_path
     active_archive = active_db.parent.resolve()
-    db = (active_archive / "index.db").resolve()
-    source_db = (active_archive / "source.db").resolve()
-    embeddings_db = (active_archive / "embeddings.db").resolve()
-    ops_db = (active_archive / "ops.db").resolve()
-    user_db = (active_archive / "user.db").resolve()
+    db = location.active_tier("index").resolved_path
+    source_db = location.active_tier("source").resolved_path
+    embeddings_db = location.active_tier("embeddings").resolved_path
+    ops_db = location.active_tier("ops").resolved_path
+    user_db = location.active_tier("user").resolved_path
     tier_paths = {
         "source": source_db,
         "index": db,
@@ -116,6 +117,8 @@ def paths_command(output_format: str) -> None:
             "active_database_role": active_database_role,
             "active_database_exists": active_db.exists(),
             "active_database_size_bytes": active_db.stat().st_size if active_db.exists() else None,
+            "active_index_pointer": str(location.active_pointer) if location.active_pointer is not None else None,
+            "shadow_configured_index": location.shadow_index.as_dict() if location.shadow_index is not None else None,
             "storage_layout": storage_layout,
             "archive_ready": archive_ready,
             "archive_materialization_ready": archive_materialization_ready,

--- a/polylogue/cli/commands/reset.py
+++ b/polylogue/cli/commands/reset.py
@@ -51,7 +51,9 @@ def _archive_root() -> Path:
 
 
 def _index_db_path() -> Path:
-    return _archive_root() / "index.db"
+    from polylogue.storage.archive_identity import ArchiveLocation
+
+    return ArchiveLocation.resolve(_archive_root()).active_index_path
 
 
 def _source_db_path() -> Path:
@@ -80,6 +82,11 @@ def _archive_database_targets(
         *_REBUILDABLE_ARCHIVE_DATABASES,
         *((_USER_ARCHIVE_DATABASE,) if include_user_db else ()),
     ]
+    if (root / ".index-active-pointer").exists() and any(filename == "index.db" for _name, filename in databases):
+        raise click.ClickException(
+            "reset --database is unsafe for a managed active generation; "
+            "use `polylogue ops maintenance rebuild-index` to create and promote a replacement"
+        )
     targets: list[tuple[str, Path]] = []
     for name, filename in databases:
         path = root / filename
@@ -95,8 +102,16 @@ def _archive_database_targets(
 def _archive_index_targets() -> list[tuple[str, Path]]:
     """Resolve only the rebuildable index tier files for schema rebuilds."""
     root = _archive_root()
-    name, filename = _INDEX_ARCHIVE_DATABASE
-    path = root / filename
+    name, _filename = _INDEX_ARCHIVE_DATABASE
+    path = _index_db_path()
+    # A managed generation is not a disposable sibling of the configured
+    # root.  Deleting it in place bypasses blue/green promotion and can leave
+    # a second writable index beside the pointer (the July live incident).
+    if (root / ".index-active-pointer").exists():
+        raise click.ClickException(
+            "reset --index is unsafe for a managed active generation; "
+            "use `polylogue ops maintenance rebuild-index` to create and promote a replacement"
+        )
     targets: list[tuple[str, Path]] = []
     if path.exists():
         targets.append((name, path))

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -158,6 +158,8 @@ def get_config() -> Config:
         archive_root=archive_root(),
         render_root=render_root(),
         sources=get_sources(),
+        # The configured root owns durable tiers; its active query tier may
+        # be selected by an atomic generation pointer elsewhere.
         db_path=default_db_path(),
         drive_config=get_drive_config(),
         index_config=get_index_config(),

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -1215,14 +1215,12 @@ async def run_daemon_services(
     global _daemon_lifecycle, _pidfile_path
     _process_start.started_at_wall()
     archive_root_path = Path(archive_root())
-    from polylogue.paths import active_index_db_path
     from polylogue.storage.archive_identity import assert_writable_archive_identity
 
     # Identity precedes schema checks, pidfiles, HTTP startup, and every other
     # component: a split-root daemon must not become partially observable as a
     # healthy writer before its first ArchiveStore happens to open.
-    active_root = active_index_db_path().parent
-    assert_writable_archive_identity(configured_root=archive_root_path, active_root=active_root)
+    assert_writable_archive_identity(configured_root=archive_root_path, active_root=archive_root_path)
 
     if (
         enable_api

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -687,9 +687,11 @@ def make_default_convergence_stages(
 ) -> tuple[ConvergenceStage, ...]:
     """Build daemon stages, failing explicitly when backed mode lacks transport."""
     from polylogue.archive.query.production_evaluator import ArchiveCanonicalPlanEvaluator
+    from polylogue.paths import archive_root
     from polylogue.sinex.models import PublicationMode
     from polylogue.sinex.service import PublicationService
     from polylogue.sinex.transport import resolve_configured_transport
+    from polylogue.storage.archive_identity import ArchiveLocation
 
     mode = PublicationMode.from_string(load_polylogue_config().sinex_mode)
     stages: list[ConvergenceStage] = []
@@ -699,7 +701,7 @@ def make_default_convergence_stages(
             make_sinex_publication_stage(
                 db_path,
                 PublicationService(
-                    source_db_path=db_path.parent / "source.db",
+                    source_db_path=ArchiveLocation.resolve(archive_root()).configured_tier("source").configured_path,
                     mode=mode,
                     transport=transport,
                 ),

--- a/polylogue/maintenance/replay.py
+++ b/polylogue/maintenance/replay.py
@@ -144,7 +144,12 @@ async def rebuild_index_from_source(
     replay expands to complete logical cohorts so a partial selection cannot
     make an older snapshot look newest.
     """
-    del raw_batch_size, ingest_workers, materialize
+    if raw_batch_size <= 0:
+        raise ValueError("raw_batch_size must be positive")
+    # The caller owns page selection.  Do not widen its bounded page here:
+    # revision backfill may still expand that page to a complete authority
+    # cohort, which is required for correct newest-revision selection.
+    del ingest_workers, materialize
     import asyncio
 
     from polylogue.sources.revision_backfill import backfill_historical_revision_evidence
@@ -166,6 +171,8 @@ async def rebuild_index_from_source(
         "quarantined_raw_count": result.quarantined,
         "adoption_deferred_raw_count": result.adoption_deferred,
         "authority_selection_expanded": True,
+        "scheduled_raw_count": len(raw_ids) if raw_ids is not None else None,
+        "raw_batch_size": raw_batch_size,
     }
 
 

--- a/polylogue/paths/_roots.py
+++ b/polylogue/paths/_roots.py
@@ -78,8 +78,9 @@ def resolve_active_index_db_path(*, db_anchor: Path, index_db: Path) -> Path:
     pointer = archive_root() / ".index-active-pointer"
     if pointer.exists():
         target = Path(pointer.read_text(encoding="utf-8").strip())
-        if target.is_absolute() and target.name == "index.db":
-            return target
+        if not target.is_absolute() or target.name != "index.db":
+            raise RuntimeError(f"invalid active index pointer: {target}")
+        return target
     if db_anchor.name == "index.db":
         return db_anchor
     return index_db

--- a/polylogue/paths/_roots.py
+++ b/polylogue/paths/_roots.py
@@ -75,6 +75,11 @@ def embeddings_db_path() -> Path:
 
 def resolve_active_index_db_path(*, db_anchor: Path, index_db: Path) -> Path:
     """Resolve the active query/index database path."""
+    pointer = archive_root() / ".index-active-pointer"
+    if pointer.exists():
+        target = Path(pointer.read_text(encoding="utf-8").strip())
+        if target.is_absolute() and target.name == "index.db":
+            return target
     if db_anchor.name == "index.db":
         return db_anchor
     return index_db
@@ -122,7 +127,14 @@ def archive_file_set_root_for_paths(*, archive_root_path: Path, db_anchor: Path)
 
 def active_index_db_path() -> Path:
     """Currently active query/index database path."""
-    return index_db_path()
+    root = archive_root()
+    pointer = root / ".index-active-pointer"
+    if pointer.exists():
+        target = Path(pointer.read_text(encoding="utf-8").strip())
+        if not target.is_absolute() or target.name != "index.db":
+            raise RuntimeError(f"invalid active index pointer: {target}")
+        return target
+    return root / "index.db"
 
 
 def browser_capture_spool_root() -> Path:

--- a/polylogue/storage/archive_identity.py
+++ b/polylogue/storage/archive_identity.py
@@ -20,6 +20,79 @@ TIER_FILENAMES: tuple[tuple[ArchiveTierName, str], ...] = (
 )
 
 
+class ArchiveLocationError(RuntimeError):
+    """A configured archive does not name one coherent active file set."""
+
+
+@dataclass(frozen=True)
+class ArchiveLocation:
+    """Resolved archive topology with the active index kept distinct from its root.
+
+    A split-tier installation intentionally keeps durable tiers under the
+    configured root while an atomic pointer selects an index generation
+    elsewhere.  Treating the parent directory of that index as the archive
+    root silently invents sibling tier paths; treating ``root/index.db`` as
+    authoritative silently bypasses a promoted generation.  This value is the
+    one place where those two facts are joined.
+    """
+
+    configured_root: Path
+    configured_tiers: tuple[TierFileIdentity, ...]
+    active_index: TierFileIdentity
+    active_pointer: Path | None
+    shadow_index: TierFileIdentity | None
+
+    @classmethod
+    def resolve(cls, root: Path) -> ArchiveLocation:
+        configured_root = root.absolute()
+        configured = tuple(
+            TierFileIdentity.resolve(name, configured_root / filename) for name, filename in TIER_FILENAMES
+        )
+        configured_index = next(tier for tier in configured if tier.name == "index")
+        pointer_file = configured_root / ".index-active-pointer"
+        pointer: Path | None = None
+        if pointer_file.exists():
+            raw = pointer_file.read_text(encoding="utf-8").strip()
+            candidate = Path(raw)
+            if not candidate.is_absolute() or candidate.name != "index.db":
+                raise ArchiveLocationError(f"invalid active index pointer: {candidate}")
+            pointer = candidate
+        active_index = TierFileIdentity.resolve("index", pointer or configured_index.configured_path)
+        shadow_index: TierFileIdentity | None = None
+        if pointer is not None and configured_index.exists and not configured_index.same_file(active_index):
+            shadow_index = configured_index
+        return cls(
+            configured_root=configured_root,
+            configured_tiers=configured,
+            active_index=active_index,
+            active_pointer=pointer,
+            shadow_index=shadow_index,
+        )
+
+    def configured_tier(self, name: ArchiveTierName) -> TierFileIdentity:
+        return next(tier for tier in self.configured_tiers if tier.name == name)
+
+    def active_tier(self, name: ArchiveTierName) -> TierFileIdentity:
+        return self.active_index if name == "index" else self.configured_tier(name)
+
+    @property
+    def active_index_path(self) -> Path:
+        return self.active_index.configured_path
+
+    @property
+    def active_generation(self) -> str:
+        return self.active_index.stable_id
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "configured_root": str(self.configured_root),
+            "active_pointer": str(self.active_pointer) if self.active_pointer is not None else None,
+            "active_index": self.active_index.as_dict(),
+            "configured_tiers": [tier.as_dict() for tier in self.configured_tiers],
+            "shadow_index": self.shadow_index.as_dict() if self.shadow_index is not None else None,
+        }
+
+
 @dataclass(frozen=True)
 class TierFileIdentity:
     name: ArchiveTierName
@@ -86,6 +159,18 @@ class ArchiveIdentity:
         index = next(tier for tier in tiers if tier.name == "index")
         return cls(root, tiers, index.stable_id, generation_owner, generation_state)
 
+    @classmethod
+    def resolve_location(
+        cls,
+        location: ArchiveLocation,
+        *,
+        generation_owner: str | None = None,
+        generation_state: Literal["active", "inactive"] = "active",
+    ) -> ArchiveIdentity:
+        tiers = tuple(location.active_tier(name) for name, _filename in TIER_FILENAMES)
+        index = next(tier for tier in tiers if tier.name == "index")
+        return cls(location.configured_root, tiers, index.stable_id, generation_owner, generation_state)
+
     def tier(self, name: ArchiveTierName) -> TierFileIdentity:
         return next(tier for tier in self.tiers if tier.name == name)
 
@@ -126,16 +211,18 @@ class ArchiveIdentityConflictError(RuntimeError):
 
 
 def archive_identity_conflicts(*, configured_root: Path, active_root: Path) -> tuple[ArchiveIdentity, ...]:
-    configured = ArchiveIdentity.resolve(configured_root)
-    active = ArchiveIdentity.resolve(active_root)
-    if configured_root.resolve(strict=False) == active_root.resolve(strict=False):
+    configured_location = ArchiveLocation.resolve(configured_root)
+    active_location = ArchiveLocation.resolve(active_root)
+    configured = ArchiveIdentity.resolve_location(configured_location)
+    active = ArchiveIdentity.resolve_location(active_location)
+    if configured.active_generation == active.active_generation:
         return ()
     return (configured,) if configured.conflicts_with(active) else ()
 
 
 def assert_writable_archive_identity(*, configured_root: Path, active_root: Path) -> ArchiveIdentity:
     """Fail before bootstrap when one durable archive has two active indexes."""
-    active = ArchiveIdentity.resolve(active_root)
+    active = ArchiveIdentity.resolve_location(ArchiveLocation.resolve(active_root))
     conflicts = archive_identity_conflicts(configured_root=configured_root, active_root=active_root)
     if conflicts:
         configured = conflicts[0]

--- a/polylogue/storage/index_generation.py
+++ b/polylogue/storage/index_generation.py
@@ -30,6 +30,35 @@ class IndexGeneration:
     source_snapshot: str = ""
 
 
+@dataclass(frozen=True, slots=True)
+class IndexRebuildTransaction:
+    """Durable cursor and candidate ownership for one source-index rebuild.
+
+    A transaction is deliberately retained while it is paused or failed.  The
+    inactive generation is useful work, not disposable scratch: resuming the
+    same source snapshot continues from the next raw key without exposing a
+    partial index to readers.
+    """
+
+    operation_id: str
+    generation_id: str
+    generation_owner_id: str
+    source_snapshot: str
+    status: str
+    created_at_ms: int
+    updated_at_ms: int
+    last_acquired_at_ms: int | None = None
+    last_raw_id: str | None = None
+    processed_raw_count: int = 0
+    error: str | None = None
+
+    @property
+    def cursor(self) -> str | None:
+        if self.last_acquired_at_ms is None or self.last_raw_id is None:
+            return None
+        return f"source:{self.last_acquired_at_ms}:{self.last_raw_id}"
+
+
 class RebuildLeaseUnavailableError(RuntimeError):
     """Another process owns the archive-wide rebuild lease."""
 
@@ -115,6 +144,104 @@ class IndexGenerationStore:
             os.replace(temporary, anchor)
             _fsync_directory(anchor.parent)
         self.generations_root = self.active_pointer.parent / ".index-generations"
+        self.transactions_root = self.active_pointer.parent / ".index-rebuild-transactions"
+
+    def create_transaction(
+        self,
+        *,
+        source_snapshot: str,
+        operation_id: str | None = None,
+    ) -> IndexRebuildTransaction:
+        """Create an inactive candidate and its resumable transaction record."""
+        op_id = operation_id or str(uuid.uuid4())
+        path = self._transaction_path(op_id)
+        if path.exists():
+            raise RuntimeError(f"rebuild transaction already exists: {op_id}")
+        generation = self.create(source_snapshot=source_snapshot)
+        now = int(time.time() * 1000)
+        transaction = IndexRebuildTransaction(
+            operation_id=op_id,
+            generation_id=generation.generation_id,
+            generation_owner_id=generation.owner_id,
+            source_snapshot=source_snapshot,
+            status="running",
+            created_at_ms=now,
+            updated_at_ms=now,
+        )
+        self.save_transaction(transaction)
+        return transaction
+
+    def load_transaction(self, operation_id: str) -> IndexRebuildTransaction:
+        """Load a rebuild transaction; corrupt or missing state is never resumed."""
+        payload = json.loads(self._transaction_path(operation_id).read_text(encoding="utf-8"))
+        return IndexRebuildTransaction(**payload)
+
+    def save_transaction(self, transaction: IndexRebuildTransaction) -> IndexRebuildTransaction:
+        """Atomically checkpoint a transaction after one bounded replay pass."""
+        updated = IndexRebuildTransaction(**{**asdict(transaction), "updated_at_ms": int(time.time() * 1000)})
+        path = self._transaction_path(transaction.operation_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_suffix(".json.tmp")
+        temporary.write_text(json.dumps(asdict(updated), indent=2, sort_keys=True), encoding="utf-8")
+        os.replace(temporary, path)
+        _fsync_directory(path.parent)
+        return updated
+
+    def checkpoint_transaction(
+        self,
+        transaction: IndexRebuildTransaction,
+        *,
+        status: str,
+        last_acquired_at_ms: int | None = None,
+        last_raw_id: str | None = None,
+        processed_raw_count: int | None = None,
+        error: str | None = None,
+    ) -> IndexRebuildTransaction:
+        """Persist one state transition without changing candidate ownership."""
+        return self.save_transaction(
+            IndexRebuildTransaction(
+                **{
+                    **asdict(transaction),
+                    "status": status,
+                    "last_acquired_at_ms": last_acquired_at_ms
+                    if last_acquired_at_ms is not None
+                    else transaction.last_acquired_at_ms,
+                    "last_raw_id": last_raw_id if last_raw_id is not None else transaction.last_raw_id,
+                    "processed_raw_count": processed_raw_count
+                    if processed_raw_count is not None
+                    else transaction.processed_raw_count,
+                    "error": error,
+                }
+            )
+        )
+
+    def next_raw_page(
+        self,
+        transaction: IndexRebuildTransaction,
+        *,
+        limit: int,
+    ) -> tuple[tuple[str, int], ...]:
+        """Read one source-order page without archive-wide raw-id materialization."""
+        if limit <= 0:
+            raise ValueError("rebuild raw page limit must be positive")
+        source_db = self.archive_root / "source.db"
+        if transaction.last_acquired_at_ms is None or transaction.last_raw_id is None:
+            query = """
+                SELECT raw_id, acquired_at_ms FROM raw_sessions
+                ORDER BY acquired_at_ms, raw_id LIMIT ?
+            """
+            params: tuple[object, ...] = (limit,)
+        else:
+            query = """
+                SELECT raw_id, acquired_at_ms FROM raw_sessions
+                WHERE acquired_at_ms > ?
+                   OR (acquired_at_ms = ? AND raw_id > ?)
+                ORDER BY acquired_at_ms, raw_id LIMIT ?
+            """
+            params = (transaction.last_acquired_at_ms, transaction.last_acquired_at_ms, transaction.last_raw_id, limit)
+        with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as conn:
+            rows = conn.execute(query, params).fetchall()
+        return tuple((str(raw_id), int(acquired_at_ms)) for raw_id, acquired_at_ms in rows)
 
     def create(self, *, owner_id: str | None = None, source_snapshot: str) -> IndexGeneration:
         generation_id = f"gen-{int(time.time() * 1000)}-{uuid.uuid4().hex[:8]}"
@@ -202,6 +329,9 @@ class IndexGenerationStore:
     def _metadata_path(self, generation_id: str) -> Path:
         return self.generations_root / generation_id / "generation.json"
 
+    def _transaction_path(self, operation_id: str) -> Path:
+        return self.transactions_root / f"{operation_id}.json"
+
     def _write(self, generation: IndexGeneration) -> None:
         path = self._metadata_path(generation.generation_id)
         temporary = path.with_suffix(".json.tmp")
@@ -244,6 +374,7 @@ def _fsync_directory(path: Path) -> None:
 __all__ = [
     "ActiveWriterLease",
     "IndexGeneration",
+    "IndexRebuildTransaction",
     "IndexGenerationStore",
     "RebuildLease",
     "RebuildLeaseUnavailableError",

--- a/polylogue/storage/index_generation.py
+++ b/polylogue/storage/index_generation.py
@@ -50,6 +50,9 @@ class IndexRebuildTransaction:
     last_acquired_at_ms: int | None = None
     last_raw_id: str | None = None
     processed_raw_count: int = 0
+    processed_blob_bytes: int = 0
+    pass_byte_budget: int | None = None
+    pass_deadline_ms: int | None = None
     error: str | None = None
 
     @property
@@ -57,6 +60,20 @@ class IndexRebuildTransaction:
         if self.last_acquired_at_ms is None or self.last_raw_id is None:
             return None
         return f"source:{self.last_acquired_at_ms}:{self.last_raw_id}"
+
+
+@dataclass(frozen=True, slots=True)
+class RebuildRawPage:
+    """One bounded source-order scheduling decision.
+
+    ``deferred_reason`` is scheduling evidence, not an admission decision: an
+    oversized first row is still scheduled alone, and every later row remains
+    reachable from the persisted keyset cursor on a later invocation.
+    """
+
+    rows: tuple[tuple[str, int, int], ...]
+    has_more: bool
+    deferred_reason: str | None = None
 
 
 class RebuildLeaseUnavailableError(RuntimeError):
@@ -151,6 +168,8 @@ class IndexGenerationStore:
         *,
         source_snapshot: str,
         operation_id: str | None = None,
+        pass_byte_budget: int | None = None,
+        pass_deadline_ms: int | None = None,
     ) -> IndexRebuildTransaction:
         """Create an inactive candidate and its resumable transaction record."""
         op_id = operation_id or str(uuid.uuid4())
@@ -167,6 +186,8 @@ class IndexGenerationStore:
             status="running",
             created_at_ms=now,
             updated_at_ms=now,
+            pass_byte_budget=pass_byte_budget,
+            pass_deadline_ms=pass_deadline_ms,
         )
         self.save_transaction(transaction)
         return transaction
@@ -195,6 +216,7 @@ class IndexGenerationStore:
         last_acquired_at_ms: int | None = None,
         last_raw_id: str | None = None,
         processed_raw_count: int | None = None,
+        processed_blob_bytes: int | None = None,
         error: str | None = None,
     ) -> IndexRebuildTransaction:
         """Persist one state transition without changing candidate ownership."""
@@ -210,6 +232,9 @@ class IndexGenerationStore:
                     "processed_raw_count": processed_raw_count
                     if processed_raw_count is not None
                     else transaction.processed_raw_count,
+                    "processed_blob_bytes": processed_blob_bytes
+                    if processed_blob_bytes is not None
+                    else transaction.processed_blob_bytes,
                     "error": error,
                 }
             )
@@ -220,28 +245,50 @@ class IndexGenerationStore:
         transaction: IndexRebuildTransaction,
         *,
         limit: int,
-    ) -> tuple[tuple[str, int], ...]:
-        """Read one source-order page without archive-wide raw-id materialization."""
+    ) -> RebuildRawPage:
+        """Schedule one source-order page without materializing archive-wide IDs."""
         if limit <= 0:
             raise ValueError("rebuild raw page limit must be positive")
         source_db = self.archive_root / "source.db"
         if transaction.last_acquired_at_ms is None or transaction.last_raw_id is None:
             query = """
-                SELECT raw_id, acquired_at_ms FROM raw_sessions
+                SELECT raw_id, acquired_at_ms, blob_size FROM raw_sessions
                 ORDER BY acquired_at_ms, raw_id LIMIT ?
             """
-            params: tuple[object, ...] = (limit,)
+            params: tuple[object, ...] = (limit + 1,)
         else:
             query = """
-                SELECT raw_id, acquired_at_ms FROM raw_sessions
+                SELECT raw_id, acquired_at_ms, blob_size FROM raw_sessions
                 WHERE acquired_at_ms > ?
                    OR (acquired_at_ms = ? AND raw_id > ?)
                 ORDER BY acquired_at_ms, raw_id LIMIT ?
             """
-            params = (transaction.last_acquired_at_ms, transaction.last_acquired_at_ms, transaction.last_raw_id, limit)
+            params = (
+                transaction.last_acquired_at_ms,
+                transaction.last_acquired_at_ms,
+                transaction.last_raw_id,
+                limit + 1,
+            )
         with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as conn:
             rows = conn.execute(query, params).fetchall()
-        return tuple((str(raw_id), int(acquired_at_ms)) for raw_id, acquired_at_ms in rows)
+        selected: list[tuple[str, int, int]] = []
+        selected_bytes = 0
+        deferred_reason: str | None = None
+        budget = transaction.pass_byte_budget
+        for raw_id, acquired_at_ms, blob_size in rows:
+            raw = (str(raw_id), int(acquired_at_ms), int(blob_size or 0))
+            if budget is not None and selected and selected_bytes + raw[2] > budget:
+                deferred_reason = "byte-budget"
+                break
+            # A single oversized raw must never become permanently ineligible.
+            selected.append(raw)
+            selected_bytes += raw[2]
+            if len(selected) == limit:
+                break
+        has_more = len(rows) > len(selected)
+        if has_more and deferred_reason is None:
+            deferred_reason = "raw-batch"
+        return RebuildRawPage(rows=tuple(selected), has_more=has_more, deferred_reason=deferred_reason)
 
     def create(self, *, owner_id: str | None = None, source_snapshot: str) -> IndexGeneration:
         generation_id = f"gen-{int(time.time() * 1000)}-{uuid.uuid4().hex[:8]}"
@@ -346,12 +393,16 @@ def source_revision_snapshot(archive_root: Path) -> str:
 
     digest = hashlib.sha256()
     with closing(sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True)) as conn:
-        for raw_id, acquired_at_ms in conn.execute(
-            "SELECT raw_id, acquired_at_ms FROM raw_sessions ORDER BY acquired_at_ms, raw_id"
+        for raw_id, acquired_at_ms, blob_hash, blob_size, validation_status in conn.execute(
+            """
+            SELECT raw_id, acquired_at_ms, blob_hash, blob_size, validation_status
+            FROM raw_sessions
+            ORDER BY acquired_at_ms, raw_id
+            """
         ):
-            digest.update(str(raw_id).encode())
-            digest.update(b"\0")
-            digest.update(str(acquired_at_ms).encode())
+            for value in (raw_id, acquired_at_ms, bytes(blob_hash).hex(), blob_size, validation_status):
+                digest.update(str(value).encode())
+                digest.update(b"\0")
             digest.update(b"\n")
     return digest.hexdigest()
 
@@ -376,6 +427,7 @@ __all__ = [
     "IndexGeneration",
     "IndexRebuildTransaction",
     "IndexGenerationStore",
+    "RebuildRawPage",
     "RebuildLease",
     "RebuildLeaseUnavailableError",
     "source_revision_snapshot",

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -1722,6 +1722,82 @@ def test_all_index_rebuild_raw_ids_uses_source_acquisition_order(
     ]
 
 
+def test_rebuild_index_full_source_resumes_one_candidate_until_terminal_promotion(
+    cli_workspace: dict[str, Path], cli_runner: CliRunner
+) -> None:
+    """A bounded pass retains its generation; only the terminal resume promotes it."""
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    root = cli_workspace["archive_root"]
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        for native_id, acquired_at_ms in (("first", 1), ("second", 2)):
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=(
+                    f'{{"type":"session_meta","payload":{{"id":"{native_id}"}}}}\\n'
+                    f'{{"type":"response_item","payload":{{"type":"message","role":"user",'
+                    f'"content":[{{"type":"input_text","text":"{native_id}"}}]}}}}\\n'
+                ).encode(),
+                source_path=f"{native_id}.jsonl",
+                acquired_at_ms=acquired_at_ms,
+            )
+
+    first = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "rebuild-index", "--raw-batch-size", "1", "--output-format", "json"],
+        catch_exceptions=False,
+    )
+    assert first.exit_code == 0
+    first_payload = json.loads(first.output)
+    operation_id = first_payload["transaction"]["operation_id"]
+    generation_path = Path(first_payload["generation"]["index_path"])
+    assert first_payload["status"] == "paused"
+    assert first_payload["transaction"]["processed_raw_count"] == 1
+    assert generation_path.exists()
+    assert root.joinpath("index.db").resolve() != generation_path.resolve()
+
+    second = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "rebuild-index",
+            "--operation-id",
+            operation_id,
+            "--raw-batch-size",
+            "1",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert second.exit_code == 0
+    assert json.loads(second.output)["status"] == "paused"
+
+    terminal = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "rebuild-index",
+            "--operation-id",
+            operation_id,
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert terminal.exit_code == 0
+    terminal_payload = json.loads(terminal.output)
+    assert terminal_payload["status"] == "replayed"
+    assert terminal_payload["transaction"]["status"] == "promoted"
+    assert root.joinpath("index.db").resolve() == generation_path.resolve()
+    with sqlite3.connect(root / "index.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone() == (2,)
+
+
 def test_rebuild_index_helper_returns_typed_empty_replay_receipt(tmp_path: Path) -> None:
     config = Config(
         archive_root=tmp_path,
@@ -1748,6 +1824,8 @@ def test_rebuild_index_helper_returns_typed_empty_replay_receipt(tmp_path: Path)
         "quarantined_raw_count": 0,
         "adoption_deferred_raw_count": 0,
         "authority_selection_expanded": True,
+        "scheduled_raw_count": 2,
+        "raw_batch_size": 7,
     }
 
 

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -1756,7 +1756,7 @@ def test_rebuild_index_full_source_resumes_one_candidate_until_terminal_promotio
     assert generation_path.exists()
     assert root.joinpath("index.db").resolve() != generation_path.resolve()
 
-    second = cli_runner.invoke(
+    terminal = cli_runner.invoke(
         cli,
         [
             "--plain",
@@ -1772,9 +1772,53 @@ def test_rebuild_index_full_source_resumes_one_candidate_until_terminal_promotio
         ],
         catch_exceptions=False,
     )
-    assert second.exit_code == 0
-    assert json.loads(second.output)["status"] == "paused"
+    assert terminal.exit_code == 0
+    terminal_payload = json.loads(terminal.output)
+    assert terminal_payload["status"] == "replayed"
+    assert terminal_payload["transaction"]["status"] == "promoted"
+    assert root.joinpath("index.db").resolve() == generation_path.resolve()
+    with sqlite3.connect(root / "index.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone() == (2,)
 
+
+def test_rebuild_index_byte_budget_defers_then_reaches_terminal_ready_candidate(
+    cli_workspace: dict[str, Path], cli_runner: CliRunner
+) -> None:
+    """The real CLI replays every raw over passes; byte budgeting never filters archive data."""
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    root = cli_workspace["archive_root"]
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        for native_id, acquired_at_ms, padding in (("large", 1, "x" * 1_024), ("later", 2, "y")):
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=(
+                    f'{{"type":"session_meta","payload":{{"id":"{native_id}"}}}}\\n'
+                    f'{{"type":"response_item","payload":{{"type":"message","role":"user",'
+                    f'"content":[{{"type":"input_text","text":"{padding}"}}]}}}}\\n'
+                ).encode(),
+                source_path=f"{native_id}.jsonl",
+                acquired_at_ms=acquired_at_ms,
+            )
+    first = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "rebuild-index",
+            "--pass-byte-budget-mb",
+            "0.0001",
+            "--no-promote",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert first.exit_code == 0
+    first_payload = json.loads(first.output)
+    assert first_payload["status"] == "deferred"
+    operation_id = first_payload["transaction"]["operation_id"]
     terminal = cli_runner.invoke(
         cli,
         [
@@ -1784,18 +1828,110 @@ def test_rebuild_index_full_source_resumes_one_candidate_until_terminal_promotio
             "rebuild-index",
             "--operation-id",
             operation_id,
+            "--no-promote",
             "--output-format",
             "json",
         ],
         catch_exceptions=False,
     )
     assert terminal.exit_code == 0
-    terminal_payload = json.loads(terminal.output)
-    assert terminal_payload["status"] == "replayed"
-    assert terminal_payload["transaction"]["status"] == "promoted"
-    assert root.joinpath("index.db").resolve() == generation_path.resolve()
-    with sqlite3.connect(root / "index.db") as conn:
+    payload = json.loads(terminal.output)
+    assert payload["transaction"]["status"] == "ready"
+    assert payload["generation"]["state"] == "inactive"
+    with sqlite3.connect(Path(payload["generation"]["index_path"])) as conn:
         assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone() == (2,)
+
+
+def test_rebuild_index_source_snapshot_drift_marks_candidate_stale_before_promotion(
+    cli_workspace: dict[str, Path], cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A changed source vector is terminal evidence, never a ready/promoted candidate."""
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    root = cli_workspace["archive_root"]
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=(
+                b'{"type":"session_meta","payload":{"id":"drift"}}\n'
+                b'{"type":"response_item","payload":{"type":"message","role":"user",'
+                b'"content":[{"type":"input_text","text":"drift"}]}}\n'
+            ),
+            source_path="drift.jsonl",
+            acquired_at_ms=1,
+        )
+    snapshots = iter(("source-v1", "source-v1", "source-v2"))
+    monkeypatch.setattr("polylogue.storage.index_generation.source_revision_snapshot", lambda _root: next(snapshots))
+    result = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "rebuild-index", "--output-format", "json"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 1
+    assert "stale because source evidence changed" in result.output
+    transaction = next((root / ".index-rebuild-transactions").glob("*.json"))
+    assert json.loads(transaction.read_text())["status"] == "stale"
+    assert not root.joinpath("index.db").is_symlink()
+
+
+def test_rebuild_index_deadline_defers_postflight_until_resume(
+    cli_workspace: dict[str, Path], cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deadline expiry preserves the replayed candidate instead of permitting early promotion."""
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    root = cli_workspace["archive_root"]
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=(
+                b'{"type":"session_meta","payload":{"id":"deadline"}}\n'
+                b'{"type":"response_item","payload":{"type":"message","role":"user",'
+                b'"content":[{"type":"input_text","text":"deadline"}]}}\n'
+            ),
+            source_path="deadline.jsonl",
+            acquired_at_ms=1,
+        )
+    clock = [100.0, 102.0]
+    monkeypatch.setattr(
+        "polylogue.cli.commands.maintenance._rebuild_index.time.time",
+        lambda: clock.pop(0) if clock else 102.0,
+    )
+    first = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "rebuild-index",
+            "--pass-deadline-seconds",
+            "1",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert first.exit_code == 0
+    payload = json.loads(first.output)
+    assert payload["status"] == "deferred"
+    assert payload["transaction"]["status"] == "deferred"
+    assert not root.joinpath("index.db").is_symlink()
+    resumed = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "rebuild-index",
+            "--operation-id",
+            payload["transaction"]["operation_id"],
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert resumed.exit_code == 0
+    assert json.loads(resumed.output)["transaction"]["status"] == "promoted"
 
 
 def test_rebuild_index_helper_returns_typed_empty_replay_receipt(tmp_path: Path) -> None:

--- a/tests/unit/cli/test_debt_command.py
+++ b/tests/unit/cli/test_debt_command.py
@@ -64,15 +64,13 @@ def test_debt_list_json_uses_shared_payload(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    index_db = tmp_path / "index.db"
-    index_db.touch()
     captured: dict[str, object] = {}
 
     def fake_archive_debt_list(**kwargs: object) -> ArchiveDebtListPayload:
         captured.update(kwargs)
         return _payload(tmp_path)
 
-    monkeypatch.setattr("polylogue.cli.commands.debt.active_index_db_path", lambda: index_db)
+    monkeypatch.setattr("polylogue.cli.commands.debt.archive_root", lambda: tmp_path)
     monkeypatch.setattr("polylogue.cli.commands.debt.archive_debt_list", fake_archive_debt_list)
 
     result = cli_runner.invoke(cli, ["--plain", "ops", "debt", "list", "--kind", "embedding", "--format", "json"])
@@ -91,15 +89,13 @@ def test_debt_list_json_passes_status_filter(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    index_db = tmp_path / "index.db"
-    index_db.touch()
     captured: dict[str, object] = {}
 
     def fake_archive_debt_list(**kwargs: object) -> ArchiveDebtListPayload:
         captured.update(kwargs)
         return _payload(tmp_path)
 
-    monkeypatch.setattr("polylogue.cli.commands.debt.active_index_db_path", lambda: index_db)
+    monkeypatch.setattr("polylogue.cli.commands.debt.archive_root", lambda: tmp_path)
     monkeypatch.setattr("polylogue.cli.commands.debt.archive_debt_list", fake_archive_debt_list)
 
     result = cli_runner.invoke(
@@ -116,9 +112,7 @@ def test_debt_list_text_renders_actionable_summary(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    index_db = tmp_path / "index.db"
-    index_db.touch()
-    monkeypatch.setattr("polylogue.cli.commands.debt.active_index_db_path", lambda: index_db)
+    monkeypatch.setattr("polylogue.cli.commands.debt.archive_root", lambda: tmp_path)
     monkeypatch.setattr("polylogue.cli.commands.debt.archive_debt_list", lambda **_kwargs: _payload(tmp_path))
 
     result = cli_runner.invoke(cli, ["--plain", "ops", "debt", "list"])

--- a/tests/unit/cli/test_reset.py
+++ b/tests/unit/cli/test_reset.py
@@ -283,6 +283,50 @@ class TestResetCommandDeletion:
         assert all(path.exists() for path in preserved)
         assert "index database" in result.output
 
+    def test_reset_index_refuses_to_delete_managed_active_generation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
+        archive_root = tmp_path / "archive"
+        _source_db, _rebuildable, _user_db = self._seed_archive_tiers(archive_root)
+        canonical = tmp_path / "canonical"
+        canonical.mkdir()
+        active = canonical / "index.db"
+        active.write_text("active generation", encoding="utf-8")
+        (archive_root / ".index-active-pointer").write_text(str(active), encoding="utf-8")
+
+        with (
+            patch("polylogue.cli.commands.reset.archive_root", return_value=archive_root),
+            patch("polylogue.cli.commands.reset.data_home", return_value=tmp_path),
+        ):
+            result = CliRunner().invoke(cli, ["ops", "reset", "--index", "--yes"])
+
+        assert result.exit_code == 1
+        assert "unsafe for a managed active generation" in result.output
+        assert active.read_text(encoding="utf-8") == "active generation"
+
+    def test_reset_database_refuses_to_delete_managed_active_generation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
+        archive_root = tmp_path / "archive"
+        _source_db, _rebuildable, _user_db = self._seed_archive_tiers(archive_root)
+        canonical = tmp_path / "canonical"
+        canonical.mkdir()
+        active = canonical / "index.db"
+        active.write_text("active generation", encoding="utf-8")
+        (archive_root / ".index-active-pointer").write_text(str(active), encoding="utf-8")
+
+        with (
+            patch("polylogue.cli.commands.reset.archive_root", return_value=archive_root),
+            patch("polylogue.cli.commands.reset.data_home", return_value=tmp_path),
+        ):
+            result = CliRunner().invoke(cli, ["ops", "reset", "--database", "--yes"])
+
+        assert result.exit_code == 1
+        assert "unsafe for a managed active generation" in result.output
+        assert active.read_text(encoding="utf-8") == "active generation"
+
     def test_reset_database_preserves_source_and_irreplaceable_user_db(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/core/test_paths.py
+++ b/tests/unit/core/test_paths.py
@@ -7,7 +7,22 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
+from polylogue.paths import active_index_db_path
 from polylogue.paths.sanitize import is_within_root, safe_path_component
+
+
+def test_active_index_path_follows_managed_pointer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "archive"
+    root.mkdir()
+    canonical = tmp_path / "canonical" / "index.db"
+    canonical.parent.mkdir()
+    canonical.touch()
+    (root / ".index-active-pointer").write_text(str(canonical), encoding="utf-8")
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+
+    assert active_index_db_path() == canonical
 
 
 class TestSafePathComponent:

--- a/tests/unit/core/test_paths.py
+++ b/tests/unit/core/test_paths.py
@@ -9,7 +9,8 @@ from pathlib import Path
 
 import pytest
 
-from polylogue.paths import active_index_db_path
+from polylogue.config import get_config
+from polylogue.paths import active_index_db_path, resolve_active_index_db_path
 from polylogue.paths.sanitize import is_within_root, safe_path_component
 
 
@@ -23,6 +24,39 @@ def test_active_index_path_follows_managed_pointer(tmp_path: Path, monkeypatch: 
     monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
 
     assert active_index_db_path() == canonical
+
+
+def test_external_active_pointer_changes_only_the_index_tier(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "archive"
+    root.mkdir()
+    canonical = tmp_path / "canonical" / "index.db"
+    canonical.parent.mkdir()
+    canonical.touch()
+    (root / ".index-active-pointer").write_text(str(canonical), encoding="utf-8")
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+
+    config = get_config()
+
+    assert config.archive_root == root
+    assert config.db_path == canonical
+    assert config.archive_root / "source.db" == root / "source.db"
+    assert config.archive_root / "user.db" == root / "user.db"
+    assert config.archive_root / "ops.db" == root / "ops.db"
+
+
+@pytest.mark.parametrize("pointer_value", ("relative/index.db", "/tmp/not-index.db"))
+def test_all_active_index_resolvers_reject_malformed_pointer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, pointer_value: str
+) -> None:
+    root = tmp_path / "archive"
+    root.mkdir()
+    (root / ".index-active-pointer").write_text(pointer_value, encoding="utf-8")
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+
+    with pytest.raises(RuntimeError, match="invalid active index pointer"):
+        active_index_db_path()
+    with pytest.raises(RuntimeError, match="invalid active index pointer"):
+        resolve_active_index_db_path(db_anchor=root / "source.db", index_db=root / "index.db")
 
 
 class TestSafePathComponent:

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -69,6 +69,34 @@ def test_default_convergence_stages_retry_bounded_false_results(tmp_path: Path) 
     assert stages_by_name["insights"].false_means_pending is True
 
 
+def test_sinex_stage_uses_configured_source_tier_not_active_index_parent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from polylogue.sinex.models import PublicationMode
+
+    configured_root = tmp_path / "configured"
+    captured: dict[str, object] = {}
+
+    class CapturePublicationService:
+        mode = PublicationMode.PRIMARY
+
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def blocking_object_ids(self, object_ids: object) -> set[str]:
+            del object_ids
+            return set()
+
+    monkeypatch.setattr(stages, "load_polylogue_config", lambda: SimpleNamespace(sinex_mode="primary"))
+    monkeypatch.setattr("polylogue.paths.archive_root", lambda: configured_root)
+    monkeypatch.setattr("polylogue.sinex.service.PublicationService", CapturePublicationService)
+    monkeypatch.setattr("polylogue.sinex.transport.resolve_configured_transport", lambda: object())
+
+    make_default_convergence_stages(tmp_path / "external-generation" / "index.db")
+
+    assert captured["source_db_path"] == configured_root / "source.db"
+
+
 def test_file_probe_exceptions_log_and_fail_toward_work(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -2722,7 +2722,6 @@ def test_run_daemon_services_checks_archive_identity_before_component_startup(tm
     configure = Mock()
     with (
         patch("polylogue.paths.archive_root", return_value=tmp_path / "configured"),
-        patch("polylogue.paths.active_index_db_path", return_value=tmp_path / "active" / "index.db"),
         patch(
             "polylogue.storage.archive_identity.assert_writable_archive_identity",
             side_effect=ArchiveIdentityConflictError("split root"),

--- a/tests/unit/storage/test_archive_identity.py
+++ b/tests/unit/storage/test_archive_identity.py
@@ -7,6 +7,7 @@ import pytest
 from polylogue.storage.archive_identity import (
     ArchiveIdentity,
     ArchiveIdentityConflictError,
+    ArchiveLocation,
     assert_writable_archive_identity,
 )
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -30,6 +31,25 @@ def test_path_aliases_resolve_to_equal_archive_identity(tmp_path: Path) -> None:
     assert direct.durable_id == through_alias.durable_id
     assert direct.active_generation == through_alias.active_generation
     assert not direct.conflicts_with(through_alias)
+
+
+def test_location_keeps_durable_tiers_at_configured_root_and_follows_active_pointer(tmp_path: Path) -> None:
+    configured = tmp_path / "configured"
+    canonical = tmp_path / "canonical"
+    _touch_tiers(configured)
+    _touch_tiers(canonical)
+    for name in ("source.db", "user.db", "ops.db", "embeddings.db"):
+        (configured / name).unlink()
+        (configured / name).symlink_to(canonical / name)
+    (configured / ".index-active-pointer").write_text(str(canonical / "index.db"), encoding="utf-8")
+
+    location = ArchiveLocation.resolve(configured)
+
+    assert location.active_index_path == canonical / "index.db"
+    assert location.active_tier("source").resolved_path == (canonical / "source.db").resolve()
+    assert location.active_tier("ops").resolved_path == (canonical / "ops.db").resolve()
+    assert location.shadow_index is not None
+    assert location.shadow_index.resolved_path == configured / "index.db"
 
 
 def test_split_roots_sharing_durable_tiers_reject_distinct_indexes_before_mutation(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_incremental_rebuild_equivalence.py
+++ b/tests/unit/storage/test_incremental_rebuild_equivalence.py
@@ -1069,6 +1069,8 @@ def test_incremental_restart_and_fresh_generation_rebuild_are_equivalent(
         "quarantined_raw_count": 0,
         "adoption_deferred_raw_count": 0,
         "authority_selection_expanded": True,
+        "scheduled_raw_count": 4,
+        "raw_batch_size": 500,
     }
     rebuilt_insights = repair_session_insights(
         _config(generation_root, index_path=generation_path),

--- a/tests/unit/storage/test_index_generation.py
+++ b/tests/unit/storage/test_index_generation.py
@@ -12,6 +12,7 @@ from polylogue.storage.index_generation import (
     IndexGenerationStore,
     RebuildLease,
     RebuildLeaseUnavailableError,
+    source_revision_snapshot,
 )
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
@@ -198,9 +199,12 @@ def test_rebuild_transaction_persists_keyset_cursor_without_materializing_archiv
             )
 
     store = IndexGenerationStore(tmp_path)
-    transaction = store.create_transaction(source_snapshot="source-v1", operation_id="resume-me")
+    transaction = store.create_transaction(
+        source_snapshot="source-v1", operation_id="resume-me", pass_byte_budget=2, pass_deadline_ms=5_000
+    )
     first_page = store.next_raw_page(transaction, limit=2)
-    assert first_page == (("raw-a", 10), ("raw-b", 10))
+    assert first_page.rows == (("raw-a", 10, 1), ("raw-b", 10, 1))
+    assert first_page.deferred_reason == "raw-batch"
 
     transaction = store.checkpoint_transaction(
         transaction,
@@ -211,4 +215,45 @@ def test_rebuild_transaction_persists_keyset_cursor_without_materializing_archiv
     )
     assert transaction.cursor == "source:10:raw-b"
     assert store.load_transaction("resume-me") == transaction
-    assert store.next_raw_page(transaction, limit=2) == (("raw-c", 30),)
+    assert store.next_raw_page(transaction, limit=2).rows == (("raw-c", 30, 1),)
+    assert transaction.pass_byte_budget == 2
+
+
+def test_rebuild_byte_budget_defers_without_excluding_an_oversized_first_raw(tmp_path: Path) -> None:
+    _archive(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        for raw_id, acquired_at_ms, blob_size in (("large", 1, 100), ("later", 2, 1)):
+            conn.execute(
+                """INSERT INTO raw_sessions (raw_id, origin, native_id, source_path, source_index, blob_hash,
+                   blob_size, acquired_at_ms, validation_status)
+                   VALUES (?, 'codex-session', ?, ?, 0, randomblob(32), ?, ?, 'passed')""",
+                (raw_id, raw_id, f"/{raw_id}", blob_size, acquired_at_ms),
+            )
+    store = IndexGenerationStore(tmp_path)
+    transaction = store.create_transaction(source_snapshot="source-v1", pass_byte_budget=10)
+    first = store.next_raw_page(transaction, limit=10)
+    assert first.rows == (("large", 1, 100),)
+    assert first.deferred_reason == "byte-budget"
+    transaction = store.checkpoint_transaction(
+        transaction,
+        status="deferred",
+        last_acquired_at_ms=1,
+        last_raw_id="large",
+        processed_raw_count=1,
+        processed_blob_bytes=100,
+    )
+    assert store.next_raw_page(transaction, limit=10).rows == (("later", 2, 1),)
+
+
+def test_source_snapshot_changes_when_retained_blob_identity_changes(tmp_path: Path) -> None:
+    _archive(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute(
+            """INSERT INTO raw_sessions (raw_id, origin, native_id, source_path, source_index, blob_hash,
+               blob_size, acquired_at_ms, validation_status)
+               VALUES ('raw-a', 'codex-session', 'raw-a', '/raw-a', 0, randomblob(32), 1, 1, 'passed')"""
+        )
+    before = source_revision_snapshot(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute("UPDATE raw_sessions SET blob_hash = randomblob(32), blob_size = 2 WHERE raw_id = 'raw-a'")
+    assert source_revision_snapshot(tmp_path) != before

--- a/tests/unit/storage/test_index_generation.py
+++ b/tests/unit/storage/test_index_generation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import multiprocessing
+import sqlite3
 from dataclasses import replace
 from pathlib import Path
 
@@ -180,3 +181,34 @@ def test_symlinked_configured_index_promotes_canonical_target(tmp_path: Path) ->
     assert configured.joinpath("index.db").stat().st_ino == canonical.joinpath("index.db").stat().st_ino
     assert canonical.joinpath("index.db").resolve() == Path(second.index_path).resolve()
     assert len(tuple(store.generations_root.glob("retired-*/index.db"))) == 2
+
+
+def test_rebuild_transaction_persists_keyset_cursor_without_materializing_archive(tmp_path: Path) -> None:
+    _archive(tmp_path)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        for raw_id, acquired_at_ms in (("raw-c", 30), ("raw-a", 10), ("raw-b", 10)):
+            conn.execute(
+                """
+                INSERT INTO raw_sessions (
+                    raw_id, origin, native_id, source_path, source_index, blob_hash,
+                    blob_size, acquired_at_ms, validation_status
+                ) VALUES (?, 'codex-session', ?, ?, 0, randomblob(32), 1, ?, 'passed')
+                """,
+                (raw_id, raw_id, f"/{raw_id}.jsonl", acquired_at_ms),
+            )
+
+    store = IndexGenerationStore(tmp_path)
+    transaction = store.create_transaction(source_snapshot="source-v1", operation_id="resume-me")
+    first_page = store.next_raw_page(transaction, limit=2)
+    assert first_page == (("raw-a", 10), ("raw-b", 10))
+
+    transaction = store.checkpoint_transaction(
+        transaction,
+        status="paused",
+        last_acquired_at_ms=10,
+        last_raw_id="raw-b",
+        processed_raw_count=2,
+    )
+    assert transaction.cursor == "source:10:raw-b"
+    assert store.load_transaction("resume-me") == transaction
+    assert store.next_raw_page(transaction, limit=2) == (("raw-c", 30),)


### PR DESCRIPTION
## Summary

Make the configured archive root and its atomically selected index generation one explicit location contract.

## Problem

A split-tier archive may keep durable tiers under its configured root while an active-index pointer selects a generation elsewhere. Direct `root/index.db` consumers bypassed that pointer, allowed reset to create a shadow index, and made diagnostics infer missing durable siblings from the generation directory.

## Solution

Adds `ArchiveLocation`, routes active-index configuration, reset, rebuild planning, and path diagnostics through it, and refuses destructive reset operations against a managed active generation. Legacy no-pointer layouts retain their prior behavior.

## Verification

- `devtools test tests/unit/storage/test_archive_identity.py tests/unit/storage/test_index_generation.py tests/unit/core/test_paths.py tests/unit/cli/test_reset.py tests/unit/cli/test_archive_maintenance_cli.py` — 124 passed.
- `ruff check …` and strict mypy on changed production modules — clean.
- `devtools verify --seed-testmon --skip-slow` — all static/generated gates passed; seeded full pytest had 41 broad failures outside this path change (including existing fast-forward fixture and mocked `ArchiveStore` signature failures).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managed archive generations with active index locations selected through a pointer.
  * Enhanced `paths` output with active index and shadow index details.
  * Added validation for inconsistent archive layouts.

* **Bug Fixes**
  * Maintenance and reset operations now target the active index correctly.
  * Reset operations prevent accidental deletion of managed active indexes and provide recovery guidance.

* **Tests**
  * Added coverage for managed index resolution and reset safety behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->