### PR TITLE
docs: add provider fidelity, MCP, search-boundary, and limitations sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,36 @@ See [Proof Artifacts](docs/proof-artifacts.md) for bounded claims and their evid
 - a private-archive claim-versus-evidence field finding with its sampling and calibration caveats;
 - an honesty anti-demo that returns `not_supported` for evidence the archive does not contain.
 
+## What it captures
+
+Public query and read surfaces use `origin` (the source family, e.g. `codex-session`); `provider_wire` is an internal parser/schema coordinate, not a public filter. "Complete" below means the importer package has a detector, parser, fixtures, schema mapping, and query/read coverage — it does not mean every provider field is lossless. Check the live registry yourself from a source checkout with `devtools lab provider completeness --json`; it currently reports 8 accepted-complete origins, `grok-export` as a reserved token with no wired parser, and a proposed browser-capture-live-receiver mode.
+
+| Public origin | Accepted input | Fidelity boundary | Verify against your own archive |
+|---|---|---|---|
+| `claude-code-session` | Claude Code export JSONL | Roles, prose, thinking, tool calls/results, structural errors, file/git actions, subagent and compaction records | `polylogue --origin claude-code-session read --all --limit 1 --format json` |
+| `codex-session` | Codex session JSONL across three auto-detected format generations | Roles, prose, session metadata, normalized tool-call pairing for supported records; fidelity varies by generation | `polylogue --origin codex-session read --all --limit 1 --format json` |
+| `chatgpt-export` | ChatGPT Takeout `sessions.json`, message lists, or JSONL | Message text, roles, ordering, session metadata; attachment metadata only, no binaries; usage is estimate-only | `polylogue --origin chatgpt-export read --all --limit 1 --format json` |
+| `claude-ai-export` | Claude.ai export JSON or ZIP | Typed message IDs, text, sender, timestamps, normalized blocks; attachment metadata only; usage is estimate-only | `polylogue --origin claude-ai-export read --all --limit 1 --format json` |
+| `aistudio-drive` | Google AI Studio / Drive-style export | Ordered prompt chunks, attachment references; Drive acquisition can store attachment bytes but needs OAuth | `polylogue --origin aistudio-drive read --all --limit 1 --format json` |
+| `gemini-cli-session` | Gemini CLI local-agent document | Normalized sessions/messages and supported action evidence; usage coverage is partial | `polylogue --origin gemini-cli-session read --all --limit 1 --format json` |
+| `antigravity-session` | Antigravity language-server export | Normalized sessions and messages from accepted export shapes; no provider usage | `polylogue --origin antigravity-session read --all --limit 1 --format json` |
+| `hermes-session` | Hermes `state.db` | Sessions, messages, exact usage where state counters exist. A separate NeMo Relay ATIF-v1.7 trajectory importer (`polylogue/sources/parsers/hermes_spans.py`) maps top-level and message-only steps exactly, infers tool/observation/subagent shapes, and leaves approval/error decisions absent rather than fabricated | `polylogue --origin hermes-session read --all --limit 1 --format json` |
+
+The seeded demo corpus (`demo receipts` / `demo tour` above) only populates five of these origins — `claude-code-session`, `codex-session`, `chatgpt-export`, `claude-ai-export`, and `aistudio-drive`. The `--origin` read commands for `gemini-cli-session`, `antigravity-session`, and `hermes-session` return zero rows against the demo archive; those three packages are verified by their own parser unit tests under `tests/unit/sources/` (e.g. `test_antigravity_language_server.py`, `parsers/test_hermes_spans.py`) rather than the demo world, and become populated once you import real data from those sources.
+
+Detector and parser decisions for any file are inspectable before import — this never touches the archive:
+
+```bash
+polylogue import path/to/export.jsonl --explain --format json
+```
+
+An input that matches no provider-specific shape still imports through a generic fallback (`detected_origin: unknown-export`, best-effort message extraction only; the current CLI does not accept `unknown-export` as a public `--origin` filter value):
+
+```bash
+printf '%s\n' '{"id":"fallback-demo","messages":[{"role":"user","content":"hello"}]}' > /tmp/polylogue-fallback-demo.json
+polylogue import /tmp/polylogue-fallback-demo.json --explain --format json
+```
+
 ## The model
 
 ```mermaid
@@ -175,6 +205,36 @@ Other surfaces use the same archive and query substrate:
 - browser-capture extension and local receiver — opt-in capture for supported web chats;
 - OpenTelemetry-shaped import and export projections.
 
+## MCP and agent integration
+
+`polylogue-mcp` is a standalone stdio server over the same local archive — not a `polylogue` subcommand, and it never mutates without an elevated role. It currently registers 104 tools across search/list/get, insights, corrections, correlation, and postmortem categories; the default `read` role exposes 66 of them (mutation, candidate-review, and maintenance tools require `write`, `review`, or `admin`). Verify both the runtime roles and the exact registered count yourself:
+
+```bash
+polylogue-mcp --help
+devtools render all --check   # regenerates and checks docs/mcp-reference.md against the live registry
+```
+
+```json
+{
+  "mcpServers": {
+    "polylogue": {
+      "command": "polylogue-mcp",
+      "args": ["--role", "read"]
+    }
+  }
+}
+```
+
+See [MCP Integration](docs/mcp-integration.md) for setup and [MCP Reference](docs/mcp-reference.md) for the generated tool catalog.
+
+## Search boundaries
+
+Ordinary queries use the lexical FTS lane by default; `--semantic` and `--retrieval-lane hybrid` are explicit opt-ins that require embeddings (`polylogue ops embed status`). FTS indexes message prose, thinking/reasoning text, tool-result output, tool names, and selected path fields — it does **not** index full `Write` tool-input content or `Edit` old/new bodies. Search those through the unindexed action-evidence predicate instead, which scans stored action inputs directly (against the seeded demo archive from [Run the first proof](#run-the-first-proof), this matches a captured file edit):
+
+```bash
+polylogue 'actions where tool:edit AND text:"shared_clock"'
+```
+
 References:
 
 - [Getting Started](docs/getting-started.md)
@@ -227,6 +287,15 @@ bd list --status open
 ```
 
 Do not infer roadmap state from GitHub Issues.
+
+## Limitations
+
+- Provider fidelity is uneven — see [What it captures](#what-it-captures) and verify per-origin with `devtools lab provider completeness --json` before relying on any single provider being lossless.
+- Rebuilding derived tiers is not free: embedding backfill can call an external provider. Check estimated cost first with `polylogue ops embed preflight --max-sessions 10 --format json`.
+- Cost output is an evidence model, not a billing reconciliation. Run `polylogue analyze usage --detail full --format json --limit 0` to see missing-model coverage, provider-vs-catalog-vs-subscription-credit lanes, and caveats side by side.
+- Polylogue does not reconstruct an ambient desktop timeline (window focus, independent shell history, browser-tab activity) — the archive schema has no tables for those domains today: `grep -h "CREATE TABLE" polylogue/storage/sqlite/archive_tiers/*.py | grep -iE "window|focus|shell_history|browser_tab|activitywatch" | wc -l` returns `0`.
+- `grok-export` is a reserved origin token with no wired parser; browser capture is a proposed capture mode, not an accepted-complete package.
+- Polylogue is pre-1.0. There is no long-term-support branch — check `polylogue --version` and the release channel before depending on a documented surface.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Do not infer roadmap state from GitHub Issues.
 - Rebuilding derived tiers is not free: embedding backfill can call an external provider. Check estimated cost first with `polylogue ops embed preflight --max-sessions 10 --format json`.
 - Cost output is an evidence model, not a billing reconciliation. Run `polylogue analyze usage --detail full --format json --limit 0` to see missing-model coverage, provider-vs-catalog-vs-subscription-credit lanes, and caveats side by side.
 - Polylogue does not reconstruct an ambient desktop timeline (window focus, independent shell history, browser-tab activity) — the archive schema has no tables for those domains today: `grep -h "CREATE TABLE" polylogue/storage/sqlite/archive_tiers/*.py | grep -iE "window|focus|shell_history|browser_tab|activitywatch" | wc -l` returns `0`.
-- `grok-export` is a reserved origin token with no wired parser; browser capture is a proposed capture mode, not an accepted-complete package.
+- `grok-export` is a reserved origin token with no wired parser. Browser capture (`polylogued browser-capture serve`, see [Browser Capture](docs/browser-capture.md)) is operational and opt-in today; only its entry in the provider-completeness registry is classified `proposed` rather than complete — that is a fidelity/documentation-coverage classification, not a statement that the feature does not work.
 - Polylogue is pre-1.0. There is no long-term-support branch — check `polylogue --version` and the release channel before depending on a documented surface.
 
 ## Development


### PR DESCRIPTION
## Summary

Adds four sections to the root README — What it captures (per-origin fidelity table), MCP and agent integration, Search boundaries, and an expanded Limitations section — closing gaps an external deep-research audit found in the current README against the live CLI, without disturbing the existing (working) quickstart.

## Problem

An external deep-research pass (res-04, GPT-Pro wave-2 campaign — `.agent/handoffs/external-agent-campaigns/2026-07-17-gpt-pro-wave-2/missions/res-04-readme-positioning.md`, deliverable escrowed at `res-04-readme-positioning-r01.zip`) audited the README against a same-day snapshot (`536a53ef`, 13 commits behind this PR's base, no README changes in between) and found real, still-live gaps:

- no per-origin provider-fidelity table (only prose naming providers);
- no MCP/agent-integration section at all, despite `polylogue-mcp` being a first-class surface;
- no mention that FTS excludes `Write` tool-input content and `Edit` old/new bodies;
- a thin Security section with no broader Limitations coverage (rebuild cost, cost-vs-billing, no ambient-timeline, `grok-export` reserved, pre-1.0).

The same audit's own proposed quickstart rewrite was independently re-verified and found broken: `polylogue import --demo --wait` does not converge to the same corpus as `polylogue demo seed` in the current source. That rewrite is **not** adopted — the existing, working quickstart (`demo receipts --compact` / `demo tour`) is left untouched, per the mission's own instruction to adapt rather than copy verbatim when parts of a draft are stale.

## Solution

Added, adapted (not copied) from the external draft, with every command independently re-verified against a fresh scratch demo archive rather than trusted from the source memo:

- **What it captures**: an 8-row provider fidelity table (origin, accepted input, fidelity boundary, verify command), with an explicit callout that the seeded demo corpus only populates 5 of the 8 accepted origins (`gemini-cli-session`, `antigravity-session`, `hermes-session` return zero rows against the demo archive — a gap the external report itself did not catch, found during this PR's own verification pass).
- **MCP and agent integration**: `polylogue-mcp` role/config example plus the exact current tool counts (104 total, 66 under the default `read` role).
- **Search boundaries**: lexical/semantic/hybrid distinction plus a real, reproducible example of the unindexed action-evidence workaround for `Edit`/`Write` bodies.
- **Limitations**: provider fidelity, rebuild/embedding cost, cost-vs-billing, no ambient-desktop-timeline (with a reproducible `grep`/`wc -l` proof), `grok-export`/browser-capture status, pre-1.0/no-LTS.

Not done, deliberately: no hero-restructure of the lead section or quickstart ordering — `polylogue-3tl.12` already gates that kind of restructuring behind a cold-reader comparison via `polylogue-3tl.19`, which has not run yet; no six-tool MCP table, since that registry does not exist in the current source (per `polylogue-3tl.12`'s own notes); the demo-shelf packet-registry drift the external report also flagged is out of scope for this docs-only PR.

## Verification

- `devtools lab provider completeness --json` → 8 accepted-complete origins, `grok-export` reserved, `unknown-export` proposed (matches the new table).
- `polylogue --origin <origin> read --all --limit 1 --format json` run for all 8 origins against a fresh `polylogue demo seed --force --with-overlays --format json` archive — 5 returned a row, 3 (`gemini-cli-session`, `antigravity-session`, `hermes-session`) returned zero, which the README now states explicitly instead of implying a uniform command.
- `polylogue-mcp --help` → roles `read|write|review|admin` (default `read`); `tests.infra.mcp.declared_tool_names("admin")` = 104, `("read")` = 66.
- `polylogue 'actions where tool:edit AND text:"shared_clock"'` → matches the seeded `acompact-demo` file edit, exit 0.
- `polylogue ops embed preflight --max-sessions 10 --format json`, `polylogue analyze usage --detail full --format json --limit 0`, `polylogue import <path> --explain --format json`, and the `unknown-export` fallback import — all ran clean.
- `grep -h "CREATE TABLE" polylogue/storage/sqlite/archive_tiers/*.py | grep -iE "window|focus|shell_history|browser_tab|activitywatch" | wc -l` → `0`.
- `devtools verify doc-commands`, `devtools render all --check` (grepped for "out of sync": none), `devtools verify --quick` → all exit 0.
- Pre-push quick verification baseline (ruff format/check, mypy, render all, topology, layering, closure-matrix, manifests, ci-workflows, doc-commands, docs-coverage, test-infra-currency, test-clock-hygiene, pytest-timeout-overrides, degrade-loudly) → all green on push.

Ref polylogue-3tl.12