### PR TITLE
feat(annotations): seed ontology schemas and governed bootstrap lifecycle

### DIFF
--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -158,6 +158,56 @@ User tags are assertion rows in `user.db`; auto-tags remain heuristic
 `session_tags` rows in `index.db`. The user side is irreplaceable durable
 overlay state; the auto side is rebuildable read-model state.
 
+## Typed annotations and seed ontologies
+
+Typed labels reuse the user-tier assertion substrate rather than a parallel
+annotation store. `annotation_schemas` holds immutable, versioned construct
+definitions; `annotation_batches` records label-run provenance; each label is
+an `assertions` row with `kind="annotation"`. Agent-authored labels are always
+candidate-scoped and non-injected until an operator judgment accepts them.
+Schema vocabulary can therefore grow by inserting immutable registry rows;
+the five v1 seed families do not change the user-tier DDL or
+`USER_SCHEMA_VERSION`.
+
+| Schema | Grain | Required construct fields | Authority model |
+|--------|-------|---------------------------|-----------------|
+| `seed.activity@v1` | session, phase, message, block | `activity`, `confidence` | Evidence-linked candidate label; activities are debugging, design, implementation, research, writing, ideation, ops, or procurement. |
+| `seed.goal-event@v1` | message, block, work event, observed event | `event_type`, `goal_ref`, `declared_by_ref`, `declaration_authority`, `confidence` | Prospective actor declaration only. Events are opened, blocked, resumed, declared resolved, superseded, or explicitly abandoned. Inactive unresolved goals are a separate, horizon-bound goal-graph derivation and are never emitted as abandonment annotations. |
+| `seed.outcome-evidence@v1` | session, work/observed event, commit, check run, pull request, delegation | `outcome_type`, `authority`, `authority_ref`, `temporal_mode`, `confidence` | Structural, rule, and judged evidence remain distinct. Historical backfill is explicit. Outcomes are test passed, commit observed, deployment observed, user accepted, answer declared, or unknown. |
+| `seed.knowledge-artifact@v1` | session, message, block, work event, assertion | `artifact_type`, `statement`, `authority`, `authority_ref`, `confidence` | Decision, lesson, preference, fact candidate, fact established, or commitment under a named agent, actor, structural, rule, or operator authority. |
+| `seed.reusability@v1` | session, phase, message, block, work event, assertion | `purpose`, `worthy`, `authority`, `authority_ref`, `confidence` | Purpose-specific snippet, recipe, or demo judgment; agent labels remain candidates and operator judgments are explicit. |
+
+Every seed also permits optional `abstain` and `rationale` fields and requires
+evidence refs. A schema row is identified by `(schema_id, schema_version)` and
+its canonical definition fingerprint; a conflicting re-registration fails
+closed rather than mutating the existing definition.
+
+### Governed archive-local bootstrap
+
+Informal tags and affinity scores may nominate an archive-specific draft
+schema, but cannot activate it. A nomination is an agent-authored
+`ontology_candidate` assertion with `inject:false`. It separately records tag
+affinity, nomination confidence, classifier and definition, version crosswalk,
+analysis frame and epoch, content/action-pattern/temporal-cost/outcome view
+proposals, cross-view disagreement, residue, rare samples, evidence, and privacy
+exclusions.
+
+An operator then accepts, renames, splits, or rejects the candidate. The
+preserve/read/write sequence runs under `BEGIN IMMEDIATE`; the judgment,
+immutable active schema row or rows, and typed `ontology_governance` receipt
+are committed atomically. Acceptance does not itself manufacture formal
+ontology labels. A subsequent annotation batch writes labels against the
+active schema, and those agent-authored rows remain candidates until separately
+judged.
+
+Batch annotators consume `AnnotationBatchImportRequest` and
+`import_annotation_batch` (also exposed by the archive facade). The importer
+resolves target and evidence refs, verifies the durable schema fingerprint,
+persists batch provenance, and writes through the assertion chokepoint inside
+`BEGIN IMMEDIATE`. This same interface supports built-in seed schemas and
+operator-promoted archive-local schemas without adding them to the process-wide
+registry.
+
 ---
 
 **See also:** [Schema](schema.md) · [Library API](library-api.md) · [CLI Reference](cli-reference.md) · [Configuration](configuration.md)

--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -1758,6 +1758,8 @@ components:
       - judgment
       - run_state
       - prompt_eval
+      - ontology_candidate
+      - ontology_governance
       - transform_candidate
       - pathology
       - finding

--- a/docs/plans/layering.yaml
+++ b/docs/plans/layering.yaml
@@ -94,7 +94,7 @@ writer_modules:
         - tier: user
           durability: durable
           interruption: atomic
-      entrypoints: [persist_annotation_batch, persist_annotation_schema]
+      entrypoints: [persist_annotation_batch, persist_annotation_schema, persist_builtin_annotation_schemas]
     - path: polylogue/storage/sqlite/archive_tiers/context_delivery_write.py
       surfaces:
         - tier: user

--- a/docs/schemas/cli-output/query-unit-envelope.schema.json
+++ b/docs/schemas/cli-output/query-unit-envelope.schema.json
@@ -202,6 +202,8 @@
         "judgment",
         "run_state",
         "prompt_eval",
+        "ontology_candidate",
+        "ontology_governance",
         "transform_candidate",
         "pathology",
         "finding",

--- a/polylogue/annotations/__init__.py
+++ b/polylogue/annotations/__init__.py
@@ -12,9 +12,9 @@ holds:
 - :mod:`polylogue.annotations.batch` -- immutable source/actor/model/prompt,
   validation, and count provenance for independent labeling batches.
 
-The JSONL/CLI/MCP import surface that loops over
-:func:`polylogue.annotations.write.upsert_annotation_assertion` remains in
-``polylogue-rxdo.7.2``; this package owns its durable schema/batch contracts.
+The JSONL/CLI/MCP import surface loops over
+:func:`polylogue.annotations.write.upsert_annotation_assertion` through the
+shared durable schema/batch contracts in :mod:`polylogue.annotations.importer`.
 """
 
 from __future__ import annotations
@@ -23,7 +23,14 @@ from polylogue.annotations.batch import AnnotationBatch, AnnotationBatchError
 from polylogue.annotations.schema import (
     ANNOTATION_SCHEMA_DEFINITION_FORMAT,
     ANNOTATION_SCHEMA_REGISTRY,
+    BUILTIN_ANNOTATION_SCHEMAS,
     DELEGATION_DISCOURSE_SCHEMA,
+    SEED_ACTIVITY_SCHEMA,
+    SEED_ANNOTATION_SCHEMAS,
+    SEED_GOAL_EVENT_SCHEMA,
+    SEED_KNOWLEDGE_ARTIFACT_SCHEMA,
+    SEED_OUTCOME_EVIDENCE_SCHEMA,
+    SEED_REUSABILITY_SCHEMA,
     AnnotationEvidencePolicy,
     AnnotationField,
     AnnotationFieldType,
@@ -38,15 +45,36 @@ from polylogue.annotations.schema import (
     validate_annotation_value,
 )
 from polylogue.annotations.write import (
+    ONTOLOGY_CANDIDATE_FORMAT,
+    ONTOLOGY_GOVERNANCE_FORMAT,
     AnnotationValidationError,
+    OntologyBootstrapView,
+    OntologyCandidateGovernance,
+    OntologyCandidateNomination,
+    OntologyGovernanceDecision,
+    OntologyGovernanceResult,
+    OntologyViewProposal,
+    assertion_id_for_ontology_candidate,
+    assertion_id_for_ontology_governance,
     assertion_id_for_schema_annotation,
+    govern_ontology_candidate,
+    nominate_ontology_candidate,
     upsert_annotation_assertion,
 )
 
 __all__ = [
     "ANNOTATION_SCHEMA_REGISTRY",
     "ANNOTATION_SCHEMA_DEFINITION_FORMAT",
+    "BUILTIN_ANNOTATION_SCHEMAS",
     "DELEGATION_DISCOURSE_SCHEMA",
+    "ONTOLOGY_CANDIDATE_FORMAT",
+    "ONTOLOGY_GOVERNANCE_FORMAT",
+    "SEED_ACTIVITY_SCHEMA",
+    "SEED_ANNOTATION_SCHEMAS",
+    "SEED_GOAL_EVENT_SCHEMA",
+    "SEED_KNOWLEDGE_ARTIFACT_SCHEMA",
+    "SEED_OUTCOME_EVIDENCE_SCHEMA",
+    "SEED_REUSABILITY_SCHEMA",
     "AnnotationBatch",
     "AnnotationBatchError",
     "AnnotationEvidencePolicy",
@@ -57,10 +85,20 @@ __all__ = [
     "AnnotationSchemaRegistry",
     "AnnotationSchemaStatus",
     "AnnotationValidationError",
+    "OntologyBootstrapView",
+    "OntologyCandidateGovernance",
+    "OntologyCandidateNomination",
+    "OntologyGovernanceDecision",
+    "OntologyGovernanceResult",
+    "OntologyViewProposal",
+    "assertion_id_for_ontology_candidate",
+    "assertion_id_for_ontology_governance",
     "assertion_id_for_schema_annotation",
     "get_annotation_schema",
     "list_annotation_schemas",
     "register_annotation_schema",
+    "govern_ontology_candidate",
+    "nominate_ontology_candidate",
     "upsert_annotation_assertion",
     "validate_annotation_row",
     "validate_annotation_value",

--- a/polylogue/annotations/importer.py
+++ b/polylogue/annotations/importer.py
@@ -27,7 +27,9 @@ from polylogue.storage.sqlite.archive_tiers.user_annotations import (
     persist_annotation_batch,
     persist_annotation_schema,
     read_annotation_batch,
+    read_durable_annotation_schema,
 )
+from polylogue.storage.sqlite.connection_profile import open_connection, open_readonly_connection
 
 if TYPE_CHECKING:
     from polylogue.api import Polylogue
@@ -102,6 +104,53 @@ class AnnotationBatchImportResult(BaseModel):
 
 
 RefResolver = Callable[[str], Awaitable[bool]]
+
+
+def _resolve_import_schema(
+    user_db_path: Path,
+    request: AnnotationBatchImportRequest,
+    registry: AnnotationSchemaRegistry,
+) -> tuple[AnnotationSchema, AnnotationSchemaRegistry]:
+    """Resolve packaged, caller-supplied, or governed archive-local schemas.
+
+    A promoted archive-specific ontology is durable in ``user.db`` rather than
+    injected into the process-global registry (which would leak one archive's
+    vocabulary into another). The importer builds a one-schema local registry
+    when only the durable definition exists, while still rejecting any
+    caller/global definition that disagrees with the archive authority.
+    """
+
+    try:
+        registered = registry.get(request.schema_id, request.schema_version)
+    except KeyError:
+        registered = None
+
+    conn = open_readonly_connection(user_db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        durable = read_durable_annotation_schema(conn, request.schema_id, request.schema_version)
+    finally:
+        conn.close()
+
+    if durable is not None:
+        if registered is not None and (
+            registered.canonical_definition_json() != durable.definition_json
+            or registered.definition_fingerprint != durable.definition_sha256
+        ):
+            raise AnnotationBatchImportError(
+                f"annotation schema {durable.schema.qualified_id!r} disagrees with its durable archive definition"
+            )
+        if registered is not None:
+            return registered, registry
+        local_registry = AnnotationSchemaRegistry()
+        local_registry.register(durable.schema)
+        return durable.schema, local_registry
+
+    if registered is None:
+        raise AnnotationBatchImportError(
+            f"no registered annotation schema {request.schema_id!r}@v{request.schema_version}"
+        )
+    return registered, registry
 
 
 def _ref_preview(ref: str) -> str:
@@ -194,10 +243,9 @@ async def import_annotation_batch(
     """Validate live refs, persist provenance, and write candidates atomically."""
 
     _validate_request_bounds(request)
-    try:
-        schema = registry.get(request.schema_id, request.schema_version)
-    except KeyError as exc:
-        raise AnnotationBatchImportError(str(exc)) from exc
+    user_db_path = Path(poly.archive_root) / "user.db"
+    initialize_archive_database(user_db_path, ArchiveTier.USER)
+    schema, effective_registry = _resolve_import_schema(user_db_path, request, registry)
 
     async def default_resolver(ref: str) -> bool:
         return (await poly.resolve_ref(ref)).resolved
@@ -253,9 +301,7 @@ async def import_annotation_batch(
     abstained_count = sum(
         row.value.get(schema.abstain_field) is True for _, row, _, _ in valid_rows if schema.abstain_field is not None
     )
-    user_db_path = Path(poly.archive_root) / "user.db"
-    initialize_archive_database(user_db_path, ArchiveTier.USER)
-    conn = sqlite3.connect(user_db_path)
+    conn = open_connection(user_db_path)
     conn.row_factory = sqlite3.Row
     imported_outcomes: list[AnnotationImportRowOutcome] = []
     batch: AnnotationBatch
@@ -289,7 +335,7 @@ async def import_annotation_batch(
             envelope = upsert_annotation_assertion(
                 conn,
                 schema=schema,
-                registry=registry,
+                registry=effective_registry,
                 target_ref=request.target_ref,
                 value=row.value,
                 row_key=row.row_key,

--- a/polylogue/annotations/schema.py
+++ b/polylogue/annotations/schema.py
@@ -14,9 +14,11 @@ that validates one row against a schema and then upserts it through the
 existing single assertion-write chokepoint
 (:func:`polylogue.storage.sqlite.archive_tiers.user_write.upsert_assertion`).
 
-The registry includes the production delegation-discourse v1 definition and
-each schema can be lowered to one canonical definition JSON/fingerprint for
-durable storage. Batch provenance is declared in
+The registry includes the production delegation-discourse v1 definition plus
+the governed seed ontology families (activity, prospective goal events,
+observed outcome evidence, knowledge artifacts, and reusability). Each schema
+can be lowered to one canonical definition JSON/fingerprint for durable
+storage. Batch provenance is declared in
 :mod:`polylogue.annotations.batch`; JSONL/CLI/MCP import remains a leaf
 surface owned by polylogue-rxdo.7.2.
 """
@@ -744,10 +746,364 @@ DELEGATION_DISCOURSE_SCHEMA = register_annotation_schema(
 )
 
 
+SEED_ACTIVITY_SCHEMA = register_annotation_schema(
+    AnnotationSchema(
+        schema_id="seed.activity",
+        version=1,
+        title="Activity",
+        description=(
+            "Primary activity at an explicit session or structural segment grain. "
+            "The target ref declares the grain: session is session-level; phase/message/block are segment-level."
+        ),
+        fields=(
+            AnnotationField(
+                name="activity",
+                value_type="enum",
+                description="Primary activity evidenced by the target.",
+                enum_values=(
+                    "debugging",
+                    "design",
+                    "implementation",
+                    "research",
+                    "writing",
+                    "ideation",
+                    "ops",
+                    "procurement",
+                ),
+            ),
+            AnnotationField(
+                name="confidence",
+                value_type="number",
+                description="Label confidence on the closed interval from zero to one.",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            AnnotationField(
+                name="abstain",
+                value_type="boolean",
+                required=False,
+                description="True when the available evidence does not support one primary activity.",
+            ),
+            AnnotationField(
+                name="rationale",
+                value_type="string",
+                required=False,
+                description="Concise evidence-grounded rationale for the label or abstention.",
+            ),
+        ),
+        target_ref_kinds=("session", "phase", "message", "block"),
+        abstain_field="abstain",
+        evidence_policy="required",
+        status="active",
+    )
+)
+
+
+SEED_GOAL_EVENT_SCHEMA = register_annotation_schema(
+    AnnotationSchema(
+        schema_id="seed.goal-event",
+        version=1,
+        title="Prospective goal event",
+        description=(
+            "Actor-declared prospective goal events. This construct never infers abandonment or unresolved state; "
+            "unresolved_inactive(H) belongs to the goal graph with a named horizon/frame/evaluation receipt."
+        ),
+        fields=(
+            AnnotationField(
+                name="event_type",
+                value_type="enum",
+                description="The prospective event actually declared by an actor.",
+                enum_values=(
+                    "opened",
+                    "blocked",
+                    "resumed",
+                    "declared_resolved",
+                    "superseded",
+                    "explicitly_abandoned",
+                ),
+            ),
+            AnnotationField(
+                name="goal_ref",
+                value_type="string",
+                description="Stable goal/question graph identity addressed by the declaration.",
+            ),
+            AnnotationField(
+                name="declared_by_ref",
+                value_type="string",
+                description="Actor ref whose declaration the annotation records.",
+            ),
+            AnnotationField(
+                name="declaration_authority",
+                value_type="enum",
+                description="Authority mode; the seed admits declarations, not inferred lifecycle states.",
+                enum_values=("actor_declared",),
+            ),
+            AnnotationField(
+                name="opening_event_ref",
+                value_type="string",
+                required=False,
+                description="Opening event ref for a close/block/resume/supersession declaration when known.",
+            ),
+            AnnotationField(
+                name="related_goal_ref",
+                value_type="string",
+                required=False,
+                description="Replacement or related goal identity for a supersession declaration.",
+            ),
+            AnnotationField(
+                name="confidence",
+                value_type="number",
+                description="Confidence that the evidence contains the declared event.",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            AnnotationField(
+                name="abstain",
+                value_type="boolean",
+                required=False,
+                description="True when declaration evidence is insufficient.",
+            ),
+            AnnotationField(
+                name="rationale",
+                value_type="string",
+                required=False,
+                description="Concise evidence-grounded rationale for the label or abstention.",
+            ),
+        ),
+        target_ref_kinds=("message", "block", "work_event", "observed-event"),
+        abstain_field="abstain",
+        evidence_policy="required",
+        status="active",
+    )
+)
+
+
+SEED_OUTCOME_EVIDENCE_SCHEMA = register_annotation_schema(
+    AnnotationSchema(
+        schema_id="seed.outcome-evidence",
+        version=1,
+        title="Outcome evidence",
+        description=(
+            "Observed outcome evidence, kept distinct from prospective goal events. Structural, rule-derived, "
+            "and judged authority remain explicit provenance; historical backfill is marked rather than rewritten "
+            "as prospective truth."
+        ),
+        fields=(
+            AnnotationField(
+                name="outcome_type",
+                value_type="enum",
+                description="Observed or explicitly unknown outcome evidence.",
+                enum_values=(
+                    "test_passed",
+                    "commit_observed",
+                    "deployment_observed",
+                    "user_accepted",
+                    "answer_declared",
+                    "unknown",
+                ),
+            ),
+            AnnotationField(
+                name="authority",
+                value_type="enum",
+                description="Authority class under which the evidence is asserted.",
+                enum_values=("structural", "rule", "judged"),
+            ),
+            AnnotationField(
+                name="authority_ref",
+                value_type="string",
+                description="Named parser, rule, metric, judgment, or operator authority.",
+            ),
+            AnnotationField(
+                name="temporal_mode",
+                value_type="enum",
+                description="Whether this is contemporaneous evidence or an explicit historical backfill.",
+                enum_values=("observed", "historical_backfill"),
+            ),
+            AnnotationField(
+                name="confidence",
+                value_type="number",
+                description="Evidence confidence on the closed interval from zero to one.",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            AnnotationField(
+                name="abstain",
+                value_type="boolean",
+                required=False,
+                description="True when available evidence cannot support an outcome classification.",
+            ),
+            AnnotationField(
+                name="rationale",
+                value_type="string",
+                required=False,
+                description="Concise evidence-grounded rationale for the label or abstention.",
+            ),
+        ),
+        target_ref_kinds=(
+            "session",
+            "work_event",
+            "observed-event",
+            "commit",
+            "check-run",
+            "github-pr",
+            "delegation",
+        ),
+        abstain_field="abstain",
+        evidence_policy="required",
+        status="active",
+    )
+)
+
+
+SEED_KNOWLEDGE_ARTIFACT_SCHEMA = register_annotation_schema(
+    AnnotationSchema(
+        schema_id="seed.knowledge-artifact",
+        version=1,
+        title="Knowledge artifact",
+        description=(
+            "Evidence-linked decisions, lessons, preferences, fact candidates/established facts under a named "
+            "authority, and commitments."
+        ),
+        fields=(
+            AnnotationField(
+                name="artifact_type",
+                value_type="enum",
+                description="Knowledge artifact family.",
+                enum_values=(
+                    "decision",
+                    "lesson",
+                    "preference",
+                    "fact_candidate",
+                    "fact_established",
+                    "commitment",
+                ),
+            ),
+            AnnotationField(
+                name="statement",
+                value_type="string",
+                description="The bounded proposition or commitment represented by the artifact.",
+            ),
+            AnnotationField(
+                name="authority",
+                value_type="enum",
+                description="Authority class under which the artifact is proposed or established.",
+                enum_values=("agent_candidate", "actor_declared", "structural", "rule", "operator_judged"),
+            ),
+            AnnotationField(
+                name="authority_ref",
+                value_type="string",
+                description="Named actor, parser, rule, or judgment authority.",
+            ),
+            AnnotationField(
+                name="confidence",
+                value_type="number",
+                description="Artifact confidence on the closed interval from zero to one.",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            AnnotationField(
+                name="abstain",
+                value_type="boolean",
+                required=False,
+                description="True when evidence is insufficient to classify the artifact.",
+            ),
+            AnnotationField(
+                name="rationale",
+                value_type="string",
+                required=False,
+                description="Concise evidence-grounded rationale for the label or abstention.",
+            ),
+        ),
+        target_ref_kinds=("session", "message", "block", "work_event", "assertion"),
+        abstain_field="abstain",
+        evidence_policy="required",
+        status="active",
+    )
+)
+
+
+SEED_REUSABILITY_SCHEMA = register_annotation_schema(
+    AnnotationSchema(
+        schema_id="seed.reusability",
+        version=1,
+        title="Reusability judgment",
+        description="Purpose-specific snippet, recipe, or demo reusability judgment.",
+        fields=(
+            AnnotationField(
+                name="purpose",
+                value_type="enum",
+                description="Reuse purpose being judged independently.",
+                enum_values=("snippet", "recipe", "demo"),
+            ),
+            AnnotationField(
+                name="worthy",
+                value_type="boolean",
+                description="Whether the target is worthy for the declared reuse purpose.",
+            ),
+            AnnotationField(
+                name="authority",
+                value_type="enum",
+                description="Authority class for the purpose-specific judgment.",
+                enum_values=("agent_candidate", "operator_judged"),
+            ),
+            AnnotationField(
+                name="authority_ref",
+                value_type="string",
+                description="Named classifier, agent, or operator judgment authority.",
+            ),
+            AnnotationField(
+                name="confidence",
+                value_type="number",
+                description="Judgment confidence on the closed interval from zero to one.",
+                minimum=0.0,
+                maximum=1.0,
+            ),
+            AnnotationField(
+                name="abstain",
+                value_type="boolean",
+                required=False,
+                description="True when available evidence cannot support this purpose-specific judgment.",
+            ),
+            AnnotationField(
+                name="rationale",
+                value_type="string",
+                required=False,
+                description="Concise evidence-grounded rationale for the label or abstention.",
+            ),
+        ),
+        target_ref_kinds=("session", "phase", "message", "block", "work_event", "assertion"),
+        abstain_field="abstain",
+        evidence_policy="required",
+        status="active",
+    )
+)
+
+
+SEED_ANNOTATION_SCHEMAS: tuple[AnnotationSchema, ...] = (
+    SEED_ACTIVITY_SCHEMA,
+    SEED_GOAL_EVENT_SCHEMA,
+    SEED_OUTCOME_EVIDENCE_SCHEMA,
+    SEED_KNOWLEDGE_ARTIFACT_SCHEMA,
+    SEED_REUSABILITY_SCHEMA,
+)
+
+BUILTIN_ANNOTATION_SCHEMAS: tuple[AnnotationSchema, ...] = (
+    DELEGATION_DISCOURSE_SCHEMA,
+    *SEED_ANNOTATION_SCHEMAS,
+)
+
+
 __all__ = [
     "ANNOTATION_SCHEMA_REGISTRY",
     "ANNOTATION_SCHEMA_DEFINITION_FORMAT",
+    "BUILTIN_ANNOTATION_SCHEMAS",
     "DELEGATION_DISCOURSE_SCHEMA",
+    "SEED_ACTIVITY_SCHEMA",
+    "SEED_ANNOTATION_SCHEMAS",
+    "SEED_GOAL_EVENT_SCHEMA",
+    "SEED_KNOWLEDGE_ARTIFACT_SCHEMA",
+    "SEED_OUTCOME_EVIDENCE_SCHEMA",
+    "SEED_REUSABILITY_SCHEMA",
     "AnnotationEvidencePolicy",
     "AnnotationField",
     "AnnotationFieldType",

--- a/polylogue/annotations/write.py
+++ b/polylogue/annotations/write.py
@@ -1,6 +1,6 @@
 """Single-row annotation write path: schema-validated labels as assertions.
 
-This is the atomic operation a future batch/JSONL import surface loops over.
+This is the atomic operation the batch/JSONL import surface loops over.
 It accepts durable ``annotation-batch:`` provenance but deliberately does not
 attempt the CLI/MCP surface here -- it validates one label against a declared
 :class:`~polylogue.annotations.schema.AnnotationSchema` and writes it through
@@ -25,8 +25,12 @@ import hashlib
 import json
 import math
 import sqlite3
+import time
 import unicodedata
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field, replace
+from typing import TYPE_CHECKING, Literal, cast
 
 from polylogue.annotations.schema import (
     ANNOTATION_SCHEMA_REGISTRY,
@@ -34,16 +38,27 @@ from polylogue.annotations.schema import (
     AnnotationSchemaRegistry,
     validate_annotation_row,
 )
-from polylogue.core.enums import AssertionKind
+from polylogue.core.enums import AssertionKind, AssertionStatus, AssertionVisibility
+from polylogue.core.json import JSONDocument, JSONValue, require_json_document
 from polylogue.core.refs import ObjectRef, normalize_object_ref_text, normalize_public_ref_text
 from polylogue.storage.sqlite.archive_tiers.user_write import (
     ArchiveAssertionEnvelope,
+    ArchiveAssertionJudgmentEnvelope,
+    judge_assertion_candidate,
     read_assertion_envelope,
     upsert_assertion,
 )
 
+if TYPE_CHECKING:
+    from polylogue.storage.sqlite.archive_tiers.user_annotations import DurableAnnotationSchema
+
 _SCHEMA_PROVENANCE_KEY = "_schema"
 _BATCH_PROVENANCE_KEY = "_batch"
+ONTOLOGY_CANDIDATE_FORMAT = "polylogue.ontology-candidate/v1"
+ONTOLOGY_GOVERNANCE_FORMAT = "polylogue.ontology-governance/v1"
+
+OntologyBootstrapView = Literal["content", "action_pattern", "temporal_cost", "outcome"]
+OntologyGovernanceDecision = Literal["accept", "rename", "split", "reject"]
 
 
 class AnnotationValidationError(ValueError):
@@ -59,13 +74,213 @@ class AnnotationValidationError(ValueError):
         super().__init__(message)
 
 
+@dataclass(frozen=True, slots=True)
+class OntologyViewProposal:
+    """One independently-declared bootstrap view and its candidate label."""
+
+    view: OntologyBootstrapView
+    label: str
+    confidence: float
+    evidence_refs: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.view not in {"content", "action_pattern", "temporal_cost", "outcome"}:
+            raise ValueError(f"unsupported ontology bootstrap view: {self.view!r}")
+        normalized_label = self.label.strip()
+        if not normalized_label:
+            raise ValueError("ontology view label cannot be empty")
+        if not math.isfinite(self.confidence) or not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("ontology view confidence must be finite and between zero and one")
+        object.__setattr__(self, "label", normalized_label)
+        normalized_evidence_refs = tuple(dict.fromkeys(normalize_public_ref_text(ref) for ref in self.evidence_refs))
+        if not normalized_evidence_refs:
+            raise ValueError("ontology view proposal requires at least one evidence ref")
+        object.__setattr__(self, "evidence_refs", normalized_evidence_refs)
+
+    def as_json_document(self) -> JSONDocument:
+        return {
+            "view": self.view,
+            "label": self.label,
+            "confidence": self.confidence,
+            "evidence_refs": list(self.evidence_refs),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class OntologyCandidateNomination:
+    """Governed candidate-schema nomination produced by archive-local analysis.
+
+    Every source axis is retained separately. In particular, ``source_tag_refs``
+    and ``affinity`` are nomination evidence only; this request never writes an
+    annotation row or an active ``annotation_schemas`` definition.
+    """
+
+    candidate_schema: AnnotationSchema
+    target_ref: str
+    affinity: float
+    confidence: float
+    classifier_ref: str
+    classifier_definition: JSONDocument
+    version_crosswalk: JSONDocument
+    frame_ref: str
+    epoch_ref: str
+    privacy_policy_ref: str
+    author_ref: str
+    view_proposals: tuple[OntologyViewProposal, ...]
+    source_tag_refs: tuple[str, ...] = ()
+    residue_refs: tuple[str, ...] = ()
+    rare_sample_refs: tuple[str, ...] = ()
+    privacy_excluded_refs: tuple[str, ...] = ()
+    evidence_refs: tuple[str, ...] = ()
+    _canonical_nomination: bytes = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self.candidate_schema.status != "draft":
+            raise ValueError("ontology candidate schema must have status='draft'")
+        if not math.isfinite(self.affinity) or not 0.0 <= self.affinity <= 1.0:
+            raise ValueError("ontology candidate affinity must be finite and between zero and one")
+        if not math.isfinite(self.confidence) or not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("ontology candidate confidence must be finite and between zero and one")
+        proposals = tuple(self.view_proposals)
+        if not proposals:
+            raise ValueError("ontology candidate requires at least one declared bootstrap view")
+        if not all(isinstance(proposal, OntologyViewProposal) for proposal in proposals):
+            raise TypeError("ontology candidate view_proposals must contain OntologyViewProposal values")
+        views = [proposal.view for proposal in proposals]
+        if len(views) != len(set(views)):
+            raise ValueError("ontology candidate bootstrap views must be unique")
+        object.__setattr__(self, "view_proposals", proposals)
+
+        object.__setattr__(self, "target_ref", normalize_object_ref_text(self.target_ref))
+        object.__setattr__(self, "classifier_ref", normalize_object_ref_text(self.classifier_ref))
+        object.__setattr__(self, "frame_ref", normalize_object_ref_text(self.frame_ref))
+        object.__setattr__(self, "epoch_ref", normalize_object_ref_text(self.epoch_ref))
+        object.__setattr__(self, "privacy_policy_ref", normalize_object_ref_text(self.privacy_policy_ref))
+        object.__setattr__(self, "author_ref", normalize_object_ref_text(self.author_ref))
+        if ObjectRef.parse(self.author_ref).kind != "agent":
+            raise ValueError("ontology candidate author_ref must identify an agent")
+        object.__setattr__(
+            self,
+            "classifier_definition",
+            _detached_json_document(self.classifier_definition, context="ontology classifier definition"),
+        )
+        object.__setattr__(
+            self,
+            "version_crosswalk",
+            _detached_json_document(self.version_crosswalk, context="ontology version crosswalk"),
+        )
+        for field_name in (
+            "source_tag_refs",
+            "residue_refs",
+            "rare_sample_refs",
+            "privacy_excluded_refs",
+            "evidence_refs",
+        ):
+            refs = cast(tuple[str, ...], getattr(self, field_name))
+            object.__setattr__(
+                self,
+                field_name,
+                tuple(dict.fromkeys(normalize_public_ref_text(ref) for ref in refs)),
+            )
+        object.__setattr__(self, "_canonical_nomination", _canonical_json_bytes(self._document_from_fields()))
+
+    @property
+    def cross_view_state(self) -> Literal["agreement", "disagreement", "insufficient"]:
+        if len(self.view_proposals) < 2:
+            return "insufficient"
+        return "agreement" if len({proposal.label for proposal in self.view_proposals}) == 1 else "disagreement"
+
+    def _document_from_fields(self) -> JSONDocument:
+        return {
+            "format": ONTOLOGY_CANDIDATE_FORMAT,
+            "candidate_schema": cast(JSONValue, self.candidate_schema.definition_document()),
+            "source_tag_refs": list(self.source_tag_refs),
+            "affinity": self.affinity,
+            "confidence": self.confidence,
+            "classifier_ref": self.classifier_ref,
+            "classifier_definition": dict(self.classifier_definition),
+            "version_crosswalk": dict(self.version_crosswalk),
+            "frame_ref": self.frame_ref,
+            "epoch_ref": self.epoch_ref,
+            "view_proposals": [proposal.as_json_document() for proposal in self.view_proposals],
+            "cross_view_state": self.cross_view_state,
+            "residue_refs": list(self.residue_refs),
+            "rare_sample_refs": list(self.rare_sample_refs),
+            "privacy_policy_ref": self.privacy_policy_ref,
+            "privacy_excluded_refs": list(self.privacy_excluded_refs),
+        }
+
+    def as_json_document(self) -> JSONDocument:
+        """Return a detached copy of the immutable nomination provenance."""
+
+        return require_json_document(json.loads(self._canonical_nomination), context="ontology nomination")
+
+
+@dataclass(frozen=True, slots=True)
+class OntologyCandidateGovernance:
+    """One operator decision over an ontology candidate schema."""
+
+    candidate_ref: str
+    decision: OntologyGovernanceDecision
+    actor_ref: str
+    reason: str | None = None
+    active_schemas: tuple[AnnotationSchema, ...] = ()
+
+    def __post_init__(self) -> None:
+        parsed = ObjectRef.parse(normalize_object_ref_text(self.candidate_ref))
+        if parsed.kind != "assertion" or parsed.qualifiers:
+            raise ValueError("ontology governance candidate_ref must be an assertion ref")
+        if self.decision not in {"accept", "rename", "split", "reject"}:
+            raise ValueError(f"unsupported ontology governance decision: {self.decision!r}")
+        object.__setattr__(self, "candidate_ref", parsed.format())
+        object.__setattr__(self, "actor_ref", normalize_object_ref_text(self.actor_ref))
+        if ObjectRef.parse(self.actor_ref).kind != "user":
+            raise ValueError("ontology governance actor_ref must identify an operator user")
+        if self.reason is not None and not self.reason.strip():
+            raise ValueError("ontology governance reason cannot be blank")
+        if self.reason is not None:
+            object.__setattr__(self, "reason", self.reason.strip())
+        active_schemas = tuple(self.active_schemas)
+        if not all(isinstance(schema, AnnotationSchema) for schema in active_schemas):
+            raise TypeError("ontology governance outputs must be AnnotationSchema values")
+        if any(schema.status != "active" for schema in active_schemas):
+            raise ValueError("ontology governance outputs must have status='active'")
+        object.__setattr__(self, "active_schemas", active_schemas)
+        identities = [schema.qualified_id for schema in active_schemas]
+        if len(identities) != len(set(identities)):
+            raise ValueError("ontology governance outputs must have unique schema identities")
+        if self.decision in {"accept", "rename"} and len(self.active_schemas) != 1:
+            raise ValueError(f"ontology governance decision {self.decision!r} requires exactly one active schema")
+        if self.decision == "split" and len(self.active_schemas) < 2:
+            raise ValueError("ontology governance decision 'split' requires at least two active schemas")
+        if self.decision == "reject" and self.active_schemas:
+            raise ValueError("ontology governance decision 'reject' cannot register active schemas")
+
+
+@dataclass(frozen=True, slots=True)
+class OntologyGovernanceResult:
+    """Atomic judgment, registry, and governance-receipt result."""
+
+    judgment: ArchiveAssertionJudgmentEnvelope
+    governance_receipt: ArchiveAssertionEnvelope
+    active_schemas: tuple[DurableAnnotationSchema, ...]
+
+
 def _nfc_json_value(value: object) -> object:
     if isinstance(value, str):
         return unicodedata.normalize("NFC", value)
     if isinstance(value, list):
         return [_nfc_json_value(item) for item in value]
     if isinstance(value, dict):
-        return {unicodedata.normalize("NFC", str(key)): _nfc_json_value(item) for key, item in value.items()}
+        normalized: dict[str, object] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("canonical JSON object keys must be strings")
+            normalized_key = unicodedata.normalize("NFC", key)
+            if normalized_key in normalized:
+                raise ValueError(f"NFC-normalized JSON keys collide at {normalized_key!r}")
+            normalized[normalized_key] = _nfc_json_value(item)
+        return normalized
     return value
 
 
@@ -77,6 +292,35 @@ def _canonical_json_bytes(value: object) -> bytes:
         sort_keys=True,
         separators=(",", ":"),
     ).encode("utf-8")
+
+
+def _detached_json_document(value: object, *, context: str) -> JSONDocument:
+    try:
+        document = require_json_document(value, context=context)
+        return require_json_document(json.loads(_canonical_json_bytes(document)), context=context)
+    except (TypeError, ValueError, UnicodeEncodeError) as exc:
+        raise ValueError(f"{context} must be finite canonical JSON") from exc
+
+
+@contextmanager
+def _immediate_user_write(conn: sqlite3.Connection) -> Iterator[None]:
+    """Own one complete preserve/read/write decision under ``BEGIN IMMEDIATE``.
+
+    The caller must supply an idle connection. Accepting an already-open
+    deferred transaction would reintroduce the judgment-preservation TOCTOU
+    described by polylogue-41ow, so this path fails closed instead.
+    """
+
+    if conn.in_transaction:
+        raise RuntimeError("governed ontology writes require an idle connection so they can BEGIN IMMEDIATE")
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        yield
+    except BaseException:
+        conn.rollback()
+        raise
+    else:
+        conn.commit()
 
 
 def _normalized_annotation_confidence(value: object) -> float | None:
@@ -137,6 +381,278 @@ def assertion_id_for_schema_annotation(
         digest.update(part.encode("utf-8", errors="surrogatepass"))
         digest.update(b"\0")
     return f"assertion-annotation-schema:{digest.hexdigest()}"
+
+
+def _nomination_evidence_refs(nomination: OntologyCandidateNomination) -> tuple[str, ...]:
+    refs = [
+        nomination.classifier_ref,
+        nomination.frame_ref,
+        nomination.epoch_ref,
+        nomination.privacy_policy_ref,
+        *nomination.source_tag_refs,
+        *nomination.residue_refs,
+        *nomination.rare_sample_refs,
+        *nomination.privacy_excluded_refs,
+        *nomination.evidence_refs,
+    ]
+    for proposal in nomination.view_proposals:
+        refs.extend(proposal.evidence_refs)
+    return tuple(dict.fromkeys(refs))
+
+
+def assertion_id_for_ontology_candidate(nomination: OntologyCandidateNomination) -> str:
+    """Return the content-addressed identity for one complete nomination."""
+
+    identity = {
+        "target_ref": nomination.target_ref,
+        "author_ref": nomination.author_ref,
+        "value": nomination.as_json_document(),
+        "evidence_refs": list(_nomination_evidence_refs(nomination)),
+    }
+    return f"assertion-ontology-candidate:{hashlib.sha256(_canonical_json_bytes(identity)).hexdigest()}"
+
+
+def nominate_ontology_candidate(
+    conn: sqlite3.Connection,
+    nomination: OntologyCandidateNomination,
+    *,
+    now_ms: int | None = None,
+) -> ArchiveAssertionEnvelope:
+    """Write one archive-specific schema nomination, never an active construct.
+
+    The entire terminal-status read/preserve/write decision runs under
+    ``BEGIN IMMEDIATE``. An identical retry returns the existing candidate or
+    judged lifecycle row unchanged; it cannot resurrect a rejected/accepted
+    candidate or mutate any source tag assertion.
+    """
+
+    from polylogue.storage.sqlite.archive_tiers.user_annotations import read_durable_annotation_schema
+
+    assertion_id = assertion_id_for_ontology_candidate(nomination)
+    value = nomination.as_json_document()
+    evidence_refs = _nomination_evidence_refs(nomination)
+    with _immediate_user_write(conn):
+        existing = read_assertion_envelope(conn, assertion_id)
+        if existing is not None:
+            if (
+                existing.kind != AssertionKind.ONTOLOGY_CANDIDATE
+                or existing.target_ref != nomination.target_ref
+                or existing.scope_ref != nomination.frame_ref
+                or existing.author_ref != nomination.author_ref
+                or existing.value != value
+                or tuple(existing.evidence_refs) != evidence_refs
+            ):
+                raise RuntimeError(f"ontology candidate assertion identity collision: {assertion_id}")
+            return existing
+        durable = read_durable_annotation_schema(
+            conn,
+            nomination.candidate_schema.schema_id,
+            nomination.candidate_schema.version,
+        )
+        if durable is not None:
+            raise ValueError(
+                f"ontology candidate {nomination.candidate_schema.qualified_id!r} already has a durable schema row; "
+                "propose a new version"
+            )
+        return upsert_assertion(
+            conn,
+            assertion_id=assertion_id,
+            scope_ref=nomination.frame_ref,
+            target_ref=nomination.target_ref,
+            key=nomination.candidate_schema.qualified_id,
+            kind=AssertionKind.ONTOLOGY_CANDIDATE,
+            value=value,
+            body_text=nomination.candidate_schema.title,
+            author_ref=nomination.author_ref,
+            author_kind="agent",
+            evidence_refs=evidence_refs,
+            status=AssertionStatus.CANDIDATE,
+            visibility=AssertionVisibility.PRIVATE,
+            confidence=nomination.confidence,
+            context_policy={"inject": False, "promotion_required": True},
+            now_ms=now_ms,
+        )
+
+
+def assertion_id_for_ontology_governance(
+    *,
+    candidate_ref: str,
+    decision: OntologyGovernanceDecision,
+    active_schemas: Sequence[AnnotationSchema],
+) -> str:
+    """Return a deterministic receipt id for one candidate decision/output set."""
+
+    identity = {
+        "candidate_ref": normalize_object_ref_text(candidate_ref),
+        "decision": decision,
+        "active_schema_fingerprints": [schema.definition_fingerprint for schema in active_schemas],
+    }
+    return f"assertion-ontology-governance:{hashlib.sha256(_canonical_json_bytes(identity)).hexdigest()}"
+
+
+def _ontology_candidate_schema(candidate: ArchiveAssertionEnvelope) -> AnnotationSchema:
+    if candidate.kind != AssertionKind.ONTOLOGY_CANDIDATE:
+        raise ValueError(f"assertion:{candidate.assertion_id} is not an ontology candidate")
+    if not isinstance(candidate.value, dict) or candidate.value.get("format") != ONTOLOGY_CANDIDATE_FORMAT:
+        raise ValueError(f"assertion:{candidate.assertion_id} has malformed ontology candidate provenance")
+    definition = candidate.value.get("candidate_schema")
+    schema = AnnotationSchema.from_definition_document(definition)
+    if schema.status != "draft":
+        raise ValueError(f"assertion:{candidate.assertion_id} candidate schema is not draft")
+    return schema
+
+
+def _governance_replacement_value(
+    candidate: ArchiveAssertionEnvelope,
+    governance: OntologyCandidateGovernance,
+) -> JSONDocument:
+    value = require_json_document(candidate.value, context="ontology candidate value")
+    replacement_value = dict(value)
+    replacement_value["governance_decision"] = governance.decision
+    replacement_value["governance_output_schemas"] = [
+        cast(JSONValue, schema.definition_document()) for schema in governance.active_schemas
+    ]
+    return replacement_value
+
+
+def govern_ontology_candidate(
+    conn: sqlite3.Connection,
+    governance: OntologyCandidateGovernance,
+    *,
+    now_ms: int | None = None,
+) -> OntologyGovernanceResult:
+    """Judge a schema candidate and atomically register governed active versions.
+
+    ``accept`` preserves the draft definition exactly except for its status.
+    ``rename`` and ``split`` record explicit supersession outputs. ``reject``
+    leaves every source tag and evidence row intact. All decisions reuse the
+    ordinary candidate judgment lifecycle and add a deterministic typed
+    governance receipt; no formal annotation membership is written here.
+    """
+
+    from polylogue.storage.sqlite.archive_tiers.user_annotations import persist_annotation_schema
+
+    timestamp = now_ms if now_ms is not None else int(time.time() * 1000)
+    candidate_id = ObjectRef.parse(governance.candidate_ref).object_id
+    with _immediate_user_write(conn):
+        candidate = read_assertion_envelope(conn, candidate_id)
+        if candidate is None:
+            raise ValueError(f"ontology candidate not found: {governance.candidate_ref}")
+        draft_schema = _ontology_candidate_schema(candidate)
+        expected_active = replace(draft_schema, status="active")
+        if governance.decision == "accept":
+            if governance.active_schemas[0].canonical_definition_json() != expected_active.canonical_definition_json():
+                raise ValueError(
+                    "ontology accept must preserve the candidate schema definition exactly except for status='active'"
+                )
+        elif (
+            governance.decision == "rename"
+            and governance.active_schemas[0].canonical_definition_json() == expected_active.canonical_definition_json()
+        ):
+            raise ValueError("ontology rename must change the accepted schema definition")
+
+        judgment_decision = "reject" if governance.decision == "reject" else "accept"
+        replacement_value: JSONDocument | None = None
+        if governance.decision in {"rename", "split"}:
+            judgment_decision = "supersede"
+            replacement_value = _governance_replacement_value(candidate, governance)
+
+        judgment = judge_assertion_candidate(
+            conn,
+            candidate_ref=governance.candidate_ref,
+            decision=judgment_decision,
+            reason=governance.reason,
+            actor_ref=governance.actor_ref,
+            inject=False,
+            replacement_value=replacement_value,
+            now_ms=timestamp,
+        )
+        persisted = tuple(
+            persist_annotation_schema(conn, schema, registered_at_ms=timestamp) for schema in governance.active_schemas
+        )
+        judgment_ref = f"assertion:{judgment.judgment.assertion_id}"
+        resulting_ref = (
+            None if judgment.resulting_assertion is None else f"assertion:{judgment.resulting_assertion.assertion_id}"
+        )
+        candidate_value = require_json_document(candidate.value, context="ontology candidate value")
+        source_tag_refs_raw = candidate_value.get("source_tag_refs", [])
+        source_tag_refs = (
+            [str(ref) for ref in source_tag_refs_raw]
+            if isinstance(source_tag_refs_raw, list) and all(isinstance(ref, str) for ref in source_tag_refs_raw)
+            else []
+        )
+        receipt_value: JSONDocument = {
+            "format": ONTOLOGY_GOVERNANCE_FORMAT,
+            "decision": governance.decision,
+            "candidate_ref": governance.candidate_ref,
+            "judgment_ref": judgment_ref,
+            "resulting_candidate_ref": resulting_ref,
+            "active_schemas": [
+                {
+                    "qualified_id": durable.schema.qualified_id,
+                    "definition_sha256": durable.definition_sha256,
+                }
+                for durable in persisted
+            ],
+            "source_tag_refs": cast("list[JSONValue]", source_tag_refs),
+            "affinity": candidate_value.get("affinity"),
+            "confidence": candidate_value.get("confidence"),
+            "classifier_ref": candidate_value.get("classifier_ref"),
+            "version_crosswalk": candidate_value.get("version_crosswalk"),
+            "frame_ref": candidate_value.get("frame_ref"),
+            "epoch_ref": candidate_value.get("epoch_ref"),
+            "cross_view_state": candidate_value.get("cross_view_state"),
+            "privacy_policy_ref": candidate_value.get("privacy_policy_ref"),
+            "annotation_batch_required": governance.decision != "reject",
+        }
+        receipt_id = assertion_id_for_ontology_governance(
+            candidate_ref=governance.candidate_ref,
+            decision=governance.decision,
+            active_schemas=governance.active_schemas,
+        )
+        receipt_evidence = list(
+            dict.fromkeys(
+                (
+                    *candidate.evidence_refs,
+                    governance.candidate_ref,
+                    judgment_ref,
+                    *((resulting_ref,) if resulting_ref is not None else ()),
+                )
+            )
+        )
+        existing_receipt = read_assertion_envelope(conn, receipt_id)
+        if existing_receipt is not None:
+            if (
+                existing_receipt.kind != AssertionKind.ONTOLOGY_GOVERNANCE
+                or existing_receipt.value != receipt_value
+                or existing_receipt.author_ref != governance.actor_ref
+                or existing_receipt.evidence_refs != receipt_evidence
+            ):
+                raise RuntimeError(f"ontology governance receipt identity collision: {receipt_id}")
+            receipt = existing_receipt
+        else:
+            receipt = upsert_assertion(
+                conn,
+                assertion_id=receipt_id,
+                scope_ref=judgment_ref,
+                target_ref=governance.candidate_ref,
+                key=f"{governance.decision}/{draft_schema.qualified_id}",
+                kind=AssertionKind.ONTOLOGY_GOVERNANCE,
+                value=receipt_value,
+                body_text=governance.reason,
+                author_ref=governance.actor_ref,
+                author_kind="user",
+                evidence_refs=receipt_evidence,
+                status=AssertionStatus.ACTIVE,
+                visibility=AssertionVisibility.PRIVATE,
+                context_policy={"inject": False},
+                now_ms=timestamp,
+            )
+        return OntologyGovernanceResult(
+            judgment=judgment,
+            governance_receipt=receipt,
+            active_schemas=persisted,
+        )
 
 
 def upsert_annotation_assertion(
@@ -344,7 +860,19 @@ def upsert_annotation_assertion(
 
 
 __all__ = [
+    "ONTOLOGY_CANDIDATE_FORMAT",
+    "ONTOLOGY_GOVERNANCE_FORMAT",
     "AnnotationValidationError",
+    "OntologyBootstrapView",
+    "OntologyCandidateGovernance",
+    "OntologyCandidateNomination",
+    "OntologyGovernanceDecision",
+    "OntologyGovernanceResult",
+    "OntologyViewProposal",
+    "assertion_id_for_ontology_candidate",
+    "assertion_id_for_ontology_governance",
     "assertion_id_for_schema_annotation",
+    "govern_ontology_candidate",
+    "nominate_ontology_candidate",
     "upsert_annotation_assertion",
 ]

--- a/polylogue/core/enums.py
+++ b/polylogue/core/enums.py
@@ -433,6 +433,13 @@ class AssertionKind(PolylogueStrEnum):
     JUDGMENT = "judgment"
     RUN_STATE = "run_state"
     PROMPT_EVAL = "prompt_eval"
+    ONTOLOGY_CANDIDATE = "ontology_candidate"
+    """Agent-proposed archive-specific annotation schema plus nomination evidence.
+    Informal tags/affinity can create this non-injected candidate, never a formal
+    annotation fact or active schema on their own."""
+    ONTOLOGY_GOVERNANCE = "ontology_governance"
+    """Operator-authored receipt for accepting, renaming, splitting, or rejecting
+    an ontology candidate and, when applicable, registering active schema rows."""
     TRANSFORM_CANDIDATE = "transform_candidate"
     PATHOLOGY = "pathology"
     FINDING = "finding"

--- a/polylogue/storage/sqlite/archive_tiers/bootstrap.py
+++ b/polylogue/storage/sqlite/archive_tiers/bootstrap.py
@@ -89,8 +89,18 @@ def initialize_archive_tier(conn: sqlite3.Connection, tier: ArchiveTier) -> None
         from polylogue.storage.sqlite.archive_tiers.pricing_seed import seed_price_catalog
 
         seed_price_catalog(conn)
+    if tier is ArchiveTier.USER:
+        _ensure_user_annotation_schemas(conn)
     conn.execute(f"PRAGMA user_version = {spec.version}")
     conn.commit()
+
+
+def _ensure_user_annotation_schemas(conn: sqlite3.Connection) -> None:
+    """Replay packaged schema rows without changing the user-tier DDL version."""
+
+    from polylogue.storage.sqlite.archive_tiers.user_annotations import persist_builtin_annotation_schemas
+
+    persist_builtin_annotation_schemas(conn, registered_at_ms=0)
 
 
 def _ensure_ops_runtime_columns(conn: sqlite3.Connection) -> None:
@@ -161,6 +171,9 @@ def initialize_archive_database(
             # archives receive newly introduced tables and indexes.
             if tier is ArchiveTier.OPS:
                 initialize_archive_tier(conn, tier)
+            elif tier is ArchiveTier.USER:
+                _ensure_user_annotation_schemas(conn)
+                conn.commit()
             return
         if (
             current_version != 0

--- a/polylogue/storage/sqlite/archive_tiers/user_annotations.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_annotations.py
@@ -12,7 +12,11 @@ from dataclasses import dataclass
 from typing import cast
 
 from polylogue.annotations.batch import AnnotationBatch, AnnotationBatchError
-from polylogue.annotations.schema import AnnotationSchema, AnnotationSchemaError
+from polylogue.annotations.schema import (
+    BUILTIN_ANNOTATION_SCHEMAS,
+    AnnotationSchema,
+    AnnotationSchemaError,
+)
 from polylogue.core.json import JSONDocument, require_json_document
 from polylogue.core.json import loads as json_loads
 from polylogue.core.refs import ObjectRef, normalize_object_ref_text
@@ -129,6 +133,26 @@ def persist_annotation_schema(
     if persisted is None:  # pragma: no cover - INSERT followed by same-connection SELECT
         raise AnnotationSchemaError(f"annotation schema {schema.qualified_id!r} was not persisted")
     return persisted
+
+
+def persist_builtin_annotation_schemas(
+    conn: sqlite3.Connection,
+    *,
+    registered_at_ms: int = 0,
+) -> tuple[DurableAnnotationSchema, ...]:
+    """Ensure every packaged annotation construct has an immutable user-tier row.
+
+    Built-in vocabulary growth is data-only: ``annotation_schemas`` is already
+    the versioned registry and ``assertions.kind`` is plain ``TEXT``. Replaying
+    this function on a same-version ``user.db`` therefore adds missing rows
+    without a durable-tier schema migration, while ``persist_annotation_schema``
+    still fails closed if an existing identity has drifted.
+    """
+
+    return tuple(
+        persist_annotation_schema(conn, schema, registered_at_ms=registered_at_ms)
+        for schema in BUILTIN_ANNOTATION_SCHEMAS
+    )
 
 
 def _json_array_text(value: tuple[object, ...]) -> str:
@@ -356,6 +380,7 @@ __all__ = [
     "list_annotation_batches",
     "list_durable_annotation_schemas",
     "persist_annotation_batch",
+    "persist_builtin_annotation_schemas",
     "persist_annotation_schema",
     "read_annotation_batch",
     "read_durable_annotation_schema",

--- a/polylogue/storage/sqlite/archive_tiers/user_audit.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_audit.py
@@ -29,6 +29,8 @@ _ASSERTION_BACKED_SURFACES: dict[str, AssertionKind] = {
     "judgments": AssertionKind.JUDGMENT,
     "run_state": AssertionKind.RUN_STATE,
     "prompt_evals": AssertionKind.PROMPT_EVAL,
+    "ontology_candidates": AssertionKind.ONTOLOGY_CANDIDATE,
+    "ontology_governance_receipts": AssertionKind.ONTOLOGY_GOVERNANCE,
     "transform_candidates": AssertionKind.TRANSFORM_CANDIDATE,
     "pathologies": AssertionKind.PATHOLOGY,
     "findings": AssertionKind.FINDING,

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -1566,6 +1566,7 @@ ASSERTION_CANDIDATE_JUDGMENT_KINDS: tuple[AssertionKind, ...] = (
     AssertionKind.BLOCKER,
     AssertionKind.LESSON,
     AssertionKind.RUN_STATE,
+    AssertionKind.ONTOLOGY_CANDIDATE,
     AssertionKind.TRANSFORM_CANDIDATE,
     AssertionKind.PATHOLOGY,
     AssertionKind.FINDING,

--- a/tests/unit/annotations/test_seed_ontology.py
+++ b/tests/unit/annotations/test_seed_ontology.py
@@ -1,0 +1,586 @@
+"""Seed annotation ontologies and governed archive-local bootstrap (polylogue-dve1)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from polylogue.annotations.importer import AnnotationBatchImportRequest, import_annotation_batch
+from polylogue.annotations.join import AnnotationStructuralJoinRequest, join_typed_annotations
+from polylogue.annotations.schema import (
+    SEED_ACTIVITY_SCHEMA,
+    SEED_ANNOTATION_SCHEMAS,
+    SEED_GOAL_EVENT_SCHEMA,
+    SEED_KNOWLEDGE_ARTIFACT_SCHEMA,
+    SEED_OUTCOME_EVIDENCE_SCHEMA,
+    SEED_REUSABILITY_SCHEMA,
+    AnnotationField,
+    AnnotationSchema,
+    AnnotationSchemaError,
+    list_annotation_schemas,
+    validate_annotation_value,
+)
+from polylogue.annotations.write import (
+    OntologyCandidateGovernance,
+    OntologyCandidateNomination,
+    OntologyViewProposal,
+    assertion_id_for_schema_annotation,
+    govern_ontology_candidate,
+    nominate_ontology_candidate,
+)
+from polylogue.core.enums import AssertionKind, AssertionStatus
+from polylogue.core.json import require_json_document
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.user import USER_SCHEMA_VERSION
+from polylogue.storage.sqlite.archive_tiers.user_annotations import (
+    persist_annotation_schema,
+    read_durable_annotation_schema,
+)
+from polylogue.storage.sqlite.archive_tiers.user_write import (
+    judge_assertion_candidate,
+    read_assertion_envelope,
+    upsert_assertion,
+)
+
+
+def _draft_topic_schema(*, schema_id: str = "archive.topic", version: int = 1) -> AnnotationSchema:
+    return AnnotationSchema(
+        schema_id=schema_id,
+        version=version,
+        title="Archive topic",
+        description="Archive-local topic proposed from multiple declared views.",
+        fields=(
+            AnnotationField(name="topic", value_type="enum", enum_values=("procurement", "operations")),
+            AnnotationField(name="confidence", value_type="number", minimum=0, maximum=1),
+            AnnotationField(name="abstain", value_type="boolean", required=False),
+        ),
+        target_ref_kinds=("session",),
+        abstain_field="abstain",
+        evidence_policy="required",
+        status="draft",
+    )
+
+
+def _nomination(schema: AnnotationSchema, *, source_tag_ref: str) -> OntologyCandidateNomination:
+    return OntologyCandidateNomination(
+        candidate_schema=schema,
+        target_ref="workspace:archive-local",
+        affinity=0.97,
+        confidence=0.81,
+        classifier_ref="ranker:archive-topic-v1",
+        classifier_definition={"kind": "nearest-centroid", "version": 1},
+        version_crosswalk={"from": "archive.topic@v0", "labels": {"buying": "procurement"}},
+        frame_ref="result-set:ontology-bootstrap-frame",
+        epoch_ref="analysis:archive-epoch-17",
+        privacy_policy_ref="assertion:privacy-policy-v1",
+        author_ref="agent:ontology-bootstrap",
+        view_proposals=(
+            OntologyViewProposal(
+                view="content",
+                label="procurement",
+                confidence=0.91,
+                evidence_refs=("session:content-exemplar",),
+            ),
+            OntologyViewProposal(
+                view="action_pattern",
+                label="operations",
+                confidence=0.83,
+                evidence_refs=("session:action-exemplar",),
+            ),
+        ),
+        source_tag_refs=(source_tag_ref,),
+        residue_refs=("session:unclassified-residue",),
+        rare_sample_refs=("session:rare-category",),
+        privacy_excluded_refs=("session:privacy-excluded",),
+        evidence_refs=("session:bootstrap-evidence",),
+    )
+
+
+def _seed_tag(conn: sqlite3.Connection) -> str:
+    tag = upsert_assertion(
+        conn,
+        assertion_id="assertion-source-tag",
+        target_ref="session:tagged-session",
+        kind=AssertionKind.TAG,
+        key="procurement",
+        value={"tag": "procurement", "affinity": 0.97},
+        author_ref="user:local",
+        author_kind="user",
+        status=AssertionStatus.ACTIVE,
+        context_policy={"inject": False},
+        require_promotion=False,
+        now_ms=10,
+    )
+    conn.commit()
+    return f"assertion:{tag.assertion_id}"
+
+
+def test_seed_catalog_is_registered_and_replayed_without_user_schema_bump(tmp_path: Path) -> None:
+    qualified_ids = {schema.qualified_id for schema in list_annotation_schemas()}
+    assert {schema.qualified_id for schema in SEED_ANNOTATION_SCHEMAS} <= qualified_ids
+    assert len({schema.definition_fingerprint for schema in SEED_ANNOTATION_SCHEMAS}) == 5
+    for schema in SEED_ANNOTATION_SCHEMAS:
+        assert schema.status == "active"
+        assert schema.evidence_policy == "required"
+        assert {"confidence", "abstain", "rationale"} <= {field.name for field in schema.fields}
+
+    activity = next(field for field in SEED_ACTIVITY_SCHEMA.fields if field.name == "activity")
+    assert activity.enum_values == (
+        "debugging",
+        "design",
+        "implementation",
+        "research",
+        "writing",
+        "ideation",
+        "ops",
+        "procurement",
+    )
+    assert SEED_ACTIVITY_SCHEMA.target_ref_kinds == ("session", "phase", "message", "block")
+
+    artifact_type = next(field for field in SEED_KNOWLEDGE_ARTIFACT_SCHEMA.fields if field.name == "artifact_type")
+    artifact_authority = next(field for field in SEED_KNOWLEDGE_ARTIFACT_SCHEMA.fields if field.name == "authority")
+    assert artifact_type.enum_values == (
+        "decision",
+        "lesson",
+        "preference",
+        "fact_candidate",
+        "fact_established",
+        "commitment",
+    )
+    assert artifact_authority.enum_values == (
+        "agent_candidate",
+        "actor_declared",
+        "structural",
+        "rule",
+        "operator_judged",
+    )
+
+    reuse_purpose = next(field for field in SEED_REUSABILITY_SCHEMA.fields if field.name == "purpose")
+    reuse_authority = next(field for field in SEED_REUSABILITY_SCHEMA.fields if field.name == "authority")
+    assert reuse_purpose.enum_values == ("snippet", "recipe", "demo")
+    assert reuse_authority.enum_values == ("agent_candidate", "operator_judged")
+
+    user_db = tmp_path / "user.db"
+    initialize_archive_database(user_db, ArchiveTier.USER)
+    with sqlite3.connect(user_db) as conn:
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == USER_SCHEMA_VERSION
+        rows = {
+            f"{schema_id}@v{version}"
+            for schema_id, version in conn.execute(
+                "SELECT schema_id, schema_version FROM annotation_schemas"
+            ).fetchall()
+        }
+        assert {schema.qualified_id for schema in SEED_ANNOTATION_SCHEMAS} <= rows
+
+        activity_v2 = replace(SEED_ACTIVITY_SCHEMA, version=2, title="Activity v2")
+        persist_annotation_schema(conn, activity_v2, registered_at_ms=1)
+        with pytest.raises(AnnotationSchemaError, match="incompatible durable definition"):
+            persist_annotation_schema(
+                conn,
+                replace(SEED_ACTIVITY_SCHEMA, title="Drifted activity"),
+                registered_at_ms=2,
+            )
+        conn.execute(
+            "DELETE FROM annotation_schemas WHERE schema_id = ? AND schema_version = ?",
+            (SEED_ACTIVITY_SCHEMA.schema_id, SEED_ACTIVITY_SCHEMA.version),
+        )
+        conn.commit()
+
+    # Same user_version: data-only bootstrap replays the missing immutable row.
+    initialize_archive_database(user_db, ArchiveTier.USER)
+    with sqlite3.connect(user_db) as conn:
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == USER_SCHEMA_VERSION
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM annotation_schemas WHERE schema_id = ? AND schema_version = ?",
+                (SEED_ACTIVITY_SCHEMA.schema_id, SEED_ACTIVITY_SCHEMA.version),
+            ).fetchone()[0]
+            == 1
+        )
+        assert [
+            int(row[0])
+            for row in conn.execute(
+                "SELECT schema_version FROM annotation_schemas WHERE schema_id = ? ORDER BY schema_version",
+                (SEED_ACTIVITY_SCHEMA.schema_id,),
+            ).fetchall()
+        ] == [1, 2]
+
+
+def test_goal_events_exclude_derived_inactivity_and_remain_distinct_from_outcomes() -> None:
+    goal_event = next(field for field in SEED_GOAL_EVENT_SCHEMA.fields if field.name == "event_type")
+    assert goal_event.enum_values == (
+        "opened",
+        "blocked",
+        "resumed",
+        "declared_resolved",
+        "superseded",
+        "explicitly_abandoned",
+    )
+    assert "abandoned" not in goal_event.enum_values
+    assert "unresolved_inactive" not in goal_event.enum_values
+    errors = validate_annotation_value(
+        SEED_GOAL_EVENT_SCHEMA,
+        {
+            "event_type": "unresolved_inactive",
+            "goal_ref": "goal:1",
+            "declared_by_ref": "user:local",
+            "declaration_authority": "actor_declared",
+            "confidence": 0.9,
+        },
+    )
+    assert any("event_type" in error for error in errors)
+
+    assert SEED_GOAL_EVENT_SCHEMA.schema_id != SEED_OUTCOME_EVIDENCE_SCHEMA.schema_id
+    outcome_type = next(field for field in SEED_OUTCOME_EVIDENCE_SCHEMA.fields if field.name == "outcome_type")
+    authority = next(field for field in SEED_OUTCOME_EVIDENCE_SCHEMA.fields if field.name == "authority")
+    temporal_mode = next(field for field in SEED_OUTCOME_EVIDENCE_SCHEMA.fields if field.name == "temporal_mode")
+    assert "test_passed" in outcome_type.enum_values
+    assert set(goal_event.enum_values).isdisjoint(outcome_type.enum_values)
+    assert authority.enum_values == ("structural", "rule", "judged")
+    assert temporal_mode.enum_values == ("observed", "historical_backfill")
+
+    shared_identity = {
+        "target_ref": "session:historical",
+        "author_ref": "agent:backfill",
+        "row_key": "event-1",
+    }
+    assert assertion_id_for_schema_annotation(
+        schema_qualified_id=SEED_GOAL_EVENT_SCHEMA.qualified_id,
+        **shared_identity,
+    ) != assertion_id_for_schema_annotation(
+        schema_qualified_id=SEED_OUTCOME_EVIDENCE_SCHEMA.qualified_id,
+        **shared_identity,
+    )
+
+
+def test_rejected_nomination_preserves_tag_and_full_bootstrap_evidence(tmp_path: Path) -> None:
+    user_db = tmp_path / "user.db"
+    initialize_archive_database(user_db, ArchiveTier.USER)
+    conn = sqlite3.connect(user_db)
+    conn.row_factory = sqlite3.Row
+    try:
+        source_tag_ref = _seed_tag(conn)
+        nomination = _nomination(_draft_topic_schema(), source_tag_ref=source_tag_ref)
+        statements: list[str] = []
+        conn.set_trace_callback(statements.append)
+        candidate = nominate_ontology_candidate(conn, nomination, now_ms=20)
+        conn.set_trace_callback(None)
+
+        assert next(statement for statement in statements if statement.strip()).upper().startswith("BEGIN IMMEDIATE")
+        assert candidate.kind == AssertionKind.ONTOLOGY_CANDIDATE
+        assert candidate.status == AssertionStatus.CANDIDATE
+        assert candidate.context_policy == {"inject": False, "promotion_required": True}
+        assert isinstance(candidate.value, dict)
+        assert candidate.value["source_tag_refs"] == [source_tag_ref]
+        assert candidate.value["affinity"] == 0.97
+        assert candidate.value["confidence"] == 0.81
+        assert candidate.value["version_crosswalk"] == {
+            "from": "archive.topic@v0",
+            "labels": {"buying": "procurement"},
+        }
+        assert candidate.confidence == 0.81
+        assert candidate.value["cross_view_state"] == "disagreement"
+        assert candidate.value["residue_refs"] == ["session:unclassified-residue"]
+        assert candidate.value["rare_sample_refs"] == ["session:rare-category"]
+        assert candidate.value["epoch_ref"] == "analysis:archive-epoch-17"
+        assert candidate.value["privacy_excluded_refs"] == ["session:privacy-excluded"]
+        assert read_durable_annotation_schema(conn, "archive.topic", 1) is None
+        assert conn.execute("SELECT COUNT(*) FROM assertions WHERE kind = 'annotation'").fetchone()[0] == 0
+
+        result = govern_ontology_candidate(
+            conn,
+            OntologyCandidateGovernance(
+                candidate_ref=f"assertion:{candidate.assertion_id}",
+                decision="reject",
+                actor_ref="user:operator",
+                reason="category boundary is not stable",
+            ),
+            now_ms=30,
+        )
+        assert result.judgment.candidate.status == AssertionStatus.REJECTED
+        assert result.governance_receipt.kind == AssertionKind.ONTOLOGY_GOVERNANCE
+        receipt_value = require_json_document(result.governance_receipt.value, context="governance receipt value")
+        candidate_value = require_json_document(candidate.value, context="candidate value")
+        assert receipt_value["decision"] == "reject"
+        assert receipt_value["affinity"] == 0.97
+        assert receipt_value["confidence"] == 0.81
+        assert receipt_value["version_crosswalk"] == candidate_value["version_crosswalk"]
+        assert read_durable_annotation_schema(conn, "archive.topic", 1) is None
+
+        tag = read_assertion_envelope(conn, source_tag_ref.removeprefix("assertion:"))
+        assert tag is not None
+        assert tag.kind == AssertionKind.TAG
+        assert tag.status == AssertionStatus.ACTIVE
+        assert tag.value == {"tag": "procurement", "affinity": 0.97}
+
+        # A later autonomous retry cannot resurrect the terminal rejection.
+        retried = nominate_ontology_candidate(conn, nomination, now_ms=40)
+        assert retried.status == AssertionStatus.REJECTED
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize(
+    ("decision", "draft_schema_id", "active_schema_ids"),
+    (
+        ("rename", "archive.topic.rename", ("archive.workflow",)),
+        (
+            "split",
+            "archive.topic.split",
+            ("archive.topic.procurement", "archive.topic.operations"),
+        ),
+    ),
+)
+def test_rename_and_split_register_only_operator_output_schemas(
+    tmp_path: Path,
+    decision: str,
+    draft_schema_id: str,
+    active_schema_ids: tuple[str, ...],
+) -> None:
+    user_db = tmp_path / "user.db"
+    initialize_archive_database(user_db, ArchiveTier.USER)
+    conn = sqlite3.connect(user_db)
+    conn.row_factory = sqlite3.Row
+    try:
+        source_tag_ref = _seed_tag(conn)
+        draft = _draft_topic_schema(schema_id=draft_schema_id)
+        candidate = nominate_ontology_candidate(
+            conn,
+            _nomination(draft, source_tag_ref=source_tag_ref),
+            now_ms=50,
+        )
+        active_schemas = tuple(
+            replace(
+                _draft_topic_schema(schema_id=schema_id),
+                status="active",
+                title=f"Operator-governed {schema_id}",
+            )
+            for schema_id in active_schema_ids
+        )
+        request = OntologyCandidateGovernance(
+            candidate_ref=f"assertion:{candidate.assertion_id}",
+            decision=decision,  # type: ignore[arg-type]
+            actor_ref="user:operator",
+            reason=f"operator chose to {decision} the proposed category",
+            active_schemas=active_schemas,
+        )
+        result = govern_ontology_candidate(conn, request, now_ms=60)
+
+        assert result.judgment.candidate.status == AssertionStatus.SUPERSEDED
+        assert result.judgment.resulting_assertion is not None
+        resulting_value = require_json_document(
+            result.judgment.resulting_assertion.value, context="resulting assertion value"
+        )
+        assert resulting_value["governance_decision"] == decision
+        assert read_durable_annotation_schema(conn, draft.schema_id, draft.version) is None
+        assert {durable.schema.qualified_id for durable in result.active_schemas} == {
+            schema.qualified_id for schema in active_schemas
+        }
+        assert all(
+            read_durable_annotation_schema(conn, schema.schema_id, schema.version) is not None
+            for schema in active_schemas
+        )
+        receipt_value = require_json_document(result.governance_receipt.value, context="governance receipt value")
+        assert receipt_value["decision"] == decision
+        assert receipt_value["annotation_batch_required"] is True
+
+        retry = govern_ontology_candidate(conn, request, now_ms=70)
+        assert retry.judgment.outcome == "idempotent"
+        assert retry.governance_receipt.assertion_id == result.governance_receipt.assertion_id
+
+        tag = read_assertion_envelope(conn, source_tag_ref.removeprefix("assertion:"))
+        assert tag is not None
+        assert tag.status == AssertionStatus.ACTIVE
+    finally:
+        conn.close()
+
+
+def test_governance_rolls_back_judgment_when_schema_registration_conflicts(tmp_path: Path) -> None:
+    user_db = tmp_path / "user.db"
+    initialize_archive_database(user_db, ArchiveTier.USER)
+    conn = sqlite3.connect(user_db)
+    conn.row_factory = sqlite3.Row
+    try:
+        source_tag_ref = _seed_tag(conn)
+        draft = _draft_topic_schema(schema_id="archive.atomic-topic")
+        candidate = nominate_ontology_candidate(
+            conn,
+            _nomination(draft, source_tag_ref=source_tag_ref),
+            now_ms=80,
+        )
+        persist_annotation_schema(
+            conn,
+            replace(draft, status="active", title="Conflicting durable definition"),
+            registered_at_ms=85,
+        )
+        conn.commit()
+
+        with pytest.raises(AnnotationSchemaError, match="incompatible durable definition"):
+            govern_ontology_candidate(
+                conn,
+                OntologyCandidateGovernance(
+                    candidate_ref=f"assertion:{candidate.assertion_id}",
+                    decision="accept",
+                    actor_ref="user:operator",
+                    active_schemas=(replace(draft, status="active"),),
+                ),
+                now_ms=90,
+            )
+
+        unchanged = read_assertion_envelope(conn, candidate.assertion_id)
+        assert unchanged is not None
+        assert unchanged.status == AssertionStatus.CANDIDATE
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM assertions WHERE kind IN ('judgment', 'ontology_governance')"
+            ).fetchone()[0]
+            == 0
+        )
+    finally:
+        conn.close()
+
+
+class _ArchiveFacade:
+    def __init__(self, archive_root: Path) -> None:
+        self.archive_root = archive_root
+
+    async def resolve_ref(self, ref: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            resolved=True,
+            caveats=(),
+            object_refs=(ref,),
+            payload_kind="session",
+            payload={},
+        )
+
+    async def get_session_summary(self, session_id: str) -> None:
+        return None
+
+
+async def _resolved(_ref: str) -> bool:
+    return True
+
+
+def test_accept_then_durable_batch_import_requires_label_judgment_for_active_query(tmp_path: Path) -> None:
+    user_db = tmp_path / "user.db"
+    initialize_archive_database(user_db, ArchiveTier.USER)
+    conn = sqlite3.connect(user_db)
+    conn.row_factory = sqlite3.Row
+    try:
+        source_tag_ref = _seed_tag(conn)
+        draft = _draft_topic_schema()
+        candidate = nominate_ontology_candidate(conn, _nomination(draft, source_tag_ref=source_tag_ref), now_ms=100)
+        active = replace(draft, status="active")
+        governance_request = OntologyCandidateGovernance(
+            candidate_ref=f"assertion:{candidate.assertion_id}",
+            decision="accept",
+            actor_ref="user:operator",
+            reason="cross-view evidence is useful despite a documented boundary disagreement",
+            active_schemas=(active,),
+        )
+        governance = govern_ontology_candidate(conn, governance_request, now_ms=110)
+        assert governance.active_schemas[0].schema == active
+        governance_receipt_value = require_json_document(
+            governance.governance_receipt.value, context="governance receipt value"
+        )
+        assert governance_receipt_value["annotation_batch_required"] is True
+
+        governance_retry = govern_ontology_candidate(conn, governance_request, now_ms=115)
+        assert governance_retry.judgment.outcome == "idempotent"
+        assert governance_retry.governance_receipt.assertion_id == governance.governance_receipt.assertion_id
+
+        # An identical autonomous retry returns the terminal accepted lifecycle row.
+        retried = nominate_ontology_candidate(conn, _nomination(draft, source_tag_ref=source_tag_ref), now_ms=116)
+        assert retried.status == AssertionStatus.ACCEPTED
+        assert read_durable_annotation_schema(conn, active.schema_id, active.version) is not None
+    finally:
+        conn.close()
+
+    facade = _ArchiveFacade(tmp_path)
+    active_request = AnnotationStructuralJoinRequest(
+        schema_id=active.schema_id,
+        schema_version=active.version,
+        statuses=(AssertionStatus.ACTIVE,),
+    )
+    assert asyncio.run(join_typed_annotations(facade, active_request)).joined_count == 0
+
+    batch_request = AnnotationBatchImportRequest(
+        jsonl=json.dumps(
+            {
+                "row_key": "topic-1",
+                "value": {"topic": "procurement", "confidence": 0.88},
+                "evidence_refs": ["session:topic-session"],
+            }
+        ),
+        batch_id="archive-topic-backfill-1",
+        schema_id=active.schema_id,
+        schema_version=active.version,
+        target_ref="session:topic-session",
+        source_result_ref="result-set:ontology-bootstrap-frame",
+        actor_ref="agent:ontology-labeler",
+        model_ref="agent:model-v1",
+        prompt_ref="block:prompt-session:0",
+        metadata={"ontology_governance_ref": f"assertion:{governance.governance_receipt.assertion_id}"},
+        created_at_ms=120,
+    )
+    imported = asyncio.run(
+        import_annotation_batch(
+            facade,  # type: ignore[arg-type]
+            batch_request,
+            resolve_ref=_resolved,
+        )
+    )
+    assert imported.valid_count == 1
+    assertion_ref = next(row.assertion_ref for row in imported.rows if row.status == "imported")
+    assert assertion_ref is not None
+
+    # The governed schema exists, but an agent batch is still candidate-only.
+    assert asyncio.run(join_typed_annotations(facade, active_request)).joined_count == 0
+    candidate_request = AnnotationStructuralJoinRequest(
+        schema_id=active.schema_id,
+        schema_version=active.version,
+        statuses=(AssertionStatus.CANDIDATE,),
+    )
+    assert asyncio.run(join_typed_annotations(facade, candidate_request)).joined_count == 1
+
+    conn = sqlite3.connect(user_db)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+        judged = judge_assertion_candidate(
+            conn,
+            candidate_ref=assertion_ref,
+            decision="accept",
+            reason="operator accepts the batch label",
+            actor_ref="user:operator",
+            inject=False,
+            now_ms=130,
+        )
+        conn.commit()
+        assert judged.resulting_assertion is not None
+        assert judged.resulting_assertion.status == AssertionStatus.ACTIVE
+    finally:
+        conn.close()
+
+    # Exact agent replay uses the same BEGIN IMMEDIATE path and preserves the operator judgment.
+    replayed = asyncio.run(
+        import_annotation_batch(
+            facade,  # type: ignore[arg-type]
+            batch_request,
+            resolve_ref=_resolved,
+        )
+    )
+    assert replayed.valid_count == 1
+    assert asyncio.run(join_typed_annotations(facade, candidate_request)).joined_count == 0
+
+    active_join = asyncio.run(join_typed_annotations(facade, active_request))
+    assert active_join.joined_count == 1
+    assert active_join.rows[0].batch_ref == "annotation-batch:archive-topic-backfill-1"
+    assert active_join.rows[0].adjudicator_ref == "user:operator"

--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -1047,7 +1047,7 @@
         "version_status": "ok",
         "table_counts": {
           "assertions": 0,
-          "annotation_schemas": 1,
+          "annotation_schemas": 6,
           "annotation_batches": 0,
           "user_settings": 0,
           "context_deliveries": 0

--- a/webui/src/api/generated.ts
+++ b/webui/src/api/generated.ts
@@ -104,7 +104,7 @@ export type AssertionClaimPayload = {
   readonly visibility?: AssertionVisibility | null;
 };
 
-export type AssertionKind = "mark" | "highlight" | "annotation" | "correction" | "suppression" | "tag" | "metadata" | "saved_query" | "recall_pack" | "workspace_note" | "note" | "decision" | "caveat" | "lesson" | "blocker" | "handoff" | "judgment" | "run_state" | "prompt_eval" | "transform_candidate" | "pathology" | "finding" | "secret_candidate" | "excision_record" | "excision_request" | "comparative_judgment";
+export type AssertionKind = "mark" | "highlight" | "annotation" | "correction" | "suppression" | "tag" | "metadata" | "saved_query" | "recall_pack" | "workspace_note" | "note" | "decision" | "caveat" | "lesson" | "blocker" | "handoff" | "judgment" | "run_state" | "prompt_eval" | "ontology_candidate" | "ontology_governance" | "transform_candidate" | "pathology" | "finding" | "secret_candidate" | "excision_record" | "excision_request" | "comparative_judgment";
 
 export type AssertionQueryRowPayload = {
   readonly assertion_id: string;


### PR DESCRIPTION
## Summary

Implements polylogue-dve1: five versioned v1 seed annotation schemas
(activity, goal-event, outcome-evidence, knowledge-artifact,
reusability) plus a governed archive-local ontology candidate/bootstrap
lifecycle (nominate -> accept/rename/split/reject), landed on the
existing typed-annotation substrate (annotation_schemas,
annotation_batches, assertions).

## Problem

polylogue-dve1 asks for packaged seed ontologies plus an ontology
bootstrap loop where informal tags/affinity can nominate ontology
candidates but never become formal ontology facts without a judged
annotation batch/schema. No such packaged vocabulary or governance
state machine existed yet.

## Solution

- `polylogue/annotations/schema.py`: five new `AnnotationSchema`
  constants (`seed.activity@v1`, `seed.goal-event@v1`,
  `seed.outcome-evidence@v1`, `seed.knowledge-artifact@v1`,
  `seed.reusability@v1`), added to `BUILTIN_ANNOTATION_SCHEMAS`
  alongside the pre-existing `delegation.discourse@v1`.
- `polylogue/storage/sqlite/archive_tiers/user_annotations.py`:
  `persist_builtin_annotation_schemas()` replays the six built-in rows
  idempotently; wired into `bootstrap.py` for both fresh-DB init and
  same-version replay on an already-current `user.db`. **No
  `USER_SCHEMA_VERSION` bump** -- verified against current
  `archive_tiers/user.py` that `annotation_schemas` is already the
  immutable versioned registry and `assertions.kind` is plain `TEXT`
  with no `CHECK` constraint, so new vocabulary is pure data.
- `polylogue/annotations/write.py`: `OntologyCandidateNomination` /
  `nominate_ontology_candidate()` writes a private, non-injected
  `AssertionKind.ONTOLOGY_CANDIDATE` row carrying source tag refs,
  affinity, classifier definition, multi-view proposals/agreement, and
  privacy/excision refs, kept structurally separate from `confidence`.
  `OntologyCandidateGovernance` / `govern_ontology_candidate()` runs
  the full read/judge/register/receipt sequence in one `BEGIN
  IMMEDIATE`, reusing `judge_assertion_candidate()` for the durable
  lifecycle and writing a deterministic `AssertionKind.ONTOLOGY_GOVERNANCE`
  receipt. Schema persistence failure rolls back the whole transaction.
- Two new `AssertionKind` values wired through `core/enums.py`,
  `user_write.py` (candidate-review queue admission), `user_audit.py`
  (exhaustive per-kind audit), and regenerated
  `docs/openapi/search.yaml` / `docs/schemas/cli-output/query-unit-envelope.schema.json`.
- `polylogue/annotations/importer.py`: the existing
  `AnnotationBatchImportRequest` route now resolves archive-local
  (operator-promoted) schemas via a one-schema local registry, without
  polluting the process-global registry.

## Provenance and independent verification

This originated as external-agent packet `ann-01-ontology-seed-r01`
(GPT Pro wave 2, snapshot `536a53efac0cbe4a2473ad379e4db49ef3fce74d`,
unreviewed). I treated its claims adversarially rather than trusting
its own `TESTS.md`:

- Confirmed against live source (not the packet's assertion) that
  `assertions.kind` is unconstrained `TEXT` and `annotation_schemas` is
  the existing immutable versioned registry -- no user-tier DDL/migration
  needed, `USER_SCHEMA_VERSION` stays 9.
- `git apply --check` against current `origin/master` (12 commits
  ahead of the packet's snapshot): clean, one 23-line hunk offset.
- Found and fixed two real defects the packet's dependency-starved
  sandbox couldn't catch:
  - `devtools verify layering` failed (`writer_module_entrypoint_inventory_mismatch`)
    because `docs/plans/layering.yaml` wasn't updated for the new
    `persist_builtin_annotation_schemas` entrypoint. Confirmed this is
    a real regression, not pre-existing, by stash-testing the baseline
    (`master` alone: `No layering violations found`).
  - `mypy --strict` found 17 real errors: redundant `cast(JSONValue,
    ...)` calls, one `list[str]` assigned into a `dict[str, JSONValue]`
    dict-item position, and 8 test call sites indexing
    `JSONValue | None` with `# type: ignore[index]` comments that
    didn't even match the mypy version's actual error code
    (`call-overload`). Fixed via `require_json_document()` narrowing
    instead of suppressing.
- Ran the two `sqlite-vec`-dependent round-trip tests
  (`test_write.py::TestAnnotationRoundtripWithQueryAndJudge`) the
  packet's bare container couldn't execute -- both pass here.

## Verification

```
devtools test tests/unit/annotations/ tests/unit/storage/test_archive_tiers_assertions.py
-> 155 passed

devtools test tests/unit/annotations/test_schema.py tests/unit/annotations/test_write.py \
  tests/unit/storage/test_archive_tiers_user_audit.py tests/unit/devtools/test_render_openapi.py \
  tests/unit/cli/test_cli_output_schemas.py tests/unit/storage/test_archive_tiers_ddl.py
-> 154 passed

devtools verify --quick
-> exit 0 (ruff format/check, mypy --strict, render all --check, layering + all lab policy checks)
```

Not run: the full non-quick `devtools verify` (testmon inner loop) and
the post-merge heavy CI `test` suite; per-PR CI intentionally skips it.

Ref polylogue-dve1