### PR TITLE
test: replay MCP continuity transactions

### DIFF
--- a/devtools/continuity_replay.py
+++ b/devtools/continuity_replay.py
@@ -3,14 +3,201 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
+import os
 import sys
+import tempfile
+import time
 from pathlib import Path
+from typing import Any
 
 if __package__ in {None, ""}:  # pragma: no cover - exercised by the script entry point
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from polylogue.product.continuity_scenarios import continuity_scenario
+
+_LIVE_MCP_SCENARIO = "mcp-query-transaction"
+_LIVE_MCP_EXPRESSION = "actions where tool:Workflow"
+_LIVE_MCP_PAGE_SIZE = 2
+
+
+def _seed_live_mcp_archive(archive_root: Path) -> None:
+    """Create the deterministic, independently-censused replay corpus."""
+    from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType, Provider
+    from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    with ArchiveStore(archive_root) as archive:
+        for number in range(1, 5):
+            native_id = f"continuity-{number:02d}"
+            archive.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CODEX,
+                    provider_session_id=native_id,
+                    title=f"continuity workflow {number:02d}",
+                    messages=[
+                        ParsedMessage(
+                            provider_message_id=f"{native_id}-message",
+                            role=Role.ASSISTANT,
+                            blocks=[
+                                ParsedContentBlock(
+                                    type=BlockType.TOOL_USE,
+                                    tool_name="Workflow",
+                                    tool_id=f"workflow-{number:02d}",
+                                    tool_input={"step": number},
+                                )
+                            ],
+                        )
+                    ],
+                )
+            )
+
+
+def _mcp_server_parameters(archive_root: Path) -> Any:
+    """Return a fresh stdio server process; no continuation state is shared."""
+    from mcp import StdioServerParameters
+
+    environment = dict(os.environ)
+    environment["POLYLOGUE_ARCHIVE_ROOT"] = str(archive_root)
+    return StdioServerParameters(
+        command=sys.executable,
+        args=["-c", "from polylogue.mcp.cli import main; main()"],
+        env=environment,
+        cwd=Path(__file__).resolve().parents[1],
+    )
+
+
+def _tool_text(result: Any) -> str:
+    if result.isError:
+        raise RuntimeError(f"MCP query_units failed: {result.content!r}")
+    text = "".join(item.text for item in result.content if hasattr(item, "text"))
+    if not text:
+        raise RuntimeError("MCP query_units returned no text payload")
+    return text
+
+
+async def _mcp_query_page(
+    archive_root: Path, arguments: dict[str, object], *, discover: bool
+) -> tuple[dict[str, object], dict[str, object]]:
+    """Make one real MCP stdio client/server call and return its transcript row."""
+    from mcp.client.session import ClientSession
+    from mcp.client.stdio import stdio_client
+    from pydantic import AnyUrl
+
+    started = time.monotonic()
+    async with (
+        stdio_client(_mcp_server_parameters(archive_root)) as (read_stream, write_stream),
+        ClientSession(read_stream, write_stream) as client,
+    ):
+        await client.initialize()
+        discovery: dict[str, object] = {}
+        if discover:
+            tools = await client.list_tools()
+            resources = await client.list_resources()
+            tool_names = {tool.name for tool in tools.tools}
+            resource_uris = {str(resource.uri) for resource in resources.resources}
+            if "query_units" not in tool_names or "polylogue://capabilities/query" not in resource_uris:
+                raise RuntimeError("MCP discovery did not expose the canonical query transaction")
+            capability = await client.read_resource(AnyUrl("polylogue://capabilities/query"))
+            discovery = {
+                "query_units_discovered": True,
+                "capability_resource_read": bool(capability.contents),
+            }
+        result = await client.call_tool("query_units", arguments)
+    payload = json.loads(_tool_text(result))
+    if not isinstance(payload, dict):
+        raise RuntimeError("MCP query_units payload must be an object")
+    elapsed = time.monotonic() - started
+    return payload, {
+        "tool": "query_units",
+        "arguments": arguments,
+        "elapsed_seconds": elapsed,
+        "page_bytes": len(json.dumps(payload, sort_keys=True).encode("utf-8")),
+        **discovery,
+    }
+
+
+async def run_live_mcp_replay(scenario_name: str, fixture: dict[str, object]) -> dict[str, object]:
+    """Run a cold-server MCP continuity walk over a local synthetic archive.
+
+    The first page is intentionally the cancellation point. Its opaque
+    continuation is recorded, the client and server are torn down, and every
+    remaining page is fetched through a new stdio server process. This proves
+    that progress is carried by transaction evidence rather than process memory.
+    """
+    if scenario_name != _LIVE_MCP_SCENARIO:
+        raise ValueError(f"live MCP replay only supports {_LIVE_MCP_SCENARIO!r}")
+    with tempfile.TemporaryDirectory(prefix="polylogue-continuity-") as temporary:
+        archive_root = Path(temporary) / "archive"
+        _seed_live_mcp_archive(archive_root)
+        first, first_transcript = await _mcp_query_page(
+            archive_root,
+            {"expression": _LIVE_MCP_EXPRESSION, "limit": _LIVE_MCP_PAGE_SIZE},
+            discover=True,
+        )
+        continuation = first.get("continuation")
+        if not isinstance(continuation, str):
+            raise RuntimeError("first MCP page did not issue an advancing continuation")
+        transcript: list[dict[str, object]] = [
+            {"phase": "initial-page", **first_transcript, "query_ref": first.get("query_ref")},
+            {
+                "phase": "cancelled-walk",
+                "continuation": continuation,
+                "reason": "client stopped after bounded page",
+            },
+        ]
+        pages = [first]
+        while isinstance(continuation, str):
+            page, row = await _mcp_query_page(
+                archive_root,
+                {"expression": "actions where tool:ignored", "continuation": continuation},
+                discover=False,
+            )
+            if page.get("query_ref") != first.get("query_ref") or page.get("result_ref") != first.get("result_ref"):
+                raise RuntimeError("cold MCP resume changed transaction identity")
+            transcript.append({"phase": "cold-resume-page", **row, "query_ref": page.get("query_ref")})
+            pages.append(page)
+            next_continuation = page.get("continuation")
+            if next_continuation == continuation:
+                raise RuntimeError("MCP continuation did not advance")
+            continuation = next_continuation if isinstance(next_continuation, str) else None
+        refs: list[str] = []
+        for page in pages:
+            items = page.get("items", [])
+            if not isinstance(items, list):
+                raise RuntimeError("MCP query_units page has invalid items")
+            for item in items:
+                if not isinstance(item, dict) or not isinstance(item.get("session_id"), str):
+                    raise RuntimeError("MCP action row has no session identity")
+                refs.append(f"session:{item['session_id']}")
+        page_sizes: list[int] = []
+        for row in transcript:
+            page_bytes = row.get("page_bytes")
+            if isinstance(page_bytes, int):
+                page_sizes.append(page_bytes)
+        observation = {
+            "refs": refs,
+            "calls": len(pages),
+            "page_bytes": max(page_sizes, default=0),
+            "cancel_seconds": 0.0,
+            "continuation_state_lost": False,
+            "non_progressing_continuation": False,
+        }
+        evaluated = evaluate_replay(scenario_name, fixture, observation)
+        return {
+            **evaluated,
+            "receipt": {
+                "kind": "mcp-continuity-replay-v1",
+                "scenario": scenario_name,
+                "query_ref": first.get("query_ref"),
+                "result_ref": first.get("result_ref"),
+                "cancelled_after_pages": 1,
+                "resumed_with_fresh_server_process": True,
+                "transcript": transcript,
+            },
+        }
 
 
 def evaluate_replay(
@@ -74,11 +261,22 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("scenario")
     parser.add_argument("fixture", type=Path)
-    parser.add_argument("observation", type=Path)
+    parser.add_argument("observation", type=Path, nargs="?")
+    parser.add_argument("--live-mcp", action="store_true", help="execute the deterministic stdio MCP replay")
+    parser.add_argument("--receipt", type=Path, help="write the replay receipt JSON to this path")
     args = parser.parse_args(argv)
     fixture = json.loads(args.fixture.read_text(encoding="utf-8"))
-    observation = json.loads(args.observation.read_text(encoding="utf-8"))
-    result = evaluate_replay(args.scenario, fixture, observation)
+    if args.live_mcp:
+        if args.observation is not None:
+            parser.error("observation is not accepted with --live-mcp")
+        result = asyncio.run(run_live_mcp_replay(args.scenario, fixture))
+    else:
+        if args.observation is None:
+            parser.error("observation is required unless --live-mcp is used")
+        observation = json.loads(args.observation.read_text(encoding="utf-8"))
+        result = evaluate_replay(args.scenario, fixture, observation)
+    if args.receipt is not None:
+        args.receipt.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     print(json.dumps(result, indent=2, sort_keys=True))
     return 0 if result["classification"] == "pass" else 1
 
@@ -87,4 +285,4 @@ if __name__ == "__main__":
     raise SystemExit(main())
 
 
-__all__ = ["evaluate_replay", "main"]
+__all__ = ["evaluate_replay", "main", "run_live_mcp_replay"]

--- a/polylogue/product/continuity_scenarios.py
+++ b/polylogue/product/continuity_scenarios.py
@@ -213,6 +213,20 @@ CONTINUITY_SCENARIOS: tuple[ContinuityScenarioSpec, ...] = (
         ("unpaged-capability-catalog",),
     ),
     _scenario(
+        "mcp-query-transaction",
+        "Replay a bounded MCP query transaction",
+        "Enumerate workflow actions without losing progress after interruption.",
+        ("query-discovery", "action", "continuation", "receipt"),
+        (
+            "session:codex-session:continuity-01",
+            "session:codex-session:continuity-02",
+            "session:codex-session:continuity-03",
+            "session:codex-session:continuity-04",
+        ),
+        ("capability-discovery", "action-query", "continuation-recovery"),
+        ("lost-continuation-state", "non-progressing-continuation"),
+    ),
+    _scenario(
         "parallel-claude-incident",
         "Reconstruct parallel Claude work",
         "Which agents handled the concerns and what changed?",

--- a/tests/data/continuity/incident.json
+++ b/tests/data/continuity/incident.json
@@ -6,6 +6,14 @@
   "postmortem": {"refs": ["run:failed-1", "action:failed-1"], "source": "fixture-run-and-action-evidence"},
   "cost": {"refs": ["usage:run-1"], "source": "fixture-reported-usage"},
   "self-inspection": {"refs": ["capability:query"], "source": "declaration-fixture"},
+  "mcp-query-transaction": {
+    "refs": [
+      "session:codex-session:continuity-01",
+      "session:codex-session:continuity-02",
+      "session:codex-session:continuity-03",
+      "session:codex-session:continuity-04"
+    ]
+  },
   "parallel-claude-incident": {
     "refs": ["session:coordinator", "run:wf-1", "commit:abc123", "bead:xyz"],
     "coordinator_session": "cf0c6474-da22-44be-af3e-666037aa5ea4",

--- a/tests/integration/test_continuity_replay.py
+++ b/tests/integration/test_continuity_replay.py
@@ -1,0 +1,60 @@
+"""Terminal continuity replay through a real local MCP stdio client/server."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from devtools.continuity_replay import main, run_live_mcp_replay
+
+FIXTURE = json.loads((Path(__file__).parents[1] / "data" / "continuity" / "incident.json").read_text(encoding="utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_live_mcp_replay_enumerates_known_answer_after_cold_resume() -> None:
+    """The registered stdio server, not a supplied observation, earns pass."""
+    result = await run_live_mcp_replay("mcp-query-transaction", FIXTURE)
+
+    assert result["classification"] == "pass"
+    assert result["observed_refs"] == result["expected_refs"]
+    receipt = result["receipt"]
+    assert isinstance(receipt, dict)
+    assert receipt["cancelled_after_pages"] == 1
+    assert receipt["resumed_with_fresh_server_process"] is True
+    transcript = receipt["transcript"]
+    assert isinstance(transcript, list)
+    assert transcript[0]["query_units_discovered"] is True
+    assert transcript[0]["capability_resource_read"] is True
+    assert transcript[1]["phase"] == "cancelled-walk"
+    assert any(row["phase"] == "cold-resume-page" for row in transcript)
+
+
+@pytest.mark.asyncio
+async def test_live_mcp_replay_rejects_changed_independent_known_answer() -> None:
+    """Anti-vacuity: the route cannot bless its own output as the oracle."""
+    mutated = {**FIXTURE, "mcp-query-transaction": {"refs": ["session:missing"]}}
+
+    result = await run_live_mcp_replay("mcp-query-transaction", mutated)
+
+    assert result["classification"] == "projection"
+
+
+def test_live_mcp_command_writes_durable_receipt(tmp_path: Path) -> None:
+    receipt = tmp_path / "continuity-receipt.json"
+
+    exit_code = main(
+        [
+            "mcp-query-transaction",
+            str(Path(__file__).parents[1] / "data" / "continuity" / "incident.json"),
+            "--live-mcp",
+            "--receipt",
+            str(receipt),
+        ]
+    )
+
+    written = json.loads(receipt.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert written["classification"] == "pass"
+    assert written["receipt"]["transcript"][1]["phase"] == "cancelled-walk"

--- a/tests/unit/product/test_continuity_scenarios.py
+++ b/tests/unit/product/test_continuity_scenarios.py
@@ -18,6 +18,7 @@ def test_continuity_catalog_contains_all_operator_jobs_and_incident_variant() ->
         "postmortem",
         "cost",
         "self-inspection",
+        "mcp-query-transaction",
         "parallel-claude-incident",
     }
     assert all(scenario.required_facts for scenario in CONTINUITY_SCENARIOS)


### PR DESCRIPTION
## Summary

Adds a deterministic terminal continuity replay that drives Polylogue through
an actual local MCP stdio client/server exchange.

## Problem

The continuity replay command previously graded only observations supplied by
a caller. That could validate an invented transcript without proving that MCP
discovery, pagination, interruption, and recovery work through the registered
transport.

## Solution

- Add the fixture-owned `mcp-query-transaction` known-answer scenario.
- Seed a private synthetic action corpus, discover `query_units` and its
  capability resource through the MCP protocol, and collect a bounded first
  page.
- Treat that page boundary as a cooperative client cancellation, preserve its
  opaque continuation, then resume remaining pages through fresh stdio MCP
  server processes.
- Emit a durable JSON receipt/transcript with transaction refs, discovery
  evidence, cancellation point, and cold-resume pages.
- Add integration coverage for exact enumeration, independent-oracle
  rejection, and CLI receipt persistence.

This deliberately does not modify aliases, raw-authority repair, rebuild
transactions, or Beads state.

## Verification

- `devtools test tests/unit/product/test_continuity_scenarios.py tests/integration/test_continuity_replay.py` — 8 passed.
- `devtools verify --quick` — success.
- The pre-push hook ran the same quick baseline successfully.

## Remaining scope

`2qx.2` still needs full Claude artifact admission/provenance and
degraded-state proof. `1vpm.6.2` still needs observed git/GitHub/Beads/
verification effect adapters and reconciliation proof; both remain
prerequisites before claiming the wider `z9gh.7` closure.
