### PR TITLE
fix(pipeline): run provider assembly in canonical raw-record ingest

### DIFF
--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -474,6 +474,39 @@ def _parse_plan_sessions(
     )
 
 
+def _enrich_parsed_sessions(
+    context: _IngestContext,
+    plan: _ParsePlan,
+    parsed_sessions: list[ParsedSession],
+) -> list[ParsedSession]:
+    """Apply the same provider assembly enrichment direct ingest uses.
+
+    Canonical raw-record ingest historically bypassed provider assembly, so
+    daemon-ingested Codex sessions kept native-id titles (polylogue-ih67).
+    ``context.raw_source`` is always the blob path here, so discovery keys
+    off the recorded acquisition path (``raw_record.source_path``). When
+    that path's runtime root is absent (foreign machine, deleted source),
+    discovery yields nothing and only the parsed-content fallbacks apply.
+    """
+    from polylogue.sources.assembly import get_assembly_spec
+
+    spec = get_assembly_spec(plan.provider)
+    if spec is None:
+        return parsed_sessions
+    source_path = context.raw_record.source_path
+    if not source_path:
+        return parsed_sessions
+    try:
+        sidecar_data = spec.discover_sidecars([Path(source_path)])
+        return [spec.enrich_session(convo, sidecar_data) for convo in parsed_sessions]
+    except Exception:
+        logger.exception(
+            "assembly enrichment failed for %s; keeping unenriched sessions",
+            context.raw_record.raw_id,
+        )
+        return parsed_sessions
+
+
 def _materialize_parsed_sessions(
     context: _IngestContext,
     plan: _ParsePlan,
@@ -569,7 +602,7 @@ def _run_parse_plan(
         context,
         plan,
         validation=validation,
-        parsed_sessions=parsed_sessions,
+        parsed_sessions=_enrich_parsed_sessions(context, plan, parsed_sessions),
     )
 
 

--- a/polylogue/sources/assembly.py
+++ b/polylogue/sources/assembly.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 ClaudeCodeSessionIndex: TypeAlias = dict[str, "SessionIndexEntry"]
 ClaudeCodeHistoryPasteIndex: TypeAlias = dict[str, list["HistoryEntry"]]
 CodexThreadNames: TypeAlias = dict[str, str]
+CodexHistoryTitles: TypeAlias = dict[str, str]
 
 
 class _ClaudeCodeSidecarData(TypedDict, total=False):
@@ -36,6 +37,7 @@ class _ClaudeCodeSidecarData(TypedDict, total=False):
 
 class _CodexSidecarData(TypedDict, total=False):
     thread_names: CodexThreadNames
+    history_titles: CodexHistoryTitles
 
 
 class SidecarData(_ClaudeCodeSidecarData, _CodexSidecarData, total=False):
@@ -89,6 +91,7 @@ def get_assembly_spec(provider: Provider) -> ProviderAssemblySpec | None:
 __all__ = [
     "ClaudeCodeHistoryPasteIndex",
     "ClaudeCodeSessionIndex",
+    "CodexHistoryTitles",
     "CodexThreadNames",
     "ProviderAssemblySpec",
     "SidecarData",

--- a/polylogue/sources/assembly_codex.py
+++ b/polylogue/sources/assembly_codex.py
@@ -1,23 +1,46 @@
-"""Codex provider assembly — session_index.jsonl thread name sidecar."""
+"""Codex provider assembly — session_index.jsonl and history.jsonl sidecars."""
 
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from pathlib import Path
 
-from polylogue.core.enums import TitleSource
+from polylogue.core.enums import MaterialOrigin, TitleSource
 from polylogue.core.json import json_document
 from polylogue.logging import get_logger
 
-from .assembly import CodexThreadNames, SidecarData
+from .assembly import CodexHistoryTitles, CodexThreadNames, SidecarData
 from .parsers.base import ParsedSession
 
 logger = get_logger(__name__)
 
+_TITLE_PREVIEW_LIMIT = 80
+
+# Per-process sidecar parse cache keyed by absolute path, validated by
+# (mtime_ns, size). Canonical raw-record ingest discovers sidecars once per
+# raw record; without this cache a catch-up batch re-reads the same
+# append-only sidecar files thousands of times.
+_SIDECAR_CACHE: dict[str, tuple[tuple[int, int], dict[str, str]]] = {}
+
+
+def _cached_parse(path: Path, parse: Callable[[Path], dict[str, str]]) -> dict[str, str]:
+    try:
+        stat = path.stat()
+    except OSError:
+        return {}
+    key = str(path)
+    fingerprint = (stat.st_mtime_ns, stat.st_size)
+    cached = _SIDECAR_CACHE.get(key)
+    if cached is not None and cached[0] == fingerprint:
+        return cached[1]
+    data = parse(path)
+    _SIDECAR_CACHE[key] = (fingerprint, data)
+    return data
+
 
 def _parse_codex_session_index(sessions_root: Path) -> dict[str, str]:
-    """Parse ~/.codex/session_index.jsonl — append-only, newest entry wins per thread_id.
+    """Parse ``session_index.jsonl`` — append-only, newest entry wins per thread id.
 
     Args:
         sessions_root: The ``sessions/`` directory. The index file lives at
@@ -29,6 +52,10 @@ def _parse_codex_session_index(sessions_root: Path) -> dict[str, str]:
     index_path = sessions_root.parent / "session_index.jsonl"
     if not index_path.exists():
         return {}
+    return _cached_parse(index_path, _parse_session_index_file)
+
+
+def _parse_session_index_file(index_path: Path) -> dict[str, str]:
     names: dict[str, str] = {}
     try:
         for line in index_path.read_text(encoding="utf-8").splitlines():
@@ -51,15 +78,71 @@ def _parse_codex_session_index(sessions_root: Path) -> dict[str, str]:
     return names
 
 
+def _parse_codex_history(sessions_root: Path) -> dict[str, str]:
+    """Parse ``history.jsonl`` — the earliest authored entry per session wins.
+
+    Live Codex appends ``{"session_id": ..., "ts": ..., "text": ...}`` rows
+    for every operator-typed prompt. The earliest entry for a session is its
+    opening request, which is the authoritative authored title material.
+    Ties on ``ts`` keep the first-seen row so repeated parses of an
+    append-only file stay deterministic.
+    """
+    history_path = sessions_root.parent / "history.jsonl"
+    if not history_path.exists():
+        return {}
+    return _cached_parse(history_path, _parse_history_file)
+
+
+def _parse_history_file(history_path: Path) -> dict[str, str]:
+    titles: dict[str, str] = {}
+    earliest_ts: dict[str, float] = {}
+    try:
+        for line in history_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                parsed = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            sid = parsed.get("session_id")
+            text = parsed.get("text")
+            ts = parsed.get("ts")
+            if not (isinstance(sid, str) and sid and isinstance(text, str) and text.strip()):
+                continue
+            ts_value = float(ts) if isinstance(ts, (int, float)) and not isinstance(ts, bool) else float("inf")
+            known = earliest_ts.get(sid)
+            if known is None or ts_value < known:
+                earliest_ts[sid] = ts_value
+                titles[sid] = text
+    except OSError as exc:
+        logger.debug("Failed to read Codex history.jsonl: %s", exc)
+    return titles
+
+
+def _title_preview(text: str) -> str | None:
+    """First non-empty line, bounded, or None when nothing usable remains."""
+    for line in text.strip().splitlines():
+        line = line.strip()
+        if line:
+            if len(line) > _TITLE_PREVIEW_LIMIT:
+                return line[:_TITLE_PREVIEW_LIMIT] + "..."
+            return line
+    return None
+
+
 class CodexAssemblySpec:
-    """Codex provider assembly — session_index.jsonl thread name sidecar."""
+    """Codex provider assembly — thread-name and authored-history sidecars."""
 
     def discover_sidecars(self, source_paths: list[Path]) -> SidecarData:
-        """Discover Codex thread names from session_index.jsonl.
+        """Discover Codex thread names and authored-history titles.
 
-        Returns ``{"thread_names": {thread_id: thread_name, ...}}``.
+        Returns ``{"thread_names": {...}, "history_titles": {...}}``.
         """
         thread_names: dict[str, str] = {}
+        history_titles: dict[str, str] = {}
         seen_roots: set[Path] = set()
         for path in source_paths:
             # Walk up to find the sessions root
@@ -67,42 +150,72 @@ class CodexAssemblySpec:
                 if parent.name == "sessions" and parent not in seen_roots:
                     seen_roots.add(parent)
                     thread_names.update(_parse_codex_session_index(parent))
+                    history_titles.update(_parse_codex_history(parent))
                     break
-        return {"thread_names": thread_names}
+        return {"thread_names": thread_names, "history_titles": history_titles}
 
     def enrich_session(
         self,
         conv: ParsedSession,
         sidecar_data: SidecarData,
     ) -> ParsedSession:
-        """Enrich a Codex session with thread name or first-user-message title."""
+        """Resolve a Codex title: thread name → authored history → first
+        human-authored message → leave the native id.
+
+        A ``role=user`` row alone never becomes a title: Codex runtime
+        context and operator protocol rows share that role, so only
+        ``material_origin == HUMAN_AUTHORED`` text qualifies for the message
+        fallback.
+        """
         thread_names: CodexThreadNames = sidecar_data.get("thread_names", {})
+        history_titles: CodexHistoryTitles = sidecar_data.get("history_titles", {})
         cid = conv.provider_session_id
 
-        # Try thread name from side index
+        # 1. Provider thread name — authoritative, may replace a stale title.
         name = thread_names.get(cid)
-        if name and name != conv.title:
-            return conv.model_copy(
-                update={
-                    "title": name,
-                    "title_source": TitleSource.ORIGIN,
-                }
-            )
+        if name:
+            if name != conv.title:
+                return conv.model_copy(
+                    update={
+                        "title": name,
+                        "title_source": TitleSource.ORIGIN,
+                    }
+                )
+            return conv
 
-        # Fallback: use first user message as title if current title is just the session_id
-        if conv.title == cid and conv.messages:
-            for msg in conv.messages:
-                if msg.role == "user" and msg.text and msg.text.strip():
-                    preview = msg.text.strip()[:80]
-                    if len(msg.text.strip()) > 80:
-                        preview += "..."
-                    return conv.model_copy(
-                        update={
-                            "title": preview,
-                            "title_source": TitleSource.HEURISTIC,
-                        }
-                    )
+        # The remaining lanes only fill in when the title is missing or is
+        # the bare native id — they never replace a real title.
+        if conv.title and conv.title != cid:
+            return conv
 
+        # 2. Authored history entry recorded by Codex for this session.
+        history_text = history_titles.get(cid)
+        if history_text:
+            preview = _title_preview(history_text)
+            if preview:
+                return conv.model_copy(
+                    update={
+                        "title": preview,
+                        "title_source": TitleSource.ORIGIN,
+                    }
+                )
+
+        # 3. First human-authored message in the parsed session.
+        for msg in conv.messages:
+            if msg.material_origin is not MaterialOrigin.HUMAN_AUTHORED:
+                continue
+            if not (msg.text and msg.text.strip()):
+                continue
+            preview = _title_preview(msg.text)
+            if preview:
+                return conv.model_copy(
+                    update={
+                        "title": preview,
+                        "title_source": TitleSource.HEURISTIC,
+                    }
+                )
+
+        # 4. Nothing enrichable — the native id stands.
         return conv
 
 
@@ -120,5 +233,6 @@ def _coerce_codex_thread_name(entry: Mapping[str, object]) -> str | None:
 
 __all__ = [
     "CodexAssemblySpec",
+    "_parse_codex_history",
     "_parse_codex_session_index",
 ]

--- a/tests/unit/pipeline/test_ingest_worker_assembly.py
+++ b/tests/unit/pipeline/test_ingest_worker_assembly.py
@@ -1,0 +1,132 @@
+"""Canonical raw-record ingest applies provider assembly enrichment (polylogue-ih67).
+
+The daemon's raw-record worker historically bypassed the assembly layer that
+direct ingest runs, so every daemon-ingested Codex session kept its native
+UUID as title. These tests pin the parity contract: removing the
+``_enrich_parsed_sessions`` call from ``_run_parse_plan`` (the named
+production mutation) fails ``test_canonical_ingest_applies_thread_name``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from polylogue.core.enums import Provider, TitleSource
+from polylogue.pipeline.services.ingest_worker import ingest_record
+from polylogue.storage.blob_store import BlobStore, reset_blob_store
+from polylogue.storage.runtime import RawSessionRecord
+
+
+@pytest.fixture
+def blob_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[BlobStore]:
+    root = tmp_path / "blobs"
+    store = BlobStore(root)
+    monkeypatch.setattr("polylogue.paths.blob_store_root", lambda: root)
+    reset_blob_store()
+    yield store
+    reset_blob_store()
+
+
+def _codex_stream(session_id: str, *texts: str) -> bytes:
+    lines = [
+        json.dumps({"type": "session_meta", "payload": {"id": session_id, "timestamp": "2026-01-01T00:00:00Z"}}),
+    ]
+    for text in texts:
+        lines.append(
+            json.dumps(
+                {
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": text}],
+                    },
+                }
+            )
+        )
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def _codex_runtime_root(tmp_path: Path, session_id: str, content: bytes) -> Path:
+    codex_dir = tmp_path / ".codex"
+    rollout = codex_dir / "sessions" / "2026" / f"rollout-{session_id}.jsonl"
+    rollout.parent.mkdir(parents=True)
+    rollout.write_bytes(content)
+    return rollout
+
+
+def _record(store: BlobStore, content: bytes, *, source_path: str) -> RawSessionRecord:
+    raw_id, blob_size = store.write_from_bytes(content)
+    return RawSessionRecord(
+        raw_id=raw_id,
+        source_name="codex",
+        source_path=source_path,
+        payload_provider=Provider.CODEX,
+        source_index=None,
+        blob_size=blob_size,
+        acquired_at="2026-01-01T00:00:00+00:00",
+        file_mtime=None,
+    )
+
+
+def _ingest_title(record: RawSessionRecord, tmp_path: Path, store: BlobStore) -> tuple[str | None, str | None]:
+    result = ingest_record(record, str(tmp_path / "archive"), "advisory", blob_root_str=str(store.root))
+    assert result.error is None, result.error
+    assert result.sessions, "expected one materializable session"
+    parsed = result.sessions[0].parsed_session
+    source = parsed.title_source
+    return parsed.title, str(source) if source is not None else None
+
+
+def test_canonical_ingest_applies_thread_name(blob_store: BlobStore, tmp_path: Path) -> None:
+    """The daemon worker resolves the provider thread name, like direct ingest."""
+    session_id = "aaaa1111-2222-3333-4444-555566667777"
+    content = _codex_stream(session_id, "please fix the ingest bug")
+    rollout = _codex_runtime_root(tmp_path, session_id, content)
+    (rollout.parents[2] / "session_index.jsonl").write_text(
+        json.dumps({"id": session_id, "thread_name": "Ingest bug hunt"}) + "\n",
+        encoding="utf-8",
+    )
+
+    record = _record(blob_store, content, source_path=str(rollout))
+    title, title_source = _ingest_title(record, tmp_path, blob_store)
+
+    assert title == "Ingest bug hunt"
+    assert title_source == TitleSource.ORIGIN.value
+
+
+def test_canonical_ingest_uses_history_title(blob_store: BlobStore, tmp_path: Path) -> None:
+    """Without a thread name, the authored history entry becomes the title."""
+    session_id = "bbbb1111-2222-3333-4444-555566667777"
+    content = _codex_stream(session_id, "opening prompt typed by the operator")
+    rollout = _codex_runtime_root(tmp_path, session_id, content)
+    (rollout.parents[2] / "history.jsonl").write_text(
+        json.dumps({"session_id": session_id, "ts": 1, "text": "Wire the Hermes bridge"}) + "\n",
+        encoding="utf-8",
+    )
+
+    record = _record(blob_store, content, source_path=str(rollout))
+    title, title_source = _ingest_title(record, tmp_path, blob_store)
+
+    assert title == "Wire the Hermes bridge"
+    assert title_source == TitleSource.ORIGIN.value
+
+
+def test_canonical_ingest_message_fallback_without_sidecars(blob_store: BlobStore, tmp_path: Path) -> None:
+    """A missing runtime root leaves only the human-authored message fallback."""
+    session_id = "cccc1111-2222-3333-4444-555566667777"
+    content = _codex_stream(session_id, "refactor the daemon status loop")
+
+    record = _record(
+        blob_store,
+        content,
+        source_path=str(tmp_path / "gone" / "sessions" / f"rollout-{session_id}.jsonl"),
+    )
+    title, title_source = _ingest_title(record, tmp_path, blob_store)
+
+    assert title == "refactor the daemon status loop"
+    assert title_source == TitleSource.HEURISTIC.value

--- a/tests/unit/sources/test_assembly.py
+++ b/tests/unit/sources/test_assembly.py
@@ -9,10 +9,10 @@ import pytest
 
 from polylogue.archive.message.roles import Role
 from polylogue.archive.session.branch_type import BranchType
-from polylogue.core.enums import Provider, TitleSource
+from polylogue.core.enums import MaterialOrigin, Provider, TitleSource
 from polylogue.sources.assembly import SidecarData, get_assembly_spec
 from polylogue.sources.assembly_claude_code import ClaudeCodeAssemblySpec
-from polylogue.sources.assembly_codex import CodexAssemblySpec, _parse_codex_session_index
+from polylogue.sources.assembly_codex import CodexAssemblySpec, _parse_codex_history, _parse_codex_session_index
 from polylogue.sources.assembly_gemini import GeminiAssemblySpec
 from polylogue.sources.parsers.base import ParsedAttachment, ParsedMessage, ParsedSession, ParsedSessionEvent
 from polylogue.sources.parsers.claude.index import (
@@ -22,11 +22,29 @@ from polylogue.sources.parsers.claude.index import (
 )
 
 
-def _parsed_message(provider_message_id: str, role: str, text: str) -> ParsedMessage:
-    return ParsedMessage(
+def _parsed_message(
+    provider_message_id: str,
+    role: str,
+    text: str,
+    *,
+    material_origin: MaterialOrigin | None = None,
+) -> ParsedMessage:
+    message = ParsedMessage(
         provider_message_id=provider_message_id,
         role=Role.normalize(role),
         text=text,
+    )
+    if material_origin is not None:
+        message.material_origin = material_origin
+    return message
+
+
+def _authored_message(provider_message_id: str, text: str) -> ParsedMessage:
+    return _parsed_message(
+        provider_message_id,
+        "user",
+        text,
+        material_origin=MaterialOrigin.HUMAN_AUTHORED,
     )
 
 
@@ -57,8 +75,14 @@ def _parsed_session(
     )
 
 
-def _thread_sidecars(thread_names: dict[str, str] | None = None) -> SidecarData:
-    return {"thread_names": {} if thread_names is None else thread_names}
+def _thread_sidecars(
+    thread_names: dict[str, str] | None = None,
+    history_titles: dict[str, str] | None = None,
+) -> SidecarData:
+    return {
+        "thread_names": {} if thread_names is None else thread_names,
+        "history_titles": {} if history_titles is None else history_titles,
+    }
 
 
 def _session_sidecars(
@@ -367,7 +391,7 @@ class TestCodexAssemblySpec:
             "thread-1",
             "thread-1",
             [
-                _parsed_message("m1", "user", "Implement the payment gateway"),
+                _authored_message("m1", "Implement the payment gateway"),
                 _parsed_message("m2", "assistant", "Sure, here is the code"),
             ],
         )
@@ -382,7 +406,7 @@ class TestCodexAssemblySpec:
         """Truncates first user message to 80 chars + ellipsis."""
         spec = CodexAssemblySpec()
         long_text = "A" * 100
-        conv = _parsed_session(Provider.CODEX, "thread-1", "thread-1", [_parsed_message("m1", "user", long_text)])
+        conv = _parsed_session(Provider.CODEX, "thread-1", "thread-1", [_authored_message("m1", long_text)])
         sidecar_data = _thread_sidecars()
 
         enriched = spec.enrich_session(conv, sidecar_data)
@@ -408,9 +432,9 @@ class TestCodexAssemblySpec:
             "thread-1",
             "thread-1",
             [
-                _parsed_message("m1", "user", ""),
-                _parsed_message("m2", "user", "   "),
-                _parsed_message("m3", "user", "Real message here"),
+                _authored_message("m1", ""),
+                _authored_message("m2", "   "),
+                _authored_message("m3", "Real message here"),
             ],
         )
         sidecar_data = _thread_sidecars()
@@ -601,3 +625,160 @@ class TestLooksLikeGitBranch:
 
         assert enriched.title == "Hello world"
         assert enriched.title_source == "heuristic"
+
+
+# ---------------------------------------------------------------------------
+# Codex history.jsonl titles + material-origin title discipline (polylogue-ih67)
+# ---------------------------------------------------------------------------
+
+
+def _codex_root_with(
+    tmp_path: Path,
+    *,
+    history_lines: list[str] | None = None,
+    index_lines: list[str] | None = None,
+) -> Path:
+    codex_dir = tmp_path / ".codex"
+    sessions_dir = codex_dir / "sessions"
+    sessions_dir.mkdir(parents=True)
+    if history_lines is not None:
+        (codex_dir / "history.jsonl").write_text("\n".join(history_lines) + "\n", encoding="utf-8")
+    if index_lines is not None:
+        (codex_dir / "session_index.jsonl").write_text("\n".join(index_lines) + "\n", encoding="utf-8")
+    session_file = sessions_dir / "thread-1" / "session.jsonl"
+    session_file.parent.mkdir()
+    session_file.touch()
+    return session_file
+
+
+class TestCodexHistoryTitles:
+    def test_discover_sidecars_includes_history_titles(self, tmp_path: Path) -> None:
+        """history.jsonl yields earliest authored text per session; junk skipped."""
+        session_file = _codex_root_with(
+            tmp_path,
+            history_lines=[
+                '{"session_id": "thread-1", "ts": 200, "text": "later prompt"}',
+                '{"session_id": "thread-1", "ts": 100, "text": "Fix the ingest bug"}',
+                "not json at all",
+                '{"session_id": "", "ts": 1, "text": "no session"}',
+                '{"session_id": "thread-2", "ts": 50, "text": "   "}',
+                '{"session_id": "thread-2", "ts": 60, "text": "Second thread opening"}',
+            ],
+        )
+
+        sidecar_data = CodexAssemblySpec().discover_sidecars([session_file])
+
+        assert sidecar_data["history_titles"] == {
+            "thread-1": "Fix the ingest bug",
+            "thread-2": "Second thread opening",
+        }
+
+    def test_thread_name_beats_history(self, tmp_path: Path) -> None:
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(Provider.CODEX, "thread-1", "thread-1", [])
+        sidecar_data = _thread_sidecars(
+            {"thread-1": "Named thread"},
+            {"thread-1": "history prompt"},
+        )
+
+        enriched = spec.enrich_session(conv, sidecar_data)
+
+        assert enriched.title == "Named thread"
+        assert enriched.title_source == TitleSource.ORIGIN
+
+    def test_history_beats_message_fallback(self) -> None:
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(
+            Provider.CODEX,
+            "thread-1",
+            "thread-1",
+            [_authored_message("m1", "message body that would otherwise win")],
+        )
+        sidecar_data = _thread_sidecars(None, {"thread-1": "History opening prompt"})
+
+        enriched = spec.enrich_session(conv, sidecar_data)
+
+        assert enriched.title == "History opening prompt"
+        assert enriched.title_source == TitleSource.ORIGIN
+
+    def test_history_title_uses_first_line_bounded(self) -> None:
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(Provider.CODEX, "thread-1", "thread-1", [])
+        long_first_line = "B" * 100
+        sidecar_data = _thread_sidecars(None, {"thread-1": f"\n\n{long_first_line}\nsecond line"})
+
+        enriched = spec.enrich_session(conv, sidecar_data)
+
+        assert enriched.title == "B" * 80 + "..."
+
+    def test_history_never_replaces_real_title(self) -> None:
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(Provider.CODEX, "thread-1", "A real existing title", [])
+        sidecar_data = _thread_sidecars(None, {"thread-1": "history prompt"})
+
+        result = spec.enrich_session(conv, sidecar_data)
+
+        assert result is conv
+
+    def test_runtime_context_user_row_never_becomes_title(self) -> None:
+        """An injected-context role=user row must not win over the authored request."""
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(
+            Provider.CODEX,
+            "thread-1",
+            "thread-1",
+            [
+                _parsed_message(
+                    "m1",
+                    "user",
+                    "<AGENTS.md> repository instructions injected as context",
+                    material_origin=MaterialOrigin.RUNTIME_CONTEXT,
+                ),
+                _authored_message("m2", "Please fix the payment bug"),
+            ],
+        )
+
+        enriched = spec.enrich_session(conv, _thread_sidecars())
+
+        assert enriched.title == "Please fix the payment bug"
+        assert enriched.title_source == TitleSource.HEURISTIC
+
+    def test_unknown_authorship_is_not_title_material(self) -> None:
+        """role=user alone (material_origin UNKNOWN) is not proof a human typed it."""
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(
+            Provider.CODEX,
+            "thread-1",
+            "thread-1",
+            [_parsed_message("m1", "user", "ambiguous channel content")],
+        )
+
+        result = spec.enrich_session(conv, _thread_sidecars())
+
+        assert result is conv
+        assert result.title == "thread-1"
+
+    def test_history_cache_invalidates_on_file_change(self, tmp_path: Path) -> None:
+        import os
+
+        session_file = _codex_root_with(
+            tmp_path,
+            history_lines=['{"session_id": "thread-1", "ts": 1, "text": "first version"}'],
+        )
+        history_path = tmp_path / ".codex" / "history.jsonl"
+        spec = CodexAssemblySpec()
+
+        first = spec.discover_sidecars([session_file])["history_titles"]
+        assert first == {"thread-1": "first version"}
+
+        history_path.write_text('{"session_id": "thread-1", "ts": 1, "text": "rewritten"}\n', encoding="utf-8")
+        stat = history_path.stat()
+        os.utime(history_path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+
+        second = spec.discover_sidecars([session_file])["history_titles"]
+        assert second == {"thread-1": "rewritten"}
+
+    def test_parse_codex_history_missing_file(self, tmp_path: Path) -> None:
+        sessions_root = tmp_path / ".codex" / "sessions"
+        sessions_root.mkdir(parents=True)
+        assert _parse_codex_history(sessions_root) == {}


### PR DESCRIPTION
## Summary
Canonical raw-record (daemon) ingest now applies the same provider assembly enrichment as direct ingest, and the Codex assembly gains the live `history.jsonl` authored-title source plus material-origin title discipline. First slice of `polylogue-ih67`.

## Problem
All 3,101 indexed Codex sessions carry native UUIDs as titles: the daemon worker parsed raw records without ever invoking `get_assembly_spec` enrichment. Separately, the Codex fallback picked the first `role=user` message — a channel that also carries injected runtime context — and live Codex supplies `history.jsonl` + a titled `threads` table rather than the expected sidecar shape (verified locally: 2,757/3,040 threads titled; 17,762 history entries).

## Solution
- `_run_parse_plan` enriches parsed sessions via the provider assembly before materialization/hash, discovering sidecars from the recorded acquisition path (`raw_record.source_path`); blob-path-only contexts and missing runtime roots degrade to parsed-content fallbacks.
- `assembly_codex` parses `history.jsonl` (earliest authored entry per session, stat-fingerprint cached) and resolves titles: provider thread name → authored history → first `material_origin=HUMAN_AUTHORED` message → native id. `role=user` alone never titles a session.

## Verification
- `devtools test tests/unit/sources/test_assembly.py tests/unit/pipeline/test_ingest_worker_assembly.py tests/unit/pipeline/test_malformed_jsonl_accounting.py tests/unit/sources/test_parsers_codex.py tests/unit/pipeline/test_archive_ingest_shared_raw.py` → 133 passed.
- Anti-vacuity: reverting the `_enrich_parsed_sessions` call fails all 3 parity tests (`3 failed`).
- `devtools verify --quick` → all steps ok.

Remaining `ih67` scope (sidecar acquisition as raw authority evidence, persisted TitleSource provenance, reprocess + before/after census) stays on the bead.

Ref polylogue-ih67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ