### PR TITLE
fix(ci): satisfy Circle strict mypy checks

### DIFF
--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -293,11 +293,12 @@ def _execute_count_terminal(ctx: TerminalExecutionContext) -> QueryUnitResultEnv
     """Terminal ``count`` action: emit the aggregate group rollup page."""
 
     pipeline = ctx.source.pipeline
-    aggregate_sort = (
-        cast(Literal["count", "key"], pipeline.sort.field)
-        if pipeline.sort is not None and pipeline.sort.field in {"count", "key"}
-        else None
-    )
+    aggregate_sort: Literal["count", "key"] | None = None
+    if pipeline.sort is not None:
+        if pipeline.sort.field == "count":
+            aggregate_sort = "count"
+        elif pipeline.sort.field == "key":
+            aggregate_sort = "key"
     aggregate_sort_direction: Literal["asc", "desc"] = (
         pipeline.sort.direction if aggregate_sort is not None and pipeline.sort is not None else "desc"
     )

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -185,7 +185,7 @@ def _socket_peer_disconnected(connection: object | None) -> bool:
     if flags is None:
         return False
     try:
-        readable, _, _ = select.select([connection], [], [], 0)
+        readable, _, _ = select.select([cast(socket.socket, connection)], [], [], 0)
     except (OSError, TypeError, ValueError):
         return False
     if not readable:

--- a/polylogue/hooks/__init__.py
+++ b/polylogue/hooks/__init__.py
@@ -761,8 +761,10 @@ def _default_sidecar_dir() -> Path:
 
 def _detect_hook_provider(payload: dict[str, object]) -> HookHarness | None:
     forced = os.environ.get("POLYLOGUE_HOOK_PROVIDER")
-    if forced in EVENTS_BY_HARNESS:
-        return cast(HookHarness, forced)
+    if forced == "claude-code":
+        return "claude-code"
+    if forced == "codex":
+        return "codex"
     if "turn_id" in payload:
         return "codex"
     if "permission_mode" in payload or "model" in payload:


### PR DESCRIPTION
## Summary

Repair the three strict-mypy failures exposed by Circle after SQLite compatibility was restored.

## Problem

Circle reached `mypy` and reported two redundant casts plus an invalid `select.select()` argument inference. These were hidden locally only until the CI environment exercised the updated source set.

## Solution

Use explicit literal narrowing for hook-provider and aggregate-sort paths, and narrow the socket-like HTTP connection before passing it to `select`.

## Verification

- Circle raw job output identified all three failures.
- `uv run mypy polylogue/` — passed.
- `devtools verify --quick` — passed before push; pre-push quick verification also passed.