### PR TITLE
feat(daemon): watch Hermes runtime evidence

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -342,6 +342,7 @@ A few keys not shown in the full example above, with their TOML path:
 | `daemon_client_mode` | `daemon.client_mode` | How the CLI/MCP client reaches the daemon: `auto` (default), or an explicit forced mode. |
 | `no_daemon` | `client.no_daemon` | Force direct in-process archive access, bypassing the daemon client even when one is reachable. |
 | `debug_timing` | `ui.debug_timing` | Emit per-stage timing diagnostics in CLI output. |
+| `hermes_root` | `sources.hermes.root` | Runtime root watched for Hermes state, snapshots, NeMo Relay ATIF/ATOF artifacts, and verification evidence. Defaults to `~/.hermes`. |
 | `hook_sidecar_dir` | `sources.hook_sidecar_dir` | Directory for hook-event sidecar files consumed by the Claude Code/Codex hook harness. |
 | `backup_verify_tmpdir` | `maintenance.backup_verify_tmpdir` | Scratch directory for backup-restore verification; defaults to the system temp dir when unset. |
 | `antigravity_language_server` | `sources.antigravity_language_server` | Path to an Antigravity language-server binary, when parsing Antigravity sessions needs it. |
@@ -373,6 +374,7 @@ Common runtime overrides:
 | `POLYLOGUE_CONFIG` | config layer | Explicit user config path. |
 | `POLYLOGUE_SITE_CONFIG` | config layer | Explicit site config path; empty disables site config. |
 | `POLYLOGUE_ARCHIVE_ROOT` | `archive_root` | Override the archive root. |
+| `POLYLOGUE_HERMES_ROOT` | `hermes_root` | Override the Hermes runtime root watched by the daemon. |
 | `POLYLOGUE_DAEMON_URL` | `daemon_url` | CLI/MCP client daemon base URL. |
 | `POLYLOGUE_API_HOST` / `POLYLOGUE_API_PORT` | `api_host` / `api_port` | Daemon HTTP API bind. |
 | `POLYLOGUE_API_AUTH_TOKEN` | `api_auth_token` | API bearer token; redacted in config output. |

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -507,6 +507,11 @@ class PolylogueConfig:
         return ()
 
     @property
+    def hermes_root(self) -> str:
+        """Optional layered override for the Hermes runtime root."""
+        return str(self._data.get("hermes_root", ""))
+
+    @property
     def drive_credentials_path(self) -> str:
         return str(self._data.get("drive_credentials_path", ""))
 
@@ -754,6 +759,14 @@ _CONFIG_INVENTORY: tuple[ConfigInventoryEntry, ...] = (
         owner_class="path-layout",
         reload_behavior="startup-bound",
         description="Additional source roots watched by the daemon.",
+    ),
+    ConfigInventoryEntry(
+        "hermes_root",
+        toml_path="sources.hermes.root",
+        env_var="POLYLOGUE_HERMES_ROOT",
+        owner_class="path-layout",
+        reload_behavior="startup-bound",
+        description="Hermes runtime root containing state, snapshots, and observability artifacts.",
     ),
     ConfigInventoryEntry(
         "embedding_enabled",
@@ -1317,6 +1330,7 @@ def _default_config_values(bootstrap: _BootstrapPaths | None = None) -> dict[str
         "browser_capture_allow_remote": False,
         "browser_capture_allow_no_auth": False,
         "source_roots": (),
+        "hermes_root": "",
         "drive_credentials_path": str(captured.config_home / "polylogue-credentials.json"),
         "drive_token_path": str(captured.state_home / "token.json"),
         "hook_sidecar_dir": str(captured.data_home / "hooks"),
@@ -1668,7 +1682,11 @@ def resolve_runtime_config(
         claude_code=bootstrap.home / ".claude" / "projects",
         codex=bootstrap.home / ".codex" / "sessions",
         gemini_cli=bootstrap.home / ".gemini" / "tmp",
-        hermes=bootstrap.home / ".hermes",
+        hermes=_resolved_runtime_path(
+            settings.hermes_root,
+            bootstrap=bootstrap,
+            fallback=bootstrap.home / ".hermes",
+        ),
         antigravity=bootstrap.home / ".gemini" / "antigravity",
         browser_capture=browser_spool,
         inbox=paths.inbox_root,

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -138,6 +138,7 @@ def _watch_sources_from_roots(
     roots: tuple[Path, ...],
     *,
     browser_capture_spool_path: Path | None = None,
+    hermes_root: Path | None = None,
 ) -> tuple[WatchSource, ...]:
     """Build watch sources for explicit daemon roots.
 
@@ -148,7 +149,7 @@ def _watch_sources_from_roots(
     default inbox source.
     """
     if not roots:
-        sources = list(default_sources())
+        sources = list(default_sources(hermes_root=hermes_root))
         if browser_capture_spool_path is not None:
             spool = browser_capture_spool_path.expanduser()
             sources = [source for source in sources if source.name != "browser-capture"]
@@ -1992,9 +1993,10 @@ def run_command(
     _enable_faulthandler_if_supported()
     configure_logging()
 
-    from polylogue.config import load_polylogue_config
+    from polylogue.config import resolve_runtime_config
 
-    cfg = load_polylogue_config()
+    runtime = resolve_runtime_config()
+    cfg = runtime.settings
 
     def parameter_is_default(name: str) -> bool:
         source = ctx.get_parameter_source(name)
@@ -2045,7 +2047,11 @@ def run_command(
 
     atexit.register(_cleanup_pidfile)
 
-    sources = _watch_sources_from_roots(roots, browser_capture_spool_path=spool_path)
+    sources = _watch_sources_from_roots(
+        roots,
+        browser_capture_spool_path=spool_path,
+        hermes_root=runtime.source_paths.hermes,
+    )
     components = []
     if enable_watch:
         components.append(f"watch={len(sources)} source(s)")
@@ -2099,7 +2105,9 @@ def run_command(
     help="Quiet-period (seconds) before parsing a modified file.",
 )
 def watch_command(roots: tuple[Path, ...], debounce_s: float) -> None:
-    sources = _watch_sources_from_roots(roots)
+    from polylogue.config import resolve_runtime_config
+
+    sources = _watch_sources_from_roots(roots, hermes_root=resolve_runtime_config().source_paths.hermes)
 
     click.echo(
         f"Watching {len(sources)} source(s); debounce={debounce_s}s. Ctrl-C to stop.",

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -1098,7 +1098,7 @@ def _interleave_by_source(candidates: list[CandidateSourceFile]) -> list[Candida
     return ordered
 
 
-def default_sources() -> tuple[WatchSource, ...]:
+def default_sources(*, hermes_root: Path | None = None) -> tuple[WatchSource, ...]:
     """Discover the default live-source roots from XDG/home conventions.
 
     Includes the archive inbox so that ``polylogue ingest PATH``
@@ -1119,7 +1119,17 @@ def default_sources() -> tuple[WatchSource, ...]:
         WatchSource(name="claude-code", root=claude_code_path()),
         WatchSource(name="codex", root=codex_path()),
         WatchSource(name="gemini-cli", root=gemini_cli_path(), suffixes=(".json", ".jsonl")),
-        WatchSource(name="hermes", root=hermes_sessions_path(), suffixes=(".json", ".db", ".sqlite", ".sqlite3")),
+        # Hermes emits four independently durable source classes under its
+        # runtime root: state.db, optional session snapshots, NeMo Relay ATIF
+        # documents, and append-only ATOF JSONL.  The ledger database is
+        # admitted as a live SQLite source too; parsing it remains a separate
+        # fidelity/normalization contract rather than an implicit filename
+        # fallback.
+        WatchSource(
+            name="hermes",
+            root=hermes_root if hermes_root is not None else hermes_sessions_path(),
+            suffixes=(".json", ".jsonl", ".db", ".sqlite", ".sqlite3"),
+        ),
         WatchSource(name="antigravity", root=antigravity_path(), suffixes=(".metadata.json",)),
         WatchSource(name="browser-capture", root=browser_capture_spool_root(), suffixes=(".json",)),
         # #1683: inbox accepts archive, zip, and json-line formats so that

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -440,6 +440,11 @@ class TestPolylogueConfigDefaults:
         cfg = load_polylogue_config()
         assert cfg.source_roots == ()
 
+    def test_hermes_root_default(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        assert load_polylogue_config().hermes_root == ""
+
     def test_watch_debounce_default(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.config import load_polylogue_config
 
@@ -525,6 +530,12 @@ class TestPolylogueConfigEnvOverrides:
         cfg = load_polylogue_config()
         assert cfg.watch_debounce_s == 5.0
 
+    def test_env_overrides_hermes_root(self, monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        monkeypatch.setenv("POLYLOGUE_HERMES_ROOT", "/srv/hermes")
+        assert load_polylogue_config().hermes_root == "/srv/hermes"
+
 
 class TestPolylogueConfigCLIOverrides:
     """CLI overrides take highest precedence."""
@@ -591,6 +602,14 @@ class TestPolylogueConfigTOML:
         )
         cfg = load_polylogue_config(config_path=toml_path)
         assert cfg.source_roots == ("/tmp/extra", "/tmp/more")
+
+    def test_toml_sets_hermes_root(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config, resolve_runtime_config
+
+        toml_path = tmp_path / "polylogue.toml"
+        toml_path.write_text('[sources.hermes]\nroot = "/srv/hermes"\n', encoding="utf-8")
+        assert load_polylogue_config(config_path=toml_path).hermes_root == "/srv/hermes"
+        assert resolve_runtime_config(config_path=toml_path).source_paths.hermes == Path("/srv/hermes")
 
     def test_toml_env_cli_precedence(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, workspace_env: dict[str, Path]

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -1268,7 +1268,8 @@ def test_polylogued_run_uses_default_sources() -> None:
         result = CliRunner().invoke(main, ["run", "--no-browser-capture", "--no-api", "--debounce-s", "0.25"])
 
     assert result.exit_code == 0
-    default_sources.assert_called_once_with()
+    assert default_sources.call_count == 1
+    assert default_sources.call_args.kwargs["hermes_root"] == Path.home() / ".hermes"
     coroutine = run.call_args.kwargs.get("main") or run.call_args.args[0]
     assert inspect.iscoroutine(coroutine)
     coroutine.close()
@@ -1341,7 +1342,8 @@ def test_polylogued_watch_uses_default_sources() -> None:
         result = runner.invoke(main, ["watch", "--debounce-s", "0.25"])
 
     assert result.exit_code == 0
-    default_sources.assert_called_once_with()
+    assert default_sources.call_count == 1
+    assert default_sources.call_args.kwargs["hermes_root"] == Path.home() / ".hermes"
     coroutine = run.call_args.kwargs.get("main") or run.call_args.args[0]
     assert inspect.iscoroutine(coroutine)
     coroutine.close()

--- a/tests/unit/sources/test_live_watcher_catchup_order.py
+++ b/tests/unit/sources/test_live_watcher_catchup_order.py
@@ -63,5 +63,18 @@ def test_default_sources_watch_hermes_state_db(monkeypatch: Any, tmp_path: Path)
     hermes = sources["hermes"]
     assert hermes.root == tmp_path / ".hermes"
     assert hermes.accepts(tmp_path / ".hermes" / "state.db")
+    assert hermes.accepts(tmp_path / ".hermes" / "verification_evidence.db")
     assert hermes.accepts(tmp_path / ".hermes" / "sessions" / "snapshot.json")
+    assert hermes.accepts(tmp_path / ".hermes" / "observability" / "hermes-atof.jsonl")
     assert sources["inbox"].accepts(tmp_path / "archive" / "inbox" / "state.db")
+
+
+def test_default_sources_uses_resolved_hermes_root(tmp_path: Path) -> None:
+    configured_root = tmp_path / "hermes-profile"
+
+    hermes = next(
+        source for source in live_watcher.default_sources(hermes_root=configured_root) if source.name == "hermes"
+    )
+
+    assert hermes.root == configured_root
+    assert hermes.accepts(configured_root / "observability" / "hermes-atof.jsonl")


### PR DESCRIPTION
## Summary

Makes Hermes runtime evidence first-class in default daemon discovery: the watcher now accepts NeMo Relay ATOF JSONL beside state snapshots and SQLite artifacts, while a five-layer configuration override selects the Hermes root.

## Problem

The live Hermes runtime stores evidence in several source classes. The watcher admitted JSON and SQLite files but not append-only ATOF JSONL, and `~/.hermes` could not be overridden through the resolved runtime configuration.

## Solution

Adds `sources.hermes.root` / `POLYLOGUE_HERMES_ROOT`, resolves it through `ResolvedRuntimeConfig`, and passes it into both daemon watcher entry points. The watcher admits snapshots, ATIF JSON, ATOF JSONL, `state.db`, and `verification_evidence.db`. Admission deliberately remains separate from parser fidelity: the verification-ledger SQLite schema will be normalized only against its observed producer contract.

Ref polylogue-elmm.

## Verification

- `devtools test tests/unit/core/test_config.py tests/unit/sources/test_live_watcher_catchup_order.py tests/unit/daemon/test_daemon_cli.py` — 183 passed.
- `devtools verify --quick` — all quick gates passed.
- Pre-push quick baseline — all quick gates passed.