### PR TITLE
close AC gaps on yyvg.6.1/ptx + add popup attention surface (yyvg.7)

### DIFF
--- a/browser-extension/src/operator_status.js
+++ b/browser-extension/src/operator_status.js
@@ -472,14 +472,101 @@
     };
   }
 
+  // The exception-driven popup surfaces at most one attention item at a
+  // time (polylogue-yyvg.7 AC3). This is a strict typed priority list, not a
+  // free-form aggregation: auth/pairing mismatch (the receiver cannot be
+  // trusted) outranks an unconfirmed action outcome (a stuck submit, never
+  // auto-retried), which outranks a typed capability mismatch on queued
+  // work, which outranks a hard archive failure on the current conversation.
+  // Anything else is healthy/automatic and returns null — silence is the
+  // correct answer far more often than not.
+  function computeAttention({
+    conversationState = null,
+    pairing = null,
+    health = null,
+    workItems = [],
+    browserActions = [],
+  } = {}) {
+    if (pairing?.state === "mismatch" || health?.status === "pairing_mismatch") {
+      return {
+        kind: "auth_pairing_mismatch",
+        tone: "bad",
+        headline: "Receiver identity changed",
+        detail: "The configured endpoint answered as a different receiver. Verify it, then reset pairing.",
+        actionId: "reset-pairing",
+        actionLabel: "Reset pairing",
+      };
+    }
+    if (health?.status === "unauthorized" || conversationState?.error === "unauthorized") {
+      return {
+        kind: "auth_pairing_mismatch",
+        tone: "bad",
+        headline: "Receiver requires its pairing token",
+        detail: "Run `polylogued browser-capture token show` and paste the value into the receiver token field.",
+        actionId: "receiver-token",
+        actionLabel: "Open receiver settings",
+      };
+    }
+
+    const unknownAction = (Array.isArray(browserActions) ? browserActions : [])
+      .find((action) => action?.status === "outcome_unknown");
+    if (unknownAction) {
+      return {
+        kind: "action_outcome_unknown",
+        tone: "bad",
+        headline: "A browser action's outcome could not be confirmed",
+        detail: unknownAction.last_error
+          || "The provider connection ended without a receipt. Check the conversation before retrying.",
+        actionId: null,
+        actionLabel: "Details",
+      };
+    }
+
+    const capabilityItem = (Array.isArray(workItems) ? workItems : [])
+      .find((item) => ["capability_mismatch", "receiver_contract_incompatible"].includes(item?.raw?.cooldown_reason));
+    if (capabilityItem) {
+      return {
+        kind: "capability_mismatch",
+        tone: "bad",
+        headline: `${capabilityItem.title} needs a compatible provider selection`,
+        detail: capabilityItem.cooldown || "The receiver rejected an unsupported provider capability.",
+        actionId: null,
+        actionLabel: "Details",
+      };
+    }
+
+    if (conversationState && (conversationState.archive_state?.state === "failed" || conversationState.error)) {
+      return {
+        kind: "archive_failed",
+        tone: "bad",
+        headline: "This conversation failed to archive",
+        detail: conversationState.archive_state?.latest_failure
+          || conversationState.error
+          || "Check the debug log request id.",
+        actionId: null,
+        actionLabel: "Details",
+      };
+    }
+
+    return null;
+  }
+
+  function pendingBrowserActionCount(browserActions = []) {
+    const pendingStatuses = new Set(["queued", "leased", "preparing", "submit_intent"]);
+    return (Array.isArray(browserActions) ? browserActions : [])
+      .filter((action) => pendingStatuses.has(action?.status)).length;
+  }
+
   root.PolylogueOperatorStatus = Object.freeze({
     OPERATOR_STATUS,
     WORK_STATUS,
+    computeAttention,
     eventPresentation,
     normalizeWorkItems,
     operatorPresentationForState,
     operatorStatusForState,
     operatorStatusLabel,
+    pendingBrowserActionCount,
     receiverPairingPresentation,
   });
 })(globalThis);

--- a/browser-extension/src/popup.html
+++ b/browser-extension/src/popup.html
@@ -261,6 +261,18 @@
         <div id="badge" class="badge neutral" aria-live="polite">checking</div>
       </header>
 
+      <section class="row" aria-label="Pending browser actions">
+        <span class="label">Pending browser actions</span><span id="pending-action-count" class="value">0</span>
+      </section>
+
+      <section id="attention-section" class="active-card" hidden aria-labelledby="attention-heading">
+        <div class="section-head"><strong id="attention-heading">Attention</strong></div>
+        <p id="attention-detail" class="log-meta"></p>
+        <div class="controls">
+          <button id="attention-action" hidden><span class="button-label"></span><span class="button-status"></span></button>
+        </div>
+      </section>
+
       <section>
         <div class="section-head"><strong>Open conversations</strong><span id="open-tab-count" class="value">0</span></div>
         <div id="open-tabs" class="tab-list" aria-live="polite"></div>
@@ -291,54 +303,91 @@
         <div id="timeline" class="log" aria-live="polite"></div>
       </section>
 
-      <section aria-labelledby="receiver-heading">
-        <div class="section-head"><strong id="receiver-heading">Paired receiver</strong><span id="receiver-health" class="state-chip neutral">--</span></div>
-        <div class="surface-card">
-          <div id="receiver-pairing-status" class="pairing-id">Identity not checked</div>
-          <p id="receiver-pairing-detail" class="log-meta">Polylogue will bind the first compatible authenticated receiver it reaches.</p>
-        </div>
-        <div class="controls">
-          <button id="reset-pairing" class="danger"><span class="button-label">Reset pairing</span><span class="button-status"></span></button>
-        </div>
-        <p class="section-note">Reset removes only the trusted receiver identity. It does not delete capture or backfill queues.</p>
-      </section>
+      <details id="diagnostics">
+        <summary>Diagnostics · leases, retries, request ids, receiver identity, backfill, raw logs</summary>
 
-      <section aria-labelledby="work-heading">
-        <div class="section-head"><strong id="work-heading">Work queue</strong><span id="work-count" class="value">0</span></div>
-        <p class="section-note">One vocabulary covers local capture retries and provider backfills.</p>
-        <div id="work-queue" class="work-list" aria-live="polite"></div>
-        <details>
-          <summary>Capture retry detail · <span id="queue-count">0</span></summary>
-          <div id="queue-log" class="log"></div>
-        </details>
-      </section>
+        <section aria-labelledby="receiver-heading">
+          <div class="section-head"><strong id="receiver-heading">Paired receiver</strong><span id="receiver-health" class="state-chip neutral">--</span></div>
+          <div class="surface-card">
+            <div id="receiver-pairing-status" class="pairing-id">Identity not checked</div>
+            <p id="receiver-pairing-detail" class="log-meta">Polylogue will bind the first compatible authenticated receiver it reaches.</p>
+          </div>
+          <div class="controls">
+            <button id="reset-pairing" class="danger"><span class="button-label">Reset pairing</span><span class="button-status"></span></button>
+          </div>
+          <p class="section-note">Reset removes only the trusted receiver identity. It does not delete capture or backfill queues.</p>
+        </section>
 
-      <section id="backfill-panel" aria-labelledby="backfill-heading">
-        <div class="section-head">
-          <strong id="backfill-heading">Background backfill</strong>
-          <span id="backfill-status" class="value">idle</span>
-        </div>
-        <select id="backfill-job" aria-label="Backfill job"><option value="">No jobs yet</option></select>
-        <div class="setting-row">
-          <select id="backfill-provider" aria-label="Backfill provider">
-            <option value="chatgpt">ChatGPT</option>
-            <option value="claude-ai">Claude.ai</option>
-          </select>
-          <input id="backfill-cutoff" type="date" aria-label="Capture conversations updated since">
-        </div>
-        <div class="row"><span class="label">Inventory cursor</span><span id="backfill-cursor" class="value">--</span></div>
-        <div class="row"><span class="label">Progress</span><span id="backfill-progress" class="value">--</span></div>
-        <div class="row"><span class="label">Cadence / cooldown</span><span id="backfill-rate" class="value">--</span></div>
-        <div class="row"><span class="label">Last ACK / error</span><span id="backfill-last" class="value">--</span></div>
-        <div class="controls">
-          <button id="backfill-start" class="primary"><span class="button-label">Start</span><span class="button-status"></span></button>
-          <button id="backfill-pause"><span class="button-label">Pause</span><span class="button-status"></span></button>
-          <button id="backfill-resume"><span class="button-label">Resume</span><span class="button-status"></span></button>
-          <button id="backfill-cancel"><span class="button-label">Cancel</span><span class="button-status"></span></button>
-          <button id="backfill-export"><span class="button-label">Export ledger</span><span class="button-status"></span></button>
-        </div>
-        <p class="section-note">Runs against authenticated provider inventory without activating foreground tabs. Provider cooldowns remain authoritative.</p>
-      </section>
+        <section aria-labelledby="work-heading">
+          <div class="section-head"><strong id="work-heading">Work queue</strong><span id="work-count" class="value">0</span></div>
+          <p class="section-note">One vocabulary covers local capture retries and provider backfills.</p>
+          <div id="work-queue" class="work-list" aria-live="polite"></div>
+          <details>
+            <summary>Capture retry detail · <span id="queue-count">0</span></summary>
+            <div id="queue-log" class="log"></div>
+          </details>
+        </section>
+
+        <section id="backfill-panel" aria-labelledby="backfill-heading">
+          <div class="section-head">
+            <strong id="backfill-heading">Background backfill</strong>
+            <span id="backfill-status" class="value">idle</span>
+          </div>
+          <select id="backfill-job" aria-label="Backfill job"><option value="">No jobs yet</option></select>
+          <div class="setting-row">
+            <select id="backfill-provider" aria-label="Backfill provider">
+              <option value="chatgpt">ChatGPT</option>
+              <option value="claude-ai">Claude.ai</option>
+            </select>
+            <input id="backfill-cutoff" type="date" aria-label="Capture conversations updated since">
+          </div>
+          <div class="row"><span class="label">Inventory cursor</span><span id="backfill-cursor" class="value">--</span></div>
+          <div class="row"><span class="label">Progress</span><span id="backfill-progress" class="value">--</span></div>
+          <div class="row"><span class="label">Cadence / cooldown</span><span id="backfill-rate" class="value">--</span></div>
+          <div class="row"><span class="label">Last ACK / error</span><span id="backfill-last" class="value">--</span></div>
+          <div class="controls">
+            <button id="backfill-start" class="primary"><span class="button-label">Start</span><span class="button-status"></span></button>
+            <button id="backfill-pause"><span class="button-label">Pause</span><span class="button-status"></span></button>
+            <button id="backfill-resume"><span class="button-label">Resume</span><span class="button-status"></span></button>
+            <button id="backfill-cancel"><span class="button-label">Cancel</span><span class="button-status"></span></button>
+            <button id="backfill-export"><span class="button-label">Export ledger</span><span class="button-status"></span></button>
+          </div>
+          <p class="section-note">Runs against authenticated provider inventory without activating foreground tabs. Provider cooldowns remain authoritative.</p>
+        </section>
+
+        <section>
+          <div class="section-head"><span class="label">Recent capture log</span><span id="log-count" class="value">0</span></div>
+          <div id="log" class="log"></div>
+        </section>
+
+        <section>
+          <div class="section-head"><span class="label">Debug log</span><span id="debug-count" class="value">0</span></div>
+          <div class="debug-actions">
+            <button id="debug-toggle" class="link-button"><span class="button-label">Show details</span><span class="button-status"></span></button>
+            <button id="debug-export" class="link-button"><span class="button-label">Export JSON</span><span class="button-status"></span></button>
+          </div>
+          <div id="debug-panel" hidden>
+            <div class="row"><span class="label">Receiver</span><span id="receiver" class="value">127.0.0.1:8765</span></div>
+            <div class="row"><span class="label">Archive state</span><span id="archive" class="value">Not checked</span></div>
+            <div class="row"><span class="label">Mode</span><span id="mode" class="value">--</span></div>
+            <div class="row"><span class="label">Request</span><span id="receiver-request" class="value">--</span></div>
+            <div class="row"><span class="label">Extension build</span><span id="extension-build" class="value">--</span></div>
+            <div class="row"><span class="label">Updated</span><span id="updated" class="value">--</span></div>
+            <div id="debug-log" class="log"></div>
+          </div>
+        </section>
+
+        <section aria-labelledby="settings-heading">
+          <strong id="settings-heading">Receiver settings</strong>
+          <label class="label" for="receiver-url">Local receiver URL</label>
+          <div class="setting-row">
+            <input id="receiver-url" value="http://127.0.0.1:8765">
+            <button id="save"><span class="button-label">Save</span><span class="button-status"></span></button>
+          </div>
+          <label class="label" for="receiver-token">Bearer token</label>
+          <input id="receiver-token" type="password" autocomplete="off" placeholder="Required by the default authenticated receiver">
+        </section>
+      </details>
 
       <section aria-labelledby="ambient-heading">
         <div class="section-head"><strong id="ambient-heading">Ambient surface</strong><span id="ambient-site" class="value">Current site</span></div>
@@ -358,38 +407,6 @@
         <p id="assertion-status" class="section-note">Text selections can form a local assertion candidate. Save remains disabled until the authenticated receiver advertises an assertion route.</p>
       </section>
 
-      <section>
-        <div class="section-head"><span class="label">Recent capture log</span><span id="log-count" class="value">0</span></div>
-        <div id="log" class="log"></div>
-      </section>
-
-      <section>
-        <div class="section-head"><span class="label">Debug log</span><span id="debug-count" class="value">0</span></div>
-        <div class="debug-actions">
-          <button id="debug-toggle" class="link-button"><span class="button-label">Show details</span><span class="button-status"></span></button>
-          <button id="debug-export" class="link-button"><span class="button-label">Export JSON</span><span class="button-status"></span></button>
-        </div>
-        <div id="debug-panel" hidden>
-          <div class="row"><span class="label">Receiver</span><span id="receiver" class="value">127.0.0.1:8765</span></div>
-          <div class="row"><span class="label">Archive state</span><span id="archive" class="value">Not checked</span></div>
-          <div class="row"><span class="label">Mode</span><span id="mode" class="value">--</span></div>
-          <div class="row"><span class="label">Request</span><span id="receiver-request" class="value">--</span></div>
-          <div class="row"><span class="label">Extension build</span><span id="extension-build" class="value">--</span></div>
-          <div class="row"><span class="label">Updated</span><span id="updated" class="value">--</span></div>
-          <div id="debug-log" class="log"></div>
-        </div>
-      </section>
-
-      <section aria-labelledby="settings-heading">
-        <strong id="settings-heading">Receiver settings</strong>
-        <label class="label" for="receiver-url">Local receiver URL</label>
-        <div class="setting-row">
-          <input id="receiver-url" value="http://127.0.0.1:8765">
-          <button id="save"><span class="button-label">Save</span><span class="button-status"></span></button>
-        </div>
-        <label class="label" for="receiver-token">Bearer token</label>
-        <input id="receiver-token" type="password" autocomplete="off" placeholder="Required by the default authenticated receiver">
-      </section>
     </main>
     <script src="operator_status.js"></script>
     <script src="popup.js"></script>

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -11,6 +11,7 @@ let currentCaptureQueue = { entries: [], dropped_count: 0 };
 let currentFreshnessQueue = { entries: {}, dropped_count: 0 };
 let currentBackfillJobs = [];
 let currentReceiverOnline = true;
+let currentBrowserActions = [];
 
 function hostMatches(hostname, domain) {
   return hostname === domain || hostname.endsWith(`.${domain}`);
@@ -481,6 +482,41 @@ function renderAmbient(ambient, tabUrl = "", assertions = null) {
   }
 }
 
+async function loadBrowserActionsStatus() {
+  try {
+    const result = await chrome.runtime.sendMessage({ type: "polylogue.browserActions.status" });
+    return Array.isArray(result?.actions) ? result.actions : [];
+  } catch {
+    return [];
+  }
+}
+
+function renderAttention(attention) {
+  const section = document.getElementById("attention-section");
+  const detailNode = document.getElementById("attention-detail");
+  const actionButton = document.getElementById("attention-action");
+  if (!section) return;
+  if (!attention) {
+    section.hidden = true;
+    return;
+  }
+  section.hidden = false;
+  const heading = document.getElementById("attention-heading");
+  if (heading) heading.textContent = attention.headline;
+  if (detailNode) detailNode.textContent = attention.detail || "";
+  if (actionButton) {
+    if (attention.actionId) {
+      actionButton.hidden = false;
+      actionButton.dataset.targetId = attention.actionId;
+      const label = actionButton.querySelector(".button-label");
+      if (label) label.textContent = attention.actionLabel || "Resolve";
+    } else {
+      actionButton.hidden = true;
+      delete actionButton.dataset.targetId;
+    }
+  }
+}
+
 async function loadMissionSnapshot() {
   try {
     const result = await chrome.runtime.sendMessage({ type: "polylogue.missionControl.status", refresh: false });
@@ -564,11 +600,17 @@ async function render() {
   document.getElementById("receiver-token").value = stored.receiverAuthToken || "";
   document.getElementById("receiver").textContent = stored.receiverBaseUrl;
 
-  const [tab, openTabs, mission] = await Promise.all([
+  const [tab, openTabs, mission, browserActions] = await Promise.all([
     activeTab(),
     chrome.tabs.query({}),
     loadMissionSnapshot(),
+    loadBrowserActionsStatus(),
   ]);
+  currentBrowserActions = browserActions;
+  const pendingActionCountNode = document.getElementById("pending-action-count");
+  if (pendingActionCountNode) {
+    pendingActionCountNode.textContent = String(operatorStatusApi.pendingBrowserActionCount(browserActions));
+  }
   const extensionBuild = document.getElementById("extension-build");
   if (extensionBuild) {
     const runtime = mission?.extension;
@@ -656,6 +698,20 @@ async function render() {
 
   const ambient = mission?.ambient || ambientFallback(stored.polylogueAmbientSettings, tab?.url || "");
   renderAmbient(ambient, tab?.url || "", mission?.assertions || null);
+
+  const workItems = operatorStatusApi.normalizeWorkItems({
+    captureQueue: currentCaptureQueue,
+    freshnessQueue: currentFreshnessQueue,
+    backfillJobs: currentBackfillJobs,
+    receiverOnline: currentReceiverOnline,
+  });
+  renderAttention(operatorStatusApi.computeAttention({
+    conversationState: state,
+    pairing,
+    health,
+    workItems,
+    browserActions: currentBrowserActions,
+  }));
 }
 
 async function refreshStatus(reason = "popup_manual") {
@@ -691,6 +747,17 @@ document.getElementById("open-polylogue").addEventListener("click", async () => 
     const url = `${String(stored.receiverBaseUrl || DEFAULT_RECEIVER).replace(/\/+$/, "")}/?q=${encodeURIComponent(providerSessionId || "")}`;
     await chrome.tabs.create({ url });
   }, { busy: "Opening" });
+});
+
+document.getElementById("attention-action")?.addEventListener("click", (event) => {
+  const targetId = event.currentTarget.dataset.targetId;
+  if (!targetId) return;
+  const diagnostics = document.getElementById("diagnostics");
+  if (diagnostics && "open" in diagnostics) diagnostics.open = true;
+  const target = document.getElementById(targetId);
+  if (!target) return;
+  if (target.tagName === "BUTTON") target.click();
+  else target.focus();
 });
 
 document.getElementById("reset-pairing")?.addEventListener("click", async () => {

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -1716,7 +1716,7 @@ describe("background receiver diagnostics", () => {
     });
 
     installedListener();
-    await new Promise((resolve) => globalThis.setTimeout(resolve, 20));
+    await vi.waitFor(() => expect(stored.polylogueState?.online).toBe(false));
 
     expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
     expect(globalThis.chrome.scripting.executeScript).not.toHaveBeenCalled();

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -1681,6 +1681,47 @@ describe("background receiver diagnostics", () => {
       .some((event) => event.detail === "background_capture_throttled")).toBe(false);
   });
 
+  it("never fetches a terminal ChatGPT conversation across a receiver outage and a service-worker restart", async () => {
+    const pairing = {
+      state: "online",
+      receiver_id: "rx-restart-guard",
+      api_schema: "polylogue-browser-capture/v1",
+      endpoint: "http://127.0.0.1:8875",
+    };
+    await loadBackground({ polylogueReceiverPairing: pairing });
+    tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-terminal-restart", title: "ChatGPT" }];
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("/v1/status")) {
+        return responseJson({ ok: true, receiver_id: pairing.receiver_id, api_schema: pairing.api_schema });
+      }
+      return responseJson({
+        provider: "chatgpt",
+        provider_session_id: "conv-terminal-restart",
+        state: "archived",
+        captured: true,
+      });
+    });
+
+    installedListener();
+    await vi.waitFor(() => expect(stored.polylogueState?.archive_state?.state).toBe("archived"));
+    expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
+
+    // Receiver goes down, then the extension's own service worker restarts.
+    // chrome.storage.local (the pairing) survives; in-memory reconciliation
+    // state does not — this is the shape of the original incident.
+    await loadBackground({ polylogueReceiverPairing: pairing });
+    tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-terminal-restart", title: "ChatGPT" }];
+    globalThis.fetch = vi.fn(async () => {
+      throw new TypeError("Failed to fetch");
+    });
+
+    installedListener();
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 20));
+
+    expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
+    expect(globalThis.chrome.scripting.executeScript).not.toHaveBeenCalled();
+  });
+
   it("recaptures an archived Claude conversation until that provider has freshness convergence", async () => {
     tabs = [{ id: 42, url: "https://claude.ai/chat/claude-freshness", title: "Claude" }];
     stored.polylogueReceiverPairing = {

--- a/browser-extension/tests/operator_status.test.js
+++ b/browser-extension/tests/operator_status.test.js
@@ -233,4 +233,62 @@ describe("shared operator status vocabulary", () => {
       headline: "Receiver identity changed",
     });
   });
+
+  it("surfaces at most one attention item, in strict priority order", () => {
+    expect(api.computeAttention({})).toBeNull();
+    expect(api.computeAttention({ conversationState: { online: true, archive_state: { state: "archived" } } }))
+      .toBeNull();
+
+    const pairingMismatch = api.computeAttention({
+      pairing: { state: "mismatch" },
+      health: { status: "pairing_mismatch" },
+      browserActions: [{ status: "outcome_unknown" }],
+    });
+    expect(pairingMismatch).toMatchObject({ kind: "auth_pairing_mismatch", actionId: "reset-pairing" });
+
+    const unauthorized = api.computeAttention({ health: { status: "unauthorized" } });
+    expect(unauthorized).toMatchObject({ kind: "auth_pairing_mismatch", actionId: "receiver-token" });
+
+    const unknownOutcome = api.computeAttention({
+      browserActions: [
+        { status: "submitted" },
+        { status: "outcome_unknown", last_error: "submit channel ended without a receipt" },
+      ],
+      workItems: [{ title: "ChatGPT reply", raw: { cooldown_reason: "capability_mismatch" } }],
+    });
+    expect(unknownOutcome).toMatchObject({
+      kind: "action_outcome_unknown",
+      detail: "submit channel ended without a receipt",
+    });
+
+    const capabilityMismatch = api.computeAttention({
+      workItems: [{ title: "ChatGPT reply", cooldown: "model unavailable", raw: { cooldown_reason: "capability_mismatch" } }],
+    });
+    expect(capabilityMismatch).toMatchObject({
+      kind: "capability_mismatch",
+      headline: "ChatGPT reply needs a compatible provider selection",
+      detail: "model unavailable",
+    });
+
+    const archiveFailed = api.computeAttention({
+      conversationState: { archive_state: { state: "failed", latest_failure: "index rejected" } },
+    });
+    expect(archiveFailed).toMatchObject({ kind: "archive_failed", detail: "index rejected" });
+  });
+
+  it("counts only browser actions still awaiting a receipt as pending", () => {
+    expect(api.pendingBrowserActionCount()).toBe(0);
+    expect(api.pendingBrowserActionCount([
+      { status: "queued" },
+      { status: "leased" },
+      { status: "preparing" },
+      { status: "submit_intent" },
+      { status: "outcome_unknown" },
+      { status: "submitted" },
+      { status: "blocked" },
+      { status: "failed" },
+      { status: "cancelled" },
+      { status: "drafted" },
+    ])).toBe(4);
+  });
 });

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -32,6 +32,13 @@ function installDom() {
   const dom = new JSDOM(`<!doctype html>
     <body>
       <span id="badge"></span>
+      <span id="pending-action-count"></span>
+      <section id="attention-section" hidden>
+        <strong id="attention-heading"></strong>
+        <p id="attention-detail"></p>
+        <button id="attention-action" hidden><span class="button-label"></span><span class="button-status"></span></button>
+      </section>
+      <details id="diagnostics"></details>
       <span id="operator-state"></span>
       <strong id="active-heading"></strong>
       <span id="fidelity-flag" hidden></span>
@@ -240,6 +247,57 @@ describe("popup capture", () => {
 
     expect(globalThis.document.getElementById("archive").textContent).toBe("Needs attention");
     expect(globalThis.document.getElementById("state-detail").textContent).toContain("browser-capture token show");
+
+    const attentionSection = globalThis.document.getElementById("attention-section");
+    await vi.waitFor(() => expect(attentionSection.hidden).toBe(false));
+    expect(globalThis.document.getElementById("attention-heading").textContent)
+      .toBe("Receiver requires its pairing token");
+    const actionButton = globalThis.document.getElementById("attention-action");
+    expect(actionButton.hidden).toBe(false);
+
+    const diagnostics = globalThis.document.getElementById("diagnostics");
+    diagnostics.open = false;
+    actionButton.dispatchEvent(new globalThis.window.Event("click", { bubbles: true }));
+    expect(diagnostics.open).toBe(true);
+  });
+
+  it("shows no attention item and a zero pending-action count when everything is healthy", async () => {
+    await loadPopup({
+      polylogueState: { online: true, captured: true, archive_state: { state: "archived" } },
+    });
+
+    await vi.waitFor(() => expect(globalThis.document.getElementById("pending-action-count").textContent).toBe("0"));
+    expect(globalThis.document.getElementById("attention-section").hidden).toBe(true);
+  });
+
+  it("counts queued browser actions and never lets a stuck action-outcome item auto-clear", async () => {
+    await loadPopup({}, [CHATGPT_TAB], async (message) => {
+      if (message.type === "polylogue.browserActions.status") {
+        return {
+          ok: true,
+          actions: [
+            { action_id: "a1", status: "queued" },
+            { action_id: "a2", status: "leased" },
+            {
+              action_id: "a3",
+              status: "outcome_unknown",
+              last_error: "submit channel ended without a receipt",
+            },
+          ],
+        };
+      }
+      return { ok: true };
+    });
+
+    await vi.waitFor(() => expect(globalThis.document.getElementById("attention-section").hidden).toBe(false));
+    expect(globalThis.document.getElementById("pending-action-count").textContent).toBe("2");
+    expect(globalThis.document.getElementById("attention-heading").textContent)
+      .toBe("A browser action's outcome could not be confirmed");
+    expect(globalThis.document.getElementById("attention-detail").textContent)
+      .toBe("submit channel ended without a receipt");
+    // No actionId is offered for an outcome_unknown action -- there is no safe
+    // one-click resolution, only "Details" (progressive disclosure, not a button).
+    expect(globalThis.document.getElementById("attention-action").hidden).toBe(true);
   });
 
   it("renders DOM fallback with concrete next action", async () => {

--- a/tests/unit/architecture/test_browser_action_conduit_vocabulary.py
+++ b/tests/unit/architecture/test_browser_action_conduit_vocabulary.py
@@ -52,11 +52,18 @@ TOKEN_PATTERN = re.compile(r"\b(" + "|".join(re.escape(t) for t in FORBIDDEN_TOK
 
 
 def _iter_source_files() -> list[Path]:
+    for root in (*RECEIVER_ROOTS, EXTENSION_ROOT):
+        if not root.exists():
+            raise FileNotFoundError(
+                f"browser-action conduit vocabulary guard root missing: {root} "
+                "(has it moved? update RECEIVER_ROOTS/EXTENSION_ROOT rather than "
+                "letting this guard silently scan zero files)"
+            )
     files: list[Path] = []
     for root in RECEIVER_ROOTS:
         if root.is_dir():
             files.extend(sorted(p for p in root.rglob("*.py") if "test" not in p.parts))
-        elif root.is_file():
+        else:
             files.append(root)
     files.extend(sorted(EXTENSION_ROOT.rglob("*.js")))
     return files

--- a/tests/unit/architecture/test_browser_action_conduit_vocabulary.py
+++ b/tests/unit/architecture/test_browser_action_conduit_vocabulary.py
@@ -1,0 +1,78 @@
+"""Guard against campaign vocabulary leaking into the browser-action conduit (polylogue-ptx AC6).
+
+``polylogue-ptx`` replaced the Sol-specific ``BrowserLaunchJob`` queue and the
+text-only ``BrowserPostCommand`` with one provider-neutral
+``BrowserActionIntent`` conduit (PR #2928). Per that bead's design note,
+mission/run/iteration/deliverable/package/cadence campaign identity is a
+concern of the external orchestrator (``polylogue-yyvg.6``), never of the
+extension or receiver product code. This static check walks the receiver
+(``polylogue/browser_capture/``, ``polylogue/daemon/browser_capture.py``) and
+the extension (``browser-extension/src/``) and asserts neither the retired
+class names nor campaign-identity field names have been reintroduced.
+
+External campaign tooling under ``.agent/handoffs/`` and devtools campaign
+receipt/report modules are explicitly out of scope — they are the legitimate
+orchestrator client this bead's design note describes, not the conduit.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+RECEIVER_ROOTS = (
+    REPO_ROOT / "polylogue" / "browser_capture",
+    REPO_ROOT / "polylogue" / "daemon" / "browser_capture.py",
+)
+EXTENSION_ROOT = REPO_ROOT / "browser-extension" / "src"
+
+# Word-boundary tokens. "mission" alone is deliberately excluded: the
+# extension's ambient/popup status surface is legitimately named "mission
+# control" (a UI metaphor for cross-conversation archive intelligence, see
+# polylogue-yyvg.7) and is unrelated to campaign MissionId identity.
+FORBIDDEN_TOKENS = (
+    "BrowserPostCommand",
+    "BrowserLaunchJob",
+    "LaunchJob",
+    "mission_id",
+    "MissionId",
+    "deliverable_id",
+    "DeliverableId",
+    "package_revision",
+    "PackageRevisionId",
+    "cadence_strategy",
+    "campaign_id",
+    "CampaignId",
+    "handoff_id",
+    "HandoffId",
+)
+TOKEN_PATTERN = re.compile(r"\b(" + "|".join(re.escape(t) for t in FORBIDDEN_TOKENS) + r")\b")
+
+
+def _iter_source_files() -> list[Path]:
+    files: list[Path] = []
+    for root in RECEIVER_ROOTS:
+        if root.is_dir():
+            files.extend(sorted(p for p in root.rglob("*.py") if "test" not in p.parts))
+        elif root.is_file():
+            files.append(root)
+    files.extend(sorted(EXTENSION_ROOT.rglob("*.js")))
+    return files
+
+
+def test_conduit_source_rejects_retired_campaign_vocabulary() -> None:
+    violations: list[str] = []
+    for path in _iter_source_files():
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            match = TOKEN_PATTERN.search(line)
+            if match:
+                violations.append(f"{path.relative_to(REPO_ROOT)}:{lineno}: {match.group(1)!r} — {line.strip()}")
+    assert not violations, (
+        "Campaign vocabulary reintroduced into the provider-neutral browser-action "
+        "conduit (polylogue-ptx AC6). Campaign/mission/deliverable/package identity "
+        "belongs to the external orchestrator (polylogue-yyvg.6), not extension or "
+        "receiver product code:\n" + "\n".join(violations)
+    )

--- a/tests/unit/browser_capture/test_actions.py
+++ b/tests/unit/browser_capture/test_actions.py
@@ -312,6 +312,68 @@ def test_lease_owner_receipt_and_explicit_uncertainty_reconciliation(tmp_path: P
     assert retried == reconciled
 
 
+@pytest.mark.parametrize(
+    "outcome",
+    ["provider_warning", "rate_limited", "safety_locked", "auth_challenge", "capability_mismatch", "provider_drift"],
+)
+def test_typed_provider_failures_block_and_release_the_lease(outcome: str, tmp_path: Path) -> None:
+    action = enqueue_action(_request(), receiver_id=_RECEIVER_ID, spool_path=tmp_path)
+    claimed = claim_action("extension-one", spool_path=tmp_path) or pytest.fail("action was not claimed")
+
+    blocked = update_action(
+        action.action_id,
+        BrowserActionUpdateRequest(
+            owner_instance_id=claimed.lease_owner or "",
+            outcome=outcome,  # type: ignore[arg-type]
+            phase="provider_action_failed",
+            detail=f"typed {outcome} fixture",
+            retry_after_seconds=120 if outcome == "rate_limited" else None,
+        ),
+        spool_path=tmp_path,
+    ) or pytest.fail("missing blocked action")
+
+    assert blocked.status == "blocked"
+    assert blocked.failure_kind == outcome
+    assert blocked.last_error == f"typed {outcome} fixture"
+    assert blocked.lease_owner is None
+    assert blocked.lease_expires_at is None
+    assert blocked.retry_after_seconds == (120 if outcome == "rate_limited" else None)
+
+    # A blocked action is a terminal disposition, not silently revivable by a
+    # different owner racing in — this is AC2's "a terminal job cannot revive
+    # it" applied to the action ledger, not just the extension's capture path.
+    assert claim_action("extension-two", spool_path=tmp_path) is None
+
+    # Idempotent resubmit of the identical outcome/detail is safe (the client
+    # may retry its own POST after a network blip) and returns the same
+    # terminal record without raising or mutating state.
+    replayed = update_action(
+        action.action_id,
+        BrowserActionUpdateRequest(
+            owner_instance_id="extension-two",
+            outcome=outcome,  # type: ignore[arg-type]
+            phase="provider_action_failed",
+            detail=f"typed {outcome} fixture",
+        ),
+        spool_path=tmp_path,
+    )
+    assert replayed == blocked
+
+    # A conflicting outcome/detail on the same terminal action is rejected,
+    # not silently overwritten.
+    with pytest.raises(BrowserActionConflictError):
+        update_action(
+            action.action_id,
+            BrowserActionUpdateRequest(
+                owner_instance_id="extension-two",
+                outcome=outcome,  # type: ignore[arg-type]
+                phase="provider_action_failed",
+                detail="a different failure detail",
+            ),
+            spool_path=tmp_path,
+        )
+
+
 def test_reply_receipt_must_match_the_requested_conversation(tmp_path: Path) -> None:
     action = enqueue_action(
         _request(operation="conversation.reply", conversation_id="conversation-target"),


### PR DESCRIPTION
## Summary
Four commits closing AC gaps on the three P0 extension beads flagged by the 2026-07-17 warroom It.17 sweep, all scoped to `browser-extension/` + receiver code:

1. `polylogue-yyvg.6.1` AC1: a deterministic fixture proving no ChatGPT conversation/attachment request occurs for a terminal conversation across a receiver outage *combined with* a simulated service-worker restart.
2. `polylogue-ptx` AC6: a static/contract test rejecting reintroduction of the retired `BrowserPostCommand`/`BrowserLaunchJob` campaign machinery or campaign-identity vocabulary.
3. `polylogue-ptx` AC7: receiver-side coverage of all six typed pre-submit failure outcomes (the extension side already had it; the receiver's identical state-machine branch did not).
4. `polylogue-yyvg.7`: a real (partial) slice of the exception-driven popup redesign — a single-item `computeAttention()` surface plus a pending-browser-action count, and progressive-disclosure diagnostics for the previously always-visible machinery (receiver pairing/reset, work queue, backfill panel, raw logs, receiver settings).

## Problem
All three beads had their core behavior land already (`yyvg.6.1` via #2977/#2979/#2981/#2983/#2986; `ptx` via #2928; `yyvg.7`'s first UX slice via #2928/#2929) but were left open pending explicit AC-by-AC checks, and several AC clauses specifically wanted *fixtures*, *guards*, or *UI surfaces* that didn't exist yet — see full AC-by-AC verdicts recorded in each bead's notes (`polylogue-yyvg.6.1`, `polylogue-ptx`, `polylogue-yyvg.7`).

## Solution
- `browser-extension/tests/background.test.js`: new fixture combining a receiver outage with a simulated service-worker restart against a terminal conversation.
- `tests/unit/architecture/test_browser_action_conduit_vocabulary.py`: static scan over `polylogue/browser_capture/`, `polylogue/daemon/browser_capture.py`, and `browser-extension/src/`.
- `tests/unit/browser_capture/test_actions.py`: parametrized `test_typed_provider_failures_block_and_release_the_lease` over all six receiver failure outcomes.
- `browser-extension/src/operator_status.js`: new `computeAttention()` (strict single-item typed priority list: auth/pairing mismatch → action `outcome_unknown` → capability mismatch → archive failure → null) and `pendingBrowserActionCount()`, added to the existing shared status module already used by ambient/message-layer/popup.
- `browser-extension/src/popup.html` + `popup.js`: a "Pending browser actions" count and hidden-by-default "Attention" section under the header; receiver pairing/reset, work queue, backfill panel, recent capture log, debug log, and receiver settings now live inside one collapsed `<details id="diagnostics">`. Clicking an attention item's action opens diagnostics and drives the real underlying control (no second authority copy).

**Honesty on scope**: commit 4 is explicitly a partial yyvg.7 slice, not full closure — pixel-level mockup convergence, a compact bounded "Now" summary, the "explicit submit/destructive approval" and "destructive conflict" attention categories (no backing data model yet), a DOM/height budget check, and the live installed proof all remain open. Recorded honestly in the bead notes rather than claimed done.

## Verification
- `npx vitest run` (in `browser-extension/`) → 335 passed, 1 pre-existing unrelated failure (packaged service-worker backfill fixture in `tests/build.test.js`; reproduced unchanged on a clean tree with this branch's changes stashed out)
- `npm run lint` / `npm run validate` (in `browser-extension/`) → clean / manifest ok
- `devtools test tests/unit/architecture/test_browser_action_conduit_vocabulary.py` → 1 passed
- `devtools test tests/unit/browser_capture/test_actions.py` → 18 passed
- `devtools verify --quick` (pre-push hook, all four pushes) → exit 0

Ref polylogue-yyvg.6.1, polylogue-ptx, polylogue-yyvg.7