### PR TITLE
fix(storage): stop async raw writer clobbering revision evidence

### DIFF
--- a/polylogue/storage/sqlite/async_sqlite_raw.py
+++ b/polylogue/storage/sqlite/async_sqlite_raw.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager
 from typing import TYPE_CHECKING
@@ -10,16 +9,12 @@ from typing import TYPE_CHECKING
 import aiosqlite
 
 from polylogue.core.enums import Provider, ValidationMode, ValidationStatus
-from polylogue.core.sources import origin_from_provider
 from polylogue.storage.raw.models import RawSessionState, RawSessionStateUpdate
 from polylogue.storage.runtime import ArtifactObservationRecord, RawSessionRecord
-from polylogue.storage.sqlite.archive_tiers.write import _timestamp_ms
 from polylogue.storage.sqlite.queries import artifacts as artifacts_q
 from polylogue.storage.sqlite.queries import raw as raw_queries
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from polylogue.storage.sqlite.query_store import SQLiteQueryStore
 
 
@@ -29,7 +24,6 @@ class SQLiteRawMixin:
     if TYPE_CHECKING:
         queries: SQLiteQueryStore
         _transaction_depth: int
-        _source_db_path: Path
 
         def _get_connection(self) -> AbstractAsyncContextManager[aiosqlite.Connection]: ...
 
@@ -94,85 +88,16 @@ class SQLiteRawMixin:
             yield raw_header
 
     async def save_raw_session(self, record: RawSessionRecord) -> bool:
-        """Save a raw session record. Returns True if inserted."""
-        # payload_provider wins when the payload has been classified; otherwise
-        # fall back to the source_name token (#1743 collapses both onto origin).
-        if record.payload_provider is not None:
-            origin = origin_from_provider(record.payload_provider)
-        else:
-            origin = origin_from_provider(Provider.from_string(record.source_name or "unknown"))
-        # ``payload_provider`` may be the canonical compatibility projection
-        # for a historical NULL capture mode.  Preserve that NULL unless an
-        # acquisition path explicitly supplied capture provenance.
-        capture_mode = record.capture_mode
-        blob_hash_hex = record.blob_hash or record.raw_id
-        try:
-            blob_hash = bytes.fromhex(blob_hash_hex)
-        except ValueError:
-            blob_hash = blob_hash_hex.encode("utf-8")
-        if len(blob_hash) != 32:
-            blob_hash = hashlib.sha256(blob_hash).digest()
+        """Save a raw session record. Returns True if inserted.
 
-        acquired_at_ms = _timestamp_ms(record.acquired_at) or 0
-        async with aiosqlite.connect(self._source_db_path) as conn:
-            conn.row_factory = aiosqlite.Row
-            await conn.execute("PRAGMA foreign_keys = ON")
-            cursor = await conn.execute("SELECT capture_mode FROM raw_sessions WHERE raw_id = ?", (record.raw_id,))
-            existing = await cursor.fetchone()
-            existed = existing is not None
-            if existing is not None and existing["capture_mode"] is not None:
-                capture_mode = Provider.from_string(str(existing["capture_mode"]))
-            await conn.execute(
-                """
-                INSERT OR REPLACE INTO raw_sessions (
-                    raw_id, origin, capture_mode, native_id, source_path, source_index, blob_hash,
-                    blob_size, acquired_at_ms, file_mtime_ms, parsed_at_ms, parse_error,
-                    validated_at_ms, validation_status, validation_error, validation_drift_count,
-                    validation_mode, detection_warnings_json
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    record.raw_id,
-                    origin.value,
-                    capture_mode.value if capture_mode is not None else None,
-                    None,
-                    record.source_path,
-                    int(record.source_index or 0),
-                    blob_hash,
-                    int(record.blob_size),
-                    acquired_at_ms,
-                    _timestamp_ms(record.file_mtime),
-                    _timestamp_ms(record.parsed_at),
-                    record.parse_error,
-                    _timestamp_ms(record.validated_at),
-                    record.validation_status.value if record.validation_status is not None else None,
-                    record.validation_error,
-                    int(record.validation_drift_count or 0),
-                    record.validation_mode.value if record.validation_mode is not None else None,
-                    record.detection_warnings or "[]",
-                ),
-            )
-            await conn.execute(
-                """
-                INSERT OR REPLACE INTO blob_refs (
-                    blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms
-                ) VALUES (?, ?, 'raw_payload', ?, ?, ?)
-                """,
-                (
-                    blob_hash,
-                    record.raw_id,
-                    record.source_path,
-                    int(record.blob_size),
-                    acquired_at_ms,
-                ),
-            )
-            if record.blob_publication_receipt_id is not None:
-                await conn.execute(
-                    "DELETE FROM blob_publication_reservations WHERE publication_id = ? AND blob_hash = ?",
-                    (record.blob_publication_receipt_id, blob_hash),
-                )
-            await conn.commit()
-            return not existed
+        Delegates to the single canonical writer (``queries/raw_writes.py``)
+        instead of hand-rolling SQL here: a second, narrower column list for
+        the same durable-tier table let re-saves silently reset revision
+        evidence (raw_id, revision_kind, source_revision, ...) to defaults
+        (polylogue-vwia). Do not reintroduce a parallel INSERT here.
+        """
+        async with self._get_connection() as conn:
+            return await raw_queries.save_raw_session(conn, record, self._transaction_depth)
 
     async def save_artifact_observation(self, record: ArtifactObservationRecord) -> bool:
         """Persist or refresh one durable artifact observation."""

--- a/tests/unit/storage/test_raw.py
+++ b/tests/unit/storage/test_raw.py
@@ -10,11 +10,13 @@ This module contains tests for:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import aiosqlite
 import pytest
 
+from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
 from polylogue.core.enums import Provider
 from polylogue.storage.raw.models import RawSessionStateUpdate
 from polylogue.storage.repository import SessionRepository
@@ -25,6 +27,8 @@ from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
 from polylogue.storage.sqlite.queries.raw_reads import get_raw_session as get_query_raw_session
 from polylogue.storage.sqlite.queries.raw_writes import save_raw_session as save_query_raw_session
 from tests.infra.storage_records import make_raw_session, make_session, save_session_to_archive
+
+_REPO_ROOT = Path(__file__).parent.parent.parent.parent
 
 # test_db and test_conn fixtures are in conftest.py
 
@@ -383,6 +387,86 @@ class TestRawSessionStorage:
         records = await backend.get_raw_sessions_batch(["raw-c", "raw-a", "missing", "raw-b"])
 
         assert [record.raw_id for record in records] == ["raw-c", "raw-a", "raw-b"]
+
+
+class TestRawSessionWriterSingleSource:
+    """polylogue-vwia: the async and sync-core raw writers must not diverge.
+
+    ``SQLiteRawMixin.save_raw_session`` (async_sqlite_raw.py) used to hand-roll
+    its own 18-column ``INSERT OR REPLACE``, while the durable-tier writer
+    (queries/raw_writes.py) used a 28-column ``INSERT OR IGNORE`` including
+    revision-authority evidence. A re-save through the async path silently
+    reset revision lineage to defaults. The async mixin now delegates to the
+    same writer function; these tests guard against either a column-list
+    regression in that writer or a second hand-rolled INSERT reappearing.
+    """
+
+    @pytest.fixture
+    def backend(self, tmp_path: Path) -> SQLiteBackend:
+        """Create a SQLiteBackend with a temp database."""
+        db_path = tmp_path / "test.db"
+        return SQLiteBackend(db_path=db_path)
+
+    async def test_writer_insert_covers_every_live_raw_sessions_column(self, tmp_path: Path) -> None:
+        """The canonical writer's INSERT must name every column the live DDL defines."""
+        source_db = tmp_path / "source.db"
+        initialize_archive_database(source_db, ArchiveTier.SOURCE)
+        async with aiosqlite.connect(source_db) as conn:
+            cursor = await conn.execute("PRAGMA table_info(raw_sessions)")
+            live_columns = {row[1] for row in await cursor.fetchall()}
+
+        writer_source = (_REPO_ROOT / "polylogue/storage/sqlite/queries/raw_writes.py").read_text()
+        match = re.search(r"INSERT OR IGNORE INTO raw_sessions \(([^)]+)\)", writer_source)
+        assert match is not None, "expected exactly one canonical raw_sessions INSERT in raw_writes.py"
+        writer_columns = {c.strip() for c in match.group(1).split(",")}
+
+        assert writer_columns == live_columns, (
+            "queries/raw_writes.py's INSERT column list has drifted from the live raw_sessions "
+            f"DDL: missing from writer={live_columns - writer_columns} "
+            f"extra in writer={writer_columns - live_columns}"
+        )
+
+    async def test_async_backend_has_no_second_raw_sessions_insert(self) -> None:
+        """The async mixin must delegate, not hand-roll a competing INSERT/REPLACE."""
+        mixin_source = (_REPO_ROOT / "polylogue/storage/sqlite/async_sqlite_raw.py").read_text()
+        assert "INTO raw_sessions" not in mixin_source, (
+            "async_sqlite_raw.py should delegate save_raw_session to "
+            "queries/raw_writes.py, not embed its own INSERT statement (polylogue-vwia)"
+        )
+
+    async def test_resave_never_alters_revision_evidence(self, backend: SQLiteBackend) -> None:
+        """Re-saving an existing raw_id must never reset durable revision authority."""
+        envelope = RawRevisionEnvelope(
+            logical_source_key="chatgpt:conv-1",
+            kind=RawRevisionKind.FULL,
+            source_revision="rev-1",
+            acquisition_generation=1,
+            authority=RawRevisionAuthority.BYTE_PROVEN,
+        )
+        original = make_raw_session(
+            raw_id="revision-guarded",
+            source_name="chatgpt",
+            source_path="/tmp/export.json",
+            blob_size=2,
+            acquired_at="2026-02-02T12:00:00+00:00",
+            revision=envelope,
+        )
+        assert await backend.save_raw_session(original) is True
+
+        # A retried/duplicate acquisition of the same raw_id carries no revision
+        # evidence of its own; it must not be able to wipe the original's.
+        resave = make_raw_session(
+            raw_id="revision-guarded",
+            source_name="chatgpt",
+            source_path="/tmp/export.json",
+            blob_size=2,
+            acquired_at="2026-02-02T12:00:00+00:00",
+        )
+        assert await backend.save_raw_session(resave) is False
+
+        recovered = await backend.get_raw_session("revision-guarded")
+        assert recovered is not None
+        assert recovered.revision == envelope
 
     async def test_raw_provider_filters_prefer_payload_provider_when_present(self, backend: SQLiteBackend) -> None:
         """Raw provider filtering should use payload_provider when validation/parsing has classified the payload."""


### PR DESCRIPTION
## Summary
Deletes the async SQLite backend's hand-rolled `save_raw_session` INSERT and delegates to the single canonical durable-tier writer, closing a latent revision-evidence clobber.

## Problem
`SQLiteRawMixin.save_raw_session` (`polylogue/storage/sqlite/async_sqlite_raw.py`) hand-rolled its own 18-column `INSERT OR REPLACE` into `raw_sessions`, while the production writer (`polylogue/storage/sqlite/queries/raw_writes.py`, reached via `RepositoryRawMixin` from the real acquire path) uses a 28-column `INSERT OR IGNORE` that also carries revision-authority evidence (`logical_source_key`, `revision_kind`, `source_revision`, `predecessor_source_revision`, `predecessor_raw_id`, `baseline_raw_id`, `append_start_offset`, `append_end_offset`, `acquisition_generation`, `revision_authority`). A re-save of an existing `raw_id` through the async path would silently reset all of those columns to defaults on the durable source tier, destroying revision lineage. The mixin also wrote directly into `blob_refs`, duplicating the separate canonical `write_source_raw_session_blob_ref` path and its lifecycle.

No production caller of the async mixin's method was found — the real acquire path (`AcquisitionService` → `persist_raw_record` → `SessionRepository.save_raw_session`) already goes through `RepositoryRawMixin`, which already delegates to the correct writer. The clobber was latent (reachable only via direct `backend.save_raw_session` calls, as many tests do), one refactor away from being wired into production.

## Solution
Deleted the hand-rolled SQL body and made `SQLiteRawMixin.save_raw_session` delegate to `queries/raw_writes.save_raw_session`, matching what `RepositoryRawMixin.save_raw_session` already does — single source of truth for the INSERT, no possibility of column-list divergence. Removed now-unused imports (`hashlib`, `origin_from_provider`, `_timestamp_ms`) and the now-dead `_source_db_path` type stub.

Added two regression tests in `tests/unit/storage/test_raw.py`:
- `test_writer_insert_covers_every_live_raw_sessions_column`: introspects the live `raw_sessions` DDL via `PRAGMA table_info` and asserts the canonical writer's INSERT column list matches exactly — fails if a future migration adds a column the writer doesn't reference, or vice versa.
- `test_async_backend_has_no_second_raw_sessions_insert`: fails if a hand-rolled `INTO raw_sessions` INSERT reappears in the async mixin.
- `test_resave_never_alters_revision_evidence`: saves a record with populated `RawRevisionEnvelope` (byte-proven authority), re-saves the same `raw_id` with a bare record, and asserts the original revision evidence survives unchanged.

## Verification
- `devtools test tests/unit/storage/test_raw.py tests/unit/storage/test_raw_authority_ledger.py tests/unit/storage/test_duplicate_raw_identity_repair.py` → 60 passed
- Anti-vacuity: reverted the source fix (keeping the new tests) via `git stash` — exactly `test_async_backend_has_no_second_raw_sessions_insert` and `test_resave_never_alters_revision_evidence` failed; the DDL-parity test passed (it targets `raw_writes.py`, which was already correct).
- `devtools test` on every other `backend.save_raw_session` call site (parsing service, quarantine fixtures, parse tracking, search misc, storage twins, daemon ingest idempotency, ingest pipeline correctness) → all pass except 6 pre-existing `test_parsing_service.py` failures (`Mock has no attribute 'drive_config'`), confirmed to reproduce identically on pre-fix code via the same stash technique — unrelated to this change.
- `devtools verify --quick` → exit 0 (format, lint, mypy --strict, render-all, layering, closure-matrix, schema roundtrip, manifests, ci-workflows, doc-commands, docs-coverage, test-infra-currency, clock-hygiene, timeout-overrides, degrade-loudly).

Ref polylogue-vwia