### PR TITLE
fix(storage): upgrade a caller-owned deferred transaction before assertion preservation reads

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -9,6 +9,7 @@ Writer module: user.
 from __future__ import annotations
 
 import hashlib
+import itertools
 import json
 import sqlite3
 from collections.abc import Iterator, Mapping, Sequence
@@ -27,6 +28,7 @@ from polylogue.core.assertions import (
 from polylogue.core.enums import AssertionKind, AssertionStatus, AssertionVisibility
 from polylogue.core.json import JSONValue
 from polylogue.core.refs import ObjectRef, normalize_object_ref_text, normalize_public_ref_text
+from polylogue.storage.sqlite.connection_profile import WRITE_CONNECTION_PROFILE
 from polylogue.storage.table_existence import table_exists as _table_exists
 
 if TYPE_CHECKING:
@@ -61,6 +63,9 @@ _ASSERTION_TERMINAL_JUDGED_STATUSES: Final[frozenset[AssertionStatus]] = frozens
 _ASSERTION_AGENT_CANDIDATE_CONTEXT_POLICY: Final[dict[str, JSONValue]] = {"inject": False, "promotion_required": True}
 
 
+_ASSERTION_WRITE_SAVEPOINTS = itertools.count()
+
+
 @contextmanager
 def _immediate_user_write_transaction(conn: sqlite3.Connection) -> Iterator[None]:
     """Start the outer user-tier write scope before observing mutable state.
@@ -70,16 +75,38 @@ def _immediate_user_write_transaction(conn: sqlite3.Connection) -> Iterator[None
     immediate transaction when none exists, and rolls that transaction back if
     the guarded operation fails.  Nested bulk operations already hold the
     immediate transaction and continue to use savepoints for item isolation.
+
+    A caller that already has an open transaction is not necessarily
+    write-locked: a plain/deferred transaction has not yet reserved the
+    SQLite writer slot, so a preservation read taken inside it can still race
+    a concurrent operator judgment landing between that read and this
+    connection's eventual write (polylogue-41ow). The savepoint-scoped
+    zero-row ``UPDATE`` forces the RESERVED lock before any preserve/read
+    decision runs, without committing or rolling back state the caller owns.
+    If the caller's transaction already holds the write lock (e.g. a prior
+    nested call already ran this same upgrade), the forced write is a no-op.
     """
-    if conn.in_transaction:
-        yield
+    if not conn.in_transaction:
+        conn.execute(f"PRAGMA busy_timeout = {WRITE_CONNECTION_PROFILE.busy_timeout_ms}")
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            yield
+        except BaseException:
+            conn.rollback()
+            raise
         return
-    conn.execute("BEGIN IMMEDIATE")
+
+    savepoint = f"assertion_write_{next(_ASSERTION_WRITE_SAVEPOINTS)}"
+    conn.execute(f"SAVEPOINT {savepoint}")
     try:
+        conn.execute("UPDATE assertions SET updated_at_ms = updated_at_ms WHERE 0")
         yield
     except BaseException:
-        conn.rollback()
+        conn.execute(f"ROLLBACK TO {savepoint}")
+        conn.execute(f"RELEASE {savepoint}")
         raise
+    else:
+        conn.execute(f"RELEASE {savepoint}")
 
 
 def _default_context_policy() -> dict[str, JSONValue]:

--- a/tests/unit/storage/test_archive_tiers_assertions.py
+++ b/tests/unit/storage/test_archive_tiers_assertions.py
@@ -1560,6 +1560,112 @@ def test_cross_connection_replay_cannot_resurrect_operator_accept(tmp_path: Path
         conflict.close()
 
 
+def test_cross_connection_replay_inside_caller_owned_deferred_transaction_cannot_resurrect_operator_accept(
+    tmp_path: Path,
+) -> None:
+    """A caller-owned deferred transaction is upgraded before the preservation read.
+
+    ``_immediate_user_write_transaction`` only issues ``BEGIN IMMEDIATE`` when
+    the connection is idle. A connection that already has an open transaction
+    when it enters ``upsert_assertion`` -- e.g. a caller batching several
+    overlay writes under its own transaction boundary rather than a fresh
+    connection per call -- used to fall through to a bare ``yield`` with no
+    write-lock upgrade, leaving the preservation read unprotected even though
+    the outer transaction had not yet reserved the SQLite writer slot
+    (polylogue-41ow). This reproduces that shape directly: the detector's
+    transaction is opened with a plain ``BEGIN`` (deferred), not
+    ``BEGIN IMMEDIATE``, before it calls into ``upsert_assertion``.
+    """
+
+    db_path = tmp_path / "user.db"
+    setup = open_connection(db_path)
+    initialize_archive_tier(setup, ArchiveTier.USER)
+    try:
+        candidate = upsert_assertion(
+            setup,
+            assertion_id="concurrent-candidate-deferred",
+            target_ref="session:concurrent-deferred",
+            kind=AssertionKind.DECISION,
+            body_text="detector candidate",
+            author_kind="detector",
+            now_ms=1,
+        )
+        setup.commit()
+    finally:
+        setup.close()
+
+    conflict = open_connection(db_path)
+    looked_up = threading.Event()
+    release_detector = threading.Event()
+    operator_done = threading.Event()
+    detector_errors: list[BaseException] = []
+    operator_errors: list[BaseException] = []
+    try:
+
+        def replay_detector() -> None:
+            detector = open_connection(db_path)
+            try:
+                # Caller-owned deferred transaction: not BEGIN IMMEDIATE, so
+                # the writer slot is not yet reserved at this point.
+                detector.execute("BEGIN")
+                assert detector.in_transaction
+                upsert_assertion(
+                    _PauseAfterCandidateLookup(detector, looked_up, release_detector),  # type: ignore[arg-type]
+                    assertion_id=candidate.assertion_id,
+                    target_ref=candidate.target_ref,
+                    kind=candidate.kind,
+                    body_text="detector replay",
+                    author_kind="detector",
+                    now_ms=2,
+                )
+                detector.commit()
+            except BaseException as exc:  # pragma: no cover - asserted by the parent thread
+                detector_errors.append(exc)
+            finally:
+                detector.close()
+
+        def accept_candidate() -> None:
+            operator = open_connection(db_path)
+            try:
+                judge_assertion_candidate(
+                    operator,
+                    candidate_ref=f"assertion:{candidate.assertion_id}",
+                    decision="accept",
+                    actor_ref="user:operator",
+                    now_ms=3,
+                )
+                operator.commit()
+            except BaseException as exc:  # pragma: no cover - asserted by the parent thread
+                operator_errors.append(exc)
+            finally:
+                operator.close()
+                operator_done.set()
+
+        detector_thread = threading.Thread(target=replay_detector)
+        detector_thread.start()
+        assert looked_up.wait(timeout=5)
+
+        operator_thread = threading.Thread(target=accept_candidate)
+        operator_thread.start()
+        assert not operator_done.wait(timeout=0.15), (
+            "operator bypassed the detector's deferred-but-upgraded transaction"
+        )
+        release_detector.set()
+        detector_thread.join(timeout=5)
+        operator_thread.join(timeout=5)
+        assert not detector_thread.is_alive()
+        assert not operator_thread.is_alive()
+        assert detector_errors == []
+        assert operator_errors == []
+
+        final = read_assertion_envelope(conflict, candidate.assertion_id)
+        assert final is not None
+        assert final.status is AssertionStatus.ACCEPTED
+    finally:
+        release_detector.set()
+        conflict.close()
+
+
 def test_assertion_upsert_rolls_back_its_immediate_transaction(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     db_path = tmp_path / "user.db"
     conn = open_connection(db_path)


### PR DESCRIPTION
## Summary
Closes a latent residual in the assertion write-lock TOCTOU fix (#3051): a caller-owned deferred transaction was never upgraded to hold the SQLite write lock before the terminal-status preservation read.

## Problem
`#3051` fixed `upsert_assertion`'s TOCTOU race for the common case by wrapping the preserve/read/write decision in `BEGIN IMMEDIATE` when the connection is idle (`_immediate_user_write_transaction`). But its fallback for an already-open transaction — `if conn.in_transaction: yield; return` — never upgrades that transaction to hold the write lock. A caller-owned deferred (plain `BEGIN`) transaction has not yet reserved the SQLite writer slot, so the terminal-status preservation read taken inside it can still race a concurrent operator judgment landing between that read and this connection's eventual write — reintroducing the exact silent-revert bug `polylogue-41ow` tracks, for any caller that reuses a connection across a transaction it opened itself rather than a fresh connection per call.

I audited every production caller of `upsert_assertion`/`judge_assertion_candidate` (`annotations/write.py`, `security/lifecycle.py`, `security/secret_scan.py`, `scenarios/corpus.py`, `storage/repair.py`, `storage/raw_reconciler.py`, and `user_write.py`'s own batch helpers): none currently reach these functions with a caller-owned deferred transaction open, so this exact gap is not yet exploitable in production — but it is latent, one refactor away, the same character as the `vwia` writer-twin bug fixed earlier in this hardening sweep (#3099).

## Solution
Closed it defensively. When the connection already has an open transaction, open a `SAVEPOINT` and force a zero-row `UPDATE assertions SET updated_at_ms = updated_at_ms WHERE 0` before yielding — this forces SQLite to acquire the `RESERVED` lock immediately, before any preserve/read decision runs, without committing or rolling back state the caller owns. If the caller's transaction already holds the write lock (the common in-repo case: a batch of `upsert_mark`/`upsert_blackboard_note`/`upsert_saved_view`/`upsert_assertion` calls sharing one `BEGIN IMMEDIATE` opened by the first call in the batch), the forced write is a no-op. Also added the canonical `busy_timeout` PRAGMA to the fresh-transaction branch.

Deliberately did **not** port the auto-commit-on-fresh-transaction behavior from an available external delivery patch (`feature/assertions/judgment-transaction`): tracing `scenarios/corpus.py`'s intentional multi-call batch (five upserts sharing one transaction, one final caller commit) confirmed that change would silently split one atomic batch into five separate commits. Also did not port that delivery's non-overlapping additive scope (evidence previews, queue health, capture idempotency, canary script) — that's feature delivery, tracked separately as `polylogue-2o3d`.

## Verification
- New regression: `test_cross_connection_replay_inside_caller_owned_deferred_transaction_cannot_resurrect_operator_accept` (`tests/unit/storage/test_archive_tiers_assertions.py`) — two real SQLite connections; the detector opens a plain `BEGIN` (not `IMMEDIATE`) before calling `upsert_assertion`, then a concurrent operator judgment attempts to land between the detector's SELECT and its write.
- Anti-vacuity: reverted the source fix via `git stash`, keeping the new test — it fails (operator resurrects the candidate within 0.15s); passes after restoring the fix.
- `devtools test tests/unit/storage/test_archive_tiers_assertions.py tests/unit/storage/test_archive_tiers_assertion_write_through.py tests/unit/storage/test_comparative_judgment_assertions.py` → 61 passed
- `devtools test` across every other `upsert_assertion`/`judge_assertion_candidate` write-path suite (annotations, security, cli judge/note/candidates, mcp judgment tools, storage user_audit/user_overlay/blackboard/public_claims, scenarios/corpus demo seeding) → 128 passed, no batching regression.
- `devtools verify --quick` → exit 0.

Ref polylogue-41ow