### PR TITLE
perf(daemon): drain raw-materialization backlog in bursts, unblock startup

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -7,6 +7,7 @@ import atexit
 import contextlib
 import faulthandler
 import fcntl
+import functools
 import os
 import sqlite3
 import sys
@@ -69,7 +70,13 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 _CONVERGENCE_DEBT_RETRY_INTERVAL_SECONDS = 60
 _RAW_MATERIALIZATION_CONVERGENCE_INTERVAL_SECONDS = 30
-_RAW_MATERIALIZATION_CONVERGENCE_BATCH_LIMIT = 1
+# Rows per bounded writer-held pass. Small enough to keep the write
+# coordinator responsive to live appends, large enough to amortise the
+# per-pass census/recovery overhead over more than one row.
+_RAW_MATERIALIZATION_CONVERGENCE_BATCH_LIMIT = 16
+# Between backlog burst passes the loop yields the writer briefly so live
+# ingest and interactive writes never queue behind a long drain.
+_RAW_MATERIALIZATION_BACKLOG_BURST_PAUSE_SECONDS = 1
 _RAW_MATERIALIZATION_DAEMON_BLOB_LIMIT_BYTES = 64 * 1024 * 1024
 _RAW_MATERIALIZATION_LIVE_SPOOL_BACKOFF_SECONDS = 60
 
@@ -379,13 +386,18 @@ async def _run_drive_source_catchup_safely() -> int:
 
 
 async def _periodic_drive_source_catchup() -> None:
-    """Periodically converge remote Drive sources such as AiStudio exports."""
+    """Periodically converge remote Drive sources such as AiStudio exports.
+
+    The first pass runs immediately in the background: Drive catch-up is
+    serial network I/O and must never sit between daemon startup and the
+    local convergence loops or the live watcher.
+    """
     while True:
-        await asyncio.sleep(_DRIVE_SOURCE_CATCHUP_INTERVAL_SECONDS)
         coordinator = daemon_write_coordinator()
         changed = await coordinator.run("maintenance.drive_catchup", _run_drive_source_catchup_safely)
         if changed:
             logger.info("daemon: Drive catch-up refreshed %d session(s)", changed)
+        await asyncio.sleep(_DRIVE_SOURCE_CATCHUP_INTERVAL_SECONDS)
 
 
 async def _periodic_heartbeat() -> None:
@@ -499,32 +511,40 @@ async def _retry_convergence_debt_once(db: Path) -> None:
 
 
 async def _periodic_raw_materialization_convergence() -> None:
-    """Continuously converge durable raw source rows into the index tier."""
-    await _periodic_raw_materialization_convergence_after()
+    """Continuously converge durable raw source rows into the index tier.
 
-
-async def _periodic_raw_materialization_convergence_after(
-    catch_up_complete: asyncio.Event | None = None,
-) -> None:
-    """Continuously converge durable raw rows after initial source catch-up."""
-    if catch_up_complete is not None:
-        await catch_up_complete.wait()
+    Deliberately ungated on watcher catch-up: the candidates live in the
+    local durable ``source.db``, so materializing them has no acquisition
+    precondition. When a backlog exists (e.g. after an index rebuild) the
+    loop bursts through bounded passes back-to-back — yielding the writer
+    between passes — instead of waiting a full interval per pass, which
+    would stretch a large drain into weeks.
+    """
     while True:
         if _browser_capture_spool_has_pending_files():
             logger.info("raw materialization: yielding to pending browser-capture spool files")
             await asyncio.sleep(_RAW_MATERIALIZATION_LIVE_SPOOL_BACKOFF_SECONDS)
             continue
+        recover = True
         try:
-            materialized = await daemon_write_coordinator().run_sync(
-                "maintenance.raw_materialization",
-                _drain_raw_materialization_once,
-            )
-            if materialized.made_progress:
-                logger.info(
-                    "raw materialization: repaired %d session(s), executed %d frontier plan(s)",
-                    materialized.repaired_sessions,
-                    materialized.executed_plans,
+            while True:
+                materialized = await daemon_write_coordinator().run_sync(
+                    "maintenance.raw_materialization",
+                    functools.partial(_drain_raw_materialization_once, recover=recover),
                 )
+                recover = False
+                if materialized.made_progress:
+                    logger.info(
+                        "raw materialization: repaired %d session(s), executed %d frontier plan(s), %d candidate(s) remaining",
+                        materialized.repaired_sessions,
+                        materialized.executed_plans,
+                        materialized.remaining_candidates,
+                    )
+                if materialized.remaining_candidates <= 0 or not materialized.made_progress:
+                    break
+                if _browser_capture_spool_has_pending_files():
+                    break
+                await asyncio.sleep(_RAW_MATERIALIZATION_BACKLOG_BURST_PAUSE_SECONDS)
         except sqlite3.OperationalError as exc:
             if is_transient_sqlite_lock(exc):
                 logger.info("raw materialization: archive busy; retrying on next tick: %s", exc)
@@ -612,8 +632,17 @@ async def _reconcile_blob_publications() -> None:
         )
 
 
-def _drain_raw_materialization_once(*, limit: int = _RAW_MATERIALIZATION_CONVERGENCE_BATCH_LIMIT) -> Any:
-    """Run one bounded raw source→index convergence pass."""
+def _drain_raw_materialization_once(
+    *,
+    limit: int = _RAW_MATERIALIZATION_CONVERGENCE_BATCH_LIMIT,
+    recover: bool = True,
+) -> Any:
+    """Run one bounded raw source→index convergence pass.
+
+    ``recover`` gates the interrupted-frontier recovery scan: it only has
+    work after a crash/restart, so backlog burst continuations within one
+    healthy cycle skip it instead of re-scanning per pass.
+    """
     from polylogue.config import Config
     from polylogue.paths import archive_root, render_root
     from polylogue.product import raw_authority
@@ -637,7 +666,8 @@ def _drain_raw_materialization_once(*, limit: int = _RAW_MATERIALIZATION_CONVERG
         render_root=render_root(),
         sources=[],
     )
-    raw_authority.recover_interrupted_frontier(config)
+    if recover:
+        raw_authority.recover_interrupted_frontier(config)
     try:
         result = raw_authority.repair_materialization(
             config,
@@ -651,9 +681,12 @@ def _drain_raw_materialization_once(*, limit: int = _RAW_MATERIALIZATION_CONVERG
     frontier_repaired = _converge_raw_authority_frontier(config, limit=min(limit, 8))
     if not result.success:
         logger.warning("raw materialization: bounded convergence incomplete: %s", result.detail)
+    metrics = dict(getattr(result, "metrics", {}))
+    remaining = int(metrics.get("raw_materialization_remaining_candidate_count", 0))
     return raw_authority.RawMaterializationCounts(
         repaired_sessions=result.repaired_count,
         executed_plans=frontier_repaired,
+        remaining_candidates=remaining,
     )
 
 
@@ -1462,18 +1495,11 @@ async def run_daemon_services(
             # not trigger a merge of the full (hundreds-of-MB) existing
             # segments (#1851).  A periodic merge pass amortises the cost.
             await _configure_fts_automerge()
-            if enable_source_catchup:
-                changed_drive_sessions = await write_coordinator.run(
-                    "startup.drive_catchup",
-                    _run_drive_source_catchup_safely,
-                )
-                if changed_drive_sessions:
-                    logger.info("daemon: startup Drive catch-up refreshed %d session(s)", changed_drive_sessions)
-            else:
+            if not enable_source_catchup:
                 logger.info("daemon: configured source catch-up disabled for this run")
             catch_up_complete_gate = asyncio.Event() if enable_watch else None
             periodic_loops = [
-                _periodic_raw_materialization_convergence_after(catch_up_complete_gate),
+                _periodic_raw_materialization_convergence(),
                 _periodic_session_insight_convergence_after(catch_up_complete_gate),
                 _periodic_convergence_check(sources, catch_up_complete=catch_up_complete_gate),
                 _periodic_wal_checkpoint(),

--- a/polylogue/product/raw_authority.py
+++ b/polylogue/product/raw_authority.py
@@ -21,6 +21,7 @@ class RawMaterializationCounts:
 
     repaired_sessions: int = 0
     executed_plans: int = 0
+    remaining_candidates: int = 0
 
     @property
     def made_progress(self) -> bool:

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import functools
 import inspect
 import os
 import sqlite3
@@ -586,6 +587,10 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
     assert counts.repaired_sessions == 7
     assert counts.executed_plans == 3
     assert order == ["restore", "recover-frontier", "materialize", "frontier"]
+
+    order.clear()
+    daemon_cli._drain_raw_materialization_once(limit=11, recover=False)
+    assert order == ["restore", "materialize", "frontier"]
     assert calls == {
         "restore_db_path": tmp_path / "archive" / "source.db",
         "restore_dry_run": False,
@@ -935,9 +940,10 @@ def test_periodic_raw_materialization_convergence_treats_sqlite_lock_as_retry(
     warning.assert_not_called()
 
 
-def test_periodic_raw_materialization_convergence_waits_for_catch_up_complete(
+def test_periodic_raw_materialization_convergence_starts_without_catch_up(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Materializing durable local raws has no acquisition precondition."""
     from polylogue.daemon import cli as daemon_cli
 
     calls: list[str] = []
@@ -947,24 +953,99 @@ def test_periodic_raw_materialization_convergence_waits_for_catch_up_complete(
         raise asyncio.CancelledError
 
     async def exercise() -> None:
-        catch_up_complete = asyncio.Event()
         monkeypatch.setattr(
             daemon_cli,
             "daemon_write_coordinator",
             lambda: SimpleNamespace(run_sync=fake_run_sync),
         )
-        task = asyncio.create_task(
-            daemon_cli._periodic_raw_materialization_convergence_after(catch_up_complete=catch_up_complete)
-        )
-        await asyncio.sleep(0)
-        assert calls == []
-        catch_up_complete.set()
+        task = asyncio.create_task(daemon_cli._periodic_raw_materialization_convergence())
         with pytest.raises(asyncio.CancelledError):
             await task
 
     asyncio.run(exercise())
 
     assert calls == ["drain"]
+
+
+def test_periodic_raw_materialization_bursts_through_backlog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A backlog drains in back-to-back bounded passes within one cycle,
+    recovery scans run on the first pass only, and quiescence returns the
+    loop to the plain interval sleep."""
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.product.raw_authority import RawMaterializationCounts
+
+    remaining_schedule = [40, 24, 8, 0]
+    recover_flags: list[bool] = []
+    sleeps: list[float] = []
+
+    async def fake_run_sync(_actor: str, func: object, *args: object, **kwargs: object) -> object:
+        partial = cast(functools.partial[object], func)
+        recover_flags.append(bool(partial.keywords["recover"]))
+        remaining = remaining_schedule.pop(0)
+        return RawMaterializationCounts(
+            repaired_sessions=daemon_cli._RAW_MATERIALIZATION_CONVERGENCE_BATCH_LIMIT,
+            executed_plans=0,
+            remaining_candidates=remaining,
+        )
+
+    async def fake_sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        if seconds == daemon_cli._RAW_MATERIALIZATION_CONVERGENCE_INTERVAL_SECONDS:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(daemon_cli, "_browser_capture_spool_has_pending_files", lambda: False)
+    monkeypatch.setattr(
+        daemon_cli,
+        "daemon_write_coordinator",
+        lambda: SimpleNamespace(run_sync=fake_run_sync),
+    )
+    with patch("asyncio.sleep", side_effect=fake_sleep), pytest.raises(asyncio.CancelledError):
+        asyncio.run(daemon_cli._periodic_raw_materialization_convergence())
+
+    assert remaining_schedule == []
+    assert recover_flags == [True, False, False, False]
+    assert sleeps == [
+        daemon_cli._RAW_MATERIALIZATION_BACKLOG_BURST_PAUSE_SECONDS,
+        daemon_cli._RAW_MATERIALIZATION_BACKLOG_BURST_PAUSE_SECONDS,
+        daemon_cli._RAW_MATERIALIZATION_BACKLOG_BURST_PAUSE_SECONDS,
+        daemon_cli._RAW_MATERIALIZATION_CONVERGENCE_INTERVAL_SECONDS,
+    ]
+
+
+def test_periodic_raw_materialization_burst_stops_without_progress(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Blocked candidates must not hot-loop the burst: no progress ends it."""
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.product.raw_authority import RawMaterializationCounts
+
+    drains = 0
+
+    async def fake_run_sync(_actor: str, _func: object, *_args: object, **_kwargs: object) -> object:
+        nonlocal drains
+        drains += 1
+        return RawMaterializationCounts(
+            repaired_sessions=0,
+            executed_plans=0,
+            remaining_candidates=1906,
+        )
+
+    async def fake_sleep(seconds: float) -> None:
+        assert seconds == daemon_cli._RAW_MATERIALIZATION_CONVERGENCE_INTERVAL_SECONDS
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(daemon_cli, "_browser_capture_spool_has_pending_files", lambda: False)
+    monkeypatch.setattr(
+        daemon_cli,
+        "daemon_write_coordinator",
+        lambda: SimpleNamespace(run_sync=fake_run_sync),
+    )
+    with patch("asyncio.sleep", side_effect=fake_sleep), pytest.raises(asyncio.CancelledError):
+        asyncio.run(daemon_cli._periodic_raw_materialization_convergence())
+
+    assert drains == 1
 
 
 def test_periodic_raw_materialization_yields_to_pending_browser_capture_spool(
@@ -2938,8 +3019,8 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
         stack.enter_context(
             patch.object(
                 daemon_cli,
-                "_periodic_raw_materialization_convergence_after",
-                lambda _gate=None: fake_loop("raw-materialization"),
+                "_periodic_raw_materialization_convergence",
+                lambda: fake_loop("raw-materialization"),
             )
         )
         stack.enter_context(
@@ -2989,8 +3070,9 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
     assert events.index("fts") < events.index("watcher")
     assert events.index("fts") < events.index("lineage") < events.index("watcher")
     assert events.index("lineage") < events.index("blob-publications") < events.index("watcher")
-    assert events.index("drive-once") < events.index("watcher")
-    assert events.index("blob-publications") < events.index("drive-once")
+    # Drive catch-up is background work: it must never gate the watcher or
+    # the local convergence loops on serial network I/O.
+    assert "drive-once" not in events
     assert events.index("lineage") < events.index("convergence")
     assert events.index("lineage") < events.index("raw-materialization")
     assert events.index("lineage") < events.index("drive")


### PR DESCRIPTION
## Summary

Fixes the P0 daemon-convergence starvation from the 2026-07-18 poisoned-index incident investigation (bead `polylogue-5jak`): the raw source→index conveyor could only self-heal at 1 row per 30s tick (~25 days for the current 73,311-row backlog), and daemon startup serialized all convergence and the live watcher behind serial Drive network I/O.

## Problem

Live evidence from the incident restore (see `.agent/scratch/warroom-2026-07-17/perf-investigation-2026-07-18.md`):

- `_RAW_MATERIALIZATION_CONVERGENCE_BATCH_LIMIT = 1` every 30s → 2 rows/min; a rebuilt-but-empty index inherits the entire corpus as backlog and the daemon "heals" it homeopathically. Each tick also paid fixed overhead (blob-ref restore scan, interrupted-frontier recovery, FTS close) amortized over one row.
- `startup.drive_catchup` was awaited before every periodic loop and before the LiveWatcher was constructed — measured live at ~4 serial attachment fetches/min; every restart on a Drive-heavy archive blocks all local convergence for tens of minutes to hours.
- The conveyor additionally waited on the watcher's full catch-up (`catch_up_complete` gate) despite operating purely on durable local `source.db` rows, which have no acquisition precondition.

## Solution

- `_periodic_raw_materialization_convergence` is now ungated and backlog-aware: bounded 16-row passes run back-to-back while `remaining_candidates > 0` and the pass made progress, sleeping 1s between passes so the write coordinator stays responsive to live appends (per the #1498-cascade retro discipline: bounded per-cycle work, no busy loops — a no-progress pass with blocked candidates ends the burst). Pending browser-capture spool files still preempt the loop, including mid-burst.
- `RawMaterializationCounts` gains `remaining_candidates`, populated from the repair pass's existing `raw_materialization_remaining_candidate_count` metric.
- Interrupted-frontier recovery runs on the first pass of each cycle only (`recover=False` on burst continuations) — it only has work after a crash/restart.
- The awaited startup Drive pass is deleted; `_periodic_drive_source_catchup` now runs its first pass immediately as a background task. Nothing gates on it.

Insight/embedding/derived-debt loops keep their catch-up gates — they read from the index the catch-up populates, so waiting is correct there.

## Verification

- `devtools test tests/unit/daemon/test_daemon_cli.py` — 87 passed, including new tests: burst-through-backlog (multi-pass single cycle, recovery gated to first pass, sleep schedule pinned), burst-stops-without-progress (blocked candidates can't hot-loop), starts-without-catch-up, recover=False skips the frontier recovery scan, and the lifecycle-ordering test now asserts Drive catch-up does NOT precede the watcher.
- `mypy polylogue/daemon/cli.py polylogue/product/raw_authority.py` — clean; `ruff` clean; pre-push quick gate green.
- Not run: full `devtools verify --all` (testmon-affected scope only).

Ref polylogue-5jak

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ