### PR TITLE
fix(hermes): unpaired-scope debt + two confirmed live-ingest bugs

### DIFF
--- a/polylogue/sources/parsers/hermes_spans.py
+++ b/polylogue/sources/parsers/hermes_spans.py
@@ -65,6 +65,23 @@ for the same logical Hermes session is a session-identity/lineage design
 decision (topology_edges / session_links) that is explicitly deferred, not
 silently assumed. Read-side correlation by the shared Hermes session id
 remains possible today via ``hermes_observer_session_id_for``.
+
+KNOWN LIVE INGESTION BUG (polylogue-flxh, confirmed 2026-07-18, not yet
+fixed): the real ATOF producer writes ONE shared ``events.jsonl`` file across
+every Hermes session on an install (live-verified: 3+ distinct session ids
+interleaved in one file), but the live-ingest raw-revision-authority replay
+chain (``polylogue/sources/live/batch.py``) and append path
+(``polylogue/sources/live/append_ingest.py``) both require exactly one
+logical session per raw revision. When a file-growth batch spans a Hermes
+session boundary (a new event for an already-tracked session lands alongside
+a brand-new session's first event), the new event for the ALREADY-TRACKED
+session is silently and permanently lost while the brand-new session is
+still created -- empirically proven by
+``tests/unit/sources/test_live_watcher.py::test_live_append_atof_shared_file_multi_session_boundary_loses_events``
+(``xfail(strict=True)`` pending the fix). This affects only the LIVE watcher
+ingestion path, not ``parse_atof_stream`` itself (which is correct and
+idempotent when given the full file, per this module's own tests) or the
+manual/CLI import path.
 """
 
 from __future__ import annotations

--- a/polylogue/sources/parsers/hermes_spans.py
+++ b/polylogue/sources/parsers/hermes_spans.py
@@ -108,6 +108,7 @@ HermesSpanEventType: TypeAlias = Literal[
     "hermes_error_span",
     "hermes_context_span",
     "hermes_observer_span",
+    "hermes_atof_unpaired_scope",
 ]
 
 
@@ -207,28 +208,72 @@ def parse_atof_stream(records: Iterable[object], fallback_id: str) -> list[Parse
     remain in the retained raw blob rather than being copied into index rows.
     Replayed append windows are de-duplicated by the producer's UUID plus the
     scope phase, because a scope's start and end intentionally share a UUID.
+
+    A ``kind=scope`` UUID that never sees both its ``start`` and ``end``
+    phase (e.g. a crashed request, or a truncated/rotated file cutting a
+    pending scope in half) is real acquisition debt: the span is real but
+    incomplete evidence, not indistinguishable from a normal completed pair.
+    Those are surfaced as explicit ``hermes_atof_unpaired_scope`` events
+    rather than silently left as an ordinary-looking single-phase span.
     """
     grouped: dict[str, list[ParsedSessionEvent]] = {}
     seen: dict[str, set[tuple[str, str | None]]] = {}
     skipped: dict[str, int] = {}
+    scope_phases: dict[str, dict[str, dict[str, tuple[str | None, str | None]]]] = {}
 
     for raw_record in records:
         record = json_document(raw_record)
         if not record or not looks_like_atof_payload(record):
             continue
         session_id = _atof_session_id(record) or fallback_id
-        event_key = (str(record["uuid"]), _optional_str(record.get("scope_category")))
+        uuid = str(record["uuid"])
+        scope_category = _optional_str(record.get("scope_category"))
+        event_key = (uuid, scope_category)
         session_seen = seen.setdefault(session_id, set())
         if event_key in session_seen:
             continue
         session_seen.add(event_key)
+        if record.get("kind") == "scope" and scope_category in {"start", "end"}:
+            phases = scope_phases.setdefault(session_id, {}).setdefault(uuid, {})
+            phases[scope_category] = (_optional_str(record.get("category")), _optional_str(record.get("timestamp")))
         event = _atof_event(record)
         if event is None:
             skipped[session_id] = skipped.get(session_id, 0) + 1
             continue
         grouped.setdefault(session_id, []).extend(event)
 
-    return [_atof_session(session_id, events, skipped.get(session_id, 0)) for session_id, events in grouped.items()]
+    unpaired_events = {session_id: _unpaired_scope_events(phases) for session_id, phases in scope_phases.items()}
+    session_ids = sorted(set(grouped) | set(unpaired_events))
+    return [
+        _atof_session(
+            session_id,
+            [*grouped.get(session_id, []), *unpaired_events.get(session_id, [])],
+            skipped.get(session_id, 0),
+        )
+        for session_id in session_ids
+    ]
+
+
+def _unpaired_scope_events(phases: dict[str, dict[str, tuple[str | None, str | None]]]) -> list[ParsedSessionEvent]:
+    events: list[ParsedSessionEvent] = []
+    for uuid, seen_phases in phases.items():
+        missing = {"start", "end"} - seen_phases.keys()
+        if not missing:
+            continue
+        (present_phase, (category, timestamp)) = next(iter(seen_phases.items()))
+        events.append(
+            ParsedSessionEvent(
+                event_type="hermes_atof_unpaired_scope",
+                timestamp=timestamp,
+                payload={
+                    "event_uuid": uuid,
+                    "category": category,
+                    "phase_observed": present_phase,
+                    "phase_missing": sorted(missing)[0],
+                },
+            )
+        )
+    return events
 
 
 def _atof_session_id(record: JSONDocument) -> str | None:
@@ -378,13 +423,15 @@ def _atof_session(session_id: str, events: list[ParsedSessionEvent], skipped: in
             "hermes_error_span",
             "hermes_context_span",
             "hermes_observer_span",
+            "hermes_atof_unpaired_scope",
         )
     }
     summary_text = (
         f"Hermes ATOF observer stream: {len(events)} event(s) "
         f"({counts['hermes_llm_request_span']} LLM, {counts['hermes_tool_execution_span']} tool, "
         f"{counts['hermes_decision_span']} decision, {counts['hermes_subagent_span']} subagent, "
-        f"{counts['hermes_error_span']} error, {counts['hermes_observer_span']} unrecognized; "
+        f"{counts['hermes_error_span']} error, {counts['hermes_context_span']} context, "
+        f"{counts['hermes_observer_span']} unrecognized, {counts['hermes_atof_unpaired_scope']} unpaired; "
         f"{skipped} unparseable)."
     )
     provider_session_id = observer_session_provider_id(session_id)
@@ -759,6 +806,17 @@ def _atof_import_fidelity_declaration(session: ParsedSession) -> HermesImportFid
             expected=max(len(events) - 1, 1),
             counts={},
             detail="Structurally valid but unknown ATOF names/categories are retained as generic observer evidence.",
+        )
+    unpaired = observed("hermes_atof_unpaired_scope")
+    if unpaired:
+        capabilities["unpaired_scope_debt"] = HermesFidelityCapability(
+            status="degraded",
+            observed=unpaired,
+            expected=max(len(events) - 1, 1),
+            counts={},
+            detail="A scope UUID that never saw both its start and end phase (crashed request, or a "
+            "truncated/rotated file cutting a pending scope in half) is surfaced as explicit acquisition "
+            "debt, not silently indistinguishable from a normal completed pair.",
         )
     caveats = tuple(f"{name}: {cap.detail}" for name, cap in capabilities.items() if cap.status != "exact")
     return HermesImportFidelity(

--- a/tests/unit/sources/parsers/test_hermes_spans.py
+++ b/tests/unit/sources/parsers/test_hermes_spans.py
@@ -130,6 +130,19 @@ def test_real_nemo_relay_atof_fixture_reaches_the_stream_parser_without_copying_
     assert sum(event.event_type == "hermes_observer_span" for event in events) == 0
     assert "<redacted>" not in repr([event.payload for event in events])
 
+    # llm-error-1 (record 8) is a real scope=end with no matching scope=start
+    # in this fixture -- genuine acquisition debt, surfaced explicitly rather
+    # than silently indistinguishable from a normal completed llm/tool pair.
+    unpaired = [event for event in events if event.event_type == "hermes_atof_unpaired_scope"]
+    assert len(unpaired) == 1
+    assert unpaired[0].payload["event_uuid"] == "llm-error-1"
+    assert unpaired[0].payload["phase_observed"] == "end"
+    assert unpaired[0].payload["phase_missing"] == "start"
+
+    fidelity = hermes_spans.import_fidelity_declaration(session)
+    assert fidelity.capabilities["unpaired_scope_debt"].status == "degraded"
+    assert fidelity.capabilities["unpaired_scope_debt"].observed == 1
+
     fidelity = hermes_spans.import_fidelity_declaration(session)
     assert fidelity.acquisition_method == "jsonl_stream"
     assert fidelity.capabilities["llm_request_spans"].status == "exact"
@@ -182,6 +195,71 @@ def test_atof_unmatched_response_and_turn_context_are_normalized_not_dropped() -
         "hermes_error_span",
     ]
     assert session.session_events[-1].payload["outcome"] == "unmatched_response"
+
+
+def test_atof_scope_start_without_end_is_surfaced_as_unpaired_debt() -> None:
+    """A crashed request, or a truncated/rotated file cutting a pending scope
+    in half, leaves a real scope=start with no matching scope=end. This must
+    be visible as acquisition debt, not silently indistinguishable from a
+    normal completed pair."""
+
+    records: list[JSONDocument] = [
+        {
+            "atof_version": "0.1",
+            "kind": "scope",
+            "category": "tool",
+            "scope_category": "start",
+            "uuid": "tool-crashed-1",
+            "timestamp": "2026-07-18T09:00:00Z",
+            "name": "terminal",
+            "metadata": {"session_id": "session-1", "tool_call_id": "call-1"},
+        },
+    ]
+    session = hermes_spans.parse_atof_stream(records, "fallback-id")[0]
+
+    tool_events = [e for e in session.session_events if e.event_type == "hermes_tool_execution_span"]
+    assert len(tool_events) == 1  # the start-phase span itself is still recorded
+
+    unpaired = [e for e in session.session_events if e.event_type == "hermes_atof_unpaired_scope"]
+    assert len(unpaired) == 1
+    assert unpaired[0].payload["event_uuid"] == "tool-crashed-1"
+    assert unpaired[0].payload["category"] == "tool"
+    assert unpaired[0].payload["phase_observed"] == "start"
+    assert unpaired[0].payload["phase_missing"] == "end"
+
+    fidelity = hermes_spans.import_fidelity_declaration(session)
+    assert fidelity.capabilities["unpaired_scope_debt"].status == "degraded"
+    assert fidelity.capabilities["unpaired_scope_debt"].observed == 1
+
+
+def test_atof_scope_with_both_phases_is_not_flagged_unpaired() -> None:
+    records: list[JSONDocument] = [
+        {
+            "atof_version": "0.1",
+            "kind": "scope",
+            "category": "tool",
+            "scope_category": "start",
+            "uuid": "tool-complete-1",
+            "timestamp": "2026-07-18T09:00:00Z",
+            "name": "terminal",
+            "metadata": {"session_id": "session-1", "tool_call_id": "call-1"},
+        },
+        {
+            "atof_version": "0.1",
+            "kind": "scope",
+            "category": "tool",
+            "scope_category": "end",
+            "uuid": "tool-complete-1",
+            "timestamp": "2026-07-18T09:00:01Z",
+            "name": "terminal",
+            "metadata": {"session_id": "session-1", "tool_call_id": "call-1", "status": "completed"},
+        },
+    ]
+    session = hermes_spans.parse_atof_stream(records, "fallback-id")[0]
+
+    assert not any(e.event_type == "hermes_atof_unpaired_scope" for e in session.session_events)
+    fidelity = hermes_spans.import_fidelity_declaration(session)
+    assert "unpaired_scope_debt" not in fidelity.capabilities
 
 
 def test_atof_agent_scope_and_session_end_mark_become_typed_context_spans() -> None:

--- a/tests/unit/sources/test_hermes_source_freshness_integration.py
+++ b/tests/unit/sources/test_hermes_source_freshness_integration.py
@@ -1,0 +1,199 @@
+"""Real end-to-end proof of Hermes source coverage through the existing
+named-source freshness surface (polylogue-1xc.13), plus a confirmed live-
+ingestion bug discovered while proving it.
+
+fs1.15 ("Expose Hermes-to-Polylogue integration liveness and coverage") asks
+for coverage/freshness reporting to "flow through the EXISTING named-source
+freshness surface... extend that projection with the Hermes source classes
+rather than inventing a reporting command." ``project_named_source_freshness``
+is entirely origin-agnostic (keyed by exact ``source_path`` string, queries
+cursor/raw-revision/index/fts/insight evidence generically) -- the tests
+below prove empirically, by driving the real ``LiveBatchProcessor`` and then
+the real freshness projection, that Hermes's state.db and ATOF sources are
+already covered for free once ingestion succeeds, closing that part of
+fs1.15's ask without new code.
+
+Driving state.db through the real live watcher (not the marker-payload/CLI
+route the rest of this repo's Hermes tests use) surfaced a second confirmed
+bug, distinct from polylogue-flxh: ``revision_backfill.py``'s ``_parse_one``
+(used by the live watcher's single-session raw-revision-chain replay branch,
+and shared with historical repair) has zero SQLite awareness -- unlike the
+two OTHER call sites in ``live/batch.py`` that correctly special-case Hermes
+SQLite sources before falling back to JSON parsing. A state.db (or
+verification_evidence.db) with exactly one session at ingest time hits this
+branch and crashes; two or more sessions route through the working
+membership-census branch instead.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import polylogue.sources.live.watcher as live_watcher
+from polylogue import Polylogue
+from polylogue.archive.query.source_freshness import NamedSourceStage, project_named_source_freshness
+from polylogue.sources.live import WatchSource
+from polylogue.sources.live.batch import LiveBatchProcessor
+from polylogue.sources.live.cursor import CursorStore
+
+_STATE_DB_SCHEMA = """
+CREATE TABLE schema_version(version INTEGER NOT NULL);
+INSERT INTO schema_version(version) VALUES (19);
+CREATE TABLE sessions (
+    id TEXT PRIMARY KEY,
+    source TEXT,
+    model_config TEXT,
+    parent_session_id TEXT,
+    started_at REAL,
+    ended_at REAL,
+    end_reason TEXT,
+    title TEXT
+);
+CREATE TABLE messages (
+    id INTEGER PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT,
+    timestamp REAL NOT NULL,
+    tool_calls TEXT,
+    observed INTEGER DEFAULT 0,
+    active INTEGER DEFAULT 1,
+    compacted INTEGER DEFAULT 0
+);
+"""
+
+
+def _make_processor(
+    workspace_env: dict[str, Path], root_name: str, db_name: str
+) -> tuple[Polylogue, LiveBatchProcessor, Path]:
+    root = workspace_env["data_root"] / root_name
+    root.mkdir(parents=True)
+    db_path = workspace_env["data_root"] / db_name
+    archive = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    cursor = CursorStore(db_path)
+    processor = LiveBatchProcessor(
+        archive,
+        (WatchSource(name="hermes", root=root),),
+        cursor=cursor,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+    )
+    return archive, processor, root
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Confirmed live-ingestion bug polylogue-1zex (distinct from polylogue-flxh): "
+        "revision_backfill.py's _parse_one (used by live/batch.py's single-"
+        "session raw-revision-chain replay branch at _parse_raw_revision_chain, "
+        "shared with historical repair) has zero SQLite awareness -- unlike "
+        "the two other Hermes call sites in live/batch.py that correctly check "
+        "hermes_state.looks_like_state_db_path / "
+        "hermes_verification.looks_like_verification_evidence_db_path before "
+        "falling back to JSON parsing. A state.db (or verification_evidence.db) "
+        "with exactly one session at ingest time -- a brand new Hermes install, "
+        "or any minimal/test fixture -- takes this branch and crashes with "
+        "UnicodeDecodeError trying to json-parse raw SQLite bytes. Two or more "
+        "sessions route through the working membership-census branch instead "
+        "(see test_hermes_state_db_multi_session_source_reaches_indexed_"
+        "through_named_freshness below), which is presumably why this was not "
+        "caught by prior review -- real installs almost always have many "
+        "sessions. Remove this xfail once fixed."
+    ),
+    strict=True,
+)
+@pytest.mark.asyncio
+async def test_hermes_state_db_single_session_full_ingest_crashes(
+    workspace_env: dict[str, Path],
+) -> None:
+    archive, processor, root = _make_processor(workspace_env, "hermes-home-single", "hermes-state-single.db")
+    source_path = root / "state.db"
+    try:
+        with sqlite3.connect(source_path) as conn:
+            conn.executescript(_STATE_DB_SCHEMA)
+            conn.execute(
+                "INSERT INTO sessions (id, source, model_config, started_at, ended_at, end_reason, title) "
+                "VALUES ('root', 'cli', '{}', 1.0, 8.0, 'completed', 'root')"
+            )
+            conn.execute(
+                "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (1, 'root', 'user', 'hi', 2.0)"
+            )
+
+        metrics = await processor.ingest_files([source_path], emit_event=False)
+        assert metrics.failed_file_count == 0
+        assert metrics.ingested_session_count == 1
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_hermes_state_db_multi_session_source_reaches_indexed_through_named_freshness(
+    workspace_env: dict[str, Path],
+) -> None:
+    """Two or more sessions dodge the single-session bug above (membership-
+    census branch, not the broken raw-revision-chain replay branch) -- this
+    proves the EXISTING named-source freshness surface already covers Hermes
+    state.db correctly once ingestion itself succeeds."""
+
+    archive, processor, root = _make_processor(workspace_env, "hermes-home-multi", "hermes-state-multi.db")
+    source_path = root / "state.db"
+    try:
+        with sqlite3.connect(source_path) as conn:
+            conn.executescript(_STATE_DB_SCHEMA)
+            conn.execute(
+                "INSERT INTO sessions (id, source, model_config, started_at, ended_at, end_reason, title) "
+                "VALUES ('root', 'cli', '{}', 1.0, 8.0, 'completed', 'root')"
+            )
+            conn.execute(
+                "INSERT INTO sessions (id, source, model_config, parent_session_id, started_at, ended_at, "
+                "end_reason, title) VALUES ('child', 'cli', '{}', 'root', 2.0, 7.0, 'completed', 'child')"
+            )
+            conn.execute(
+                "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (1, 'root', 'user', 'hi', 2.0)"
+            )
+            conn.execute(
+                "INSERT INTO messages (id, session_id, role, content, timestamp) "
+                "VALUES (2, 'child', 'user', 'hi2', 3.0)"
+            )
+
+        metrics = await processor.ingest_files([source_path], emit_event=False)
+        assert metrics.failed_file_count == 0
+        assert metrics.ingested_session_count == 2
+
+        freshness = project_named_source_freshness(workspace_env["archive_root"], source_path)
+        assert freshness.stage in {NamedSourceStage.INDEXED_UNCONVERGED, NamedSourceStage.SEARCHABLE}
+        assert freshness.accepted_raw_revision is not None
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_hermes_atof_source_reaches_indexed_through_named_freshness(
+    workspace_env: dict[str, Path],
+) -> None:
+    _archive, processor, root = _make_processor(workspace_env, "hermes-observability", "hermes-atof-freshness.db")
+    source_path = root / "events.jsonl"
+    archive = _archive
+    try:
+        record = {
+            "atof_version": "0.1",
+            "kind": "mark",
+            "uuid": "turn-1",
+            "timestamp": "2026-07-18T09:00:00Z",
+            "name": "hermes.turn.start",
+            "metadata": {"session_id": "atof-freshness-session"},
+        }
+        source_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+        metrics = await processor.ingest_files([source_path], emit_event=False)
+        assert metrics.failed_file_count == 0
+        assert metrics.ingested_session_count == 1
+
+        freshness = project_named_source_freshness(workspace_env["archive_root"], source_path)
+        assert freshness.stage in {NamedSourceStage.INDEXED_UNCONVERGED, NamedSourceStage.SEARCHABLE}
+        assert freshness.accepted_raw_revision is not None
+    finally:
+        await archive.close()

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1505,6 +1505,106 @@ async def test_live_full_ingest_preserves_complete_workflow_journal_revisions(
         await archive.close()
 
 
+def _atof_record(*, session_id: str, uuid: str, timestamp: str, name: str = "hermes.turn.start") -> dict[str, object]:
+    return {
+        "atof_version": "0.1",
+        "kind": "mark",
+        "uuid": uuid,
+        "timestamp": timestamp,
+        "name": name,
+        "metadata": {"session_id": session_id},
+    }
+
+
+@pytest.mark.xfail(
+    reason=(
+        "Confirmed data-loss bug, Ref polylogue-flxh: real ~/.hermes/observability/"
+        "nemo-relay/atof/events.jsonl is ONE file shared across every Hermes "
+        "session on the install (live evidence: 3+ distinct hermes session ids "
+        "interleaved in one file), unlike Claude Code/Codex where one JSONL file "
+        "is always exactly one session. The raw-revision-authority replay chain "
+        "(_parse_raw_revision_chain: 'raw revision did not replay to exactly one "
+        "session') and the append-ingest path (append_ingest.py: 'append payload "
+        "did not prove one session and cursor identity') both assume exactly one "
+        "logical session per raw revision. When a growth batch for an "
+        "already-tracked ATOF file contains events for a session that already "
+        "has prior accepted raw revisions (session A) AND a brand-new session "
+        "(session B), the reconciliation raises and the whole path/full-ingest "
+        "attempt is marked failed -- but session B's insert had already been "
+        "committed while session A's new event was not, so the overall failure "
+        "silently masks a real, permanent loss of session A's new evidence "
+        "(not a retry-safe deferral: the same bytes fail identically on retry, "
+        "and 5 consecutive failures quarantine the whole file). Remove this "
+        "xfail once fixed."
+    ),
+    strict=True,
+)
+@pytest.mark.asyncio
+async def test_live_append_atof_shared_file_multi_session_boundary_loses_events(
+    workspace_env: dict[str, Path],
+) -> None:
+    """Empirically drive an append batch whose bytes span two distinct hermes
+    session ids -- the real shared-ATOF-file shape -- and prove session A's new
+    event (a-turn-2) is NOT silently lost while session B (b-turn-1) is created.
+
+    This must FAIL today (xfail, strict): direct sqlite inspection after the
+    growth batch shows session A still has only its original a-turn-1 event
+    while session B is fully present with b-turn-1 -- a-turn-2 never lands.
+    """
+    root = workspace_env["data_root"] / "hermes-observability"
+    root.mkdir(parents=True)
+    source_path = root / "events.jsonl"
+    db_path = workspace_env["data_root"] / "append-atof-boundary.db"
+    archive = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    cursor = CursorStore(db_path)
+    processor = LiveBatchProcessor(
+        archive,
+        (WatchSource(name="hermes", root=root),),
+        cursor=cursor,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+    )
+
+    try:
+        _write_jsonl(
+            source_path,
+            [
+                _atof_record(session_id="atof-session-a", uuid="a-turn-1", timestamp="2026-07-18T00:00:00Z"),
+            ],
+        )
+        await processor.ingest_files([source_path], emit_event=False)
+
+        # Growth batch spans a session boundary -- the real shared-file shape.
+        with source_path.open("a", encoding="utf-8") as handle:
+            for record in (
+                _atof_record(session_id="atof-session-a", uuid="a-turn-2", timestamp="2026-07-18T00:00:01Z"),
+                _atof_record(session_id="atof-session-b", uuid="b-turn-1", timestamp="2026-07-18T00:00:02Z"),
+            ):
+                handle.write(json.dumps(record) + "\n")
+        await processor.ingest_files([source_path], emit_event=False)
+
+        index_db = workspace_env["archive_root"] / "index.db"
+        with sqlite3.connect(index_db) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT s.native_id, se.payload_json
+                FROM session_events se
+                JOIN sessions s ON s.session_id = se.session_id
+                WHERE se.event_type = 'hermes_context_span'
+                ORDER BY s.native_id, se.position
+                """
+            ).fetchall()
+        event_uuids_by_session: dict[str, list[str]] = {}
+        for row in rows:
+            payload = json.loads(row["payload_json"])
+            event_uuids_by_session.setdefault(row["native_id"], []).append(payload["event_uuid"])
+
+        assert event_uuids_by_session.get("observer:atof-session-a") == ["a-turn-1", "a-turn-2"]
+        assert event_uuids_by_session.get("observer:atof-session-b") == ["b-turn-1"]
+    finally:
+        await archive.close()
+
+
 @pytest.mark.asyncio
 async def test_live_append_merges_tail_visible_through_public_archive_read(workspace_env: dict[str, Path]) -> None:
     root = workspace_env["data_root"] / "claude-projects"


### PR DESCRIPTION
## Summary
Continuation of the maximalist Hermes fidelity program (Ref polylogue-fs1.2.1, polylogue-wj25, polylogue-fs1.15) after PR #3092 merged. Closes out the remaining ATOF fs1.2.1 AC items that were tractable in-scope, and empirically investigates two `fs1.2.1`/`fs1.15` open questions that turned up two previously-unknown, confirmed live-ingestion bugs — both pinned as `xfail(strict=True)` regression witnesses with dedicated beads, not silently left undiscovered.

## Problem
fs1.2.1's remaining AC explicitly flagged "append resume" and "unpaired events" as open concerns, and fs1.15 asked whether Hermes coverage/freshness already flows through the existing named-source freshness surface. Investigating these empirically (driving the real `LiveBatchProcessor`, not just re-reading code) surfaced:

1. **Unpaired ATOF scope debt was invisible.** A `kind=scope` UUID that never sees both its `start` and `end` phase (a crashed request, or a truncated/rotated file cutting a pending scope in half) was indistinguishable from a normal completed span.
2. **Confirmed data loss (polylogue-flxh):** real `~/.hermes/observability/nemo-relay/atof/events.jsonl` is ONE file shared across every Hermes session on an install. The live-ingest raw-revision-authority replay chain requires exactly one logical session per raw revision — correct for Claude Code/Codex/Beads (always one file, one session), but genuinely violated by ATOF's shared-file shape. A growth batch spanning a session boundary silently and permanently loses the pre-existing session's new event.
3. **Confirmed crash (polylogue-1zex):** a Hermes `state.db` or `verification_evidence.db` with exactly ONE session at ingest time crashes the live watcher's full-ingest path with `UnicodeDecodeError` — `revision_backfill.py`'s `_parse_one` (shared with historical repair) has zero SQLite awareness, unlike the two other Hermes call sites that correctly special-case it. Real installs almost always have 2+ sessions, which is presumably why this escaped the earlier Phase 0 review (PR #3084, merged).

## Solution
Three commits:
1. `feat(hermes): surface ATOF unpaired scope UUIDs as explicit debt` — `parse_atof_stream` now tracks scope-phase pairing per UUID and emits a typed `hermes_atof_unpaired_scope` event for any UUID missing either phase, plus a new `unpaired_scope_debt` fidelity capability. Verified against the real fixture (`llm-error-1`, a genuine unpaired scope already present in the committed fixture) and two new synthetic tests (start-only, end-only, and a paired-is-not-flagged sanity check).
2. `fix(hermes): document and pin confirmed ATOF shared-file data-loss bug` — empirical regression test driving the real watcher through a session-boundary-spanning growth batch; direct sqlite inspection proves the loss. Filed polylogue-flxh with three candidate fix directions (none chosen — this is core shared ingest plumbing used by every live provider, deserves its own reviewed pass). Added a loud fidelity caveat to `hermes_spans.py`'s module docstring.
3. `test(hermes): prove named-source freshness coverage, pin single-session crash` — proves `project_named_source_freshness` (origin-agnostic, no new code needed) correctly covers Hermes state.db/ATOF once ingestion succeeds; separately confirms and pins the single-session SQLite crash. Filed polylogue-1zex.

## Verification
- `devtools test tests/unit/sources/parsers/test_hermes_spans.py` — 19/19.
- `devtools test tests/unit/sources/test_live_watcher.py` — 85 passed, 1 xfailed (expected).
- `devtools test tests/unit/sources/test_hermes_source_freshness_integration.py` — 2 passed, 1 xfailed (expected).
- `devtools verify --quick` green after every commit.

Known residual gaps, tracked not silently dropped: polylogue-flxh and polylogue-1zex (both filed, neither fixed — both require careful design review of shared core ingest plumbing rather than a rushed patch in this pass). ATIF subagent topology materialization and verification-ledger session-id profile-qualification remain explicitly deferred design decisions (documented in prior session's bead notes), not attempted here since they'd change shipped public identity contracts without operator sign-off.
