### PR TITLE
fix(storage): reconcile blob publication reservations under real writer exclusion

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -596,14 +596,17 @@ async def _bridge_catch_up_complete(
 async def _reconcile_blob_publications() -> None:
     """Classify crash-left publication reservations before source catch-up."""
     from polylogue.paths import archive_root
-    from polylogue.storage.blob_publication import reconcile_blob_publication_reservations
+    from polylogue.storage.blob_publication import reconcile_blob_publication_reservations_under_exclusion
 
     root = archive_root()
     if not (root / "source.db").exists():
         return
+    # Reconciliation only clears rows under a live ArchiveWriterExclusion; the
+    # `_under_exclusion` entry point acquires it itself so this startup call
+    # cannot silently regress into a no-op reconciliation (polylogue-qs0a).
     outcome = await daemon_write_coordinator().run_sync(
         "startup.blob_publications",
-        reconcile_blob_publication_reservations,
+        reconcile_blob_publication_reservations_under_exclusion,
         root / "source.db",
         root / "blob",
         index_db_path=root / "index.db",

--- a/polylogue/storage/blob_publication.py
+++ b/polylogue/storage/blob_publication.py
@@ -371,6 +371,30 @@ def reconcile_blob_publication_reservations(
     )
 
 
+def reconcile_blob_publication_reservations_under_exclusion(
+    source_db_path: Path,
+    blob_root: Path,
+    *,
+    index_db_path: Path | None = None,
+) -> BlobPublicationReconciliation:
+    """Reconcile receipts while holding archive-wide publisher exclusion.
+
+    ``reconcile_blob_publication_reservations`` only clears rows when handed
+    a live ``ArchiveWriterExclusion`` -- without one, ``may_clear`` is always
+    false and every classified row is merely retained forever, a durable
+    reservation leak. This entry point acquires the exclusion itself so a
+    caller (daemon startup, a maintenance command) cannot silently make
+    deletion unreachable by forgetting to pass one (polylogue-qs0a).
+    """
+    with exclude_archive_blob_publishers(source_db_path) as exclusion:
+        return reconcile_blob_publication_reservations(
+            source_db_path,
+            blob_root,
+            index_db_path=index_db_path,
+            writer_exclusion=exclusion,
+        )
+
+
 def abandon_blob_publication_receipts(
     source_db_path: Path,
     blob_root: Path,
@@ -438,4 +462,5 @@ __all__ = [
     "inspect_blob_publication_receipts",
     "publication_receipt_id",
     "reconcile_blob_publication_reservations",
+    "reconcile_blob_publication_reservations_under_exclusion",
 ]

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -2685,6 +2685,55 @@ def test_ensure_fts_startup_readiness_uses_extended_write_timeout(
     assert seen_busy_timeout == [fts_startup._FTS_STARTUP_BUSY_TIMEOUT_MS]
 
 
+def test_reconcile_blob_publications_clears_terminal_receipts_at_startup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Startup reconciliation must run under real writer exclusion (polylogue-qs0a).
+
+    Without a live ``ArchiveWriterExclusion``, ``reconcile_blob_publication_reservations``'s
+    ``may_clear`` gate is always false and every classified row is only ever
+    retained -- a durable reservation leak. This proves the daemon startup
+    call actually acquires the exclusion and clears the two terminal buckets
+    (referenced, missing-bytes) it already knows how to classify safely.
+    """
+    from polylogue.core.enums import Origin
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.storage.blob_publication import ArchiveBlobPublisher
+    from polylogue.storage.blob_store import BlobStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+    from polylogue.storage.sqlite.archive_tiers.source_write import write_source_raw_session_blob_ref
+
+    archive_root_path = tmp_path / "archive"
+    initialize_active_archive_root(archive_root_path)
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(archive_root_path))
+
+    source_db = archive_root_path / "source.db"
+    store = BlobStore(archive_root_path / "blob")
+    publisher = ArchiveBlobPublisher(source_db, store.root)
+    missing_hash, _ = publisher.write_from_bytes(b"startup-missing-terminal")
+    referenced_hash, referenced_size = publisher.write_from_bytes(b"startup-referenced-terminal")
+    publisher.flush()
+    store.blob_path(missing_hash).unlink()
+    with sqlite3.connect(source_db) as conn:
+        write_source_raw_session_blob_ref(
+            conn,
+            origin=Origin.CHATGPT_EXPORT,
+            source_path="startup-referenced.json",
+            source_index=0,
+            blob_hash=bytes.fromhex(referenced_hash),
+            blob_size=referenced_size,
+            acquired_at_ms=1,
+            raw_id="startup-referenced-raw",
+        )
+        assert conn.execute("SELECT COUNT(*) FROM blob_publication_reservations").fetchone()[0] == 2
+
+    asyncio.run(daemon_cli._reconcile_blob_publications())
+
+    with sqlite3.connect(source_db) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM blob_publication_reservations").fetchone()[0] == 0
+
+
 def test_run_daemon_services_stops_live_watcher_on_failure() -> None:
     from polylogue.daemon import cli as daemon_cli
 


### PR DESCRIPTION
## Summary
Daemon startup reconciliation was calling `reconcile_blob_publication_reservations` without a writer exclusion, so its `may_clear` gate was permanently false and reservations were never actually released — an unbounded resource leak on every restart.

## Problem
`_reconcile_blob_publications` (`polylogue/daemon/cli.py`) called `reconcile_blob_publication_reservations` with `writer_exclusion` defaulting to `None`. `reconcile_blob_publication_reservations`'s `may_clear` gate requires a live `ArchiveWriterExclusion` before deleting anything — with `writer_exclusion=None`, `may_clear` is permanently `False`, so every classified row (including the two buckets the reconciler already knows how to release safely: durably-referenced-elsewhere, and bytes-missing-from-disk) was only ever counted and retained, never cleared. This is an unconditional, unbounded `blob_publication_reservations` leak on every daemon restart — confirmed with a captured live log line before the fix: `cleared_ref=0 cleared_missing=0 retained_ref=1 retained_missing=1`.

## Solution
Added `reconcile_blob_publication_reservations_under_exclusion()` (`storage/blob_publication.py`), which acquires `exclude_archive_blob_publishers` itself before calling the existing reconciler — so a caller can no longer silently make deletion unreachable by forgetting to pass an exclusion. Repointed the daemon startup call at it. No schema change: the fix is pure writer/reconciler wiring, matching this lane's hard rule that items 1–3 need none.

## Investigated but not fixed (recorded in `polylogue-qs0a` bead notes with full evidence)
The reconciler's `unresolved` bucket (`referenced=false, blob_present=true` — the literal orphaned-abandoned-publish case) is never cleared regardless of exclusion, which looks at first like the bead's namesake bug. But an existing, deliberately-worded test (`test_reconciliation_with_writer_exclusion_clears_only_terminal_receipts`) explicitly asserts this bucket must stay retained even under exclusion, suggesting the classification design intentionally defers that case to `blob_gc.py`'s own age-gated authority. Changing it without being sure which behavior is correct risks a regression in a durable-tier resource-lifecycle path. Left for follow-up coordination with `polylogue-0puw`, which owns the adjacent ingest-batch crash-schedule investigation.

## Verification
- New regression: `test_reconcile_blob_publications_clears_terminal_receipts_at_startup` (`tests/unit/daemon/test_daemon_cli.py`) — seeds one referenced and one missing-bytes terminal reservation, calls the real daemon startup coroutine, asserts both are cleared.
- Anti-vacuity: reverted the source fix via `git stash`, keeping the new test — it fails, and the captured log shows the exact pre-fix leak signature (`cleared_ref=0 cleared_missing=0 retained_ref=1 retained_missing=1`); passes after restoring the fix.
- `devtools test tests/unit/daemon/test_daemon_cli.py tests/unit/pipeline/test_acquisition_blob_gc_age_gate.py` → 97 passed.
- `devtools verify --quick` → exit 0.

Ref polylogue-qs0a