### PR TITLE
perf(daemon): defer per-chunk embedding into debt during source catch-up

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -1515,8 +1515,16 @@ async def run_daemon_services(
                 periodic_loops.append(_periodic_drive_source_catchup())
             maintenance_tasks.extend(asyncio.create_task(loop) for loop in periodic_loops)
             _db = _active_index_db_path()
+            # While the watcher's initial source catch-up is still running,
+            # per-chunk embedding (serial network I/O) is deferred into
+            # convergence debt; the gated embedding backlog loop drains it
+            # once catch-up completes.
+            embed_gate = catch_up_complete_gate
             converger = DaemonConverger(
-                stages=make_default_convergence_stages(_db),
+                stages=make_default_convergence_stages(
+                    _db,
+                    embed_defer=(lambda: embed_gate is not None and not embed_gate.is_set()),
+                ),
                 max_workers=2,
             )
             await converger.start()

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import sqlite3
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -265,13 +265,26 @@ def make_fts_stage(db_path: Path) -> ConvergenceStage:
 # ── Stage: embed ───────────────────────────────────────────────────
 
 
-def make_embed_stage(db_path: Path) -> ConvergenceStage:
+def make_embed_stage(db_path: Path, *, defer: Callable[[], bool] | None = None) -> ConvergenceStage:
     """Generate vector embeddings for changed sessions that need them.
 
     Before embedding, detects model/dimension config changes and marks
     affected rows for reindex. Enforces the configured cost cap during
     embedding.
+
+    ``defer`` returning True (e.g. while watcher source catch-up is still
+    running) converts every execute into a ``false_means_pending`` deferral:
+    the work lands in convergence debt for the post-catch-up retry loops
+    instead of paying serial network embedding inside each bulk ingest
+    chunk. Embeddings are a rebuildable read-model — bulk backfill ordering
+    is sessions first, vectors when quiet.
     """
+
+    def _deferred() -> bool:
+        if defer is not None and defer():
+            logger.debug("embed: deferred to convergence debt (source catch-up in progress)")
+            return True
+        return False
 
     def check(path: Path) -> bool:
         if not _embedding_config_enabled():
@@ -282,6 +295,8 @@ def make_embed_stage(db_path: Path) -> ConvergenceStage:
     def execute(path: Path) -> StageExecuteReturn:
         if not _embedding_config_enabled():
             return True
+        if _deferred():
+            return False
         archive_db = _active_archive_index_path(db_path)
         return _archive_embed_execute(archive_db, path) if archive_db is not None else True
 
@@ -294,6 +309,8 @@ def make_embed_stage(db_path: Path) -> ConvergenceStage:
     def execute_many(paths: Sequence[Path]) -> StageExecuteReturn:
         if not paths or not _embedding_config_enabled():
             return True
+        if _deferred():
+            return False
         archive_db = _active_archive_index_path(db_path)
         return _archive_embed_execute_many(archive_db, paths) if archive_db is not None else True
 
@@ -306,6 +323,8 @@ def make_embed_stage(db_path: Path) -> ConvergenceStage:
     def execute_sessions(session_ids: Sequence[str]) -> StageExecuteReturn:
         if not session_ids or not _embedding_config_enabled():
             return True
+        if _deferred():
+            return False
         archive_db = _active_archive_index_path(db_path)
         return _archive_embed_execute_sessions(archive_db, session_ids) if archive_db is not None else True
 
@@ -754,6 +773,7 @@ def make_default_convergence_stages(
     db_path: Path,
     *,
     sinex_transport: SinexTransport | None = None,
+    embed_defer: Callable[[], bool] | None = None,
 ) -> tuple[ConvergenceStage, ...]:
     """Build daemon stages, failing explicitly when backed mode lacks transport."""
     from polylogue.archive.query.production_evaluator import ArchiveCanonicalPlanEvaluator
@@ -780,7 +800,7 @@ def make_default_convergence_stages(
     stages.extend(
         (
             make_fts_stage(db_path),
-            make_embed_stage(db_path),
+            make_embed_stage(db_path, defer=embed_defer),
             make_claude_workflow_stage(db_path),
             make_insights_stage(db_path),
             make_standing_query_stage(db_path, evaluator=ArchiveCanonicalPlanEvaluator(db_path)),

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -903,6 +903,55 @@ def test_embed_stage_is_noop_when_disabled(
     assert stage.execute(tmp_path / "source.jsonl") is True
 
 
+def test_embed_stage_defers_to_pending_debt_while_predicate_holds(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """During source catch-up the embed stage must not embed inline: every
+    execute lane returns False (false_means_pending -> convergence debt)
+    without touching the embedding implementation; once the predicate
+    releases, execution falls through to the real implementation again."""
+    monkeypatch.setattr(stages, "_embedding_config_enabled", lambda: True)
+    db_path = tmp_path / "index.db"
+    db_path.touch()
+    monkeypatch.setattr(stages, "_active_archive_index_path", lambda _db: db_path)
+
+    embed_calls: list[str] = []
+    monkeypatch.setattr(
+        stages,
+        "_archive_embed_execute",
+        lambda _db, _path: embed_calls.append("execute") or True,
+    )
+    monkeypatch.setattr(
+        stages,
+        "_archive_embed_execute_many",
+        lambda _db, _paths: embed_calls.append("execute_many") or True,
+    )
+    monkeypatch.setattr(
+        stages,
+        "_archive_embed_execute_sessions",
+        lambda _db, _ids: embed_calls.append("execute_sessions") or True,
+    )
+
+    deferring = True
+    stage = stages.make_embed_stage(db_path, defer=lambda: deferring)
+    assert stage.false_means_pending is True
+
+    source = tmp_path / "source.jsonl"
+    assert stage.execute(source) is False
+    assert stage.execute_many is not None
+    assert stage.execute_many([source]) is False
+    assert stage.execute_sessions is not None
+    assert stage.execute_sessions(["origin:native"]) is False
+    assert embed_calls == []
+
+    deferring = False
+    assert stage.execute(source) is True
+    assert stage.execute_many([source]) is True
+    assert stage.execute_sessions(["origin:native"]) is True
+    assert embed_calls == ["execute", "execute_many", "execute_sessions"]
+
+
 def test_insights_stage_batches_sync_rebuild_chunks(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -917,21 +917,22 @@ def test_embed_stage_defers_to_pending_debt_while_predicate_holds(
     monkeypatch.setattr(stages, "_active_archive_index_path", lambda _db: db_path)
 
     embed_calls: list[str] = []
-    monkeypatch.setattr(
-        stages,
-        "_archive_embed_execute",
-        lambda _db, _path: embed_calls.append("execute") or True,
-    )
-    monkeypatch.setattr(
-        stages,
-        "_archive_embed_execute_many",
-        lambda _db, _paths: embed_calls.append("execute_many") or True,
-    )
-    monkeypatch.setattr(
-        stages,
-        "_archive_embed_execute_sessions",
-        lambda _db, _ids: embed_calls.append("execute_sessions") or True,
-    )
+
+    def fake_execute(_db: Path, _path: Path) -> bool:
+        embed_calls.append("execute")
+        return True
+
+    def fake_execute_many(_db: Path, _paths: object) -> bool:
+        embed_calls.append("execute_many")
+        return True
+
+    def fake_execute_sessions(_db: Path, _ids: object) -> bool:
+        embed_calls.append("execute_sessions")
+        return True
+
+    monkeypatch.setattr(stages, "_archive_embed_execute", fake_execute)
+    monkeypatch.setattr(stages, "_archive_embed_execute_many", fake_execute_many)
+    monkeypatch.setattr(stages, "_archive_embed_execute_sessions", fake_execute_sessions)
 
     deferring = True
     stage = stages.make_embed_stage(db_path, defer=lambda: deferring)


### PR DESCRIPTION
## Summary

Second daemon-drain fix from the 2026-07-18 restore telemetry (follows #3102): during the watcher's initial source catch-up, the embed convergence stage ran inline in every ingest chunk — serial Voyage network calls dominating chunk wall time. Embeddings now defer into convergence debt until catch-up completes.

## Problem

Live chunk telemetry during the archive restore: `catch-up chunk 1/726 complete: … convergence_s=41.425 stages=embed:29.636,…` — ~30s of embedding inside a ~60s chunk, projected across 726 chunks ≈ 6 hours of serial network embedding inside the bulk drain path, for a rebuildable read-model that already has a dedicated post-catch-up backlog loop (`periodic_embedding_backlog_check`, gated on `catch_up_complete`).

## Solution

- `make_embed_stage(db_path, *, defer=None)`: while the predicate holds, every execute lane (`execute`/`execute_many`/`execute_sessions`) returns `False`, which the stage's existing `false_means_pending=True` contract converts to convergence debt — no new mechanism, no scope reduction, just ordering: sessions first, vectors when quiet.
- `make_default_convergence_stages` passes the predicate through; the daemon wires it to the watcher catch-up gate (`not catch_up_complete_gate.is_set()`). All other call sites default to no deferral.
- Embed has no barrier hooks, so deferral cannot block downstream stages (workflow/insights). The debt retry loop and embedding backlog loop are both already gated on catch-up completion, so a deferral cannot ping-pong during catch-up.

## Verification

- `devtools test tests/unit/daemon/test_convergence_stages.py tests/unit/daemon/test_daemon_cli.py` — 130 passed; new test proves all three execute lanes defer without touching the embedding implementation while the predicate holds, then fall through when it releases, and pins `false_means_pending=True`.
- `mypy` clean via `devtools verify --quick` (pre-push gate green).
- Not run: full `devtools verify --all`.

Ref polylogue-5jak

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ