### PR TITLE
fix(daemon): stop terminal spool states parking raw materialization

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -691,7 +691,16 @@ def _drain_raw_materialization_once(
 
 
 def _browser_capture_spool_has_pending_files() -> bool:
-    """Whether live browser evidence is awaiting its normal ingest route."""
+    """Whether live browser evidence is awaiting its normal ingest route.
+
+    Only files genuinely waiting on the live route's writer count: a file
+    with no cursor yet, or one whose bytes changed since its cursor. Files
+    in a terminal or failure disposition (``excluded``, ``failure_count``)
+    are owned by exclusion/retry policy — the writer is not what they wait
+    for, and treating them as pending parked raw materialization forever
+    (2026-07-18 restore: the conveyor never ran once while failed spool
+    files sat on disk).
+    """
     from polylogue.paths import browser_capture_spool_root
     from polylogue.sources.live.batch import fingerprint_file
     from polylogue.sources.live.cursor import CursorStore
@@ -707,8 +716,10 @@ def _browser_capture_spool_has_pending_files() -> bool:
         except FileNotFoundError:
             continue
         cursor = cursor_store.get_record(path)
-        if cursor is None or cursor.excluded or cursor.failure_count:
+        if cursor is None:
             return True
+        if cursor.excluded or cursor.failure_count:
+            continue
         if (
             cursor.parser_fingerprint != _PARSER_FINGERPRINT
             or cursor.byte_size != stat.st_size

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -1066,6 +1066,52 @@ def test_periodic_raw_materialization_yields_to_pending_browser_capture_spool(
         asyncio.run(daemon_cli._periodic_raw_materialization_convergence())
 
 
+def test_spool_pending_check_ignores_terminal_cursor_states(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Excluded or repeatedly-failed spool files are owned by exclusion and
+    retry policy; they must not park raw materialization indefinitely. Only
+    a file with no cursor yet (genuinely awaiting its live route) yields."""
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.sources.live.watcher import _PARSER_FINGERPRINT
+
+    spool = tmp_path / "browser-capture"
+    spool.mkdir()
+    capture = spool / "chatgpt-capture.json"
+    capture.write_bytes(b"{}\n")
+    stat = capture.stat()
+
+    records: dict[Path, object] = {}
+    monkeypatch.setattr("polylogue.paths.browser_capture_spool_root", lambda: spool)
+    monkeypatch.setattr(daemon_cli, "_active_index_db_path", lambda: tmp_path / "index.db")
+    monkeypatch.setattr(
+        "polylogue.sources.live.cursor.CursorStore",
+        lambda _db: SimpleNamespace(get_record=lambda path: records.get(path)),
+    )
+
+    def cursor_record(*, excluded: bool = False, failure_count: int = 0) -> SimpleNamespace:
+        return SimpleNamespace(
+            excluded=excluded,
+            failure_count=failure_count,
+            parser_fingerprint=_PARSER_FINGERPRINT,
+            byte_size=stat.st_size,
+            st_dev=stat.st_dev,
+            st_ino=stat.st_ino,
+            mtime_ns=stat.st_mtime_ns,
+            content_fingerprint="fp",
+        )
+
+    records.clear()
+    assert daemon_cli._browser_capture_spool_has_pending_files() is True
+
+    records[capture] = cursor_record(excluded=True)
+    assert daemon_cli._browser_capture_spool_has_pending_files() is False
+
+    records[capture] = cursor_record(failure_count=3)
+    assert daemon_cli._browser_capture_spool_has_pending_files() is False
+
+
 def test_periodic_session_insight_convergence_waits_for_catch_up_complete(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Third daemon-drain fix from the 2026-07-18 restore (follows #3102, #3105): the browser-capture spool yield treated *excluded* and *repeatedly-failed* spool files as "pending live ingest", parking the raw-materialization conveyor on every tick — indefinitely when such files never succeed.

## Problem

`_browser_capture_spool_has_pending_files` (added in #2975 to keep raw maintenance from monopolizing the writer ahead of fresh browser evidence) returned True for `cursor.excluded` and `cursor.failure_count > 0`. Observed live during the restore: "raw materialization: yielding to pending browser-capture spool files" every tick with 607 spooled captures queued — and after catch-up, any capture left in a failure/excluded disposition would park the conveyor forever. That inverts the priority the yield was built to protect: terminal files are not waiting on the writer.

## Solution

Only files genuinely awaiting the live route count as pending: no cursor yet, or bytes changed since the cursor. Excluded files are terminally disposed (exclusion policy owns them); failed files are owned by retry/backoff. Both now `continue` instead of yielding.

## Verification

`devtools test tests/unit/daemon/test_daemon_cli.py` — 89 passed; new test `test_spool_pending_check_ignores_terminal_cursor_states` pins: no-cursor ⇒ yield, excluded ⇒ no yield, failure_count ⇒ no yield. Pre-push quick gate green.

Ref polylogue-5jak

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ