### PR TITLE
perf(daemon): open archive once per hook-spool drain, bound writer holds

### DIFF
--- a/polylogue/sources/hooks.py
+++ b/polylogue/sources/hooks.py
@@ -20,6 +20,7 @@ for the durability/finalization semantics this spool exists to capture.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
@@ -66,10 +67,15 @@ class HookSpoolRecordError(ValueError):
 
 @dataclass(frozen=True, slots=True)
 class HookSpoolDrainResult:
-    """Outcome of one durable hook-spool drain attempt."""
+    """Outcome of one durable hook-spool drain attempt.
+
+    ``remaining`` counts pending files left after the pass — failures plus
+    anything beyond ``limit`` — so a bounded caller knows to drain again.
+    """
 
     acknowledged: int
     failed: int
+    remaining: int = 0
 
 
 def pending_hook_spool_dir(root: Path | None = None) -> Path:
@@ -132,30 +138,55 @@ def drain_hook_event_spool(
     archive_root: Path,
     *,
     root: Path | None = None,
+    limit: int | None = None,
 ) -> HookSpoolDrainResult:
-    """Persist every pending event and acknowledge only committed records.
+    """Persist pending events and acknowledge only committed records.
 
     Pending files deliberately remain in place when archive writes or envelope
     validation fail.  The next daemon pass can retry a transient write failure;
     a malformed producer record remains inspectable rather than disappearing.
+
+    The archive is opened ONCE per drain, not per record: this runs on the
+    daemon's single writer, and a per-record open/initialize turned a few
+    thousand spooled events into a multi-minute writer monopoly that starved
+    every other ingest path (observed live 2026-07-18). ``limit`` bounds one
+    writer hold; the caller loops on ``remaining``.
     """
 
     pending = pending_hook_spool_dir(root)
     if not pending.exists():
         return HookSpoolDrainResult(acknowledged=0, failed=0)
+    paths = sorted(pending.glob("*.json"))
+    selected = paths if limit is None else paths[:limit]
+    if not selected:
+        return HookSpoolDrainResult(acknowledged=0, failed=0)
     acknowledged = 0
     failed = 0
-    for path in sorted(pending.glob("*.json")):
-        try:
-            record = _read_record(path)
-            _persist_record(archive_root, path, record)
-            _acknowledge(path, root=root)
-        except (HookSpoolRecordError, OSError, sqlite3.Error, ValueError):
-            failed += 1
-            logger.warning("hook spool event remains pending: %s", path, exc_info=True)
-        else:
-            acknowledged += 1
-    return HookSpoolDrainResult(acknowledged=acknowledged, failed=failed)
+    try:
+        initialize_active_archive_root(archive_root)
+        store = ArchiveStore.open_existing(archive_root, read_only=False)
+    except (OSError, sqlite3.Error, ValueError):
+        logger.warning("hook spool drain could not open the archive; all events remain pending", exc_info=True)
+        return HookSpoolDrainResult(acknowledged=0, failed=len(selected), remaining=len(paths))
+    with store as archive:
+        for path in selected:
+            try:
+                record = _read_record(path)
+                _persist_record(archive, path, record)
+                archive.commit()
+                _acknowledge(path, root=root)
+            except (HookSpoolRecordError, OSError, sqlite3.Error, ValueError):
+                with contextlib.suppress(Exception):
+                    archive.rollback()
+                failed += 1
+                logger.warning("hook spool event remains pending: %s", path, exc_info=True)
+            else:
+                acknowledged += 1
+    return HookSpoolDrainResult(
+        acknowledged=acknowledged,
+        failed=failed,
+        remaining=len(paths) - acknowledged,
+    )
 
 
 def _read_record(path: Path) -> dict[str, object]:
@@ -216,8 +247,7 @@ def _timestamp_ms(value: str) -> int:
         raise HookSpoolRecordError(f"invalid hook timestamp: {value!r}") from exc
 
 
-def _persist_record(archive_root: Path, path: Path, record: dict[str, object]) -> None:
-    initialize_active_archive_root(archive_root)
+def _persist_record(archive: ArchiveStore, path: Path, record: dict[str, object]) -> None:
     provider_token = str(record["provider"])
     provider = Provider.from_string(provider_token)
     try:
@@ -238,32 +268,31 @@ def _persist_record(archive_root: Path, path: Path, record: dict[str, object]) -
         raise HookSpoolRecordError("hook spool envelope has an invalid observed timestamp")
     observed_at_ms = observed_at_ms_value
     source_path = str(path)
-    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
-        raw_id = archive.write_raw_payload(
-            provider=provider,
-            payload=payload,
-            source_path=source_path,
-            acquired_at_ms=observed_at_ms,
-        )
-        write_source_raw_session(
-            archive._ensure_source_conn(),
+    raw_id = archive.write_raw_payload(
+        provider=provider,
+        payload=payload,
+        source_path=source_path,
+        acquired_at_ms=observed_at_ms,
+    )
+    write_source_raw_session(
+        archive._ensure_source_conn(),
+        origin=origin,
+        source_path=source_path,
+        source_index=0,
+        payload=payload,
+        acquired_at_ms=observed_at_ms,
+        raw_id=raw_id,
+        hook_event=ArchiveHookEvent(
+            hook_event_id=f"hook:{record['event_id']}",
             origin=origin,
             source_path=source_path,
-            source_index=0,
-            payload=payload,
-            acquired_at_ms=observed_at_ms,
-            raw_id=raw_id,
-            hook_event=ArchiveHookEvent(
-                hook_event_id=f"hook:{record['event_id']}",
-                origin=origin,
-                source_path=source_path,
-                event_type=str(record["event_type"]),
-                payload=record,
-                observed_at_ms=observed_at_ms,
-                native_id=f"{record['session_id']}:{record['event_type']}:{record['event_id']}",
-                session_native_id=str(record["session_id"]),
-            ),
-        )
+            event_type=str(record["event_type"]),
+            payload=record,
+            observed_at_ms=observed_at_ms,
+            native_id=f"{record['session_id']}:{record['event_type']}:{record['event_id']}",
+            session_native_id=str(record["session_id"]),
+        ),
+    )
 
 
 def _acknowledge(path: Path, *, root: Path | None) -> None:

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -50,6 +50,9 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 _PARSER_FINGERPRINT = "live-batched-v2"
+# One bounded writer hold per hook-spool drain batch; the drain loops until
+# the backlog is gone, releasing the writer between batches.
+_HOOK_SPOOL_DRAIN_BATCH_LIMIT = 250
 _CATCH_UP_MAX_BATCH_FILES = 50
 _CATCH_UP_MAX_BATCH_BYTES = 64 * 1024 * 1024
 _INCOMPLETE_APPEND_PROBE_BYTES = 64 * 1024 * 1024
@@ -385,21 +388,32 @@ class LiveWatcher:
         await self._drain_hook_spool()
 
     async def _drain_hook_spool(self) -> None:
-        """Acknowledge hook envelopes only after their source-tier write commits."""
+        """Acknowledge hook envelopes only after their source-tier write commits.
 
-        result = await self._run_writer_sync(
-            "watcher.hook_spool.drain",
-            drain_hook_event_spool,
-            Path(self._polylogue.archive_root),
-            root=self._hook_spool_root(),
-        )
-        if result.failed:
-            logger.warning(
-                "live.watcher: hook spool drain left %d event(s) pending",
-                result.failed,
+        Drains in bounded batches, releasing the writer between them, so a
+        large spool backlog cannot monopolize the single writer against
+        live ingest and catch-up chunks.
+        """
+
+        total_acknowledged = 0
+        while True:
+            result = await self._run_writer_sync(
+                "watcher.hook_spool.drain",
+                drain_hook_event_spool,
+                Path(self._polylogue.archive_root),
+                root=self._hook_spool_root(),
+                limit=_HOOK_SPOOL_DRAIN_BATCH_LIMIT,
             )
-        elif result.acknowledged:
-            logger.info("live.watcher: acknowledged %d hook spool event(s)", result.acknowledged)
+            total_acknowledged += result.acknowledged
+            if result.failed:
+                logger.warning(
+                    "live.watcher: hook spool drain left %d event(s) pending",
+                    result.failed,
+                )
+            if result.acknowledged == 0 or result.remaining <= result.failed:
+                break
+        if total_acknowledged:
+            logger.info("live.watcher: acknowledged %d hook spool event(s)", total_acknowledged)
 
     def _scan_catch_up_candidates(self, roots: list[Path]) -> tuple[CandidateSourceFile, ...]:
         root_set = {root.resolve() for root in roots}

--- a/tests/unit/sources/test_hook_spool.py
+++ b/tests/unit/sources/test_hook_spool.py
@@ -457,10 +457,10 @@ def test_drain_opens_archive_once_per_pass_and_honors_limit(
     open_calls = 0
     real_open = ArchiveStore.open_existing
 
-    def counting_open(root: Path, **kwargs: object) -> ArchiveStore:
+    def counting_open(root: Path, *, read_only: bool = True, read_timeout: float = 5.0) -> ArchiveStore:
         nonlocal open_calls
         open_calls += 1
-        return real_open(root, **kwargs)
+        return real_open(root, read_only=read_only, read_timeout=read_timeout)
 
     monkeypatch.setattr(
         "polylogue.sources.hooks.ArchiveStore",

--- a/tests/unit/sources/test_hook_spool.py
+++ b/tests/unit/sources/test_hook_spool.py
@@ -90,7 +90,7 @@ def test_hook_spool_keeps_event_pending_when_source_tier_write_fails(tmp_path: P
 
     result = drain_hook_event_spool(blocked_root, root=spool_root)
 
-    assert result == type(result)(acknowledged=0, failed=1)
+    assert result == type(result)(acknowledged=0, failed=1, remaining=1)
     assert event_path.exists()
     assert list(acknowledged_hook_spool_dir(spool_root).glob("*.json")) == []
     assert list(pending_hook_spool_dir(spool_root).glob("*.json")) == [event_path]
@@ -432,6 +432,53 @@ def test_hermes_hook_spool_survives_a_truncated_envelope_alongside_a_valid_one(t
         assert conn.execute("SELECT COUNT(*) FROM raw_hook_events").fetchone() == (1,)
 
 
+def test_drain_opens_archive_once_per_pass_and_honors_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One archive open per drain pass (never per record), bounded by limit,
+    with remaining telling the caller to drain again."""
+    from types import SimpleNamespace
+
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    spool_root = tmp_path / "hooks"
+    for index in range(5):
+        enqueue_hook_event(
+            event_id=f"batch-event-{index}",
+            provider="codex",
+            event_type="PostToolUse",
+            session_id="session-1",
+            timestamp="2026-07-12T10:00:00Z",
+            payload={"tool_name": "exec"},
+            root=spool_root,
+        )
+    archive_root = tmp_path / "archive"
+    open_calls = 0
+    real_open = ArchiveStore.open_existing
+
+    def counting_open(root: Path, **kwargs: object) -> ArchiveStore:
+        nonlocal open_calls
+        open_calls += 1
+        return real_open(root, **kwargs)
+
+    monkeypatch.setattr(
+        "polylogue.sources.hooks.ArchiveStore",
+        SimpleNamespace(open_existing=counting_open),
+    )
+
+    first = drain_hook_event_spool(archive_root, root=spool_root, limit=2)
+    assert first.acknowledged == 2
+    assert first.failed == 0
+    assert first.remaining == 3
+    assert open_calls == 1
+
+    second = drain_hook_event_spool(archive_root, root=spool_root)
+    assert second.acknowledged == 3
+    assert second.remaining == 0
+    assert open_calls == 2
+
+
 def test_persist_record_raises_rather_than_defaulting_an_unmapped_provider_to_codex(tmp_path: Path) -> None:
     """``_validated_record`` already rejects any provider outside
     ``_SUPPORTED_PROVIDERS`` before a record reaches ``_persist_record``, so
@@ -440,9 +487,11 @@ def test_persist_record_raises_rather_than_defaulting_an_unmapped_provider_to_co
     ``_ORIGIN_TOKEN_BY_PROVIDER`` would). It must raise, not silently
     misclassify a genuinely-unknown provider as Codex."""
 
-    from polylogue.sources.hooks import _persist_record
+    from typing import cast
 
-    archive_root = tmp_path / "archive"
+    from polylogue.sources.hooks import _persist_record
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
     record: dict[str, object] = {
         "event_id": "unmapped-provider-event",
         "event_type": "tool_start",
@@ -451,8 +500,10 @@ def test_persist_record_raises_rather_than_defaulting_an_unmapped_provider_to_co
         "payload": {},
         "observed_at_ms": 0,
     }
+    # The mapping check precedes any archive access, so a sentinel proves the
+    # raise happens before anything touches the store.
     with pytest.raises(HookSpoolRecordError, match="no origin mapping"):
-        _persist_record(archive_root, tmp_path / "unused.json", record)
+        _persist_record(cast(ArchiveStore, object()), tmp_path / "unused.json", record)
 
 
 def test_hermes_per_turn_end_and_durable_finalize_remain_distinct_event_types(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fourth daemon-drain fix from the 2026-07-18 restore (follows #3102, #3105, #3108): the hook-event spool drain re-opened and re-initialized the whole 5-tier archive **per record** inside the daemon writer hold, and every live hook-spool file event triggers a full drain — with 2,226 pending events and five active agent sessions continuously producing hook events, the single writer was monopolized for tens of minutes and watcher catch-up starved behind it.

## Problem

py-spy against the live daemon during a 22-minute stalled catch-up chunk showed the writer thread `polylogue-writer:watcher.hook_spool.drain` pinned inside `initialize_archive_tier` ← `ArchiveStore.open_existing` ← `_persist_record`, called from `drain_hook_event_spool`'s per-record loop. Index session count was frozen the whole time.

## Solution

- `drain_hook_event_spool` opens the archive once per pass; each record still commits individually (explicit `archive.commit()`) before its file is acknowledged — the ack-after-commit receipt contract is unchanged, and a failed record rolls back and stays pending, isolated from its neighbors.
- Archive-open failure marks the whole selected batch failed and leaves every file pending (same fail-closed behavior the blocked-root test pins).
- New `limit` parameter bounds one writer hold; `HookSpoolDrainResult` gains `remaining` so callers know to continue.
- The watcher drains in 250-event batches in a loop, releasing the writer between batches, and logs the total once.

## Verification

- `devtools test tests/unit/sources/test_hook_spool.py` — 24 passed, including new `test_drain_opens_archive_once_per_pass_and_honors_limit` (one open per pass counted via patched `open_existing`, limit honored, `remaining` drives the second pass, second pass drains the rest).
- `devtools test tests/unit/sources/test_live_watcher.py -k spool` — 1 passed.
- `mypy` clean; pre-push quick gate green.

Ref polylogue-5jak

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ