### PR TITLE
refactor(storage): normalize foreign_keys pragma across user-tier overlay writers

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -66,6 +66,23 @@ _ASSERTION_AGENT_CANDIDATE_CONTEXT_POLICY: Final[dict[str, JSONValue]] = {"injec
 _ASSERTION_WRITE_SAVEPOINTS = itertools.count()
 
 
+def _ensure_foreign_keys_pragma(conn: sqlite3.Connection) -> None:
+    """Enable FK enforcement before any transaction begins.
+
+    SQLite silently no-ops this pragma once a transaction is active, so it
+    only takes effect when called on an idle connection. Centralized here so
+    every user-tier overlay writer applies it consistently through the single
+    ``upsert_assertion`` chokepoint instead of a handful of independently
+    inconsistent inline calls (some callers had it, most didn't, and the one
+    formerly inside ``upsert_assertion`` itself ran after ``BEGIN IMMEDIATE``
+    and was therefore always a no-op). Low-impact today since ``assertions``
+    declares no FK constraint, but keeps future FK adoption safe without
+    re-auditing every write call site.
+    """
+    if not conn.in_transaction:
+        conn.execute("PRAGMA foreign_keys = ON")
+
+
 @contextmanager
 def _immediate_user_write_transaction(conn: sqlite3.Connection) -> Iterator[None]:
     """Start the outer user-tier write scope before observing mutable state.
@@ -578,7 +595,6 @@ def upsert_suppression(
     now_ms: int | None = None,
 ) -> ArchiveSuppressionEnvelope:
     """Upsert one suppression assertion by ``session_id``."""
-    conn.execute("PRAGMA foreign_keys = ON")
     timestamp = now_ms if now_ms is not None else _now_ms()
     upsert_assertion(
         conn,
@@ -604,7 +620,6 @@ def upsert_mark(
     now_ms: int | None = None,
 ) -> ArchiveMarkEnvelope:
     """Insert-or-update one mark assertion with deterministic ``mark_id``."""
-    conn.execute("PRAGMA foreign_keys = ON")
     timestamp = now_ms if now_ms is not None else _now_ms()
     mark_id = _deterministic_id("mark", target_type, target_id, mark_type)
     upsert_assertion(
@@ -704,7 +719,6 @@ def upsert_annotation(
     now_ms: int | None = None,
 ) -> ArchiveAnnotationEnvelope:
     """Insert-or-update one annotation assertion with deterministic identity."""
-    conn.execute("PRAGMA foreign_keys = ON")
     timestamp = now_ms if now_ms is not None else _now_ms()
     resolved_id = annotation_id or _deterministic_id("annotation", target_type, target_id, body)
     upsert_assertion(
@@ -732,7 +746,6 @@ def upsert_correction(
     now_ms: int | None = None,
 ) -> ArchiveCorrectionEnvelope:
     """Insert-or-update one correction assertion with deterministic id."""
-    conn.execute("PRAGMA foreign_keys = ON")
     timestamp = now_ms if now_ms is not None else _now_ms()
     correction_id = correction_id_for(target_type, target_id, correction_type)
     upsert_assertion(
@@ -1130,8 +1143,8 @@ def upsert_assertion(
     per-call-site deliberately; it is never inferred from ``kind``/
     ``author_kind`` inside this function.
     """
+    _ensure_foreign_keys_pragma(conn)
     with _immediate_user_write_transaction(conn):
-        conn.execute("PRAGMA foreign_keys = ON")
         timestamp = now_ms if now_ms is not None else _now_ms()
         existing = conn.execute(
             "SELECT created_at_ms, status FROM assertions WHERE assertion_id = ?",

--- a/tests/unit/storage/test_archive_tiers_assertions.py
+++ b/tests/unit/storage/test_archive_tiers_assertions.py
@@ -154,6 +154,28 @@ def test_fresh_user_tier_creates_assertions_table(tmp_path: Path) -> None:
         conn.close()
 
 
+def test_overlay_writers_enable_foreign_keys_before_first_transaction(tmp_path: Path) -> None:
+    """Every user-tier overlay writer must enable FK enforcement pre-transaction.
+
+    Previously only 4 of 10 overlay-write functions (upsert_suppression,
+    upsert_mark, upsert_annotation, upsert_correction) set PRAGMA
+    foreign_keys themselves, and upsert_assertion's own internal call ran
+    after BEGIN IMMEDIATE -- a guaranteed no-op, since SQLite silently
+    ignores this pragma once a transaction is active. upsert_saved_view was
+    one of the six callers that never enabled it at all. Now the single
+    upsert_assertion chokepoint applies it before any transaction begins,
+    covering every caller (direct or through a wrapper) uniformly.
+    """
+    conn = _connect(tmp_path / "user.db")
+    try:
+        conn.execute("PRAGMA foreign_keys = OFF")
+        assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 0
+        user_write.upsert_saved_view(conn, "test-view", {"query": "x"})
+        assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+    finally:
+        conn.close()
+
+
 def test_fresh_user_tier_has_no_legacy_overlay_tables(tmp_path: Path) -> None:
     conn = _connect(tmp_path / "user.db")
     try:


### PR DESCRIPTION
## Summary
Small follow-up from polylogue-41ow's completeness addendum: consolidates nine independently-inconsistent `PRAGMA foreign_keys = ON` call sites into one, actually-effective call at the `upsert_assertion` chokepoint.

## Problem
Only 4 of 10 user-tier overlay-write functions (`upsert_suppression`, `upsert_mark`, `upsert_annotation`, `upsert_correction`) set `PRAGMA foreign_keys` themselves, and the copy inside `upsert_assertion` itself ran *after* `BEGIN IMMEDIATE` had already started the transaction — SQLite silently no-ops this pragma once a transaction is active, so that call was dead code on every invocation. The other 6 overlay functions (`upsert_session_tag_assertion`, `upsert_session_metadata_assertion`, `upsert_saved_view`, `upsert_recall_pack`, `upsert_workspace`, `upsert_blackboard_note`) never enabled it at all.

## Solution
Added `_ensure_foreign_keys_pragma(conn)`, called once at the top of `upsert_assertion` before entering `_immediate_user_write_transaction` (so it actually takes effect instead of running mid-transaction). `upsert_assertion` is the single write chokepoint every overlay function and every direct external caller (`security/lifecycle.py`, `security/secret_scan.py`, `scenarios/corpus.py`, `storage/repair.py`, `storage/raw_reconciler.py`, `annotations/write.py`) already funnels through, so consolidating here covers all of them uniformly. Removed the four now-fully-redundant inline calls.

No behavior change for any current test: `assertions` has no FK constraint, so enforcement being on or off doesn't affect any write today. This is a pure future-safety normalization.

## Verification
- New regression: `test_overlay_writers_enable_foreign_keys_before_first_transaction` (`tests/unit/storage/test_archive_tiers_assertions.py`) — explicitly disables the pragma, calls `upsert_saved_view` (one of the six writers that never enabled it before), asserts it's enabled afterward.
- Anti-vacuity: reverted the source change via `git stash`, keeping the new test — it fails (`0 == 1`); passes after restoring the fix.
- `devtools test` across the full assertion/annotation/security write-path suite → 146 passed.
- `devtools verify --quick` → exit 0.

Ref polylogue-41ow