### PR TITLE
fix(storage): stop upsert_recall_pack forking a named pack on content change

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -754,9 +754,16 @@ def upsert_recall_pack(
     recall_pack_id: str | None = None,
     now_ms: int | None = None,
 ) -> ArchiveRecallPackEnvelope:
-    """Insert-or-update one recall-pack assertion."""
+    """Insert-or-update one recall pack by stable name identity.
+
+    A caller-provided id remains authoritative. Without one, the id must not
+    incorporate the payload: doing so made a content change to a named pack
+    compute a different assertion_id, so ON CONFLICT never matched and each
+    update appended a new, disconnected row instead of updating the existing
+    logical pack (polylogue-2o3d).
+    """
     timestamp = now_ms if now_ms is not None else _now_ms()
-    resolved_id = recall_pack_id or _deterministic_id("recall-pack", name, _json_dumps(payload))
+    resolved_id = recall_pack_id or _deterministic_id("recall-pack", name)
     upsert_assertion(
         conn,
         assertion_id=assertion_id_for_recall_pack(resolved_id),

--- a/tests/unit/storage/test_archive_tiers_user_write.py
+++ b/tests/unit/storage/test_archive_tiers_user_write.py
@@ -243,3 +243,29 @@ def test_archive_tiers_user_write_minimal_upserts(tmp_path: Path) -> None:
     assert refreshed_note.body == "updated note"
     assert refreshed_note.target_type == "session"
     assert refreshed_note.target_id == "session-1"
+
+
+def test_upsert_recall_pack_without_explicit_id_updates_same_named_pack(tmp_path: Path) -> None:
+    """A changed payload for the same name must update, not fork, the pack.
+
+    Without a caller-supplied recall_pack_id, the id used to incorporate the
+    payload's content hash: a content change for the same name then computed
+    a different assertion_id, so the ON CONFLICT upsert in upsert_assertion
+    never matched and the update appended a second, disconnected row instead
+    of updating the existing logical pack (polylogue-2o3d).
+    """
+    conn = _connect(tmp_path / "user.db")
+
+    first = upsert_recall_pack(conn, "launch-pack", {"session_ids": ["session-1"]}, now_ms=1)
+    second = upsert_recall_pack(conn, "launch-pack", {"session_ids": ["session-1", "session-2"]}, now_ms=2)
+
+    assert second.recall_pack_id == first.recall_pack_id
+
+    pack_assertions = list_assertions_for_target(
+        conn, f"recall_pack:{first.recall_pack_id}", kind=AssertionKind.RECALL_PACK
+    )
+    assert len(pack_assertions) == 1
+    assert pack_assertions[0].value == {"session_ids": ["session-1", "session-2"]}
+
+    refreshed = read_archive_recall_pack_envelope(conn, first.recall_pack_id)
+    assert refreshed.payload == {"session_ids": ["session-1", "session-2"]}


### PR DESCRIPTION
## Summary
Fixes a latent bug in `upsert_recall_pack`'s fallback identity computation, surfaced while assessing the parked `feature/assertions/judgment-transaction` delivery branch (`polylogue-2o3d`) for portable, independent fixes.

## Problem
Without a caller-supplied `recall_pack_id`, `upsert_recall_pack` computed the assertion id from `_deterministic_id("recall-pack", name, _json_dumps(payload))` — the id incorporated the payload's content hash. A second call for the same `name` with a changed `payload` therefore computed a *different* `assertion_id`, so `upsert_assertion`'s `ON CONFLICT(assertion_id)` never matched: the update appended a new, disconnected row instead of updating the existing logical pack, leaving both the stale and current version queryable under the same name with no way to tell which is current.

Currently unreachable in production: the sole caller (`ArchiveStore.save_recall_pack`) always supplies an explicit `recall_pack_id`, which short-circuits the buggy fallback. Same latent-bug character as `polylogue-vwia` earlier in this hardening sweep — fixing it now closes the gap before any future caller relies on the documented "insert-or-update by name" contract.

## Solution
Drop the payload from the id computation (`_deterministic_id("recall-pack", name)`), matching every sibling overlay writer (`upsert_saved_view`, `upsert_workspace`) which already key by name alone.

## Verification
- New regression: `test_upsert_recall_pack_without_explicit_id_updates_same_named_pack` (`tests/unit/storage/test_archive_tiers_user_write.py`) — two upserts for the same name with different payloads and no explicit id; asserts the same `recall_pack_id`, exactly one assertion row, and the refreshed payload.
- Anti-vacuity: reverted the source fix via `git stash`, keeping the new test — it fails (two different ids/rows); passes after restoring the fix.
- `devtools test tests/unit/storage/test_archive_tiers_user_write.py tests/unit/storage/test_archive_tiers_assertion_write_through.py` → 22 passed.
- `devtools verify --quick` → exit 0.

Ref polylogue-2o3d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed recall pack updates so changing a pack’s payload no longer creates duplicate or disconnected records.
  - Repeated saves for the same named pack now consistently update the existing pack and display its latest payload.

- **Tests**
  - Added coverage verifying stable pack identification, single-record behavior, and correct retrieval of updated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->