### PR TITLE
fix(storage): stop archive debt reports locking on ArchiveStore's long-lived connection

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -4440,8 +4440,8 @@ class ArchiveStore:
             _archive_profile_rows_debt(self._conn),
             _archive_profile_counts_debt(self._conn),
             _archive_materialization_debt(self._conn),
-            _archive_source_raw_link_debt(self._conn, self.source_db_path),
-            _archive_user_overlay_debt(self._conn, self.user_db_path),
+            _archive_source_raw_link_debt(self.index_db_path, self.source_db_path),
+            _archive_user_overlay_debt(self.index_db_path, self.user_db_path),
         ]
         insights.sort(key=lambda insight: (insight.category, insight.debt_name))
         if category is not None:
@@ -11840,24 +11840,28 @@ def _archive_materialization_debt(conn: sqlite3.Connection) -> ArchiveDebtInsigh
     )
 
 
-def _archive_source_raw_link_debt(conn: sqlite3.Connection, source_db_path: Path) -> ArchiveDebtInsight:
-    raw_links = _count_scalar(conn, "SELECT COUNT(*) FROM sessions WHERE raw_id IS NOT NULL")
-    if not source_db_path.exists():
-        issue_count = raw_links
-        detail = (
-            "archive sessions have no source raw links"
-            if raw_links == 0
-            else f"source.db missing while {raw_links:,} sessions carry raw_id links"
-        )
-        return _archive_debt(
-            name="archive_source_raw_links",
-            category="source_ingest",
-            issue_count=issue_count,
-            detail=detail,
-        )
-    source_uri = f"file:{source_db_path}?mode=ro"
-    conn.execute("ATTACH DATABASE ? AS source_debt", (source_uri,))
-    try:
+def _archive_source_raw_link_debt(index_db_path: Path, source_db_path: Path) -> ArchiveDebtInsight:
+    # Cross-tier debt reads use a dedicated connection.  The long-lived
+    # ArchiveStore connection may already own a transaction; attaching and
+    # detaching on that connection can fail with "database ... is locked".
+    # Closing this short-lived connection releases the attached schema and all
+    # statement cursors as one lifetime, so no DETACH race is possible.
+    with closing(open_readonly_connection(index_db_path)) as conn:
+        raw_links = _count_scalar(conn, "SELECT COUNT(*) FROM sessions WHERE raw_id IS NOT NULL")
+        if not source_db_path.exists():
+            issue_count = raw_links
+            detail = (
+                "archive sessions have no source raw links"
+                if raw_links == 0
+                else f"source.db missing while {raw_links:,} sessions carry raw_id links"
+            )
+            return _archive_debt(
+                name="archive_source_raw_links",
+                category="source_ingest",
+                issue_count=issue_count,
+                detail=detail,
+            )
+        conn.execute("ATTACH DATABASE ? AS source_debt", (f"file:{source_db_path}?mode=ro",))
         missing = _count_scalar(
             conn,
             """
@@ -11869,8 +11873,6 @@ def _archive_source_raw_link_debt(conn: sqlite3.Connection, source_db_path: Path
               )
             """,
         )
-    finally:
-        conn.execute("DETACH DATABASE source_debt")
     detail = "archive source raw links resolve" if missing == 0 else f"{missing:,} sessions reference missing raw rows"
     return _archive_debt(
         name="archive_source_raw_links",
@@ -11880,7 +11882,7 @@ def _archive_source_raw_link_debt(conn: sqlite3.Connection, source_db_path: Path
     )
 
 
-def _archive_user_overlay_debt(conn: sqlite3.Connection, user_db_path: Path) -> ArchiveDebtInsight:
+def _archive_user_overlay_debt(index_db_path: Path, user_db_path: Path) -> ArchiveDebtInsight:
     if not user_db_path.exists():
         return _archive_debt(
             name="archive_user_overlay_orphans",
@@ -11888,8 +11890,11 @@ def _archive_user_overlay_debt(conn: sqlite3.Connection, user_db_path: Path) -> 
             issue_count=0,
             detail="archive user tier absent; no overlay orphan check needed",
         )
-    conn.execute("ATTACH DATABASE ? AS user_debt", (f"file:{user_db_path}?mode=ro",))
-    try:
+    # See _archive_source_raw_link_debt: a dedicated short-lived connection
+    # avoids ATTACH/DETACH racing the long-lived ArchiveStore connection's
+    # own transaction.
+    with closing(open_readonly_connection(index_db_path)) as conn:
+        conn.execute("ATTACH DATABASE ? AS user_debt", (f"file:{user_db_path}?mode=ro",))
         checks = (
             "SELECT COUNT(*) FROM user_debt.assertions u "
             "WHERE u.target_ref LIKE 'session:%' "
@@ -11912,8 +11917,6 @@ def _archive_user_overlay_debt(conn: sqlite3.Connection, user_db_path: Path) -> 
             "AND NOT EXISTS (SELECT 1 FROM sessions s WHERE s.session_id = substr(u.target_ref, 9))",
         )
         issue_count = sum(_count_scalar(conn, sql) for sql in checks)
-    finally:
-        conn.execute("DETACH DATABASE user_debt")
     detail = (
         "archive user overlays resolve to index sessions"
         if issue_count == 0

--- a/tests/unit/storage/test_archive_tiers_archive.py
+++ b/tests/unit/storage/test_archive_tiers_archive.py
@@ -1481,3 +1481,44 @@ def test_archive_coverage_averages_render_none_not_zero_over_empty_denominator(t
     assert day_row.avg_assistant_words is None
     assert day_row.tool_use_percentage is None
     assert day_row.thinking_percentage is None
+
+
+def test_list_archive_debt_insights_correct_while_main_connection_holds_transaction(tmp_path: Path) -> None:
+    """Cross-tier debt reads use their own connection, not the long-lived one.
+
+    _archive_source_raw_link_debt / _archive_user_overlay_debt used to
+    ATTACH/DETACH sibling tiers directly on ArchiveStore's own long-lived
+    connection. That connection may already own a transaction by the time a
+    debt report runs (e.g. a caller mid-batch); coupling the attach lifecycle
+    to it risked interference with whatever transaction state the caller
+    holds. They now open a dedicated short-lived read-only connection per
+    call, so the report is correct (and does not disturb the caller's
+    transaction) even while the main connection has one open.
+    """
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="debt-under-open-transaction",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.USER,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="debt target")],
+            )
+        ],
+    )
+    root = tmp_path / "archive"
+    with ArchiveStore(root) as facade:
+        facade.write_parsed(session)
+
+    with ArchiveStore.open_existing(root) as facade:
+        facade._conn.execute("BEGIN")
+        try:
+            insights = facade.list_archive_debt_insights()
+            by_name = {insight.debt_name: insight for insight in insights}
+            assert by_name["archive_source_raw_links"].issue_count == 0
+            assert by_name["archive_user_overlay_orphans"].issue_count == 0
+            # The debt read must not have consumed or altered the caller's
+            # own still-open transaction.
+            assert facade._conn.in_transaction
+        finally:
+            facade._conn.rollback()


### PR DESCRIPTION
## Summary
Fixes a reproducible `sqlite3.OperationalError: database source_debt is locked` crash in archive consistency/debt reporting, surfaced while assessing the parked `feature/assertions/judgment-transaction` delivery branch (`polylogue-2o3d`) for portable, independent fixes.

## Problem
`_archive_source_raw_link_debt` / `_archive_user_overlay_debt` ran `ATTACH DATABASE` / `DETACH DATABASE` directly on `ArchiveStore`'s own long-lived connection (`self._conn`). When that connection already owns an open transaction — e.g. a caller mid-batch write, or simply `BEGIN` issued for a read snapshot — the `DETACH` statement fails outright: `sqlite3.OperationalError: database source_debt is locked`. Confirmed with a direct repro: opening a transaction on `self._conn` before calling `list_archive_debt_insights()` raises immediately on current master.

## Solution
Both debt readers now open a dedicated, short-lived read-only connection (`open_readonly_connection(index_db_path)`) per call instead of reusing the caller's connection. Closing it releases the attached schema and every statement cursor as one lifetime, so there is no `DETACH` race, and the debt report no longer disturbs whatever transaction the caller holds. As a side effect the report now reads only committed state (matching what a consistency/debt report should reflect) rather than seeing the caller's own uncommitted rows via same-connection read-your-own-writes visibility.

## Verification
- New regression: `test_list_archive_debt_insights_correct_while_main_connection_holds_transaction` (`tests/unit/storage/test_archive_tiers_archive.py`) — opens a transaction on the `ArchiveStore`'s own connection, calls `list_archive_debt_insights()`, asserts correct results and that the caller's transaction is left intact.
- Anti-vacuity: reverted the source fix via `git stash`, keeping the new test — it fails with the exact predicted error (`sqlite3.OperationalError: database source_debt is locked`); passes after restoring the fix.
- `devtools test tests/unit/storage/test_archive_tiers_archive.py tests/unit/storage/test_archive_tiers_user_overlay.py tests/unit/api/test_facade_contracts.py -k "archive_debt or main_connection_holds_transaction"` → passed. One unrelated pre-existing failure in the same file (`test_exact_session_action_count_bounds_pairing_before_global_ranking`) confirmed present on unmodified master via the same stash technique.
- `devtools verify --quick` → exit 0.

Ref polylogue-2o3d