### PR TITLE
fix(hermes): resolve confirmed live-ingest bugs polylogue-1zex and polylogue-flxh

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -2110,6 +2110,20 @@ class LiveBatchProcessor:
         # mutable browser snapshots can arrive through the generic inbox.
         if path.suffix.lower() != ".jsonl":
             return None
+        if self._source_name_for(path) == "hermes":
+            # polylogue-flxh: the Hermes watch source's only .jsonl artifact
+            # class is NeMo Relay ATOF (state.db is .db, ATIF/session
+            # snapshots are .json -- see default_sources()'s own docstring).
+            # A real ATOF file is shared across every Hermes session on the
+            # install, so a growth batch can span a session boundary; the
+            # raw-revision-authority replay chain requires exactly one
+            # logical session per raw revision, and incremental append on
+            # such a batch silently and permanently drops the pre-existing
+            # session's new event (confirmed, see the regression test this
+            # commit removes the xfail from). ATOF is therefore always
+            # routed through the full/bundle ingest path below instead,
+            # which already handles multi-session grouping correctly.
+            return None
         cursor = cursor or self._cursor.get_record(path)
         if (
             cursor is None

--- a/polylogue/sources/parsers/hermes_spans.py
+++ b/polylogue/sources/parsers/hermes_spans.py
@@ -66,22 +66,25 @@ decision (topology_edges / session_links) that is explicitly deferred, not
 silently assumed. Read-side correlation by the shared Hermes session id
 remains possible today via ``hermes_observer_session_id_for``.
 
-KNOWN LIVE INGESTION BUG (polylogue-flxh, confirmed 2026-07-18, not yet
-fixed): the real ATOF producer writes ONE shared ``events.jsonl`` file across
-every Hermes session on an install (live-verified: 3+ distinct session ids
-interleaved in one file), but the live-ingest raw-revision-authority replay
-chain (``polylogue/sources/live/batch.py``) and append path
-(``polylogue/sources/live/append_ingest.py``) both require exactly one
-logical session per raw revision. When a file-growth batch spans a Hermes
-session boundary (a new event for an already-tracked session lands alongside
-a brand-new session's first event), the new event for the ALREADY-TRACKED
-session is silently and permanently lost while the brand-new session is
-still created -- empirically proven by
-``tests/unit/sources/test_live_watcher.py::test_live_append_atof_shared_file_multi_session_boundary_loses_events``
-(``xfail(strict=True)`` pending the fix). This affects only the LIVE watcher
-ingestion path, not ``parse_atof_stream`` itself (which is correct and
-idempotent when given the full file, per this module's own tests) or the
-manual/CLI import path.
+LIVE INGESTION FIX (polylogue-flxh, confirmed 2026-07-18, fixed same day):
+the real ATOF producer writes ONE shared ``events.jsonl`` file across every
+Hermes session on an install (live-verified: 3+ distinct session ids
+interleaved in one file), unlike Claude Code/Codex where one JSONL file is
+always exactly one session. A growth batch can therefore span a Hermes
+session boundary. Two changes: (1) the live watcher (``live/batch.py``)
+never attempts incremental append for the Hermes ATOF source class, always
+routing it through the full/bundle ingest path, which already handles
+multi-session grouping correctly (Fable-adjudicated Direction 3); (2) the
+real root cause -- the ATOF/ATIF summary message text below used to embed
+live event/step counts, which changed on every reparse and broke the
+archive's membership-classifier invariant that message content must be an
+unchanging prefix across revisions to safely recognize append-only growth,
+causing a genuinely-monotonic growth batch to look non-monotonic and get
+silently rejected in favor of the stale revision. The summary text is now
+session-id-only and permanently stable; counts remain fully queryable from
+session_events / ``import_fidelity_declaration``. Regression proof:
+``tests/unit/sources/test_live_watcher.py::test_live_append_atof_shared_file_multi_session_boundary_retains_all_events``
+(also proves idempotent replay of a growth batch).
 """
 
 from __future__ import annotations
@@ -413,27 +416,16 @@ def _atof_event(record: JSONDocument) -> list[ParsedSessionEvent] | None:
 
 
 def _atof_session(session_id: str, events: list[ParsedSessionEvent], skipped: int) -> ParsedSession:
-    counts = {
-        event_type: sum(event.event_type == event_type for event in events)
-        for event_type in (
-            "hermes_llm_request_span",
-            "hermes_tool_execution_span",
-            "hermes_subagent_span",
-            "hermes_decision_span",
-            "hermes_error_span",
-            "hermes_context_span",
-            "hermes_observer_span",
-            "hermes_atof_unpaired_scope",
-        )
-    }
-    summary_text = (
-        f"Hermes ATOF observer stream: {len(events)} event(s) "
-        f"({counts['hermes_llm_request_span']} LLM, {counts['hermes_tool_execution_span']} tool, "
-        f"{counts['hermes_decision_span']} decision, {counts['hermes_subagent_span']} subagent, "
-        f"{counts['hermes_error_span']} error, {counts['hermes_context_span']} context, "
-        f"{counts['hermes_observer_span']} unrecognized, {counts['hermes_atof_unpaired_scope']} unpaired; "
-        f"{skipped} unparseable)."
-    )
+    del skipped  # counts live in session_events/import_fidelity_declaration, never in message text
+    # Deliberately stable across every replay/revision of this session (never
+    # embeds live event counts): the archive's membership classifier
+    # (session_revision_membership.classify_membership_revisions) requires
+    # message content to be an unchanging prefix across revisions to safely
+    # recognize append-only growth. A count-bearing summary that gets
+    # rewritten on every reparse breaks that invariant and makes new events
+    # for an already-observed session look like a non-monotonic edit,
+    # silently discarding them.
+    summary_text = f"Hermes ATOF observer stream: {session_id}"
     provider_session_id = observer_session_provider_id(session_id)
     return ParsedSession(
         source_name=Provider.HERMES,
@@ -510,17 +502,13 @@ def parse_atif_document(payload: JSONDocument, fallback_id: str) -> ParsedSessio
             continue
         events.append(_subagent_span_event(subagent, index))
 
-    llm_events = sum(1 for e in events if e.event_type == "hermes_llm_request_span")
-    tool_events = sum(1 for e in events if e.event_type == "hermes_tool_execution_span")
-    subagent_events = sum(1 for e in events if e.event_type == "hermes_subagent_span")
-    generic_events = sum(1 for e in events if e.event_type == "hermes_observer_span")
-
-    summary_text = (
-        f"Hermes ATIF trajectory: {len(raw_steps)} step(s) "
-        f"({tool_events} tool call span(s), {llm_events} message span(s), "
-        f"{subagent_events} subagent trajectory(ies), {generic_events} unrecognized, "
-        f"{skipped} unparseable)."
-    )
+    # Deliberately stable across every replay/revision of this session (never
+    # embeds live step/event counts): see _atof_session's identical note --
+    # the archive's membership classifier requires message content to be an
+    # unchanging prefix across revisions to safely recognize append-only
+    # growth. Counts remain fully queryable from session_events /
+    # import_fidelity_declaration.
+    summary_text = f"Hermes ATIF trajectory: {session_id}"
     provider_session_id = observer_session_provider_id(session_id)
     return ParsedSession(
         source_name=Provider.HERMES,

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -7,7 +7,8 @@ import os
 import pickle
 import sqlite3
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
@@ -25,7 +26,9 @@ from polylogue.core.enums import Provider
 from polylogue.pipeline.ids import session_revision_projection
 from polylogue.sources.decoders import _iter_json_stream
 from polylogue.sources.dispatch import is_stream_record_provider, parse_payload, parse_stream_payload
+from polylogue.sources.parsers import hermes_state, hermes_verification
 from polylogue.sources.parsers.base import ParsedSession
+from polylogue.sources.sqlite_snapshot import looks_like_sqlite_bytes
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
 
@@ -497,12 +500,19 @@ def parse_retained_raw_sessions(archive: ArchiveStore, raw_id: str) -> list[Pars
     seemingly harmless live replay helper from reintroducing ``read_all()``
     for Codex/Claude JSONL evidence.
     """
-    provider, _blob_hash, source_path, _kind, _payload_size = archive.raw_revision_descriptor(raw_id)
+    provider, blob_hash, source_path, _kind, _payload_size = archive.raw_revision_descriptor(raw_id)
     if is_stream_record_provider(source_path, str(provider)):
         with archive.open_raw_revision_material(raw_id) as (stream_provider, payload, stream_path, _stream_kind):
             return _parse_stream(stream_provider, payload, stream_path)
     _provider, eager_payload, _source_path, _eager_kind = archive.raw_revision_material(raw_id)
-    return _parse_one(provider, eager_payload, source_path)
+    payload_path = archive.blob_path_for_hash(blob_hash) if provider is Provider.HERMES else None
+    return _parse_one(
+        provider,
+        eager_payload,
+        source_path,
+        payload_path=payload_path,
+        archive_root=archive.archive_root,
+    )
 
 
 class _ParsedSessionSpill:
@@ -579,7 +589,14 @@ class _ParsedSessionSpill:
         return sessions, payload_bytes
 
 
-def _parse_one(provider: Provider, payload: bytes, source_path: str) -> list[ParsedSession]:
+def _parse_one(
+    provider: Provider,
+    payload: bytes,
+    source_path: str,
+    *,
+    payload_path: Path | None = None,
+    archive_root: Path | None = None,
+) -> list[ParsedSession]:
     source_name = Path(source_path).name
     fallback_id = Path(source_path).stem
     if is_stream_record_provider(source_path, str(provider)):
@@ -589,12 +606,48 @@ def _parse_one(provider: Provider, payload: bytes, source_path: str) -> list[Par
             fallback_id,
             source_path=source_path,
         )
+    if provider is Provider.HERMES and looks_like_sqlite_bytes(payload):
+        with _sqlite_payload_path(payload, payload_path, archive_root) as sqlite_path:
+            if hermes_state.looks_like_state_db_path(sqlite_path):
+                return hermes_state.parse_state_db(
+                    sqlite_path,
+                    fallback_id=fallback_id,
+                    profile_root=Path(source_path).parent,
+                )
+            if hermes_verification.looks_like_verification_evidence_db_path(sqlite_path):
+                return hermes_verification.parse_verification_evidence_db(sqlite_path, fallback_id=fallback_id)
     return parse_payload(
         provider,
         list(_iter_json_stream(BytesIO(payload), source_name)),
         fallback_id,
         source_path=source_path,
     )
+
+
+@contextmanager
+def _sqlite_payload_path(
+    payload: bytes,
+    payload_path: Path | None,
+    archive_root: Path | None,
+) -> Iterator[Path]:
+    """Yield a real filesystem path for SQLite-shaped raw revision bytes.
+
+    ``sqlite3.connect`` cannot open in-memory bytes. Prefer the already-
+    materialized blob path (no copy); only spill to a bounded temp file when
+    no real path is available (e.g. the blob is not yet flushed to disk).
+    """
+    if payload_path is not None:
+        yield payload_path
+        return
+    scratch_dir = archive_root if archive_root is not None else Path(tempfile.gettempdir())
+    fd, name = tempfile.mkstemp(prefix=".revision-sqlite-spill-", suffix=".sqlite", dir=scratch_dir)
+    os.close(fd)
+    temp_path = Path(name)
+    try:
+        temp_path.write_bytes(payload)
+        yield temp_path
+    finally:
+        temp_path.unlink(missing_ok=True)
 
 
 def _parse_stream(provider: Provider, payload: BinaryIO, source_path: str) -> list[ParsedSession]:

--- a/polylogue/sources/sqlite_snapshot.py
+++ b/polylogue/sources/sqlite_snapshot.py
@@ -18,6 +18,7 @@ _SQLITE_SIDECAR_SUFFIXES = ("-wal", "-shm")
 _STAGING_METADATA_SUFFIX = ".polylogue-import"
 _STAGING_METADATA_VERSION = 1
 _HERMES_RAW_ID_DOMAIN = b"polylogue:hermes-profile-raw:v1\0"
+_SQLITE_MAGIC_HEADER = b"SQLite format 3\x00"
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,6 +51,18 @@ def hermes_profile_raw_id(source_path: Path | str, source_index: int, blob_hash:
 
 def is_sqlite_path(path: Path) -> bool:
     return path.suffix.lower() in _SQLITE_SUFFIXES
+
+
+def looks_like_sqlite_bytes(payload: bytes) -> bool:
+    """Return whether *payload* starts with the SQLite file-format magic header.
+
+    Path-suffix detection (``is_sqlite_path``) is useless once bytes have
+    already been read into memory as a raw revision (e.g. replay/backfill
+    call sites, which only have ``payload: bytes`` -- see
+    ``revision_backfill.py``). This is the single shared byte-level sniffer
+    for that case; do not duplicate it.
+    """
+    return payload.startswith(_SQLITE_MAGIC_HEADER)
 
 
 def sqlite_database_for_sidecar(path: Path) -> Path | None:

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2258,6 +2258,19 @@ class ArchiveStore:
         assert self._blob_publisher is not None
         return provider, self._blob_publisher.read_all(blob_hash), source_path, kind
 
+    def blob_path_for_hash(self, blob_hash: str) -> Path | None:
+        """Return the real on-disk path for a content-addressed blob, if materialized.
+
+        Some payload shapes (Hermes state.db/verification_evidence.db) need a
+        real filesystem path -- ``sqlite3.connect`` cannot open in-memory
+        bytes. Returns ``None`` when the blob is not (yet) materialized on
+        disk so callers fall back to a bounded temp-file spill instead of
+        trusting an unverified path.
+        """
+        assert self._blob_publisher is not None
+        path = self._blob_publisher.blob_path(blob_hash)
+        return path if path.exists() else None
+
     def _raw_revision_payload_digest_and_size(self, raw_id: str) -> tuple[str, int]:
         digest = hashlib.sha256()
         size = 0

--- a/tests/unit/sources/parsers/test_hermes_spans.py
+++ b/tests/unit/sources/parsers/test_hermes_spans.py
@@ -433,9 +433,13 @@ def test_malformed_steps_and_tool_calls_are_skipped_and_counted_not_crashing() -
     # event instead of being counted as unparseable).
     generic_events = [event for event in session.session_events if event.event_type == "hermes_observer_span"]
     assert generic_events == []
+    # The summary message text is deliberately stable across replays (see
+    # _atof_session/parse_atif_document's own note) and never embeds a live
+    # skip count -- real_events == [] and generic_events == [] above already
+    # prove the 3 malformed steps were skipped-and-counted, not silently
+    # coerced into a fabricated event.
     summary_message = session.messages[0]
-    assert summary_message.text is not None
-    assert "3 unparseable" in summary_message.text
+    assert summary_message.text == "Hermes ATIF trajectory: hermes-session-1"
 
 
 def test_decision_points_and_error_taxonomy_are_honestly_absent_not_fabricated() -> None:

--- a/tests/unit/sources/test_hermes_source_freshness_integration.py
+++ b/tests/unit/sources/test_hermes_source_freshness_integration.py
@@ -1,6 +1,6 @@
 """Real end-to-end proof of Hermes source coverage through the existing
-named-source freshness surface (polylogue-1xc.13), plus a confirmed live-
-ingestion bug discovered while proving it.
+named-source freshness surface (polylogue-1xc.13), plus a regression test for
+a confirmed live-ingestion bug (polylogue-1zex) found and fixed here.
 
 fs1.15 ("Expose Hermes-to-Polylogue integration liveness and coverage") asks
 for coverage/freshness reporting to "flow through the EXISTING named-source
@@ -15,14 +15,18 @@ fs1.15's ask without new code.
 
 Driving state.db through the real live watcher (not the marker-payload/CLI
 route the rest of this repo's Hermes tests use) surfaced a second confirmed
-bug, distinct from polylogue-flxh: ``revision_backfill.py``'s ``_parse_one``
-(used by the live watcher's single-session raw-revision-chain replay branch,
-and shared with historical repair) has zero SQLite awareness -- unlike the
-two OTHER call sites in ``live/batch.py`` that correctly special-case Hermes
-SQLite sources before falling back to JSON parsing. A state.db (or
-verification_evidence.db) with exactly one session at ingest time hits this
-branch and crashes; two or more sessions route through the working
-membership-census branch instead.
+bug (polylogue-1zex), distinct from polylogue-flxh: ``revision_backfill.py``'s
+``_parse_one`` (used by the live watcher's single-session raw-revision-chain
+replay branch, and shared with historical repair) had zero SQLite awareness
+-- unlike the two OTHER call sites in ``live/batch.py`` that correctly
+special-case Hermes SQLite sources before falling back to JSON parsing. A
+state.db (or verification_evidence.db) with exactly one session at ingest
+time hit this branch and crashed; two or more sessions routed through the
+working membership-census branch instead. Fixed (2026-07-18, Fable-adjudicated
+hybrid): SQLite magic-byte detection in ``_parse_one``
+(``sqlite_snapshot.looks_like_sqlite_bytes``) plus the real on-disk blob path
+threaded through via ``ArchiveStore.blob_path_for_hash`` (falling back to a
+bounded temp-file spill only when no real path is materialized).
 """
 
 from __future__ import annotations
@@ -66,6 +70,33 @@ CREATE TABLE messages (
 );
 """
 
+_VERIFICATION_DB_SCHEMA = """
+CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE verification_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at TEXT NOT NULL,
+    session_id TEXT NOT NULL,
+    cwd TEXT NOT NULL,
+    root TEXT NOT NULL,
+    command TEXT NOT NULL,
+    canonical_command TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    scope TEXT NOT NULL,
+    status TEXT NOT NULL,
+    exit_code INTEGER NOT NULL,
+    output_summary TEXT NOT NULL
+);
+CREATE TABLE verification_state (
+    session_id TEXT NOT NULL,
+    root TEXT NOT NULL,
+    last_event_id INTEGER,
+    last_edit_at TEXT,
+    changed_paths_json TEXT NOT NULL DEFAULT '[]',
+    PRIMARY KEY (session_id, root)
+);
+INSERT INTO meta(key, value) VALUES ('schema_version', '1');
+"""
+
 
 def _make_processor(
     workspace_env: dict[str, Path], root_name: str, db_name: str
@@ -84,31 +115,15 @@ def _make_processor(
     return archive, processor, root
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Confirmed live-ingestion bug polylogue-1zex (distinct from polylogue-flxh): "
-        "revision_backfill.py's _parse_one (used by live/batch.py's single-"
-        "session raw-revision-chain replay branch at _parse_raw_revision_chain, "
-        "shared with historical repair) has zero SQLite awareness -- unlike "
-        "the two other Hermes call sites in live/batch.py that correctly check "
-        "hermes_state.looks_like_state_db_path / "
-        "hermes_verification.looks_like_verification_evidence_db_path before "
-        "falling back to JSON parsing. A state.db (or verification_evidence.db) "
-        "with exactly one session at ingest time -- a brand new Hermes install, "
-        "or any minimal/test fixture -- takes this branch and crashes with "
-        "UnicodeDecodeError trying to json-parse raw SQLite bytes. Two or more "
-        "sessions route through the working membership-census branch instead "
-        "(see test_hermes_state_db_multi_session_source_reaches_indexed_"
-        "through_named_freshness below), which is presumably why this was not "
-        "caught by prior review -- real installs almost always have many "
-        "sessions. Remove this xfail once fixed."
-    ),
-    strict=True,
-)
 @pytest.mark.asyncio
-async def test_hermes_state_db_single_session_full_ingest_crashes(
+async def test_hermes_state_db_single_session_full_ingest_reaches_indexed_through_named_freshness(
     workspace_env: dict[str, Path],
 ) -> None:
+    """Regression test for polylogue-1zex: a state.db with exactly ONE
+    session used to crash the live watcher's full-ingest path with
+    UnicodeDecodeError (_parse_one had no SQLite awareness). This is the
+    real-world common case for a brand-new Hermes install."""
+
     archive, processor, root = _make_processor(workspace_env, "hermes-home-single", "hermes-state-single.db")
     source_path = root / "state.db"
     try:
@@ -125,6 +140,44 @@ async def test_hermes_state_db_single_session_full_ingest_crashes(
         metrics = await processor.ingest_files([source_path], emit_event=False)
         assert metrics.failed_file_count == 0
         assert metrics.ingested_session_count == 1
+
+        freshness = project_named_source_freshness(workspace_env["archive_root"], source_path)
+        assert freshness.stage in {NamedSourceStage.INDEXED_UNCONVERGED, NamedSourceStage.SEARCHABLE}
+        assert freshness.accepted_raw_revision is not None
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
+async def test_hermes_verification_evidence_db_single_session_full_ingest_reaches_indexed(
+    workspace_env: dict[str, Path],
+) -> None:
+    """Sibling regression for polylogue-1zex's other affected source:
+    verification_evidence.db with exactly one session hit the same
+    SQLite-unaware _parse_one branch."""
+
+    archive, processor, root = _make_processor(
+        workspace_env, "hermes-home-verification-single", "hermes-verification-single.db"
+    )
+    source_path = root / "verification_evidence.db"
+    try:
+        with sqlite3.connect(source_path) as conn:
+            conn.executescript(_VERIFICATION_DB_SCHEMA)
+            conn.execute(
+                "INSERT INTO verification_events "
+                "(created_at, session_id, cwd, root, command, canonical_command, kind, scope, status, "
+                "exit_code, output_summary) VALUES "
+                "('2026-07-18T00:00:00Z', 'verify-session-1', '/repo', '/repo', 'pytest', 'pytest', "
+                "'test', 'targeted', 'passed', 0, 'ok')"
+            )
+
+        metrics = await processor.ingest_files([source_path], emit_event=False)
+        assert metrics.failed_file_count == 0
+        assert metrics.ingested_session_count == 1
+
+        freshness = project_named_source_freshness(workspace_env["archive_root"], source_path)
+        assert freshness.stage in {NamedSourceStage.INDEXED_UNCONVERGED, NamedSourceStage.SEARCHABLE}
+        assert freshness.accepted_raw_revision is not None
     finally:
         await archive.close()
 

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1516,40 +1516,58 @@ def _atof_record(*, session_id: str, uuid: str, timestamp: str, name: str = "her
     }
 
 
-@pytest.mark.xfail(
-    reason=(
-        "Confirmed data-loss bug, Ref polylogue-flxh: real ~/.hermes/observability/"
-        "nemo-relay/atof/events.jsonl is ONE file shared across every Hermes "
-        "session on the install (live evidence: 3+ distinct hermes session ids "
-        "interleaved in one file), unlike Claude Code/Codex where one JSONL file "
-        "is always exactly one session. The raw-revision-authority replay chain "
-        "(_parse_raw_revision_chain: 'raw revision did not replay to exactly one "
-        "session') and the append-ingest path (append_ingest.py: 'append payload "
-        "did not prove one session and cursor identity') both assume exactly one "
-        "logical session per raw revision. When a growth batch for an "
-        "already-tracked ATOF file contains events for a session that already "
-        "has prior accepted raw revisions (session A) AND a brand-new session "
-        "(session B), the reconciliation raises and the whole path/full-ingest "
-        "attempt is marked failed -- but session B's insert had already been "
-        "committed while session A's new event was not, so the overall failure "
-        "silently masks a real, permanent loss of session A's new evidence "
-        "(not a retry-safe deferral: the same bytes fail identically on retry, "
-        "and 5 consecutive failures quarantine the whole file). Remove this "
-        "xfail once fixed."
-    ),
-    strict=True,
-)
+def _atof_event_uuids_by_session(archive_root: Path) -> dict[str, list[str]]:
+    index_db = archive_root / "index.db"
+    with sqlite3.connect(index_db) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """
+            SELECT s.native_id, se.payload_json
+            FROM session_events se
+            JOIN sessions s ON s.session_id = se.session_id
+            WHERE se.event_type = 'hermes_context_span'
+            ORDER BY s.native_id, se.position
+            """
+        ).fetchall()
+    event_uuids_by_session: dict[str, list[str]] = {}
+    for row in rows:
+        payload = json.loads(row["payload_json"])
+        event_uuids_by_session.setdefault(row["native_id"], []).append(payload["event_uuid"])
+    return event_uuids_by_session
+
+
 @pytest.mark.asyncio
-async def test_live_append_atof_shared_file_multi_session_boundary_loses_events(
+async def test_live_append_atof_shared_file_multi_session_boundary_retains_all_events(
     workspace_env: dict[str, Path],
 ) -> None:
-    """Empirically drive an append batch whose bytes span two distinct hermes
-    session ids -- the real shared-ATOF-file shape -- and prove session A's new
-    event (a-turn-2) is NOT silently lost while session B (b-turn-1) is created.
+    """Regression test for polylogue-flxh: real ~/.hermes/observability/
+    nemo-relay/atof/events.jsonl is ONE file shared across every Hermes
+    session on the install (live evidence: 3+ distinct hermes session ids
+    interleaved in one file), unlike Claude Code/Codex where one JSONL file
+    is always exactly one session.
 
-    This must FAIL today (xfail, strict): direct sqlite inspection after the
-    growth batch shows session A still has only its original a-turn-1 event
-    while session B is fully present with b-turn-1 -- a-turn-2 never lands.
+    Drives a growth batch whose bytes span two distinct hermes session ids
+    -- the real shared-file shape -- and proves session A's new event
+    (a-turn-2) is NOT lost while session B (b-turn-1) is created alongside
+    it. Also proves idempotent replay: re-ingesting the identical growth
+    batch a second time must not duplicate or otherwise change the stored
+    state (the producer's own UUID+scope-phase dedup, unaffected by this
+    fix, must still hold end-to-end).
+
+    Root cause (found empirically, corrected the original polylogue-flxh
+    diagnosis which assumed the bug was in the incremental-append path):
+    the ATOF summary message's text used to embed live event counts, which
+    changed on every reparse. The archive's membership classifier
+    (session_revision_membership.classify_membership_revisions) requires
+    message content to be an unchanging prefix across revisions to safely
+    recognize append-only growth -- a count-bearing summary broke that
+    invariant, so a genuinely-monotonic growth batch looked like a
+    non-monotonic edit and the classifier conservatively kept the stale
+    revision. Fixed by making the summary message text session-id-only
+    (stable forever); ATOF is also now origin-scoped away from the
+    incremental-append path entirely (Fable-adjudicated Direction 3),
+    since a real ATOF file can span a session boundary in a growth delta
+    in a way Claude Code/Codex/Beads JSONL files structurally cannot.
     """
     root = workspace_env["data_root"] / "hermes-observability"
     root.mkdir(parents=True)
@@ -1582,25 +1600,16 @@ async def test_live_append_atof_shared_file_multi_session_boundary_loses_events(
                 handle.write(json.dumps(record) + "\n")
         await processor.ingest_files([source_path], emit_event=False)
 
-        index_db = workspace_env["archive_root"] / "index.db"
-        with sqlite3.connect(index_db) as conn:
-            conn.row_factory = sqlite3.Row
-            rows = conn.execute(
-                """
-                SELECT s.native_id, se.payload_json
-                FROM session_events se
-                JOIN sessions s ON s.session_id = se.session_id
-                WHERE se.event_type = 'hermes_context_span'
-                ORDER BY s.native_id, se.position
-                """
-            ).fetchall()
-        event_uuids_by_session: dict[str, list[str]] = {}
-        for row in rows:
-            payload = json.loads(row["payload_json"])
-            event_uuids_by_session.setdefault(row["native_id"], []).append(payload["event_uuid"])
-
+        event_uuids_by_session = _atof_event_uuids_by_session(workspace_env["archive_root"])
         assert event_uuids_by_session.get("observer:atof-session-a") == ["a-turn-1", "a-turn-2"]
         assert event_uuids_by_session.get("observer:atof-session-b") == ["b-turn-1"]
+
+        # Idempotent replay: re-ingesting the SAME growth batch bytes again
+        # (e.g. a poll cycle firing before the cursor advanced, or a daemon
+        # restart replaying its tail) must not duplicate or lose anything.
+        await processor.ingest_files([source_path], emit_event=False)
+        replayed = _atof_event_uuids_by_session(workspace_env["archive_root"])
+        assert replayed == event_uuids_by_session
     finally:
         await archive.close()
 

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -70,6 +70,73 @@ def test_revision_reparse_preserves_beads_workspace_identity(tmp_path: Path) -> 
     assert sessions[0].working_directories == [str(source_path.parent.parent.resolve())]
 
 
+def _single_session_state_db_bytes(tmp_path: Path) -> bytes:
+    db_path = tmp_path / "state-source.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE schema_version(version INTEGER NOT NULL);
+            INSERT INTO schema_version(version) VALUES (19);
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, source TEXT, model_config TEXT, parent_session_id TEXT,
+                started_at REAL, ended_at REAL, end_reason TEXT, title TEXT
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY, session_id TEXT NOT NULL, role TEXT NOT NULL, content TEXT,
+                timestamp REAL NOT NULL, tool_calls TEXT, observed INTEGER DEFAULT 0,
+                active INTEGER DEFAULT 1, compacted INTEGER DEFAULT 0
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions (id, source, model_config, started_at, ended_at, end_reason, title) "
+            "VALUES ('root', 'cli', '{}', 1.0, 8.0, 'completed', 'root')"
+        )
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (1, 'root', 'user', 'hi', 2.0)"
+        )
+    return db_path.read_bytes()
+
+
+def test_parse_one_replays_single_session_state_db_bytes_via_temp_spill(tmp_path: Path) -> None:
+    """Regression for polylogue-1zex: _parse_one previously had no SQLite
+    awareness and crashed with UnicodeDecodeError trying to json-parse raw
+    SQLite bytes for a single-session state.db. Calling _parse_one directly
+    with no payload_path exercises the bounded temp-file spill fallback (the
+    real on-disk blob path is proven separately by the live-watcher and
+    historical-backfill end-to-end tests, which always have one)."""
+
+    payload = _single_session_state_db_bytes(tmp_path)
+
+    sessions = _parse_one(Provider.HERMES, payload, str(tmp_path / "hermes-home" / "state.db"))
+
+    assert len(sessions) == 1
+    assert sessions[0].messages
+    assert sessions[0].messages[0].text == "hi"
+
+
+def test_historical_backfill_replays_single_session_state_db(tmp_path: Path) -> None:
+    """End-to-end proof that the historical-repair entry point (which always
+    has a real on-disk blob path, unlike the direct-bytes test above) also
+    replays a single-session state.db raw revision correctly."""
+
+    initialize_active_archive_root(tmp_path)
+    payload = _single_session_state_db_bytes(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.HERMES,
+            payload=payload,
+            source_path=str(tmp_path / "hermes-home" / "state.db"),
+            acquired_at_ms=1,
+        )
+
+    result = backfill_historical_revision_evidence(tmp_path)
+
+    assert result.scanned == 1
+    assert result.replayed_logical_sources == 1
+    assert result.quarantined == 0
+
+
 def test_historical_backfill_streams_codex_raw_without_eager_blob_read(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
Fixes both confirmed, previously-open Hermes live-ingestion data-loss/crash bugs (polylogue-1zex, polylogue-flxh) per operator-delegated design decisions recorded in the beads. Continuation of the maximalist Hermes fidelity program (Ref polylogue-fs1.2.1, polylogue-wj25, polylogue-fs1.15).

## Problem
Two confirmed bugs from the prior investigation pass (PR #3103) remained open, pending design decisions the coordinator adjudicated this session:

1. **polylogue-1zex**: a Hermes `state.db`/`verification_evidence.db` with exactly one session at ingest time crashed the live watcher's full-ingest path (`UnicodeDecodeError` trying to json-parse raw SQLite bytes) — `revision_backfill.py`'s `_parse_one` (shared with historical repair) had no SQLite awareness, unlike two sibling call sites.
2. **polylogue-flxh**: real ATOF `events.jsonl` is one file shared across every Hermes session on an install. A growth batch spanning a session boundary silently and permanently lost the pre-existing session's new events.

## Solution

**1zex** (Fable-adjudicated hybrid): SQLite magic-byte detection in `_parse_one` (`sqlite_snapshot.looks_like_sqlite_bytes`, one shared sniffer) + threading the real on-disk blob path through (`ArchiveStore.blob_path_for_hash`) to the existing `hermes_state`/`hermes_verification` parsers, falling back to a bounded temp-file spill only when no real path is materialized. Both entry points (live full-ingest and historical repair) get direct regression coverage.

**flxh** (Fable-adjudicated Direction 3, plus a root-cause correction found empirically): implementing Direction 3 alone (origin-scoped routing — ATOF never takes the incremental-append path, always full/bundle ingest) did **not** fix the regression test, because the append path was never actually involved in the repro. Deeper investigation (direct tracing of the archive's membership-reconciliation internals) found the real cause: the ATOF/ATIF summary message text embedded live event/step counts that changed on every reparse, breaking the membership classifier's requirement that message content be an unchanging prefix across revisions to safely recognize append-only growth — a genuinely-monotonic growth batch looked non-monotonic and got silently rejected. Fixed by making the summary text permanently stable (session-id only; counts remain fully queryable from `session_events`/`import_fidelity_declaration`). Direction 3's append-routing change is kept as real defense-in-depth (matches the adjudicated rationale, zero risk to other origins), documented as not the load-bearing fix. Filed `polylogue-5rp1` as the recorded Direction-1 successor (per-session raw-revision splitting) for when ATOF files exceed the ~128MB/5s threshold named in the design decision.

## Verification
- `devtools test tests/unit/sources/test_revision_backfill.py` — 14/14.
- `devtools test tests/unit/sources/test_hermes_source_freshness_integration.py` — 4/4 (no xfail).
- `devtools test tests/unit/sources/parsers/test_hermes_spans.py` — 19/19.
- `devtools test tests/unit/sources/test_live_watcher.py` — 86/86 (no xfail — both prior xfails now pass for real, including a new idempotent-replay assertion for the flxh fix).
- `devtools test tests/unit/sources` (full sweep) — 1774/1776 (2 known pre-existing, unrelated ChatGPT failures verified against baseline).
- `devtools verify --quick` green after every commit.

Both beads (`polylogue-flxh`, `polylogue-1zex`) updated with implementation notes; `polylogue-5rp1` filed as the flxh Direction-1 successor.
