### PR TITLE
fix(storage): name the differing fields when a raw revision rebind refuses

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/source_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/source_write.py
@@ -678,13 +678,32 @@ def bind_source_raw_revision(conn: sqlite3.Connection, raw_id: str, revision: Ra
                 """,
                 (raw_id,),
             ).fetchone()
-            if existing is not None:
-                existing_values = tuple(existing)
-                if existing_values == _revision_values(revision) or _is_compatible_classification_refinement(
-                    existing_values, revision
-                ):
-                    return
-            raise ValueError(f"raw revision is already authoritative or missing: {raw_id}")
+            if existing is None:
+                raise ValueError(f"raw revision bind found no raw row: {raw_id}")
+            existing_values = tuple(existing)
+            if existing_values == _revision_values(revision) or _is_compatible_classification_refinement(
+                existing_values, revision
+            ):
+                return
+            field_names = (
+                "logical_source_key",
+                "revision_kind",
+                "source_revision",
+                "predecessor_source_revision",
+                "predecessor_raw_id",
+                "baseline_raw_id",
+                "append_start_offset",
+                "append_end_offset",
+                "acquisition_generation",
+                "revision_authority",
+            )
+            proposed_values = _revision_values(revision)
+            differing = ", ".join(
+                f"{name}: stored={stored!r} proposed={proposed!r}"
+                for name, stored, proposed in zip(field_names, existing_values, proposed_values, strict=True)
+                if stored != proposed
+            )
+            raise ValueError(f"raw revision is already authoritative and differs for {raw_id}: {differing}")
 
 
 def read_archive_raw_session_envelope(conn: sqlite3.Connection, raw_id: str) -> ArchiveRawSessionEnvelope:

--- a/tests/unit/storage/test_raw_revision_authority.py
+++ b/tests/unit/storage/test_raw_revision_authority.py
@@ -240,19 +240,19 @@ def test_revision_binding_is_idempotent_only_for_the_exact_envelope() -> None:
     bind_source_raw_revision(conn, raw_id, first)
 
     bind_source_raw_revision(conn, raw_id, first)
-    with pytest.raises(ValueError, match="already authoritative"):
+    with pytest.raises(ValueError, match="acquisition_generation: stored=0 proposed=99"):
         bind_source_raw_revision(
             conn,
             raw_id,
             RawRevisionEnvelope("codex:session-1", RawRevisionKind.FULL, "revision-1", 99),
         )
-    with pytest.raises(ValueError, match="already authoritative"):
+    with pytest.raises(ValueError, match="source_revision: stored='revision-1' proposed='different'"):
         bind_source_raw_revision(
             conn,
             raw_id,
             RawRevisionEnvelope("codex:session-1", RawRevisionKind.FULL, "different", 1),
         )
-    with pytest.raises(ValueError, match="already authoritative or missing"):
+    with pytest.raises(ValueError, match="found no raw row"):
         bind_source_raw_revision(conn, "missing", first)
 
 


### PR DESCRIPTION
## Summary

Instrumentation for the polylogue-emx2 investigation: the mass adoption refusals during the 2026-07-18 index restore are opaque — reconstructing the proposed envelope from the ingest code and comparing against the stored row yields *equal* tuples after the fact, so whatever field actually differs at runtime cannot be recovered from the one-line error. This makes the refusal self-explaining.

## Problem

`bind_source_raw_revision` raises `raw revision is already authoritative or missing: <raw_id>` for both the missing-row case and the conflicting-values case, without saying which values conflict. Live during the restore: 21–50 of 50 files per catch-up chunk refuse re-adoption with this error while the stored rows (`kind='full'`, `authority='quarantined'`, `source_revision=raw_id`, generation 0) match a faithful reconstruction of the proposed envelope exactly — the actual runtime difference is invisible.

## Solution

- Missing row → `raw revision bind found no raw row: <raw_id>`.
- Value conflict → `raw revision is already authoritative and differs for <raw_id>: <field>: stored=… proposed=…` for every differing field.

No semantic change: the accept/refuse decision logic is untouched.

## Verification

`devtools test tests/unit/storage/test_raw_revision_authority.py` — 21 passed; the rebind-refusal tests now pin the specific field diffs (`acquisition_generation: stored=0 proposed=99`, `source_revision: stored='revision-1' proposed='different'`) and the missing-row message. `mypy` clean; quick gate green on push.

Ref polylogue-emx2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ