### PR TITLE
test(pipeline): prove consume_blob_publication_receipt is idempotent

### DIFF
--- a/tests/unit/pipeline/test_acquisition_blob_gc_age_gate.py
+++ b/tests/unit/pipeline/test_acquisition_blob_gc_age_gate.py
@@ -21,6 +21,7 @@ from polylogue.storage.blob_publication import (
     ArchiveBlobPublisher,
     BlobPublicationReceipt,
     BlobPublicationReservationStore,
+    consume_blob_publication_receipt,
     exclude_archive_blob_publishers,
     reconcile_blob_publication_reservations,
 )
@@ -96,6 +97,58 @@ async def test_slow_following_source_cannot_age_uncommitted_blob_into_gc(
     assert final_gc.deleted_count == 0
     assert final_gc.skipped_reserved == 0
     assert final_gc.skipped_referenced >= 1
+
+
+def test_consume_blob_publication_receipt_is_idempotent(tmp_path: Path) -> None:
+    """The common finalizer's release is safe to call more than once (polylogue-0puw AC2).
+
+    consume_blob_publication_receipt is the durable-reference-commit boundary
+    every ingest path (raw, index-attachment, batch) relies on to release a
+    reservation. A retried or duplicated finalization call for the same
+    publication_id/blob_hash must not raise and must not affect an unrelated
+    reservation for the same blob_hash held by a different publication_id.
+    """
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    payload = b"idempotent finalizer target"
+    publisher = ArchiveBlobPublisher(archive_root / "source.db", archive_root / "blob")
+    blob_hash, _ = publisher.write_from_bytes(payload)
+    receipt_id = publisher.receipt_id(blob_hash)
+    assert receipt_id is not None
+    publisher.flush()
+
+    other_publisher = ArchiveBlobPublisher(archive_root / "source.db", archive_root / "blob")
+    other_blob_hash, _ = other_publisher.write_from_bytes(payload)
+    other_receipt_id = other_publisher.receipt_id(other_blob_hash)
+    assert other_receipt_id is not None
+    other_publisher.flush()
+
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM blob_publication_reservations WHERE blob_hash = ?", (bytes.fromhex(blob_hash),)
+            ).fetchone()[0]
+            == 2
+        )
+
+        consume_blob_publication_receipt(conn, receipt_id, bytes.fromhex(blob_hash))
+        conn.commit()
+        remaining = conn.execute(
+            "SELECT publication_id FROM blob_publication_reservations WHERE blob_hash = ?",
+            (bytes.fromhex(blob_hash),),
+        ).fetchall()
+        assert remaining == [(other_receipt_id,)]
+
+        # A retried/duplicated finalization of the already-consumed receipt
+        # is a no-op: no error, and the sibling publisher's reservation for
+        # the same content is untouched.
+        consume_blob_publication_receipt(conn, receipt_id, bytes.fromhex(blob_hash))
+        conn.commit()
+        remaining_after_retry = conn.execute(
+            "SELECT publication_id FROM blob_publication_reservations WHERE blob_hash = ?",
+            (bytes.fromhex(blob_hash),),
+        ).fetchall()
+        assert remaining_after_retry == [(other_receipt_id,)]
 
 
 def test_two_same_hash_publishers_consume_only_their_own_receipt(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Bounded progress on `polylogue-0puw`: re-verifies AC1 (still no reproduction) and adds the one piece of AC2 with no direct coverage (finalizer idempotency).

## Context
`polylogue-0puw`'s design calls for "successful batches leave zero reservations owned by the attempt after authoritative references commit, and duplicate finalization is idempotent" (AC2). The release path itself (`consume_blob_publication_receipt`, the common finalizer every raw/index/batch ingest route funnels through to release a publication reservation) had no direct test.

Re-verified AC1 first: the originally-cited failure (`test_process_ingest_batch_sync_reserves_inline_attachment_until_index_commit`) still does not reproduce on current master — 3 consecutive clean runs, both parametrizations, matching the bead's prior 2026-07-16 finding. The "leaves zero reservations after commit" half of AC2 and AC5's mutation sensitivity are already covered by existing production-route tests (`test_process_ingest_batch_sync_reserves_inline_attachment_until_index_commit` itself asserts `blob_publication_reservations` is empty after a real batch completes, and would fail if the finalizer call were removed).

This adds the one piece that had no direct coverage: idempotency of a retried/duplicated finalization call, and non-interference with a sibling publisher's reservation for the same content hash.

## Verification
- `devtools test tests/unit/pipeline/test_acquisition_blob_gc_age_gate.py` → 10 passed.
- Mutation-sensitivity: manually broadened the finalizer's `DELETE` `WHERE` clause from `(publication_id, blob_hash)` to `(blob_hash)` alone — the new test failed immediately (asserting the sibling reservation was wrongly deleted too); reverted the mutation, test passes again.
- `devtools verify --quick` → exit 0.

## Remaining scope
`polylogue-0puw`'s AC3 (deterministic-interruption-at-each-boundary crash-schedule matrix: after reservation, blob write, source commit, index commit, finalization) is a substantial standalone test-authoring effort distinct from this bounded addition; left open with findings recorded on the bead.

Ref polylogue-0puw