### PR TITLE
perf(coordination): bound the archive_evidence stage to a deadline

### DIFF
--- a/polylogue/coordination/__init__.py
+++ b/polylogue/coordination/__init__.py
@@ -1,10 +1,15 @@
 """Agent coordination envelope over existing local evidence."""
 
-from polylogue.coordination.envelope import build_coordination_envelope, project_coordination_envelope
+from polylogue.coordination.envelope import (
+    CoordinationEnvelopeCache,
+    build_coordination_envelope,
+    project_coordination_envelope,
+)
 from polylogue.coordination.payloads import AgentCoordinationPayload, CoordinationView
 
 __all__ = [
     "AgentCoordinationPayload",
+    "CoordinationEnvelopeCache",
     "CoordinationView",
     "build_coordination_envelope",
     "project_coordination_envelope",

--- a/polylogue/coordination/envelope.py
+++ b/polylogue/coordination/envelope.py
@@ -8,6 +8,7 @@ import re
 import shlex
 import sqlite3
 import subprocess
+import threading
 from collections.abc import Callable, MutableMapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
@@ -44,6 +45,7 @@ from polylogue.coordination.payloads import (
     CoordinationWorkItemPayload,
 )
 from polylogue.logging import get_logger
+from polylogue.operations.status_protocol import StatusComponentRegistry, StatusComponentSpec
 from polylogue.paths import active_index_db_path, archive_root
 from polylogue.storage.sqlite.run_projection_relations import (
     context_snapshot_relation_sql,
@@ -160,6 +162,14 @@ def build_coordination_envelope(
         "handoff",
         lambda: _handoff_payloads(repo.root or str(root_cwd), archive=archive, limit=peer_limit),
     )
+    archive_evidence_fallback: tuple[
+        tuple[CoordinationSessionTreePayload, ...],
+        tuple[CoordinationActivityEpisodePayload, ...],
+        tuple[CoordinationSubagentExchangePayload, ...],
+        tuple[CoordinationProofRefPayload, ...],
+        tuple[CoordinationContextFlowRefPayload, ...],
+        str | None,
+    ] = ((), (), (), (), (), f"archive-evidence lookup exceeded {_ARCHIVE_EVIDENCE_DEADLINE_S:g}s deadline")
     (
         session_trees,
         activity_episodes,
@@ -167,7 +177,7 @@ def build_coordination_envelope(
         proof_refs,
         context_flow_refs,
         archive_evidence_degraded_reason,
-    ) = _timed_stage(
+    ) = _bounded_stage(
         stage_timings_ms,
         "archive_evidence",
         lambda: _archive_evidence_payloads(
@@ -176,6 +186,8 @@ def build_coordination_envelope(
             archive,
             limit=peer_limit,
         ),
+        deadline_s=_ARCHIVE_EVIDENCE_DEADLINE_S,
+        fallback=archive_evidence_fallback,
     )
     overlaps = _timed_stage(stage_timings_ms, "overlaps", lambda: _overlap_payloads(repo, work_item, peers, resources))
     advisories = _timed_stage(
@@ -244,6 +256,130 @@ def _timed_stage(
     finally:
         if timings is not None:
             timings[name] = round((perf_counter() - started) * 1_000, 3)
+
+
+_ARCHIVE_EVIDENCE_DEADLINE_S = 3.0
+
+
+def _bounded_stage(
+    timings: MutableMapping[str, float] | None,
+    name: str,
+    call: Callable[[], _StageResult],
+    *,
+    deadline_s: float,
+    fallback: _StageResult,
+) -> _StageResult:
+    """Execute one envelope stage under a deadline, falling back on timeout.
+
+    Unlike :func:`_timed_stage`, an unbounded blocking stage (a full-table
+    archive query with no per-query SQL timeout of its own) cannot delay the
+    whole envelope past ``deadline_s``. Live measurement against a large
+    archive found ``archive_evidence`` alone taking ~10s while every other
+    stage stayed under 1s (polylogue-20d.17) — this bounds exactly that
+    stage. The underlying call keeps running on its own thread past the
+    deadline (no cooperative cancellation for a blocking SQLite query), but
+    the caller gets control back with an explicit degraded result instead
+    of waiting out however long the query takes.
+    """
+    registry = StatusComponentRegistry(
+        [
+            StatusComponentSpec(
+                name=name,
+                scope="coordination",
+                collector=call,
+                deadline_s=deadline_s,
+                cost_class="expensive",
+            )
+        ]
+    )
+    started = perf_counter()
+    snapshot = registry.collect()[name]
+    if timings is not None:
+        timings[name] = round((perf_counter() - started) * 1_000, 3)
+    if snapshot.state in ("fresh", "stale") and snapshot.value is not None:
+        return cast(_StageResult, snapshot.value)
+    return fallback
+
+
+def _coordination_fingerprint(root_cwd: Path) -> str:
+    """Cheap proxy for "has the repo/Beads/archive source changed" (polylogue-20d.17 AC #5).
+
+    A prior TTL-only cache could serve a stale compact envelope past a git
+    commit, a Beads write, or an archive ingest for up to the whole TTL
+    window. Stat-only (no subprocess) so checking it stays cheap even when
+    the cached envelope itself is reused; a mismatch forces a fresh build
+    regardless of TTL age.
+    """
+    parts: list[str] = []
+    for candidate in (
+        root_cwd / ".git" / "HEAD",
+        root_cwd / ".git" / "logs" / "HEAD",
+        root_cwd / ".beads" / "issues.jsonl",
+    ):
+        try:
+            parts.append(f"{candidate.name}:{candidate.stat().st_mtime_ns}")
+        except OSError:
+            parts.append(f"{candidate.name}:?")
+    try:
+        db = active_index_db_path()
+        wal = db.with_suffix(".db-wal")
+        target = wal if wal.exists() else db
+        parts.append(f"archive:{target.stat().st_mtime_ns}")
+    except OSError:
+        parts.append("archive:?")
+    return "|".join(parts)
+
+
+class CoordinationEnvelopeCache:
+    """Warm-cache compact coordination envelopes with source-fingerprint invalidation.
+
+    Replaces a prior TTL-only in-memory cache: a changed git HEAD, Beads
+    export, or archive index cannot hide behind an unexpired TTL because
+    :func:`_coordination_fingerprint` is checked on every call, not only
+    after the TTL expires. One instance per long-lived server process (or
+    per test) — its registries are process-local state, not a module
+    singleton, so a fresh instance starts warm-cache-empty.
+    """
+
+    _TTL_S = 1.0
+    _DEADLINE_S = 15.0
+
+    def __init__(self) -> None:
+        self._registries: dict[tuple[str, str, int], StatusComponentRegistry] = {}
+        self._lock = threading.Lock()
+
+    def get_or_build(self, *, view: CoordinationView, cwd: Path | None, limit: int) -> AgentCoordinationPayload:
+        """Return the compact envelope for ``(view, cwd, limit)``, cached and fingerprinted.
+
+        Callers that need a live, uncached read (``detail`` or an explicit
+        ``fresh`` request) should call :func:`build_coordination_envelope`
+        directly instead of this method.
+        """
+        root_cwd = (cwd or Path.cwd()).resolve()
+        key = (view, str(root_cwd), limit)
+        with self._lock:
+            registry = self._registries.get(key)
+            if registry is None:
+                registry = StatusComponentRegistry(
+                    [
+                        StatusComponentSpec(
+                            name="envelope",
+                            scope="coordination",
+                            collector=lambda: build_coordination_envelope(
+                                view=view, cwd=root_cwd, limit=limit, detail=False
+                            ),
+                            deadline_s=self._DEADLINE_S,
+                            ttl_s=self._TTL_S,
+                            fingerprint=lambda: _coordination_fingerprint(root_cwd),
+                            cost_class="expensive",
+                        )
+                    ]
+                )
+                self._registries[key] = registry
+        snapshot = registry.collect()["envelope"]
+        if snapshot.value is not None:
+            return cast(AgentCoordinationPayload, snapshot.value)
+        return build_coordination_envelope(view=view, cwd=root_cwd, limit=limit, detail=False)
 
 
 def project_coordination_envelope(

--- a/tests/unit/coordination/test_envelope.py
+++ b/tests/unit/coordination/test_envelope.py
@@ -10,7 +10,12 @@ from time import sleep
 
 import pytest
 
-from polylogue.coordination.envelope import CommandResult, _session_ref, build_coordination_envelope
+from polylogue.coordination.envelope import (
+    CommandResult,
+    CoordinationEnvelopeCache,
+    _session_ref,
+    build_coordination_envelope,
+)
 
 
 def _seed_coordination_archive(index: Path) -> None:
@@ -959,3 +964,58 @@ def test_handoff_projection_uses_supported_live_sources_or_empty_list(
         )
     with_assertion = build_coordination_envelope(cwd=root, runner=FakeRunner(root, beads_rows=None), detail=True)
     assert {item.kind for item in with_assertion.handoff} == {"scratch-handoff", "assertion-handoff"}
+
+
+def test_coordination_envelope_cache_reuses_within_ttl_and_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "repo"
+    (root / ".git").mkdir(parents=True)
+    (root / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+
+    calls: list[tuple[str, int]] = []
+
+    def fake_build(*, view: str, cwd: Path | None, limit: int, detail: bool) -> object:
+        calls.append((view, limit))
+        return object()
+
+    monkeypatch.setattr("polylogue.coordination.envelope.build_coordination_envelope", fake_build)
+    cache = CoordinationEnvelopeCache()
+
+    first = cache.get_or_build(view="status", cwd=root, limit=5)
+    second = cache.get_or_build(view="status", cwd=root, limit=5)
+    assert first is second
+    assert calls == [("status", 5)]
+
+    # A distinct key (different limit) is not served from the same entry.
+    cache.get_or_build(view="status", cwd=root, limit=10)
+    assert calls == [("status", 5), ("status", 10)]
+
+
+def test_coordination_envelope_cache_invalidates_on_fingerprint_change(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A changed git HEAD forces a refresh even inside the TTL window (AC #5).
+
+    This is exactly the gap the prior TTL-only cache had: a changed source
+    could hide behind an unexpired TTL. Here the fingerprint is checked on
+    every call, independent of TTL age.
+    """
+    root = tmp_path / "repo"
+    (root / ".git").mkdir(parents=True)
+    (root / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+
+    calls: list[int] = []
+
+    def fake_build(*, view: str, cwd: Path | None, limit: int, detail: bool) -> object:
+        calls.append(len(calls))
+        return object()
+
+    monkeypatch.setattr("polylogue.coordination.envelope.build_coordination_envelope", fake_build)
+    cache = CoordinationEnvelopeCache()
+
+    cache.get_or_build(view="status", cwd=root, limit=5)
+    cache.get_or_build(view="status", cwd=root, limit=5)
+    assert len(calls) == 1  # second call reused the cached value
+
+    (root / ".git" / "HEAD").write_text("ref: refs/heads/other-branch\n")
+    cache.get_or_build(view="status", cwd=root, limit=5)
+    assert len(calls) == 2  # fingerprint changed -> forced refresh despite unexpired TTL


### PR DESCRIPTION
## Summary

Second PR for polylogue-20d.17: extends the budgeted component-snapshot
protocol from PR #3107 (daemon/archive status) to the agent-coordination
envelope, bounding its one genuinely expensive, unbounded stage. Scope
narrowed mid-implementation after a real architectural discovery — see
"Scope note" below.

## Problem

Live measurement of `build_coordination_envelope` against the real (large,
currently mid-restore) archive found its `archive_evidence` stage — session
trees, activity episodes, subagent exchanges, proof refs, and context-flow
refs, one read-only SQLite connection with no per-query timeout — taking
**~10s**, while every other stage (repo, process, self, work_item, beads,
peers, resources, archive, handoff, overlaps, advisories) stayed under 1s.
Any caller of `build_coordination_envelope` paid this cost on every call,
including the live `polylogue agents status` CLI command — the same
"one slow probe stalls the whole answer" failure shape PR #3107 fixed for
daemon status.

## Solution

- `polylogue/coordination/envelope.py`: new `_bounded_stage` helper, backed
  by the shared `StatusComponentRegistry` protocol from PR #3107, wraps
  `archive_evidence` with a 3s deadline and an explicit degraded fallback
  (surfaced in the envelope's `advisories`) instead of blocking however long
  the query takes. The query keeps running on its own thread past the
  deadline (no cooperative cancellation for a blocking SQLite read), but the
  caller gets control back.
- New `CoordinationEnvelopeCache` class (also `StatusComponentRegistry`-
  backed, fingerprint-invalidated on git HEAD/logs, `.beads/issues.jsonl`,
  and the active index db/WAL mtimes) is ready substrate for a future
  warm-cached coordination-status consumer. Not wired to a live surface in
  this PR — see below.

## Scope note (read this before reviewing the diff)

This PR originally also rewired the MCP `agent_coordination` tool's ad-hoc
1s TTL-only cache onto `CoordinationEnvelopeCache`, mirroring PR #3107's
MCP-cache treatment. While rebasing onto master (which had moved past a
six-tool MCP surface cutover, `feature/mcp/retire-legacy-registrars`), I
found that tool is **already dead code**: `register_tools()` — the actual
live MCP server wiring in `polylogue/mcp/server.py` — only calls
`register_cutover_read_tools`/`register_cutover_privileged_tools` from
`server_cutover.py`, never `register_read_tools` (where `agent_coordination`
lives). Its dedicated test file was already deleted by the six-tool cutover
(#3095) with no replacement coverage, which is how this went unnoticed.

The live, reachable coordination-status path today is
`status(scope="coordination")` in `server_cutover.py` — and it has a
separate, pre-existing bug: every scope value except `"operation"` falls
through to the same generic `archive.stats()` projection, so
`status(scope="coordination")` silently returns archive stats, never
coordination data. Wiring `CoordinationEnvelopeCache` into that handler is
real, valuable follow-up work, but it sits inside another lane's actively
in-flight cutover and risks colliding with concurrent changes there. Filed
as **polylogue-qink** instead of attempted here.

## Verification

```
devtools test tests/unit/coordination/ tests/unit/mcp/   # 199 passed
mypy --strict polylogue/coordination/envelope.py polylogue/coordination/__init__.py   # clean
devtools verify --quick   # green
```

Live-archive read-only measurement (provisional — archive mid-restore from
the 2026-07-18 incident):

| Path | Before | After |
| --- | --- | --- |
| `archive_evidence` stage (in-process) | ~10.0s (unbounded) | capped at the 3.0s deadline, degraded reason surfaced in `advisories` |
| `polylogue agents status --format json` (live CLI, no MCP) | would be ~11s+ with the unbounded stage | ~5.1s (import tax + bounded stages) |

Ref polylogue-20d.17