### PR TITLE
fix(test): align browser-fixture survivor with the generation-dedup contract

### DIFF
--- a/tests/unit/sources/test_chatgpt_normalization_survivors.py
+++ b/tests/unit/sources/test_chatgpt_normalization_survivors.py
@@ -419,8 +419,12 @@ def test_native_full_fidelity_replaces_or_resists_longer_dom_fallback_and_keeps_
     assert final_fallback.counts["skipped_sessions"] == 1
     assert retained_raw_id == native_outcome.raw_id
     assert retained_reported_duration_ms == 5_190_000
-    assert retained_message_facts["thought-active-message"] == ("extended", 5_190_000)
-    assert retained_message_facts["answer-active-message"] == ("extended", 5_190_000)
+    # One recap owns the branch's semantic duration (the generation-dedup
+    # contract pinned above on the export fixture); sibling rows keep their
+    # effort but not a second copy of the same 5,190,000 ms.
+    assert retained_message_facts["recap-active-message"] == ("extended", 5_190_000)
+    assert retained_message_facts["thought-active-message"] == ("extended", None)
+    assert retained_message_facts["answer-active-message"] == ("extended", None)
     assert provider is Provider.CHATGPT
     assert raw_source_path == "/fixture/native-capture.json"
     assert b'"reasoning_start_time":1784164541.690012' in raw_material


### PR DESCRIPTION
## Summary

Fixes the standing "2 pre-existing unrelated ChatGPT failures" every lane has been stepping around: `test_native_full_fidelity_replaces_or_resists_longer_dom_fallback_and_keeps_raw_fields` (both arrival orders) asserted `('extended', 5_190_000)` for two sibling messages and got `('extended', None)`.

## Problem

The expectations contradicted the generation-dedup contract that the *same file's* export-fixture tests pin three times over (and that #2944's parser implements deliberately, with comments): one recap message owns the branch's semantic duration; sibling rows carrying the identical legacy `durationMs` are nulled so `reported_duration_ms` isn't multiplied. Traced empirically: the browser fixture parses to `recap-active-message = 5_190_000`, siblings `None`, session total `5_190_000`, exactly one lifecycle event — the deliberate design. The wrong expectations landed in #3044 unrun (per-PR CI skips the heavy suite) and have never passed on master.

## Solution

The assertions now name `recap-active-message` as the duration owner and pin the siblings to `(effort, None)`. The keeps-raw-fields half (raw payload bytes retain both duration spellings, reasoning timestamps, thinking effort) was already passing and is untouched. No production code change.

## Verification

`devtools test tests/unit/sources/test_chatgpt_normalization_survivors.py` — 9 passed (was 7 passed / 2 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ