### PR TITLE
fix(devshell): stop Nix mypy shadowing the uv.lock-pinned version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ venv/
 .pytest_cache/
 .hypothesis/
 .mypy_cache/
+.dmypy.json
 .ruff_cache/
 .benchmarks/
 /artifacts/

--- a/flake.nix
+++ b/flake.nix
@@ -166,7 +166,6 @@
           devtoolsCli
           git
           ruff
-          mypy
           py-spy
           python.pkgs.pyinstrument
           bat

--- a/tests/unit/coordination/test_envelope.py
+++ b/tests/unit/coordination/test_envelope.py
@@ -210,9 +210,10 @@ def test_coordination_envelope_overlaps_independent_beads_probes(tmp_path: Path)
         }:
             calls.append(key)
             sleep(0.05)
-            if key[1] == "hooks":
+            subcommand: str = key[1]
+            if subcommand == "hooks":
                 return CommandResult(key, 0, '{"hooks": []}', "")
-            if key[1] == "gate":
+            if subcommand == "gate":
                 return CommandResult(key, 0, "[]", "")
             return CommandResult(key, 0, '{"available": true}', "")
         return CommandResult(key, 1, "", "unexpected command")

--- a/tests/unit/cost/test_contract_suite.py
+++ b/tests/unit/cost/test_contract_suite.py
@@ -200,7 +200,6 @@ def test_estimated_status_signals_non_exact() -> None:
     """
     estimate = _priced_estimate()
     assert estimate.status in {"priced", "partial"}
-    assert estimate.status != "exact"
     # Confidence is bounded below 0.95 reserved for exact status.
     assert estimate.confidence < 0.95
 


### PR DESCRIPTION
## Summary

The Nix devshell's `mypy` entry in `buildInputs` silently shadowed the
uv.lock-pinned mypy 2.3.0 with the Nix store's 1.20.1, hiding real
strict-mypy findings locally that CircleCI's bare-Docker quick-gate
would catch.

## Problem

`devShells.default.buildInputs` listed `mypy` directly (a Python
library package). mkShell's Python setup hooks add such packages'
site-packages to `PYTHONPATH`, and `PYTHONPATH` entries are consulted
before a venv's own site-packages when Python builds `sys.path`. So
`.venv/bin/mypy` (and any `uv run mypy`) ran the Nix-provided 1.20.1
instead of the correctly-installed 2.3.0 in `.venv`, even inside an
activated devshell.

This is exactly the class of drift PR #3077 hit and fixed for
`polylogue/` on CircleCI: findings invisible locally, red on CI.
Running the real 2.3.0 against the full `[tool.mypy] files` config
(`polylogue`, `tests/**`, `devtools/**` — CircleCI checks `polylogue/`
only) surfaced two further findings CI has never covered:

- `tests/unit/coordination/test_envelope.py:215` — a real mypy
  narrowing limitation: after `key in {tuple_a, tuple_b, tuple_c}`
  narrows a tuple, mypy only tracks one alternative's literal type for
  a later subscript (`key[1]`), so a subsequent sibling `if key[1] ==
  "gate":` is flagged as comparing non-overlapping literals even
  though the runtime behavior is correct.
- `tests/unit/cost/test_contract_suite.py:203` — a tautological
  assertion (`!= "exact"`) already entailed by the preceding `in
  {"priced", "partial"}` check on the same narrowed value.

## Solution

- Drop `mypy` from the devshell's `buildInputs`. `.venv` (via
  `uv sync --extra dev`) is already the sole mypy provider; the Nix
  copy served no purpose except colliding with it.
- `test_envelope.py`: bind the tuple element to an explicit `str`
  local (`subcommand: str = key[1]`) before comparing, which stops
  mypy from carrying an overly narrow literal type across the two
  sibling checks. No runtime behavior change.
- `test_contract_suite.py`: delete the redundant assertion; the
  preceding line already proves it.
- `.gitignore`: add `.dmypy.json`, the dmypy daemon state file that a
  now-actually-working `dmypy` invocation creates at the repo root
  (alongside the existing `.mypy_cache/` entry).

## Verification

- `nix develop --command bash -c 'python3 -c "import mypy; print(mypy.__file__, mypy.__version__)"'`
  → resolves to `.venv/.../mypy` at 2.3.0 (was the Nix store's 1.20.1
  before this change).
- `nix develop --command uv run mypy polylogue/` → clean (matches
  CircleCI, whose 3 original findings were already fixed by #3077).
- `nix develop --command devtools verify --quick` → 17/17 steps green,
  `exit_code: 0`.
- `devtools test tests/unit/coordination/test_envelope.py tests/unit/cost/test_contract_suite.py`
  → 40 passed. 1 pre-existing failure unrelated to this change
  (`KeyError: 'cost_outlook'` in
  `test_mcp_cost_outlook_tool_uses_shared_envelope`) reproduces
  identically with these edits stashed out — MCP six-tool-cutover
  registry drift from #3095, not touched by this PR.

Ref polylogue-i0ep