### PR TITLE
fix(mcp): adapt cross-surface parity tests to the six-tool cutover

### DIFF
--- a/polylogue/mcp/server_cutover.py
+++ b/polylogue/mcp/server_cutover.py
@@ -43,6 +43,9 @@ async def _query_sessions(
     since: str | None,
     until: str | None,
     sort: str | None,
+    min_messages: int | None,
+    max_messages: int | None,
+    min_words: int | None,
 ) -> str:
     """Session-level rows for ``query(projection="sessions", ...)``.
 
@@ -66,6 +69,9 @@ async def _query_sessions(
         until=until,
         sort=sort,
         limit=limit,
+        min_messages=min_messages,
+        max_messages=max_messages,
+        min_words=min_words,
     )
     clamped_limit = hooks.clamp_limit(request.limit)
     spec = request.build_spec(hooks.clamp_limit)
@@ -212,14 +218,18 @@ def register_cutover_read_tools(mcp: ToolRegistrar, hooks: ServerCallbacks) -> N
         since: str | None = None,
         until: str | None = None,
         sort: str | None = None,
+        min_messages: int | None = None,
+        max_messages: int | None = None,
+        min_words: int | None = None,
     ) -> str:
         """Execute a terminal DSL page, or resume it using only its q2 token.
 
         ``projection="sessions"`` switches to session-level rows instead of
         unit-source rows: ``expression`` becomes a free-text ranked search
         (top-k) when given, or an exhaustive listing filtered by
-        origin/tag/repo/since/until/sort when omitted. Continuation is not
-        yet implemented for this projection.
+        origin/tag/repo/since/until/sort/min_messages/max_messages/min_words
+        when omitted. Continuation is not yet implemented for this
+        projection.
         """
 
         async def run() -> str:
@@ -240,6 +250,9 @@ def register_cutover_read_tools(mcp: ToolRegistrar, hooks: ServerCallbacks) -> N
                     since=since,
                     until=until,
                     sort=sort,
+                    min_messages=min_messages,
+                    max_messages=max_messages,
+                    min_words=min_words,
                 )
 
             from polylogue.archive.query.transaction import (
@@ -1102,6 +1115,9 @@ async def _dispatch_run(hooks: ServerCallbacks, *, ref: str, limit: int | None) 
         since=query.get("since"),
         until=query.get("until"),
         sort=query.get("sort"),
+        min_messages=query.get("min_messages"),
+        max_messages=query.get("max_messages"),
+        min_words=query.get("min_words"),
     )
 
 
@@ -1125,6 +1141,7 @@ def _build_mcp_scope_filter(
     from pathlib import Path
 
     from polylogue.core.enums import Origin
+    from polylogue.maintenance.scope import MaintenanceScopeFilter
 
     time_range: tuple[datetime, datetime] | None
     if since is not None or until is not None:

--- a/tests/unit/cost/test_contract_suite.py
+++ b/tests/unit/cost/test_contract_suite.py
@@ -484,6 +484,16 @@ def test_api_cost_outlook_returns_typed_cycle_outlook() -> None:
         assert key in payload, f"missing key {key!r} in outlook envelope"
 
 
+@pytest.mark.xfail(
+    reason=(
+        "The six-tool MCP cutover (polylogue-t46.8, #3095) retired the standalone "
+        "cost_outlook tool without a replacement -- cost/usage rollup MCP wiring "
+        "needs a design decision (point-fix vs. generic re-hosting of the whole "
+        "INSIGHT_REGISTRY cost/usage family), tracked in polylogue-hg97."
+    ),
+    raises=KeyError,
+    strict=True,
+)
 @pytest.mark.asyncio
 async def test_mcp_cost_outlook_tool_uses_shared_envelope() -> None:
     """The MCP ``cost_outlook`` tool serializes the same typed envelope.

--- a/tests/unit/maintenance/test_envelope_contracts.py
+++ b/tests/unit/maintenance/test_envelope_contracts.py
@@ -245,26 +245,24 @@ class TestMaintenanceMCPTools:
 
         server = build_server(role="admin")
         tools = server._tool_manager._tools
-        assert "maintenance_preview" in tools
-        assert "maintenance_execute" in tools
+        assert "maintenance" in tools
 
     def test_maintenance_tools_absent_from_read_server(self) -> None:
         from polylogue.mcp.server import build_server
 
         server = build_server(role="read")
         tools = server._tool_manager._tools
-        assert "maintenance_preview" not in tools
-        assert "maintenance_execute" not in tools
+        assert "maintenance" not in tools
 
     def test_maintenance_preview_returns_envelope(self) -> None:
         from polylogue.mcp.server import build_server
 
         operation = _example_operation()
         server = build_server(role="admin")
-        fn = server._tool_manager._tools["maintenance_preview"].fn
+        fn = server._tool_manager._tools["maintenance"].fn
 
         with _patched_preview(operation):
-            result = asyncio.run(fn())
+            result = asyncio.run(fn(operation="preview"))
 
         payload = json.loads(result)
         assert set(payload.keys()) == EXPECTED_ENVELOPE_KEYS

--- a/tests/unit/maintenance/test_scope_filter.py
+++ b/tests/unit/maintenance/test_scope_filter.py
@@ -324,11 +324,12 @@ def _capture_mcp_preview(operation: BackfillOperation) -> dict[str, Any]:
     from polylogue.mcp.server import build_server
 
     server = build_server(role="admin")
-    fn = server._tool_manager._tools["maintenance_preview"].fn
+    fn = server._tool_manager._tools["maintenance"].fn
 
     with patch("polylogue.maintenance.planner.preview_backfill", return_value=operation):
         result = asyncio.run(
             fn(
+                operation="preview",
                 session_ids=["c1", "c2"],
                 origin="claude-code-session",
                 source_family="claude-code-session",

--- a/tests/unit/maintenance/test_scope_filter_envelope_contract.py
+++ b/tests/unit/maintenance/test_scope_filter_envelope_contract.py
@@ -193,7 +193,7 @@ def _invoke_daemon_plan(body: dict[str, Any]) -> tuple[dict[str, Any], Maintenan
 
 
 def _invoke_mcp_preview() -> tuple[dict[str, Any], MaintenanceScopeFilter]:
-    """Drive ``maintenance_preview`` with the canonical filter args."""
+    """Drive ``maintenance(operation="preview")`` with the canonical filter args."""
     from polylogue.mcp.server import build_server
 
     captured: dict[str, MaintenanceScopeFilter] = {}
@@ -203,11 +203,12 @@ def _invoke_mcp_preview() -> tuple[dict[str, Any], MaintenanceScopeFilter]:
         return _operation_for(scope_filter)
 
     server = build_server(role="admin")
-    fn = server._tool_manager._tools["maintenance_preview"].fn
+    fn = server._tool_manager._tools["maintenance"].fn
 
     with patch("polylogue.maintenance.planner.preview_backfill", side_effect=_capture):
         result = asyncio.run(
             fn(
+                operation="preview",
                 targets=["session_insights"],
                 session_ids=["c1", "c2"],
                 origin="claude-code-session",

--- a/tests/unit/storage/test_query_parity.py
+++ b/tests/unit/storage/test_query_parity.py
@@ -71,7 +71,8 @@ class _MCPSurface:
         return self._server._tool_manager._tools[name].fn
 
     async def list_ids(self, *, origin: str | None = None, limit: int | None = None) -> tuple[str, ...]:
-        payload = await self._tool("list_sessions")(
+        payload = await self._tool("query")(
+            projection="sessions",
             limit=1000 if limit is None else limit,
             origin=origin,
         )
@@ -82,7 +83,7 @@ class _MCPSurface:
         return len(await self.list_ids(origin=origin, limit=1000))
 
     async def search_ids(self, query: str, *, limit: int = 50) -> tuple[str, ...]:
-        payload = await self._tool("search")(query=query, limit=limit)
+        payload = await self._tool("query")(expression=query, projection="sessions", limit=limit)
         parsed = json.loads(payload)
         hits = parsed.get("hits", parsed.get("items", []))
         ids: list[str] = []

--- a/tests/unit/storage/test_surface_parity_adapters.py
+++ b/tests/unit/storage/test_surface_parity_adapters.py
@@ -177,11 +177,14 @@ class _MCPSurface:
 
     async def ids(self, case: _Case) -> tuple[str, ...]:
         if case.search is not None:
-            payload = await self._server._tool_manager._tools["search"].fn(query=case.search, limit=case.limit or 100)
+            payload = await self._server._tool_manager._tools["query"].fn(
+                expression=case.search, projection="sessions", limit=case.limit or 100
+            )
             parsed = json.loads(payload)
             hits = parsed.get("hits", parsed.get("items", []))
             return tuple(sorted({_hit_id(hit) for hit in hits}))
-        payload = await self._server._tool_manager._tools["list_sessions"].fn(
+        payload = await self._server._tool_manager._tools["query"].fn(
+            projection="sessions",
             limit=case.limit if case.limit is not None else 100,
             origin=_origin_for_provider(case.provider),
             min_messages=case.min_messages,


### PR DESCRIPTION
## Summary

Fixes ~20 tests left broken by the six-tool MCP cutover (#3095) that still
call individually-named MCP tools which no longer exist, and fixes a real
production bug (`NameError`) found while doing so in `maintenance()`'s
preview/execute path.

**Stacked on #3118** (dead-code cleanup) — base branch is
`feature/mcp/retire-legacy-registrars`, not `master`. Merge #3118 first.

## Problem

`devtools verify --all` (the first full run since #3095 merged) found
`tests/unit/storage/{test_surface_parity_adapters,test_query_parity}.py` and
`tests/unit/maintenance/{test_scope_filter_envelope_contract,
test_envelope_contracts,test_scope_filter}.py` still calling
`server._tool_manager._tools["list_sessions"|"search"|"maintenance_preview"]`
— tools retired by the cutover. Deterministic `KeyError` on every run,
confirmed via isolated reruns (not a fixture-cache artifact). Never caught by
`devtools test tests/unit/mcp/` because these files live outside that
directory, and per-PR CI skips the heavy test suite entirely.

## Solution

- Extended `query()`'s signature and `_query_sessions` with
  `min_messages`/`max_messages`/`min_words`, mirroring the existing
  `origin`/`tag`/`repo`/`since`/`until`/`sort` filters — closes a real
  (narrow) parameter gap in `query(projection="sessions", ...)` rather than
  weakening the parity test, since the old `list_sessions` tool supported
  these. Also threaded through `_dispatch_run`'s saved-query replay for
  symmetry.
- Rewired both storage parity files' `_MCPSurface` from
  `_tools["search"]`/`_tools["list_sessions"]` to
  `_tools["query"].fn(expression=..., projection="sessions", ...)` — same
  underlying payload-building machinery, response shape unchanged.
- Rewired the three maintenance test files' `_tools["maintenance_preview"]`
  call sites to `_tools["maintenance"].fn(operation="preview", ...)`, and
  fixed two registration-presence assertions that were checking for names
  (`maintenance_preview`/`maintenance_execute`) that never existed
  post-cutover — vacuously true, testing nothing.
- **Found and fixed a real production bug**: `server_cutover.py`'s
  `_build_mcp_scope_filter` only had `MaintenanceScopeFilter` imported under
  `TYPE_CHECKING`, but constructs one at runtime — every
  `maintenance(operation="preview"/"execute")` call was raising `NameError`.
  Added the runtime import to the function's existing lazy-import block.
- Marked `test_mcp_cost_outlook_tool_uses_shared_envelope` `xfail`
  (`strict=True`, `raises=KeyError`): `cost_outlook` has no six-tool-surface
  replacement yet — cost/usage rollup MCP wiring needs a design decision
  explicitly deferred this session, tracked in `polylogue-hg97`.

Filed `polylogue-p6rz` for the remaining ~40-file pre-existing failure list
from the same `--all` run that are **not** MCP-related (`no_color_requested()`
signature drift, a stale migration-count assertion, `query_units`
telemetry-key naming) — confirmed unrelated by isolated reruns, left
untouched here.

## Verification

- `devtools test tests/unit/mcp/ tests/unit/maintenance/
  tests/unit/storage/test_surface_parity_adapters.py
  tests/unit/storage/test_query_parity.py tests/unit/cost/test_contract_suite.py
  tests/unit/verification/test_code_refs_resolve.py` — 576 passed, 1 xfailed.
- `mypy --strict` / `ruff` clean.
- `devtools render all --check` clean.

Ref polylogue-t46.8