### PR TITLE
fix(sources): parallelize raw-authority census parse; hjpx.2/yla8 evidence

### DIFF
--- a/.agent/reports/hjpx2-july15-scale-proof-2026-07-18.md
+++ b/.agent/reports/hjpx2-july15-scale-proof-2026-07-18.md
@@ -37,29 +37,36 @@ a close on unmet acceptance criteria.
 | **Pressure-gate mutation** (skipped recheck → gate miss) | Proven | Three tests in `test_raw_authority_scale_proof.py` (`_rechecks_pressure_during_generation`, `_around_census_and_replay`, `_after_census`) exercise the continuous recheck; independently, this session's own three real attempts (below) are a live demonstration of the gate firing correctly under genuine contention. |
 | **July-15-scale execution itself** (AC1, AC6, AC7) | **NOT achieved this session** | Three (going on four) real attempts at `--components 10163 --raws 15264 --expanded-raws 21398`, all self-aborted under genuine host I/O pressure. See below. |
 
-## The three (four, pending) real attempts
+## Four real attempts, all self-aborted
 
 The host has run 4+ concurrent warroom lanes throughout this session
 (per SONNET-NOTE 2026-07-18); `io_full_avg10` has oscillated between 0.02 and
-16.96 over roughly 90 minutes of observation, never sustaining a quiet window
-long enough to complete the ~21,398-row synthetic corpus generation phase.
-The gate was never loosened and the corpus was never shrunk to dodge it, per
-explicit instruction.
+16.96 over roughly 140 minutes of observation across four attempts, never
+surviving the synthetic corpus generation phase (~21,398 rows). The gate was
+never loosened and the corpus was never shrunk to dodge it, per explicit
+instruction.
 
 | Attempt | Wrapper strategy | Result | Abort point |
 | --- | --- | --- | --- |
 | 1 | Immediate, no wait | Self-abort, avg10=3.06 | Initial admission check (before any work) |
 | 2 | 40 min bound, single-tick quiet required | Self-abort, avg10=2.46 | Early in generation (`raw_authority_scale_proof.py:781`) |
 | 3 | 90 min bound, 3-consecutive-tick quiet required | Self-abort, avg10=3.63 | Mid-generation, past first publish-batch flush (`raw_authority_scale_proof.py:853`) |
-| 4 | 2h bound, 5-consecutive-tick quiet required | *pending at report time* | — |
+| 4 | 2h bound, **5**-consecutive-tick (5 min sustained) quiet required | Self-abort, avg10=2.36 | Same line as attempt 3 (`raw_authority_scale_proof.py:853`) |
 
-Each attempt got measurably further before aborting (immediate → early-gen →
-past-first-flush), consistent with a gate that is working exactly as designed
-against a genuinely, persistently contended host — not a harness defect and
-not evidence the July-15 shape itself is unreachable, only that it hasn't
-been reached *this session* under *this* load.
+**Diagnostic finding, not just a repeated failure:** attempt 4 required 5
+minutes of genuinely quiet host (avg10 sequence 1.97/1.25/0.32/1.56/0.13
+immediately beforehand) and *still* aborted at the identical code location as
+attempt 3, moments after generation began. That recurrence at the same point
+across two independently-triggered attempts suggests the **generation phase
+itself** — writing and flushing the first `_PUBLISH_BATCH_SIZE` batch of raw
+payload files — is I/O-intensive enough to push `avg10` over 2.0 on its own,
+not purely a function of *other* lanes' contention. A longer external wait
+does not fix this; it only guarantees a clean starting point that the
+generation phase's own I/O then disturbs. This is worth investigating
+separately from "wait for the host to be quiet" (which this session's four
+attempts show is necessary but not sufficient).
 
-Receipts: `/realm/tmp/raw-authority-july15-v2-20260718/{attempt1,attempt2,attempt3}.stderr.log`,
+Receipts: `/realm/tmp/raw-authority-july15-v2-20260718/{attempt1,attempt2,attempt3,attempt4}.stderr.log`,
 `wrapper{,2,3}.log` (full poll history, PSI samples at every check).
 
 ## Follow-up beads filed this session
@@ -70,6 +77,10 @@ Receipts: `/realm/tmp/raw-authority-july15-v2-20260718/{attempt1,attempt2,attemp
 - **polylogue-agvo** (P1) — daemon-health-responsiveness proof harness (a real
   `polylogued` subprocess + concurrent HTTP status polling), the one law this
   bead cannot currently prove. Discovered-from polylogue-hjpx.2.
+- **polylogue-cmw2** (P2) — investigate whether the scale-proof's own
+  generation phase is self-inducing the I/O pressure that aborted attempts
+  3 and 4 at the identical code location; if confirmed, add batch pacing or
+  a separate generation-phase pressure budget. Discovered-from polylogue-hjpx.2.
 
 ## hjpx.2 closable: **NO**
 
@@ -77,20 +88,24 @@ AC1 (corpus matches July-15 shape), AC6 (mutation proofs *at that scale*,
 though the mutation *mechanisms* are proven at smaller scale), and AC7 (exact
 July-15-shaped result artifacts) are not satisfied. The bead remains
 **in_progress** with this report and the four attempt receipts appended to
-its notes. The concrete remaining step is: retry the same command
-(`devtools workspace raw-authority-scale-proof --components 10163 --raws
-15264 --expanded-raws 21398 --pass-limit 1000 --keep --json` under
-`sinnix-scope background --`) once the host has a sustained quiet window —
-no code change is needed for this, only a quieter host. Separately,
-`polylogue-agvo` needs to land before the daemon-health clause of AC2 can
-close at all, independent of host contention.
+its notes. The concrete remaining step is either: (a) retry the same command
+once the host has a sustained quiet window that survives the generation
+phase's own I/O (attempt 4 shows external quiet alone is not sufficient — see
+`polylogue-cmw2`), or (b) land `polylogue-cmw2`'s fix first so generation no
+longer self-triggers the gate. Separately, `polylogue-agvo` needs to land
+before the daemon-health clause of AC2 can close at all, independent of host
+contention.
 
 ## What IS ready to merge from this lane
 
 - `polylogue-9p8x`: parallel census parse + spill-cache decoupling, tested,
   `devtools verify --quick` green. Real, measured (if modest) speedup;
   honest correction of the original 4x hypothesis, with `polylogue-amg1`
-  filed for the remaining lever.
+  filed for the remaining lever. Rebased onto master's #3113 (Hermes
+  SQLite-detection fix to `_parse_one`) with a parity fix so the new
+  parallel-census worker threads the real on-disk blob path through for
+  Hermes `state.db`/`verification_evidence.db` raws the same way the
+  sequential path already does (`test_parallel_census_threads_hermes_sqlite_payload_path`).
 - `polylogue-yla8`: read-only authorization packet, recommending the
   operator hold the live gate given the backup/drain-rate/scale-proof
   blockers found live in the current archive state.

--- a/.agent/reports/hjpx2-july15-scale-proof-2026-07-18.md
+++ b/.agent/reports/hjpx2-july15-scale-proof-2026-07-18.md
@@ -1,0 +1,97 @@
+# hjpx.2 — July-15-scale raw-authority replay convergence proof (2026-07-18, Lane D)
+
+## Status: NOT CLOSABLE this session — AC6 (July-15-scale execution) unproven; other clauses have durable evidence
+
+This report is honest about what was and was not achieved. It does not force
+a close on unmet acceptance criteria.
+
+## What this bead requires (from its own AC, verbatim scope)
+
+1. Sanitized corpus matches July-15 candidate/component/byte/skew distributions
+   within documented tolerances.
+2. Every bounded pass stays within declared RSS/PSS/swap/temp-write/wall-time
+   envelopes while daemon health remains responsive.
+3. Executable plan backlog decreases monotonically modulo explicit retry
+   injection; every finite retry resolves once; no component starves.
+4. Cursor positions, source heads, accepted index heads, FTS readiness, and
+   durable raw authority never regress across interruption/resume.
+5. Two final quiescent census digests match with zero executable plans and
+   identical typed residual debt.
+6. Removing fair rotation recreates starvation; removing
+   conservation/carry-forward accounting recreates a census mismatch.
+7. Exact commands, containment receipts, corpus seed, and result artifacts
+   are durable and reviewable.
+8. No live archive apply is part of this bead; yla8 retains the separate
+   verified-backup/explicit-authorization gate.
+
+## Verdict per law
+
+| Law | Status | Evidence |
+| --- | --- | --- |
+| **Resource envelopes** (AC2, partial) | Proven at small/medium synthetic scale, **not yet at July-15 cardinality** | `_PassProcessSampler` records RSS/PSS/swap/CPU/IO per pass in the harness (`devtools/raw_authority_scale_proof.py`); exercised by 21 passing tests in `tests/unit/devtools/test_raw_authority_scale_proof.py`. The July-15-shaped run itself has not completed (see below), so envelope numbers *at that cardinality* are not yet recorded. |
+| **Daemon-health responsiveness** (AC2, other half) | **Not provable with the current harness — confirmed gap, not just unautomated** | Both `raw_authority_scale_proof.py` and `raw_authority_restart_proof.py` (#3080) call `repair.repair_raw_materialization` directly in-process against a synthetic archive; neither starts an actual `polylogued` process, so there is no HTTP/heartbeat surface to probe. Filed `polylogue-agvo` (P1) to build that harness variant. This AC clause cannot close without that follow-up landing. |
+| **Monotonic, fair draining / no starvation** (AC3, AC6 mutation) | **Mechanism proven; not yet exercised at July-15 cardinality** | The pass loop in `run_raw_authority_scale_proof` raises `RuntimeError` if any pass leaves executable candidates undrained. Fairness mutation coverage: `test_raw_materialization_fair_rotation_mutation_recreates_starvation` (`tests/unit/storage/test_repair.py:2082`) — removing durable attempt-age fairness in a one-slot retry-injected scenario reproduces starvation; the production scheduler correctly advances to the next independent component instead. Verified passing this session. |
+| **Interruption/resume, mid-census and mid-apply** (AC4) | **Proven, cited not duplicated** | PR #3080 (`devtools/raw_authority_restart_proof.py`, merged `5571fa2b7`) proves interrupted production repair reconciles durable outcomes without duplication and reaches a two-census fixed point across the transaction boundaries that matter. `tests/unit/devtools/test_raw_authority_restart_proof.py`: 4/4 passing this session. Per this bead's own instruction ("don't duplicate #3080's crash-recovery proof"), no new work was added here. |
+| **Fixed point + conservation** (AC5, AC6 mutation) | **Mechanism proven; not yet exercised at July-15 cardinality** | The harness requires two consecutive quiescent dry-run passes with matching digests, raising on mismatch. Conservation mutation coverage: `test_raw_materialization_fails_closed_on_plan_conservation_mismatch` (`tests/unit/storage/test_repair.py:2174`) — any nonzero immutable replay-plan conservation error fails closed. Verified passing this session. |
+| **Byte-skew fidelity / envelope-breach mutation** | Proven at unit scale | `test_historical_backfill_reparses_multi_gib_shaped_raw_instead_of_spilling_archive_wide` (`tests/unit/sources/test_revision_backfill.py`) proves a declared multi-GiB raw does not get cached archive-wide (bounded retention preserved); `RawRevisionReplayResourceBlockedError` is raised for genuinely oversized components. Verified passing this session. |
+| **Pressure-gate mutation** (skipped recheck → gate miss) | Proven | Three tests in `test_raw_authority_scale_proof.py` (`_rechecks_pressure_during_generation`, `_around_census_and_replay`, `_after_census`) exercise the continuous recheck; independently, this session's own three real attempts (below) are a live demonstration of the gate firing correctly under genuine contention. |
+| **July-15-scale execution itself** (AC1, AC6, AC7) | **NOT achieved this session** | Three (going on four) real attempts at `--components 10163 --raws 15264 --expanded-raws 21398`, all self-aborted under genuine host I/O pressure. See below. |
+
+## The three (four, pending) real attempts
+
+The host has run 4+ concurrent warroom lanes throughout this session
+(per SONNET-NOTE 2026-07-18); `io_full_avg10` has oscillated between 0.02 and
+16.96 over roughly 90 minutes of observation, never sustaining a quiet window
+long enough to complete the ~21,398-row synthetic corpus generation phase.
+The gate was never loosened and the corpus was never shrunk to dodge it, per
+explicit instruction.
+
+| Attempt | Wrapper strategy | Result | Abort point |
+| --- | --- | --- | --- |
+| 1 | Immediate, no wait | Self-abort, avg10=3.06 | Initial admission check (before any work) |
+| 2 | 40 min bound, single-tick quiet required | Self-abort, avg10=2.46 | Early in generation (`raw_authority_scale_proof.py:781`) |
+| 3 | 90 min bound, 3-consecutive-tick quiet required | Self-abort, avg10=3.63 | Mid-generation, past first publish-batch flush (`raw_authority_scale_proof.py:853`) |
+| 4 | 2h bound, 5-consecutive-tick quiet required | *pending at report time* | — |
+
+Each attempt got measurably further before aborting (immediate → early-gen →
+past-first-flush), consistent with a gate that is working exactly as designed
+against a genuinely, persistently contended host — not a harness defect and
+not evidence the July-15 shape itself is unreachable, only that it hasn't
+been reached *this session* under *this* load.
+
+Receipts: `/realm/tmp/raw-authority-july15-v2-20260718/{attempt1,attempt2,attempt3}.stderr.log`,
+`wrapper{,2,3}.log` (full poll history, PSI samples at every check).
+
+## Follow-up beads filed this session
+
+- **polylogue-amg1** (P1) — commit-batching + size-aware parse dispatch, the
+  throughput lever needed to make ordinary catch-up viable at scale (9p8x's
+  deferred "Fix 3"). Discovered-from polylogue-9p8x.
+- **polylogue-agvo** (P1) — daemon-health-responsiveness proof harness (a real
+  `polylogued` subprocess + concurrent HTTP status polling), the one law this
+  bead cannot currently prove. Discovered-from polylogue-hjpx.2.
+
+## hjpx.2 closable: **NO**
+
+AC1 (corpus matches July-15 shape), AC6 (mutation proofs *at that scale*,
+though the mutation *mechanisms* are proven at smaller scale), and AC7 (exact
+July-15-shaped result artifacts) are not satisfied. The bead remains
+**in_progress** with this report and the four attempt receipts appended to
+its notes. The concrete remaining step is: retry the same command
+(`devtools workspace raw-authority-scale-proof --components 10163 --raws
+15264 --expanded-raws 21398 --pass-limit 1000 --keep --json` under
+`sinnix-scope background --`) once the host has a sustained quiet window —
+no code change is needed for this, only a quieter host. Separately,
+`polylogue-agvo` needs to land before the daemon-health clause of AC2 can
+close at all, independent of host contention.
+
+## What IS ready to merge from this lane
+
+- `polylogue-9p8x`: parallel census parse + spill-cache decoupling, tested,
+  `devtools verify --quick` green. Real, measured (if modest) speedup;
+  honest correction of the original 4x hypothesis, with `polylogue-amg1`
+  filed for the remaining lever.
+- `polylogue-yla8`: read-only authorization packet, recommending the
+  operator hold the live gate given the backup/drain-rate/scale-proof
+  blockers found live in the current archive state.
+- This report and its bead-note trail.

--- a/.agent/reports/yla8-authorization-packet-2026-07-18.md
+++ b/.agent/reports/yla8-authorization-packet-2026-07-18.md
@@ -1,0 +1,180 @@
+# yla8 authorization packet — 2026-07-18 (Lane D)
+
+**Read-only.** No live gate, backup, catch-up, reset, replay, or SQL mutation
+was run to produce this packet. All commands below were `--check`/`status`/
+read-only queries against the live archive
+(`POLYLOGUE_ARCHIVE_ROOT=/home/sinity/.local/share/polylogue`).
+
+**Provisional caveat (per SONNET-NOTE 2026-07-18):** the archive is mid-restore
+from the same-day poisoned-index incident (two divergent `index.db` identities
+— see `polylogue-yla8` notes). A fresh index generation
+(`gen-1784381541560-2d4fc3f4`) was promoted and the daemon (build 0.3.0)
+restarted at 17:51 CEST, ~9 minutes before this packet's status snapshot. Every
+count below reflects that in-flight state, not a settled archive. Lane A
+flagged this first; this packet does not repeat that diagnosis, only the
+counts relevant to an authorization decision.
+
+## Recommendation
+
+**Do not authorize the live gate yet.** Four independent blockers, detailed
+below. None is a new regression from this session — they are the current,
+directly observed state.
+
+## 1. Current population counts vs July-15 baseline
+
+| Metric | 2026-07-15 (yla8 preflight) | 2026-07-18 18:00 CEST (this packet) | Comparable? |
+| --- | --- | --- | --- |
+| Build | source v11/index v36/embeddings v2/user v8/ops v1 | source v13/index v40/embeddings v3/user v10/ops v1 | schema advanced on every tier |
+| Raw artifacts (source.db) | ~18,347 checked (frontier sample) | 79,571 (`raw_artifact_count`) | archive grew; live capture continued through the incident |
+| Materialized (index) | not directly comparable (frontier used a different metric) | 170 (`materialized_raw_artifact_count`) | fresh index, 99.8% unconverged |
+| Join gap (source rows with no index session) | — | 79,401 (`join_gap_count`) | **this is the backlog a live gate would need to drain** |
+| Broken active heads | 1,890 / 18,347 checked | 0 / 170 checked (`broken_head_status: healthy`) | **NOT comparable** — sample is 170 of 79,571 rows (0.2%), not a population verdict |
+| Cursor-ahead | 40 / 739 comparisons | unknown / 1 comparison | **NOT comparable** — same reason |
+| Incomparable cursor/head | 34 | — (not reported at this sample size) | **NOT comparable** |
+| Cursor-authority gaps | — | 26 (partial, early signal — mostly Antigravity brain metadata sidecars) | new projection, not in the 07-15 baseline |
+| Critical archive-debt groups | 5, affecting 207 artifacts | excluded from this bounded snapshot (`archive_debt.available: false`) | not captured this pass |
+| Replay backlog (raw-authority) | 15,264 direct / 21,398 expanded / 10,163 components / 4.788 GB | excluded from this bounded snapshot (`raw_replay_backlog.available: false, reason: excluded_from_bounded_status_snapshot`) | not captured this pass — needs a dedicated raw-authority census, deliberately not run live this session (see §5) |
+| FTS readiness | — | **not ready**: 0/0 indexed, `messages_fts` freshness `stale`, "archive message FTS drift exceeds bounded startup reconciliation" | blocking search until convergence catches up |
+| Quarantined raws | 28 (durable authority-debt) | 248 (`raw_quarantined`) | grew; not yet reconciled against the new generation |
+
+**Bottom line:** the archive-wide frontier-integrity numbers from July-15 are
+**not reproducible from current evidence** — the fresh index has materialized
+0.2% of the source-tier raw population, so any "broken heads: 0" or
+"cursor-ahead: unknown" reading right now is a sample-size artifact, not a
+health verdict. A meaningful re-run of the July-15-style frontier census needs
+to wait until materialization has substantially caught up, or needs its own
+bounded sampling strategy that doesn't assume the index is populated.
+
+## 2. Backup-manifest currency verdict — **BLOCKS authorization**
+
+- Most recent **formal, verified** per-tier backup (`polylogue-sqlite-backup.service`,
+  zstd-compressed, timestamped): **2026-07-12T03:17:17Z** — **6 days stale**.
+  Predates the 2026-07-15 authority work, the entire hjpx/lkrc/yla8 program
+  through today, and the 2026-07-18 poisoned-index incident and restore.
+- An informal snapshot exists at
+  `/realm/staging/polylogue-sqlite/pre-deploy-20260718T132033Z/` (source.db +
+  user.db only, copied 15:20 CEST today) but it is **not** a
+  `polylogue ops backup --profile full_evidence --verify` output: no
+  `manifest.json`, no `verification-receipt.json`, missing the
+  index/embeddings/ops tiers entirely. It does not satisfy this gate's backup
+  prerequisite.
+- `polylogue ops backup --output-dir /realm/staging/polylogue-sqlite/yla8-preflight-check-DRYRUN --profile full_evidence --check` (read-only, no directory created) reports **"Backup prerequisites: OK"** — the *mechanism* is available; no backup has actually been taken against the *current* (post-restore) archive identity.
+- **Verdict: no current verified full-evidence backup exists. This alone blocks authorization** per this gate's own AC2.
+
+## 3. Blocker inventory
+
+1. **polylogue-5jak (P0, open, unclaimed)** — daemon raw-materialization
+   conveyor processes `raw_artifact_limit=1` every 30s (`daemon/cli.py:70-72`),
+   ~2 rows/min. Directly evidenced today: watcher-level catch-up (a related
+   but distinct stage) measured `files_per_second: 0.184867`,
+   `ingest_worker_count_max: 1` in the most recent ingestion batch receipt. At
+   that rate, draining the current 79,401-row join gap takes **~4.97 days**
+   for watcher catch-up alone; 5jak's own math for the separate
+   raw_materialization conveyor (~1 row/30s) is **~27.6 days** for a
+   comparably sized backlog. **"Just let the daemon drain it" is not a viable
+   plan at current throughput** — this is not a hypothesis, it's today's
+   measured rate applied to today's measured backlog.
+2. **polylogue-emx2 (P1, open, unclaimed)** — watcher catch-up trusts
+   `ingest_cursor` rows as "materialized" when they only mean "acquired."
+   After today's index reset, cursors pointing at the now-empty fresh
+   generation risk being treated as already-satisfied and skipped, pushing
+   more of the drain onto the slow conveyor in (1) instead of the fast
+   parallel batch pipeline. `cursor_authority_gap_count: 26` is an early,
+   partial signal of this class of gap (not yet a population-wide count,
+   for the same 170-row sample-size reason as §1).
+3. **polylogue-5vft (P2, open, unclaimed)** — maintenance CLI hygiene
+   (`--only-missing` promotion, `reset --index` managed-generation escape,
+   self-healing preflight). Not directly blocking this gate, but is why the
+   07-18 incident needed manual layout surgery instead of a sanctioned repair
+   path; relevant context for "why we're here."
+4. **polylogue-hjpx.2 (P1, in progress — this lane)** — the raw-authority
+   replay convergence proof at July-15 scale has **not yet completed**. Corpus
+   preparation is retrying under the continuous I/O pressure gate (host is
+   contended: 4+ concurrent warroom lanes; `io_full_avg10` has ranged 3.8–11.2
+   this session, above the 2.0 admission threshold). The executor this gate
+   would authorize (`RawAuthorityReconciler` / `repair_raw_materialization`)
+   has proof coverage at small-fixture scale (hjpx.1, merged) but not yet at
+   the archive's actual cardinality. See hjpx.2 bead notes for live receipts
+   as they land.
+
+FTS convergence also shows one failed stage today (`messages_fts`, "startup
+found inconsistent messages_fts ready freshness ledger", retry due) — likely
+transient post-restore noise, not separately gating, but should clear before
+re-checking readiness.
+
+## 4. Immutable plan digest
+
+**Not captured this session.** `raw_replay_backlog` and `archive_debt` were
+both excluded from the bounded `ops status --json --full` snapshot
+(`reason: excluded_from_bounded_status_snapshot`). Computing a raw-authority
+census digest requires either (a) a dedicated `repair_raw_materialization(dry_run=True)`
+call, or (b) waiting for materialization to progress. Given the daemon is
+*actively* mid-drain right now (single writer, `raw_artifact_limit`-bounded
+passes), this session deliberately did not invoke a competing manual
+raw-authority operation against the live archive — that risks contending with
+the daemon's own writer coordinator during an already-fragile restore. This is
+a gap in this packet, not a finding of "no debt": treat the plan digest as
+**unknown, not zero**, until a dedicated read-only census is run once the
+daemon's own drain has progressed or is paused for that purpose.
+
+## 5. Exact apply command (for reference — not authorized to run)
+
+```
+# Prerequisite: a fresh verified backup (see §2)
+POLYLOGUE_ARCHIVE_ROOT=/home/sinity/.local/share/polylogue \
+  polylogue ops backup --output-dir /realm/staging/polylogue-sqlite/yla8-<UTC-timestamp> \
+  --profile full_evidence --verify
+
+# The gate itself, once backup + hjpx.2 proof + blocker triage are done:
+# ordinary packaged daemon catch-up under bounded journal capture — no
+# cursor reset, force replay, evidence deletion, or ad hoc SQL writes.
+# (Mechanism already running automatically; this gate is about whether to
+# let it keep running unattended vs. pausing for 5jak/emx2 first.)
+```
+
+## 6. Expected duration / resources
+
+From hjpx.2's proof envelopes: **not yet available** — the scale proof has not
+completed a pass at July-15 cardinality this session (host pressure gate
+self-aborted the first two attempts; see hjpx.2 bead notes for exact PSI
+receipts). From today's *live* measurement instead: at the observed
+0.185 files/sec watcher-catchup rate and 5jak's documented ~1-row/30s
+raw-materialization rate, draining the current 79,401-row gap is a
+**multi-day-to-multi-week** operation, not hours. This number will only
+improve once 5jak's backlog-aware batch scaling lands.
+
+## 7. Postflight checks (once authorized and run)
+
+Re-run `ops status --json --full`; require `raw_frontier_integrity.overall_status`
+computed over a population-representative sample (not the current 170-row
+slice), `join_gap_count` trending to 0, `fts_readiness.invariant_ready: true`,
+and zero unresolved `raw_authority_ledger_counts.unresolved_blockers`.
+
+## 8. Abort conditions
+
+Any of: I/O or memory pressure gate breach during the live pass; a new
+`RawRevisionReplayResourceBlockedError` on a previously-clean component;
+`convergence.failed_count` growing instead of shrinking; daemon heartbeat age
+exceeding its configured staleness threshold; any cursor advancing past
+unmaterialized content (the original no-shrink invariant this whole program
+protects).
+
+## 9. Rollback statement
+
+The daemon's own convergence is already the "live" state — there is no
+separate mutation to roll back from *authorizing continued automatic drain*.
+If a *manual* gate action were taken (none is proposed here) and needed
+rollback, the durable tiers (`source.db`, `user.db`) are restorable from the
+most recent verified backup (currently 6 days stale — see §2); `index.db` and
+`embeddings.db` are rebuildable-tier and would be regenerated from source, not
+restored byte-for-byte.
+
+---
+
+## The operator's question
+
+**Authorize the live raw-authority catch-up gate now, given: no current
+verified backup (§2), a 79,401-row unconverged materialization gap that would
+take days-to-weeks at today's measured throughput without polylogue-5jak
+(§3.1), an uncomputed plan digest (§4), and hjpx.2's scale proof still
+in-flight (§3.4)? (yes / no)**

--- a/polylogue/maintenance/replay.py
+++ b/polylogue/maintenance/replay.py
@@ -88,6 +88,14 @@ _CURSOR_TARGET_PREFIX: Final[str] = "target:"
 #: files. One JSON file per ``operation_id``.
 _STATE_DIRNAME: Final[str] = ".maintenance-state"
 
+#: Spill-cache bound for the offline ``rebuild-index`` command's one-shot,
+#: archive-wide census (``selected_raw_ids=None`` has no resource envelope,
+#: so this is independent of any envelope block). It only avoids the
+#: census-then-replay double parse for typical raws; oversized raws are
+#: deliberately still not cached (see ``_ParsedSessionSpill``), so the cache
+#: never becomes a second archive-wide materialization.
+_REBUILD_CENSUS_SPILL_CACHE_BYTES: Final[int] = 512 * 1024 * 1024
+
 
 # ---------------------------------------------------------------------------
 # Target dispatch
@@ -149,11 +157,13 @@ async def rebuild_index_from_source(
     # The caller owns page selection.  Do not widen its bounded page here:
     # revision backfill may still expand that page to a complete authority
     # cohort, which is required for correct newest-revision selection.
-    del ingest_workers, materialize
+    del materialize
     import asyncio
 
+    from polylogue.pipeline.services.process_pool import resolve_parse_worker_count
     from polylogue.sources.revision_backfill import backfill_historical_revision_evidence
 
+    resolved_ingest_workers = ingest_workers if ingest_workers is not None else resolve_parse_worker_count()
     if progress_callback is not None:
         progress_callback(0, "classifying retained raw revision cohorts")
     result = await asyncio.to_thread(
@@ -161,6 +171,8 @@ async def rebuild_index_from_source(
         Path(config.archive_root),
         selected_raw_ids=raw_ids,
         owned_inactive_generation=owned_inactive_generation,
+        max_cached_payload_bytes=_REBUILD_CENSUS_SPILL_CACHE_BYTES,
+        ingest_workers=resolved_ingest_workers,
     )
     if progress_callback is not None:
         progress_callback(result.replayed_logical_sources, "revision replay complete")
@@ -173,6 +185,7 @@ async def rebuild_index_from_source(
         "authority_selection_expanded": True,
         "scheduled_raw_count": len(raw_ids) if raw_ids is not None else None,
         "raw_batch_size": raw_batch_size,
+        "ingest_workers": resolved_ingest_workers,
     }
 
 

--- a/polylogue/pipeline/services/archive_ingest.py
+++ b/polylogue/pipeline/services/archive_ingest.py
@@ -15,6 +15,7 @@ from polylogue.core.enums import Provider
 from polylogue.core.sources import origin_from_provider
 from polylogue.logging import get_logger
 from polylogue.pipeline.services.parsing_models import ParseResult
+from polylogue.pipeline.services.process_pool import resolve_parse_worker_count
 from polylogue.sources.parsers.base import ParsedSession, RawSessionData
 from polylogue.sources.source_parsing import (
     iter_antigravity_language_server_sessions,
@@ -58,17 +59,10 @@ def _parse_worker_count() -> int:
 
     Parse is ~44% of re-ingest wall time and CPU-bound; the single SQLite
     writer is I/O-bound. Running file parsing across worker processes overlaps
-    parse CPU with write I/O. Default = min(8, cpus-1), clamped to >=1. A value
-    of 1 disables the pool entirely and preserves the exact sequential behavior
-    as an escape hatch.
+    parse CPU with write I/O. A value of 1 disables the pool entirely and
+    preserves the exact sequential behavior as an escape hatch.
     """
-    raw = os.environ.get("POLYLOGUE_INGEST_PARSE_WORKERS")
-    if raw is None:
-        return max(1, min(8, (os.cpu_count() or 2) - 1))
-    try:
-        return max(1, int(raw))
-    except ValueError:
-        return max(1, min(8, (os.cpu_count() or 2) - 1))
+    return resolve_parse_worker_count()
 
 
 def _parse_source_path_worker(

--- a/polylogue/pipeline/services/process_pool.py
+++ b/polylogue/pipeline/services/process_pool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import multiprocessing
+import os
 import time
 from concurrent.futures import ProcessPoolExecutor
 
@@ -24,6 +25,25 @@ def process_pool_context() -> multiprocessing.context.BaseContext:
     if "forkserver" in start_methods:
         return multiprocessing.get_context("forkserver")
     return multiprocessing.get_context("spawn")
+
+
+def resolve_parse_worker_count(*, env_var: str = "POLYLOGUE_INGEST_PARSE_WORKERS") -> int:
+    """Resolve a CPU-bound parse worker count from ``env_var`` or CPU count.
+
+    Default is ``min(8, cpus-1)`` clamped to at least 1. A value of ``1``
+    (including an invalid override) disables pooling entirely and preserves
+    exact sequential parse behavior as an escape hatch. Shared by every
+    read-only blob->parsed-session decode stage (direct ingest, raw-authority
+    census) so one operator knob bounds all of them consistently.
+    """
+    default = max(1, min(8, (os.cpu_count() or 2) - 1))
+    raw = os.environ.get(env_var)
+    if raw is None:
+        return default
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return default
 
 
 def process_pool_executor(*, max_workers: int) -> ProcessPoolExecutor:
@@ -57,5 +77,6 @@ __all__ = [
     "_initialize_worker_logging",
     "process_pool_context",
     "process_pool_executor",
+    "resolve_parse_worker_count",
     "terminate_process_pool",
 ]

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -541,7 +541,17 @@ def _census_parse_worker(
             with publisher.open(blob_hash) as payload:
                 sessions = _parse_stream(provider, payload, source_path)
         else:
-            sessions = _parse_one(provider, publisher.read_all(blob_hash), source_path)
+            payload_path = None
+            if provider is Provider.HERMES:
+                candidate_path = publisher.blob_path(blob_hash)
+                payload_path = candidate_path if candidate_path.exists() else None
+            sessions = _parse_one(
+                provider,
+                publisher.read_all(blob_hash),
+                source_path,
+                payload_path=payload_path,
+                archive_root=Path(blob_root_str).parent,
+            )
         return raw_id, sessions, None
     except Exception as exc:
         return raw_id, None, str(exc)

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -227,6 +227,7 @@ def _census_historical_revision_evidence(
     *,
     selected_raw_ids: list[str] | None,
     max_payload_bytes: int | None,
+    ingest_workers: int = 1,
 ) -> _RevisionCensusState:
     """Persist a complete bounded parser census without mutating index.db."""
     state = _RevisionCensusState(0, 0, 0, set(), {}, {})
@@ -249,6 +250,13 @@ def _census_historical_revision_evidence(
                     raise RawRevisionReplayResourceBlockedError(
                         sorted(blocked_ids), max_payload_bytes, total_payload_bytes
                     )
+            # Parse is read-only blob->ParsedSession decode and authority-neutral;
+            # spread it across a process pool when there is more than one raw to
+            # parse. Archive writes below stay in fixed `pending_rows` order
+            # regardless of worker completion order, so parallel and sequential
+            # runs remain byte-identical.
+            parseable_raw_ids = [raw_id for raw_id, source_index in pending_rows if source_index >= 0]
+            parsed_outcomes = _parse_retained_raws(archive, parseable_raw_ids, ingest_workers=ingest_workers)
             for raw_id, source_index in pending_rows:
                 state.scanned += 1
                 state.censused.add(raw_id)
@@ -262,18 +270,18 @@ def _census_historical_revision_evidence(
                     )
                     state.quarantined += 1
                     continue
-                try:
-                    sessions, payload_bytes, revision_kind = _parse_retained_raw(archive, raw_id)
-                except Exception as exc:
+                outcome = parsed_outcomes[raw_id]
+                if isinstance(outcome, Exception):
                     archive.replace_raw_membership_census(
                         raw_id,
                         None,
                         parser_fingerprint="revision-membership-v1",
                         censused_at_ms=0,
-                        detail=str(exc),
+                        detail=str(outcome),
                     )
                     state.quarantined += 1
                     continue
+                sessions, payload_bytes, revision_kind = outcome
                 state.classified += int(len(sessions) == 1)
                 spill.add(raw_id, sessions, payload_bytes=payload_bytes)
                 if len(sessions) == 1 and revision_kind is RawRevisionKind.UNKNOWN:
@@ -314,6 +322,7 @@ def census_historical_revision_evidence(
     *,
     selected_raw_ids: list[str] | None = None,
     max_payload_bytes: int | None = None,
+    ingest_workers: int = 1,
 ) -> RevisionCensusResult:
     """Complete the source-tier census stage without applying index changes."""
     with (
@@ -325,6 +334,7 @@ def census_historical_revision_evidence(
             spill,
             selected_raw_ids=selected_raw_ids,
             max_payload_bytes=max_payload_bytes,
+            ingest_workers=ingest_workers,
         )
         expanded, logical_keys = archive.expand_raw_membership_selection(selected_raw_ids)
     _record_raw_authority_parser_census(archive_root, tuple(expanded))
@@ -344,12 +354,23 @@ def backfill_historical_revision_evidence(
     owned_inactive_generation: tuple[str, str] | None = None,
     retention_observer: Callable[[int, int], None] | None = None,
     max_payload_bytes: int | None = None,
+    max_cached_payload_bytes: int | None = None,
+    ingest_workers: int = 1,
 ) -> RevisionBackfillResult:
     """Census every retained raw, then replay byte and bundle authority cohorts.
 
     Parser output is spilled beside the target archive during the census and
     loaded one logical authority cohort at a time. Peak retained session trees
     therefore follow the largest raw/cohort, not the archive-wide raw count.
+
+    ``max_cached_payload_bytes`` bounds the spill cache independently of
+    ``max_payload_bytes``: the latter is a component resource-envelope block
+    (``None`` means unbounded, e.g. a one-shot full-archive rebuild) while the
+    former only avoids doubling I/O for census-then-replay reparse. It
+    defaults to ``max_payload_bytes`` so every existing bounded-envelope
+    caller keeps its current exactly-sized cache; pass it explicitly to cache
+    parse output for an unbounded (``max_payload_bytes=None``) census without
+    also activating envelope blocking.
     """
     adoption_deferred = 0
     quarantined = 0
@@ -363,15 +384,17 @@ def backfill_historical_revision_evidence(
         if owned_inactive_generation is not None
         else ArchiveStore.open_existing(archive_root, read_only=False)
     )
+    spill_cache_bytes = max_cached_payload_bytes if max_cached_payload_bytes is not None else max_payload_bytes
     with (
         archive_context as archive,
-        _ParsedSessionSpill(archive_root, max_cached_payload_bytes=max_payload_bytes) as spill,
+        _ParsedSessionSpill(archive_root, max_cached_payload_bytes=spill_cache_bytes) as spill,
     ):
         census = _census_historical_revision_evidence(
             archive,
             spill,
             selected_raw_ids=selected_raw_ids,
             max_payload_bytes=max_payload_bytes,
+            ingest_workers=ingest_workers,
         )
         censused_raw_ids, _censused_keys = archive.expand_raw_membership_selection(selected_raw_ids)
         # The direct backfill entry point must publish the same current-parser
@@ -490,6 +513,100 @@ def backfill_historical_revision_evidence(
 def _parse_retained_raw(archive: ArchiveStore, raw_id: str) -> tuple[list[ParsedSession], int, RawRevisionKind]:
     provider, _blob_hash, source_path, kind, payload_size = archive.raw_revision_descriptor(raw_id)
     return parse_retained_raw_sessions(archive, raw_id), payload_size, kind
+
+
+def _census_parse_worker(
+    raw_id: str,
+    provider_token: str,
+    blob_hash: str,
+    source_path: str,
+    is_stream: bool,
+    blob_root_str: str,
+    source_db_path_str: str,
+) -> tuple[str, list[ParsedSession] | None, str | None]:
+    """ProcessPool worker: parse one retained raw's already-published blob bytes.
+
+    Pure read-only blob->ParsedSession decode; the caller already knows this
+    raw's payload size and revision kind from its own source-tier descriptor
+    lookup, so only sessions (or a typed error string) cross the process
+    boundary. Errors are returned rather than raised so the writer process can
+    apply the exact same per-raw quarantine handling as the sequential path.
+    """
+    from polylogue.storage.blob_publication import ArchiveBlobPublisher
+
+    provider = Provider(provider_token)
+    publisher = ArchiveBlobPublisher(Path(source_db_path_str), Path(blob_root_str))
+    try:
+        if is_stream:
+            with publisher.open(blob_hash) as payload:
+                sessions = _parse_stream(provider, payload, source_path)
+        else:
+            sessions = _parse_one(provider, publisher.read_all(blob_hash), source_path)
+        return raw_id, sessions, None
+    except Exception as exc:
+        return raw_id, None, str(exc)
+
+
+def _parse_retained_raws(
+    archive: ArchiveStore,
+    raw_ids: list[str],
+    *,
+    ingest_workers: int,
+) -> dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception]:
+    """Parse a batch of retained raws, optionally across a process pool.
+
+    Returns each outcome keyed by raw_id: either the parsed
+    ``(sessions, payload_bytes, revision_kind)`` tuple or the caught
+    exception. Read-only blob->ParsedSession decode is authority-neutral and
+    embarrassingly parallel; callers apply archive writes afterwards in a
+    fixed deterministic order independent of completion order here, so
+    parallel and sequential execution produce byte-identical archive state.
+    """
+    if ingest_workers <= 1 or len(raw_ids) <= 1:
+        results: dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception] = {}
+        for raw_id in raw_ids:
+            try:
+                results[raw_id] = _parse_retained_raw(archive, raw_id)
+            except Exception as exc:
+                results[raw_id] = exc
+        return results
+
+    from concurrent.futures import as_completed
+
+    from polylogue.pipeline.services.process_pool import process_pool_executor
+
+    descriptors = {raw_id: archive.raw_revision_descriptor(raw_id) for raw_id in raw_ids}
+    blob_root_str = str(archive.archive_root / "blob")
+    source_db_path_str = str(archive.source_db_path)
+    results = {}
+    with process_pool_executor(max_workers=min(ingest_workers, len(raw_ids))) as pool:
+        future_to_raw_id = {}
+        for raw_id in raw_ids:
+            provider, blob_hash, source_path, _kind, _payload_size = descriptors[raw_id]
+            future = pool.submit(
+                _census_parse_worker,
+                raw_id,
+                provider.value,
+                blob_hash,
+                source_path,
+                is_stream_record_provider(source_path, str(provider)),
+                blob_root_str,
+                source_db_path_str,
+            )
+            future_to_raw_id[future] = raw_id
+        for future in as_completed(future_to_raw_id):
+            raw_id = future_to_raw_id[future]
+            try:
+                _raw_id, sessions, error = future.result()
+            except Exception as exc:
+                results[raw_id] = exc
+                continue
+            if error is not None:
+                results[raw_id] = RuntimeError(error)
+                continue
+            _provider, _blob_hash, _source_path, kind, payload_size = descriptors[raw_id]
+            results[raw_id] = (sessions or [], payload_size, kind)
+    return results
 
 
 def parse_retained_raw_sessions(archive: ArchiveStore, raw_id: str) -> list[ParsedSession]:

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -5570,11 +5570,24 @@ def repair_raw_materialization(
     source_root: Path | None = None,
     raw_artifact_limit: int | None = None,
     max_payload_bytes: int = RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES,
+    ingest_workers: int | None = None,
     progress_callback: ProgressCallback | None = None,
 ) -> RepairResult:
-    """Converge retained raws through typed per-session revision authority."""
+    """Converge retained raws through typed per-session revision authority.
+
+    ``ingest_workers`` bounds how many processes parse independent raws
+    within one census/replay component in parallel; ``None`` resolves the
+    shared default (``POLYLOGUE_INGEST_PARSE_WORKERS`` / cpu-1). Parse is
+    read-only and authority-neutral; component classification and apply
+    order remain strictly sequential in this single writer regardless of
+    worker count.
+    """
     if max_payload_bytes < 1:
         raise ValueError("max_payload_bytes must be positive")
+    if ingest_workers is None:
+        from polylogue.pipeline.services.process_pool import resolve_parse_worker_count
+
+        ingest_workers = resolve_parse_worker_count()
     archive_root = _raw_materialization_archive_root(config)
     recovered_censuses = recover_interrupted_raw_authority_censuses(archive_root)
     for recovered_census_id, recovered_scope in recovered_censuses:
@@ -5648,6 +5661,7 @@ def repair_raw_materialization(
                     archive_root,
                     selected_raw_ids=[seed],
                     max_payload_bytes=max_payload_bytes,
+                    ingest_workers=ingest_workers,
                 )
             except RawRevisionReplayResourceBlockedError as exc:
                 logger.warning(
@@ -6058,6 +6072,7 @@ def repair_raw_materialization(
                 archive_root,
                 selected_raw_ids=[raw_id],
                 max_payload_bytes=max_payload_bytes,
+                ingest_workers=ingest_workers,
             )
         except RawRevisionReplayResourceBlockedError as exc:
             metrics["raw_materialization_resource_blocked_count"] = max(

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -2029,6 +2029,7 @@ def test_rebuild_index_helper_returns_typed_empty_replay_receipt(tmp_path: Path)
         "authority_selection_expanded": True,
         "scheduled_raw_count": 2,
         "raw_batch_size": 7,
+        "ingest_workers": 1,
     }
 
 

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -658,3 +658,126 @@ def test_historical_backfill_reparses_multi_gib_shaped_raw_instead_of_spilling_a
     # The former archive-wide spill served the second lookup from a retained
     # pickle. A bounded cache deliberately reparses the durable source row.
     assert parses >= 2
+
+
+def _append_chain_archive(root: Path) -> tuple[str, str]:
+    """Two revisions of one logical session: an accepted-cohort replay fixture."""
+    initialize_active_archive_root(root)
+    baseline = (
+        b'{"type":"session_meta","payload":{"id":"chain","timestamp":"2026-07-01T00:00:00Z"}}\n'
+        b'{"type":"response_item","payload":{"type":"message","role":"user","content":'
+        b'[{"type":"input_text","text":"old"}]}}\n'
+    )
+    newest = baseline + (
+        b'{"type":"response_item","payload":{"type":"message","role":"assistant","content":'
+        b'[{"type":"output_text","text":"new"}]}}\n'
+    )
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        newest_raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=newest,
+            source_path="chain.jsonl",
+            acquired_at_ms=1,
+        )
+        baseline_raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=baseline,
+            source_path="chain.jsonl",
+            acquired_at_ms=2,
+        )
+    return baseline_raw_id, newest_raw_id
+
+
+def test_backfill_replay_reparses_when_spill_cache_absent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Baseline (pre-fix) shape: an unbounded (envelope=None) backfill with no
+    explicit spill-cache bound reparses every accepted revision during replay
+    even though census already parsed it once. This is exactly the CLI
+    rebuild-index path's behavior before max_cached_payload_bytes decoupled
+    caching from the resource envelope. Paired with the fixed-behavior test
+    below to pin both sides of the regression.
+    """
+    _append_chain_archive(tmp_path)
+    original = revision_backfill._parse_retained_raw
+    parse_calls: list[str] = []
+
+    def counted(archive: ArchiveStore, raw_id: str) -> tuple[list[ParsedSession], int, RawRevisionKind]:
+        parse_calls.append(raw_id)
+        return original(archive, raw_id)
+
+    monkeypatch.setattr(revision_backfill, "_parse_retained_raw", counted)
+
+    result = backfill_historical_revision_evidence(tmp_path, max_payload_bytes=None)
+
+    assert result.replayed_logical_sources == 1
+    # Census parses both raws once each (2 calls); replay then reparses the
+    # selected newest revision again from blob because nothing was cached
+    # (a 3rd call, duplicating one raw_id) instead of reusing census output.
+    assert len(parse_calls) == 3
+    assert len(set(parse_calls)) == 2
+
+
+def test_backfill_replay_reuses_spill_cache_when_bound_explicitly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """max_cached_payload_bytes caches census parse output independently of
+    max_payload_bytes (the resource-envelope block), so an unbounded backfill
+    still avoids reparsing accepted revisions during replay. Mutation:
+    reverting to the paired baseline test's call (omitting
+    max_cached_payload_bytes) reproduces the doubled parse count above --
+    this is the anti-vacuity pairing for the CLI rebuild-index fix.
+    """
+    _append_chain_archive(tmp_path)
+    original = revision_backfill._parse_retained_raw
+    parse_calls: list[str] = []
+
+    def counted(archive: ArchiveStore, raw_id: str) -> tuple[list[ParsedSession], int, RawRevisionKind]:
+        parse_calls.append(raw_id)
+        return original(archive, raw_id)
+
+    monkeypatch.setattr(revision_backfill, "_parse_retained_raw", counted)
+
+    result = backfill_historical_revision_evidence(
+        tmp_path,
+        max_payload_bytes=None,
+        max_cached_payload_bytes=64 * 1024 * 1024,
+    )
+
+    assert result.replayed_logical_sources == 1
+    # Both raws are parsed exactly once during census; replay hits the
+    # census-populated spill cache instead of reparsing the selected
+    # revision from blob a second time (contrast the 3-call baseline above).
+    assert len(parse_calls) == 2
+    assert len(set(parse_calls)) == 2
+
+
+def test_parallel_census_matches_sequential_archive_state(tmp_path: Path) -> None:
+    """Parsing spread across a process pool must produce byte-identical
+    archive state to the sequential path. Only read-only blob->ParsedSession
+    decode is parallelized; archive writes apply in fixed pending-rows order
+    regardless of worker completion order, so parallel and sequential runs
+    are authority-equivalent (not merely "close enough").
+    """
+    sequential_root = tmp_path / "sequential"
+    parallel_root = tmp_path / "parallel"
+    for root in (sequential_root, parallel_root):
+        initialize_active_archive_root(root)
+        with ArchiveStore.open_existing(root, read_only=False) as archive:
+            for index in range(6):
+                payload = _bundle(_chatgpt_session(f"session-{index}", f"hello {index}", f"world {index}"))
+                archive.write_raw_payload(
+                    provider=Provider.CHATGPT,
+                    payload=payload,
+                    source_path=f"chat-{index}.json",
+                    acquired_at_ms=index,
+                )
+
+    seq_result = backfill_historical_revision_evidence(sequential_root, ingest_workers=1)
+    par_result = backfill_historical_revision_evidence(parallel_root, ingest_workers=4)
+
+    assert seq_result == par_result
+
+    def _sessions(root: Path) -> list[tuple[object, ...]]:
+        with sqlite3.connect(root / "index.db") as conn:
+            return conn.execute("SELECT native_id, message_count, raw_id FROM sessions ORDER BY native_id").fetchall()
+
+    assert _sessions(sequential_root) == _sessions(parallel_root)

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -781,3 +781,66 @@ def test_parallel_census_matches_sequential_archive_state(tmp_path: Path) -> Non
             return conn.execute("SELECT native_id, message_count, raw_id FROM sessions ORDER BY native_id").fetchall()
 
     assert _sessions(sequential_root) == _sessions(parallel_root)
+
+
+def _state_db_bytes_for_session(tmp_path: Path, *, session_id: str, message_text: str) -> bytes:
+    """Variant of _single_session_state_db_bytes with a distinct session id."""
+    db_path = tmp_path / f"state-source-{session_id}.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE schema_version(version INTEGER NOT NULL);
+            INSERT INTO schema_version(version) VALUES (19);
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY, source TEXT, model_config TEXT, parent_session_id TEXT,
+                started_at REAL, ended_at REAL, end_reason TEXT, title TEXT
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY, session_id TEXT NOT NULL, role TEXT NOT NULL, content TEXT,
+                timestamp REAL NOT NULL, tool_calls TEXT, observed INTEGER DEFAULT 0,
+                active INTEGER DEFAULT 1, compacted INTEGER DEFAULT 0
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions (id, source, model_config, started_at, ended_at, end_reason, title) "
+            "VALUES (?, 'cli', '{}', 1.0, 8.0, 'completed', ?)",
+            (session_id, session_id),
+        )
+        conn.execute(
+            "INSERT INTO messages (id, session_id, role, content, timestamp) VALUES (1, ?, 'user', ?, 2.0)",
+            (session_id, message_text),
+        )
+    return db_path.read_bytes()
+
+
+def test_parallel_census_threads_hermes_sqlite_payload_path(tmp_path: Path) -> None:
+    """Regression for the #3113/polylogue-1zex SQLite-detection branch under
+    parallel dispatch: _census_parse_worker must thread payload_path (the
+    real on-disk blob path) and archive_root through to _parse_one the same
+    way the sequential parse_retained_raw_sessions does, so a Hermes
+    state.db raw parsed by a pool worker still opens via sqlite3 against a
+    real file instead of only working by accident through the temp-file
+    fallback. Two independent single-session state.db raws force
+    ingest_workers>1 to actually dispatch through the process pool.
+    """
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        for index in range(2):
+            payload = _state_db_bytes_for_session(tmp_path, session_id=f"hermes-{index}", message_text=f"hi {index}")
+            archive.write_raw_payload(
+                provider=Provider.HERMES,
+                payload=payload,
+                source_path=str(tmp_path / f"hermes-home-{index}" / "state.db"),
+                acquired_at_ms=index,
+            )
+
+    result = backfill_historical_revision_evidence(tmp_path, ingest_workers=4)
+
+    assert result.scanned == 2
+    assert result.replayed_logical_sources == 2
+    assert result.quarantined == 0
+    with sqlite3.connect(tmp_path / "index.db") as conn:
+        rows = conn.execute("SELECT native_id, message_count FROM sessions ORDER BY native_id").fetchall()
+    assert [native_id.startswith("hermes-") for native_id, _count in rows] == [True, True]
+    assert [count for _native_id, count in rows] == [1, 1]

--- a/tests/unit/storage/test_incremental_rebuild_equivalence.py
+++ b/tests/unit/storage/test_incremental_rebuild_equivalence.py
@@ -1056,7 +1056,7 @@ def test_incremental_restart_and_fresh_generation_rebuild_are_equivalent(
             _config(generation_root, index_path=generation_path),
             raw_ids=list(raw_ids.all()),
             raw_batch_size=500,
-            ingest_workers=None,
+            ingest_workers=1,
             materialize=True,
             progress_callback=None,
             owned_inactive_generation=(generation.generation_id, generation.owner_id),
@@ -1071,6 +1071,7 @@ def test_incremental_restart_and_fresh_generation_rebuild_are_equivalent(
         "authority_selection_expanded": True,
         "scheduled_raw_count": 4,
         "raw_batch_size": 500,
+        "ingest_workers": 1,
     }
     rebuilt_insights = repair_session_insights(
         _config(generation_root, index_path=generation_path),


### PR DESCRIPTION
## Summary

- Parallelizes raw-authority census parse across a process pool and decouples the spill-cache bound from the resource-envelope block, fixing the CLI `rebuild-index` path's dead `ingest_workers` parameter and silent double-parse (`polylogue-9p8x`).
- Delivers a read-only yla8 live-archive authorization packet recommending the operator hold the live catch-up gate.
- Delivers an honest hjpx.2 proof-status report: mutation-proof laws verified via existing regression coverage, but the July-15-scale execution itself did not complete this session (4 self-aborts under genuine host I/O contention — receipts included).

## Problem

`maintenance/replay.py::rebuild_index_from_source` accepted `ingest_workers` but immediately `del`eted it, funneling the CLI `rebuild-index` command's parser census into one sequential call. Its spill cache also never activated on that path because it received `max_payload_bytes=None`, so every accepted revision was reparsed during replay after census had already parsed it once (measured live: ~204 sessions/35min single-core).

Separately, hjpx.2 needed a July-15-archive-shape proof of raw-authority replay convergence, and yla8 needed a current live-archive preflight before any operator authorization decision.

## Solution

- `polylogue/sources/revision_backfill.py`: new `_parse_retained_raws`/`_census_parse_worker` spread read-only blob→`ParsedSession` decode across a `ProcessPoolExecutor`; archive writes still apply in fixed `pending_rows` order regardless of worker completion order, proven byte-identical to sequential (`test_parallel_census_matches_sequential_archive_state`). New `max_cached_payload_bytes` parameter decouples the spill-cache bound from the resource-envelope block (the two were previously the same parameter — passing a finite cache bound on the CLI's unbounded `selected_raw_ids=None` full-archive census would otherwise immediately raise `RawRevisionReplayResourceBlockedError`, since `raw_membership_census_rows(None)` returns every raw in the archive in one selection).
- `polylogue/storage/repair.py`, `polylogue/maintenance/replay.py`: both gained `ingest_workers`, defaulting to a new shared `resolve_parse_worker_count()` (`polylogue/pipeline/services/process_pool.py`), so the daemon convergence path and the hjpx.2 scale-proof harness get parallel census automatically with no harness changes needed.
- Rebased onto master's `#3113` (Hermes SQLite-detection fix to `_parse_one`); added parity so the parallel worker threads the real on-disk blob path through for Hermes raws the same way the sequential path does.
- `.agent/reports/yla8-authorization-packet-2026-07-18.md`: read-only live-archive audit (no mutation). Recommends holding authorization: no current verified backup (6 days stale), archive mid-restore (99.8% unmaterialized), and at observed throughput a full drain would take days-to-weeks without `polylogue-5jak` landing.
- `.agent/reports/hjpx2-july15-scale-proof-2026-07-18.md`: verdict per law. Envelope/fairness/conservation/interruption-resume mechanisms are proven (via existing + this session's regression tests); daemon-health responsiveness is a confirmed harness gap (`polylogue-agvo` filed); the July-15-scale execution itself self-aborted 4 times under genuine, sustained host I/O contention (receipts included, plus a diagnostic finding that the generation phase may be self-inducing pressure — `polylogue-cmw2` filed).

## Alternatives rejected

- The bead's own suggested one-line fix (`max_payload_bytes=64MiB` on the CLI path) was not applied as literally stated: it would have broken the unbounded full-archive rebuild by activating the resource-envelope block archive-wide. Introduced the separate `max_cached_payload_bytes` parameter instead.
- Did not implement commit-batching (the bead's own "Fix 3 (optional)") to chase the originally-hypothesized 4x speedup — measured evidence (cProfile) shows SQLite commit overhead is comparable to parse time, so parse-parallelism alone cannot reach 4x; filed `polylogue-amg1` as separately-scoped follow-up rather than force a larger, transaction-boundary-touching change into this PR.
- Did not build a real-daemon-process harness for daemon-health responsiveness within this PR; that's a genuinely separate harness component (`polylogue-agvo`).

## Verification

- `devtools test tests/unit/sources/test_revision_backfill.py`: 18 passed
- `devtools test -k "raw_materialization or raw_authority"`: 148 passed
- `devtools test tests/unit/devtools/test_raw_authority_scale_proof.py`: 21 passed
- `devtools test tests/unit/devtools/test_raw_authority_restart_proof.py`: 4 passed
- `devtools test tests/unit/storage/test_incremental_rebuild_equivalence.py tests/unit/cli/test_archive_maintenance_cli.py`: 58 passed
- `devtools verify --quick`: exit 0 (16/16 steps), green after every commit

## AC matrix

- **polylogue-9p8x**: Fix 1 (honor `ingest_workers`) and Fix 2 (decouple spill cache) — satisfied, tested. AC4 (≥4x measured speedup) — **not satisfied**, corrected by evidence to ~1.2-1.7x (Amdahl-limited); deferred to `polylogue-amg1`.
- **polylogue-yla8**: read-only packet delivered per spec; no live mutation. Not closed (that decision is the operator's, per the packet's own yes/no question).
- **polylogue-hjpx.2**: mutation-proof laws (envelope, fairness, conservation, interruption/resume) — proven via regression. Daemon-health responsiveness — not provable with current harness, `polylogue-agvo` filed. July-15-scale execution (AC1/AC6/AC7) — **not achieved this session**; 4 honest self-abort receipts recorded, `polylogue-cmw2` filed for the generation-phase self-induced-pressure finding. Bead remains open, not force-closed.

Ref polylogue-9p8x
Ref polylogue-yla8
Ref polylogue-hjpx.2

Co-Authored-By: Claude <noreply@anthropic.com>