### PR TITLE
perf(daemon): drain browser-capture spool first in catch-up interleave

### DIFF
--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -1093,13 +1093,20 @@ def _interleave_by_source(candidates: list[CandidateSourceFile]) -> list[Candida
     small-source ingestion progress for hours. Bucket by source_name,
     sort each bucket by path for determinism, then round-robin across
     buckets so the first chunk contains some of every present family.
+
+    Exception: browser-capture spool files drain FIRST. The raw
+    materialization conveyor yields the writer while any spool file
+    lacks a cursor (daemon/cli.py), so interleaving them across the
+    whole plan parks source→index self-healing for the entire catch-up
+    (observed live 2026-07-18: conveyor idle for hours behind ~600
+    spooled captures spread over ~700 chunks).
     """
     buckets: dict[str, list[CandidateSourceFile]] = {}
     for candidate in candidates:
         buckets.setdefault(candidate.source_name, []).append(candidate)
     for source_name in buckets:
         buckets[source_name].sort(key=lambda candidate: candidate.path)
-    ordered: list[CandidateSourceFile] = []
+    ordered: list[CandidateSourceFile] = list(buckets.pop("browser-capture", []))
     iterators = [iter(buckets[name]) for name in sorted(buckets)]
     while iterators:
         next_round = []

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -2674,3 +2674,31 @@ def test_end_to_end_deletion_does_not_ingest(tmp_path: Path) -> None:
         assert parse_sources.await_count == baseline  # deletion did not trigger ingest
 
     asyncio.run(_drive())
+
+
+def test_interleave_drains_browser_capture_spool_before_round_robin(tmp_path: Path) -> None:
+    """Spool files gate the raw-materialization conveyor's writer yield, so
+    catch-up must cursor them first instead of spreading them across the
+    whole plan; remaining families keep the #1616 round-robin."""
+    from polylogue.sources.live.watcher import CandidateSourceFile, _interleave_by_source
+
+    def candidate(name: str, source: str) -> CandidateSourceFile:
+        path = tmp_path / source / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"{}")
+        return CandidateSourceFile(path=path, source_name=source, suffix=path.suffix, stat=path.stat())
+
+    candidates = [
+        candidate("a.jsonl", "codex"),
+        candidate("b.json", "browser-capture"),
+        candidate("c.jsonl", "claude-code"),
+        candidate("d.json", "browser-capture"),
+        candidate("e.jsonl", "codex"),
+    ]
+
+    ordered = _interleave_by_source(candidates)
+
+    assert [item.source_name for item in ordered[:2]] == ["browser-capture", "browser-capture"]
+    rest = [item.source_name for item in ordered[2:]]
+    assert sorted(rest) == ["claude-code", "codex", "codex"]
+    assert rest[0] != rest[1] or rest[1] != rest[2]


### PR DESCRIPTION
## Summary

Fifth daemon-drain fix from the 2026-07-18 restore: the catch-up plan's round-robin interleave (#1616) spreads browser-capture spool files across the entire plan, and the raw-materialization conveyor yields the writer while *any* spool file lacks a cursor — so the conveyor (the archive's only self-heal path for quarantined cohorts, i.e. most of the restore population) stays parked for the whole multi-hour catch-up.

## Problem

Observed live: ~600 spooled captures interleaved across ~700 chunks; `raw materialization: yielding to pending browser-capture spool files` every tick for hours across two daemon restarts, with the burst-capable conveyor (#3102) never executing a single pass.

## Solution

`_interleave_by_source` emits the browser-capture bucket first, then round-robins the remaining families exactly as before (the #1616 progress-visibility rationale is preserved for them). Spool files gain cursors in the first chunks; the conveyor unparks minutes into catch-up.

## Verification

`devtools test tests/unit/sources/test_live_watcher.py -k "interleave or catch_up"` — 13 passed, including the new test pinning spool-first ordering with round-robin preserved for the rest. `mypy` clean; pre-push quick gate green.

Ref polylogue-5jak

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ