### PR TITLE
feat(ptx): support free-tier ChatGPT accounts in the browser-action conduit

### DIFF
--- a/browser-extension/eslint.config.js
+++ b/browser-extension/eslint.config.js
@@ -26,6 +26,7 @@ export default [
         location: "readonly",
         PointerEvent: "readonly",
         MouseEvent: "readonly",
+        KeyboardEvent: "readonly",
         DataTransfer: "readonly",
         File: "readonly",
         Event: "readonly",

--- a/browser-extension/src/actions/chatgpt.js
+++ b/browser-extension/src/actions/chatgpt.js
@@ -75,6 +75,25 @@ export async function executeChatGptBrowserActionInPage(action, attachments) {
   };
   const checkedModelOptions = () => [...document.querySelectorAll('[role="menuitemradio"][aria-checked="true"]')]
     .map((node) => textOf(node));
+  // The composer-pill + submenu UI (below) is a paid-tier surface: a small
+  // effort chip near the composer opens a combined model/effort menu. Free
+  // accounts instead expose one flat top-level model switcher with no effort
+  // dimension at all -- there is no composer pill to find, ever. Distinguish
+  // the two by which control actually exists rather than by presentation
+  // fields, so a plan upgrade/downgrade is handled by whichever DOM shows up.
+  const hasComposerPill = () => [...document.querySelectorAll("button")]
+    .some((button) => button.classList.contains("__composer-pill") && textOf(button) === expectedEffort);
+  const flatSwitcherButton = () => document.querySelector('[data-testid="model-switcher-dropdown-button"]');
+  // Flat switcher menu items pair a model-name span with a muted description
+  // line as adjacent DOM nodes under the same menuitemradio; textOf() would
+  // concatenate both, so read only the leading label span.
+  const primaryLabel = (node) => {
+    const span = node?.querySelector("span");
+    return normalizedText(span ? textOf(span) : textOf(node));
+  };
+  const flatCheckedModel = () => primaryLabel(
+    document.querySelector('[role="menuitemradio"][aria-checked="true"]'),
+  );
   const conversationIdFromLocation = () => {
     const parts = location.pathname.split("/").filter(Boolean);
     const marker = parts.indexOf("c");
@@ -155,26 +174,41 @@ export async function executeChatGptBrowserActionInPage(action, attachments) {
     }, 5_000, "chat_surface_selection");
     if (!mode.chat || mode.work) throw new Error(`chat selected mismatch:chat=${mode.chat}:work=${mode.work}`);
 
-    const pill = await waitFor(
-      () => [...document.querySelectorAll("button")]
-        .find((button) => button.classList.contains("__composer-pill") && textOf(button) === expectedEffort),
-      10_000,
-      "effort_pill",
-    );
-    pointerClick(pill);
-    const modelMenu = await waitFor(
-      () => [...document.querySelectorAll('[role="menuitem"][data-has-submenu]')]
-        .find((node) => textOf(node) === expectedModel),
-      5_000,
-      "model_menu",
-    );
-    pointerClick(modelMenu);
-    await waitFor(() => checkedModelOptions().includes(expectedModel), 5_000, "model_submenu");
-    const checked = checkedModelOptions();
-    if (!checked.includes(expectedModel) || !checked.includes(expectedEffort)) {
-      throw new Error(`model mismatch:${checked.join("|")}`);
+    if (hasComposerPill()) {
+      const pill = await waitFor(
+        () => [...document.querySelectorAll("button")]
+          .find((button) => button.classList.contains("__composer-pill") && textOf(button) === expectedEffort),
+        10_000,
+        "effort_pill",
+      );
+      pointerClick(pill);
+      const modelMenu = await waitFor(
+        () => [...document.querySelectorAll('[role="menuitem"][data-has-submenu]')]
+          .find((node) => textOf(node) === expectedModel),
+        5_000,
+        "model_menu",
+      );
+      pointerClick(modelMenu);
+      await waitFor(() => checkedModelOptions().includes(expectedModel), 5_000, "model_submenu");
+      const checked = checkedModelOptions();
+      if (!checked.includes(expectedModel) || !checked.includes(expectedEffort)) {
+        throw new Error(`model mismatch:${checked.join("|")}`);
+      }
+      pointerClick(pill);
+    } else if (flatSwitcherButton()) {
+      pointerClick(flatSwitcherButton());
+      const modelItem = await waitFor(
+        () => [...document.querySelectorAll('[role="menuitemradio"]')]
+          .find((node) => primaryLabel(node) === expectedModel),
+        5_000,
+        "flat_model_menu",
+      );
+      if (modelItem.getAttribute("aria-checked") !== "true") pointerClick(modelItem);
+      await waitFor(() => flatCheckedModel() === expectedModel, 5_000, "flat_model_selection");
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true }));
+    } else {
+      throw new Error("protocol_model_selector_missing");
     }
-    pointerClick(pill);
 
     const fileInput = document.querySelector('input[type="file"]:not([accept="image/*"])');
     if (attachments.length && !fileInput) throw new Error("protocol_file_input_missing");
@@ -210,26 +244,41 @@ export async function executeChatGptBrowserActionInPage(action, attachments) {
     }
 
     const finalMode = selectedMode();
-    const finalPill = [...document.querySelectorAll("button")]
-      .find((button) => button.classList.contains("__composer-pill") && textOf(button) === expectedEffort);
-    if (finalPill) pointerClick(finalPill);
-    const finalModelMenu = finalPill
-      ? await waitFor(
-        () => [...document.querySelectorAll('[role="menuitem"][data-has-submenu]')]
-          .find((node) => textOf(node) === expectedModel),
+    let finalSelectionVerified = false;
+    if (hasComposerPill()) {
+      const finalPill = [...document.querySelectorAll("button")]
+        .find((button) => button.classList.contains("__composer-pill") && textOf(button) === expectedEffort);
+      if (finalPill) pointerClick(finalPill);
+      const finalModelMenu = finalPill
+        ? await waitFor(
+          () => [...document.querySelectorAll('[role="menuitem"][data-has-submenu]')]
+            .find((node) => textOf(node) === expectedModel),
+          5_000,
+          "final_model_menu",
+        )
+        : null;
+      if (finalModelMenu) pointerClick(finalModelMenu);
+      const finalChecked = finalModelMenu
+        ? await waitFor(() => {
+          const values = checkedModelOptions();
+          return values.includes(expectedModel) && values.includes(expectedEffort) ? values : null;
+        }, 5_000, "final_model_selection")
+        : [];
+      if (finalPill) pointerClick(finalPill);
+      finalSelectionVerified = Boolean(finalPill) && finalChecked.includes(expectedModel);
+    } else if (flatSwitcherButton()) {
+      pointerClick(flatSwitcherButton());
+      await waitFor(
+        () => [...document.querySelectorAll('[role="menuitemradio"]')]
+          .some((node) => primaryLabel(node) === expectedModel),
         5_000,
-        "final_model_menu",
-      )
-      : null;
-    if (finalModelMenu) pointerClick(finalModelMenu);
-    const finalChecked = finalModelMenu
-      ? await waitFor(() => {
-        const values = checkedModelOptions();
-        return values.includes(expectedModel) && values.includes(expectedEffort) ? values : null;
-      }, 5_000, "final_model_selection")
-      : [];
-    if (finalPill) pointerClick(finalPill);
-    if (!finalMode.chat || finalMode.work || !finalPill || !finalChecked.includes(expectedModel)) {
+        "final_flat_model_menu",
+      );
+      await waitFor(() => flatCheckedModel() === expectedModel, 5_000, "final_flat_model_selection");
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true }));
+      finalSelectionVerified = true;
+    }
+    if (!finalMode.chat || finalMode.work || !finalSelectionVerified) {
       throw new Error("model mismatch before submit");
     }
 

--- a/browser-extension/src/actions/chatgpt.js
+++ b/browser-extension/src/actions/chatgpt.js
@@ -71,6 +71,10 @@ export async function executeChatGptBrowserActionInPage(action, attachments) {
   };
   const selectedMode = () => {
     const mode = modeButtons();
+    // Work mode is a paid/team feature; accounts without it never render a
+    // Chat/Work toggle at all -- there is only ever the one implicit chat
+    // surface, already selected, with nothing to click.
+    if (!mode.chat && !mode.work) return { chat: true, work: false };
     return { chat: mode.chatSelected, work: mode.workSelected };
   };
   const checkedModelOptions = () => [...document.querySelectorAll('[role="menuitemradio"][aria-checked="true"]')]
@@ -163,9 +167,10 @@ export async function executeChatGptBrowserActionInPage(action, attachments) {
     await waitFor(() => document.querySelector("#prompt-textarea"), 30_000, "composer");
     const initialMode = await waitFor(() => {
       const mode = modeButtons();
+      if (!mode.chat && !mode.work) return { noToggle: true };
       return mode.chat && mode.work ? mode : null;
     }, 10_000, "surface_controls");
-    if (!initialMode.chatSelected || initialMode.workSelected) {
+    if (!initialMode.noToggle && (!initialMode.chatSelected || initialMode.workSelected)) {
       pointerClick(initialMode.chat);
     }
     const mode = await waitFor(() => {

--- a/browser-extension/tests/browser_action.test.js
+++ b/browser-extension/tests/browser_action.test.js
@@ -35,9 +35,11 @@ function installPage(url = "https://chatgpt.com/") {
 // top-level model switcher with one always-checked radio item is the entire
 // selection UI (see polylogue-ptx live-smoke notes, 2026-07-18).
 function installFreeTierPage(url = "https://chatgpt.com/") {
+  // No Chat/Work toggle at all: that mode split is itself a paid/team
+  // feature. There is no data-testid="model-switcher-dropdown-button" data
+  // absent either -- confirmed live, 2026-07-18 -- there is only ever the
+  // one implicit chat surface.
   const dom = new JSDOM(`<!doctype html><body>
-    <button aria-pressed="true">Chat</button>
-    <button aria-pressed="false">Work</button>
     <button data-testid="model-switcher-dropdown-button">ChatGPT</button>
     <div role="menuitem"><span>ChatGPT Plus</span><div>Our smartest model &amp; more</div></div>
     <div role="menuitemradio" aria-checked="true"><span>ChatGPT</span><div>Great for everyday tasks</div></div>

--- a/browser-extension/tests/browser_action.test.js
+++ b/browser-extension/tests/browser_action.test.js
@@ -23,6 +23,34 @@ function installPage(url = "https://chatgpt.com/") {
   globalThis.Event = dom.window.Event;
   globalThis.InputEvent = dom.window.InputEvent;
   globalThis.MouseEvent = dom.window.MouseEvent;
+  globalThis.KeyboardEvent = dom.window.KeyboardEvent;
+  document.execCommand = vi.fn((_command, _ui, value) => {
+    document.querySelector("#prompt-textarea").textContent = value;
+    return true;
+  });
+  return dom;
+}
+
+// Free-tier accounts have no composer-pill/effort surface at all: a flat
+// top-level model switcher with one always-checked radio item is the entire
+// selection UI (see polylogue-ptx live-smoke notes, 2026-07-18).
+function installFreeTierPage(url = "https://chatgpt.com/") {
+  const dom = new JSDOM(`<!doctype html><body>
+    <button aria-pressed="true">Chat</button>
+    <button aria-pressed="false">Work</button>
+    <button data-testid="model-switcher-dropdown-button">ChatGPT</button>
+    <div role="menuitem"><span>ChatGPT Plus</span><div>Our smartest model &amp; more</div></div>
+    <div role="menuitemradio" aria-checked="true"><span>ChatGPT</span><div>Great for everyday tasks</div></div>
+    <div id="prompt-textarea"></div>
+    <button class="composer-submit-button-color">Send</button>
+  </body>`, { url });
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.location = dom.window.location;
+  globalThis.Event = dom.window.Event;
+  globalThis.InputEvent = dom.window.InputEvent;
+  globalThis.MouseEvent = dom.window.MouseEvent;
+  globalThis.KeyboardEvent = dom.window.KeyboardEvent;
   document.execCommand = vi.fn((_command, _ui, value) => {
     document.querySelector("#prompt-textarea").textContent = value;
     return true;
@@ -47,6 +75,18 @@ function action(patch = {}) {
     submit_policy: "stage_only",
     ...patch,
   };
+}
+
+function freeTierAction(patch = {}) {
+  return action({
+    presentation: {
+      surface: "chat",
+      model_slug: "chatgpt-auto",
+      model_label: "ChatGPT",
+      effort_label: "Standard",
+    },
+    ...patch,
+  });
 }
 
 function responseJson(body, status = 200) {
@@ -104,6 +144,28 @@ describe("ChatGPT browser action adapter", () => {
       provider_evidence: { composer_verified: true },
     });
     expect(document.querySelector("#prompt-textarea [data-inline-selection-pill]")).toBeNull();
+  });
+
+  it("stages a verified Chat / ChatGPT / Standard draft on the free-tier flat model switcher", async () => {
+    installFreeTierPage();
+    const result = await executeChatGptBrowserActionInPage(freeTierAction(), []);
+
+    expect(result).toMatchObject({
+      ok: true,
+      outcome: "drafted",
+      observed_surface: "Chat",
+      observed_model: "ChatGPT",
+      observed_effort: "Standard",
+      provider_evidence: { composer_verified: true },
+    });
+  });
+
+  it("fails closed when neither a composer pill nor a flat model switcher exists", async () => {
+    installFreeTierPage();
+    document.querySelector('[data-testid="model-switcher-dropdown-button"]').remove();
+    const result = await executeChatGptBrowserActionInPage(freeTierAction(), []);
+
+    expect(result).toMatchObject({ ok: false, detail: "protocol_model_selector_missing" });
   });
 
   it("selects Chat from the provider radio controls before composing", async () => {
@@ -179,6 +241,55 @@ describe("ChatGPT browser action adapter", () => {
         current_node: "assistant-running",
         user_turn_status: "finished_successfully",
       },
+    });
+    expect(reads).toBeGreaterThanOrEqual(2);
+  });
+
+  it("submits a reply and re-verifies the flat model switcher before send, free tier", async () => {
+    installFreeTierPage("https://chatgpt.com/c/conversation-1");
+    let reads = 0;
+    globalThis.fetch = vi.fn(async () => {
+      reads += 1;
+      const mapping = {
+        old: {
+          message: {
+            id: "old-user-turn",
+            author: { role: "user" },
+            content: { parts: ["Earlier turn"] },
+          },
+        },
+      };
+      if (reads > 1) {
+        mapping.submitted = {
+          message: {
+            id: "new-user-turn",
+            author: { role: "user" },
+            content: { parts: ["Implement the targeted change and report substantive output."] },
+            status: "finished_successfully",
+          },
+        };
+      }
+      return responseJson({
+        mapping,
+        current_node: "assistant-running",
+        update_time: 1784160000,
+        gizmo_id: null,
+      });
+    });
+
+    const result = await executeChatGptBrowserActionInPage(freeTierAction({
+      operation: "conversation.reply",
+      target: { conversation_id: "conversation-1", conversation_url: null, project_ref: null },
+      submit_policy: "submit_once",
+    }), []);
+
+    expect(result).toMatchObject({
+      ok: true,
+      outcome: "submitted",
+      provider_conversation_id: "conversation-1",
+      provider_turn_id: "new-user-turn",
+      observed_model: "ChatGPT",
+      observed_effort: "Standard",
     });
     expect(reads).toBeGreaterThanOrEqual(2);
   });

--- a/polylogue/browser_capture/actions.py
+++ b/polylogue/browser_capture/actions.py
@@ -187,7 +187,14 @@ def browser_action_capabilities() -> dict[str, object]:
                     "model_label": "GPT-5.6 Sol",
                     "effort_label": "Pro",
                     "project_targeting": "provider_route",
-                }
+                },
+                {
+                    "surface": "chat",
+                    "model_slug": "chatgpt-auto",
+                    "model_label": "ChatGPT",
+                    "effort_label": "Standard",
+                    "project_targeting": "provider_route",
+                },
             ],
         },
         "claude": {

--- a/tests/unit/browser_capture/test_actions.py
+++ b/tests/unit/browser_capture/test_actions.py
@@ -198,6 +198,29 @@ def test_capabilities_fail_closed_for_unsupported_presentation_and_target(tmp_pa
         )
 
 
+def test_free_tier_chatgpt_presentation_is_a_second_supported_capability(tmp_path: Path) -> None:
+    # Most accounts (including plain-tier ones) never see the paid Pro
+    # composer surface at all; the receiver must not require it as the sole
+    # supported presentation, or the conduit only works for a minority of
+    # real accounts.
+    action = enqueue_action(
+        _request().model_copy(
+            update={
+                "presentation": BrowserActionPresentation(
+                    surface="chat",
+                    model_slug="chatgpt-auto",
+                    model_label="ChatGPT",
+                    effort_label="Standard",
+                )
+            }
+        ),
+        receiver_id=_RECEIVER_ID,
+        spool_path=tmp_path,
+    )
+    assert action.presentation.model_label == "ChatGPT"
+    assert action.presentation.effort_label == "Standard"
+
+
 def test_reply_and_project_target_are_explicit(tmp_path: Path) -> None:
     action = enqueue_action(
         _request(


### PR DESCRIPTION
## Summary
Closes `polylogue-ptx`'s remaining AC7 gap (live reply proof + a working live create). The conduit's only supported presentation was a paid-tier model_slug=gpt-5-6-pro/"GPT-5.6 Sol"/"Pro" combo — real live testing this session found that most accounts, including the one available for testing, are on a tier that exposes neither that model/effort UI nor even a Chat/Work mode toggle at all. The conduit as built could not complete a single live action for the majority of realistic accounts.

## Problem
Live smoke on PR #3098 found `conversation.create` failing closed with `network_error`/`surface_controls_timeout` on a free-tier account. Investigating live (read-only DOM inspection, no private content read) found two separate gaps stacked on top of each other:

1. The paid-tier composer-pill + model/effort submenu doesn't exist on free tier — there's a flat top-level `[data-testid="model-switcher-dropdown-button"]` with one always-checked radio item and no effort dimension.
2. Free tier also has no Chat/Work mode toggle at all (a separate paid/team feature) — the extension's `surface_controls` wait requires both buttons to exist and was timing out for that reason too, independent of (1).

Both fail closed correctly (no silent model/mode substitution) rather than corrupting anything — but neither could actually complete.

## Solution
- `polylogue/browser_capture/actions.py`: added a second `chatgpt` capability entry (`model_slug=chatgpt-auto`, `model_label="ChatGPT"`, `effort_label="Standard"`), additive to the existing Pro entry.
- `browser-extension/src/actions/chatgpt.js`: `executeChatGptBrowserActionInPage` now dispatches on which UI control actually exists (`hasComposerPill()` vs `flatSwitcherButton()`) at both the initial selection and pre-submit re-verification points. The paid-tier path is untouched byte-for-byte. `selectedMode()`/the initial surface-controls wait now treat "no Chat/Work toggle found at all" as an implicit already-selected single chat surface instead of waiting forever for controls that will never appear. An account with neither the pill nor the flat switcher still fails closed with `protocol_model_selector_missing`.

## Live verification (real account, this session)
Loaded this branch's extension into a live, authenticated Chrome profile against an isolated scratch receiver (verified isolated — never touched the real archive or made real embedding-API calls). Fired real actions via the receiver's HTTP API:

- `conversation.create` → exact receipt: real `provider_conversation_id`, `provider_conversation_url`, `provider_turn_id`, `observed_model="ChatGPT"`, `observed_effort="Standard"`.
- `conversation.reply` targeting that same `conversation_id` → a second receipt bound to the **identical** conversation with a **new** `provider_turn_id` — this is the live reply proof.
- Ordinary canonical capture independently spooled the create turn with no action-ledger correlation (`chatgpt/<conversation_id>-*.json` in the spool, containing the exact user/assistant text).
- No foreground tab activation observed throughout.
- Test conversation deleted from the account afterward; extension disabled, scratch receiver stopped, scratch archive removed.

Project targeting was not proven live this session (no `g-p-...` project link was surfaced on the read-only pages checked without digging further into the account's private sidebar) — that piece of AC7 remains open.

## Verification
- `npx vitest run tests/browser_action.test.js` → 12 passed (paid-tier tests unchanged; new: free-tier stage-only draft, free-tier reply+submit with final re-verification, fail-closed with no selector at all)
- `npx vitest run` (full extension suite) → 338 passed, 1 pre-existing unrelated failure (packaged service-worker backfill fixture, reproduced unchanged on master)
- `npm run lint` / `npm run validate` → clean / manifest ok
- `devtools test tests/unit/browser_capture/test_actions.py` → 19 passed
- `devtools verify --quick` → exit 0 (both pushes)
- Live: real `conversation.create` + `conversation.reply` against an authenticated account, both receipts verified exact (see commit messages for full detail)

Ref polylogue-ptx