### PR TITLE
fix(mcp): wire status(scope=coordination) to coordination logic

### DIFF
--- a/polylogue/mcp/server_cutover.py
+++ b/polylogue/mcp/server_cutover.py
@@ -16,6 +16,7 @@ from polylogue.mcp.declarations.models import mcp_role_allows
 from polylogue.mcp.payloads import MCPArchiveStatsPayload, MCPRootPayload, session_topology_payload
 
 if TYPE_CHECKING:
+    from polylogue.coordination import CoordinationEnvelopeCache
     from polylogue.maintenance.scope import MaintenanceScopeFilter
     from polylogue.mcp.declarations.adapter import ToolRegistrar
     from polylogue.mcp.server_support import ServerCallbacks
@@ -206,6 +207,20 @@ async def _resume_preamble(
 
 def register_cutover_read_tools(mcp: ToolRegistrar, hooks: ServerCallbacks) -> None:
     """Register exactly the six default, role-read transactions."""
+
+    # Deferred import + lazy singleton: every other branch in this module
+    # imports its dependencies inside the closure that uses them, to keep
+    # server construction itself cheap; a status(scope="coordination") call
+    # never needs to happen in a given session, so this avoids paying
+    # coordination.envelope's import cost for sessions that never make one.
+    _coordination_cache_holder: list[CoordinationEnvelopeCache] = []
+
+    def _coordination_cache() -> CoordinationEnvelopeCache:
+        if not _coordination_cache_holder:
+            from polylogue.coordination import CoordinationEnvelopeCache
+
+            _coordination_cache_holder.append(CoordinationEnvelopeCache())
+        return _coordination_cache_holder[0]
 
     async def query(
         expression: str | None = None,
@@ -430,6 +445,16 @@ def register_cutover_read_tools(mcp: ToolRegistrar, hooks: ServerCallbacks) -> N
                     include_cached=True,
                     mcp_call_delivery=asdict(mcp_call_outbox_status()),
                 ).model_dump(mode="json", exclude_none=True)
+                return hooks.json_payload(MCPRootPayload(root=root), exclude_none=True)
+
+            if scope == "coordination":
+                from polylogue.coordination import build_coordination_envelope
+
+                if "detail" in include:
+                    envelope = build_coordination_envelope(view="status", detail=True)
+                else:
+                    envelope = _coordination_cache().get_or_build(view="status", cwd=None, limit=10)
+                root["coordination"] = envelope.model_dump(mode="json", exclude_none=True)
                 return hooks.json_payload(MCPRootPayload(root=root), exclude_none=True)
 
             from polylogue.archive.query.transaction import QueryTransaction, QueryTransactionRequest

--- a/tests/unit/mcp/test_status_scope_coordination.py
+++ b/tests/unit/mcp/test_status_scope_coordination.py
@@ -1,0 +1,100 @@
+"""status(scope="coordination") must dispatch to coordination logic, not archive stats.
+
+Regression test for polylogue-qink: the six-tool cutover surface declared a
+"coordination" scope on ``status`` but every scope value except "operation"
+fell through to the same generic ``archive.stats()`` projection, so
+``status(scope="coordination")`` silently returned archive stats and never
+touched :func:`build_coordination_envelope`.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import cast
+
+import pytest
+
+from polylogue.coordination.payloads import (
+    AgentCoordinationPayload,
+    CoordinationLimitsPayload,
+    CoordinationProvenancePayload,
+    CoordinationRepoPayload,
+    CoordinationSelfPayload,
+    CoordinationView,
+    CoordinationWorkItemPayload,
+)
+from tests.infra.mcp import MCPServerUnderTest, invoke_surface
+
+
+def _payload(view: str = "status") -> AgentCoordinationPayload:
+    provenance = CoordinationProvenancePayload(source="test", confidence=1.0, freshness="fixture")
+    return AgentCoordinationPayload(
+        view=cast(CoordinationView, view),
+        generated_at="2026-07-18T18:00:00+00:00",
+        repo=CoordinationRepoPayload(cwd="/repo", root="/repo", branch="feature/test", provenance=provenance),
+        self=CoordinationSelfPayload(
+            identity_status="resolved",
+            agent_kind="codex",
+            logical_id="codex:thread",
+            owner_pid=123,
+            invocation_pid=456,
+            cwd="/repo",
+            branch="feature/test",
+            session_ref="thread",
+            provenance=provenance,
+        ),
+        work_item=CoordinationWorkItemPayload(
+            source="beads", ref="polylogue-qink", confidence=0.95, provenance=provenance
+        ),
+        limits=CoordinationLimitsPayload(peer_limit=10, resource_limit=10, changed_path_limit=40, command_chars=220),
+        provenance=(provenance,),
+    )
+
+
+def test_status_coordination_scope_returns_coordination_envelope_not_archive_stats(
+    mcp_server: MCPServerUnderTest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[bool] = []
+
+    def fake_build(**kwargs: object) -> AgentCoordinationPayload:
+        calls.append(bool(kwargs["detail"]))
+        return _payload(str(kwargs["view"]))
+
+    # Both the fresh/detail path (server_cutover.py's own import) and the
+    # cached path (CoordinationEnvelopeCache's internal collector, resolved
+    # against coordination.envelope's own globals) need patching.
+    monkeypatch.setattr("polylogue.coordination.build_coordination_envelope", fake_build)
+    monkeypatch.setattr("polylogue.coordination.envelope.build_coordination_envelope", fake_build)
+
+    raw = invoke_surface(mcp_server._tool_manager._tools["status"].fn, scope="coordination")
+    body = json.loads(raw)
+
+    assert body["scope"] == "coordination"
+    assert "archive" not in body
+    assert body["coordination"]["self"]["logical_id"] == "codex:thread"
+    assert body["coordination"]["work_item"]["ref"] == "polylogue-qink"
+    assert calls == [False]
+
+
+def test_status_coordination_scope_detail_bypasses_cache(
+    mcp_server: MCPServerUnderTest,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[bool] = []
+
+    def fake_build(**kwargs: object) -> AgentCoordinationPayload:
+        calls.append(bool(kwargs["detail"]))
+        return _payload(str(kwargs["view"]))
+
+    monkeypatch.setattr("polylogue.coordination.build_coordination_envelope", fake_build)
+    monkeypatch.setattr("polylogue.coordination.envelope.build_coordination_envelope", fake_build)
+
+    tool = mcp_server._tool_manager._tools["status"].fn
+    invoke_surface(tool, scope="coordination")
+    invoke_surface(tool, scope="coordination")
+    invoke_surface(tool, scope="coordination", include=("detail",))
+
+    # The second compact call hits the warm cache (no new build call); the
+    # detail request always goes live.
+    assert calls == [False, True]


### PR DESCRIPTION
## Summary
`status(scope="coordination")` on the six-tool MCP cutover surface silently returned generic `archive.stats()` instead of coordination status.

## Problem
`register_cutover_read_tools`'s `status` verb dispatched every scope except `"operation"` to the same `archive.stats()` projection. An agent calling `status(scope="coordination")` got archive stats, not coordination data — discovered while porting polylogue-20d.17's budgeted component-snapshot protocol to coordination status (#3116).

## Solution
- `status(scope="coordination")` now dispatches to real coordination logic: compact requests reuse a lazily-constructed `CoordinationEnvelopeCache` (fingerprint-invalidated on git HEAD/logs/`.beads/issues.jsonl`/index db-WAL mtimes, per #3116's substrate), `"detail"` requests bypass the cache and call `build_coordination_envelope` directly — matching the fresh/detail semantics the other status scopes already use.
- The cache is constructed lazily inside `register_cutover_read_tools`'s closure so sessions that never call `status(scope="coordination")` don't pay `polylogue.coordination`'s import cost.

## Scope note (polylogue-qink AC-3)
qink's AC also asked to "decide and act on `register_read_tools`/`agent_coordination`'s fate" (the old standalone MCP tool, unreachable from the live server). That deletion is Lane C's in-flight six-tool-cutover scope (polylogue-t46.8) and has since landed on master via #3118 (`refactor(mcp): delete dead legacy MCP registrar code`) — no action needed here.

## Verification
- `devtools test tests/unit/mcp/test_status_scope_coordination.py` — 2 passed. Drives the live registered `status` tool function end-to-end (not a hand-built registrar): proves the response is coordination-shaped with no `"archive"` key (regression for the silent-fallthrough bug), and that a second compact call hits the warm cache (1 build call across 2 compact + 1 detail invocation) while detail always goes live.
- `mypy --strict polylogue/mcp/server_cutover.py` — clean.
- `devtools verify --quick` — exit 0 (ran pre-commit and pre-push).

Ref polylogue-qink