### PR TITLE
fix(sources): stop miscounting deferred membership as a full-ingest failure

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -219,6 +219,15 @@ def _captured_jsonl_ends_at_record_boundary(
 @dataclass(slots=True)
 class _ArchiveFullWriteResult:
     raw_ids: dict[str, str] = field(default_factory=dict)
+    # polylogue-emx2: a raw whose membership census completed but whose
+    # authority decision is still pending (arbitration deferred to the async
+    # raw-materialization conveyor) is a hand-off, not a failure. Bytes are
+    # durably acquired; only the classification decision is outstanding.
+    # Tracked separately from raw_ids so the aggregation layer in
+    # _ingest_full_paths_sync can treat re-observation of these files as
+    # idempotent (cursor succeeded, no retry churn) instead of silently
+    # counting them as full-ingest failures with no exception ever raised.
+    deferred_raw_ids: dict[str, str] = field(default_factory=dict)
     session_ids: list[str] = field(default_factory=list)
     session_count: int = 0
     message_count: int = 0
@@ -1542,8 +1551,17 @@ class LiveBatchProcessor:
                     force=True,
                 )
             archive_write = self._ingest_full_records_archive(raw_records, raw_payloads, blob_store)
-            failed.extend(raw_by_id[raw_id] for raw_id in raw_by_id if raw_id not in archive_write.raw_ids)
-            raw_by_id = {archive_write.raw_ids.get(raw_id, raw_id): path for raw_id, path in raw_by_id.items()}
+            # deferred_raw_ids is a conveyor hand-off, not a failure -- only
+            # raws in neither map (a real exception was raised) count below.
+            failed.extend(
+                raw_by_id[raw_id]
+                for raw_id in raw_by_id
+                if raw_id not in archive_write.raw_ids and raw_id not in archive_write.deferred_raw_ids
+            )
+            raw_by_id = {
+                (archive_write.raw_ids.get(raw_id) or archive_write.deferred_raw_ids.get(raw_id) or raw_id): path
+                for raw_id, path in raw_by_id.items()
+            }
             if heartbeat is not None:
                 heartbeat(
                     "full_archive_write_completed",
@@ -1804,6 +1822,8 @@ class LiveBatchProcessor:
                             )
                             plan = archive.classify_raw_revision_cohort(logical_source_key)
                             if not plan.accepted_raw_ids:
+                                # No candidate accepted yet -- deferred, not failed.
+                                result.deferred_raw_ids[record.raw_id] = record_raw_id
                                 continue
                             parsed_by_raw_id = self._parse_raw_revision_chain(archive, plan)
                             session_id, applied_raw_ids = archive.apply_raw_revision_replay(
@@ -1842,6 +1862,11 @@ class LiveBatchProcessor:
                         )
                     if raw_authority_complete:
                         result.raw_ids[record.raw_id] = record_raw_id
+                    else:
+                        # Census recorded, no exception -- the raw-authority
+                        # protocol's own async classification hasn't decided
+                        # this raw yet. Not a failure; see deferred_raw_ids.
+                        result.deferred_raw_ids[record.raw_id] = record_raw_id
                     result.session_ids.extend(record_session_ids)
                     result.session_count += record_session_count
                     result.message_count += record_message_count

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1614,6 +1614,124 @@ async def test_live_append_atof_shared_file_multi_session_boundary_retains_all_e
         await archive.close()
 
 
+def _browser_capture_payload(*, provider_session_id: str, assistant_turn_id: str, updated_at: str) -> dict[str, object]:
+    return {
+        "polylogue_capture_kind": "browser_llm_session",
+        "schema_version": 1,
+        "capture_id": f"chatgpt:{provider_session_id}",
+        "provenance": {
+            "source_url": f"https://chatgpt.com/c/{provider_session_id}",
+            "page_title": "title",
+            "captured_at": updated_at,
+            "adapter_name": "chatgpt-dom-v1",
+            "capture_mode": "snapshot",
+        },
+        "session": {
+            "provider": "chatgpt",
+            "provider_session_id": provider_session_id,
+            "title": "title",
+            "updated_at": updated_at,
+            "turns": [
+                {"provider_turn_id": "u1", "role": "user", "text": "hello", "ordinal": 0},
+                {
+                    "provider_turn_id": assistant_turn_id,
+                    "role": "assistant",
+                    "text": "hi",
+                    "ordinal": 1,
+                    "attachments": [
+                        {
+                            "provider_attachment_id": "att-1",
+                            "name": "f.md",
+                            "mime_type": "text/markdown",
+                            "url": "https://chatgpt.com/attachment/1",
+                        }
+                    ],
+                },
+            ],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_live_full_ingest_over_ambiguous_membership_defers_instead_of_failing(
+    workspace_env: dict[str, Path],
+) -> None:
+    """Regression test for polylogue-emx2 (adoption idempotency). Live
+    evidence 2026-07-18: 24,626/25,324 complete-census raws in the production
+    archive had a pending (NULL/'ambiguous') membership decision --
+    classify_membership_revisions correctly refuses to pick a winner between
+    two genuinely conflicting browser-capture snapshots of the same session,
+    but before this fix the watcher's full-ingest aggregation
+    (_ingest_full_paths_sync) silently counted that outcome as a FAILED
+    file: no exception was ever raised, no log line was ever written, yet
+    the cursor was marked failed and the file was retried on every
+    subsequent catch-up sweep with no progress. This proves the fix: a raw
+    whose census completed but whose authority decision is legitimately
+    deferred to async arbitration is treated as succeeded/idempotent, not
+    failed.
+    """
+    root = workspace_env["data_root"] / "browser-capture"
+    chatgpt_dir = root / "chatgpt"
+    chatgpt_dir.mkdir(parents=True)
+    source_path = chatgpt_dir / "conv-emx2.json"
+    db_path = workspace_env["data_root"] / "membership-defer.db"
+    archive = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    cursor = CursorStore(db_path)
+    processor = LiveBatchProcessor(
+        archive,
+        (WatchSource(name="browser-capture", root=root, suffixes=(".json",)),),
+        cursor=cursor,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+    )
+
+    try:
+        source_path.write_text(
+            json.dumps(
+                _browser_capture_payload(
+                    provider_session_id="conv-emx2",
+                    assistant_turn_id="a1",
+                    updated_at="2026-07-18T00:00:00+00:00",
+                )
+            ),
+            encoding="utf-8",
+        )
+        first = await processor.ingest_files([source_path], emit_event=False)
+        assert first.succeeded_file_count == 1
+        assert first.failed_file_count == 0
+
+        # Second snapshot: same message count/shape but a genuinely
+        # different assistant turn identity -- classify_membership_revisions
+        # cannot pick a winner (identity not preserved, frontier doesn't
+        # strictly grow) and correctly returns ambiguous, not accepted.
+        source_path.write_text(
+            json.dumps(
+                _browser_capture_payload(
+                    provider_session_id="conv-emx2",
+                    assistant_turn_id="a2",
+                    updated_at="2026-07-18T00:05:00+00:00",
+                )
+            ),
+            encoding="utf-8",
+        )
+        second = await processor.ingest_files([source_path], emit_event=False)
+        assert second.failed_file_count == 0, "ambiguous membership decision must defer, not fail"
+        assert second.succeeded_file_count == 1
+
+        record = cursor.get_record(source_path)
+        assert record is not None
+        assert record.failure_count == 0
+
+        # Idempotent re-observation: identical bytes must not be reprocessed
+        # as a fresh failure/retry.
+        third = await processor.ingest_files([source_path], emit_event=False)
+        assert third.failed_file_count == 0
+        record_after_replay = cursor.get_record(source_path)
+        assert record_after_replay is not None
+        assert record_after_replay.failure_count == 0
+    finally:
+        await archive.close()
+
+
 @pytest.mark.asyncio
 async def test_live_append_merges_tail_visible_through_public_archive_read(workspace_env: dict[str, Path]) -> None:
     root = workspace_env["data_root"] / "claude-projects"


### PR DESCRIPTION
## Summary

Watcher catch-up over already-acquired files was silently marking the overwhelming majority of them as "failed" — with no exception raised and no log line written — because the aggregation layer conflated "membership decision not yet made" (a legitimate async hand-off to the raw-materialization conveyor) with "genuine failure". This directly fixes the emx2 restore-class gap: a rebuilt-index-over-intact-source scenario can now self-heal without retry-churning the entire population.

## Problem

Live evidence from the mid-restore archive (2026-07-18 evening): every watcher catch-up chunk was reporting `succeeded=0 failed=35-50/50`, but only 2 of ~400+ "failed" files in that window had a matching exception logged (`RuntimeError: raw revision CAS rejected an older accepted frontier`). Direct read-only inspection of `source.db` found the real cause:

- `raw_membership_census` had 25,324 rows with `status='complete'`.
- Of those, **24,626 (97.2%)** had at least one `raw_session_memberships` row with `decision IS NULL` or `'ambiguous'` — i.e. the raw-authority protocol's own async classification correctly hadn't decided the winner yet (arbitration deferred to the raw-materialization conveyor, by design).
- `_ingest_full_paths_sync` (`polylogue/sources/live/batch.py`) computed the failed set as *every raw not present in `archive_write.raw_ids`* — which only gets populated when `raw_authority_complete` is `True`. A raw with a pending decision has no exception, no log, but also never lands in `raw_ids` — so it was silently added to `failed`, triggering `mark_failed` on its cursor (retry churn) forever with zero net progress.

This is `polylogue-emx2` ("Watcher catch-up trusts ingest cursors that the index cannot corroborate"), evidenced through a different live mechanism than the bead's originally-hypothesized ValueError diagnostic (which never fired on the current, post-#3114 deployed daemon — 0 log hits either format).

## Solution

- `_ArchiveFullWriteResult` gains `deferred_raw_ids: dict[str, str]`, populated at both no-exception non-completion points in `_ingest_full_records_archive`:
  - `raw_authority_complete=False` after `_apply_membership_sessions` (census complete, decision pending/ambiguous).
  - `classify_raw_revision_cohort` returning no accepted candidates in the non-membership-governed single-session path.
- `_ingest_full_paths_sync`'s aggregation now excludes `deferred_raw_ids` from the failed set and folds them into the succeeded raw-id remap, so the cursor for that path is recorded as a normal succeeded full-ingest — the bytes ARE durably acquired, only the membership *decision* is outstanding, which is the conveyor's job, not the watcher's.
- Genuine exceptions (the CAS `RuntimeError`, `ValueError`s, `"no longer parses uniquely"` guards) are unaffected — still caught by the existing `except Exception` block, still call `mark_raw_parse_failed`, still fail loudly.

## Verification

- New regression test `test_live_full_ingest_over_ambiguous_membership_defers_instead_of_failing` (`tests/unit/sources/test_live_watcher.py`): ingests two genuinely conflicting browser-capture snapshots of one session (`classify_membership_revisions` correctly returns `ambiguous`, not `accepted`) and proves the second observation lands as succeeded/idempotent with `failure_count == 0` on the cursor, including a third identical re-observation.
- Anti-vacuity: confirmed this test **fails** against the pre-fix code (`failed_file_count=1`, zero exceptions/log lines in captured output) before restoring the fix.
- `devtools test tests/unit/sources/test_live_watcher.py` — 88 passed.
- `devtools verify --quick` — exit 0 (format, lint, mypy --strict, render all --check, topology/layering/manifest/doc-commands/clock-hygiene/timeout/degrade-loudly gates).
- Not run: the heavy `test` suite (skipped per-PR by CI policy, runs post-merge).

Ref polylogue-emx2