### PR TITLE
feat(mcp): close three read-capability gaps left by the six-tool cutover

### DIFF
--- a/polylogue/mcp/server_cutover.py
+++ b/polylogue/mcp/server_cutover.py
@@ -9,6 +9,8 @@ roles whose ladder includes them.
 
 from __future__ import annotations
 
+import json
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
 from polylogue.mcp.declarations.adapter import register_declared_handler
@@ -16,11 +18,19 @@ from polylogue.mcp.declarations.models import mcp_role_allows
 from polylogue.mcp.payloads import MCPArchiveStatsPayload, MCPRootPayload, session_topology_payload
 
 if TYPE_CHECKING:
+    from polylogue.config import Config
     from polylogue.coordination import CoordinationEnvelopeCache
     from polylogue.maintenance.scope import MaintenanceScopeFilter
     from polylogue.mcp.declarations.adapter import ToolRegistrar
     from polylogue.mcp.server_support import ServerCallbacks
     from polylogue.surfaces.payloads import ContextPreambleProjectState
+
+
+@dataclass(frozen=True)
+class _EmbeddingStatusEnv:
+    """Adapts ``ServerCallbacks`` config access to ``embedding_status_payload``'s ``_HasConfig`` protocol."""
+
+    config: Config
 
 
 def _object_ref(ref: str) -> str:
@@ -130,6 +140,297 @@ async def _query_sessions(
             await transaction.run(
                 lambda archive: archive_session_list_payload(archive, spec, config=config, archive_root=archive_root)
             )
+        )
+
+
+#: ``query(projection=..., ...)`` values that list a durable personal-state
+#: record kind rather than an archive content unit. Restores read access the
+#: retired per-tool registrars (``server_mutation_tools.py``,
+#: ``server_personal_state_tools.py``, ``server_tools.py``'s
+#: ``blackboard_list``) used to provide -- the underlying facade calls never
+#: moved.
+_PERSONAL_STATE_PROJECTIONS = frozenset(
+    {"marks", "annotations", "saved_views", "recall_packs", "workspaces", "corrections", "blackboard"}
+)
+
+#: ``query(projection=..., ...)`` values that compile a distilled insight
+#: report over a matched session scope, rather than listing content units.
+_INSIGHT_PROJECTIONS = frozenset({"postmortem", "pathologies", "abandoned_sessions", "stuck_sessions"})
+
+
+def _saved_view_payload(row: dict[str, str]) -> Any:
+    from polylogue.mcp.payloads import MCPSavedViewPayload
+
+    try:
+        query = json.loads(row["query_json"])
+    except (json.JSONDecodeError, TypeError):
+        query = {}
+    if not isinstance(query, dict):
+        query = {}
+    return MCPSavedViewPayload(view_id=row["view_id"], name=row["name"], query=query, created_at=row["created_at"])
+
+
+def _recall_pack_payload(row: dict[str, str]) -> Any:
+    from polylogue.mcp.payloads import MCPRecallPackPayload
+
+    try:
+        session_ids = json.loads(row["session_ids_json"])
+    except (json.JSONDecodeError, TypeError):
+        session_ids = []
+    if not isinstance(session_ids, list):
+        session_ids = []
+    try:
+        payload = json.loads(row["payload_json"])
+    except (json.JSONDecodeError, TypeError):
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+    return MCPRecallPackPayload(
+        pack_id=row["pack_id"],
+        label=row["label"],
+        session_ids=tuple(str(item) for item in session_ids),
+        payload=payload,
+        created_at=row["created_at"],
+    )
+
+
+def _workspace_payload(row: dict[str, str]) -> Any:
+    from polylogue.mcp.payloads import MCPReaderWorkspacePayload
+
+    try:
+        open_targets = json.loads(row["open_targets_json"])
+    except (json.JSONDecodeError, TypeError):
+        open_targets = []
+    if not isinstance(open_targets, list):
+        open_targets = []
+    try:
+        layout = json.loads(row["layout_json"])
+    except (json.JSONDecodeError, TypeError):
+        layout = {}
+    if not isinstance(layout, dict):
+        layout = {}
+    try:
+        active_target = json.loads(row["active_target_json"])
+    except (json.JSONDecodeError, TypeError):
+        active_target = {}
+    if not isinstance(active_target, dict):
+        active_target = {}
+    return MCPReaderWorkspacePayload(
+        workspace_id=row["workspace_id"],
+        name=row["name"],
+        mode=row["mode"],
+        open_targets=tuple(item for item in open_targets if isinstance(item, dict)),
+        layout=layout,
+        active_target=active_target,
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+async def _query_personal_state(hooks: ServerCallbacks, projection: str, *, limit: int | None) -> str:
+    """``query(projection=<personal-state kind>, ...)`` -- list durable personal-state records.
+
+    Thin dispatch onto the already-live, already-tested ``Polylogue`` list
+    facade methods. Offset pagination is not yet exposed here, mirroring the
+    ``projection="sessions"`` precedent (also fixed at offset 0).
+    """
+    from polylogue.mcp.archive_support import blackboard_note_payload
+    from polylogue.mcp.mutation_support import page_items
+    from polylogue.mcp.payloads import (
+        MCPBlackboardNoteListPayload,
+        MCPReaderWorkspaceListPayload,
+        MCPRecallPackListPayload,
+        MCPSavedViewListPayload,
+        MCPUserAnnotationListPayload,
+        MCPUserAnnotationPayload,
+        MCPUserMarkListPayload,
+        MCPUserMarkPayload,
+    )
+
+    poly = hooks.get_polylogue()
+    clamped_limit = hooks.clamp_limit(limit)
+
+    with hooks.response_context("query", {"projection": projection, "limit": clamped_limit}):
+        if projection == "marks":
+            rows = await poly.list_marks()
+            mark_items = tuple(
+                MCPUserMarkPayload(
+                    target_type=row["target_type"],
+                    target_id=row["target_id"],
+                    session_id=row["session_id"],
+                    message_id=row.get("message_id") or None,
+                    mark_type=row["mark_type"],
+                    created_at=row["created_at"],
+                )
+                for row in rows
+            )
+            mark_page, mark_total, mark_offset, mark_next_offset = page_items(mark_items, limit=clamped_limit, offset=0)
+            return hooks.json_payload(
+                MCPUserMarkListPayload(
+                    items=mark_page,
+                    total=mark_total,
+                    limit=clamped_limit,
+                    offset=mark_offset,
+                    next_offset=mark_next_offset,
+                )
+            )
+
+        if projection == "annotations":
+            rows = await poly.list_annotations()
+            annotation_items = tuple(
+                MCPUserAnnotationPayload(
+                    annotation_id=row["annotation_id"],
+                    target_type=row["target_type"],
+                    target_id=row["target_id"],
+                    session_id=row["session_id"],
+                    message_id=row.get("message_id") or None,
+                    note_text=row["note_text"],
+                    created_at=row["created_at"],
+                    updated_at=row["updated_at"],
+                )
+                for row in rows
+            )
+            annotation_page, annotation_total, annotation_offset, annotation_next_offset = page_items(
+                annotation_items, limit=clamped_limit, offset=0
+            )
+            return hooks.json_payload(
+                MCPUserAnnotationListPayload(
+                    items=annotation_page,
+                    total=annotation_total,
+                    limit=clamped_limit,
+                    offset=annotation_offset,
+                    next_offset=annotation_next_offset,
+                )
+            )
+
+        if projection == "saved_views":
+            rows = await poly.list_views()
+            view_items = tuple(_saved_view_payload(row) for row in rows)
+            view_page, view_total, view_offset, view_next_offset = page_items(view_items, limit=clamped_limit, offset=0)
+            return hooks.json_payload(
+                MCPSavedViewListPayload(
+                    items=view_page,
+                    total=view_total,
+                    limit=clamped_limit,
+                    offset=view_offset,
+                    next_offset=view_next_offset,
+                )
+            )
+
+        if projection == "recall_packs":
+            rows = await poly.list_recall_packs()
+            pack_items = tuple(_recall_pack_payload(row) for row in rows)
+            pack_page, pack_total, pack_offset, pack_next_offset = page_items(pack_items, limit=clamped_limit, offset=0)
+            return hooks.json_payload(
+                MCPRecallPackListPayload(
+                    items=pack_page,
+                    total=pack_total,
+                    limit=clamped_limit,
+                    offset=pack_offset,
+                    next_offset=pack_next_offset,
+                )
+            )
+
+        if projection == "workspaces":
+            rows = await poly.list_workspaces()
+            workspace_items = tuple(_workspace_payload(row) for row in rows)
+            workspace_page, workspace_total, workspace_offset, workspace_next_offset = page_items(
+                workspace_items, limit=clamped_limit, offset=0
+            )
+            return hooks.json_payload(
+                MCPReaderWorkspaceListPayload(
+                    items=workspace_page,
+                    total=workspace_total,
+                    limit=clamped_limit,
+                    offset=workspace_offset,
+                    next_offset=workspace_next_offset,
+                )
+            )
+
+        if projection == "corrections":
+            corrections = await poly.list_corrections()
+            all_correction_items = [
+                {
+                    "session_id": correction.session_id,
+                    "kind": correction.kind.value,
+                    "payload": dict(correction.payload),
+                    "note": correction.note,
+                    "created_at": correction.created_at.isoformat(),
+                }
+                for correction in corrections
+            ]
+            correction_page = all_correction_items[:clamped_limit]
+            correction_next_offset = len(correction_page) if len(correction_page) < len(all_correction_items) else None
+            return hooks.json_payload(
+                MCPRootPayload(
+                    root={
+                        "corrections": correction_page,
+                        "total": len(all_correction_items),
+                        "limit": clamped_limit,
+                        "offset": 0,
+                        "next_offset": correction_next_offset,
+                    }
+                )
+            )
+
+        assert projection == "blackboard", f"unhandled personal-state projection: {projection}"
+        notes = await poly.list_blackboard_notes(limit=clamped_limit)
+        note_items = tuple(blackboard_note_payload(note) for note in notes)
+        return hooks.json_payload(MCPBlackboardNoteListPayload(items=note_items, total=len(note_items)))
+
+
+async def _query_insight_projection(
+    hooks: ServerCallbacks,
+    projection: str,
+    *,
+    limit: int | None,
+    origin: str | None,
+    tag: str | None,
+    repo: str | None,
+    since: str | None,
+    until: str | None,
+) -> str:
+    """``query(projection="postmortem"|"pathologies"|"abandoned_sessions"|"stuck_sessions", ...)``.
+
+    ``postmortem``/``pathologies`` reuse the same filter-building scaffolding
+    ``_query_sessions`` does (``build_session_query_request`` ->
+    ``.build_spec(...)``), then drop the MCP default page limit before handing
+    the spec to the analysis-capped facade call -- otherwise the shared
+    ``build_spec`` page-size default (10) would silently cap the matched scope
+    to 10 sessions and defeat the facade's own 200-session analysis cap.
+    """
+    from dataclasses import replace
+
+    from polylogue.mcp.query_contracts import build_session_query_request
+
+    poly = hooks.get_polylogue()
+
+    with hooks.response_context(
+        "query",
+        {"projection": projection, "origin": origin, "tag": tag, "repo": repo, "since": since, "until": until},
+    ):
+        if projection in ("postmortem", "pathologies"):
+            request = build_session_query_request(origin=origin, tag=tag, repo=repo, since=since, until=until)
+            spec = replace(request.build_spec(hooks.clamp_limit), limit=None)
+            if projection == "postmortem":
+                bundle = await poly.postmortem_bundle(spec, limit=limit)
+                return hooks.json_payload(bundle, exclude_none=True)
+            report = await poly.pathology_report(spec, limit=limit)
+            return hooks.json_payload(report, exclude_none=True)
+
+        if projection == "abandoned_sessions":
+            abandoned = await poly.find_abandoned_sessions(since=since, repo_path=repo, limit=hooks.clamp_limit(limit))
+            return hooks.json_payload(MCPRootPayload(root=abandoned), exclude_none=True)
+
+        assert projection == "stuck_sessions", f"unhandled insight projection: {projection}"
+        from polylogue.insights.archive import SessionLatencyProfileInsightQuery
+
+        stuck = await poly.find_stuck_session_latency_profile_insights(
+            SessionLatencyProfileInsightQuery(origin=origin, since=since, until=until, limit=hooks.clamp_limit(limit))
+        )
+        return hooks.json_payload(
+            MCPRootPayload(root={"items": [insight.model_dump(mode="json") for insight in stuck], "total": len(stuck)}),
+            exclude_none=True,
         )
 
 
@@ -243,8 +544,23 @@ def register_cutover_read_tools(mcp: ToolRegistrar, hooks: ServerCallbacks) -> N
         unit-source rows: ``expression`` becomes a free-text ranked search
         (top-k) when given, or an exhaustive listing filtered by
         origin/tag/repo/since/until/sort/min_messages/max_messages/min_words
-        when omitted. Continuation is not yet implemented for this
-        projection.
+        when omitted.
+
+        ``projection`` also accepts durable personal-state kinds --
+        ``"marks"``, ``"annotations"``, ``"saved_views"``, ``"recall_packs"``,
+        ``"workspaces"``, ``"corrections"``, ``"blackboard"`` -- each listing
+        that record kind (unfiltered, ``limit``-bounded, offset fixed at 0).
+
+        ``projection="postmortem"``/``"pathologies"`` compile a distilled
+        postmortem bundle / pathology-finding report over the session scope
+        matched by origin/tag/repo/since/until (200-session analysis cap by
+        default; ``limit`` raises or lowers it). ``projection`` also accepts
+        ``"abandoned_sessions"`` (dangling-work terminal states) and
+        ``"stuck_sessions"`` (latency-profile-flagged stuck sessions), scoped
+        by the same origin/since/until filters.
+
+        Continuation is not yet implemented for any of these non-default
+        projections.
         """
 
         async def run() -> str:
@@ -268,6 +584,33 @@ def register_cutover_read_tools(mcp: ToolRegistrar, hooks: ServerCallbacks) -> N
                     min_messages=min_messages,
                     max_messages=max_messages,
                     min_words=min_words,
+                )
+
+            if projection in _PERSONAL_STATE_PROJECTIONS:
+                if continuation is not None:
+                    return hooks.error_json(
+                        f"query(projection={projection!r}) does not support continuation yet",
+                        code="invalid_continuation",
+                        tool="query",
+                    )
+                return await _query_personal_state(hooks, projection, limit=limit)
+
+            if projection in _INSIGHT_PROJECTIONS:
+                if continuation is not None:
+                    return hooks.error_json(
+                        f"query(projection={projection!r}) does not support continuation yet",
+                        code="invalid_continuation",
+                        tool="query",
+                    )
+                return await _query_insight_projection(
+                    hooks,
+                    projection,
+                    limit=limit,
+                    origin=origin,
+                    tag=tag,
+                    repo=repo,
+                    since=since,
+                    until=until,
                 )
 
             from polylogue.archive.query.transaction import (
@@ -426,7 +769,18 @@ def register_cutover_read_tools(mcp: ToolRegistrar, hooks: ServerCallbacks) -> N
         include: tuple[str, ...] = (),
         ref: str | None = None,
     ) -> str:
-        """Report compact archive authority and readiness status."""
+        """Report compact archive authority and readiness status.
+
+        ``scope="sources"`` requires ``ref=<source_path>`` and returns bounded
+        freshness evidence for that one configured source (inherently
+        single-source, matching the retired ``named_source_freshness`` tool).
+        ``scope="embeddings"`` returns embedding catch-up/readiness status;
+        ``include=("detail",)`` and/or ``include=("bands",)`` add retrieval
+        detail and band statistics. ``scope="coordination"`` returns the
+        multi-agent coordination envelope (``include=("detail",)`` for the
+        undiscounted view). ``scope="operation"`` returns readiness plus MCP
+        call-delivery outbox pressure.
+        """
 
         async def run() -> str:
             root: dict[str, object] = {"scope": scope}
@@ -455,6 +809,37 @@ def register_cutover_read_tools(mcp: ToolRegistrar, hooks: ServerCallbacks) -> N
                 else:
                     envelope = _coordination_cache().get_or_build(view="status", cwd=None, limit=10)
                 root["coordination"] = envelope.model_dump(mode="json", exclude_none=True)
+                return hooks.json_payload(MCPRootPayload(root=root), exclude_none=True)
+
+            if scope == "sources":
+                if ref is None:
+                    return hooks.error_json(
+                        "status(scope='sources') requires ref=<source_path>",
+                        code="invalid_argument",
+                        tool="status",
+                    )
+                from polylogue.archive.query.source_freshness_surfaces import make_source_freshness_mcp_handler
+                from polylogue.mcp.archive_support import mcp_archive_root
+
+                freshness_handler = make_source_freshness_mcp_handler(lambda: mcp_archive_root(hooks.get_config()))
+                root["sources"] = await freshness_handler(ref)
+                return hooks.json_payload(MCPRootPayload(root=root), exclude_none=True)
+
+            if scope == "embeddings":
+                from polylogue.readiness.capability import component_from_embedding_payload
+                from polylogue.storage.embeddings.status_payload import embedding_status_payload
+
+                embeddings_payload = embedding_status_payload(
+                    _EmbeddingStatusEnv(hooks.get_config()),
+                    include_retrieval_bands="bands" in include,
+                    include_detail="detail" in include,
+                )
+                embeddings_result = dict(embeddings_payload)
+                embedding_component = component_from_embedding_payload(embeddings_result)
+                embeddings_result["component_readiness"] = {
+                    embedding_component.component: embedding_component.to_dict()
+                }
+                root["embeddings"] = embeddings_result
                 return hooks.json_payload(MCPRootPayload(root=root), exclude_none=True)
 
             from polylogue.archive.query.transaction import QueryTransaction, QueryTransactionRequest

--- a/tests/unit/mcp/test_query_gap_projections.py
+++ b/tests/unit/mcp/test_query_gap_projections.py
@@ -1,0 +1,358 @@
+"""Tests for the read-capability gaps closed onto ``query()``/``status()``.
+
+Three capabilities lost no equivalent MCP dispatch during the six-tool
+cutover: personal-state listing (marks/annotations/saved-views/recall-packs/
+workspaces/corrections/blackboard notes), postmortem/pathology reports, and
+``status(scope="sources"/"embeddings")``. The underlying ``Polylogue`` facade
+calls were always live and independently tested; only the ``query()``/
+``status()`` dispatch was missing. Verified against a real seeded archive via
+``RuntimeServices``, matching the pattern in ``test_privileged_tools.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from polylogue.mcp.declarations.models import MCPRole
+from tests.infra.mcp import MCPServerUnderTest, invoke_surface_async
+
+
+def _seed_archive(archive_root: Path) -> str:
+    """Write one session with searchable text; returns its canonical id."""
+    from polylogue.archive.message.roles import Role
+    from polylogue.core.enums import BlockType, Provider
+    from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    with ArchiveStore(archive_root) as archive:
+        return archive.write_parsed(
+            ParsedSession(
+                source_name=Provider.CHATGPT,
+                provider_session_id="query-gap-contract",
+                title="Query gap contract probe",
+                messages=[
+                    ParsedMessage(
+                        provider_message_id="m1",
+                        role=Role.USER,
+                        text="needle query gap evidence",
+                        blocks=[ParsedContentBlock(type=BlockType.TEXT, text="needle query gap evidence")],
+                    )
+                ],
+            )
+        )
+
+
+@contextmanager
+def _installed_runtime_services(archive_root: Path) -> Iterator[None]:
+    """Install real RuntimeServices for ``archive_root``, restoring whatever was active before."""
+    from polylogue.config import Config
+    from polylogue.mcp import server_support
+    from polylogue.services import RuntimeServices
+
+    services = RuntimeServices(
+        config=Config(archive_root=archive_root, render_root=archive_root.parent / "render", sources=[]),
+    )
+    try:
+        original: RuntimeServices | None = server_support._get_runtime_services()
+    except RuntimeError:
+        original = None
+    server_support._set_runtime_services(services)
+    try:
+        yield
+    finally:
+        server_support._set_runtime_services(original)
+
+
+def _build_tools(role: MCPRole) -> dict[str, Callable[..., str | Awaitable[str]]]:
+    from polylogue.mcp.server import build_server
+
+    server = cast(MCPServerUnderTest, build_server(role=role))
+    return {name: tool.fn for name, tool in server._tool_manager._tools.items()}
+
+
+class TestPersonalStateProjections:
+    @pytest.mark.asyncio
+    async def test_marks_round_trip(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive(archive_root)
+        tools = _build_tools("write")
+        query_fn, write_fn = tools["query"], tools["write"]
+
+        with _installed_runtime_services(archive_root):
+            added = json.loads(
+                await invoke_surface_async(
+                    write_fn, operation="add_mark", session_id=session_id, fields={"mark_type": "star"}
+                )
+            )
+            assert added.get("is_error") is not True, added
+
+            listed = json.loads(await invoke_surface_async(query_fn, projection="marks"))
+            assert listed.get("is_error") is not True, listed
+            assert listed["total"] >= 1
+            assert any(item["mark_type"] == "star" and item["session_id"] == session_id for item in listed["items"])
+
+    @pytest.mark.asyncio
+    async def test_annotations_round_trip(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive(archive_root)
+        tools = _build_tools("write")
+        query_fn, write_fn = tools["query"], tools["write"]
+
+        with _installed_runtime_services(archive_root):
+            saved = json.loads(
+                await invoke_surface_async(
+                    write_fn,
+                    operation="save_annotation",
+                    session_id=session_id,
+                    fields={"annotation_id": "ann-1", "note_text": "a note"},
+                )
+            )
+            assert saved.get("is_error") is not True, saved
+
+            listed = json.loads(await invoke_surface_async(query_fn, projection="annotations"))
+            assert listed.get("is_error") is not True, listed
+            assert any(item["annotation_id"] == "ann-1" and item["note_text"] == "a note" for item in listed["items"])
+
+    @pytest.mark.asyncio
+    async def test_saved_views_round_trip(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        tools = _build_tools("write")
+        query_fn, write_fn = tools["query"], tools["write"]
+
+        with _installed_runtime_services(archive_root):
+            saved = json.loads(
+                await invoke_surface_async(
+                    write_fn,
+                    operation="save_saved_view",
+                    fields={"name": "needle sessions", "query_json": json.dumps({"query": "needle"})},
+                )
+            )
+            assert saved.get("is_error") is not True, saved
+            view_id = saved["key"]
+
+            listed = json.loads(await invoke_surface_async(query_fn, projection="saved_views"))
+            assert listed.get("is_error") is not True, listed
+            assert any(item["view_id"] == view_id and item["name"] == "needle sessions" for item in listed["items"])
+
+    @pytest.mark.asyncio
+    async def test_recall_packs_round_trip(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive(archive_root)
+        tools = _build_tools("write")
+        query_fn, write_fn = tools["query"], tools["write"]
+
+        with _installed_runtime_services(archive_root):
+            saved = json.loads(
+                await invoke_surface_async(
+                    write_fn,
+                    operation="save_recall_pack",
+                    fields={
+                        "pack_id": "pack-1",
+                        "label": "handoff pack",
+                        "payload_json": json.dumps({"items": [{"target_type": "session", "session_id": session_id}]}),
+                    },
+                )
+            )
+            assert saved.get("is_error") is not True, saved
+
+            listed = json.loads(await invoke_surface_async(query_fn, projection="recall_packs"))
+            assert listed.get("is_error") is not True, listed
+            assert any(item["pack_id"] == "pack-1" and item["label"] == "handoff pack" for item in listed["items"])
+
+    @pytest.mark.asyncio
+    async def test_workspaces_round_trip(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        tools = _build_tools("write")
+        query_fn, write_fn = tools["query"], tools["write"]
+
+        with _installed_runtime_services(archive_root):
+            saved = json.loads(
+                await invoke_surface_async(
+                    write_fn,
+                    operation="save_workspace",
+                    fields={"workspace_id": "ws-1", "name": "my workspace"},
+                )
+            )
+            assert saved.get("is_error") is not True, saved
+
+            listed = json.loads(await invoke_surface_async(query_fn, projection="workspaces"))
+            assert listed.get("is_error") is not True, listed
+            assert any(item["workspace_id"] == "ws-1" and item["name"] == "my workspace" for item in listed["items"])
+
+    @pytest.mark.asyncio
+    async def test_corrections_round_trip(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive(archive_root)
+        tools = _build_tools("write")
+        query_fn, write_fn = tools["query"], tools["write"]
+
+        with _installed_runtime_services(archive_root):
+            recorded = json.loads(
+                await invoke_surface_async(
+                    write_fn,
+                    operation="record_correction",
+                    session_id=session_id,
+                    fields={"kind": "tag_accept", "payload": {"tag": "reviewed"}},
+                )
+            )
+            assert recorded.get("is_error") is not True, recorded
+
+            listed = json.loads(await invoke_surface_async(query_fn, projection="corrections"))
+            assert listed.get("is_error") is not True, listed
+            assert any(c["session_id"] == session_id and c["kind"] == "tag_accept" for c in listed["corrections"])
+
+    @pytest.mark.asyncio
+    async def test_blackboard_round_trip(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        tools = _build_tools("write")
+        query_fn, write_fn = tools["query"], tools["write"]
+
+        with _installed_runtime_services(archive_root):
+            # author_kind="user" is required for the note to land as an
+            # active (visible) blackboard note: the promotion gate coerces
+            # any other author_kind (the "agent" default) to a candidate
+            # status, which list_blackboard_notes() deliberately excludes
+            # (candidates surface only through the judgment queue).
+            posted = json.loads(
+                await invoke_surface_async(
+                    write_fn,
+                    operation="blackboard_post",
+                    fields={
+                        "kind": "finding",
+                        "title": "a finding",
+                        "content": "some content",
+                        "author_kind": "user",
+                    },
+                )
+            )
+            assert posted.get("is_error") is not True, posted
+
+            listed = json.loads(await invoke_surface_async(query_fn, projection="blackboard"))
+            assert listed.get("is_error") is not True, listed
+            assert any(item["title"] == "a finding" for item in listed["items"])
+
+    @pytest.mark.asyncio
+    async def test_personal_state_projection_rejects_continuation(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        tools = _build_tools("read")
+        query_fn = tools["query"]
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(await invoke_surface_async(query_fn, projection="marks", continuation="bogus"))
+            assert result.get("is_error") is True
+            assert result.get("code") == "invalid_continuation"
+
+
+class TestInsightProjections:
+    @pytest.mark.asyncio
+    async def test_postmortem_projection(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        tools = _build_tools("read")
+        query_fn = tools["query"]
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(await invoke_surface_async(query_fn, projection="postmortem"))
+            assert result.get("is_error") is not True, result
+            assert "scope" in result
+
+    @pytest.mark.asyncio
+    async def test_pathologies_projection(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        tools = _build_tools("read")
+        query_fn = tools["query"]
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(await invoke_surface_async(query_fn, projection="pathologies"))
+            assert result.get("is_error") is not True, result
+            assert "findings" in result
+
+    @pytest.mark.asyncio
+    async def test_abandoned_sessions_projection(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        tools = _build_tools("read")
+        query_fn = tools["query"]
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(await invoke_surface_async(query_fn, projection="abandoned_sessions"))
+            assert result.get("is_error") is not True, result
+            assert "total" in result
+
+    @pytest.mark.asyncio
+    async def test_stuck_sessions_projection(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        tools = _build_tools("read")
+        query_fn = tools["query"]
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(await invoke_surface_async(query_fn, projection="stuck_sessions"))
+            assert result.get("is_error") is not True, result
+            assert "items" in result
+
+    @pytest.mark.asyncio
+    async def test_insight_projection_rejects_continuation(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        tools = _build_tools("read")
+        query_fn = tools["query"]
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(await invoke_surface_async(query_fn, projection="postmortem", continuation="bogus"))
+            assert result.get("is_error") is True
+            assert result.get("code") == "invalid_continuation"
+
+
+class TestStatusSourcesAndEmbeddingsScopes:
+    @pytest.mark.asyncio
+    async def test_status_sources_requires_ref(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        tools = _build_tools("read")
+        status_fn = tools["status"]
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(await invoke_surface_async(status_fn, scope="sources"))
+            assert result.get("is_error") is True
+            assert result.get("code") == "invalid_argument"
+
+    @pytest.mark.asyncio
+    async def test_status_sources_with_ref_returns_freshness_projection(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        tools = _build_tools("read")
+        status_fn = tools["status"]
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(
+                await invoke_surface_async(status_fn, scope="sources", ref=str(tmp_path / "nonexistent-source"))
+            )
+            assert result.get("is_error") is not True, result
+            assert result["scope"] == "sources"
+            assert "sources" in result
+
+    @pytest.mark.asyncio
+    async def test_status_embeddings_scope_returns_readiness_payload(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        tools = _build_tools("read")
+        status_fn = tools["status"]
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(await invoke_surface_async(status_fn, scope="embeddings"))
+            assert result.get("is_error") is not True, result
+            assert result["scope"] == "embeddings"
+            assert "embeddings" in result
+            assert "component_readiness" in result["embeddings"]


### PR DESCRIPTION
## Summary

Closes the three documented "Known gaps" from PR #3095's six-tool MCP read algebra: no way to list personal-state records back, no postmortem/pathology reports, and `status(scope="sources"/"embeddings")` silently falling through to archive stats.

## Problem

PR #3095 replaced the ~97-tool MCP surface with six read transactions (`query`/`read`/`get`/`explain`/`context`/`status`) plus four privileged transactions. It shipped with a documented "Known gaps" section admitting three read capabilities lost no equivalent dispatch in the new surface:

1. Personal-state listing (marks/annotations/saved-views/recall-packs/workspaces/corrections/blackboard notes) — `write()` could create these records but nothing could list them back.
2. Postmortem/pathology reports — the retired `get_postmortem_bundle`/`get_pathologies` tools had no successor.
3. `status(scope="sources"/"embeddings")` — declared in the `status()` signature but both silently fell through to the same `scope="archive"` payload.

All three were confirmed "trivial": the underlying `Polylogue` facade calls stayed live and independently tested through the cutover (unchanged by it); only the MCP dispatch wiring was missing.

## Solution

All changes are in `polylogue/mcp/server_cutover.py`:

- **`query(projection=...)`** gains 7 personal-state projections (`marks`, `annotations`, `saved_views`, `recall_packs`, `workspaces`, `corrections`, `blackboard`), each a thin dispatch onto the existing `list_*` facade call + `page_items` + the existing typed payload class (`MCPUserMarkListPayload` etc., which survived the cleanup PR unused). Offset pagination is not yet exposed (mirrors the existing `projection="sessions"` precedent, which also fixes offset at 0).
- **`query(projection=...)`** gains `postmortem`/`pathologies`, reusing `build_session_query_request`'s filter scaffolding and dropping the MCP default page limit (`replace(spec, limit=None)`) before handing the spec to the 200-session analysis cap — the same trick the retired `get_postmortem_bundle`/`get_pathologies` tools used, otherwise the shared page-size default of 10 silently caps the matched scope and defeats the facade's own analysis cap. Also adds `abandoned_sessions`/`stuck_sessions` as two more thin projections (no semantic overlap found with postmortem/pathologies, so kept separate per the plan's documented fallback).
- **`status(scope="sources")`** wires the existing `named_source_freshness` handler through the already-unused `ref` parameter (single-source by design, matching the retired tool's own scope).
- **`status(scope="embeddings")`** wires `embedding_status_payload` via a small `_EmbeddingStatusEnv` config adapter (mirrors the retired `embedding_status` tool), with `include=("detail",)`/`include=("bands",)` mapping to its `include_detail`/`include_retrieval_bands` params.

Rebased onto master after #3128 landed a fifth `status()` scope (`coordination`) concurrently — merged cleanly since it's a disjoint `if scope == ...` branch in the same function; also updated `status()`'s docstring to describe all four now-wired non-archive scopes.

No new MCP declaration rows needed: `query`/`status` already exist in `TARGET_DEFAULT_READ_ALGEBRA` with result-semantics broad enough to cover the new projections/scopes (documented in each function's docstring, matching the `context(intent="resume")` precedent).

## Verification

- `devtools test tests/unit/mcp/` — 184 passed (16 new, in `tests/unit/mcp/test_query_gap_projections.py`).
- `devtools verify --quick` — green (format/lint/mypy --strict/render-all-check).
- Live read-only smoke pass (`POLYLOGUE_ARCHIVE_ROOT=~/.local/share/polylogue` via `sinnix-scope background`, same pattern as #3095) against the real ~18k-session archive: all 12 new projections/scopes returned valid payloads with no errors — `postmortem`/`pathologies` matched 153 sessions over the last 7 days, `abandoned_sessions` found 74, `status(scope=embeddings)` reported real catch-up state (`total_sessions=2498`), `status(scope=sources)` returned a real freshness projection.

Ref polylogue-t46.8.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)