### PR TITLE
fix(daemon): self-heal preflight for disposable tiers, recheck while blocked

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -97,6 +97,30 @@ _SESSION_INSIGHT_CONVERGENCE_BURST_LIMIT = 10
 _SESSION_INSIGHT_CONVERGENCE_BURST_PAUSE_SECONDS = 1
 _DRIVE_SOURCE_CATCHUP_INTERVAL_SECONDS = 3600
 _BLOB_REFERENCE_RESTORE_CONVERGENCE_BATCH_LIMIT = 25
+_SCHEMA_PREFLIGHT_RECHECK_INTERVAL_SECONDS = 60
+
+
+async def _periodic_schema_preflight_recheck() -> None:
+    """Poll for tier-layout recovery while the watcher is schema-blocked.
+
+    The blocked decision is made once at startup, but tiers heal out of
+    band: an operator migrates a durable tier, a derived tier is rebuilt,
+    or a disposable tier bootstraps. Without this loop the daemon stayed
+    watcher-less forever after recovery (2026-07-18: an hour of dead
+    watcher until a manual restart). When the layout becomes ready, raise
+    so the supervisor restarts the daemon into a healthy boot — the
+    startup sequence is the only sanctioned way to construct the watcher.
+    """
+    while True:
+        await asyncio.sleep(_SCHEMA_PREFLIGHT_RECHECK_INTERVAL_SECONDS)
+        alert = _check_schema_version_fast()
+        if alert.severity != HealthSeverity.CRITICAL:
+            logger.info(
+                "daemon: schema preflight recovered (%s); exiting for supervised restart",
+                alert.message,
+            )
+            raise RuntimeError("schema preflight recovered; restart required to start the live watcher")
+
 
 # Track the pidfile path for atexit cleanup.
 _pidfile_path: Path | None = None
@@ -1403,6 +1427,8 @@ async def run_daemon_services(
     # surviving API/health process is still alive while archive work is
     # intentionally withheld.
     maintenance_tasks: list[asyncio.Task[None]] = [asyncio.create_task(_periodic_lifecycle_heartbeat())]
+    if watcher_blocked:
+        maintenance_tasks.append(asyncio.create_task(_periodic_schema_preflight_recheck()))
 
     api_server: ThreadingHTTPServer | None = None
     api_server_task: asyncio.Task[None] | None = None

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -297,9 +297,18 @@ def _check_schema_version_fast() -> HealthAlert:
         archive_dir = dbf.parent
         mismatches: list[str] = []
         missing: list[str] = []
+        missing_disposable: list[str] = []
         for spec in ARCHIVE_TIER_SPECS.values():
             path = archive_dir / spec.filename
             if not path.exists():
+                if spec.durability == "disposable":
+                    # A disposable tier (ops.db) is recreated by the next
+                    # bootstrap-touching write; its absence must never block
+                    # the watcher (2026-07-18: preflight raced the bootstrap
+                    # and refused the watcher for an hour over a tier that
+                    # self-healed seconds after the decision).
+                    missing_disposable.append(spec.filename)
+                    continue
                 missing.append(spec.filename)
                 continue
             conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=2.0)
@@ -314,6 +323,8 @@ def _check_schema_version_fast() -> HealthAlert:
         if not missing and not mismatches:
             severity = HealthSeverity.OK
             message = "archive tier layout matches runtime"
+            if missing_disposable:
+                message += f" (disposable tier(s) pending bootstrap: {', '.join(missing_disposable)})"
         else:
             severity = HealthSeverity.CRITICAL
             parts: list[str] = []

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -3546,3 +3546,40 @@ def test_run_daemon_services_schema_block_skips_db_background_work() -> None:
     assert server.shutdown_called is False
     assert server.close_called is True
     assert lifecycle_tick_started is True
+
+
+def test_periodic_schema_preflight_recheck_exits_on_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A schema-blocked daemon must not stay watcher-less after tiers heal:
+    when the preflight turns non-critical the recheck loop raises so the
+    supervisor restarts the daemon into a healthy boot."""
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.daemon.health import HealthAlert, HealthSeverity, HealthTier
+
+    def alert(severity: HealthSeverity) -> HealthAlert:
+        return HealthAlert(
+            check_name="schema_version",
+            tier=HealthTier.FAST,
+            severity=severity,
+            message="probe",
+            checked_at="now",
+        )
+
+    schedule = [alert(HealthSeverity.CRITICAL), alert(HealthSeverity.OK)]
+    sleeps = 0
+
+    async def fake_sleep(seconds: float) -> None:
+        nonlocal sleeps
+        sleeps += 1
+        assert seconds == daemon_cli._SCHEMA_PREFLIGHT_RECHECK_INTERVAL_SECONDS
+
+    monkeypatch.setattr(daemon_cli, "_check_schema_version_fast", lambda: schedule.pop(0))
+    with (
+        patch("asyncio.sleep", side_effect=fake_sleep),
+        pytest.raises(RuntimeError, match="schema preflight recovered"),
+    ):
+        asyncio.run(daemon_cli._periodic_schema_preflight_recheck())
+
+    assert schedule == []
+    assert sleeps == 2

--- a/tests/unit/daemon/test_schema_preflight.py
+++ b/tests/unit/daemon/test_schema_preflight.py
@@ -411,3 +411,27 @@ async def test_live_batch_marks_structural_database_error_degraded(
     assert second.source_payload_read_bytes == 0
     assert second.full_file_count == 0
     assert second.skipped_file_count == 1
+
+
+def test_schema_version_health_tolerates_missing_disposable_tier(
+    workspace_env: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing ops.db (disposable) self-heals via bootstrap and must not
+    block the watcher; a missing durable tier stays CRITICAL."""
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    root = workspace_env["archive_root"]
+    initialize_active_archive_root(root)
+    monkeypatch.setattr("polylogue.daemon.health.index_db_path", lambda: root / "index.db")
+
+    (root / "ops.db").unlink()
+    alert = _check_schema_version_fast()
+    assert alert.severity == HealthSeverity.OK
+    assert "pending bootstrap" in alert.message
+    assert "ops.db" in alert.message
+
+    (root / "user.db").unlink()
+    alert = _check_schema_version_fast()
+    assert alert.severity == HealthSeverity.CRITICAL
+    assert "user.db" in alert.message
+    assert "ops.db" not in alert.message


### PR DESCRIPTION
## Summary

Closes the 5vft preflight liveness gap that bit twice during the 2026-07-18 restore: the schema preflight decides `watcher_blocked` once at startup for the whole process lifetime, and treats a missing `ops.db` — a *disposable* tier that the next bootstrap-touching write recreates — as CRITICAL.

## Problem

At the 16:37 restart the preflight raced the ops.db bootstrap: it declared `missing tiers: ops.db`, refused the watcher, and the daemon sat heartbeat-only for an hour — while ops.db existed again seconds after the decision. Nothing re-evaluated; only a manual restart recovered.

## Solution

- `_check_schema_version_fast` classifies missing tiers by durability: missing **disposable** tiers no longer produce CRITICAL (the OK message names them as pending bootstrap). Missing durable/rebuildable tiers and every version mismatch stay fail-closed exactly as before.
- When the watcher *is* schema-blocked, a new maintenance loop re-runs the preflight every 60s. On recovery it raises out of the task gather, so the daemon exits nonzero and systemd (`Restart=on-failure`, verified on the live unit) restarts it into a healthy boot — the startup sequence remains the only sanctioned path that constructs the watcher, per the existing restart-after-schema-bump pattern.

## Verification

- `devtools test tests/unit/daemon/test_schema_preflight.py tests/unit/daemon/test_daemon_cli.py` — 104 passed, including: missing ops.db → OK with pending-bootstrap note while missing user.db stays CRITICAL (real bootstrapped tier layout, not mocks); and the recheck loop raising exactly when the alert turns non-critical.
- `mypy` clean; pre-push quick gate green.

Ref polylogue-5vft

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ