### PR TITLE
perf(daemon): census-sized batches while replay planning is paused

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -77,6 +77,11 @@ _RAW_MATERIALIZATION_CONVERGENCE_BATCH_LIMIT = 16
 # Between backlog burst passes the loop yields the writer briefly so live
 # ingest and interactive writes never queue behind a long drain.
 _RAW_MATERIALIZATION_BACKLOG_BURST_PAUSE_SECONDS = 1
+# Census-mode passes (replay planning paused behind the persisted parser
+# census) run no replay transaction, so the batch bounds parse work, not a
+# writer-transaction length — amortize the per-pass census fixed costs
+# (candidate discovery, component ordering, receipt) over more components.
+_RAW_MATERIALIZATION_CENSUS_BATCH_LIMIT = 64
 _RAW_MATERIALIZATION_DAEMON_BLOB_LIMIT_BYTES = 64 * 1024 * 1024
 _RAW_MATERIALIZATION_LIVE_SPOOL_BACKOFF_SECONDS = 60
 
@@ -544,6 +549,7 @@ async def _periodic_raw_materialization_convergence() -> None:
     between passes — instead of waiting a full interval per pass, which
     would stretch a large drain into weeks.
     """
+    census_mode = False
     while True:
         if _browser_capture_spool_has_pending_files():
             logger.info("raw materialization: yielding to pending browser-capture spool files")
@@ -552,11 +558,28 @@ async def _periodic_raw_materialization_convergence() -> None:
         recover = True
         try:
             while True:
+                # While replay planning is paused behind the persisted parser
+                # census, a pass does census-only work: no replay transaction
+                # runs, so the small replay-sized batch limit (which bounds
+                # writer-transaction length) only throttles parse-bound census
+                # throughput and stretches a large census into days. Use a
+                # larger batch for census-mode passes; the first pass that
+                # repairs or plans anything drops back to the replay limit.
+                limit = (
+                    _RAW_MATERIALIZATION_CENSUS_BATCH_LIMIT
+                    if census_mode
+                    else _RAW_MATERIALIZATION_CONVERGENCE_BATCH_LIMIT
+                )
                 materialized = await daemon_write_coordinator().run_sync(
                     "maintenance.raw_materialization",
-                    functools.partial(_drain_raw_materialization_once, recover=recover),
+                    functools.partial(_drain_raw_materialization_once, limit=limit, recover=recover),
                 )
                 recover = False
+                census_mode = (
+                    materialized.censused_components > 0
+                    and materialized.repaired_sessions == 0
+                    and materialized.executed_plans == 0
+                )
                 if materialized.made_progress:
                     logger.info(
                         "raw materialization: repaired %d session(s), executed %d frontier plan(s), %d candidate(s) remaining",

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -1033,8 +1033,10 @@ def test_periodic_raw_materialization_burst_continues_through_census_passes(
         RawMaterializationCounts(repaired_sessions=16, executed_plans=0, remaining_candidates=0),
     ]
     sleeps: list[float] = []
+    limits: list[int] = []
 
-    async def fake_run_sync(_actor: str, _func: object, *_args: object, **_kwargs: object) -> object:
+    async def fake_run_sync(_actor: str, func: object, *_args: object, **_kwargs: object) -> object:
+        limits.append(int(cast(functools.partial[object], func).keywords["limit"]))
         return schedule.pop(0)
 
     async def fake_sleep(seconds: float) -> None:
@@ -1056,6 +1058,14 @@ def test_periodic_raw_materialization_burst_continues_through_census_passes(
         daemon_cli._RAW_MATERIALIZATION_BACKLOG_BURST_PAUSE_SECONDS,
         daemon_cli._RAW_MATERIALIZATION_BACKLOG_BURST_PAUSE_SECONDS,
         daemon_cli._RAW_MATERIALIZATION_CONVERGENCE_INTERVAL_SECONDS,
+    ]
+    # Census-only results escalate the next pass to the census batch size;
+    # the repairing third pass would drop the following one back to the
+    # replay-sized limit.
+    assert limits == [
+        daemon_cli._RAW_MATERIALIZATION_CONVERGENCE_BATCH_LIMIT,
+        daemon_cli._RAW_MATERIALIZATION_CENSUS_BATCH_LIMIT,
+        daemon_cli._RAW_MATERIALIZATION_CENSUS_BATCH_LIMIT,
     ]
 
 


### PR DESCRIPTION
## Summary

Caller-side census throughput fix for the live restore: the conveyor's batch limit (16) is sized to bound *replay writer-transaction length*, but while replay planning is paused behind the persisted parser census, a pass runs no replay transaction at all — the replay-sized limit only throttles parse-bound census work. Live measurement: ~16 components per ~2-minute pass against a 23k-raw census backlog that currently grows faster than it drains.

## Solution

The burst loop tracks census mode from the previous pass's counts (census work performed, zero repairs/plans) and escalates the next pass to a 64-item batch, amortizing the per-pass fixed costs (candidate discovery, component ordering, census receipt) 4×. The first pass that repairs or executes anything drops straight back to the replay-sized limit, so writer-transaction bounds are untouched the moment real replay resumes. Entirely in `daemon/cli.py` — no change to the repair engine's interface or semantics; polylogue-amg1's commit batching remains the deeper lever and composes with this.

## Verification

`devtools test tests/unit/daemon/test_daemon_cli.py` — 91 passed; the census-burst test now pins the limit escalation sequence (first pass replay-sized, census-only results escalate to 64, repairing pass ends the burst). `mypy` clean; pre-push quick gate green.

Ref polylogue-5jak / Ref polylogue-amg1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ