### PR TITLE
fix(daemon): only stalled spool files park raw materialization

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -12,6 +12,7 @@ import os
 import sqlite3
 import sys
 import threading
+import time
 from contextlib import redirect_stdout
 from datetime import UTC, datetime
 from http.server import ThreadingHTTPServer
@@ -84,6 +85,9 @@ _RAW_MATERIALIZATION_BACKLOG_BURST_PAUSE_SECONDS = 1
 _RAW_MATERIALIZATION_CENSUS_BATCH_LIMIT = 64
 _RAW_MATERIALIZATION_DAEMON_BLOB_LIMIT_BYTES = 64 * 1024 * 1024
 _RAW_MATERIALIZATION_LIVE_SPOOL_BACKOFF_SECONDS = 60
+# A spool file younger than this is in the live route's normal debounce/
+# batch flow, not stalled; only older cursor-less files park the conveyor.
+_SPOOL_PENDING_GRACE_SECONDS = 300
 
 
 async def _run_startup_fts_readiness(coordinator: DaemonWriteCoordinator) -> None:
@@ -744,7 +748,7 @@ def _drain_raw_materialization_once(
 
 
 def _browser_capture_spool_has_pending_files() -> bool:
-    """Whether live browser evidence is awaiting its normal ingest route.
+    """Whether live browser evidence is STALLED short of its ingest route.
 
     Only files genuinely waiting on the live route's writer count: a file
     with no cursor yet, or one whose bytes changed since its cursor. Files
@@ -753,6 +757,13 @@ def _browser_capture_spool_has_pending_files() -> bool:
     for, and treating them as pending parked raw materialization forever
     (2026-07-18 restore: the conveyor never ran once while failed spool
     files sat on disk).
+
+    Files younger than the grace window never count either: a capture that
+    arrived seconds ago is in the live watcher's debounce/batch flow — its
+    normal route — and the write coordinator already interleaves that work.
+    The yield exists for a backlog the live route is NOT digesting; without
+    the grace, steady live capture traffic re-parked the conveyor for 60s
+    per fresh file all through the 2026-07-18 restore.
     """
     from polylogue.paths import browser_capture_spool_root
     from polylogue.sources.live.batch import fingerprint_file
@@ -762,11 +773,14 @@ def _browser_capture_spool_has_pending_files() -> bool:
     spool = browser_capture_spool_root()
     if not spool.exists():
         return False
+    now = time.time()
     cursor_store = CursorStore(_active_index_db_path())
     for path in spool.rglob("*.json"):
         try:
             stat = path.stat()
         except FileNotFoundError:
+            continue
+        if now - stat.st_mtime < _SPOOL_PENDING_GRACE_SECONDS:
             continue
         cursor = cursor_store.get_record(path)
         if cursor is None:

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -7,6 +7,7 @@ import inspect
 import os
 import sqlite3
 import threading
+import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -1135,7 +1136,6 @@ def test_spool_pending_check_ignores_terminal_cursor_states(
     spool.mkdir()
     capture = spool / "chatgpt-capture.json"
     capture.write_bytes(b"{}\n")
-    stat = capture.stat()
 
     records: dict[Path, object] = {}
     monkeypatch.setattr("polylogue.paths.browser_capture_spool_root", lambda: spool)
@@ -1144,6 +1144,16 @@ def test_spool_pending_check_ignores_terminal_cursor_states(
         "polylogue.sources.live.cursor.CursorStore",
         lambda _db: SimpleNamespace(get_record=lambda path: records.get(path)),
     )
+
+    # A capture that JUST arrived is in the live route's debounce flow —
+    # it must not park the conveyor even without a cursor.
+    records.clear()
+    assert daemon_cli._browser_capture_spool_has_pending_files() is False
+
+    # Age the file past the grace window: now it is a stalled backlog.
+    stale = time.time() - daemon_cli._SPOOL_PENDING_GRACE_SECONDS - 60
+    os.utime(capture, (stale, stale))
+    stat = capture.stat()
 
     def cursor_record(*, excluded: bool = False, failure_count: int = 0) -> SimpleNamespace:
         return SimpleNamespace(

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -7,7 +7,6 @@ import inspect
 import os
 import sqlite3
 import threading
-import time
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -1151,7 +1150,7 @@ def test_spool_pending_check_ignores_terminal_cursor_states(
     assert daemon_cli._browser_capture_spool_has_pending_files() is False
 
     # Age the file past the grace window: now it is a stalled backlog.
-    stale = time.time() - daemon_cli._SPOOL_PENDING_GRACE_SECONDS - 60
+    stale = capture.stat().st_mtime - daemon_cli._SPOOL_PENDING_GRACE_SECONDS - 60
     os.utime(capture, (stale, stale))
     stat = capture.stat()
 


### PR DESCRIPTION
## Summary

Final piece of the conveyor-parking saga: the spool yield counts every cursor-less capture as pending, including files that arrived seconds ago and are already in the live watcher's debounce flow — so steady live capture traffic re-parks the conveyor for a 60s backoff per fresh file. Live measurement after the census-mode deploy: one 93-second conveyor pass, then five consecutive spool yields caused by freshly-arriving captures.

## Solution

A 5-minute staleness grace: files younger than the window never count (the live route owns them; the write coordinator interleaves that work). Only a cursor-less file *older* than the window — a backlog the live route is demonstrably not digesting, the case #2975 built the yield for — parks the conveyor. Terminal states remain non-parking per #3108.

## Verification

`devtools test tests/unit/daemon/test_daemon_cli.py` — 91 passed; the spool test pins all four states: fresh cursor-less → no park, aged cursor-less → park, aged excluded → no park, aged failed → no park (file aged via its own mtime to satisfy the clock-hygiene lint). `mypy` clean; pre-push quick gate green.

Ref polylogue-5jak

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser-capture processing status detection by allowing a short grace period for newly arrived files.
  * Prevented recently created captures from being incorrectly flagged as stalled or pending.
  * Continued identifying files that remain pending after the grace period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->