### PR TITLE
perf(sources): batch raw-authority census commits, keep large payloads off the parse pool

### DIFF
--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -228,92 +228,130 @@ def _census_historical_revision_evidence(
     selected_raw_ids: list[str] | None,
     max_payload_bytes: int | None,
     ingest_workers: int = 1,
+    commit_batch_size: int | None = None,
 ) -> _RevisionCensusState:
-    """Persist a complete bounded parser census without mutating index.db."""
+    """Persist a complete bounded parser census without mutating index.db.
+
+    ``commit_batch_size`` (polylogue-amg1): when set to a positive integer,
+    ``replace_raw_membership_census``/``bind_raw_revision`` writes for up to
+    that many raws share one source.db commit instead of one commit per raw
+    (``sqlite3.Connection.__exit__`` -- fsync -- measured at 42.6% of wall
+    time on an independent-raw corpus). This only defers WHEN bytes already
+    proven durable by ``write_raw_payload`` become visible as census rows; a
+    crash mid-batch loses at most one batch's progress, which the caller
+    re-derives identically on retry (census is idempotent and re-run from
+    durable raw bytes) -- it never leaves a raw half-written or duplicates
+    an outcome. Every batch is committed (or the whole batch is discarded on
+    an exception, via the caller's ``rollback()``) before this function
+    returns or propagates; a crash further downstream (replay phase) cannot
+    observe a partially-committed census. Default ``None`` preserves the
+    original per-raw-commit behavior for every existing caller.
+    """
     state = _RevisionCensusState(0, 0, 0, set(), {}, {})
+    batch_size = commit_batch_size if commit_batch_size is not None and commit_batch_size > 0 else None
+    batched = batch_size is not None
+    pending_commits = 0
     census_selections: tuple[tuple[str, ...] | None, ...]
     if selected_raw_ids is None:
         census_selections = (None,)
     else:
         census_selections = archive.raw_membership_selection_components(selected_raw_ids)
-    for initial_selection in census_selections:
-        census_selection = initial_selection
-        while True:
-            rows = archive.raw_membership_census_rows(census_selection)
-            pending_rows = [(raw_id, source_index) for raw_id, source_index in rows if raw_id not in state.censused]
-            if max_payload_bytes is not None:
-                payload_sizes = archive.raw_payload_sizes([raw_id for raw_id, _index in rows])
-                total_payload_bytes = sum(payload_sizes.values())
-                oversized = [raw_id for raw_id, size in payload_sizes.items() if size > max_payload_bytes]
-                if oversized or total_payload_bytes > max_payload_bytes:
-                    blocked_ids = oversized or list(payload_sizes)
-                    raise RawRevisionReplayResourceBlockedError(
-                        sorted(blocked_ids), max_payload_bytes, total_payload_bytes
-                    )
-            # Parse is read-only blob->ParsedSession decode and authority-neutral;
-            # spread it across a process pool when there is more than one raw to
-            # parse. Archive writes below stay in fixed `pending_rows` order
-            # regardless of worker completion order, so parallel and sequential
-            # runs remain byte-identical.
-            parseable_raw_ids = [raw_id for raw_id, source_index in pending_rows if source_index >= 0]
-            parsed_outcomes = _parse_retained_raws(archive, parseable_raw_ids, ingest_workers=ingest_workers)
-            for raw_id, source_index in pending_rows:
-                state.scanned += 1
-                state.censused.add(raw_id)
-                if source_index < 0:
-                    archive.replace_raw_membership_census(
-                        raw_id,
-                        None,
-                        parser_fingerprint="revision-membership-v1",
-                        censused_at_ms=0,
-                        detail=BYTE_AUTHORITY_CENSUS_DETAIL,
-                    )
-                    state.quarantined += 1
-                    continue
-                outcome = parsed_outcomes[raw_id]
-                if isinstance(outcome, Exception):
-                    archive.replace_raw_membership_census(
-                        raw_id,
-                        None,
-                        parser_fingerprint="revision-membership-v1",
-                        censused_at_ms=0,
-                        detail=str(outcome),
-                    )
-                    state.quarantined += 1
-                    continue
-                sessions, payload_bytes, revision_kind = outcome
-                state.classified += int(len(sessions) == 1)
-                spill.add(raw_id, sessions, payload_bytes=payload_bytes)
-                if len(sessions) == 1 and revision_kind is RawRevisionKind.UNKNOWN:
-                    session = sessions[0]
-                    logical_key = f"{session.source_name.value}:{session.provider_session_id}"
-                    archive.bind_raw_revision(
-                        raw_id,
-                        RawRevisionEnvelope(
-                            logical_source_key=logical_key,
-                            kind=RawRevisionKind.FULL,
-                            source_revision=raw_id,
-                            acquisition_generation=0,
-                            authority=RawRevisionAuthority.QUARANTINED,
-                        ),
-                    )
-                    state.provisional_full_raw_ids.setdefault(logical_key, set()).add(raw_id)
-                elif revision_kind is RawRevisionKind.UNKNOWN:
-                    archive.replace_raw_membership_census(
-                        raw_id,
-                        sessions,
-                        parser_fingerprint="revision-membership-v1",
-                        censused_at_ms=0,
-                    )
-                    for session in sessions:
-                        logical_key = f"{session.source_name.value}:{session.provider_session_id}"
-                        state.membership_candidates.setdefault(logical_key, set()).add(raw_id)
-            if census_selection is None:
-                break
-            expanded, _keys = archive.expand_raw_membership_selection(list(census_selection))
-            if set(expanded) == set(census_selection):
-                break
-            census_selection = expanded
+    try:
+        for initial_selection in census_selections:
+            census_selection = initial_selection
+            while True:
+                rows = archive.raw_membership_census_rows(census_selection)
+                pending_rows = [(raw_id, source_index) for raw_id, source_index in rows if raw_id not in state.censused]
+                if max_payload_bytes is not None:
+                    payload_sizes = archive.raw_payload_sizes([raw_id for raw_id, _index in rows])
+                    total_payload_bytes = sum(payload_sizes.values())
+                    oversized = [raw_id for raw_id, size in payload_sizes.items() if size > max_payload_bytes]
+                    if oversized or total_payload_bytes > max_payload_bytes:
+                        blocked_ids = oversized or list(payload_sizes)
+                        raise RawRevisionReplayResourceBlockedError(
+                            sorted(blocked_ids), max_payload_bytes, total_payload_bytes
+                        )
+                # Parse is read-only blob->ParsedSession decode and authority-neutral;
+                # spread it across a process pool when there is more than one raw to
+                # parse. Archive writes below stay in fixed `pending_rows` order
+                # regardless of worker completion order, so parallel and sequential
+                # runs remain byte-identical.
+                parseable_raw_ids = [raw_id for raw_id, source_index in pending_rows if source_index >= 0]
+                parsed_outcomes = _parse_retained_raws(archive, parseable_raw_ids, ingest_workers=ingest_workers)
+                for raw_id, source_index in pending_rows:
+                    state.scanned += 1
+                    state.censused.add(raw_id)
+                    if source_index < 0:
+                        archive.replace_raw_membership_census(
+                            raw_id,
+                            None,
+                            parser_fingerprint="revision-membership-v1",
+                            censused_at_ms=0,
+                            detail=BYTE_AUTHORITY_CENSUS_DETAIL,
+                            manage_transaction=not batched,
+                        )
+                        state.quarantined += 1
+                        pending_commits += 1
+                    else:
+                        outcome = parsed_outcomes[raw_id]
+                        if isinstance(outcome, Exception):
+                            archive.replace_raw_membership_census(
+                                raw_id,
+                                None,
+                                parser_fingerprint="revision-membership-v1",
+                                censused_at_ms=0,
+                                detail=str(outcome),
+                                manage_transaction=not batched,
+                            )
+                            state.quarantined += 1
+                            pending_commits += 1
+                        else:
+                            sessions, payload_bytes, revision_kind = outcome
+                            state.classified += int(len(sessions) == 1)
+                            spill.add(raw_id, sessions, payload_bytes=payload_bytes)
+                            if len(sessions) == 1 and revision_kind is RawRevisionKind.UNKNOWN:
+                                session = sessions[0]
+                                logical_key = f"{session.source_name.value}:{session.provider_session_id}"
+                                archive.bind_raw_revision(
+                                    raw_id,
+                                    RawRevisionEnvelope(
+                                        logical_source_key=logical_key,
+                                        kind=RawRevisionKind.FULL,
+                                        source_revision=raw_id,
+                                        acquisition_generation=0,
+                                        authority=RawRevisionAuthority.QUARANTINED,
+                                    ),
+                                    manage_transaction=not batched,
+                                )
+                                state.provisional_full_raw_ids.setdefault(logical_key, set()).add(raw_id)
+                                pending_commits += 1
+                            elif revision_kind is RawRevisionKind.UNKNOWN:
+                                archive.replace_raw_membership_census(
+                                    raw_id,
+                                    sessions,
+                                    parser_fingerprint="revision-membership-v1",
+                                    censused_at_ms=0,
+                                    manage_transaction=not batched,
+                                )
+                                for session in sessions:
+                                    logical_key = f"{session.source_name.value}:{session.provider_session_id}"
+                                    state.membership_candidates.setdefault(logical_key, set()).add(raw_id)
+                                pending_commits += 1
+                    if batch_size is not None and pending_commits >= batch_size:
+                        archive.commit()
+                        pending_commits = 0
+                if census_selection is None:
+                    break
+                expanded, _keys = archive.expand_raw_membership_selection(list(census_selection))
+                if set(expanded) == set(census_selection):
+                    break
+                census_selection = expanded
+    except BaseException:
+        if batched and pending_commits > 0:
+            archive.rollback()
+        raise
+    if batched and pending_commits > 0:
+        archive.commit()
     return state
 
 
@@ -323,6 +361,7 @@ def census_historical_revision_evidence(
     selected_raw_ids: list[str] | None = None,
     max_payload_bytes: int | None = None,
     ingest_workers: int = 1,
+    commit_batch_size: int | None = None,
 ) -> RevisionCensusResult:
     """Complete the source-tier census stage without applying index changes."""
     with (
@@ -335,6 +374,7 @@ def census_historical_revision_evidence(
             selected_raw_ids=selected_raw_ids,
             max_payload_bytes=max_payload_bytes,
             ingest_workers=ingest_workers,
+            commit_batch_size=commit_batch_size,
         )
         expanded, logical_keys = archive.expand_raw_membership_selection(selected_raw_ids)
     _record_raw_authority_parser_census(archive_root, tuple(expanded))
@@ -356,6 +396,7 @@ def backfill_historical_revision_evidence(
     max_payload_bytes: int | None = None,
     max_cached_payload_bytes: int | None = None,
     ingest_workers: int = 1,
+    commit_batch_size: int | None = None,
 ) -> RevisionBackfillResult:
     """Census every retained raw, then replay byte and bundle authority cohorts.
 
@@ -371,6 +412,15 @@ def backfill_historical_revision_evidence(
     caller keeps its current exactly-sized cache; pass it explicitly to cache
     parse output for an unbounded (``max_payload_bytes=None``) census without
     also activating envelope blocking.
+
+    ``commit_batch_size`` (polylogue-amg1) batches the CENSUS phase's
+    per-raw source.db commits only; the replay phase's cohort-apply and
+    terminal-raw finalize commit granularity is unchanged (see
+    ``_census_historical_revision_evidence`` for why: the replay phase's
+    "index commits, then source terminal marker commits" ordering is a
+    crash-recovery invariant pinned by
+    ``test_backfill_resumes_after_index_receipt_commits_before_source_terminal``
+    et al. and batching it needs its own reviewed change).
     """
     adoption_deferred = 0
     quarantined = 0
@@ -395,6 +445,7 @@ def backfill_historical_revision_evidence(
             selected_raw_ids=selected_raw_ids,
             max_payload_bytes=max_payload_bytes,
             ingest_workers=ingest_workers,
+            commit_batch_size=commit_batch_size,
         )
         censused_raw_ids, _censused_keys = archive.expand_raw_membership_selection(selected_raw_ids)
         # The direct backfill entry point must publish the same current-parser
@@ -557,6 +608,48 @@ def _census_parse_worker(
         return raw_id, None, str(exc)
 
 
+_DEFAULT_PARSE_DISPATCH_MAX_BYTES = 262_144  # 256 KiB
+
+
+def _parse_dispatch_max_bytes() -> int:
+    """Payload-size ceiling for pool dispatch to still be a net win (polylogue-amg1).
+
+    polylogue-amg1's own measurement: 200 raws at ~50KB average with 8
+    workers measured 1.22x (net win); 80 raws at ~1.7MB average measured
+    0.63x (net LOSS, slower than sequential) on the same machine. The
+    process-pool round trip pickles the returned ``ParsedSession`` list back
+    across the process boundary -- for large payloads that pickle cost
+    exceeds the parse time saved by running concurrently. Raws at or above
+    this size parse sequentially in-process (no IPC); raws below it dispatch
+    to the pool, where aggregate parse time genuinely dominates transfer
+    cost. Override with POLYLOGUE_REVISION_PARSE_DISPATCH_MAX_BYTES.
+    """
+    raw = os.environ.get("POLYLOGUE_REVISION_PARSE_DISPATCH_MAX_BYTES")
+    if raw is None:
+        return _DEFAULT_PARSE_DISPATCH_MAX_BYTES
+    try:
+        return int(raw)
+    except ValueError:
+        return _DEFAULT_PARSE_DISPATCH_MAX_BYTES
+
+
+def _partition_raws_by_dispatch_size(
+    raw_ids: list[str],
+    payload_sizes: dict[str, int],
+    *,
+    dispatch_max_bytes: int,
+) -> tuple[list[str], list[str]]:
+    """Split raw ids into (pool-eligible, sequential) by payload size.
+
+    Preserves ``raw_ids`` input order within each bucket so callers stay
+    deterministic. See ``_parse_dispatch_max_bytes`` for why size, not count,
+    decides pool eligibility (polylogue-amg1).
+    """
+    pool_raw_ids = [raw_id for raw_id in raw_ids if payload_sizes[raw_id] < dispatch_max_bytes]
+    sequential_raw_ids = [raw_id for raw_id in raw_ids if payload_sizes[raw_id] >= dispatch_max_bytes]
+    return pool_raw_ids, sequential_raw_ids
+
+
 def _parse_retained_raws(
     archive: ArchiveStore,
     raw_ids: list[str],
@@ -570,11 +663,32 @@ def _parse_retained_raws(
     exception. Read-only blob->ParsedSession decode is authority-neutral and
     embarrassingly parallel; callers apply archive writes afterwards in a
     fixed deterministic order independent of completion order here, so
-    parallel and sequential execution produce byte-identical archive state.
+    parallel and sequential execution produce byte-identical archive state
+    regardless of which raws take the pool path versus the sequential path.
     """
+    results: dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception] = {}
     if ingest_workers <= 1 or len(raw_ids) <= 1:
-        results: dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception] = {}
         for raw_id in raw_ids:
+            try:
+                results[raw_id] = _parse_retained_raw(archive, raw_id)
+            except Exception as exc:
+                results[raw_id] = exc
+        return results
+
+    descriptors = {raw_id: archive.raw_revision_descriptor(raw_id) for raw_id in raw_ids}
+    payload_sizes = {raw_id: descriptor[4] for raw_id, descriptor in descriptors.items()}
+    pool_raw_ids, sequential_raw_ids = _partition_raws_by_dispatch_size(
+        raw_ids, payload_sizes, dispatch_max_bytes=_parse_dispatch_max_bytes()
+    )
+
+    for raw_id in sequential_raw_ids:
+        try:
+            results[raw_id] = _parse_retained_raw(archive, raw_id)
+        except Exception as exc:
+            results[raw_id] = exc
+
+    if len(pool_raw_ids) <= 1:
+        for raw_id in pool_raw_ids:
             try:
                 results[raw_id] = _parse_retained_raw(archive, raw_id)
             except Exception as exc:
@@ -585,13 +699,11 @@ def _parse_retained_raws(
 
     from polylogue.pipeline.services.process_pool import process_pool_executor
 
-    descriptors = {raw_id: archive.raw_revision_descriptor(raw_id) for raw_id in raw_ids}
     blob_root_str = str(archive.archive_root / "blob")
     source_db_path_str = str(archive.source_db_path)
-    results = {}
-    with process_pool_executor(max_workers=min(ingest_workers, len(raw_ids))) as pool:
+    with process_pool_executor(max_workers=min(ingest_workers, len(pool_raw_ids))) as pool:
         future_to_raw_id = {}
-        for raw_id in raw_ids:
+        for raw_id in pool_raw_ids:
             provider, blob_hash, source_path, _kind, _payload_size = descriptors[raw_id]
             future = pool.submit(
                 _census_parse_worker,

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses
 import hashlib
 import json
+import os
 import re
 import sqlite3
 import time
@@ -80,6 +81,14 @@ _PROBE_ONLY_EXACT_MESSAGE_ROW_LIMIT = 100_000
 RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES = 1024 * 1024 * 1024
 RAW_MATERIALIZATION_RESOURCE_BLOCK_REASON = "non-stream-safe raw payload exceeds the bounded replay limit"
 RAW_MATERIALIZATION_CENSUS_COMPONENT_LIMIT = 25
+# polylogue-amg1: census-phase commit batching. Measured on independent-raw
+# corpora (200 raws/~50KB avg, 80 raws/~1.7MB avg): batch sizes 20/50/100
+# performed similarly (~1.1x-1.34x median wall-clock vs per-raw commit);
+# 20 was chosen as the default -- no measured benefit from larger batches,
+# and a smaller batch bounds how much census progress one crash can lose.
+# Override with POLYLOGUE_RAW_AUTHORITY_COMMIT_BATCH_SIZE; <= 0 restores
+# per-raw commit (escape hatch, matches COMMIT_BATCH_MESSAGE_THRESHOLD).
+RAW_MATERIALIZATION_COMMIT_BATCH_SIZE = 20
 RAW_MATERIALIZATION_OUTCOME_SAMPLE_LIMIT = 8
 _TRANSIENT_LOCK_PARSE_ERROR = "OperationalError: database is locked"
 _QUARANTINED_ACCEPTED_RAW_REPAIR_DETAIL = "repair:accepted_quarantined_raw_exact_byte_and_semantic_proof"
@@ -5560,6 +5569,20 @@ def preview_session_insights(*, count: int) -> RepairResult:
     )
 
 
+def _resolve_raw_authority_commit_batch_size(commit_batch_size: int | None) -> int | None:
+    """Resolve the census-phase commit batch size (polylogue-amg1)."""
+    if commit_batch_size is not None:
+        return commit_batch_size
+    raw = os.environ.get("POLYLOGUE_RAW_AUTHORITY_COMMIT_BATCH_SIZE")
+    if raw is None:
+        return RAW_MATERIALIZATION_COMMIT_BATCH_SIZE
+    try:
+        resolved = int(raw)
+    except ValueError:
+        return RAW_MATERIALIZATION_COMMIT_BATCH_SIZE
+    return resolved if resolved > 0 else None
+
+
 def repair_raw_materialization(
     config: Config,
     dry_run: bool = False,
@@ -5571,6 +5594,7 @@ def repair_raw_materialization(
     raw_artifact_limit: int | None = None,
     max_payload_bytes: int = RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES,
     ingest_workers: int | None = None,
+    commit_batch_size: int | None = None,
     progress_callback: ProgressCallback | None = None,
 ) -> RepairResult:
     """Converge retained raws through typed per-session revision authority.
@@ -5581,6 +5605,13 @@ def repair_raw_materialization(
     read-only and authority-neutral; component classification and apply
     order remain strictly sequential in this single writer regardless of
     worker count.
+
+    ``commit_batch_size`` (polylogue-amg1) batches the CENSUS phase's
+    per-raw source.db commits; ``None`` resolves
+    ``POLYLOGUE_RAW_AUTHORITY_COMMIT_BATCH_SIZE`` /
+    ``RAW_MATERIALIZATION_COMMIT_BATCH_SIZE``. Only the census phase batches
+    -- see ``_census_historical_revision_evidence`` for why the replay
+    phase's commit granularity is unchanged.
     """
     if max_payload_bytes < 1:
         raise ValueError("max_payload_bytes must be positive")
@@ -5588,6 +5619,7 @@ def repair_raw_materialization(
         from polylogue.pipeline.services.process_pool import resolve_parse_worker_count
 
         ingest_workers = resolve_parse_worker_count()
+    commit_batch_size = _resolve_raw_authority_commit_batch_size(commit_batch_size)
     archive_root = _raw_materialization_archive_root(config)
     recovered_censuses = recover_interrupted_raw_authority_censuses(archive_root)
     for recovered_census_id, recovered_scope in recovered_censuses:
@@ -5662,6 +5694,7 @@ def repair_raw_materialization(
                     selected_raw_ids=[seed],
                     max_payload_bytes=max_payload_bytes,
                     ingest_workers=ingest_workers,
+                    commit_batch_size=commit_batch_size,
                 )
             except RawRevisionReplayResourceBlockedError as exc:
                 logger.warning(
@@ -6073,6 +6106,7 @@ def repair_raw_materialization(
                 selected_raw_ids=[raw_id],
                 max_payload_bytes=max_payload_bytes,
                 ingest_workers=ingest_workers,
+                commit_batch_size=commit_batch_size,
             )
         except RawRevisionReplayResourceBlockedError as exc:
             metrics["raw_materialization_resource_blocked_count"] = max(

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -12,7 +12,7 @@ import math
 import sqlite3
 import time
 from collections.abc import Callable, Iterator, Mapping, Sequence
-from contextlib import closing, contextmanager
+from contextlib import closing, contextmanager, nullcontext
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -1887,8 +1887,9 @@ class ArchiveStore:
             stage_timings_s[key] = stage_timings_s.get(key, 0.0) + (time.perf_counter() - index_started)
         return result
 
-    def bind_raw_revision(self, raw_id: str, revision: RawRevisionEnvelope) -> None:
-        bind_source_raw_revision(self._ensure_source_conn(), raw_id, revision)
+    def bind_raw_revision(self, raw_id: str, revision: RawRevisionEnvelope, *, manage_transaction: bool = True) -> None:
+        """Bind acquisition evidence; ``manage_transaction=False`` batches (polylogue-amg1)."""
+        bind_source_raw_revision(self._ensure_source_conn(), raw_id, revision, manage_transaction=manage_transaction)
 
     def release_provisional_full_revisions(self, raw_ids: Sequence[str]) -> None:
         """Undo census-time bindings when index authority rejects adoption.
@@ -2415,10 +2416,16 @@ class ArchiveStore:
         censused_at_ms: int,
         detail: str = "",
         retire_full_revision_governance: bool = False,
+        manage_transaction: bool = True,
     ) -> None:
-        """Atomically replace one raw's complete parser census and memberships."""
+        """Replace one raw's complete parser census and memberships.
+
+        ``manage_transaction=False`` batches multiple raws' census writes
+        into one caller-managed commit window (polylogue-amg1) -- the caller
+        must call ``commit()`` (or ``rollback()`` on failure) itself.
+        """
         conn = self._ensure_source_conn()
-        with conn:
+        with conn if manage_transaction else nullcontext():
             if retire_full_revision_governance:
                 revision = conn.execute(
                     "SELECT logical_source_key, revision_kind FROM raw_sessions WHERE raw_id = ?",

--- a/polylogue/storage/sqlite/archive_tiers/source_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/source_write.py
@@ -647,9 +647,20 @@ def write_source_raw_session_blob_ref(
     return resolved_raw_id
 
 
-def bind_source_raw_revision(conn: sqlite3.Connection, raw_id: str, revision: RawRevisionEnvelope) -> None:
-    """Bind acquisition evidence after a payload proves a single session identity."""
-    with conn:
+def bind_source_raw_revision(
+    conn: sqlite3.Connection,
+    raw_id: str,
+    revision: RawRevisionEnvelope,
+    *,
+    manage_transaction: bool = True,
+) -> None:
+    """Bind acquisition evidence after a payload proves a single session identity.
+
+    ``manage_transaction=False`` batches multiple raws' binds into one
+    caller-managed commit window (polylogue-amg1) -- the caller must call
+    ``conn.commit()`` (or ``conn.rollback()`` on failure) itself.
+    """
+    with conn if manage_transaction else nullcontext():
         cursor = conn.execute(
             """
             UPDATE raw_sessions

--- a/tests/infra/revision_backfill_benchmark.py
+++ b/tests/infra/revision_backfill_benchmark.py
@@ -1,0 +1,98 @@
+"""Synthetic corpora for raw-authority replay throughput benchmarks (polylogue-amg1).
+
+Builds a population of independent, never-classified raws directly into
+source.db -- the exact shape ``census_historical_revision_evidence`` /
+``backfill_historical_revision_evidence`` operate on for a CLI
+``rebuild-index`` over historical evidence (polylogue-9p8x's original
+scenario). Each raw is its own logical source (no cohort/append
+relationships), which isolates per-raw census/commit overhead from cohort
+classification complexity -- the same isolation polylogue-amg1's own
+profiling used to attribute wall time between parse and
+``sqlite3.Connection.__exit__`` (commit/fsync).
+
+Two shapes are provided, matching amg1's own recorded measurements:
+``SMALL_PAYLOAD_SHAPE`` (200 raws, ~50KB average) and
+``LARGE_PAYLOAD_SHAPE`` (80 raws, ~1.7MB average).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from polylogue.core.enums import Provider
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+SMALL_PAYLOAD_SHAPE: dict[str, int] = {"raw_count": 200, "avg_payload_bytes": 50_000}
+LARGE_PAYLOAD_SHAPE: dict[str, int] = {"raw_count": 80, "avg_payload_bytes": 1_700_000}
+
+# Fixed per-record JSON envelope overhead (quotes, keys, braces) that isn't
+# part of the padded text field -- subtracted from the target size so the
+# generated payload lands close to the requested average.
+_ENVELOPE_OVERHEAD_BYTES = 220
+
+
+def _codex_raw_payload(index: int, *, target_bytes: int) -> bytes:
+    """One independent, single-session Codex JSONL raw sized near target_bytes."""
+    session_meta = (
+        json.dumps(
+            {
+                "type": "session_meta",
+                "payload": {"id": f"amg1-session-{index:06d}", "timestamp": "2026-06-01T00:00:00Z"},
+            },
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    text_len = max(1, target_bytes - len(session_meta) - _ENVELOPE_OVERHEAD_BYTES)
+    text = f"amg1-payload-{index:06d}-" + ("x" * text_len)
+    response_item = (
+        json.dumps(
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": "one",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": text}],
+                },
+            },
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    return (session_meta + response_item).encode()
+
+
+def build_independent_raw_corpus(
+    archive_root: Path,
+    *,
+    raw_count: int,
+    avg_payload_bytes: int,
+) -> list[str]:
+    """Write ``raw_count`` independent, uncensused, single-session raws.
+
+    Returns the written raw ids in insertion order. The archive root is
+    initialized fresh; call once per corpus.
+    """
+    initialize_active_archive_root(archive_root)
+    raw_ids: list[str] = []
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        for index in range(raw_count):
+            payload = _codex_raw_payload(index, target_bytes=avg_payload_bytes)
+            raw_id = archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=payload,
+                source_path=f"synthetic-amg1/session-{index:06d}.jsonl",
+                acquired_at_ms=index + 1,
+            )
+            raw_ids.append(raw_id)
+    return raw_ids
+
+
+__all__ = [
+    "LARGE_PAYLOAD_SHAPE",
+    "SMALL_PAYLOAD_SHAPE",
+    "build_independent_raw_corpus",
+]

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -13,10 +13,15 @@ from polylogue.sources import revision_backfill
 from polylogue.sources.decoders import _iter_json_stream
 from polylogue.sources.dispatch import parse_payload
 from polylogue.sources.parsers.base import ParsedSession
-from polylogue.sources.revision_backfill import _parse_one, backfill_historical_revision_evidence
+from polylogue.sources.revision_backfill import (
+    _parse_one,
+    backfill_historical_revision_evidence,
+    census_historical_revision_evidence,
+)
 from polylogue.storage.blob_publication import ArchiveBlobPublisher
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from tests.infra.revision_backfill_benchmark import build_independent_raw_corpus
 
 
 def _chatgpt_session(native_id: str, *texts: str) -> dict[str, object]:
@@ -844,3 +849,186 @@ def test_parallel_census_threads_hermes_sqlite_payload_path(tmp_path: Path) -> N
         rows = conn.execute("SELECT native_id, message_count FROM sessions ORDER BY native_id").fetchall()
     assert [native_id.startswith("hermes-") for native_id, _count in rows] == [True, True]
     assert [count for _native_id, count in rows] == [1, 1]
+
+
+def test_independent_raw_corpus_fixture_backfills_cleanly(tmp_path: Path) -> None:
+    """polylogue-amg1 benchmark fixture sanity: every synthetic raw census-and-replays
+    to exactly one session with no quarantine, at both recorded payload shapes' scale
+    (downscaled here for test speed; devtools/scripts run the full recorded counts)."""
+    raw_ids = build_independent_raw_corpus(tmp_path, raw_count=12, avg_payload_bytes=5_000)
+
+    result = backfill_historical_revision_evidence(tmp_path)
+
+    assert result.scanned == 12
+    assert result.replayed_logical_sources == 12
+    assert result.quarantined == 0
+    with sqlite3.connect(tmp_path / "index.db") as conn:
+        session_count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    assert session_count == 12
+    assert len(set(raw_ids)) == 12
+
+
+def test_census_batching_reduces_commit_count(tmp_path: Path) -> None:
+    """polylogue-amg1 lever (a): commit_batch_size must defer per-raw
+    self-commits (manage_transaction=False) and drive the batch boundary
+    through exactly ``ceil(raw_count / batch_size)`` explicit ArchiveStore
+    commits, versus one self-commit per raw when unset -- while producing
+    identical scan/classification results either way. sqlite3.Connection is
+    an immutable C type and cannot be monkeypatched directly, so this
+    verifies the actual mechanism (the manage_transaction contract each
+    write call receives, and how many times the batch-boundary commit()
+    fires) rather than a raw connection-level commit count."""
+    unbatched_root = tmp_path / "unbatched"
+    batched_root = tmp_path / "batched"
+    build_independent_raw_corpus(unbatched_root, raw_count=9, avg_payload_bytes=1_000)
+    build_independent_raw_corpus(batched_root, raw_count=9, avg_payload_bytes=1_000)
+
+    import unittest.mock as mock
+
+    def _manage_transaction_flags(archive_root: Path, *, commit_batch_size: int | None) -> tuple[list[bool], int]:
+        flags: list[bool] = []
+        commit_count = 0
+        original_bind = ArchiveStore.bind_raw_revision
+        original_commit = ArchiveStore.commit
+
+        def recording_bind(self: ArchiveStore, raw_id: str, revision: object, **bind_kwargs: object) -> None:
+            flags.append(bool(bind_kwargs.get("manage_transaction", True)))
+            original_bind(self, raw_id, revision, **bind_kwargs)  # type: ignore[arg-type]
+
+        def counting_commit(self: ArchiveStore) -> None:
+            nonlocal commit_count
+            commit_count += 1
+            original_commit(self)
+
+        with (
+            mock.patch.object(ArchiveStore, "bind_raw_revision", recording_bind),
+            mock.patch.object(ArchiveStore, "commit", counting_commit),
+        ):
+            census_historical_revision_evidence(archive_root, commit_batch_size=commit_batch_size)
+        return flags, commit_count
+
+    unbatched_flags, unbatched_explicit_commits = _manage_transaction_flags(unbatched_root, commit_batch_size=None)
+    batched_flags, batched_explicit_commits = _manage_transaction_flags(batched_root, commit_batch_size=4)
+
+    assert len(unbatched_flags) == len(batched_flags) == 9
+    # Unbatched: every write self-commits immediately (manage_transaction=True).
+    assert all(unbatched_flags)
+    assert unbatched_explicit_commits == 0
+    # Batched (size 4, 9 raws): writes defer (manage_transaction=False) and
+    # the loop drives exactly ceil(9/4) = 3 explicit batch-boundary commits.
+    assert not any(batched_flags)
+    assert batched_explicit_commits == 3
+
+
+def test_census_batch_crash_loses_at_most_one_batch_and_resumes_cleanly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """polylogue-amg1 crash-mid-batch proof: a fault partway through an
+    uncommitted census batch must discard exactly that batch (not a partial
+    raw, not prior committed batches), and a resume must converge to the
+    same terminal state as an uninterrupted run with zero duplication."""
+    raw_count = 10
+    batch_size = 4
+    root = tmp_path / "archive"
+    build_independent_raw_corpus(root, raw_count=raw_count, avg_payload_bytes=1_000)
+
+    original_bind = ArchiveStore.bind_raw_revision
+    calls = 0
+    # Crash on the 7th bind call: batch 1 (calls 1-4) has already committed;
+    # batch 2 (calls 5-8) is interrupted after its 3rd call (7), before it
+    # reaches batch_size and self-commits.
+    crash_at_call = 7
+
+    def crash_partway(self: ArchiveStore, raw_id: str, revision: object, **kwargs: object) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == crash_at_call:
+            raise RuntimeError("injected crash mid-batch")
+        original_bind(self, raw_id, revision, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(ArchiveStore, "bind_raw_revision", crash_partway)
+    with pytest.raises(RuntimeError, match="injected crash mid-batch"):
+        backfill_historical_revision_evidence(root, commit_batch_size=batch_size)
+
+    with sqlite3.connect(root / "source.db") as conn:
+        complete_after_crash = conn.execute(
+            "SELECT COUNT(*) FROM raw_sessions WHERE revision_kind != 'unknown'"
+        ).fetchone()[0]
+    # Exactly one fully-committed batch survives the crash -- never a partial one.
+    assert complete_after_crash == batch_size
+
+    monkeypatch.setattr(ArchiveStore, "bind_raw_revision", original_bind)
+    result = backfill_historical_revision_evidence(root, commit_batch_size=batch_size)
+
+    assert result.scanned == raw_count
+    assert result.replayed_logical_sources == raw_count
+    assert result.quarantined == 0
+    with sqlite3.connect(root / "index.db") as conn:
+        session_count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        application_count = conn.execute("SELECT COUNT(*) FROM raw_revision_applications").fetchone()[0]
+    assert session_count == raw_count
+    # One application receipt per raw, no duplicates from the retried batch.
+    assert application_count == raw_count
+    with sqlite3.connect(root / "source.db") as conn:
+        assert (
+            conn.execute("SELECT COUNT(*) FROM raw_sessions WHERE revision_kind != 'unknown'").fetchone()[0]
+            == raw_count
+        )
+
+
+def test_partition_raws_by_dispatch_size_routes_small_to_pool_large_sequential() -> None:
+    """polylogue-amg1 lever (b): raws under the size ceiling are pool-eligible
+    (parallel parse pays off), raws at/above it stay sequential (pickling the
+    large returned ParsedSession back across the process boundary would cost
+    more than the parse saved -- the bead's own 0.63x/net-loss measurement)."""
+    payload_sizes = {"small-1": 1_000, "small-2": 200_000, "large-1": 262_144, "large-2": 1_700_000}
+
+    pool_ids, sequential_ids = revision_backfill._partition_raws_by_dispatch_size(
+        ["small-1", "small-2", "large-1", "large-2"], payload_sizes, dispatch_max_bytes=262_144
+    )
+
+    assert pool_ids == ["small-1", "small-2"]
+    assert sequential_ids == ["large-1", "large-2"]
+
+
+def test_size_aware_dispatch_keeps_large_raws_off_the_process_pool(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End-to-end proof: with a low dispatch ceiling, only the small raw in a
+    mixed corpus is submitted to the process pool; the large one parses
+    in-process, and the archive state matches ingest_workers=1 exactly."""
+    monkeypatch.setenv("POLYLOGUE_REVISION_PARSE_DISPATCH_MAX_BYTES", "5000")
+    initialize_active_archive_root(tmp_path)
+    small_text = "s" * 200
+    large_text = "l" * 20_000
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        for index, text in enumerate((small_text, large_text, small_text)):
+            payload = (
+                f'{{"type":"session_meta","payload":{{"id":"amg1-mix-{index}"}}}}\n'
+                f'{{"type":"response_item","payload":{{"type":"message","id":"one","role":"user",'
+                f'"content":[{{"type":"input_text","text":"{text}"}}]}}}}\n'
+            ).encode()
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=payload,
+                source_path=f"amg1-mix-{index}.jsonl",
+                acquired_at_ms=index,
+            )
+
+    submitted_raw_ids: list[str] = []
+    original_partition = revision_backfill._partition_raws_by_dispatch_size
+
+    def recording_partition(raw_ids: list[str], payload_sizes: dict[str, int], **kwargs: object) -> object:
+        pool_ids, sequential_ids = original_partition(raw_ids, payload_sizes, **kwargs)  # type: ignore[arg-type]
+        submitted_raw_ids.extend(pool_ids)
+        return pool_ids, sequential_ids
+
+    monkeypatch.setattr(revision_backfill, "_partition_raws_by_dispatch_size", recording_partition)
+
+    result = backfill_historical_revision_evidence(tmp_path, ingest_workers=4)
+
+    assert result.scanned == 3
+    assert result.replayed_logical_sources == 3
+    assert result.quarantined == 0
+    # Only the two small raws (well under the 5000-byte ceiling) were pool-eligible.
+    assert len(submitted_raw_ids) == 2


### PR DESCRIPTION
## Summary

Two safe, bounded performance levers for `polylogue-amg1`: batch the raw-authority census phase's per-raw SQLite commits, and route large payloads off the parse process-pool (which was previously a net throughput *loss* for them). A real, deliberately-tested crash-recovery ordering invariant in the replay phase bounds this pass's scope — see below.

## Problem

`polylogue-9p8x`'s own profiling (cProfile, synthetic 60-raw/1.7MB corpus) found `sqlite3.Connection.__exit__` (per-write commit/fsync) at 42.6% of `backfill_historical_revision_evidence`'s wall time — comparable to parse itself (40.6%). Census-phase writes (`replace_raw_membership_census`/`bind_raw_revision`) each self-commit via `with conn:`, once per raw. A direct throughput benchmark also found the process-pool parse path was a net **loss** (0.63x) on large payloads (~1.7MB avg) — pickling the returned `ParsedSession` list back across the process boundary cost more than the parse time it saved — while it was a real win (1.22x) on small payloads (~50KB avg).

## Solution

- `replace_raw_membership_census` and `bind_raw_revision`/`bind_source_raw_revision` gain `manage_transaction: bool = True` (default unchanged), using the `with conn if manage_transaction else nullcontext()` pattern already established elsewhere in `archive.py`.
- `_census_historical_revision_evidence` gains `commit_batch_size`: when set, census writes defer commit and a batch boundary fires `archive.commit()` every N raws (default `None` preserves per-raw commit for every existing caller — fully backward compatible). Threaded through `census_historical_revision_evidence` / `backfill_historical_revision_evidence` / `repair_raw_materialization`; the daemon/CLI path resolves a default of 20 via `RAW_MATERIALIZATION_COMMIT_BATCH_SIZE` / `POLYLOGUE_RAW_AUTHORITY_COMMIT_BATCH_SIZE`.
- `_parse_retained_raws` now partitions raws by payload size (`_partition_raws_by_dispatch_size`): raws under `POLYLOGUE_REVISION_PARSE_DISPATCH_MAX_BYTES` (default 256KiB) stay pool-eligible; raws at/above it parse sequentially in-process, avoiding the pickle-back cost that made large payloads a net loss.

### Deliberately NOT touched (and why)

`apply_raw_revision_replay`'s per-cohort `index.db` commit and `finalize_raw_parse_state`'s per-raw `source.db` commit. Two existing crash-recovery tests (`test_backfill_resumes_after_index_receipt_commits_before_source_terminal`, `test_backfill_resumes_after_only_some_source_markers_commit`) pin **"index commits, then source terminal marker commits"** as a load-bearing ordering invariant in the replay phase. Batching across cohorts there would require deferring the corresponding source-marker commits to the same boundary, or the invariant inverts (source could become durable before its index counterpart — worse than today). That's a materially bigger, riskier change, matching this bead's own design note ("this is the hard part and needs its own adversarial review, not a quick change") — left for a follow-up rather than folded in here.

## Measured (honest ceiling, not a fabricated pass)

Benchmark fixture: `tests/infra/revision_backfill_benchmark.py` (committed, reusable — matches `polylogue-amg1`'s two recorded corpus shapes). Median of 3 runs, same-session/same-machine load:

| Shape | Config | Speedup |
|---|---|---|
| SMALL (200 raws, ~50KB avg) | `commit_batch_size=20`, workers=1 | **1.34x** |
| SMALL | `commit_batch_size=20`, workers=8 | 1.05x |
| LARGE (80 raws, ~1.7MB avg) | `commit_batch_size=20`, workers=1 | **1.12x** |
| LARGE | `commit_batch_size=20`, workers=8 | 1.13x |

This is a real, modest, consistent 1.05x–1.34x — well short of the originally-hypothesized 4x (or even the ~1.7x Amdahl estimate), which is the honest ceiling for this pass's safe scope. Full detail (including a deployment caveat: `repair_raw_materialization` calls `backfill_historical_revision_evidence` per-component, so the full benchmark gain applies most directly to the CLI `rebuild-index` full-archive scenario, not the daemon's per-component loop) recorded on `polylogue-amg1`.

## Verification

- New tests prove the crash-mid-batch guarantee (`test_census_batch_crash_loses_at_most_one_batch_and_resumes_cleanly`: exactly one committed batch survives an injected fault, a resume converges to the correct terminal state with zero duplication) and the size-aware dispatch split (`test_partition_raws_by_dispatch_size_routes_small_to_pool_large_sequential`, `test_size_aware_dispatch_keeps_large_raws_off_the_process_pool`). Both proven to fail against the pre-fix code before restoring the fix.
- `devtools test tests/unit/sources/test_revision_backfill.py tests/unit/storage/test_repair.py` — 78 passed.
- `devtools test tests/unit/devtools/test_raw_authority_restart_proof.py tests/unit/devtools/test_raw_authority_scale_proof.py` — 25 passed (crash-recovery/conservation invariants intact).
- Broader sweep `-k "raw_authority or raw_materialization or revision_backfill or revision_replay"` — 187 passed, 1 pre-existing unrelated failure (`test_live_multi_session_divergence_reopens_raw_authority`), confirmed via stash-and-rerun to fail identically on clean `origin/master`.
- `devtools verify --quick` — exit 0.
- Not run: the heavy `test` suite (skipped per-PR by CI policy, runs post-merge).

Ref polylogue-amg1