### PR TITLE
fix(browser-capture): scope receiver token + spool root under archive_root

### DIFF
--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -1642,7 +1642,7 @@ def resolve_runtime_config(
     browser_spool = _resolved_runtime_path(
         settings.browser_capture_spool_path,
         bootstrap=bootstrap,
-        fallback=bootstrap.data_home / "browser-capture",
+        fallback=archive / "browser-capture",
     )
     hook_sidecar = _resolved_runtime_path(
         settings.hook_sidecar_dir,
@@ -1671,7 +1671,7 @@ def resolve_runtime_config(
         blob_root=archive / "blob",
         inbox_root=archive / "inbox",
         browser_capture_spool_root=browser_spool,
-        browser_capture_receiver_token_path=bootstrap.state_home / "browser-capture-receiver-token",
+        browser_capture_receiver_token_path=archive / "browser-capture-receiver-token",
         hook_sidecar_root=hook_sidecar,
         drive_cache_root=drive_cache,
     )

--- a/polylogue/paths/_roots.py
+++ b/polylogue/paths/_roots.py
@@ -139,13 +139,28 @@ def active_index_db_path() -> Path:
 
 
 def browser_capture_spool_root() -> Path:
-    """Default browser-capture source artifact spool."""
-    return data_home() / "browser-capture"
+    """Browser-capture source artifact spool, scoped under the archive root.
+
+    Must track ``archive_root()`` (not ``data_home()``) so a
+    ``POLYLOGUE_ARCHIVE_ROOT`` override genuinely isolates a scratch/test
+    archive's capture spool from the default archive's.
+    """
+    return archive_root() / "browser-capture"
 
 
 def browser_capture_receiver_token_path() -> Path:
-    """Default path for the auto-minted browser-capture receiver bearer token."""
-    return state_home() / "browser-capture-receiver-token"
+    """Path for the auto-minted browser-capture receiver bearer token, scoped under the archive root.
+
+    Must track ``archive_root()`` (not ``state_home()``): ``receiver_identity()``
+    hashes this token to derive the receiver's stable id, so an archive-scoped
+    token is also what gives two archive roots distinct receiver identities.
+    Before this, two ``polylogued`` instances with different
+    ``POLYLOGUE_ARCHIVE_ROOT`` values shared one token and one receiver
+    identity, letting a scratch instance silently authenticate against (and,
+    via the extension's canonical-endpoint self-heal, silently reconnect to)
+    a different instance's receiver.
+    """
+    return archive_root() / "browser-capture-receiver-token"
 
 
 def archive_root() -> Path:

--- a/tests/unit/browser_capture/test_receiver_token.py
+++ b/tests/unit/browser_capture/test_receiver_token.py
@@ -20,11 +20,14 @@ from pathlib import Path
 from threading import Thread
 from typing import cast
 
+import pytest
+
 from polylogue.browser_capture.receiver import (
     load_or_mint_receiver_token,
     resolve_receiver_auth_token,
 )
 from polylogue.browser_capture.server import make_server
+from polylogue.paths import browser_capture_receiver_token_path, browser_capture_spool_root
 
 _EXTENSION_ORIGIN = "chrome-extension://polylogue-test"
 
@@ -83,6 +86,35 @@ def test_load_or_mint_receiver_token_rotate_changes_the_value(tmp_path: Path) ->
 
     assert rotated != original
     assert reloaded == rotated
+
+
+def test_default_token_and_spool_paths_are_scoped_to_archive_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two POLYLOGUE_ARCHIVE_ROOT values must never resolve to the same
+    default token file (polylogue-x2q3): a scratch archive that collides on
+    port with the real daemon must not silently authenticate against it.
+    """
+    root_a = tmp_path / "archive-a"
+    root_b = tmp_path / "archive-b"
+
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root_a))
+    token_path_a = browser_capture_receiver_token_path()
+    spool_root_a = browser_capture_spool_root()
+    token_a = load_or_mint_receiver_token()
+
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root_b))
+    token_path_b = browser_capture_receiver_token_path()
+    spool_root_b = browser_capture_spool_root()
+    token_b = load_or_mint_receiver_token()
+
+    assert token_path_a != token_path_b
+    assert spool_root_a != spool_root_b
+    assert token_a != token_b
+    assert root_a in token_path_a.parents
+    assert root_b in token_path_b.parents
+    assert root_a in spool_root_a.parents
+    assert root_b in spool_root_b.parents
 
 
 def test_resolve_receiver_auth_token_prefers_explicit_token(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
`browser_capture_receiver_token_path()` and `browser_capture_spool_root()`
resolved from XDG defaults (`state_home()`/`data_home()`) regardless of
`POLYLOGUE_ARCHIVE_ROOT`. Every archive root shared one auth token, and
since `receiver_identity()` hashes that token to derive the receiver's
stable id, every archive root shared one receiver identity too.

## Problem
Discovered via a real incident during live browser-extension proof work
(polylogue-ptx / polylogue-yyvg.7): a scratch `polylogued run --spool
<scratch>` on the default port crashed on startup (`Address already in
use`) because the real `polylogued.service` was already bound there — but
because the token wasn't archive-scoped, the scratch instance's pairing
token authenticated successfully against the real running daemon instead
of failing loudly. Two real browser-action test conversations and their
captured content briefly landed in the production archive before being
caught and fully cleaned up. Separately, even a *correctly*-isolated
scratch instance on an alternate port got silently reconnected to the
canonical production endpoint by the extension's own
`checkReceiverHealth({allowCanonicalRecovery:true})` self-heal, because
the two instances' `receiver_id` matched (same non-scoped token → same
hash).

## Solution
Both path functions now resolve under `archive_root()`, matching every
other archive-tier path (`index.db`, `source.db`, `blob/`, `render/`,
etc). Also fixed the parallel (currently unconsumed by any live code path)
`ResolvedRuntimeConfig` construction in `config.py` for consistency, so it
doesn't silently diverge from the now-correct `polylogue.paths` behavior
once something starts reading it.

For the default/unconfigured case this is a no-op for the spool root
(`archive_root()` already equals `data_home()` when
`POLYLOGUE_ARCHIVE_ROOT` is unset — verified live) and a one-time
relocation for the token (`~/.local/state/polylogue/browser-capture-receiver-token`
→ `~/.local/share/polylogue/browser-capture-receiver-token`).

New regression test (`test_default_token_and_spool_paths_are_scoped_to_archive_root`)
proves two `POLYLOGUE_ARCHIVE_ROOT` values never share a token, spool
root, or (by construction) receiver_id — the exact contract the incident
violated.

## Migration note
Any already-running `polylogued.service` picks this up on its next
restart after deployment. Its receiver token relocates, so it auto-mints
a fresh one, and any currently-paired browser extension needs a one-time
re-pair (`polylogued browser-capture token show`, paste into the popup's
Receiver settings) — the extension's existing "Reset pairing"/Attention
flow already covers this; no new UI needed.

## Verification
- `devtools test tests/unit/browser_capture/test_receiver_token.py` → 8 passed
- `devtools test tests/unit/browser_capture/ tests/unit/daemon/test_daemon_cli.py tests/unit/sources/test_live_watcher.py` → 304 passed
- `devtools test tests/unit/core/test_paths.py tests/unit/core/test_config.py` → 115 passed, 1 pre-existing unrelated failure (`test_external_active_pointer_changes_only_the_index_tier`, confirmed failing identically on master without this change)
- `devtools verify --quick` → exit 0
- Live sanity check: two `POLYLOGUE_ARCHIVE_ROOT` values now mint genuinely distinct tokens; default (no override) spool path unchanged, token path intentionally relocated as documented above

Ref polylogue-x2q3

🤖 Generated with [Claude Code](https://claude.com/claude-code)