### PR TITLE
fix(yyvg.7): stop a stale mission snapshot overriding a fresher ledger read

### DIFF
--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -161,12 +161,25 @@ function activeConversationState(tab, globalState, ledger) {
     provider_session_id: context.sessionId,
     active_page_state: "conversation",
   };
+  const item = context.ledger;
   if (
     globalState?.provider === context.provider
     && globalState?.provider_session_id === context.sessionId
-  ) return globalState;
+  ) {
+    // globalState (background's live/mission snapshot) agrees with the ledger
+    // on which conversation this is, but the two are updated by separate,
+    // independently-timed paths (a synchronous storage read vs. an async
+    // background round-trip) and can transiently disagree -- e.g. right
+    // after a receiver reconfiguration, the snapshot can lag a ledger write
+    // that already landed. Prefer whichever is actually newer instead of
+    // unconditionally trusting globalState.
+    const globalUpdatedAt = Date.parse(globalState?.updated_at || "");
+    const ledgerUpdatedAt = Date.parse(item.updated_at || "");
+    const ledgerIsFresher = Number.isFinite(ledgerUpdatedAt)
+      && (!Number.isFinite(globalUpdatedAt) || ledgerUpdatedAt > globalUpdatedAt);
+    if (!ledgerIsFresher) return globalState;
+  }
 
-  const item = context.ledger;
   return {
     ...onlineState,
     provider: context.provider,

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -440,6 +440,34 @@ describe("popup capture", () => {
     expect(document.getElementById("open-tabs").textContent).toContain("Catching up");
   });
 
+  it("prefers a fresher ledger entry over a stale global snapshot for the same conversation", async () => {
+    // Reproduces a live incident: right after a receiver reconfiguration,
+    // the async mission/global-state snapshot can lag a ledger write that
+    // already landed, even though both describe the exact same tracked
+    // conversation. The active card must not show a stale "nothing tracked
+    // yet" fallback when the ledger already knows this conversation is
+    // archived.
+    await loadPopup({
+      polylogueState: {
+        online: true,
+        provider: "chatgpt",
+        provider_session_id: "test-conversation",
+        updated_at: "2026-07-18T22:00:00.000Z",
+      },
+      polylogueSessionLedger: {
+        "chatgpt:test-conversation": {
+          archive_state: { state: "archived" },
+          turn_count: 2,
+          updated_at: "2026-07-18T22:05:00.000Z",
+        },
+      },
+    });
+
+    expect(document.getElementById("badge").textContent).toBe("safe / current");
+    expect(document.getElementById("state").textContent).toBe("The latest capture is visible in the archive.");
+    expect(document.getElementById("attention-section").hidden).toBe(true);
+  });
+
   it("renders the ledger and timeline for a Grok query conversation", async () => {
     await loadPopup({
       polylogueState: {


### PR DESCRIPTION
## Summary
Fixes a real AC5 violation found while doing live installed-proof testing
for polylogue-yyvg.7: the popup's "Open conversations" list and its
"Current page" active-card could transiently disagree about the same
conversation's captured state.

## Problem
`activeConversationState()` in popup.js, when the background's global/
mission-snapshot state (`globalState`) named the same provider+session as
the current tab, returned `globalState` unconditionally — even when it was
staler than `polylogueSessionLedger`'s entry for that exact conversation.
The two are updated on independent paths (a synchronous `storage.local`
read for the ledger vs. an async round-trip to the background script for
the mission snapshot) and can transiently disagree.

Live-reproduced during the AC7 proof session: right after a receiver
reconfiguration, the mission-snapshot round-trip raced and returned stale
data for one popup render — the active card fell through to the generic
"Receiver online. Open a supported conversation to capture." placeholder
while the "Open conversations" list (ledger-driven) correctly showed the
identical conversation as "Safe / current". Confirmed via direct
`chrome.storage.local` inspection that both sources agree once the race
window passes (properly `activate`d tab, stable connection) — this is
specifically a transient race, not a permanent inconsistency.

## Solution
When `globalState` and the ledger agree on which conversation this is,
prefer whichever has the newer `updated_at` instead of unconditionally
trusting `globalState`. Deliberately narrow — does not touch the sibling
branch where `globalState` omits provider/session entirely (that's an
intentional, separately-tested contract: background's response to some
messages describes "the conversation I just acted on" implicitly,
trusting the caller to associate it with the current tab; changing that
would have broken 3+ existing tests exercising it).

New test proves the exact race (matching provider+session, older
`globalState.updated_at`, newer ledger `updated_at` with archived state).
Verified it fails without the fix (`needs attention` instead of
`safe / current`) via `git stash` on just `popup.js`, then passes with it.

## Verification
- `npx vitest run tests/popup.test.js` → 31 passed (was 30; new test added)
- `npx vitest run` (full extension suite) → 340 passed, 1 pre-existing
  unrelated failure (packaged-worker fixture, unchanged)
- `npm run lint` / `npm run validate` → clean / manifest ok
- `devtools verify --quick` → exit 0

Ref polylogue-yyvg.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)