### PR TITLE
perf(storage): seed planner stats at fresh index bootstrap, re-analyze per rebuild page

### DIFF
--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -21,6 +21,27 @@ from polylogue.maintenance.offline_guard import offline_maintenance_block_reason
 from polylogue.paths import render_root
 from polylogue.storage.archive_identity import ArchiveLocation
 
+_PLANNER_STATS_ANALYSIS_LIMIT = 1000
+
+
+def _refresh_generation_planner_statistics(index_path: Path) -> None:
+    """Replace bootstrap-seeded planner stats with measured ones after a page.
+
+    A generation is bulk-written from empty, so the relative selectivities the
+    planner needs (session-scoped indexes are narrow, type-scoped ones are not)
+    drift fast as tables grow.  A bounded ANALYZE per page keeps writer-hot
+    plans (e.g. per-session ``action_pairs`` refresh) on the session-scoped
+    indexes; skipping it reproduced an O(N^2) replay measured at >20x slower.
+    Failures are non-fatal: stale stats degrade speed, never correctness.
+    """
+    try:
+        with contextlib.closing(sqlite3.connect(index_path, timeout=60)) as conn:
+            conn.execute(f"PRAGMA analysis_limit = {_PLANNER_STATS_ANALYSIS_LIMIT}")
+            conn.execute("ANALYZE")
+            conn.commit()
+    except sqlite3.Error:
+        return
+
 
 @dataclass(frozen=True, slots=True)
 class RebuildIndexRequest:
@@ -256,6 +277,8 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
                 progress_callback=None,
                 owned_inactive_generation=(generation.generation_id, generation.owner_id),
             )
+            if selected_raw_ids:
+                _refresh_generation_planner_statistics(Path(generation.index_path))
             if transaction is not None and selected_raw_ids:
                 if source_revision_snapshot(root) != transaction.source_snapshot:
                     transaction = generation_store.checkpoint_transaction(

--- a/polylogue/storage/sqlite/schema.py
+++ b/polylogue/storage/sqlite/schema.py
@@ -16,6 +16,7 @@ import aiosqlite
 from polylogue.core.errors import SchemaVersionMismatchError
 from polylogue.storage.sqlite.runtime_indexes import ensure_runtime_indexes_async, ensure_runtime_indexes_sync
 from polylogue.storage.sqlite.schema_bootstrap import (
+    PLANNER_STAT1_SEED_SQL,
     SCHEMA_DDL,
     SCHEMA_VERSION,
     capture_schema_snapshot,
@@ -62,6 +63,7 @@ def _ensure_schema(conn: sqlite3.Connection) -> None:
         conn.executescript(SCHEMA_DDL)
         ensure_vec0_table(conn)
         ensure_runtime_indexes_sync(conn)
+        conn.executescript(PLANNER_STAT1_SEED_SQL)
         conn.execute("PRAGMA optimize")
         conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
         conn.commit()
@@ -91,6 +93,7 @@ async def ensure_schema_async(conn: aiosqlite.Connection) -> None:
         await conn.executescript(SCHEMA_DDL)
         await ensure_vec0_table_async(conn)
         await ensure_runtime_indexes_async(conn)
+        await conn.executescript(PLANNER_STAT1_SEED_SQL)
         await conn.execute("PRAGMA optimize")
         await conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
         await conn.commit()

--- a/polylogue/storage/sqlite/schema_bootstrap.py
+++ b/polylogue/storage/sqlite/schema_bootstrap.py
@@ -88,7 +88,55 @@ async def ensure_vec0_table_async(conn: aiosqlite.Connection) -> None:
     del conn
 
 
+# Representative index selectivities for a mature archive, captured from a live
+# ~470K-block index (2026-07-19) and rounded. A freshly bootstrapped database
+# has no sqlite_stat1, and without it the planner prefers low-cardinality
+# equality indexes (idx_blocks_type_tool: ~100K rows/key) over session-scoped
+# ones (idx_blocks_session_position: ~350 rows/key) for writer-hot queries like
+# action_pairs_refresh_sql — turning per-session maintenance into full
+# tool_use-population scans that grow with archive size (O(N^2) over a bulk
+# rebuild; measured >20x replay slowdown before ANALYZE). Seeding stat1 at
+# bootstrap makes plans correct from the first write; later ANALYZE / PRAGMA
+# optimize passes replace these rows with measured values. Only relative
+# magnitudes matter here.
+PLANNER_STAT1_SEED_SQL = """
+ANALYZE;
+INSERT OR REPLACE INTO sqlite_stat1(tbl, idx, stat) VALUES
+  ('blocks', 'idx_blocks_session_position', '500000 350 2 1'),
+  ('blocks', 'idx_blocks_content_hash', '500000 2'),
+  ('blocks', 'idx_blocks_search_text_populated', '500000 1 1'),
+  ('blocks', 'idx_blocks_tool_id', '380000 3'),
+  ('blocks', 'idx_blocks_tool_result_outcome', '190000 190000 63000 21000 60 1 1'),
+  ('blocks', 'idx_blocks_type', '500000 100000'),
+  ('blocks', 'idx_blocks_type_tool', '500000 100000 4000'),
+  ('blocks', 'sqlite_autoindex_blocks_1', '500000 1'),
+  ('blocks', 'sqlite_autoindex_blocks_2', '500000 1 1'),
+  ('messages', 'idx_messages_session_position', '500000 350 1 1'),
+  ('messages', 'idx_messages_session_sortkey', '500000 350 340 2 1'),
+  ('messages', 'idx_messages_parent', '200000 1'),
+  ('messages', 'idx_messages_session_role', '500000 350 110'),
+  ('messages', 'idx_messages_role', '500000 125000'),
+  ('messages', 'idx_messages_session_material_origin', '500000 350 105'),
+  ('messages', 'idx_messages_message_type', '500000 83000'),
+  ('messages', 'idx_messages_material_origin', '500000 62000'),
+  ('messages', 'idx_messages_embedding_prose', '110000 75 1 1 1 1'),
+  ('messages', 'idx_messages_active_path', '500000 350 350 1'),
+  ('messages', 'idx_messages_active_leaf', '1500 1 1'),
+  ('messages', 'sqlite_autoindex_messages_1', '500000 1'),
+  ('messages', 'sqlite_autoindex_messages_2', '500000 350 1 1'),
+  ('action_pairs', 'idx_action_pairs_session_order', '190000 140 1 1'),
+  ('action_pairs', 'idx_action_pairs_message', '190000 1'),
+  ('action_pairs', 'idx_action_pairs_tool', '190000 1600 35 1'),
+  ('action_pairs', 'idx_action_pairs_semantic', '190000 19000 35 1'),
+  ('action_pairs', 'idx_action_pairs_path', '33000 6 3 1'),
+  ('action_pairs', 'idx_action_pairs_outcome', '50000 25000 6000 26 1'),
+  ('action_pairs', 'sqlite_autoindex_action_pairs_1', '190000 1');
+ANALYZE sqlite_master;
+"""
+
+
 __all__ = [
+    "PLANNER_STAT1_SEED_SQL",
     "SCHEMA_DDL",
     "SCHEMA_VERSION",
     "SchemaBootstrapDecision",

--- a/tests/unit/storage/test_planner_statistics_seed.py
+++ b/tests/unit/storage/test_planner_statistics_seed.py
@@ -1,0 +1,88 @@
+"""Fresh index bootstrap must give the planner correct relative selectivities.
+
+A database without ``sqlite_stat1`` makes the query planner prefer
+low-cardinality equality indexes (``idx_blocks_type_tool``) over
+session-scoped ones for writer-hot maintenance queries: the per-session
+``action_pairs`` refresh then scans the archive's entire ``tool_use``
+population on every session write — O(N^2) over a bulk rebuild, measured live
+at >20x replay slowdown (polylogue-l3tk, 2026-07-19). Bootstrap therefore
+seeds representative statistics so plans are correct from the first write.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import aiosqlite
+import pytest
+
+from polylogue.maintenance.rebuild_index import _refresh_generation_planner_statistics
+from polylogue.storage.sqlite.action_pairs import action_pairs_refresh_sql
+from polylogue.storage.sqlite.schema import _ensure_schema, ensure_schema_async
+
+
+def _block_search_plans(conn: sqlite3.Connection) -> list[str]:
+    rows = conn.execute(
+        "EXPLAIN QUERY PLAN " + action_pairs_refresh_sql("?"),
+        ("session", "session", "session"),
+    ).fetchall()
+    return [str(row[3]) for row in rows if "idx_blocks" in str(row[3])]
+
+
+def test_fresh_bootstrap_seeds_planner_statistics(tmp_path: Path) -> None:
+    conn = sqlite3.connect(tmp_path / "index.db")
+    try:
+        _ensure_schema(conn)
+        seeded = conn.execute(
+            "SELECT count(*) FROM sqlite_stat1 WHERE tbl IN ('blocks', 'messages', 'action_pairs')"
+        ).fetchone()[0]
+        assert seeded > 0
+    finally:
+        conn.close()
+
+
+def test_fresh_bootstrap_plans_session_scoped_action_pairs_refresh(tmp_path: Path) -> None:
+    """Without seeded stats this exact query planned three full
+    ``idx_blocks_type_tool (block_type=?)`` scans on a fresh database."""
+    conn = sqlite3.connect(tmp_path / "index.db")
+    try:
+        _ensure_schema(conn)
+        plans = _block_search_plans(conn)
+        assert plans, "expected block search steps in the action-pairs refresh plan"
+        assert all("idx_blocks_session_position" in step for step in plans), plans
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_async_bootstrap_seeds_planner_statistics(tmp_path: Path) -> None:
+    async with aiosqlite.connect(tmp_path / "index.db") as conn:
+        await ensure_schema_async(conn)
+        cursor = await conn.execute("SELECT count(*) FROM sqlite_stat1 WHERE tbl = 'blocks'")
+        row = await cursor.fetchone()
+        assert row is not None and row[0] > 0
+
+
+def test_refresh_generation_planner_statistics_measures_real_tables(tmp_path: Path) -> None:
+    db_path = tmp_path / "index.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        _ensure_schema(conn)
+        conn.execute("DELETE FROM sqlite_stat1")
+        conn.commit()
+    finally:
+        conn.close()
+
+    _refresh_generation_planner_statistics(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        measured = conn.execute("SELECT count(*) FROM sqlite_stat1").fetchone()[0]
+        assert measured > 0
+    finally:
+        conn.close()
+
+
+def test_refresh_generation_planner_statistics_tolerates_missing_file(tmp_path: Path) -> None:
+    _refresh_generation_planner_statistics(tmp_path / "missing" / "index.db")


### PR DESCRIPTION
## Summary

Fresh index tiers bootstrap with no `sqlite_stat1`, so the query planner picks low-cardinality equality indexes over session-scoped ones for writer-hot maintenance queries — turning per-session `action_pairs` refresh into whole-archive `tool_use` scans that grow with archive size. This PR seeds representative planner statistics at `create_fresh` (sync + async paths) and re-analyzes the generation after each bulk-rebuild page.

## Problem

Found live during the 2026-07-19 emergency restore (`Ref polylogue-l3tk`, umbrella `Ref polylogue-5jak`): py-spy showed 72% of replay CPU inside `refresh_action_pairs`; `EXPLAIN QUERY PLAN` showed all three subqueries of `action_pairs_refresh_sql` using `idx_blocks_type_tool (block_type=?)` (~100K rows/key) instead of `idx_blocks_session_position` (~350 rows/key), scanning 181K tool_use blocks per session write. A manual `ANALYZE` on the running generation flipped the plans and replay went from ~2.9 to ~60 sessions/min sustained (**>20x**, +134K messages in 146s). The bad plan reproduces on an EMPTY fresh database; bootstrap's existing `PRAGMA optimize` is a no-op there because optimize needs query history and data.

## Solution

- `storage/sqlite/schema_bootstrap.py`: `PLANNER_STAT1_SEED_SQL` — representative selectivities for `blocks`/`messages`/`action_pairs` indexes (captured from a live ~470K-block archive, rounded; only relative magnitudes matter), applied at `create_fresh` in both sync and async bootstrap. Existing databases untouched; later ANALYZE/optimize passes replace seeds with measured values.
- `maintenance/rebuild_index.py`: bounded `ANALYZE` (`analysis_limit=1000`) on the generation after each replayed page — stats track table growth during bulk rebuilds; failures non-fatal (stale stats degrade speed, never correctness).
- Deliberately NOT changed: `action_pairs_refresh_sql` text (embedded in trigger DDL — would be a derived-schema bump; deterministic unary-plus steering recorded on the bead as a future option), daemon steady-state (daily bounded optimize covers it).

## Verification

- `devtools test tests/unit/storage/test_planner_statistics_seed.py` — 5 passed. Anti-vacuity: with the schema changes stashed, 3/5 fail (fresh-bootstrap plan assertion shows the `idx_blocks_type_tool` plan; seed-presence sync + async fail).
- `devtools test tests/unit/storage/test_schema_policy_contracts.py tests/unit/storage/test_schema_safety.py tests/unit/storage/test_planner_statistics_seed.py` — 44 passed, 1 failed: `test_fresh_init_creates_canonical_fts_trigger_set`, classified **pre-existing on clean master** via stash-and-rerun (ohbx trigram triggers missing from the canonical set; filed as its own bead).
- `devtools verify --quick` — exit 0.
- Live measurement backing the approach: the identical ANALYZE applied manually to the in-flight rebuild generation produced the >20x sustained replay speedup quoted above.

Ref polylogue-l3tk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved SQLite query planning for session-scoped action-pair refreshes through seeded and refreshed planner statistics.
  * Rebuilt indexes now refresh planner statistics after bounded replay operations.

* **Reliability**
  * Planner-statistics refresh failures no longer interrupt successful index rebuilding.
  * Fresh databases consistently initialize planner statistics across synchronous and asynchronous setup paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->