### PR TITLE
perf(pipeline): eliminate redundant hash-payload serialization in census

### DIFF
--- a/polylogue/pipeline/ids.py
+++ b/polylogue/pipeline/ids.py
@@ -146,13 +146,17 @@ def _session_hash_payload(
     }
 
 
-def session_content_hash(convo: ParsedSession) -> ContentHash:
-    """Generate the content hash for a session.
+def _session_hash_components(
+    convo: ParsedSession,
+) -> tuple[list[dict[str, JSONValue]], list[dict[str, JSONValue]], list[dict[str, JSONValue]]]:
+    """Build the hash-stable message/attachment/event payloads once.
 
-    Uses sentinel values to distinguish None from empty/missing fields. The
-    hash incorporates the per-message payload (id, role, text, timestamp,
-    content blocks), attachments, and session events, so any change to a
-    message also changes the session hash.
+    ``session_content_hash`` and ``session_revision_projection`` both need
+    these payloads (the former to hash the whole tree, the latter to also
+    hash each item individually); building them once and sharing halves the
+    payload-construction and nested tool_input hashing volume versus each
+    caller re-deriving its own copy. Byte-identical to computing each
+    payload independently -- pure sharing of an already-pure computation.
     """
     messages_payload = [
         _message_hash_payload(msg, msg.provider_message_id or f"msg-{idx}")
@@ -169,40 +173,67 @@ def session_content_hash(convo: ParsedSession) -> ContentHash:
         }
         for event_index, event in enumerate(convo.session_events)
     ]
+    return messages_payload, attachments_payload, session_events_payload
+
+
+def _session_tree_hash(
+    convo: ParsedSession,
+    *,
+    messages_payload: list[dict[str, JSONValue]],
+    attachments_payload: list[dict[str, JSONValue]],
+    session_events_payload: list[dict[str, JSONValue]],
+) -> str:
+    return hash_payload(
+        _session_hash_payload(
+            title=convo.title,
+            created_at=convo.created_at,
+            updated_at=convo.updated_at,
+            messages=messages_payload,
+            attachments=attachments_payload,
+            session_events=session_events_payload,
+        )
+    )
+
+
+def session_content_hash(convo: ParsedSession) -> ContentHash:
+    """Generate the content hash for a session.
+
+    Uses sentinel values to distinguish None from empty/missing fields. The
+    hash incorporates the per-message payload (id, role, text, timestamp,
+    content blocks), attachments, and session events, so any change to a
+    message also changes the session hash.
+    """
+    messages_payload, attachments_payload, session_events_payload = _session_hash_components(convo)
     return ContentHash(
-        hash_payload(
-            _session_hash_payload(
-                title=convo.title,
-                created_at=convo.created_at,
-                updated_at=convo.updated_at,
-                messages=messages_payload,
-                attachments=attachments_payload,
-                session_events=session_events_payload,
-            )
+        _session_tree_hash(
+            convo,
+            messages_payload=messages_payload,
+            attachments_payload=attachments_payload,
+            session_events_payload=session_events_payload,
         )
     )
 
 
 def session_revision_projection(convo: ParsedSession) -> SessionRevisionProjection:
-    """Project canonical content hashes used to prove append-only session growth."""
-    message_payloads = [
-        _message_hash_payload(message, message.provider_message_id or f"msg-{index}")
-        for index, message in enumerate(convo.messages, start=1)
-    ]
-    attachment_payloads = [_attachment_hash_payload(attachment) for attachment in convo.attachments]
-    event_payloads = [
-        {
-            "event_index": event_index,
-            "event_type": _normalize_for_hash(event.event_type),
-            "timestamp": _normalize_for_hash(event.timestamp),
-            "source_message_provider_id": _normalize_for_hash(event.source_message_provider_id),
-            "payload": hash_payload(event.payload),
-        }
-        for event_index, event in enumerate(convo.session_events)
-    ]
+    """Project canonical content hashes used to prove append-only session growth.
+
+    Builds message/attachment/event payloads once (``_session_hash_components``)
+    and reuses them for both the whole-tree ``session_hash`` and the per-item
+    hashes below, instead of recomputing each payload from scratch a second
+    time. Output is byte-identical to the previous double-computation --
+    this is a pure elimination of redundant work, not an identity-hash
+    change (polylogue-fqp0).
+    """
+    messages_payload, attachments_payload, session_events_payload = _session_hash_components(convo)
+    session_hash_hex = _session_tree_hash(
+        convo,
+        messages_payload=messages_payload,
+        attachments_payload=attachments_payload,
+        session_events_payload=session_events_payload,
+    )
     return SessionRevisionProjection(
-        session_hash=bytes.fromhex(session_content_hash(convo)),
-        message_hashes=tuple(bytes.fromhex(hash_payload(payload)) for payload in message_payloads),
-        attachment_hashes=frozenset(bytes.fromhex(hash_payload(payload)) for payload in attachment_payloads),
-        event_hashes=tuple(bytes.fromhex(hash_payload(payload)) for payload in event_payloads),
+        session_hash=bytes.fromhex(session_hash_hex),
+        message_hashes=tuple(bytes.fromhex(hash_payload(payload)) for payload in messages_payload),
+        attachment_hashes=frozenset(bytes.fromhex(hash_payload(payload)) for payload in attachments_payload),
+        event_hashes=tuple(bytes.fromhex(hash_payload(payload)) for payload in session_events_payload),
     )

--- a/tests/infra/hash_economics_benchmark.py
+++ b/tests/infra/hash_economics_benchmark.py
@@ -1,0 +1,403 @@
+"""Benchmark harness for identity-hash serialization strategies (polylogue-fqp0).
+
+py-spy profile of the 2026-07-19 rebuild found ``hash_payload`` at 32%
+cumulative CPU during census, dominated by json serialization of the session
+tree run at least twice per revision: once inside ``session_content_hash``
+(the whole tree, nested) and again inside ``session_revision_projection``
+(each message/attachment/event payload rebuilt from scratch and hashed
+individually). This module compares four strategies for computing the same
+projection:
+
+- ``status_quo_projection`` -- frozen copy of the pre-fix double-serialization
+  behavior (build payloads once inside ``session_content_hash``, then build
+  them again for per-item hashing). Kept here as a fixed baseline so benchmark
+  numbers stay comparable after ``pipeline/ids.py`` is patched.
+- ``dedup_projection`` -- build every hash-stable payload exactly once and
+  reuse it for both the whole-tree hash and the per-item hashes. Produces
+  byte-identical output to status-quo (same payloads, same hash_payload
+  calls, just not duplicated) -- epoch-free. This is what
+  ``polylogue.pipeline.ids.session_revision_projection`` now implements.
+- ``merkle_projection`` -- compose ``session_hash`` from the per-message hash
+  list plus a normalized header instead of re-serializing the full tree.
+  Eliminates the O(total content) whole-tree dump entirely, but changes
+  ``session_hash`` bytes -- a durable-evidence epoch, NOT wired into the
+  pipeline.
+- ``orjson_projection`` -- swap ``hash_payload``'s stdlib ``json.dumps`` for
+  ``orjson.dumps``. Faster C serializer, but ``orjson`` escapes non-ASCII
+  differently than stdlib json's default ``ensure_ascii=True`` and rejects
+  ``NaN``/``Infinity`` -- changes hash bytes for any non-ASCII content. Also
+  NOT wired into the pipeline.
+
+Only ``dedup_projection``'s logic is shipped (as the new
+``session_revision_projection``); ``merkle_projection`` and
+``orjson_projection`` exist to give the epoch-vs-cache-first decision on
+polylogue-fqp0 real numbers instead of guesses.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import orjson
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
+from polylogue.pipeline.ids import (
+    SessionRevisionProjection,
+    _attachment_hash_payload,
+    _message_hash_payload,
+    _normalize_for_hash,
+    _session_hash_payload,
+)
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.sources.parsers.base_models import ParsedSessionEvent
+
+
+def build_synthetic_session(
+    *,
+    message_count: int = 300,
+    tool_call_every: int = 3,
+    avg_text_chars: int = 800,
+    session_event_count: int = 20,
+) -> ParsedSession:
+    """A realistic-shaped session: mixed text/tool_use/tool_result blocks.
+
+    ``tool_call_every`` controls how often an assistant message carries a
+    tool_use+tool_result pair (the ``tool_input`` dict is the one nested
+    payload that gets its own recursive ``hash_payload`` call today).
+    """
+    filler = "lorem ipsum dolor sit amet consectetur adipiscing elit "
+    messages: list[ParsedMessage] = []
+    for i in range(message_count):
+        role = Role.USER if i % 2 == 0 else Role.ASSISTANT
+        text = f"message body {i} " + (filler * max(1, avg_text_chars // len(filler)))
+        blocks: list[ParsedContentBlock] = []
+        if role is Role.ASSISTANT and tool_call_every > 0 and i % tool_call_every == 0:
+            blocks = [
+                ParsedContentBlock(
+                    type=BlockType.TOOL_USE,
+                    tool_name="Bash",
+                    tool_id=f"tool-{i}",
+                    tool_input={
+                        "command": f"echo synthetic-{i}",
+                        "description": "synthetic benchmark tool call",
+                        "extra_context": [f"line-{n}" for n in range(20)],
+                    },
+                ),
+                ParsedContentBlock(type=BlockType.TOOL_RESULT, tool_id=f"tool-{i}", text=f"output-{i} " * 15),
+            ]
+        messages.append(
+            ParsedMessage(
+                provider_message_id=f"msg-{i:06d}",
+                role=role,
+                text=text,
+                timestamp=f"2026-07-19T00:{i // 60 % 60:02d}:{i % 60:02d}Z",
+                blocks=blocks,
+            )
+        )
+    session_events = [
+        ParsedSessionEvent(
+            event_type="turn_context",
+            timestamp=f"2026-07-19T00:00:{i % 60:02d}Z",
+            payload={"turn": i, "detail": "x" * 200, "tags": [f"tag-{n}" for n in range(5)]},
+        )
+        for i in range(session_event_count)
+    ]
+    return ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="hash-economics-benchmark-session",
+        title="hash economics benchmark session",
+        messages=messages,
+        session_events=session_events,
+    )
+
+
+# ---------------------------------------------------------------------------
+# status quo -- frozen copy of the pre-fix double-serialization behavior.
+# ---------------------------------------------------------------------------
+
+
+def _status_quo_session_content_hash(convo: ParsedSession) -> str:
+    messages_payload = [
+        _message_hash_payload(msg, msg.provider_message_id or f"msg-{idx}")
+        for idx, msg in enumerate(convo.messages, start=1)
+    ]
+    attachments_payload = [_attachment_hash_payload(a) for a in convo.attachments]
+    session_events_payload = [
+        {
+            "event_index": event_index,
+            "event_type": _normalize_for_hash(event.event_type),
+            "timestamp": _normalize_for_hash(event.timestamp),
+            "source_message_provider_id": _normalize_for_hash(event.source_message_provider_id),
+            "payload": _hash_payload_stdlib(event.payload),
+        }
+        for event_index, event in enumerate(convo.session_events)
+    ]
+    return _hash_payload_stdlib(
+        _session_hash_payload(
+            title=convo.title,
+            created_at=convo.created_at,
+            updated_at=convo.updated_at,
+            messages=messages_payload,
+            attachments=attachments_payload,
+            session_events=session_events_payload,
+        )
+    )
+
+
+def _hash_payload_stdlib(payload: object) -> str:
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def status_quo_projection(convo: ParsedSession) -> SessionRevisionProjection:
+    """Pre-fix behavior: build every payload twice (once per hash target)."""
+    session_hash_hex = _status_quo_session_content_hash(convo)
+
+    message_payloads = [
+        _message_hash_payload(message, message.provider_message_id or f"msg-{index}")
+        for index, message in enumerate(convo.messages, start=1)
+    ]
+    attachment_payloads = [_attachment_hash_payload(a) for a in convo.attachments]
+    event_payloads = [
+        {
+            "event_index": event_index,
+            "event_type": _normalize_for_hash(event.event_type),
+            "timestamp": _normalize_for_hash(event.timestamp),
+            "source_message_provider_id": _normalize_for_hash(event.source_message_provider_id),
+            "payload": _hash_payload_stdlib(event.payload),
+        }
+        for event_index, event in enumerate(convo.session_events)
+    ]
+    return SessionRevisionProjection(
+        session_hash=bytes.fromhex(session_hash_hex),
+        message_hashes=tuple(bytes.fromhex(_hash_payload_stdlib(p)) for p in message_payloads),
+        attachment_hashes=frozenset(bytes.fromhex(_hash_payload_stdlib(p)) for p in attachment_payloads),
+        event_hashes=tuple(bytes.fromhex(_hash_payload_stdlib(p)) for p in event_payloads),
+    )
+
+
+# ---------------------------------------------------------------------------
+# dedup -- build every hash-stable payload exactly once, reuse for both the
+# whole-tree hash and the per-item hashes. Byte-identical to status quo
+# (same payloads, same hash_payload calls, just not duplicated) -- epoch-free.
+# This is what polylogue.pipeline.ids.session_revision_projection now ships.
+# ---------------------------------------------------------------------------
+
+
+def dedup_projection(convo: ParsedSession) -> SessionRevisionProjection:
+    message_payloads = [
+        _message_hash_payload(message, message.provider_message_id or f"msg-{index}")
+        for index, message in enumerate(convo.messages, start=1)
+    ]
+    attachment_payloads = [_attachment_hash_payload(a) for a in convo.attachments]
+    event_payloads = [
+        {
+            "event_index": event_index,
+            "event_type": _normalize_for_hash(event.event_type),
+            "timestamp": _normalize_for_hash(event.timestamp),
+            "source_message_provider_id": _normalize_for_hash(event.source_message_provider_id),
+            "payload": _hash_payload_stdlib(event.payload),
+        }
+        for event_index, event in enumerate(convo.session_events)
+    ]
+    session_hash_hex = _hash_payload_stdlib(
+        _session_hash_payload(
+            title=convo.title,
+            created_at=convo.created_at,
+            updated_at=convo.updated_at,
+            messages=message_payloads,
+            attachments=attachment_payloads,
+            session_events=event_payloads,
+        )
+    )
+    return SessionRevisionProjection(
+        session_hash=bytes.fromhex(session_hash_hex),
+        message_hashes=tuple(bytes.fromhex(_hash_payload_stdlib(p)) for p in message_payloads),
+        attachment_hashes=frozenset(bytes.fromhex(_hash_payload_stdlib(p)) for p in attachment_payloads),
+        event_hashes=tuple(bytes.fromhex(_hash_payload_stdlib(p)) for p in event_payloads),
+    )
+
+
+# ---------------------------------------------------------------------------
+# merkle -- session_hash composed from the per-message hash list. Changes
+# session_hash bytes: NOT wired into the pipeline, benchmark-only.
+# ---------------------------------------------------------------------------
+
+
+def merkle_projection(convo: ParsedSession) -> SessionRevisionProjection:
+    message_payloads = [
+        _message_hash_payload(message, message.provider_message_id or f"msg-{index}")
+        for index, message in enumerate(convo.messages, start=1)
+    ]
+    attachment_payloads = [_attachment_hash_payload(a) for a in convo.attachments]
+    event_payloads = [
+        {
+            "event_index": event_index,
+            "event_type": _normalize_for_hash(event.event_type),
+            "timestamp": _normalize_for_hash(event.timestamp),
+            "source_message_provider_id": _normalize_for_hash(event.source_message_provider_id),
+            "payload": _hash_payload_stdlib(event.payload),
+        }
+        for event_index, event in enumerate(convo.session_events)
+    ]
+    message_hashes = tuple(bytes.fromhex(_hash_payload_stdlib(p)) for p in message_payloads)
+    attachment_hashes = frozenset(bytes.fromhex(_hash_payload_stdlib(p)) for p in attachment_payloads)
+    event_hashes = tuple(bytes.fromhex(_hash_payload_stdlib(p)) for p in event_payloads)
+
+    # Composed from digests + a small header only -- O(N) in message count,
+    # not O(total content) like the whole-tree dump.
+    header = {
+        "title": _normalize_for_hash(convo.title),
+        "created_at": _normalize_for_hash(convo.created_at),
+        "updated_at": _normalize_for_hash(convo.updated_at),
+        "message_hashes": [h.hex() for h in message_hashes],
+        "attachment_hashes": sorted(h.hex() for h in attachment_hashes),
+        "event_hashes": [h.hex() for h in event_hashes],
+    }
+    session_hash = bytes.fromhex(_hash_payload_stdlib(header))
+    return SessionRevisionProjection(
+        session_hash=session_hash,
+        message_hashes=message_hashes,
+        attachment_hashes=attachment_hashes,
+        event_hashes=event_hashes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# orjson -- same dedup shape as the shipped fix, but hash_payload's stdlib
+# json.dumps swapped for orjson.dumps(option=OPT_SORT_KEYS). Changes hash
+# bytes for non-ASCII content (orjson does not escape to \\uXXXX); benchmark
+# only, NOT wired into the pipeline.
+# ---------------------------------------------------------------------------
+
+
+def _hash_payload_orjson(payload: object) -> str:
+    serialized = orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)
+    return hashlib.sha256(serialized).hexdigest()
+
+
+def orjson_projection(convo: ParsedSession) -> SessionRevisionProjection:
+    message_payloads = [
+        _message_hash_payload(message, message.provider_message_id or f"msg-{index}")
+        for index, message in enumerate(convo.messages, start=1)
+    ]
+    attachment_payloads = [_attachment_hash_payload(a) for a in convo.attachments]
+    event_payloads = [
+        {
+            "event_index": event_index,
+            "event_type": _normalize_for_hash(event.event_type),
+            "timestamp": _normalize_for_hash(event.timestamp),
+            "source_message_provider_id": _normalize_for_hash(event.source_message_provider_id),
+            "payload": _hash_payload_orjson(event.payload),
+        }
+        for event_index, event in enumerate(convo.session_events)
+    ]
+    session_hash_hex = _hash_payload_orjson(
+        _session_hash_payload(
+            title=convo.title,
+            created_at=convo.created_at,
+            updated_at=convo.updated_at,
+            messages=message_payloads,
+            attachments=attachment_payloads,
+            session_events=event_payloads,
+        )
+    )
+    return SessionRevisionProjection(
+        session_hash=bytes.fromhex(session_hash_hex),
+        message_hashes=tuple(bytes.fromhex(_hash_payload_orjson(p)) for p in message_payloads),
+        attachment_hashes=frozenset(bytes.fromhex(_hash_payload_orjson(p)) for p in attachment_payloads),
+        event_hashes=tuple(bytes.fromhex(_hash_payload_orjson(p)) for p in event_payloads),
+    )
+
+
+# ---------------------------------------------------------------------------
+# ceiling -- dedup + merkle + orjson combined, for reference only. Shows the
+# theoretical maximum if every non-epoch-free lever were pulled together;
+# NOT a candidate for immediate implementation (needs a durable-evidence
+# epoch bump like merkle/orjson alone).
+# ---------------------------------------------------------------------------
+
+
+def dedup_merkle_orjson_projection(convo: ParsedSession) -> SessionRevisionProjection:
+    message_payloads = [
+        _message_hash_payload(message, message.provider_message_id or f"msg-{index}")
+        for index, message in enumerate(convo.messages, start=1)
+    ]
+    attachment_payloads = [_attachment_hash_payload(a) for a in convo.attachments]
+    event_payloads = [
+        {
+            "event_index": event_index,
+            "event_type": _normalize_for_hash(event.event_type),
+            "timestamp": _normalize_for_hash(event.timestamp),
+            "source_message_provider_id": _normalize_for_hash(event.source_message_provider_id),
+            "payload": _hash_payload_orjson(event.payload),
+        }
+        for event_index, event in enumerate(convo.session_events)
+    ]
+    message_hashes = tuple(bytes.fromhex(_hash_payload_orjson(p)) for p in message_payloads)
+    attachment_hashes = frozenset(bytes.fromhex(_hash_payload_orjson(p)) for p in attachment_payloads)
+    event_hashes = tuple(bytes.fromhex(_hash_payload_orjson(p)) for p in event_payloads)
+    header = {
+        "title": _normalize_for_hash(convo.title),
+        "created_at": _normalize_for_hash(convo.created_at),
+        "updated_at": _normalize_for_hash(convo.updated_at),
+        "message_hashes": [h.hex() for h in message_hashes],
+        "attachment_hashes": sorted(h.hex() for h in attachment_hashes),
+        "event_hashes": [h.hex() for h in event_hashes],
+    }
+    session_hash = bytes.fromhex(_hash_payload_orjson(header))
+    return SessionRevisionProjection(
+        session_hash=session_hash,
+        message_hashes=message_hashes,
+        attachment_hashes=attachment_hashes,
+        event_hashes=event_hashes,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class BenchmarkResult:
+    label: str
+    ns_per_session: float
+    sessions_timed: int
+    repeats: int
+
+
+def time_projection(
+    label: str,
+    fn: Callable[[ParsedSession], SessionRevisionProjection],
+    sessions: list[ParsedSession],
+    *,
+    repeats: int = 5,
+) -> BenchmarkResult:
+    """Median wall-time per session across ``repeats`` full passes."""
+    totals: list[float] = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        for session in sessions:
+            fn(session)
+        totals.append(time.perf_counter() - start)
+    totals.sort()
+    median_total = totals[len(totals) // 2]
+    return BenchmarkResult(
+        label=label,
+        ns_per_session=(median_total / len(sessions)) * 1e9,
+        sessions_timed=len(sessions),
+        repeats=repeats,
+    )
+
+
+__all__ = [
+    "BenchmarkResult",
+    "build_synthetic_session",
+    "dedup_merkle_orjson_projection",
+    "dedup_projection",
+    "merkle_projection",
+    "orjson_projection",
+    "status_quo_projection",
+    "time_projection",
+]

--- a/tests/unit/pipeline/test_pipeline_ids.py
+++ b/tests/unit/pipeline/test_pipeline_ids.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 import pytest
 
 from polylogue.archive.message.roles import Role
-from polylogue.core.enums import Provider
+from polylogue.core.enums import BlockType, Provider
+from polylogue.core.hashing import hash_payload
 from polylogue.pipeline.ids import (
+    _attachment_hash_payload,
+    _message_hash_payload,
+    _normalize_for_hash,
+    _session_hash_payload,
     session_content_hash,
     session_id,
+    session_revision_projection,
 )
-from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
+from polylogue.sources.parsers.base import ParsedAttachment, ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.sources.parsers.base_models import ParsedSessionEvent
 
 
 def _parsed_message(provider_message_id: str, role: str, text: str, timestamp: str | None) -> ParsedMessage:
@@ -133,3 +140,124 @@ def test_session_hash_timestamps_affect_hash() -> None:
     session_two = _parsed_session("conv-1", "Test", [message], created_at="2024-01-02", updated_at=None)
 
     assert session_content_hash(session_one) != session_content_hash(session_two)
+
+
+def _golden_session() -> ParsedSession:
+    """Fixed session covering every hashed shape: text, tool_use/tool_result
+    blocks (the nested tool_input path), an attachment, and a session event.
+    """
+    return ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="golden-1",
+        title="Golden Session",
+        created_at="2026-01-01T00:00:00Z",
+        updated_at="2026-01-01T00:05:00Z",
+        messages=[
+            ParsedMessage(provider_message_id="m1", role=Role.USER, text="hello", timestamp="2026-01-01T00:00:00Z"),
+            ParsedMessage(
+                provider_message_id="m2",
+                role=Role.ASSISTANT,
+                text=None,
+                timestamp="2026-01-01T00:01:00Z",
+                blocks=[
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_USE,
+                        tool_name="Bash",
+                        tool_id="t1",
+                        tool_input={"command": "echo hi", "nested": {"a": 1, "b": [1, 2, 3]}},
+                    ),
+                    ParsedContentBlock(type=BlockType.TOOL_RESULT, tool_id="t1", text="hi"),
+                ],
+            ),
+        ],
+        attachments=[
+            ParsedAttachment(
+                provider_attachment_id="a1",
+                message_provider_id="m1",
+                name="f.txt",
+                mime_type="text/plain",
+                size_bytes=3,
+            )
+        ],
+        session_events=[
+            ParsedSessionEvent(event_type="turn_context", timestamp="2026-01-01T00:00:30Z", payload={"k": "v"})
+        ],
+    )
+
+
+def test_session_revision_projection_golden_hashes() -> None:
+    """Pin exact hash bytes (polylogue-fqp0's dedup refactor must not change them).
+
+    These digests were captured from the pre-refactor double-serialization
+    implementation. ``session_revision_projection`` now builds each hash-stable
+    payload once and reuses it for both the whole-tree hash and the per-item
+    hashes -- a pure elimination of redundant computation, not an identity-hash
+    change. If this test ever needs updating, that is an evidence epoch and
+    requires the migration/fingerprint-bump story in polylogue-fqp0's design,
+    not a routine test-fixture update.
+    """
+    session = _golden_session()
+    projection = session_revision_projection(session)
+
+    assert projection.session_hash.hex() == "4d768f0de553d68aa26dd2a3edc137cebbbcc147ec51ab75a5b55e05bd563f87"
+    assert [h.hex() for h in projection.message_hashes] == [
+        "65a99313c3ed8b81e69ecc0b36f314b3bf7848bc10fcea11415ddb9b07188941",
+        "8efbf7b5b70bef4d73ec3550fe97e6f4d456cd724550bc5621a36766fe7f1f8b",
+    ]
+    assert {h.hex() for h in projection.attachment_hashes} == {
+        "f0a9ad8518ab2426ed33575cf5eb0ee0a55d852d3c40c7a2f8f600f4f2f8e89b"
+    }
+    assert [h.hex() for h in projection.event_hashes] == [
+        "8f6539c2bc89ff2c78e183cda534a04f4d14823a0416df54d73fbee6f1f0824f"
+    ]
+
+
+def test_session_revision_projection_session_hash_matches_session_content_hash() -> None:
+    """The projection's session_hash must always equal session_content_hash's output."""
+    for session in (_golden_session(), _parsed_session("conv-2", "Empty", [], created_at=None, updated_at=None)):
+        projection = session_revision_projection(session)
+        assert projection.session_hash.hex() == session_content_hash(session)
+
+
+def test_session_revision_projection_matches_independent_recomputation() -> None:
+    """Dedup sharing must not drift from recomputing each payload independently.
+
+    Directly reproduces the pre-refactor "build payloads twice" shape inline
+    (not by calling pipeline internals) and asserts identical output --
+    guards the dedup refactor (polylogue-fqp0) against silently changing what
+    gets hashed while eliminating the redundant construction.
+    """
+    session = _golden_session()
+    projection = session_revision_projection(session)
+
+    independent_message_payloads = [
+        _message_hash_payload(m, m.provider_message_id or f"msg-{i}") for i, m in enumerate(session.messages, start=1)
+    ]
+    independent_attachment_payloads = [_attachment_hash_payload(a) for a in session.attachments]
+    independent_event_payloads = [
+        {
+            "event_index": idx,
+            "event_type": _normalize_for_hash(e.event_type),
+            "timestamp": _normalize_for_hash(e.timestamp),
+            "source_message_provider_id": _normalize_for_hash(e.source_message_provider_id),
+            "payload": hash_payload(e.payload),
+        }
+        for idx, e in enumerate(session.session_events)
+    ]
+    independent_session_hash = hash_payload(
+        _session_hash_payload(
+            title=session.title,
+            created_at=session.created_at,
+            updated_at=session.updated_at,
+            messages=independent_message_payloads,
+            attachments=independent_attachment_payloads,
+            session_events=independent_event_payloads,
+        )
+    )
+
+    assert projection.session_hash.hex() == independent_session_hash
+    assert list(projection.message_hashes) == [bytes.fromhex(hash_payload(p)) for p in independent_message_payloads]
+    assert projection.attachment_hashes == frozenset(
+        bytes.fromhex(hash_payload(p)) for p in independent_attachment_payloads
+    )
+    assert list(projection.event_hashes) == [bytes.fromhex(hash_payload(p)) for p in independent_event_payloads]


### PR DESCRIPTION
## Summary

`session_revision_projection` built every message/attachment/event hash-stable payload **twice** per revision — once inside `session_content_hash` (embedded in the whole-tree hash) and again from scratch for the per-item hashes. This PR eliminates the duplicate construction (epoch-free, byte-identical output) and separately benchmarks two bigger, byte-changing levers (merkle, orjson) that are recorded as an operator-gated follow-up decision rather than implemented here.

## Problem

py-spy profile of the 2026-07-19 rebuild (5912 samples) found `hash_payload` at 32% cumulative census CPU, dominated by json serialization of the session tree run at least twice per revision, across all 101K revisions including superseded ones. `session_content_hash` (`pipeline/ids.py`) builds `messages_payload`/`attachments_payload`/`session_events_payload` once to hash the whole tree; `session_revision_projection` then rebuilt the *exact same* payloads a second time (re-running `_message_hash_payload`/`_attachment_hash_payload`, including nested `tool_input` `hash_payload` sub-calls) purely to hash each item individually.

## Solution

- Extracted payload construction into `_session_hash_components` (`polylogue/pipeline/ids.py`), called once and shared by both `session_content_hash` and `session_revision_projection` instead of each rebuilding it independently.
- Output is **byte-identical** to before — same payloads, same `hash_payload` calls, just not duplicated. This is a pure elimination of redundant work, not an identity-hash change.
- Added `tests/infra/hash_economics_benchmark.py`: a benchmark harness comparing 4 candidate strategies against realistic synthetic sessions (text + tool_use/tool_result blocks with `tool_input`, attachments, session_events).

### Benchmark results (median of 7 passes × 20 sessions)

| candidate | epoch? | 100 msg | 300 msg | 800 msg |
| --- | --- | --- | --- | --- |
| status quo (pre-fix baseline) | – | 1134us | 3016us | 7503us |
| **dedup (SHIPPED)** | **no** | 959us (**-15.5%**) | 2586us (**-14.2%**) | 6483us (**-13.6%**) |
| merkle (session_hash from message-hash list) | yes | 720us (-36.6%) | 1901us (-37.0%) | 4815us (-35.8%) |
| orjson (swap stdlib `json.dumps`) | yes | 333us (-70.6%) | 983us (-67.4%) | 2543us (-66.1%) |
| dedup+merkle+orjson (ceiling, reference only) | yes | 284us (-74.9%) | 812us (-73.1%) | 2157us (-71.3%) |

**Standout finding, contrary to the bead's cheapest-first ordering:** orjson alone beats merkle by ~2x (67-71% vs 35-37% savings) — it's the dominant lever, not the whole-tree-reserialization elimination that merkle provides. orjson's C serializer is intrinsically faster per byte than stdlib json even for equivalent work.

### Consumer map (durable vs rebuildable)

`session_hash` bytes land in two tiers:
- **Durable** `source.db`: `raw_session_memberships.normalized_content_hash` (BLOB), `raw_sessions.source_revision` (via `bind_source_raw_revision`, `storage/sqlite/archive_tiers/source_write.py:650`).
- **Rebuildable** `index.db`: `sessions.content_hash` (`storage/sqlite/archive_tiers/write.py`).

The durable side is the real epoch constraint. Everything else (`repair.py`, `raw_reconciler.py`, `archive.py` comparisons) computes fresh and compares against one of the two stored forms above. The existing `parser_fingerprint='revision-membership-v1'` census-receipt scheme (`raw_authority_parser_census`) is already the clean invalidation mechanism — bumping the fingerprint forces full re-census under a new hash definition without a destructive migration.

### Decision (recorded on polylogue-fqp0)

Shipped the epoch-free dedup fix now: ~14-16% real CPU cut, zero behavior change, no operator sign-off needed. Did **not** implement merkle or orjson — both change `session_hash` bytes, a durable-evidence epoch requiring explicit coordinator/operator sign-off per the lane brief. Recorded both with real measured numbers (not estimates) as the follow-up decision point; **orjson is the higher-leverage candidate** but carries its own risk merkle doesn't — orjson's byte-output stability across *library* version upgrades isn't guaranteed the way stdlib json's is (this is literally why `hash_payload`'s docstring already rejects orjson today). An epoch bump adopting orjson would need to pin the orjson version tightly or accept periodic re-epochs on orjson upgrades.

Cache-first (projection cache keyed by blob_hash+parser_fingerprint) was considered per the lane brief but not implemented: it gives zero benefit on a cold full rebuild (the exact profiled scenario — nothing is cached yet on a fresh `ops reset --index && polylogued run`), whereas dedup gives an immediate, unconditional win on every census pass, cold or warm.

## Verification

- `devtools test tests/unit/pipeline/test_pipeline_ids.py` — 11 passed
- `devtools test tests/unit/pipeline/test_pipeline_ids.py tests/unit/archive/test_session_revision_membership.py tests/unit/storage/test_revision_replay.py tests/unit/core/test_hashing.py` — 81 passed
- `devtools verify --quick` — exit 0 (ruff format/check, mypy --strict, render all --check, topology/layering/manifests/etc.)
- **Byte-identity proof:** `test_session_revision_projection_golden_hashes` pins exact hex digests for a fixed session covering every hashed shape (text, tool_use/tool_result with nested `tool_input`, attachment, session_event); `test_session_revision_projection_matches_independent_recomputation` inlines the pre-refactor "build every payload independently" shape and asserts identical output. Both pass. Also interactively verified the frozen pre-fix reference implementation (`status_quo_projection` in the benchmark module) and the patched `session_revision_projection` produce byte-identical `session_hash`/`message_hashes`/`attachment_hashes`/`event_hashes` across message counts 1/5/100/300.
- 5 pre-existing `test_live_batch_support.py` failures (filesystem/spool-cleanup timing, unrelated to hash bytes) reproduced identically on `master` via `git stash` — not caused by this change.

Ref polylogue-fqp0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
