### PR TITLE
fix(pipeline): switch process pool to spawn, pin start method

### DIFF
--- a/polylogue/pipeline/services/process_pool.py
+++ b/polylogue/pipeline/services/process_pool.py
@@ -20,10 +20,22 @@ def _initialize_worker_logging() -> None:
 
 
 def process_pool_context() -> multiprocessing.context.BaseContext:
-    """Return a start method safe for multi-threaded callers."""
-    start_methods = multiprocessing.get_all_start_methods()
-    if "forkserver" in start_methods:
-        return multiprocessing.get_context("forkserver")
+    """Return a start method safe for multi-threaded callers.
+
+    ``forkserver`` preloads ``__main__`` (via ``runpy.run_path`` on
+    ``sys.argv[0]``) once, at forkserver-process boot, then forks each worker
+    from that single preloaded process. For the real CLI entry point, that
+    preload executes polylogue's entire import graph inside the forkserver
+    process. Any thread or lock created as a side effect of that import is
+    inherited — already running or held — by every subsequently forked
+    worker, which can deadlock workers before they ever service a task
+    (observed in production: forkserver alive in its serve loop, zero workers
+    ever spawned, parent parked forever in ``as_completed``). ``spawn`` reruns
+    the same ``__main__`` import once per worker instead of forking a shared
+    preloaded process, so no inherited thread/lock state crosses into a
+    worker. That per-worker import cost (~1-2s) is acceptable here because
+    pool workers are long-lived and reused across many parse tasks.
+    """
     return multiprocessing.get_context("spawn")
 
 

--- a/tests/unit/pipeline/test_process_pool.py
+++ b/tests/unit/pipeline/test_process_pool.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import threading
+from concurrent.futures import as_completed
+
+import pytest
+
 from polylogue.pipeline.services.process_pool import process_pool_context, process_pool_executor
 
 
@@ -11,8 +16,24 @@ def _worker_wrapper_class_name() -> str:
     return name if isinstance(name, str) else str(name)
 
 
+def _square(x: int) -> int:
+    return x * x
+
+
 def test_process_pool_context_avoids_fork() -> None:
     assert process_pool_context().get_start_method() != "fork"
+
+
+def test_process_pool_context_is_spawn() -> None:
+    # Pins the start method explicitly rather than only excluding "fork":
+    # forkserver forks every worker from a single preloaded process, so any
+    # thread/lock created as a side effect of preloading __main__ (the whole
+    # CLI import graph, in production) is inherited by every worker — this
+    # caused a production deadlock where the forkserver stayed alive but
+    # never spawned a single worker (polylogue-p0pw). spawn reruns __main__
+    # fresh per worker instead of forking a shared preloaded process, so no
+    # inherited thread/lock state can cross into a worker.
+    assert process_pool_context().get_start_method() == "spawn"
 
 
 def test_process_pool_workers_initialize_info_logging() -> None:
@@ -20,3 +41,34 @@ def test_process_pool_workers_initialize_info_logging() -> None:
         wrapper_name = executor.submit(_worker_wrapper_class_name).result(timeout=10)
 
     assert wrapper_name == "BoundLoggerFilteringAtInfo"
+
+
+@pytest.mark.timeout(45)
+def test_process_pool_dispatch_from_worker_thread_completes() -> None:
+    """Regression guard for polylogue-p0pw: production dispatches the pool
+    from a thread-pool executor thread under an asyncio event loop, not the
+    main thread. A pool start method that forks from a preloaded process
+    (forkserver) is vulnerable to inherited thread/lock state hanging every
+    worker forever; this must complete within a bounded timeout regardless
+    of which thread creates the pool.
+    """
+    outcome: list[list[int]] = []
+    error: list[BaseException] = []
+
+    def dispatch() -> None:
+        try:
+            with process_pool_executor(max_workers=4) as executor:
+                futures = {executor.submit(_square, i): i for i in range(8)}
+                results = [future.result(timeout=30) for future in as_completed(futures, timeout=30)]
+                outcome.append(sorted(results))
+        except BaseException as exc:
+            error.append(exc)
+
+    worker_thread = threading.Thread(target=dispatch, daemon=True)
+    worker_thread.start()
+    worker_thread.join(timeout=40)
+
+    assert not worker_thread.is_alive(), "pool dispatch from a worker thread hung past the bounded timeout"
+    if error:
+        raise error[0]
+    assert outcome == [[i * i for i in range(8)]]


### PR DESCRIPTION
## Summary

- `process_pool_context()` now unconditionally returns a `spawn` multiprocessing context instead of preferring `forkserver` when available.
- Added a config-assertion test pinning the exact start method, and a regression test that dispatches a real pool from a worker thread (mirroring the production `asyncio.to_thread -> pool -> as_completed` shape) and asserts bounded-timeout completion.

## Problem

Production `ops maintenance rebuild-index` sat 17+ minutes at 16% CPU with zero index-generation growth (2026-07-19). `py-spy` showed the parent process parked forever in `as_completed` (`revision_backfill.py:719`) while the forkserver process sat alive in its serve loop — the multiprocessing resource-tracker and forkserver were both running, but **zero pool workers were ever spawned**. Killing the run and resuming with `POLYLOGUE_INGEST_PARSE_WORKERS=1` (the sequential escape hatch) immediately went to 97% CPU and the generation resumed growing, confirming the pooled dispatch path itself was the failure, not the parse work.

This pooled dispatch branch (`_parse_retained_raws` in `sources/revision_backfill.py`) had effectively been dead code before #3122 (merged 2026-07-18) — `ingest_workers` was previously accepted and immediately discarded. The very first real exercise of the newly-activated pool hit this hang within ~8 hours of that merge.

## Investigation

`forkserver` forks every worker from a single process that preloads `__main__` once via `runpy.run_path(sys.argv[0], run_name="__mp_main__")` at forkserver boot. In production `sys.argv[0]` resolves to `.venv/bin/polylogue`, whose top-level code is `from polylogue.cli import main` — so the forkserver process runs polylogue's entire CLI import graph before ever forking a worker. Any thread or lock created as a side effect of that import would be inherited (already running/held) by every subsequently forked worker, which is a well-known forkserver hazard class.

An extended repro that isolates exactly this shape — a real script file (so `sys.argv[0]` resolves like production), top-level `from polylogue.cli import main`, then dispatching `process_pool_executor()` from a worker thread under both `forkserver` and `spawn` — completed in 0.6s under **both** contexts. So the leading hypothesis from the initial triage does not reproduce synthetically in isolation; the exact trigger inside the live forkserver preload was not pinned down further within the investigation timebox. Full bisect trail is recorded on `polylogue-p0pw`.

## Solution

Per the fix direction agreed in the bead notes, applied the unconditional-safe option rather than continuing to chase the exact trigger: `spawn` reruns `__main__` fresh per worker instead of forking one shared preloaded process, so no thread/lock state created during CLI import can ever be inherited by a worker. This structurally eliminates the whole class of inherited-state hazards forkserver is exposed to, independent of whether the precise trigger is later identified. The cost is ~1-2s import per worker, which is acceptable since pool workers here are long-lived and reused across many parse tasks, not spun up per task.

Modules touched: `polylogue/pipeline/services/process_pool.py` (the fix + explanatory docstring), `tests/unit/pipeline/test_process_pool.py` (two new tests).

## Audit (report only, no code change)

Per AC item 4 ("verify daemon census throughput with pooling active"), audited whether the daemon's convergence process pool or the #3122-wired census pool has ever actually parallelized in production:

- `DaemonConverger.start()` logs `"started with N worker(s)"` when any `ConvergenceStage` is `cpu_bound=True`, else `"started without worker pool"`. `journalctl` across 30+ `polylogued` restarts (2026-07-16..19) shows **only** `"started without worker pool"` — zero exceptions. Every registered stage (`fts`, `embed`, `claude_workflow`, `insights`, `standing-queries`) sets `cpu_bound=False`, so this pool has never activated. This corroborates the independent finding on `polylogue-7uqr` (converger pool machinery is dead), which I cross-linked.
- The #3122-wired census/replay pool is reachable from a live daemon via the HTTP `--daemon` bridge (`daemon/http.py`), but `journalctl` shows every `ops maintenance rebuild-index` invocation on this host was a direct CLI run, never with `--daemon` — so that variant has zero production exercise to date.
- Filed `polylogue-7saq` as separate follow-up debt: `archive_ingest.py`'s `parse_sources_archive()` builds its `ProcessPoolExecutor` directly without going through `process_pool_context()`, so it uses the platform-default start method (`fork` on this host) — a strictly more dangerous hazard class than forkserver. Currently reached only by the public async API facade and demo seeding, not the daemon's normal ingest ticks (which already go through the now-fixed `process_pool_executor()` helper) — out of this PR's scope.

## Acceptance criteria

1. **Reproduce or conclusively explain the forkserver no-worker deadlock** — partially satisfied: mechanism explained (forkserver forks every worker from one preloaded process that runs the full CLI import graph in production), but not conclusively reproduced in isolation — the isolated import+dispatch repro passed under both contexts. Documented honestly on the bead.
2. **Switch to a start method that demonstrably spawns workers under a threaded parent** — satisfied: `spawn`, verified by the new regression test.
3. **Regression test that a pool dispatch from a worker thread completes** — satisfied (`test_process_pool_dispatch_from_worker_thread_completes`). Note: this test does not reproduce the pre-fix hang either, consistent with the repro gap above — it's a forward-looking guard, not proof the pre-fix code fails it.
4. **Verify daemon census throughput with pooling active** — answered via audit above: no production daemon-census throughput exists yet to measure (the pooled path has only run via direct CLI so far).
5. **Remove/keep the `workers=1` escape hatch documented** — kept as-is; `resolve_parse_worker_count()`'s existing `env_var` override remains the documented escape hatch.

## Verification

- `devtools test tests/unit/pipeline/ -k process_pool` — 7 passed in 8.05s.
- `devtools verify --quick` — all 16 steps green (ruff format/check, mypy --strict, render all --check, topology/layering/closure-matrix, schema roundtrip, manifests, ci-workflows, doc-commands, docs-coverage, test-infra-currency, test-clock-hygiene, pytest-timeout-overrides, degrade-loudly).
- Not run: full `devtools verify --all` / broad pytest suite (per-PR CI intentionally skips the heavy suite; will run post-merge on master per repo convention).

Ref polylogue-p0pw

🤖 Generated with [Claude Code](https://claude.com/claude-code)
