### PR TITLE
test(storage): reconcile canonical FTS trigger set with fresh-init reality

### DIFF
--- a/tests/unit/storage/test_schema_policy_contracts.py
+++ b/tests/unit/storage/test_schema_policy_contracts.py
@@ -349,15 +349,39 @@ def test_async_path_rejects_unknown_version(tmp_path: Path) -> None:
 
 
 def test_fresh_init_creates_canonical_fts_trigger_set(tmp_path: Path) -> None:
-    """Fresh index initialization creates the current message FTS triggers."""
+    """Fresh index initialization creates exactly the current FTS-backing triggers.
+
+    Fresh init also creates a larger family of *non*-FTS triggers —
+    ``query_unit_frame_*`` (cache-invalidation epoch bump on
+    ``query_unit_frame_state``) and the ``blocks_action_pairs_*`` /
+    ``session_links_delegation_facts_*`` / ``session_profiles_delegation_facts_*``
+    family (materializing the plain ``action_pairs``/``delegation_facts``
+    tables). Neither writes into an FTS5 virtual table, so per the ohbx
+    precedent above (a trigger belongs in this set only if it is genuinely
+    *FTS-backing*, not merely "any trigger fresh init happens to create"),
+    they are excluded here by construction rather than by an ever-growing
+    name list.
+    """
     db_path = tmp_path / "fts.db"
     conn = sqlite3.connect(db_path)
     _ensure_schema(conn)
 
-    rows = conn.execute("SELECT name FROM sqlite_master WHERE type='trigger'").fetchall()
+    fts5_tables = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND sql LIKE '%USING fts5%'"
+        ).fetchall()
+    }
+    assert fts5_tables, "expected at least one FTS5 virtual table in fresh init"
+
+    trigger_rows = conn.execute("SELECT name, sql FROM sqlite_master WHERE type='trigger'").fetchall()
     conn.close()
 
-    triggers = {row[0] for row in rows}
+    triggers = {
+        name
+        for name, sql in trigger_rows
+        if any(f"INSERT INTO {fts_table}" in sql or f"DELETE FROM {fts_table}" in sql for fts_table in fts5_tables)
+    }
     missing = _CANONICAL_FTS_TRIGGERS - triggers
     assert not missing, f"Fresh init is missing canonical FTS triggers: {sorted(missing)}"
     assert triggers == _CANONICAL_FTS_TRIGGERS


### PR DESCRIPTION
## Summary

Fixes `tests/unit/storage/test_schema_policy_contracts.py::test_fresh_init_creates_canonical_fts_trigger_set`, which failed on master by asserting exact equality between a hand-maintained trigger-name set and the full `sqlite_master` trigger inventory of a fresh `index.db`.

## Problem

`_CANONICAL_FTS_TRIGGERS` lists 12 triggers backing the four FTS5 virtual tables (`messages_fts`, `session_work_events_fts`, `threads_fts`, `blocks_command_trigram`). The test compared this set for *exact* equality against `SELECT name FROM sqlite_master WHERE type='trigger'` — i.e. literally every trigger fresh init creates.

Two trigger families landed since the `blocks_command_trigram` (ohbx) addition and were never reconciled with this test:

- `query_unit_frame_*` (21 triggers) — bump a `query_unit_frame_state` epoch counter on writes to `sessions`/`messages`/`blocks`/`session_links`/`session_profiles`/`session_tags`/`delegation_facts`.
- `blocks_action_pairs_*` / `session_links_delegation_facts_*` / `session_profiles_delegation_facts_*` (7 triggers) — materialize the plain `action_pairs` and `delegation_facts` tables.

Neither family writes into an FTS5 virtual table, so the test failed with 28 unexpected "extra" trigger names. Per-PR CI skips the heavy `test` suite, so this landed silently (confirmed via `polylogue-dyno`, filed after a stash-and-rerun while landing an unrelated bead).

## Solution

Rather than hand-listing every non-FTS trigger to exclude (which would rot again at the next unrelated trigger addition), the test now:

1. Discovers the actual FTS5 virtual tables fresh init creates (`SELECT name FROM sqlite_master WHERE type='table' AND sql LIKE '%USING fts5%'`).
2. Keeps only triggers whose body writes into one of those tables (`INSERT INTO <table>`, or `DELETE FROM <table>` for the three `_ad` triggers that don't use the FTS5 external-content special-delete form).
3. Asserts exact equality between that *structurally filtered* set and `_CANONICAL_FTS_TRIGGERS`, unchanged (not weakened to a subset/superset check).

This reading is consistent with the existing `ohbx` comment on `_CANONICAL_FTS_TRIGGERS`: `blocks_command_trigram`'s triggers belong because they are genuinely FTS-backing (even though not tracked by `fts_trigger_state`), not because the set is meant to enumerate "every trigger fresh init happens to create." `query_unit_frame_*` and the `delegation_facts` family are legitimately out of scope for an *FTS* trigger inventory.

Only `tests/unit/storage/test_schema_policy_contracts.py` changed — no production DDL touched.

## Verification

- `devtools test tests/unit/storage/test_schema_policy_contracts.py` — `14 passed` (was `1 failed, 13 passed` before the fix).
- `devtools verify --quick` — `exit_code: 0`.
- Pre-push quick verification baseline (ruff format/check, mypy, render all, topology/layering/closure-matrix/manifests/ci-workflows/doc-commands/docs-coverage/test-infra-currency/test-clock-hygiene/pytest-timeout-overrides/degrade-loudly) — all `ok`.

Ref polylogue-dyno

Co-Authored-By: Claude <noreply@anthropic.com>