### PR TITLE
feat(daemon): warn loudly when raw materialization backlog is bulk-scale

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -67,6 +67,7 @@ from polylogue.version import POLYLOGUE_VERSION
 
 if TYPE_CHECKING:
     from polylogue.daemon.lifecycle import DaemonLifecycle
+    from polylogue.product.raw_authority import RawMaterializationCounts
 
 logger = get_logger(__name__)
 _CONVERGENCE_DEBT_RETRY_INTERVAL_SECONDS = 60
@@ -88,6 +89,20 @@ _RAW_MATERIALIZATION_LIVE_SPOOL_BACKOFF_SECONDS = 60
 # A spool file younger than this is in the live route's normal debounce/
 # batch flow, not stalled; only older cursor-less files park the conveyor.
 _SPOOL_PENDING_GRACE_SECONDS = 300
+# Lesson from the 2026-07-18/19 restore (polylogue-m6tp, polylogue-5jak): the
+# trickle conveyor's bounded per-pass passes are sized for steady-state
+# drift, not a bulk-scale backlog. Above this many pending raws or this many
+# pending bytes, grinding through bounded passes turns ~1h of parse work into
+# a weeks-scale projection; `polylogue ops maintenance rebuild-index` (a
+# resumable blue-green generation rebuild) does the same work in one sweep.
+# The daemon does not switch to that path itself (open questions: pausing
+# the watcher, a frozen source-snapshot requirement, and the restart story —
+# tracked as a polylogue-m6tp follow-up); it only recommends it, loudly and
+# rate-limited so a long-lived backlog doesn't spam the journal every pass.
+_BULK_REBUILD_RECOMMENDATION_CANDIDATE_THRESHOLD = 2_000
+_BULK_REBUILD_RECOMMENDATION_BYTES_THRESHOLD = 2 * 1024 * 1024 * 1024  # 2 GiB
+_BULK_REBUILD_RECOMMENDATION_MIN_INTERVAL_SECONDS = 3600.0  # at most once/hour
+_last_bulk_rebuild_recommendation_monotonic: float | None = None
 
 
 async def _run_startup_fts_readiness(coordinator: DaemonWriteCoordinator) -> None:
@@ -543,6 +558,42 @@ async def _retry_convergence_debt_once(db: Path) -> None:
         logger.warning("convergence: check failed", exc_info=True)
 
 
+def _bulk_scale_raw_materialization_backlog(counts: RawMaterializationCounts) -> bool:
+    """Whether a pass's measured backlog is bulk-scale, not steady-state drift."""
+    return (
+        counts.candidate_count > _BULK_REBUILD_RECOMMENDATION_CANDIDATE_THRESHOLD
+        or counts.pending_blob_bytes > _BULK_REBUILD_RECOMMENDATION_BYTES_THRESHOLD
+    )
+
+
+def _maybe_recommend_bulk_rebuild(counts: RawMaterializationCounts) -> None:
+    """Loudly recommend the bulk rebuild path once a backlog is bulk-scale.
+
+    This only journals a recommendation; it does not run the bulk path
+    itself (see the module-level constants' comment and polylogue-m6tp for
+    why: watcher-pause, frozen source-snapshot, and restart semantics are
+    still open questions for a daemon-driven bulk path). Rate-limited to at
+    most once per hour per daemon process so a long-lived backlog doesn't
+    re-log every burst pass.
+    """
+    global _last_bulk_rebuild_recommendation_monotonic
+    if not _bulk_scale_raw_materialization_backlog(counts):
+        return
+    now = time.monotonic()
+    last = _last_bulk_rebuild_recommendation_monotonic
+    if last is not None and (now - last) < _BULK_REBUILD_RECOMMENDATION_MIN_INTERVAL_SECONDS:
+        return
+    _last_bulk_rebuild_recommendation_monotonic = now
+    logger.warning(
+        "raw materialization: backlog is bulk-scale (%d candidate(s), %.2f GiB pending) -- "
+        "the trickle conveyor is sized for steady-state drift and can take weeks on a backlog "
+        "this size; run `polylogue ops maintenance rebuild-index` for a resumable blue-green "
+        "bulk rebuild instead of waiting on this conveyor",
+        counts.candidate_count,
+        counts.pending_blob_bytes / (1024**3),
+    )
+
+
 async def _periodic_raw_materialization_convergence() -> None:
     """Continuously converge durable raw source rows into the index tier.
 
@@ -584,6 +635,7 @@ async def _periodic_raw_materialization_convergence() -> None:
                     and materialized.repaired_sessions == 0
                     and materialized.executed_plans == 0
                 )
+                _maybe_recommend_bulk_rebuild(materialized)
                 if materialized.made_progress:
                     logger.info(
                         "raw materialization: repaired %d session(s), executed %d frontier plan(s), %d candidate(s) remaining",
@@ -744,6 +796,8 @@ def _drain_raw_materialization_once(
         executed_plans=frontier_repaired,
         remaining_candidates=remaining,
         censused_components=int(metrics.get("raw_materialization_census_components_attempted", 0)),
+        candidate_count=int(metrics.get("raw_materialization_candidate_count", 0)),
+        pending_blob_bytes=int(metrics.get("raw_materialization_total_blob_bytes", 0)),
     )
 
 

--- a/polylogue/product/raw_authority.py
+++ b/polylogue/product/raw_authority.py
@@ -23,12 +23,21 @@ class RawMaterializationCounts:
     paused replay plan: no sessions were repaired yet, but the pass moved
     the backlog and the caller's backlog burst must continue instead of
     treating the census phase as quiescence.
+
+    ``candidate_count`` and ``pending_blob_bytes`` describe the *whole*
+    unbounded backlog the pass measured (not the bounded per-pass batch):
+    ``repair_materialization`` enumerates every matching raw before
+    applying ``raw_artifact_limit``, so these two fields are how a caller
+    detects a bulk-scale backlog the trickle conveyor is not designed for
+    (polylogue-m6tp) without re-querying storage itself.
     """
 
     repaired_sessions: int = 0
     executed_plans: int = 0
     remaining_candidates: int = 0
     censused_components: int = 0
+    candidate_count: int = 0
+    pending_blob_bytes: int = 0
 
     @property
     def made_progress(self) -> bool:

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -607,6 +607,141 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
     }
 
 
+def test_maybe_recommend_bulk_rebuild_silent_below_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A backlog under both thresholds must not trigger the bulk-rebuild
+    recommendation: this exercises the real threshold predicate
+    (`_bulk_scale_raw_materialization_backlog`), not a stub -- removing the
+    predicate's comparisons (e.g. hardcoding it to always return True) makes
+    this test fail because the journal would then log unconditionally."""
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.product.raw_authority import RawMaterializationCounts
+
+    monkeypatch.setattr(daemon_cli, "_last_bulk_rebuild_recommendation_monotonic", None)
+    counts = RawMaterializationCounts(
+        repaired_sessions=1,
+        candidate_count=daemon_cli._BULK_REBUILD_RECOMMENDATION_CANDIDATE_THRESHOLD,
+        pending_blob_bytes=daemon_cli._BULK_REBUILD_RECOMMENDATION_BYTES_THRESHOLD,
+    )
+    with patch.object(daemon_cli.logger, "warning") as warning:
+        daemon_cli._maybe_recommend_bulk_rebuild(counts)
+
+    warning.assert_not_called()
+
+
+def test_maybe_recommend_bulk_rebuild_fires_on_candidate_count_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exceeding the candidate-count threshold alone (bytes below threshold)
+    must trigger the loud journal recommendation naming the bulk rebuild
+    command. This exercises `_maybe_recommend_bulk_rebuild` ->
+    `_bulk_scale_raw_materialization_backlog` against production constants;
+    deleting either comparison in the predicate makes this test fail."""
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.product.raw_authority import RawMaterializationCounts
+
+    monkeypatch.setattr(daemon_cli, "_last_bulk_rebuild_recommendation_monotonic", None)
+    monkeypatch.setattr("polylogue.daemon.cli.time.monotonic", lambda: 1_000.0)
+    counts = RawMaterializationCounts(
+        candidate_count=daemon_cli._BULK_REBUILD_RECOMMENDATION_CANDIDATE_THRESHOLD + 1,
+        pending_blob_bytes=0,
+    )
+    with patch.object(daemon_cli.logger, "warning") as warning:
+        daemon_cli._maybe_recommend_bulk_rebuild(counts)
+
+    warning.assert_called_once()
+    message, *args = warning.call_args.args
+    assert "rebuild-index" in message
+    assert "polylogue ops maintenance rebuild-index" in message
+    assert args[0] == counts.candidate_count
+
+
+def test_maybe_recommend_bulk_rebuild_fires_on_byte_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exceeding the pending-bytes threshold alone (candidate count below
+    threshold) must also trigger the recommendation -- the two thresholds
+    are independent tripwires, not a combined one."""
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.product.raw_authority import RawMaterializationCounts
+
+    monkeypatch.setattr(daemon_cli, "_last_bulk_rebuild_recommendation_monotonic", None)
+    monkeypatch.setattr("polylogue.daemon.cli.time.monotonic", lambda: 1_000.0)
+    counts = RawMaterializationCounts(
+        candidate_count=0,
+        pending_blob_bytes=daemon_cli._BULK_REBUILD_RECOMMENDATION_BYTES_THRESHOLD + 1,
+    )
+    with patch.object(daemon_cli.logger, "warning") as warning:
+        daemon_cli._maybe_recommend_bulk_rebuild(counts)
+
+    warning.assert_called_once()
+
+
+def test_maybe_recommend_bulk_rebuild_is_rate_limited_to_once_per_hour(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated passes over a still bulk-scale backlog must not re-log the
+    recommendation more than once per hour; the third call, past the
+    interval, must log again."""
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.product.raw_authority import RawMaterializationCounts
+
+    monkeypatch.setattr(daemon_cli, "_last_bulk_rebuild_recommendation_monotonic", None)
+    clock = iter(
+        [
+            1_000.0,  # first call: logs, records last=1000.0
+            1_000.0 + daemon_cli._BULK_REBUILD_RECOMMENDATION_MIN_INTERVAL_SECONDS - 1,  # within interval: silent
+            1_000.0 + daemon_cli._BULK_REBUILD_RECOMMENDATION_MIN_INTERVAL_SECONDS + 1,  # past interval: logs again
+        ]
+    )
+    monkeypatch.setattr("polylogue.daemon.cli.time.monotonic", lambda: next(clock))
+    counts = RawMaterializationCounts(
+        candidate_count=daemon_cli._BULK_REBUILD_RECOMMENDATION_CANDIDATE_THRESHOLD + 1,
+        pending_blob_bytes=0,
+    )
+    with patch.object(daemon_cli.logger, "warning") as warning:
+        daemon_cli._maybe_recommend_bulk_rebuild(counts)
+        daemon_cli._maybe_recommend_bulk_rebuild(counts)
+        daemon_cli._maybe_recommend_bulk_rebuild(counts)
+
+    assert warning.call_count == 2
+
+
+def test_periodic_raw_materialization_convergence_recommends_bulk_rebuild_for_bulk_backlog(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The periodic conveyor loop must actually invoke the bulk-rebuild
+    recommendation check per pass, not merely define it unreachably."""
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.product.raw_authority import RawMaterializationCounts
+
+    async def fake_run_sync(_actor: str, _func: object, *_args: object, **_kwargs: object) -> object:
+        return RawMaterializationCounts(
+            repaired_sessions=0,
+            executed_plans=0,
+            remaining_candidates=0,
+            candidate_count=daemon_cli._BULK_REBUILD_RECOMMENDATION_CANDIDATE_THRESHOLD + 1,
+            pending_blob_bytes=0,
+        )
+
+    async def fake_sleep(_seconds: float) -> None:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(daemon_cli, "_browser_capture_spool_has_pending_files", lambda: False)
+    monkeypatch.setattr(
+        daemon_cli,
+        "daemon_write_coordinator",
+        lambda: SimpleNamespace(run_sync=fake_run_sync),
+    )
+    recommended: list[int] = []
+    monkeypatch.setattr(
+        daemon_cli,
+        "_maybe_recommend_bulk_rebuild",
+        lambda counts: recommended.append(counts.candidate_count),
+    )
+    with patch("asyncio.sleep", side_effect=fake_sleep), pytest.raises(asyncio.CancelledError):
+        asyncio.run(daemon_cli._periodic_raw_materialization_convergence())
+
+    assert recommended == [daemon_cli._BULK_REBUILD_RECOMMENDATION_CANDIDATE_THRESHOLD + 1]
+
+
 def test_raw_materialization_pass_emits_conserved_plan_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
     from polylogue.daemon import cli as daemon_cli
 


### PR DESCRIPTION
## Summary

The daemon's raw-materialization trickle conveyor now journals a loud,
rate-limited warning recommending `polylogue ops maintenance rebuild-index`
whenever the pending backlog it measures is bulk-scale (>2000 candidates or
>2 GiB pending payload), instead of silently grinding bounded passes for
weeks.

## Problem

Lesson from the 2026-07-18/19 restore (polylogue-m6tp, polylogue-5jak,
polylogue-l3tk, polylogue-p0pw): the raw-materialization conveyor (bounded
16/64-row passes, per-pass candidate recomputation, writer interleaving
with the catch-up walk) is designed for steady-state trickle. Applied to a
large backlog after an index rebuild, it turned ~1h of parse work into a
weeks-scale projection, and census progress went net-negative once the
live watcher minted new pending raws faster than the conveyor cleared
them. The correct bulk path already existed the whole time --
`polylogue ops maintenance rebuild-index` (resumable blue-green
generation, full envelope, one census+replay sweep) -- but nothing routed
to it or even mentioned it.

## Solution

- `polylogue/product/raw_authority.py`: `RawMaterializationCounts` gains
  two fields, `candidate_count` and `pending_blob_bytes`, describing the
  *whole* unbounded backlog a pass measured (not the bounded per-pass
  batch) -- `repair_materialization` already enumerates every matching
  raw before applying `raw_artifact_limit`, so these ride on metrics the
  repair result already carries (`raw_materialization_candidate_count`,
  `raw_materialization_total_blob_bytes`). No new plumbing invented.
- `polylogue/daemon/cli.py`: `_drain_raw_materialization_once` populates
  the two new fields from `result.metrics`. A new
  `_maybe_recommend_bulk_rebuild` helper, called once per burst pass from
  `_periodic_raw_materialization_convergence`, logs
  `logger.warning(...)` naming the bulk-rebuild command once the backlog
  crosses either threshold, rate-limited to at most once per hour
  (module-level monotonic timestamp) so a long-lived backlog doesn't spam
  the journal on every pass.

**Scope decision (recorded on polylogue-m6tp):** the bead offered two
options -- (a) a loud status/journal recommendation, or (b) the daemon
running the bulk path itself. This PR implements (a) only: it is safe,
small, and honest. (b) is deferred to a follow-up because it has real open
design questions this PR does not resolve: pausing the live watcher during
a bulk pass, the frozen source-snapshot requirement a blue-green rebuild
needs, and the restart-required story for swapping generations under a
live daemon.

**No daemon status-payload wiring:** the existing
`RawMaterializationReadiness` status surface (`daemon/status.py`) is a
separate on-demand snapshot computed via `polylogue.readiness.capability`,
not fed by the conveyor's per-pass metrics -- wiring the recommendation
into it would be a materially larger change than this PR's scope.
Journal-only is the honest surface for now; noted on the bead.

## Verification

- `devtools test tests/unit/daemon/test_daemon_cli.py` -- 96 passed,
  including 6 new tests: below-threshold silence, independent
  candidate-count/byte-count triggers, once-per-hour rate limiting (three
  calls -> two log lines), and that the periodic loop actually invokes the
  check (not merely defines it unreachably). Anti-vacuity: the tests
  exercise the real `_bulk_scale_raw_materialization_backlog` predicate
  against production threshold constants -- removing either comparison in
  the predicate (or hardcoding it True/False) fails the below-threshold or
  above-threshold test respectively.
- `devtools verify --quick` -- exit 0 (ruff format/check, mypy --strict,
  render all --check). Ran again automatically via the pre-push hook.
- Not run: `devtools verify --all` (full suite) -- the per-PR CI runs the
  heavy `test` suite post-merge, per repo convention; the pre-existing
  master failure `test_fresh_init_creates_canonical_fts_trigger_set` is
  known and tracked separately (polylogue-dyno), unrelated to this change.

Ref polylogue-m6tp