### PR TITLE
perf(sources): skip full parse for byte-proven superseded revisions

### DIFF
--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -246,11 +246,119 @@ def _census_historical_revision_evidence(
     returns or propagates; a crash further downstream (replay phase) cannot
     observe a partially-committed census. Default ``None`` preserves the
     original per-raw-commit behavior for every existing caller.
+
+    Untyped raws sharing one ``source_path`` are first checked for a proven
+    byte-growth chain (``ArchiveStore.classify_untyped_full_revision_groups``,
+    polylogue-nh44) before any of them is parsed. Only the newest member of a
+    proven chain is actually parsed; every older member is bound to the same
+    learned identity without independently parsing bytes that byte comparison
+    already proved are a strict prefix of the newest capture. This is a
+    census-time parse-cost optimization only: it never grants authority --
+    ``classify_raw_revision_cohort`` (called later, during replay) still
+    independently re-derives byte-provenness from raw bytes for every raw.
     """
     state = _RevisionCensusState(0, 0, 0, set(), {}, {})
     batch_size = commit_batch_size if commit_batch_size is not None and commit_batch_size > 0 else None
     batched = batch_size is not None
     pending_commits = 0
+
+    def commit_unit() -> None:
+        nonlocal pending_commits
+        pending_commits += 1
+        if batch_size is not None and pending_commits >= batch_size:
+            archive.commit()
+            pending_commits = 0
+
+    def apply_outcome(
+        raw_id: str,
+        source_index: int,
+        outcomes: dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception],
+    ) -> None:
+        state.scanned += 1
+        state.censused.add(raw_id)
+        if source_index < 0:
+            archive.replace_raw_membership_census(
+                raw_id,
+                None,
+                parser_fingerprint="revision-membership-v1",
+                censused_at_ms=0,
+                detail=BYTE_AUTHORITY_CENSUS_DETAIL,
+                manage_transaction=not batched,
+            )
+            state.quarantined += 1
+            commit_unit()
+            return
+        outcome = outcomes[raw_id]
+        if isinstance(outcome, Exception):
+            archive.replace_raw_membership_census(
+                raw_id,
+                None,
+                parser_fingerprint="revision-membership-v1",
+                censused_at_ms=0,
+                detail=str(outcome),
+                manage_transaction=not batched,
+            )
+            state.quarantined += 1
+            commit_unit()
+            return
+        sessions, payload_bytes, revision_kind = outcome
+        state.classified += int(len(sessions) == 1)
+        spill.add(raw_id, sessions, payload_bytes=payload_bytes)
+        if len(sessions) == 1 and revision_kind is RawRevisionKind.UNKNOWN:
+            session = sessions[0]
+            logical_key = f"{session.source_name.value}:{session.provider_session_id}"
+            archive.bind_raw_revision(
+                raw_id,
+                RawRevisionEnvelope(
+                    logical_source_key=logical_key,
+                    kind=RawRevisionKind.FULL,
+                    source_revision=raw_id,
+                    acquisition_generation=0,
+                    authority=RawRevisionAuthority.QUARANTINED,
+                ),
+                manage_transaction=not batched,
+            )
+            state.provisional_full_raw_ids.setdefault(logical_key, set()).add(raw_id)
+            commit_unit()
+        elif revision_kind is RawRevisionKind.UNKNOWN:
+            archive.replace_raw_membership_census(
+                raw_id,
+                sessions,
+                parser_fingerprint="revision-membership-v1",
+                censused_at_ms=0,
+                manage_transaction=not batched,
+            )
+            for session in sessions:
+                logical_key = f"{session.source_name.value}:{session.provider_session_id}"
+                state.membership_candidates.setdefault(logical_key, set()).add(raw_id)
+            commit_unit()
+        # else: raw_id was already typed by an earlier run; this parse was a
+        # wasted (but harmless, no-op) reparse -- existing retry behavior.
+
+    def bind_byte_proven_older_member(raw_id: str, logical_key: str) -> None:
+        """Bind an older chain member to the head's learned key without parsing it.
+
+        Its own bytes were never independently opened here; identity is
+        established by construction (byte-prefix of the parsed head), not by
+        inspecting this raw's content.
+        """
+        archive.bind_raw_revision(
+            raw_id,
+            RawRevisionEnvelope(
+                logical_source_key=logical_key,
+                kind=RawRevisionKind.FULL,
+                source_revision=raw_id,
+                acquisition_generation=0,
+                authority=RawRevisionAuthority.QUARANTINED,
+            ),
+            manage_transaction=not batched,
+        )
+        state.scanned += 1
+        state.censused.add(raw_id)
+        state.classified += 1
+        state.provisional_full_raw_ids.setdefault(logical_key, set()).add(raw_id)
+        commit_unit()
+
     census_selections: tuple[tuple[str, ...] | None, ...]
     if selected_raw_ids is None:
         census_selections = (None,)
@@ -277,69 +385,40 @@ def _census_historical_revision_evidence(
                 # regardless of worker completion order, so parallel and sequential
                 # runs remain byte-identical.
                 parseable_raw_ids = [raw_id for raw_id, source_index in pending_rows if source_index >= 0]
-                parsed_outcomes = _parse_retained_raws(archive, parseable_raw_ids, ingest_workers=ingest_workers)
+                chain_older_by_head = archive.classify_untyped_full_revision_groups(parseable_raw_ids)
+                head_by_older = {
+                    older_raw_id: head_raw_id
+                    for head_raw_id, older_raw_ids in chain_older_by_head.items()
+                    for older_raw_id in older_raw_ids
+                }
+                dispatch_raw_ids = [raw_id for raw_id in parseable_raw_ids if raw_id not in head_by_older]
+                parsed_outcomes = _parse_retained_raws(archive, dispatch_raw_ids, ingest_workers=ingest_workers)
                 for raw_id, source_index in pending_rows:
-                    state.scanned += 1
-                    state.censused.add(raw_id)
-                    if source_index < 0:
-                        archive.replace_raw_membership_census(
-                            raw_id,
-                            None,
-                            parser_fingerprint="revision-membership-v1",
-                            censused_at_ms=0,
-                            detail=BYTE_AUTHORITY_CENSUS_DETAIL,
-                            manage_transaction=not batched,
-                        )
-                        state.quarantined += 1
-                        pending_commits += 1
-                    else:
-                        outcome = parsed_outcomes[raw_id]
-                        if isinstance(outcome, Exception):
-                            archive.replace_raw_membership_census(
-                                raw_id,
-                                None,
-                                parser_fingerprint="revision-membership-v1",
-                                censused_at_ms=0,
-                                detail=str(outcome),
-                                manage_transaction=not batched,
-                            )
-                            state.quarantined += 1
-                            pending_commits += 1
+                    if raw_id in head_by_older:
+                        continue
+                    apply_outcome(raw_id, source_index, parsed_outcomes)
+                if head_by_older:
+                    head_to_key = {
+                        raw_id: key for key, raw_ids in state.provisional_full_raw_ids.items() for raw_id in raw_ids
+                    }
+                    unresolved = [
+                        older_raw_id
+                        for older_raw_id, head_raw_id in head_by_older.items()
+                        if head_raw_id not in head_to_key
+                    ]
+                    # The head's parse did not yield a clean single-session bind
+                    # (e.g. a coincidental byte-prefix among multi-session
+                    # bundles) -- fall back to parsing every deferred member
+                    # individually, exactly as if no chain had been proven.
+                    fallback_outcomes = (
+                        _parse_retained_raws(archive, unresolved, ingest_workers=ingest_workers) if unresolved else {}
+                    )
+                    for older_raw_id, head_raw_id in head_by_older.items():
+                        resolved_key = head_to_key.get(head_raw_id)
+                        if resolved_key is not None:
+                            bind_byte_proven_older_member(older_raw_id, resolved_key)
                         else:
-                            sessions, payload_bytes, revision_kind = outcome
-                            state.classified += int(len(sessions) == 1)
-                            spill.add(raw_id, sessions, payload_bytes=payload_bytes)
-                            if len(sessions) == 1 and revision_kind is RawRevisionKind.UNKNOWN:
-                                session = sessions[0]
-                                logical_key = f"{session.source_name.value}:{session.provider_session_id}"
-                                archive.bind_raw_revision(
-                                    raw_id,
-                                    RawRevisionEnvelope(
-                                        logical_source_key=logical_key,
-                                        kind=RawRevisionKind.FULL,
-                                        source_revision=raw_id,
-                                        acquisition_generation=0,
-                                        authority=RawRevisionAuthority.QUARANTINED,
-                                    ),
-                                    manage_transaction=not batched,
-                                )
-                                state.provisional_full_raw_ids.setdefault(logical_key, set()).add(raw_id)
-                                pending_commits += 1
-                            elif revision_kind is RawRevisionKind.UNKNOWN:
-                                archive.replace_raw_membership_census(
-                                    raw_id,
-                                    sessions,
-                                    parser_fingerprint="revision-membership-v1",
-                                    censused_at_ms=0,
-                                    manage_transaction=not batched,
-                                )
-                                for session in sessions:
-                                    logical_key = f"{session.source_name.value}:{session.provider_session_id}"
-                                    state.membership_candidates.setdefault(logical_key, set()).add(raw_id)
-                                pending_commits += 1
-                    if batch_size is not None and pending_commits >= batch_size:
-                        archive.commit()
-                        pending_commits = 0
+                            apply_outcome(older_raw_id, 0, fallback_outcomes)
                 if census_selection is None:
                     break
                 expanded, _keys = archive.expand_raw_membership_selection(list(census_selection))

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2037,6 +2037,68 @@ class ArchiveStore:
             self._promote_contiguous_append_evidence(source_conn, logical_source_key)
         return self.raw_revision_replay_plan(logical_source_key)
 
+    def classify_untyped_full_revision_groups(self, raw_ids: Sequence[str]) -> dict[str, tuple[str, ...]]:
+        """Group never-typed retained raws into proven byte-growth chains, no parse.
+
+        A restore/backfill census over legacy raws otherwise has to fully parse
+        every retained revision just to learn its ``logical_source_key`` --
+        including revisions that a byte-only comparison already proves are a
+        strict prefix of a later capture of the *same* file (polylogue-nh44:
+        45GB/46% of a real restore's parse work was exactly this waste).
+        ``source_path`` is an established cohort-equivalence edge elsewhere in
+        this codebase (see ``raw_membership_selection_components_sync``), so
+        grouping candidates by it before parsing is sound: two raws at the same
+        path are always the same logical file at different capture times.
+
+        Returns ``{head_raw_id: (older_raw_id, ...)}`` for every source_path
+        cohort of >=2 raws whose bytes form a unique linear growth chain per
+        ``classify_historical_full_revision_streams``. The caller still owns
+        parsing the head (the only member whose content is ever actually
+        indexed) and binding the proven-older members to its learned identity;
+        this method performs no writes. Ambiguous, branching, or singleton
+        groups are omitted so callers fall back to parsing every member.
+        """
+        if self._blob_publisher is None:
+            raise RuntimeError("raw revision classification requires a writable blob publisher")
+        if not raw_ids:
+            return {}
+        placeholders = ",".join("?" for _ in raw_ids)
+        rows = (
+            self._ensure_source_conn()
+            .execute(
+                f"""
+            SELECT raw_id, source_path, lower(hex(blob_hash)), blob_size
+            FROM raw_sessions
+            WHERE raw_id IN ({placeholders}) AND revision_kind = 'unknown'
+            """,
+                tuple(raw_ids),
+            )
+            .fetchall()
+        )
+        by_path: dict[str, list[tuple[str, str, int]]] = {}
+        for raw_id, source_path, blob_hash, blob_size in rows:
+            by_path.setdefault(str(source_path), []).append((str(raw_id), str(blob_hash), int(blob_size)))
+        groups: dict[str, tuple[str, ...]] = {}
+        for members in by_path.values():
+            if len(members) < 2:
+                continue
+
+            streams = []
+            for raw_id, blob_hash, blob_size in members:
+
+                def open_payload(blob_hash: str = blob_hash) -> BinaryIO:
+                    assert self._blob_publisher is not None
+                    return self._blob_publisher.open(blob_hash)
+
+                streams.append(
+                    HistoricalRawRevisionStream(raw_id=raw_id, payload_size=blob_size, open_payload=open_payload)
+                )
+            decisions = classify_historical_full_revision_streams(streams)
+            if not decisions or decisions[0].authority is not RawRevisionAuthority.BYTE_PROVEN:
+                continue
+            groups[decisions[-1].raw_id] = tuple(decision.raw_id for decision in decisions[:-1])
+        return groups
+
     @staticmethod
     def _promote_contiguous_append_evidence(conn: sqlite3.Connection, logical_source_key: str) -> None:
         while True:

--- a/tests/infra/revision_backfill_benchmark.py
+++ b/tests/infra/revision_backfill_benchmark.py
@@ -27,6 +27,12 @@ from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_a
 SMALL_PAYLOAD_SHAPE: dict[str, int] = {"raw_count": 200, "avg_payload_bytes": 50_000}
 LARGE_PAYLOAD_SHAPE: dict[str, int] = {"raw_count": 80, "avg_payload_bytes": 1_700_000}
 
+# polylogue-nh44: one growing-file cohort shaped after the bead's own live
+# evidence (a Codex rollout file re-captured on every scan, each capture a
+# byte-superset of the last). ~1MB final size, 50 superseded snapshots plus
+# the winner -- the "45GB/46% of a restore is stale snapshots" shape.
+REVISION_CHAIN_SHAPE: dict[str, int] = {"superseded_count": 50, "final_payload_bytes": 1_000_000}
+
 # Fixed per-record JSON envelope overhead (quotes, keys, braces) that isn't
 # part of the padded text field -- subtracted from the target size so the
 # generated payload lands close to the requested average.
@@ -91,8 +97,65 @@ def build_independent_raw_corpus(
     return raw_ids
 
 
+def build_revision_chain_corpus(
+    archive_root: Path,
+    *,
+    superseded_count: int,
+    final_payload_bytes: int,
+) -> list[str]:
+    """Write one growing-file cohort: ``superseded_count`` older captures plus
+    a final winner, all at the same ``source_path`` and each a strict byte
+    prefix of the next -- the shape a re-scanned, ever-appended Codex rollout
+    file produces on disk (polylogue-nh44). Returns raw ids oldest-first;
+    the last id is the winner (the only one that should ever be parsed by an
+    optimized census).
+    """
+    initialize_active_archive_root(archive_root)
+    revision_count = superseded_count + 1
+    session_meta = (
+        json.dumps(
+            {"type": "session_meta", "payload": {"id": "nh44-chain-session", "timestamp": "2026-06-01T00:00:00Z"}},
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    per_line_budget = max(1, (final_payload_bytes - len(session_meta)) // revision_count)
+    raw_ids: list[str] = []
+    payload = session_meta.encode()
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        for index in range(revision_count):
+            if index > 0:
+                text = f"nh44-append-{index:04d}-" + ("x" * per_line_budget)
+                response_item = (
+                    json.dumps(
+                        {
+                            "type": "response_item",
+                            "payload": {
+                                "type": "message",
+                                "id": f"msg-{index:04d}",
+                                "role": "user" if index % 2 else "assistant",
+                                "content": [{"type": "input_text", "text": text}],
+                            },
+                        },
+                        separators=(",", ":"),
+                    )
+                    + "\n"
+                )
+                payload = payload + response_item.encode()
+            raw_id = archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=payload,
+                source_path="nh44-chain/session.jsonl",
+                acquired_at_ms=index + 1,
+            )
+            raw_ids.append(raw_id)
+    return raw_ids
+
+
 __all__ = [
     "LARGE_PAYLOAD_SHAPE",
+    "REVISION_CHAIN_SHAPE",
     "SMALL_PAYLOAD_SHAPE",
     "build_independent_raw_corpus",
+    "build_revision_chain_corpus",
 ]

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -695,7 +695,7 @@ def _append_chain_archive(root: Path) -> tuple[str, str]:
 
 def test_backfill_replay_reparses_when_spill_cache_absent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Baseline (pre-fix) shape: an unbounded (envelope=None) backfill with no
-    explicit spill-cache bound reparses every accepted revision during replay
+    explicit spill-cache bound reparses the accepted revision during replay
     even though census already parsed it once. This is exactly the CLI
     rebuild-index path's behavior before max_cached_payload_bytes decoupled
     caching from the resource envelope. Paired with the fixed-behavior test
@@ -714,11 +714,14 @@ def test_backfill_replay_reparses_when_spill_cache_absent(monkeypatch: pytest.Mo
     result = backfill_historical_revision_evidence(tmp_path, max_payload_bytes=None)
 
     assert result.replayed_logical_sources == 1
-    # Census parses both raws once each (2 calls); replay then reparses the
-    # selected newest revision again from blob because nothing was cached
-    # (a 3rd call, duplicating one raw_id) instead of reusing census output.
-    assert len(parse_calls) == 3
-    assert len(set(parse_calls)) == 2
+    # polylogue-nh44: census now proves the baseline raw is a byte-prefix of
+    # the newest capture (same source_path) without parsing it at all, so
+    # only the newest raw is ever ONE parse during census; replay then
+    # reparses that same accepted revision again from blob because nothing
+    # was cached (a 2nd call, duplicating that one raw_id) instead of reusing
+    # census output.
+    assert len(parse_calls) == 2
+    assert len(set(parse_calls)) == 1
 
 
 def test_backfill_replay_reuses_spill_cache_when_bound_explicitly(
@@ -748,11 +751,12 @@ def test_backfill_replay_reuses_spill_cache_when_bound_explicitly(
     )
 
     assert result.replayed_logical_sources == 1
-    # Both raws are parsed exactly once during census; replay hits the
-    # census-populated spill cache instead of reparsing the selected
-    # revision from blob a second time (contrast the 3-call baseline above).
-    assert len(parse_calls) == 2
-    assert len(set(parse_calls)) == 2
+    # polylogue-nh44: only the newest raw is ever parsed (the baseline is
+    # proven a byte-prefix and bound without parsing); replay hits the
+    # census-populated spill cache instead of reparsing it from blob a
+    # second time (contrast the 2-call baseline above).
+    assert len(parse_calls) == 1
+    assert len(set(parse_calls)) == 1
 
 
 def test_parallel_census_matches_sequential_archive_state(tmp_path: Path) -> None:

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -21,7 +21,11 @@ from polylogue.sources.revision_backfill import (
 from polylogue.storage.blob_publication import ArchiveBlobPublisher
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
-from tests.infra.revision_backfill_benchmark import build_independent_raw_corpus
+from tests.infra.revision_backfill_benchmark import (
+    REVISION_CHAIN_SHAPE,
+    build_independent_raw_corpus,
+    build_revision_chain_corpus,
+)
 
 
 def _chatgpt_session(native_id: str, *texts: str) -> dict[str, object]:
@@ -722,6 +726,42 @@ def test_backfill_replay_reparses_when_spill_cache_absent(monkeypatch: pytest.Mo
     # census output.
     assert len(parse_calls) == 2
     assert len(set(parse_calls)) == 1
+
+
+def test_census_skips_parse_for_byte_proven_superseded_revisions_at_scale(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """polylogue-nh44 regression at the bead's own recorded corpus shape: a
+    growing-file cohort (one re-scanned Codex rollout, 50 superseded captures
+    plus the winner) must census-parse only the winner, never the 50 byte-
+    proven-superseded snapshots. Measured on this exact shape: 52->2 parse
+    calls (1 unique raw parsed instead of 51), ~3.3x wall-time reduction for
+    the cohort (see PR body for the before/after numbers)."""
+    raw_ids = build_revision_chain_corpus(tmp_path, **REVISION_CHAIN_SHAPE)
+    original = revision_backfill._parse_retained_raw
+    parse_calls: list[str] = []
+
+    def counted(archive: ArchiveStore, raw_id: str) -> tuple[list[ParsedSession], int, RawRevisionKind]:
+        parse_calls.append(raw_id)
+        return original(archive, raw_id)
+
+    monkeypatch.setattr(revision_backfill, "_parse_retained_raw", counted)
+
+    result = backfill_historical_revision_evidence(tmp_path)
+
+    assert result.scanned == len(raw_ids)
+    assert result.classified_full == len(raw_ids)
+    assert result.replayed_logical_sources == 1
+    assert result.quarantined == 0
+    # Only the newest raw (the winner) is ever independently parsed; the 50
+    # older captures are bound to its learned identity by byte-prefix proof.
+    assert set(parse_calls) == {raw_ids[-1]}
+    with sqlite3.connect(tmp_path / "index.db") as conn:
+        assert conn.execute("SELECT raw_id FROM sessions").fetchone() == (raw_ids[-1],)
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM raw_sessions WHERE revision_kind = 'full' AND logical_source_key IS NOT NULL"
+        ).fetchone()[0] == len(raw_ids)
 
 
 def test_backfill_replay_reuses_spill_cache_when_bound_explicitly(


### PR DESCRIPTION
## Summary

Census-phase historical revision replay (`sources/revision_backfill.py`) no
longer fully JSON-parses every retained raw in a growing-file cohort — only
the newest (winner) member is parsed; older members that byte comparison
already proves are a strict prefix are bound to the winner's learned
identity without independent parsing.

## Problem

Live evidence (2026-07-19, source.db): 101,095 raw rows, 97.4GB total blob
bytes, but the newest-revision-per-cohort total is only 52.2GB — 45.2GB
(46%) is superseded full snapshots of files that grew over time via repeated
re-capture (one Codex rollout file alone: 800 stored revisions / 6.2GB for a
file whose final size is ~8MB). `backfill_historical_revision_evidence`
parsed *every* uncensused revision in a cohort even though
`plan_revision_replay` (`archive/revision_replay.py`) only ever keeps the
newest full raw (+ byte-proven append tail) as `accepted_chain` — every
older full snapshot is marked `SUPERSEDED` and its parsed content is never
read again. So a restore parsed ~97GB where a fresh import of the live
files parses ~34GB once.

Separately, `classify_raw_revision_cohort` (`storage/sqlite/archive_tiers/archive.py`)
already proves a unique byte-prefix growth chain among same-cohort "full"
raws via pure streamed byte comparison (`classify_historical_full_revision_streams`,
zero parse cost) — but it only runs *after* census, per `logical_source_key`,
which itself only gets assigned by fully parsing every raw. Chicken-and-egg.

## Solution

- New `ArchiveStore.classify_untyped_full_revision_groups` (`archive.py`):
  groups never-typed (`revision_kind='unknown'`) retained raw candidates by
  `source_path` — an established cohort-equivalence edge elsewhere in this
  codebase (see `raw_membership_selection_components_sync`'s docstring) — and
  runs the existing byte-prefix chain proof within each group of ≥2. Read-only,
  no writes.
- `_census_historical_revision_evidence` (`sources/revision_backfill.py`) now
  calls this before dispatching parses. For a proven chain: only the head
  (newest) is parsed to learn `logical_source_key`; every older member is
  bound to that same key via a cheap `bind_raw_revision` call with no
  independent parse. Ambiguous/branching groups, or a head parse that doesn't
  cleanly resolve to a single-session key (e.g. a coincidental byte-prefix
  among unrelated multi-session bundles), fall back to parsing every member
  individually — identical to today's behavior, zero regression risk.
- `classify_raw_revision_cohort` (called later, during replay) is
  **untouched** and still independently re-derives byte-provenness from raw
  bytes for every raw — this is a census-time parse-cost optimization, never
  a shortcut on authority. Already-typed raws are excluded from the new
  grouping by construction (`WHERE revision_kind='unknown'`), so retry/resume
  behavior for previously-typed raws is byte-for-byte unchanged.

Two existing tests hard-coded parse-call counts that assumed every raw in a
2-member growth chain gets independently census-parsed — exactly the
assumption this fix removes (`test_backfill_replay_reparses_when_spill_cache_absent`,
`test_backfill_replay_reuses_spill_cache_when_bound_explicitly`); both are
updated with the new (lower) counts and a comment explaining why. No other
test in `test_revision_backfill.py` / `test_raw_authority_restart_proof.py`
/ `test_raw_authority_scale_proof.py` / `test_repair.py` asserts per-raw
parse-derived content for a superseded raw in a growth chain (verified by
reading all of them — restart_proof's 6-raw fixture uses 6 distinct
`source_path` values so never triggers this path).

Added `build_revision_chain_corpus`/`REVISION_CHAIN_SHAPE` to the shared
benchmark infra (`tests/infra/revision_backfill_benchmark.py`, 50
superseded captures + 1 winner, ~1MB final size — shaped after the bead's
own live-source.db evidence) plus a scale regression test pinning that only
the winner is ever parsed at this scale.

## Verification

- `devtools test tests/unit/sources/test_revision_backfill.py tests/unit/devtools/test_raw_authority_restart_proof.py tests/unit/devtools/test_raw_authority_scale_proof.py tests/unit/storage/test_repair.py` — 103 passed (24 in `test_revision_backfill.py` after adding the new scale test).
- `mypy --strict` and `ruff check`/`format --check` clean on all changed files.
- `devtools verify --quick` (format+lint+mypy+render-all-check) — passed, ran automatically on push via the pre-push hook.
- Before/after measurement on `REVISION_CHAIN_SHAPE` (51 raws, ~1MB final payload): reverted `revision_backfill.py`+`archive.py` to the parent commit, ran the identical script both ways —
  - Before: 52 parse calls (51 unique raws parsed), 0.303s wall time for `backfill_historical_revision_evidence`.
  - After: 2 parse calls (1 unique raw parsed), 0.091s wall time — ~3.3x faster on this synthetic cohort. Real archives see a larger effect since parse cost grows with payload size while the byte-streaming proof stays I/O-only (the bead's own live evidence: one real cohort was 800 revisions/6.2GB for an ~8MB final file — near-total elimination of parse work for that cohort).

## Acceptance criteria (polylogue-nh44)

- Design decision recorded on the bead before implementation (see bead design field) — satisfied.
- Newest-only census implemented behind the existing authority model without weakening newest-revision selection — satisfied; `classify_raw_revision_cohort`/`plan_revision_replay` untouched, still the sole source of replay authority.
- Restore-scale parse bytes drop to near newest-only total — satisfied for the growing-file-cohort case (the dominant 45GB/46% waste in the bead's evidence); membership/bundle-route cohorts (different `source_path`s per session) are a separate axis not covered by this fix and were out of scope for this lane.
- Existing crash-recovery + authority tests stay green — satisfied, 103 tests pass unmodified except the two documented count updates.

Ref polylogue-nh44