### PR TITLE
perf(sources): batch replay-phase index+source commits across cohorts

### DIFF
--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -492,18 +492,32 @@ def backfill_historical_revision_evidence(
     parse output for an unbounded (``max_payload_bytes=None``) census without
     also activating envelope blocking.
 
-    ``commit_batch_size`` (polylogue-amg1) batches the CENSUS phase's
-    per-raw source.db commits only; the replay phase's cohort-apply and
-    terminal-raw finalize commit granularity is unchanged (see
-    ``_census_historical_revision_evidence`` for why: the replay phase's
-    "index commits, then source terminal marker commits" ordering is a
-    crash-recovery invariant pinned by
+    ``commit_batch_size`` (polylogue-amg1, extended to the replay phase by
+    polylogue-oikv) batches commits in BOTH phases: the CENSUS phase's
+    per-raw source.db commits (see ``_census_historical_revision_evidence``),
+    and the REPLAY phase's per-cohort index.db writes plus terminal source.db
+    parse-state markers (see ``apply_raw_revision_replay`` /
+    ``apply_raw_membership_classification``), across up to
+    ``commit_batch_size`` cohorts sharing one commit window.
+
+    ``None`` (the default) preserves the exact original per-unit commit
+    granularity for every existing caller in both phases. When set, the
+    "index commits, then source terminal marker commits" ordering invariant
+    pinned by
     ``test_backfill_resumes_after_index_receipt_commits_before_source_terminal``
-    et al. and batching it needs its own reviewed change).
+    et al. still holds for the replay phase -- just at BATCH granularity
+    instead of per-cohort: a crash inside an open batch discards every
+    cohort in that batch (its index writes and terminal markers together,
+    since neither has committed), never leaves index ahead of source across
+    a batch boundary, and a resume reprocesses every lost cohort from
+    scratch with zero duplication (proof:
+    ``test_backfill_resumes_after_replay_batch_crash_discards_whole_batch_cleanly``).
     """
     adoption_deferred = 0
     quarantined = 0
     logical_keys: set[str] = set()
+    replay_batch_size = commit_batch_size if commit_batch_size is not None and commit_batch_size > 0 else None
+    replay_batched = replay_batch_size is not None
     archive_context = (
         ArchiveStore.open_owned_inactive_generation(
             archive_root,
@@ -540,6 +554,15 @@ def backfill_historical_revision_evidence(
         logical_keys.update(selected_keys)
         _selected_membership_raws, selected_membership_keys = archive.expand_raw_membership_selection(selected_raw_ids)
         membership_keys = set(selected_membership_keys)
+
+        pending_replay_commits = 0
+
+        def commit_replay_unit() -> None:
+            nonlocal pending_replay_commits
+            pending_replay_commits += 1
+            if replay_batch_size is not None and pending_replay_commits >= replay_batch_size:
+                archive.commit()
+                pending_replay_commits = 0
 
         replayed = 0
         byte_replayed_keys: set[str] = set()
@@ -584,9 +607,13 @@ def backfill_historical_revision_evidence(
                     archive.release_provisional_full_revisions(sorted(plan_raw_ids))
                 adoption_deferred += len(plan.accepted_raw_ids)
                 continue
-            archive.apply_raw_revision_replay(plan, parsed_by_raw_id, acquired_at_ms=0)
+            archive.apply_raw_revision_replay(
+                plan, parsed_by_raw_id, acquired_at_ms=0, manage_transaction=not replay_batched
+            )
             replayed += 1
             byte_replayed_keys.add(logical_key)
+            if replay_batched:
+                commit_replay_unit()
 
         for logical_key in sorted(membership_keys):
             if logical_key in byte_replayed_keys:
@@ -628,9 +655,14 @@ def backfill_historical_revision_evidence(
                 member_sessions,
                 projections,
                 acquired_at_ms=0,
+                manage_transaction=not replay_batched,
             )
             if classification.accepted_raw_ids:
                 replayed += 1
+            if replay_batched:
+                commit_replay_unit()
+        if replay_batched:
+            archive.commit()
     return RevisionBackfillResult(
         census.scanned,
         census.classified,

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -5606,12 +5606,20 @@ def repair_raw_materialization(
     order remain strictly sequential in this single writer regardless of
     worker count.
 
-    ``commit_batch_size`` (polylogue-amg1) batches the CENSUS phase's
-    per-raw source.db commits; ``None`` resolves
+    ``commit_batch_size`` (polylogue-amg1, extended to the replay phase by
+    polylogue-oikv) batches both the CENSUS phase's per-raw source.db
+    commits and the REPLAY phase's per-cohort index.db + terminal source.db
+    marker commits; ``None`` resolves
     ``POLYLOGUE_RAW_AUTHORITY_COMMIT_BATCH_SIZE`` /
-    ``RAW_MATERIALIZATION_COMMIT_BATCH_SIZE``. Only the census phase batches
-    -- see ``_census_historical_revision_evidence`` for why the replay
-    phase's commit granularity is unchanged.
+    ``RAW_MATERIALIZATION_COMMIT_BATCH_SIZE`` (default 20) -- see
+    ``backfill_historical_revision_evidence`` for the batch-commit ordering
+    invariant. This loop calls ``backfill_historical_revision_evidence``
+    once per plan/component (``selected_raw_ids=[raw_id]``), so a single
+    call typically covers only that component's own cohort(s); replay
+    batching's cross-cohort benefit is realized by callers that pass a
+    wider ``selected_raw_ids=None`` scope (e.g. the CLI
+    ``ops maintenance rebuild-index`` full-archive path), not by this
+    per-component daemon loop.
     """
     if max_payload_bytes < 1:
         raise ValueError("max_payload_bytes must be positive")

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2919,8 +2919,25 @@ class ArchiveStore:
         acquired_at_ms: int,
         stage_timings_s: dict[str, float] | None = None,
         stage_timing_prefix: str = "revision_replay",
+        manage_transaction: bool = True,
     ) -> tuple[str, tuple[str, ...]]:
-        """Apply a proven chain and atomically receipt its exact index state."""
+        """Apply a proven chain and atomically receipt its exact index state.
+
+        ``manage_transaction=False`` batches this cohort's index.db writes
+        and terminal source.db parse-state markers into the caller's open
+        transaction/pending-state instead of committing them immediately
+        (polylogue-oikv) -- the caller must call ``commit()`` (or
+        ``rollback()`` on failure) itself, exactly once per batch, after
+        every cohort in the batch has been applied. ``commit()`` always
+        commits the index connection before flushing pending source markers
+        (``_flush_pending_raw_parse_states``), so the "index commits, then
+        source terminal markers commit" ordering invariant now holds at
+        BATCH granularity instead of per-cohort: a crash anywhere before the
+        shared ``commit()`` call discards the whole uncommitted batch (every
+        batched cohort's index writes and terminal markers together), never
+        a partial one, and a resume reprocesses every lost cohort from
+        scratch with zero duplication.
+        """
         if not plan.accepted_raw_ids:
             raise ValueError("cannot apply a revision plan without an accepted chain")
         candidates = {item.raw_id: item for item in self._raw_revision_candidates(plan.logical_source_key)}
@@ -2944,7 +2961,7 @@ class ArchiveStore:
         for raw_id, refs in attachment_refs_by_raw_id.items():
             write_source_blob_refs(self._ensure_source_conn(), raw_id, refs)
         session_ids: set[str] = set()
-        with self._conn:
+        with self._conn if manage_transaction else nullcontext():
             existing_head = self._conn.execute(
                 """SELECT session_id, accepted_raw_id, accepted_source_revision,
                           accepted_content_hash, accepted_frontier_kind, accepted_frontier
@@ -3049,7 +3066,10 @@ class ArchiveStore:
         }
         for raw_id in terminal_raw_ids:
             provider, _blob_hash, _source_path, _kind, _blob_size = self.raw_revision_descriptor(raw_id)
-            self.mark_raw_parse_succeeded(raw_id, provider=provider)
+            if manage_transaction:
+                self.mark_raw_parse_succeeded(raw_id, provider=provider)
+            else:
+                self._pending_raw_parse_states.append((raw_id, self._raw_parse_success_state(provider)))
         return session_id, plan.accepted_raw_ids
 
     def apply_raw_membership_classification(
@@ -3062,8 +3082,17 @@ class ArchiveStore:
         acquired_at_ms: int,
         stage_timings_s: dict[str, float] | None = None,
         stage_timing_prefix: str = "membership_replay",
+        manage_transaction: bool = True,
     ) -> str | None:
-        """Apply one semantic member head and persist every membership decision."""
+        """Apply one semantic member head and persist every membership decision.
+
+        ``manage_transaction=False`` batches this cohort's index.db head
+        write, its source.db membership-decision updates, and its terminal
+        source.db parse-state marker into the caller's open
+        transaction/pending-state instead of committing them immediately
+        (polylogue-oikv) -- see ``apply_raw_revision_replay`` for the shared
+        batch-commit invariant this mirrors.
+        """
         conn = self._ensure_source_conn()
         decided_at_ms = int(datetime.now(UTC).timestamp() * 1000)
         decisions: dict[str, str] = dict.fromkeys(classification.ambiguous_raw_ids, "ambiguous")
@@ -3086,7 +3115,7 @@ class ArchiveStore:
             if self._blob_publisher is not None:
                 self._blob_publisher.flush()
             write_source_blob_refs(conn, accepted_raw_id, refs)
-            with self._conn:
+            with self._conn if manage_transaction else nullcontext():
                 existing_head = self._conn.execute(
                     """
                     SELECT accepted_raw_id, accepted_content_hash, accepted_frontier_kind, session_id
@@ -3187,7 +3216,7 @@ class ArchiveStore:
                     )
             decisions[accepted_raw_id] = "applied"
 
-        with conn:
+        with conn if manage_transaction else nullcontext():
             for raw_id, decision in decisions.items():
                 conn.execute(
                     """
@@ -3223,8 +3252,15 @@ class ArchiveStore:
             ).fetchone()
             if complete is not None and bool(complete[0]):
                 provider, _blob_hash, _source_path, _kind, _blob_size = self.raw_revision_descriptor(raw_id)
-                self.mark_raw_parse_succeeded(raw_id, provider=provider)
+                if manage_transaction:
+                    self.mark_raw_parse_succeeded(raw_id, provider=provider)
+                else:
+                    self._pending_raw_parse_states.append((raw_id, self._raw_parse_success_state(provider)))
             else:
+                # Incomplete cohort: this raw is not yet finalized (a sibling
+                # member is still undecided), so this is a correction, not a
+                # terminal marker -- always commits immediately regardless of
+                # batching, matching prior behavior.
                 with conn:
                     conn.execute(
                         "UPDATE raw_sessions SET parsed_at_ms = NULL, parse_error = NULL WHERE raw_id = ?",

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -1020,6 +1020,69 @@ def test_census_batch_crash_loses_at_most_one_batch_and_resumes_cleanly(
         )
 
 
+def test_backfill_resumes_after_replay_batch_crash_discards_whole_batch_cleanly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """polylogue-oikv: with ``commit_batch_size`` set, the REPLAY phase now
+    batches index.db writes + terminal source.db markers across MULTIPLE
+    independent cohorts (not just within one cohort, as the two
+    unbatched-default pinned tests above still prove unmodified). A fault
+    partway through an uncommitted replay batch must discard the WHOLE
+    batch -- every cohort's index writes and terminal markers together,
+    since neither side ever committed -- never a partial one, and a resume
+    must converge to the same terminal state as an uninterrupted run with
+    zero duplication (mirrors the census-phase proof above)."""
+    raw_count = 10
+    batch_size = 4
+    root = tmp_path / "archive"
+    build_independent_raw_corpus(root, raw_count=raw_count, avg_payload_bytes=1_000)
+
+    original_apply = ArchiveStore.apply_raw_revision_replay
+    calls = 0
+    # Batch 1 (cohorts 1-4) commits cleanly and resets the counter. Batch 2
+    # starts (cohort 5 applies, uncommitted), then crashes on cohort 6 --
+    # before batch 2 reaches batch_size and self-commits.
+    crash_at_call = 6
+
+    def crash_partway(self: ArchiveStore, plan: object, parsed_by_raw_id: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        if calls == crash_at_call:
+            raise RuntimeError("injected crash mid replay-batch")
+        return original_apply(self, plan, parsed_by_raw_id, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(ArchiveStore, "apply_raw_revision_replay", crash_partway)
+    with pytest.raises(RuntimeError, match="injected crash mid replay-batch"):
+        backfill_historical_revision_evidence(root, commit_batch_size=batch_size)
+
+    with sqlite3.connect(root / "index.db") as conn:
+        session_count_after_crash = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    # Exactly one fully-committed batch survives the crash -- never a partial one.
+    assert session_count_after_crash == batch_size
+    with sqlite3.connect(root / "source.db") as conn:
+        parsed_after_crash = conn.execute(
+            "SELECT COUNT(*) FROM raw_sessions WHERE parsed_at_ms IS NOT NULL"
+        ).fetchone()[0]
+    assert parsed_after_crash == batch_size
+
+    monkeypatch.setattr(ArchiveStore, "apply_raw_revision_replay", original_apply)
+    result = backfill_historical_revision_evidence(root, commit_batch_size=batch_size)
+
+    assert result.scanned == raw_count
+    assert result.replayed_logical_sources == raw_count
+    assert result.quarantined == 0
+    with sqlite3.connect(root / "index.db") as conn:
+        session_count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        application_count = conn.execute("SELECT COUNT(*) FROM raw_revision_applications").fetchone()[0]
+    assert session_count == raw_count
+    # One application receipt per raw, no duplicates from the retried batch.
+    assert application_count == raw_count
+    with sqlite3.connect(root / "source.db") as conn:
+        assert (
+            conn.execute("SELECT COUNT(*) FROM raw_sessions WHERE parsed_at_ms IS NOT NULL").fetchone()[0] == raw_count
+        )
+
+
 def test_partition_raws_by_dispatch_size_routes_small_to_pool_large_sequential() -> None:
     """polylogue-amg1 lever (b): raws under the size ceiling are pool-eligible
     (parallel parse pays off), raws at/above it stay sequential (pickling the


### PR DESCRIPTION
## Summary

Extends polylogue-amg1's commit-batching to the replay phase. amg1 (PR #3136) batched the CENSUS phase's per-raw source.db commits but deliberately left the REPLAY phase's per-cohort index.db commit + per-raw terminal source.db marker commit unbatched, because a naive multi-cohort batch risked inverting a pinned crash-recovery ordering invariant. This PR does the deferred redesign: `commit_batch_size` now also batches replay commits across multiple independent cohorts, while preserving the invariant at batch granularity.

## Problem

`backfill_historical_revision_evidence`'s replay loop calls `ArchiveStore.apply_raw_revision_replay` (and `apply_raw_membership_classification`) once per logical-source cohort. Each call self-committed index.db immediately (`with self._conn:`), then looped over terminal raw ids calling `mark_raw_parse_succeeded` — an independent, immediate source.db commit per raw. For amg1's own benchmark shape (independent single-session raws, cohort size == 1), this meant the replay phase still committed once per raw on BOTH tiers — the larger lever amg1's own notes explicitly named and deferred to this bead (polylogue-oikv), pending its own adversarial review of the crash-recovery stakes.

## Solution

- `ArchiveStore.apply_raw_revision_replay` / `apply_raw_membership_classification` gain a `manage_transaction: bool = True` parameter, following the exact `with conn if manage_transaction else nullcontext()` pattern amg1 already established for census (`replace_raw_membership_census`, `bind_raw_revision`). When `False`, the cohort's index.db writes stay in the caller's open transaction, and its terminal parse-state marker is pushed onto the existing `_pending_raw_parse_states` queue instead of committing immediately via `mark_raw_parse_succeeded`.
- `backfill_historical_revision_evidence`'s existing `commit_batch_size` parameter now governs BOTH phases: a `commit_replay_unit()` closure (mirroring census's own) fires `archive.commit()` every `commit_batch_size` cohorts across the byte-cohort and membership-classification loops, plus a final flush commit after both loops. `None` (the default) preserves the exact original per-cohort commit behavior for every existing caller.
- **Why the invariant still holds**: `ArchiveStore.commit()` already commits the index connection *before* flushing pending source markers (`_flush_pending_raw_parse_states`). Batching multiple cohorts into one shared `commit()` call means the ordering invariant now holds at BATCH granularity instead of per-cohort: a crash anywhere in an open (uncommitted) batch discards every cohort in that batch — index writes and terminal markers together, since neither side ever committed (SQLite implicitly rolls back an uncommitted transaction when the connection closes) — never a partial batch, and a resume reprocesses every lost cohort from scratch with zero duplication.
- The rare non-terminal "incomplete cohort" NULL-reset branch in `apply_raw_membership_classification` (a sibling member still undecided) is left immediately-committing regardless of batching — it's a correction path, not a terminal marker, out of scope for this bead.
- `repair_raw_materialization`'s docstring is updated to note its per-component call shape (`selected_raw_ids=[raw_id]`) means this daemon loop sees minimal cross-cohort benefit; the wider `selected_raw_ids=None` CLI `rebuild-index` path is where the batching pays off — same caveat lane I (polylogue-nh44) already documented for census.

## Acceptance criteria (polylogue-oikv)

- Design decision recorded (this PR body): the new batch-boundary invariant is "index commits, then source terminal markers commit" at BATCH granularity, equivalent-or-stronger than the prior per-cohort invariant (still index-before-source, just deferred over N cohorts) — satisfied.
- Both existing crash-recovery tests (`test_backfill_resumes_after_index_receipt_commits_before_source_terminal`, `test_backfill_resumes_after_only_some_source_markers_commit`) pass **unmodified** — satisfied; they call `backfill_historical_revision_evidence` with no `commit_batch_size`, so default (`None` → unbatched) behavior is byte-for-byte unchanged.
- New crash-mid-batch test (`test_backfill_resumes_after_replay_batch_crash_discards_whole_batch_cleanly`) proves a fault between two cohorts in the same batch discards the whole batch cleanly — satisfied; also verified non-vacuous by temporarily forcing `replay_batched=False` and confirming the same assertion fails (`5 != 4`).
- Benchmark shows measurable additional speedup beyond amg1's 1.05x-1.34x ceiling — satisfied (below).

## Verification

- `devtools test tests/unit/sources/test_revision_backfill.py tests/unit/storage/test_repair.py tests/unit/devtools/test_raw_authority_restart_proof.py tests/unit/devtools/test_raw_authority_scale_proof.py` — 105 passed.
- Broader sweep `devtools test -k "raw_authority or raw_materialization or revision_backfill or revision_replay"` — 190 passed, 1 pre-existing unrelated failure (`test_live_multi_session_divergence_reopens_raw_authority` in `test_live_batch_support.py`, already documented by amg1's own notes as failing identically on clean master with none of this bead's/amg1's changes present).
- `mypy --strict` clean on `archive.py`, `revision_backfill.py`, `repair.py`, and the test file.
- `devtools verify --quick` (format+lint+mypy+render-all-check) — clean.
- Ad-hoc before/after benchmark (`tests/infra/revision_backfill_benchmark.py` fixtures, not committed — same convention amg1 used), `commit_batch_size=None` vs `20` (production default `RAW_MATERIALIZATION_COMMIT_BATCH_SIZE`), median of 3 runs each:
  - `SMALL_PAYLOAD_SHAPE` (200 raws, ~50KB avg): 11.734s → 5.453s, **2.15x**
  - `LARGE_PAYLOAD_SHAPE` (80 raws, ~1.7MB avg): 9.743s → 7.492s, **1.30x**

Ref polylogue-oikv