### PR TITLE
perf(storage): ensure prefix-dependent indexes on ArchiveStore write open

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1290,6 +1290,18 @@ class ArchiveStore:
             self._conn.execute(statement)
         if read_only:
             self._conn.execute(f"PRAGMA busy_timeout = {max(0, int(read_timeout * 1000))}")
+        else:
+            # Fresh-bootstrap and same-version reopen both skip runtime-index
+            # ensure elsewhere (initialize_archive_tier only replays DDL once,
+            # at current_version==0; the read-only path has its own ensure in
+            # _ensure_read_runtime_indexes). Owned inactive generations (bulk
+            # rebuilds, revision backfill) open exactly this write connection
+            # and nothing else, so without this call a generation could run
+            # its whole lifetime — including prefix-tail dependent rewrites —
+            # against an index.db missing performance indexes such as
+            # idx_session_events_source_message /
+            # idx_session_agent_policies_source_message (polylogue-crd8).
+            ensure_runtime_indexes_sync(self._conn)
         self._user_tier_attached = False
         self._tags_relation = "session_tags"
         self._source_conn: sqlite3.Connection | None = None

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -4097,6 +4097,67 @@ def repair_stale_prefix_branch_points(conn: sqlite3.Connection, *, limit: int | 
     return _repair_stale_prefix_branch_points_db(conn, limit=limit)
 
 
+def clear_messages_parent_sql(placeholders: str) -> str:
+    """Return the prefix-delete ``messages.parent_message_id`` clear statement.
+
+    Shared by :func:`_delete_all_session_message_dependents` and
+    :func:`_delete_prefix_message_dependents` so tests can assert its query
+    plan against the exact production SQL rather than a hand-copied string.
+    Covered by ``idx_messages_parent`` (leading column ``parent_message_id``).
+    """
+    return f"""
+        UPDATE messages
+        SET parent_message_id = NULL
+        WHERE parent_message_id IN ({placeholders})
+        """
+
+
+def clear_session_events_source_message_sql(placeholders: str) -> str:
+    """Return the prefix-delete ``session_events.source_message_id`` clear statement.
+
+    Covered by the partial index ``idx_session_events_source_message ...
+    WHERE source_message_id IS NOT NULL`` (polylogue-crd8) — the planner can
+    use a partial index for an ``IN (<non-null literals>)`` predicate because
+    every value in the list necessarily satisfies ``IS NOT NULL``.
+    """
+    return f"""
+        UPDATE session_events
+        SET source_message_id = NULL
+        WHERE source_message_id IN ({placeholders})
+        """
+
+
+def clear_session_agent_policies_source_message_sql(placeholders: str) -> str:
+    """Return the prefix-delete ``session_agent_policies.source_message_id`` clear statement.
+
+    Covered by the partial index ``idx_session_agent_policies_source_message
+    ... WHERE source_message_id IS NOT NULL`` (polylogue-crd8), same
+    partial-index-usability reasoning as
+    :func:`clear_session_events_source_message_sql`.
+    """
+    return f"""
+        UPDATE session_agent_policies
+        SET source_message_id = NULL
+        WHERE source_message_id IN ({placeholders})
+        """
+
+
+def _clear_prefix_message_id_references(
+    conn: sqlite3.Connection,
+    placeholders: str,
+    params: tuple[str, ...],
+) -> None:
+    """Null out every ``messages(message_id)``-keyed back-reference to a deleted prefix.
+
+    Shared by the two prefix/full dependent-delete helpers below so the three
+    statements (and their index coverage) can't silently drift apart between
+    the partial-tail and whole-session deletion paths.
+    """
+    conn.execute(clear_messages_parent_sql(placeholders), params)
+    conn.execute(clear_session_events_source_message_sql(placeholders), params)
+    conn.execute(clear_session_agent_policies_source_message_sql(placeholders), params)
+
+
 def _delete_all_session_message_dependents(
     conn: sqlite3.Connection,
     session_id: str,
@@ -4112,30 +4173,7 @@ def _delete_all_session_message_dependents(
         return
     placeholders = ",".join("?" for _ in prefix_message_ids)
     params = tuple(prefix_message_ids)
-    conn.execute(
-        f"""
-        UPDATE messages
-        SET parent_message_id = NULL
-        WHERE parent_message_id IN ({placeholders})
-        """,
-        params,
-    )
-    conn.execute(
-        f"""
-        UPDATE session_events
-        SET source_message_id = NULL
-        WHERE source_message_id IN ({placeholders})
-        """,
-        params,
-    )
-    conn.execute(
-        f"""
-        UPDATE session_agent_policies
-        SET source_message_id = NULL
-        WHERE source_message_id IN ({placeholders})
-        """,
-        params,
-    )
+    _clear_prefix_message_id_references(conn, placeholders, params)
     conn.execute("DELETE FROM web_content_constructs WHERE session_id = ?", (session_id,))
     conn.execute(
         """
@@ -4156,30 +4194,7 @@ def _delete_prefix_message_dependents(conn: sqlite3.Connection, prefix_message_i
         return
     placeholders = ",".join("?" for _ in prefix_message_ids)
     params = tuple(prefix_message_ids)
-    conn.execute(
-        f"""
-        UPDATE messages
-        SET parent_message_id = NULL
-        WHERE parent_message_id IN ({placeholders})
-        """,
-        params,
-    )
-    conn.execute(
-        f"""
-        UPDATE session_events
-        SET source_message_id = NULL
-        WHERE source_message_id IN ({placeholders})
-        """,
-        params,
-    )
-    conn.execute(
-        f"""
-        UPDATE session_agent_policies
-        SET source_message_id = NULL
-        WHERE source_message_id IN ({placeholders})
-        """,
-        params,
-    )
+    _clear_prefix_message_id_references(conn, placeholders, params)
     conn.execute(
         f"""
         DELETE FROM attachment_native_ids

--- a/tests/unit/storage/test_prefix_dependent_delete_indexes.py
+++ b/tests/unit/storage/test_prefix_dependent_delete_indexes.py
@@ -1,0 +1,129 @@
+"""Plan-assertion coverage for polylogue-crd8.
+
+Live evidence (2026-07-19): a whale prefix-sharing lineage session's
+``_reextract_prefix_tail_db`` -> ``_delete_prefix_message_dependents`` held the
+writer for hours doing full scans of ``session_events``/``session_agent_policies``
+because those tables' write-mode connections were never guaranteed to carry
+the ``idx_session_events_source_message`` / ``idx_session_agent_policies_source_message``
+partial indexes. The indexes themselves were already present in the canonical
+DDL and in ``runtime_indexes.py`` (added 2026-06-24, ddf4f3efc7) -- since that
+DDL addition was not accompanied by an ``ArchiveTier.INDEX`` version bump
+(correct, additive-derived policy), any archive/generation whose ``index.db``
+reached the current version *before* that DDL addition landed never replays
+the DDL again (``initialize_archive_database`` only re-applies DDL for
+OPS/USER tiers on a same-version reopen) and only reads the index in via one
+of the "ensure" call sites. The read-only path
+(``ArchiveStore._ensure_read_runtime_indexes``) already had that ensure call;
+the write-mode path did not -- meaning every ``ArchiveStore`` write open,
+including ``open_owned_inactive_generation`` (used by bulk rebuilds/revision
+backfill), could run its entire lifetime against an index.db missing these
+indexes. This module asserts both the DDL-level index shape and the
+write-open retrofit fix.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.write import (
+    clear_messages_parent_sql,
+    clear_session_agent_policies_source_message_sql,
+    clear_session_events_source_message_sql,
+)
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    initialize_archive_tier(conn, ArchiveTier.INDEX)
+    return conn
+
+
+def _plan(conn: sqlite3.Connection, sql: str, placeholders: str) -> list[str]:
+    params = tuple(f"m{i}" for i in range(placeholders.count("?")))
+    rows = conn.execute("EXPLAIN QUERY PLAN " + sql, params).fetchall()
+    return [str(row["detail"]) for row in rows]
+
+
+def test_prefix_dependent_clear_statements_use_leading_indexes(tmp_path: Path) -> None:
+    """Fresh-bootstrapped DB: the three prefix-delete UPDATEs used by both
+    ``_delete_prefix_message_dependents`` and
+    ``_delete_all_session_message_dependents`` must each probe a leading
+    index, not scan their whole table."""
+    conn = _connect(tmp_path / "index.db")
+    try:
+        placeholders = ",".join("?" for _ in range(3))
+
+        messages_plan = _plan(conn, clear_messages_parent_sql(placeholders), placeholders)
+        assert any("SEARCH" in step and "idx_messages_parent" in step for step in messages_plan), messages_plan
+
+        events_plan = _plan(conn, clear_session_events_source_message_sql(placeholders), placeholders)
+        assert any("SEARCH" in step and "idx_session_events_source_message" in step for step in events_plan), (
+            events_plan
+        )
+
+        policies_plan = _plan(conn, clear_session_agent_policies_source_message_sql(placeholders), placeholders)
+        assert any(
+            "SEARCH" in step and "idx_session_agent_policies_source_message" in step for step in policies_plan
+        ), policies_plan
+    finally:
+        conn.close()
+
+
+def test_archive_store_write_open_retrofits_dropped_prefix_indexes(tmp_path: Path) -> None:
+    """Anti-vacuity target for the ``ArchiveStore`` write-open fix.
+
+    Simulates a same-version ``index.db`` that predates the
+    ``idx_session_events_source_message`` / ``idx_session_agent_policies_source_message``
+    DDL addition (or was otherwise stripped of them) by dropping both indexes
+    after a fresh bootstrap, then reopening the archive root through
+    ``ArchiveStore`` in write mode -- the exact code path
+    ``open_owned_inactive_generation`` (bulk rebuild / revision backfill) and
+    every other write-mode caller use. Before the fix in
+    ``ArchiveStore._initialize_store``, the write branch never called
+    ``ensure_runtime_indexes_sync`` on its own connection (only the read-only
+    branch did), so a dropped/never-created index stayed missing for the
+    entire lifetime of that write connection. Revert the ``else:
+    ensure_runtime_indexes_sync(self._conn)`` branch in
+    ``polylogue/storage/sqlite/archive_tiers/archive.py`` to see this test
+    fail (SCAN instead of SEARCH, and the index missing from
+    ``PRAGMA index_list``).
+    """
+    root = tmp_path / "archive"
+    with ArchiveStore(root):
+        pass  # fresh bootstrap only; index.db now exists at current version.
+
+    index_db_path = root / "index.db"
+    conn = sqlite3.connect(index_db_path)
+    try:
+        conn.execute("DROP INDEX idx_session_events_source_message")
+        conn.execute("DROP INDEX idx_session_agent_policies_source_message")
+        conn.commit()
+        remaining = {row[1] for row in conn.execute("PRAGMA index_list('session_events')")} | {
+            row[1] for row in conn.execute("PRAGMA index_list('session_agent_policies')")
+        }
+        assert "idx_session_events_source_message" not in remaining
+        assert "idx_session_agent_policies_source_message" not in remaining
+    finally:
+        conn.close()
+
+    with ArchiveStore.open_existing(root, read_only=False) as facade:
+        events_indexes = {row["name"] for row in facade._conn.execute("PRAGMA index_list('session_events')")}
+        policies_indexes = {row["name"] for row in facade._conn.execute("PRAGMA index_list('session_agent_policies')")}
+        assert "idx_session_events_source_message" in events_indexes
+        assert "idx_session_agent_policies_source_message" in policies_indexes
+
+        placeholders = ",".join("?" for _ in range(3))
+        events_plan = _plan(facade._conn, clear_session_events_source_message_sql(placeholders), placeholders)
+        assert any("SEARCH" in step and "idx_session_events_source_message" in step for step in events_plan), (
+            events_plan
+        )
+        policies_plan = _plan(facade._conn, clear_session_agent_policies_source_message_sql(placeholders), placeholders)
+        assert any(
+            "SEARCH" in step and "idx_session_agent_policies_source_message" in step for step in policies_plan
+        ), policies_plan


### PR DESCRIPTION
## Summary

Fixes a write-open gap where `ArchiveStore` write-mode connections never called `ensure_runtime_indexes_sync`, letting a whale prefix-sharing lineage rewrite scan `session_events`/`session_agent_policies` for hours on a same-version `index.db` that predates the indexes' DDL addition.

## Problem

Live evidence (polylogue-crd8, 2026-07-19): a whale prefix-sharing lineage session's `_reextract_prefix_tail_db` -> `_delete_prefix_message_dependents` held the writer for 3+ hours doing ~520MB/s reads (7.97TB cumulative) because `UPDATE session_events`/`session_agent_policies SET source_message_id = NULL WHERE source_message_id IN (...)` ran full table scans. The coordinator's live index audit found `idx_gen_tmp_session_events_source_message_id` / `idx_gen_tmp_session_agent_policies_source_message_id` missing on the in-flight rebuild generation and hand-created mitigation indexes as a stopgap.

Investigation found the canonical indexes already exist: `idx_session_events_source_message` / `idx_session_agent_policies_source_message` are defined both in the DDL (`archive_tiers/index.py`) and in the ensure-on-every-open catalog (`runtime_indexes.py`), added together in `ddf4f3efc7` (2026-06-24) without an `ArchiveTier.INDEX` version bump (correct, additive-derived policy per this repo's schema regimes). Because the version wasn't bumped, `initialize_archive_database`'s same-version reopen never re-runs DDL for the INDEX tier (only OPS/USER get idempotent DDL replay), so any `index.db` that reached the current version *before* that DDL addition can only pick the two indexes up via one of the "ensure" call sites. `ArchiveStore._ensure_read_runtime_indexes` already covered read-only opens (added in the same commit); the write-mode branch of `ArchiveStore._initialize_store` never called `ensure_runtime_indexes_sync` on its own connection, so every write-mode `ArchiveStore` open -- `open_owned_inactive_generation` (bulk rebuild / revision backfill) included -- could run its entire lifetime against an `index.db` missing these indexes.

## Solution

**Mechanism decision:** wiring fix to the existing `runtime_indexes` ensure catalog, not a new index definition or a derived-tier version bump. The two indexes and their partial shape (`WHERE source_message_id IS NOT NULL`) already exist and already match house style (see `idx_messages_active_leaf`); nothing new needed adding to the DDL or the ensure catalog itself.

- `polylogue/storage/sqlite/archive_tiers/archive.py`: call `ensure_runtime_indexes_sync(self._conn)` in the write branch of `_initialize_store`, mirroring the existing read-only defensive pattern (`_ensure_read_runtime_indexes`).
- `polylogue/storage/sqlite/archive_tiers/write.py`: extracted the messages/session_events/session_agent_policies clear statements -- duplicated verbatim between `_delete_prefix_message_dependents` and `_delete_all_session_message_dependents` -- into `clear_messages_parent_sql` / `clear_session_events_source_message_sql` / `clear_session_agent_policies_source_message_sql` plus a shared `_clear_prefix_message_id_references` helper, both for DRY and so tests can assert query plans against the exact production SQL text.
- **Sibling-statement audit** (bead item 4): every other statement in both dependent-delete functions for the same unindexed-`IN (...)` shape is already covered in the canonical DDL: `messages.parent_message_id` (`idx_messages_parent`), `attachment_refs.message_id` (`PK(message_id,position)` autoindex + `idx_attachment_refs_message`), `attachment_native_ids.ref_id` (`PK(ref_id,id_kind,native_id)` autoindex, leftmost column), `web_content_constructs.message_id` (`idx_web_constructs_message`, polylogue-rgbj), `paste_spans.message_id` and `blocks.message_id` (both `PK(message_id,position)` autoindexes). No further index gaps found.
- `tests/unit/storage/test_prefix_dependent_delete_indexes.py`: fresh-bootstrap `EXPLAIN QUERY PLAN` coverage for the three `clear_*_sql` statements (asserts `SEARCH` via the named index, not `SCAN`), plus an anti-vacuity test that drops both indexes post-bootstrap and reopens through `ArchiveStore.open_existing(read_only=False)` -- the exact write-mode retrofit path -- asserting the indexes and `SEARCH` plans come back.

## Verification

- `devtools test tests/unit/storage/test_planner_statistics_seed.py tests/unit/storage/test_prefix_dependent_delete_indexes.py tests/unit/storage/test_schema_policy_contracts.py` -> 21 passed
- Anti-vacuity: reverted the `archive.py` hunk (`git stash`) and reran the new test file -- `test_archive_store_write_open_retrofits_dropped_prefix_indexes` failed with `AssertionError: assert 'idx_session_events_source_message' in {'sqlite_autoindex_session_events_1', 'sqlite_autoindex_session_events_2'}`; restored the fix and it passed again.
- `devtools test tests/unit/storage/test_archive_tiers_write.py tests/unit/storage/test_archive_tiers_archive.py tests/unit/storage/test_archive_tiers_ddl.py tests/unit/storage/test_index_generation.py` -> 142 passed, 1 pre-existing failure (`test_exact_session_action_count_bounds_pairing_before_global_ranking`, `assert 0 >= 50000`) confirmed unrelated by reproducing it identically with this diff fully reverted.
- `devtools verify --quick` -> exit 0

Ref polylogue-crd8

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive write operations by restoring required database indexes when opening existing archives.
  * Prevented inefficient database scans during lineage re-extraction and dependent-record cleanup.
  * Improved consistency when clearing references to deleted inherited messages.

* **Tests**
  * Added coverage verifying index usage and automatic restoration of missing indexes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->