### PR TITLE
perf(sources): sequential parse below aggregate pool floor, stop worker churn

### DIFF
--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -761,6 +761,40 @@ def _partition_raws_by_dispatch_size(
     return pool_raw_ids, sequential_raw_ids
 
 
+_DEFAULT_PARSE_POOL_MIN_AGGREGATE_BYTES = 48 * 1024 * 1024  # 48 MiB
+
+
+def _parse_pool_min_aggregate_bytes() -> int:
+    """Aggregate-payload floor below which pool dispatch cannot amortize.
+
+    Each spawned worker pays the full interpreter + polylogue import before
+    its first task (~1.5-2.0s measured live 2026-07-19: a 25s py-spy capture
+    of the bulk rebuild census showed 20 short-lived workers spending ~95%
+    of their lifetime inside importlib, because per-cohort census batches
+    dispatch 1-2 sub-256KiB raws at a time and the executor is created per
+    call). Sequential small-payload parse runs at roughly 20MB/s, so with 8
+    workers the pool only beats sequential once the pool-eligible aggregate
+    exceeds ~45MB; below that, worker spawn dominates and "parallel" is
+    strictly slower. Override with
+    ``POLYLOGUE_REVISION_PARSE_POOL_MIN_BYTES`` (polylogue-crd8 follow-up).
+    """
+    raw = os.environ.get("POLYLOGUE_REVISION_PARSE_POOL_MIN_BYTES")
+    if raw is None:
+        return _DEFAULT_PARSE_POOL_MIN_AGGREGATE_BYTES
+    try:
+        return int(raw)
+    except ValueError:
+        return _DEFAULT_PARSE_POOL_MIN_AGGREGATE_BYTES
+
+
+def _pool_dispatch_amortizes(pool_raw_ids: list[str], payload_sizes: dict[str, int]) -> bool:
+    """Decide whether a pool-eligible batch is worth spawning workers for."""
+    if len(pool_raw_ids) <= 1:
+        return False
+    total = sum(payload_sizes[raw_id] for raw_id in pool_raw_ids)
+    return total >= _parse_pool_min_aggregate_bytes()
+
+
 def _parse_retained_raws(
     archive: ArchiveStore,
     raw_ids: list[str],
@@ -798,7 +832,7 @@ def _parse_retained_raws(
         except Exception as exc:
             results[raw_id] = exc
 
-    if len(pool_raw_ids) <= 1:
+    if not _pool_dispatch_amortizes(pool_raw_ids, payload_sizes):
         for raw_id in pool_raw_ids:
             try:
                 results[raw_id] = _parse_retained_raw(archive, raw_id)

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -1098,6 +1098,53 @@ def test_partition_raws_by_dispatch_size_routes_small_to_pool_large_sequential()
     assert sequential_ids == ["large-1", "large-2"]
 
 
+def test_pool_dispatch_floor_rejects_small_aggregate_batches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Worker spawn+import (~1.5-2s each, measured live 2026-07-19) dominates
+    tiny batches: a per-cohort census batch of a few sub-256KiB raws must parse
+    sequentially, not spawn a short-lived pool that spends ~95% of its life in
+    importlib."""
+    sizes = {"a": 100_000, "b": 200_000, "c": 50_000}
+    assert not revision_backfill._pool_dispatch_amortizes(["a", "b", "c"], sizes)
+    assert not revision_backfill._pool_dispatch_amortizes(["a"], sizes)
+    big = {f"r{i}": 250_000 for i in range(400)}  # 100MB aggregate
+    assert revision_backfill._pool_dispatch_amortizes(list(big), big)
+    monkeypatch.setenv("POLYLOGUE_REVISION_PARSE_POOL_MIN_BYTES", "100000")
+    assert revision_backfill._pool_dispatch_amortizes(["a", "b"], sizes)
+    monkeypatch.setenv("POLYLOGUE_REVISION_PARSE_POOL_MIN_BYTES", "not-a-number")
+    assert not revision_backfill._pool_dispatch_amortizes(["a", "b"], sizes)
+
+
+def test_parse_retained_raws_small_batch_never_creates_a_pool(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """End-to-end: a small pool-eligible batch under the aggregate floor must
+    not construct a ProcessPoolExecutor at all (the churn measured live: 20
+    workers in 25s, each ~95% importlib)."""
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        for index in range(3):
+            payload = (
+                f'{{"type":"session_meta","payload":{{"id":"floor-{index}"}}}}\n'
+                f'{{"type":"response_item","payload":{{"type":"message","id":"one","role":"user",'
+                f'"content":[{{"type":"input_text","text":"tiny"}}]}}}}\n'
+            ).encode()
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=payload,
+                source_path=f"floor-{index}.jsonl",
+                acquired_at_ms=index,
+            )
+
+    def forbidden_pool(**kwargs: object) -> object:
+        raise AssertionError("pool must not be created for a sub-floor batch")
+
+    import polylogue.pipeline.services.process_pool as process_pool_module
+
+    monkeypatch.setattr(process_pool_module, "process_pool_executor", forbidden_pool)
+
+    result = backfill_historical_revision_evidence(tmp_path, ingest_workers=4)
+    assert result.scanned == 3
+    assert result.quarantined == 0
+
+
 def test_size_aware_dispatch_keeps_large_raws_off_the_process_pool(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

Pool dispatch in `_parse_retained_raws` now requires the pool-eligible aggregate payload to clear an amortization floor (default 48MiB, `POLYLOGUE_REVISION_PARSE_POOL_MIN_BYTES` override); below it the batch parses sequentially in-process. This stops the worker-churn pathology where "parallel" census was nearly 100% spawn/import overhead.

## Problem

Measured live on the 2026-07-19 bulk rebuild (py-spy `--subprocesses`, 25s at 150Hz): **20 pool workers spawned in 25 seconds, each alive ~1.5-2.0s, spending ~95% of their lifetime inside `importlib`** (`spawn_main → _find_and_load → exec_module`), with visible gaps where no workers existed at all. Mechanics: census dispatches per-cohort batches of 1-2 sub-256KiB raws; `_parse_retained_raws` creates a fresh `ProcessPoolExecutor` per call with `max_workers=min(workers, len(pool_raw_ids))` (=2); every spawn-method worker (#3143) re-imports the full polylogue CLI graph (~1.4s — the polylogue-h1wt import tax, now paid per worker per call) before parsing for milliseconds. Sequential mode was strictly faster. The daemon's per-component census path (#3122) has the same call shape.

## Solution

- New `_pool_dispatch_amortizes(pool_raw_ids, payload_sizes)`: pool only when the pool-eligible aggregate clears `_parse_pool_min_aggregate_bytes()` (default 48MiB — derived in the docstring from ~20MB/s sequential small-payload parse vs ~2s worker spawn+import at 8 workers; env-overridable). The existing per-raw size partition (#3136, keeps >256KiB payloads off the pool) is unchanged; genuinely large small-payload batches keep the pool path.
- Deliberately NOT a shared long-lived executor: that would fix churn too but parks ~8 idle spawn workers (~0.5GB+ RSS with polylogue imported) inside the long-running daemon; the floor gets ~all of the win with zero idle cost. Recorded as a future option on polylogue-crd8 alongside the h1wt import-tax reduction which would lower the floor.

## Verification

- `devtools test tests/unit/sources/test_revision_backfill.py` — 27 passed.
- New tests: `test_pool_dispatch_floor_rejects_small_aggregate_batches` (decision thresholds, env override, invalid-env fallback) and `test_parse_retained_raws_small_batch_never_creates_a_pool` (end-to-end: a sub-floor batch must never construct a `ProcessPoolExecutor` — monkeypatched constructor raises). Anti-vacuity verified via stash of the implementation file: both fail on pre-fix code (`2 failed`), pass with it restored.
- `devtools verify --quick` — exit 0.

Ref polylogue-crd8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ