### PR TITLE
fix(storage): rebuild-path robustness — dead-pid lock, stale index pointer, drift receipts

### DIFF
--- a/polylogue/archive/query/transaction.py
+++ b/polylogue/archive/query/transaction.py
@@ -103,9 +103,38 @@ def archive_snapshot_epoch(archive: ArchiveStore) -> str:
             conn.execute("SELECT epoch FROM user_tier.query_unit_frame_state WHERE singleton = 1").fetchone()[0]
         )
     except (AttributeError, IndexError, sqlite3.Error, TypeError) as exc:
+        if _is_missing_query_unit_frame_state(exc):
+            # A derived tier reporting the current schema version yet missing
+            # this table is schema drift, not a transient read glitch (a
+            # generation built before the epoch-tracking table was added to
+            # the canonical DDL, or an interrupted rebuild that never
+            # promoted a generation carrying it -- polylogue-k8kj finding 2).
+            # Derived tiers have no in-place upgrade chain: reject clearly
+            # with the same rebuild guidance schema-version mismatches give,
+            # instead of letting the bare sqlite3.OperationalError surface as
+            # an opaque crash on every query.
+            logger.error(
+                "query transaction: archive generation is missing query_unit_frame_state "
+                "(derived-tier schema drift, not a transient error)",
+            )
+            raise QueryArchiveEpochUnreadableError(
+                "this archive generation predates the query_unit_frame_state epoch-tracking table (or an "
+                "interrupted rebuild never promoted a generation that has it) and cannot serve query "
+                "continuations; rebuild the index tier from source with "
+                "`polylogue ops reset --index && polylogued run`"
+            ) from exc
         logger.warning("query transaction: could not read archive snapshot epoch", exc_info=True)
         raise QueryArchiveEpochUnreadableError("could not establish archive frame for query continuation") from exc
     return f"archive:v1:index:v{index_version}:{index_epoch}:user:v{user_version}:{user_epoch}"
+
+
+def _is_missing_query_unit_frame_state(exc: Exception) -> bool:
+    """Whether ``exc`` is specifically sqlite reporting the epoch table absent."""
+    return (
+        isinstance(exc, sqlite3.OperationalError)
+        and "no such table" in str(exc)
+        and "query_unit_frame_state" in str(exc)
+    )
 
 
 class QueryContinuationStaleError(ValueError):

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -21,6 +21,7 @@ import tomllib
 from .core.errors import PolylogueError
 from .core.loopback import bind_hosts_overlap, is_loopback_host
 from .paths import GEMINI_DRIVE_FOLDER
+from .storage.archive_identity import resolve_active_index_path
 
 
 class ConfigError(PolylogueError):
@@ -72,7 +73,14 @@ class Config:
 
     ``Config`` never reads the environment, current directory, home directory,
     or :mod:`polylogue.paths`.  When ``db_path`` is omitted it is derived only
-    from the explicit ``archive_root`` supplied by the caller.
+    from the explicit ``archive_root`` supplied by the caller -- including
+    following that archive's own ``.index-active-pointer`` file when present,
+    so a bare ``Config(archive_root=..., sources=[])`` (the common MCP/CLI/
+    daemon-status construction) can never silently resolve to a stale
+    conventional ``index.db`` left behind by an interrupted rebuild
+    (polylogue-k8kj). This is still a pure function of ``archive_root``, not
+    an ambient read: no environment variable, cwd, or home directory is
+    consulted.
 
     Handwritten (not ``@dataclass``) so that the constructor can accept an
     optional ``db_path`` while the resolved attribute is always a concrete
@@ -99,7 +107,7 @@ class Config:
         self.archive_root = archive_root
         self.render_root = render_root
         self.sources = sources
-        self.db_path = db_path if db_path is not None else archive_root / "index.db"
+        self.db_path = db_path if db_path is not None else resolve_active_index_path(archive_root)
         self.drive_config = drive_config
         self.index_config = index_config
         for attr in ("archive_root", "render_root", "db_path"):
@@ -1663,7 +1671,7 @@ def resolve_runtime_config(
     paths = ResolvedArchivePaths(
         archive_root=archive,
         source_db=archive / "source.db",
-        index_db=archive / "index.db",
+        index_db=resolve_active_index_path(archive),
         embeddings_db=archive / "embeddings.db",
         user_db=archive / "user.db",
         ops_db=archive / "ops.db",

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -306,7 +306,7 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
                     processed_blob_bytes=transaction.processed_blob_bytes + sum(row[2] for row in page.rows),
                 )
                 if page.has_more or deadline_expired:
-                    return RebuildIndexReceipt(
+                    pass_receipt = RebuildIndexReceipt(
                         archive_root=str(root),
                         raw_session_count=raw_count,
                         selected_raw_count=selected_raw_count,
@@ -319,6 +319,8 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
                         replay=replay,
                         transaction=cast(dict[str, object], asdict(transaction)),
                     )
+                    generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
+                    return pass_receipt
             insight_result = repair_session_insights(
                 config,
                 dry_run=False,
@@ -367,7 +369,7 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
                 with contextlib.suppress(Exception):
                     generation_store.discard_if_inactive(generation)
             raise
-    return RebuildIndexReceipt(
+    final_receipt = RebuildIndexReceipt(
         archive_root=str(root),
         raw_session_count=raw_count,
         selected_raw_count=selected_raw_count,
@@ -380,6 +382,9 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
         replay=replay,
         transaction=cast(dict[str, object], asdict(transaction)) if transaction is not None else None,
     )
+    if transaction is not None:
+        generation_store.save_pass_receipt(transaction.operation_id, final_receipt.to_dict())
+    return final_receipt
 
 
 def rebuild_index_from_source_sync(request: RebuildIndexRequest) -> RebuildIndexReceipt:

--- a/polylogue/storage/archive_identity.py
+++ b/polylogue/storage/archive_identity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from dataclasses import dataclass
@@ -9,6 +10,8 @@ from pathlib import Path
 from typing import Literal
 
 from polylogue.version import VERSION_INFO
+
+logger = logging.getLogger(__name__)
 
 ArchiveTierName = Literal["source", "index", "embeddings", "user", "ops"]
 TIER_FILENAMES: tuple[tuple[ArchiveTierName, str], ...] = (
@@ -22,6 +25,32 @@ TIER_FILENAMES: tuple[tuple[ArchiveTierName, str], ...] = (
 
 class ArchiveLocationError(RuntimeError):
     """A configured archive does not name one coherent active file set."""
+
+
+def resolve_active_index_path(archive_root: Path) -> Path:
+    """Resolve the effective ``index.db`` path for ``archive_root``.
+
+    Pure function of ``archive_root`` alone (no ambient environment/cwd
+    reads): follows ``.index-active-pointer`` when present so ordinary
+    config resolution can never silently diverge from a promoted generation
+    (polylogue-k8kj finding 1). When the plain ``archive_root/index.db``
+    path exists as a stale regular file that diverges from the active
+    pointer target -- the signature of an interrupted rebuild that updated
+    the pointer without ever swapping the conventional path over to a
+    symlink -- that divergence is reported loudly via a warning log line
+    rather than served silently; the correct (pointer) data is still what
+    gets returned.
+    """
+    location = ArchiveLocation.resolve(archive_root)
+    if location.shadow_index is not None:
+        logger.warning(
+            "stale conventional index path %s diverges from the active generation %s "
+            "(likely an interrupted rebuild promotion that never replaced the conventional "
+            "path with a symlink); resolving to the active pointer target instead of the stale file",
+            location.shadow_index.resolved_path,
+            location.active_index.resolved_path,
+        )
+    return location.active_index_path
 
 
 @dataclass(frozen=True)

--- a/polylogue/storage/index_generation.py
+++ b/polylogue/storage/index_generation.py
@@ -271,6 +271,28 @@ class IndexGenerationStore:
         payload = json.loads(self._transaction_path(operation_id).read_text(encoding="utf-8"))
         return IndexRebuildTransaction(**payload)
 
+    def save_pass_receipt(self, operation_id: str, receipt: dict[str, object]) -> Path:
+        """Durably persist one rebuild pass's receipt for post-hoc recovery.
+
+        The CLI's only other copy of a pass receipt is a JSON blob written to
+        stdout; if the invoking shell's pipe dies (killed shell, SIGPIPE) an
+        orphaned rebuild process keeps working but the receipt is gone
+        (polylogue-k8kj live incident: two page receipts lost this way in one
+        night). Each pass gets its own numbered file under a
+        ``<operation_id>.receipts/`` directory alongside the transaction
+        record, written with the same tmp+os.replace+fsync pattern as
+        ``save_transaction``.
+        """
+        directory = self.transactions_root / f"{operation_id}.receipts"
+        directory.mkdir(parents=True, exist_ok=True)
+        sequence = len(list(directory.glob("pass-*.json")))
+        path = directory / f"pass-{sequence:06d}.json"
+        temporary = path.with_suffix(".json.tmp")
+        temporary.write_text(json.dumps(receipt, indent=2, sort_keys=True, default=str), encoding="utf-8")
+        os.replace(temporary, path)
+        _fsync_directory(directory)
+        return path
+
     def save_transaction(self, transaction: IndexRebuildTransaction) -> IndexRebuildTransaction:
         """Atomically checkpoint a transaction after one bounded replay pass."""
         updated = IndexRebuildTransaction(**{**asdict(transaction), "updated_at_ms": int(time.time() * 1000)})

--- a/polylogue/storage/index_generation.py
+++ b/polylogue/storage/index_generation.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import fcntl
 import json
+import logging
 import os
+import re
 import shutil
 import socket
 import sqlite3
@@ -17,6 +19,10 @@ from types import TracebackType
 
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+logger = logging.getLogger(__name__)
+
+_LOCK_PID_PATTERN = re.compile(r"pid=(\d+)")
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,6 +86,79 @@ class RebuildLeaseUnavailableError(RuntimeError):
     """Another process owns the archive-wide rebuild lease."""
 
 
+def _lock_holder_pid(path: Path) -> int | None:
+    """Best-effort recorded pid from an existing lock file; ``None`` if absent/unreadable."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = _LOCK_PID_PATTERN.search(text)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Whether ``pid`` still names a live process, best-effort via ``kill(pid, 0)``."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Owned by another user but still running.
+        return True
+    return True
+
+
+def _open_lock_fd(path: Path, lock_type: int, *, unavailable_message: str) -> int:
+    """Open ``path`` and acquire ``lock_type`` (``LOCK_EX``/``LOCK_SH``), non-blocking.
+
+    ``flock`` is scoped to the open file description's *inode*, so a holder
+    that died without releasing it -- a crashed rebuild, or a forked worker
+    that inherited the fd and outlived a since-reaped parent -- cannot be
+    un-blocked by simply re-opening the same path; whatever still references
+    the old inode keeps it locked. When the lock file's recorded pid is no
+    longer a running process, the stale lock is reclaimed instead: a fresh
+    file is written at the same path and swapped in atomically, handing out
+    a brand-new, guaranteed-unlocked inode while any surviving reference to
+    the old one is left orphaned (polylogue-k8kj finding: a dead-pid lock
+    was blocking nothing in particular while confusing operators who read
+    its stale content as an active rebuild).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, lock_type | fcntl.LOCK_NB)
+        return fd
+    except BlockingIOError as exc:
+        os.close(fd)
+        blocking_error = exc
+
+    holder_pid = _lock_holder_pid(path)
+    if holder_pid is None or _pid_is_alive(holder_pid):
+        suffix = f" (pid={holder_pid})" if holder_pid is not None else ""
+        raise RebuildLeaseUnavailableError(unavailable_message + suffix) from blocking_error
+
+    logger.warning(
+        "reclaiming stale index rebuild lease %s: recorded holder pid=%d is no longer running",
+        path,
+        holder_pid,
+    )
+    temporary = path.with_name(f".{path.name}.reclaim-{uuid.uuid4().hex}")
+    reclaimed_fd = os.open(temporary, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        fcntl.flock(reclaimed_fd, lock_type | fcntl.LOCK_NB)
+    except BlockingIOError:
+        os.close(reclaimed_fd)
+        temporary.unlink(missing_ok=True)
+        raise RebuildLeaseUnavailableError(unavailable_message) from blocking_error
+    os.replace(temporary, path)
+    _fsync_directory(path.parent)
+    return reclaimed_fd
+
+
 class RebuildLease:
     """Process-held exclusive lease for an offline index rebuild."""
 
@@ -88,13 +167,11 @@ class RebuildLease:
         self._fd: int | None = None
 
     def __enter__(self) -> RebuildLease:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        fd = os.open(self.path, os.O_RDWR | os.O_CREAT, 0o600)
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError as exc:
-            os.close(fd)
-            raise RebuildLeaseUnavailableError(f"index rebuild lease is already held: {self.path}") from exc
+        fd = _open_lock_fd(
+            self.path,
+            fcntl.LOCK_EX,
+            unavailable_message=f"index rebuild lease is already held: {self.path}",
+        )
         os.ftruncate(fd, 0)
         os.write(fd, f"pid={os.getpid()} host={socket.gethostname()}\n".encode())
         os.fsync(fd)
@@ -122,14 +199,11 @@ class ActiveWriterLease:
         self._fd: int | None = None
 
     def acquire(self) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        fd = os.open(self.path, os.O_RDWR | os.O_CREAT, 0o600)
-        try:
-            fcntl.flock(fd, fcntl.LOCK_SH | fcntl.LOCK_NB)
-        except BlockingIOError as exc:
-            os.close(fd)
-            raise RebuildLeaseUnavailableError(f"offline index rebuild owns archive: {self.path}") from exc
-        self._fd = fd
+        self._fd = _open_lock_fd(
+            self.path,
+            fcntl.LOCK_SH,
+            unavailable_message=f"offline index rebuild owns archive: {self.path}",
+        )
 
     def close(self) -> None:
         if self._fd is not None:

--- a/tests/unit/archive/query/test_transaction.py
+++ b/tests/unit/archive/query/test_transaction.py
@@ -4,10 +4,12 @@ import base64
 import json
 import sqlite3
 from pathlib import Path
+from typing import cast
 
 import pytest
 
 from polylogue.archive.query.transaction import (
+    QueryArchiveEpochUnreadableError,
     QueryContinuation,
     QueryContinuationInvalidError,
     QueryContinuationStaleError,
@@ -119,6 +121,51 @@ def test_archive_snapshot_epoch_changes_for_user_assertion_mutation(tmp_path: Pa
         )
 
     assert _snapshot_epoch(tmp_path) != issued
+
+
+class _BareConnArchive:
+    """Minimal stand-in exposing only the ``_conn`` attribute ``archive_snapshot_epoch`` reads.
+
+    Deliberately bypasses ``ArchiveStore``'s open/bootstrap path (which
+    ensures runtime indexes on open and could self-heal a missing table) so
+    the test controls the exact physical schema shape rather than depending
+    on that unrelated machinery's current completeness.
+    """
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self._conn = connection
+
+
+def test_archive_snapshot_epoch_gives_clear_rebuild_guidance_when_frame_table_missing(tmp_path: Path) -> None:
+    """A generation missing query_unit_frame_state must reject clearly, not crash opaquely.
+
+    Reproduces polylogue-k8kj finding 2: a derived-tier generation can lack
+    ``query_unit_frame_state`` (built before the epoch-tracking table existed,
+    or an interrupted rebuild that never promoted a generation carrying it)
+    even though nothing about opening it looked wrong. The bare
+    ``sqlite3.OperationalError: no such table`` must not leak through the
+    generic "could not establish archive frame" message -- the operator
+    needs the specific rebuild command, since derived tiers have no
+    in-place upgrade chain.
+    """
+    # Neither tier has query_unit_frame_state -- SQLite resolves an
+    # unqualified table name across every attached schema, so the table must
+    # be absent from *both* index.db and user.db or the query would silently
+    # succeed against whichever schema happens to have it.
+    index_db = tmp_path / "index.db"
+    user_db = tmp_path / "user.db"
+    with sqlite3.connect(index_db) as conn:
+        conn.execute("CREATE TABLE placeholder(x INTEGER)")
+    with sqlite3.connect(user_db) as conn:
+        conn.execute("CREATE TABLE other_placeholder(x INTEGER)")
+
+    conn = sqlite3.connect(index_db)
+    conn.execute("ATTACH DATABASE ? AS user_tier", (str(user_db),))
+    try:
+        with pytest.raises(QueryArchiveEpochUnreadableError, match="query_unit_frame_state epoch-tracking table"):
+            archive_snapshot_epoch(cast(ArchiveStore, _BareConnArchive(conn)))
+    finally:
+        conn.close()
 
 
 def test_result_ref_binds_query_identity_to_declared_archive_epoch() -> None:

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -1848,6 +1848,76 @@ def test_rebuild_index_full_source_resumes_one_candidate_until_terminal_promotio
         assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone() == (2,)
 
 
+def test_rebuild_index_persists_durable_pass_receipt_alongside_transaction(
+    cli_workspace: dict[str, Path], cli_runner: CliRunner
+) -> None:
+    """Every rebuild pass receipt survives on disk, not only on the CLI's stdout.
+
+    Reproduces the fix for a live incident (polylogue-k8kj): two rebuild page
+    receipts were lost because the CLI writes the receipt JSON only to
+    stdout, and the invoking shell's pipe died while an orphaned rebuild
+    process kept working. Each pass must also be durably persisted under the
+    transaction directory so a lost pipe never means a lost receipt.
+    """
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    root = cli_workspace["archive_root"]
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        for native_id, acquired_at_ms in (("first", 1), ("second", 2)):
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=(
+                    f'{{"type":"session_meta","payload":{{"id":"{native_id}"}}}}\\n'
+                    f'{{"type":"response_item","payload":{{"type":"message","role":"user",'
+                    f'"content":[{{"type":"input_text","text":"{native_id}"}}]}}}}\\n'
+                ).encode(),
+                source_path=f"{native_id}.jsonl",
+                acquired_at_ms=acquired_at_ms,
+            )
+
+    first = cli_runner.invoke(
+        cli,
+        ["--plain", "ops", "maintenance", "rebuild-index", "--raw-batch-size", "1", "--output-format", "json"],
+        catch_exceptions=False,
+    )
+    assert first.exit_code == 0
+    first_payload = json.loads(first.output)
+    operation_id = first_payload["transaction"]["operation_id"]
+    assert first_payload["status"] == "paused"
+
+    receipts_dir = root / ".index-rebuild-transactions" / f"{operation_id}.receipts"
+    receipt_files = sorted(receipts_dir.glob("pass-*.json"))
+    assert len(receipt_files) == 1
+    persisted = json.loads(receipt_files[0].read_text(encoding="utf-8"))
+    assert persisted["status"] == "paused"
+    assert persisted["transaction"]["operation_id"] == operation_id
+
+    terminal = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "rebuild-index",
+            "--operation-id",
+            operation_id,
+            "--raw-batch-size",
+            "1",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+    assert terminal.exit_code == 0
+    terminal_payload = json.loads(terminal.output)
+    assert terminal_payload["status"] == "replayed"
+
+    receipt_files = sorted(receipts_dir.glob("pass-*.json"))
+    assert len(receipt_files) == 2
+    final_persisted = json.loads(receipt_files[-1].read_text(encoding="utf-8"))
+    assert final_persisted["status"] == "replayed"
+
+
 def test_rebuild_index_byte_budget_defers_then_reaches_terminal_ready_candidate(
     cli_workspace: dict[str, Path], cli_runner: CliRunner
 ) -> None:

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -5,6 +5,7 @@ Consolidated from test_config.py and test_logging.py.
 
 from __future__ import annotations
 
+import logging
 import sys
 from io import StringIO
 from pathlib import Path
@@ -74,6 +75,54 @@ class TestConfig:
         monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "data-b"))
 
         assert config.db_path == archive_root / "index.db"
+
+    def test_config_db_path_follows_active_generation_pointer(self, tmp_path: Path) -> None:
+        """A promoted generation's pointer must not be silently bypassed (polylogue-k8kj).
+
+        Ordinary ``Config(archive_root=..., sources=[])`` construction (the
+        common MCP/CLI/daemon-status pattern) must resolve db_path through
+        ``.index-active-pointer`` rather than the conventional
+        ``archive_root/index.db`` join, or a fresh process can silently see a
+        stale generation left behind by an interrupted rebuild.
+        """
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        generation_dir = tmp_path / "generation"
+        generation_dir.mkdir()
+        active_index = generation_dir / "index.db"
+        active_index.write_text("active generation data")
+        (archive_root / ".index-active-pointer").write_text(str(active_index), encoding="utf-8")
+
+        config = Config(archive_root=archive_root, render_root=tmp_path / "render", sources=[])
+
+        assert config.db_path == active_index
+
+    def test_config_db_path_warns_on_stale_conventional_index_shadowing_pointer(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A stale regular file at the conventional path must not be served silently.
+
+        An interrupted rebuild can update ``.index-active-pointer`` without
+        ever swapping the conventional ``archive_root/index.db`` path over to
+        a symlink, leaving a stale regular file behind (polylogue-k8kj
+        finding 1, live incident). ``Config`` must still resolve to the
+        pointer target -- never the stale file -- and must report the
+        divergence loudly rather than silently.
+        """
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        (archive_root / "index.db").write_text("stale near-empty generation")
+        generation_dir = tmp_path / "generation"
+        generation_dir.mkdir()
+        active_index = generation_dir / "index.db"
+        active_index.write_text("real active generation")
+        (archive_root / ".index-active-pointer").write_text(str(active_index), encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING):
+            config = Config(archive_root=archive_root, render_root=tmp_path / "render", sources=[])
+
+        assert config.db_path == active_index
+        assert "stale conventional index path" in caplog.text
 
     def test_active_index_resolver_uses_index_db(self, tmp_path: Path) -> None:
         """index.db is the active query store."""

--- a/tests/unit/storage/test_index_generation.py
+++ b/tests/unit/storage/test_index_generation.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import fcntl
+import logging
 import multiprocessing
+import os
 import sqlite3
 from dataclasses import replace
 from pathlib import Path
@@ -14,6 +17,10 @@ from polylogue.storage.index_generation import (
     RebuildLeaseUnavailableError,
     source_revision_snapshot,
 )
+
+# A pid guaranteed to never correspond to a running process: it exceeds any
+# realistic pid_max (Linux defaults to <= 4194304 even with 64-bit pids).
+_DEFINITELY_DEAD_PID = 2**31 - 1
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -53,6 +60,56 @@ def test_rebuild_lease_refuses_new_active_writer(tmp_path: Path) -> None:
         writer = ActiveWriterLease(tmp_path)
         with pytest.raises(RebuildLeaseUnavailableError):
             writer.acquire()
+
+
+def test_rebuild_lease_reclaims_lock_held_by_dead_pid(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """A lock file recorded as held by a pid that no longer exists is stale and reclaimable.
+
+    Simulates the polylogue-k8kj live incident: a genuinely-locked inode
+    (held here by a raw fd we keep open in-process, standing in for a
+    crashed rebuild or an orphaned forked worker) whose lock file records a
+    pid that is not actually running. A fresh ``RebuildLease`` acquisition
+    must reclaim it -- not raise ``RebuildLeaseUnavailableError`` -- and log
+    the reclamation loudly.
+    """
+    lock_path = tmp_path / ".index-rebuild.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    holder_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    fcntl.flock(holder_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    os.write(holder_fd, f"pid={_DEFINITELY_DEAD_PID} host=nowhere\n".encode())
+    os.fsync(holder_fd)
+    try:
+        with caplog.at_level(logging.WARNING):
+            with RebuildLease(tmp_path):
+                pass
+        assert "reclaiming stale index rebuild lease" in caplog.text
+        assert str(_DEFINITELY_DEAD_PID) in caplog.text
+    finally:
+        fcntl.flock(holder_fd, fcntl.LOCK_UN)
+        os.close(holder_fd)
+
+
+def test_rebuild_lease_still_refuses_lock_held_by_live_pid(tmp_path: Path) -> None:
+    """A lock recorded as held by a genuinely running process must still block.
+
+    Complements the dead-pid reclaim test: recording *this* test process's
+    own (very much alive) pid in the lock file must never be treated as
+    stale, even though the mechanism for detecting staleness is the same
+    read-the-file-then-check-liveness path.
+    """
+    lock_path = tmp_path / ".index-rebuild.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    holder_fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    fcntl.flock(holder_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    os.write(holder_fd, f"pid={os.getpid()} host=here\n".encode())
+    os.fsync(holder_fd)
+    try:
+        with pytest.raises(RebuildLeaseUnavailableError):
+            with RebuildLease(tmp_path):
+                pass
+    finally:
+        fcntl.flock(holder_fd, fcntl.LOCK_UN)
+        os.close(holder_fd)
 
 
 def test_generation_is_inactive_until_atomic_promotion(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Four fixes for rebuild-path robustness discovered during a live-proof pass (bead polylogue-k8kj, P0) plus a receipt-durability gap discovered the same night. All four are code+test changes verified against fixtures only; no live archive was touched.

## Problem

A live-proof pass against the daemon-served archive found two serious issues, and separately two rebuild page receipts were lost the same night because the CLI writes receipts only to stdout:

1. `.index-rebuild.lock` was held by a long-dead pid, blocking nothing in particular but reading, to an operator inspecting the file, as an active rebuild in progress.
2. Ordinary `Config`/`resolve_runtime_config()` db_path resolution joined `archive_root / "index.db"` directly, never consulting `.index-active-pointer`. An interrupted rebuild had updated the pointer without ever swapping the conventional path over to a symlink, leaving a stale 4-session regular file that a freshly spawned MCP client silently read instead of the real 18k-session active index.
3. A live archive generation was missing `query_unit_frame_state` (the z9gh.9.1 epoch-tracking table) even though its recorded schema version matched — `archive_snapshot_epoch()` converted the resulting `sqlite3.OperationalError` into an opaque generic message instead of actionable rebuild guidance.
4. Rebuild pass receipts existed only as a stdout JSON blob; a dead shell pipe meant a lost receipt even though the rebuild itself kept running.

## Solution

- **`polylogue/storage/index_generation.py`**: `_open_lock_fd()` (shared by `RebuildLease`/`ActiveWriterLease`) checks the recorded lock-file pid's liveness via `kill(pid, 0)` on `BlockingIOError`. A live holder still refuses exactly as before. A dead holder is reclaimed: since `flock` is scoped to the open file description's inode, a fresh file is written at the same path and atomically swapped in via `os.replace`, handing out a brand-new unlocked inode while any surviving reference to the old one is orphaned. Reclamation is logged loudly (warning), never silent.
- **`polylogue/storage/archive_identity.py` + `polylogue/config.py`**: new `resolve_active_index_path()` — a pure function of `archive_root` (no env/cwd reads) that follows `.index-active-pointer` when present, reusing the existing `ArchiveLocation`/`shadow_index` machinery. Wired into `Config.__init__`'s default `db_path` and `resolve_runtime_config()`'s `ResolvedArchivePaths` projection — the two chokepoints most callers (MCP server, daemon status, several CLI entrypoints) go through. A stale conventional file diverging from the pointer is reported via a loud warning log while the correct (pointer) data is still what gets served — never silent staleness.
- **`polylogue/archive/query/transaction.py`**: `archive_snapshot_epoch()` now recognizes the specific `no such table: query_unit_frame_state` failure and raises the same `QueryArchiveEpochUnreadableError` type (same `.code`, no surface changes needed) with a specific message pointing at `polylogue ops reset --index && polylogued run`, instead of the generic "could not establish archive frame" message.
- **`polylogue/maintenance/rebuild_index.py` + `IndexGenerationStore.save_pass_receipt()`**: every rebuild pass receipt is now durably persisted as its own numbered JSON file under `<operation_id>.receipts/pass-NNNNNN.json` alongside the transaction record, using the same tmp+`os.replace`+fsync pattern as `save_transaction()`. Stdout output is unchanged; this adds a durable copy.

### Decisions (per task framing)

- **Finding 1 (stale path)**: fixed by making db_path resolution *follow* the pointer (not by forcing promote/recovery to always keep the conventional path physically in sync) — the pointer-following machinery already existed in three other places (`ArchiveLocation`, `resolve_active_index_db_path`, `active_index_db_path` in `paths/_roots.py`) but wasn't wired into the `Config`/`resolve_runtime_config` chokepoint most callers use. Noted as a residual duplication worth a follow-up consolidation (not attempted here — out of scope and touches call sites this PR doesn't need to change).
- **Finding 2 (`query_unit_frame_state`)**: existing `schema_bootstrap.py`/`schema.py` version-gating (`decide_schema_bootstrap`) already rejects any on-disk `user_version` outside `{0, SCHEMA_VERSION}`. This gap is specifically a generation whose *recorded* version matches yet is missing a structural piece — not something that gate can catch, and not something to patch with a runtime auto-upgrade (derived tiers have no in-place upgrade chain). `polylogue/storage/sqlite/runtime_indexes.py`, which owns ensuring runtime-created indexes/tables on open, was deliberately left untouched — it's actively owned by another change (bead polylogue-crd8) per this PR's constraints. The fix here is purely "convert an opaque crash into a clear, actionable rejection" in `transaction.py`.

## Verification

- `devtools test tests/unit/core/test_config.py` — 95 passed
- `devtools test tests/unit/storage/test_index_generation.py` — 16 passed
- `devtools test tests/unit/archive/query/test_transaction.py` — 14 passed
- `devtools test tests/unit/cli/test_archive_maintenance_cli.py -k rebuild_index` — 14 passed
- `devtools verify --quick` — exit 0
- Anti-vacuity: each new regression test (config pointer-following + shadow warning, lock stale-reclaim, epoch-unreadable message, durable receipt) was run against pre-fix code via a stashed/reverted diff and confirmed to fail with the exact expected symptom (stale path served, `RebuildLeaseUnavailableError` instead of reclaim, generic epoch message, zero receipt files respectively), then confirmed to pass restored.

## Residual scope

Bead polylogue-k8kj also references the live archive's actual stale-index/missing-table state at `/home/sinity/.local/share/polylogue` and `/realm/db/polylogue`; this PR is code+tests against fixtures only and does not touch or resolve that live state (explicitly out of scope per the operator's live-rebuild-in-progress constraint). The bead stays open for that residual live-state remediation (which needs explicit operator authorization for any live reset/rebuild) and for the noted `paths/_roots.py` vs `archive_identity.py` pointer-resolution duplication follow-up.

Ref polylogue-k8kj