### PR TITLE
perf(sources): parse byte-identical raw rows once per (blob_hash, source_path)

### DIFF
--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -801,11 +801,52 @@ def _parse_retained_raws(
     *,
     ingest_workers: int,
 ) -> dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception]:
-    """Parse a batch of retained raws, optionally across a process pool.
+    """Parse a batch of retained raws, deduplicating byte-identical inputs.
 
     Returns each outcome keyed by raw_id: either the parsed
     ``(sessions, payload_bytes, revision_kind)`` tuple or the caught
-    exception. Read-only blob->ParsedSession decode is authority-neutral and
+    exception. Rows sharing the same ``(blob_hash, source_path)`` are parsed
+    exactly once and the outcome fanned out: identical bytes at an identical
+    path decode deterministically identically, so re-parsing them is pure
+    waste (measured live 2026-07-19: 17% of newest-only bytes — e.g. one
+    442MB codex rollout stored under 8 raw rows — were byte-identical
+    duplicates each paying a full parse). ``source_path`` stays in the key
+    because some parsers derive identity from the path (e.g. beads workspace
+    ids), so cross-path duplicates are deliberately NOT deduplicated.
+    Per-row ``revision_kind`` is re-attached from each row's own descriptor.
+    """
+    descriptors = {raw_id: archive.raw_revision_descriptor(raw_id) for raw_id in raw_ids}
+    grouped: dict[tuple[str, str], list[str]] = {}
+    for raw_id in raw_ids:
+        _provider, blob_hash, source_path, _kind, _size = descriptors[raw_id]
+        grouped.setdefault((blob_hash, source_path), []).append(raw_id)
+    representatives = [members[0] for members in grouped.values()]
+    unique = _parse_unique_retained_raws(
+        archive, representatives, descriptors=descriptors, ingest_workers=ingest_workers
+    )
+    results: dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception] = {}
+    for members in grouped.values():
+        outcome = unique[members[0]]
+        for raw_id in members:
+            if isinstance(outcome, Exception):
+                results[raw_id] = outcome
+            else:
+                sessions, _rep_size, _rep_kind = outcome
+                _provider, _blob_hash, _source_path, kind, size = descriptors[raw_id]
+                results[raw_id] = (sessions, size, kind)
+    return results
+
+
+def _parse_unique_retained_raws(
+    archive: ArchiveStore,
+    raw_ids: list[str],
+    *,
+    descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int]],
+    ingest_workers: int,
+) -> dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception]:
+    """Parse already-deduplicated raws, optionally across a process pool.
+
+    Read-only blob->ParsedSession decode is authority-neutral and
     embarrassingly parallel; callers apply archive writes afterwards in a
     fixed deterministic order independent of completion order here, so
     parallel and sequential execution produce byte-identical archive state
@@ -820,8 +861,7 @@ def _parse_retained_raws(
                 results[raw_id] = exc
         return results
 
-    descriptors = {raw_id: archive.raw_revision_descriptor(raw_id) for raw_id in raw_ids}
-    payload_sizes = {raw_id: descriptor[4] for raw_id, descriptor in descriptors.items()}
+    payload_sizes = {raw_id: descriptors[raw_id][4] for raw_id in raw_ids}
     pool_raw_ids, sequential_raw_ids = _partition_raws_by_dispatch_size(
         raw_ids, payload_sizes, dispatch_max_bytes=_parse_dispatch_max_bytes()
     )

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -1098,6 +1098,73 @@ def test_partition_raws_by_dispatch_size_routes_small_to_pool_large_sequential()
     assert sequential_ids == ["large-1", "large-2"]
 
 
+def test_parse_retained_raws_dedupes_identical_blob_and_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Byte-identical rows at the same source_path parse once and the outcome
+    fans out with each row's own revision_kind; the same bytes at a DIFFERENT
+    path still parse separately (path participates in some parsers' identity).
+    Live shape (polylogue-869u): one 442MB codex rollout acquired 8x within
+    2.3s during a stampede — 8 raw rows, one blob, 8 full parses."""
+    descriptors = {
+        "dup-1": (Provider.CODEX, "hash-A", "same.jsonl", RawRevisionKind.FULL, 10),
+        "dup-2": (Provider.CODEX, "hash-A", "same.jsonl", RawRevisionKind.UNKNOWN, 10),
+        "dup-3": (Provider.CODEX, "hash-A", "same.jsonl", RawRevisionKind.FULL, 10),
+        "other-path": (Provider.CODEX, "hash-A", "different.jsonl", RawRevisionKind.FULL, 10),
+        "other-bytes": (Provider.CODEX, "hash-B", "same.jsonl", RawRevisionKind.FULL, 20),
+    }
+
+    class FakeArchive:
+        def raw_revision_descriptor(self, raw_id: str) -> tuple[Provider, str, str, RawRevisionKind, int]:
+            return descriptors[raw_id]
+
+    parsed: list[str] = []
+
+    def fake_parse(archive: object, raw_id: str) -> tuple[list[ParsedSession], int, RawRevisionKind]:
+        parsed.append(raw_id)
+        descriptor = descriptors[raw_id]
+        return [], descriptor[4], descriptor[3]
+
+    monkeypatch.setattr(revision_backfill, "_parse_retained_raw", fake_parse)
+
+    results = revision_backfill._parse_retained_raws(
+        FakeArchive(),  # type: ignore[arg-type]
+        list(descriptors),
+        ingest_workers=1,
+    )
+
+    # one parse per distinct (blob_hash, source_path): dup-2/dup-3 reuse dup-1's
+    assert parsed == ["dup-1", "other-path", "other-bytes"]
+    assert set(results) == set(descriptors)
+    sessions, size, kind = results["dup-2"]  # type: ignore[misc]
+    assert (sessions, size, kind) == ([], 10, RawRevisionKind.UNKNOWN)
+    _sessions, _size, dup3_kind = results["dup-3"]  # type: ignore[misc]
+    assert dup3_kind == RawRevisionKind.FULL
+
+
+def test_parse_retained_raws_fans_out_exceptions_to_duplicate_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    descriptors = {
+        "dup-1": (Provider.CODEX, "hash-A", "same.jsonl", RawRevisionKind.FULL, 10),
+        "dup-2": (Provider.CODEX, "hash-A", "same.jsonl", RawRevisionKind.FULL, 10),
+    }
+
+    class FakeArchive:
+        def raw_revision_descriptor(self, raw_id: str) -> tuple[Provider, str, str, RawRevisionKind, int]:
+            return descriptors[raw_id]
+
+    def failing_parse(archive: object, raw_id: str) -> tuple[list[ParsedSession], int, RawRevisionKind]:
+        raise ValueError(f"boom {raw_id}")
+
+    monkeypatch.setattr(revision_backfill, "_parse_retained_raw", failing_parse)
+
+    results = revision_backfill._parse_retained_raws(
+        FakeArchive(),  # type: ignore[arg-type]
+        list(descriptors),
+        ingest_workers=1,
+    )
+
+    assert isinstance(results["dup-1"], ValueError)
+    assert results["dup-2"] is results["dup-1"]
+
+
 def test_pool_dispatch_floor_rejects_small_aggregate_batches(monkeypatch: pytest.MonkeyPatch) -> None:
     """Worker spawn+import (~1.5-2s each, measured live 2026-07-19) dominates
     tiny batches: a per-cohort census batch of a few sub-256KiB raws must parse


### PR DESCRIPTION
## Summary

`_parse_retained_raws` now groups its batch by `(blob_hash, source_path)`, parses one representative per group, and fans the outcome out to duplicate rows (with each row's own `revision_kind` re-attached). Byte-identical raw rows — 17% of the live archive's newest-only bytes — stop paying repeated full parses.

## Problem

Live evidence (2026-07-19, source.db): newest-revision-per-logical-key = 87,177 rows / 52.1GB, but only 85,066 distinct `blob_hash`es / 43.4GB — 8.7GB of parse work is byte-identical duplicates. Worst case: one 442MB codex rollout acquired **8 times within 2.3 seconds** (acquisition stampede; 8 raw rows, same blob, same path), each row fully parsed by census. The blob store dedups storage by hash; the parse layer did not.

## Solution

- `_parse_retained_raws` becomes a dedup wrapper: group by `(blob_hash, source_path)`, delegate representatives to `_parse_unique_retained_raws` (the previous body, unchanged sequential/pool logic including the #3149 amortization floor), fan out outcomes. `source_path` stays in the key deliberately — some parsers derive identity from the path (beads workspace-scoped native ids), so cross-path duplicates of the same bytes still parse separately. Exceptions fan out to every row of the failed group.
- Forward-looking: current `write_raw_payload` is idempotent for identical (payload, path) — verified by probe — so new stampedes can't recreate the shape; this covers the historical rows and any future writer regression.

## Verification

- `devtools test tests/unit/sources/test_revision_backfill.py` — 29 passed.
- New: `test_parse_retained_raws_dedupes_identical_blob_and_path` (parse-call sequence is exactly one per distinct (blob, path); duplicate rows get their own `revision_kind`; different path with same bytes still parses) and `test_parse_retained_raws_fans_out_exceptions_to_duplicate_rows`. Anti-vacuity via patch-revert of the implementation file (not `git stash` — `refs/stash` is shared across worktrees): both fail on pre-fix code (`2 failed`).
- `devtools verify --quick` — exit 0.

Ref polylogue-869u

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ