### PR TITLE
perf(storage): guard-gate messages_fts triggers for prefix-tail bulk delete

### DIFF
--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -276,6 +276,13 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
                 materialize=True,
                 progress_callback=None,
                 owned_inactive_generation=(generation.generation_id, generation.owner_id),
+                # polylogue-crd8: this is the offline rebuild path (an owned
+                # inactive generation, never the live daemon ingest path), so
+                # the guard-gated bulk FTS mode is safe to enable unconditionally
+                # here -- it collapses whale prefix-sharing lineage cascades'
+                # per-row messages_fts trigger storm into one bulk delete+insert
+                # per affected session.
+                bulk_fts=True,
             )
             if selected_raw_ids:
                 _refresh_generation_planner_statistics(Path(generation.index_path))

--- a/polylogue/maintenance/replay.py
+++ b/polylogue/maintenance/replay.py
@@ -145,12 +145,18 @@ async def rebuild_index_from_source(
     materialize: bool,
     progress_callback: StageProgressCallback | None,
     owned_inactive_generation: tuple[str, str] | None = None,
+    bulk_fts: bool = False,
 ) -> dict[str, object]:
     """Replay retained bytes through typed revision authority.
 
     ``raw_ids`` is an initial scheduling hint, not an authority boundary: the
     replay expands to complete logical cohorts so a partial selection cannot
     make an older snapshot look newest.
+
+    ``bulk_fts`` (polylogue-crd8, default ``False``) enables the guard-gated
+    bulk FTS mode for whale prefix-sharing lineage cascades encountered during
+    replay; see ``backfill_historical_revision_evidence``. The offline
+    ``rebuild-index`` maintenance command passes ``True``.
     """
     if raw_batch_size <= 0:
         raise ValueError("raw_batch_size must be positive")
@@ -173,6 +179,7 @@ async def rebuild_index_from_source(
         owned_inactive_generation=owned_inactive_generation,
         max_cached_payload_bytes=_REBUILD_CENSUS_SPILL_CACHE_BYTES,
         ingest_workers=resolved_ingest_workers,
+        bulk_fts=bulk_fts,
     )
     if progress_callback is not None:
         progress_callback(result.replayed_logical_sources, "revision replay complete")

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -476,6 +476,7 @@ def backfill_historical_revision_evidence(
     max_cached_payload_bytes: int | None = None,
     ingest_workers: int = 1,
     commit_batch_size: int | None = None,
+    bulk_fts: bool = False,
 ) -> RevisionBackfillResult:
     """Census every retained raw, then replay byte and bundle authority cohorts.
 
@@ -512,6 +513,12 @@ def backfill_historical_revision_evidence(
     a batch boundary, and a resume reprocesses every lost cohort from
     scratch with zero duplication (proof:
     ``test_backfill_resumes_after_replay_batch_crash_discards_whole_batch_cleanly``).
+
+    ``bulk_fts`` (polylogue-crd8, default ``False``) is threaded to both
+    ``apply_raw_revision_replay`` and ``apply_raw_membership_classification``
+    to enable the guard-gated bulk FTS mode for whale prefix-sharing lineage
+    cascades. Offline rebuild callers (``maintenance/rebuild_index.py`` via
+    ``maintenance/replay.py``) pass ``True``; other callers leave it off.
     """
     adoption_deferred = 0
     quarantined = 0
@@ -608,7 +615,11 @@ def backfill_historical_revision_evidence(
                 adoption_deferred += len(plan.accepted_raw_ids)
                 continue
             archive.apply_raw_revision_replay(
-                plan, parsed_by_raw_id, acquired_at_ms=0, manage_transaction=not replay_batched
+                plan,
+                parsed_by_raw_id,
+                acquired_at_ms=0,
+                manage_transaction=not replay_batched,
+                bulk_fts=bulk_fts,
             )
             replayed += 1
             byte_replayed_keys.add(logical_key)
@@ -656,6 +667,7 @@ def backfill_historical_revision_evidence(
                 projections,
                 acquired_at_ms=0,
                 manage_transaction=not replay_batched,
+                bulk_fts=bulk_fts,
             )
             if classification.accepted_raw_ids:
                 replayed += 1

--- a/polylogue/storage/fts/sql.py
+++ b/polylogue/storage/fts/sql.py
@@ -39,19 +39,28 @@ FTS_REBUILD_SQL = """
     DELETE FROM messages_fts
 """
 
+# polylogue-crd8: dedicated guard name gating the messages_fts per-row trigger
+# BODIES (not their existence -- see FTS_BULK_SESSION_WRITE_GUARD docstring
+# below for why this must never be the shared 'session-write' guard name).
+FTS_BULK_SESSION_WRITE_GUARD = "fts-bulk-session-write"
+
+_FTS_BULK_GUARD_NOT_SET = (
+    f"NOT EXISTS (SELECT 1 FROM derived_refresh_guard WHERE guard_name = '{FTS_BULK_SESSION_WRITE_GUARD}')"
+)
+
 # FTS trigger DDL for message/block FTS maintenance.
 BLOCKS_FTS_TRIGGER_DDL = [
     f"""CREATE TRIGGER IF NOT EXISTS messages_fts_ai
-       AFTER INSERT ON blocks WHEN new.search_text != '' BEGIN
+       AFTER INSERT ON blocks WHEN new.search_text != '' AND {_FTS_BULK_GUARD_NOT_SET} BEGIN
            INSERT INTO messages_fts(rowid, block_id, message_id, session_id, block_type, text)
            VALUES (new.rowid, new.block_id, new.message_id, new.session_id, new.block_type, {pl_fold_sql_expr("new.search_text")});
        END""",
-    """CREATE TRIGGER IF NOT EXISTS messages_fts_ad
-       AFTER DELETE ON blocks WHEN old.search_text != '' BEGIN
+    f"""CREATE TRIGGER IF NOT EXISTS messages_fts_ad
+       AFTER DELETE ON blocks WHEN old.search_text != '' AND {_FTS_BULK_GUARD_NOT_SET} BEGIN
            DELETE FROM messages_fts WHERE rowid = old.rowid;
        END""",
     f"""CREATE TRIGGER IF NOT EXISTS messages_fts_au
-       AFTER UPDATE ON blocks BEGIN
+       AFTER UPDATE ON blocks WHEN {_FTS_BULK_GUARD_NOT_SET} BEGIN
            DELETE FROM messages_fts WHERE rowid = old.rowid;
            INSERT INTO messages_fts(rowid, block_id, message_id, session_id, block_type, text)
            SELECT new.rowid, new.block_id, new.message_id, new.session_id, new.block_type, {pl_fold_sql_expr("new.search_text")}
@@ -196,6 +205,7 @@ def excess_message_rows_sql(limit: int) -> str:
 
 __all__ = [
     "BLOCKS_FTS_TRIGGER_DDL",
+    "FTS_BULK_SESSION_WRITE_GUARD",
     "FTS_INDEXABLE_MESSAGE_COUNT_SQL",
     "FTS_INDEX_DOC_COUNT_SQL",
     "FTS_INDEX_EXISTS_SQL",

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1550,6 +1550,7 @@ class ArchiveStore:
         manage_transaction: bool,
         preacquired_attachment_blobs: dict[int, tuple[bytes | None, int, str]] | None = None,
         revision_authoritative: bool = False,
+        bulk_fts: bool = False,
     ) -> ArchiveRawParsedWriteResult:
         session_id = str(make_session_id(session.source_name, session.provider_session_id))
         content_hash = str(session_content_hash(session))
@@ -1580,6 +1581,7 @@ class ArchiveStore:
                 stage_timing_prefix=stage_timing_prefix,
                 preacquired_attachment_blobs=preacquired_attachment_blobs,
                 manage_transaction=manage_transaction,
+                bulk_fts=bulk_fts,
             )
             return ArchiveRawParsedWriteResult(
                 raw_id=raw_id,
@@ -2932,6 +2934,7 @@ class ArchiveStore:
         stage_timings_s: dict[str, float] | None = None,
         stage_timing_prefix: str = "revision_replay",
         manage_transaction: bool = True,
+        bulk_fts: bool = False,
     ) -> tuple[str, tuple[str, ...]]:
         """Apply a proven chain and atomically receipt its exact index state.
 
@@ -2949,6 +2952,12 @@ class ArchiveStore:
         batched cohort's index writes and terminal markers together), never
         a partial one, and a resume reprocesses every lost cohort from
         scratch with zero duplication.
+
+        ``bulk_fts`` (polylogue-crd8, default ``False``) enables the
+        guard-gated bulk FTS mode described on ``_bulk_fts_session_guard`` for
+        whale prefix-sharing lineage cascades this replay triggers. Only the
+        offline rebuild/backfill path passes ``True``; ordinary daemon replay
+        stays on the unguarded per-row trigger path.
         """
         if not plan.accepted_raw_ids:
             raise ValueError("cannot apply a revision plan without an accepted chain")
@@ -3004,6 +3013,7 @@ class ArchiveStore:
                     preacquired_attachment_blobs=attachments_by_raw_id[raw_id],
                     finalize_raw_parse=False,
                     revision_authoritative=True,
+                    bulk_fts=bulk_fts,
                 )
                 if stage_timings_s is not None:
                     key = f"{stage_timing_prefix}.index_parsed_write"
@@ -3095,6 +3105,7 @@ class ArchiveStore:
         stage_timings_s: dict[str, float] | None = None,
         stage_timing_prefix: str = "membership_replay",
         manage_transaction: bool = True,
+        bulk_fts: bool = False,
     ) -> str | None:
         """Apply one semantic member head and persist every membership decision.
 
@@ -3104,6 +3115,9 @@ class ArchiveStore:
         transaction/pending-state instead of committing them immediately
         (polylogue-oikv) -- see ``apply_raw_revision_replay`` for the shared
         batch-commit invariant this mirrors.
+
+        ``bulk_fts`` mirrors ``apply_raw_revision_replay``'s guard-gated bulk
+        FTS mode (polylogue-crd8); default ``False``.
         """
         conn = self._ensure_source_conn()
         decided_at_ms = int(datetime.now(UTC).timestamp() * 1000)
@@ -3174,6 +3188,7 @@ class ArchiveStore:
                     preacquired_attachment_blobs=attachments,
                     finalize_raw_parse=False,
                     revision_authoritative=True,
+                    bulk_fts=bulk_fts,
                 )
                 if stage_timings_s is not None:
                     key = f"{stage_timing_prefix}.index_parsed_write"
@@ -3323,6 +3338,7 @@ class ArchiveStore:
         preacquired_attachment_blobs: dict[int, tuple[bytes | None, int, str]],
         finalize_raw_parse: bool,
         revision_authoritative: bool = False,
+        bulk_fts: bool = False,
     ) -> ArchiveRawParsedWriteResult:
         provider = Provider.from_string(session.source_name)
         try:
@@ -3335,6 +3351,7 @@ class ArchiveStore:
                 manage_transaction=manage_transaction,
                 preacquired_attachment_blobs=preacquired_attachment_blobs,
                 revision_authoritative=revision_authoritative,
+                bulk_fts=bulk_fts,
             )
         except Exception as exc:
             self.finalize_raw_parse_state(raw_id, state=self._raw_parse_failure_state(provider, exc))

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -15,8 +15,8 @@ import re
 import sqlite3
 import time
 from collections import Counter
-from collections.abc import Callable, Iterable, Mapping, Sequence
-from contextlib import nullcontext
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import cast
@@ -45,7 +45,11 @@ from polylogue.storage.fts.fts_lifecycle import (
     suspend_message_fts_triggers_sync,
 )
 from polylogue.storage.fts.pl_fold import pl_fold_sql_expr
-from polylogue.storage.fts.sql import delete_session_rows_sql, insert_session_rows_sql
+from polylogue.storage.fts.sql import (
+    FTS_BULK_SESSION_WRITE_GUARD,
+    delete_session_rows_sql,
+    insert_session_rows_sql,
+)
 from polylogue.storage.runtime import (
     LINEAGE_TRUNCATION_DANGLING_BRANCH_POINT,
     LINEAGE_TRUNCATION_DEPTH_LIMIT,
@@ -214,6 +218,7 @@ def write_parsed_session_to_archive(
     signature_cache: dict[str, list[tuple[str, str]]] | None = None,
     preacquired_attachment_blobs: dict[int, tuple[bytes | None, int, str]] | None = None,
     manage_transaction: bool = True,
+    bulk_fts: bool = False,
 ) -> str:
     """Write one parsed session into an initialized archive index DB.
 
@@ -222,6 +227,13 @@ def write_parsed_session_to_archive(
     transaction — to amortize the per-commit fsync and WAL page churn that
     dominate re-ingest I/O — passes ``manage_transaction=False`` and owns the
     surrounding commit and any rollback-on-error itself.
+
+    ``bulk_fts`` (polylogue-crd8, default ``False`` so ordinary daemon ingest
+    is byte-for-byte unchanged) enables the guard-gated bulk FTS mode for the
+    cascading prefix-tail re-extraction this write can trigger on *other*
+    (child) sessions via ``_resolve_session_graph`` -- see
+    ``_bulk_fts_session_guard``. Only the offline rebuild/backfill replay path
+    turns this on.
     """
     t0 = time.perf_counter()
 
@@ -562,6 +574,7 @@ def write_parsed_session_to_archive(
             origin.value,
             cache=signature_cache,
             add_timing=add_timing,
+            bulk_fts=bulk_fts,
         )
         add_timing("index.graph_resolve", t0)
         t0 = time.perf_counter()
@@ -2143,6 +2156,7 @@ def _resolve_session_graph(
     *,
     cache: dict[str, list[tuple[str, str]]] | None = None,
     add_timing: Callable[[str, float], None] | None = None,
+    bulk_fts: bool = False,
 ) -> None:
     def record_substage(name: str, started_at: float) -> None:
         if add_timing is not None:
@@ -2207,6 +2221,7 @@ def _resolve_session_graph(
             cache=cache,
             composed_cache=composed_cache,
             add_timing=add_timing,
+            bulk_fts=bulk_fts,
         )
     record_substage("reextract_prefix_tails", t0)
 
@@ -3779,6 +3794,55 @@ def _composed_db_signatures(
     return composed
 
 
+@contextmanager
+def _bulk_fts_session_guard(conn: sqlite3.Connection, session_id: str, *, enabled: bool) -> Iterator[None]:
+    """Suspend per-row ``messages_fts`` trigger maintenance for one session.
+
+    polylogue-crd8: whale prefix-sharing lineage sessions (fork/resume/
+    auto-compaction) can carry 10K+ tool blocks in the inherited prefix that
+    ``_reextract_prefix_tail_db`` deletes wholesale once the parent is known.
+    Deleting those blocks one row at a time fires ``messages_fts_ad`` once per
+    row (contentless-FTS posting-list maintenance), which measured as a
+    25+ minute single-DELETE stall on the live rebuild.
+
+    While ``enabled``, this sets a **dedicated** ``derived_refresh_guard`` row
+    (``fts-bulk-session-write``) that gates only the ``messages_fts_{ai,ad,au}``
+    trigger BODIES (see ``polylogue.storage.fts.sql``); the triggers stay
+    structurally present in ``sqlite_master`` throughout; only their WHEN
+    clause short-circuits. This is deliberately a *different* guard name from
+    the existing ``session-write`` guard: that guard is set unconditionally
+    for every session write (see ``write_parsed_session_to_archive``), so
+    gating FTS maintenance on it would silently stop FTS indexing for
+    ordinary daemon ingest, not just whale bulk replays.
+
+    The caller's block deletion is bracketed by one explicit session-scoped
+    FTS delete (covering both the doomed prefix rows and the surviving tail
+    rows) and, in the ``finally``, one explicit session-scoped FTS re-insert
+    (repopulating whatever blocks remain for ``session_id`` -- the surviving
+    tail after the caller's mutation). This mirrors the same delete-then-
+    insert shape ``_replace_full_session_messages_and_blocks`` already uses
+    for a session's own full replace, just gated by a guard row instead of a
+    raw ``DROP TRIGGER``/``CREATE TRIGGER`` pair, so the trigger-presence half
+    of ``assert_session_fts_exact_sync`` never observes a trigger-less window.
+    """
+    if not enabled:
+        yield
+        return
+    conn.execute(delete_session_rows_sql(1), (session_id,))
+    conn.execute(
+        "INSERT OR REPLACE INTO derived_refresh_guard(guard_name) VALUES (?)",
+        (FTS_BULK_SESSION_WRITE_GUARD,),
+    )
+    try:
+        yield
+    finally:
+        conn.execute(insert_session_rows_sql(1), (session_id,))
+        conn.execute(
+            "DELETE FROM derived_refresh_guard WHERE guard_name = ?",
+            (FTS_BULK_SESSION_WRITE_GUARD,),
+        )
+
+
 def _reextract_prefix_tail_db(
     conn: sqlite3.Connection,
     child_session_id: str,
@@ -3787,6 +3851,7 @@ def _reextract_prefix_tail_db(
     cache: dict[str, list[tuple[str, str]]] | None = None,
     composed_cache: dict[str, list[tuple[str, str]]] | None = None,
     add_timing: Callable[[str, float], None] | None = None,
+    bulk_fts: bool = False,
 ) -> None:
     """Normalize a child that was stored whole because its parent was ingested
     later (#2467). Aligns the child's already-stored messages against the parent's
@@ -3930,19 +3995,20 @@ def _reextract_prefix_tail_db(
     )
     record_substage("provider_usage_tail", t0)
     t0 = time.perf_counter()
-    if k == len(child_composed):
-        _delete_all_session_message_dependents(conn, child_session_id, prefix_message_ids)
-        record_substage("dependent_delete", t0)
-    else:
-        placeholders = ",".join("?" for _ in prefix_message_ids)
-        _delete_prefix_message_dependents(conn, prefix_message_ids)
-        record_substage("dependent_delete", t0)
-        t0 = time.perf_counter()
-        conn.execute(
-            f"DELETE FROM messages WHERE message_id IN ({placeholders})",
-            tuple(prefix_message_ids),
-        )
-        record_substage("message_delete", t0)
+    with _bulk_fts_session_guard(conn, child_session_id, enabled=bulk_fts):
+        if k == len(child_composed):
+            _delete_all_session_message_dependents(conn, child_session_id, prefix_message_ids)
+            record_substage("dependent_delete", t0)
+        else:
+            placeholders = ",".join("?" for _ in prefix_message_ids)
+            _delete_prefix_message_dependents(conn, prefix_message_ids)
+            record_substage("dependent_delete", t0)
+            t0 = time.perf_counter()
+            conn.execute(
+                f"DELETE FROM messages WHERE message_id IN ({placeholders})",
+                tuple(prefix_message_ids),
+            )
+            record_substage("message_delete", t0)
     # The child's own rows just changed (inherited prefix deleted); drop its
     # memoized own-signatures so any later compose in this batch recomputes them.
     t0 = time.perf_counter()

--- a/tests/unit/sources/test_live_cursor_persistence.py
+++ b/tests/unit/sources/test_live_cursor_persistence.py
@@ -68,6 +68,7 @@ def _lock_first_index_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
         manage_transaction: bool,
         preacquired_attachment_blobs: dict[int, tuple[bytes | None, int, str]] | None = None,
         revision_authoritative: bool = False,
+        bulk_fts: bool = False,
     ) -> ArchiveRawParsedWriteResult:
         nonlocal attempts
         attempts += 1
@@ -83,6 +84,7 @@ def _lock_first_index_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
             manage_transaction=manage_transaction,
             preacquired_attachment_blobs=preacquired_attachment_blobs,
             revision_authoritative=revision_authoritative,
+            bulk_fts=bulk_fts,
         )
 
     monkeypatch.setattr(ArchiveStore, "_write_parsed_precedence_result", lock_once)

--- a/tests/unit/storage/test_bulk_fts_prefix_reextract.py
+++ b/tests/unit/storage/test_bulk_fts_prefix_reextract.py
@@ -1,0 +1,263 @@
+"""Guard-gated bulk FTS mode for whale prefix-sharing lineage cascades (crd8).
+
+Background: a prefix-sharing child (fork/resume/auto-compaction) ingested
+before its parent is stored whole; once the parent arrives,
+``_resolve_session_graph`` -> ``_reextract_prefix_tail_db`` deletes the now
+-inherited prefix rows from the child. For a whale lineage session with a
+huge prefix, deleting those ``blocks`` rows one at a time fires
+``messages_fts_ad`` per row -- measured as a 25+ minute single-DELETE stall
+on the live rebuild (bead polylogue-crd8).
+
+``bulk_fts=True`` (threaded from the offline replay path only; ordinary
+daemon writes default to ``False`` and are therefore byte-for-byte
+unchanged) makes ``write_parsed_session_to_archive`` set a *dedicated*
+``derived_refresh_guard`` row ('fts-bulk-session-write') around the
+dependent-delete call, gating only the ``messages_fts_{ai,ad,au}`` trigger
+BODIES (the triggers stay present in ``sqlite_master`` throughout -- see
+``_bulk_fts_session_guard`` in ``write.py``), and performs one explicit
+session-scoped FTS delete-then-reinsert bracketing the mutation instead.
+
+These tests prove: (a) mode-off keeps today's per-row-trigger-maintained FTS
+content: (b) mode-on produces byte-identical FTS content for the same
+session; (c) the guard row never leaks past an exception; (d) the apply-side
+``assert_session_fts_exact_sync`` parity+trigger-presence proof still passes
+after a bulk-mode apply; (e) the explicit bulk re-insert is load-bearing, not
+vacuous -- removing it makes the parity proof fail.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.message.roles import Role
+from polylogue.archive.session.branch_type import BranchType
+from polylogue.core.enums import BlockType, Provider
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.fts.sql import FTS_BULK_SESSION_WRITE_GUARD
+from polylogue.storage.sqlite.archive_tiers import write as _write_module
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.revision_application import assert_session_fts_exact_sync
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    initialize_archive_tier(conn, ArchiveTier.INDEX)
+    return conn
+
+
+def _msg(pid: str, role: Role, text: str, position: int) -> ParsedMessage:
+    return ParsedMessage(
+        provider_message_id=pid,
+        role=role,
+        text=text,
+        position=position,
+        variant_index=0,
+        is_active_path=True,
+        is_active_leaf=False,
+        blocks=[ParsedContentBlock(type=BlockType.TEXT, text=text)],
+    )
+
+
+def _fts_rows_for_session(conn: sqlite3.Connection, session_id: str) -> list[tuple[object, ...]]:
+    """Session-scoped ``messages_fts`` content, independent of literal rowid."""
+    rows = conn.execute(
+        """
+        SELECT block_id, message_id, session_id, block_type, text
+        FROM messages_fts
+        WHERE rowid IN (SELECT rowid FROM blocks WHERE session_id = ?)
+        ORDER BY block_id
+        """,
+        (session_id,),
+    ).fetchall()
+    return sorted(tuple(row) for row in rows)
+
+
+def _write_partial_tail_scenario(conn: sqlite3.Connection, *, bulk_fts: bool) -> str:
+    """Child stores a divergent tail after a shared prefix (`_delete_prefix_message_dependents`)."""
+    child = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="child",
+        title="child",
+        parent_session_provider_id="parent",
+        branch_type=BranchType.FORK,
+        messages=[
+            _msg("c0", Role.USER, "hello", 0),
+            _msg("c1", Role.ASSISTANT, "hi there", 1),
+            _msg("cx", Role.USER, "child diverges here", 2),
+            _msg("cy", Role.ASSISTANT, "child reply", 3),
+        ],
+    )
+    child_id = write_parsed_session_to_archive(conn, child)
+    parent = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="parent",
+        title="parent",
+        messages=[
+            _msg("p0", Role.USER, "hello", 0),
+            _msg("p1", Role.ASSISTANT, "hi there", 1),
+            _msg("p2", Role.USER, "parent continues alone", 2),
+        ],
+    )
+    write_parsed_session_to_archive(conn, parent, bulk_fts=bulk_fts)
+    return child_id
+
+
+_Scenario = Callable[..., str]
+
+
+def _write_full_tail_scenario(conn: sqlite3.Connection, *, bulk_fts: bool) -> str:
+    """Child is entirely inherited (`_delete_all_session_message_dependents`)."""
+    child = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="child",
+        title="child",
+        parent_session_provider_id="parent",
+        branch_type=BranchType.SUBAGENT,
+        messages=[
+            _msg("c0", Role.USER, "hello", 0),
+            _msg("c1", Role.ASSISTANT, "hi there", 1),
+        ],
+    )
+    child_id = write_parsed_session_to_archive(conn, child)
+    parent = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="parent",
+        title="parent",
+        messages=[
+            _msg("p0", Role.USER, "hello", 0),
+            _msg("p1", Role.ASSISTANT, "hi there", 1),
+        ],
+    )
+    write_parsed_session_to_archive(conn, parent, bulk_fts=bulk_fts)
+    return child_id
+
+
+@pytest.mark.parametrize("scenario", [_write_partial_tail_scenario, _write_full_tail_scenario])
+def test_bulk_fts_off_reextract_matches_trigger_maintained_fts(tmp_path: Path, scenario: _Scenario) -> None:
+    """Mode OFF (today's default): per-row triggers keep FTS in exact sync."""
+    conn = _connect(tmp_path / "index.db")
+    child_id = scenario(conn, bulk_fts=False)
+    assert_session_fts_exact_sync(conn, child_id)
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM derived_refresh_guard WHERE guard_name = ?",
+            (FTS_BULK_SESSION_WRITE_GUARD,),
+        ).fetchone()[0]
+        == 0
+    )
+    conn.close()
+
+
+@pytest.mark.parametrize("scenario", [_write_partial_tail_scenario, _write_full_tail_scenario])
+def test_bulk_fts_on_produces_identical_fts_rows_as_off(tmp_path: Path, scenario: _Scenario) -> None:
+    """THE key equivalence proof: bulk mode must not change FTS content, only how it gets there."""
+    conn_off = _connect(tmp_path / "off.db")
+    child_id_off = scenario(conn_off, bulk_fts=False)
+    rows_off = _fts_rows_for_session(conn_off, child_id_off)
+    assert_session_fts_exact_sync(conn_off, child_id_off)
+    conn_off.close()
+
+    conn_on = _connect(tmp_path / "on.db")
+    child_id_on = scenario(conn_on, bulk_fts=True)
+    rows_on = _fts_rows_for_session(conn_on, child_id_on)
+    assert_session_fts_exact_sync(conn_on, child_id_on)
+    # The guard row must never leak past the write it protected.
+    assert (
+        conn_on.execute(
+            "SELECT COUNT(*) FROM derived_refresh_guard WHERE guard_name = ?",
+            (FTS_BULK_SESSION_WRITE_GUARD,),
+        ).fetchone()[0]
+        == 0
+    )
+    conn_on.close()
+
+    assert child_id_off == child_id_on
+    assert rows_on == rows_off
+    if scenario is _write_partial_tail_scenario:
+        # The full-tail scenario legitimately ends with zero surviving blocks
+        # (the whole child was inherited) -- only the partial-tail scenario's
+        # surviving divergent-tail rows prove this isn't a vacuous empty==empty
+        # comparison.
+        assert rows_off, "scenario produced no FTS rows -- test would pass vacuously"
+
+
+def test_bulk_fts_guard_row_cleared_even_on_exception(tmp_path: Path) -> None:
+    """A failure mid-guard must not leave the dedicated guard row set."""
+    conn = _connect(tmp_path / "index.db")
+    child = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="child",
+        title="child",
+        parent_session_provider_id="parent",
+        branch_type=BranchType.FORK,
+        messages=[
+            _msg("c0", Role.USER, "hello", 0),
+            _msg("c1", Role.ASSISTANT, "hi there", 1),
+            _msg("cx", Role.USER, "child diverges here", 2),
+        ],
+    )
+    write_parsed_session_to_archive(conn, child)
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("injected dependent-delete failure")
+
+    original = _write_module._delete_prefix_message_dependents
+    _write_module._delete_prefix_message_dependents = _boom
+    try:
+        parent = ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="parent",
+            title="parent",
+            messages=[
+                _msg("p0", Role.USER, "hello", 0),
+                _msg("p1", Role.ASSISTANT, "hi there", 1),
+            ],
+        )
+        with pytest.raises(RuntimeError, match="injected dependent-delete failure"):
+            write_parsed_session_to_archive(conn, parent, bulk_fts=True)
+    finally:
+        _write_module._delete_prefix_message_dependents = original
+
+    # write_parsed_session_to_archive runs in its own `with conn:` transaction,
+    # so the failed write rolled back entirely -- including the guard-row
+    # insert. Confirm no leaked guard row survives (transaction-rollback state,
+    # not merely in-process cleanup).
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM derived_refresh_guard WHERE guard_name = ?",
+            (FTS_BULK_SESSION_WRITE_GUARD,),
+        ).fetchone()[0]
+        == 0
+    )
+    conn.close()
+
+
+def test_bulk_fts_explicit_reinsert_is_load_bearing_not_vacuous(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Anti-vacuity: removing the explicit bulk re-insert must break the parity proof.
+
+    If this test passed with the mutation applied, the equivalence tests above
+    would not actually be exercising the new bulk-insert code path.
+    """
+    conn = _connect(tmp_path / "index.db")
+
+    def _no_op_insert_sql(_chunk_size: int) -> str:
+        # Same single ``?`` binding shape as the real insert_session_rows_sql(1)
+        # call site, but never touches messages_fts.
+        return "SELECT 1 WHERE ? IS NOT NULL"
+
+    monkeypatch.setattr(_write_module, "insert_session_rows_sql", _no_op_insert_sql)
+
+    child_id = _write_partial_tail_scenario(conn, bulk_fts=True)
+    with pytest.raises(RuntimeError, match="FTS proof failed"):
+        assert_session_fts_exact_sync(conn, child_id)
+    conn.close()

--- a/tests/unit/storage/test_lineage_normalization.py
+++ b/tests/unit/storage/test_lineage_normalization.py
@@ -769,6 +769,7 @@ def test_full_replace_graph_failure_rolls_back_then_retries_idempotently(
         *,
         cache: dict[str, list[tuple[str, str]]] | None = None,
         add_timing: Callable[[str, float], None] | None = None,
+        bulk_fts: bool = False,
     ) -> None:
         real_resolve(
             conn_inner,
@@ -777,6 +778,7 @@ def test_full_replace_graph_failure_rolls_back_then_retries_idempotently(
             origin,
             cache=cache,
             add_timing=add_timing,
+            bulk_fts=bulk_fts,
         )
         fired["count"] += 1
         raise RuntimeError("fault after graph resolution")


### PR DESCRIPTION
## Summary

Adds a guard-row-gated bulk FTS mode for whale prefix-sharing lineage sessions
so the offline rebuild/backfill path can collapse per-row `messages_fts`
trigger maintenance into one bulk delete+insert per affected session, without
changing ordinary daemon-ingest behavior.

## Problem

Whale prefix-sharing lineage sessions (fork/resume/auto-compaction) can carry
10K+ tool blocks in an inherited prefix. `write_parsed_session_to_archive` ->
`_resolve_session_graph` -> `_reextract_prefix_tail_db` deletes that prefix's
blocks one row at a time once the parent session is known, and
`messages_fts_ad` fires per deleted row (contentless-FTS posting-list
maintenance) with no bulk fallback on this path — measured live as a 25+
minute single-DELETE stall during the ongoing archive rebuild (bead
polylogue-crd8, 2026-07-19). A prior attempt to suspend the trigger via raw
`DROP TRIGGER` across the whole write broke `assert_session_fts_exact_sync`'s
trigger-presence check and was reverted; that postmortem designed the
guard-row approach implemented in this PR.

## Solution

- `messages_fts_{ai,ad,au}` (`polylogue/storage/fts/sql.py`) gain a
  `WHEN NOT EXISTS (SELECT 1 FROM derived_refresh_guard WHERE guard_name =
  'fts-bulk-session-write')` clause — a *dedicated* guard name, deliberately
  not the existing `'session-write'` guard (that guard is set unconditionally
  for every write; reusing it would silently stop FTS indexing for ordinary
  daemon ingest, not just whale replays). Triggers stay structurally present
  in `sqlite_master` at all times; only their bodies short-circuit, so
  `assert_session_fts_exact_sync`'s trigger-presence check needs no change.
- `write.py`'s new `_bulk_fts_session_guard` context manager sets the guard
  row, does one explicit session-scoped FTS delete (`delete_session_rows_sql`)
  before the caller's block mutation, and one explicit re-insert
  (`insert_session_rows_sql`) in the `finally`, mirroring the same
  delete-then-insert shape `_replace_full_session_messages_and_blocks`
  already uses for a session's own full replace. `_reextract_prefix_tail_db`
  wraps both dependent-delete branches (`_delete_prefix_message_dependents`
  and `_delete_all_session_message_dependents`) in this guard when
  `bulk_fts=True`.
- The flag threads default-`False` through `write_parsed_session_to_archive`
  -> `_resolve_session_graph` -> `_reextract_prefix_tail_db`, and through
  `archive.py`'s `apply_raw_revision_replay` / `apply_raw_membership_classification`
  -> `_index_parsed_for_retained_raw` -> `_write_parsed_precedence_result`
  (only its `revision_authoritative` branch), and
  `sources/revision_backfill.py`'s `backfill_historical_revision_evidence`.
  Only `maintenance/rebuild_index.py`'s offline rebuild call (an owned
  inactive generation, never live daemon ingest) passes `bulk_fts=True`;
  ordinary daemon writes are byte-for-byte unchanged (deferred as an explicit
  follow-up on the bead, per its notes).

**Deviation from the bead's literal design text:** the design named
`_replace_full_session_messages_and_blocks`/`_clear_session_projection_rows`
as the guard locus. Source tracing showed those already have their own
separate, always-on, DROP/CREATE-based FTS optimization for a session's own
replace, and are not on the measured whale call path.
`_reextract_prefix_tail_db` (invoked via `_resolve_session_graph`, itself
called from inside the same `'session-write'`-guarded transaction) is the
actual site deleting a cascading child session's inherited-prefix blocks, so
the new guard targets that instead. Recorded on the bead.

**Version-bump decision:** no `INDEX_SCHEMA_VERSION` bump. The trigger DDL
change is additive/inert on an existing archive — `CREATE TRIGGER IF NOT
EXISTS` keeps the old (unguarded) trigger body until a rebuild, so the guard
row is simply never consulted on old archives; they behave exactly as before
(no correctness change, only forgone perf until rebuilt).
`test_fresh_init_creates_canonical_fts_trigger_set`
(`test_schema_policy_contracts.py`, #3144) compares trigger *names* via an
`INSERT/DELETE INTO <fts_table>` substring match, not bodies, so it is
unaffected by the new `WHEN` clause.

## Verification

```
devtools test tests/unit/storage/test_bulk_fts_prefix_reextract.py \
  tests/unit/storage/test_lineage_normalization.py \
  tests/unit/storage/test_revision_application.py \
  tests/unit/storage/test_schema_policy_contracts.py \
  tests/unit/storage/test_archive_tiers_write.py \
  tests/unit/storage/test_prefix_dependent_delete_indexes.py \
  tests/unit/sources/test_live_cursor_persistence.py \
  tests/unit/sources/test_revision_backfill.py \
  tests/unit/storage/test_repair.py
# 214 passed

devtools verify --quick
# exit 0
```

New test file `tests/unit/storage/test_bulk_fts_prefix_reextract.py` proves:
mode-off matches today's per-row-trigger-maintained FTS content; mode-on
produces byte-identical `messages_fts` rows for the same session across both
the partial-tail (`_delete_prefix_message_dependents`) and full-tail
(`_delete_all_session_message_dependents`) branches (the key equivalence
proof); the guard row never leaks past an injected exception (verified via
transaction rollback, not just in-process cleanup); `assert_session_fts_exact_sync`
passes after a bulk-mode apply; and an anti-vacuity check (monkeypatching the
explicit bulk re-insert into a no-op) confirms the parity proof actually
fails without it — the equivalence tests are exercising the new code path,
not passing vacuously.

Confirmed via `git diff`/`checkout`/`apply` revert-and-rerun (no stash, per
worktree policy) that all failures seen in a broader `tests/unit/storage/`
sweep (5 in `test_live_batch_support.py`, 14 across
`test_retrieval_readiness_laws.py` / `test_dangling_fts_derived_surfaces.py`
/ `test_embedding_freshness_invariant.py` / `test_durable_migrations.py` /
`test_index_fast_forward_lifecycle.py` / `test_delegations_view.py` /
`test_archive_tiers_archive.py`) reproduce identically on `master` without
this change — pre-existing drift, not caused here.

Ref polylogue-crd8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved offline index rebuilds by using a bulk search-index refresh process, reducing expensive per-record maintenance.
  * Preserved search results while improving rebuild efficiency.

* **Reliability**
  * Added safeguards to ensure temporary bulk-refresh state is cleared, including when an operation fails.

* **Tests**
  * Added coverage for bulk refresh accuracy, rollback behavior, and lineage-related scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->