### PR TITLE
fix(concurrency): thread-safety hardening wave 1 (schema cache, lazy singletons, search freeze)

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -4265,7 +4265,7 @@ class PolylogueArchiveMixin:
             operation="archive.search",
             arguments={"query": query, "source": source, "since": since},
             work=lambda archive: SearchResult(
-                hits=[
+                hits=tuple(
                     _archive_search_hit_to_domain(hit)
                     for hit in archive.search_summaries(
                         query,
@@ -4273,7 +4273,7 @@ class PolylogueArchiveMixin:
                         origin=source,
                         since_ms=_archive_query_date_ms("since", since),
                     )
-                ]
+                )
             ),
             page_size=limit,
             projection="search-hits",

--- a/polylogue/mcp/server.py
+++ b/polylogue/mcp/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING
 
 from polylogue.config import resolve_runtime_config
@@ -91,16 +92,18 @@ def build_server(*, role: MCPRole = "read", services: RuntimeServices | None = N
 
 _server_instance: FastMCP | None = None
 _server_instance_role: MCPRole | None = None
+_server_instance_lock = threading.Lock()
 
 
 def _get_server(services: RuntimeServices | None = None, *, role: MCPRole = "read") -> FastMCP:
     global _server_instance, _server_instance_role
     if services is not None:
         _set_runtime_services(services)
-    if _server_instance is None or _server_instance_role != role:
-        _server_instance = build_server(role=role, services=services)
-        _server_instance_role = role
-    return _server_instance
+    with _server_instance_lock:
+        if _server_instance is None or _server_instance_role != role:
+            _server_instance = build_server(role=role, services=services)
+            _server_instance_role = role
+        return _server_instance
 
 
 def serve_stdio(services: RuntimeServices | None = None, *, role: MCPRole = "read") -> None:

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import pickle
 import re
+import threading
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -42,6 +43,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 _SOURCE_HASH_SUFFIX = re.compile(r"-(?:[0-9a-f]{16,64})$", re.IGNORECASE)
 _SCHEMA_REGISTRY: SchemaRegistry | None = None
+_SCHEMA_REGISTRY_LOCK = threading.Lock()
 
 
 class _TimestampUpdates(TypedDict, total=False):
@@ -151,12 +153,13 @@ def _make_ref_id(
 
 def _runtime_schema_registry() -> SchemaRegistry:
     global _SCHEMA_REGISTRY
-    if _SCHEMA_REGISTRY is None:
-        from polylogue.schemas.runtime_registry import SchemaRegistry
+    with _SCHEMA_REGISTRY_LOCK:
+        if _SCHEMA_REGISTRY is None:
+            from polylogue.schemas.runtime_registry import SchemaRegistry
 
-        _SCHEMA_REGISTRY = SchemaRegistry()
-    assert _SCHEMA_REGISTRY is not None
-    return _SCHEMA_REGISTRY
+            _SCHEMA_REGISTRY = SchemaRegistry()
+        assert _SCHEMA_REGISTRY is not None
+        return _SCHEMA_REGISTRY
 
 
 def _finalize_result(result: IngestRecordResult, *, measure_serialized_size: bool) -> IngestRecordResult:

--- a/polylogue/rendering/renderers/html_template.py
+++ b/polylogue/rendering/renderers/html_template.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -12,6 +13,7 @@ from polylogue.rendering.renderers.html_sanitizer import sanitize_html
 DEFAULT_HTML_TEMPLATE = (Path(__file__).parent.parent / "templates" / "session.html").read_text()
 
 _CACHED_TEMPLATE_ENV: Environment | None = None
+_CACHED_TEMPLATE_ENV_LOCK = threading.Lock()
 
 if TYPE_CHECKING:
     from jinja2 import Template
@@ -29,9 +31,15 @@ def _build_template_environment() -> Environment:
 def get_cached_template() -> Template:
     """Return a module-level cached Jinja2 template for HTML rendering."""
     global _CACHED_TEMPLATE_ENV
-    if _CACHED_TEMPLATE_ENV is None:
-        _CACHED_TEMPLATE_ENV = _build_template_environment()
-    return _CACHED_TEMPLATE_ENV.get_template("session.html")
+    with _CACHED_TEMPLATE_ENV_LOCK:
+        if _CACHED_TEMPLATE_ENV is None:
+            _CACHED_TEMPLATE_ENV = _build_template_environment()
+        env = _CACHED_TEMPLATE_ENV
+    # Jinja2 Environment/Template objects are documented thread-safe for
+    # concurrent template retrieval/rendering once built, so get_template()
+    # runs outside the lock -- only the singleton's first-build race needs
+    # guarding.
+    return env.get_template("session.html")
 
 
 __all__ = ["DEFAULT_HTML_TEMPLATE", "get_cached_template"]

--- a/polylogue/schemas/runtime_registry.py
+++ b/polylogue/schemas/runtime_registry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import gzip
 import json
+import threading
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -242,12 +243,23 @@ class SchemaRegistry:
         self._catalog_cache: dict[str, SchemaPackageCatalog | None] = {}
         self._schema_cache: dict[SchemaCacheKey, PublicSchemaDocument | None] = {}
         self._workload_profile_cache: dict[WorkloadProfileCacheKey, PublicSchemaDocument | None] = {}
+        # Guards read-check/populate/clear of the three cache dicts above so a
+        # concurrent clear_cache() (e.g. from save_package_catalog()) cannot
+        # land between a reader's membership check and its dict access and
+        # raise KeyError. Construction of cache values (file reads, JSON
+        # parsing, object building) intentionally happens OUTSIDE the lock —
+        # only the dict access itself is serialized, so parallel parse
+        # threads never block on each other's schema-loading I/O, only on the
+        # cheap dict read/write. A redundant miss just re-does the (idempotent)
+        # load; the last writer's value wins the dict slot.
+        self._cache_lock = threading.Lock()
 
     def clear_cache(self) -> None:
         """Clear internal caches. Call after modifying schema packages."""
-        self._catalog_cache.clear()
-        self._schema_cache.clear()
-        self._workload_profile_cache.clear()
+        with self._cache_lock:
+            self._catalog_cache.clear()
+            self._schema_cache.clear()
+            self._workload_profile_cache.clear()
 
     @property
     def storage_root(self) -> Path:
@@ -293,14 +305,17 @@ class SchemaRegistry:
 
     def load_package_catalog(self, provider: str) -> SchemaPackageCatalog | None:
         provider_token = _provider_token(provider)
-        if provider_token in self._catalog_cache:
-            return self._catalog_cache[provider_token]
+        with self._cache_lock:
+            if provider_token in self._catalog_cache:
+                return self._catalog_cache[provider_token]
         provider_dir = self._provider_dir_for_catalog(provider_token)
-        if provider_dir is None:
-            self._catalog_cache[provider_token] = None
-            return None
-        catalog = SchemaPackageCatalog.from_dict(_read_json_dict(_catalog_path(provider_dir)))
-        self._catalog_cache[provider_token] = catalog
+        catalog = (
+            SchemaPackageCatalog.from_dict(_read_json_dict(_catalog_path(provider_dir)))
+            if provider_dir is not None
+            else None
+        )
+        with self._cache_lock:
+            self._catalog_cache[provider_token] = catalog
         return catalog
 
     def save_package_catalog(self, catalog: SchemaPackageCatalog) -> Path:
@@ -329,32 +344,39 @@ class SchemaRegistry:
     ) -> PublicSchemaDocument | None:
         provider_token = _provider_token(provider)
         cache_key: SchemaCacheKey = (provider_token, version, element_kind)
-        if cache_key in self._schema_cache:
-            return self._schema_cache[cache_key]
+        with self._cache_lock:
+            if cache_key in self._schema_cache:
+                return self._schema_cache[cache_key]
 
+        schema = self._load_element_schema(provider_token, version=version, element_kind=element_kind)
+        with self._cache_lock:
+            self._schema_cache[cache_key] = schema
+        return schema
+
+    def _load_element_schema(
+        self,
+        provider_token: str,
+        *,
+        version: str,
+        element_kind: str | None,
+    ) -> PublicSchemaDocument | None:
         package = self.get_package(provider_token, version=version)
         if package is None:
-            self._schema_cache[cache_key] = None
             return None
 
         element = package.element(element_kind)
         if element is None or element.schema_file is None:
-            self._schema_cache[cache_key] = None
             return None
 
         provider_dir = self._provider_dir_for_package(provider_token, package.version)
         if provider_dir is None:
-            self._schema_cache[cache_key] = None
             return None
 
         path = provider_dir / "versions" / package.version / "elements" / element.schema_file
         if not path.exists():
-            self._schema_cache[cache_key] = None
             return None
 
-        schema = _read_gzip_json_dict(path)
-        self._schema_cache[cache_key] = schema
-        return schema
+        return _read_gzip_json_dict(path)
 
     def get_schema(self, provider: str, version: str = "default") -> PublicSchemaDocument | None:
         return self.get_element_schema(provider, version=version)
@@ -367,23 +389,25 @@ class SchemaRegistry:
         """Load the privacy-safe workload profile carried by a package."""
         provider_token = _provider_token(provider)
         cache_key = (provider_token, version)
-        if cache_key in self._workload_profile_cache:
-            return self._workload_profile_cache[cache_key]
+        with self._cache_lock:
+            if cache_key in self._workload_profile_cache:
+                return self._workload_profile_cache[cache_key]
+        profile = self._load_workload_profile(provider_token, version=version)
+        with self._cache_lock:
+            self._workload_profile_cache[cache_key] = profile
+        return profile
+
+    def _load_workload_profile(self, provider_token: str, *, version: str) -> PublicSchemaDocument | None:
         package = self.get_package(provider_token, version=version)
         if package is None or package.workload_profile_file is None:
-            self._workload_profile_cache[cache_key] = None
             return None
         provider_dir = self._provider_dir_for_package(provider_token, package.version)
         if provider_dir is None:
-            self._workload_profile_cache[cache_key] = None
             return None
         path = provider_dir / "versions" / package.version / package.workload_profile_file
         if not path.exists():
-            self._workload_profile_cache[cache_key] = None
             return None
-        profile = _read_gzip_json_dict(path)
-        self._workload_profile_cache[cache_key] = profile
-        return profile
+        return _read_gzip_json_dict(path)
 
     def list_versions(self, provider: str) -> list[str]:
         provider_token = _provider_token(provider)

--- a/polylogue/storage/blob_store.py
+++ b/polylogue/storage/blob_store.py
@@ -21,6 +21,7 @@ import logging
 import os
 import re
 import tempfile
+import threading
 from collections.abc import Callable, Iterable, Iterator
 from contextlib import suppress
 from dataclasses import dataclass
@@ -541,6 +542,7 @@ builtins_open = open
 
 # Module-level singleton, lazily initialized
 _DEFAULT_STORE: BlobStore | None = None
+_DEFAULT_STORE_LOCK = threading.Lock()
 
 
 def get_blob_store() -> BlobStore:
@@ -549,15 +551,17 @@ def get_blob_store() -> BlobStore:
     from polylogue.paths import blob_store_root
 
     root = blob_store_root()
-    if _DEFAULT_STORE is None or _DEFAULT_STORE.root != root:
-        _DEFAULT_STORE = BlobStore(root)
-    return _DEFAULT_STORE
+    with _DEFAULT_STORE_LOCK:
+        if _DEFAULT_STORE is None or _DEFAULT_STORE.root != root:
+            _DEFAULT_STORE = BlobStore(root)
+        return _DEFAULT_STORE
 
 
 def reset_blob_store() -> None:
     """Reset the singleton (for testing)."""
     global _DEFAULT_STORE
-    _DEFAULT_STORE = None
+    with _DEFAULT_STORE_LOCK:
+        _DEFAULT_STORE = None
 
 
 def load_raw_content(raw_id: str) -> bytes:

--- a/polylogue/storage/search/models.py
+++ b/polylogue/storage/search/models.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 
 
-@dataclass
+@dataclass(frozen=True)
 class SearchHit:
     session_id: str
     source_name: str | None
@@ -17,9 +17,15 @@ class SearchHit:
     session_url: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class SearchResult:
-    hits: list[SearchHit]
+    """Immutable so ``search_messages_cached``'s ``@lru_cache`` can safely hand
+    the same instance to concurrent callers by reference: a mutable ``hits``
+    list would let one caller's in-place sort/filter/append corrupt the value
+    every other concurrent or subsequent identical-query cache hit observes.
+    """
+
+    hits: tuple[SearchHit, ...]
 
 
 @dataclass(frozen=True)

--- a/polylogue/storage/search/runtime.py
+++ b/polylogue/storage/search/runtime.py
@@ -48,7 +48,7 @@ def search_messages_impl(
         include_snippet=True,
     )
     if query_spec is None:
-        return SearchResult(hits=[])
+        return SearchResult(hits=())
 
     sql, params = query_spec.sql, query_spec.params
     with open_read_connection(db_path) as conn:
@@ -86,7 +86,7 @@ def search_messages_impl(
                 session_url=session_web_url(session_id),
             )
         )
-    return SearchResult(hits=hits)
+    return SearchResult(hits=tuple(hits))
 
 
 def _search_archive_blocks(

--- a/tests/unit/core/test_runtime_registry_helpers.py
+++ b/tests/unit/core/test_runtime_registry_helpers.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import gzip
 import json
+import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -251,3 +253,95 @@ def test_resolve_payload_returns_none_when_catalog_is_absent(monkeypatch: pytest
     monkeypatch.setattr(registry, "load_package_catalog", lambda _provider: None)
 
     assert registry.resolve_payload("chatgpt", {"mapping": {}}) is None
+
+
+# ---------------------------------------------------------------------------
+# Thread safety (polylogue-xikl.1): SchemaRegistry's three cache dicts used to
+# be read via unlocked check-then-get, so a concurrent clear_cache() (as
+# save_package_catalog()/write_package() perform after an admin schema
+# update) could land between a reader's membership check and its dict
+# access and raise an uncaught KeyError. The cache_lock now makes each
+# check+get (or check+set) atomic.
+# ---------------------------------------------------------------------------
+
+
+class _SlowContainsDict(dict):  # type: ignore[type-arg]
+    """Dict whose ``__contains__`` sleeps *after* a positive membership check.
+
+    This reproduces the exact check-then-get race deterministically: the
+    membership check answers ``True`` against the current (populated) state,
+    then sleeps -- giving a concurrent ``clear_cache()`` a wide window to
+    empty the dict -- and only then returns ``True`` to the caller, which
+    proceeds to a ``cache[key]`` access that now raises ``KeyError``. Under
+    the fix, the whole check+get happens inside ``self._cache_lock``, so this
+    sleep just makes the lock-holding reader slower -- the clearer thread
+    blocks on the same lock for the sleep's duration and cannot interleave,
+    proving the lock (not scheduling luck) is what prevents the KeyError.
+    """
+
+    def __contains__(self, key: object) -> bool:
+        found = super().__contains__(key)
+        if found:
+            time.sleep(0.01)
+        return found
+
+
+def test_concurrent_schema_reads_survive_concurrent_clear_cache(tmp_path: Path) -> None:
+    """Regression test for the SchemaRegistry unlocked-cache-vs-clear_cache race.
+
+    Reader threads repeatedly resolve the same cached catalog/schema/workload
+    profile while a separate thread repeatedly calls clear_cache(). The three
+    cache dicts are swapped for ``_SlowContainsDict`` after warming so every
+    check-then-get on a cache hit has an artificially widened window: on the
+    pre-fix unlocked dict this reproduced KeyError on essentially every run;
+    with the lock in place it must never raise, since the clearer cannot
+    acquire the lock while a reader's slow membership check holds it.
+    """
+    registry = SchemaRegistry(storage_root=tmp_path / "schemas")
+    catalog = _catalog(_package("v1", schema_file="session_document.schema.json.gz"))
+    registry.replace_provider_packages(
+        "chatgpt",
+        catalog,
+        {"v1": {"session_document": {"type": "object"}}},
+    )
+    # Warm all three caches via the normal path first, then swap in the
+    # artificially slow dicts so every subsequent access is a cache hit
+    # (the vulnerable check-then-get path), not a cold-miss populate.
+    registry.get_element_schema("chatgpt", version="v1")
+    registry.load_package_catalog("chatgpt")
+    registry.get_workload_profile("chatgpt", version="v1")
+    registry._schema_cache = _SlowContainsDict(registry._schema_cache)
+    registry._catalog_cache = _SlowContainsDict(registry._catalog_cache)
+    registry._workload_profile_cache = _SlowContainsDict(registry._workload_profile_cache)
+
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+    stop = threading.Event()
+
+    def reader() -> None:
+        while not stop.is_set():
+            try:
+                registry.get_element_schema("chatgpt", version="v1")
+                registry.load_package_catalog("chatgpt")
+                registry.get_workload_profile("chatgpt", version="v1")
+            except BaseException as exc:  # want to observe any race failure, not just KeyError
+                with errors_lock:
+                    errors.append(exc)
+                return
+
+    def clearer() -> None:
+        while not stop.is_set():
+            registry.clear_cache()
+
+    readers = [threading.Thread(target=reader) for _ in range(4)]
+    clear_thread = threading.Thread(target=clearer)
+    for reader_thread in readers:
+        reader_thread.start()
+    clear_thread.start()
+    time.sleep(0.5)
+    stop.set()
+    clear_thread.join(timeout=5)
+    for reader_thread in readers:
+        reader_thread.join(timeout=5)
+
+    assert errors == [], f"concurrent cache read/clear race triggered: {errors!r}"

--- a/tests/unit/mcp/test_server_runtime.py
+++ b/tests/unit/mcp/test_server_runtime.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -51,6 +53,58 @@ def test_get_server_caches_instance_and_updates_runtime_services() -> None:
         mock_build.assert_called_once_with(role="read", services=services)
     finally:
         server_module._server_instance = original
+
+
+def test_get_server_singleton_is_race_safe_under_concurrent_first_access() -> None:
+    """Concurrent first access must build exactly one FastMCP server (polylogue-xikl.2).
+
+    ``_get_server()``'s check-then-set on ``_server_instance``/
+    ``_server_instance_role`` used to be unguarded. The daemon's real
+    ``archive_query_executor`` already dispatches concurrent request
+    handlers onto real OS threads today, so this is a live hazard, not a
+    hypothetical one. A short delay in ``build_server`` forces the
+    interleaving window open: before the fix this reliably produced
+    multiple distinct server builds; with the lock guarding the whole
+    check-then-build section, exactly one thread ever builds a server.
+    """
+    original_instance = server_module._server_instance
+    original_role = server_module._server_instance_role
+    server_module._server_instance = None
+    server_module._server_instance_role = None
+
+    build_calls: list[object] = []
+    build_calls_lock = threading.Lock()
+
+    def delayed_build(*, role: str, services: object | None = None) -> object:
+        del services
+        time.sleep(0.02)
+        built = SimpleNamespace(role=role)
+        with build_calls_lock:
+            build_calls.append(built)
+        return built
+
+    servers: list[object] = []
+    servers_lock = threading.Lock()
+
+    def worker() -> None:
+        server = server_module._get_server()
+        with servers_lock:
+            servers.append(server)
+
+    try:
+        with patch("polylogue.mcp.server.build_server", side_effect=delayed_build):
+            threads = [threading.Thread(target=worker) for _ in range(8)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join(timeout=5)
+
+        assert len(servers) == 8
+        assert len(build_calls) == 1, f"concurrent first access built {len(build_calls)} servers, expected exactly 1"
+        assert len({id(server) for server in servers}) == 1
+    finally:
+        server_module._server_instance = original_instance
+        server_module._server_instance_role = original_role
 
 
 def test_serve_stdio_runs_cached_server() -> None:

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -1917,7 +1917,7 @@ def test_process_ingest_batch_sync_commits_fts_repair_and_invalidates_search_cac
 
     first_result = search_messages(needle, archive_root=archive_root, db_path=db_path, limit=10)
     cache_version_before = get_cache_stats()["cache_version"]
-    assert first_result.hits == []
+    assert first_result.hits == ()
 
     def fake_ingest_record(
         record: RawSessionRecord,

--- a/tests/unit/pipeline/test_ingest_worker_assembly.py
+++ b/tests/unit/pipeline/test_ingest_worker_assembly.py
@@ -10,12 +10,15 @@ production mutation) fails ``test_canonical_ingest_applies_thread_name``.
 from __future__ import annotations
 
 import json
+import threading
+import time
 from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
 from polylogue.core.enums import Provider, TitleSource
+from polylogue.pipeline.services import ingest_worker as ingest_worker_module
 from polylogue.pipeline.services.ingest_worker import ingest_record
 from polylogue.storage.blob_store import BlobStore, reset_blob_store
 from polylogue.storage.runtime import RawSessionRecord
@@ -130,3 +133,55 @@ def test_canonical_ingest_message_fallback_without_sidecars(blob_store: BlobStor
 
     assert title == "refactor the daemon status loop"
     assert title_source == TitleSource.HEURISTIC.value
+
+
+def test_runtime_schema_registry_singleton_is_race_safe_under_concurrent_first_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent first access must construct exactly one SchemaRegistry (polylogue-xikl.1).
+
+    ``_runtime_schema_registry()``'s check-then-set on the module-global
+    ``_SCHEMA_REGISTRY`` used to be unguarded, and this is called once per
+    parsed record on the parse path that phase 2 plans to run on a
+    ThreadPoolExecutor. A short delay in the registry constructor forces the
+    interleaving window open: before the fix this reliably produced multiple
+    distinct registries (last writer wins); with the lock guarding the whole
+    check-then-construct section, exactly one thread ever constructs one.
+    """
+    original = ingest_worker_module._SCHEMA_REGISTRY
+    ingest_worker_module._SCHEMA_REGISTRY = None
+
+    from polylogue.schemas.runtime_registry import SchemaRegistry
+
+    original_init = SchemaRegistry.__init__
+    built: list[object] = []
+    built_lock = threading.Lock()
+
+    def delayed_init(self: SchemaRegistry, *args: object, **kwargs: object) -> None:
+        time.sleep(0.02)
+        original_init(self, *args, **kwargs)  # type: ignore[arg-type]
+        with built_lock:
+            built.append(self)
+
+    monkeypatch.setattr(SchemaRegistry, "__init__", delayed_init)
+
+    registries: list[object] = []
+    registries_lock = threading.Lock()
+
+    def worker() -> None:
+        registry = ingest_worker_module._runtime_schema_registry()
+        with registries_lock:
+            registries.append(registry)
+
+    try:
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+
+        assert len(registries) == 8
+        assert len(built) == 1, f"concurrent first access built {len(built)} registries, expected exactly 1"
+        assert len({id(registry) for registry in registries}) == 1
+    finally:
+        ingest_worker_module._SCHEMA_REGISTRY = original

--- a/tests/unit/rendering/test_html_template_thread_safety.py
+++ b/tests/unit/rendering/test_html_template_thread_safety.py
@@ -1,0 +1,69 @@
+"""Thread-safety regression tests for get_cached_template() (polylogue-xikl.2).
+
+get_cached_template()'s module-level Jinja2 Environment singleton used to be
+built via an unguarded check-then-set. The daemon's real archive_query_executor
+already dispatches concurrent request handlers (including HTML rendering) onto
+real OS threads today under the standard GIL build, so this race is live now,
+not merely a free-threading concern.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Iterator
+
+import pytest
+
+import polylogue.rendering.renderers.html_template as html_template_module
+from polylogue.rendering.renderers.html_template import get_cached_template
+
+
+@pytest.fixture(autouse=True)
+def _reset_cached_template_env() -> Iterator[None]:
+    original = html_template_module._CACHED_TEMPLATE_ENV
+    html_template_module._CACHED_TEMPLATE_ENV = None
+    yield
+    html_template_module._CACHED_TEMPLATE_ENV = original
+
+
+def test_get_cached_template_singleton_is_race_safe_under_concurrent_first_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent first access must build exactly one Environment instance.
+
+    A short delay is injected into ``_build_template_environment`` to force
+    the interleaving window open regardless of scheduling luck: before the
+    fix this reliably produced multiple distinct Environment instances
+    (duplicate construction); with the lock guarding the check-then-build
+    section, exactly one thread ever builds the Environment.
+    """
+    original_build = html_template_module._build_template_environment
+    built_envs: list[object] = []
+    built_envs_lock = threading.Lock()
+
+    def delayed_build() -> object:
+        time.sleep(0.02)
+        env = original_build()
+        with built_envs_lock:
+            built_envs.append(env)
+        return env
+
+    monkeypatch.setattr(html_template_module, "_build_template_environment", delayed_build)
+
+    templates: list[object] = []
+    templates_lock = threading.Lock()
+
+    def worker() -> None:
+        template = get_cached_template()
+        with templates_lock:
+            templates.append(template)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert len(templates) == 8
+    assert len(built_envs) == 1, f"concurrent first access built {len(built_envs)} Environments, expected exactly 1"

--- a/tests/unit/storage/test_blob_store.py
+++ b/tests/unit/storage/test_blob_store.py
@@ -2,13 +2,19 @@ from __future__ import annotations
 
 import hashlib
 import os
+import threading
+import time
 from io import BytesIO
 from pathlib import Path
+
+import pytest
 
 from polylogue.storage.blob_store import (
     BlobStore,
     BlobVerifyAllResult,
     BlobVerifyFailure,
+    get_blob_store,
+    reset_blob_store,
 )
 
 # ---------------------------------------------------------------------------
@@ -483,3 +489,57 @@ def test_blob_verify_all_result_failed_property() -> None:
     r = BlobVerifyAllResult(checked=10, checked_bytes=100, failures=(f,), truncated=False)
     assert not r.passed
     assert r.failed_count == 1
+
+
+# ---------------------------------------------------------------------------
+# get_blob_store() lazy-singleton thread safety (polylogue-xikl.2)
+# ---------------------------------------------------------------------------
+
+
+def test_get_blob_store_singleton_is_race_safe_under_concurrent_first_access(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Concurrent first access must not construct duplicate BlobStore instances.
+
+    ``get_blob_store()``'s check-then-set used to be unguarded; the daemon's
+    real ``archive_query_executor`` already dispatches concurrent request
+    handlers onto real OS threads today, so N threads racing the very first
+    ``get_blob_store()`` call is a live scenario, not a hypothetical one. A
+    short delay is injected into ``BlobStore.__init__`` to force the
+    interleaving window open regardless of scheduling luck: before the fix
+    this reliably produced multiple distinct instances (last writer wins);
+    with the lock guarding the whole check-then-construct section, exactly
+    one thread ever constructs the instance.
+    """
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "archive"))
+    reset_blob_store()
+
+    original_init = BlobStore.__init__
+
+    def delayed_init(self: BlobStore, *args: object, **kwargs: object) -> None:
+        time.sleep(0.02)
+        original_init(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(BlobStore, "__init__", delayed_init)
+
+    results: list[BlobStore] = []
+    results_lock = threading.Lock()
+
+    def worker() -> None:
+        store = get_blob_store()
+        with results_lock:
+            results.append(store)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    try:
+        assert len(results) == 8
+        assert len({id(store) for store in results}) == 1, (
+            "concurrent first access constructed more than one BlobStore instance"
+        )
+    finally:
+        reset_blob_store()


### PR DESCRIPTION
## Summary

Wave 1 of thread-safety hardening for the free-threading adoption program (`polylogue-xikl`). Fixes three shared-mutable-state races the completed audit found already reachable today under the standard GIL build, since `daemon/http.py`/`daemon/uds.py` already dispatch every archive-query request onto a real `ThreadPoolExecutor` (`archive_query_executor`).

## Problem

The `polylogue-xikl` audit (see `polylogue-xikl.1`/`polylogue-xikl.2` beads) found:

1. **`SchemaRegistry`** (`polylogue/schemas/runtime_registry.py`) held three unlocked instance dicts (`_catalog_cache`, `_schema_cache`, `_workload_profile_cache`) read via classic check-then-get. `save_package_catalog()`'s `clear_cache()` could land between a reader's membership check and its dict access, raising an uncaught `KeyError`. Schema resolution runs on every eligible parse record, so this directly blocks the planned parse-path parallelization (phase 2). Two independent entry points feed the same class: `pipeline/services/ingest_worker.py`'s `_runtime_schema_registry()` (its own unguarded singleton check-then-set) and `schemas/validator_resolution.py`'s `_shared_registry()` (`functools.lru_cache`, already thread-safe internally).

2. **Three lazy-singleton check-then-set races**, all reachable from the live `archive_query_executor` today: `get_blob_store()` (`storage/blob_store.py`), `get_cached_template()` (`rendering/renderers/html_template.py`), `_get_server()` (`mcp/server.py`). Currently benign in effect (duplicate construction, not corruption, since both racing objects are idempotent/stateless-after-init) but any future stateful addition would turn this into silent corruption with no warning.

3. **`SearchResult`** (`storage/search/models.py`), flagged in the audit narrative (not beaded): `search_messages_cached()`'s `@lru_cache` hands the same `SearchResult` instance to every concurrent cache-hit caller by reference, and its `hits` field was a mutable `list`. No current caller mutates `.hits` (audited), but this is the textbook shared-cached-mutable-object trap.

## Solution

- `SchemaRegistry`: added a single `threading.Lock` (`_cache_lock`) guarding the three cache dicts' read/populate/clear (including inside `clear_cache()`). Cache-value construction (file I/O, JSON parse) happens outside the lock so parallel parse threads never block on each other's I/O, only on the cheap dict access. `ingest_worker.py`'s `_runtime_schema_registry()` singleton now uses the same lock-guarded check-then-set pattern already established elsewhere in the codebase (`storage/sqlite/connection.py`, `daemon/status_snapshot.py`, `core/degraded.py`, `archive/query/execution_control.py`); `validator_resolution.py`'s `_shared_registry()` needed no change since `lru_cache` already serializes internally — the actual hazard lived entirely inside the shared `SchemaRegistry` instance, which the lock now covers regardless of which entry point handed out the reference.
- Three lazy singletons: each wraps its whole check-then-construct section in its own module-level `threading.Lock`, matching house style. `get_cached_template()` builds the `Environment` under the lock but calls the (documented thread-safe) `Template.get_template()` outside it.
- `SearchResult`/`SearchHit`: frozen dataclasses, `hits: tuple[SearchHit, ...]` instead of `list[SearchHit]`. Updated the three production constructors. Audited every constructor/consumer first — blast radius was 3 constructors + one test assertion (`.hits == []` → `== ()`), well within a narrow fix. A separate, unrelated `SessionSearchResult` class (already `frozen=True` but with `hits: list`) exists in the same file and is intentionally out of scope — it is not the class returned by the cached path.

## Verification

Each fix has a race-shaped regression test that deterministically reproduces the pre-fix bug (not relying on iteration-count luck):

- `tests/unit/core/test_runtime_registry_helpers.py::test_concurrent_schema_reads_survive_concurrent_clear_cache` — swaps the cache dicts for a subclass whose `__contains__` sleeps *after* a positive membership check, widening the check-then-get window. **Anti-vacuity**: verified via `git diff`/`checkout`/`apply` (not stash) that reverting the production fix reproduces `KeyError(('chatgpt', 'v1', None))` on every run; with the fix, passes reliably.
- `tests/unit/pipeline/test_ingest_worker_assembly.py::test_runtime_schema_registry_singleton_is_race_safe_under_concurrent_first_access` — 8 concurrent first-access threads must construct exactly one `SchemaRegistry`. Reverting reproduces 8 distinct instances.
- `tests/unit/storage/test_blob_store.py`, `tests/unit/rendering/test_html_template_thread_safety.py`, `tests/unit/mcp/test_server_runtime.py` — one test each for the three lazy singletons, injecting a short constructor delay to force the interleaving window open; 8 threads race first access, exactly one construction expected. Reverting reproduces 8 distinct constructions on every run for all three.

Commands run:
```
devtools test tests/unit/core/test_runtime_registry_helpers.py tests/unit/core/test_schema_registry.py \
  tests/unit/core/test_schema_registry_versions.py tests/unit/storage/test_blob_store.py \
  tests/unit/storage/test_blob_store_contracts.py tests/unit/rendering/test_html_template_thread_safety.py \
  tests/unit/rendering/test_html_messages.py tests/unit/rendering/test_rendering.py \
  tests/unit/mcp/test_server_runtime.py tests/unit/mcp/test_server_surfaces.py \
  tests/unit/pipeline/test_ingest_worker_assembly.py tests/unit/pipeline/test_ingest_batch.py \
  tests/unit/storage/test_search_timeless_since_filter.py tests/unit/storage/test_search_misc.py \
  tests/unit/api/test_facade_contracts.py
-> 546 passed in 12.18s

devtools verify --quick -> exit_code 0 (format/lint/mypy --strict/render all/topology/layering/etc all ok)
```

`devtools verify --seed-testmon --skip-slow` was also run as a full-suite baseline (16283 collected, ~13 min): 78 failed / 11 errors, but **none overlap this PR's diff** — `git diff origin/master --stat` touches exactly 13 files (8 production + 5 test), and none of the 78 failing test node IDs exercise any of them (confirmed by name/module: `test_execution_control.py`, `api/insights.py` attribute errors, `test_diagnostics.py`, `test_durable_migrations.py`, `test_index_v37_fast_forward.py`, etc. — none touch `schemas/runtime_registry.py`, `pipeline/services/ingest_worker.py`, `storage/blob_store.py`, `rendering/renderers/html_template.py`, `mcp/server.py`, `storage/search/*`, or `api/archive.py`'s changed lines). Classified as pre-existing baseline drift per repo convention (unmodified files → identical behavior regardless of branch).

## Not in scope

- `DaemonConverger._file_states`/`_session_states` and `daemon/cli.py`'s rate-limit global — flagged in the audit as adoption-wave design notes, not live bugs today (rely on an implicit asyncio single-task-at-a-time invariant); deferred to phase 2 per the audit.
- `assembly_codex.py`'s `_SIDECAR_CACHE` — idempotent-value race, redundant I/O only, not corruption; deferred to phase 2.
- `SessionSearchResult`'s own `hits: list` (separate class, same file) — pre-existing inconsistency, out of scope to avoid widening this PR's blast radius past the audited call sites.

Ref polylogue-xikl.1
Ref polylogue-xikl.2

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability during concurrent access by preventing duplicate initialization and inconsistent state across server, storage, rendering, ingestion, and schema components.
  - Strengthened cache handling when reads and cache resets occur simultaneously.
  - Search results now use immutable result data, reducing the risk of accidental changes during processing.

- **Tests**
  - Added comprehensive concurrency and regression coverage for singleton initialization, cache operations, template loading, and search result behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->