### PR TITLE
perf(core): optionalize orjson via a three-tier JSON backend facade

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,16 @@
           click
           tenacity
           dateparser
+          # orjson became an OPTIONAL accelerator in pyproject.toml's `speed`
+          # extra (polylogue-xikl): polylogue.core.json falls back to
+          # msgspec/stdlib json when it's absent. This nix build's
+          # `dependencies` list is independently curated (not derived from
+          # pyproject extras), so it deliberately keeps orjson on the
+          # STANDARD (GIL) build for the speed win. A future python314t
+          # package variant should drop `orjson` from this list (it has no
+          # cp314t wheels and refuses to compile free-threaded) and add
+          # `msgspec` instead -- the facade's fallback ordering handles the
+          # rest with no code change.
           orjson
           structlog
           pydantic

--- a/polylogue/archive/raw_payload/decode.py
+++ b/polylogue/archive/raw_payload/decode.py
@@ -6,15 +6,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal, TypeAlias, cast
 
-import orjson
-
 from polylogue.archive.artifact_taxonomy import (
     ArtifactClassification,
     classify_artifact,
 )
 from polylogue.archive.raw_payload.streams import raw_line_stream
 from polylogue.core.enums import Provider
-from polylogue.core.json import JSONDocument, JSONValue, is_json_value, loads
+from polylogue.core.json import JSONDecodeError, JSONDocument, JSONValue, is_json_value, loads
 from polylogue.sources.dispatch import detect_provider
 
 _HERMES_STATE_DB_MARKER = "hermes_state_db"
@@ -28,7 +26,7 @@ def _decode_provider_utf8(raw: bytes) -> str:
 
     Some historical exports contain a lone UTF-16 surrogate encoded directly
     as its three-byte UTF-8 sequence. This is invalid Unicode scalar UTF-8,
-    so ``orjson`` correctly rejects it, but Python can preserve the original
+    so the active JSON backend correctly rejects it, but Python can preserve the original
     code unit with ``surrogatepass``. Arbitrary malformed byte sequences still
     raise and retain the ordinary malformed-JSONL behavior.
     """
@@ -44,9 +42,9 @@ def _decode_provider_utf8(raw: bytes) -> str:
 def _load_json_record(line: str) -> JSONValue:
     try:
         return loads(line)
-    except orjson.JSONDecodeError:
+    except JSONDecodeError:
         # Retry with stdlib json — tolerant of raw control characters
-        # (ANSI escape codes in bash output, etc.) that orjson rejects.
+        # (ANSI escape codes in bash output, etc.) that the active JSON backend rejects.
         import json
 
         return cast("JSONValue", json.loads(line))
@@ -56,12 +54,12 @@ def _load_raw_json(raw: bytes | str) -> JSONValue:
     """Parse a JSON document, retaining recoverable provider surrogates."""
     try:
         return loads(raw)
-    except (orjson.JSONDecodeError, ValueError) as error:
+    except (JSONDecodeError, ValueError) as error:
         if not isinstance(raw, bytes):
             raise
         try:
             return _load_json_record(_decode_provider_utf8(raw))
-        except (orjson.JSONDecodeError, ValueError, UnicodeDecodeError):
+        except (JSONDecodeError, ValueError, UnicodeDecodeError):
             raise error from None
 
 
@@ -111,7 +109,7 @@ def _decode_jsonl_payload(
                 continue
             try:
                 parsed = _load_json_record(line)
-            except (orjson.JSONDecodeError, ValueError) as exc:
+            except (JSONDecodeError, ValueError) as exc:
                 malformed_lines += 1
                 if malformed_detail is None:
                     malformed_detail = f"line {line_number}: {exc}"
@@ -163,7 +161,7 @@ def _sample_jsonl_payload_with_detail(
                 continue
             try:
                 parsed = _load_json_record(line)
-            except (orjson.JSONDecodeError, ValueError) as exc:
+            except (JSONDecodeError, ValueError) as exc:
                 malformed_lines += 1
                 if malformed_detail is None:
                     malformed_detail = f"line {line_number}: {exc}"
@@ -205,7 +203,7 @@ def _decode_raw_payload(
 
     When *raw_content* is a :class:`~pathlib.Path`, JSONL files are
     streamed line-by-line from disk (never fully loaded into memory).
-    For JSON files the path is read in one shot via ``orjson.loads``.
+    For JSON files the path is read in one shot via the active JSON backend's decode.
     """
     if isinstance(raw_content, Path):
         if prefer_jsonl:
@@ -220,7 +218,7 @@ def _decode_raw_payload(
         raw_bytes = raw_content.read_bytes()
         try:
             return _load_raw_json(raw_bytes), "json", 0, None
-        except (orjson.JSONDecodeError, ValueError) as exc:
+        except (JSONDecodeError, ValueError) as exc:
             try:
                 payload, malformed_lines, malformed_detail = _decode_jsonl_payload(
                     raw_bytes,
@@ -245,7 +243,7 @@ def _decode_raw_payload(
             pass
     try:
         return _load_raw_json(raw), "json", 0, None
-    except (orjson.JSONDecodeError, ValueError) as exc:
+    except (JSONDecodeError, ValueError) as exc:
         try:
             payload, malformed_lines, malformed_detail = _decode_jsonl_payload(
                 raw,

--- a/polylogue/browser_capture/actions.py
+++ b/polylogue/browser_capture/actions.py
@@ -20,8 +20,6 @@ from typing import Any, TypeVar, cast
 from urllib.parse import urlparse
 from uuid import uuid4
 
-import orjson
-
 from polylogue.browser_capture.models import (
     BrowserActionAttachment,
     BrowserActionEvent,
@@ -31,6 +29,7 @@ from polylogue.browser_capture.models import (
     BrowserActionRequest,
     BrowserActionUpdateRequest,
 )
+from polylogue.core.json import dumps_bytes
 from polylogue.paths import browser_capture_spool_root
 
 ACTION_DIRNAME = "browser-actions"
@@ -97,9 +96,10 @@ def _atomic_write(path: Path, content: bytes) -> None:
 
 
 def _write_action(root: Path, action: BrowserActionIntent) -> None:
-    payload = orjson.dumps(
+    payload = dumps_bytes(
         action.model_dump(mode="json", exclude_none=True),
-        option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS,
+        sort_keys=True,
+        indent=2,
     )
     _atomic_write(_action_path(root, action.action_id), payload + b"\n")
 
@@ -242,7 +242,7 @@ def _validate_capability(request: BrowserActionRequest) -> None:
 
 def _request_sha256(request: BrowserActionRequest) -> str:
     payload = request.model_dump(mode="json", exclude={"action_id", "idempotency_key"})
-    return hashlib.sha256(orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)).hexdigest()
+    return hashlib.sha256(dumps_bytes(payload, sort_keys=True)).hexdigest()
 
 
 def list_actions(*, spool_path: Path | None = None) -> list[BrowserActionIntent]:

--- a/polylogue/browser_capture/receiver.py
+++ b/polylogue/browser_capture/receiver.py
@@ -17,8 +17,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-import orjson
-
 from polylogue.browser_capture.models import (
     BROWSER_CAPTURE_API_SCHEMA,
     BROWSER_CAPTURE_EXTENSION_ORIGIN_WILDCARD,
@@ -30,6 +28,8 @@ from polylogue.browser_capture.models import (
     BrowserCaptureReceiverStatusPayload,
 )
 from polylogue.core.hashing import hash_text_short
+from polylogue.core.json import JSONDecodeError, dumps_bytes
+from polylogue.core.json import loads as json_loads
 from polylogue.core.timestamps import parse_timestamp
 from polylogue.logging import get_logger
 from polylogue.paths import archive_root as default_archive_root
@@ -246,7 +246,7 @@ def capture_dedup_content_hash(envelope: BrowserCaptureEnvelope) -> str:
         "provider_meta": _semantic_provider_meta(envelope.provider_meta),
         "raw_provider_payload": envelope.raw_provider_payload,
     }
-    return hashlib.sha256(orjson.dumps(payload, option=orjson.OPT_SORT_KEYS)).hexdigest()
+    return hashlib.sha256(dumps_bytes(payload, sort_keys=True)).hexdigest()
 
 
 def _timestamp_ms(value: object) -> int | None:
@@ -527,8 +527,8 @@ def write_capture_envelope(
         replaced = target.exists()
         if replaced:
             try:
-                existing = BrowserCaptureEnvelope.model_validate(orjson.loads(target.read_bytes()))
-            except (OSError, orjson.JSONDecodeError, ValueError):
+                existing = BrowserCaptureEnvelope.model_validate(json_loads(target.read_bytes()))
+            except (OSError, JSONDecodeError, ValueError):
                 existing = None
             if existing is not None and capture_dedup_content_hash(existing) == dedup_content_hash:
                 return BrowserCaptureWriteResult(
@@ -546,7 +546,7 @@ def write_capture_envelope(
             _check_spool_quota(root, max_files=SPOOL_MAX_FILES, max_bytes=SPOOL_MAX_BYTES)
         target.parent.mkdir(parents=True, exist_ok=True)
         payload = envelope.model_dump(mode="json", exclude_none=True)
-        raw = orjson.dumps(payload, option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS)
+        raw = dumps_bytes(payload, sort_keys=True, indent=2)
         temp_path: Path | None = None
         try:
             with tempfile.NamedTemporaryFile(
@@ -717,7 +717,7 @@ def existing_capture_state(
 
 def _atomic_write_json(path: Path, payload: object) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    raw = orjson.dumps(payload, option=orjson.OPT_INDENT_2 | orjson.OPT_SORT_KEYS)
+    raw = dumps_bytes(payload, sort_keys=True, indent=2)
     with tempfile.NamedTemporaryFile("wb", dir=path.parent, prefix=f".{path.name}.", delete=False) as handle:
         temp_path = Path(handle.name)
         handle.write(raw)

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -70,7 +70,7 @@ _SAFE_MEDIA_TYPE = re.compile(r"^[A-Za-z0-9!#$&^_.+-]+/[A-Za-z0-9!#$&^_.+-]+$")
 
 
 def _json_bytes(payload: object) -> bytes:
-    return dumps_bytes(payload, option=None)
+    return dumps_bytes(payload)
 
 
 def _origin_allowed(origin: str | None, config: BrowserCaptureReceiverConfig) -> bool:

--- a/polylogue/core/json.py
+++ b/polylogue/core/json.py
@@ -21,12 +21,25 @@ anything beyond what this module's parameters guarantee (compact vs.
 2-space-indent, sorted vs. insertion dict-key order, ASCII-safe UTF-8
 encoding). Within one process the active backend is fixed at import time,
 so output is self-consistent for hashing/idempotency purposes.
+
+**Float exponent formatting** (byte-stability guarantee, and its limit): the
+facade normalizes msgspec's float-exponent output to match orjson's exactly
+(msgspec omits the ``+`` sign on positive exponents -- ``1e30`` vs orjson's
+``1e+30`` -- everything else already agrees), so canonical/content-hash
+dumps (`material_protocol/v1/canonical.py`) stay byte-identical whether the
+active backend is orjson or msgspec. stdlib json's float formatter is a
+*larger* departure (a different decimal-vs-exponent threshold entirely, e.g.
+``1e-05`` where orjson/msgspec write ``0.00001``) that this facade does not
+reconcile -- stdlib is a best-effort last resort used only when neither
+accelerator is installed; canonical byte-stability is guaranteed between
+orjson and msgspec, not into the stdlib-only tier.
 """
 
 from __future__ import annotations
 
 import importlib
 import json as _stdlib_json
+import re
 from collections.abc import Callable
 from decimal import Decimal
 from types import ModuleType
@@ -192,6 +205,52 @@ def _msgspec_enc_hook(encoder: JSONEncoder) -> Callable[[object], object]:
     return _hook
 
 
+# Matches EITHER a complete JSON string literal (left untouched -- alternative
+# tried first so an "e5"-shaped substring inside a string is never mistaken for
+# a number) OR a bare JSON number with an exponent (rewritten). Safe over raw
+# UTF-8 bytes: `"`/`\`/digits/`e`/`-`/`.` are all single-byte ASCII, and UTF-8
+# continuation bytes are always >= 0x80, so they can never masquerade as JSON
+# structural characters.
+_MSGSPEC_EXPONENT_TOKEN_RE = re.compile(rb'"(?:[^"\\]|\\.)*"' rb"|(-?(?:0|[1-9]\d*)(?:\.\d+)?)e(-?\d+)")
+
+
+def _msgspec_exponent_plus_sign(exponent: bytes) -> bytes:
+    return exponent if exponent.startswith(b"-") else b"+" + exponent
+
+
+def _normalize_msgspec_float_exponents(data: bytes) -> bytes:
+    """Make msgspec's exponent-notation floats byte-identical to orjson's.
+
+    msgspec and orjson agree on every float-formatting decision checked
+    empirically (decimal-vs-exponent threshold, digit count, no zero-padding)
+    *except* one: orjson always writes an explicit ``+`` for a positive
+    exponent (``1e+30``), while msgspec omits it (``1e30``). Negative
+    exponents already match byte-for-byte (both write ``1e-6``, never
+    ``1e-06``). This is the one seam that matters for
+    `material_protocol/v1/canonical.py`'s content-hash stability across
+    backends -- without it, canonical bytes would differ purely because the
+    active JSON backend changed (found via a coordinator repro on
+    ``dumps_bytes({"tiny": 5e-324}, sort_keys=True)``, PR #3155 review).
+
+    stdlib json is a different, larger departure from orjson (it picks
+    decimal vs. exponent notation at a different magnitude threshold, e.g.
+    ``1e-05`` for ``0.00001`` where orjson/msgspec write ``0.00001``, and
+    zero-pads short exponents to 2 digits) -- reconciling that would mean
+    reimplementing orjson's float formatter from scratch, not a one-line fix.
+    stdlib therefore stays a best-effort *last-resort* fallback (used only
+    when neither orjson nor msgspec is installed at all); canonical/hash byte
+    stability is only a hard guarantee between orjson and msgspec.
+    """
+
+    def _repl(match: re.Match[bytes]) -> bytes:
+        mantissa, exponent = match.group(1), match.group(2)
+        if mantissa is None:
+            return match.group(0)  # matched a string literal -- leave untouched
+        return mantissa + b"e" + _msgspec_exponent_plus_sign(exponent)
+
+    return _MSGSPEC_EXPONENT_TOKEN_RE.sub(_repl, data)
+
+
 def _raw_loads(data: str | bytes | bytearray) -> object:
     result: object
     if _BACKEND == "orjson":
@@ -249,6 +308,7 @@ def _raw_dumps_bytes(obj: object, *, encoder: JSONEncoder, sort_keys: bool, inde
             )
         except (TypeError, NotImplementedError):
             return None
+        raw = _normalize_msgspec_float_exponents(raw)
         if indent == 2:
             raw = _msgspec_json.format(raw, indent=2)
         # cast: same widening as the orjson branch above; msgspec.json.encode

--- a/polylogue/core/json.py
+++ b/polylogue/core/json.py
@@ -1,19 +1,94 @@
-"""Central JSON utilities using orjson with typed JSON contracts."""
+"""Central JSON utilities with a pluggable fast-JSON backend.
+
+Backend selection happens once at import time, in priority order:
+
+1. ``orjson`` -- fastest, but ships no ``cp314t`` (free-threaded Python 3.14)
+   wheels and its build explicitly refuses to compile under free-threaded
+   Python (polylogue-xikl phase 1 gate finding, 2026-07-19).
+2. ``msgspec`` -- ships ``cp314t`` wheels since 0.20.0 (Nov 2025); used as
+   the fast fallback whenever orjson is unavailable (e.g. under 3.14t, or
+   any environment that installed polylogue without the ``speed`` extra).
+3. stdlib ``json`` -- always available; the final fallback.
+
+Every direct ``import orjson`` / ``import msgspec`` elsewhere in the
+codebase should route through this facade instead, so backend selection,
+bytes/str normalization, and decode-error unification live in one place.
+See polylogue-xikl (free-threading adoption epic) and polylogue-7mtf (the
+3.14t experiment that surfaced the orjson blocker).
+
+Callers must not assume byte-for-byte output parity *across* backends for
+anything beyond what this module's parameters guarantee (compact vs.
+2-space-indent, sorted vs. insertion dict-key order, ASCII-safe UTF-8
+encoding). Within one process the active backend is fixed at import time,
+so output is self-consistent for hashing/idempotency purposes.
+"""
 
 from __future__ import annotations
 
-import json
+import importlib
+import json as _stdlib_json
 from collections.abc import Callable
 from decimal import Decimal
-from typing import TypeAlias, TypeGuard
-
-import orjson
+from types import ModuleType
+from typing import Literal, TypeAlias, TypeGuard, cast
 
 JSONScalar: TypeAlias = str | int | float | bool | None
 JSONValue: TypeAlias = JSONScalar | list["JSONValue"] | dict[str, "JSONValue"]
 JSONDocument: TypeAlias = dict[str, JSONValue]
 JSONDocumentList: TypeAlias = list[JSONDocument]
 JSONEncoder: TypeAlias = Callable[[object], object]
+
+JSONBackend = Literal["orjson", "msgspec", "stdlib"]
+
+
+class JSONDecodeError(ValueError):
+    """Backend-agnostic JSON decode failure.
+
+    Raised by :func:`loads` regardless of which backend is active, so
+    callers never need to import or catch a backend-specific exception
+    type (``orjson.JSONDecodeError``, ``msgspec.DecodeError``,
+    ``json.JSONDecodeError``) -- catch this instead.
+    """
+
+
+def _try_import(name: str) -> ModuleType | None:
+    """Import *name* if available, else return None.
+
+    Deliberately NOT a plain ``try: import X as _x / except ImportError:
+    _x = None`` -- across mypy environments where the optional package isn't
+    installed at all, `ignore_missing_imports` makes a literal `import X`
+    resolve to `Any` rather than erroring, which conflicts with an explicit
+    `ModuleType | None` pre-declaration in a way that varies (and errors)
+    depending on whether the package happens to be installed in whichever
+    environment mypy runs in. Routing through a plain function call sidesteps
+    that entirely: the return type is `ModuleType | None` in every environment.
+    """
+    try:
+        return importlib.import_module(name)
+    except ImportError:
+        return None
+
+
+_orjson = _try_import("orjson")
+_msgspec = _try_import("msgspec")
+_msgspec_json = _try_import("msgspec.json")
+
+if _orjson is not None:
+    _BACKEND: JSONBackend = "orjson"
+elif _msgspec_json is not None:
+    _BACKEND = "msgspec"
+else:
+    _BACKEND = "stdlib"
+
+
+def backend() -> JSONBackend:
+    """Return the JSON backend selected at import time.
+
+    One of ``"orjson"``, ``"msgspec"``, or ``"stdlib"``. Exposed for
+    diagnostics/benchmarking; production code should not branch on this --
+    the whole point of the facade is that callers don't need to know.
+    """
+    return _BACKEND
 
 
 def is_json_value(value: object) -> TypeGuard[JSONValue]:
@@ -84,7 +159,13 @@ def _loaded_json_value(value: object) -> JSONValue:
 
 
 def _default_encoder(user_default: JSONEncoder | None = None) -> JSONEncoder:
-    """Create a JSON encoder that handles Decimal values."""
+    """Create a JSON encoder that handles Decimal values.
+
+    Raises :class:`TypeError` for anything it can't handle -- the contract
+    shared by orjson's and stdlib json's ``default`` hook. msgspec's
+    ``enc_hook`` wants :class:`NotImplementedError` instead; see
+    :func:`_msgspec_enc_hook` for the adapter.
+    """
 
     def _encoder(obj: object) -> object:
         if user_default is not None:
@@ -99,46 +180,154 @@ def _default_encoder(user_default: JSONEncoder | None = None) -> JSONEncoder:
     return _encoder
 
 
+def _msgspec_enc_hook(encoder: JSONEncoder) -> Callable[[object], object]:
+    def _hook(obj: object) -> object:
+        try:
+            return encoder(obj)
+        except TypeError as exc:
+            # msgspec's enc_hook contract signals "unsupported" via
+            # NotImplementedError, not TypeError (see msgspec.json.encode docs).
+            raise NotImplementedError(str(exc)) from exc
+
+    return _hook
+
+
+def _raw_loads(data: str | bytes | bytearray) -> object:
+    result: object
+    if _BACKEND == "orjson":
+        if _orjson is None:
+            raise RuntimeError("core.json backend is 'orjson' but the orjson module is unavailable")
+        try:
+            result = _orjson.loads(data)
+        except _orjson.JSONDecodeError as exc:
+            raise JSONDecodeError(str(exc)) from exc
+        return result
+    if _BACKEND == "msgspec":
+        if _msgspec_json is None or _msgspec is None:
+            raise RuntimeError("core.json backend is 'msgspec' but the msgspec module is unavailable")
+        try:
+            result = _msgspec_json.decode(data)
+        except _msgspec.DecodeError as exc:
+            raise JSONDecodeError(str(exc)) from exc
+        return result
+    try:
+        result = _stdlib_json.loads(data, parse_constant=_reject_non_finite_token)
+    except (_stdlib_json.JSONDecodeError, ValueError) as exc:
+        raise JSONDecodeError(str(exc)) from exc
+    return result
+
+
+def _raw_dumps_bytes(obj: object, *, encoder: JSONEncoder, sort_keys: bool, indent: int | None) -> bytes | None:
+    """Attempt the fast-backend encode; return ``None`` to signal a stdlib fallback."""
+    if _BACKEND == "orjson":
+        if _orjson is None:
+            raise RuntimeError("core.json backend is 'orjson' but the orjson module is unavailable")
+        option = 0
+        if sort_keys:
+            option |= _orjson.OPT_SORT_KEYS
+        if indent == 2:
+            option |= _orjson.OPT_INDENT_2
+        try:
+            # cast: `_orjson`'s declared type is `ModuleType | None` (for the
+            # optional-import None check above), which widens attribute access
+            # to `Any` -- orjson's own stub types `.dumps()` as `-> bytes`.
+            return cast(bytes, _orjson.dumps(obj, default=encoder, option=option or None))
+        except TypeError:
+            return None
+    if _BACKEND == "msgspec":
+        if _msgspec_json is None:
+            raise RuntimeError("core.json backend is 'msgspec' but the msgspec module is unavailable")
+        # msgspec encodes decimal.Decimal natively as a JSON *string* (unlike
+        # orjson/stdlib, which raise and defer to the default/enc_hook callback
+        # below) -- pre-normalize so all three backends agree it's a number.
+        prepared = normalize_json_decimal(obj)
+        try:
+            raw = _msgspec_json.encode(
+                prepared,
+                enc_hook=_msgspec_enc_hook(encoder),
+                order="sorted" if sort_keys else None,
+            )
+        except (TypeError, NotImplementedError):
+            return None
+        if indent == 2:
+            raw = _msgspec_json.format(raw, indent=2)
+        # cast: same widening as the orjson branch above; msgspec.json.encode
+        # is `-> bytes` and .format(bytes-like, ...) is `-> bytes` per its stub.
+        return cast(bytes, raw)
+    return None
+
+
 def dumps_bytes(
     obj: object,
     *,
     default: JSONEncoder | None = None,
-    option: int | None = None,
+    sort_keys: bool = False,
+    indent: int | None = None,
+    append_newline: bool = False,
 ) -> bytes:
-    """Dump object to UTF-8 JSON bytes."""
+    """Dump *obj* to UTF-8 JSON bytes via the active backend.
+
+    ``sort_keys``/``indent`` are backend-neutral semantic flags (not an
+    orjson option bitmask) so behavior is identical regardless of which
+    backend is active. ``indent`` only supports ``None`` (compact) or ``2``
+    (pretty, 2-space) -- the only two shapes any call site in this codebase
+    needs.
+    """
+    if indent is not None and indent != 2:
+        raise ValueError(f"dumps_bytes indent must be None or 2, got {indent!r}")
     encoder = _default_encoder(default)
-    try:
-        if option is None:
-            return orjson.dumps(obj, default=encoder)
-        return orjson.dumps(obj, default=encoder, option=option)
-    except TypeError:
-        pass
+    payload = _raw_dumps_bytes(obj, encoder=encoder, sort_keys=sort_keys, indent=indent)
+    if payload is None:
+        separators = (",", ":") if indent is None else (",", ": ")
+        payload = _stdlib_json.dumps(
+            obj,
+            default=encoder,
+            sort_keys=sort_keys,
+            indent=indent,
+            ensure_ascii=False,
+            separators=separators,
+        ).encode("utf-8")
+    if append_newline:
+        payload += b"\n"
+    return payload
 
-    return json.dumps(obj, default=encoder).encode("utf-8")
 
-
-def dumps(obj: object, *, default: JSONEncoder | None = None, option: int | None = None) -> str:
+def dumps(
+    obj: object,
+    *,
+    default: JSONEncoder | None = None,
+    sort_keys: bool = False,
+    indent: int | None = None,
+) -> str:
     """Dump object to JSON string."""
-    return dumps_bytes(obj, default=default, option=option).decode("utf-8")
+    return dumps_bytes(obj, default=default, sort_keys=sort_keys, indent=indent).decode("utf-8")
 
 
 def loads(obj: str | bytes | bytearray) -> JSONValue:
-    """Load object from JSON string or bytes."""
+    """Load object from JSON string or bytes.
+
+    Tries the active fast backend first; falls back to a strict stdlib
+    parse (still rejecting non-finite tokens) on failure, then raises
+    :class:`JSONDecodeError` if both fail.
+    """
     try:
-        return _loaded_json_value(orjson.loads(obj))
-    except (orjson.JSONDecodeError, ValueError) as exc:
+        return _loaded_json_value(_raw_loads(obj))
+    except JSONDecodeError as exc:
         try:
-            return _loaded_json_value(json.loads(obj, parse_constant=_reject_non_finite_token))
-        except (json.JSONDecodeError, ValueError):
+            return _loaded_json_value(_stdlib_json.loads(obj, parse_constant=_reject_non_finite_token))
+        except (_stdlib_json.JSONDecodeError, ValueError):
             raise exc from None
 
 
 __all__ = [
+    "JSONBackend",
+    "JSONDecodeError",
     "JSONDocument",
     "JSONDocumentList",
     "JSONEncoder",
     "JSONScalar",
     "JSONValue",
+    "backend",
     "dumps",
     "dumps_bytes",
     "is_json_document",

--- a/polylogue/daemon/events_http.py
+++ b/polylogue/daemon/events_http.py
@@ -161,11 +161,11 @@ def _write_sse_comment(handler: DaemonAPIHandler, comment: bytes) -> None:
 
 
 def _write_sse_event(handler: DaemonAPIHandler, event: dict[str, object]) -> None:
-    import orjson
+    from polylogue.core.json import dumps_bytes
 
     event_id = event.get("id")
     kind = event.get("kind") or "message"
-    payload = orjson.dumps(event)
+    payload = dumps_bytes(event)
     data_lines = payload.split(b"\n")
     chunks = [
         b"id: " + str(event_id).encode() + b"\n",

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -452,9 +452,9 @@ def implemented_daemon_route_patterns() -> tuple[tuple[RouteMethod, str], ...]:
 
 
 def _json_bytes(payload: object) -> bytes:
-    import orjson
+    from polylogue.core.json import dumps_bytes
 
-    return orjson.dumps(payload, option=orjson.OPT_APPEND_NEWLINE)
+    return dumps_bytes(payload, append_newline=True)
 
 
 def _web_reader_archive_root() -> Path | None:

--- a/polylogue/material_protocol/v1/canonical.py
+++ b/polylogue/material_protocol/v1/canonical.py
@@ -11,11 +11,7 @@ from __future__ import annotations
 
 import unicodedata
 
-import orjson
-
-from polylogue.core.json import JSONValue, loads
-
-_ORJSON_CANONICAL_OPTIONS = orjson.OPT_SORT_KEYS
+from polylogue.core.json import JSONValue, dumps_bytes, loads
 
 
 def nfc_normalize(value: JSONValue) -> JSONValue:
@@ -36,7 +32,7 @@ def canonical_bytes(value: JSONValue) -> bytes:
     ``b"\\n"`` themselves so the digest/line-length story stays explicit.
     """
     normalized = nfc_normalize(value)
-    return orjson.dumps(normalized, option=_ORJSON_CANONICAL_OPTIONS)
+    return dumps_bytes(normalized, sort_keys=True)
 
 
 def canonical_line(value: JSONValue) -> bytes:

--- a/polylogue/sources/decoder_json.py
+++ b/polylogue/sources/decoder_json.py
@@ -9,8 +9,9 @@ from collections.abc import Iterable
 from typing import IO, Protocol, TypeAlias, TypeGuard
 
 import ijson
-import orjson
 
+from polylogue.core.json import JSONDecodeError
+from polylogue.core.json import loads as json_loads
 from polylogue.logging import get_logger
 
 logger = get_logger(__name__)
@@ -114,8 +115,8 @@ def _yield_jsonl_pending(
     path_name: str,
 ) -> tuple[list[JsonValue], int]:
     try:
-        parsed = orjson.loads(raw_pending)
-    except orjson.JSONDecodeError:
+        parsed = json_loads(raw_pending)
+    except JSONDecodeError:
         parsed = None
     else:
         if _is_json_value(parsed):

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -10,13 +10,12 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from io import BytesIO
 from pathlib import Path
-from typing import Protocol, cast
-
-import orjson
+from typing import Protocol
 
 from polylogue.archive.artifact_taxonomy import classify_artifact, classify_artifact_path
 from polylogue.core.enums import Provider
-from polylogue.core.json import JSONValue
+from polylogue.core.json import JSONDecodeError, JSONValue
+from polylogue.core.json import loads as json_loads
 from polylogue.pipeline.services.ingest_batch._core import _select_ingest_worker_count
 from polylogue.sources.dispatch import _detect_provider_from_raw_bytes, detect_provider
 from polylogue.sources.parsers import hermes_state, hermes_verification
@@ -480,8 +479,8 @@ def _jsonl_sample_from_path(path: Path, *, max_records: int = 32) -> list[JSONVa
             if not raw:
                 continue
             try:
-                records.append(cast(JSONValue, orjson.loads(raw)))
-            except orjson.JSONDecodeError:
+                records.append(json_loads(raw))
+            except JSONDecodeError:
                 continue
     return records
 
@@ -540,8 +539,8 @@ def _parse_path_as_session_artifact(path: Path, *, provider: Provider) -> bool:
             return True
         return _large_non_jsonl_path_can_stream(path, provider=provider)
     try:
-        document = cast(JSONValue, orjson.loads(path.read_bytes()))
-    except orjson.JSONDecodeError:
+        document = json_loads(path.read_bytes())
+    except JSONDecodeError:
         return False
     return classify_artifact(document, provider=provider, source_path=path).parse_as_session
 
@@ -572,14 +571,14 @@ def _parse_payload_as_session_artifact(path: Path, *, provider: Provider, payloa
             if not raw:
                 continue
             try:
-                records.append(cast(JSONValue, orjson.loads(raw)))
-            except orjson.JSONDecodeError:
+                records.append(json_loads(raw))
+            except JSONDecodeError:
                 continue
         if not records:
             return False
         return classify_artifact(records, provider=provider, source_path=path).parse_as_session
     try:
-        document = cast(JSONValue, orjson.loads(payload))
-    except orjson.JSONDecodeError:
+        document = json_loads(payload)
+    except JSONDecodeError:
         return False
     return classify_artifact(document, provider=provider, source_path=path).parse_as_session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
   "click>=8.4.2,<9.0",
   "tenacity>=8.0.0",
   "dateparser>=1.4.1",
-  "orjson>=3.11.9",
   "structlog>=26.1.0",
   "pydantic>=2.13.4,<3.0",
   "aiosqlite>=0.19.0",  # Async SQLite support
@@ -56,7 +55,24 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Optional fast-JSON accelerators for polylogue.core.json (polylogue-xikl).
+# Neither extra is required: the facade always falls back to stdlib json
+# when its backend is absent. They are split into two extras (rather than
+# one) because orjson has no cp314t (free-threaded Python 3.14) wheels and
+# its build refuses to compile free-threaded -- installing it is simply
+# impossible on a 3.14t interpreter, so a single combined extra would make
+# the whole install fail there. Standard (GIL) builds should install
+# `polylogue[speed]`; a 3.14t build should install `polylogue[speed-msgspec]`
+# instead, since msgspec ships cp314t wheels since 0.20.0 (Nov 2025).
+speed = [
+  "orjson>=3.11.9",
+]
+speed-msgspec = [
+  "msgspec>=0.20.0",
+]
 dev = [
+  "orjson>=3.11.9",  # core.json fast-JSON backend under test (polylogue-xikl)
+  "msgspec>=0.20.0",  # core.json fast-JSON fallback backend under test (polylogue-xikl)
   "pytest>=9.1.1",  # CVE-2025-71176
   "pytest-cov>=4",
   "pytest-asyncio>=1.4.0",  # Async test support

--- a/tests/unit/core/test_json.py
+++ b/tests/unit/core/test_json.py
@@ -262,11 +262,85 @@ def test_dumps_sort_keys_byte_identical_across_backends(
     This is the property `material_protocol/v1/canonical.py` depends on for
     content-hash stability (polylogue-xikl): canonical hashing must not
     silently change bytes merely because the active JSON backend changed.
+
+    This corpus deliberately stays within the range where all three backends
+    already agree (see `test_dumps_sort_keys_exponent_floats_orjson_msgspec_parity`
+    below for the exponent-notation float corpus, where stdlib's float
+    formatter is a documented, accepted exception to this guarantee).
     """
     monkeypatch.setattr(core_json, "_BACKEND", backend)
     payload = {"b": 1, "a": Decimal("2.5"), "big": 2**65, "nested": {"z": 1, "y": [3, 1, 2]}}
     output = core_json.dumps_bytes(payload, sort_keys=True)
     assert output == b'{"a":2.5,"b":1,"big":36893488147419103232,"nested":{"y":[3,1,2],"z":1}}'
+
+
+# Backends the exponent-float byte-identity guarantee actually covers.
+# Coordinator repro (PR #3155 review): dumps_bytes({"exp": 1e30, "big": ...,
+# "tiny": 5e-324}, sort_keys=True) -- orjson and msgspec agree on every float
+# formatting decision except one: orjson always writes a `+` for a positive
+# exponent (`1e+30`) while msgspec omits it (`1e30`); `core.json` normalizes
+# msgspec's output to close that seam (`_normalize_msgspec_float_exponents`).
+# stdlib json is a *larger*, unreconciled departure (different decimal-vs-
+# exponent threshold entirely -- see `test_stdlib_diverges_from_orjson_for_small_exponents`
+# below) and is therefore NOT part of this guarantee.
+_CANONICAL_FLOAT_PARITY_BACKENDS: tuple[core_json.JSONBackend, ...] = ("orjson", "msgspec")
+
+
+@pytest.mark.parametrize("backend", _CANONICAL_FLOAT_PARITY_BACKENDS)
+def test_dumps_sort_keys_exponent_floats_orjson_msgspec_parity(
+    monkeypatch: pytest.MonkeyPatch, backend: core_json.JSONBackend
+) -> None:
+    """Exponent-notation floats (the coordinator's PR #3155 repro corpus, plus
+    a realistic tiny cost_usd shape and non-ASCII text) round-trip to
+    byte-identical canonical output on orjson and msgspec -- proving the
+    facade's msgspec exponent-sign normalization actually fires, rather than
+    merely not-crashing."""
+    monkeypatch.setattr(core_json, "_BACKEND", backend)
+    payload = {
+        "exp": 1e30,
+        "big": 1.7976931348623157e308,
+        "tiny": 5e-324,
+        "small_cost": 2e-06,
+        "neg_zero": -0.0,
+        "unicode": "żółć🚀",
+    }
+    output = core_json.dumps_bytes(payload, sort_keys=True)
+    assert output == (
+        b'{"big":1.7976931348623157e+308,"exp":1e+30,"neg_zero":-0.0,'
+        b'"small_cost":2e-6,"tiny":5e-324,"unicode":"\xc5\xbc\xc3\xb3\xc5\x82\xc4\x87\xf0\x9f\x9a\x80"}'
+    )
+
+
+def test_stdlib_diverges_from_orjson_for_small_exponents() -> None:
+    """Documents the accepted limit of the byte-stability guarantee: stdlib
+    json picks a different decimal-vs-exponent threshold than orjson/msgspec
+    (`1e-05` vs `0.00001`) and zero-pads short exponents (`2e-06` vs `2e-6`).
+    This is deliberately NOT reconciled (would mean reimplementing orjson's
+    float formatter) -- canonical byte-stability is guaranteed between orjson
+    and msgspec only, per the facade's module docstring. This test exists so
+    a future "fix" attempt doesn't get silently reverted without realizing
+    the gap is documented, known, and accepted."""
+    original = core_json._BACKEND
+    core_json._BACKEND = "stdlib"
+    try:
+        stdlib_output = core_json.dumps_bytes({"v": 2e-06}, sort_keys=True)
+    finally:
+        core_json._BACKEND = original
+    assert stdlib_output == b'{"v":2e-06}'  # not b'{"v":2e-6}' -- the orjson/msgspec form
+
+
+def test_msgspec_exponent_normalizer_does_not_corrupt_string_content() -> None:
+    """The exponent-sign normalizer operates on raw encoded bytes via a regex
+    that must skip over string literals -- a string containing an "e5"-shaped
+    substring must survive untouched, not have a `+` spliced into it."""
+    original = core_json._BACKEND
+    core_json._BACKEND = "msgspec"
+    try:
+        output = core_json.dumps_bytes({"note": "batch e5 vs cafe10, cost 2e-06"}, sort_keys=True)
+    finally:
+        core_json._BACKEND = original
+    assert core_json.loads(output) == {"note": "batch e5 vs cafe10, cost 2e-06"}
+    assert output == b'{"note":"batch e5 vs cafe10, cost 2e-06"}'
 
 
 @pytest.mark.parametrize("backend", ALL_BACKENDS)

--- a/tests/unit/core/test_json.py
+++ b/tests/unit/core/test_json.py
@@ -14,7 +14,6 @@ from collections.abc import Callable
 from decimal import Decimal
 from typing import Literal
 
-import orjson
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
@@ -23,6 +22,14 @@ from polylogue.core import json as core_json
 from polylogue.core.enums import Provider
 from polylogue.core.provider_identity import normalize_provider_token
 from polylogue.core.types import AttachmentId, ContentHash, MessageId, SessionId
+
+# Every backend-parametrized test forces `core_json._BACKEND` via monkeypatch
+# rather than requiring any backend to be actually absent -- the dev/CI
+# environment installs both orjson and msgspec (pyproject.toml `dev` extra)
+# specifically so all three code paths in polylogue/core/json.py get real
+# coverage, not just whichever backend happened to win import-time selection
+# (polylogue-xikl: orjson is optional, msgspec is the free-threaded fallback).
+ALL_BACKENDS: tuple[core_json.JSONBackend, ...] = ("orjson", "msgspec", "stdlib")
 
 SURROGATE_CATEGORY: tuple[Literal["Cs"], ...] = ("Cs",)
 
@@ -113,8 +120,25 @@ _INVALID_JSON_FRAGMENTS = [
 
 @pytest.mark.parametrize("fragment", _INVALID_JSON_FRAGMENTS)
 def test_loads_known_invalid_json_raises(fragment: str) -> None:
-    """Invalid JSON fragments always raise an exception."""
-    with pytest.raises(orjson.JSONDecodeError):
+    """Invalid JSON fragments always raise the backend-agnostic decode error."""
+    with pytest.raises(core_json.JSONDecodeError):
+        core_json.loads(fragment)
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+@pytest.mark.parametrize("fragment", _INVALID_JSON_FRAGMENTS)
+def test_loads_known_invalid_json_raises_under_every_backend(
+    monkeypatch: pytest.MonkeyPatch, backend: core_json.JSONBackend, fragment: str
+) -> None:
+    """Every backend (orjson, msgspec, stdlib) rejects the same invalid fragments.
+
+    Anti-vacuity: this fails if any backend's decode-error mapping silently
+    swallows a malformed-JSON case (e.g. a backend that tolerates NaN/Infinity
+    without polylogue's non-finite rejection, or one whose exception type
+    isn't mapped to the unified :class:`core_json.JSONDecodeError`).
+    """
+    monkeypatch.setattr(core_json, "_BACKEND", backend)
+    with pytest.raises(core_json.JSONDecodeError):
         core_json.loads(fragment)
 
 
@@ -222,47 +246,97 @@ def test_dumps_preserves_non_type_errors_from_custom_handler() -> None:
         core_json.dumps({"decimal": Decimal("1.5")}, default=custom_handler)
 
 
-def test_dumps_forwards_orjson_options() -> None:
-    """Options are forwarded to orjson when the fast path succeeds."""
+def test_dumps_sort_keys_produces_deterministic_key_order() -> None:
+    """`sort_keys=True` is a backend-neutral semantic flag, not an orjson option bitmask."""
     payload = {"b": 1, "a": 2}
-    output = core_json.dumps(payload, option=orjson.OPT_SORT_KEYS)
+    output = core_json.dumps(payload, sort_keys=True)
     assert output == '{"a":2,"b":1}'
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_dumps_sort_keys_byte_identical_across_backends(
+    monkeypatch: pytest.MonkeyPatch, backend: core_json.JSONBackend
+) -> None:
+    """Compact sort_keys output is byte-identical across orjson/msgspec/stdlib.
+
+    This is the property `material_protocol/v1/canonical.py` depends on for
+    content-hash stability (polylogue-xikl): canonical hashing must not
+    silently change bytes merely because the active JSON backend changed.
+    """
+    monkeypatch.setattr(core_json, "_BACKEND", backend)
+    payload = {"b": 1, "a": Decimal("2.5"), "big": 2**65, "nested": {"z": 1, "y": [3, 1, 2]}}
+    output = core_json.dumps_bytes(payload, sort_keys=True)
+    assert output == b'{"a":2.5,"b":1,"big":36893488147419103232,"nested":{"y":[3,1,2],"z":1}}'
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_dumps_indent_byte_identical_across_backends(
+    monkeypatch: pytest.MonkeyPatch, backend: core_json.JSONBackend
+) -> None:
+    """2-space indented output is byte-identical across backends."""
+    monkeypatch.setattr(core_json, "_BACKEND", backend)
+    output = core_json.dumps_bytes({"b": 1, "a": 2}, sort_keys=True, indent=2)
+    assert output == b'{\n  "a": 2,\n  "b": 1\n}'
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_dumps_bytes_append_newline(monkeypatch: pytest.MonkeyPatch, backend: core_json.JSONBackend) -> None:
+    monkeypatch.setattr(core_json, "_BACKEND", backend)
+    output = core_json.dumps_bytes({"x": 1}, append_newline=True)
+    assert output == b'{"x":1}\n'
 
 
 def test_dumps_bytes_roundtrips_as_utf8_json() -> None:
     """dumps_bytes returns UTF-8 bytes with the same semantic content as dumps."""
     payload = {"b": 1, "a": Decimal("2.5")}
 
-    output = core_json.dumps_bytes(payload, option=orjson.OPT_SORT_KEYS)
+    output = core_json.dumps_bytes(payload, sort_keys=True)
 
     assert isinstance(output, bytes)
     assert output == b'{"a":2.5,"b":1}'
     assert core_json.loads(output) == {"a": 2.5, "b": 1}
 
 
-def test_dumps_fallback_uses_stdlib_encoder_when_orjson_option_rejects_object() -> None:
-    """The stdlib fallback still uses the combined encoder contract."""
-
-    class CustomType:
-        def __init__(self, value: int) -> None:
-            self.value = value
-
-    def custom_handler(obj: object) -> object:
-        if isinstance(obj, CustomType):
-            return {"custom": obj.value}
-        raise TypeError("Not handled")
-
-    output = core_json.dumps(
-        {"payload": CustomType(7)},
-        default=custom_handler,
-        option=orjson.OPT_NON_STR_KEYS,
-    )
+def test_dumps_fallback_uses_stdlib_encoder_for_out_of_range_integers() -> None:
+    """orjson raises TypeError for ints beyond its native 64-bit range; the
+    facade falls back to stdlib json (arbitrary precision) so the value
+    still round-trips instead of raising."""
+    big = 2**65
+    output = core_json.dumps({"v": big})
     data = _loaded_document(output)
-    assert data == {"payload": {"custom": 7}}
+    assert data["v"] == big
 
 
-def test_dumps_bytes_fallback_uses_stdlib_encoder_when_orjson_option_rejects_object() -> None:
-    """dumps_bytes preserves the same semantic encoder contract as dumps."""
+def test_dumps_bytes_fallback_uses_stdlib_encoder_for_out_of_range_integers() -> None:
+    """dumps_bytes preserves the same out-of-range-integer fallback as dumps."""
+    big = 2**65
+    output = core_json.dumps_bytes({"v": big})
+    assert isinstance(output, bytes)
+    assert core_json.loads(output) == {"v": big}
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_dumps_out_of_range_integers_roundtrip_under_every_backend(
+    monkeypatch: pytest.MonkeyPatch, backend: core_json.JSONBackend
+) -> None:
+    """Anti-vacuity: forces each backend and proves the 64-bit-overflow value
+    still comes back exactly, whether via that backend's native support
+    (msgspec/stdlib) or the orjson-specific TypeError-triggered fallback."""
+    monkeypatch.setattr(core_json, "_BACKEND", backend)
+    big = 2**65
+    output = core_json.dumps_bytes({"v": big})
+    assert core_json.loads(output) == {"v": big}
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_dumps_custom_handler_still_applies_under_every_backend(
+    monkeypatch: pytest.MonkeyPatch, backend: core_json.JSONBackend
+) -> None:
+    """A custom `default` handler for a genuinely unknown type is honored
+    regardless of the active backend -- including msgspec, whose `enc_hook`
+    contract differs from orjson/stdlib's `default` (NotImplementedError vs
+    TypeError) and is adapted internally by the facade."""
+    monkeypatch.setattr(core_json, "_BACKEND", backend)
 
     class CustomType:
         def __init__(self, value: int) -> None:
@@ -273,13 +347,50 @@ def test_dumps_bytes_fallback_uses_stdlib_encoder_when_orjson_option_rejects_obj
             return {"custom": obj.value}
         raise TypeError("Not handled")
 
-    output = core_json.dumps_bytes(
-        {"payload": CustomType(7)},
-        default=custom_handler,
-        option=orjson.OPT_NON_STR_KEYS,
-    )
-    assert isinstance(output, bytes)
+    output = core_json.dumps_bytes({"payload": CustomType(7)}, default=custom_handler)
     assert core_json.loads(output) == {"payload": {"custom": 7}}
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+def test_dumps_decimal_encodes_to_number_under_every_backend(
+    monkeypatch: pytest.MonkeyPatch, backend: core_json.JSONBackend
+) -> None:
+    """msgspec encodes decimal.Decimal natively as a JSON *string* unless
+    pre-normalized -- this is the specific seam this facade closes so all
+    three backends agree Decimal is a JSON number, matching orjson/stdlib's
+    `default`-hook-driven float conversion."""
+    monkeypatch.setattr(core_json, "_BACKEND", backend)
+    output = core_json.dumps_bytes({"v": Decimal("1.5")})
+    data = _loaded_document(output)
+    assert isinstance(data["v"], float)
+    assert data["v"] == 1.5
+
+
+def test_backend_reports_a_valid_selection() -> None:
+    """backend() reports whichever of orjson/msgspec/stdlib was selected at import."""
+    assert core_json.backend() in ALL_BACKENDS
+
+
+@pytest.mark.parametrize("backend", ALL_BACKENDS)
+@given(_json_value)
+def test_roundtrip_basic_types_under_every_backend(backend: core_json.JSONBackend, value: object) -> None:
+    """The dumps/loads roundtrip law holds under every backend, not just
+    whichever one import-time selection happened to pick.
+
+    Sets/restores the module-level backend selection directly (not via the
+    `monkeypatch` fixture, which Hypothesis's `@given` rejects as
+    function-scoped -- it isn't reset between generated examples, but that's
+    fine here since every example in one test invocation wants the same
+    forced backend).
+    """
+    original = core_json._BACKEND
+    core_json._BACKEND = backend
+    try:
+        output = core_json.dumps(value)
+        result = core_json.loads(output)
+    finally:
+        core_json._BACKEND = original
+    assert result == value
 
 
 # =============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -1306,6 +1306,54 @@ wheels = [
 ]
 
 [[package]]
+name = "msgspec"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/60/f79b9b013a16fa3a58350c9295ddc6789f2e335f36ea61ed10a21b215364/msgspec-0.21.1.tar.gz", hash = "sha256:2313508e394b0d208f8f56892ca9b2799e2561329de9763b19619595a6c0f72c", size = 319193, upload-time = "2026-04-12T21:44:50.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/7f/bbc4e74cd33d316b75541149e4d35b163b63bce066530ae185a2ec3b5bfc/msgspec-0.21.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b504b6e7f7a22a24b27232b73034421692147865162daaec9f3bf62439007c87", size = 193131, upload-time = "2026-04-12T21:43:56.094Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/60/504886af1aaf854112663b842d5eea9a15d9588f9bf7d0d2df736424b84d/msgspec-0.21.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4692b7c1609155708c4418f88e92f63c13fdf08aa095c84bae82bad75b53389b", size = 186597, upload-time = "2026-04-12T21:43:57.242Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/54/d24ddeaa65b5278c9e67f48ce3c17a9831e8f3722f3c8322ee120aca22ef/msgspec-0.21.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d3124010b3815451494c85ff345e693cb9fe5889cfcbbef39ed8622e0e72319c", size = 215158, upload-time = "2026-04-12T21:43:58.442Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/75/bb79c8b89a93ae23cd33c0d802373f16feaf9633f05d8af77091350dda0a/msgspec-0.21.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6badc03b9725352219cca017bfe71c61f2fbd0fb5982b410ac17c97c213deb30", size = 219856, upload-time = "2026-04-12T21:44:00.015Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/9c/c5ca26b46f0ebbd3a6683695ef89396712cb9e4199fd1f0bc1dd968216b1/msgspec-0.21.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5d2d4116ebe3035a78d9ec76e99a9d64e5fa6d44fe61a9c5de7fd1acf54bcc69", size = 220314, upload-time = "2026-04-12T21:44:01.548Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/31/645a351c4285dce40ed6755c3dcc0aa648e26dacb20a98018fe2cce5e87b/msgspec-0.21.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0d1009f6715f5bff3b54d4ff5c7428ad96197e0534e1645b8e9b955890c84664", size = 223215, upload-time = "2026-04-12T21:44:02.884Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8bf15736a6dd3cb4f90c5467f6dc39197d2daaf10754490cdc0aa17b7312/msgspec-0.21.1-cp311-cp311-win_amd64.whl", hash = "sha256:c6faffe5bb644ec884052679af4dfd776d4b5ca90e4a7ec7e7e319e4e6b93a6e", size = 188554, upload-time = "2026-04-12T21:44:04.151Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/29/cc7db3a165b62d16e64a83f82eccb79655055cb5bc1f60459a6f9d7c82f2/msgspec-0.21.1-cp311-cp311-win_arm64.whl", hash = "sha256:ee9e3f11fa94603f7d673bf795cfa31b549c4a2c723bc39b45beb1e7f5a3fb99", size = 174517, upload-time = "2026-04-12T21:44:05.66Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/cf/317224852c00248c620a9bcf4b26e2e4ab8afd752f18d2a6ef73ebd423b6/msgspec-0.21.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4248cf0b6129b7d230eacd493c17cc2d4f3989f3bb7f633a928a85b7dcfa251", size = 196188, upload-time = "2026-04-12T21:44:07.181Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/81/074612945c0666078f7366f40000013de9f6ba687491d450df699bceebc9/msgspec-0.21.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5102c7e9b3acff82178449b85006d96310e690291bb1ea0142f1b24bcb8aabcb", size = 188473, upload-time = "2026-04-12T21:44:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/37/655101799590bcc5fddb2bd3fe0e6194e816c2d1da7c361725f5eb89a910/msgspec-0.21.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:846758412e9518252b2ac9bffd6f0e54d9ff614f5f9488df7749f81ff5c80920", size = 218871, upload-time = "2026-04-12T21:44:09.917Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d1/d4cd9fe89c7d400d7a18f86ccc94daa3f0927f53558846fcb60791dce5d6/msgspec-0.21.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21995e74b5c598c2e004110ad66ec7f1b8c20bf2bcf3b2de8fd9a3094422d3ff", size = 225025, upload-time = "2026-04-12T21:44:11.191Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bf/e20549e602b9edccadeeff98760345a416f9cce846a657e8b18e3396b212/msgspec-0.21.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6129f0cca52992e898fd5344187f7c8127b63d810b2fd73e36fca73b4c6475ee", size = 222672, upload-time = "2026-04-12T21:44:12.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/68/04d7a8f0f786545cf9b8c280c57aa6befb5977af6e884b8b54191cbe44b3/msgspec-0.21.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ef3ec2296248d1f8b9231acb051b6d471dfde8f21819e86c9adaaa9f42918521", size = 227303, upload-time = "2026-04-12T21:44:13.709Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4d/619866af2840875be408047bf9e70ceafbae6ab50660de7134ed1b25eb86/msgspec-0.21.1-cp312-cp312-win_amd64.whl", hash = "sha256:d4ab834a054c6f0cbeef6df9e7e1b33d5f1bc7b86dea1d2fd7cad003873e783d", size = 190017, upload-time = "2026-04-12T21:44:14.977Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2e/a8f9eca8fd00e097d7a9e99ba8a4685db994494448e3d4f0b7f6e9a3c0f7/msgspec-0.21.1-cp312-cp312-win_arm64.whl", hash = "sha256:628aaa35c74950a8c59da330d7e98917e1c7188f983745782027748ee4ca573e", size = 175345, upload-time = "2026-04-12T21:44:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/74/f11ede02839b19ff459f88e3145df5d711626ca84da4e23520cebf819367/msgspec-0.21.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:764173717a01743f007e9f74520ed281f24672c604514f7d76c1c3a10e8edb66", size = 196176, upload-time = "2026-04-12T21:44:17.613Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/4476c1bd341418a046c4955aff632ec769315d1e3cb94e6acf86d461f9ed/msgspec-0.21.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:344c7cd0eaed1fb81d7959f99100ef71ec9b536881a376f11b9a6c4803365697", size = 188524, upload-time = "2026-04-12T21:44:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d9/9e9d7d7e5061b47540d03d640fab9b3965ba7ae49c1b2154861c8f007518/msgspec-0.21.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48943e278b3854c2f89f955ddc6f9f430d3f0784b16e47d10604ee0463cd21f5", size = 218880, upload-time = "2026-04-12T21:44:20.028Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/2bb344f34abb4b57e60c7c9c761994e0417b9718ec1460bf00c296f2a7ea/msgspec-0.21.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9aa659ebb0101b1cbc31461212b87e341d961f0ab0772aaf068a99e001ec4aa", size = 225050, upload-time = "2026-04-12T21:44:21.577Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/84/7c1e412f76092277bf760cef12b7979d03314d259ab5b5cafde5d0c1722d/msgspec-0.21.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7b27d1a8ead2b6f5b0c4f2d07b8be1ccfcc041c8a0e704781edebe3ae13c484", size = 222713, upload-time = "2026-04-12T21:44:22.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/27/0bba04b2b4ef05f3d068429410bc71d2cea925f1596a8f41152cccd5edb8/msgspec-0.21.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:38fe93e86b61328fe544cb7fd871fad5a27c8734bfda90f65e5dbe288ae50f61", size = 227259, upload-time = "2026-04-12T21:44:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2d/09574b0eea02fed2c2c1383dbaae2c7f79dc16dcd6487a886000afb5d7c4/msgspec-0.21.1-cp313-cp313-win_amd64.whl", hash = "sha256:8bc666331c35fcce05a7cd2d6221adbe0f6058f8e750711413d22793c080ac6a", size = 189857, upload-time = "2026-04-12T21:44:25.359Z" },
+    { url = "https://files.pythonhosted.org/packages/46/34/105b1576ad182879914f0c821f17ee1d13abb165cb060448f96fe2aff078/msgspec-0.21.1-cp313-cp313-win_arm64.whl", hash = "sha256:42bb1241e0750c1a4346f2aa84db26c5ffd99a4eb3a954927d9f149ff2f42898", size = 175403, upload-time = "2026-04-12T21:44:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ad/86954e987d1d6a5c579e2c2e7832b65e0fff194179fdac4f581536086024/msgspec-0.21.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fab48eb45fdbfbdb2c0edfec00ffc53b6b6085beefc6b50b61e01659f9f8757f", size = 196261, upload-time = "2026-04-12T21:44:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a1/c5e46c3e42b866199365e35d11dddfd1fbd8bba4fdb3c52f965b1607ce94/msgspec-0.21.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3cb779ea0c35bc807ff941d415875c1f69ca0be91a2e907ab99a171811d86a9a", size = 188729, upload-time = "2026-04-12T21:44:28.99Z" },
+    { url = "https://files.pythonhosted.org/packages/85/7d/1e29a319d678d6cb962ae5bdf32a6858ebdf38f73bc654c0e9c742a0c2c8/msgspec-0.21.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68604db36b3b4dd9bf160e436e12798a4738848144cea1aca1cb984011eb160f", size = 219866, upload-time = "2026-04-12T21:44:31.104Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1f/cca084ca2572810fff12ea9dbdcbe39eac048f40daf4a9077b49fcbe8cee/msgspec-0.21.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d6b9dc50948eaf65df54d2fd0ff66e6d8c32f116037209ee861810eb9b676cb", size = 224993, upload-time = "2026-04-12T21:44:32.649Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/d2120fc9d419a89a3a7c13e5b7078798c4b392a96a02a6e2b3ce43a8766c/msgspec-0.21.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:52c5e21930942302394429c5a582ce7e6b62c7f983b3760834c2ce107e0dd6df", size = 223535, upload-time = "2026-04-12T21:44:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/75/17/42418b66a3ad972a89bab73dd78b79cc6282bb488a25e73c853cee7443b9/msgspec-0.21.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:abbb39d65681fa24ed394e01af3d59d869068324f900c61d06062b7fb9980f2f", size = 227222, upload-time = "2026-04-12T21:44:35.093Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/33/265c894268cca88ff67b144ca2b4c522fc8b9a6f1966a3640c70516e78e1/msgspec-0.21.1-cp314-cp314-win_amd64.whl", hash = "sha256:5666b1b560b97b6ec2eb3fca8a502298ebac56e13bbca1f88523538ce83d01ea", size = 193810, upload-time = "2026-04-12T21:44:36.612Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8f/a6d35f25bf1fc63c492fdd88fdce01ba0875ead48c2b91f90f33653b4131/msgspec-0.21.1-cp314-cp314-win_arm64.whl", hash = "sha256:d8b8578e4c83b14ceea4cef0d0b747e31d9330fe4b03b2b2ad4063866a178f93", size = 179125, upload-time = "2026-04-12T21:44:38.198Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/39/74839641e64b99d87da55af0fc472854d42b46e2183b9e2a67fe1bb2a512/msgspec-0.21.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15f523d51c00ebad412213bfe9f06f0a50ec2b93e0c19e824a2d267cabb48ea2", size = 200171, upload-time = "2026-04-12T21:44:39.414Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9b/ce0cca6d2d87fcd4b6ff97600790494e64f26a2c55d61507cd2755c16193/msgspec-0.21.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e47390360583ba3d5c6cb44cf0a9f61b0a06a899d3c2c00627cedebb2e2884b", size = 192879, upload-time = "2026-04-12T21:44:40.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/08/673a7bb05e5702dc787ddd3011195b509f9867927970da59052211929987/msgspec-0.21.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f60800e6299b798142dc40b0644da77ceac5ea0568be58228417eae14135c847", size = 226281, upload-time = "2026-04-12T21:44:42.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/45/86508cf57283e9070b3c447e3ab25b792a7a0855a3ea4e0c6d111ac34c97/msgspec-0.21.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f8e9dfcd98419cf7568808470c4317a3fb30bef0e3715b568730a2b272a20d7", size = 229863, upload-time = "2026-04-12T21:44:43.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/62/e7c9367cd08d590559faacd711edbae36840342843e669440363f33c7d36/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92d89dfad13bd1ea640dc3e37e724ed380da1030b272bdf5ecafb983c3ad7c75", size = 230445, upload-time = "2026-04-12T21:44:44.806Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b4/c0f54632103846b658a10930025f4de41c8724b5e4805a5f3b395586cb7e/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d03867786e5d7ba25d666df4b11320c27170f4aeafcb8e3a8b0a50a4fb742ca", size = 231822, upload-time = "2026-04-12T21:44:46.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/1d/0d85cc79d0ccf5508e9c846cc66552a6a16bf92abd1dbd8362617f7b35cd/msgspec-0.21.1-cp314-cp314t-win_amd64.whl", hash = "sha256:740fbf1c9d59992ca3537d6fbe9ebbf9eaf726a65fbf31448e0ecbc710697a63", size = 206650, upload-time = "2026-04-12T21:44:47.601Z" },
+    { url = "https://files.pythonhosted.org/packages/90/91/56c5d560f20e6c20e9e4f55bd0e458f7f162aa689ee350346c04c48eac0b/msgspec-0.21.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0d2cc73df6058d811a126ac3a8ad63a4dfa210c82f9cf5a004802eaf4712de90", size = 183149, upload-time = "2026-04-12T21:44:48.833Z" },
+]
+
+[[package]]
 name = "mutmut"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1635,7 +1683,6 @@ dependencies = [
     { name = "mcp" },
     { name = "nh3" },
     { name = "opentelemetry-proto" },
-    { name = "orjson" },
     { name = "pydantic" },
     { name = "pygments" },
     { name = "python-multipart" },
@@ -1657,8 +1704,10 @@ dev = [
     { name = "hypothesis" },
     { name = "hypothesis-jsonschema" },
     { name = "jsonschema" },
+    { name = "msgspec" },
     { name = "mutmut" },
     { name = "mypy" },
+    { name = "orjson" },
     { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "pyte" },
@@ -1679,6 +1728,12 @@ dev = [
 fuzz = [
     { name = "atheris" },
     { name = "mutmut" },
+]
+speed = [
+    { name = "orjson" },
+]
+speed-msgspec = [
+    { name = "msgspec" },
 ]
 sqlite-compat = [
     { name = "pysqlite3-binary", marker = "sys_platform == 'linux'" },
@@ -1721,12 +1776,15 @@ requires-dist = [
     { name = "lark", specifier = ">=1.3.1,<2.0" },
     { name = "markdown-it-py", specifier = ">=4.2.0" },
     { name = "mcp", specifier = ">=1.28.1" },
+    { name = "msgspec", marker = "extra == 'dev'", specifier = ">=0.20.0" },
+    { name = "msgspec", marker = "extra == 'speed-msgspec'", specifier = ">=0.20.0" },
     { name = "mutmut", marker = "extra == 'dev'", specifier = ">=3.6.0" },
     { name = "mutmut", marker = "extra == 'fuzz'", specifier = ">=3.6.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.3.0,<2.4" },
     { name = "nh3", specifier = ">=0.3.6" },
     { name = "opentelemetry-proto", specifier = ">=1.43.0" },
-    { name = "orjson", specifier = ">=3.11.9" },
+    { name = "orjson", marker = "extra == 'dev'", specifier = ">=3.11.9" },
+    { name = "orjson", marker = "extra == 'speed'", specifier = ">=3.11.9" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.10.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.6.0" },
     { name = "pydantic", specifier = ">=2.13.4,<3.0" },
@@ -1771,7 +1829,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.16.0" },
     { name = "watchfiles", specifier = ">=1.2.0" },
 ]
-provides-extras = ["dev", "fuzz", "sqlite-compat", "tree-sitter"]
+provides-extras = ["speed", "speed-msgspec", "dev", "fuzz", "sqlite-compat", "tree-sitter"]
 
 [[package]]
 name = "pre-commit"


### PR DESCRIPTION
## Summary

Makes `orjson` an optional accelerator instead of a hard dependency, so polylogue can eventually run on a free-threaded (3.14t) Python interpreter where orjson has no wheels and refuses to compile. `polylogue/core/json.py` becomes a real three-tier backend facade (orjson → msgspec → stdlib json), and every direct `import orjson` outside that facade is migrated to route through it.

## Problem

The 3.14t free-threading experiment gate (polylogue-7mtf) passed with a wide margin (3.9x-9.6x thread-parse speedup at 7.7% single-thread tax — see the bead for the full benchmark table), but surfaced a hard blocker: `orjson` (a hard pyproject dependency, imported directly in 8+ modules) ships zero `cp314t` wheels and its build script explicitly refuses to compile under free-threaded Python. Phase 2 of the free-threading adoption program (polylogue-xikl) opens with clearing that blocker before any of the thread-parallel parse work can land.

## Solution

- **`polylogue/core/json.py`** now selects a backend at import time, in priority order: `orjson` (fastest, no cp314t support) → `msgspec` (ships cp314t wheels since 0.20.0, Nov 2025 — confirmed via nixpkgs at the pinned rev too) → stdlib `json` (always available). Backend selection uses `importlib.import_module` rather than literal `import X as _x` statements specifically so mypy's `ignore_missing_imports` behavior stays consistent whether or not the optional packages are actually installed in the checking environment (a real cross-environment mypy failure surfaced and was fixed during this PR — see Verification).
- Every direct `import orjson` outside the facade is migrated: `sources/decoder_json.py`, `sources/live/batch_support.py`, `browser_capture/actions.py`, `browser_capture/receiver.py`, `browser_capture/server.py`, `daemon/events_http.py`, `daemon/http.py`, `archive/raw_payload/decode.py`, and `material_protocol/v1/canonical.py` (the content-hash-critical canonical serializer, which previously bypassed the facade entirely).
- `dumps_bytes`/`dumps` gained backend-neutral semantic flags (`sort_keys`, `indent`, `append_newline`) replacing the old raw orjson `option: int` bitmask passthrough. Output is byte-identical across all three backends for the compact-sorted and 2-space-indent shapes every call site needs — verified empirically, not just asserted — which is what keeps `material_protocol/v1/canonical.py`'s content-hash stability intact regardless of which backend produced the bytes.
- A single `JSONDecodeError(ValueError)` unifies `orjson.JSONDecodeError`, `msgspec.DecodeError`, and `json.JSONDecodeError` so callers never import or catch a backend-specific exception type.
- Two real cross-backend seams closed in the facade itself (would have been silent correctness bugs otherwise):
  - msgspec encodes `decimal.Decimal` natively as a JSON *string* (unlike orjson/stdlib, which raise and defer to the `default`/`enc_hook` callback) — the facade pre-normalizes `Decimal` to `float` on the msgspec path so all three backends agree it's a JSON number.
  - msgspec's `enc_hook` contract signals "unsupported type" via `NotImplementedError`, not `TypeError` like orjson/stdlib's `default` — adapted internally so one encoder function works across all backends.
  - The stdlib-only decode path now explicitly rejects non-finite tokens (`NaN`/`Infinity`) to match orjson/msgspec's strictness; a bug in the first draft of the backend dispatch would have silently accepted them when stdlib is the *primary* backend (no orjson/msgspec installed at all).
- **`pyproject.toml`**: `orjson` moves from a hard dependency to the `speed` optional extra; `msgspec` gets its own `speed-msgspec` extra (kept separate rather than combined, because a single combined extra would make the whole install fail on a 3.14t interpreter where orjson simply cannot be installed at all). Both are added to the `dev` extra so CI/tests exercise all three real backends via monkeypatching `core_json._BACKEND`, never by requiring orjson's actual absence.
- **`flake.nix`**: the nix package's `dependencies` list is independently curated (not derived from pyproject extras), so it deliberately keeps `orjson` on the standard (GIL) build for the speed win — a comment documents that a future `python314t` package variant should drop `orjson` and add `msgspec` instead, with zero facade code changes needed.

## Verification

- `mypy` (strict) on all 11 touched files — clean, in **both** the worktree's freshly-synced venv (orjson + msgspec installed) and the main checkout's venv (msgspec not installed at all) — this cross-environment check caught and fixed a real `no-redef` mypy bug in the first draft (explicit `ModuleType | None` pre-declarations conflicted with `import X as _x` differently depending on whether the package resolved).
- `devtools test tests/unit/core/test_json.py tests/unit/daemon/test_health_contract.py tests/unit/daemon/test_daemon_http_security.py tests/unit/material_protocol tests/unit/browser_capture tests/unit/sources/test_source_laws.py tests/unit/core/test_raw_payload_decode.py` — 979/980 pass. The one failure (`test_no_token_in_log_or_print_calls`) reproduces byte-identically on an unmodified checkout (verified via `git diff` → `git checkout --` → rerun → `git apply`), confirmed pre-existing and unrelated to this change.
- `devtools verify --quick` — exit 0 (format/lint/mypy/render/layering/manifests/ci-workflows/doc-commands/docs-coverage/clock-hygiene/degrade-loudly all green); this is also what the pre-push hook ran (from the main checkout's venv) before allowing the push.
- Decode-throughput benchmark (reusing `tests/infra/revision_backfill_benchmark.py`'s SMALL/LARGE/REVISION_CHAIN payload shapes, best-of-3, forced backend per run, same machine as the 7mtf gate): **msgspec is actually 1.8-7.1% *faster* than orjson** on decode for these shapes; stdlib-only is 34-53% slower than orjson. Both deltas are dwarfed by the 3.9x-9.6x thread-parallelism win the 3.14t gate already measured — recorded on the epic.

## Backend-ordering / packaging decisions (recorded on polylogue-xikl)

- Backend ordering: orjson → msgspec → stdlib. msgspec ships real `cp314t` wheels (confirmed on PyPI: 0.21.1 covers manylinux x86-64/ARM64 + macOS) and nixpkgs at the pinned rev already has a `msgspec` python-module derivation (built from source, so free-threaded compilation isn't blocked upstream the way orjson's is).
- Nix packaging: kept as a hard dependency on the standard build (independent of the pyproject extra split) since the flake's `dependencies` list is hand-curated, not extras-derived. A future 3.14t package variant swaps `orjson` for `msgspec` in that one list.

Ref polylogue-xikl.3