### PR TITLE
feat(benchmarks): add nightly perf-floors regression lane

### DIFF
--- a/.github/workflows/nightly-scale.yml
+++ b/.github/workflows/nightly-scale.yml
@@ -3,6 +3,11 @@ name: Nightly Scale
 # Runs the large-tier scale fixtures (issue #1183) outside the normal
 # CI critical path, captures benchmark results as structured JSON, and
 # compares against the committed baseline to detect regressions (#1220).
+#
+# The perf-floors job (polylogue-196x) is a separate, smaller curated lane:
+# it runs tests/benchmarks/perf_floors.py against the committed
+# tests/benchmarks/floors.json and posts a visible warning annotation on
+# regression without ever failing the workflow (fail-soft by design).
 
 on:
   schedule:
@@ -11,6 +16,10 @@ on:
     inputs:
       update-baseline:
         description: "Update the committed benchmark baseline after a successful run"
+        type: boolean
+        default: false
+      update-perf-floors:
+        description: "Regenerate tests/benchmarks/floors.json from this run's measurements"
         type: boolean
         default: false
 
@@ -77,4 +86,50 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add tests/benchmarks/baselines/nightly-baseline.json
           git commit -m "chore(benchmarks): update nightly baseline" || true
+          git push
+
+  perf-floors:
+    name: perf-floors (curated war-room regression lane, polylogue-196x)
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    # Fail-soft by design: a regression here must never block this workflow
+    # or any other job. It posts a visible ::warning:: annotation instead.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v8.3.2
+        with:
+          python-version: "3.14"
+      - run: uv sync --extra dev --frozen
+
+      - name: Run curated perf-floor set
+        id: perf_floors
+        continue-on-error: true
+        env:
+          POLYLOGUE_FORCE_PLAIN: "1"
+        run: |
+          uv run python tests/benchmarks/perf_floors.py --out perf-floors-results.json
+
+      - name: Upload perf-floors results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: perf-floors-${{ github.run_id }}
+          path: perf-floors-results.json
+          retention-days: 30
+
+      - name: Report regression
+        if: steps.perf_floors.outcome == 'failure'
+        run: |
+          echo "::warning::Nightly perf floors regressed beyond tolerance — see the perf-floors-${{ github.run_id }} artifact for the delta table (polylogue-196x)."
+
+      - name: Update floors
+        if: inputs.update-perf-floors
+        run: |
+          uv run python tests/benchmarks/perf_floors.py --update-floors \
+            --note "Updated via workflow_dispatch on $(date -u +%Y-%m-%dT%H:%M:%SZ)."
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add tests/benchmarks/floors.json
+          git commit -m "chore(benchmarks): update perf floors" || true
           git push

--- a/docs/plans/test-clock-allowlist.yaml
+++ b/docs/plans/test-clock-allowlist.yaml
@@ -81,6 +81,8 @@ files:
     reason: "Ingest pipeline correctness tests (#1736) use time.monotonic for real process wait/retry timing that cannot be satisfied by a frozen clock."
   - path: tests/benchmarks/test_daemon_uds.py
     reason: "polylogue-20d.1 daemon UDS benchmark fixture polls a real background-thread HTTP server's readiness with a bounded wall-clock deadline; frozen_clock cannot substitute for waiting on real socket/thread startup."
+  - path: tests/benchmarks/perf_floors.py
+    reason: "polylogue-196x nightly perf-floors runner stamps its measurement report with the real wall-clock generation time (machine fingerprint metadata for the committed floors artifact); a frozen clock would misdate every real nightly run."
   - path: tests/unit/cli/test_daemon_golden_parity.py
     reason: "polylogue-20d.1 golden-parity test starts a real UDS daemon server in a background thread and polls its readiness with a bounded wall-clock deadline before comparing direct vs daemon-proxied CLI output; frozen_clock cannot substitute for waiting on real socket/thread startup."
   - path: tests/unit/archive/query/test_execution_control.py

--- a/tests/benchmarks/floors.json
+++ b/tests/benchmarks/floors.json
@@ -1,0 +1,75 @@
+{
+  "default_tolerance_pct": 50.0,
+  "generated_at": "2026-07-19T14:14:47.730474+00:00",
+  "git_sha": "c9784b648717",
+  "machine": {
+    "cpu_count": 24,
+    "hostname": "sinnix-prime",
+    "platform": "Linux-6.18.38-x86_64-with-glibc2.42",
+    "python_version": "3.14.4"
+  },
+  "measured_under_load": true,
+  "metrics": {
+    "action_pairs_refresh_mean_ms": {
+      "baseline": 3.3244214973819908,
+      "direction": "lower_is_better",
+      "tolerance_pct": 70.0,
+      "unit": "ms"
+    },
+    "action_pairs_refresh_p95_ms": {
+      "baseline": 7.476726997992955,
+      "direction": "lower_is_better",
+      "tolerance_pct": 70.0,
+      "unit": "ms"
+    },
+    "census_chain_revisions_per_s": {
+      "baseline": 1844.2279717443803,
+      "direction": "higher_is_better",
+      "tolerance_pct": 50.0,
+      "unit": "revisions/s"
+    },
+    "census_large_raws_per_s": {
+      "baseline": 68.12016096009881,
+      "direction": "higher_is_better",
+      "tolerance_pct": 50.0,
+      "unit": "raws/s"
+    },
+    "census_small_raws_per_s": {
+      "baseline": 1692.1938766054334,
+      "direction": "higher_is_better",
+      "tolerance_pct": 50.0,
+      "unit": "raws/s"
+    },
+    "query_list_summaries_p50_ms": {
+      "baseline": 20.0,
+      "direction": "lower_is_better",
+      "tolerance_pct": 70.0,
+      "unit": "ms"
+    },
+    "query_list_summaries_p95_ms": {
+      "baseline": 31.95,
+      "direction": "lower_is_better",
+      "tolerance_pct": 70.0,
+      "unit": "ms"
+    },
+    "query_search_summaries_p50_ms": {
+      "baseline": 18.5,
+      "direction": "lower_is_better",
+      "tolerance_pct": 70.0,
+      "unit": "ms"
+    },
+    "query_search_summaries_p95_ms": {
+      "baseline": 20.700000000000003,
+      "direction": "lower_is_better",
+      "tolerance_pct": 70.0,
+      "unit": "ms"
+    },
+    "replay_sessions_per_min": {
+      "baseline": 5647.120545909368,
+      "direction": "higher_is_better",
+      "tolerance_pct": 50.0,
+      "unit": "sessions/min"
+    }
+  },
+  "note": "Initial floors recorded 2026-07-19 on sinnix-prime under active shared load (load avg ~7, concurrent live index rebuild + nix build + parallel agent pytest run). Tolerances are intentionally generous; tighten after a quiet-machine re-run (see polylogue-196x)."
+}

--- a/tests/benchmarks/perf_floors.py
+++ b/tests/benchmarks/perf_floors.py
@@ -1,0 +1,610 @@
+"""Nightly perf floors: curated regression lane over the war-room harnesses (polylogue-196x).
+
+The 2026-07-18/19 campaign produced measured wins (>20x replay throughput via
+planner-statistics seeding, 8x/3.3x elsewhere) that nothing protected from
+silent regression. This module is the single entry point that turns four of
+those harnesses into a floor-checked measurement:
+
+* **census throughput** (raws/s) over the three
+  ``tests/infra/revision_backfill_benchmark`` shapes -- SMALL/LARGE payload
+  and the REVISION_CHAIN growing-file shape that polylogue-nh44 targeted.
+* **replay throughput** (sessions/min) via
+  ``backfill_historical_revision_evidence`` end to end (census + replay) on a
+  fresh corpus.
+* **action_pairs refresh timing** (ms/session) via the real production
+  ``refresh_action_pairs`` over a realistically-shaped seeded archive -- the
+  exact regression class polylogue-l3tk fixed (missing planner statistics on
+  a fresh generation turning a session-scoped refresh into a full-table scan).
+* **query latency** (p50/p95 ms) for ``search_summaries``/``list_summaries``,
+  computed through the real production
+  ``polylogue.operations.route_observation.compute_latency_percentiles``.
+
+Usage::
+
+    python tests/benchmarks/perf_floors.py                       # measure + compare
+    python tests/benchmarks/perf_floors.py --quick                # smaller corpora
+    python tests/benchmarks/perf_floors.py --json --out run.json  # raw results artifact
+    python tests/benchmarks/perf_floors.py --update-floors         # ratchet baseline
+
+Exit code: 0 (within tolerance or ``--update-floors``), 1 (a metric regressed
+beyond its tolerance). The nightly workflow runs this fail-soft (a regression
+posts a visible annotation, it does not block the job or other jobs).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import subprocess
+import sys
+import tempfile
+import time
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+REPORT_VERSION = 1
+DEFAULT_FLOORS_PATH = Path(__file__).parent / "floors.json"
+DEFAULT_TOLERANCE_PCT = 35.0
+_GIT_TIMEOUT_S = 2.0
+
+# Quick mode shrinks corpora for a fast smoke check (local dev / CI dry runs);
+# it still exercises every measured surface, just at a smaller scale.
+_ACTION_PAIRS_TARGET_MESSAGES = 3000
+_ACTION_PAIRS_TARGET_MESSAGES_QUICK = 600
+_ACTION_PAIRS_SAMPLE_SESSIONS = 20
+_REPLAY_RAW_COUNT = 200
+_REPLAY_RAW_COUNT_QUICK = 40
+_QUERY_TERMS: tuple[str, ...] = ("analysis", "error", "function", "test")
+_QUERY_LIST_REPEATS = 4
+
+
+@dataclass(frozen=True, slots=True)
+class FloorMetric:
+    """One measured, floor-checkable quantity."""
+
+    name: str
+    value: float
+    unit: str
+    direction: str  # "higher_is_better" | "lower_is_better"
+    detail: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Measurement group 1: census throughput per revision-backfill shape
+# ---------------------------------------------------------------------------
+
+
+def measure_census_throughput(workdir: Path, *, quick: bool = False) -> list[FloorMetric]:
+    from polylogue.sources.revision_backfill import census_historical_revision_evidence
+    from tests.infra.revision_backfill_benchmark import (
+        LARGE_PAYLOAD_SHAPE,
+        REVISION_CHAIN_SHAPE,
+        SMALL_PAYLOAD_SHAPE,
+        build_independent_raw_corpus,
+        build_revision_chain_corpus,
+    )
+
+    metrics: list[FloorMetric] = []
+
+    small_root = workdir / "census-small"
+    build_independent_raw_corpus(
+        small_root,
+        raw_count=SMALL_PAYLOAD_SHAPE["raw_count"],
+        avg_payload_bytes=SMALL_PAYLOAD_SHAPE["avg_payload_bytes"],
+    )
+    start = time.perf_counter()
+    result = census_historical_revision_evidence(small_root)
+    elapsed = time.perf_counter() - start
+    metrics.append(
+        FloorMetric(
+            "census_small_raws_per_s",
+            result.scanned / elapsed if elapsed > 0 else 0.0,
+            "raws/s",
+            "higher_is_better",
+            {"raw_count": result.scanned, "elapsed_s": round(elapsed, 4), "shape": "SMALL_PAYLOAD_SHAPE"},
+        )
+    )
+
+    if not quick:
+        large_root = workdir / "census-large"
+        build_independent_raw_corpus(
+            large_root,
+            raw_count=LARGE_PAYLOAD_SHAPE["raw_count"],
+            avg_payload_bytes=LARGE_PAYLOAD_SHAPE["avg_payload_bytes"],
+        )
+        start = time.perf_counter()
+        result = census_historical_revision_evidence(large_root)
+        elapsed = time.perf_counter() - start
+        metrics.append(
+            FloorMetric(
+                "census_large_raws_per_s",
+                result.scanned / elapsed if elapsed > 0 else 0.0,
+                "raws/s",
+                "higher_is_better",
+                {"raw_count": result.scanned, "elapsed_s": round(elapsed, 4), "shape": "LARGE_PAYLOAD_SHAPE"},
+            )
+        )
+
+    chain_root = workdir / "census-chain"
+    build_revision_chain_corpus(
+        chain_root,
+        superseded_count=REVISION_CHAIN_SHAPE["superseded_count"],
+        final_payload_bytes=REVISION_CHAIN_SHAPE["final_payload_bytes"],
+    )
+    start = time.perf_counter()
+    result = census_historical_revision_evidence(chain_root)
+    elapsed = time.perf_counter() - start
+    metrics.append(
+        FloorMetric(
+            "census_chain_revisions_per_s",
+            result.scanned / elapsed if elapsed > 0 else 0.0,
+            "revisions/s",
+            "higher_is_better",
+            {"revisions_scanned": result.scanned, "elapsed_s": round(elapsed, 4), "shape": "REVISION_CHAIN_SHAPE"},
+        )
+    )
+    return metrics
+
+
+# ---------------------------------------------------------------------------
+# Measurement group 2: replay throughput (census + replay end to end)
+# ---------------------------------------------------------------------------
+
+
+def measure_replay_throughput(workdir: Path, *, quick: bool = False) -> list[FloorMetric]:
+    from polylogue.sources.revision_backfill import backfill_historical_revision_evidence
+    from tests.infra.revision_backfill_benchmark import SMALL_PAYLOAD_SHAPE, build_independent_raw_corpus
+
+    raw_count = _REPLAY_RAW_COUNT_QUICK if quick else _REPLAY_RAW_COUNT
+    root = workdir / "replay"
+    build_independent_raw_corpus(
+        root,
+        raw_count=raw_count,
+        avg_payload_bytes=SMALL_PAYLOAD_SHAPE["avg_payload_bytes"],
+    )
+    start = time.perf_counter()
+    result = backfill_historical_revision_evidence(root)
+    elapsed = time.perf_counter() - start
+    sessions_per_min = (result.replayed_logical_sources / elapsed) * 60.0 if elapsed > 0 else 0.0
+    return [
+        FloorMetric(
+            "replay_sessions_per_min",
+            sessions_per_min,
+            "sessions/min",
+            "higher_is_better",
+            {
+                "sessions_replayed": result.replayed_logical_sources,
+                "raw_count": raw_count,
+                "elapsed_s": round(elapsed, 4),
+            },
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Shared seeded archive for groups 3 + 4 (action_pairs timing, query latency)
+# ---------------------------------------------------------------------------
+
+
+def _seed_bench_archive(workdir: Path, *, target_messages: int) -> Path:
+    """Seed a realistic-distribution archive and return its ``index.db`` path.
+
+    Reuses the same generator ``tests/benchmarks/conftest.py`` uses for its
+    session-scoped fixtures, so this measurement exercises the identical
+    write path (session/message/block records through the production
+    writer) that the rest of the benchmark suite already trusts.
+    """
+    from tests.benchmarks.conftest import _seed_realistic_db
+
+    db_path = workdir / "seeded" / "index.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    _seed_realistic_db(db_path, target_messages=target_messages)
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# Measurement group 3: action_pairs refresh timing (polylogue-l3tk regression class)
+# ---------------------------------------------------------------------------
+
+
+def measure_action_pairs_refresh(
+    index_db: Path, *, sample_size: int = _ACTION_PAIRS_SAMPLE_SESSIONS
+) -> list[FloorMetric]:
+    import sqlite3
+
+    from polylogue.storage.sqlite.action_pairs import refresh_action_pairs
+
+    conn = sqlite3.connect(str(index_db))
+    try:
+        rows = conn.execute("SELECT session_id FROM sessions ORDER BY session_id LIMIT ?", (sample_size,)).fetchall()
+        session_ids = [row[0] for row in rows]
+        durations_ms: list[float] = []
+        for session_id in session_ids:
+            start = time.perf_counter()
+            refresh_action_pairs(conn, session_id)
+            conn.commit()
+            durations_ms.append((time.perf_counter() - start) * 1000.0)
+    finally:
+        conn.close()
+
+    if not durations_ms:
+        return [
+            FloorMetric(
+                "action_pairs_refresh_mean_ms",
+                0.0,
+                "ms",
+                "lower_is_better",
+                {"sample_size": 0, "note": "no sessions found in seeded archive"},
+            )
+        ]
+
+    durations_ms.sort()
+    mean_ms = sum(durations_ms) / len(durations_ms)
+    p95_ms = durations_ms[min(len(durations_ms) - 1, round(0.95 * (len(durations_ms) - 1)))]
+    return [
+        FloorMetric(
+            "action_pairs_refresh_mean_ms",
+            mean_ms,
+            "ms",
+            "lower_is_better",
+            {"sample_size": len(durations_ms)},
+        ),
+        FloorMetric(
+            "action_pairs_refresh_p95_ms",
+            p95_ms,
+            "ms",
+            "lower_is_better",
+            {"sample_size": len(durations_ms)},
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Measurement group 4: query p50/p95 latency via real route-latency percentiles
+# ---------------------------------------------------------------------------
+
+
+def measure_query_latency(index_db: Path) -> list[FloorMetric]:
+    from polylogue.operations.route_observation import compute_latency_percentiles
+    from polylogue.storage.sqlite.archive_tiers.ops_write import ArchiveRouteObservation
+    from tests.benchmarks.helpers import open_bench_store
+
+    durations_by_route: dict[str, list[float]] = defaultdict(list)
+    with open_bench_store(index_db) as store:
+        for term in _QUERY_TERMS:
+            start = time.perf_counter()
+            results = store.run(store.repository.search_summaries(term, limit=20))
+            list(results)
+            durations_by_route["query.search_summaries"].append((time.perf_counter() - start) * 1000.0)
+        for _ in range(_QUERY_LIST_REPEATS):
+            start = time.perf_counter()
+            results = store.run(store.repository.list_summaries(limit=20))
+            list(results)
+            durations_by_route["query.list_summaries"].append((time.perf_counter() - start) * 1000.0)
+
+    observations: list[ArchiveRouteObservation] = []
+    started_at_ms = 1_700_000_000_000
+    for route, durations in durations_by_route.items():
+        for index, duration_ms in enumerate(durations):
+            observations.append(
+                ArchiveRouteObservation(
+                    observation_id=f"perf-floor-{route}-{index}",
+                    trace_id=f"perf-floor-{route}",
+                    surface="perf-floor",
+                    route=route,
+                    verb=None,
+                    daemon_path="direct",
+                    phase="total",
+                    started_at_ms=started_at_ms + index,
+                    duration_ms=round(duration_ms),
+                    status="ok",
+                    git_head=None,
+                    archive_epoch=None,
+                    attributes={},
+                    sampled=True,
+                )
+            )
+
+    buckets = compute_latency_percentiles(observations)
+    metrics: list[FloorMetric] = []
+    for bucket in buckets:
+        metric_stub = bucket.route.replace(".", "_").replace("-", "_")
+        if bucket.p50_ms is not None:
+            metrics.append(
+                FloorMetric(
+                    f"{metric_stub}_p50_ms",
+                    bucket.p50_ms,
+                    "ms",
+                    "lower_is_better",
+                    {"sample_count": bucket.sample_count},
+                )
+            )
+        if bucket.p95_ms is not None:
+            metrics.append(
+                FloorMetric(
+                    f"{metric_stub}_p95_ms",
+                    bucket.p95_ms,
+                    "ms",
+                    "lower_is_better",
+                    {"sample_count": bucket.sample_count},
+                )
+            )
+    return metrics
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+
+def _git_sha(cwd: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(cwd), "rev-parse", "--short=12", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def machine_fingerprint() -> dict[str, Any]:
+    import os
+
+    return {
+        "hostname": platform.node(),
+        "platform": platform.platform(),
+        "python_version": platform.python_version(),
+        "cpu_count": os.cpu_count(),
+    }
+
+
+def run_perf_floor_set(workdir: Path | None = None, *, quick: bool = False) -> dict[str, Any]:
+    """Run every curated measurement group and return one JSON-serializable report."""
+    owns_workdir = workdir is None
+    base = Path(workdir) if workdir is not None else Path(tempfile.mkdtemp(prefix="plg-perf-floors-"))
+    base.mkdir(parents=True, exist_ok=True)
+
+    try:
+        metrics: list[FloorMetric] = []
+        metrics.extend(measure_census_throughput(base / "census", quick=quick))
+        metrics.extend(measure_replay_throughput(base / "replay", quick=quick))
+
+        target_messages = _ACTION_PAIRS_TARGET_MESSAGES_QUICK if quick else _ACTION_PAIRS_TARGET_MESSAGES
+        index_db = _seed_bench_archive(base / "seed", target_messages=target_messages)
+        metrics.extend(measure_action_pairs_refresh(index_db))
+        metrics.extend(measure_query_latency(index_db))
+
+        return {
+            "report_version": REPORT_VERSION,
+            "tool": "bench perf-floors",
+            "generated_at": datetime.now(UTC).isoformat(),
+            "git_sha": _git_sha(Path(__file__).resolve().parents[2]),
+            "machine": machine_fingerprint(),
+            "quick": quick,
+            "metrics": {
+                metric.name: {
+                    "value": metric.value,
+                    "unit": metric.unit,
+                    "direction": metric.direction,
+                    "detail": metric.detail,
+                }
+                for metric in metrics
+            },
+        }
+    finally:
+        if owns_workdir:
+            import shutil
+            from contextlib import suppress
+
+            with suppress(OSError):
+                shutil.rmtree(base)
+
+
+# ---------------------------------------------------------------------------
+# Floors file I/O + comparison
+# ---------------------------------------------------------------------------
+
+
+def load_floors(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"metrics": {}}
+    loaded: dict[str, Any] = json.loads(path.read_text())
+    return loaded
+
+
+def save_floors(
+    path: Path,
+    report: dict[str, Any],
+    *,
+    default_tolerance_pct: float,
+    measured_under_load: bool,
+    note: str | None,
+) -> None:
+    floors_metrics: dict[str, Any] = {}
+    for name, entry in report["metrics"].items():
+        floors_metrics[name] = {
+            "baseline": entry["value"],
+            "unit": entry["unit"],
+            "direction": entry["direction"],
+            "tolerance_pct": default_tolerance_pct,
+        }
+    payload = {
+        "generated_at": report["generated_at"],
+        "git_sha": report["git_sha"],
+        "machine": report["machine"],
+        "measured_under_load": measured_under_load,
+        "default_tolerance_pct": default_tolerance_pct,
+        "note": note,
+        "metrics": floors_metrics,
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+@dataclass(frozen=True, slots=True)
+class FloorComparison:
+    name: str
+    baseline: float
+    candidate: float
+    unit: str
+    direction: str
+    delta_pct: float
+    tolerance_pct: float
+    regressed: bool
+    is_new: bool = False
+
+
+def _metric_regressed(direction: str, delta_pct: float, tolerance_pct: float) -> bool:
+    if direction == "higher_is_better":
+        return delta_pct < -tolerance_pct
+    return delta_pct > tolerance_pct
+
+
+def compare_to_floors(
+    report: dict[str, Any],
+    floors: dict[str, Any],
+    *,
+    default_tolerance_pct: float = DEFAULT_TOLERANCE_PCT,
+) -> list[FloorComparison]:
+    """Direction-aware comparison: higher_is_better metrics regress on a drop,
+    lower_is_better metrics regress on a rise. Each metric may carry its own
+    ``tolerance_pct`` in the floors file; otherwise the file's
+    ``default_tolerance_pct`` (or the caller's) applies."""
+    floor_metrics: dict[str, Any] = floors.get("metrics", {})
+    file_default = floors.get("default_tolerance_pct", default_tolerance_pct)
+    results: list[FloorComparison] = []
+    for name, entry in sorted(report["metrics"].items()):
+        candidate = entry["value"]
+        direction = entry["direction"]
+        unit = entry["unit"]
+        floor = floor_metrics.get(name)
+        if floor is None:
+            results.append(
+                FloorComparison(
+                    name=name,
+                    baseline=0.0,
+                    candidate=candidate,
+                    unit=unit,
+                    direction=direction,
+                    delta_pct=0.0,
+                    tolerance_pct=0.0,
+                    regressed=False,
+                    is_new=True,
+                )
+            )
+            continue
+        baseline = float(floor["baseline"])
+        tolerance_pct = float(floor.get("tolerance_pct", file_default))
+        delta_pct = ((candidate - baseline) / baseline * 100.0) if baseline > 0 else 0.0
+        regressed = baseline > 0 and _metric_regressed(direction, delta_pct, tolerance_pct)
+        results.append(
+            FloorComparison(
+                name=name,
+                baseline=baseline,
+                candidate=candidate,
+                unit=unit,
+                direction=direction,
+                delta_pct=delta_pct,
+                tolerance_pct=tolerance_pct,
+                regressed=regressed,
+                is_new=False,
+            )
+        )
+    return results
+
+
+def format_delta_table(comparisons: Sequence[FloorComparison]) -> str:
+    lines: list[str] = []
+    lines.append(f"{'metric':<38} {'baseline':>12} {'candidate':>12} {'delta':>9}  status")
+    lines.append("-" * 90)
+    for comparison in comparisons:
+        if comparison.is_new:
+            lines.append(
+                f"{comparison.name:<38} {'--':>12} {comparison.candidate:>12.2f} {'--':>9}  NEW (no floor recorded)"
+            )
+            continue
+        status = "REGRESSED" if comparison.regressed else "ok"
+        lines.append(
+            f"{comparison.name:<38} {comparison.baseline:>12.2f} {comparison.candidate:>12.2f} "
+            f"{comparison.delta_pct:>+8.1f}%  {status} (tolerance {comparison.tolerance_pct:.0f}%)"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--floors", type=Path, default=DEFAULT_FLOORS_PATH, help="Path to the committed floors JSON")
+    parser.add_argument("--out", type=Path, default=None, help="Write the raw measurement report JSON here")
+    parser.add_argument("--json", action="store_true", help="Print the raw measurement report JSON to stdout")
+    parser.add_argument("--quick", action="store_true", help="Smaller corpora for a fast smoke check")
+    parser.add_argument(
+        "--update-floors",
+        action="store_true",
+        help="Regenerate the floors file from this run's measurements (ratchet) instead of comparing",
+    )
+    parser.add_argument(
+        "--tolerance-pct",
+        type=float,
+        default=DEFAULT_TOLERANCE_PCT,
+        help="Default per-metric tolerance when writing floors with --update-floors",
+    )
+    parser.add_argument(
+        "--measured-under-load",
+        action="store_true",
+        help="Record that this run shared the host with other heavy work (widens the recorded tolerance intent)",
+    )
+    parser.add_argument("--note", default=None, help="Free-text note to record alongside --update-floors")
+    parser.add_argument("--workdir", type=Path, default=None, help="Reuse a directory instead of a private temp dir")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    report = run_perf_floor_set(workdir=args.workdir, quick=args.quick)
+
+    if args.out is not None:
+        args.out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    if args.update_floors:
+        save_floors(
+            args.floors,
+            report,
+            default_tolerance_pct=args.tolerance_pct,
+            measured_under_load=args.measured_under_load,
+            note=args.note,
+        )
+        print(f"Floors updated: {args.floors}")
+        return 0
+
+    floors = load_floors(args.floors)
+    comparisons = compare_to_floors(report, floors)
+    if not args.json:
+        print(format_delta_table(comparisons))
+    regressions = [c for c in comparisons if c.regressed]
+    if regressions:
+        if not args.json:
+            print(f"\nFAIL: {len(regressions)} metric(s) regressed beyond tolerance.")
+        return 1
+    if not args.json:
+        print("\nOK: no perf-floor regressions detected.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/infra/test_perf_floors.py
+++ b/tests/unit/infra/test_perf_floors.py
@@ -1,0 +1,212 @@
+"""Tests for the nightly perf-floors runner (polylogue-196x).
+
+Covers the pure comparison/serialization logic exhaustively (fast, no I/O)
+plus one end-to-end smoke run of the full curated measurement pipeline in
+``--quick`` shape, so a broken import or signature drift in any of the four
+underlying production surfaces (revision-backfill census/replay,
+``refresh_action_pairs``, ``compute_latency_percentiles``) fails loudly here
+rather than silently in the nightly workflow.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from tests.benchmarks.perf_floors import (
+    FloorComparison,
+    compare_to_floors,
+    format_delta_table,
+    load_floors,
+    run_perf_floor_set,
+    save_floors,
+)
+
+
+def _sample_report(*, throughput_value: float = 100.0, latency_value: float = 10.0) -> dict[str, Any]:
+    return {
+        "generated_at": "2026-07-19T00:00:00+00:00",
+        "git_sha": "abc123",
+        "machine": {"hostname": "test-host"},
+        "metrics": {
+            "throughput_metric": {
+                "value": throughput_value,
+                "unit": "raws/s",
+                "direction": "higher_is_better",
+                "detail": {},
+            },
+            "latency_metric": {
+                "value": latency_value,
+                "unit": "ms",
+                "direction": "lower_is_better",
+                "detail": {},
+            },
+        },
+    }
+
+
+def _floors_with(*, latency_tolerance_pct: float = 20.0) -> dict[str, Any]:
+    return {
+        "default_tolerance_pct": 20.0,
+        "metrics": {
+            "throughput_metric": {
+                "baseline": 100.0,
+                "unit": "raws/s",
+                "direction": "higher_is_better",
+                "tolerance_pct": 20.0,
+            },
+            "latency_metric": {
+                "baseline": 10.0,
+                "unit": "ms",
+                "direction": "lower_is_better",
+                "tolerance_pct": latency_tolerance_pct,
+            },
+        },
+    }
+
+
+def test_higher_is_better_regresses_only_on_a_drop_beyond_tolerance() -> None:
+    floors = _floors_with()
+
+    within = {c.name: c for c in compare_to_floors(_sample_report(throughput_value=85.0), floors)}  # -15%
+    assert within["throughput_metric"].regressed is False
+
+    beyond = {c.name: c for c in compare_to_floors(_sample_report(throughput_value=70.0), floors)}  # -30%
+    assert beyond["throughput_metric"].regressed is True
+
+    # A rise in a higher_is_better metric is never a regression.
+    improved = {c.name: c for c in compare_to_floors(_sample_report(throughput_value=500.0), floors)}
+    assert improved["throughput_metric"].regressed is False
+
+
+def test_lower_is_better_regresses_only_on_a_rise_beyond_tolerance() -> None:
+    floors = _floors_with()
+
+    within = {c.name: c for c in compare_to_floors(_sample_report(latency_value=11.5), floors)}  # +15%
+    assert within["latency_metric"].regressed is False
+
+    beyond = {c.name: c for c in compare_to_floors(_sample_report(latency_value=14.0), floors)}  # +40%
+    assert beyond["latency_metric"].regressed is True
+
+    # A drop in a lower_is_better metric (faster) is never a regression.
+    improved = {c.name: c for c in compare_to_floors(_sample_report(latency_value=0.5), floors)}
+    assert improved["latency_metric"].regressed is False
+
+
+def test_metric_without_a_recorded_floor_is_flagged_new_not_regressed() -> None:
+    report = _sample_report()
+    report["metrics"]["brand_new_metric"] = {
+        "value": 1.0,
+        "unit": "ms",
+        "direction": "lower_is_better",
+        "detail": {},
+    }
+    floors = _floors_with()
+
+    comparisons = {c.name: c for c in compare_to_floors(report, floors)}
+    assert comparisons["brand_new_metric"].is_new is True
+    assert comparisons["brand_new_metric"].regressed is False
+
+
+def test_per_metric_tolerance_overrides_the_file_default() -> None:
+    floors = _floors_with(latency_tolerance_pct=5.0)
+    report = _sample_report(latency_value=10.8)  # +8%
+
+    comparisons = {c.name: c for c in compare_to_floors(report, floors)}
+    # +8% breaches the metric's own 5% tolerance even though the file default is 20%.
+    assert comparisons["latency_metric"].regressed is True
+    assert comparisons["latency_metric"].tolerance_pct == 5.0
+
+
+def test_save_and_load_floors_round_trips(tmp_path: Path) -> None:
+    floors_path = tmp_path / "floors.json"
+    save_floors(
+        floors_path,
+        _sample_report(),
+        default_tolerance_pct=25.0,
+        measured_under_load=True,
+        note="test note",
+    )
+
+    loaded = load_floors(floors_path)
+    assert loaded["default_tolerance_pct"] == 25.0
+    assert loaded["measured_under_load"] is True
+    assert loaded["note"] == "test note"
+    assert loaded["metrics"]["throughput_metric"]["baseline"] == 100.0
+    assert loaded["metrics"]["throughput_metric"]["tolerance_pct"] == 25.0
+    assert loaded["metrics"]["latency_metric"]["baseline"] == 10.0
+
+    # File is valid, stable JSON.
+    json.loads(floors_path.read_text())
+
+
+def test_load_floors_missing_file_returns_empty_metrics(tmp_path: Path) -> None:
+    loaded = load_floors(tmp_path / "does-not-exist.json")
+    assert loaded == {"metrics": {}}
+
+
+def test_format_delta_table_marks_regressions_and_new_metrics() -> None:
+    comparisons = [
+        FloorComparison(
+            name="a_metric",
+            baseline=100.0,
+            candidate=50.0,
+            unit="raws/s",
+            direction="higher_is_better",
+            delta_pct=-50.0,
+            tolerance_pct=20.0,
+            regressed=True,
+        ),
+        FloorComparison(
+            name="b_metric",
+            baseline=0.0,
+            candidate=5.0,
+            unit="ms",
+            direction="lower_is_better",
+            delta_pct=0.0,
+            tolerance_pct=0.0,
+            regressed=False,
+            is_new=True,
+        ),
+    ]
+    table = format_delta_table(comparisons)
+    assert "a_metric" in table
+    assert "REGRESSED" in table
+    assert "b_metric" in table
+    assert "NEW" in table
+
+
+def test_run_perf_floor_set_quick_measures_every_curated_metric(tmp_path: Path) -> None:
+    """End-to-end smoke run in --quick shape over every measurement group.
+
+    Exercises the real production surfaces (revision_backfill census/replay,
+    ``refresh_action_pairs``, ``compute_latency_percentiles``) so a signature
+    or import drift in any of them fails here instead of silently in CI.
+    Only shape/type/non-negativity is asserted -- wall-clock values are
+    host-variable and covered by the floors mechanism, not this test.
+    """
+    report = run_perf_floor_set(workdir=tmp_path, quick=True)
+
+    assert report["report_version"] == 1
+    assert report["tool"] == "bench perf-floors"
+    assert report["quick"] is True
+    assert isinstance(report["machine"], dict)
+    assert report["machine"]["cpu_count"]
+
+    expected_metrics = {
+        "census_small_raws_per_s",
+        "census_chain_revisions_per_s",
+        "replay_sessions_per_min",
+        "action_pairs_refresh_mean_ms",
+        "action_pairs_refresh_p95_ms",
+        "query_search_summaries_p50_ms",
+        "query_search_summaries_p95_ms",
+        "query_list_summaries_p50_ms",
+        "query_list_summaries_p95_ms",
+    }
+    assert expected_metrics.issubset(report["metrics"].keys())
+    for name, entry in report["metrics"].items():
+        assert entry["value"] >= 0.0, name
+        assert entry["direction"] in ("higher_is_better", "lower_is_better")
+        assert entry["unit"]


### PR DESCRIPTION
## Summary

Turns the 2026-07-18/19 war-room benchmark harnesses into a committed, floor-checked regression lane so this week's measured wins (>20x replay throughput, 8x/3.3x elsewhere) can't silently rot.

## Problem

The campaign produced real, measured performance fixes — planner-statistics seeding (polylogue-l3tk, >20x sustained replay), identity-hashing dedup (polylogue-fqp0), byte-proven superseded-revision skip (polylogue-nh44) — but nothing protected them from regression. `revision_backfill_benchmark.py` (SMALL/LARGE/REVISION_CHAIN corpus shapes) existed only as a correctness-test fixture, not a timed floor. The existing `nightly-scale.yml` lane runs the broad `scale_large` pytest-benchmark suite against a baseline, but doesn't specifically exercise the war-room harnesses or carry a lightweight direction-aware floors mechanism.

## Solution

- **`tests/benchmarks/perf_floors.py`** — single entry point measuring four curated groups through real production code paths (no toy replicas):
  - **Census throughput** (raws/s) over the SMALL/LARGE/REVISION_CHAIN shapes from `tests/infra/revision_backfill_benchmark.py`, via `census_historical_revision_evidence`.
  - **Replay throughput** (sessions/min) via `backfill_historical_revision_evidence` end to end (census + replay).
  - **`action_pairs` refresh timing** (ms/session) via the real `refresh_action_pairs` over a realistically-seeded archive — the exact regression class polylogue-l3tk fixed (missing planner statistics turning a session-scoped refresh into a full-table scan).
  - **Query p50/p95 latency** for `search_summaries`/`list_summaries`, computed through the real `polylogue.operations.route_observation.compute_latency_percentiles` (production route-latency surface computes p50/p95, not p99 — using the real function rather than fabricating a metric it doesn't produce).
  - Emits a JSON report (`metric -> {value, unit, direction, detail}` + machine fingerprint + git sha). Supports `--quick` (smaller corpora), `--update-floors` (ratchet), `--out` (write report artifact).
- **`tests/benchmarks/floors.json`** — committed baseline with direction-aware per-metric tolerances (50-70%). Recorded on `sinnix-prime` under **active shared load** (load avg ~7, concurrent live index rebuild + `nix build` + a parallel agent's pytest run) — `measured_under_load: true` and a `note` field record this explicitly; tolerances are intentionally generous rather than tight. A quiet-machine re-run with `--update-floors` can tighten them later.
- **`tests/unit/infra/test_perf_floors.py`** — unit coverage for the direction-aware comparison (higher-is-better vs lower-is-better regress in opposite directions, per-metric tolerance override, unrecorded-metric handling), floors.json round-trip, and one `--quick` end-to-end smoke run exercising every real production surface so an import/signature drift fails here, not silently in the nightly workflow.
- **`.github/workflows/nightly-scale.yml`** — new `perf-floors` job, **fail-soft by design** (job- and step-level `continue-on-error: true`): a regression posts a `::warning::` annotation and uploads the raw JSON artifact without blocking the workflow or the existing `scale-large` job. Adds an `update-perf-floors` `workflow_dispatch` input to ratchet the baseline the same way the existing lane's `update-baseline` input does.
- **`docs/plans/test-clock-allowlist.yaml`** — allowlists `perf_floors.py`'s real `datetime.now(UTC)` report timestamp (measurement metadata, not a frozen-clock candidate — same class as the existing `test_scale.py` entry).

## Verification

```
devtools verify --quick                              # exit 0, all 16 steps green
devtools test tests/unit/infra/test_perf_floors.py   # 8 passed
actionlint .github/workflows/nightly-scale.yml       # clean
```

Manual end-to-end run (`uv run python tests/benchmarks/perf_floors.py`), ~8s wall time, 0 regressions against the committed floors:

```
metric                                     baseline    candidate     delta  status
------------------------------------------------------------------------------------------
action_pairs_refresh_mean_ms                   3.32         3.75    +12.7%  ok (tolerance 70%)
action_pairs_refresh_p95_ms                    7.48         8.93    +19.5%  ok (tolerance 70%)
census_chain_revisions_per_s                1844.23      1777.60     -3.6%  ok (tolerance 50%)
census_large_raws_per_s                       68.12        65.14     -4.4%  ok (tolerance 50%)
census_small_raws_per_s                     1692.19      1664.73     -1.6%  ok (tolerance 50%)
query_list_summaries_p50_ms                   20.00        14.50    -27.5%  ok (tolerance 70%)
query_list_summaries_p95_ms                   31.95        15.85    -50.4%  ok (tolerance 70%)
query_search_summaries_p50_ms                 18.50        23.00    +24.3%  ok (tolerance 70%)
query_search_summaries_p95_ms                 20.70        26.40    +27.5%  ok (tolerance 70%)
replay_sessions_per_min                     5647.12      5906.02     +4.6%  ok (tolerance 50%)

OK: no perf-floor regressions detected.
```

The +/-20-50% swings between two back-to-back runs on the same (loaded) machine validate the generous-tolerance decision above — a tight floor recorded right now would false-positive on host noise alone.

## Deferred / follow-ups

- Tighter, per-metric tolerances after a quiet-machine re-run (`--update-floors` once load settles) — tracked as a note in `floors.json` itself rather than a separate issue, since it's a one-command follow-up.
- The "3.14t gil_bench harness" mentioned in the bead's design as living in a session scratchpad was not located as a committed artifact in this checkout; it is not included here. If it exists elsewhere it should be committed and added as a fifth measurement group in a follow-up.
- p99 was not produced because the real production route-latency surface (`compute_latency_percentiles`) only computes p50/p95; using a fabricated p99 not backed by any production code path was rejected in favor of the real metric.

Ref polylogue-196x