### PR TITLE
perf(storage): stop materializing action_pairs text copies

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -173,6 +173,25 @@ Polylogue has two schema-evolution regimes, keyed by tier durability.
   hash, so concurrent publishers of identical bytes remain independent.
   Existing v3 tiers migrate additively through
   `004_blob_publication_reservations.sql` after a verified backup manifest.
+- Index schema version 41 stops materializing `tool_input`/`output_text` text
+  copies on `action_pairs` (polylogue-2i2w). `action_pairs` keeps only
+  join/rank/outcome columns for a paired `tool_use`/`tool_result` block
+  (`tool_use_block_id`, `tool_result_block_id`, `session_id`, `message_id`,
+  `tool_id`, `use_rank`, `tool_name`, `semantic_type`, `tool_command`,
+  `tool_path`, `is_error`, `exit_code`); the text itself already lives once in
+  `blocks.tool_input`/`blocks.text`. On a live generation this table stored
+  868,522 rows at ~4.7KB/row (~4.1GB) — every tool interaction existed ~3x on
+  disk (blocks, action_pairs, FTS) — and the ~4.7KB rows lived in SQLite
+  overflow-page chains, so a per-session `DELETE FROM action_pairs WHERE
+  session_id=?` paid dozens of scattered page reads per row, turning a whale
+  session replace into hours of random IO. The `actions` VIEW is rewritten to
+  re-join `blocks` by `tool_use_block_id`/`tool_result_block_id` at read time,
+  so every reader (CLI, API, MCP, insights, `delegation_facts_source`) keeps
+  byte-identical `tool_input`/`output_text` payloads with no caller change.
+  Existing index tiers must be rebuilt from source evidence (`polylogue ops
+  reset --index && polylogued run`), though the transition itself needs no raw
+  reparse (see `polylogue/storage/sqlite/lifecycle.py`'s `IndexDeltaDeclaration`
+  for v41).
 - Index schema version 37 drops the three run-projection materialized cache
   tables — `session_runs`, `session_observed_events`,
   `session_context_snapshots` — added by v11 (polylogue-dab). Their write

--- a/polylogue/storage/sqlite/action_pairs.py
+++ b/polylogue/storage/sqlite/action_pairs.py
@@ -6,17 +6,29 @@ import sqlite3
 
 
 def action_pairs_refresh_sql(session_expr: str) -> str:
-    """Return the bounded insert used by writers and fixture-maintaining triggers."""
+    """Return the bounded insert used by writers and fixture-maintaining triggers.
+
+    ``action_pairs`` (index schema v41+, polylogue-2i2w) keeps only the
+    join/rank/outcome columns for a paired tool invocation -- NOT the full
+    ``tool_input``/``output_text`` payload text. Those bytes already live in
+    ``blocks`` (the ``tool_use``/``tool_result`` block rows this table's
+    ``tool_use_block_id``/``tool_result_block_id`` point at); copying them
+    again here made every tool interaction exist ~3x on disk and turned a
+    per-session DELETE into a scattered-overflow-page random-IO storm on
+    large archives (measured: ~4.7KB/row, hours of IO on a whale session
+    replace). The ``actions`` VIEW re-joins ``blocks`` by block_id to expose
+    ``tool_input``/``output_text`` to readers at query time instead.
+    """
     return f"""
         INSERT INTO action_pairs (
             tool_use_block_id, session_id, message_id, tool_id, use_rank,
-            tool_name, semantic_type, tool_command, tool_path, tool_input,
-            tool_result_block_id, output_text, is_error, exit_code
+            tool_name, semantic_type, tool_command, tool_path,
+            tool_result_block_id, is_error, exit_code
         )
         WITH ranked_uses AS (
             SELECT u.session_id, u.message_id, u.block_id AS tool_use_block_id,
                    u.tool_name, u.semantic_type, u.tool_command, u.tool_path,
-                   u.tool_input, u.tool_id,
+                   u.tool_id,
                    ROW_NUMBER() OVER (
                        PARTITION BY u.session_id, u.tool_id
                        ORDER BY um.position, um.variant_index, u.position
@@ -26,7 +38,7 @@ def action_pairs_refresh_sql(session_expr: str) -> str:
               AND u.tool_id IS NOT NULL AND u.tool_id != ''
         ), ranked_results AS (
             SELECT r.session_id, r.tool_id, r.block_id AS tool_result_block_id,
-                   r.text AS output_text, r.tool_result_is_error AS is_error,
+                   r.tool_result_is_error AS is_error,
                    r.tool_result_exit_code AS exit_code,
                    ROW_NUMBER() OVER (
                        PARTITION BY r.session_id, r.tool_id
@@ -37,14 +49,14 @@ def action_pairs_refresh_sql(session_expr: str) -> str:
               AND r.tool_id IS NOT NULL AND r.tool_id != ''
         )
         SELECT u.tool_use_block_id, u.session_id, u.message_id, u.tool_id, u.use_rank,
-               u.tool_name, u.semantic_type, u.tool_command, u.tool_path, u.tool_input,
-               r.tool_result_block_id, r.output_text, r.is_error, r.exit_code
+               u.tool_name, u.semantic_type, u.tool_command, u.tool_path,
+               r.tool_result_block_id, r.is_error, r.exit_code
         FROM ranked_uses u LEFT JOIN ranked_results r
           ON r.session_id = u.session_id AND r.tool_id = u.tool_id AND r.result_rank = u.use_rank
         UNION ALL
         SELECT u.block_id, u.session_id, u.message_id, u.tool_id, NULL,
-               u.tool_name, u.semantic_type, u.tool_command, u.tool_path, u.tool_input,
-               NULL, NULL, NULL, NULL
+               u.tool_name, u.semantic_type, u.tool_command, u.tool_path,
+               NULL, NULL, NULL
         FROM blocks u
         WHERE u.session_id = {session_expr} AND u.block_type = 'tool_use'
           AND (u.tool_id IS NULL OR u.tool_id = '')

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -24,7 +24,7 @@ from polylogue.storage.sqlite.archive_tiers.common import (
 )
 from polylogue.storage.sqlite.delegation_facts import delegation_facts_insert_sql
 
-INDEX_SCHEMA_VERSION = 40
+INDEX_SCHEMA_VERSION = 41
 
 FTS_FRESHNESS_STATE_DDL = """
 CREATE TABLE IF NOT EXISTS fts_freshness_state (
@@ -459,6 +459,14 @@ END;
 
 {FTS_FRESHNESS_STATE_DDL}
 
+-- polylogue-2i2w: deliberately NO tool_input/output_text columns here. This
+-- table is a join/rank/outcome index over paired tool_use/tool_result
+-- blocks -- the text itself already lives once in blocks.tool_input /
+-- blocks.text. Storing it again (index schema <= v40) made every tool
+-- interaction exist ~3x on disk (868K rows, ~4.7KB/row overflow-chained,
+-- ~4.1GB) and turned per-session DELETE into scattered random IO (measured:
+-- hours on a whale session replace). The actions VIEW below re-joins blocks
+-- by block_id to serve tool_input/output_text to readers at query time.
 CREATE TABLE IF NOT EXISTS action_pairs (
     tool_use_block_id      TEXT PRIMARY KEY REFERENCES blocks(block_id) ON DELETE CASCADE,
     session_id             TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
@@ -469,9 +477,7 @@ CREATE TABLE IF NOT EXISTS action_pairs (
     semantic_type          TEXT,
     tool_command           TEXT,
     tool_path              TEXT,
-    tool_input             TEXT,
     tool_result_block_id   TEXT REFERENCES blocks(block_id) ON DELETE SET NULL,
-    output_text            TEXT,
     is_error               INTEGER CHECK(is_error IN (0, 1) OR is_error IS NULL),
     exit_code              INTEGER,
     FOREIGN KEY(message_id) REFERENCES messages(message_id) ON DELETE CASCADE
@@ -508,12 +514,22 @@ WHERE is_error IS NOT NULL OR exit_code IS NOT NULL;
 -- preserves that (still surfaced, just with NULL result columns) while the
 -- empty-string guard stops '' specifically from cross-joining as if it
 -- were a real shared id (parsers currently only ever emit NULL, not '').
+-- polylogue-2i2w: tool_input/output_text are no longer materialized on
+-- action_pairs itself -- they are re-joined from blocks (by
+-- tool_use_block_id / tool_result_block_id) here, at read time, so every
+-- consumer of this view keeps byte-identical payloads without any caller
+-- change. tu is an INNER JOIN because tool_use_block_id is a NOT NULL FK
+-- ON DELETE CASCADE (the action_pairs row cannot outlive its use block); tr
+-- is a LEFT JOIN because tool_result_block_id is nullable (unpaired uses)
+-- and ON DELETE SET NULL.
 CREATE VIEW IF NOT EXISTS actions AS
 SELECT
-    session_id, message_id, tool_use_block_id, tool_name, semantic_type,
-    tool_command, tool_path, tool_input, output_text, is_error, exit_code,
-    tool_result_block_id
-FROM action_pairs;
+    ap.session_id, ap.message_id, ap.tool_use_block_id, ap.tool_name, ap.semantic_type,
+    ap.tool_command, ap.tool_path, tu.tool_input AS tool_input, tr.text AS output_text,
+    ap.is_error, ap.exit_code, ap.tool_result_block_id
+FROM action_pairs ap
+JOIN blocks tu ON tu.block_id = ap.tool_use_block_id
+LEFT JOIN blocks tr ON tr.block_id = ap.tool_result_block_id;
 
 CREATE TABLE IF NOT EXISTS session_events (
     event_id                   TEXT GENERATED ALWAYS AS (session_id || ':' || position) STORED UNIQUE,

--- a/polylogue/storage/sqlite/lifecycle.py
+++ b/polylogue/storage/sqlite/lifecycle.py
@@ -231,6 +231,31 @@ INDEX_DELTA_DECLARATIONS: tuple[IndexDeltaDeclaration, ...] = (
         # source evidence its nodes and edges cite.
         classes=(DerivedDeltaClass.SEMANTIC_REPARSE,),
     ),
+    IndexDeltaDeclaration(
+        version=41,
+        # action_pairs stops materializing tool_input/output_text text
+        # copies (polylogue-2i2w) -- every tool interaction existed ~3x on
+        # disk (blocks + action_pairs + FTS), and the copy turned a
+        # per-session delete into scattered overflow-page random IO. The
+        # surviving join/rank/outcome columns are copy-forward safe (no
+        # parser semantics involved): a clone drops the two columns from
+        # action_pairs and the actions VIEW is replaced to re-join blocks
+        # for the dropped text at read time, so every reader keeps
+        # byte-identical payloads without any reparse of raw evidence.
+        classes=(DerivedDeltaClass.CACHE_REMOVAL, DerivedDeltaClass.VIEW_ONLY),
+        operations=(
+            FastForwardOperation(
+                name="v41-action-pairs-text-copy-removal",
+                kind=FastForwardOperationKind.REPLACE_TABLE,
+                objects=(("table", "action_pairs"),),
+            ),
+            FastForwardOperation(
+                name="v41-action-pairs-text-copy-removal",
+                kind=FastForwardOperationKind.REPLACE_VIEW,
+                objects=(("view", "actions"),),
+            ),
+        ),
+    ),
 )
 
 

--- a/tests/unit/sources/test_codex_event_stream_contract.py
+++ b/tests/unit/sources/test_codex_event_stream_contract.py
@@ -687,9 +687,7 @@ class TestFunctionsExecLowering:
                 semantic_type TEXT,
                 tool_command TEXT,
                 tool_path TEXT,
-                tool_input TEXT,
                 tool_result_block_id TEXT,
-                output_text TEXT,
                 is_error INTEGER,
                 exit_code INTEGER
             );
@@ -728,12 +726,16 @@ class TestFunctionsExecLowering:
                     ),
                 )
         refresh_action_pairs(conn, "session")
+        # output_text is no longer materialized on action_pairs itself
+        # (polylogue-2i2w) -- it is re-joined from the paired tool_result
+        # block, mirroring the production `actions` VIEW.
         rows = conn.execute(
             """
-            SELECT use_rank, tool_command, output_text, is_error, exit_code
-            FROM action_pairs
-            WHERE tool_id = 'repeated-exec::polylogue-child::0'
-            ORDER BY use_rank
+            SELECT ap.use_rank, ap.tool_command, tr.text AS output_text, ap.is_error, ap.exit_code
+            FROM action_pairs ap
+            LEFT JOIN blocks tr ON tr.block_id = ap.tool_result_block_id
+            WHERE ap.tool_id = 'repeated-exec::polylogue-child::0'
+            ORDER BY ap.use_rank
             """
         ).fetchall()
         assert [dict(row) for row in rows] == [

--- a/tests/unit/storage/test_archive_tiers_ddl.py
+++ b/tests/unit/storage/test_archive_tiers_ddl.py
@@ -246,6 +246,36 @@ def test_agent_action_and_delegation_views_are_indexed_projections(tmp_path: Pat
     assert "WITH" not in view_sql["delegations"].upper()
 
 
+def test_action_pairs_does_not_materialize_text_copies(tmp_path: Path) -> None:
+    """polylogue-2i2w: action_pairs is a join/rank/outcome index over paired
+    tool_use/tool_result blocks, not a second copy of their text. Storing
+    tool_input/output_text again here made every tool interaction exist ~3x
+    on disk and turned per-session deletes into scattered overflow-page
+    random IO on large archives. This locks the storage shape in place --
+    the `actions` view (tested below) is responsible for re-joining blocks
+    to serve that text to readers, not this table."""
+    conn = _connect(tmp_path / "index.db")
+    _apply_tier(conn, ArchiveTier.INDEX)
+
+    columns = {row["name"] for row in conn.execute("PRAGMA table_info(action_pairs)").fetchall()}
+    assert "tool_input" not in columns
+    assert "output_text" not in columns
+    assert columns == {
+        "tool_use_block_id",
+        "session_id",
+        "message_id",
+        "tool_id",
+        "use_rank",
+        "tool_name",
+        "semantic_type",
+        "tool_command",
+        "tool_path",
+        "tool_result_block_id",
+        "is_error",
+        "exit_code",
+    }
+
+
 def test_actions_view_pairs_reemitted_tool_id_by_transcript_rank_not_cross_product(tmp_path: Path) -> None:
     """xnkf: a provider can re-emit the same tool_id on distinct messages (verified
     live, not a variant). A plain equality join on tool_id fans out N uses x M


### PR DESCRIPTION
## Summary

`action_pairs` stops storing copies of `tool_input`/`output_text`; it now keeps only join/rank/outcome columns, and the `actions` VIEW re-joins `blocks` for the text at read time so every reader keeps byte-identical payloads.

## Problem

dbstat on the live rebuild generation showed `action_pairs` at 4.1GB for 868,522 rows (~4.7KB/row) — every tool interaction existed ~3x on disk (`blocks.text`/`blocks.tool_input`, `action_pairs.output_text`/`action_pairs.tool_input`, plus FTS). The ~4.7KB rows live in SQLite overflow-page chains, so a per-session `DELETE FROM action_pairs WHERE session_id=?` pays dozens of scattered page reads per row. strace on a live whale-session delete confirmed the mechanism: 27K distinct `pread64`/s concentrated in the `action_pairs` tail with zero sample overlap 30s apart — pure forward progress through a colossal random-IO workload, turning a whale session replace into hours of IO. This is tracked as `polylogue-2i2w`.

## Solution

- `action_pairs` (`polylogue/storage/sqlite/archive_tiers/index.py`) drops `tool_input`/`output_text`; surviving columns: `tool_use_block_id`, `tool_result_block_id`, `session_id`, `message_id`, `tool_id`, `use_rank`, `tool_name`, `semantic_type`, `tool_command`, `tool_path`, `is_error`, `exit_code`.
- `action_pairs_refresh_sql` (`polylogue/storage/sqlite/action_pairs.py`) no longer selects/inserts the dropped columns.
- The `actions` VIEW is rewritten to INNER JOIN `blocks` by `tool_use_block_id` (NOT NULL FK, cascade) and LEFT JOIN `blocks` by `tool_result_block_id` (nullable, SET NULL) to re-serve `tool_input`/`output_text` at read time — same column names/order as before, so every consumer is unaffected.
- **Consumer audit** (`rg` across `storage/repository`, `insights`, `daemon`, `mcp`, `cli`, `api`, `devtools`): every reader of pair text goes through the `actions` view. None reads `action_pairs.output_text`/`tool_input` directly except the DDL/refresh/lifecycle machinery this PR edits (`action_pairs.py`, `write.py`'s `refresh_action_pairs` calls, `schema_bootstrap.py`'s stat1 seed rows, `archive_verification.py`'s planner-stats table-name list). `delegation_facts_source`/`delegation_facts` (subagent-dispatch cohort) reads through the view too and is transparently unaffected (verified via its own tests, unchanged).
- Index schema version 40 -> 41 (derived tier, no migration chain per the schema regime — `docs/internals.md` § Schema Versioning Model). Added `IndexDeltaDeclaration(version=41, classes=(CACHE_REMOVAL, VIEW_ONLY))` to `polylogue/storage/sqlite/lifecycle.py` since the transition is copy-forward safe (no parser semantics involved). Added the matching `docs/internals.md` changelog entry.
- Noted this bump on `polylogue-bo9n` and `polylogue-v6i3` per the schema-regime batching convention — their own decisions (session_events aggregation, FTS bulk-mode skip) remain open and are **not** implemented here.

## Discovered, filed separately (not fixed here, to keep blast radius narrow)

- `polylogue-5h5y`: index schema v40 (`query_unit_frame_state`, PR #3068) never got a declared delta class in `lifecycle.py` — `devtools lab policy schema-versioning` already failed before this PR (confirmed by reverting my changes to HEAD and re-running the lint: identical `missing: [40]` failure).
- `polylogue-m8nj`: `delegation_facts` still materializes its own (smaller, subagent-dispatch-only) copy of `instruction_payload`/`artifact_text`.

## Verification

- `devtools test tests/unit/sources/test_codex_event_stream_contract.py tests/unit/storage/test_archive_tiers_ddl.py tests/unit/storage/test_archive_tiers_write.py tests/unit/storage/test_archive_tiers_assertions.py tests/unit/storage/test_planner_statistics_seed.py tests/unit/maintenance/test_archive_verification.py tests/unit/storage/test_schema_policy_contracts.py tests/unit/insights/test_tool_usage.py tests/unit/storage/test_delegations_view.py tests/unit/pipeline/test_delegation_provider_fixtures.py tests/unit/storage/test_schema_safety.py` → all green except 4 pre-existing failures in `test_tool_usage.py`/`test_delegations_view.py` (`unknown database user_tier` / `unable to open database file`) — confirmed identical failure set on unmodified HEAD (reverted files, re-ran, same 4 failures), unrelated to this change.
- `devtools verify --quick` → exit 0 (ran automatically again via the pre-push hook).
- `devtools render all --check` → exit 0, no `out of sync`.
- `devtools lab policy docs-drift` → "zero unhandled drift".
- `devtools lab policy schema-versioning` → 1 pre-existing failure (v40 gap, tracked as `polylogue-5h5y`), no new failures introduced by v41.
- **Byte-equivalence proof**: `tests/unit/storage/test_archive_tiers_ddl.py` already pins exact `output_text`/`tool_command`/`is_error`/`exit_code` values through the `actions` view across matched/unmatched/error/reemitted-tool_id/variant-tie/empty-string-tool_id scenarios — all pass unchanged against the new join-based view (this *is* the golden-fixture proof: values were pinned before this change and are reproduced by the rewritten view). `test_agent_action_and_delegation_views_are_indexed_projections` (asserts `USING INDEX` in the `actions` query plan, no `WINDOW`/`WITH` in the view SQL) also passes unchanged. Added `test_action_pairs_does_not_materialize_text_copies` to lock the trimmed column set in place as a regression guard.
- Index-size estimate (not directly measured — no live archive access from this isolated worktree): the removed bytes are essentially all of the ~4.7KB/row footprint (surviving columns are short strings/ints/ids already part of that row), so `action_pairs` should collapse from ~4.1GB to a small fraction of that (likely low hundreds of MB, in-page, no overflow chains) on a real rebuild — most of the measured 4.1GB is expected to be reclaimed from `index.db`'s ~19.6GB total. Confirming this needs a real `polylogue ops reset --index && polylogued run` + dbstat pass, which is the coordinator's call.

Ref polylogue-2i2w