### PR TITLE
perf(sources): thread-parallel census parse under free-threaded Python

### DIFF
--- a/polylogue/pipeline/services/process_pool.py
+++ b/polylogue/pipeline/services/process_pool.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import multiprocessing
 import os
+import sys
 import time
 from concurrent.futures import ProcessPoolExecutor
 
@@ -58,6 +59,37 @@ def resolve_parse_worker_count(*, env_var: str = "POLYLOGUE_INGEST_PARSE_WORKERS
         return default
 
 
+def parallel_threads_effective() -> bool:
+    """True iff this interpreter is a genuinely free-threaded (no-GIL) build.
+
+    Gates every ``ThreadPoolExecutor``-based CPU-bound parse dispatch (see
+    ``sources/revision_backfill.py::_parse_unique_retained_raws``). The
+    polylogue-7mtf control-run measurement is the entire reason this check
+    exists: the SAME ``ThreadPoolExecutor`` parse code measured 3.9x-9.6x
+    speedup (w=4..16) on a real free-threaded 3.14t build, but 0.93x-0.96x
+    (i.e. no speedup, pure lock overhead) on a standard GIL build -- and,
+    worse, a concurrent SQLite writer thread's commit latency inflated
+    ~5000x (208ms vs an ~0.04ms/5ms cadence) when CPU-bound parse threads
+    ran alongside it under the GIL. Threads must never take the
+    parse-parallel path unless free-threading is provably active; a mistaken
+    "yes" here would silently reintroduce that writer-starvation hazard in
+    the daemon.
+
+    ``sys._is_gil_enabled`` only exists on interpreters built with PEP 703/779
+    support (CPython 3.13+); its absence means there is no free-threaded
+    build to speak of, so that case is treated as "GIL enabled" (the safe
+    default), not as an error. Resolved via ``getattr`` (not a literal
+    ``sys._is_gil_enabled`` attribute expression) so mypy --strict does not
+    require a per-Python-version type: ignore -- the underlying interpreter
+    either has the attribute or it doesn't, independent of which stub set
+    mypy resolves against.
+    """
+    is_gil_enabled = getattr(sys, "_is_gil_enabled", None)
+    if is_gil_enabled is None:
+        return False
+    return not is_gil_enabled()
+
+
 def process_pool_executor(*, max_workers: int) -> ProcessPoolExecutor:
     """Create a process pool that avoids bare fork() in multi-threaded parents."""
     return ProcessPoolExecutor(
@@ -87,6 +119,7 @@ def terminate_process_pool(executor: ProcessPoolExecutor, *, timeout: float = 1.
 
 __all__ = [
     "_initialize_worker_logging",
+    "parallel_threads_effective",
     "process_pool_context",
     "process_pool_executor",
     "resolve_parse_worker_count",

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -24,6 +24,7 @@ from polylogue.archive.revision_authority import (
 from polylogue.archive.session_revision_membership import MembershipRevision, classify_membership_revisions
 from polylogue.core.enums import Provider
 from polylogue.pipeline.ids import session_revision_projection
+from polylogue.pipeline.services.process_pool import parallel_threads_effective
 from polylogue.sources.decoders import _iter_json_stream
 from polylogue.sources.dispatch import is_stream_record_provider, parse_payload, parse_stream_payload
 from polylogue.sources.parsers import hermes_state, hermes_verification
@@ -698,13 +699,22 @@ def _census_parse_worker(
     blob_root_str: str,
     source_db_path_str: str,
 ) -> tuple[str, list[ParsedSession] | None, str | None]:
-    """ProcessPool worker: parse one retained raw's already-published blob bytes.
+    """Parse one retained raw's already-published blob bytes.
 
     Pure read-only blob->ParsedSession decode; the caller already knows this
     raw's payload size and revision kind from its own source-tier descriptor
-    lookup, so only sessions (or a typed error string) cross the process
-    boundary. Errors are returned rather than raised so the writer process can
-    apply the exact same per-raw quarantine handling as the sequential path.
+    lookup, so only primitive strings cross into this function -- no shared
+    ``ArchiveStore`` (and thus no thread-affine sqlite connection, see
+    ``_parse_unique_retained_raws_via_threads``) and no pickled object graph
+    to construct one. Errors are returned rather than raised so the caller
+    can apply the exact same per-raw quarantine handling as the sequential
+    path.
+
+    Dispatched onto BOTH a ``ProcessPoolExecutor`` (GIL-build fallback, see
+    ``_parse_unique_retained_raws``) and a ``ThreadPoolExecutor`` (real
+    free-threading, see ``_parse_unique_retained_raws_via_threads``) -- the
+    function is identical either way; only the executor and the recreated
+    ``ArchiveBlobPublisher``'s process/thread affinity differ.
     """
     from polylogue.storage.blob_publication import ArchiveBlobPublisher
 
@@ -849,6 +859,83 @@ def _parse_retained_raws(
     return results
 
 
+def _parse_unique_retained_raws_via_threads(
+    archive: ArchiveStore,
+    raw_ids: list[str],
+    *,
+    descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int]],
+    ingest_workers: int,
+) -> dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception]:
+    """Thread-parallel parse, reachable only when ``parallel_threads_effective()``.
+
+    Under a real free-threaded (no-GIL) interpreter, a plain
+    ``ThreadPoolExecutor`` shares parsed ``ParsedSession`` object graphs by
+    reference between threads, so neither of the process pool's two
+    amortization costs applies: no pickle-back of the return value (#3136
+    measured 0.63x/net-loss above 256KiB) and no per-worker spawn+import tax
+    (#3149's ~1.5-2s floor -- threads share the one already-imported
+    interpreter, they never re-pay ``import polylogue``). Both
+    ``_partition_raws_by_dispatch_size`` and ``_pool_dispatch_amortizes``
+    exist solely to protect against those two process-pool-specific costs
+    (#3136/#3149), so this path applies NEITHER: every raw in ``raw_ids``
+    dispatches to the thread pool regardless of payload size or aggregate
+    bytes.
+
+    Dispatches the same ``_census_parse_worker`` function the process-pool
+    path uses, deliberately -- NOT ``_parse_retained_raw(archive, raw_id)``
+    directly. ``ArchiveStore`` lazily opens ``_source_conn`` as a plain
+    ``sqlite3.Connection`` with the default ``check_same_thread=True``
+    (``storage/sqlite/archive_tiers/archive.py:_ensure_source_conn``); the
+    caller of this function (``_parse_unique_retained_raws``) already
+    resolved every raw's descriptor sequentially on the calling thread
+    before dispatch, so calling ``archive.raw_revision_descriptor`` again
+    from a worker thread (as ``_parse_retained_raw`` does) raises
+    ``sqlite3.ProgrammingError: SQLite objects created in a thread can only
+    be used in that same thread`` -- confirmed empirically, not
+    theoretical. ``_census_parse_worker`` sidesteps this entirely: it never
+    touches the shared ``ArchiveStore`` or its connections, only a fresh,
+    stateless ``ArchiveBlobPublisher`` built from primitive strings
+    (blob root + source.db path), whose blob reads are plain filesystem I/O.
+
+    Result assembly is keyed by raw_id exactly like the process-pool path,
+    so completion order never affects the archive state callers build from
+    these results.
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed
+
+    results: dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception] = {}
+    blob_root_str = str(archive.archive_root / "blob")
+    source_db_path_str = str(archive.source_db_path)
+    with ThreadPoolExecutor(max_workers=min(ingest_workers, len(raw_ids))) as pool:
+        future_to_raw_id = {}
+        for raw_id in raw_ids:
+            provider, blob_hash, source_path, _kind, _payload_size = descriptors[raw_id]
+            future = pool.submit(
+                _census_parse_worker,
+                raw_id,
+                provider.value,
+                blob_hash,
+                source_path,
+                is_stream_record_provider(source_path, str(provider)),
+                blob_root_str,
+                source_db_path_str,
+            )
+            future_to_raw_id[future] = raw_id
+        for future in as_completed(future_to_raw_id):
+            raw_id = future_to_raw_id[future]
+            try:
+                _raw_id, sessions, error = future.result()
+            except Exception as exc:
+                results[raw_id] = exc
+                continue
+            if error is not None:
+                results[raw_id] = RuntimeError(error)
+                continue
+            _provider, _blob_hash, _source_path, kind, payload_size = descriptors[raw_id]
+            results[raw_id] = (sessions or [], payload_size, kind)
+    return results
+
+
 def _parse_unique_retained_raws(
     archive: ArchiveStore,
     raw_ids: list[str],
@@ -856,13 +943,25 @@ def _parse_unique_retained_raws(
     descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int]],
     ingest_workers: int,
 ) -> dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception]:
-    """Parse already-deduplicated raws, optionally across a process pool.
+    """Parse already-deduplicated raws, optionally in parallel.
 
     Read-only blob->ParsedSession decode is authority-neutral and
     embarrassingly parallel; callers apply archive writes afterwards in a
     fixed deterministic order independent of completion order here, so
     parallel and sequential execution produce byte-identical archive state
-    regardless of which raws take the pool path versus the sequential path.
+    regardless of which raws take a parallel path versus the sequential
+    path.
+
+    Two parallel strategies, mutually exclusive per call:
+    ``parallel_threads_effective()`` (real free-threading, e.g. 3.14t) routes
+    to ``_parse_unique_retained_raws_via_threads`` with no size partition or
+    amortization floor. Otherwise (the standard GIL build -- today's default
+    and the only build the daemon deploys) falls through to the
+    ``ProcessPoolExecutor`` path below, unchanged: the polylogue-7mtf
+    control-run measurement proved GIL-build threads give zero parse
+    speedup (0.93x-0.96x) and inflate a concurrent writer thread's commit
+    latency ~5000x, so threads must never engage without a genuinely
+    disabled GIL.
     """
     results: dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception] = {}
     if ingest_workers <= 1 or len(raw_ids) <= 1:
@@ -872,6 +971,11 @@ def _parse_unique_retained_raws(
             except Exception as exc:
                 results[raw_id] = exc
         return results
+
+    if parallel_threads_effective():
+        return _parse_unique_retained_raws_via_threads(
+            archive, raw_ids, descriptors=descriptors, ingest_workers=ingest_workers
+        )
 
     payload_sizes = {raw_id: descriptors[raw_id][4] for raw_id in raw_ids}
     pool_raw_ids, sequential_raw_ids = _partition_raws_by_dispatch_size(

--- a/tests/unit/pipeline/test_process_pool.py
+++ b/tests/unit/pipeline/test_process_pool.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import sys
 import threading
 from concurrent.futures import as_completed
 
 import pytest
 
-from polylogue.pipeline.services.process_pool import process_pool_context, process_pool_executor
+from polylogue.pipeline.services.process_pool import (
+    parallel_threads_effective,
+    process_pool_context,
+    process_pool_executor,
+)
 
 
 def _worker_wrapper_class_name() -> str:
@@ -72,3 +77,32 @@ def test_process_pool_dispatch_from_worker_thread_completes() -> None:
     if error:
         raise error[0]
     assert outcome == [[i * i for i in range(8)]]
+
+
+def test_parallel_threads_effective_true_when_gil_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``sys._is_gil_enabled() -> False`` (real free-threading) must gate the
+    thread-parallel parse path OPEN. This is the only state under which
+    revision_backfill's ThreadPoolExecutor parse path may engage. Patching
+    the real ``sys`` module (imported here directly, not via the production
+    module's reference to it) affects ``process_pool.py``'s own
+    ``sys._is_gil_enabled`` lookup identically, since both names resolve the
+    same singleton module object at call time."""
+    monkeypatch.setattr(sys, "_is_gil_enabled", lambda: False, raising=False)
+    assert parallel_threads_effective() is True
+
+
+def test_parallel_threads_effective_false_when_gil_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``sys._is_gil_enabled() -> True`` (GIL build, or a free-threaded build
+    that re-enabled the GIL at runtime) must gate the thread-parallel parse
+    path CLOSED -- the polylogue-7mtf control run measured GIL-build threads
+    give zero parse speedup and starve a concurrent writer thread ~5000x."""
+    monkeypatch.setattr(sys, "_is_gil_enabled", lambda: True, raising=False)
+    assert parallel_threads_effective() is False
+
+
+def test_parallel_threads_effective_treats_missing_probe_as_gil_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Interpreters without PEP 703/779 support (no ``sys._is_gil_enabled``
+    attribute at all, e.g. every CPython before 3.13) have no free-threaded
+    build to speak of -- the safe default is "GIL enabled", not an error."""
+    monkeypatch.delattr(sys, "_is_gil_enabled", raising=False)
+    assert parallel_threads_effective() is False

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import time
 from io import BytesIO
 from pathlib import Path
 
@@ -1184,7 +1185,12 @@ def test_pool_dispatch_floor_rejects_small_aggregate_batches(monkeypatch: pytest
 def test_parse_retained_raws_small_batch_never_creates_a_pool(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """End-to-end: a small pool-eligible batch under the aggregate floor must
     not construct a ProcessPoolExecutor at all (the churn measured live: 20
-    workers in 25s, each ~95% importlib)."""
+    workers in 25s, each ~95% importlib). This is a GIL-build-fallback
+    mechanic specifically (the amortization floor exists only to protect
+    process-pool spawn costs, polylogue-xikl) -- pin the probe so this test's
+    claim is exercised deterministically regardless of which interpreter
+    (GIL or genuinely free-threaded) runs the suite."""
+    monkeypatch.setattr(revision_backfill, "parallel_threads_effective", lambda: False)
     initialize_active_archive_root(tmp_path)
     with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
         for index in range(3):
@@ -1217,7 +1223,13 @@ def test_size_aware_dispatch_keeps_large_raws_off_the_process_pool(
 ) -> None:
     """End-to-end proof: with a low dispatch ceiling, only the small raw in a
     mixed corpus is submitted to the process pool; the large one parses
-    in-process, and the archive state matches ingest_workers=1 exactly."""
+    in-process, and the archive state matches ingest_workers=1 exactly.
+    Size-based partitioning is a GIL-build-fallback mechanic specifically
+    (the thread path applies no size partition at all, polylogue-xikl) --
+    pin the probe so this test's claim is exercised deterministically
+    regardless of which interpreter (GIL or genuinely free-threaded) runs
+    the suite."""
+    monkeypatch.setattr(revision_backfill, "parallel_threads_effective", lambda: False)
     monkeypatch.setenv("POLYLOGUE_REVISION_PARSE_DISPATCH_MAX_BYTES", "5000")
     initialize_active_archive_root(tmp_path)
     small_text = "s" * 200
@@ -1253,3 +1265,249 @@ def test_size_aware_dispatch_keeps_large_raws_off_the_process_pool(
     assert result.quarantined == 0
     # Only the two small raws (well under the 5000-byte ceiling) were pool-eligible.
     assert len(submitted_raw_ids) == 2
+
+
+def test_thread_parse_matches_sequential_archive_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """polylogue-xikl adoption wave: the ThreadPoolExecutor parse path (forced
+    here by patching ``parallel_threads_effective`` -- these tests run under
+    the GIL, where threads still parse *correctly*, just without a
+    speedup) must produce byte-identical archive state to the sequential
+    path, mirroring the process-pool equivalence proof above
+    (``test_parallel_census_matches_sequential_archive_state``). No size
+    partition or amortization floor applies on this path, so every raw
+    (including tiny ones that a size-based ceiling would otherwise route
+    straight to sequential) is actually dispatched through the thread pool.
+
+    Anti-vacuity (patch-revert, performed live during implementation): making
+    ``_parse_unique_retained_raws_via_threads`` skip one raw_id when building
+    ``future_to_raw_id`` (dropping a raw from the batch) makes this test fail
+    with a KeyError / unequal session counts; duplicating a raw_id's future
+    against a second raw_id's descriptor makes the two archives' session
+    rows diverge. Both mutations were applied and reverted by hand against
+    this exact test to confirm it catches them before this test was
+    finalized.
+    """
+    sequential_root = tmp_path / "sequential"
+    thread_root = tmp_path / "threaded"
+    for root in (sequential_root, thread_root):
+        initialize_active_archive_root(root)
+        with ArchiveStore.open_existing(root, read_only=False) as archive:
+            for index in range(6):
+                payload = _bundle(_chatgpt_session(f"session-{index}", f"hello {index}", f"world {index}"))
+                archive.write_raw_payload(
+                    provider=Provider.CHATGPT,
+                    payload=payload,
+                    source_path=f"chat-{index}.json",
+                    acquired_at_ms=index,
+                )
+
+    seq_result = backfill_historical_revision_evidence(sequential_root, ingest_workers=1)
+
+    monkeypatch.setattr(revision_backfill, "parallel_threads_effective", lambda: True)
+    thread_result = backfill_historical_revision_evidence(thread_root, ingest_workers=4)
+
+    assert seq_result == thread_result
+
+    def _sessions(root: Path) -> list[tuple[object, ...]]:
+        with sqlite3.connect(root / "index.db") as conn:
+            return conn.execute("SELECT native_id, message_count, raw_id FROM sessions ORDER BY native_id").fetchall()
+
+    assert _sessions(sequential_root) == _sessions(thread_root)
+
+
+def test_thread_parse_never_touches_shared_archive_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression guard for the sqlite ``check_same_thread`` hazard this
+    thread path was designed around: ``ArchiveStore._source_conn`` is a
+    plain ``sqlite3.Connection`` created with the default
+    ``check_same_thread=True``, so calling ``archive.raw_revision_descriptor``
+    (as ``_parse_retained_raw`` does) from a worker thread other than the
+    connection's owning thread raises ``sqlite3.ProgrammingError`` --
+    confirmed empirically during implementation. This test uses a fake
+    archive whose only usable attributes are ``archive_root``/
+    ``source_db_path`` (plain ``Path`` values, no live sqlite connection at
+    all); any code path that tried to call a *method* on it (as
+    ``_parse_retained_raw`` would) fails immediately with ``AttributeError``,
+    proving ``_parse_unique_retained_raws_via_threads`` only ever reads two
+    static attributes off the shared archive object, never queries it.
+    """
+
+    class _NoMethodsArchive:
+        archive_root = Path("/fake-root")
+        source_db_path = Path("/fake-root/source.db")
+
+    descriptors = {
+        "raw-a": (Provider.CODEX, "hash-a", "a.jsonl", RawRevisionKind.FULL, 111),
+        "raw-b": (Provider.CODEX, "hash-b", "b.jsonl", RawRevisionKind.FULL, 222),
+    }
+
+    def fake_worker(
+        raw_id: str,
+        provider_token: str,
+        blob_hash: str,
+        source_path: str,
+        is_stream: bool,
+        blob_root_str: str,
+        source_db_path_str: str,
+    ) -> tuple[str, list[ParsedSession] | None, str | None]:
+        return raw_id, [], None
+
+    monkeypatch.setattr(revision_backfill, "_census_parse_worker", fake_worker)
+
+    results = revision_backfill._parse_unique_retained_raws_via_threads(
+        _NoMethodsArchive(),  # type: ignore[arg-type]
+        list(descriptors),
+        descriptors=descriptors,
+        ingest_workers=2,
+    )
+
+    assert results["raw-a"] == ([], 111, RawRevisionKind.FULL)
+    assert results["raw-b"] == ([], 222, RawRevisionKind.FULL)
+
+
+def test_thread_parse_propagates_per_raw_exception_without_poisoning_batch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One raw's parse failure on the thread path must be isolated to that
+    raw_id's result slot, matching the process-pool path's fan-out contract
+    (``test_parse_retained_raws_fans_out_exceptions_to_duplicate_rows``
+    proves the same isolation on the sequential/dedup layer). Anti-vacuity:
+    if a future's exception were allowed to propagate out of the
+    ``as_completed`` loop uncaught, this whole test (and every other raw's
+    result) would never be reached -- the two surviving successful results
+    are asserted explicitly, not merely "no exception raised"."""
+    descriptors = {
+        "ok-1": (Provider.CODEX, "hash-A", "a.jsonl", RawRevisionKind.FULL, 10),
+        "bad-1": (Provider.CODEX, "hash-B", "b.jsonl", RawRevisionKind.FULL, 20),
+        "ok-2": (Provider.CODEX, "hash-C", "c.jsonl", RawRevisionKind.FULL, 30),
+    }
+
+    class _FakeArchive:
+        archive_root = Path("/fake-root")
+        source_db_path = Path("/fake-root/source.db")
+
+    def fake_worker(
+        raw_id: str,
+        provider_token: str,
+        blob_hash: str,
+        source_path: str,
+        is_stream: bool,
+        blob_root_str: str,
+        source_db_path_str: str,
+    ) -> tuple[str, list[ParsedSession] | None, str | None]:
+        if raw_id == "bad-1":
+            raise RuntimeError(f"boom {raw_id}")
+        return raw_id, [], None
+
+    monkeypatch.setattr(revision_backfill, "_census_parse_worker", fake_worker)
+
+    results = revision_backfill._parse_unique_retained_raws_via_threads(
+        _FakeArchive(),  # type: ignore[arg-type]
+        list(descriptors),
+        descriptors=descriptors,
+        ingest_workers=3,
+    )
+
+    assert isinstance(results["bad-1"], RuntimeError)
+    assert "boom bad-1" in str(results["bad-1"])
+    assert results["ok-1"] == ([], 10, RawRevisionKind.FULL)
+    assert results["ok-2"] == ([], 30, RawRevisionKind.FULL)
+
+
+def test_thread_parse_results_keyed_by_raw_id_not_completion_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Determinism proof: results must be assembled by looking up each
+    completed future's OWN raw_id (``future_to_raw_id[future]``), never by
+    zipping ``raw_ids`` (submission order) against ``as_completed(futures)``
+    (completion order) -- that zip-based shape is a real historical bug
+    class in concurrent code and would silently pair a fast-finishing raw's
+    result with a different, slower raw_id's descriptor. Delays are
+    inverted here (the raw submitted LAST finishes FIRST) so submission
+    order and completion order actively diverge; each raw_id's own
+    descriptor-derived payload_size must still come back attached to it
+    regardless."""
+    raw_ids = [f"raw-{i}" for i in range(6)]
+    descriptors = {
+        raw_id: (Provider.CODEX, f"hash-{i}", f"path-{i}.jsonl", RawRevisionKind.FULL, 100 + i)
+        for i, raw_id in enumerate(raw_ids)
+    }
+    # raw-0 (submitted first) sleeps longest; raw-5 (submitted last) returns
+    # immediately -- completion order is the exact reverse of submission order.
+    delay_by_raw_id = {raw_id: 0.02 * (len(raw_ids) - index) for index, raw_id in enumerate(raw_ids)}
+
+    class _FakeArchive:
+        archive_root = Path("/fake-root")
+        source_db_path = Path("/fake-root/source.db")
+
+    def fake_worker(
+        raw_id: str,
+        provider_token: str,
+        blob_hash: str,
+        source_path: str,
+        is_stream: bool,
+        blob_root_str: str,
+        source_db_path_str: str,
+    ) -> tuple[str, list[ParsedSession] | None, str | None]:
+        time.sleep(delay_by_raw_id[raw_id])
+        return raw_id, [], None
+
+    monkeypatch.setattr(revision_backfill, "_census_parse_worker", fake_worker)
+
+    results = revision_backfill._parse_unique_retained_raws_via_threads(
+        _FakeArchive(),  # type: ignore[arg-type]
+        raw_ids,
+        descriptors=descriptors,
+        ingest_workers=len(raw_ids),
+    )
+
+    for index, raw_id in enumerate(raw_ids):
+        sessions, size, kind = results[raw_id]  # type: ignore[misc]
+        assert sessions == []
+        assert size == 100 + index
+        assert kind == RawRevisionKind.FULL
+
+
+def test_parse_unique_retained_raws_routes_to_threads_when_probe_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wiring proof for ``_parse_unique_retained_raws`` itself: when
+    ``parallel_threads_effective()`` is true, it must call
+    ``_parse_unique_retained_raws_via_threads`` (no size partition / floor)
+    rather than falling through to the process-pool branch below it."""
+    descriptors = {
+        "raw-a": (Provider.CODEX, "hash-a", "a.jsonl", RawRevisionKind.FULL, 10),
+        "raw-b": (Provider.CODEX, "hash-b", "b.jsonl", RawRevisionKind.FULL, 20),
+    }
+
+    sentinel: dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception] = {
+        "raw-a": ([], 10, RawRevisionKind.FULL),
+        "raw-b": ([], 20, RawRevisionKind.FULL),
+    }
+    calls: list[tuple[object, ...]] = []
+
+    def fake_thread_dispatch(
+        archive: object,
+        raw_ids: list[str],
+        *,
+        descriptors: dict[str, tuple[Provider, str, str, RawRevisionKind, int]],
+        ingest_workers: int,
+    ) -> dict[str, tuple[list[ParsedSession], int, RawRevisionKind] | Exception]:
+        calls.append((tuple(raw_ids), ingest_workers))
+        return sentinel
+
+    def forbidden_pool(**kwargs: object) -> object:
+        raise AssertionError("process pool must not be constructed when the thread path is taken")
+
+    monkeypatch.setattr(revision_backfill, "parallel_threads_effective", lambda: True)
+    monkeypatch.setattr(revision_backfill, "_parse_unique_retained_raws_via_threads", fake_thread_dispatch)
+    import polylogue.pipeline.services.process_pool as process_pool_module
+
+    monkeypatch.setattr(process_pool_module, "process_pool_executor", forbidden_pool)
+
+    results = revision_backfill._parse_unique_retained_raws(
+        object(),  # type: ignore[arg-type]
+        list(descriptors),
+        descriptors=descriptors,
+        ingest_workers=4,
+    )
+
+    assert results == sentinel
+    assert calls == [(("raw-a", "raw-b"), 4)]


### PR DESCRIPTION
## Summary

`_parse_unique_retained_raws` in `sources/revision_backfill.py` gains a
`ThreadPoolExecutor`-based parse path, gated on a new
`parallel_threads_effective()` probe (`sys._is_gil_enabled()`). The path
engages only under a genuinely free-threaded interpreter (3.14t); the
standard GIL-build `ProcessPoolExecutor` fallback is unchanged.

## Problem

polylogue-7mtf's control-run measurement (recorded on the epic) proved two
things about threads under the current standard (GIL) build:

- CPU-bound `ThreadPoolExecutor` parse gives **zero speedup** (0.93x-0.96x,
  pure lock overhead) — confirmed by the exact same code under 3.14t
  measuring 3.9x-9.6x (w=4..16) instead.
- A concurrent SQLite writer thread's commit latency **inflates ~5000x**
  (208ms vs an ~5ms cadence) when CPU-bound parse threads run alongside it
  under the GIL; under 3.14t there is zero interference (0.04ms).

The process-pool parse path also carries two GIL-only amortization costs
that don't apply to threads at all: pickle-back of `ParsedSession` graphs
across the process boundary (#3136, measured 0.63x/net-loss above 256KiB)
and per-worker spawn+import tax (#3149, ~1.5-2s floor). Threads share one
already-imported interpreter, so neither cost exists for them.

## Solution

- `polylogue/pipeline/services/process_pool.py`: add
  `parallel_threads_effective() -> bool`, resolving `sys._is_gil_enabled`
  via `getattr` (so mypy --strict needs no per-Python-version
  `type: ignore`); its absence (pre-3.13 interpreters) is treated as "GIL
  enabled" — the safe default.
- `polylogue/sources/revision_backfill.py`: `_parse_unique_retained_raws`
  routes to a new `_parse_unique_retained_raws_via_threads` whenever the
  probe is true. That path applies **no size partition and no amortization
  floor** — both exist solely to protect the process pool's two named costs.
  The `ProcessPoolExecutor` branch below it is byte-for-byte unchanged; it
  stays the deployed daemon's fallback until the daemon itself migrates to
  3.14t (a separate, later step per the epic's deployment ordering — CLI/
  offline rebuild adopts 3.14t first).
- The thread path dispatches the existing `_census_parse_worker` function,
  **not** `_parse_retained_raw(archive, raw_id)` directly. `ArchiveStore`
  lazily opens its `source.db` connection with the default
  `check_same_thread=True`; calling `archive.raw_revision_descriptor` from
  a worker thread other than the connection's owning thread raises
  `sqlite3.ProgrammingError` — confirmed empirically (see PR discussion /
  commit message). `_census_parse_worker` never touches the shared
  `ArchiveStore` at all — it reconstructs a stateless `ArchiveBlobPublisher`
  from primitive strings, whose blob reads are plain filesystem I/O.
- Two pre-existing tests asserted process-pool-specific size-partition/floor
  mechanics without pinning which branch they exercise; they now force
  `parallel_threads_effective() -> False` so their claims hold regardless of
  which interpreter runs the suite (one of them, `test_size_aware_dispatch_
  keeps_large_raws_off_the_process_pool`, was found failing under a real
  3.14t smoke run precisely because it wasn't pinned — see Verification).

## Verification

- `devtools test tests/unit/sources/test_revision_backfill.py
  tests/unit/pipeline/test_process_pool.py`: **41 passed** (standard GIL
  build, Python 3.13.13).
- Anti-vacuity (patch-revert): temporarily made
  `_parse_unique_retained_raws_via_threads` drop the first `raw_id` from
  dispatch (`for raw_id in raw_ids[1:]:`) — all 4 new thread-path tests
  failed (`KeyError` / missing session rows). Reverted; all 41 pass again.
- `mypy --strict` on all 4 touched files: clean. `ruff check` / `ruff
  format --check`: clean. `devtools verify --quick`: exit 0.
- **Real 3.14t smoke** (per the task brief): built a scratch venv via
  `nix shell nixpkgs#python314FreeThreading` + `uv`, with `orjson`
  deliberately excluded (polylogue-xikl.3's `core/json.py` facade falls back
  to `msgspec`, no shim needed — confirms polylogue now genuinely runs on
  3.14t today). Ran the same two test modules: **41/41 pass**, with
  `parallel_threads_effective()` naturally `True` (unforced — this is a
  real free-threaded interpreter). A broader `tests/unit/sources` +
  `tests/unit/pipeline` sweep under the same interpreter found 14
  pre-existing failures in unrelated modules (live/batch watcher timing,
  `validation_flow` decode-error-message text, `parsing_service` /
  `quarantine_fixtures` mock specs, drive mocks) plus one collection error
  from a test file that imports `orjson` directly outside the facade
  (`test_validation_parallelism_contracts.py`, excluded from this run) — all
  pre-existing 3.14t-migration gaps outside this PR's scope. Spot-verified
  one (`test_ingest_empty_sources_returns_empty_result`) reproduces
  identically on the standard GIL 3.13.13 devshell, confirming
  pre-existing/unrelated rather than caused by this change.
- Full-suite `devtools verify --seed-testmon --skip-slow` bootstrap attempt
  hit `sqlite3.OperationalError: database is locked` inside an unrelated
  CLI-snapshot fixture (`tests/unit/cli/test_plain_cli_snapshots.py`) —
  transient contention from other concurrent agent sessions' full-suite
  pytest runs on this shared host (confirmed via `ps aux` at the time: 3+
  concurrent `devtools verify --seed-testmon` processes across other
  worktrees), not a regression from this change. Not retried given ongoing
  host contention; the targeted + `--quick` + real-3.14t verification above
  stands in its place.

## Follow-ups

- polylogue-xikl.4 (this PR's tracking bead) recommends **re-scoping, not
  closing**, polylogue-9as9 (the GIL-world pass-scoped-executor design): the
  daemon has not yet migrated to 3.14t, so that bead's warm-pool/
  worker-side-lowering design retains narrow, near-term value for the
  still-deployed GIL-build daemon specifically. Recorded on both beads.

Ref polylogue-xikl.4, polylogue-xikl

🤖 Generated with [Claude Code](https://claude.com/claude-code)