### PR TITLE
build: add python3.14t free-threaded package variant (-orjson +msgspec)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,16 @@
       system = "x86_64-linux";
       pkgs = import nixpkgs {
         inherit system;
+        # See the long comment above `mkNoCheckOverride`/`freeThreadedNoCheckOverlay`
+        # below (polylogue-xikl): this MUST be a top-level `pkgs` overlay, not a
+        # locally-scoped `.pkgs.overrideScope` on a `let`-bound variable --
+        # transitive dependency resolution for packages pulled in via ANOTHER
+        # python314FreeThreading package's own `nativeBuildInputs` (e.g. `sphinx`
+        # via `pyjwt`) goes through nixpkgs' own internal fixed point, which a
+        # locally-scoped override never reaches (proven by a failed build:
+        # local-only scoping left `sphinx`/`defusedxml` resolving to the
+        # original, still-broken derivations).
+        overlays = [ freeThreadedNoCheckOverlay ];
       };
       python = pkgs.python314;
 
@@ -40,7 +50,17 @@
         else
           "unknown";
 
-      polylogue = pkgs.python314Packages.buildPythonPackage {
+      # Shared package builder for both the standard (GIL) interpreter and the
+      # free-threaded (3.14t) variant (polylogue-xikl phase-0/deployment-edge:
+      # CLI-first rebuild lane on 3.14t while the daemon stays standard). The
+      # two variants differ ONLY in which interpreter/package set they build
+      # against and which fast-JSON accelerator they carry -- orjson has no
+      # cp314t wheels and its build refuses to compile free-threaded, so the
+      # free-threaded variant carries `msgspec` instead (polylogue.core.json's
+      # facade picks whichever backend is importable, no code change needed).
+      mkPolylogue =
+        { python', pythonPackages, jsonAccelerator }:
+        pythonPackages.buildPythonPackage {
         pname = "polylogue";
         # Single authoritative version: pyproject.toml (release-please owns bumps).
         version = (builtins.fromTOML (builtins.readFile ./pyproject.toml)).project.version;
@@ -54,7 +74,7 @@
           BUILDEOF
         '';
 
-        build-system = with pkgs.python314Packages; [
+        build-system = with pythonPackages; [
           hatchling
         ];
 
@@ -62,7 +82,7 @@
           pkgs.makeWrapper
         ];
 
-        dependencies = with pkgs.python314Packages; [
+        dependencies = (with pythonPackages; [
           google-auth-oauthlib
           google-api-python-client
           google-auth-httplib2
@@ -80,24 +100,13 @@
           click
           tenacity
           dateparser
-          # orjson became an OPTIONAL accelerator in pyproject.toml's `speed`
-          # extra (polylogue-xikl): polylogue.core.json falls back to
-          # msgspec/stdlib json when it's absent. This nix build's
-          # `dependencies` list is independently curated (not derived from
-          # pyproject extras), so it deliberately keeps orjson on the
-          # STANDARD (GIL) build for the speed win. A future python314t
-          # package variant should drop `orjson` from this list (it has no
-          # cp314t wheels and refuses to compile free-threaded) and add
-          # `msgspec` instead -- the facade's fallback ordering handles the
-          # rest with no code change.
-          orjson
           structlog
           pydantic
           aiosqlite
           mcp
           pyyaml
           watchfiles
-        ];
+        ]) ++ [ jsonAccelerator ];
 
         doCheck = false;
         pythonImportsCheck = [
@@ -106,7 +115,7 @@
         dontCheckRuntimeDeps = true;
 
         postFixup = ''
-          test -f "$out/${python.sitePackages}/polylogue/daemon/static/dist/manifest.json"
+          test -f "$out/${python'.sitePackages}/polylogue/daemon/static/dist/manifest.json"
           for program in polylogue polylogued polylogue-mcp; do
             wrapProgram "$out/bin/$program" \
               --unset PYTHONPATH \
@@ -124,6 +133,167 @@
           homepage = "https://github.com/Sinity/polylogue";
           platforms = pkgs.lib.platforms.linux;
         };
+      };
+
+      polylogue = mkPolylogue {
+        python' = python;
+        pythonPackages = pkgs.python314Packages;
+        jsonAccelerator = pkgs.python314Packages.orjson;
+      };
+
+      # Free-threaded (3.14t, PEP 779) build variant (polylogue-xikl /
+      # polylogue-7mtf): same package, built against
+      # `python314FreeThreading.pkgs` so the CLI can run with the GIL
+      # disabled. This is the offline/bulk-rebuild deployment edge -- the
+      # daemon stays on the standard build until the free-threading adoption
+      # gate + thread-safety audit (phase 1/3 of polylogue-xikl) land.
+      #
+      # `python314FreeThreading` is uncached at this nixpkgs pin (2026-07-19):
+      # nothing in its `.pkgs` set has a prebuilt binary on cache.nixos.org
+      # yet, so *every* Python package in the closure builds from source with
+      # its upstream `doCheck`/`doInstallCheck` default (true), pulling each
+      # package's own test-only `checkInputs` transitively. In practice that
+      # fans out to ~500 unrelated packages (django, matplotlib, scipy,
+      # mercurial, sphinx, ...) and hits real, unrelated packaging bugs in
+      # that long tail that have nothing to do with polylogue itself: e.g.
+      # nixpkgs' `boost` built with Python bindings against the free-threaded
+      # ABI fails outright (`wrap_python.hpp: pyconfig.h: No such file or
+      # directory` -- boost 1.89.0's python integration doesn't know the
+      # cp314t layout yet), and `defusedxml`'s own installCheckPhase fails
+      # against Python 3.14's stdlib (`gzip.GzipFile.__del__` AttributeError +
+      # a DeprecationWarning -> RuntimeWarning category change) -- both
+      # cascade to every package whose checkInputs pull them in transitively
+      # (matplotlib/pytest-mpl/sphinx-pytest et al., pulled in only to run
+      # OTHER packages' test suites, not by anything polylogue needs at
+      # runtime).
+      #
+      # `pythonFreeThreadedPkgs` disables `doCheck`/`doInstallCheck` across the
+      # whole package set by wrapping `buildPythonPackage`/
+      # `buildPythonApplication` themselves via `overrideScope`, rather than
+      # patching already-built package derivations after the fact. Two other
+      # approaches were tried and empirically rejected first (verified via
+      # `nix derivation show`/`.drvPath` comparisons before running the full
+      # build, since each is a ~15-30 minute source build to disprove):
+      #   1. `python314FreeThreading.override { packageOverrides = ...; }` on
+      #      the interpreter itself silently no-ops here -- `.drvPath` was
+      #      byte-identical before/after, so nothing was applied at all.
+      #   2. `pkgs.overrideScope (final: prev: mapAttrs (_: drv: drv.
+      #      overridePythonAttrs (_: {doCheck=false;...})) prev)` DOES change
+      #      the *targeted* package's own hash/env, but `overridePythonAttrs`
+      #      patches an already-constructed derivation whose OWN
+      #      `dependencies`/`nativeBuildInputs` list is a fixed reference to
+      #      sibling packages as originally composed -- so a downstream
+      #      package like `sphinx` still built against the *original* (still
+      #      failing) `defusedxml`, even though `sphinx`'s own doCheck flag
+      #      flipped. The cascade only breaks when the failing leaf's
+      #      `nativeCheckInputs` are dropped as part of *constructing*
+      #      `sphinx` with `doCheck=false` from the start, not retrofitted.
+      # Wrapping the shared `buildPythonPackage`/`buildPythonApplication`
+      # builder functions instead means every package -- including ones this
+      # override never names, like `sphinx` or `defusedxml` -- is constructed
+      # with checks off from the moment `callPackage` invokes it, so sibling
+      # dependency resolution stays self-consistent. Confirmed via `nix
+      # derivation show`: `sphinx`'s own `nativeCheckInputs` becomes `[]` and
+      # its hash changes accordingly. The wrapper handles both
+      # `buildPythonPackage` calling conventions (a plain attrset, and the
+      # newer `finalAttrs: {...}` self-referencing function -- naively doing
+      # `args // {...}` on the latter throws "expected a set but found a
+      # function", hit and fixed while developing this).
+      #
+      # Packaging-only: upstream test suites for these packages still run on
+      # the standard (GIL) build via `pkgs.python314Packages`, and polylogue's
+      # own test suite is unaffected (`doCheck = false` was already set on the
+      # `polylogue` derivation itself, standard build included). Filed as a
+      # nixpkgs-upstream gap, not fixed here (out of this lane's packaging
+      # scope): see polylogue-xikl for the tracking note.
+      mkNoCheckOverride =
+        argsOrFn:
+        if builtins.isFunction argsOrFn then
+          (finalAttrs: (argsOrFn finalAttrs) // { doCheck = false; doInstallCheck = false; })
+        else
+          (argsOrFn // { doCheck = false; doInstallCheck = false; });
+      # Applied as a top-level `pkgs` overlay (see the `pkgs` binding above) so
+      # every package in `python314FreeThreading.pkgs` -- including ones never
+      # named here, like `sphinx` or `defusedxml` -- is *constructed* with
+      # checks off from the moment nixpkgs' own internal `callPackage`
+      # invokes it, keeping sibling dependency resolution self-consistent.
+      freeThreadedNoCheckOverlay = _final: prev: {
+        python314FreeThreading = prev.python314FreeThreading // {
+          pkgs = prev.python314FreeThreading.pkgs.overrideScope (
+            pyFinal: pySuper: {
+              buildPythonPackage = argsOrFn: pySuper.buildPythonPackage (mkNoCheckOverride argsOrFn);
+              buildPythonApplication = argsOrFn: pySuper.buildPythonApplication (mkNoCheckOverride argsOrFn);
+              # `pyjwt` (an mcp -> polylogue transitive dependency) unconditionally
+              # builds Sphinx-based docs (`nativeBuildInputs = [ sphinxHook
+              # sphinx-rtd-theme ... ]`, `outputs = [ "out" "doc" ]`) -- this is
+              # NOT gated by doCheck at all, so the builder-wrap above doesn't
+              # touch it, and it's the ONLY path from polylogue into the
+              # sphinx -> defusedxml chain (defusedxml's own installCheckPhase
+              # fails against Python 3.14's stdlib, see the long comment
+              # above). Strip the sphinx build tools from nativeBuildInputs;
+              # the CLI never needs pyjwt's docs. Two follow-on breakages hit
+              # and fixed while developing this: (1) forcing `outputs` down to
+              # `[ "out" ]` broke `pythonOutputDistPhase`'s always-present
+              # `dist` output wiring ("mv: cannot move 'dist' to '': Device or
+              # resource busy") -- so `outputs` is left untouched, still
+              # `[ "out" "doc" ]`; (2) but removing sphinxHook means nothing
+              # ever creates the `$doc` output path at all, so nix then fails
+              # with "failed to produce output path for output 'doc'" --
+              # fixed by explicitly `mkdir -p $doc` in `postInstall` (an
+              # empty doc output is harmless; nothing consumes it).
+              pyjwt = pySuper.pyjwt.overrideAttrs (old: {
+                doCheck = false;
+                doInstallCheck = false;
+                nativeBuildInputs = builtins.filter (
+                  # `hasInfix`, not `hasPrefix`: the setup-hook derivation's
+                  # own name is "python3.14-sphinx-hook" (prefixed by the
+                  # STANDARD interpreter version, not "sphinx"), so a prefix
+                  # check misses it while still catching "sphinx-rtd-theme"
+                  # -- caught empirically when the first attempt (hasPrefix)
+                  # left sphinx-hook in place and the build still cascaded.
+                  i: !(prev.lib.hasInfix "sphinx" (i.pname or (i.name or "")))
+                ) old.nativeBuildInputs;
+                postInstall = (old.postInstall or "") + ''
+                  mkdir -p "$doc"
+                '';
+              });
+              # `sqlite-vec`'s wheel metadata lists an optional `numpy` extra
+              # (a convenience helper for feeding numpy arrays into
+              # `serialize_float32`; polylogue never uses it -- the package is
+              # otherwise a thin ctypes wrapper loading a self-contained
+              # SQLite `.so` extension, ABI-independent of the Python build).
+              # nixpkgs' `pythonRuntimeDepsCheckHook` fails the build because
+              # this free-threaded package set has no `numpy` in this
+              # closure; the standard (GIL) build silently passes only
+              # because numpy happens to already be resolvable there for
+              # unrelated reasons. `dontCheckRuntimeDeps = true` mirrors what
+              # `polylogue`'s own derivation already sets for the same class
+              # of over-strict wheel-metadata check.
+              sqlite-vec = pySuper.sqlite-vec.overrideAttrs (_old: {
+                dontCheckRuntimeDeps = true;
+              });
+              # nixpkgs' own `sse-starlette` package definition (an mcp ->
+              # polylogue transitive dependency) lists only `dependencies =
+              # [ anyio ]`, but the package's actual wheel metadata declares
+              # `starlette` as a required runtime import -- a genuine, narrow
+              # nixpkgs packaging gap (present for the standard build too;
+              # just never triggers the failure there because `mcp`'s other
+              # direct dependencies already happen to pull `starlette` into
+              # that build's closure). Adding it here is the correct fix
+              # (starlette is a real runtime need), not merely suppressing
+              # the check the way `sqlite-vec` above does.
+              sse-starlette = pySuper.sse-starlette.overrideAttrs (old: {
+                propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [ pyFinal.starlette ];
+              });
+            }
+          );
+        };
+      };
+      pythonFreeThreaded = pkgs.python314FreeThreading;
+      polylogueFreeThreaded = mkPolylogue {
+        python' = pythonFreeThreaded;
+        pythonPackages = pythonFreeThreaded.pkgs;
+        jsonAccelerator = pythonFreeThreaded.pkgs.msgspec;
       };
 
       # Python environment with polylogue pre-installed (for scripting/notebooks).
@@ -167,9 +337,11 @@
         default = polylogue;
         api-python = polylogueApiPythonWrapped;
         api-python-raw = polylogueApiPython;
+        polylogue-freethreaded = polylogueFreeThreaded;
       };
 
-      devShells.${system}.default = pkgs.mkShell {
+      devShells.${system} = {
+      default = pkgs.mkShell {
         buildInputs = with pkgs; [
           python
           uv
@@ -267,6 +439,37 @@
             export POLYLOGUE_MOTD_RENDERED=1
           fi
         '';
+      };
+
+      # Free-threaded (3.14t) devShell variant (polylogue-xikl / polylogue-7mtf
+      # experiment gate). Deliberately lean: it provides the free-threaded
+      # interpreter for interactive smoke/benchmark work, but it does NOT
+      # auto-sync `--extra dev` into a venv the way the standard shell does,
+      # because pyproject.toml's `dev` extra pulls in `orjson` unconditionally
+      # -- orjson has no cp314t wheels and its build refuses to compile
+      # free-threaded, so a frozen sync targeting this interpreter would fail
+      # outright. Running the unit suite here today means a manual,
+      # non-frozen `uv pip install` of the test tooling (pytest/hypothesis/
+      # etc.) plus `msgspec` in place of `orjson`; a proper `dev-freethreaded`
+      # pyproject extra + uv.lock entry is tracked as follow-up, not done
+      # here to keep this lane scoped to packaging.
+      freethreaded = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          pythonFreeThreaded
+          uv
+          devtoolsCli
+          git
+          ruff
+        ];
+
+        shellHook = ''
+          export LD_LIBRARY_PATH=${pkgs.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH
+          export PYTHONDONTWRITEBYTECODE=1
+          export POLYLOGUE_REPO_ROOT="$PWD"
+          echo "devshell(freethreaded): $(python3 -c 'import sys; print(sys.version, "GIL enabled:", sys._is_gil_enabled())')" >&2
+          echo "devshell(freethreaded): venv not auto-synced -- see flake.nix comment above this shell for the manual setup" >&2
+        '';
+      };
       };
 
       checks.${system} = {


### PR DESCRIPTION
## Summary

Adds `packages.polylogue-freethreaded`: the polylogue CLI built on `pkgs.python314FreeThreading` with the dependency set adjusted per the #3155 facade (orjson dropped — no free-threaded wheels/build upstream yet; msgspec added as the fast JSON backend), plus the `overrideScope`-based check/doc-closure overrides required to build the dependency set on the free-threaded interpreter.

## Problem

The free-threading adoption program (`Ref polylogue-xikl`; gate results on `polylogue-7mtf`: 3.9-9.6x thread-parallel parse at ~7.7% single-thread tax, zero writer interference vs ~5000x under GIL) needs a runnable 3.14t artifact. The deployment edge is CLI-first: the offline bulk rebuild can run free-threaded with zero daemon blast radius. orjson refuses free-threaded compilation upstream, which #3155 made survivable via the three-tier backend facade.

## Solution

- `flake.nix`: `polylogue-freethreaded` package on `python314FreeThreading` via `overrideScope` (the earlier `.override { packageOverrides }` form was verified ineffective at the derivation level and replaced); dependency deltas: `-orjson +msgspec`; targeted `doCheck`/doc-input removals for chain members whose test/doc closures fail under 3.14t (inventory in the flake comments).
- Provenance note: this branch was authored by a lane agent that stalled in a build-wait loop one derivation short of success; the coordinator salvaged the uncommitted work, completed the build, and ran the acceptance below.

## Verification

- `nix build .#polylogue-freethreaded` → `/nix/store/j942p5kkbl42w2pjbh7vggwdlcspil7q-python3.14t-polylogue-0.3.0` (cached-clean rebuild reproduces in seconds).
- GIL proof: closure interpreter `python3-3.14.4` → `sys._is_gil_enabled() == False`.
- Demo cold-pass ON the free-threaded binary (clean env): `polylogue demo seed` + `demo verify` → `Demo archive verification: ok — Sessions 16, Messages 62, Query hits 4`.
- `polylogue --version` → `0.3.0+2123ea55`; `--help` clean.
- Known caveat (follow-up, not blocking): the bin wrapper inherits the caller's `PYTHONPATH` — a 3.13-era PYTHONPATH in the environment breaks `_sysconfigdata` resolution (`ModuleNotFoundError: _sysconfigdata__linux_x86_64-linux-gnu`); reproduced and worked around with a clean env. The wrapper should unset/scrub `PYTHONPATH` — filed as follow-up on the epic.
- With #3161 merged, `parallel_threads_effective()` is naturally true on this build: census parse runs thread-parallel out of the box.

Ref polylogue-xikl

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ