### PR TITLE
perf(storage): productize empty-derived-state bulk-build lifecycle

### DIFF
--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -20,8 +20,62 @@ from polylogue.config import Config
 from polylogue.maintenance.offline_guard import offline_maintenance_block_reason
 from polylogue.paths import render_root
 from polylogue.storage.archive_identity import ArchiveLocation
+from polylogue.storage.fts.fts_lifecycle import rebuild_command_trigram_index_sync, rebuild_fts_index_sync
+from polylogue.storage.fts.sql import FTS_REBUILD_SQL, TRIGRAM_REBUILD_DELETE_ALL_SQL
+from polylogue.storage.sqlite.action_pairs import rebuild_all_action_pairs_sync
+from polylogue.storage.sqlite.delegation_facts import rebuild_all_delegation_facts_sync
+from polylogue.storage.table_existence import table_exists
 
 _PLANNER_STATS_ANALYSIS_LIMIT = 1000
+
+
+def _clear_bulk_build_derived_stores(index_path: Path) -> None:
+    """Idempotently empty ``messages_fts``/``blocks_command_trigram``.
+
+    polylogue-v6i3: a fresh generation already starts with both derived
+    stores empty by construction (bootstrap creates empty schema), so the
+    very first pass of a brand-new bulk-build transaction never has
+    meaningful work to do here -- but calling this unconditionally on every
+    resumed pass (guarded by the transaction's own ``derived_stores_cleared``
+    marker so it fires at most once per operation) converts "derived stores
+    are empty throughout bulk-build replay" from an assumption inherited from
+    generation creation into an explicit, verified invariant. This mirrors
+    the manual pre-promote recovery script's clearing action
+    (``/realm/tmp/trigram-restore-pre-promote.py``, the live incident this
+    bead productizes), now automatic. Delete-all on an already-empty table is
+    near-instant (28.7s was measured against a *populated* table during the
+    live incident this bead responds to; an empty one is orders of magnitude
+    faster), so this is cheap even when it turns out to be a no-op.
+    """
+    with contextlib.closing(sqlite3.connect(index_path, timeout=60)) as conn:
+        conn.execute("PRAGMA busy_timeout = 60000")
+        if table_exists(conn, "messages_fts"):
+            conn.execute(FTS_REBUILD_SQL)
+        if table_exists(conn, "blocks_command_trigram"):
+            conn.execute(TRIGRAM_REBUILD_DELETE_ALL_SQL)
+        conn.commit()
+
+
+def _repopulate_bulk_build_derived_state(index_path: Path) -> None:
+    """One archive-wide repopulate of every surface bulk-build replay skipped.
+
+    polylogue-v6i3: ``write_parsed_session_to_archive``'s ``bulk_build`` mode
+    leaves ``messages_fts``, ``blocks_command_trigram``, ``action_pairs``, and
+    ``delegation_facts`` empty (or stale from a prior page) throughout replay
+    -- this runs exactly once, right before readiness, to bring all four back
+    into exact sync from ``blocks``/``messages``/``session_links`` in one bulk
+    delete+insert per surface instead of the per-session maintenance replay
+    skipped. Order matters: ``action_pairs`` must be repopulated before
+    ``delegation_facts`` (the latter's ``delegation_facts_source`` view joins
+    through the ``actions`` view, which reads ``action_pairs``).
+    """
+    with contextlib.closing(sqlite3.connect(index_path, timeout=600)) as conn:
+        conn.execute("PRAGMA busy_timeout = 600000")
+        rebuild_fts_index_sync(conn)
+        rebuild_command_trigram_index_sync(conn)
+        rebuild_all_action_pairs_sync(conn)
+        rebuild_all_delegation_facts_sync(conn)
+        conn.commit()
 
 
 def _refresh_generation_planner_statistics(index_path: Path) -> None:
@@ -184,6 +238,7 @@ def select_rebuild_raw_ids(request: RebuildIndexRequest) -> tuple[int, list[str]
 async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildIndexReceipt:
     """Replay one source snapshot into an owned generation and optionally promote it."""
     from polylogue.cli.commands.status import _archive_readiness_status
+    from polylogue.maintenance.archive_verification import verify_archive
     from polylogue.maintenance.replay import rebuild_index_from_source as replay_source
     from polylogue.storage.index_generation import IndexGenerationStore, RebuildLease, source_revision_snapshot
     from polylogue.storage.repair import repair_session_insights
@@ -251,6 +306,13 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
             generation = generation_store.load(transaction.generation_id)
             if generation.owner_id != transaction.generation_owner_id or generation.state != "inactive":
                 raise RuntimeError(f"rebuild operation {transaction.operation_id} lost its inactive candidate")
+            if not transaction.derived_stores_cleared:
+                _clear_bulk_build_derived_stores(Path(generation.index_path))
+                transaction = generation_store.checkpoint_transaction(
+                    transaction,
+                    status=transaction.status,
+                    derived_stores_cleared=True,
+                )
             page = generation_store.next_raw_page(transaction, limit=request.raw_batch_size)
             selected_raw_ids = [raw_id for raw_id, _acquired_at_ms, _blob_size in page.rows]
             selected_raw_count = len(selected_raw_ids)
@@ -283,6 +345,15 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
                 # per-row messages_fts trigger storm into one bulk delete+insert
                 # per affected session.
                 bulk_fts=True,
+                # polylogue-v6i3: the broader bulk-generation-build lifecycle --
+                # every per-session messages_fts/blocks_command_trigram/
+                # action_pairs/delegation_facts refresh is skipped during this
+                # replay (safe for a full OR partial/diagnostic selection: a
+                # repopulate from `blocks` always matches whatever sessions
+                # actually got replayed into this generation); see
+                # _repopulate_bulk_build_derived_state, called below right
+                # before readiness.
+                bulk_build=True,
             )
             if selected_raw_ids:
                 _refresh_generation_planner_statistics(Path(generation.index_path))
@@ -345,6 +416,18 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
                     )
                     source_drifted = True
                 raise RuntimeError(f"source evidence changed while rebuilding {generation.generation_id}")
+            # polylogue-v6i3: bulk-build replay (bulk_build=True above) left
+            # messages_fts/blocks_command_trigram/action_pairs/delegation_facts
+            # empty or stale for every session -- repopulate all four
+            # archive-wide exactly once here, then prove exact parity before
+            # readiness can observe (and silently accept) a mismatch.
+            _repopulate_bulk_build_derived_state(Path(generation.index_path))
+            parity_report = verify_archive(generation_root, checks=["fts-parity"])
+            if parity_report.blocking:
+                failing = "; ".join(check.summary for check in parity_report.checks if check.status.value == "error")
+                raise RuntimeError(
+                    f"bulk-build FTS/trigram parity failed for generation {generation.generation_id}: {failing}"
+                )
             readiness = _archive_readiness_status(generation_root)
             if not readiness.get("checked") or int(readiness.get("blocked_surface_count", 1)) != 0:
                 blocked = [

--- a/polylogue/maintenance/replay.py
+++ b/polylogue/maintenance/replay.py
@@ -146,6 +146,7 @@ async def rebuild_index_from_source(
     progress_callback: StageProgressCallback | None,
     owned_inactive_generation: tuple[str, str] | None = None,
     bulk_fts: bool = False,
+    bulk_build: bool = False,
 ) -> dict[str, object]:
     """Replay retained bytes through typed revision authority.
 
@@ -157,6 +158,13 @@ async def rebuild_index_from_source(
     bulk FTS mode for whale prefix-sharing lineage cascades encountered during
     replay; see ``backfill_historical_revision_evidence``. The offline
     ``rebuild-index`` maintenance command passes ``True``.
+
+    ``bulk_build`` (polylogue-v6i3, default ``False``) enables the broader
+    bulk-generation-build lifecycle -- skip every per-session
+    messages_fts/blocks_command_trigram/action_pairs/delegation_facts
+    refresh during replay, deferred to one archive-wide repopulate at
+    readiness. The offline ``rebuild-index`` maintenance command passes
+    ``True``.
     """
     if raw_batch_size <= 0:
         raise ValueError("raw_batch_size must be positive")
@@ -180,6 +188,7 @@ async def rebuild_index_from_source(
         max_cached_payload_bytes=_REBUILD_CENSUS_SPILL_CACHE_BYTES,
         ingest_workers=resolved_ingest_workers,
         bulk_fts=bulk_fts,
+        bulk_build=bulk_build,
     )
     if progress_callback is not None:
         progress_callback(result.replayed_logical_sources, "revision replay complete")

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -478,6 +478,7 @@ def backfill_historical_revision_evidence(
     ingest_workers: int = 1,
     commit_batch_size: int | None = None,
     bulk_fts: bool = False,
+    bulk_build: bool = False,
 ) -> RevisionBackfillResult:
     """Census every retained raw, then replay byte and bundle authority cohorts.
 
@@ -520,6 +521,13 @@ def backfill_historical_revision_evidence(
     to enable the guard-gated bulk FTS mode for whale prefix-sharing lineage
     cascades. Offline rebuild callers (``maintenance/rebuild_index.py`` via
     ``maintenance/replay.py``) pass ``True``; other callers leave it off.
+
+    ``bulk_build`` (polylogue-v6i3, default ``False``) mirrors ``bulk_fts``'s
+    threading to the same two apply calls, enabling the broader
+    bulk-generation-build lifecycle: every per-session
+    messages_fts/blocks_command_trigram/action_pairs/delegation_facts refresh
+    is skipped during replay, deferred to one archive-wide repopulate at
+    readiness. Only the offline rebuild caller passes ``True``.
     """
     adoption_deferred = 0
     quarantined = 0
@@ -621,6 +629,7 @@ def backfill_historical_revision_evidence(
                 acquired_at_ms=0,
                 manage_transaction=not replay_batched,
                 bulk_fts=bulk_fts,
+                bulk_build=bulk_build,
             )
             replayed += 1
             byte_replayed_keys.add(logical_key)
@@ -669,6 +678,7 @@ def backfill_historical_revision_evidence(
                 acquired_at_ms=0,
                 manage_transaction=not replay_batched,
                 bulk_fts=bulk_fts,
+                bulk_build=bulk_build,
             )
             if classification.accepted_raw_ids:
                 replayed += 1

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -21,11 +21,13 @@ from polylogue.storage.fts.sql import (
     FTS_TRIGGER_DDL,
     SESSION_WORK_EVENT_FTS_TRIGGER_DDL,
     THREAD_FTS_TRIGGER_DDL,
+    TRIGRAM_REBUILD_DELETE_ALL_SQL,
     IndexedMessage,
     chunked,
     delete_session_rows_sql,
     excess_message_rows_sql,
     insert_all_message_rows_sql,
+    insert_all_trigram_rows_sql,
     insert_missing_message_rows_range_sql,
     insert_session_rows_sql,
 )
@@ -328,6 +330,23 @@ def rebuild_fts_index_sync(conn: sqlite3.Connection) -> None:
     from polylogue.storage.fts.freshness import record_fts_invariant_snapshot_sync
 
     record_fts_invariant_snapshot_sync(conn, fts_invariant_snapshot_sync(conn))
+
+
+def rebuild_command_trigram_index_sync(conn: sqlite3.Connection) -> None:
+    """Rebuild the full ``blocks_command_trigram`` index from persisted blocks.
+
+    polylogue-v6i3: companion to :func:`rebuild_fts_index_sync` for the
+    bulk-build readiness repopulate. ``blocks_command_trigram`` is an
+    external-content FTS5 table, so it is cleared with the FTS5
+    ``'delete-all'`` command (see :data:`TRIGRAM_REBUILD_DELETE_ALL_SQL`) and
+    repopulated from ``blocks.tool_detail_text`` in one bulk insert -- the
+    same shape as the manual pre-promote recovery script this supersedes.
+    A no-op when either table is absent (pre-trigram-schema archives).
+    """
+    if not _table_exists_sync(conn, "blocks") or not _table_exists_sync(conn, "blocks_command_trigram"):
+        return
+    conn.execute(TRIGRAM_REBUILD_DELETE_ALL_SQL)
+    conn.execute(insert_all_trigram_rows_sql())
 
 
 def reset_message_fts_index_sync(conn: sqlite3.Connection) -> None:
@@ -1016,6 +1035,7 @@ __all__ = [
     "message_fts_triggers_present_sync",
     "delete_excess_message_rows_batched_sync",
     "insert_missing_message_rows_batched_sync",
+    "rebuild_command_trigram_index_sync",
     "rebuild_fts_index_async",
     "rebuild_fts_index_sync",
     "rebuild_session_insight_fts_sync",

--- a/polylogue/storage/fts/sql.py
+++ b/polylogue/storage/fts/sql.py
@@ -203,6 +203,31 @@ def excess_message_rows_sql(limit: int) -> str:
     """
 
 
+# polylogue-v6i3: ``blocks_command_trigram`` is an EXTERNAL-CONTENT FTS5 table
+# (content='blocks'), unlike contentless ``messages_fts``. A bare
+# ``DELETE FROM blocks_command_trigram`` does not fully release its shadow
+# postings for an external-content table -- the sanctioned bulk-empty
+# operation is the special ``'delete-all'`` command (verified against the
+# manual pre-promote recovery script this constant supersedes,
+# ``/realm/tmp/trigram-restore-pre-promote.py``).
+TRIGRAM_REBUILD_DELETE_ALL_SQL = "INSERT INTO blocks_command_trigram(blocks_command_trigram) VALUES ('delete-all')"
+
+
+def insert_all_trigram_rows_sql() -> str:
+    """Bulk repopulate ``blocks_command_trigram`` from ``blocks``.
+
+    Mirrors the ``blocks_command_trigram_ai`` trigger body's insert shape
+    (see ``BLOCKS_FTS_TRIGGER_DDL``'s sibling trigram DDL in
+    ``archive_tiers/index.py``), applied archive-wide instead of per-row.
+    """
+    return """
+        INSERT INTO blocks_command_trigram(rowid, tool_detail_text)
+        SELECT rowid, tool_detail_text
+        FROM blocks
+        WHERE block_type = 'tool_use' AND tool_detail_text != ' '
+    """
+
+
 __all__ = [
     "BLOCKS_FTS_TRIGGER_DDL",
     "FTS_BULK_SESSION_WRITE_GUARD",
@@ -215,10 +240,12 @@ __all__ = [
     "IndexedMessage",
     "SESSION_WORK_EVENT_FTS_TRIGGER_DDL",
     "THREAD_FTS_TRIGGER_DDL",
+    "TRIGRAM_REBUILD_DELETE_ALL_SQL",
     "chunked",
     "delete_session_rows_sql",
     "excess_message_rows_sql",
     "insert_all_message_rows_sql",
+    "insert_all_trigram_rows_sql",
     "insert_missing_message_rows_range_sql",
     "insert_missing_message_rows_sql",
     "insert_session_rows_sql",

--- a/polylogue/storage/index_generation.py
+++ b/polylogue/storage/index_generation.py
@@ -60,6 +60,16 @@ class IndexRebuildTransaction:
     pass_byte_budget: int | None = None
     pass_deadline_ms: int | None = None
     error: str | None = None
+    # polylogue-v6i3: set once a RESUMED pass has explicitly emptied this
+    # generation's messages_fts/blocks_command_trigram (defensive idempotent
+    # bookkeeping -- a fresh generation starts empty by construction and never
+    # needs this, but a resumed pass makes "derived stores are empty" an
+    # explicit, code-verified invariant instead of an assumption inherited
+    # from generation creation). Missing on older persisted transaction JSON
+    # defaults to ``False`` via the dataclass default, so an in-flight
+    # transaction created before this field existed is treated as not yet
+    # cleared and clears exactly once on its next resume.
+    derived_stores_cleared: bool = False
 
     @property
     def cursor(self) -> str | None:
@@ -314,6 +324,7 @@ class IndexGenerationStore:
         processed_raw_count: int | None = None,
         processed_blob_bytes: int | None = None,
         error: str | None = None,
+        derived_stores_cleared: bool | None = None,
     ) -> IndexRebuildTransaction:
         """Persist one state transition without changing candidate ownership."""
         return self.save_transaction(
@@ -332,6 +343,9 @@ class IndexGenerationStore:
                     if processed_blob_bytes is not None
                     else transaction.processed_blob_bytes,
                     "error": error,
+                    "derived_stores_cleared": derived_stores_cleared
+                    if derived_stores_cleared is not None
+                    else transaction.derived_stores_cleared,
                 }
             )
         )

--- a/polylogue/storage/sqlite/action_pairs.py
+++ b/polylogue/storage/sqlite/action_pairs.py
@@ -69,4 +69,77 @@ def refresh_action_pairs(conn: sqlite3.Connection, session_id: str) -> None:
     conn.execute(action_pairs_refresh_sql("?"), (session_id, session_id, session_id))
 
 
-__all__ = ["action_pairs_refresh_sql", "refresh_action_pairs"]
+def action_pairs_refresh_all_sql() -> str:
+    """Set-based, archive-wide equivalent of :func:`action_pairs_refresh_sql`.
+
+    polylogue-v6i3: a bulk-generation-build replay skips the per-session
+    ``refresh_action_pairs`` call for every session (see
+    ``write_parsed_session_to_archive``'s ``bulk_build`` mode) and instead
+    repopulates ``action_pairs`` archive-wide exactly once at readiness.
+    Measured (4,000 synthetic sessions, 6 tool_use/tool_result pairs each):
+    a per-session ``refresh_action_pairs`` loop took 64.2s vs 0.3s for this
+    one set-based statement -- 216x, the same shape of win #3152/#3147
+    already proved for FTS/index commits. The predicate is simply the
+    per-session ``WHERE session_id = ?`` removed; the CTE/window-function
+    body is otherwise identical to :func:`action_pairs_refresh_sql`.
+    """
+    return """
+        INSERT INTO action_pairs (
+            tool_use_block_id, session_id, message_id, tool_id, use_rank,
+            tool_name, semantic_type, tool_command, tool_path,
+            tool_result_block_id, is_error, exit_code
+        )
+        WITH ranked_uses AS (
+            SELECT u.session_id, u.message_id, u.block_id AS tool_use_block_id,
+                   u.tool_name, u.semantic_type, u.tool_command, u.tool_path,
+                   u.tool_id,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY u.session_id, u.tool_id
+                       ORDER BY um.position, um.variant_index, u.position
+                   ) AS use_rank
+            FROM blocks u JOIN messages um ON um.message_id = u.message_id
+            WHERE u.block_type = 'tool_use'
+              AND u.tool_id IS NOT NULL AND u.tool_id != ''
+        ), ranked_results AS (
+            SELECT r.session_id, r.tool_id, r.block_id AS tool_result_block_id,
+                   r.tool_result_is_error AS is_error,
+                   r.tool_result_exit_code AS exit_code,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY r.session_id, r.tool_id
+                       ORDER BY rm.position, rm.variant_index, r.position
+                   ) AS result_rank
+            FROM blocks r JOIN messages rm ON rm.message_id = r.message_id
+            WHERE r.block_type = 'tool_result'
+              AND r.tool_id IS NOT NULL AND r.tool_id != ''
+        )
+        SELECT u.tool_use_block_id, u.session_id, u.message_id, u.tool_id, u.use_rank,
+               u.tool_name, u.semantic_type, u.tool_command, u.tool_path,
+               r.tool_result_block_id, r.is_error, r.exit_code
+        FROM ranked_uses u LEFT JOIN ranked_results r
+          ON r.session_id = u.session_id AND r.tool_id = u.tool_id AND r.result_rank = u.use_rank
+        UNION ALL
+        SELECT u.block_id, u.session_id, u.message_id, u.tool_id, NULL,
+               u.tool_name, u.semantic_type, u.tool_command, u.tool_path,
+               NULL, NULL, NULL
+        FROM blocks u
+        WHERE u.block_type = 'tool_use'
+          AND (u.tool_id IS NULL OR u.tool_id = '')
+    """
+
+
+def rebuild_all_action_pairs_sync(conn: sqlite3.Connection) -> None:
+    """Repopulate ``action_pairs`` for every session in one bulk delete+insert.
+
+    The bulk-build readiness repopulate step (``maintenance/rebuild_index.py``)
+    calls this once after replay instead of relying on any per-session refresh.
+    """
+    conn.execute("DELETE FROM action_pairs")
+    conn.execute(action_pairs_refresh_all_sql())
+
+
+__all__ = [
+    "action_pairs_refresh_all_sql",
+    "action_pairs_refresh_sql",
+    "rebuild_all_action_pairs_sync",
+    "refresh_action_pairs",
+]

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1551,6 +1551,7 @@ class ArchiveStore:
         preacquired_attachment_blobs: dict[int, tuple[bytes | None, int, str]] | None = None,
         revision_authoritative: bool = False,
         bulk_fts: bool = False,
+        bulk_build: bool = False,
     ) -> ArchiveRawParsedWriteResult:
         session_id = str(make_session_id(session.source_name, session.provider_session_id))
         content_hash = str(session_content_hash(session))
@@ -1582,6 +1583,7 @@ class ArchiveStore:
                 preacquired_attachment_blobs=preacquired_attachment_blobs,
                 manage_transaction=manage_transaction,
                 bulk_fts=bulk_fts,
+                bulk_build=bulk_build,
             )
             return ArchiveRawParsedWriteResult(
                 raw_id=raw_id,
@@ -2935,6 +2937,7 @@ class ArchiveStore:
         stage_timing_prefix: str = "revision_replay",
         manage_transaction: bool = True,
         bulk_fts: bool = False,
+        bulk_build: bool = False,
     ) -> tuple[str, tuple[str, ...]]:
         """Apply a proven chain and atomically receipt its exact index state.
 
@@ -2958,6 +2961,13 @@ class ArchiveStore:
         whale prefix-sharing lineage cascades this replay triggers. Only the
         offline rebuild/backfill path passes ``True``; ordinary daemon replay
         stays on the unguarded per-row trigger path.
+
+        ``bulk_build`` (polylogue-v6i3, default ``False``) is the broader
+        bulk-generation-build lifecycle -- when ``True`` this skips the
+        trailing ``repair_message_fts_index_sync`` per-session repopulate and
+        relaxes ``assert_session_fts_exact_sync`` to its trigger-presence-only
+        check, since the bulk-build caller repopulates ``messages_fts``
+        archive-wide exactly once at readiness instead.
         """
         if not plan.accepted_raw_ids:
             raise ValueError("cannot apply a revision plan without an accepted chain")
@@ -3014,6 +3024,7 @@ class ArchiveStore:
                     finalize_raw_parse=False,
                     revision_authoritative=True,
                     bulk_fts=bulk_fts,
+                    bulk_build=bulk_build,
                 )
                 if stage_timings_s is not None:
                     key = f"{stage_timing_prefix}.index_parsed_write"
@@ -3026,8 +3037,9 @@ class ArchiveStore:
                 "UPDATE sessions SET content_hash = ? WHERE session_id = ?",
                 (aggregate_content_hash, session_id),
             )
-            repair_message_fts_index_sync(self._conn, [session_id], record_exact_snapshot=False)
-            assert_session_fts_exact_sync(self._conn, session_id)
+            if not bulk_build:
+                repair_message_fts_index_sync(self._conn, [session_id], record_exact_snapshot=False)
+            assert_session_fts_exact_sync(self._conn, session_id, bulk_build=bulk_build)
             stored = self._conn.execute(
                 "SELECT content_hash FROM sessions WHERE session_id = ?", (session_id,)
             ).fetchone()
@@ -3106,6 +3118,7 @@ class ArchiveStore:
         stage_timing_prefix: str = "membership_replay",
         manage_transaction: bool = True,
         bulk_fts: bool = False,
+        bulk_build: bool = False,
     ) -> str | None:
         """Apply one semantic member head and persist every membership decision.
 
@@ -3117,7 +3130,9 @@ class ArchiveStore:
         batch-commit invariant this mirrors.
 
         ``bulk_fts`` mirrors ``apply_raw_revision_replay``'s guard-gated bulk
-        FTS mode (polylogue-crd8); default ``False``.
+        FTS mode (polylogue-crd8); default ``False``. ``bulk_build`` mirrors
+        its broader bulk-generation-build lifecycle (polylogue-v6i3); default
+        ``False``.
         """
         conn = self._ensure_source_conn()
         decided_at_ms = int(datetime.now(UTC).timestamp() * 1000)
@@ -3189,13 +3204,15 @@ class ArchiveStore:
                     finalize_raw_parse=False,
                     revision_authoritative=True,
                     bulk_fts=bulk_fts,
+                    bulk_build=bulk_build,
                 )
                 if stage_timings_s is not None:
                     key = f"{stage_timing_prefix}.index_parsed_write"
                     stage_timings_s[key] = stage_timings_s.get(key, 0.0) + (time.perf_counter() - index_started)
                 session_id = result.session_id
-                repair_message_fts_index_sync(self._conn, [session_id], record_exact_snapshot=False)
-                assert_session_fts_exact_sync(self._conn, session_id)
+                if not bulk_build:
+                    repair_message_fts_index_sync(self._conn, [session_id], record_exact_snapshot=False)
+                assert_session_fts_exact_sync(self._conn, session_id, bulk_build=bulk_build)
                 stored = self._conn.execute(
                     "SELECT content_hash FROM sessions WHERE session_id = ?", (session_id,)
                 ).fetchone()
@@ -3339,6 +3356,7 @@ class ArchiveStore:
         finalize_raw_parse: bool,
         revision_authoritative: bool = False,
         bulk_fts: bool = False,
+        bulk_build: bool = False,
     ) -> ArchiveRawParsedWriteResult:
         provider = Provider.from_string(session.source_name)
         try:
@@ -3352,6 +3370,7 @@ class ArchiveStore:
                 preacquired_attachment_blobs=preacquired_attachment_blobs,
                 revision_authoritative=revision_authoritative,
                 bulk_fts=bulk_fts,
+                bulk_build=bulk_build,
             )
         except Exception as exc:
             self.finalize_raw_parse_state(raw_id, state=self._raw_parse_failure_state(provider, exc))

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -14,7 +14,7 @@ from polylogue.core.enums import (
     SessionKind,
     WebConstructType,
 )
-from polylogue.storage.fts.sql import FTS_TRIGGER_DDL
+from polylogue.storage.fts.sql import FTS_BULK_SESSION_WRITE_GUARD, FTS_TRIGGER_DDL
 from polylogue.storage.sqlite.action_pairs import action_pairs_refresh_sql
 from polylogue.storage.sqlite.archive_tiers.common import (
     CONTENT_HASH_CHECK,
@@ -25,6 +25,17 @@ from polylogue.storage.sqlite.archive_tiers.common import (
 from polylogue.storage.sqlite.delegation_facts import delegation_facts_insert_sql
 
 INDEX_SCHEMA_VERSION = 41
+
+# polylogue-v6i3: shared WHEN-clause fragment gating the blocks_command_trigram
+# trigger BODIES on the same dedicated bulk-build guard row messages_fts's
+# triggers already use (see storage/fts/sql.py's _FTS_BULK_GUARD_NOT_SET).
+# Additive/inert on existing archives -- CREATE TRIGGER IF NOT EXISTS keeps
+# the prior (ungated) trigram trigger body on an archive until its next
+# rebuild, matching the messages_fts precedent from #3152 (no
+# INDEX_SCHEMA_VERSION bump needed for an additive, inert trigger-body change).
+_TRIGRAM_BULK_GUARD_NOT_SET = (
+    f"NOT EXISTS (SELECT 1 FROM derived_refresh_guard WHERE guard_name = '{FTS_BULK_SESSION_WRITE_GUARD}')"
+)
 
 FTS_FRESHNESS_STATE_DDL = """
 CREATE TABLE IF NOT EXISTS fts_freshness_state (
@@ -428,7 +439,8 @@ CREATE VIRTUAL TABLE IF NOT EXISTS blocks_command_trigram USING fts5(
 );
 
 CREATE TRIGGER IF NOT EXISTS blocks_command_trigram_ai
-AFTER INSERT ON blocks WHEN new.block_type = 'tool_use' AND new.tool_detail_text != ' ' BEGIN
+AFTER INSERT ON blocks
+WHEN new.block_type = 'tool_use' AND new.tool_detail_text != ' ' AND {_TRIGRAM_BULK_GUARD_NOT_SET} BEGIN
     INSERT INTO blocks_command_trigram(rowid, tool_detail_text)
     VALUES (new.rowid, new.tool_detail_text);
 END;
@@ -442,13 +454,14 @@ END;
 -- to remove rather than re-reading it from the (already-deleted) content
 -- row.
 CREATE TRIGGER IF NOT EXISTS blocks_command_trigram_ad
-AFTER DELETE ON blocks WHEN old.block_type = 'tool_use' AND old.tool_detail_text != ' ' BEGIN
+AFTER DELETE ON blocks
+WHEN old.block_type = 'tool_use' AND old.tool_detail_text != ' ' AND {_TRIGRAM_BULK_GUARD_NOT_SET} BEGIN
     INSERT INTO blocks_command_trigram(blocks_command_trigram, rowid, tool_detail_text)
     VALUES ('delete', old.rowid, old.tool_detail_text);
 END;
 
 CREATE TRIGGER IF NOT EXISTS blocks_command_trigram_au
-AFTER UPDATE ON blocks BEGIN
+AFTER UPDATE ON blocks WHEN {_TRIGRAM_BULK_GUARD_NOT_SET} BEGIN
     INSERT INTO blocks_command_trigram(blocks_command_trigram, rowid, tool_detail_text)
     SELECT 'delete', old.rowid, old.tool_detail_text
     WHERE old.block_type = 'tool_use' AND old.tool_detail_text != ' ';

--- a/polylogue/storage/sqlite/archive_tiers/revision_application.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_application.py
@@ -91,14 +91,29 @@ class FullSnapshotFoldAuthorization:
         )
 
 
-def assert_session_fts_exact_sync(conn: sqlite3.Connection, session_id: str) -> None:
-    """Fail unless the current session's indexable blocks have exact FTS rows."""
+def assert_session_fts_exact_sync(conn: sqlite3.Connection, session_id: str, *, bulk_build: bool = False) -> None:
+    """Fail unless the current session's indexable blocks have exact FTS rows.
+
+    ``bulk_build`` (polylogue-v6i3, default ``False``): a bulk-generation-
+    build replay deliberately leaves ``messages_fts`` empty for every session
+    throughout the build (see ``write_parsed_session_to_archive``'s
+    ``bulk_build`` mode) and repopulates it archive-wide exactly once at
+    readiness -- so the per-session row-count parity check below does not
+    apply mid-build; it is *expected* to be out of sync, not a bug. The
+    trigger-presence check still runs unconditionally: the guard row only
+    gates trigger BODIES (see ``_bulk_fts_session_guard``), the triggers
+    themselves remain structurally present in ``sqlite_master`` throughout,
+    so this half of the proof is unaffected by bulk-build mode and stays a
+    real check, not a weakened default.
+    """
     triggers = {
         str(row[0])
         for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'trigger' AND name LIKE 'messages_fts_a%'")
     }
     if not _MESSAGE_FTS_TRIGGERS.issubset(triggers):
         raise RuntimeError("raw revision application requires canonical message FTS triggers")
+    if bulk_build:
+        return
     expected, indexed = conn.execute(
         """
         SELECT

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -219,6 +219,7 @@ def write_parsed_session_to_archive(
     preacquired_attachment_blobs: dict[int, tuple[bytes | None, int, str]] | None = None,
     manage_transaction: bool = True,
     bulk_fts: bool = False,
+    bulk_build: bool = False,
 ) -> str:
     """Write one parsed session into an initialized archive index DB.
 
@@ -234,6 +235,20 @@ def write_parsed_session_to_archive(
     (child) sessions via ``_resolve_session_graph`` -- see
     ``_bulk_fts_session_guard``. Only the offline rebuild/backfill replay path
     turns this on.
+
+    ``bulk_build`` (polylogue-v6i3, default ``False``) is the broader
+    bulk-generation-build lifecycle this session write may be part of: a
+    full source-to-index replay that always finishes with exactly one
+    archive-wide repopulate of ``messages_fts``/``blocks_command_trigram``/
+    ``action_pairs``/``delegation_facts`` before readiness (see
+    ``maintenance/rebuild_index.py``). When ``True``, this write skips every
+    per-session refresh of those four derived surfaces entirely (not just the
+    guard-gated bulk delete+insert ``bulk_fts`` performs) -- the final
+    repopulate covers every session regardless, so per-session work here is
+    pure waste. Only the offline rebuild call passes ``True``; ordinary
+    daemon writes (and ``bulk_fts=True`` used alone, e.g. in
+    ``tests/unit/storage/test_bulk_fts_prefix_reextract.py``) keep those
+    surfaces exactly in sync after every write, unchanged.
     """
     t0 = time.perf_counter()
 
@@ -330,6 +345,17 @@ def write_parsed_session_to_archive(
     transaction = conn if manage_transaction else nullcontext()
     with transaction:
         conn.execute("INSERT OR REPLACE INTO derived_refresh_guard(guard_name) VALUES ('session-write')")
+        if bulk_build:
+            # polylogue-v6i3: gate messages_fts/blocks_command_trigram trigger
+            # BODIES for this session's *entire* write (block inserts in the
+            # ordinary merge/full-replace paths, not just the prefix-tail
+            # reextract cascade -- see _bulk_fts_session_guard, which detects
+            # this outer guard and becomes a no-op rather than double-managing
+            # the same row). Cleared alongside the 'session-write' guard below.
+            conn.execute(
+                "INSERT OR REPLACE INTO derived_refresh_guard(guard_name) VALUES (?)",
+                (FTS_BULK_SESSION_WRITE_GUARD,),
+            )
         t0 = time.perf_counter()
         conn.execute(
             """
@@ -438,6 +464,7 @@ def write_parsed_session_to_archive(
                 duplicate_native_ids=duplicate_message_native_ids,
                 stage_timings_s=stage_timings_s,
                 stage_timing_prefix=stage_timing_prefix,
+                bulk_build=bulk_build,
             )
             add_timing("index.full_replace", t0)
         if merge_append:
@@ -460,7 +487,8 @@ def write_parsed_session_to_archive(
             )
             add_timing("index.blocks", t0)
             t0 = time.perf_counter()
-            refresh_action_pairs(conn, session_id)
+            if not bulk_build:
+                refresh_action_pairs(conn, session_id)
             add_timing("index.action_pairs", t0)
             t0 = time.perf_counter()
             _write_web_constructs(
@@ -575,12 +603,19 @@ def write_parsed_session_to_archive(
             cache=signature_cache,
             add_timing=add_timing,
             bulk_fts=bulk_fts,
+            bulk_build=bulk_build,
         )
         add_timing("index.graph_resolve", t0)
         t0 = time.perf_counter()
-        refresh_delegation_facts_for_session(conn, session_id)
+        if not bulk_build:
+            refresh_delegation_facts_for_session(conn, session_id)
         add_timing("index.delegation_facts", t0)
         conn.execute("DELETE FROM derived_refresh_guard WHERE guard_name = 'session-write'")
+        if bulk_build:
+            conn.execute(
+                "DELETE FROM derived_refresh_guard WHERE guard_name = ?",
+                (FTS_BULK_SESSION_WRITE_GUARD,),
+            )
         if merge_append and session.ingest_flags:
             t0 = time.perf_counter()
             _write_ingest_flag_tags(conn, session_id, session.ingest_flags)
@@ -1713,7 +1748,19 @@ def _replace_full_session_messages_and_blocks(
     duplicate_native_ids: frozenset[str],
     stage_timings_s: dict[str, float] | None = None,
     stage_timing_prefix: str = "append",
+    bulk_build: bool = False,
 ) -> None:
+    """Replace one session's messages/blocks wholesale.
+
+    ``bulk_build`` (polylogue-v6i3, default ``False``) skips this function's
+    own scoped ``messages_fts`` delete/suspend-trigger/insert/restore dance
+    and its ``action_pairs`` refresh entirely -- see
+    ``write_parsed_session_to_archive``'s docstring for why: a bulk-build
+    caller always repopulates both surfaces archive-wide exactly once at
+    readiness, so per-session maintenance here is pure waste. Ordinary
+    (non-bulk-build) full-session replaces are byte-for-byte unchanged.
+    """
+
     def add_timing(name: str, started_at: float) -> None:
         _add_stage_timing(
             stage_timings_s,
@@ -1725,7 +1772,7 @@ def _replace_full_session_messages_and_blocks(
     origin = origin_from_provider(session.source_name)
     session_id = archive_session_id(origin.value, session.provider_session_id)
     t0 = time.perf_counter()
-    use_scoped_fts_rebuild = message_fts_triggers_present_sync(conn)
+    use_scoped_fts_rebuild = not bulk_build and message_fts_triggers_present_sync(conn)
     add_timing("fts_probe", t0)
     if use_scoped_fts_rebuild:
         t0 = time.perf_counter()
@@ -1758,7 +1805,8 @@ def _replace_full_session_messages_and_blocks(
         )
         add_timing("blocks", t0)
         t0 = time.perf_counter()
-        refresh_action_pairs(conn, session_id)
+        if not bulk_build:
+            refresh_action_pairs(conn, session_id)
         add_timing("action_pairs", t0)
         t0 = time.perf_counter()
         _write_web_constructs(
@@ -2157,6 +2205,7 @@ def _resolve_session_graph(
     cache: dict[str, list[tuple[str, str]]] | None = None,
     add_timing: Callable[[str, float], None] | None = None,
     bulk_fts: bool = False,
+    bulk_build: bool = False,
 ) -> None:
     def record_substage(name: str, started_at: float) -> None:
         if add_timing is not None:
@@ -2222,6 +2271,7 @@ def _resolve_session_graph(
             composed_cache=composed_cache,
             add_timing=add_timing,
             bulk_fts=bulk_fts,
+            bulk_build=bulk_build,
         )
     record_substage("reextract_prefix_tails", t0)
 
@@ -3795,7 +3845,13 @@ def _composed_db_signatures(
 
 
 @contextmanager
-def _bulk_fts_session_guard(conn: sqlite3.Connection, session_id: str, *, enabled: bool) -> Iterator[None]:
+def _bulk_fts_session_guard(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    enabled: bool,
+    bulk_build: bool = False,
+) -> Iterator[None]:
     """Suspend per-row ``messages_fts`` trigger maintenance for one session.
 
     polylogue-crd8: whale prefix-sharing lineage sessions (fork/resume/
@@ -3824,7 +3880,23 @@ def _bulk_fts_session_guard(conn: sqlite3.Connection, session_id: str, *, enable
     for a session's own full replace, just gated by a guard row instead of a
     raw ``DROP TRIGGER``/``CREATE TRIGGER`` pair, so the trigger-presence half
     of ``assert_session_fts_exact_sync`` never observes a trigger-less window.
+
+    ``bulk_build`` (polylogue-v6i3, default ``False``): when the caller is
+    inside a bulk-generation-build session write, ``write_parsed_session_to_
+    archive`` already set the same dedicated guard row for the whole
+    transaction (every block mutation across the entire session write, not
+    just this dependent-delete) and owns clearing it at the end. This
+    context manager becomes a plain no-op in that case -- it must not
+    re-insert/re-delete the same row (that would prematurely clear the
+    guard for the remainder of the outer write) and must not perform the
+    explicit delete-then-reinsert either: the bulk-build lifecycle leaves
+    ``messages_fts``/``blocks_command_trigram`` empty throughout replay and
+    repopulates both archive-wide exactly once at readiness, so any
+    per-session insert here would just be redone work.
     """
+    if bulk_build:
+        yield
+        return
     if not enabled:
         yield
         return
@@ -3852,6 +3924,7 @@ def _reextract_prefix_tail_db(
     composed_cache: dict[str, list[tuple[str, str]]] | None = None,
     add_timing: Callable[[str, float], None] | None = None,
     bulk_fts: bool = False,
+    bulk_build: bool = False,
 ) -> None:
     """Normalize a child that was stored whole because its parent was ingested
     later (#2467). Aligns the child's already-stored messages against the parent's
@@ -3995,7 +4068,7 @@ def _reextract_prefix_tail_db(
     )
     record_substage("provider_usage_tail", t0)
     t0 = time.perf_counter()
-    with _bulk_fts_session_guard(conn, child_session_id, enabled=bulk_fts):
+    with _bulk_fts_session_guard(conn, child_session_id, enabled=bulk_fts, bulk_build=bulk_build):
         if k == len(child_composed):
             _delete_all_session_message_dependents(conn, child_session_id, prefix_message_ids)
             record_substage("dependent_delete", t0)

--- a/polylogue/storage/sqlite/delegation_facts.py
+++ b/polylogue/storage/sqlite/delegation_facts.py
@@ -39,6 +39,28 @@ def refresh_delegation_facts(conn: sqlite3.Connection, parent_session_id: str) -
         conn.execute("DELETE FROM delegation_refresh_scope")
 
 
+def rebuild_all_delegation_facts_sync(conn: sqlite3.Connection) -> None:
+    """Repopulate ``delegation_facts`` for every session in one bulk pass.
+
+    polylogue-v6i3: ``delegation_facts_source`` (the view backing
+    ``delegation_facts_insert_sql``) is already scoped by the
+    ``delegation_refresh_scope`` allow-list table rather than by an inline
+    predicate -- populating that scope with every session id turns the
+    existing per-cohort insert into an archive-wide one, with no new SQL
+    shape to keep in sync with ``delegation_facts_insert_sql``. The
+    bulk-build readiness repopulate step calls this once after replay
+    instead of relying on ``refresh_delegation_facts_for_session`` per
+    session (skipped during bulk-build writes, see
+    ``write_parsed_session_to_archive``'s ``bulk_build`` mode).
+    """
+    conn.execute("DELETE FROM delegation_facts")
+    conn.execute("INSERT OR REPLACE INTO delegation_refresh_scope(parent_session_id) SELECT session_id FROM sessions")
+    try:
+        conn.execute(delegation_facts_insert_sql("?"))
+    finally:
+        conn.execute("DELETE FROM delegation_refresh_scope")
+
+
 def refresh_delegation_facts_for_session(conn: sqlite3.Connection, session_id: str) -> None:
     """Refresh the session and every parent cohort affected by its links."""
     parent_ids = {session_id}
@@ -57,4 +79,9 @@ def refresh_delegation_facts_for_session(conn: sqlite3.Connection, session_id: s
         refresh_delegation_facts(conn, parent_id)
 
 
-__all__ = ["delegation_facts_insert_sql", "refresh_delegation_facts", "refresh_delegation_facts_for_session"]
+__all__ = [
+    "delegation_facts_insert_sql",
+    "rebuild_all_delegation_facts_sync",
+    "refresh_delegation_facts",
+    "refresh_delegation_facts_for_session",
+]

--- a/tests/unit/maintenance/test_rebuild_index_bulk_build.py
+++ b/tests/unit/maintenance/test_rebuild_index_bulk_build.py
@@ -1,0 +1,157 @@
+"""``maintenance/rebuild_index.py``'s bulk-build derived-state lifecycle
+(polylogue-v6i3): the two direct-file helpers the offline rebuild orchestrator
+calls around a bulk-build replay -- ``_clear_bulk_build_derived_stores`` (once
+per resumed operation, defensive idempotent bookkeeping) and
+``_repopulate_bulk_build_derived_state`` (once at readiness, the real
+archive-wide repopulate that retires the manual pre-promote recovery script).
+
+Tested at the direct-function level (mirroring
+``test_planner_statistics_seed.py``'s ``_refresh_generation_planner_
+statistics`` pattern) rather than through the full ``RebuildLease``/generation
+orchestration, which is exercised elsewhere and is not what these two
+functions' correctness depends on.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
+from polylogue.maintenance.archive_verification import verify_archive
+from polylogue.maintenance.rebuild_index import (
+    _clear_bulk_build_derived_stores,
+    _repopulate_bulk_build_derived_state,
+)
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    initialize_archive_tier(conn, ArchiveTier.INDEX)
+    return conn
+
+
+def _session(session_id: str) -> ParsedSession:
+    return ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id=session_id,
+        title=f"session {session_id}",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m0",
+                role=Role.USER,
+                text="hello searchable text",
+                position=0,
+                variant_index=0,
+                is_active_path=True,
+                is_active_leaf=False,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="hello searchable text")],
+            ),
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.ASSISTANT,
+                text=None,
+                position=1,
+                variant_index=0,
+                is_active_path=True,
+                is_active_leaf=False,
+                blocks=[
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_USE,
+                        tool_name="Bash",
+                        tool_id=f"{session_id}-tool",
+                        tool_input={"command": "echo hi"},
+                    ),
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_RESULT,
+                        tool_id=f"{session_id}-tool",
+                        text="hi",
+                        is_error=False,
+                        exit_code=0,
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+def test_clear_bulk_build_derived_stores_empties_populated_tables(tmp_path: Path) -> None:
+    db_path = tmp_path / "index.db"
+    conn = _connect(db_path)
+    write_parsed_session_to_archive(conn, _session("s1"))
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] > 0
+    assert conn.execute("SELECT COUNT(*) FROM blocks_command_trigram_docsize").fetchone()[0] > 0
+    action_pairs_before = conn.execute("SELECT COUNT(*) FROM action_pairs").fetchone()[0]
+    assert action_pairs_before > 0
+    blocks_before = conn.execute("SELECT COUNT(*) FROM blocks").fetchone()[0]
+    conn.close()
+
+    _clear_bulk_build_derived_stores(db_path)
+
+    conn = sqlite3.connect(db_path)
+    assert conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM blocks_command_trigram_docsize").fetchone()[0] == 0
+    # Only the two named surfaces clear here; action_pairs/blocks are a
+    # readiness-time concern, not a resume-clear concern.
+    assert conn.execute("SELECT COUNT(*) FROM action_pairs").fetchone()[0] == action_pairs_before
+    assert conn.execute("SELECT COUNT(*) FROM blocks").fetchone()[0] == blocks_before
+    conn.close()
+
+
+def test_clear_bulk_build_derived_stores_idempotent_on_already_empty(tmp_path: Path) -> None:
+    db_path = tmp_path / "index.db"
+    conn = _connect(db_path)
+    conn.commit()
+    conn.close()
+
+    _clear_bulk_build_derived_stores(db_path)
+    _clear_bulk_build_derived_stores(db_path)  # must not raise on an already-empty table
+
+    conn = sqlite3.connect(db_path)
+    assert conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] == 0
+    conn.close()
+
+
+def test_repopulate_bulk_build_derived_state_produces_exact_parity(tmp_path: Path) -> None:
+    """A corpus written entirely in bulk_build mode (derived surfaces
+    deliberately empty) must reach exact archive-wide parity after one
+    repopulate call -- the same check ``rebuild_index_from_source`` runs
+    right before readiness."""
+    db_path = tmp_path / "index.db"
+    conn = _connect(db_path)
+    for label in ("alpha", "beta", "gamma"):
+        write_parsed_session_to_archive(conn, _session(label), bulk_fts=True, bulk_build=True)
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM action_pairs").fetchone()[0] == 0
+    conn.close()
+
+    _repopulate_bulk_build_derived_state(db_path)
+
+    report = verify_archive(tmp_path, checks=["fts-parity"])
+    assert not report.blocking, [check.summary for check in report.checks]
+
+    conn = sqlite3.connect(db_path)
+    text_block_count = conn.execute("SELECT COUNT(*) FROM blocks WHERE search_text != ''").fetchone()[0]
+    fts_count = conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0]
+    assert text_block_count > 0
+    assert fts_count == text_block_count
+
+    tool_use_count = conn.execute(
+        "SELECT COUNT(*) FROM blocks WHERE block_type = 'tool_use' AND tool_detail_text != ' '"
+    ).fetchone()[0]
+    trigram_count = conn.execute("SELECT COUNT(*) FROM blocks_command_trigram_docsize").fetchone()[0]
+    assert tool_use_count > 0
+    assert trigram_count == tool_use_count
+
+    action_pairs_count = conn.execute("SELECT COUNT(*) FROM action_pairs").fetchone()[0]
+    assert action_pairs_count == tool_use_count
+    conn.close()

--- a/tests/unit/storage/test_bulk_build_lifecycle.py
+++ b/tests/unit/storage/test_bulk_build_lifecycle.py
@@ -1,0 +1,318 @@
+"""Bulk-generation-build lifecycle (polylogue-v6i3): empty derived state
+throughout replay, one archive-wide repopulate at readiness.
+
+Background: a whale offline rebuild measured a 3h+ stall doing per-session
+FTS/trigram/action_pairs/delegation_facts maintenance one session at a time,
+where an ARCHIVE-WIDE ``messages_fts`` + ``blocks_command_trigram``
+delete-all took 28.7s (bead polylogue-v6i3). ``write_parsed_session_to_
+archive(..., bulk_build=True)`` -- the offline rebuild path's mode, layered
+on top of the existing ``bulk_fts`` guard-gated bulk FTS mode (#3152) --
+skips ALL per-session maintenance of these four derived surfaces (not just
+the whale prefix-reextract cascade #3152 already handles) and defers
+everything to one archive-wide repopulate the caller runs once at readiness
+(``maintenance/rebuild_index.py``'s ``_repopulate_bulk_build_derived_state``).
+
+These tests prove: (a) ``bulk_build=True`` writes leave ``messages_fts`` /
+``blocks_command_trigram`` / ``action_pairs`` empty for the written session,
+where mode-off leaves them populated (so (a) is not vacuously true for every
+write); (b) the readiness repopulate (``rebuild_fts_index_sync`` +
+``rebuild_command_trigram_index_sync`` + ``rebuild_all_action_pairs_sync``)
+produces byte-identical content to trickle-mode (``bulk_build=False``)
+population of the SAME corpus, including a prefix-sharing lineage cascade
+that exercises ``_bulk_fts_session_guard``'s bulk-build no-op branch; (c) the
+whole-transaction ``FTS_BULK_SESSION_WRITE_GUARD`` row never leaks past an
+exception; (d) an anti-vacuity check -- skip the readiness repopulate for one
+surface and show the parity comparison then fails, proving the equivalence
+test in (b) is actually exercising the repopulate code, not passing by
+coincidence.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.fts.fts_lifecycle import rebuild_command_trigram_index_sync, rebuild_fts_index_sync
+from polylogue.storage.fts.sql import FTS_BULK_SESSION_WRITE_GUARD
+from polylogue.storage.sqlite.action_pairs import rebuild_all_action_pairs_sync
+from polylogue.storage.sqlite.archive_tiers import write as _write_module
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.revision_application import assert_session_fts_exact_sync
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    initialize_archive_tier(conn, ArchiveTier.INDEX)
+    return conn
+
+
+def _tool_pair(idx: int, position: int, *, tool_id_prefix: str = "tool") -> ParsedMessage:
+    tool_id = f"{tool_id_prefix}-{idx}"
+    return ParsedMessage(
+        provider_message_id=f"m{idx}",
+        role=Role.ASSISTANT,
+        text=None,
+        position=position,
+        variant_index=0,
+        is_active_path=True,
+        is_active_leaf=False,
+        blocks=[
+            ParsedContentBlock(
+                type=BlockType.TOOL_USE,
+                tool_name="Bash",
+                tool_id=tool_id,
+                tool_input={"command": f"echo {idx}"},
+            ),
+            ParsedContentBlock(
+                type=BlockType.TOOL_RESULT,
+                tool_id=tool_id,
+                text=f"output {idx}",
+                is_error=False,
+                exit_code=0,
+            ),
+        ],
+    )
+
+
+def _text_message(idx: int, position: int, text: str) -> ParsedMessage:
+    return ParsedMessage(
+        provider_message_id=f"text{idx}",
+        role=Role.USER,
+        text=text,
+        position=position,
+        variant_index=0,
+        is_active_path=True,
+        is_active_leaf=False,
+        blocks=[ParsedContentBlock(type=BlockType.TEXT, text=text)],
+    )
+
+
+def _session(session_id: str, *, n_pairs: int = 2) -> ParsedSession:
+    messages = [_text_message(0, 0, f"session {session_id} opening remark")]
+    for i in range(n_pairs):
+        messages.append(_tool_pair(i, position=i + 1, tool_id_prefix=f"{session_id}-tool"))
+    return ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id=session_id,
+        title=f"session {session_id}",
+        messages=messages,
+    )
+
+
+def _lineage_scenario(conn: sqlite3.Connection, *, bulk_fts: bool, bulk_build: bool) -> tuple[str, str]:
+    """A prefix-sharing child+parent pair, mirroring
+    ``test_bulk_fts_prefix_reextract.py``'s partial-tail scenario, extended
+    with tool_use/tool_result pairs so action_pairs/trigram content exists
+    to compare, not just messages_fts."""
+    child = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="lineage-child",
+        title="lineage child",
+        parent_session_provider_id="lineage-parent",
+        messages=[
+            _text_message(0, 0, "hello"),
+            _tool_pair(0, position=1, tool_id_prefix="child"),
+            _text_message(1, 2, "child diverges here"),
+        ],
+    )
+    child_id = write_parsed_session_to_archive(conn, child, bulk_fts=bulk_fts, bulk_build=bulk_build)
+    parent = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="lineage-parent",
+        title="lineage parent",
+        messages=[
+            _text_message(0, 0, "hello"),
+            _tool_pair(0, position=1, tool_id_prefix="parent"),
+            _text_message(1, 2, "parent continues alone"),
+        ],
+    )
+    parent_id = write_parsed_session_to_archive(conn, parent, bulk_fts=bulk_fts, bulk_build=bulk_build)
+    return child_id, parent_id
+
+
+def _build_corpus(conn: sqlite3.Connection, *, bulk_build: bool) -> list[str]:
+    """Two independent sessions plus one prefix-sharing lineage pair."""
+    session_ids = []
+    for label in ("alpha", "beta"):
+        session_ids.append(
+            write_parsed_session_to_archive(conn, _session(label), bulk_fts=bulk_build, bulk_build=bulk_build)
+        )
+    child_id, parent_id = _lineage_scenario(conn, bulk_fts=bulk_build, bulk_build=bulk_build)
+    session_ids.extend([child_id, parent_id])
+    return session_ids
+
+
+def _fts_rows(conn: sqlite3.Connection) -> list[tuple[object, ...]]:
+    rows = conn.execute(
+        "SELECT block_id, message_id, session_id, block_type, text FROM messages_fts ORDER BY block_id"
+    ).fetchall()
+    return sorted(tuple(row) for row in rows)
+
+
+def _trigram_rows(conn: sqlite3.Connection) -> list[tuple[object, ...]]:
+    rows = conn.execute(
+        """
+        SELECT b.block_id, t.tool_detail_text
+        FROM blocks_command_trigram AS t
+        JOIN blocks AS b ON b.rowid = t.rowid
+        ORDER BY b.block_id
+        """
+    ).fetchall()
+    return sorted(tuple(row) for row in rows)
+
+
+def _action_pair_rows(conn: sqlite3.Connection) -> list[tuple[object, ...]]:
+    rows = conn.execute(
+        """
+        SELECT tool_use_block_id, session_id, message_id, tool_id, use_rank, tool_name,
+               semantic_type, tool_command, tool_path, tool_result_block_id, is_error, exit_code
+        FROM action_pairs
+        ORDER BY tool_use_block_id
+        """
+    ).fetchall()
+    return sorted(tuple(row) for row in rows)
+
+
+def test_bulk_build_write_leaves_derived_surfaces_empty(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    session_id = write_parsed_session_to_archive(conn, _session("solo"), bulk_fts=True, bulk_build=True)
+
+    assert conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM blocks_command_trigram_docsize").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM action_pairs WHERE session_id = ?", (session_id,)).fetchone()[0] == 0
+    # The guard row must never leak past the write it protected.
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM derived_refresh_guard WHERE guard_name = ?",
+            (FTS_BULK_SESSION_WRITE_GUARD,),
+        ).fetchone()[0]
+        == 0
+    )
+    # Real rows exist to index -- an empty derived surface here is a
+    # deliberate skip, not an artifact of an empty session.
+    assert conn.execute("SELECT COUNT(*) FROM blocks WHERE search_text != ''").fetchone()[0] > 0
+    conn.close()
+
+
+def test_bulk_build_off_matches_todays_per_session_population(tmp_path: Path) -> None:
+    """Anti-vacuity baseline for the test above: without bulk_build, the same
+    session write populates all three surfaces immediately, proving the
+    empty result above is a real skip, not something every write produces."""
+    conn = _connect(tmp_path / "index.db")
+    session_id = write_parsed_session_to_archive(conn, _session("solo"))
+
+    assert conn.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] > 0
+    assert conn.execute("SELECT COUNT(*) FROM blocks_command_trigram_docsize").fetchone()[0] > 0
+    assert conn.execute("SELECT COUNT(*) FROM action_pairs WHERE session_id = ?", (session_id,)).fetchone()[0] > 0
+    conn.close()
+
+
+def test_bulk_build_readiness_repopulate_matches_trickle_mode(tmp_path: Path) -> None:
+    """THE key equivalence proof: a bulk-build corpus, repopulated once at
+    readiness, must be byte-identical to the same corpus built entirely in
+    today's per-session trickle mode."""
+    conn_trickle = _connect(tmp_path / "trickle.db")
+    _build_corpus(conn_trickle, bulk_build=False)
+    fts_trickle = _fts_rows(conn_trickle)
+    trigram_trickle = _trigram_rows(conn_trickle)
+    action_pairs_trickle = _action_pair_rows(conn_trickle)
+    conn_trickle.close()
+
+    conn_bulk = _connect(tmp_path / "bulk.db")
+    _build_corpus(conn_bulk, bulk_build=True)
+    # Confirm the empty-throughout invariant actually held for this corpus
+    # before repopulating -- otherwise the parity check below could pass
+    # vacuously if bulk_build silently did nothing.
+    assert conn_bulk.execute("SELECT COUNT(*) FROM messages_fts").fetchone()[0] == 0
+    assert conn_bulk.execute("SELECT COUNT(*) FROM action_pairs").fetchone()[0] == 0
+
+    rebuild_fts_index_sync(conn_bulk)
+    rebuild_command_trigram_index_sync(conn_bulk)
+    rebuild_all_action_pairs_sync(conn_bulk)
+    conn_bulk.commit()
+
+    fts_bulk = _fts_rows(conn_bulk)
+    trigram_bulk = _trigram_rows(conn_bulk)
+    action_pairs_bulk = _action_pair_rows(conn_bulk)
+
+    assert fts_bulk == fts_trickle
+    assert trigram_bulk == trigram_trickle
+    assert action_pairs_bulk == action_pairs_trickle
+    assert fts_bulk, "corpus produced no messages_fts rows -- comparison would be vacuous"
+    assert trigram_bulk, "corpus produced no trigram rows -- comparison would be vacuous"
+    assert action_pairs_bulk, "corpus produced no action_pairs rows -- comparison would be vacuous"
+    conn_bulk.close()
+
+
+def test_bulk_build_exact_sync_assertion_accepts_empty_state_but_still_checks_triggers(tmp_path: Path) -> None:
+    """``assert_session_fts_exact_sync(..., bulk_build=True)`` must not raise
+    for a session left deliberately unindexed, but must still fail if the
+    canonical triggers are somehow missing (the trigger-presence half of the
+    proof is unaffected by bulk-build mode)."""
+    conn = _connect(tmp_path / "index.db")
+    session_id = write_parsed_session_to_archive(conn, _session("solo"), bulk_fts=True, bulk_build=True)
+
+    # Deliberately out of sync (0 indexed vs >0 expected) -- must not raise.
+    assert_session_fts_exact_sync(conn, session_id, bulk_build=True)
+
+    # Without bulk_build, the same out-of-sync state must be caught.
+    with pytest.raises(RuntimeError, match="FTS proof failed"):
+        assert_session_fts_exact_sync(conn, session_id, bulk_build=False)
+    conn.close()
+
+
+def test_bulk_build_guard_row_cleared_even_on_exception(tmp_path: Path) -> None:
+    """A failure mid-write must not leave the whole-transaction guard row set."""
+    conn = _connect(tmp_path / "index.db")
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("injected write failure")
+
+    original = _write_module._write_blocks
+    _write_module._write_blocks = _boom
+    try:
+        with pytest.raises(RuntimeError, match="injected write failure"):
+            write_parsed_session_to_archive(conn, _session("solo"), bulk_fts=True, bulk_build=True)
+    finally:
+        _write_module._write_blocks = original
+
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM derived_refresh_guard WHERE guard_name = ?",
+            (FTS_BULK_SESSION_WRITE_GUARD,),
+        ).fetchone()[0]
+        == 0
+    )
+    conn.close()
+
+
+def test_bulk_build_anti_vacuity_repopulate_is_load_bearing(tmp_path: Path) -> None:
+    """Skip the messages_fts half of the readiness repopulate and show the
+    equivalence proof then fails -- confirming the parity test above is
+    actually exercising ``rebuild_fts_index_sync``, not passing by accident."""
+    conn_trickle = _connect(tmp_path / "trickle.db")
+    _build_corpus(conn_trickle, bulk_build=False)
+    fts_trickle = _fts_rows(conn_trickle)
+    conn_trickle.close()
+
+    conn_bulk = _connect(tmp_path / "bulk.db")
+    _build_corpus(conn_bulk, bulk_build=True)
+    # Deliberately DO NOT call rebuild_fts_index_sync here.
+    rebuild_command_trigram_index_sync(conn_bulk)
+    rebuild_all_action_pairs_sync(conn_bulk)
+    conn_bulk.commit()
+
+    fts_bulk = _fts_rows(conn_bulk)
+    assert fts_bulk != fts_trickle
+    assert fts_bulk == []
+    assert fts_trickle, "trickle-mode reference produced no rows -- comparison would be vacuous"
+    conn_bulk.close()

--- a/tests/unit/storage/test_delegation_facts_bulk_rebuild.py
+++ b/tests/unit/storage/test_delegation_facts_bulk_rebuild.py
@@ -1,0 +1,228 @@
+"""``rebuild_all_delegation_facts_sync`` (polylogue-v6i3): the bulk-build
+readiness repopulate step for ``delegation_facts``.
+
+``delegation_facts_source`` (the view backing ``delegation_facts_insert_sql``)
+is scoped by the ``delegation_refresh_scope`` allow-list table rather than an
+inline per-parent predicate. ``rebuild_all_delegation_facts_sync`` populates
+that scope with every session id instead of one parent at a time, turning the
+existing per-cohort insert into an archive-wide one with no new SQL shape to
+maintain. These tests prove: the bulk rebuild produces byte-identical content
+to the existing per-session ``refresh_delegation_facts_for_session`` path for
+the same underlying dispatch/link evidence, across resolved/ambiguous/edge-
+only/unresolved mapping states; and the scope-population step is load-bearing
+(without it, ``delegation_facts_source``'s EXISTS-gated view produces zero
+rows for every parent, not a coincidentally-correct empty set)."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.delegation_facts import (
+    rebuild_all_delegation_facts_sync,
+    refresh_delegation_facts_for_session,
+)
+
+_HASH = b"x" * 32
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    initialize_archive_tier(conn, ArchiveTier.INDEX)
+    return conn
+
+
+def _insert_session(conn: sqlite3.Connection, *, native_id: str, origin: str = "claude-code-session") -> str:
+    conn.execute(
+        """
+        INSERT INTO sessions (native_id, origin, title, content_hash, created_at_ms, updated_at_ms)
+        VALUES (?, ?, ?, ?, 1767225600000, 1767225601000)
+        """,
+        (native_id, origin, f"session {native_id}", _HASH),
+    )
+    return str(
+        conn.execute(
+            "SELECT session_id FROM sessions WHERE native_id = ? AND origin = ?", (native_id, origin)
+        ).fetchone()["session_id"]
+    )
+
+
+def _insert_message(conn: sqlite3.Connection, *, session_id: str, native_id: str, position: int) -> str:
+    conn.execute(
+        """
+        INSERT INTO messages (session_id, native_id, position, role, message_type, content_hash, occurred_at_ms)
+        VALUES (?, ?, ?, 'assistant', 'message', ?, ?)
+        """,
+        (session_id, native_id, position, _HASH, 1767225600000 + position),
+    )
+    return str(
+        conn.execute(
+            "SELECT message_id FROM messages WHERE session_id = ? AND native_id = ?", (session_id, native_id)
+        ).fetchone()["message_id"]
+    )
+
+
+def _insert_dispatch_action(
+    conn: sqlite3.Connection,
+    *,
+    message_id: str,
+    session_id: str,
+    position: int,
+    tool_id: str,
+    result_text: str | None = "done",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO blocks (
+            message_id, session_id, position, block_type, tool_name, tool_id, semantic_type, tool_input
+        ) VALUES (?, ?, ?, 'tool_use', 'Task', ?, 'subagent', '{}')
+        """,
+        (message_id, session_id, position, tool_id),
+    )
+    if result_text is not None:
+        conn.execute(
+            """
+            INSERT INTO blocks (
+                message_id, session_id, position, block_type, text, tool_id,
+                tool_result_is_error, tool_result_exit_code
+            ) VALUES (?, ?, ?, 'tool_result', ?, ?, 0, 0)
+            """,
+            (message_id, session_id, position + 1, result_text, tool_id),
+        )
+
+
+def _insert_session_link(
+    conn: sqlite3.Connection,
+    *,
+    child_session_id: str,
+    dst_origin: str,
+    dst_native_id: str,
+    parent_session_id: str | None,
+    link_type: str = "subagent",
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO session_links (
+            src_session_id, dst_origin, dst_native_id, link_type, resolved_dst_session_id, observed_at_ms
+        ) VALUES (?, ?, ?, ?, ?, 1767225600000)
+        """,
+        (child_session_id, dst_origin, dst_native_id, link_type, parent_session_id),
+    )
+
+
+def _build_delegation_corpus(conn: sqlite3.Connection) -> list[str]:
+    """Three parent cohorts spanning resolved, ambiguous, and edge-only
+    mapping states -- so the comparison below is not just the trivial single-
+    row case."""
+    parent_ids = []
+
+    # Resolved: one dispatch, one resolved child.
+    parent_a = _insert_session(conn, native_id="parent-a")
+    child_a = _insert_session(conn, native_id="child-a")
+    msg_a = _insert_message(conn, session_id=parent_a, native_id="dispatch", position=0)
+    _insert_dispatch_action(conn, message_id=msg_a, session_id=parent_a, position=0, tool_id="task-a")
+    _insert_session_link(
+        conn,
+        child_session_id=child_a,
+        dst_origin="claude-code-session",
+        dst_native_id="parent-a",
+        parent_session_id=parent_a,
+    )
+    parent_ids.append(parent_a)
+
+    # Ambiguous: two dispatches, one resolved child (rank-pairing can't disambiguate).
+    parent_b = _insert_session(conn, native_id="parent-b")
+    child_b = _insert_session(conn, native_id="child-b")
+    msg_b = _insert_message(conn, session_id=parent_b, native_id="dispatch", position=0)
+    _insert_dispatch_action(conn, message_id=msg_b, session_id=parent_b, position=0, tool_id="task-b1")
+    _insert_dispatch_action(conn, message_id=msg_b, session_id=parent_b, position=2, tool_id="task-b2")
+    _insert_session_link(
+        conn,
+        child_session_id=child_b,
+        dst_origin="claude-code-session",
+        dst_native_id="parent-b",
+        parent_session_id=parent_b,
+    )
+    parent_ids.append(parent_b)
+
+    # Edge-only: a resolved child with no parent Task action at all (Codex-style).
+    parent_c = _insert_session(conn, native_id="parent-c", origin="codex-session")
+    child_c = _insert_session(conn, native_id="child-c", origin="codex-session")
+    _insert_session_link(
+        conn, child_session_id=child_c, dst_origin="codex-session", dst_native_id="parent-c", parent_session_id=parent_c
+    )
+    parent_ids.append(parent_c)
+
+    return parent_ids
+
+
+def _delegation_facts_rows(conn: sqlite3.Connection) -> list[tuple[object, ...]]:
+    rows = conn.execute(
+        """
+        SELECT delegation_id, parent_session_id, child_session_id, mapping_state, link_confidence,
+               link_method, inheritance, branch_point_message_id, instruction_message_id,
+               instruction_tool_use_block_id, instruction_payload, dispatch_turn_model, requested_model,
+               artifact_block_id, artifact_text, result_is_error, result_exit_code, result_status,
+               parent_origin
+        FROM delegation_facts
+        ORDER BY delegation_id
+        """
+    ).fetchall()
+    return sorted(tuple(row) for row in rows)
+
+
+def test_rebuild_all_delegation_facts_matches_per_session_refresh(tmp_path: Path) -> None:
+    conn_per_session = _connect(tmp_path / "per_session.db")
+    parent_ids = _build_delegation_corpus(conn_per_session)
+    for parent_id in parent_ids:
+        refresh_delegation_facts_for_session(conn_per_session, parent_id)
+    conn_per_session.commit()
+    per_session_rows = _delegation_facts_rows(conn_per_session)
+    conn_per_session.close()
+
+    conn_bulk = _connect(tmp_path / "bulk.db")
+    _build_delegation_corpus(conn_bulk)
+    # Before the bulk rebuild, delegation_facts is untouched by the raw
+    # INSERTs above (no write_parsed_session_to_archive transaction ran, so
+    # the 'session-write' guard was never set -- the ordinary
+    # blocks_action_pairs_ai/session_links_delegation_facts_ai triggers fire
+    # on each raw insert and already populate it via the trigger path). Clear
+    # it explicitly so this test proves the BULK rebuild path, not residual
+    # trigger-driven content.
+    conn_bulk.execute("DELETE FROM delegation_facts")
+    conn_bulk.commit()
+    rebuild_all_delegation_facts_sync(conn_bulk)
+    conn_bulk.commit()
+    bulk_rows = _delegation_facts_rows(conn_bulk)
+    # The scope table must never leak past the bulk rebuild call.
+    assert conn_bulk.execute("SELECT COUNT(*) FROM delegation_refresh_scope").fetchone()[0] == 0
+    conn_bulk.close()
+
+    assert bulk_rows == per_session_rows
+    assert bulk_rows, "corpus produced no delegation_facts rows -- comparison would be vacuous"
+    mapping_states = {row[3] for row in bulk_rows}
+    assert mapping_states == {"resolved", "ambiguous", "edge_only"}, mapping_states
+
+
+def test_rebuild_all_delegation_facts_scope_population_is_load_bearing(tmp_path: Path) -> None:
+    """Anti-vacuity: without populating delegation_refresh_scope, the insert
+    produces zero rows for every parent (the view's EXISTS clauses never
+    match), proving the scope-population step is not incidental."""
+    conn = _connect(tmp_path / "index.db")
+    _build_delegation_corpus(conn)
+    conn.execute("DELETE FROM delegation_facts")
+    conn.commit()
+
+    from polylogue.storage.sqlite.delegation_facts import delegation_facts_insert_sql
+
+    # Real corpus, real dispatch/link evidence -- but delegation_refresh_scope
+    # deliberately left empty (skipping rebuild_all_delegation_facts_sync's
+    # scope-population step).
+    conn.execute(delegation_facts_insert_sql("?"))
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM delegation_facts").fetchone()[0] == 0
+    conn.close()

--- a/tests/unit/storage/test_index_generation.py
+++ b/tests/unit/storage/test_index_generation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import fcntl
+import json
 import logging
 import multiprocessing
 import os
@@ -314,3 +315,41 @@ def test_source_snapshot_changes_when_retained_blob_identity_changes(tmp_path: P
     with sqlite3.connect(tmp_path / "source.db") as conn:
         conn.execute("UPDATE raw_sessions SET blob_hash = randomblob(32), blob_size = 2 WHERE raw_id = 'raw-a'")
     assert source_revision_snapshot(tmp_path) != before
+
+
+def test_derived_stores_cleared_defaults_false_and_round_trips_through_checkpoint(tmp_path: Path) -> None:
+    """polylogue-v6i3: ``derived_stores_cleared`` is the transaction marker
+    guarding the bulk-build "empty derived stores at resume" clear from
+    re-firing on every subsequent page of the same operation. It must
+    default False for a fresh transaction, persist True once checkpointed,
+    and survive a reload via ``load_transaction``."""
+    _archive(tmp_path)
+    store = IndexGenerationStore(tmp_path)
+    transaction = store.create_transaction(source_snapshot="source-v1", operation_id="bulk-build-op")
+    assert transaction.derived_stores_cleared is False
+
+    transaction = store.checkpoint_transaction(transaction, status="running", derived_stores_cleared=True)
+    assert transaction.derived_stores_cleared is True
+    assert store.load_transaction("bulk-build-op").derived_stores_cleared is True
+
+    # A later checkpoint that doesn't mention the field must not reset it.
+    transaction = store.checkpoint_transaction(transaction, status="paused")
+    assert transaction.derived_stores_cleared is True
+
+
+def test_derived_stores_cleared_missing_from_persisted_json_defaults_false(tmp_path: Path) -> None:
+    """A transaction persisted before this field existed (no key in its JSON)
+    must load as ``False`` via the dataclass default, not raise or silently
+    invent a different value."""
+    _archive(tmp_path)
+    store = IndexGenerationStore(tmp_path)
+    transaction = store.create_transaction(source_snapshot="source-v1", operation_id="pre-existing-op")
+    path = store._transaction_path("pre-existing-op")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert "derived_stores_cleared" in payload
+    del payload["derived_stores_cleared"]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    reloaded = store.load_transaction("pre-existing-op")
+    assert reloaded.derived_stores_cleared is False
+    assert reloaded.operation_id == transaction.operation_id

--- a/tests/unit/storage/test_lineage_normalization.py
+++ b/tests/unit/storage/test_lineage_normalization.py
@@ -770,6 +770,7 @@ def test_full_replace_graph_failure_rolls_back_then_retries_idempotently(
         cache: dict[str, list[tuple[str, str]]] | None = None,
         add_timing: Callable[[str, float], None] | None = None,
         bulk_fts: bool = False,
+        bulk_build: bool = False,
     ) -> None:
         real_resolve(
             conn_inner,
@@ -779,6 +780,7 @@ def test_full_replace_graph_failure_rolls_back_then_retries_idempotently(
             cache=cache,
             add_timing=add_timing,
             bulk_fts=bulk_fts,
+            bulk_build=bulk_build,
         )
         fired["count"] += 1
         raise RuntimeError("fault after graph resolution")


### PR DESCRIPTION
## Summary

Extends the offline rebuild path (`maintenance/rebuild_index.py`) so a bulk
generation build keeps `messages_fts`, `blocks_command_trigram`,
`action_pairs`, and `delegation_facts` empty for every session throughout
replay, then repopulates all four archive-wide exactly once at readiness —
replacing per-session maintenance that a full rebuild pays for and then
immediately discards.

## Problem

A live whale offline rebuild (bead polylogue-v6i3) stalled for 3+ hours doing
per-session FTS/trigram maintenance one session at a time. During the same
incident, an archive-wide `messages_fts` + `blocks_command_trigram`
delete-all measured **28.7s** — evidence that the correct bulk-build lifecycle
is "empty once, repopulate once," not per-session upkeep. The operator
manually intervened mid-rebuild with a one-off script
(`/realm/tmp/trigram-restore-pre-promote.py`) to clear and repopulate both
surfaces between rebuild pages.

#3152 already made the offline replay path avoid per-row trigger storms for
one whale prefix-reextraction cascade (a guard-gated bulk delete+insert), but
every session write still did its own `action_pairs`/`delegation_facts`
refresh, and a full-session replace still did its own `messages_fts`
delete/suspend-trigger/insert/restore dance — real, avoidable per-session
work when a single archive-wide repopulate happens anyway at the end.

## Solution

- `write_parsed_session_to_archive` gains `bulk_build` (alongside the
  existing `bulk_fts`), threaded through the same call chain #3152 built:
  `archive.py`'s `_write_parsed_precedence_result` /
  `apply_raw_revision_replay` / `apply_raw_membership_classification`,
  `sources/revision_backfill.py`, `maintenance/replay.py`. When `True`:
  - The whole-transaction `FTS_BULK_SESSION_WRITE_GUARD` row is set once per
    session write, gating **both** `messages_fts` and (newly)
    `blocks_command_trigram` trigger bodies for every block mutation in that
    write — not just the prefix-reextract cascade #3152 already guarded.
  - `_replace_full_session_messages_and_blocks` skips its own scoped FTS
    dance and `action_pairs` refresh entirely.
  - The merge-append path skips its `action_pairs` refresh.
  - `refresh_delegation_facts_for_session` is skipped.
  - `_bulk_fts_session_guard` becomes a no-op (the outer guard already covers
    it; no redundant per-session delete+insert).
- `assert_session_fts_exact_sync` gains `bulk_build=False`: when `True` it
  skips the per-session row-count parity check (expected to be empty
  mid-build) but still enforces trigger presence — an explicit mode per the
  bead's requirement, not a weakened default.
- New bulk repopulate primitives:
  - `rebuild_command_trigram_index_sync` (`storage/fts/fts_lifecycle.py`) —
    uses the FTS5 `'delete-all'` command required for this external-content
    table, then one bulk insert from `blocks`.
  - `action_pairs_refresh_all_sql` / `rebuild_all_action_pairs_sync` — a
    set-based, archive-wide variant with the per-session predicate simply
    removed.
  - `rebuild_all_delegation_facts_sync` — populates `delegation_refresh_scope`
    with every session id, reusing the existing view/insert SQL unmodified
    (that table already scopes `delegation_facts_source` by an allow-list,
    not an inline predicate, so no new SQL shape was needed).
- `maintenance/rebuild_index.py` orchestrates the lifecycle:
  - `_clear_bulk_build_derived_stores` runs once per **resumed** operation,
    guarded by a new `IndexRebuildTransaction.derived_stores_cleared` marker
    (default `False`, persisted through `checkpoint_transaction`) so it never
    re-fires on a later page of the same operation. A fresh generation starts
    empty by construction and never needs this.
  - `_repopulate_bulk_build_derived_state` runs once at readiness (before
    `_archive_readiness_status`), followed by
    `verify_archive(checks=["fts-parity"])` — failing the operation loudly on
    any mismatch before promotion can ever see it.
- `blocks_command_trigram`'s three triggers gain the same guard-row `WHEN`
  clause `messages_fts`'s triggers already had. No `INDEX_SCHEMA_VERSION`
  bump: additive/inert via `CREATE TRIGGER IF NOT EXISTS`, matching #3152's
  own precedent for this exact situation.

**Measured** (`action_pairs` per-session vs set-based, 4,000 synthetic
sessions × 6 tool_use/tool_result pairs): a per-session
`refresh_action_pairs` loop took 64.2s vs 0.3s for the set-based statement —
**216x**. This confirms the set-based readiness repopulate over a per-session
loop for `action_pairs`.

The manual pre-promote recovery script is the prototype this productizes; it
is not deleted here (it references a specific in-flight generation path from
a live incident that may still be relevant to the operator), but its
clear+repopulate action is now this PR's automatic, code-verified lifecycle
for every future bulk rebuild.

## Verification

```
devtools test tests/unit/storage/test_bulk_build_lifecycle.py \
  tests/unit/storage/test_delegation_facts_bulk_rebuild.py \
  tests/unit/maintenance/test_rebuild_index_bulk_build.py \
  tests/unit/storage/test_index_generation.py \
  tests/unit/storage/test_lineage_normalization.py \
  tests/unit/storage/test_bulk_fts_prefix_reextract.py
# 63 passed

devtools verify --quick
# exit 0
```

New tests prove: `bulk_build=True` writes leave all four derived surfaces
empty for the written session where mode-off populates them immediately (not
vacuously true for every write); the readiness repopulate produces
byte-identical `messages_fts`/`blocks_command_trigram`/`action_pairs` content
to trickle-mode population of the same corpus (including a prefix-sharing
lineage cascade exercising `_bulk_fts_session_guard`'s bulk-build no-op
branch); `rebuild_all_delegation_facts_sync` matches per-session
`refresh_delegation_facts_for_session` across resolved/ambiguous/edge-only
mapping states; the whole-transaction guard row never leaks past an
exception; `_clear_bulk_build_derived_stores` only touches the two named
surfaces (not `action_pairs`/`blocks`) and is idempotent on an already-empty
table; `_repopulate_bulk_build_derived_state` reaches exact archive-wide
parity via `verify_archive`'s `fts-parity` check; two anti-vacuity tests
(skip the readiness repopulate, skip the delegation scope population) show
the corresponding equivalence proof then fails.

Confirmed via `git diff`/`checkout`/`apply` revert-and-rerun (no stash, per
worktree policy) that 5 pre-existing failures in `test_live_batch_support.py`
and 3 in `test_delegations_view.py` (an unrelated `PRAGMA user_tier`
attached-database gap in the query-transaction test fixture) reproduce
identically on `master` without this change — pre-existing drift, not caused
here.

Ref polylogue-v6i3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bulk-build support for faster archive indexing by deferring derived search and relationship indexes until completion.
  - Added archive-wide rebuilding for full-text search, trigram search, action pairs, and delegation facts.
  - Added validation to confirm rebuilt indexes match archive content.

- **Bug Fixes**
  - Prevented stale derived index data during resumed rebuilds.
  - Added safeguards to ensure temporary bulk-build state is cleared after failures.

- **Tests**
  - Added coverage for bulk-build parity, recovery behavior, and index rebuild correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->