### PR TITLE
perf(insights): fan out per-session insight compute across threads

### DIFF
--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from collections.abc import AsyncIterator, Callable, Iterable, Iterator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from typing import TypeVar
 
 import aiosqlite
 
@@ -717,6 +718,8 @@ def build_session_insight_records(
     )
 
 
+_InsightComputeResult = TypeVar("_InsightComputeResult")
+
 _INSIGHT_COMPUTE_WORKERS_ENV_VAR = "POLYLOGUE_INSIGHT_COMPUTE_WORKERS"
 
 
@@ -732,9 +735,16 @@ def _insight_compute_workers(job_count: int) -> int:
 
 
 def compute_session_insight_bundles(
-    jobs: Sequence[Callable[[], SessionInsightRecordBundle]],
-) -> list[SessionInsightRecordBundle]:
+    jobs: Sequence[Callable[[], _InsightComputeResult]],
+) -> list[_InsightComputeResult]:
     """Run each independent per-session insight-compute job, in ``jobs`` order.
+
+    Generic in its result type rather than pinned to
+    ``SessionInsightRecordBundle``: this is a plain job-runner with no
+    knowledge of what a job computes, which keeps it directly unit-testable
+    with trivial jobs (see ``tests/unit/storage/
+    test_session_insight_parallel_fanout.py``) without constructing full
+    bundle objects.
 
     Fan-out is gated on ``parallel_threads_effective()`` -- see
     ``polylogue.pipeline.services.process_pool`` for why: a standard GIL

--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import functools
 import json as _json
 import sqlite3
+import threading
 import time
 from collections import defaultdict
 from collections.abc import AsyncIterator, Callable, Iterable, Iterator, Mapping, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
 import aiosqlite
@@ -25,6 +28,7 @@ from polylogue.insights.archive_models import (
     SessionInferencePayload,
 )
 from polylogue.insights.fallback import FallbackReason
+from polylogue.pipeline.services.process_pool import parallel_threads_effective, resolve_parse_worker_count
 from polylogue.storage.hydrators import session_from_records
 from polylogue.storage.insights.session.aggregates import (
     list_async_provider_day_groups,
@@ -713,6 +717,59 @@ def build_session_insight_records(
     )
 
 
+_INSIGHT_COMPUTE_WORKERS_ENV_VAR = "POLYLOGUE_INSIGHT_COMPUTE_WORKERS"
+
+
+def _insight_compute_workers(job_count: int) -> int:
+    """Bounded worker count for per-session insight compute fan-out.
+
+    Reuses the same CPU-count-clamped default as parse-pool dispatch
+    (``resolve_parse_worker_count``) under a distinct env var, since the
+    underlying question -- "how many CPU-bound workers is reasonable here"
+    -- is identical.
+    """
+    return min(job_count, resolve_parse_worker_count(env_var=_INSIGHT_COMPUTE_WORKERS_ENV_VAR))
+
+
+def compute_session_insight_bundles(
+    jobs: Sequence[Callable[[], SessionInsightRecordBundle]],
+) -> list[SessionInsightRecordBundle]:
+    """Run each independent per-session insight-compute job, in ``jobs`` order.
+
+    Fan-out is gated on ``parallel_threads_effective()`` -- see
+    ``polylogue.pipeline.services.process_pool`` for why: a standard GIL
+    build gets zero speedup from CPU-bound threads and risks starving a
+    concurrent SQLite writer thread, so a ``ThreadPoolExecutor`` only
+    engages under a genuinely free-threaded interpreter (3.14t). Below that,
+    or for zero/one jobs, every job runs sequentially on the calling thread
+    -- byte-identical to the pre-fan-out behavior.
+
+    Each job is expected to be pure Python compute over an already-hydrated
+    ``Session`` (see ``build_session_insight_record_bundles`` and
+    ``storage/insights/session/refresh.py``): no SQLite connection, no
+    shared mutable state, so results are safe to compute concurrently. A
+    caller-supplied ``stage_timing_add`` sink is the one shared piece of
+    mutable state jobs may still touch; callers that pass one MUST make its
+    write path thread-safe (``rebuild_session_insights_sync`` does this with
+    a lock) since it is invoked from worker threads whenever fan-out is
+    active.
+
+    Results are returned in ``jobs`` order regardless of completion order,
+    so callers can zip them back onto per-session bookkeeping
+    deterministically, and the single writer always applies per-session
+    writes in a fixed, reproducible order independent of which path (or how
+    many workers) computed them.
+    """
+    if len(jobs) <= 1 or not parallel_threads_effective():
+        return [job() for job in jobs]
+    with ThreadPoolExecutor(
+        max_workers=_insight_compute_workers(len(jobs)),
+        thread_name_prefix="insight-compute",
+    ) as pool:
+        futures = [pool.submit(job) for job in jobs]
+        return [future.result() for future in futures]
+
+
 def build_session_insight_record_bundles(
     sessions: Iterable[Session],
     *,
@@ -722,8 +779,9 @@ def build_session_insight_record_bundles(
 ) -> list[SessionInsightRecordBundle]:
     compaction_counts = compaction_counts_by_session or {}
     logical_ids = logical_session_ids_by_session or {}
-    return [
-        build_session_insight_records(
+    jobs = [
+        functools.partial(
+            build_session_insight_records,
             session,
             compaction_count=compaction_counts.get(str(session.id)),
             logical_session_id=logical_ids.get(str(session.id)),
@@ -731,6 +789,7 @@ def build_session_insight_record_bundles(
         )
         for session in sessions
     ]
+    return compute_session_insight_bundles(jobs)
 
 
 def _session_count_row(conn: sqlite3.Connection, session_id: str) -> sqlite3.Row:
@@ -1333,11 +1392,25 @@ def rebuild_session_insights_sync(
     stage_timings_s: dict[str, float] | None = None,
     stage_timing_prefix: str = "insights",
 ) -> SessionInsightCounts:
+    # ``add_timing`` is handed to ``build_session_insight_record_bundles`` as
+    # ``stage_timing_add`` and invoked from every per-session compute job
+    # (build_session_insight_records fires it ~8x per session). When
+    # ``compute_session_insight_bundles`` fans those jobs out across a
+    # ThreadPoolExecutor (parallel_threads_effective()), multiple worker
+    # threads race on the exact same read-modify-write of
+    # ``stage_timings_s[key]``; without a lock that race silently drops
+    # increments (undercounting stage timings, not a crash). The lock is
+    # cheap enough to hold unconditionally rather than branch on whether
+    # fan-out is actually active this call.
+    timing_lock = threading.Lock()
+
     def add_timing(name: str, started_at: float) -> None:
         if stage_timings_s is None:
             return
         key = f"{stage_timing_prefix}.{name}"
-        stage_timings_s[key] = stage_timings_s.get(key, 0.0) + (time.perf_counter() - started_at)
+        elapsed = time.perf_counter() - started_at
+        with timing_lock:
+            stage_timings_s[key] = stage_timings_s.get(key, 0.0) + elapsed
 
     session_chunks: Iterable[_SessionInsightRebuildChunk]
     previous_profile_groups: set[tuple[str, str]] = set()
@@ -1746,6 +1819,7 @@ __all__ = [
     "SessionInsightRecordBundle",
     "build_session_insight_record_bundles",
     "build_session_insight_records",
+    "compute_session_insight_bundles",
     "hydrate_sessions",
     "iter_session_id_pages_async",
     "iter_session_id_pages_sync",

--- a/polylogue/storage/insights/session/refresh.py
+++ b/polylogue/storage/insights/session/refresh.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -551,20 +552,38 @@ async def _apply_session_insight_session_updates_async(
             root_id = root_ids_by_session.get(session_id)
             if root_id is not None:
                 thread_root_ids.add(root_id)
+        # Sessions with no hydrated content (deleted concurrently, or an
+        # empty tree) never reach compute -- only their old provider-day
+        # group needs tracking. Everything else is independent, read-only
+        # compute over an already-hydrated Session, so it fans out across
+        # compute_session_insight_bundles's bounded thread pool exactly like
+        # the full-rebuild path (rebuild_session_insights_sync/_async), gated
+        # the same way on parallel_threads_effective(). Building the job list
+        # first (rather than computing inline) keeps this chunk's write order
+        # identical to the pre-fan-out sequential loop regardless of which
+        # jobs actually ran in parallel.
+        present_full_ids: list[str] = []
         for session_id in chunk_full_ids:
-            old_profile_record = old_profile_records.get(session_id)
-            hydrated_session = hydrated_by_id.get(session_id)
-            if hydrated_session is None:
-                old_group = profile_provider_day(old_profile_record)
+            if hydrated_by_id.get(session_id) is None:
+                old_group = profile_provider_day(old_profile_records.get(session_id))
                 if old_group is not None:
                     affected_groups.add(old_group)
                 continue
+            present_full_ids.append(session_id)
 
-            record_bundle = build_session_insight_records(
-                hydrated_session,
+        full_jobs = [
+            functools.partial(
+                build_session_insight_records,
+                hydrated_by_id[session_id],
                 compaction_count=batch.compaction_counts_by_session.get(session_id) if batch is not None else None,
                 logical_session_id=root_ids_by_session.get(session_id),
             )
+            for session_id in present_full_ids
+        ]
+        full_bundles = _rebuild.compute_session_insight_bundles(full_jobs)
+
+        for session_id, record_bundle in zip(present_full_ids, full_bundles, strict=True):
+            old_profile_record = old_profile_records.get(session_id)
             record_bundles.append(record_bundle)
 
             counts.add(

--- a/tests/unit/storage/test_session_insight_parallel_fanout.py
+++ b/tests/unit/storage/test_session_insight_parallel_fanout.py
@@ -1,0 +1,286 @@
+"""polylogue-syz2: per-session insight compute fan-out.
+
+``compute_session_insight_bundles`` (rebuild.py) fans independent per-session
+insight compute out across a bounded ``ThreadPoolExecutor`` when
+``parallel_threads_effective()`` reports a genuinely free-threaded
+interpreter, and stays fully sequential otherwise. These tests pin three
+things a naive fan-out could get wrong:
+
+1. Equivalence: parallel and sequential execution must write byte-identical
+   ``session_profiles`` / ``session_latency_profiles`` / ``session_work_events``
+   / ``session_phases`` rows for the same corpus (build/rebuild.py, refresh.py).
+2. Determinism: results come back in job order regardless of which job's
+   thread finishes first, so the single writer always applies them in a
+   fixed, reproducible order.
+3. Write boundary: worker threads only ever compute and return values; every
+   actual SQLite write happens on the thread that called
+   ``rebuild_session_insights_sync`` (the single-writer invariant), never on
+   a pool worker thread.
+
+``parallel_threads_effective`` is monkeypatched directly (the same pattern
+``tests/unit/sources/test_revision_backfill.py`` uses for the analogous
+census-parse fan-out) so these tests are deterministic on a standard GIL
+interpreter and do not require a real free-threaded (3.14t) build to exercise
+the thread-pool branch.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from collections.abc import Callable
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+import polylogue.storage.insights.session.rebuild as rebuild_mod
+from polylogue.storage.insights.session.rebuild import (
+    SessionInsightRecordBundle,
+    compute_session_insight_bundles,
+    rebuild_session_insights_sync,
+)
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from polylogue.storage.sqlite.connection_profile import open_connection
+from tests.infra.storage_records import SessionBuilder
+
+_BASE_TS = "2026-01-01T00:00:00+00:00"
+
+
+def _seed_corpus(archive_root: Path, *, session_count: int = 6) -> list[str]:
+    """Seed a small, fully deterministic multi-session corpus.
+
+    Every timestamp is pinned explicitly (never the builder's wall-clock
+    default) so the only clock dependency left in the rebuilt insight rows is
+    ``now_iso()``'s ``materialized_at`` stamp, which the ``frozen_clock``
+    fixture pins for the equivalence test. Content varies deliberately
+    (plain text only / tool_use+tool_result pair / thinking block) so the
+    fanned-out compute exercises more than one code path per session.
+    """
+    initialize_active_archive_root(archive_root)
+    db_path = archive_root / "index.db"
+    session_ids: list[str] = []
+    for index in range(session_count):
+        builder = (
+            SessionBuilder(db_path, f"fanout-{index}")
+            .created_at(_BASE_TS)
+            .updated_at(_BASE_TS)
+            .add_message(
+                "u1",
+                role="user",
+                text=f"question {index}: how do I run the build pipeline",
+                timestamp=_BASE_TS,
+            )
+            .add_message(
+                "a1",
+                role="assistant",
+                text=f"answer {index}: run devtools test then devtools verify",
+                timestamp=_BASE_TS,
+            )
+        )
+        if index % 2 == 0:
+            builder = builder.add_message(
+                "a2",
+                role="assistant",
+                text="running the test suite",
+                timestamp=_BASE_TS,
+                blocks=[
+                    {
+                        "type": "tool_use",
+                        "tool_name": "Bash",
+                        "tool_id": f"tool-{index}",
+                        "input": {"command": "pytest -q"},
+                        "semantic_type": "shell",
+                    },
+                    {
+                        "type": "tool_result",
+                        "tool_id": f"tool-{index}",
+                        "text": "5 passed",
+                        "is_error": False,
+                        "exit_code": 0,
+                    },
+                ],
+            )
+        if index % 3 == 0:
+            builder = builder.add_message(
+                "a3",
+                role="assistant",
+                text="thinking it through",
+                timestamp=_BASE_TS,
+                blocks=[{"type": "thinking", "text": f"considering approach {index}"}],
+            )
+        builder.save()
+        session_ids.append(builder.native_session_id())
+    return session_ids
+
+
+def _dump_table(conn: sqlite3.Connection, table: str, *, order_by: str) -> list[dict[str, object]]:
+    rows = conn.execute(f"SELECT * FROM {table} ORDER BY {order_by}").fetchall()
+    return [dict(row) for row in rows]
+
+
+def _rebuild_and_dump(archive_root: Path) -> dict[str, list[dict[str, object]]]:
+    with closing(open_connection(archive_root / "index.db")) as conn:
+        conn.row_factory = sqlite3.Row
+        rebuild_session_insights_sync(conn, session_ids=None)
+        return {
+            "session_profiles": _dump_table(conn, "session_profiles", order_by="session_id"),
+            "session_latency_profiles": _dump_table(conn, "session_latency_profiles", order_by="session_id"),
+            "session_work_events": _dump_table(conn, "session_work_events", order_by="session_id, position"),
+            "session_phases": _dump_table(conn, "session_phases", order_by="session_id, position"),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Equivalence: parallel vs sequential fan-out produce byte-identical rows.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.frozen_clock_modules("polylogue.storage.insights.session.profiles")
+def test_rebuild_session_insights_parallel_vs_sequential_byte_identical(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    frozen_clock: object,
+) -> None:
+    sequential_root = tmp_path / "sequential"
+    parallel_root = tmp_path / "parallel"
+    sequential_ids = _seed_corpus(sequential_root, session_count=6)
+    parallel_ids = _seed_corpus(parallel_root, session_count=6)
+    assert sequential_ids == parallel_ids  # sanity: identical seeded corpora
+
+    monkeypatch.setattr(rebuild_mod, "parallel_threads_effective", lambda: False)
+    sequential_dump = _rebuild_and_dump(sequential_root)
+
+    monkeypatch.setattr(rebuild_mod, "parallel_threads_effective", lambda: True)
+    parallel_dump = _rebuild_and_dump(parallel_root)
+
+    assert len(sequential_dump["session_profiles"]) == 6
+    for table_name, sequential_rows in sequential_dump.items():
+        assert parallel_dump[table_name] == sequential_rows, f"{table_name} diverged between fan-out modes"
+
+
+# ---------------------------------------------------------------------------
+# Determinism: job-order results independent of completion order.
+# ---------------------------------------------------------------------------
+
+
+def test_compute_session_insight_bundles_sequential_preserves_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(rebuild_mod, "parallel_threads_effective", lambda: False)
+    calling_thread = threading.get_ident()
+    seen_threads: list[int] = []
+
+    def make_job(marker: int) -> Callable[[], int]:
+        def job() -> int:
+            seen_threads.append(threading.get_ident())
+            return marker
+
+        return job
+
+    jobs = [make_job(marker) for marker in range(5)]
+    results = compute_session_insight_bundles(jobs)
+
+    assert results == [0, 1, 2, 3, 4]
+    assert seen_threads == [calling_thread] * 5
+
+
+def test_compute_session_insight_bundles_fans_out_and_preserves_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Jobs finish in reverse-of-submission order; results still come back
+    in submission order, and at least one job actually ran off the calling
+    thread (proving the pool engaged, not just an accidental pass-through)."""
+    monkeypatch.setattr(rebuild_mod, "parallel_threads_effective", lambda: True)
+    calling_thread = threading.get_ident()
+    job_threads: list[int] = [-1] * 5
+
+    def make_job(marker: int, *, delay_s: float) -> Callable[[], int]:
+        def job() -> int:
+            time.sleep(delay_s)
+            job_threads[marker] = threading.get_ident()
+            return marker
+
+        return job
+
+    # Job 0 sleeps longest, job 4 returns fastest: completion order is the
+    # reverse of submission order, so an order bug (e.g. using
+    # as_completed()'s own order) would be caught here.
+    jobs = [make_job(marker, delay_s=(5 - marker) * 0.02) for marker in range(5)]
+    results = compute_session_insight_bundles(jobs)
+
+    assert results == [0, 1, 2, 3, 4]
+    assert any(thread_id != calling_thread for thread_id in job_threads), (
+        "expected at least one job to run on a pool worker thread, not the calling thread"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Write boundary: worker threads compute only; writes stay on the caller.
+# ---------------------------------------------------------------------------
+
+
+def test_rebuild_session_insights_writes_only_happen_on_calling_thread(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anti-vacuity guard for the single-writer invariant.
+
+    Forces the thread-pool fan-out path (``parallel_threads_effective`` ->
+    True) over a multi-session corpus, and wraps both the per-session
+    compute entrypoint and every bulk SQLite writer the rebuild calls to
+    record which thread invoked them. If a future change ever moved a write
+    call into the compute job (e.g. inlining a write for "efficiency"), this
+    test fails: it asserts every write-thread id equals the thread that
+    called ``rebuild_session_insights_sync``, while also asserting the
+    compute path really did run off that thread (otherwise the test would
+    trivially pass with fan-out silently disabled).
+    """
+    archive_root = tmp_path / "write-boundary"
+    _seed_corpus(archive_root, session_count=6)
+    monkeypatch.setattr(rebuild_mod, "parallel_threads_effective", lambda: True)
+
+    calling_thread = threading.get_ident()
+    compute_threads: list[int] = []
+    write_threads: list[int] = []
+
+    original_build = rebuild_mod.build_session_insight_records
+
+    def recording_build(*args: object, **kwargs: object) -> SessionInsightRecordBundle:
+        compute_threads.append(threading.get_ident())
+        return original_build(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(rebuild_mod, "build_session_insight_records", recording_build)
+
+    write_fn_names = [
+        "replace_session_profiles_bulk_sync",
+        "replace_session_latency_profiles_bulk_sync",
+        "replace_session_work_events_bulk_sync",
+        "replace_session_phases_bulk_sync",
+    ]
+    for name in write_fn_names:
+        original_write = getattr(rebuild_mod, name)
+
+        def make_recording_write(original: object, sink: list[int]) -> object:
+            def recording_write(*args: object, **kwargs: object) -> object:
+                sink.append(threading.get_ident())
+                return original(*args, **kwargs)  # type: ignore[operator]
+
+            return recording_write
+
+        monkeypatch.setattr(rebuild_mod, name, make_recording_write(original_write, write_threads))
+
+    with closing(open_connection(archive_root / "index.db")) as conn:
+        conn.row_factory = sqlite3.Row
+        counts = rebuild_session_insights_sync(conn, session_ids=None)
+
+    assert counts.profiles == 6
+    assert compute_threads, "expected build_session_insight_records to run at least once"
+    assert any(thread_id != calling_thread for thread_id in compute_threads), (
+        "fan-out did not engage a pool worker thread -- test would pass vacuously"
+    )
+    assert write_threads, "expected at least one bulk-write call"
+    assert all(thread_id == calling_thread for thread_id in write_threads), (
+        "a bulk SQLite writer ran off the calling thread -- single-writer invariant violated"
+    )


### PR DESCRIPTION
## Summary

Fans per-session insight compute (profile, latency, timeline, run-projection
counts) out across a bounded `ThreadPoolExecutor`, gated on
`parallel_threads_effective()` (3.14t free-threaded builds only), while
keeping every SQLite write on the calling thread. Sequential fallback is
byte-identical to today's behavior on the standard GIL build (the only build
the daemon currently deploys).

## Problem

`rebuild_session_insights_sync` / `rebuild_session_insights_async` (the
final phase of every insight rebuild) and the post-ingest-batch incremental
refresh path (`_apply_session_insight_session_updates_async`) each compute
per-session insight bundles one session at a time, even though every
session's compute is pure, read-only over an already-hydrated `Session` in
memory — no shared SQLite connection, no shared mutable state beyond an
optional timing sink. polylogue-xikl's free-threading program already landed
the exact gating this needs: `parallel_threads_effective()` in
`pipeline/services/process_pool.py` (PR #3161), which the polylogue-7mtf
control-run measured at 3.9x-9.6x speedup (w=4..16) for the structurally
identical parse-fan-out pattern on a real free-threaded (3.14t) interpreter,
versus zero speedup and writer-thread-starvation risk on the standard GIL
build.

## Solution

- `polylogue/storage/insights/session/rebuild.py`: new
  `compute_session_insight_bundles(jobs)` — a small, generic (TypeVar)
  `ThreadPoolExecutor` fan-out gated on `parallel_threads_effective()`
  (sequential fallback for 0/1 jobs or a non-free-threaded interpreter).
  `build_session_insight_record_bundles` now builds a list of per-session
  compute jobs and delegates to it. This single change covers **both**
  `rebuild_session_insights_sync` and `rebuild_session_insights_async` — the
  two call sites daemon convergence (`daemon/convergence_stages.py`, 4 call
  sites) and `pipeline/run_stages.py` already share.
- `polylogue/storage/insights/session/refresh.py`: the incremental
  `chunk_full_ids` loop (post-ingest-batch refresh, called from
  `pipeline/services/ingest_batch/_core.py`) is refactored the same way —
  split "which sessions have hydrated content" from "compute their
  bundles" — so the post-ingest-batch path benefits too, not just full/
  scoped rebuilds.
- Worker threads never touch SQLite: sessions are already batch-hydrated on
  the calling thread before fan-out (bulk `load_sync_batch`/`load_async_batch`
  + `hydrate_sessions`), so no per-thread read-only connection is needed for
  this compute stage — unlike the census-parse fan-out, which reads blobs
  per-worker from a fresh `ArchiveBlobPublisher`.
- `stage_timing_add`'s timing dict is the one shared mutable side channel
  worker threads can still reach (a real production path:
  `daemon/convergence_stages.py::_archive_insights_execute_ids` passes a real
  `stage_timings_s` dict). `rebuild_session_insights_sync`'s `add_timing`
  closure now holds a `threading.Lock` around the dict's read-modify-write so
  concurrent workers can't silently drop increments.

**Not in scope** (documented in the commit body, not silently dropped): the
"degraded/large session" bounded fallback
(`build_large_session_insight_record_bundle_sync`/`_async`) still reads a
single row per session directly off the caller's connection. Fanning that
out would need per-worker read-only connections (the pattern
`sources/revision_backfill.py`'s census parse uses for exactly this reason).
Left sequential since it's a rare bounded-fallback path (huge sessions only),
not the primary compute cost. Filed as remaining scope below.

## Verification

- `devtools test tests/unit/storage/test_session_insight_parallel_fanout.py
  tests/unit/storage/test_session_insight_refresh.py
  tests/unit/storage/test_session_insight_rebuild_progress.py
  tests/unit/storage/test_repair.py tests/unit/pipeline/test_process_pool.py
  tests/unit/daemon/test_convergence_stages.py` → **141 passed**.
- Broader affected-area sweep: `devtools test
  tests/unit/api/test_facade_contracts.py
  tests/unit/daemon/test_convergence_stages.py
  tests/unit/pipeline/test_run_stages_runtime.py
  tests/unit/pipeline/test_ingest_batch.py
  tests/unit/storage/test_perf_rescue_1314.py tests/unit/cli/test_insights.py`
  → **418 passed**.
- `mypy --strict` on all three touched files → **no issues found**.
- `devtools verify --quick` → **exit 0** (format, lint, mypy, render-all-check,
  layering, all static gates); also ran automatically and passed on `git push`
  via the pre-push hook.
- New test `tests/unit/storage/test_session_insight_parallel_fanout.py`
  covers, deliberately verified against mutation (reverted, not shipped):
  - **Equivalence**: identical 6-session corpus (plain text / tool_use+
    tool_result / thinking-block variants) rebuilt once with
    `parallel_threads_effective` forced False and once forced True (same
    monkeypatch pattern `test_revision_backfill.py` uses for the analogous
    parse fan-out) → byte-identical `session_profiles` /
    `session_latency_profiles` / `session_work_events` / `session_phases`
    rows (`frozen_clock` pins the one wall-clock-derived field,
    `materialized_at`).
  - **Determinism**: jobs completing in the reverse of submission order
    still return results in submission order. Swapping the result assembly
    to `as_completed()` order breaks this test (`[4,3,2,1,0] != [0,1,2,3,4]`,
    confirmed then reverted).
  - **Write boundary**: forces the thread-pool path over a real rebuild,
    instruments `build_session_insight_records` and every bulk writer to
    record the calling thread, asserts compute ran off the calling thread
    (fan-out genuinely engaged, not vacuously passing) while every write
    stayed on it. Wrapping one bulk-write call in a background thread breaks
    this test ("a bulk SQLite writer ran off the calling thread", confirmed
    then reverted).
- **Not run**: a live 3.14t free-threaded benchmark. No free-threaded
  interpreter with polylogue installed was available in this session/worktree
  (the flake's 3.14t derivations exist in the Nix store but no built devshell
  lane was set up here). This mirrors the same deployment-order rationale
  polylogue-xikl already states: CLI/offline rebuild adopts 3.14t first,
  daemon second — this PR lands the code-level fan-out ahead of that
  adoption, gated off by default. The polylogue-7mtf control-run measurement
  (3.9x-9.6x for the structurally identical parse fan-out) is the closest
  available evidence for expected speedup shape; a dedicated 3.14t benchmark
  for insight rebuild is a reasonable follow-up (not filed as a separate bead
  yet — flagging for the coordinator to decide whether it's worth a
  dedicated tracking item or folds into polylogue-7mtf's existing scope).

Ref polylogue-syz2