### PR TITLE
feat(query): continuation resume parity across HTTP/API surfaces

### DIFF
--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -3339,6 +3339,114 @@ async def test_query_units_rejects_session_expression(tmp_path: Path) -> None:
         await archive.close()
 
 
+def _write_facade_continuation_message(archive_db: ArchiveStore, native_id: str, text: str) -> None:
+    archive_db.write_parsed(
+        ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id=native_id,
+            title="Facade continuation session",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="m1",
+                    role=Role.USER,
+                    text=text,
+                    blocks=[ParsedContentBlock(type=BlockType.TEXT, text=text)],
+                )
+            ],
+        )
+    )
+
+
+async def test_query_units_continuation_resumes_and_drains_all_rows(tmp_path: Path) -> None:
+    """``query_units(continuation=...)`` advances the same request to its next page.
+
+    Reuses the shared ``QueryTransaction``/``QueryTransactionRequest``/
+    ``QueryContinuation`` primitives that MCP's ``query`` tool and daemon
+    HTTP's ``/api/query-units`` already validate directly; this facade
+    method delegates to the exact same ``query_units_transaction_request``
+    constructor (see ``polylogue/api/archive.py``), but had no direct test
+    exercising its own ``continuation`` keyword before this (polylogue-z9gh.9.1
+    residual-gap trail note dated 2026-07-18).
+    """
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            for index in range(3):
+                _write_facade_continuation_message(archive_db, f"facade-continuation-{index}", f"needle {index}")
+
+        first = await archive.query_units("messages where text:needle", limit=1)
+        assert first.continuation is not None
+        second = await archive.query_units(continuation=first.continuation)
+        assert second.continuation is not None
+        third = await archive.query_units(continuation=second.continuation)
+
+        assert first.query_ref == second.query_ref == third.query_ref
+        assert first.result_ref == second.result_ref == third.result_ref
+        message_ids = {cast(Any, item).message_id for page in (first, second, third) for item in page.items}
+        assert len(message_ids) == 3
+        assert third.continuation is None
+    finally:
+        await archive.close()
+
+
+async def test_query_units_rejects_continuation_parameter_overrides(tmp_path: Path) -> None:
+    """A continuation must be resumed alone; it cannot also carry a new expression."""
+    from polylogue.archive.query.transaction import QueryContinuationInvalidError
+
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            for index in range(2):
+                _write_facade_continuation_message(
+                    archive_db, f"facade-continuation-override-{index}", "override needle"
+                )
+
+        first = await archive.query_units("messages where text:needle", limit=1)
+        assert first.continuation is not None
+        with pytest.raises(QueryContinuationInvalidError):
+            await archive.query_units("messages where text:other", continuation=first.continuation)
+    finally:
+        await archive.close()
+
+
+async def test_query_units_rejects_stale_continuation_epoch(tmp_path: Path) -> None:
+    """A continuation issued before a write lands is rejected, never silently replayed.
+
+    Production dependency exercised: ``validate_continuation_epoch`` inside
+    ``query_unit_envelope`` (``polylogue/archive/query/unit_results.py``) --
+    removing that epoch check would let this resume advance a stale offset
+    across the newly-written session instead of raising.
+    """
+    from polylogue.archive.query.transaction import QueryContinuationStaleError
+
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            for index in range(2):
+                _write_facade_continuation_message(archive_db, f"facade-continuation-stale-{index}", "stale needle")
+
+        first = await archive.query_units("messages where text:needle", limit=1)
+
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            _write_facade_continuation_message(archive_db, "facade-continuation-stale-mutation", "stale needle")
+
+        with pytest.raises(QueryContinuationStaleError):
+            await archive.query_units(continuation=first.continuation)
+    finally:
+        await archive.close()
+
+
+async def test_query_units_rejects_malformed_continuation(tmp_path: Path) -> None:
+    from polylogue.archive.query.transaction import QueryContinuationInvalidError
+
+    archive = _archive(tmp_path)
+    try:
+        with pytest.raises(QueryContinuationInvalidError):
+            await archive.query_units(continuation="q1._not-a-real-token")
+    finally:
+        await archive.close()
+
+
 async def test_archive_tiers_api_reads_native_sessions(tmp_path: Path) -> None:
     """Archive API opt-in methods read index.db files directly."""
     from polylogue.archive.message.roles import Role

--- a/tests/unit/archive/query/test_continuation_surface_parity.py
+++ b/tests/unit/archive/query/test_continuation_surface_parity.py
@@ -1,0 +1,243 @@
+"""Cross-surface continuation resume parity: HTTP, Python API, MCP (polylogue-z9gh.9.1).
+
+The daemon HTTP ``/api/query-units`` route, the ``Polylogue.query_units()``
+facade, and the MCP ``query`` tool all delegate to the same shared primitives
+(``query_units_transaction_request``, ``QueryTransaction``,
+``QueryContinuation``, ``validate_continuation_epoch`` in
+``polylogue/archive/query/transaction.py`` and
+``polylogue/archive/query/unit_results.py``). This module proves that
+delegation holds end-to-end for a real corpus: paging the same expression
+through all three surfaces returns identical rows in identical order, and
+resuming a continuation issued before a write lands is rejected identically
+by all three, rather than three independently-drifting per-surface
+implementations (the exact failure mode the shared-transaction program
+guards against, per polylogue-z9gh.9's #2472/#2470 partitioning-bug history).
+
+These tests start a real HTTP server; they share an xdist group with the
+other web-reader HTTP lane to avoid cross-worker port/event-loop
+interference (tests/unit/daemon/test_web_reader.py).
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http import HTTPStatus
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import patch
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+import pytest
+
+from polylogue import Polylogue
+from polylogue.archive.message.roles import Role
+from polylogue.archive.query.transaction import QueryContinuationStaleError
+from polylogue.core.enums import BlockType, Provider
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from tests.infra.mcp import MCPServerUnderTest, invoke_surface_async
+
+pytestmark = pytest.mark.xdist_group("web-reader")
+
+
+def _write_needle_message(archive_root: Path, native_id: str, text: str) -> None:
+    with ArchiveStore(archive_root) as archive_db:
+        archive_db.write_parsed(
+            ParsedSession(
+                source_name=Provider.CODEX,
+                provider_session_id=native_id,
+                title="Continuation parity session",
+                messages=[
+                    ParsedMessage(
+                        provider_message_id="m1",
+                        role=Role.USER,
+                        text=text,
+                        blocks=[ParsedContentBlock(type=BlockType.TEXT, text=text)],
+                    )
+                ],
+            )
+        )
+
+
+@contextmanager
+def _running_http_server() -> Iterator[str]:
+    from polylogue.daemon.http import DaemonAPIHandler, DaemonAPIHTTPServer
+
+    server = DaemonAPIHTTPServer(("127.0.0.1", 0), DaemonAPIHandler)
+    server.auth_token = ""
+    server.api_host = "127.0.0.1"
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, name="continuation-parity-test", daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2.0)
+
+
+def _get_json(base_url: str, path: str) -> object:
+    with urlopen(Request(f"{base_url}{path}"), timeout=10) as resp:
+        assert resp.status == HTTPStatus.OK, f"unexpected status {resp.status} for {path}"
+        return json.loads(resp.read())
+
+
+def _request_json(base_url: str, path: str) -> tuple[int, object]:
+    try:
+        with urlopen(Request(f"{base_url}{path}"), timeout=10) as resp:
+            return resp.status, json.loads(resp.read())
+    except HTTPError as exc:
+        return exc.code, json.loads(exc.read().decode())
+
+
+@pytest.fixture
+def mcp_server() -> MCPServerUnderTest:
+    from polylogue.mcp.server import build_server
+
+    return cast(MCPServerUnderTest, build_server(role="read"))
+
+
+async def test_continuation_pages_match_identically_across_http_api_mcp(
+    mcp_server: MCPServerUnderTest,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Paging the same expression through HTTP/API/MCP yields identical pages.
+
+    Production dependencies exercised: ``DaemonAPIHandler._handle_query_units``,
+    ``Polylogue.query_units``, and the MCP ``query`` tool's delegation into
+    that same facade method (``server_cutover.py``). Removing the shared
+    ``query_units_transaction_request``/``QueryTransaction`` plumbing from any
+    one surface would make its rows, ``query_ref``, or ``result_ref`` diverge
+    from the other two.
+    """
+    archive_root = tmp_path / "archive"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(archive_root))
+    for index in range(3):
+        _write_needle_message(archive_root, f"parity-{index}", f"paritycheck needle {index}")
+
+    expression = "messages where text:paritycheck"
+    archive = Polylogue(archive_root=archive_root)
+
+    # --- API: page 1 then resume to page 2 ---
+    api_first = await archive.query_units(expression, limit=2)
+    assert api_first.continuation is not None
+    api_second = await archive.query_units(continuation=api_first.continuation)
+    assert api_second.continuation is None
+
+    # --- HTTP: page 1 then resume to page 2 ---
+    quoted_expression = quote(expression)
+    with _running_http_server() as base_url:
+        http_first = cast(
+            dict[str, object], _get_json(base_url, f"/api/query-units?expression={quoted_expression}&limit=2")
+        )
+        http_second = cast(
+            dict[str, object],
+            _get_json(base_url, f"/api/query-units?continuation={quote(str(http_first['continuation']), safe='')}"),
+        )
+
+    # --- MCP: page 1 then resume to page 2 ---
+    with (
+        patch("polylogue.mcp.server._get_config", return_value=SimpleNamespace(archive_root=archive_root)),
+        patch("polylogue.mcp.server._get_polylogue", return_value=Polylogue(archive_root=archive_root)),
+    ):
+        mcp_first = json.loads(
+            await invoke_surface_async(mcp_server._tool_manager._tools["query"].fn, expression=expression, limit=2)
+        )
+        mcp_second = json.loads(
+            await invoke_surface_async(
+                mcp_server._tool_manager._tools["query"].fn, continuation=mcp_first["continuation"]
+            )
+        )
+
+    def _message_ids(items: object) -> list[str]:
+        return [cast(dict[str, object], item)["message_id"] for item in cast(list[object], items)]  # type: ignore[misc]
+
+    api_first_ids = [cast(object, item).message_id for item in api_first.items]  # type: ignore[attr-defined]
+    api_second_ids = [cast(object, item).message_id for item in api_second.items]  # type: ignore[attr-defined]
+    http_first_ids = _message_ids(http_first["items"])
+    http_second_ids = _message_ids(http_second["items"])
+    mcp_first_ids = _message_ids(mcp_first["items"])
+    mcp_second_ids = _message_ids(mcp_second["items"])
+
+    assert api_first_ids == http_first_ids == mcp_first_ids
+    assert api_second_ids == http_second_ids == mcp_second_ids
+    assert len(set(api_first_ids) | set(api_second_ids)) == 3
+
+    assert api_first.query_ref == http_first["query_ref"] == mcp_first["query_ref"]
+    assert api_first.result_ref == http_first["result_ref"] == mcp_first["result_ref"]
+    assert api_second.query_ref == http_second["query_ref"] == mcp_second["query_ref"]
+    assert http_second["continuation"] is None
+    assert mcp_second["continuation"] is None
+
+
+async def test_continuation_stale_epoch_rejected_identically_across_http_api_mcp(
+    mcp_server: MCPServerUnderTest,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A continuation issued before a concurrent write lands is rejected the same way everywhere.
+
+    Production dependency exercised: ``validate_continuation_epoch`` inside
+    ``query_unit_envelope`` (``polylogue/archive/query/unit_results.py``) is
+    the single call each surface's adapter reaches on resume. Bypassing it on
+    any one surface would let a stale offset silently duplicate or skip rows
+    across the newly-written session instead of raising
+    ``query_continuation_stale``.
+    """
+    archive_root = tmp_path / "archive"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(archive_root))
+    for index in range(2):
+        _write_needle_message(archive_root, f"stale-parity-{index}", "stale paritycheck needle")
+
+    expression = "messages where text:paritycheck"
+    archive = Polylogue(archive_root=archive_root)
+
+    api_first = await archive.query_units(expression, limit=1)
+    assert api_first.continuation is not None
+
+    quoted_expression = quote(expression)
+    with _running_http_server() as base_url:
+        http_first = cast(
+            dict[str, object], _get_json(base_url, f"/api/query-units?expression={quoted_expression}&limit=1")
+        )
+
+    with (
+        patch("polylogue.mcp.server._get_config", return_value=SimpleNamespace(archive_root=archive_root)),
+        patch("polylogue.mcp.server._get_polylogue", return_value=Polylogue(archive_root=archive_root)),
+    ):
+        mcp_first = json.loads(
+            await invoke_surface_async(mcp_server._tool_manager._tools["query"].fn, expression=expression, limit=1)
+        )
+
+    # A write after every surface issued its first page moves the shared
+    # archive epoch; every resume attempt below must now be rejected.
+    _write_needle_message(archive_root, "stale-parity-mutation", "stale paritycheck needle")
+
+    with pytest.raises(QueryContinuationStaleError):
+        await archive.query_units(continuation=api_first.continuation)
+
+    with _running_http_server() as base_url:
+        http_status, http_payload = _request_json(
+            base_url, f"/api/query-units?continuation={quote(str(http_first['continuation']), safe='')}"
+        )
+    assert http_status == HTTPStatus.CONFLICT
+    assert cast(dict[str, object], http_payload)["error"] == "query_continuation_stale"
+
+    with (
+        patch("polylogue.mcp.server._get_config", return_value=SimpleNamespace(archive_root=archive_root)),
+        patch("polylogue.mcp.server._get_polylogue", return_value=Polylogue(archive_root=archive_root)),
+    ):
+        mcp_stale = json.loads(
+            await invoke_surface_async(
+                mcp_server._tool_manager._tools["query"].fn, continuation=mcp_first["continuation"]
+            )
+        )
+    assert mcp_stale["code"] == "query_continuation_stale"


### PR DESCRIPTION
## Summary

Verifies and locks in test coverage for continuation-resume parity across
Polylogue's three query_units surfaces (daemon HTTP `/api/query-units`, the
Python API `Polylogue.query_units()` facade, and the MCP `query` tool).

## Problem

polylogue-z9gh.9.1's 2026-07-18 trail note flagged a residual gap: daemon
HTTP's `/api/query-units` accepts no `continuation` query parameter (no
resume path exists there, even though it returns a continuation token), and
the Python API/CLI `query_units` path likewise has no continuation input.
MCP already accepts and validates continuation via
`validate_continuation_epoch()`/`QueryContinuationStaleError`, the reference
implementation.

Source review found both flagged gaps already closed on master, just not
reflected in the bead trail: the six-tool MCP cutover hardening pass
(`dc6fa632a` / #3095, merged the same day, *after* the note was written)
added continuation decoding + `QueryContinuationStaleError` handling to both
`DaemonAPIHandler._handle_query_units` and `Polylogue.query_units`, reusing
the same `query_units_transaction_request` / `QueryTransaction` /
`QueryContinuation` primitives MCP's `query` tool already validated — and in
fact MCP's `query` tool delegates straight into `Polylogue.query_units`
under the hood, so there was never a second implementation to build.

What was missing was direct proof that this held together end-to-end: HTTP
had its own continuation test suite (`tests/unit/daemon/test_web_reader.py`),
and only MCP+API were compared together
(`tests/unit/mcp/test_server_surfaces.py`) — no test drove all three
surfaces against the same corpus, and the Python API facade's own
`continuation=` keyword had zero direct test coverage (only indirect
coverage via MCP tests that patch the facade in).

## Solution

- `tests/unit/api/test_facade_contracts.py`: four new tests pinning
  `Polylogue.query_units(continuation=...)` directly — normal resume drains
  all rows with stable `query_ref`/`result_ref`, rejecting a continuation
  combined with a new expression (`QueryContinuationInvalidError`),
  rejecting a continuation issued before a write lands
  (`QueryContinuationStaleError`), and rejecting a malformed token.
- `tests/unit/archive/query/test_continuation_surface_parity.py` (new):
  seeds one on-disk corpus, then drives HTTP, the Python API facade, and the
  MCP `query` tool through an identical expression/continuation flow,
  asserting byte-identical `message_id` ordering and identical
  `query_ref`/`result_ref` across all three pages, plus identical
  `query_continuation_stale` rejection when a write lands between issuing
  and resuming a continuation on each surface.

No production code changed — this closes the residual test-coverage gap
the bead trail identified, without building a second continuation
mechanism (the mission's explicit anti-goal): every surface still funnels
through the single `query_units_transaction_request`/`QueryTransaction`
boundary.

**Not touched — CLI:** the CLI does not call `Polylogue.query_units` at
all today. Its `find`/`read` verbs use a separate `SessionQuerySpec` /
`cli/archive_query.py` path with plain `limit`/`offset`, not opaque
continuation tokens. There is no CLI query-units paging surface to wire
continuation resume into, so CLI is out of this change's scope.

**Reviewed but not touched — z9gh.3 execution-layer gaps:** the two
execution-layer gaps flagged in polylogue-z9gh.3's notes (`near:""`
similarity queries falling back to an unfiltered session list;
`lineage:id:` queries not materializing declared
`parent_refs`/`child_refs`/`continuation` projection columns) both live in
the generic find/read CLI route (`expression.py`, `execution_control.py`,
`unit_results.py` untouched by that prior PR), not in the HTTP/API/MCP
`query_units` continuation path this change touches. Left as already-tracked
scope, not duplicated here.

## Verification

- `devtools test tests/unit/archive/query/test_continuation_surface_parity.py
  tests/unit/api/test_facade_contracts.py tests/unit/mcp/test_server_surfaces.py`
  — 286 passed.
- `devtools test tests/unit/daemon/test_web_reader.py::TestReaderQueryUnits`
  — 13 passed (confirms no regression to the existing HTTP continuation
  suite from sharing its `xdist_group`).
- `devtools verify --quick` — green, 16/16 steps (ran automatically via the
  pre-push hook too).
- `mypy --strict` on both new/changed test files — clean.
- Noted, not caused by this change: `devtools test tests/unit/daemon/test_web_reader.py`
  run as a whole has one pre-existing failure
  (`TestReaderAssertionEndpoint::test_operational_web_payloads_redact_configured_archive_paths`,
  `sqlite3.OperationalError: unable to open database file` after the test
  deliberately unlinks `index.db` mid-run) — reproduced identically at
  `origin/master` HEAD (`71d134eaa`) with none of this PR's files present,
  confirming it predates this change.

Ref polylogue-z9gh.9.1, polylogue-z9gh.9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added continuation support for paging query results across the Python API, HTTP endpoint, and MCP tool.
  * Query pages preserve consistent ordering and shared query/result identifiers when resumed.

* **Bug Fixes**
  * Invalid, conflicting, malformed, or stale continuation tokens are now consistently rejected.
  * Stale continuations return appropriate errors across all supported query interfaces.

* **Tests**
  * Added coverage for multi-page queries and cross-interface result and error consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->