### PR TITLE
chore(loc): exclude generated artifacts and lockfile leaks from LoC stats

### DIFF
--- a/.tokeignore
+++ b/.tokeignore
@@ -17,3 +17,21 @@ docs/topology-status.md
 # Fixtures / captured provider payloads (parser witnesses, not first-party code).
 **/representatives/
 tests/data/
+
+# Lockfiles chisel's *.lock pattern misses by extension.
+webui/package-lock.json
+
+# Generated test snapshots (syrupy .ambr).
+**/__snapshots__/
+
+# Generated webui client + reports (`devtools render webui-client`).
+webui/src/api/generated.ts
+webui/src/generated/
+
+# Generated/rendered doc surfaces and demo artifacts.
+docs/cli-reference.md
+docs/examples/demo-tour/report.json
+
+# Rendered byte-identical copy of polylogue/agent_integration/data/deep-reference.md;
+# the source copy stays counted, this duplicate does not.
+docs/agent-integration-reference.md


### PR DESCRIPTION
Lynchpin chisel audit (2026-07-19): the tokei input set correctly applied
.tokeignore + chisel's DEFAULT_IGNORE (.agent/, .beads/, *.lock, vendored
litellm catalog, fixtures all excluded), but ~13.7K lines of non-code
leaked through: webui/package-lock.json (4,441 — misses the *.lock
extension pattern), syrupy __snapshots__ (6,742), generated webui client
+ contrast report (1,225), rendered docs/cli-reference.md (818), the
byte-identical rendered duplicate of agent-integration deep-reference
(809), and a generated demo-tour report (684).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ
