### PR TITLE
fix(cli): stop KeyError('rank') in transcript view after keyword find

### DIFF
--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -3290,7 +3290,6 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         session_ref = TargetRefPayload.session(session_id)
         message_ref = TargetRefPayload.message(session_id=session_id, message_id=message_id)
         return {
-            "rank": hit.rank,
             "session": {
                 "id": session_id,
                 "title": hit.title or session_id,
@@ -3300,6 +3299,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                 "actions": _dump_actions(reader_session_actions()),
             },
             "match": {
+                "rank": hit.rank,
                 "message_id": message_id,
                 "block_id": hit.block_id,
                 "snippet": hit.snippet,

--- a/tests/unit/cli/test_daemon_golden_parity.py
+++ b/tests/unit/cli/test_daemon_golden_parity.py
@@ -190,3 +190,56 @@ def test_facets_json_parity_between_direct_and_daemon(
     direct_payload.pop("generated_at", None)
     daemon_payload.pop("generated_at", None)
     assert daemon_payload == direct_payload
+
+
+def test_find_then_read_transcript_survives_daemon_proxied_keyword_search(
+    golden_parity_workspace: dict[str, Path],
+    _uds_runtime_dir: Path,
+) -> None:
+    """Regression for polylogue-ajmu.
+
+    ``find QUERY then read --view transcript`` (default plain-text rendering,
+    the "summary"/"transcript" views' shared query-set renderer) used to crash
+    with ``KeyError: 'rank'`` once a daemon was reachable and the query was a
+    keyword FTS search rather than an exact session ref -- even with exactly
+    one matching session, no disambiguation involved. Root cause: the daemon's
+    ``_archive_search_hit_payload`` (``daemon/http.py``) put ``rank`` as a
+    top-level sibling of ``session``/``match``, while the shared text renderer
+    ``_hit_line`` (``cli/archive_query.py``) -- and every other search-hit
+    producer (direct CLI ``_hit_payload``, MCP ``archive_search_hit_payload``)
+    -- reads ``match["rank"]``.
+    """
+    del golden_parity_workspace
+    from polylogue.cli import cli
+    from polylogue.daemon.http import DaemonAPIHandler
+    from polylogue.daemon.uds import DaemonAPIUnixHTTPServer, daemon_socket_path
+
+    socket_path = daemon_socket_path(str(_uds_runtime_dir))
+    server = DaemonAPIUnixHTTPServer(socket_path, DaemonAPIHandler)
+    server.auth_token = ""
+    thread = threading.Thread(target=server.serve_forever, name="golden-parity-transcript-uds", daemon=True)
+    thread.start()
+    try:
+        from polylogue.cli.daemon_client import DaemonClient
+
+        client = DaemonClient(socket_path, timeout_s=1.0)
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if client.request_json("GET", "/api/health") is not None:
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("daemon UDS server did not become ready")
+
+        runner = CliRunner()
+        # "exceptions" only appears in conv1's seeded message text, so this is
+        # a single-hit keyword search -- the exact shape the bead reported.
+        result = runner.invoke(cli, ["--plain", "find", "exceptions", "then", "read", "--view", "transcript"])
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    assert result.exit_code == 0, result.output
+    assert result.exception is None
+    assert "Python Error Handling" in result.output

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -1147,6 +1147,24 @@ class TestReaderSearchState:
         assert hit["match"]["anchor"] == "message-claude-code-session-c1-m-c1"
         assert hit["match"]["actions"]["copy_text"]["enabled"] is True
 
+    def test_search_hit_rank_lives_under_match_not_top_level(self, workspace_env: dict[str, Path]) -> None:
+        """Regression for polylogue-ajmu: the CLI's ``_hit_line`` text renderer and
+        the webui's ``_render_search_hit`` both read ``hit["match"]["rank"]`` (matching
+        the ``SessionSearchMatchPayload.rank`` contract every other search-hit
+        producer -- direct CLI ``_hit_payload``, MCP ``archive_search_hit_payload`` --
+        already honors). The daemon HTTP handler once put ``rank`` as a top-level
+        sibling of ``session``/``match`` instead, so a keyword ``find`` proxied
+        through the daemon rendered its result via ``_hit_line`` and crashed with
+        ``KeyError: 'rank'`` even for a single, unambiguous match.
+        """
+        with _running_server(workspace_env) as (_, base_url):
+            payload = _get_json(base_url, "/api/sessions?query=Hello")
+        assert isinstance(payload, dict)
+        assert payload["hits"], "fixture query must actually match rows, or this assertion is vacuous"
+        for hit in payload["hits"]:
+            assert "rank" not in hit, "rank must not be a top-level sibling of session/match"
+            assert isinstance(hit["match"]["rank"], int)
+
     def test_archive_file_set_lists_from_archive_tiers(
         self,
         workspace_env: dict[str, Path],


### PR DESCRIPTION
## Summary

`find QUERY then read --view transcript` crashed with `KeyError: 'rank'` whenever a daemon was reachable and the query was a keyword FTS search rather than an exact session ref, even with exactly one matching session. Fixed the underlying wire-shape divergence in the daemon's search-hit payload.

## Problem

Repro (per polylogue-ajmu): import `tests/fixtures/hermes/atif/nemo_relay_atif_v1.7_real_redacted.json` into a scratch archive, then run:

```
polylogue --origin hermes-session find "hermes" then read --view transcript
```

This raised `Error: unexpected error: KeyError: 'rank'`. The same session read fine via an exact ref (`find id:hermes-session:...`) instead of a keyword query.

Root cause: three producers build the same "search hit" wire shape (`session` + `match` evidence), but only two of them agree. The direct in-process CLI path (`archive_query.py::_hit_payload`) and the MCP surface (`mcp/archive_support.py::archive_search_hit_payload`) both build the typed `SessionSearchHitPayload`/`SessionSearchMatchPayload` contract, which declares `rank: int` as a *required field of `match`*. The daemon's hand-built HTTP payload (`daemon/http.py::_archive_search_hit_payload`) instead put `rank` as a **top-level sibling** of `session`/`match`.

Both consumers of the rendered dict already expect `rank` inside `match`: the CLI's plain-text renderer `_hit_line` (`cli/archive_query.py`, `match['rank']`, no `.get` fallback — the crash site) and the daemon webui's `_render_search_hit` (`daemon/webui.py`, `match.get("rank")`, which silently swallowed the same divergence instead of crashing — a masked instance of the same bug). `docs/search.md`'s documented hit-evidence contract also places `rank` under `match`.

This is entirely origin-independent — the divergence lives purely in the daemon's wire payload construction, unrelated to any provider/origin parsing. Verified with both a `hermes-session` fixture and a `chatgpt-export` fixture.

Surface scope: `read --view messages`/`raw` never resolve through the search-hit renderer at all (`accepts_query_set=False` for those views forces an upfront single-session resolution before any rendering happens), so they were never exposed to this shape. `summary`, `transcript`, and `dialogue` share the same query-set renderer (`run_read_summary_or_transcript`) and were all affected — including plain `read` with no `--view` flag at all, since `summary` is the default view.

## Solution

Moved `rank` from the top level into the nested `match` dict in `polylogue/daemon/http.py::DaemonAPIHandler._archive_search_hit_payload`, so all four producers/consumers of this shape agree, rather than adding a defensive `.get()` at the CLI crash site.

## Verification

- `devtools test polylogue/daemon/http.py tests/unit/cli/test_daemon_golden_parity.py tests/unit/daemon/test_web_reader.py tests/unit/cli/test_archive_query.py` → 280 passed, 1 failed. The 1 failure (`test_operational_web_payloads_redact_configured_archive_paths`) is confirmed pre-existing and unrelated — it reproduces identically on a clean `origin/master` worktree with none of this change's files present (a real-daemon `index.db` deletion mid-test surfaces an unhandled `sqlite3.OperationalError` as an HTTP 500, unrelated to search-hit shape).
- Anti-vacuity: reverting the `http.py` hunk reproduces `<Result KeyError('rank')>` in the new CLI end-to-end test (`test_find_then_read_transcript_survives_daemon_proxied_keyword_search`) and the top-level `"rank"` assertion failure in the new daemon-payload test (`test_search_hit_rank_lives_under_match_not_top_level`).
- `devtools verify --quick` → exit_code 0 (16/16 checks green), and again on `git push` via the pre-push hook.

Ref polylogue-ajmu

Co-Authored-By: Claude <noreply@anthropic.com>