### PR TITLE
fix(sources): capture TaskOutput poll exit codes for Claude Code

### DIFF
--- a/polylogue/sources/parsers/claude/code_parser.py
+++ b/polylogue/sources/parsers/claude/code_parser.py
@@ -306,6 +306,60 @@ def _task_notification_from_record(
     return None
 
 
+def _task_output_outcome(item: dict[str, object]) -> tuple[int | None, bool] | None:
+    """Read a polled background task's own verdict from ``toolUseResult.task``.
+
+    Claude Code's ``TaskOutput`` tool (used to poll a backgrounded command or
+    agent) reports retrieval success/failure at the Anthropic tool_result
+    envelope level (``content[].is_error``) *separately* from the underlying
+    task's own outcome: a successful *poll* of a *failed* command still
+    surfaces envelope ``is_error=false`` -- the poll itself succeeded -- which
+    would otherwise silently mask the command's real exit code from
+    ``blocks.tool_result_is_error``/``tool_result_exit_code``. The sibling
+    ``<task-notification>`` protocol (``_task_notification_from_record``)
+    only fires as an injected reminder on a *later* turn and is not always
+    present in a transcript that instead polled ``TaskOutput`` directly, so
+    this is an independent structured-evidence path, not a duplicate of it.
+
+    ``toolUseResult.task`` is Claude Code's own structured verdict for this
+    poll: ``exitCode`` for ``local_bash`` tasks, else ``status`` for
+    ``local_agent`` tasks that never carry a process exit code. Only trusted
+    when ``retrieval_status == "success"`` -- i.e. the poll actually returned
+    a terminal result, as opposed to ``not_ready``/``timeout`` (task still
+    running, no verdict yet).
+    """
+    tool_result = item.get("toolUseResult")
+    if not isinstance(tool_result, dict) or tool_result.get("retrieval_status") != "success":
+        return None
+    task = tool_result.get("task")
+    if not isinstance(task, dict):
+        return None
+    exit_code = task.get("exitCode")
+    if isinstance(exit_code, int) and not isinstance(exit_code, bool):
+        return exit_code, exit_code != 0
+    status = task.get("status")
+    if status == "completed":
+        return None, False
+    if status in ("failed", "killed"):
+        return None, True
+    return None
+
+
+def _mark_task_output_outcome(
+    content_blocks: list[ParsedContentBlock], outcome: tuple[int | None, bool] | None
+) -> list[ParsedContentBlock]:
+    """Project a polled background task's real verdict onto its TaskOutput result block."""
+    if outcome is None:
+        return content_blocks
+    exit_code, is_error = outcome
+    return [
+        block.model_copy(update={"is_error": is_error, "exit_code": exit_code})
+        if block.type is BlockType.TOOL_RESULT
+        else block
+        for block in content_blocks
+    ]
+
+
 def _mark_background_task_start(
     content_blocks: list[ParsedContentBlock], task_id: str | None
 ) -> list[ParsedContentBlock]:
@@ -548,6 +602,7 @@ def _parse_code_records(
         envelope_role = _record_role(item, message)
         content_blocks = _content_blocks_from_record(message, text)
         content_blocks = _mark_background_task_start(content_blocks, _background_task_id(item))
+        content_blocks = _mark_task_output_outcome(content_blocks, _task_output_outcome(item))
         message_type = _message_type_from_code_record(item, text)
         if envelope_role is Role.SYSTEM and message_type is MessageType.MESSAGE:
             message_type = MessageType.CONTEXT

--- a/tests/unit/sources/test_parsers_claude_code_artifacts.py
+++ b/tests/unit/sources/test_parsers_claude_code_artifacts.py
@@ -718,6 +718,206 @@ def test_parse_code_degrades_changed_background_completion_template_to_unknown()
     assert foreground.is_error is False
 
 
+def _task_output_poll_record(
+    *,
+    uuid: str,
+    tool_use_id: str,
+    retrieval_status: str,
+    task: dict[str, object],
+    content: str = "polled output",
+    session_id: str = "task-output-polls",
+) -> dict[str, object]:
+    """Real ``TaskOutput`` poll shape, reduced from persisted JSONL evidence.
+
+    The Anthropic tool_result envelope (``message.content[].is_error``) only
+    ever reports whether the *poll itself* succeeded; the polled task's own
+    verdict lives in the sibling record-level ``toolUseResult.task`` dict.
+    """
+    return {
+        "type": "user",
+        "uuid": uuid,
+        "sessionId": session_id,
+        "toolUseResult": {"retrieval_status": retrieval_status, "task": task},
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": content,
+                    "is_error": False,
+                }
+            ],
+        },
+    }
+
+
+def test_parse_code_projects_task_output_bash_exit_code_from_tool_use_result() -> None:
+    """A ``TaskOutput`` poll of a failed background *command* carries a real
+    ``exitCode`` in ``toolUseResult.task`` even though the poll's own
+    Anthropic-reported ``is_error`` is false (the poll succeeded).
+
+    This fails if ``_task_output_outcome``/``_mark_task_output_outcome`` stop
+    reading ``toolUseResult.task.exitCode`` and the block falls back to the
+    poll envelope's own (misleading) success flag.
+    """
+    records = [
+        _task_output_poll_record(
+            uuid="poll-fail",
+            tool_use_id="tool-poll-fail",
+            retrieval_status="success",
+            task={
+                "task_id": "bg-1",
+                "task_type": "local_bash",
+                "status": "completed",
+                "description": "run flaky test",
+                "output": "1 failed, 3 passed",
+                "exitCode": 1,
+            },
+        ),
+        _task_output_poll_record(
+            uuid="poll-ok",
+            tool_use_id="tool-poll-ok",
+            retrieval_status="success",
+            task={
+                "task_id": "bg-2",
+                "task_type": "local_bash",
+                "status": "completed",
+                "description": "run clean test",
+                "output": "3 passed",
+                "exitCode": 0,
+            },
+        ),
+    ]
+
+    parsed = parse_code(records, "task-output-bash")
+    by_id = {message.provider_message_id: message for message in parsed.messages}
+    assert by_id["poll-fail"].blocks[0].exit_code == 1
+    assert by_id["poll-fail"].blocks[0].is_error is True
+    assert by_id["poll-ok"].blocks[0].exit_code == 0
+    assert by_id["poll-ok"].blocks[0].is_error is False
+
+
+def test_parse_code_projects_task_output_agent_status_without_exit_code() -> None:
+    """``local_agent`` polls never carry a process ``exitCode`` -- only
+    ``status`` -- so the completed/failed verdict must still reach
+    ``is_error`` while ``exit_code`` stays ``None`` (never fabricated).
+    """
+    records = [
+        _task_output_poll_record(
+            uuid="poll-agent-ok",
+            tool_use_id="tool-poll-agent-ok",
+            retrieval_status="success",
+            task={
+                "task_id": "agent-1",
+                "task_type": "local_agent",
+                "status": "completed",
+                "description": "audit CLI surfaces",
+                "output": "{...}",
+                "prompt": "...",
+                "result": "...",
+            },
+        ),
+        _task_output_poll_record(
+            uuid="poll-agent-killed",
+            tool_use_id="tool-poll-agent-killed",
+            retrieval_status="success",
+            task={
+                "task_id": "agent-2",
+                "task_type": "local_agent",
+                "status": "killed",
+                "description": "audit CLI surfaces, interrupted",
+                "output": "",
+            },
+        ),
+    ]
+
+    parsed = parse_code(records, "task-output-agent")
+    by_id = {message.provider_message_id: message for message in parsed.messages}
+    assert by_id["poll-agent-ok"].blocks[0].exit_code is None
+    assert by_id["poll-agent-ok"].blocks[0].is_error is False
+    assert by_id["poll-agent-killed"].blocks[0].exit_code is None
+    assert by_id["poll-agent-killed"].blocks[0].is_error is True
+
+
+def test_parse_code_ignores_task_output_poll_that_is_not_yet_terminal() -> None:
+    """A ``not_ready``/``timeout`` poll has no task verdict yet -- the block
+    keeps the poll envelope's own outcome instead of fabricating one.
+    """
+    records = [
+        _task_output_poll_record(
+            uuid="poll-not-ready",
+            tool_use_id="tool-poll-not-ready",
+            retrieval_status="not_ready",
+            task={"task_id": "bg-3", "task_type": "local_bash", "status": "running", "output": "", "exitCode": None},
+        ),
+        _task_output_poll_record(
+            uuid="poll-timeout",
+            tool_use_id="tool-poll-timeout",
+            retrieval_status="timeout",
+            task={"task_id": "bg-4", "task_type": "local_bash", "status": "running", "output": "", "exitCode": None},
+        ),
+    ]
+
+    parsed = parse_code(records, "task-output-pending")
+    by_id = {message.provider_message_id: message for message in parsed.messages}
+    assert by_id["poll-not-ready"].blocks[0].exit_code is None
+    assert by_id["poll-not-ready"].blocks[0].is_error is False
+    assert by_id["poll-timeout"].blocks[0].exit_code is None
+    assert by_id["poll-timeout"].blocks[0].is_error is False
+
+
+def test_parse_code_projects_task_output_exit_code_through_actions(tmp_path: Path) -> None:
+    """Production route: ``parse_code`` -> ``ArchiveStore`` -> ``actions``.
+
+    This fails if the ``TaskOutput`` poll outcome never reaches the
+    ``actions`` view's ``is_error``/``exit_code`` columns -- the same
+    keystone surface the ``<task-notification>`` completion path is verified
+    against above.
+    """
+    records: list[object] = [
+        {
+            "type": "assistant",
+            "uuid": "assistant-poll",
+            "sessionId": "task-output-actions",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tool-poll",
+                        "name": "TaskOutput",
+                        "input": {"task_id": "bg-5", "block": True},
+                    }
+                ],
+            },
+        },
+        _task_output_poll_record(
+            uuid="poll-fail-actions",
+            tool_use_id="tool-poll",
+            retrieval_status="success",
+            task={
+                "task_id": "bg-5",
+                "task_type": "local_bash",
+                "status": "completed",
+                "description": "run migration",
+                "output": "error: constraint violation",
+                "exitCode": 2,
+            },
+            session_id="task-output-actions",
+        ),
+    ]
+
+    parsed = parse_code(records, "task-output-actions")
+    archive_root = tmp_path / "task-output-actions"
+    with ArchiveStore(archive_root) as archive:
+        session_id = archive.write_parsed(parsed)
+        actions = archive.query_session_actions([session_id], limit=10)
+
+    outcomes = {action.tool_name: (action.is_error, action.exit_code) for action in actions}
+    assert outcomes == {"TaskOutput": (1, 2)}
+
+
 def test_parse_code_drops_progress_hook_records() -> None:
     """#1617: ``type=progress`` is a hook lifecycle event, not message content."""
     items: list[object] = [


### PR DESCRIPTION
## Summary

Extends Claude Code's already-shipped background-task-notification outcome capture to a second, previously-uncovered wire path: an agent explicitly polling a backgrounded command/agent via the `TaskOutput` tool now gets the real exit code / status projected onto that poll's own `tool_result` block.

## Problem

Polylogue's headline claim is that Claude Code tool outcomes are read from structure (`blocks.tool_result_is_error` / `tool_result_exit_code`), never regex-guessed from prose. An existing feature (`ClaudeCodeBackgroundTaskNotification`, `code_parser.py`) already captures the `<task-notification>` system-reminder Claude Code injects when a backgrounded command finishes, joining it back to the original Bash `tool_result` block by `(task_id, tool_use_id)`.

But that notification is not the only way a background outcome reaches the transcript. When the agent instead calls the `TaskOutput` tool to poll a task itself, the resulting `tool_result`'s own Anthropic envelope (`content[].is_error`) only reports whether the *poll* succeeded -- not the polled task's outcome. A successful poll of a *failed* command still reports `is_error=false` at that layer, silently masking the real exit code. The real verdict was sitting unread in the sibling record-level `toolUseResult.task` dict (`exitCode` for `local_bash` tasks; `status` for `local_agent` tasks, which never carry a process exit code).

Live-archive evidence (`index.db`, read-only query) quantifies the gap precisely, via the `actions` view grouped by `tool_name` for `origin='claude-code-session'`:

| tool_name | exit_code populated | total actions |
| --- | --- | --- |
| Bash | 189 | 21811 |
| TaskOutput | **0** | 192 |

All 192 `TaskOutput` actions in the live archive have `exit_code = NULL`, even though corpus-level JSONL evidence (`~/.claude/projects/**/*.jsonl`) shows hundreds of `TaskOutput` poll records carrying a real `toolUseResult.task.exitCode` value (0, 1, 2, 4, 100, 101, 127, 128, 137, 143 observed).

## Solution

`polylogue/sources/parsers/claude/code_parser.py`:
- `_task_output_outcome(item)` -- reads `item["toolUseResult"]["retrieval_status"]` / `["task"]`, returning `(exit_code, is_error)` only when `retrieval_status == "success"` (a terminal poll). `local_bash` tasks use `task.exitCode`; `local_agent` tasks (no process exit code) fall back to `task.status in {completed, failed, killed}`. `not_ready`/`timeout` polls return `None` -- left as unknown, not fabricated.
- `_mark_task_output_outcome(content_blocks, outcome)` -- projects the outcome onto the record's own `tool_result` block(s), mirroring the existing `_mark_background_task_start` pattern.
- Wired into `_parse_code_records` right after the existing `_mark_background_task_start` call. The two are mutually exclusive by construction (`backgroundTaskId` only appears on a task-*start* acknowledgement; `retrieval_status`/`task` only appear on a `TaskOutput` *poll* result), so ordering doesn't matter.

No schema change -- this reuses the existing `blocks.tool_result_is_error`/`tool_result_exit_code` keystone columns (index v16) and the `ParsedContentBlock.is_error`/`exit_code` fields already wired through to `ArchiveStore`/`actions`.

## Verification

```
devtools test tests/unit/sources/test_parsers_claude_code_artifacts.py
# 26 passed (4 new): bash exit code, agent status without exit code,
# non-terminal polls stay unknown, and a full parse_code -> ArchiveStore
# -> actions production-route check (mirrors the existing notification-path test).

devtools verify --quick
# all 16 steps ok: ruff format/check, mypy --strict, render all,
# topology/layering/closure-matrix, schema roundtrip, manifests,
# doc-commands, docs-coverage, test-infra-currency, test-clock-hygiene,
# pytest-timeout-overrides, degrade-loudly.
```

Not run: full `devtools verify` (testmon-affected broader run) or a live index rebuild -- the live-archive coverage numbers above were read via a read-only `mode=ro` SQLite URI against the currently-deployed index (pre-fix); realizing the fix's effect on the live archive requires `polylogue ops reset --index && polylogued run` (derived-tier rebuild), which is out of scope for this PR.

Ref polylogue-lls8