### PR TITLE
fix(test): accept bulk_build kwarg in lock-retry persistence stub

### DIFF
--- a/tests/unit/sources/test_live_cursor_persistence.py
+++ b/tests/unit/sources/test_live_cursor_persistence.py
@@ -69,6 +69,7 @@ def _lock_first_index_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
         preacquired_attachment_blobs: dict[int, tuple[bytes | None, int, str]] | None = None,
         revision_authoritative: bool = False,
         bulk_fts: bool = False,
+        bulk_build: bool = False,
     ) -> ArchiveRawParsedWriteResult:
         nonlocal attempts
         attempts += 1
@@ -85,6 +86,7 @@ def _lock_first_index_persistence(monkeypatch: pytest.MonkeyPatch) -> None:
             preacquired_attachment_blobs=preacquired_attachment_blobs,
             revision_authoritative=revision_authoritative,
             bulk_fts=bulk_fts,
+            bulk_build=bulk_build,
         )
 
     monkeypatch.setattr(ArchiveStore, "_write_parsed_precedence_result", lock_once)


### PR DESCRIPTION
Ref polylogue-lvz6

**Summary**: test-only fix — the `_lock_first_index_persistence` monkeypatch stub mirrors `_write_parsed_precedence_result` but was not updated when #3165 added the `bulk_build` kwarg.

**Problem**: on clean master, both lock-retry tests in `tests/unit/sources/test_live_cursor_persistence.py` fail — the live watcher swallows the stub TypeError as "ingest failed". Surfaced while verifying a lane report; the heavy suite runs post-merge only, so per-PR CI never caught it.

**Solution**: the stub accepts and forwards `bulk_build`.

**Verification**: `devtools test tests/unit/sources/test_live_cursor_persistence.py tests/unit/sources/test_live_batch_support.py` → the 2 cursor-persistence failures clear (66 passed across the pair); the 5 remaining `test_live_batch_support` failures are unrelated pre-existing drift, being triaged under polylogue-lvz6.