### PR TITLE
fix(test): repair lineage property oracle multi-hop cascade; exercise continuity cancellation

### DIFF
--- a/devtools/continuity_replay.py
+++ b/devtools/continuity_replay.py
@@ -18,7 +18,7 @@ import re
 import sys
 import time
 from collections.abc import Callable, Mapping, Sequence
-from contextlib import AsyncExitStack
+from contextlib import AsyncExitStack, suppress
 from dataclasses import dataclass, field
 from datetime import timedelta
 from pathlib import Path
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Literal, Protocol, TypeAlias, TypeGuard, cast
 if __package__ in {None, ""}:  # pragma: no cover - exercised by the script entry point
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from polylogue.archive.query.execution_control import DEFAULT_CAPACITY
 from polylogue.core.json import JSONDocument, JSONValue, require_json_document, require_json_value
 from polylogue.product.continuity_scenarios import (
     CONTINUITY_SCENARIOS,
@@ -50,6 +51,13 @@ RouteTransport: TypeAlias = Literal["stdio", "registered"]
 ArgumentMutator: TypeAlias = Callable[[str, RouteArguments, int], RouteArguments]
 ResponseMutator: TypeAlias = Callable[[str, RouteArguments, int, str], str]
 DiscoveryMutator: TypeAlias = Callable[[JSONDocument], JSONDocument]
+#: Concurrent copies of one real route step issued by the cancellation
+#: exercise (see StdioMCPContinuityRoute.exercise_cancellation). Comfortably
+#: above the production admission controller's default per-process capacity
+#: so at least one copy is provably still queued (never touched SQLite) when
+#: the cancellation notifications are sent, making the exercise deterministic
+#: rather than a race against how fast any one query happens to run.
+_CANCELLATION_PROBE_CONCURRENCY = DEFAULT_CAPACITY + 4
 _TEMPLATE_RE = re.compile(r"\{fixture:([A-Za-z0-9_.-]+)\}")
 _ATTEMPT_TOKEN_RE = re.compile(r"(?P<key>[a-z_]+):(?P<value>[A-Za-z0-9_-]+)")
 _ATTEMPT_GRADES: frozenset[str] = frozenset(
@@ -62,6 +70,15 @@ _ATTEMPT_GRADES: frozenset[str] = frozenset(
         "unreasonable_query",
     }
 )
+
+
+CancellationOutcome: TypeAlias = Literal[
+    "cancelled_confirmed",
+    "completed_before_cancel",
+    "not_confirmed_within_grace",
+    "not_applicable",
+    "call_failed",
+]
 
 
 class ContinuityRoute(Protocol):
@@ -78,6 +95,11 @@ class ContinuityRoute(Protocol):
     async def invoke(self, tool: str, arguments: Mapping[str, object]) -> str:
         raise NotImplementedError
 
+    async def exercise_cancellation(
+        self, tool: str, arguments: Mapping[str, object], *, grace_ms: int
+    ) -> CancellationExerciseReceipt:
+        raise NotImplementedError
+
 
 class ContinuityReplayError(RuntimeError):
     """Structured replay failure that can be reported without a traceback."""
@@ -86,6 +108,41 @@ class ContinuityReplayError(RuntimeError):
         super().__init__(message)
         self.kind = kind
         self.failure_class = failure_class
+
+
+@dataclass(frozen=True, slots=True)
+class CancellationExerciseReceipt:
+    """Outcome of one genuine runner-issued mid-flight cancellation attempt.
+
+    ``confirmed`` is the only field that may make ``cancellation_exercised``
+    true in a scenario report -- it requires an actual server-observed
+    cancellation (the MCP SDK's ``RequestResponder.cancel()`` error response),
+    never an inferred/assumed state.
+    """
+
+    attempted: bool
+    confirmed: bool
+    outcome: CancellationOutcome
+    elapsed_ms: float
+    detail: str | None = None
+
+    def to_payload(self) -> JSONDocument:
+        return {
+            "attempted": self.attempted,
+            "confirmed": self.confirmed,
+            "outcome": self.outcome,
+            "elapsed_ms": round(self.elapsed_ms, 3),
+            "detail": self.detail,
+        }
+
+
+_CANCELLATION_NOT_APPLICABLE_REGISTERED = CancellationExerciseReceipt(
+    attempted=False,
+    confirmed=False,
+    outcome="not_applicable",
+    elapsed_ms=0.0,
+    detail="registered in-process route has no MCP transport-level request to cancel",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -199,6 +256,18 @@ class MCPContinuityRoute:
                 failure_class="execution",
             )
         return self._mutate_response(tool, call_arguments, invocation, result)
+
+    async def exercise_cancellation(
+        self, tool: str, arguments: Mapping[str, object], *, grace_ms: int
+    ) -> CancellationExerciseReceipt:
+        """The registered route calls the tool coroutine in-process directly:
+        there is no MCP session, so there is no wire-level cancellation
+        notification to send. Report that honestly rather than faking a
+        confirmation off a bare asyncio task cancellation, which would only
+        prove Python's generic coroutine cancellation, not that this route's
+        production QueryExecutionContext plumbing was exercised the same way
+        a real disconnected/cancelled MCP client is."""
+        return _CANCELLATION_NOT_APPLICABLE_REGISTERED
 
     def _prepare_call(self, tool: str, arguments: Mapping[str, object]) -> tuple[int, RouteArguments]:
         self._invocation_count += 1
@@ -339,6 +408,128 @@ class StdioMCPContinuityRoute:
         if self.response_mutator is not None:
             response_text = self.response_mutator(tool, call_arguments, invocation, response_text)
         return response_text
+
+    async def exercise_cancellation(
+        self, tool: str, arguments: Mapping[str, object], *, grace_ms: int
+    ) -> CancellationExerciseReceipt:
+        """Drive real MCP ``notifications/cancelled`` messages through the
+        live stdio session and observe whether the production
+        QueryExecutionContext wiring (``execute_archive_read`` catching
+        ``asyncio.CancelledError`` and calling ``ctx.cancel()``, or the
+        admission queue's own cancellation check while a call is still
+        waiting for a free slot) actually aborted an in-flight read.
+
+        This does not race a single call's wall-clock duration against a
+        settle delay: direct probing showed that approach is genuinely
+        flaky -- some scenarios' own real queries (a marker lookup with
+        ``limit=2``) complete in well under a millisecond end to end, so no
+        fixed settle window reliably wins, while heavier queries reliably
+        do; picking one or the other per scenario is not honest. Instead
+        this issues ``_CANCELLATION_PROBE_CONCURRENCY`` concurrent copies of
+        the SAME real (tool, arguments) call -- comfortably more than the
+        production admission controller's default capacity
+        (``DEFAULT_CAPACITY``, currently 4) -- and sends a cancellation
+        notification for every one of them. Regardless of how fast any
+        individual copy's own SQL work would complete, the ones that exceed
+        the shared admission ceiling are provably still queued (not yet
+        admitted, not yet touching SQLite) when the notifications are sent,
+        and the admission wait loop checks ``ctx.should_abort()`` on its own
+        short poll cadence -- making at least one confirmed cancellation
+        deterministic, not a race. Direct probing confirmed 100% success
+        (40/40 across 5 rounds) against the checked-in continuity fixture,
+        including under the same logging load that made the single-call
+        approach flake.
+
+        This does not reuse :meth:`invoke`: it issues its own calls directly
+        against the session so the exercise never consumes a mutation
+        invocation slot or perturbs ``_BudgetState`` call/byte accounting --
+        it is a probe, not a graded plan step. Request ids are predicted from
+        the session's own sequential counter read once before any of the
+        concurrent tasks are created; this is only valid because the SDK
+        assigns ids in task-creation order and the replay harness does not
+        interleave unrelated requests on this session while the probe runs.
+        """
+        session = self._session
+        if session is None:
+            return CancellationExerciseReceipt(
+                attempted=False,
+                confirmed=False,
+                outcome="not_applicable",
+                elapsed_ms=0.0,
+                detail="MCP stdio route is not open",
+            )
+        from mcp.shared.exceptions import McpError
+        from mcp.types import CancelledNotification, CancelledNotificationParams, ClientNotification
+
+        call_arguments = dict(arguments)
+        started = time.perf_counter()
+        base_request_id = session._request_id
+        probe_tasks: list[asyncio.Task[object]] = [
+            asyncio.ensure_future(session.call_tool(tool, arguments=call_arguments))
+            for _ in range(_CANCELLATION_PROBE_CONCURRENCY)
+        ]
+        await asyncio.sleep(0)  # let every probe task reach its own request write
+        for offset in range(_CANCELLATION_PROBE_CONCURRENCY):
+            await session.send_notification(
+                ClientNotification(
+                    CancelledNotification(
+                        params=CancelledNotificationParams(
+                            requestId=base_request_id + offset,
+                            reason="continuity-replay-cancellation-exercise",
+                        )
+                    )
+                )
+            )
+
+        confirmed_count = 0
+        completed_count = 0
+        failure_details: list[str] = []
+        for probe_task in probe_tasks:
+            try:
+                await asyncio.wait_for(probe_task, timeout=max(1.0, grace_ms / 1000))
+            except McpError as exc:
+                message = exc.error.message or ""
+                if exc.error.code == 0 and "cancel" in message.lower():
+                    confirmed_count += 1
+                else:
+                    failure_details.append(message or f"McpError code={exc.error.code}")
+            except TimeoutError:
+                probe_task.cancel()
+                with suppress(BaseException):
+                    await probe_task
+                failure_details.append("probe call did not resolve within the grace budget")
+            else:
+                completed_count += 1
+        elapsed_ms = (time.perf_counter() - started) * 1000
+        detail = (
+            f"{confirmed_count}/{_CANCELLATION_PROBE_CONCURRENCY} concurrent probe calls confirmed cancelled, "
+            f"{completed_count} completed normally"
+        )
+        if failure_details:
+            detail += f"; {len(failure_details)} unexpected outcome(s): {failure_details[:3]}"
+        if confirmed_count > 0:
+            return CancellationExerciseReceipt(
+                attempted=True,
+                confirmed=True,
+                outcome="cancelled_confirmed",
+                elapsed_ms=elapsed_ms,
+                detail=detail,
+            )
+        if completed_count == _CANCELLATION_PROBE_CONCURRENCY:
+            return CancellationExerciseReceipt(
+                attempted=True,
+                confirmed=False,
+                outcome="completed_before_cancel",
+                elapsed_ms=elapsed_ms,
+                detail=detail,
+            )
+        return CancellationExerciseReceipt(
+            attempted=True,
+            confirmed=False,
+            outcome="call_failed",
+            elapsed_ms=elapsed_ms,
+            detail=detail,
+        )
 
 
 @dataclass(slots=True)
@@ -627,6 +818,79 @@ def compare_attempt_grades(
     return diagnostics
 
 
+#: Tools independently confirmed to route through the interruptible archive
+#: read path (QueryTransaction/execute_archive_read/QueryExecutionContext):
+#: "query" (query_units) and "status" (scope="archive" falls through to the
+#: same QueryTransaction). "explain" is pure DSL grammar/capability
+#: introspection with no archive read to interrupt at all -- direct probing
+#: confirmed it never confirms a cancellation (every concurrent probe just
+#: completes immediately) and, worse, hammering it with
+#: _CANCELLATION_PROBE_CONCURRENCY concurrent calls plus cancellation
+#: notifications for a tool with no in-flight state to cancel occasionally
+#: destabilized the stdio session ("Connection closed"). Do not probe tools
+#: outside this set; report them honestly as not_applicable instead.
+_CANCELLATION_CAPABLE_TOOLS: frozenset[str] = frozenset({"query", "status"})
+
+
+async def _exercise_scenario_cancellation(
+    scenario: ContinuityScenarioSpec,
+    fixture: Mapping[str, JSONValue],
+    route: ContinuityRoute,
+) -> CancellationExerciseReceipt:
+    """Attempt one genuine mid-flight cancellation using the scenario's own
+    first real route step and arguments.
+
+    This runs before scenario grading and is fully isolated from it: a probe
+    failure (or an honestly unconfirmed race) never fails the scenario or
+    perturbs its observed facts/budget accounting, it only produces an
+    honest receipt for the report.
+    """
+    if not scenario.route_steps:
+        return CancellationExerciseReceipt(
+            attempted=False,
+            confirmed=False,
+            outcome="not_applicable",
+            elapsed_ms=0.0,
+            detail="scenario declares no route steps to exercise",
+        )
+    probe_step = scenario.route_steps[0]
+    if probe_step.tool not in _CANCELLATION_CAPABLE_TOOLS:
+        return CancellationExerciseReceipt(
+            attempted=False,
+            confirmed=False,
+            outcome="not_applicable",
+            elapsed_ms=0.0,
+            detail=(
+                f"tool {probe_step.tool!r} is not confirmed to route through an interruptible "
+                "archive read (only 'query' and 'status' are)"
+            ),
+        )
+    try:
+        probe_arguments = materialize_route_arguments(probe_step, fixture)
+    except Exception as exc:
+        return CancellationExerciseReceipt(
+            attempted=False,
+            confirmed=False,
+            outcome="not_applicable",
+            elapsed_ms=0.0,
+            detail=f"could not materialize probe arguments: {exc}",
+        )
+    try:
+        return await route.exercise_cancellation(
+            probe_step.tool,
+            probe_arguments,
+            grace_ms=scenario.budget.max_cancel_grace_ms,
+        )
+    except Exception as exc:
+        return CancellationExerciseReceipt(
+            attempted=True,
+            confirmed=False,
+            outcome="call_failed",
+            elapsed_ms=0.0,
+            detail=f"cancellation exercise raised {type(exc).__name__}: {exc}",
+        )
+
+
 async def execute_continuity_scenario(
     scenario_name: str,
     fixture: Mapping[str, JSONValue],
@@ -647,6 +911,7 @@ async def execute_continuity_scenario(
     observed_facts: dict[str, JSONValue] = {}
     observed_evidence: list[str] = []
     observed_attempt_grades: dict[str, str] = {}
+    cancellation_receipt = await _exercise_scenario_cancellation(scenario, fixture, route)
 
     try:
         _validate_scenario_declaration(scenario)
@@ -742,7 +1007,11 @@ async def execute_continuity_scenario(
             "observed_response_bytes": budget_state.response_bytes,
             "observed_call_elapsed_ms": round(budget_state.call_elapsed_ms, 3),
             "observed_scenario_elapsed_ms": round(budget_state.elapsed_ms, 3),
-            "cancellation_exercised": False,
+            "cancellation_exercised": cancellation_receipt.confirmed,
+            "cancellation_attempted": cancellation_receipt.attempted,
+            "cancellation_outcome": cancellation_receipt.outcome,
+            "cancellation_elapsed_ms": round(cancellation_receipt.elapsed_ms, 3),
+            "cancellation_detail": cancellation_receipt.detail,
         },
     }
     return require_json_document(report, context=f"continuity report {scenario.scenario_id}")
@@ -1645,6 +1914,8 @@ if __name__ == "__main__":
 
 __all__ = [
     "ArgumentMutator",
+    "CancellationExerciseReceipt",
+    "CancellationOutcome",
     "ContinuityReplayError",
     "ContinuityRoute",
     "DiscoveryMutator",

--- a/tests/integration/test_continuity_replay.py
+++ b/tests/integration/test_continuity_replay.py
@@ -72,7 +72,41 @@ async def test_all_scenarios_pass_through_official_mcp_stdio_json_rpc(
     budget = require_json_document(incident["budget"], context="incident budget")
     assert isinstance(budget["observed_calls"], int)
     assert budget["observed_calls"] > 4
-    assert budget["cancellation_exercised"] is False
+    # A real MCP notifications/cancelled is sent mid-flight for this
+    # scenario's own first route step and the outcome is independently
+    # classified -- not a hardcoded flag. cancellation_elapsed_ms must stay
+    # well inside the declared grace budget, proving the server actually
+    # interrupted the read rather than merely finishing before the grace
+    # timeout elapsed.
+    assert budget["cancellation_attempted"] is True
+    assert budget["cancellation_outcome"] == "cancelled_confirmed"
+    assert budget["cancellation_exercised"] is True
+    cancellation_elapsed_ms = budget["cancellation_elapsed_ms"]
+    max_cancel_grace_ms = budget["max_cancel_grace_ms"]
+    assert isinstance(cancellation_elapsed_ms, (int, float))
+    assert isinstance(max_cancel_grace_ms, (int, float))
+    assert 0 < cancellation_elapsed_ms < max_cancel_grace_ms
+
+    # Every scenario whose first route step uses an archive-read-backed tool
+    # independently exercises and confirms its own cancellation in this
+    # stdio-transport replay -- one scenario passing is not proof the harness
+    # generalizes. "self-inspection" is the sole declared exception: its only
+    # step is "explain" (pure DSL grammar/capability introspection), which has
+    # no in-flight archive read to interrupt at all -- an honest
+    # not_applicable, not a simulated confirmation.
+    for scenario_result in result_documents:
+        scenario_budget = require_json_document(
+            scenario_result["budget"], context=f"{scenario_result['scenario']} budget"
+        )
+        if scenario_result["scenario"] == "self-inspection":
+            assert scenario_budget["cancellation_attempted"] is False
+            assert scenario_budget["cancellation_outcome"] == "not_applicable"
+            assert scenario_budget["cancellation_exercised"] is False
+            continue
+        assert scenario_budget["cancellation_attempted"] is True, scenario_result["scenario"]
+        assert scenario_budget["cancellation_outcome"] == "cancelled_confirmed", scenario_result["scenario"]
+        assert scenario_budget["cancellation_exercised"] is True, scenario_result["scenario"]
+
     receipts = json_document_list(incident["route_receipts"])
     member_receipt = next(receipt for receipt in receipts if receipt["step_id"] == "incident-members")
     assert member_receipt["page_count"] == 6

--- a/tests/property/test_write_path_state_machine.py
+++ b/tests/property/test_write_path_state_machine.py
@@ -266,20 +266,30 @@ class WritePathStateMachine(RuleBasedStateMachine):
         assert parent_id is not None
         parent_messages = read_archive_session_envelope(self._conn, parent_id).messages
         branch_point = parent_messages[child.prefix_length - 1].message_id
-        parent_message_positions = {message.message_id: index for index, message in enumerate(parent_messages)}
         self._conn.execute("DELETE FROM messages WHERE message_id = ?", (branch_point,))
         self._conn.commit()
         self._deletion_done = True
         deleted_position = child.prefix_length - 1
         self._models[parent_id].own_texts.pop(deleted_position)
-        for candidate_id, candidate in self._models.items():
-            link = self._conn.execute(
-                "SELECT branch_point_message_id FROM session_links WHERE src_session_id = ?",
-                (candidate_id,),
-            ).fetchone()
-            linked_position = parent_message_positions.get(link[0]) if link is not None else None
-            if linked_position is not None and linked_position > deleted_position:
-                candidate.prefix_length -= 1
+        # Compute every descendant's shift against a pre-mutation snapshot
+        # first, then apply: a grandchild's branch point may live inside an
+        # intermediate session's own tail rather than the deleted-from
+        # session, so its shift must cascade through the intermediate
+        # session's own (not-yet-adjusted) prefix_length rather than being
+        # looked up directly against the deleted session's positions (#866e).
+        shifts = {
+            candidate_id: self._cascaded_prefix_shift(
+                candidate.parent_id,
+                candidate.prefix_length - 1,
+                cut_session_id=parent_id,
+                cut_index=deleted_position,
+            )
+            for candidate_id, candidate in self._models.items()
+            if candidate.parent_id is not None and candidate.prefix_length > 0
+        }
+        for candidate_id, shift in shifts.items():
+            if shift:
+                self._models[candidate_id].prefix_length -= shift
         self._models[parent_id].can_be_parent = False
         for candidate_id, candidate in self._models.items():
             if self._has_ancestor(candidate_id, parent_id):
@@ -356,6 +366,36 @@ class WritePathStateMachine(RuleBasedStateMachine):
                 return True
             cursor = self._models[cursor].parent_id
         return False
+
+    def _cascaded_prefix_shift(self, session_id: str, index: int, *, cut_session_id: str, cut_index: int) -> int:
+        """How much a pre-mutation 0-based logical index into ``session_id``'s
+        composed transcript should decrement after a single message is
+        removed at ``cut_index`` within ``cut_session_id``'s own texts.
+
+        A branch point may be recorded several hops away from the deleted
+        session: walk the prefix-sharing chain toward the cut root. An index
+        inside the borrowed prefix segment refers to the very same logical
+        slot in the parent's own composed transcript, so it recurses there
+        unchanged; an index inside the session's own tail is unaffected
+        physically but shifts by exactly however much that borrowed segment
+        shrank (i.e. the shift already computed for its last inherited
+        index), because the whole tail slides down by that same amount.
+        """
+        if session_id == cut_session_id:
+            return 1 if index > cut_index else 0
+        model = self._models[session_id]
+        if model.parent_id is None:
+            return 0
+        prefix_length = model.prefix_length
+        if index < prefix_length:
+            return self._cascaded_prefix_shift(
+                model.parent_id, index, cut_session_id=cut_session_id, cut_index=cut_index
+            )
+        if prefix_length == 0:
+            return 0
+        return self._cascaded_prefix_shift(
+            model.parent_id, prefix_length - 1, cut_session_id=cut_session_id, cut_index=cut_index
+        )
 
     def _new_native_id(self, kind: str) -> str:
         native_id = f"{kind}-{self._next_session}"
@@ -493,6 +533,86 @@ def test_repository_get_messages_composes_prefix_sharing_child() -> None:
             return [str(block.text) for message in messages for block in message.blocks if block.text is not None]
 
         assert asyncio.run(read_texts()) == ["parent prompt", "parent reply", "child tail"]
+
+
+def test_grandchild_transcript_recomposes_after_intermediate_ancestor_message_deletion() -> None:
+    """A grandchild's branch point may live in an intermediate child's own
+    physical row rather than the root parent's; deleting a root-parent
+    message upstream of both must still recompose the grandchild's transcript
+    from live positions, never a stale cached offset (#866e: the property
+    state machine's own model bookkeeping, not this production read path,
+    was found to mis-cascade the shift for exactly this multi-hop shape)."""
+    with tempfile.TemporaryDirectory(prefix="polylogue-write-model-", dir="/realm/tmp") as root_text:
+        archive_root = Path(root_text)
+        initialize_active_archive_root(archive_root)
+        db_path = archive_root / "index.db"
+        conn = sqlite3.connect(str(db_path))
+        try:
+            parent = ParsedSession(
+                source_name=Provider.CLAUDE_CODE,
+                provider_session_id="cascade-parent",
+                messages=[
+                    ParsedMessage(provider_message_id="parent-0", role=Role.USER, text="parent prompt", position=0),
+                    ParsedMessage(provider_message_id="parent-1", role=Role.ASSISTANT, text="parent reply", position=1),
+                ],
+            )
+            child = ParsedSession(
+                source_name=Provider.CLAUDE_CODE,
+                provider_session_id="cascade-child",
+                parent_session_provider_id="cascade-parent",
+                branch_type=BranchType.FORK,
+                messages=[
+                    ParsedMessage(provider_message_id="child-0", role=Role.USER, text="parent prompt", position=0),
+                    ParsedMessage(provider_message_id="child-1", role=Role.ASSISTANT, text="parent reply", position=1),
+                    ParsedMessage(provider_message_id="child-2", role=Role.USER, text="child tail", position=2),
+                ],
+            )
+            # The grandchild replays the CHILD's full composed transcript
+            # (parent's two messages plus the child's own tail), so its
+            # branch point resolves to a message physically stored in the
+            # child session, not the parent.
+            grandchild = ParsedSession(
+                source_name=Provider.CLAUDE_CODE,
+                provider_session_id="cascade-grandchild",
+                parent_session_provider_id="cascade-child",
+                branch_type=BranchType.FORK,
+                messages=[
+                    ParsedMessage(provider_message_id="gc-0", role=Role.USER, text="parent prompt", position=0),
+                    ParsedMessage(provider_message_id="gc-1", role=Role.ASSISTANT, text="parent reply", position=1),
+                    ParsedMessage(provider_message_id="gc-2", role=Role.USER, text="child tail", position=2),
+                    ParsedMessage(provider_message_id="gc-3", role=Role.ASSISTANT, text="grandchild tail", position=3),
+                ],
+            )
+            write_parsed_session_to_archive(conn, parent, content_hash=session_content_hash(parent))
+            write_parsed_session_to_archive(conn, child, content_hash=session_content_hash(child))
+            grandchild_id = write_parsed_session_to_archive(
+                conn, grandchild, content_hash=session_content_hash(grandchild)
+            )
+
+            branch_row = conn.execute(
+                "SELECT branch_point_message_id FROM session_links WHERE src_session_id = ?",
+                (grandchild_id,),
+            ).fetchone()
+            assert branch_row is not None
+            assert branch_row[0] == "claude-code-session:cascade-child:child-2"
+
+            # Two hops upstream of the grandchild: delete the root parent's
+            # first message, an ancestor edit that precedes every downstream
+            # branch point.
+            conn.execute(
+                "DELETE FROM messages WHERE message_id = ?",
+                ("claude-code-session:cascade-parent:parent-0",),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        async def read_texts(session_id: str) -> list[str]:
+            async with SessionRepository(db_path=db_path) as repository:
+                messages = await repository.get_messages(session_id)
+            return [str(block.text) for message in messages for block in message.blocks if block.text is not None]
+
+        assert asyncio.run(read_texts(grandchild_id)) == ["parent reply", "child tail", "grandchild tail"]
 
 
 def test_session_link_resolver_quarantines_cycle() -> None:


### PR DESCRIPTION
## Summary

Two independent trust-floor fixes from the 2026-07-19 AC-closure audit:

1. Repairs a multi-hop cascade bug in the write-path property state machine's own bookkeeping model (`tests/property/test_write_path_state_machine.py`) -- production was already correct.
2. Makes `devtools/continuity_replay.py` genuinely exercise and classify a real MCP mid-flight cancellation instead of hardcoding `cancellation_exercised: False`.

## Problem

**polylogue-866e**: `POLYLOGUE_HYPOTHESIS_REUSE_FAILURES=1 devtools test tests/property/test_write_path_state_machine.py` had passed repeatedly on master, but a fresh `--hypothesis-seed=577341254` run at the default 100-example profile produced a new falsifying sequence: `ingest_initial_parent`, `ingest_child_replaying_parent_prefix` x4 (which can chain into a grandchild via the shared `can_be_parent` selection), then `delete_parent_branch_point` -> `IndexError: tuple index out of range` inside the test's own `_assert_resolved_link`. Root-cause investigation (a direct-SQL + composed-read oracle replaying the exact call sequence outside pytest/Hypothesis) showed production's `read_archive_session_envelope` already recomposes the affected grandchild's transcript correctly; the bug was confined to the model's `delete_parent_branch_point` adjustment loop, which only compared each candidate's branch-point message id against the *directly deleted-from* session's positions and never cascaded the shift through a grandchild whose branch point lives inside an intermediate (already-shifted) session's own tail.

**polylogue-t8t**: `devtools/continuity_replay.py` declared `max_cancel_grace_ms` in `ContinuityBudget` and reported `cancellation_exercised` in every scenario's budget dict, but the value was a hardcoded `False` -- cancellation was scaffolded, never actually driven. `tests/integration/test_continuity_replay.py` asserted that `False` as the expected passing state, i.e. the test codified the gap rather than catching it.

## Solution

**866e** (`tests/property/test_write_path_state_machine.py`): replaced the direct SQL-lookup-based prefix adjustment with `WritePathStateMachine._cascaded_prefix_shift`, a recursive walk that resolves a branch point's shift against the cut root regardless of how many prefix-sharing hops separate them -- an index inside a session's borrowed prefix recurses into the parent's own composed transcript unchanged; an index inside the session's own tail shifts by whatever its borrowed segment shrank. Shifts are computed from a pre-mutation snapshot for every candidate before any `prefix_length` is mutated. Added `test_grandchild_transcript_recomposes_after_intermediate_ancestor_message_deletion` as a 4th named deterministic fixture (matching the file's existing two production-focused `test_` functions) that locks in the already-correct production behavior as a permanent regression guard.

**t8t** (`devtools/continuity_replay.py`): a naive single-call wall-clock race (create task, sleep briefly, send `notifications/cancelled`) was tried first and found genuinely flaky -- some scenarios' own real queries (a marker lookup with `limit=2`) complete in well under a millisecond end to end, so no fixed settle window reliably wins, while heavier queries reliably do. The shipped mechanism (`StdioMCPContinuityRoute.exercise_cancellation`) is deterministic instead: it issues `DEFAULT_CAPACITY + 4` concurrent copies of the scenario's own first real route step and sends a cancellation notification for every one. Regardless of how fast any individual copy's SQL work would finish, the copies that exceed the shared admission controller's ceiling are provably still queued (never touched SQLite) when the notifications arrive, and the admission wait loop checks `ctx.should_abort()` on its own poll cadence -- so at least one confirmed cancellation is guaranteed, not raced. Only tools independently confirmed to route through the interruptible archive-read path (`query`, `status`) are probed; `explain` (pure DSL grammar/capability introspection, no archive read to interrupt) is honestly reported `not_applicable` rather than forced -- probing it produced `completed_before_cancel` and occasional stdio connection instability, a genuine machinery gap, not a race to fix harder.

## Verification

- `devtools test tests/property/test_write_path_state_machine.py` -> 4 passed
- Direct non-Hypothesis reproduction script replaying the exact rule sequence confirmed `IndexError` before the fix and clean pass after, with the grandchild's shifted `prefix_length` landing at the expected value (2, not the stale 3)
- 400-example stateful stress run (`run_state_machine_as_test`, no pytest) and 11 distinct `--hypothesis-seed` runs at the default 100-example profile (including the original falsifying seed 577341254) all pass after the fix
- `devtools test tests/integration/test_continuity_replay.py tests/unit/product/test_continuity_scenarios.py tests/unit/mcp/test_prompt_query_parity.py` -> 22 passed (run twice for stability)
- `devtools test tests/unit/mcp/test_server_surfaces.py` -> 6 passed (no MCP surface regression)
- `mypy --strict` and `ruff format`/`check` clean on all touched files
- `devtools render all --check` -> exit 0, no "out of sync" surfaces
- `devtools verify --quick` -> exit 0 (all 16 steps green)

Ref polylogue-866e, polylogue-t8t