### PR TITLE
fix(storage): unify message-native-id normalization to stop FK failures

### DIFF
--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -719,14 +719,20 @@ def backfill_historical_revision_evidence(
                     archive.release_provisional_full_revisions(sorted(plan_raw_ids))
                 adoption_deferred += len(plan.accepted_raw_ids)
                 continue
-            archive.apply_raw_revision_replay(
-                plan,
-                parsed_by_raw_id,
-                acquired_at_ms=0,
-                manage_transaction=not replay_batched,
-                bulk_fts=bulk_fts,
-                bulk_build=bulk_build,
-            )
+            try:
+                archive.apply_raw_revision_replay(
+                    plan,
+                    parsed_by_raw_id,
+                    acquired_at_ms=0,
+                    manage_transaction=not replay_batched,
+                    bulk_fts=bulk_fts,
+                    bulk_build=bulk_build,
+                )
+            except sqlite3.IntegrityError as exc:
+                raise sqlite3.IntegrityError(
+                    f"backfill_historical_revision_evidence: byte-proven replay failed for "
+                    f"logical_key={plan.logical_source_key!r}: {exc}"
+                ) from exc
             replayed += 1
             byte_replayed_keys.add(logical_key)
             if replay_batched:
@@ -766,16 +772,22 @@ def backfill_historical_revision_evidence(
                 )
                 adoption_deferred += len(classification.accepted_raw_ids)
                 continue
-            archive.apply_raw_membership_classification(
-                logical_key,
-                classification,
-                member_sessions,
-                projections,
-                acquired_at_ms=0,
-                manage_transaction=not replay_batched,
-                bulk_fts=bulk_fts,
-                bulk_build=bulk_build,
-            )
+            try:
+                archive.apply_raw_membership_classification(
+                    logical_key,
+                    classification,
+                    member_sessions,
+                    projections,
+                    acquired_at_ms=0,
+                    manage_transaction=not replay_batched,
+                    bulk_fts=bulk_fts,
+                    bulk_build=bulk_build,
+                )
+            except sqlite3.IntegrityError as exc:
+                raise sqlite3.IntegrityError(
+                    f"backfill_historical_revision_evidence: membership replay failed for "
+                    f"logical_key={logical_key!r}: {exc}"
+                ) from exc
             if classification.accepted_raw_ids:
                 replayed += 1
             if replay_batched:

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -343,287 +343,293 @@ def write_parsed_session_to_archive(
     # When the caller owns the transaction (bulk batching) we must not commit
     # per session; nullcontext leaves BEGIN/COMMIT to the caller.
     transaction = conn if manage_transaction else nullcontext()
-    with transaction:
-        conn.execute("INSERT OR REPLACE INTO derived_refresh_guard(guard_name) VALUES ('session-write')")
-        if bulk_build:
-            # polylogue-v6i3: gate messages_fts/blocks_command_trigram trigger
-            # BODIES for this session's *entire* write (block inserts in the
-            # ordinary merge/full-replace paths, not just the prefix-tail
-            # reextract cascade -- see _bulk_fts_session_guard, which detects
-            # this outer guard and becomes a no-op rather than double-managing
-            # the same row). Cleared alongside the 'session-write' guard below.
-            conn.execute(
-                "INSERT OR REPLACE INTO derived_refresh_guard(guard_name) VALUES (?)",
-                (FTS_BULK_SESSION_WRITE_GUARD,),
-            )
-        t0 = time.perf_counter()
-        conn.execute(
-            """
-            INSERT INTO sessions (
-                native_id, origin, raw_id, branch_type, active_leaf_message_id,
-                title, session_kind, title_source, git_branch, git_repository_url, commit_hash,
-                instructions_text, reported_duration_ms, provider_project_ref,
-                message_count, word_count, tool_use_count, thinking_count,
-                paste_count, user_message_count, authored_user_message_count,
-                assistant_message_count, system_message_count,
-                tool_message_count, user_word_count, authored_user_word_count, assistant_word_count,
-                content_hash, created_at_ms, updated_at_ms
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ON CONFLICT(origin, native_id) DO UPDATE SET
-                raw_id = excluded.raw_id,
-                branch_type = excluded.branch_type,
-                active_leaf_message_id = excluded.active_leaf_message_id,
-                title = COALESCE(excluded.title, sessions.title),
-                session_kind = excluded.session_kind,
-                title_source = COALESCE(excluded.title_source, sessions.title_source),
-                git_branch = excluded.git_branch,
-                git_repository_url = excluded.git_repository_url,
-                commit_hash = excluded.commit_hash,
-                provider_project_ref = excluded.provider_project_ref,
-                instructions_text = COALESCE(excluded.instructions_text, sessions.instructions_text),
-                reported_duration_ms = excluded.reported_duration_ms,
-                content_hash = excluded.content_hash,
-                created_at_ms = COALESCE(sessions.created_at_ms, excluded.created_at_ms),
-                updated_at_ms = CASE
-                    WHEN ? THEN excluded.updated_at_ms
-                    ELSE MAX(COALESCE(sessions.updated_at_ms, 0), COALESCE(excluded.updated_at_ms, 0))
-                END
-            """,
-            (
-                native_id,
-                origin.value,
-                raw_id,
-                _enum_value(session.branch_type),
-                active_leaf_message_id,
-                _sqlite_text(session.title),
-                _enum_value(session.session_kind) or SessionKind.STANDARD.value,
-                _enum_value(session.title_source),
-                _sqlite_text(session.git_branch),
-                _sqlite_text(session.git_repository_url),
-                _sqlite_text(session.git_commit_hash),
-                _sqlite_text(session.instructions_text),
-                session.reported_duration_ms,
-                _sqlite_text(session.provider_project_ref),
-                session_counts["message_count"],
-                session_counts["word_count"],
-                session_counts["tool_use_count"],
-                session_counts["thinking_count"],
-                session_counts["paste_count"],
-                session_counts["user_message_count"],
-                session_counts["authored_user_message_count"],
-                session_counts["assistant_message_count"],
-                session_counts["system_message_count"],
-                session_counts["tool_message_count"],
-                session_counts["user_word_count"],
-                session_counts["authored_user_word_count"],
-                session_counts["assistant_word_count"],
-                session_content_hash,
-                _timestamp_ms(session.created_at),
-                _timestamp_ms(session.updated_at),
-                force_replace,
-            ),
-        )
-        add_timing("index.session_upsert", t0)
-        position_offset = 0
-        stale_attachment_ids: set[str] = set()
-        t0 = time.perf_counter()
-        if merge_append:
-            row = conn.execute(
-                "SELECT COALESCE(MAX(position) + 1, 0) FROM messages WHERE session_id = ?",
-                (session_id,),
-            ).fetchone()
-            position_offset = int(row[0] or 0) if row is not None else 0
+    try:
+        with transaction:
+            conn.execute("INSERT OR REPLACE INTO derived_refresh_guard(guard_name) VALUES ('session-write')")
+            if bulk_build:
+                # polylogue-v6i3: gate messages_fts/blocks_command_trigram trigger
+                # BODIES for this session's *entire* write (block inserts in the
+                # ordinary merge/full-replace paths, not just the prefix-tail
+                # reextract cascade -- see _bulk_fts_session_guard, which detects
+                # this outer guard and becomes a no-op rather than double-managing
+                # the same row). Cleared alongside the 'session-write' guard below.
+                conn.execute(
+                    "INSERT OR REPLACE INTO derived_refresh_guard(guard_name) VALUES (?)",
+                    (FTS_BULK_SESSION_WRITE_GUARD,),
+                )
+            t0 = time.perf_counter()
             conn.execute(
                 """
-                UPDATE messages
-                SET is_active_leaf = 0
-                WHERE session_id = ?
-                  AND is_active_path = 1
-                  AND is_active_leaf = 1
+                INSERT INTO sessions (
+                    native_id, origin, raw_id, branch_type, active_leaf_message_id,
+                    title, session_kind, title_source, git_branch, git_repository_url, commit_hash,
+                    instructions_text, reported_duration_ms, provider_project_ref,
+                    message_count, word_count, tool_use_count, thinking_count,
+                    paste_count, user_message_count, authored_user_message_count,
+                    assistant_message_count, system_message_count,
+                    tool_message_count, user_word_count, authored_user_word_count, assistant_word_count,
+                    content_hash, created_at_ms, updated_at_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(origin, native_id) DO UPDATE SET
+                    raw_id = excluded.raw_id,
+                    branch_type = excluded.branch_type,
+                    active_leaf_message_id = excluded.active_leaf_message_id,
+                    title = COALESCE(excluded.title, sessions.title),
+                    session_kind = excluded.session_kind,
+                    title_source = COALESCE(excluded.title_source, sessions.title_source),
+                    git_branch = excluded.git_branch,
+                    git_repository_url = excluded.git_repository_url,
+                    commit_hash = excluded.commit_hash,
+                    provider_project_ref = excluded.provider_project_ref,
+                    instructions_text = COALESCE(excluded.instructions_text, sessions.instructions_text),
+                    reported_duration_ms = excluded.reported_duration_ms,
+                    content_hash = excluded.content_hash,
+                    created_at_ms = COALESCE(sessions.created_at_ms, excluded.created_at_ms),
+                    updated_at_ms = CASE
+                        WHEN ? THEN excluded.updated_at_ms
+                        ELSE MAX(COALESCE(sessions.updated_at_ms, 0), COALESCE(excluded.updated_at_ms, 0))
+                    END
                 """,
-                (session_id,),
+                (
+                    native_id,
+                    origin.value,
+                    raw_id,
+                    _enum_value(session.branch_type),
+                    active_leaf_message_id,
+                    _sqlite_text(session.title),
+                    _enum_value(session.session_kind) or SessionKind.STANDARD.value,
+                    _enum_value(session.title_source),
+                    _sqlite_text(session.git_branch),
+                    _sqlite_text(session.git_repository_url),
+                    _sqlite_text(session.git_commit_hash),
+                    _sqlite_text(session.instructions_text),
+                    session.reported_duration_ms,
+                    _sqlite_text(session.provider_project_ref),
+                    session_counts["message_count"],
+                    session_counts["word_count"],
+                    session_counts["tool_use_count"],
+                    session_counts["thinking_count"],
+                    session_counts["paste_count"],
+                    session_counts["user_message_count"],
+                    session_counts["authored_user_message_count"],
+                    session_counts["assistant_message_count"],
+                    session_counts["system_message_count"],
+                    session_counts["tool_message_count"],
+                    session_counts["user_word_count"],
+                    session_counts["authored_user_word_count"],
+                    session_counts["assistant_word_count"],
+                    session_content_hash,
+                    _timestamp_ms(session.created_at),
+                    _timestamp_ms(session.updated_at),
+                    force_replace,
+                ),
             )
-            active_leaf_message_id = _active_leaf_message_id(
+            add_timing("index.session_upsert", t0)
+            position_offset = 0
+            stale_attachment_ids: set[str] = set()
+            t0 = time.perf_counter()
+            if merge_append:
+                row = conn.execute(
+                    "SELECT COALESCE(MAX(position) + 1, 0) FROM messages WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()
+                position_offset = int(row[0] or 0) if row is not None else 0
+                conn.execute(
+                    """
+                    UPDATE messages
+                    SET is_active_leaf = 0
+                    WHERE session_id = ?
+                      AND is_active_path = 1
+                      AND is_active_leaf = 1
+                    """,
+                    (session_id,),
+                )
+                active_leaf_message_id = _active_leaf_message_id(
+                    session_id,
+                    messages,
+                    session.active_leaf_message_provider_id,
+                    position_offset=position_offset,
+                    duplicate_native_ids=duplicate_message_native_ids,
+                )
+                conn.execute(
+                    "UPDATE sessions SET active_leaf_message_id = ? WHERE session_id = ?",
+                    (active_leaf_message_id, session_id),
+                )
+                add_timing("index.merge_prepare", t0)
+            else:
+                stale_attachment_ids = _session_attachment_ids(conn, session_id)
+                _replace_full_session_messages_and_blocks(
+                    conn,
+                    session,
+                    messages,
+                    duplicate_native_ids=duplicate_message_native_ids,
+                    stage_timings_s=stage_timings_s,
+                    stage_timing_prefix=stage_timing_prefix,
+                    bulk_build=bulk_build,
+                )
+                add_timing("index.full_replace", t0)
+            if merge_append:
+                t0 = time.perf_counter()
+                _write_messages(
+                    conn,
+                    session_id,
+                    messages,
+                    position_offset=position_offset,
+                    duplicate_native_ids=duplicate_message_native_ids,
+                )
+                add_timing("index.messages", t0)
+                t0 = time.perf_counter()
+                _write_blocks(
+                    conn,
+                    session_id,
+                    messages,
+                    position_offset=position_offset,
+                    duplicate_native_ids=duplicate_message_native_ids,
+                )
+                add_timing("index.blocks", t0)
+                t0 = time.perf_counter()
+                if not bulk_build:
+                    refresh_action_pairs(conn, session_id)
+                add_timing("index.action_pairs", t0)
+                t0 = time.perf_counter()
+                _write_web_constructs(
+                    conn,
+                    session,
+                    messages,
+                    position_offset=position_offset,
+                    duplicate_native_ids=duplicate_message_native_ids,
+                    replace_session=False,
+                )
+                add_timing("index.web_constructs", t0)
+            t0 = time.perf_counter()
+            _write_attachments(
+                conn,
                 session_id,
                 messages,
-                session.active_leaf_message_provider_id,
+                session.attachments,
+                position_offset=position_offset,
+                duplicate_native_ids=duplicate_message_native_ids,
+                refresh_attachment_ids=stale_attachment_ids,
+                preacquired_blobs=preacquired_attachment_blobs,
+            )
+            add_timing("index.attachments", t0)
+            t0 = time.perf_counter()
+            _write_paste_spans(
+                conn,
+                session_id,
+                messages,
                 position_offset=position_offset,
                 duplicate_native_ids=duplicate_message_native_ids,
             )
-            conn.execute(
-                "UPDATE sessions SET active_leaf_message_id = ? WHERE session_id = ?",
-                (active_leaf_message_id, session_id),
-            )
-            add_timing("index.merge_prepare", t0)
-        else:
-            stale_attachment_ids = _session_attachment_ids(conn, session_id)
-            _replace_full_session_messages_and_blocks(
+            add_timing("index.paste_spans", t0)
+            t0 = time.perf_counter()
+            _write_parent_links(
                 conn,
-                session,
+                session_id,
                 messages,
+                position_offset=position_offset,
                 duplicate_native_ids=duplicate_message_native_ids,
-                stage_timings_s=stage_timings_s,
-                stage_timing_prefix=stage_timing_prefix,
+            )
+            add_timing("index.parent_links", t0)
+            t0 = time.perf_counter()
+            _write_session_link(
+                conn,
+                session_id,
+                session,
+                branch_point_message_id=branch_point_message_id,
+                inheritance=lineage_inheritance,
+            )
+            add_timing("index.session_link", t0)
+            t0 = time.perf_counter()
+            event_position_offset = _next_session_event_position(conn, session_id)
+            provider_usage_baseline = (
+                _provider_usage_cumulative_baseline(conn, parent_session_id, branch_point_message_id)
+                if parent_session_id is not None
+                and branch_point_message_id is not None
+                and lineage_inheritance == "prefix-sharing"
+                else None
+            )
+            session_event_result = _write_session_events(
+                conn,
+                session_id,
+                messages,
+                session.session_events,
+                position_offset=position_offset,
+                event_position_offset=event_position_offset,
+                duplicate_native_ids=duplicate_message_native_ids,
+                provider_usage_baseline=provider_usage_baseline,
+                inherited_source_message_ids=inherited_source_message_ids,
+                ambiguous_source_provider_ids=event_duplicate_message_native_ids,
+            )
+            add_timing("index.session_events", t0)
+            t0 = time.perf_counter()
+            _write_working_dirs(conn, session_id, session.working_directories)
+            add_timing("index.working_dirs", t0)
+            t0 = time.perf_counter()
+            _write_repo_edges(conn, session_id, session)
+            add_timing("index.repo_edges", t0)
+            t0 = time.perf_counter()
+            _seed_session_model_usage_rows(
+                conn,
+                session_id,
+                session,
+                replace_existing_model_rows=not merge_append,
+                aggregate_message_tokens=not merge_append or _messages_have_token_counts(messages),
+            )
+            add_timing("index.model_usage_seed", t0)
+            if merge_append and session_event_result.wrote_provider_usage_events:
+                t0 = time.perf_counter()
+                _aggregate_appended_provider_usage_into_model_usage(
+                    conn,
+                    session_id,
+                    start_position=event_position_offset,
+                )
+                add_timing("index.provider_usage_rollup", t0)
+            elif not merge_append:
+                t0 = time.perf_counter()
+                _aggregate_provider_usage_into_model_usage(conn, session_id)
+                add_timing("index.provider_usage_rollup", t0)
+            t0 = time.perf_counter()
+            if merge_append:
+                _increment_session_counts_for_append(conn, session_id, session_counts)
+            else:
+                _refresh_session_counts(conn, session_id)
+            add_timing("index.session_counts", t0)
+            t0 = time.perf_counter()
+            _resolve_session_graph(
+                conn,
+                session_id,
+                native_id,
+                origin.value,
+                cache=signature_cache,
+                add_timing=add_timing,
+                bulk_fts=bulk_fts,
                 bulk_build=bulk_build,
             )
-            add_timing("index.full_replace", t0)
-        if merge_append:
-            t0 = time.perf_counter()
-            _write_messages(
-                conn,
-                session_id,
-                messages,
-                position_offset=position_offset,
-                duplicate_native_ids=duplicate_message_native_ids,
-            )
-            add_timing("index.messages", t0)
-            t0 = time.perf_counter()
-            _write_blocks(
-                conn,
-                session_id,
-                messages,
-                position_offset=position_offset,
-                duplicate_native_ids=duplicate_message_native_ids,
-            )
-            add_timing("index.blocks", t0)
+            add_timing("index.graph_resolve", t0)
             t0 = time.perf_counter()
             if not bulk_build:
-                refresh_action_pairs(conn, session_id)
-            add_timing("index.action_pairs", t0)
-            t0 = time.perf_counter()
-            _write_web_constructs(
-                conn,
-                session,
-                messages,
-                position_offset=position_offset,
-                duplicate_native_ids=duplicate_message_native_ids,
-                replace_session=False,
-            )
-            add_timing("index.web_constructs", t0)
-        t0 = time.perf_counter()
-        _write_attachments(
-            conn,
-            session_id,
-            messages,
-            session.attachments,
-            position_offset=position_offset,
-            duplicate_native_ids=duplicate_message_native_ids,
-            refresh_attachment_ids=stale_attachment_ids,
-            preacquired_blobs=preacquired_attachment_blobs,
-        )
-        add_timing("index.attachments", t0)
-        t0 = time.perf_counter()
-        _write_paste_spans(
-            conn,
-            session_id,
-            messages,
-            position_offset=position_offset,
-            duplicate_native_ids=duplicate_message_native_ids,
-        )
-        add_timing("index.paste_spans", t0)
-        t0 = time.perf_counter()
-        _write_parent_links(
-            conn,
-            session_id,
-            messages,
-            position_offset=position_offset,
-            duplicate_native_ids=duplicate_message_native_ids,
-        )
-        add_timing("index.parent_links", t0)
-        t0 = time.perf_counter()
-        _write_session_link(
-            conn,
-            session_id,
-            session,
-            branch_point_message_id=branch_point_message_id,
-            inheritance=lineage_inheritance,
-        )
-        add_timing("index.session_link", t0)
-        t0 = time.perf_counter()
-        event_position_offset = _next_session_event_position(conn, session_id)
-        provider_usage_baseline = (
-            _provider_usage_cumulative_baseline(conn, parent_session_id, branch_point_message_id)
-            if parent_session_id is not None
-            and branch_point_message_id is not None
-            and lineage_inheritance == "prefix-sharing"
-            else None
-        )
-        session_event_result = _write_session_events(
-            conn,
-            session_id,
-            messages,
-            session.session_events,
-            position_offset=position_offset,
-            event_position_offset=event_position_offset,
-            duplicate_native_ids=duplicate_message_native_ids,
-            provider_usage_baseline=provider_usage_baseline,
-            inherited_source_message_ids=inherited_source_message_ids,
-            ambiguous_source_provider_ids=event_duplicate_message_native_ids,
-        )
-        add_timing("index.session_events", t0)
-        t0 = time.perf_counter()
-        _write_working_dirs(conn, session_id, session.working_directories)
-        add_timing("index.working_dirs", t0)
-        t0 = time.perf_counter()
-        _write_repo_edges(conn, session_id, session)
-        add_timing("index.repo_edges", t0)
-        t0 = time.perf_counter()
-        _seed_session_model_usage_rows(
-            conn,
-            session_id,
-            session,
-            replace_existing_model_rows=not merge_append,
-            aggregate_message_tokens=not merge_append or _messages_have_token_counts(messages),
-        )
-        add_timing("index.model_usage_seed", t0)
-        if merge_append and session_event_result.wrote_provider_usage_events:
-            t0 = time.perf_counter()
-            _aggregate_appended_provider_usage_into_model_usage(
-                conn,
-                session_id,
-                start_position=event_position_offset,
-            )
-            add_timing("index.provider_usage_rollup", t0)
-        elif not merge_append:
-            t0 = time.perf_counter()
-            _aggregate_provider_usage_into_model_usage(conn, session_id)
-            add_timing("index.provider_usage_rollup", t0)
-        t0 = time.perf_counter()
-        if merge_append:
-            _increment_session_counts_for_append(conn, session_id, session_counts)
-        else:
-            _refresh_session_counts(conn, session_id)
-        add_timing("index.session_counts", t0)
-        t0 = time.perf_counter()
-        _resolve_session_graph(
-            conn,
-            session_id,
-            native_id,
-            origin.value,
-            cache=signature_cache,
-            add_timing=add_timing,
-            bulk_fts=bulk_fts,
-            bulk_build=bulk_build,
-        )
-        add_timing("index.graph_resolve", t0)
-        t0 = time.perf_counter()
-        if not bulk_build:
-            refresh_delegation_facts_for_session(conn, session_id)
-        add_timing("index.delegation_facts", t0)
-        conn.execute("DELETE FROM derived_refresh_guard WHERE guard_name = 'session-write'")
-        if bulk_build:
-            conn.execute(
-                "DELETE FROM derived_refresh_guard WHERE guard_name = ?",
-                (FTS_BULK_SESSION_WRITE_GUARD,),
-            )
-        if merge_append and session.ingest_flags:
-            t0 = time.perf_counter()
-            _write_ingest_flag_tags(conn, session_id, session.ingest_flags)
-            add_timing("index.ingest_flags", t0)
-        elif not merge_append:
-            t0 = time.perf_counter()
-            _replace_ingest_flag_tags(conn, session_id, session.ingest_flags)
-            add_timing("index.ingest_flags", t0)
+                refresh_delegation_facts_for_session(conn, session_id)
+            add_timing("index.delegation_facts", t0)
+            conn.execute("DELETE FROM derived_refresh_guard WHERE guard_name = 'session-write'")
+            if bulk_build:
+                conn.execute(
+                    "DELETE FROM derived_refresh_guard WHERE guard_name = ?",
+                    (FTS_BULK_SESSION_WRITE_GUARD,),
+                )
+            if merge_append and session.ingest_flags:
+                t0 = time.perf_counter()
+                _write_ingest_flag_tags(conn, session_id, session.ingest_flags)
+                add_timing("index.ingest_flags", t0)
+            elif not merge_append:
+                t0 = time.perf_counter()
+                _replace_ingest_flag_tags(conn, session_id, session.ingest_flags)
+                add_timing("index.ingest_flags", t0)
+    except sqlite3.IntegrityError as exc:
+        raise sqlite3.IntegrityError(
+            f"FOREIGN KEY constraint failed writing session_id={session_id!r} "
+            f"origin={origin.value!r} native_id={native_id!r}: {exc}"
+        ) from exc
     return session_id
 
 
@@ -1465,7 +1471,7 @@ def _write_messages(
             # columns with non-standard placeholders (like parent_message_id=NULL)
             yield (
                 session_id,
-                _sqlite_text(_effective_message_native_id(message, duplicate_native_ids)) or None,
+                _stored_message_native_id(message, duplicate_native_ids),
                 # parent_message_id: skipped (always NULL in VALUES)
                 position,
                 _enum_value(message.role),
@@ -4600,22 +4606,69 @@ def _message_id(
     variant_index = message.variant_index if message.variant_index is not None else 0
     return archive_message_id(
         session_id,
-        _effective_message_native_id(message, duplicate_native_ids),
+        _stored_message_native_id(message, duplicate_native_ids),
         position=position if message.position is not None else position_offset + fallback_position,
         variant_index=variant_index,
     )
 
 
 def _duplicate_message_native_ids(messages: Iterable[ParsedMessage]) -> frozenset[str]:
-    counts = Counter(message.provider_message_id for message in messages if message.provider_message_id)
+    """Native ids that collide once normalized the same way ``messages.native_id`` stores them.
+
+    Counts by the surrogate-substituted (``_sqlite_text``) form, not the raw
+    provider string, so two distinct raw ids that collapse onto the same
+    U+FFFD-substituted text are treated as ambiguous too -- otherwise the
+    ``messages`` UNIQUE generated ``message_id`` column would silently
+    resolve the collision via ``INSERT OR REPLACE`` (one message vanishes)
+    while Python-side code still believed both had distinct identities.
+    """
+    counts = Counter(
+        normalized for message in messages if (normalized := _sqlite_text(message.provider_message_id)) is not None
+    )
     return frozenset(native_id for native_id, count in counts.items() if count > 1)
 
 
 def _effective_message_native_id(message: ParsedMessage, duplicate_native_ids: frozenset[str]) -> str | None:
-    native_id = message.provider_message_id
+    """Return the surrogate-normalized native id, or ``None`` if ambiguous.
+
+    ``duplicate_native_ids`` (from ``_duplicate_message_native_ids``) is keyed
+    by the same surrogate-substituted form computed here, so membership is
+    always compared apples-to-apples.
+    """
+    native_id = _sqlite_text(message.provider_message_id)
     if native_id in duplicate_native_ids:
         return None
     return native_id
+
+
+def _stored_message_native_id(message: ParsedMessage, duplicate_native_ids: frozenset[str]) -> str | None:
+    """Return the exact value ``messages.native_id`` stores for this message.
+
+    This is the single source of truth for message identity (polylogue
+    rebuild ab5bad1f FK-failure fix): both the ``_write_messages`` INSERT and
+    ``_message_id`` (which feeds ``core.identity_law.message_id``, the
+    reference the generated ``messages.message_id`` column reimplements in
+    SQL) MUST route through this helper, or the two computations can diverge
+    and a later ``blocks`` insert can reference a ``message_id`` that was
+    never written.
+
+    Beyond duplicate suppression and surrogate substitution
+    (``_effective_message_native_id``), this maps an empty or
+    whitespace-only native id to ``None`` -- matching
+    ``identity_law.message_local_id``'s ``native_id.strip()`` truthiness
+    check, which falls back to the ``position.variant_index`` component --
+    and strips a non-empty native id, matching
+    ``identity_law._required_text``'s own ``.strip()``. Without this, a
+    provider-native id of ``"  "`` stores truthy in SQLite (survives the bare
+    ``or None`` the DB write used before this helper existed) while
+    ``identity_law`` strips it to falsy and falls back to the position/variant
+    id -- producing two different message ids for the same message.
+    """
+    native_id = _effective_message_native_id(message, duplicate_native_ids)
+    if native_id is None:
+        return None
+    stripped = native_id.strip()
+    return stripped or None
 
 
 def _block_type(block: ParsedContentBlock) -> BlockType:

--- a/tests/property/test_message_identity_normalization.py
+++ b/tests/property/test_message_identity_normalization.py
@@ -1,0 +1,113 @@
+"""Property test: the SQLite generated ``messages.message_id`` column and the
+Python-side identity computation that feeds ``blocks.message_id`` FK values
+must never diverge for any provider-native id shape.
+
+This is the actual law the v42 index rebuild (operation ab5bad1f) violated:
+``_write_messages`` stored a whitespace-only (or surrogate-bearing)
+``native_id`` as-is, while ``_message_id`` (used to compute the ``message_id``
+that ``_write_blocks`` inserts) independently re-derived identity via
+``core.identity_law``, which strips/normalizes differently. The two
+computations disagreed, so a ``blocks`` row referenced a ``message_id`` the
+``messages`` table never stored -- a FOREIGN KEY constraint failure that took
+down a 10-hour rebuild with zero context.
+
+``_stored_message_native_id`` (archive_tiers/write.py) is now the single
+source of truth both call sites route through; this sweep is the regression
+guard against the two ever splitting again.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import Provider
+from polylogue.pipeline.ids import session_content_hash
+from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
+from polylogue.storage.sqlite.archive_tiers.write import (
+    _duplicate_message_native_ids,
+    _message_id,
+    write_parsed_session_to_archive,
+)
+from polylogue.storage.sqlite.schema import _ensure_schema
+
+_SURROGATE_CHARS = st.characters(min_codepoint=0xD800, max_codepoint=0xDFFF)
+_ASCII_ID_CHARS = st.characters(min_codepoint=0x21, max_codepoint=0x7E)
+
+# Deliberately weighted toward pathological shapes (empty, whitespace-only,
+# padded, lone-surrogate, mixed) over a small alphabet so hypothesis finds
+# duplicate collisions (including post-normalization collisions) quickly,
+# rather than drowning in unique-string noise.
+_WEIRD_NATIVE_IDS = st.one_of(
+    st.just(""),
+    st.just(" "),
+    st.just("\t \n"),
+    st.just("  msg-padded  "),
+    st.text(alphabet=_ASCII_ID_CHARS, min_size=1, max_size=6),
+    st.text(alphabet=_SURROGATE_CHARS, min_size=1, max_size=3),
+    st.builds(
+        lambda prefix, surrogate: prefix + surrogate,
+        st.text(alphabet=_ASCII_ID_CHARS, min_size=1, max_size=3),
+        st.text(alphabet=_SURROGATE_CHARS, min_size=1, max_size=2),
+    ),
+)
+
+
+@settings(max_examples=40, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(st.lists(_WEIRD_NATIVE_IDS, min_size=1, max_size=6))
+def test_db_generated_message_id_matches_python_identity_law(native_ids: list[str]) -> None:
+    messages = [
+        ParsedMessage(
+            provider_message_id=native_id,
+            role=Role.USER,
+            text=f"body-{i}",
+            timestamp="2024-01-01T00:00:00Z",
+        )
+        for i, native_id in enumerate(native_ids)
+    ]
+    session = ParsedSession(
+        source_name=Provider.UNKNOWN,
+        provider_session_id="identity-law-sweep",
+        title="sweep",
+        created_at="2024-01-01T00:00:00Z",
+        updated_at="2024-01-01T00:00:00Z",
+        messages=messages,
+        attachments=[],
+    )
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        _ensure_schema(conn)
+        # Real write path, FK enforcement on (write_parsed_session_to_archive
+        # itself turns PRAGMA foreign_keys ON) -- a divergence here is exactly
+        # the FK failure that killed operation ab5bad1f.
+        session_id = write_parsed_session_to_archive(
+            conn,
+            session,
+            content_hash=session_content_hash(session),
+        )
+        rows = conn.execute(
+            "SELECT message_id FROM messages WHERE session_id = ? ORDER BY position, variant_index",
+            (session_id,),
+        ).fetchall()
+        assert len(rows) == len(messages)
+
+        duplicate_native_ids = _duplicate_message_native_ids(messages)
+        for fallback_position, message in enumerate(messages):
+            expected = _message_id(
+                session_id,
+                message,
+                fallback_position,
+                duplicate_native_ids=duplicate_native_ids,
+            )
+            actual = rows[fallback_position]["message_id"]
+            assert actual == expected, (
+                f"DB message_id {actual!r} != Python _message_id {expected!r} "
+                f"for provider_message_id={message.provider_message_id!r}"
+            )
+    finally:
+        conn.close()

--- a/tests/unit/pipeline/test_archive_write.py
+++ b/tests/unit/pipeline/test_archive_write.py
@@ -8,6 +8,7 @@ detection — rather than inspecting an intermediate counts envelope.
 
 from __future__ import annotations
 
+import sqlite3
 from collections.abc import AsyncIterator
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -338,6 +339,125 @@ async def test_preserves_empty_and_explicit_native_message_ids(async_backend: SQ
     native_ids = [row["native_id"] for row in rows]
     assert None in native_ids
     assert "msg-explicit" in native_ids
+
+
+async def test_whitespace_only_native_message_id_falls_back_and_writes_blocks(async_backend: SQLiteBackend) -> None:
+    """Regression for the v42 rebuild FK crash (operation ab5bad1f).
+
+    A whitespace-only provider-native id stores truthy under a bare
+    ``or None`` (so the old code path kept it), but ``identity_law``'s
+    ``native_id.strip()`` check falls back to the position/variant id. The
+    two disagreeing meant ``blocks`` referenced a ``message_id`` that
+    ``messages`` never stored -- a FOREIGN KEY constraint failure. This
+    write must now succeed, store ``native_id`` as NULL, and use the
+    position/variant fallback for both the DB row and any dependent block.
+    """
+    session = ParsedSession(
+        source_name=Provider.UNKNOWN,
+        provider_session_id="conv-whitespace",
+        title="Test",
+        created_at="2024-01-01T00:00:00Z",
+        updated_at="2024-01-01T00:00:00Z",
+        messages=[
+            ParsedMessage(provider_message_id="   ", role=Role.USER, text="Hello", timestamp="2024-01-01T00:00:00Z"),
+        ],
+        attachments=[],
+    )
+
+    session_id = await ingest_session(session, async_backend)
+
+    async with async_backend.connection() as conn:
+        message_row = await (
+            await conn.execute(
+                "SELECT message_id, native_id FROM messages WHERE session_id = ?",
+                (session_id,),
+            )
+        ).fetchone()
+        assert message_row is not None
+        block_count = await _count(
+            async_backend, "SELECT COUNT(*) FROM blocks WHERE message_id = ?", message_row["message_id"]
+        )
+
+    assert message_row["native_id"] is None
+    assert message_row["message_id"] == f"{session_id}:0.0"
+    assert block_count == 1
+
+
+async def test_surrogate_native_message_id_round_trips_consistently(async_backend: SQLiteBackend) -> None:
+    """A lone-surrogate provider-native id must normalize identically on both
+    the stored ``messages.native_id`` value and the generated ``message_id``
+    the dependent ``blocks`` row references (latent Divergence-2 FK-failure
+    class from the same rebuild crash)."""
+    raw_native_id = "\ud800tail"
+    session = ParsedSession(
+        source_name=Provider.UNKNOWN,
+        provider_session_id="conv-surrogate",
+        title="Test",
+        created_at="2024-01-01T00:00:00Z",
+        updated_at="2024-01-01T00:00:00Z",
+        messages=[
+            ParsedMessage(
+                provider_message_id=raw_native_id, role=Role.USER, text="Hello", timestamp="2024-01-01T00:00:00Z"
+            ),
+        ],
+        attachments=[],
+    )
+
+    session_id = await ingest_session(session, async_backend)
+
+    async with async_backend.connection() as conn:
+        message_row = await (
+            await conn.execute(
+                "SELECT message_id, native_id FROM messages WHERE session_id = ?",
+                (session_id,),
+            )
+        ).fetchone()
+        assert message_row is not None
+        block_count = await _count(
+            async_backend, "SELECT COUNT(*) FROM blocks WHERE message_id = ?", message_row["message_id"]
+        )
+
+    assert message_row["native_id"] == "�tail"
+    assert message_row["message_id"] == f"{session_id}:�tail"
+    assert block_count == 1
+
+
+def test_message_native_id_divergence_raises_fk_error_naming_the_session(
+    test_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The FK-context wrapper around the write path (polylogue rebuild
+    ab5bad1f) must chain a bare ``sqlite3.IntegrityError`` into one that names
+    the session, instead of the original bare 'FOREIGN KEY constraint
+    failed' a 10-hour rebuild died on with zero context.
+
+    Forces the divergence directly (bypassing the now-fixed single source of
+    truth) by making the Python-side identity computation disagree with
+    whatever ``messages.native_id`` actually stores, independent of whether
+    a real provider payload can still trigger it.
+    """
+    from polylogue.storage.sqlite.archive_tiers import write as archive_tier_write
+    from tests.infra.live_ingest import write_session_sync
+
+    monkeypatch.setattr(archive_tier_write, "archive_message_id", lambda *a, **k: "bogus-id-does-not-exist")
+
+    session = ParsedSession(
+        source_name=Provider.UNKNOWN,
+        provider_session_id="conv-forced-divergence",
+        title="Test",
+        created_at="2024-01-01T00:00:00Z",
+        updated_at="2024-01-01T00:00:00Z",
+        messages=[
+            ParsedMessage(provider_message_id="msg-1", role=Role.USER, text="Hello", timestamp="2024-01-01T00:00:00Z"),
+        ],
+        attachments=[],
+    )
+
+    with pytest.raises(sqlite3.IntegrityError) as exc_info:
+        write_session_sync(test_db, session)
+
+    message = str(exc_info.value)
+    assert "unknown-export:conv-forced-divergence" in message
+    assert "conv-forced-divergence" in message
 
 
 async def test_stores_typed_origin_on_session(async_backend: SQLiteBackend) -> None:


### PR DESCRIPTION
## Summary

Fixes a deterministic `sqlite3.IntegrityError` ("FOREIGN KEY constraint failed") in `_write_blocks` that killed the live v42 index rebuild (operation ab5bad1f) ~10 hours in, with zero context on which session caused it. Unifies message-native-id normalization into a single helper so the SQLite-generated `messages.message_id` column and the Python-side identity computation that feeds `blocks.message_id` can never disagree, and wraps the write path so a future divergence surfaces with session/logical-key context instead of a bare "FOREIGN KEY constraint failed".

## Problem

`_write_blocks` computes `blocks.message_id` via `_message_id()` (Python), which the SQLite `messages` table independently re-derives as a generated column (`session_id || ':' || COALESCE(native_id, position||'.'||variant_index)`). Before this change the two computations disagreed for pathological provider-native ids:

- **Whitespace-only ids** (e.g. `"  "`) stored truthy under `_write_messages`'s bare `_sqlite_text(...) or None`, but `identity_law.message_local_id`'s `native_id.strip()` check falls back to the position/variant component — two different message ids for the same message, so the `blocks` insert referenced a `message_id` the `messages` table never stored.
- **Non-empty but padded ids** (e.g. `"  msg-1  "`): `identity_law._required_text` strips the value, but the DB stored it raw/unstripped — a second, narrower divergence.
- **Lone-surrogate ids**: substituted to U+FFFD on the DB side (`_sqlite_text`) but not at all on the Python side, and duplicate-id detection counted *raw* ids, so two distinct raw ids that collapsed onto the same substituted form weren't flagged ambiguous — either an FK failure or a silent `INSERT OR REPLACE` row loss, depending on write order.

## Solution

- Added `_stored_message_native_id` (`polylogue/storage/sqlite/archive_tiers/write.py`) as the single source of truth: duplicate suppression → surrogate substitution (`_sqlite_text`) → the same strip/empty-to-`None` rule `identity_law` applies. Both `_write_messages`'s INSERT and `_message_id` (consumed by every message-id call site — blocks, web constructs, paste spans, parent links, session events, active-leaf resolution) now route through it.
- `_duplicate_message_native_ids` / `_effective_message_native_id` now operate on the same surrogate-substituted form, so two raw ids that collapse to the same normalized id are correctly treated as ambiguous (both fall back to position/variant) instead of silently colliding.
- **Twin-check**: grepped the async storage tree (`async_sqlite*.py`) for a second message/block writer — none exists; the daemon's "main process is the sole SQLite writer" invariant holds, so this single-writer fix is sufficient (no twin to patch).
- Wrapped `write_parsed_session_to_archive`'s write transaction so a `sqlite3.IntegrityError` is re-raised (chained via `from exc`, not swallowed) naming `session_id`/`origin`/`native_id`. Wrapped both `apply_raw_revision_replay` and `apply_raw_membership_classification` call sites in `backfill_historical_revision_evidence` (`polylogue/sources/revision_backfill.py`) with the `logical_key`, so this path's failures name what they were replaying.
- Did **not** change `core/identity_law.py` semantics — it remains the canonical law; the storage layer now conforms to it exactly.

## Verification

- `devtools test tests/unit/pipeline/test_archive_write.py tests/property/test_message_identity_normalization.py tests/unit/sources/test_revision_backfill.py` → 59 passed
- `devtools test tests/unit/storage/test_archive_tiers_write.py tests/property/test_write_path_state_machine.py tests/unit/storage/test_lineage_normalization.py tests/unit/storage/test_bulk_fts_prefix_reextract.py tests/unit/storage/test_bulk_build_lifecycle.py tests/unit/pipeline/test_resilience.py` → 133 passed
- `devtools test tests/unit/daemon/test_convergence_stages.py tests/unit/daemon/test_fts_readiness_fallback.py tests/unit/storage/test_repair.py tests/unit/storage/test_incremental_rebuild_equivalence.py` → 102 passed
- `devtools verify --quick` → ok (ruff format/check, mypy --strict, render all --check, topology/layering/closure-matrix/manifests/ci-workflows/docs — all green)
- **Anti-vacuity**: reverted the `_write_messages` fix locally and reran the new property test — it failed with the exact `sqlite3.IntegrityError: FOREIGN KEY constraint failed writing session_id='unknown-export:identity-law-sweep' ... native_id='identity-law-sweep'` signature on a whitespace-only native id (`native_ids=[' ']`), proving both the regression test and the new loud-failure-context wrapper actually exercise the bug; then restored the fix and reconfirmed green.
- Note: the task brief mentioned `tests/unit/storage/test_no_string_interpolated_sql.py` as a hardcoded-identifier allowlist gate to run explicitly if f-string SQL was touched — that file does not exist in this checkout (searched, no match), and this change adds no SQL-string interpolation (only Python exception-message f-strings), so it is not applicable here.

Unblocks resuming index rebuild operation ab5bad1f from its 31,882-session checkpoint.

Ref polylogue rebuild ab5bad1f.