### PR TITLE
fix(daemon): derive hook spool from the resolved archive root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,13 +264,16 @@ jobs:
         run: |
           # shellcheck disable=SC1091
           source .venv-hooks/bin/activate
-          sidecar="${RUNNER_TEMP}/polylogue-hooks-sidecar"
-          mkdir -p "${sidecar}"
-          export POLYLOGUE_HOOK_SIDECAR_DIR="${sidecar}"
-          # Supported event must succeed and write a JSONL record.
+          # polylogue-hooks derives its spool from the resolved archive root
+          # (polylogue-o7hx), not a separate hook-specific env override.
+          archive_root="${RUNNER_TEMP}/polylogue-hooks-archive"
+          export POLYLOGUE_ARCHIVE_ROOT="${archive_root}"
+          sidecar="${archive_root}/hooks"
+          # Supported event must succeed and write one pending spool envelope.
           printf '{"session_id":"abc123","model":"sonnet"}' | polylogue-hook SessionStart
-          test -f "${sidecar}/claude-code-abc123.jsonl"
-          grep -q '"event_type": "SessionStart"' "${sidecar}/claude-code-abc123.jsonl"
+          pending=$(find "${sidecar}/pending" -maxdepth 1 -type f -name '*.json')
+          test -n "${pending}"
+          grep -q '"event_type":"SessionStart"' "${pending}"
           # Unsupported event must exit non-zero without crashing the harness.
           if printf '{}' | polylogue-hook NotARealEvent; then
             echo "polylogue-hook should have rejected an unknown event type" >&2

--- a/contrib/polylogue-hook
+++ b/contrib/polylogue-hook
@@ -7,11 +7,22 @@
 # pending spool where the daemon persists and acknowledges it.
 #
 # Usage:
-#   polylogue-hook <event-type> [--provider claude-code|codex|hermes]
+#   polylogue-hook <event-type> [--provider claude-code|codex|hermes] [--sidecar-dir PATH]
+#
+# --sidecar-dir is the concrete resolved spool path baked in by
+# `polylogue hooks install` at install time (polylogue-o7hx): a hook
+# subprocess's environment cannot be trusted to carry
+# POLYLOGUE_ARCHIVE_ROOT (agent harnesses invoke hooks with their own,
+# possibly minimal, environment), so ambient env resolution alone is not
+# reliable here. Without --sidecar-dir, falls back to
+# ${POLYLOGUE_ARCHIVE_ROOT:+$POLYLOGUE_ARCHIVE_ROOT/hooks} or the XDG
+# default (byte-identical to the default archive root's hooks directory).
 #
 # Environment variables:
-#   POLYLOGUE_HOOK_SIDECAR_DIR  Override default sidecar directory
-#   POLYLOGUE_HOOK_PROVIDER      Force provider (claude-code | codex | hermes)
+#   POLYLOGUE_ARCHIVE_ROOT  Overrides the archive root (and therefore the
+#                           default sidecar directory) when --sidecar-dir
+#                           is not given
+#   POLYLOGUE_HOOK_PROVIDER Force provider (claude-code | codex | hermes)
 #
 # Supported events:
 #   Claude Code (16): SessionStart, Setup, UserPromptSubmit, PreToolUse,
@@ -52,18 +63,36 @@ fi
 
 shift
 PROVIDER_ARG=""
-if [ "${1:-}" = "--provider" ]; then
-    PROVIDER_ARG="${2:-}"
-    case "$PROVIDER_ARG" in
-        claude-code|codex|hermes) ;;
+SIDECAR_DIR_ARG=""
+while [ "$#" -gt 0 ]; do
+    case "${1:-}" in
+        --provider)
+            PROVIDER_ARG="${2:-}"
+            case "$PROVIDER_ARG" in
+                claude-code|codex|hermes) ;;
+                *)
+                    echo "polylogue-hook: --provider must be claude-code, codex, or hermes" >&2
+                    exit 2
+                    ;;
+            esac
+            shift 2
+            ;;
+        --sidecar-dir)
+            SIDECAR_DIR_ARG="${2:-}"
+            shift 2
+            ;;
         *)
-            echo "polylogue-hook: --provider must be claude-code, codex, or hermes" >&2
-            exit 2
+            shift
             ;;
     esac
-fi
+done
 
-SIDECAR_DIR="${POLYLOGUE_HOOK_SIDECAR_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/polylogue/hooks}"
+# --sidecar-dir is the concrete resolved path baked in by `polylogue hooks
+# install` at install time -- see the header comment (polylogue-o7hx). It
+# takes precedence over ambient env resolution, which cannot be trusted in
+# an agent harness's hook subprocess environment.
+SIDECAR_DIR="${SIDECAR_DIR_ARG:-${POLYLOGUE_ARCHIVE_ROOT:+$POLYLOGUE_ARCHIVE_ROOT/hooks}}"
+SIDECAR_DIR="${SIDECAR_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/polylogue/hooks}"
 
 # Save stdin payload to a temp file so python3 can read it.
 # The heredoc below consumes python's stdin for the script source.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -343,7 +343,7 @@ A few keys not shown in the full example above, with their TOML path:
 | `no_daemon` | `client.no_daemon` | Force direct in-process archive access, bypassing the daemon client even when one is reachable. |
 | `debug_timing` | `ui.debug_timing` | Emit per-stage timing diagnostics in CLI output. |
 | `hermes_root` | `sources.hermes.root` | Runtime root watched for Hermes state, snapshots, NeMo Relay ATIF/ATOF artifacts, and verification evidence. Defaults to `~/.hermes`. |
-| `hook_sidecar_dir` | `sources.hook_sidecar_dir` | Directory for hook-event sidecar files consumed by the Claude Code/Codex hook harness. |
+| `hook_sidecar_dir` | `sources.hook_sidecar_dir` | Directory for hook-event sidecar files consumed by the Claude Code/Codex hook harness. Defaults to `<archive_root>/hooks`, so a scratch/test `POLYLOGUE_ARCHIVE_ROOT` genuinely isolates its hook spool from the real one; set explicitly only if you need the spool somewhere other than the archive it belongs to. |
 | `backup_verify_tmpdir` | `maintenance.backup_verify_tmpdir` | Scratch directory for backup-restore verification; defaults to the system temp dir when unset. |
 | `antigravity_language_server` | `sources.antigravity_language_server` | Path to an Antigravity language-server binary, when parsing Antigravity sessions needs it. |
 | `ingest_commit_batch_messages` | `sources.ingest_commit_batch_messages` | Messages per commit batch during ingest (default 8000). |

--- a/docs/hermes-operators.md
+++ b/docs/hermes-operators.md
@@ -441,21 +441,16 @@ polylogue import tests/fixtures/hermes/atif/nemo_relay_atif_v1.7_real_redacted.j
 polylogue import tests/fixtures/hermes/atof/nemo_relay_atof_v0.1_real_redacted.jsonl --explain
 
 # 2. Full ingest + query, watching only the throwaway archive's own inbox
-#    (never the real ~/.claude, ~/.codex, ~/.hermes, or the hook spool):
+#    (never the real ~/.claude, ~/.codex, or ~/.hermes; the hook spool is
+#    scoped to $POLYLOGUE_ARCHIVE_ROOT/hooks automatically):
 polylogued run --no-browser-capture --no-source-catchup \
   --root "$POLYLOGUE_ARCHIVE_ROOT/inbox" &
 polylogue import tests/fixtures/hermes/atif/nemo_relay_atif_v1.7_real_redacted.json
 polylogue --origin hermes-session find "hermes" then read --all --format json
 ```
 
-Two safety notes learned the hard way while writing this guide:
+One safety note learned the hard way while writing this guide:
 
-- `--root <archive>/inbox` scopes the *watcher* to your throwaway inbox, but
-  the daemon's hook-spool drain is a **separate**, always-on component keyed
-  off `$XDG_DATA_HOME` (`~/.local/share` by default), not the archive root or
-  `--root`. If you also want to isolate that for a smoke test, override
-  `XDG_DATA_HOME` (or the config's `hook_sidecar_dir`) to the same throwaway
-  location before starting the daemon.
 - Never run `polylogued run` with source catch-up enabled (the default)
   against a throwaway archive on a machine with a real `~/.claude`,
   `~/.codex`, or `~/.hermes` — catch-up scans and ingests every configured

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -87,7 +87,7 @@ agent on stdin. The wrapper fields (`event_type`, `session_id`, `timestamp`,
 ## Sidecar Directory Layout
 
 ```
-~/.local/share/polylogue/hooks/         # Default (XDG_DATA_HOME/polylogue/hooks)
+<archive_root>/hooks/                   # Default archive root: ~/.local/share/polylogue
 ├── pending/
 │   └── <event-id>.json                 # Atomic producer envelopes
 ├── acknowledged/
@@ -96,33 +96,52 @@ agent on stdin. The wrapper fields (`event_type`, `session_id`, `timestamp`,
 └── codex-<session-id>.jsonl            # Legacy Codex journal
 ```
 
-The daemon creates and watches the pending spool directory on startup, so the
-first hook event after a cold start is captured automatically. The documented
-spool-root override applies to both the producer and daemon.
+The hooks sidecar directory always lives under the resolved archive root
+(`POLYLOGUE_ARCHIVE_ROOT`, default `~/.local/share/polylogue`), the same as
+every other archive-scoped path — a scratch/test archive root gets its own
+hook spool, never the real one. The daemon creates and watches the pending
+spool directory on startup, so the first hook event after a cold start is
+captured automatically.
+
+`polylogue hooks install` resolves the current archive root's hooks
+directory once, at install time, and bakes the concrete absolute path into
+each rendered `polylogue-hook ... --sidecar-dir <path>` command (see
+Installation below). This is deliberate: a hook subprocess's environment
+cannot be trusted to carry `POLYLOGUE_ARCHIVE_ROOT` (agent harnesses invoke
+hooks with their own, possibly minimal, environment), so re-resolving it
+ambiently at every hook invocation is not reliable. Re-run `polylogue hooks
+install` after changing the archive root to rebake the path.
 
 ## Configuration
 
 ### polylogue.toml
 
+Only set this if the hook spool genuinely needs to live somewhere other than
+`<archive_root>/hooks`; the default already tracks the archive root:
+
 ```toml
-[hooks]
-enabled = true
-sidecar_dir = "/home/user/.local/share/polylogue/hooks"
+[sources]
+hook_sidecar_dir = "/home/user/.local/share/polylogue/hooks"
 ```
 
 ### Environment Variables
 
 | Variable | Description |
 |----------|-------------|
-| `POLYLOGUE_HOOK_SIDECAR_DIR` | Override the shared producer/daemon spool root |
+| `POLYLOGUE_ARCHIVE_ROOT` | Overrides the archive root, and therefore the hook spool (`<archive_root>/hooks`) along with every other archive-scoped path |
 | `POLYLOGUE_HOOK_PROVIDER` | Force provider detection to `claude-code` or `codex` |
+
+There is no separate `POLYLOGUE_HOOK_SIDECAR_DIR` producer/daemon override
+env var: it was a manual escape hatch that had to be remembered on top of
+`POLYLOGUE_ARCHIVE_ROOT` and repeatedly wasn't (polylogue-o7hx). Use the
+`hook_sidecar_dir` config key below only if the hook spool genuinely needs
+to live somewhere other than `<archive_root>/hooks`.
 
 ### PolylogueConfig Properties
 
 | Property | Type | Default |
 |----------|------|---------|
-| `hooks_enabled` | `bool` | `False` |
-| `hooks_sidecar_dir` | `str` | `~/.local/share/polylogue/hooks` |
+| `hook_sidecar_dir` | `str` | `<archive_root>/hooks` |
 
 ## Installation
 
@@ -196,35 +215,35 @@ polylogue hooks uninstall --harness codex
         "hooks": [
           {
             "type": "command",
-            "command": "polylogue-hook SessionStart --provider claude-code",
+            "command": "polylogue-hook SessionStart --provider claude-code --sidecar-dir <archive_root>/hooks",
             "timeout": 5
           }
         ]
       }
     ],
     "UserPromptSubmit": [
-      {"hooks": [{"type": "command", "command": "polylogue-hook UserPromptSubmit --provider claude-code", "timeout": 5}]}
+      {"hooks": [{"type": "command", "command": "polylogue-hook UserPromptSubmit --provider claude-code --sidecar-dir <archive_root>/hooks", "timeout": 5}]}
     ],
     "PreToolUse": [
-      {"hooks": [{"type": "command", "command": "polylogue-hook PreToolUse --provider claude-code", "timeout": 5}]}
+      {"hooks": [{"type": "command", "command": "polylogue-hook PreToolUse --provider claude-code --sidecar-dir <archive_root>/hooks", "timeout": 5}]}
     ],
     "PostToolUse": [
-      {"hooks": [{"type": "command", "command": "polylogue-hook PostToolUse --provider claude-code", "timeout": 5}]}
+      {"hooks": [{"type": "command", "command": "polylogue-hook PostToolUse --provider claude-code --sidecar-dir <archive_root>/hooks", "timeout": 5}]}
     ],
     "PostToolUseFailure": [
-      {"hooks": [{"type": "command", "command": "polylogue-hook PostToolUseFailure --provider claude-code", "timeout": 5}]}
+      {"hooks": [{"type": "command", "command": "polylogue-hook PostToolUseFailure --provider claude-code --sidecar-dir <archive_root>/hooks", "timeout": 5}]}
     ],
     "PermissionRequest": [
-      {"hooks": [{"type": "command", "command": "polylogue-hook PermissionRequest --provider claude-code", "timeout": 5}]}
+      {"hooks": [{"type": "command", "command": "polylogue-hook PermissionRequest --provider claude-code --sidecar-dir <archive_root>/hooks", "timeout": 5}]}
     ],
     "PermissionDenied": [
-      {"hooks": [{"type": "command", "command": "polylogue-hook PermissionDenied --provider claude-code", "timeout": 5}]}
+      {"hooks": [{"type": "command", "command": "polylogue-hook PermissionDenied --provider claude-code --sidecar-dir <archive_root>/hooks", "timeout": 5}]}
     ],
     "Notification": [
-      {"hooks": [{"type": "command", "command": "polylogue-hook Notification --provider claude-code", "timeout": 5}]}
+      {"hooks": [{"type": "command", "command": "polylogue-hook Notification --provider claude-code --sidecar-dir <archive_root>/hooks", "timeout": 5}]}
     ],
     "Stop": [
-      {"hooks": [{"type": "command", "command": "polylogue-hook Stop --provider claude-code", "timeout": 5}]}
+      {"hooks": [{"type": "command", "command": "polylogue-hook Stop --provider claude-code --sidecar-dir <archive_root>/hooks", "timeout": 5}]}
     ]
   }
 }
@@ -250,7 +269,7 @@ same event/matcher-group/handler structure:
         "hooks": [
           {
             "type": "command",
-            "command": "polylogue-hook SessionStart --provider codex",
+            "command": "polylogue-hook SessionStart --provider codex --sidecar-dir <archive_root>/hooks",
             "timeout": 5
           }
         ]

--- a/packaging/polylogue-hooks/src/polylogue_hooks/cli.py
+++ b/packaging/polylogue-hooks/src/polylogue_hooks/cli.py
@@ -95,12 +95,32 @@ _MAX_TRANSCRIPT_LIKE_FIELD_CHARS = 2000
 
 
 def _default_sidecar_dir() -> Path:
-    override = os.environ.get("POLYLOGUE_HOOK_SIDECAR_DIR")
-    if override:
-        return Path(override)
+    """Resolve the sidecar dir when the command carries no ``--sidecar-dir``.
+
+    Falls back through ``POLYLOGUE_ARCHIVE_ROOT`` (mirroring the main
+    package's ``archive_root()``/``hooks_sidecar_dir()``) rather than a
+    separate, hook-specific env override: any environment that isolates a
+    scratch/test daemon must already set ``POLYLOGUE_ARCHIVE_ROOT``, so this
+    package needs no additional knob to stay isolated (polylogue-o7hx).
+    Prefer ``--sidecar-dir`` (baked in by ``polylogue hooks install``) when
+    the invoking environment cannot be trusted to carry that var at all.
+    """
+    archive_root_override = os.environ.get("POLYLOGUE_ARCHIVE_ROOT", "").strip()
+    if archive_root_override:
+        return Path(archive_root_override).expanduser() / "hooks"
     xdg_data_home = os.environ.get("XDG_DATA_HOME")
     base = Path(xdg_data_home) if xdg_data_home else Path.home() / ".local" / "share"
     return base / "polylogue" / "hooks"
+
+
+def _sidecar_dir_arg(args: list[str]) -> Path | None:
+    """Parse an explicit ``--sidecar-dir PATH`` baked in at install time."""
+    if "--sidecar-dir" not in args:
+        return None
+    index = args.index("--sidecar-dir")
+    if index + 1 >= len(args):
+        return None
+    return Path(args[index + 1]).expanduser()
 
 
 def _detect_provider(payload: dict[str, object], *, event_type: str | None = None) -> str | None:
@@ -141,10 +161,14 @@ def _extract_session_id(payload: dict[str, object]) -> str | None:
 def main(argv: list[str] | None = None) -> int:
     args = list(sys.argv[1:] if argv is None else argv)
     if not args:
-        print("Usage: polylogue-hook <event-type> [--provider claude-code|codex|hermes]", file=sys.stderr)
+        print(
+            "Usage: polylogue-hook <event-type> [--provider claude-code|codex|hermes] [--sidecar-dir PATH]",
+            file=sys.stderr,
+        )
         return 1
 
     event_type = args[0]
+    sidecar_dir_arg = _sidecar_dir_arg(args[1:])
     provider_arg: str | None = None
     if "--provider" in args[1:]:
         index = args.index("--provider")
@@ -208,7 +232,7 @@ def main(argv: list[str] | None = None) -> int:
         "payload": payload,
     }
 
-    sidecar_dir = _default_sidecar_dir()
+    sidecar_dir = sidecar_dir_arg or _default_sidecar_dir()
     pending_dir = sidecar_dir / "pending"
     pending_dir.mkdir(parents=True, exist_ok=True)
     _atomic_json_write(pending_dir / f"{record['event_id']}.json", record)

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -1365,7 +1365,13 @@ def _default_config_values(bootstrap: _BootstrapPaths | None = None) -> dict[str
         "hermes_root": "",
         "drive_credentials_path": str(captured.config_home / "polylogue-credentials.json"),
         "drive_token_path": str(captured.state_home / "token.json"),
-        "hook_sidecar_dir": str(captured.data_home / "hooks"),
+        # Blank (like browser_capture_spool_path above), not a hardcoded
+        # ``data_home / "hooks"``: resolve_runtime_config()'s archive-derived
+        # fallback only takes effect when this default is genuinely absent
+        # (polylogue-o7hx). A non-blank default here would silently override
+        # the archive-derived path for every archive root, defeating scratch
+        # archive isolation of the hook spool.
+        "hook_sidecar_dir": "",
         "backup_verify_tmpdir": None,
         "antigravity_language_server": None,
         "ingest_commit_batch_messages": 8000,
@@ -1680,7 +1686,11 @@ def resolve_runtime_config(
     hook_sidecar = _resolved_runtime_path(
         settings.hook_sidecar_dir,
         bootstrap=bootstrap,
-        fallback=bootstrap.data_home / "hooks",
+        # Mirrors browser_spool above (polylogue-o7hx): must fall back to the
+        # resolved archive root, not the XDG data home, or a scratch/test
+        # POLYLOGUE_ARCHIVE_ROOT fails to isolate its hook spool from the real
+        # one.
+        fallback=archive / "hooks",
     )
     drive_credentials = _resolved_runtime_path(
         settings.drive_credentials_path,

--- a/polylogue/hooks/__init__.py
+++ b/polylogue/hooks/__init__.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import difflib
 import json
 import os
+import shlex
 import shutil
 import sqlite3
 import sys
@@ -330,9 +331,21 @@ def _wired_events_from_hooks(hooks: dict[str, object]) -> set[str]:
 
 
 def _managed_handler(harness: HookHarness, event: str) -> dict[str, object]:
+    """Build the installed handler, baking the concrete resolved spool path.
+
+    A hook subprocess's environment cannot be trusted to carry
+    ``POLYLOGUE_ARCHIVE_ROOT`` (agent harnesses invoke hooks with their own,
+    possibly minimal, environment), so the path this daemon is actually
+    draining is resolved once here, at install time, and baked into the
+    rendered command rather than re-resolved ambiently at every hook
+    invocation (polylogue-o7hx).
+    """
+    from polylogue.paths import hooks_sidecar_dir
+
+    sidecar_dir = shlex.quote(str(hooks_sidecar_dir()))
     return {
         "type": "command",
-        "command": f"polylogue-hook {event} --provider {harness}",
+        "command": f"polylogue-hook {event} --provider {harness} --sidecar-dir {sidecar_dir}",
         "timeout": 5,
     }
 
@@ -751,12 +764,14 @@ def flow_states() -> tuple[str, ...]:
 
 
 def _default_sidecar_dir() -> Path:
-    override = os.environ.get("POLYLOGUE_HOOK_SIDECAR_DIR")
-    if override:
-        return Path(override)
-    xdg_data_home = os.environ.get("XDG_DATA_HOME")
-    base = Path(xdg_data_home) if xdg_data_home else Path.home() / ".local" / "share"
-    return base / "polylogue" / "hooks"
+    """Resolve the sidecar dir when the command carries no ``--sidecar-dir``.
+
+    Derives from the resolved archive root (polylogue-o7hx), same as every
+    other hook-spool consumer -- no separate ambient env override lives here.
+    """
+    from polylogue.paths import hooks_sidecar_dir
+
+    return hooks_sidecar_dir()
 
 
 def _detect_hook_provider(payload: dict[str, object]) -> HookHarness | None:
@@ -788,18 +803,36 @@ def _hook_provider_arg(args: list[str]) -> HookHarness | None:
     return None
 
 
+def _hook_sidecar_dir_arg(args: list[str]) -> Path | None:
+    """Parse an explicit ``--sidecar-dir PATH`` baked in by ``polylogue hooks install``.
+
+    A hook subprocess's environment cannot be trusted to carry
+    ``POLYLOGUE_ARCHIVE_ROOT`` (agent harnesses run hooks with their own,
+    possibly minimal, environment) -- so the installer bakes the concrete
+    resolved spool path into the rendered command instead of relying on
+    runtime env resolution (polylogue-o7hx).
+    """
+    if "--sidecar-dir" not in args:
+        return None
+    index = args.index("--sidecar-dir")
+    if index + 1 >= len(args):
+        return None
+    return Path(args[index + 1]).expanduser()
+
+
 def hook_main(argv: list[str] | None = None) -> int:
     """Record one harness hook event without loading the archive runtime."""
 
     args = list(sys.argv[1:] if argv is None else argv)
     if not args:
-        print("Usage: polylogue-hook <event-type> [--provider claude-code|codex]", file=sys.stderr)
+        print("Usage: polylogue-hook <event-type> [--provider claude-code|codex] [--sidecar-dir PATH]", file=sys.stderr)
         return 1
     event_type = args[0]
     provider_arg = _hook_provider_arg(args[1:])
     if "--provider" in args[1:] and provider_arg is None:
         print("polylogue-hook: --provider must be claude-code or codex", file=sys.stderr)
         return 2
+    sidecar_dir_arg = _hook_sidecar_dir_arg(args[1:])
     allowed_events = (
         EVENTS_BY_HARNESS[provider_arg]
         if provider_arg is not None
@@ -843,7 +876,7 @@ def hook_main(argv: list[str] | None = None) -> int:
     }
     from polylogue.sources.hooks import enqueue_hook_event
 
-    sidecar_dir = _default_sidecar_dir()
+    sidecar_dir = sidecar_dir_arg or _default_sidecar_dir()
     sidecar_dir.mkdir(parents=True, exist_ok=True)
     enqueue_hook_event(
         event_type=event_type,

--- a/polylogue/paths/_roots.py
+++ b/polylogue/paths/_roots.py
@@ -217,12 +217,21 @@ def blob_store_root() -> Path:
 
 
 def hooks_sidecar_dir() -> Path:
-    """Directory where hook scripts drop session event data.
+    """Directory where hook scripts drop session event data, scoped under the archive root.
 
     AI coding agent hooks (Claude Code, Codex) write structured JSONL
     event records here. The daemon watcher picks them up for ingestion.
+
+    Must track ``archive_root()`` (not ``data_home()``), mirroring
+    ``browser_capture_spool_root()``: a daemon started against a scratch or
+    test ``POLYLOGUE_ARCHIVE_ROOT`` must resolve to that scratch archive's own
+    hook spool, never the real global one (polylogue-o7hx -- a daemon pointed
+    at a scratch archive drained the real spool four separate times before
+    this was fixed). For the default production configuration the archive
+    root IS ``data_home()``, so this resolves to the exact same path as
+    before -- zero migration for real deployments.
     """
-    return data_home() / "hooks"
+    return archive_root() / "hooks"
 
 
 def drive_cache_path() -> Path:

--- a/polylogue/sources/hooks.py
+++ b/polylogue/sources/hooks.py
@@ -93,13 +93,15 @@ def acknowledged_hook_spool_dir(root: Path | None = None) -> Path:
 def hook_spool_root() -> Path:
     """Resolve the hook spool root shared by producer and daemon.
 
-    ``POLYLOGUE_HOOK_SIDECAR_DIR`` predates the durable spool and remains the
-    documented operator override.  Applying it here, rather than only in the
-    command-hook entrypoint, keeps the daemon on the same receipt path.
+    Derives from ``hooks_sidecar_dir()``, which is itself scoped under the
+    resolved archive root (polylogue-o7hx). There is no separate ad hoc env
+    override at this layer: ``POLYLOGUE_ARCHIVE_ROOT`` is the one knob that
+    already has to be set to isolate a scratch/test daemon, so a second,
+    hook-specific override was a manual escape hatch operators had to
+    remember on top of it -- and repeatedly didn't.
     """
 
-    override = os.environ.get("POLYLOGUE_HOOK_SIDECAR_DIR", "").strip()
-    return Path(override).expanduser() if override else hooks_sidecar_dir()
+    return hooks_sidecar_dir()
 
 
 def enqueue_hook_event(

--- a/polylogue/sources/live/hook_paste_enrichment.py
+++ b/polylogue/sources/live/hook_paste_enrichment.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from polylogue.archive.message.paste_detection import has_paste_indicator
 from polylogue.core.enums import PasteBoundary
 from polylogue.logging import get_logger
-from polylogue.paths import hooks_sidecar_dir
 from polylogue.storage.table_existence import table_exists as _table_exists
 
 logger = get_logger(__name__)
@@ -166,9 +165,15 @@ def _enrich_archive_paste_from_hooks(index_db: Path, events: list[dict[str, obje
 def enrich_paste_from_hooks(db_path: Path) -> int:
     """Scan hook sidecar files and update has_paste on matching messages.
 
+    ``db_path`` is the caller's ops.db path (``archive_root / "ops.db"``), so
+    the hook sidecar directory is derived from its parent rather than from an
+    ambient global (polylogue-o7hx): this enrichment always inspects the
+    archive it was actually called for, never a different one that happens to
+    be the process-wide default.
+
     Returns the number of messages updated.
     """
-    events = _iter_hook_paste_events(hooks_sidecar_dir())
+    events = _iter_hook_paste_events(db_path.parent / "hooks")
     if not events:
         return 0
 

--- a/tests/unit/cli/test_hooks.py
+++ b/tests/unit/cli/test_hooks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -82,7 +83,9 @@ def test_install_recommended_is_idempotent_and_preserves_unrelated_hooks(isolate
     assert document["hooks"]["PreToolUse"][0]["hooks"] == [{"type": "command", "command": "existing-policy"}]
     commands = _polylogue_commands(document)
     assert len(commands) == 5
-    assert "polylogue-hook SessionStart --provider claude-code" in commands
+    assert any(
+        command.startswith("polylogue-hook SessionStart --provider claude-code --sidecar-dir ") for command in commands
+    )
 
     before_second = target.read_bytes()
     second = runner.invoke(
@@ -95,6 +98,26 @@ def test_install_recommended_is_idempotent_and_preserves_unrelated_hooks(isolate
     assert second_payload["changed"] is False
     assert second_payload["written"] is False
     assert target.read_bytes() == before_second
+
+
+def test_install_bakes_the_current_archive_roots_resolved_spool_path(isolated_hook_home: Path) -> None:
+    """(polylogue-o7hx) ``polylogue hooks install`` resolves ``<archive_root>/hooks``
+    once, at install time, and bakes the concrete absolute path into the
+    rendered command -- a hook subprocess's environment cannot be trusted to
+    carry ``POLYLOGUE_ARCHIVE_ROOT`` at invocation time, so the installer is
+    the one place this gets resolved."""
+
+    archive_root = Path(os.environ["POLYLOGUE_ARCHIVE_ROOT"])
+    result = CliRunner().invoke(
+        cli,
+        ["--plain", "hooks", "install", "--harness", "claude-code", "--events", "SessionStart", "--json"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    document = json.loads(settings_path("claude-code").read_text(encoding="utf-8"))
+    commands = _polylogue_commands(document)
+    assert commands == [f"polylogue-hook SessionStart --provider claude-code --sidecar-dir {archive_root / 'hooks'}"]
 
 
 def test_install_dry_run_does_not_create_settings(isolated_hook_home: Path) -> None:
@@ -164,7 +187,11 @@ def test_hook_runtime_provider_override_records_codex_event(
 
     monkeypatch.setattr("sys.stdin", StringIO('{"session_id":"session-1","model":"gpt-test"}'))
     assert hook_main(["SessionStart", "--provider", "codex"]) == 0
-    sidecar = isolated_hook_home.parent / "data" / "polylogue" / "hooks" / "codex-session-1.jsonl"
+    # hook_main() derives its sidecar dir from the resolved archive root
+    # (polylogue-o7hx), which isolated_hook_home points at tmp_path/"archive",
+    # not XDG_DATA_HOME.
+    archive_root = Path(os.environ["POLYLOGUE_ARCHIVE_ROOT"])
+    sidecar = archive_root / "hooks" / "codex-session-1.jsonl"
     record = json.loads(sidecar.read_text(encoding="utf-8"))
     assert record["provider"] == "codex"
     assert record["event_type"] == "SessionStart"

--- a/tests/unit/sources/test_hook_paste_enrichment.py
+++ b/tests/unit/sources/test_hook_paste_enrichment.py
@@ -12,10 +12,7 @@ from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
 
-def test_hook_paste_enrichment_updates_archive_messages(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_hook_paste_enrichment_updates_archive_messages(tmp_path: Path) -> None:
     index_db = tmp_path / "index.db"
     initialize_archive_database(index_db, ArchiveTier.INDEX)
     hook_time_ms = int(datetime(2026, 5, 7, 12, 0, tzinfo=UTC).timestamp() * 1000)
@@ -52,8 +49,6 @@ def test_hook_paste_enrichment_updates_archive_messages(
         + "\n",
         encoding="utf-8",
     )
-    monkeypatch.setattr(hook_paste_enrichment, "hooks_sidecar_dir", lambda: hooks_dir)
-
     updated = hook_paste_enrichment.enrich_paste_from_hooks(tmp_path / "ops.db")
 
     assert updated == 1
@@ -78,3 +73,39 @@ def test_hook_paste_enrichment_updates_archive_messages(
             """
         ).fetchone()
         assert span == (0, 0, "hash_only")
+
+
+def test_hook_paste_enrichment_never_reads_a_sibling_archives_hooks_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(polylogue-o7hx) The hooks dir is derived from ``db_path.parent``, never
+    from an ambient global -- a different archive's hook events (including
+    one that happens to sit at the real XDG hooks location) must never leak
+    into this archive's paste enrichment."""
+
+    real_archive = tmp_path / "real-archive"
+    real_archive.mkdir()
+    real_hooks = real_archive / "hooks"
+    real_hooks.mkdir()
+    (real_hooks / "decoy.jsonl").write_text(
+        json.dumps(
+            {
+                "event_type": "UserPromptSubmit",
+                "timestamp": "2026-05-07T12:00:00Z",
+                "payload": {"session_id": "codex-native-1", "prompt": "Inspect [Pasted text #1]"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    # An ambient env override, if the implementation still read one, would
+    # point at ``real_hooks`` here -- it must have no effect.
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(real_archive))
+
+    scratch_ops_db = tmp_path / "scratch-archive" / "ops.db"
+    scratch_ops_db.parent.mkdir()
+
+    updated = hook_paste_enrichment.enrich_paste_from_hooks(scratch_ops_db)
+
+    assert updated == 0

--- a/tests/unit/sources/test_hook_spool.py
+++ b/tests/unit/sources/test_hook_spool.py
@@ -121,16 +121,20 @@ def test_hook_spool_replay_is_idempotent_after_interrupted_acknowledgement(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_live_watcher_drains_the_configured_hook_spool_root(
+async def test_live_watcher_drains_the_hook_spool_scoped_to_the_archive_root(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The documented producer override reaches the daemon's real drain path."""
+    """A daemon pointed at a scratch archive root drains that archive's own
+    hook spool, never the real global one (polylogue-o7hx: a daemon started
+    against a scratch archive drained the real spool four times before the
+    spool path was made to derive from the resolved archive root)."""
 
-    spool_root = tmp_path / "configured-hooks"
+    scratch_archive_root = tmp_path / "scratch-archive-root"
+    spool_root = scratch_archive_root / "hooks"
     archive_root = tmp_path / "archive"
     archive_root.mkdir()
-    monkeypatch.setenv("POLYLOGUE_HOOK_SIDECAR_DIR", str(spool_root))
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(scratch_archive_root))
     event_path = enqueue_hook_event(
         event_id="configured-root-event",
         provider="claude-code",
@@ -151,6 +155,34 @@ async def test_live_watcher_drains_the_configured_hook_spool_root(
     assert event_path.exists() is False
     with sqlite3.connect(archive_root / "source.db") as conn:
         assert conn.execute("SELECT session_native_id FROM raw_hook_events").fetchone() == ("session-1",)
+
+
+def test_hooks_sidecar_dir_isolates_a_scratch_archive_root_with_no_xdg_leakage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(polylogue-o7hx) A scratch ``POLYLOGUE_ARCHIVE_ROOT`` must resolve its
+    own hook spool, and a real-looking event sitting in the XDG-default
+    location must never be visible through the scratch-scoped resolution."""
+
+    from polylogue.paths import hooks_sidecar_dir
+
+    xdg_data_home = tmp_path / "xdg-data-home"
+    monkeypatch.setenv("XDG_DATA_HOME", str(xdg_data_home))
+    real_looking_spool = xdg_data_home / "polylogue" / "hooks" / "pending"
+    real_looking_spool.mkdir(parents=True)
+    (real_looking_spool / "real-event.json").write_text("{}", encoding="utf-8")
+
+    scratch_archive_root = tmp_path / "scratch-archive-root"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(scratch_archive_root))
+
+    resolved = hooks_sidecar_dir()
+
+    assert resolved == scratch_archive_root / "hooks"
+    assert list(pending_hook_spool_dir(resolved).glob("*.json")) == []
+    # The XDG-default spool, seeded above to look like a real event, must
+    # remain untouched and undiscovered by the scratch-scoped resolution.
+    assert (real_looking_spool / "real-event.json").exists()
 
 
 @pytest.mark.asyncio
@@ -231,14 +263,14 @@ def test_hook_entrypoint_spools_and_materializes_configured_runtime_events(
     provider: str,
     session_id: str,
 ) -> None:
-    """The installed hook command reaches the durable source-tier receipt path."""
+    """The installed hook command (which bakes ``--sidecar-dir``, polylogue-o7hx)
+    reaches the durable source-tier receipt path."""
 
     spool_root = tmp_path / "hooks"
     archive_root = tmp_path / "archive"
-    monkeypatch.setenv("POLYLOGUE_HOOK_SIDECAR_DIR", str(spool_root))
     monkeypatch.setattr("sys.stdin", StringIO(f'{{"session_id":"{session_id}","tool_name":"exec"}}'))
 
-    assert hook_main(["PostToolUse", "--provider", provider]) == 0
+    assert hook_main(["PostToolUse", "--provider", provider, "--sidecar-dir", str(spool_root)]) == 0
 
     pending = list(pending_hook_spool_dir(spool_root).glob("*.json"))
     assert len(pending) == 1
@@ -249,6 +281,43 @@ def test_hook_entrypoint_spools_and_materializes_configured_runtime_events(
     assert drain_hook_event_spool(archive_root, root=spool_root).acknowledged == 1
     with sqlite3.connect(archive_root / "source.db") as conn:
         assert conn.execute("SELECT session_native_id FROM raw_hook_events").fetchone() == (session_id,)
+
+
+@pytest.mark.parametrize(
+    ("command", "extra_env"),
+    [
+        (
+            (sys.executable, "-m", "polylogue_hooks.cli", "PostToolUse", "--provider", "claude-code"),
+            {"PYTHONPATH": str(Path("packaging/polylogue-hooks/src").resolve())},
+        ),
+        ((str(Path("contrib/polylogue-hook").resolve()), "PostToolUse", "--provider", "codex"), {}),
+    ],
+)
+def test_published_hook_adapters_fall_back_to_the_archive_root_env_var(
+    tmp_path: Path,
+    command: tuple[str, ...],
+    extra_env: dict[str, str],
+) -> None:
+    """Without an explicit ``--sidecar-dir``, the standalone adapters still
+    derive their spool from ``POLYLOGUE_ARCHIVE_ROOT`` -- the one env var
+    already required to isolate a scratch daemon, not a separate hook-specific
+    knob (polylogue-o7hx)."""
+
+    scratch_archive_root = tmp_path / "scratch-archive-root"
+    environment = os.environ | extra_env | {"TMPDIR": "/realm/tmp", "POLYLOGUE_ARCHIVE_ROOT": str(scratch_archive_root)}
+    result = subprocess.run(
+        command,
+        input='{"session_id":"external-session","tool_name":"exec"}',
+        text=True,
+        env=environment,
+        check=False,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    spool_root = scratch_archive_root / "hooks"
+    pending = list(pending_hook_spool_dir(spool_root).glob("*.json"))
+    assert len(pending) == 1
 
 
 @pytest.mark.parametrize(
@@ -271,13 +340,14 @@ def test_published_hook_adapters_spool_then_materialize(
     command: tuple[str, ...],
     extra_env: dict[str, str],
 ) -> None:
-    """Every documented non-bundled executable (incl. the Hermes prototype) reaches the durable receipt path."""
+    """Every documented non-bundled executable (incl. the Hermes prototype) reaches the durable receipt path
+    via ``--sidecar-dir``, the concrete resolved path an installer bakes in at install time (polylogue-o7hx)."""
 
     spool_root = tmp_path / "hooks"
     archive_root = tmp_path / "archive"
-    environment = os.environ | extra_env | {"POLYLOGUE_HOOK_SIDECAR_DIR": str(spool_root), "TMPDIR": "/realm/tmp"}
+    environment = os.environ | extra_env | {"TMPDIR": "/realm/tmp"}
     result = subprocess.run(
-        command,
+        (*command, "--sidecar-dir", str(spool_root)),
         input='{"session_id":"external-session","tool_name":"exec"}',
         text=True,
         env=environment,
@@ -311,10 +381,10 @@ def test_published_hook_adapters_refuse_duplicated_transcript_payloads(
     """The standalone (non-bundled) producers enforce the same no-transcript-duplication rule."""
 
     spool_root = tmp_path / "hooks"
-    environment = os.environ | extra_env | {"POLYLOGUE_HOOK_SIDECAR_DIR": str(spool_root), "TMPDIR": "/realm/tmp"}
+    environment = os.environ | extra_env | {"TMPDIR": "/realm/tmp"}
     oversized_payload = json.dumps({"session_id": "external-session", "text": "x" * 5000})
     result = subprocess.run(
-        command,
+        (*command, "--sidecar-dir", str(spool_root)),
         input=oversized_payload,
         text=True,
         env=environment,


### PR DESCRIPTION
## Summary

The hook-event sidecar/spool directory now derives from the resolved
archive root (`<archive_root>/hooks`) instead of a bare `XDG_DATA_HOME`
path, so a daemon pointed at a scratch or test archive genuinely isolates
its hook spool from the real one.

## Problem

`hooks_sidecar_dir()` (`polylogue/paths/_roots.py`) resolved
`data_home()/"hooks"` — pure XDG, independent of the archive root. Every
consumer that reaches it ambiently (the daemon watcher's
`default_sources()`, `sources/hooks.py`'s drain path, `hook_paste_enrichment.py`)
therefore drained the *one* real global spool regardless of `--root` or
`POLYLOGUE_ARCHIVE_ROOT`. A daemon started against a scratch archive moved
real personal hook events pending → acknowledged into a throwaway archive.
This has bitten the operator 4+ times (most recently: a lane drained 6262
real hook events into a scratch archive). The `POLYLOGUE_HOOK_SIDECAR_DIR`
env override was a second, hook-specific knob operators had to remember on
top of `POLYLOGUE_ARCHIVE_ROOT`, and repeatedly didn't — exactly the
manual-escape-hatch pattern the automagic doctrine purges.

A second, independent instance of the same bug existed in
`config.py`'s `resolve_runtime_config()`: its `hook_sidecar_dir` captured
default was a hardcoded `data_home()/"hooks"` string (unlike
`browser_capture_spool_path`'s blank default), so the archive-derived
fallback there could never actually trigger.

## Solution

- `hooks_sidecar_dir()` now resolves `archive_root() / "hooks"`, mirroring
  `browser_capture_spool_root()`. Byte-identical to the previous default
  for the default production archive root (archive root IS `data_home()`
  when `POLYLOGUE_ARCHIVE_ROOT` is unset) — zero migration. This single
  fix cascades to every ambient consumer: `sources/hooks.py`'s
  `hook_spool_root()`, the daemon watcher's
  `default_sources()`/`pending_hook_spool_dir()` chain, and
  `cli/commands/init.py`'s path table.
- `config.py`: fixed the `hook_sidecar_dir` captured default to blank
  (matching `browser_capture_spool_path`) and the `resolve_runtime_config()`
  fallback to `archive / "hooks"`, so the archive-derived fallback there
  actually takes effect.
- `hook_paste_enrichment.enrich_paste_from_hooks()` now derives the hooks
  dir from its own `db_path.parent` instead of an ambient global, so it
  always inspects the archive it was actually called for.
- Removed the ad hoc `POLYLOGUE_HOOK_SIDECAR_DIR` `os.environ.get()` reads
  scattered across `sources/hooks.py` and `hooks/__init__.py`. The
  config-integrated `hook_sidecar_dir` key in `config.py` remains for the
  rare case the spool genuinely needs to live somewhere other than
  `<archive_root>/hooks`.
- Hook **writer** scripts (`contrib/polylogue-hook`, `packaging/polylogue-hooks`,
  and the bundled package's `hook_main`) run inside agent hook subprocesses
  whose environment cannot be trusted to carry `POLYLOGUE_ARCHIVE_ROOT`.
  `polylogue hooks install` now resolves the current spool path once, at
  install time, and bakes it into each rendered command via a new
  `--sidecar-dir PATH` flag (parsed by all three writer implementations).
  Without that flag, the standalone writers fall back through
  `POLYLOGUE_ARCHIVE_ROOT` — not a separate knob — to the XDG default.
- `docs/hooks.md` and `docs/configuration.md` updated to match (including
  fixing a pre-existing stale `polylogue.toml` example that referenced a
  nonexistent `[hooks]`/`enabled` shape instead of the real
  `sources.hook_sidecar_dir` TOML path). The `docs/hermes-operators.md`
  "Try it yourself" warning that hook-spool drain ignores `--root`/the
  archive root is removed now that it's no longer true.
- `.github/workflows/release.yml`'s `polylogue-hooks` smoke test updated to
  the new env var, and (a latent, unrelated drift this touched while
  editing the same lines) fixed to assert against the pending spool file
  the standalone package actually writes, rather than a legacy per-session
  journal it never wrote.

## Verification

- `devtools test tests/unit/sources/test_hook_spool.py tests/unit/sources/test_hook_paste_enrichment.py tests/unit/cli/test_hooks.py tests/unit/daemon/test_hook_liveness.py tests/unit/core/test_paths.py` → `66 passed`
- `devtools verify --quick` → all 16 steps `ok` (ruff format/check, mypy
  --strict, `render all --check`, topology/layering/closure-matrix,
  manifests, ci-workflows, doc-commands, docs-coverage,
  test-infra-currency, test-clock-hygiene, pytest-timeout-overrides,
  degrade-loudly)
- Manual: exercised `contrib/polylogue-hook` directly with both the
  `POLYLOGUE_ARCHIVE_ROOT` fallback and an explicit `--sidecar-dir`;
  confirmed pending envelopes land under the expected archive-scoped path
  in each case, and that a seeded decoy event at the real XDG location is
  never touched by a scratch-scoped resolution (also covered by new unit
  tests: `test_hooks_sidecar_dir_isolates_a_scratch_archive_root_with_no_xdg_leakage`,
  `test_hook_paste_enrichment_never_reads_a_sibling_archives_hooks_dir`,
  `test_install_bakes_the_current_archive_roots_resolved_spool_path`).
- Also ran a full `devtools verify --seed-testmon --skip-slow` as a
  diagnostic; it surfaced ~100 unrelated failures across modules my diff
  never touches, root-caused to a missing optional `msgspec` dependency in
  this worktree's `.venv` (confirmed by re-running
  `tests/unit/core/test_json.py -k msgspec` in isolation, same error) —
  pre-existing environment drift in this specific worktree checkout, not
  caused by this change.

Ref polylogue-o7hx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explicit `--sidecar-dir` option for hook commands.
  * Hook spool storage now automatically follows the configured archive location.
  * Installed hook commands include their resolved spool path for consistent event handling.

* **Bug Fixes**
  * Improved isolation between archives, preventing hook events from leaking across archive locations.
  * Updated hook event processing to reliably use the correct archive-specific spool.

* **Documentation**
  * Clarified hook spool defaults, archive-root behavior, installation requirements, and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->