### PR TITLE
fix(sources): prevent sibling-variant continuation coordinate collisions

### DIFF
--- a/polylogue/sources/parsers/claude/common.py
+++ b/polylogue/sources/parsers/claude/common.py
@@ -473,6 +473,102 @@ def _sibling_sort_key(evidence: _ClaudeMessageEvidence) -> tuple[int, int, float
     )
 
 
+def _resolve_variant_index(
+    start_id: str,
+    evidence_by_id: Mapping[str, _ClaudeMessageEvidence],
+    branch_index_by_id: Mapping[str, int],
+    resolved: dict[str, int],
+) -> int:
+    """Resolve a tree-mode message's variant index, composing rank-0 inheritance.
+
+    A message with an explicit provider variant index, or a nonzero rank among
+    its siblings, keeps that value -- those are real branch points. A rank-0
+    ("primary") child is just the continuation of whichever variant its parent
+    belongs to, so it inherits the parent's resolved variant index rather than
+    resetting to 0. This composes through chains of rank-0 descendants (a
+    rank-0 child of a rank-0 child of a variant sibling still inherits that
+    variant), walking up until an explicit/nonzero variant, the root, or a
+    cycle is found.
+
+    Without this, two sibling variants at the same depth each contribute a
+    rank-0 continuation at the *same* (position, variant_index=0) coordinate --
+    the exact collision shape that silently drops a message via
+    `INSERT OR REPLACE` on the messages table's
+    ``PRIMARY KEY(session_id, position, variant_index)``.
+
+    Cycles degrade to variant 0 (mirrors `_lineage_depths`' cycle handling)
+    instead of looping forever; the final uniqueness pass below is the safety
+    net if that ever produces a residual collision anyway.
+    """
+    chain: list[str] = []
+    cursor: str | None = start_id
+    seen: set[str] = set()
+    value = 0
+    while cursor is not None:
+        if cursor in resolved:
+            value = resolved[cursor]
+            break
+        if cursor in seen or cursor not in evidence_by_id:
+            value = 0
+            break
+        seen.add(cursor)
+        evidence = evidence_by_id[cursor]
+        if evidence.explicit_variant_index is not None:
+            value = evidence.explicit_variant_index
+            resolved[cursor] = value
+            break
+        rank = branch_index_by_id.get(cursor, 0)
+        if rank != 0:
+            value = rank
+            resolved[cursor] = value
+            break
+        chain.append(cursor)
+        cursor = evidence.parent_message_provider_id
+    for message_id in chain:
+        resolved[message_id] = value
+    return value
+
+
+def _deduplicate_variant_collisions(
+    emitted: list[_ClaudeMessageEvidence],
+    position_by_id: Mapping[str, int],
+    variant_index_by_id: dict[str, int],
+) -> None:
+    """Guarantee (position, variant_index) uniqueness per session -- the safety net.
+
+    Parser-level variant assignment (explicit provider values, sibling rank, or
+    rank-0 inheritance) is a heuristic and cannot be proven collision-free for
+    every exotic input tree shape. No two emitted messages may share
+    (position, variant_index): the messages table is unique on exactly that
+    pair, so a silent collision here becomes a silently dropped message
+    downstream (`INSERT OR REPLACE`) whose blocks then orphan against a
+    foreign key that no longer resolves.
+
+    Mutates ``variant_index_by_id`` in place. Positions with no collision are
+    left untouched. A colliding position group is fully renumbered in
+    order_key order (current variant index, then timestamp, then provider
+    message id) so the result is deterministic regardless of which heuristic
+    produced the original assignment.
+    """
+    by_position: dict[int, list[_ClaudeMessageEvidence]] = defaultdict(list)
+    for evidence in emitted:
+        by_position[position_by_id[evidence.provider_message_id]].append(evidence)
+    for group in by_position.values():
+        variants = [variant_index_by_id[evidence.provider_message_id] for evidence in group]
+        if len(set(variants)) == len(variants):
+            continue
+        ordered = sorted(
+            group,
+            key=lambda evidence: (
+                variant_index_by_id[evidence.provider_message_id],
+                _timestamp_sort_value(evidence.timestamp),
+                evidence.provider_message_id,
+            ),
+        )
+        for rank, evidence in enumerate(ordered):
+            variant_index_by_id[evidence.provider_message_id] = rank
+
+
 def _merge_attachment_rows(attachments: list[ParsedAttachment]) -> list[ParsedAttachment]:
     merged: dict[str, ParsedAttachment] = {}
     for candidate in attachments:
@@ -742,14 +838,30 @@ def normalize_chat_messages(
                     evidence.explicit_branch_index if evidence.explicit_branch_index is not None else rank
                 )
 
-    variant_index_by_id = {
-        evidence.provider_message_id: (
-            evidence.explicit_variant_index
-            if evidence.explicit_variant_index is not None
-            else branch_index_by_id.get(evidence.provider_message_id, 0)
-        )
-        for evidence in emitted
-    }
+    if flat_mode:
+        variant_index_by_id = {
+            evidence.provider_message_id: (
+                evidence.explicit_variant_index
+                if evidence.explicit_variant_index is not None
+                else branch_index_by_id.get(evidence.provider_message_id, 0)
+            )
+            for evidence in emitted
+        }
+    else:
+        resolved_variants: dict[str, int] = {}
+        variant_index_by_id = {
+            evidence.provider_message_id: _resolve_variant_index(
+                evidence.provider_message_id,
+                evidence_by_id,
+                branch_index_by_id,
+                resolved_variants,
+            )
+            for evidence in emitted
+        }
+    # Safety net regardless of mode: no input tree shape may leave two emitted
+    # messages sharing (position, variant_index) -- see
+    # `_deduplicate_variant_collisions` docstring.
+    _deduplicate_variant_collisions(emitted, position_by_id, variant_index_by_id)
     order_key_by_id = {
         evidence.provider_message_id: (
             position_by_id[evidence.provider_message_id],

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -14,7 +14,7 @@ import json
 import re
 import sqlite3
 import time
-from collections import Counter
+from collections import Counter, defaultdict
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, replace
@@ -434,6 +434,7 @@ def write_parsed_session_to_archive(
                     (session_id,),
                 ).fetchone()
                 position_offset = int(row[0] or 0) if row is not None else 0
+                _assert_unique_message_coordinates(session_id, messages, position_offset=position_offset)
                 conn.execute(
                     """
                     UPDATE messages
@@ -1776,6 +1777,7 @@ def _replace_full_session_messages_and_blocks(
 
     origin = origin_from_provider(session.source_name)
     session_id = archive_session_id(origin.value, session.provider_session_id)
+    _assert_unique_message_coordinates(session_id, messages)
     t0 = time.perf_counter()
     use_scoped_fts_rebuild = not bulk_build and message_fts_triggers_present_sync(conn)
     add_timing("fts_probe", t0)
@@ -3571,6 +3573,60 @@ def _normalized_messages(messages: list[ParsedMessage]) -> list[ParsedMessage]:
         message.model_copy(update={"is_active_leaf": message.provider_message_id == active_leaf_message_id})
         for message in messages
     ]
+
+
+def _duplicate_message_coordinates(
+    messages: Sequence[ParsedMessage],
+    *,
+    position_offset: int = 0,
+) -> dict[tuple[int, int], list[str]]:
+    """Group native message ids by effective (position, variant_index).
+
+    Mirrors the exact position/variant_index fallback ``_write_messages``
+    uses to build INSERT rows (``position_offset + (message.position or
+    fallback_position)``, ``message.variant_index or 0``), so this reports
+    precisely the coordinate pairs that would collide against the messages
+    table's ``PRIMARY KEY(session_id, position, variant_index)``. Only
+    coordinates shared by two or more messages are returned.
+    """
+    coordinates: dict[tuple[int, int], list[str]] = defaultdict(list)
+    for fallback_position, message in enumerate(messages):
+        position = position_offset + (message.position if message.position is not None else fallback_position)
+        variant_index = message.variant_index if message.variant_index is not None else 0
+        coordinates[(position, variant_index)].append(message.provider_message_id or "<no native id>")
+    return {key: native_ids for key, native_ids in coordinates.items() if len(native_ids) > 1}
+
+
+def _assert_unique_message_coordinates(
+    session_id: str,
+    messages: Sequence[ParsedMessage],
+    *,
+    position_offset: int = 0,
+) -> None:
+    """Fail loudly, before any row is written, on a (position, variant_index) collision.
+
+    ``messages`` is unique on exactly ``(session_id, position, variant_index)``
+    (see ``storage/sqlite/archive_tiers/index.py``). If a parser bug assigns
+    that same pair to two distinct native message ids, ``INSERT OR REPLACE``
+    silently drops one message row while ``_write_blocks`` still computes
+    distinct Python-side ``message_id`` values for both -- the dropped
+    message's blocks then fail their foreign key days later, far from the
+    actual bug. Raising here turns that into an immediate, loud error naming
+    the session and the exact colliding native ids instead.
+    """
+    duplicates = _duplicate_message_coordinates(messages, position_offset=position_offset)
+    if not duplicates:
+        return
+    detail = "; ".join(
+        f"(position={position}, variant_index={variant_index}) <- {native_ids!r}"
+        for (position, variant_index), native_ids in sorted(duplicates.items())
+    )
+    raise ValueError(
+        f"duplicate message coordinates in session {session_id!r}: {detail}. "
+        "A parser assigned the same (position, variant_index) pair to distinct "
+        "native message ids; writing this batch would silently drop one "
+        "message (and orphan its blocks) via INSERT OR REPLACE."
+    )
 
 
 def _message_blocks(message: ParsedMessage) -> Sequence[ParsedContentBlock]:

--- a/tests/property/test_claude_variant_position_uniqueness.py
+++ b/tests/property/test_claude_variant_position_uniqueness.py
@@ -1,0 +1,68 @@
+"""Property test: Claude tree-mode message normalization must never assign
+two emitted messages the same (position, variant_index) pair.
+
+``messages`` is unique on exactly ``(session_id, position, variant_index)``
+(see ``storage/sqlite/archive_tiers/index.py``). Before the fix, a message
+that was the sole ("rank-0") child of its parent always reset to
+``variant_index=0`` regardless of which sibling-variant world its parent
+belonged to. Two sibling variants at the same depth, each with their own
+rank-0 continuation, then produced two distinct native messages at the exact
+same ``(position, variant_index)`` coordinate -- silently dropping one via
+``INSERT OR REPLACE`` on write (operation ab5bad1f / claude-ai-export:d24081f5).
+
+This sweep generates arbitrary parent/branch/depth tree shapes (including
+nested branch-under-branch chains) and asserts the parser's own output
+satisfies the uniqueness invariant the messages table's primary key demands,
+independent of which heuristic (rank-0 inheritance vs. the final
+deduplication safety net) ends up producing it.
+"""
+
+from __future__ import annotations
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from polylogue.sources.parsers.claude.common import normalize_chat_messages
+
+
+@st.composite
+def _message_trees(draw: st.DrawFn) -> list[object]:
+    node_count = draw(st.integers(min_value=2, max_value=25))
+    nodes: list[object] = []
+    for index in range(node_count):
+        parent_id: str | None = None
+        if index > 0:
+            # Any earlier node may be the parent -- this is what produces
+            # arbitrary branching fan-out and depth, including nested
+            # branch-under-branch shapes (a variant's variant).
+            parent_index = draw(st.integers(min_value=0, max_value=index - 1))
+            parent_id = f"n{parent_index}"
+        role = draw(st.sampled_from(["human", "assistant"]))
+        # Occasionally omit the timestamp to exercise the None-timestamp sort
+        # path (_timestamp_sort_value treats it as +inf) alongside the normal
+        # monotonic-by-creation-order path.
+        has_timestamp = draw(st.booleans())
+        node: dict[str, object] = {
+            "uuid": f"n{index}",
+            "sender": role,
+            "text": f"body-{index}",
+            "parent_message_uuid": parent_id,
+        }
+        if has_timestamp:
+            node["created_at"] = f"2026-01-01T00:{index // 60:02d}:{index % 60:02d}Z"
+        nodes.append(node)
+    return nodes
+
+
+@settings(max_examples=200, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(_message_trees())
+def test_variant_position_pairs_are_unique_for_any_tree_shape(chat_messages: list[object]) -> None:
+    normalized = normalize_chat_messages(chat_messages)
+    coordinates = [(message.position, message.variant_index) for message in normalized.messages]
+    assert len(coordinates) == len(set(coordinates)), (
+        f"duplicate (position, variant_index) pairs for tree shape: {coordinates}"
+    )
+    # Every emitted message must have a non-negative position and variant --
+    # the invariant is meaningless if either coordinate went missing.
+    assert all(message.position is not None and message.position >= 0 for message in normalized.messages)
+    assert all(message.variant_index is not None and message.variant_index >= 0 for message in normalized.messages)

--- a/tests/unit/pipeline/test_archive_write.py
+++ b/tests/unit/pipeline/test_archive_write.py
@@ -17,6 +17,7 @@ import pytest
 
 from polylogue.archive.message.roles import Role
 from polylogue.core.enums import BlockType, Provider
+from polylogue.pipeline.ids import session_content_hash
 from polylogue.pipeline.services.validation import ValidationService
 from polylogue.schemas import ValidationResult
 from polylogue.sources.parsers.base import (
@@ -26,6 +27,7 @@ from polylogue.sources.parsers.base import (
     ParsedSession,
     ParsedSessionEvent,
 )
+from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
 from tests.infra.live_ingest import ingest_session
 
@@ -458,6 +460,131 @@ def test_message_native_id_divergence_raises_fk_error_naming_the_session(
     message = str(exc_info.value)
     assert "unknown-export:conv-forced-divergence" in message
     assert "conv-forced-divergence" in message
+
+
+def test_duplicate_message_coordinates_raise_loud_value_error(test_db: Path) -> None:
+    """A parser bug that assigns the same (position, variant_index) pair to
+    two distinct messages must fail loudly with a ``ValueError`` naming the
+    session and both colliding native ids -- not reach ``INSERT OR REPLACE``
+    and silently drop one message row while its blocks are still written
+    against its own (now-orphaned) message_id.
+
+    This is the writer's own safety net (independent of the parser-level
+    fix): see ``tests/property/test_claude_variant_position_uniqueness.py``
+    and ``tests/unit/sources/test_claude_web_normalization.py`` for the
+    parser-level regression coverage that the sibling-variant continuation
+    collision (operation ab5bad1f / claude-ai-export:d24081f5) can no longer
+    happen through the real Claude parser; this test proves that even a
+    hand-built ``ParsedSession`` violating the invariant is caught before any
+    row is written, rather than manifesting minutes later as a bare
+    ``sqlite3.IntegrityError``/FK mystery.
+    """
+    from tests.infra.live_ingest import write_session_sync
+
+    session = ParsedSession(
+        source_name=Provider.UNKNOWN,
+        provider_session_id="conv-forced-coordinate-collision",
+        title="Test",
+        created_at="2024-01-01T00:00:00Z",
+        updated_at="2024-01-01T00:00:00Z",
+        messages=[
+            ParsedMessage(
+                provider_message_id="continuation-a",
+                role=Role.USER,
+                text="a",
+                timestamp="2024-01-01T00:00:00Z",
+                position=5,
+                variant_index=0,
+            ),
+            ParsedMessage(
+                provider_message_id="continuation-b",
+                role=Role.USER,
+                text="b",
+                timestamp="2024-01-01T00:00:01Z",
+                position=5,
+                variant_index=0,
+            ),
+        ],
+        attachments=[],
+    )
+
+    with pytest.raises(ValueError) as exc_info:
+        write_session_sync(test_db, session)
+
+    assert not isinstance(exc_info.value, sqlite3.IntegrityError)
+    message = str(exc_info.value)
+    assert "conv-forced-coordinate-collision" in message
+    assert "continuation-a" in message
+    assert "continuation-b" in message
+    assert "position=5" in message
+    assert "variant_index=0" in message
+
+
+def test_merge_append_duplicate_message_coordinates_also_guarded(test_db: Path) -> None:
+    """The merge-append write path (incremental extend of a live session)
+    must guard the same invariant as the full-replace path, using the
+    position_offset it computes from the existing archive state.
+    """
+    from tests.infra.live_ingest import write_session_sync
+
+    base_session = ParsedSession(
+        source_name=Provider.UNKNOWN,
+        provider_session_id="conv-merge-append-collision",
+        title="Test",
+        created_at="2024-01-01T00:00:00Z",
+        updated_at="2024-01-01T00:00:00Z",
+        messages=[
+            ParsedMessage(provider_message_id="m0", role=Role.USER, text="hi", timestamp="2024-01-01T00:00:00Z"),
+        ],
+        attachments=[],
+    )
+    write_session_sync(test_db, base_session)
+
+    # Both appended messages request the same relative position=0; the
+    # merge-append path offsets by the existing max position + 1, so both
+    # land on the exact same absolute (position, variant_index) coordinate.
+    appended_session = base_session.model_copy(
+        update={
+            "messages": [
+                ParsedMessage(
+                    provider_message_id="continuation-a",
+                    role=Role.USER,
+                    text="a",
+                    timestamp="2024-01-01T00:00:01Z",
+                    position=0,
+                    variant_index=0,
+                ),
+                ParsedMessage(
+                    provider_message_id="continuation-b",
+                    role=Role.USER,
+                    text="b",
+                    timestamp="2024-01-01T00:00:02Z",
+                    position=0,
+                    variant_index=0,
+                ),
+            ]
+        }
+    )
+
+    conn = sqlite3.connect(str(test_db))
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        with pytest.raises(ValueError) as exc_info:
+            write_parsed_session_to_archive(
+                conn,
+                appended_session,
+                content_hash=session_content_hash(appended_session),
+                merge_append=True,
+            )
+    finally:
+        conn.close()
+
+    assert not isinstance(exc_info.value, sqlite3.IntegrityError)
+    message = str(exc_info.value)
+    assert "conv-merge-append-collision" in message
+    assert "continuation-a" in message
+    assert "continuation-b" in message
 
 
 async def test_stores_typed_origin_on_session(async_backend: SQLiteBackend) -> None:

--- a/tests/unit/sources/test_claude_web_normalization.py
+++ b/tests/unit/sources/test_claude_web_normalization.py
@@ -585,7 +585,10 @@ def test_claude_normalization_survives_archive_write_and_hydration(
     assert tuple(by_native) == ("u1", "a-old", "a-new", "u2")
     assert by_native["a-old"][1:5] == (1, 0, 0, 0)
     assert by_native["a-new"][1:5] == (1, 1, 1, 0)
-    assert by_native["u2"][1:5] == (2, 0, 1, 1)
+    # u2 is a-new's only child: it inherits a-new's variant_index (1) rather
+    # than resetting to 0 -- the rank-0-inheritance fix for the sibling-variant
+    # continuation collision (see test_claude_sibling_variant_continuations_*).
+    assert by_native["u2"][1:5] == (2, 1, 1, 1)
     assert str(by_native["a-new"][5]).endswith(":u1")
     assert by_native["a-new"][6] == "completed"
     assert by_native["a-new"][7] == 1
@@ -595,3 +598,160 @@ def test_claude_normalization_survives_archive_write_and_hydration(
     attachment_only = next(message for message in hydrated.messages if str(message.id).endswith(":u2"))
     assert attachment_only.text is None
     assert [attachment.name for attachment in attachment_only.attachments] == ["evidence.json"]
+
+
+def _variant_position_collision_payload() -> dict[str, Any]:
+    """Regression fixture: two sibling variants whose continuations collide.
+
+    A 4-message linear chain (root -> chain-1 -> chain-2 -> branch-point)
+    ends at a message with two ASSISTANT sibling variants (a regenerate),
+    each of which has exactly one child continuation. Before the fix, a
+    rank-0 (only) child always reset to variant_index=0 regardless of which
+    variant its parent belonged to, so ``continuation-a`` and
+    ``continuation-b`` both landed at (position=5, variant_index=0) --
+    colliding on the messages table's
+    ``PRIMARY KEY(session_id, position, variant_index)`` and silently
+    dropping one of them via ``INSERT OR REPLACE`` while its blocks were
+    still written against its own (now-orphaned) message_id.
+    """
+    messages = [
+        {"uuid": "root", "sender": "human", "text": "root prompt", "created_at": "2026-07-10T10:00:00Z"},
+        {
+            "uuid": "chain-1",
+            "sender": "assistant",
+            "text": "chain response 1",
+            "parent_message_uuid": "root",
+            "created_at": "2026-07-10T10:00:01Z",
+        },
+        {
+            "uuid": "chain-2",
+            "sender": "human",
+            "text": "chain follow-up 2",
+            "parent_message_uuid": "chain-1",
+            "created_at": "2026-07-10T10:00:02Z",
+        },
+        {
+            "uuid": "branch-point",
+            "sender": "human",
+            "text": "prompt that gets regenerated",
+            "parent_message_uuid": "chain-2",
+            "created_at": "2026-07-10T10:00:03Z",
+        },
+        {
+            "uuid": "variant-a",
+            "sender": "assistant",
+            "text": "first regenerated response",
+            "parent_message_uuid": "branch-point",
+            "created_at": "2026-07-10T10:00:04Z",
+        },
+        {
+            "uuid": "variant-b",
+            "sender": "assistant",
+            "text": "second regenerated response",
+            "parent_message_uuid": "branch-point",
+            "created_at": "2026-07-10T10:00:05Z",
+        },
+        {
+            "uuid": "continuation-a",
+            "sender": "human",
+            "text": "follow-up inside variant a's world",
+            "parent_message_uuid": "variant-a",
+            "created_at": "2026-07-10T10:00:06Z",
+        },
+        {
+            "uuid": "continuation-b",
+            "sender": "human",
+            "text": "follow-up inside variant b's world",
+            "parent_message_uuid": "variant-b",
+            "created_at": "2026-07-10T10:00:07Z",
+        },
+    ]
+    return {
+        "uuid": "claude-variant-collision",
+        "name": "Variant continuation collision regression",
+        "created_at": "2026-07-10T10:00:00Z",
+        "updated_at": "2026-07-10T10:00:07Z",
+        "current_leaf_message_uuid": "continuation-b",
+        "chat_messages": messages,
+    }
+
+
+def test_claude_sibling_variant_continuations_get_distinct_coordinates() -> None:
+    """Mutation witness: reverting rank-0 inheritance reintroduces the (position, variant_index) collision."""
+    parsed = _parse_real_route(_variant_position_collision_payload())
+    by_id = {message.provider_message_id: message for message in parsed.messages}
+
+    assert by_id["variant-a"].position == by_id["variant-b"].position == 4
+    assert {by_id["variant-a"].variant_index, by_id["variant-b"].variant_index} == {0, 1}
+
+    assert by_id["continuation-a"].position == by_id["continuation-b"].position == 5
+    # The actual regression: both continuations must inherit their own
+    # parent's variant, not independently reset to 0.
+    assert by_id["continuation-a"].variant_index == by_id["variant-a"].variant_index
+    assert by_id["continuation-b"].variant_index == by_id["variant-b"].variant_index
+    assert by_id["continuation-a"].variant_index != by_id["continuation-b"].variant_index
+
+    coordinates = [(message.position, message.variant_index) for message in parsed.messages]
+    assert len(coordinates) == len(set(coordinates)), f"duplicate (position, variant_index) pairs: {coordinates}"
+
+
+def test_claude_sibling_variant_continuations_all_reach_archive_with_blocks(
+    workspace_env: dict[str, Path],
+) -> None:
+    """Real write witness: both continuation messages and their blocks must survive the archive write."""
+    payload = _variant_position_collision_payload()
+    raw_bytes = json.dumps(payload).encode()
+    db_path = db_setup(workspace_env)
+
+    with open_connection(db_path) as conn:
+        roundtrip = parse_payload_roundtrip("claude-ai", raw_bytes, unique_id="claude-variant-collision")
+        hydrated = write_and_hydrate(roundtrip, conn)
+        session_id = str(hydrated.id)
+        rows = conn.execute(
+            """
+            SELECT native_id, position, variant_index
+            FROM messages
+            WHERE session_id = ?
+            ORDER BY position, variant_index
+            """,
+            (session_id,),
+        ).fetchall()
+        by_native_id = {str(row[0]): (int(row[1]), int(row[2])) for row in rows}
+        block_texts_by_message = {
+            str(message_row[0]): {
+                str(block_row[0])
+                for block_row in conn.execute(
+                    """
+                    SELECT b.search_text
+                    FROM blocks AS b
+                    WHERE b.message_id = ?
+                    """,
+                    (message_row[1],),
+                ).fetchall()
+            }
+            for message_row in conn.execute(
+                "SELECT native_id, message_id FROM messages WHERE session_id = ?",
+                (session_id,),
+            ).fetchall()
+        }
+
+    # All 8 messages made it -- nothing silently dropped via INSERT OR REPLACE.
+    assert len(rows) == 8
+    assert set(by_native_id) == {
+        "root",
+        "chain-1",
+        "chain-2",
+        "branch-point",
+        "variant-a",
+        "variant-b",
+        "continuation-a",
+        "continuation-b",
+    }
+    assert by_native_id["continuation-a"][0] == by_native_id["continuation-b"][0] == 5
+    assert by_native_id["continuation-a"][1] != by_native_id["continuation-b"][1]
+    # Every message's blocks reached the archive too -- no orphaned/missing
+    # blocks from a swallowed message row.
+    assert block_texts_by_message["continuation-a"], "continuation-a lost its blocks"
+    assert block_texts_by_message["continuation-b"], "continuation-b lost its blocks"
+    assert "follow-up inside variant a's world" in " ".join(block_texts_by_message["continuation-a"])
+    assert "follow-up inside variant b's world" in " ".join(block_texts_by_message["continuation-b"])


### PR DESCRIPTION
## Summary

Fixes the root cause of the v42 index rebuild failure (operation ab5bad1f, most recently at `claude-ai-export:d24081f5`): the Claude web/browser parser could assign two distinct messages the same `(position, variant_index)` pair, which the messages table's `PRIMARY KEY(session_id, position, variant_index)` silently resolves by dropping one row via `INSERT OR REPLACE` — while its blocks are still written against its own (now-orphaned) `message_id`, surfacing as an unrelated foreign-key failure far from the actual cause. This PR fixes the parser-level cause and adds a writer-level safety net that turns any future occurrence of this class of bug into a loud, diagnosable error instead of silent data loss.

## Problem

`normalize_chat_messages` (`polylogue/sources/parsers/claude/common.py`) computed `variant_index_by_id` as `branch_index_by_id` — a message's rank among its own siblings under the same parent — independent of which sibling-variant "world" its parent belonged to. When two sibling variants at the same tree depth each had their own single-child continuation, both continuations were the sole (rank-0) child of their respective parent, so both independently reset to `variant_index=0`, colliding on the same `(position, variant_index)` coordinate their parents correctly diverged on.

Concretely, for a fixture shaped like:

```
root -> chain-1 -> chain-2 -> branch-point -> {variant-a, variant-b}  (correct: position 4, variant 0/1)
                                                  |            |
                                          continuation-a  continuation-b  (bug: both position 5, variant 0)
```

`_write_messages`' `INSERT OR REPLACE` silently dropped one of `continuation-a`/`continuation-b`, while `_write_blocks` still computed a distinct Python-side `message_id` for the dropped message and inserted its blocks against it — a foreign key referencing a row that was never (or no longer) there.

## Solution

**Parser fix** (`polylogue/sources/parsers/claude/common.py`):
- `_resolve_variant_index`: a rank-0 ("primary") child now *inherits* its parent's resolved `variant_index` instead of resetting to 0 — the continuation of variant 1 lives in variant 1's world. This walks up through chains of rank-0 descendants (composing through nested branch-under-branch shapes — a variant's variant) until it hits an explicit/nonzero variant, the root, or a cycle (degrading to 0, matching the existing `_lineage_depths` cycle-degrade pattern). Explicit provider-supplied variant indexes and nonzero sibling rank are unaffected — those are real branch points.
- `_deduplicate_variant_collisions`: a final deterministic safety net applied regardless of mode (flat or tree). No input tree shape may leave two emitted messages sharing `(position, variant_index)`; any residual collision is resolved by renumbering the colliding position group in `order_key` order (current variant, timestamp, provider message id).

**Other-parser audit** (grepped every parser under `sources/parsers/` for the same "rank among siblings, no uniqueness proof" pattern):
- `chatgpt.py` computes a similarly-shaped per-parent `branch_index`/`variant_index`, but its `position` is a monotonic enumeration index over every node in the conversation mapping (`position = idx - 1`), unique per emitted message *by construction* regardless of `variant_index` — **not vulnerable**.
- `claude/ai_parser.py` and `claude/code_parser.py` route their real parse path through this same `normalize_chat_messages()` — they inherit the fix directly; their standalone `variant_index=0` literals are for degenerate single-message cases only.
- All other parsers (`codex.py`, `drive.py` [Gemini/AI Studio], `local_agent.py` [gemini-cli], `antigravity.py`, `browser_capture.py`, `hermes_*.py`, `beads.py`) hardcode `variant_index=0` unconditionally — no branching modeled, **not vulnerable** to this shape.

**Writer safety net** (`polylogue/storage/sqlite/archive_tiers/write.py`):
- `_assert_unique_message_coordinates` computes the exact effective `(position, variant_index)` `_write_messages` uses to build INSERT rows (`position_offset + position-or-fallback-index`, `variant_index-or-0`) and raises a `ValueError` naming the session and every colliding native id if any pair repeats. Wired into both write paths: the full-replace path (`_replace_full_session_messages_and_blocks`, used for from-scratch imports — the path that hit this in production) before any row is touched, and the merge-append path right after `position_offset` is computed from the live archive state. This is independent of the parser fix — it's the writer's own guard against whatever any parser (present or future) produces.

## Verification

```
devtools test tests/unit/sources/test_claude_web_normalization.py \
  tests/unit/pipeline/test_archive_write.py \
  tests/property/test_claude_variant_position_uniqueness.py \
  tests/property/test_message_identity_normalization.py
  -> 32 passed

mypy --strict (touched files)          -> no issues
devtools verify --quick                -> exit 0 (format, lint, mypy, render-all-check,
                                           topology, layering, closure-matrix, schema
                                           roundtrip, manifests, ci-workflows, doc-commands,
                                           docs-coverage, test-infra-currency,
                                           test-clock-hygiene, pytest-timeout-overrides,
                                           degrade-loudly)
```

Test coverage added, per the four acceptance criteria this fix was scoped against:
- **(a) Regression fixture** (`tests/unit/sources/test_claude_web_normalization.py`): the exact 8-message collision shape above, run through the real `claude-ai` provider detection + parse + `write_parsed_session_to_archive` into a fresh archive store. Asserts both continuation messages, and all their blocks, are present at distinct `(position, variant_index)` coordinates. A pre-existing test in the same file (`test_claude_normalization_survives_archive_write_and_hydration`) asserted `u2`'s `variant_index == 0`; under the corrected inheritance semantics `u2` (the sole child of variant-1 sibling `a-new`) now correctly inherits `variant_index == 1` — updated with an explanatory comment, not silently changed.
- **(b) Property test** (`tests/property/test_claude_variant_position_uniqueness.py`, new file): Hypothesis-generated random parent/branch/depth trees (including nested branch-under-branch shapes and None-timestamp paths) asserting `normalize_chat_messages` output always has unique `(position, variant_index)` per session. Verified this test's minimal shrunk counterexample against the pre-fix parser reproduces exactly the collision class described above (`(2, 0)` produced twice from a two-sibling/two-grandchild tree), then passes cleanly against the fix.
- **(c) Writer collision guard** (`tests/unit/pipeline/test_archive_write.py`): two new tests — a hand-built `ParsedSession` with a forced `(position, variant_index)` collision raises a loud `ValueError` naming the session and both colliding native ids (not a bare `sqlite3.IntegrityError`) on both the full-replace and merge-append write paths.
- **(d) #3186 identity-law property test** (`tests/property/test_message_identity_normalization.py`, pre-existing, unmodified): still green — confirmed by direct run, both id-law classes (DB-generated `message_id` vs. Python identity computation, and now position/variant coordinate uniqueness) are covered by non-overlapping property tests.

**Blast radius**: not independently measured by this lane — this PR does not have real corpus dry-run scan numbers to report (an earlier draft of this description asserted a specific session count/percentage; that figure was not backed by an actual scan run in this session and has been removed as unverified). The coordinator's own corpus dry-run scan, run before resuming operation ab5bad1f, is the authoritative source for how many sessions this collision shape actually affects.

**Unrelated pre-existing failures observed and ruled out**: a broad `pytest tests/unit/sources tests/unit/storage tests/unit/pipeline tests/property` run surfaced 31 failures across files this change never touches (durable-migration schema counts, FTS derived-surface guard table, `Mock` attribute drift in `test_parsing_service.py`, browser-capture/GDPR title-coalesce ordering, retrieval-readiness `KeyError`s, etc.). Spot-checked several against a byte-for-byte revert of both changed files on the same worktree — they fail identically pre-fix, confirming baseline drift unrelated to this PR (not re-litigated here; the repo's own `devtools test <files>` convention against testmon-affected selection is what this PR's verification follows).

Ref: unblocks resume of operation ab5bad1f. The coordinator will run a corpus dry-run scan before resuming the rebuild.

Co-Authored-By: Claude <noreply@anthropic.com>
