### PR TITLE
feat(storage): content-address the embeddings tier by input hash

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -317,7 +317,12 @@ full permission audit trail (PermissionRequest/PermissionDenied).
 Vector embeddings for semantic search, powered by Voyage AI (`voyage-4`,
 1024 dimensions) via SQLite-vec (`vec0` virtual table):
 
-- **Storage**: `message_embeddings` (vec0), `message_embeddings_meta`, `embedding_status`
+- **Storage**: `message_embeddings` (vec0) and `message_embeddings_meta` are
+  content-addressed, keyed by `embedding_input_hash = SHA-256(model,
+  embedder input text)` rather than message identity — see
+  [Schema § embeddings.db](schema.md#embeddingsdb-vectors-rebuildable-expensive)
+  for why. `message_embedding_refs` maps `message_id -> embedding_input_hash`;
+  `embedding_status` remains session-scoped.
 - **Search**: `--similar` flag triggers pure vector search; hybrid mode combines
   FTS5 + vector via Reciprocal Rank Fusion
 - **Integration**: Daemon-side post-ingest and ambient catch-up embedding is

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -23,7 +23,7 @@ over the `CREATE TABLE` statement.
 |-----------|------|------------------|
 | `source.py` | `source.db` | `SOURCE_SCHEMA_VERSION = 10` |
 | `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 35` |
-| `embeddings.py` | `embeddings.db` | `EMBEDDINGS_SCHEMA_VERSION = 3` |
+| `embeddings.py` | `embeddings.db` | `EMBEDDINGS_SCHEMA_VERSION = 4` |
 | `user.py` | `user.db` | `USER_SCHEMA_VERSION = 6` |
 | `ops.py` | `ops.db` | `OPS_SCHEMA_VERSION = 1` |
 
@@ -72,14 +72,30 @@ read models (`session_profiles`, `session_work_events`, `session_phases`,
 ### `embeddings.db` — vectors (rebuildable, expensive)
 
 `message_embeddings` (a `vec0` virtual table, 1024-dimensional float
-embeddings), `message_embeddings_meta`, `embedding_derivation_state`,
-`embedding_status`, and the inspectable `embedding_failures` lifecycle ledger.
-The derivation state owns the exact source/recipe/output key and active attempt
-generation; status flags are compatibility projections rather than independent
-freshness authority. Populated only when embedding is enabled with a valid
-Voyage key (see
-[Architecture § Embedding Pipeline](architecture.md#embedding-pipeline)).
-Rebuildable, but re-embedding costs Voyage API calls.
+embeddings) and `message_embeddings_meta` are **content-addressed**: both are
+keyed by `embedding_input_hash = SHA-256(model, embedder input text)` — a pure
+function of exactly what is sent to the embedding provider, deliberately
+excluding every identity-bearing field (`session_id`, `message_id`,
+`position`, `variant_index`, ...), the same philosophy as the block evidence
+hash (`blocks` table). A hash's presence in `message_embeddings_meta` **is**
+freshness — there is no per-vector "needs_reindex" state, and identical text
+across forked/replayed/coincidentally-duplicate messages is stored exactly
+once (dedup). `message_embedding_refs` is the rebuildable per-message mapping
+(`message_id -> embedding_input_hash`) that resolves a vector back to the
+message(s) that currently reference it; it is rewritten per session re-embed,
+while the vector/meta rows themselves are write-once and never deleted by
+ordinary re-embed (an index rebuild or lineage-normalization shift that
+renumbers a message cannot invalidate its vector as long as the text is
+unchanged). `embedding_derivation_state`, `embedding_status`, and the
+inspectable `embedding_failures` lifecycle ledger remain **session**-scoped
+attempt/generation bookkeeping (unchanged in shape) — the derivation state
+owns the exact source/recipe/output key and active attempt generation; status
+flags are compatibility projections rather than independent freshness
+authority. Populated only when embedding is enabled with a valid Voyage key
+(see [Architecture § Embedding Pipeline](architecture.md#embedding-pipeline)).
+Rebuildable, but re-embedding costs Voyage API calls — content-addressing is
+what makes a rebuild (index reset, lineage renormalization) NOT imply a
+re-embed for text that has not changed.
 
 ### `user.db` — irreplaceable human input (back up this one)
 

--- a/polylogue/cli/commands/maintenance/_embeddings.py
+++ b/polylogue/cli/commands/maintenance/_embeddings.py
@@ -122,18 +122,28 @@ def embedding_orphan_reconcile_command(
 
 
 def _render_embedding_orphan_reconcile_plain(report: EmbeddingOrphanReconcileReport) -> None:
+    """Render the reconcile report honestly under the v4 content-addressed model.
+
+    polylogue-q88p: ``message_embeddings``/``message_embeddings_meta`` are
+    content-addressed and shared -- this reconciler never deletes them (a
+    vector's underlying hash may still be referenced by another live
+    message). Only ``message_embedding_refs`` (the per-message mapping) is
+    ever removed, so the report speaks in terms of refs, not "meta"/"vector
+    row(s) removed" -- that wording would claim a mutation that never
+    happens. ``scanned_message_meta_rows``/``scanned_vector_rows`` remain
+    informational counts of the (deduped) content-addressed tables.
+    """
     click.echo("Embedding orphan reconcile")
     click.echo(f"Index DB:      {report.index_db}")
     click.echo(f"Embeddings DB: {report.embeddings_db}")
     click.echo(f"Mode:          {'dry-run' if report.dry_run else 'apply'}")
     click.echo(
-        f"Scanned:       {report.scanned_message_meta_rows:,} message meta row(s), "
-        f"{report.scanned_vector_rows:,} vector row(s), "
+        f"Scanned:       {report.scanned_message_meta_rows:,} distinct vector meta row(s) "
+        f"(content-addressed, shared), {report.scanned_vector_rows:,} distinct vector row(s), "
         f"{report.scanned_status_rows:,} status row(s)"
     )
     click.echo(
-        f"Orphans:       {report.orphan_message_rows:,} message identity row(s) "
-        f"({report.orphan_message_meta_rows:,} meta, {report.orphan_vector_rows:,} vector), "
+        f"Orphans:       {report.orphan_message_rows:,} orphan message ref(s), "
         f"{report.orphan_status_rows:,} status row(s)"
     )
     if report.skipped_recent_message_rows or report.skipped_recent_status_rows:
@@ -145,14 +155,13 @@ def _render_embedding_orphan_reconcile_plain(report: EmbeddingOrphanReconcileRep
         )
     if report.dry_run:
         click.echo(
-            f"Would remove:  {report.candidate_message_meta_rows:,} meta row(s), "
-            f"{report.candidate_vector_rows:,} vector row(s), "
+            f"Would remove:  {report.candidate_message_rows:,} message ref(s), "
             f"{report.candidate_status_rows:,} status row(s)"
         )
     else:
         click.echo(
-            f"Removed:       {report.removed_message_rows:,} meta row(s), "
-            f"{report.removed_vector_rows:,} vector row(s), {report.removed_status_rows:,} status row(s)"
+            f"Removed:       {report.removed_message_rows:,} message ref(s), "
+            f"{report.removed_status_rows:,} status row(s)"
         )
     if report.sessions_recounted:
         click.echo(f"Recounted:     {report.sessions_recounted:,} session(s) message_count_embedded")

--- a/polylogue/cli/commands/maintenance/_embeddings_rescue.py
+++ b/polylogue/cli/commands/maintenance/_embeddings_rescue.py
@@ -4,10 +4,12 @@ Break-glass, offline-only migration path for polylogue-04kl: a retired
 ``embeddings.db.v2-retired-YYYYMMDD`` tier can hold hundreds of thousands of
 Voyage vectors whose ``message_id`` + ``content_hash`` identity still matches
 the freshly rebuilt index. ``--plan`` (default) is a read-only census;
-``--yes`` copies vectors for every *fully rescuable* session (see
+``--yes`` recomputes the content-addressed ``embedding_input_hash`` for each
+matched message and copies vectors for every *fully rescuable* session (see
 :mod:`polylogue.storage.embeddings.rescue` for why rescue is session-, not
-message-, granular) directly into the live ``embeddings.db``, skipping a live
-Voyage API re-embed for those sessions entirely.
+message-, granular) directly into the live, content-addressed ``embeddings.db``
+(polylogue-q88p), skipping a live Voyage API re-embed for those sessions
+entirely.
 """
 
 from __future__ import annotations

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -269,7 +269,10 @@ _ARCHIVE_TIER_TABLES: dict[str, tuple[str, ...]] = {
         "thread_sessions",
         "insight_materialization",
     ),
-    "embeddings": ("message_embeddings_meta", "embedding_status"),
+    # message_embeddings_meta/message_embeddings are content-addressed and
+    # deduped (polylogue-q88p); message_embedding_refs is the per-message
+    # count operators actually want from a row-count status summary.
+    "embeddings": ("message_embedding_refs", "message_embeddings_meta", "embedding_status"),
     "user": (
         "assertions",
         "annotation_schemas",

--- a/polylogue/daemon/metrics.py
+++ b/polylogue/daemon/metrics.py
@@ -649,6 +649,13 @@ def _emit_storage_route_metrics(lines: list[str], counts: dict[str, int]) -> Non
 
 
 def _embedding_message_count(conn: sqlite3.Connection, *, status_table: str = "", meta_table: str = "") -> int:
+    # message_embedding_refs is the per-message count (polylogue-q88p);
+    # message_embeddings/message_embeddings_meta are content-addressed and
+    # deduped, so their row count undercounts messages whenever identical
+    # text is shared across sessions -- only fall back to them for legacy
+    # (pre-v4) archives that predate the refs table.
+    if _table_exists(conn, "message_embedding_refs"):
+        return _scalar_int(conn, "SELECT COUNT(*) FROM message_embedding_refs")
     if _table_exists(conn, "message_embeddings_rowids"):
         return _scalar_int(conn, "SELECT COUNT(*) FROM message_embeddings_rowids")
     if _table_exists(conn, "message_embeddings"):

--- a/polylogue/daemon/similarity.py
+++ b/polylogue/daemon/similarity.py
@@ -138,16 +138,23 @@ def _source_message_embeddings(
 ) -> list[tuple[str, bytes]]:
     """Return ``(message_id, embedding_blob)`` rows for the source session.
 
-    The blob is returned exactly as stored in ``message_embeddings`` so
-    it can be passed back into a ``vec0`` ``MATCH`` clause without any
-    re-encoding round trip.
+    ``message_embeddings`` is content-addressed (keyed by
+    ``embedding_input_hash``, polylogue-q88p), not by ``message_id``/
+    ``session_id`` directly -- resolve through ``message_embedding_refs``.
+    ``DISTINCT`` on the hash avoids issuing duplicate ``MATCH`` queries when
+    the session has multiple messages sharing identical text. The blob is
+    returned exactly as stored so it can be passed back into a ``vec0``
+    ``MATCH`` clause without any re-encoding round trip.
     """
 
     rows = conn.execute(
         """
-        SELECT message_id, embedding
-        FROM message_embeddings
-        WHERE session_id = ?
+        SELECT MIN(r.message_id), me.embedding
+        FROM message_embedding_refs AS r
+        JOIN message_embeddings AS me
+          ON lower(hex(r.embedding_input_hash)) = me.embedding_input_hash
+        WHERE r.session_id = ?
+        GROUP BY me.embedding_input_hash
         """,
         (session_id,),
     ).fetchall()
@@ -160,9 +167,12 @@ def _source_archive_message_embeddings(
 ) -> list[tuple[str, bytes]]:
     rows = conn.execute(
         """
-        SELECT message_id, embedding
-        FROM message_embeddings
-        WHERE session_id = ?
+        SELECT MIN(r.message_id), me.embedding
+        FROM message_embedding_refs AS r
+        JOIN message_embeddings AS me
+          ON lower(hex(r.embedding_input_hash)) = me.embedding_input_hash
+        WHERE r.session_id = ?
+        GROUP BY me.embedding_input_hash
         """,
         (session_id,),
     ).fetchall()
@@ -177,18 +187,26 @@ def _knn_for_embedding(
 ) -> list[tuple[str, str, float]]:
     """Run a single ``MATCH`` and return ``(message_id, session_id, distance)``.
 
-    The vec0 column ``distance`` here is L2 distance over the indexed
-    embeddings. Cosine similarity is recovered downstream once a row's
-    embedding has been pulled into the score-aggregation step.
+    A hash hit is resolved back to every message currently referencing it
+    (content-addressed dedup, polylogue-q88p) -- one MATCH row can expand
+    into several result rows. The vec0 column ``distance`` here is L2
+    distance over the indexed embeddings. Cosine similarity is recovered
+    downstream once a row's embedding has been pulled into the
+    score-aggregation step.
     """
 
     rows = conn.execute(
         """
-        SELECT message_id, session_id, distance
-        FROM message_embeddings
-        WHERE embedding MATCH ?
-          AND k = ?
-        ORDER BY distance
+        SELECT r.message_id, r.session_id, hits.distance
+        FROM (
+            SELECT embedding_input_hash, distance
+            FROM message_embeddings
+            WHERE embedding MATCH ?
+              AND k = ?
+        ) AS hits
+        JOIN message_embedding_refs AS r
+          ON lower(hex(r.embedding_input_hash)) = hits.embedding_input_hash
+        ORDER BY hits.distance
         """,
         (embedding_blob, k),
     ).fetchall()
@@ -203,11 +221,16 @@ def _archive_knn_for_embedding(
 ) -> list[tuple[str, str, float]]:
     rows = conn.execute(
         """
-        SELECT message_id, session_id, distance
-        FROM message_embeddings
-        WHERE embedding MATCH ?
-          AND k = ?
-        ORDER BY distance
+        SELECT r.message_id, r.session_id, hits.distance
+        FROM (
+            SELECT embedding_input_hash, distance
+            FROM message_embeddings
+            WHERE embedding MATCH ?
+              AND k = ?
+        ) AS hits
+        JOIN message_embedding_refs AS r
+          ON lower(hex(r.embedding_input_hash)) = hits.embedding_input_hash
+        ORDER BY hits.distance
         """,
         (embedding_blob, k),
     ).fetchall()

--- a/polylogue/demo/constructs.py
+++ b/polylogue/demo/constructs.py
@@ -412,7 +412,6 @@ DEMO_CONSTRUCTS: tuple[DemoConstruct, ...] = (
             SELECT COUNT(*)
             FROM embeddings.message_embeddings_meta
             WHERE model = 'demo-synthetic-embedding'
-              AND needs_reindex = 0
         """,
     ),
     DemoConstruct(

--- a/polylogue/demo/seed.py
+++ b/polylogue/demo/seed.py
@@ -34,6 +34,7 @@ from polylogue.storage.embeddings.identity import (
     EmbeddingRecipe,
     EmbeddingSourceDigest,
     embedding_derivation_key,
+    embedding_input_hash,
     message_embedding_derivation_key,
 )
 from polylogue.storage.embeddings.materialization import archive_embeddable_message_where, message_prose_sql
@@ -1051,14 +1052,6 @@ def _demo_embedding_vector(message_id: str) -> list[float]:
     return [((digest[index % len(digest)] / 255.0) * 2.0) - 1.0 for index in range(EMBEDDING_DIMENSION)]
 
 
-def _demo_embedding_content_hash(value: object) -> bytes:
-    if isinstance(value, bytes):
-        return value
-    if isinstance(value, str):
-        return bytes.fromhex(value)
-    raise TypeError(f"unsupported content_hash value: {type(value).__name__}")
-
-
 def _seed_demo_embeddings(archive_root: Path) -> None:
     """Seed deterministic embeddings for one authored-prose demo session.
 
@@ -1117,14 +1110,14 @@ def _seed_demo_embeddings(archive_root: Path) -> None:
                 str(row["message_id"]),
                 str(row["session_id"]),
                 str(row["origin"]),
-                _demo_embedding_content_hash(row["content_hash"]),
+                embedding_input_hash(model=recipe.model, input_text=str(row["text"])),
             )
             for row in rows
             if row["content_hash"] is not None
         ]
         source_digest = EmbeddingSourceDigest()
-        for message_id, _session_id, _origin, content_hash in sorted(embeddable, key=lambda item: item[0]):
-            source_digest.update(message_id, content_hash)
+        for _message_id, _session_id, _origin, input_hash in sorted(embeddable, key=lambda item: item[3]):
+            source_digest.update(input_hash)
         source_hash = source_digest.digest()
         writes = [
             ArchiveEmbeddingWrite(
@@ -1134,16 +1127,16 @@ def _seed_demo_embeddings(archive_root: Path) -> None:
                 embedding=_demo_embedding_vector(message_id),
                 model=_DEMO_EMBEDDING_MODEL,
                 embedded_at_ms=_DEMO_EMBEDDING_AT_MS,
-                content_hash=content_hash,
+                embedding_input_hash=input_hash,
                 recipe_hash=recipe.recipe_hash,
                 derivation_key=message_embedding_derivation_key(
                     message_id=message_id,
-                    content_hash=content_hash,
+                    embedding_input_hash=input_hash,
                     recipe=recipe,
                 ).digest(),
                 generation=1,
             )
-            for message_id, session_id, origin, content_hash in embeddable
+            for message_id, session_id, origin, input_hash in embeddable
         ]
         upsert_message_embeddings(embeddings_conn, writes)
         session_derivation_key = embedding_derivation_key(

--- a/polylogue/security/excision.py
+++ b/polylogue/security/excision.py
@@ -334,8 +334,14 @@ def plan_session_excision(archive_root: Path, session_id: str) -> ExcisionPlan:
         try:
             try_load_sqlite_vec(conn)
             placeholders = ",".join("?" for _ in target.message_ids)
+            # message_embeddings/message_embeddings_meta are content-addressed
+            # (keyed by embedding_input_hash, polylogue-q88p) and may be
+            # shared with messages outside this excision target; the
+            # message-scoped count is the per-message ref count, not a raw
+            # vector-table count (a shared vector must not be reported as
+            # "will be removed" when another message still needs it).
             row = conn.execute(
-                f"SELECT COUNT(*) FROM message_embeddings WHERE message_id IN ({placeholders})",
+                f"SELECT COUNT(*) FROM message_embedding_refs WHERE message_id IN ({placeholders})",
                 target.message_ids,
             ).fetchone()
             embeddings_vectors = int(row[0]) if row else 0
@@ -439,6 +445,7 @@ def _apply_single_session_excision(
 
     counts: dict[str, int] = {
         "embeddings_vectors": 0,
+        "embeddings_vectors_gc": 0,
         "index_sessions": 0,
         "index_messages": len(target.message_ids),
         "index_blocks": len(target.block_ids),
@@ -454,15 +461,50 @@ def _apply_single_session_excision(
             try_load_sqlite_vec(conn)
             with conn:
                 placeholders = ",".join("?" for _ in target.message_ids)
+                # message_embeddings/message_embeddings_meta are content-
+                # addressed and may be shared with messages outside this
+                # excision target (polylogue-q88p) -- deleting a vector by
+                # message_id is no longer meaningful (there is no message_id
+                # column on those tables) and would be unsafe even if it
+                # were, since another live message could still reference the
+                # same hash. Delete this excision's refs first, then remove
+                # the underlying vector/meta rows only for hashes that no
+                # longer have ANY remaining ref -- reference-counted, scoped
+                # strictly to the hashes this excision actually touched (not
+                # a general background GC sweep).
+                affected_hashes = tuple(
+                    bytes(row[0])
+                    for row in conn.execute(
+                        f"SELECT DISTINCT embedding_input_hash FROM message_embedding_refs "
+                        f"WHERE message_id IN ({placeholders})",
+                        target.message_ids,
+                    ).fetchall()
+                )
                 cursor = conn.execute(
-                    f"DELETE FROM message_embeddings WHERE message_id IN ({placeholders})",
+                    f"DELETE FROM message_embedding_refs WHERE message_id IN ({placeholders})",
                     target.message_ids,
                 )
                 counts["embeddings_vectors"] = max(cursor.rowcount, 0)
-                conn.execute(
-                    f"DELETE FROM message_embeddings_meta WHERE message_id IN ({placeholders})",
-                    target.message_ids,
-                )
+                removed_vector_hashes = 0
+                for input_hash in affected_hashes:
+                    still_referenced = conn.execute(
+                        "SELECT 1 FROM message_embedding_refs WHERE embedding_input_hash = ? LIMIT 1",
+                        (input_hash,),
+                    ).fetchone()
+                    if still_referenced is not None:
+                        continue
+                    conn.execute(
+                        "DELETE FROM message_embeddings WHERE embedding_input_hash = ?",
+                        (input_hash.hex(),),
+                    )
+                    removed_vector_hashes += max(
+                        conn.execute(
+                            "DELETE FROM message_embeddings_meta WHERE embedding_input_hash = ?",
+                            (input_hash,),
+                        ).rowcount,
+                        0,
+                    )
+                counts["embeddings_vectors_gc"] = removed_vector_hashes
                 conn.execute("DELETE FROM embedding_status WHERE session_id = ?", (session_id,))
                 conn.execute("DELETE FROM embedding_failures WHERE session_id = ?", (session_id,))
         finally:

--- a/polylogue/storage/embeddings/embedding_stats.py
+++ b/polylogue/storage/embeddings/embedding_stats.py
@@ -176,11 +176,13 @@ def _base_parts_sync(conn: sqlite3.Connection, *, detail: bool) -> _EmbeddingSta
         ),
         pending_messages=optional_count_sync(conn, PENDING_MESSAGES_SQL) if status_exists else total_messages,
         # v4 (polylogue-q88p): this legacy monolithic-archive reader does not
-        # thread a configured model through to compute the identity-free
-        # hash comparison stale_messages_sql() needs; the split-archive path
-        # (storage/embeddings/status_payload.py, the primary runtime status
-        # surface) computes an exact stale count instead. 0 here is an
-        # honest "not computed on this path", not a claim of freshness.
+        # thread a configured embedding model through, and computing the
+        # identity-free stale comparison (embedding_input_hash != the
+        # message's current embedder input text) requires one. The
+        # split-archive path (storage/embeddings/status_payload.py, the
+        # primary runtime status surface) has the model and computes an
+        # exact stale count there. 0 here is an honest "not computed on
+        # this path", not a claim of freshness.
         stale_messages=0,
         missing_provenance=optional_count_sync(conn, MISSING_META_MESSAGES_SQL),
         sessions_exist=sessions_exist,

--- a/polylogue/storage/embeddings/embedding_stats.py
+++ b/polylogue/storage/embeddings/embedding_stats.py
@@ -18,7 +18,6 @@ from polylogue.storage.embeddings.sql import (
     MODEL_COUNTS_SQL,
     PENDING_MESSAGES_SQL,
     PENDING_SESSIONS_SQL,
-    STALE_MESSAGES_SQL,
     TOTAL_MESSAGES_SQL,
 )
 from polylogue.storage.embeddings.support import (
@@ -176,7 +175,13 @@ def _base_parts_sync(conn: sqlite3.Connection, *, detail: bool) -> _EmbeddingSta
             else optional_count_sync(conn, ELIGIBLE_SESSIONS_SQL)
         ),
         pending_messages=optional_count_sync(conn, PENDING_MESSAGES_SQL) if status_exists else total_messages,
-        stale_messages=optional_count_sync(conn, STALE_MESSAGES_SQL),
+        # v4 (polylogue-q88p): this legacy monolithic-archive reader does not
+        # thread a configured model through to compute the identity-free
+        # hash comparison stale_messages_sql() needs; the split-archive path
+        # (storage/embeddings/status_payload.py, the primary runtime status
+        # surface) computes an exact stale count instead. 0 here is an
+        # honest "not computed on this path", not a claim of freshness.
+        stale_messages=0,
         missing_provenance=optional_count_sync(conn, MISSING_META_MESSAGES_SQL),
         sessions_exist=sessions_exist,
         failure_count=optional_count_sync(conn, EMBEDDING_FAILURE_COUNT_SQL) if status_exists else 0,
@@ -219,7 +224,8 @@ async def _base_parts_async(conn: aiosqlite.Connection, *, detail: bool) -> _Emb
             else await optional_count_async(conn, ELIGIBLE_SESSIONS_SQL)
         ),
         pending_messages=await optional_count_async(conn, PENDING_MESSAGES_SQL) if status_exists else total_messages,
-        stale_messages=await optional_count_async(conn, STALE_MESSAGES_SQL),
+        # See the sync reader above: not computed on this legacy path.
+        stale_messages=0,
         missing_provenance=await optional_count_async(conn, MISSING_META_MESSAGES_SQL),
         sessions_exist=sessions_exist,
         failure_count=await optional_count_async(conn, EMBEDDING_FAILURE_COUNT_SQL) if status_exists else 0,

--- a/polylogue/storage/embeddings/identity.py
+++ b/polylogue/storage/embeddings/identity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import sqlite3
+import unicodedata
 from dataclasses import dataclass
 
 from polylogue.storage.derivation_identity import (
@@ -16,7 +17,15 @@ from polylogue.storage.sqlite.archive_tiers.index import INDEX_SCHEMA_VERSION
 
 EMBEDDING_SUBJECT_GRAIN = "archive-message-vectors"
 EMBEDDING_MESSAGE_GRAIN = "archive-message-vector"
-EMBEDDING_SOURCE_CANONICALIZATION = "ordered-message-id-content-hash-v1"
+# v2 (polylogue-q88p): the ordered aggregate now carries embedding_input_hash
+# (identity-free: H(model, embedder input text)) instead of messages.content_hash
+# (identity-contaminated: includes session_id/position/variant_index). Bumping
+# this string changes recipe_hash, which deliberately busts every stale
+# embedding_derivation_state row so the session-attempt ledger is
+# re-evaluated -- while the vectors THEMSELVES stay valid and are reused for
+# free wherever the underlying text is unchanged (hash presence is the only
+# freshness signal at vector granularity).
+EMBEDDING_SOURCE_CANONICALIZATION = "ordered-message-id-input-hash-v2"
 EMBEDDING_TEXT_CANONICALIZATION = "ordered-text-block-prose-v1"
 EMBEDDING_RECORD_SELECTOR = "authored-user-assistant-prose-v1"
 EMBEDDING_CHUNKING_VERSION = "one-vector-per-message-v1"
@@ -29,9 +38,10 @@ EMBEDDING_TOOL_IMPLEMENTATION = "polylogue.sqlite-vec-v1"
 EMBEDDING_OUTPUT_SCHEMA_VERSION = 1
 EMBEDDING_SOURCE_HASH_SQL_FUNCTION = "polylogue_embedding_source_hash"
 EMBEDDING_DERIVATION_KEY_SQL_FUNCTION = "polylogue_embedding_derivation_key"
-EMBEDDING_MESSAGE_KEY_SQL_FUNCTION = "polylogue_embedding_message_key"
+EMBEDDING_INPUT_HASH_SQL_FUNCTION = "polylogue_embedding_input_hash"
 
-_SOURCE_HASH_DOMAIN = b"polylogue.embedding-source.v1\x00"
+_SOURCE_HASH_DOMAIN = b"polylogue.embedding-source.v2\x00"
+_INPUT_HASH_DOMAIN = b"polylogue.embedding-input.v1\x00"
 
 
 @dataclass(frozen=True, slots=True)
@@ -107,8 +117,66 @@ class EmbeddingRecipe:
         return self.output_contract().digest()
 
 
+def embedding_input_hash(*, model: str, input_text: str) -> bytes:
+    """Identity-free vector key: SHA-256 over exactly (model, embedder input text).
+
+    This is a pure function of what is actually sent to the embedding
+    provider -- nothing else. Session id, message id, position, variant
+    index, role, material_origin, and every other identity-bearing field
+    that ``messages.content_hash`` includes are excluded by construction, so
+    a re-ingest, index rebuild, or lineage-normalization shift cannot
+    invalidate a vector whose underlying text is unchanged (operator ruling
+    2026-07-20, polylogue-q88p). The same philosophy as the svfj block
+    evidence hash (``_block_content_hash``), applied to the embedding tier.
+
+    ``input_text`` must be exactly the string passed to the embedder for
+    this to hold -- callers must derive this hash from the same variable
+    used to build the provider request payload, not a re-derivation, so
+    hash validity equals vector validity by construction.
+
+    NFC-normalizes the text first (matching the archive's existing
+    content-hash normalization convention, ``core/hashing.py``) so
+    Unicode-equivalent strings from different providers/encodings hash
+    identically.
+    """
+    normalized = unicodedata.normalize("NFC", input_text)
+    hasher = hashlib.sha256()
+    hasher.update(_INPUT_HASH_DOMAIN)
+    model_bytes = model.encode("utf-8", errors="surrogatepass")
+    hasher.update(len(model_bytes).to_bytes(8, "big"))
+    hasher.update(model_bytes)
+    text_bytes = normalized.encode("utf-8", errors="surrogatepass")
+    hasher.update(len(text_bytes).to_bytes(8, "big"))
+    hasher.update(text_bytes)
+    return hasher.digest()
+
+
+def _embedding_input_hash_sql(model: object, input_text: object) -> bytes | None:
+    if model is None or input_text is None:
+        return None
+    return embedding_input_hash(model=str(model), input_text=str(input_text))
+
+
+def sql_string_literal(value: str) -> str:
+    """Escape a Python string as a single-quoted SQL literal."""
+
+    return "'" + value.replace("'", "''") + "'"
+
+
 class EmbeddingSourceDigest:
-    """Incremental canonical digest of an ordered embeddable-message set."""
+    """Incremental canonical digest of an ordered embeddable-message set.
+
+    v2 (polylogue-q88p): digests only ``embedding_input_hash`` VALUES, not
+    ``(message_id, hash)`` pairs. Session-level "does this session's source
+    set need a new embedding attempt" bookkeeping must stay identity-free
+    too, or a message-set that is byte-identical in content but renumbered
+    by a rebuild (message_id shifts, hash values unchanged) would still bust
+    the session's derivation key and force a full re-embed pass through the
+    provider -- defeating the point of content-addressing the vectors
+    themselves. Message COUNT is still covered (duplicates are not
+    collapsed; the multiset of hash values must match), which still detects
+    a genuine add/remove of a message from the session.
+    """
 
     __slots__ = ("_count", "_hasher")
 
@@ -117,12 +185,9 @@ class EmbeddingSourceDigest:
         self._hasher.update(_SOURCE_HASH_DOMAIN)
         self._count = 0
 
-    def update(self, message_id: str, content_hash: bytes) -> None:
-        encoded_id = message_id.encode("utf-8", errors="surrogatepass")
-        self._hasher.update(len(encoded_id).to_bytes(8, "big"))
-        self._hasher.update(encoded_id)
-        self._hasher.update(len(content_hash).to_bytes(8, "big"))
-        self._hasher.update(content_hash)
+    def update(self, input_hash: bytes) -> None:
+        self._hasher.update(len(input_hash).to_bytes(8, "big"))
+        self._hasher.update(input_hash)
         self._count += 1
 
     def digest(self) -> bytes:
@@ -132,20 +197,20 @@ class EmbeddingSourceDigest:
 
 
 class _EmbeddingSourceHashAggregate:
-    """Order-independent SQLite adapter for the canonical ordered source set."""
+    """Order-independent SQLite adapter for the canonical source hash multiset."""
 
     def __init__(self) -> None:
-        self._messages: list[tuple[str, bytes]] = []
+        self._hashes: list[bytes] = []
 
-    def step(self, message_id: object, content_hash: object) -> None:
-        if message_id is None or content_hash is None:
+    def step(self, input_hash: object) -> None:
+        if input_hash is None:
             return
-        self._messages.append((str(message_id), _identity_bytes(content_hash)))
+        self._hashes.append(_identity_bytes(input_hash))
 
     def finalize(self) -> bytes:
         digest = EmbeddingSourceDigest()
-        for message_id, content_hash in sorted(self._messages):
-            digest.update(message_id, content_hash)
+        for input_hash in sorted(self._hashes):
+            digest.update(input_hash)
         return digest.digest()
 
 
@@ -153,8 +218,8 @@ def register_embedding_identity_sql(conn: sqlite3.Connection) -> None:
     """Install deterministic identity helpers used by the shared stale predicate."""
 
     # typeshed's _AggregateProtocol.step is narrowly typed for the single-int-arg
-    # case; sqlite3 itself accepts any step arity matching n_arg (2 here).
-    conn.create_aggregate(EMBEDDING_SOURCE_HASH_SQL_FUNCTION, 2, _EmbeddingSourceHashAggregate)  # type: ignore[arg-type]
+    # case; sqlite3 itself accepts any step arity matching n_arg (1 here).
+    conn.create_aggregate(EMBEDDING_SOURCE_HASH_SQL_FUNCTION, 1, _EmbeddingSourceHashAggregate)  # type: ignore[arg-type]
     conn.create_function(
         EMBEDDING_DERIVATION_KEY_SQL_FUNCTION,
         4,
@@ -162,9 +227,9 @@ def register_embedding_identity_sql(conn: sqlite3.Connection) -> None:
         deterministic=True,
     )
     conn.create_function(
-        EMBEDDING_MESSAGE_KEY_SQL_FUNCTION,
-        4,
-        _message_embedding_derivation_digest_sql,
+        EMBEDDING_INPUT_HASH_SQL_FUNCTION,
+        2,
+        _embedding_input_hash_sql,
         deterministic=True,
     )
 
@@ -177,19 +242,6 @@ def _embedding_derivation_digest_sql(
     return embedding_derivation_digest_from_hashes(
         session_id=str(session_id),
         source_hash=_identity_bytes(source_hash),
-        recipe_hash=_identity_bytes(recipe_hash),
-        output_contract_hash=_identity_bytes(output_contract_hash),
-    )
-
-
-def _message_embedding_derivation_digest_sql(
-    message_id: object, content_hash: object, recipe_hash: object, output_contract_hash: object
-) -> bytes | None:
-    if message_id is None or content_hash is None or recipe_hash is None or output_contract_hash is None:
-        return None
-    return message_embedding_derivation_digest_from_hashes(
-        message_id=str(message_id),
-        content_hash=_identity_bytes(content_hash),
         recipe_hash=_identity_bytes(recipe_hash),
         output_contract_hash=_identity_bytes(output_contract_hash),
     )
@@ -246,17 +298,17 @@ def embedding_derivation_digest_from_hashes(
 def message_embedding_derivation_digest_from_hashes(
     *,
     message_id: str,
-    content_hash: bytes,
+    embedding_input_hash: bytes,
     recipe_hash: bytes,
     output_contract_hash: bytes,
 ) -> bytes:
     return compose_derivation_key_digest(
         subject_digest=DerivationSubject(reference=message_id, grain=EMBEDDING_MESSAGE_GRAIN).digest(),
         source_identity_digest=DerivationIdentity.from_mapping(
-            "polylogue.embedding.message-source.v1",
+            "polylogue.embedding.message-source.v2",
             {
                 "canonicalization": EMBEDDING_SOURCE_CANONICALIZATION,
-                "content_sha256": content_hash,
+                "embedding_input_sha256": embedding_input_hash,
             },
         ).digest(),
         recipe_identity_digest=recipe_hash,
@@ -264,14 +316,16 @@ def message_embedding_derivation_digest_from_hashes(
     )
 
 
-def message_embedding_derivation_key(*, message_id: str, content_hash: bytes, recipe: EmbeddingRecipe) -> DerivationKey:
+def message_embedding_derivation_key(
+    *, message_id: str, embedding_input_hash: bytes, recipe: EmbeddingRecipe
+) -> DerivationKey:
     return DerivationKey(
         subject=DerivationSubject(reference=message_id, grain=EMBEDDING_MESSAGE_GRAIN),
         source_identity=DerivationIdentity.from_mapping(
-            "polylogue.embedding.message-source.v1",
+            "polylogue.embedding.message-source.v2",
             {
                 "canonicalization": EMBEDDING_SOURCE_CANONICALIZATION,
-                "content_sha256": content_hash,
+                "embedding_input_sha256": embedding_input_hash,
             },
         ),
         recipe_identity=recipe.identity(),
@@ -282,8 +336,8 @@ def message_embedding_derivation_key(*, message_id: str, content_hash: bytes, re
 __all__ = [
     "EMBEDDING_CHUNKING_VERSION",
     "EMBEDDING_DERIVATION_KEY_SQL_FUNCTION",
+    "EMBEDDING_INPUT_HASH_SQL_FUNCTION",
     "EMBEDDING_INPUT_TYPE",
-    "EMBEDDING_MESSAGE_KEY_SQL_FUNCTION",
     "EMBEDDING_MODEL_REVISION",
     "EMBEDDING_NORMALIZATION",
     "EMBEDDING_PROVIDER",
@@ -297,8 +351,10 @@ __all__ = [
     "EmbeddingSourceDigest",
     "embedding_derivation_digest_from_hashes",
     "embedding_derivation_key",
+    "embedding_input_hash",
     "embedding_source_identity",
     "message_embedding_derivation_digest_from_hashes",
     "message_embedding_derivation_key",
     "register_embedding_identity_sql",
+    "sql_string_literal",
 ]

--- a/polylogue/storage/embeddings/materialization.py
+++ b/polylogue/storage/embeddings/materialization.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import contextlib
 import sqlite3
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -23,12 +24,14 @@ from typing import TYPE_CHECKING, Literal, Protocol, cast
 from polylogue.config import load_polylogue_config
 from polylogue.storage.embeddings.identity import (
     EMBEDDING_DERIVATION_KEY_SQL_FUNCTION,
-    EMBEDDING_MESSAGE_KEY_SQL_FUNCTION,
+    EMBEDDING_INPUT_HASH_SQL_FUNCTION,
     EMBEDDING_SOURCE_HASH_SQL_FUNCTION,
     EmbeddingRecipe,
     EmbeddingSourceDigest,
+    embedding_input_hash,
     message_embedding_derivation_key,
     register_embedding_identity_sql,
+    sql_string_literal,
 )
 from polylogue.storage.table_existence import table_exists as _table_exists
 
@@ -374,14 +377,24 @@ def _archive_embedding_freshness_predicate(
 ) -> _ArchiveEmbeddingFreshnessPredicate | None:
     """Build the single exact-key predicate used by every archive selector.
 
-    A legacy archive without the v3 derivation ledger returns ``None`` and is
-    evaluated by the pre-existing content-aware fallback below. Fresh v3
-    archives always take this route. A missing embeddings database is simpler:
-    every exact eligible source session is pending.
+    A legacy archive without the v3+ derivation ledger returns ``None`` and is
+    evaluated by the pre-existing content-aware fallback below. Fresh archives
+    always take this route. A missing embeddings database is simpler: every
+    exact eligible source session is pending.
+
+    v4 (polylogue-q88p): per-message freshness is presence-based --
+    ``desired_messages.embedding_input_hash`` (identity-free: computed from
+    the message's *current* embedder input text) either has a
+    ``message_embeddings_meta`` row or it does not. There is no per-vector
+    "stale" comparison anymore: a hash with a meta row IS fresh, because the
+    hash only exists in the first place if that exact text has already been
+    embedded. Model/dimension drift is already covered by construction (the
+    hash embeds the model), so the message-level check no longer needs
+    ``recipe_hash``/``derivation_key``/``generation`` comparisons -- those
+    remain session-level attempt bookkeeping only (``embedding_derivation_state``).
     """
 
-    message_columns = _table_columns(conn, "messages")
-    if not _archive_session_embeddable_counts_available(conn) or "content_hash" not in message_columns:
+    if not _archive_session_embeddable_counts_available(conn):
         return None
 
     state_table = _archive_embedding_sibling_table(conn, status_table, "embedding_derivation_state")
@@ -403,14 +416,7 @@ def _archive_embedding_freshness_predicate(
             "attempt_state",
             "message_count",
         }
-        required_meta = {
-            "message_id",
-            "content_hash",
-            "needs_reindex",
-            "recipe_hash",
-            "derivation_key",
-            "generation",
-        }
+        required_meta = {"embedding_input_hash"}
         if (
             not state_table
             or not meta_table
@@ -421,17 +427,17 @@ def _archive_embedding_freshness_predicate(
             return None
 
     register_embedding_identity_sql(conn)
-    relation = archive_embeddable_messages_relation(conn, alias="desired_source")
+    relation = archive_embeddable_messages_relation(conn, alias="desired_source", model=recipe.model)
     cte_sql = f"""
         WITH desired_messages AS (
-            SELECT desired_source.message_id, desired_source.session_id, desired_source.content_hash
+            SELECT desired_source.message_id, desired_source.session_id, desired_source.embedding_input_hash
             FROM {relation}
         ),
         desired_sessions AS (
             SELECT
                 session_id,
                 COUNT(*) AS message_count,
-                {EMBEDDING_SOURCE_HASH_SQL_FUNCTION}(message_id, content_hash) AS source_hash
+                {EMBEDDING_SOURCE_HASH_SQL_FUNCTION}(embedding_input_hash) AS source_hash
             FROM desired_messages
             GROUP BY session_id
         )
@@ -457,9 +463,6 @@ def _archive_embedding_freshness_predicate(
         AND d.recipe_hash = {recipe_hash_sql}
         AND d.output_contract_hash = {output_hash_sql}
     )"""
-    message_key_sql = (
-        f"{EMBEDDING_MESSAGE_KEY_SQL_FUNCTION}(dm.message_id, dm.content_hash, {recipe_hash_sql}, {output_hash_sql})"
-    )
     materialization_is_current = f"""(
         e.session_id IS NOT NULL
         AND COALESCE(e.needs_reindex, 0) = 0
@@ -469,17 +472,9 @@ def _archive_embedding_freshness_predicate(
         AND NOT EXISTS (
             SELECT 1
             FROM desired_messages AS dm
-            LEFT JOIN {meta_table} AS em ON em.message_id = dm.message_id
             WHERE dm.session_id = s.session_id
-              AND (
-                    em.message_id IS NULL
-                 OR COALESCE(em.needs_reindex, 0) = 1
-                 OR em.content_hash != dm.content_hash
-                 OR em.recipe_hash IS NULL
-                 OR em.recipe_hash != {recipe_hash_sql}
-                 OR em.derivation_key IS NULL
-                 OR em.derivation_key != {message_key_sql}
-                 OR em.generation != d.generation
+              AND NOT EXISTS (
+                  SELECT 1 FROM {meta_table} AS em WHERE em.embedding_input_hash = dm.embedding_input_hash
               )
         )
     )"""
@@ -1113,18 +1108,28 @@ def archive_embedding_messages_table_ref(conn: sqlite3.Connection, *, alias: str
     return archive_messages_table_ref(conn, alias=alias)
 
 
-def archive_embeddable_messages_relation(conn: sqlite3.Connection, *, alias: str) -> str:
-    """Return a relation containing messages the archive embedder will send."""
+def archive_embeddable_messages_relation(conn: sqlite3.Connection, *, alias: str, model: str | None = None) -> str:
+    """Return a relation containing messages the archive embedder will send.
+
+    ``model`` is optional: legacy/pre-v4 callers (the content-hash-based
+    compat fallback, which targets an embeddings.db that has not yet been
+    rebuilt onto the v4 schema) only need ``message_id``/``session_id``/
+    ``content_hash`` and omit it. Passing ``model`` additionally projects
+    ``embedding_input_hash`` -- computed via the registered SQL function from
+    exactly the same prose expression that will be sent to the embedder --
+    for callers that need the identity-free vector key (the freshness
+    predicate, embedding materialization, rescue).
+    """
 
     message_columns = _table_columns(conn, "messages")
     base_alias = f"{alias}_base"
     messages_ref = archive_embedding_messages_table_ref(conn, alias=base_alias)
     content_hash_expr = f"{base_alias}.content_hash" if "content_hash" in message_columns else "NULL"
-    selected_columns = (
-        f"{base_alias}.message_id AS message_id, "
-        f"{base_alias}.session_id AS session_id, "
-        f"{content_hash_expr} AS content_hash"
-    )
+    model_literal = ""
+    if model is not None:
+        register_embedding_identity_sql(conn)
+        model_literal = sql_string_literal(model)
+
     base_where = archive_embeddable_message_where(base_alias)
     if _archive_message_blocks_available(conn):
         blocks_ref = (
@@ -1133,6 +1138,15 @@ def archive_embeddable_messages_relation(conn: sqlite3.Connection, *, alias: str
             else "blocks AS b"
         )
         prose_expr = message_prose_sql(base_alias, separator="char(10)||char(10)", block_types=("text",))
+        hash_expr = (
+            f"{EMBEDDING_INPUT_HASH_SQL_FUNCTION}({model_literal}, {prose_expr})" if model is not None else "NULL"
+        )
+        selected_columns = (
+            f"{base_alias}.message_id AS message_id, "
+            f"{base_alias}.session_id AS session_id, "
+            f"{content_hash_expr} AS content_hash, "
+            f"{hash_expr} AS embedding_input_hash"
+        )
         return f"""
         (
             SELECT {selected_columns}
@@ -1148,6 +1162,15 @@ def archive_embeddable_messages_relation(conn: sqlite3.Connection, *, alias: str
         ) AS {alias}
         """
     if "text" in message_columns:
+        hash_expr = (
+            f"{EMBEDDING_INPUT_HASH_SQL_FUNCTION}({model_literal}, {base_alias}.text)" if model is not None else "NULL"
+        )
+        selected_columns = (
+            f"{base_alias}.message_id AS message_id, "
+            f"{base_alias}.session_id AS session_id, "
+            f"{content_hash_expr} AS content_hash, "
+            f"{hash_expr} AS embedding_input_hash"
+        )
         return f"""
         (
             SELECT {selected_columns}
@@ -1156,6 +1179,12 @@ def archive_embeddable_messages_relation(conn: sqlite3.Connection, *, alias: str
               AND LENGTH(TRIM(COALESCE({base_alias}.text, ''))) >= 20
         ) AS {alias}
         """
+    selected_columns = (
+        f"{base_alias}.message_id AS message_id, "
+        f"{base_alias}.session_id AS session_id, "
+        f"{content_hash_expr} AS content_hash, "
+        "NULL AS embedding_input_hash"
+    )
     return f"""
     (
         SELECT {selected_columns}
@@ -1293,27 +1322,50 @@ class _ProviderRequestError(RuntimeError):
     """Marks an exception raised by the embedding provider call itself."""
 
 
-def _archive_embedding_source_hash(rows: list[sqlite3.Row]) -> bytes:
+def _archive_embedding_source_hash_from_pairs(pairs: Iterable[tuple[str, bytes]]) -> bytes:
+    """Session source identity from ``(message_id, embedding_input_hash)`` pairs.
+
+    Only the hash VALUES are digested (message_id is accepted for caller
+    convenience -- e.g. a ``dict[message_id, hash].items()`` -- but excluded
+    from the digest itself): source identity must stay content-only so a
+    message-set that is renumbered by a rebuild but unchanged in content
+    does not bust the session's derivation key (polylogue-q88p).
+    """
     digest = EmbeddingSourceDigest()
+    for _message_id, input_hash in sorted(pairs, key=lambda item: item[1]):
+        digest.update(input_hash)
+    return digest.digest()
+
+
+def _archive_embedding_source_hash(rows: list[sqlite3.Row]) -> bytes:
+    """Source identity from a relation carrying a precomputed ``embedding_input_hash`` column."""
+
     normalized: list[tuple[str, bytes]] = []
     for row in rows:
-        content_hash = row["content_hash"]
-        if content_hash is None:
-            raise ValueError("content_hash is required for embedding source identity")
-        normalized.append((str(row["message_id"]), bytes(content_hash)))
-    for message_id, content_hash in sorted(normalized):
-        digest.update(message_id, content_hash)
-    return digest.digest()
+        input_hash = row["embedding_input_hash"]
+        if input_hash is None:
+            raise ValueError("embedding_input_hash is required for embedding source identity")
+        normalized.append((str(row["message_id"]), bytes(input_hash)))
+    return _archive_embedding_source_hash_from_pairs(normalized)
 
 
 def _read_archive_embedding_source_snapshot(
     conn: sqlite3.Connection,
     session_id: str,
+    *,
+    model: str,
 ) -> tuple[bytes, int]:
-    relation = archive_embeddable_messages_relation(conn, alias="current_source")
+    """Re-read live source identity to detect drift during materialization.
+
+    Queried fresh (not from the Python-side hashes computed before the
+    provider call) so a text/message-set change racing the embed pass is
+    caught: the relation recomputes ``embedding_input_hash`` from whatever
+    text is in ``index.db`` right now.
+    """
+    relation = archive_embeddable_messages_relation(conn, alias="current_source", model=model)
     rows = conn.execute(
         f"""
-        SELECT current_source.message_id, current_source.content_hash
+        SELECT current_source.message_id, current_source.embedding_input_hash
         FROM {relation}
         WHERE current_source.session_id = ?
         ORDER BY current_source.message_id
@@ -1395,7 +1447,16 @@ def embed_archive_session_sync(
             model=str(text_provider.model),
             dimensions=int(text_provider.dimension),
         )
-        source_hash = _archive_embedding_source_hash(embeddable)
+        # Derived directly from row["text"] -- the exact same string handed to
+        # the embedder below -- so hash validity equals vector validity by
+        # construction (polylogue-q88p). Computed once here in Python, not
+        # re-derived from stored identity, and reused for both the write and
+        # the session source-identity digest.
+        input_hash_by_message_id: dict[str, bytes] = {
+            str(row["message_id"]): embedding_input_hash(model=text_provider.model, input_text=str(row["text"]))
+            for row in embeddable
+        }
+        source_hash = _archive_embedding_source_hash_from_pairs(input_hash_by_message_id.items())
         attempt = begin_embedding_attempt(
             embeddings_conn,
             session_id=session_id,
@@ -1420,30 +1481,30 @@ def embed_archive_session_sync(
             if len(vectors) != len(batch):
                 raise _ProviderRequestError("embedding provider returned a mismatched vector count")
             for row, vector in zip(batch, vectors, strict=True):
-                content_hash = row["content_hash"]
-                if content_hash is None:
-                    raise ValueError("content_hash is required for message embedding metadata")
-                content_hash_bytes = bytes(content_hash)
+                message_id = str(row["message_id"])
+                input_hash = input_hash_by_message_id[message_id]
                 writes.append(
                     ArchiveEmbeddingWrite(
-                        message_id=str(row["message_id"]),
+                        message_id=message_id,
                         session_id=session_id,
                         origin=str(session["origin"]),
                         embedding=vector,
                         model=text_provider.model,
                         embedded_at_ms=now_ms,
-                        content_hash=content_hash_bytes,
+                        embedding_input_hash=input_hash,
                         recipe_hash=attempt.recipe_hash,
                         derivation_key=message_embedding_derivation_key(
-                            message_id=str(row["message_id"]),
-                            content_hash=content_hash_bytes,
+                            message_id=message_id,
+                            embedding_input_hash=input_hash,
                             recipe=recipe,
                         ).digest(),
                         generation=attempt.generation,
                     )
                 )
 
-        current_source_hash, current_message_count = _read_archive_embedding_source_snapshot(index_conn, session_id)
+        current_source_hash, current_message_count = _read_archive_embedding_source_snapshot(
+            index_conn, session_id, model=text_provider.model
+        )
         current_recipe = _configured_embedding_recipe()
         if (
             current_source_hash != attempt.source_hash

--- a/polylogue/storage/embeddings/reconcile.py
+++ b/polylogue/storage/embeddings/reconcile.py
@@ -11,6 +11,19 @@ report over 100% (polylogue-1dk1: 675,825 meta rows vs 675,725 status-summed
 embedded messages, 11,348 orphan message ids, 6 orphan session status rows on
 the 2026-07-10 audit).
 
+v4 (polylogue-q88p): ``message_embeddings``/``message_embeddings_meta`` are now
+content-addressed (keyed by ``embedding_input_hash``) and shared/deduped
+across messages and sessions -- a vector row has no single owning message, so
+it can no longer be deleted just because *one* referencing message vanished
+from the index (another message, possibly in a different session, may still
+legitimately point at the same hash). This reconciler therefore now scopes
+strictly to ``message_embedding_refs`` (the rebuildable message_id ->
+embedding_input_hash mapping): an orphan ref whose ``message_id`` no longer
+exists in the live index is removed, but the vector/meta rows it pointed at
+are left untouched. Reference-counted vector/meta GC (removing hash rows with
+zero remaining refs) is deliberately out of scope here -- filed as follow-up
+debt, not attempted in this pass.
+
 Reconciliation here is strictly identity-scoped and applies three guards:
 
 * **Identity guard** — a row is only a reconciliation candidate when its
@@ -251,6 +264,8 @@ def reconcile_embedding_orphans(
             _assert_active_index_generation(index_path)
         conn.execute("BEGIN" if dry_run else "BEGIN IMMEDIATE")
 
+        # These now count content-addressed (deduped) rows, not per-message
+        # rows -- message_embedding_refs (below) is the per-message scan.
         scanned_message_meta_rows = _scalar(conn, "SELECT COUNT(*) FROM message_embeddings_meta")
         scanned_vector_rows = _scalar(conn, "SELECT COUNT(*) FROM message_embeddings")
         scanned_status_rows = _scalar(conn, "SELECT COUNT(*) FROM embedding_status")
@@ -305,17 +320,19 @@ def reconcile_embedding_orphans(
             affected_sessions: set[str] = set()
             for row in limited_message:
                 message_id = str(row["message_id"])
-                removed_meta = _delete_if_still_orphan(conn, "message_embeddings_meta", message_id)
-                removed_vector = _delete_if_still_orphan(conn, "message_embeddings", message_id)
-                removed_message_rows += removed_meta
-                removed_vector_rows += removed_vector
-                if (removed_meta or removed_vector) and row["session_id"]:
+                removed_ref = _delete_if_still_orphan_ref(conn, message_id)
+                removed_message_rows += removed_ref
+                # Vector/meta rows are content-addressed and shared -- never
+                # deleted by this reconciler (see module docstring).
+                if removed_ref and row["session_id"]:
                     affected_sessions.add(str(row["session_id"]))
 
             for session_id in sorted(affected_sessions):
                 if not _index_session_exists(conn, session_id):
                     continue
-                remaining = _scalar(conn, "SELECT COUNT(*) FROM message_embeddings WHERE session_id = ?", (session_id,))
+                remaining = _scalar(
+                    conn, "SELECT COUNT(*) FROM message_embedding_refs WHERE session_id = ?", (session_id,)
+                )
                 cursor = conn.execute(
                     """
                     UPDATE embedding_status
@@ -419,48 +436,38 @@ def reconcile_embedding_orphans(
 
 
 def _orphan_message_rows(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+    """Return orphan ``message_embedding_refs`` rows.
+
+    ``content_hash`` is reported as ``NULL`` -- refs carry no content-hash
+    column under content-addressing (see module docstring); ``has_meta``/
+    ``has_vector`` are reported as always-true from the ref's perspective
+    since a ref only ever points at a hash that has both (write-once,
+    atomic), even though this reconciler does not delete either.
+    """
     return conn.execute(
         """
-        WITH embedding_ids AS (
-            SELECT message_id FROM message_embeddings_meta
-            UNION
-            SELECT message_id FROM message_embeddings
-        )
-        SELECT ids.message_id,
-               COALESCE(
-                   vec.session_id,
-                   (
-                       SELECT status.session_id
-                       FROM embedding_status AS status
-                       WHERE ids.message_id LIKE status.session_id || ':%'
-                       ORDER BY length(status.session_id) DESC
-                       LIMIT 1
-                   )
-               ) AS session_id,
-               meta.content_hash,
-               meta.embedded_at_ms,
-               meta.message_id IS NOT NULL AS has_meta,
-               vec.message_id IS NOT NULL AS has_vector
-        FROM embedding_ids AS ids
-        LEFT JOIN message_embeddings_meta AS meta ON meta.message_id = ids.message_id
-        LEFT JOIN message_embeddings AS vec ON vec.message_id = ids.message_id
+        SELECT r.message_id AS message_id,
+               r.session_id AS session_id,
+               NULL AS content_hash,
+               r.embedded_at_ms AS embedded_at_ms,
+               1 AS has_meta,
+               1 AS has_vector
+        FROM message_embedding_refs AS r
         WHERE NOT EXISTS (
-            SELECT 1 FROM idx.messages AS indexed WHERE indexed.message_id = ids.message_id
+            SELECT 1 FROM idx.messages AS indexed WHERE indexed.message_id = r.message_id
         )
-        ORDER BY ids.message_id
+        ORDER BY r.message_id
         """
     ).fetchall()
 
 
-def _delete_if_still_orphan(conn: sqlite3.Connection, table: str, message_id: str) -> int:
-    if table not in {"message_embeddings_meta", "message_embeddings"}:
-        raise ValueError(f"unsupported embedding table: {table}")
+def _delete_if_still_orphan_ref(conn: sqlite3.Connection, message_id: str) -> int:
     cursor = conn.execute(
-        f"""
-        DELETE FROM {table}
+        """
+        DELETE FROM message_embedding_refs
         WHERE message_id = ?
           AND NOT EXISTS (
-              SELECT 1 FROM idx.messages WHERE idx.messages.message_id = {table}.message_id
+              SELECT 1 FROM idx.messages WHERE idx.messages.message_id = message_embedding_refs.message_id
           )
         """,
         (message_id,),

--- a/polylogue/storage/embeddings/rescue.py
+++ b/polylogue/storage/embeddings/rescue.py
@@ -1,18 +1,33 @@
-"""Rescue vectors from a retired embeddings tier by exact content-hash match.
+"""Rescue vectors from a retired embeddings tier, landing directly into the
+content-addressed (embedding_input_hash) layout.
 
 polylogue-04kl: a prior incident retired an embeddings tier
 (``embeddings.db.v2-retired-YYYYMMDD``) while the index was rebuilt from
 source. That retired tier still holds hundreds of thousands of Voyage
-vectors keyed by ``message_id`` + a 32-byte ``content_hash``. The freshly
-rebuilt index computes the *same* content-hash identity for each message, so
-an exact rescue is possible: a retired vector is safe to copy into the fresh
-``embeddings.db`` whenever
+vectors, keyed by the OLD v3 identity: ``message_id`` + a 32-byte
+identity-contaminated ``content_hash`` (``messages.content_hash`` includes
+session_id/position/variant_index -- see polylogue-q88p). The v4 embeddings
+tier this rescue writes into is keyed by ``embedding_input_hash`` instead
+(identity-free: ``H(model, embedder input text)``), so a straight copy is not
+possible; rescue must *recompute* the new key for each candidate message and
+land the vector under that key.
+
+A retired vector is safe to rescue for a message whenever:
 
 * its ``message_id`` still exists among the fresh index's *currently
   eligible* (authored-prose) messages,
 * its stored ``content_hash`` matches that message's current content hash
-  exactly, and
+  exactly (identity-contaminated, but an exact match remains a valid --
+  merely conservative -- sufficient proof that the message's text is
+  unchanged from what the retired vector was computed for), and
 * its stored ``model`` matches the configured embedding model.
+
+Once matched, this rescue recomputes ``embedding_input_hash`` from the
+message's *current* embedder input text (the same prose expression the live
+embed path uses) and writes the retired vector under that new key, plus a
+``message_embedding_refs`` row for the message. The content_hash match is
+what licenses treating "current text" and "retired text" as identical; the
+new key is never trusted from the retired file (which cannot know it).
 
 Session-level granularity is not a stylistic choice -- it is required by how
 catch-up materialization actually works. ``embed_archive_session_sync``
@@ -36,7 +51,9 @@ embed path uses (:func:`begin_embedding_attempt` +
 one embedded for real -- the daemon's freshness predicate
 (``_archive_embedding_freshness_predicate``) will no longer select it, and a
 second rescue run naturally treats it as already-fresh (idempotent, no
-re-write).
+re-write). Content-addressing also means a rescued vector is immediately
+shared with every other message (any origin/session) whose current text
+hashes to the same ``embedding_input_hash`` -- dedup applies to rescue too.
 """
 
 from __future__ import annotations
@@ -346,18 +363,27 @@ def plan_embedding_rescue(
     )
 
 
-def _session_eligible_messages(conn: sqlite3.Connection, relation: str, session_id: str) -> list[tuple[str, bytes]]:
+def _session_eligible_messages(
+    conn: sqlite3.Connection, relation: str, session_id: str
+) -> list[tuple[str, bytes, bytes]]:
+    """Return ``(message_id, content_hash, embedding_input_hash)`` triples.
+
+    ``content_hash`` licenses the retired-vector match (old, identity-
+    contaminated identity); ``embedding_input_hash`` -- computed by the
+    relation from the message's *current* embedder input text -- is the key
+    the rescued vector is written under in the new content-addressed layout.
+    """
     rows = conn.execute(
-        f"SELECT e.message_id, e.content_hash FROM {relation} WHERE e.session_id = ?",
+        f"SELECT e.message_id, e.content_hash, e.embedding_input_hash FROM {relation} WHERE e.session_id = ?",
         (session_id,),
     ).fetchall()
-    return [(str(row[0]), bytes(row[1])) for row in rows]
+    return [(str(row[0]), bytes(row[1]), bytes(row[2])) for row in rows]
 
 
-def _source_hash_for(messages: list[tuple[str, bytes]]) -> bytes:
+def _source_hash_for(messages: list[tuple[str, bytes, bytes]]) -> bytes:
     digest = EmbeddingSourceDigest()
-    for message_id, content_hash in sorted(messages):
-        digest.update(message_id, content_hash)
+    for _message_id, _content_hash, input_hash in sorted(messages, key=lambda item: item[2]):
+        digest.update(input_hash)
     return digest.digest()
 
 
@@ -432,7 +458,7 @@ def execute_embedding_rescue(
         if not loaded:
             raise RuntimeError("embedding rescue requires sqlite-vec") from error
 
-        relation = archive_embeddable_messages_relation(index_conn, alias="e")
+        relation = archive_embeddable_messages_relation(index_conn, alias="e", model=resolved_recipe.model)
         counts = _session_rollup_counts(index_conn, relation, resolved_recipe.model)
         samples = _classification_samples(index_conn, relation, resolved_recipe.model, sample_size=sample_size)
         fully_rescuable_ids = _fully_rescuable_session_ids(index_conn, relation, resolved_recipe.model)
@@ -488,7 +514,7 @@ def execute_embedding_rescue(
 
             writes: list[ArchiveEmbeddingWrite] = []
             incomplete = False
-            for message_id, content_hash in messages:
+            for message_id, _content_hash, input_hash in messages:
                 vector = _read_retired_vector(index_conn, message_id)
                 if vector is None:
                     incomplete = True
@@ -501,11 +527,11 @@ def execute_embedding_rescue(
                         embedding=vector,
                         model=resolved_recipe.model,
                         embedded_at_ms=resolved_now_ms,
-                        content_hash=content_hash,
+                        embedding_input_hash=input_hash,
                         recipe_hash=attempt.recipe_hash,
                         derivation_key=message_embedding_derivation_key(
                             message_id=message_id,
-                            content_hash=content_hash,
+                            embedding_input_hash=input_hash,
                             recipe=resolved_recipe,
                         ).digest(),
                         generation=attempt.generation,
@@ -550,16 +576,22 @@ def execute_embedding_rescue(
 
             rescued_sessions += 1
             rescued_messages += len(writes)
-            rescued_message_ids.extend(message_id for message_id, _ in messages)
+            rescued_message_ids.extend(message_id for message_id, _content_hash, _input_hash in messages)
 
         if rescued_message_ids and sample_verify_count > 0:
             step = max(1, len(rescued_message_ids) // sample_verify_count)
             sample_ids = rescued_message_ids[::step][:sample_verify_count]
             for message_id in sample_ids:
                 verified_total += 1
-                target_row = embeddings_conn.execute(
-                    "SELECT embedding FROM message_embeddings WHERE message_id = ?",
+                ref_row = embeddings_conn.execute(
+                    "SELECT embedding_input_hash FROM message_embedding_refs WHERE message_id = ?",
                     (message_id,),
+                ).fetchone()
+                if ref_row is None:
+                    continue
+                target_row = embeddings_conn.execute(
+                    "SELECT embedding FROM message_embeddings WHERE embedding_input_hash = ?",
+                    (bytes(ref_row[0]).hex(),),
                 ).fetchone()
                 source_row = index_conn.execute(
                     "SELECT embedding FROM retired.message_embeddings WHERE message_id = ?",

--- a/polylogue/storage/embeddings/sql.py
+++ b/polylogue/storage/embeddings/sql.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from polylogue.storage.embeddings.identity import EMBEDDING_INPUT_HASH_SQL_FUNCTION, sql_string_literal
-
 EMBEDDABLE_MESSAGE_WHERE = """
     m.message_type = 'message'
     AND m.role IN ('user', 'assistant')
@@ -59,56 +57,6 @@ MISSING_META_MESSAGES_SQL = """
     LEFT JOIN message_embeddings_meta em
       ON em.embedding_input_hash = r.embedding_input_hash
     WHERE em.embedding_input_hash IS NULL
-"""
-
-
-def stale_messages_sql(model: str) -> str:
-    """Count refs whose recorded hash no longer matches the message's live text.
-
-    There is no per-vector "stale" state under content-addressing (a hash
-    with a meta row is fresh by construction); "stale" instead means the
-    *ref* is out of date -- the message's current embedder input text hashes
-    differently than what was recorded the last time it was embedded, so a
-    fresh vector for the new hash has not been written yet even though an
-    old ref row still points at the superseded one. Requires
-    ``register_embedding_identity_sql(conn)`` to already be installed on the
-    connection this runs against.
-    """
-    model_literal = sql_string_literal(model)
-    prose_expr = (
-        "(SELECT GROUP_CONCAT(b.text, char(10)||char(10)) "
-        "FROM blocks b WHERE b.message_id = m.message_id "
-        "AND b.block_type = 'text' AND b.text IS NOT NULL ORDER BY b.position)"
-    )
-    return f"""
-    SELECT COUNT(*)
-    FROM message_embedding_refs r
-    JOIN messages m ON m.message_id = r.message_id
-    WHERE m.message_type = 'message'
-      AND m.role IN ('user', 'assistant')
-      AND m.material_origin IN ('human_authored', 'assistant_authored')
-      AND m.word_count > 0
-      AND r.embedding_input_hash != {EMBEDDING_INPUT_HASH_SQL_FUNCTION}({model_literal}, {prose_expr})
-    """
-
-
-# Legacy (v3) shape, kept for readers that may still be pointed at a
-# not-yet-rebuilt embeddings.db: message_embeddings/message_embeddings_meta
-# were message_id-keyed and compared against messages.content_hash directly.
-STALE_MESSAGES_SQL_LEGACY = """
-    SELECT COUNT(*)
-    FROM message_embeddings me
-    JOIN messages m ON m.message_id = me.message_id
-    LEFT JOIN message_embeddings_meta em
-      ON em.message_id = me.message_id
-    WHERE (
-            em.message_id IS NULL
-         OR (em.content_hash IS NOT NULL AND em.content_hash != m.content_hash)
-    )
-      AND m.message_type = 'message'
-      AND m.role IN ('user', 'assistant')
-      AND m.material_origin IN ('human_authored', 'assistant_authored')
-      AND m.word_count > 0
 """
 EMBEDDED_AT_BOUNDS_SQL = """
     SELECT MIN(embedded_at_ms) AS oldest_embedded_at, MAX(embedded_at_ms) AS newest_embedded_at

--- a/polylogue/storage/embeddings/sql.py
+++ b/polylogue/storage/embeddings/sql.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from polylogue.storage.embeddings.identity import EMBEDDING_INPUT_HASH_SQL_FUNCTION, sql_string_literal
+
 EMBEDDABLE_MESSAGE_WHERE = """
     m.message_type = 'message'
     AND m.role IN ('user', 'assistant')
@@ -46,15 +48,54 @@ PENDING_MESSAGES_SQL = """
       AND m.material_origin IN ('human_authored', 'assistant_authored')
       AND m.word_count > 0
 """
-EMBEDDED_MESSAGES_SQL = "SELECT COUNT(*) FROM message_embeddings"
+# v4 (polylogue-q88p): a message's vector is looked up through
+# message_embedding_refs (message_id -> embedding_input_hash), not directly
+# by message_id -- message_embeddings/message_embeddings_meta are keyed by
+# the content-addressed hash and are shared/deduped across messages.
+EMBEDDED_MESSAGES_SQL = "SELECT COUNT(*) FROM message_embedding_refs"
 MISSING_META_MESSAGES_SQL = """
     SELECT COUNT(*)
-    FROM message_embeddings me
+    FROM message_embedding_refs r
     LEFT JOIN message_embeddings_meta em
-      ON em.message_id = me.message_id
-    WHERE em.message_id IS NULL
+      ON em.embedding_input_hash = r.embedding_input_hash
+    WHERE em.embedding_input_hash IS NULL
 """
-STALE_MESSAGES_SQL = """
+
+
+def stale_messages_sql(model: str) -> str:
+    """Count refs whose recorded hash no longer matches the message's live text.
+
+    There is no per-vector "stale" state under content-addressing (a hash
+    with a meta row is fresh by construction); "stale" instead means the
+    *ref* is out of date -- the message's current embedder input text hashes
+    differently than what was recorded the last time it was embedded, so a
+    fresh vector for the new hash has not been written yet even though an
+    old ref row still points at the superseded one. Requires
+    ``register_embedding_identity_sql(conn)`` to already be installed on the
+    connection this runs against.
+    """
+    model_literal = sql_string_literal(model)
+    prose_expr = (
+        "(SELECT GROUP_CONCAT(b.text, char(10)||char(10)) "
+        "FROM blocks b WHERE b.message_id = m.message_id "
+        "AND b.block_type = 'text' AND b.text IS NOT NULL ORDER BY b.position)"
+    )
+    return f"""
+    SELECT COUNT(*)
+    FROM message_embedding_refs r
+    JOIN messages m ON m.message_id = r.message_id
+    WHERE m.message_type = 'message'
+      AND m.role IN ('user', 'assistant')
+      AND m.material_origin IN ('human_authored', 'assistant_authored')
+      AND m.word_count > 0
+      AND r.embedding_input_hash != {EMBEDDING_INPUT_HASH_SQL_FUNCTION}({model_literal}, {prose_expr})
+    """
+
+
+# Legacy (v3) shape, kept for readers that may still be pointed at a
+# not-yet-rebuilt embeddings.db: message_embeddings/message_embeddings_meta
+# were message_id-keyed and compared against messages.content_hash directly.
+STALE_MESSAGES_SQL_LEGACY = """
     SELECT COUNT(*)
     FROM message_embeddings me
     JOIN messages m ON m.message_id = me.message_id

--- a/polylogue/storage/embeddings/status_payload.py
+++ b/polylogue/storage/embeddings/status_payload.py
@@ -743,17 +743,18 @@ def _archive_embedding_status_payload(
         if embeddings_db.exists():
             conn.execute("ATTACH DATABASE ? AS embeddings", (str(embeddings_db),))
             status_table = _attached_table_name(conn, "embeddings", "embedding_status")
-            vector_table = _attached_table_name(conn, "embeddings", "message_embeddings")
             meta_table = _attached_table_name(conn, "embeddings", "message_embeddings_meta")
             failure_table = _attached_table_name(conn, "embeddings", "embedding_failures")
+            refs_table = _attached_table_name(conn, "embeddings", "message_embedding_refs")
         else:
             status_table = ""
-            vector_table = ""
             meta_table = ""
             failure_table = ""
+            refs_table = ""
         has_messages = _table_exists(conn, "messages")
         has_status = bool(status_table)
         has_meta = bool(meta_table)
+        has_refs = bool(refs_table)
         total_sessions = _scalar_int(conn, "SELECT COUNT(*) FROM sessions")
         legacy_blocked_sessions = (
             _scalar_int(
@@ -796,6 +797,19 @@ def _archive_embedding_status_payload(
                 JOIN sessions AS s ON s.session_id = e.session_id
                 """,
             )
+        elif refs_table:
+            # message_embedding_refs is per-message; message_embeddings_meta
+            # is per-distinct-vector (deduped) and would undercount identical
+            # content shared across sessions as one message.
+            exact_embedded_messages = _scalar_int_with_timeout(
+                conn,
+                f"""
+                SELECT COUNT(*)
+                FROM {refs_table}
+                """,
+                timeout_ms=DETAIL_QUERY_TIMEOUT_MS,
+            )
+            embedded_messages = exact_embedded_messages if exact_embedded_messages is not None else 0
         elif has_meta:
             exact_embedded_messages = _scalar_int_with_timeout(
                 conn,
@@ -909,7 +923,8 @@ def _archive_embedding_status_payload(
                 newest_embedded_at = _iso_from_epoch_ms(bounds_rows[0][1])
         if include_detail and has_messages:
             candidate_prose_messages, candidate_prose_messages_exact = _candidate_prose_message_count(conn)
-            messages_ref = archive_embeddable_messages_relation(conn, alias="m")
+            configured_model = str(getattr(cfg, "embedding_model", "") or "")
+            messages_ref = archive_embeddable_messages_relation(conn, alias="m", model=configured_model)
             status_join = f"LEFT JOIN {status_table} e ON e.session_id = m.session_id" if has_status else ""
             blocked_session_clause = (
                 "AND NOT (e.session_id IS NOT NULL AND COALESCE(e.needs_reindex, 0) = 0 "
@@ -925,22 +940,24 @@ def _archive_embedding_status_payload(
             if total_messages is None:
                 total_messages = 0
                 pending_messages_exact = False
-            if has_meta and embedded_messages == 0 and blocked_sessions == 0:
+            # v4 (polylogue-q88p): a message is pending unless its ref exists
+            # AND that ref's recorded hash matches the message's *current*
+            # embedding_input_hash (computed by the relation above). Presence-
+            # based -- there is no per-vector "needs_reindex" anymore.
+            if has_refs and embedded_messages == 0 and blocked_sessions == 0:
                 pending_messages = total_messages
-            elif has_meta:
-                meta_join = "ON em.message_id = m.message_id"
-                meta_missing_column = "em.message_id"
+            elif has_refs:
                 status_reindex_clause = "OR COALESCE(e.needs_reindex, 0) = 1" if has_status else ""
                 exact_pending_messages = _scalar_int_with_timeout(
                     conn,
                     f"""
                     SELECT COUNT(*)
                     FROM {messages_ref}
-                    LEFT JOIN {meta_table} em {meta_join}
+                    LEFT JOIN {refs_table} r ON r.message_id = m.message_id
                     {status_join}
                     WHERE (
-                        {meta_missing_column} IS NULL
-                        OR COALESCE(em.needs_reindex, 0) = 1
+                        r.message_id IS NULL
+                        OR r.embedding_input_hash != m.embedding_input_hash
                         {status_reindex_clause}
                       )
                       {blocked_session_clause}
@@ -954,21 +971,19 @@ def _archive_embedding_status_payload(
                     pending_messages = exact_pending_messages
             else:
                 pending_messages = total_messages
-            if has_meta and embedded_messages == 0:
+            if has_refs and embedded_messages == 0:
                 missing_provenance = 0
                 stale_messages = 0
-            elif has_meta and pending_messages_exact:
-                meta_join = "ON em.message_id = m.message_id"
-                meta_missing_column = "em.message_id"
-                if vector_table:
+            elif has_refs and pending_messages_exact:
+                if meta_table:
                     exact_missing_provenance = _scalar_int_with_timeout(
                         conn,
                         f"""
                         SELECT COUNT(*)
-                        FROM {vector_table} me
+                        FROM {refs_table} r
                         LEFT JOIN {meta_table} em
-                          ON em.message_id = me.message_id
-                        WHERE em.message_id IS NULL
+                          ON em.embedding_input_hash = r.embedding_input_hash
+                        WHERE em.embedding_input_hash IS NULL
                         """,
                         timeout_ms=DETAIL_QUERY_TIMEOUT_MS,
                     )
@@ -983,12 +998,9 @@ def _archive_embedding_status_payload(
                         f"""
                         SELECT COUNT(*)
                         FROM {messages_ref}
-                        JOIN {meta_table} em {meta_join}
+                        JOIN {refs_table} r ON r.message_id = m.message_id
                         {status_join}
-                        WHERE (
-                            COALESCE(em.needs_reindex, 0) = 1
-                            OR (em.content_hash IS NOT NULL AND em.content_hash != m.content_hash)
-                          )
+                        WHERE r.embedding_input_hash != m.embedding_input_hash
                           {blocked_session_clause}
                         """,
                         timeout_ms=DETAIL_QUERY_TIMEOUT_MS,

--- a/polylogue/storage/embeddings/support.py
+++ b/polylogue/storage/embeddings/support.py
@@ -194,7 +194,17 @@ def optional_count_sync(conn: sqlite3.Connection, sql: str) -> int:
 
 
 def embedded_message_count_sync(conn: sqlite3.Connection) -> int:
-    """Count embedded messages from canonical metadata before vector internals."""
+    """Count messages that have a current embedding.
+
+    v4 (polylogue-q88p): ``message_embeddings_meta`` is keyed by
+    ``embedding_input_hash`` and deduped -- its row count is the number of
+    *distinct vectors*, not messages (identical content across sessions
+    shares one row). ``message_embedding_refs`` (message_id -> hash) is the
+    per-message count and is checked first; older/legacy shapes fall back to
+    the pre-v4 behavior.
+    """
+    if table_exists_sync(conn, "message_embedding_refs"):
+        return optional_count_sync(conn, "SELECT COUNT(*) FROM message_embedding_refs")
     if table_exists_sync(conn, "message_embeddings_meta"):
         return optional_count_sync(conn, "SELECT COUNT(*) FROM message_embeddings_meta")
     if table_exists_sync(conn, "message_embeddings_rowids"):
@@ -232,7 +242,9 @@ async def optional_count_async(conn: aiosqlite.Connection, sql: str) -> int:
 
 
 async def embedded_message_count_async(conn: aiosqlite.Connection) -> int:
-    """Count embedded messages from canonical metadata before vector internals."""
+    """Count messages that have a current embedding (see sync counterpart)."""
+    if await table_exists_async(conn, "message_embedding_refs"):
+        return await optional_count_async(conn, "SELECT COUNT(*) FROM message_embedding_refs")
     if await table_exists_async(conn, "message_embeddings_meta"):
         return await optional_count_async(conn, "SELECT COUNT(*) FROM message_embeddings_meta")
     if await table_exists_async(conn, "message_embeddings_rowids"):

--- a/polylogue/storage/search_providers/sqlite_vec_queries.py
+++ b/polylogue/storage/search_providers/sqlite_vec_queries.py
@@ -40,7 +40,15 @@ class SqliteVecQueryMixin:
         def _get_connection(self) -> sqlite3.Connection: ...
 
     def upsert(self, session_id: str, messages: list[MessageRecord]) -> None:
-        """Upsert message embeddings into the vector store."""
+        """Upsert message embeddings into the vector store.
+
+        Delegates the actual write to the canonical content-addressed
+        primitives (:mod:`polylogue.storage.sqlite.archive_tiers.
+        embedding_write`) instead of hand-rolled SQL, so this provider's
+        vectors are keyed and deduped exactly like the daemon catch-up path
+        (``embed_archive_session_sync``) that shares the same ``embeddings.db``
+        file (polylogue-q88p).
+        """
         if not messages:
             return
 
@@ -59,62 +67,67 @@ class SqliteVecQueryMixin:
             logger.error("Failed to generate embeddings for %s: %s", session_id, exc)
             raise
 
+        from datetime import UTC, datetime
+
+        from polylogue.storage.embeddings.identity import embedding_input_hash
+        from polylogue.storage.sqlite.archive_tiers.embedding_write import (
+            ArchiveEmbeddingWrite,
+            upsert_message_embeddings,
+        )
+
         conn = self._get_connection()
         try:
-            source_name = "unknown"
+            origin = "unknown"
             row = conn.execute(
                 "SELECT origin FROM sessions WHERE session_id = ?",
                 (session_id,),
             ).fetchone()
             if row:
-                source_name = row[0] or "unknown"
+                origin = row[0] or "unknown"
 
-            for msg, embedding in zip(embeddable, embeddings, strict=True):
-                embedding_blob = _serialize_f32(embedding)
-                conn.execute(
-                    "DELETE FROM message_embeddings WHERE message_id = ?",
-                    (msg.message_id,),
+            now_ms = int(datetime.now(UTC).timestamp() * 1000)
+            writes = [
+                ArchiveEmbeddingWrite(
+                    message_id=msg.message_id,
+                    session_id=msg.session_id,
+                    origin=origin,
+                    embedding=embedding,
+                    model=self.model,
+                    embedded_at_ms=now_ms,
+                    embedding_input_hash=embedding_input_hash(model=self.model, input_text=str(msg.text)),
                 )
-                conn.execute(
-                    """
-                    INSERT INTO message_embeddings (message_id, embedding, source_name, session_id)
-                    VALUES (?, ?, ?, ?)
-                    """,
-                    (msg.message_id, embedding_blob, source_name, msg.session_id),
-                )
-                conn.execute(
-                    """
-                    INSERT OR REPLACE INTO message_embeddings_meta (
-                        message_id, model, dimension, embedded_at_ms, content_hash, needs_reindex
-                    ) VALUES (?, ?, ?, CAST(strftime('%s', 'now') AS INTEGER) * 1000, ?, 0)
-                    """,
-                    (
-                        msg.message_id,
-                        self.model,
-                        self.dimension,
-                        msg.content_hash if hasattr(msg, "content_hash") else None,
-                    ),
-                )
+                for msg, embedding in zip(embeddable, embeddings, strict=True)
+            ]
+            upsert_message_embeddings(conn, writes)
 
             conn.execute(
                 """
                 INSERT INTO embedding_status (
-                    session_id, message_count_embedded, last_embedded_at, needs_reindex
-                ) VALUES (?, ?, datetime('now'), 0)
+                    session_id, origin, message_count_embedded, last_embedded_at_ms, needs_reindex, error_message
+                ) VALUES (?, ?, ?, ?, 0, NULL)
                 ON CONFLICT(session_id) DO UPDATE SET
+                    origin = excluded.origin,
                     message_count_embedded = excluded.message_count_embedded,
-                    last_embedded_at = excluded.last_embedded_at,
+                    last_embedded_at_ms = excluded.last_embedded_at_ms,
                     needs_reindex = 0,
                     error_message = NULL
                 """,
-                (session_id, len(embeddable)),
+                (session_id, origin, len(embeddable), now_ms),
             )
             conn.commit()
         finally:
             conn.close()
 
     def query(self, text: str, limit: int = 10) -> list[tuple[str, float]]:
-        """Find semantically similar messages."""
+        """Find semantically similar messages.
+
+        ``message_embeddings`` is keyed by ``embedding_input_hash`` (content-
+        addressed, deduped), not ``message_id``: a MATCH hit is resolved back
+        to every message currently referencing that hash via
+        ``message_embedding_refs``, so identical content shared across
+        sessions surfaces every one of its messages, not just one arbitrary
+        representative.
+        """
         self._ensure_vec_available()
         self._ensure_tables()
 
@@ -128,11 +141,16 @@ class SqliteVecQueryMixin:
         try:
             rows = conn.execute(
                 """
-                SELECT message_id, distance
-                FROM message_embeddings
-                WHERE embedding MATCH ?
-                  AND k = ?
-                ORDER BY distance
+                SELECT r.message_id AS message_id, hits.distance AS distance
+                FROM (
+                    SELECT embedding_input_hash, distance
+                    FROM message_embeddings
+                    WHERE embedding MATCH ?
+                      AND k = ?
+                ) AS hits
+                JOIN message_embedding_refs AS r
+                  ON lower(hex(r.embedding_input_hash)) = hits.embedding_input_hash
+                ORDER BY hits.distance
                 """,
                 (query_embedding, limit),
             ).fetchall()
@@ -160,7 +178,13 @@ class SqliteVecQueryMixin:
             seed_rows: list[sqlite3.Row] = []
             try:
                 seed_rows = conn.execute(
-                    "SELECT message_id, embedding FROM message_embeddings WHERE session_id = ?",
+                    """
+                    SELECT DISTINCT me.embedding_input_hash AS embedding_input_hash, me.embedding AS embedding
+                    FROM message_embedding_refs AS r
+                    JOIN message_embeddings AS me
+                      ON lower(hex(r.embedding_input_hash)) = me.embedding_input_hash
+                    WHERE r.session_id = ?
+                    """,
                     (session_id,),
                 ).fetchall()
             except sqlite3.OperationalError as exc:
@@ -176,11 +200,16 @@ class SqliteVecQueryMixin:
                 embedding_blob = bytes(seed_row["embedding"])
                 neighbors = conn.execute(
                     """
-                    SELECT message_id, session_id, distance
-                    FROM message_embeddings
-                    WHERE embedding MATCH ?
-                      AND k = ?
-                    ORDER BY distance
+                    SELECT r.message_id AS message_id, r.session_id AS session_id, hits.distance AS distance
+                    FROM (
+                        SELECT embedding_input_hash, distance
+                        FROM message_embeddings
+                        WHERE embedding MATCH ?
+                          AND k = ?
+                    ) AS hits
+                    JOIN message_embedding_refs AS r
+                      ON lower(hex(r.embedding_input_hash)) = hits.embedding_input_hash
+                    ORDER BY hits.distance
                     """,
                     (embedding_blob, k),
                 ).fetchall()
@@ -203,7 +232,14 @@ class SqliteVecQueryMixin:
         provider: str,
         limit: int = 10,
     ) -> list[tuple[str, float]]:
-        """Find semantically similar messages filtered by provider."""
+        """Find semantically similar messages filtered by provider (origin).
+
+        ``message_embeddings`` no longer carries a per-vector origin column
+        (it is content-addressed and shared across origins); the filter is
+        applied post-join against ``message_embedding_refs.origin`` instead.
+        Over-fetches the KNN candidate pool so a narrow origin filter still
+        has enough candidates to fill ``limit`` after filtering.
+        """
         self._ensure_vec_available()
 
         embeddings = self._get_embeddings([text], input_type="query")
@@ -211,19 +247,26 @@ class SqliteVecQueryMixin:
             return []
 
         query_embedding = _serialize_f32(embeddings[0])
+        fanout_k = max(limit * 5, limit, 1)
 
         conn = self._get_connection()
         try:
             rows = conn.execute(
                 """
-                SELECT message_id, distance
-                FROM message_embeddings
-                WHERE embedding MATCH ?
-                  AND k = ?
-                  AND source_name = ?
-                ORDER BY distance
+                SELECT r.message_id AS message_id, hits.distance AS distance
+                FROM (
+                    SELECT embedding_input_hash, distance
+                    FROM message_embeddings
+                    WHERE embedding MATCH ?
+                      AND k = ?
+                ) AS hits
+                JOIN message_embedding_refs AS r
+                  ON lower(hex(r.embedding_input_hash)) = hits.embedding_input_hash
+                WHERE r.origin = ?
+                ORDER BY hits.distance
+                LIMIT ?
                 """,
-                (query_embedding, limit, provider),
+                (query_embedding, fanout_k, provider, limit),
             ).fetchall()
             return [(row["message_id"], row["distance"]) for row in rows]
         finally:

--- a/polylogue/storage/search_providers/sqlite_vec_runtime.py
+++ b/polylogue/storage/search_providers/sqlite_vec_runtime.py
@@ -60,45 +60,23 @@ class SqliteVecRuntimeMixin:
         Detects dimension mismatches between the configured dimension and the
         existing vec0 table. Drops and recreates the vec0 table when the
         dimension has changed.
+
+        Uses the canonical archive_tiers DDL (:mod:`polylogue.storage.sqlite.
+        archive_tiers.embeddings`) rather than a duplicate hand-rolled schema
+        -- a second, drifted declaration here previously created ``+source_name``
+        / message_id-keyed shapes that mismatched what the archive_tiers
+        bootstrap (and the daemon catch-up path) actually writes, silently
+        breaking this provider's own :meth:`SqliteVecQueryMixin.upsert` when
+        both ran against the same ``embeddings.db``.
         """
         conn = self._get_connection()
         try:
             # Detect and handle dimension mismatch before creating tables
             _reconcile_vec0_dimension(conn, self.dimension)
 
-            conn.execute(
-                f"""
-                CREATE VIRTUAL TABLE IF NOT EXISTS message_embeddings USING vec0(
-                    message_id TEXT PRIMARY KEY,
-                    embedding float[{self.dimension}],
-                    +source_name TEXT,
-                    +session_id TEXT
-                )
-                """
-            )
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS message_embeddings_meta (
-                    message_id TEXT PRIMARY KEY,
-                    model TEXT NOT NULL,
-                    dimension INTEGER NOT NULL,
-                    embedded_at_ms INTEGER,
-                    content_hash TEXT,
-                    needs_reindex INTEGER NOT NULL DEFAULT 0
-                )
-            """)
-            conn.execute("""
-                CREATE TABLE IF NOT EXISTS embedding_status (
-                    session_id TEXT PRIMARY KEY,
-                    message_count_embedded INTEGER DEFAULT 0,
-                    last_embedded_at TEXT,
-                    needs_reindex INTEGER DEFAULT 0,
-                    error_message TEXT
-                )
-            """)
-            conn.execute("""
-                CREATE INDEX IF NOT EXISTS idx_embedding_status_needs
-                ON embedding_status(needs_reindex) WHERE needs_reindex = 1
-            """)
+            from polylogue.storage.sqlite.archive_tiers.embeddings import EMBEDDINGS_DDL
+
+            conn.executescript(EMBEDDINGS_DDL)
             conn.commit()
             self._tables_ensured = True
         finally:

--- a/polylogue/storage/session_replacement.py
+++ b/polylogue/storage/session_replacement.py
@@ -73,6 +73,18 @@ async def _purge_message_fts_async(conn: aiosqlite.Connection, session_id: str) 
 
 
 def _invalidate_embedding_state_sync(conn: sqlite3.Connection, session_id: str) -> None:
+    """Drop this session's stale message_id -> vector association before re-materializing.
+
+    v4 (polylogue-q88p): ``message_embeddings``/``message_embeddings_meta``
+    are content-addressed and shared/deduped -- they are never deleted here.
+    Only ``message_embedding_refs`` (the per-message mapping) is invalidated;
+    the real re-embed pass that follows re-materialization writes fresh refs,
+    reusing any vector whose hash the new content happens to match for free.
+    """
+    if _table_exists_sync(conn, "message_embedding_refs"):
+        conn.execute("DELETE FROM message_embedding_refs WHERE session_id = ?", (session_id,))
+        return
+    # Legacy v3 (pre-q88p) shape fallback: message-id-keyed meta/vector rows.
     if _table_exists_sync(conn, "message_embeddings_meta"):
         conn.execute(
             """
@@ -88,6 +100,10 @@ def _invalidate_embedding_state_sync(conn: sqlite3.Connection, session_id: str) 
 
 
 async def _invalidate_embedding_state_async(conn: aiosqlite.Connection, session_id: str) -> None:
+    """Async counterpart of :func:`_invalidate_embedding_state_sync` (see its docstring)."""
+    if await _table_exists_async(conn, "message_embedding_refs"):
+        await conn.execute("DELETE FROM message_embedding_refs WHERE session_id = ?", (session_id,))
+        return
     if await _table_exists_async(conn, "message_embeddings_meta"):
         await conn.execute(
             """

--- a/polylogue/storage/sqlite/archive_tiers/embedding_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/embedding_write.py
@@ -40,9 +40,8 @@ class ArchiveEmbeddingMeta:
     message_id: str
     model: str
     dimension: int
-    content_hash: bytes
+    embedding_input_hash: bytes
     embedded_at_ms: int | None
-    needs_reindex: bool
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,7 +65,7 @@ class ArchiveEmbeddingWrite:
     embedding: list[float]
     model: str
     embedded_at_ms: int
-    content_hash: bytes
+    embedding_input_hash: bytes
     recipe_hash: bytes | None = None
     derivation_key: bytes | None = None
     generation: int = 0
@@ -259,11 +258,11 @@ def upsert_message_embedding(
     embedding: list[float],
     model: str,
     embedded_at_ms: int,
-    content_hash: bytes | None = None,
+    embedding_input_hash: bytes | None = None,
 ) -> ArchiveEmbeddingMeta:
     """Upsert one message vector plus its reproducibility metadata."""
-    if content_hash is None:
-        raise ValueError("content_hash is required for message embedding metadata")
+    if embedding_input_hash is None:
+        raise ValueError("embedding_input_hash is required for message embedding metadata")
     upsert_message_embeddings(
         conn,
         [
@@ -274,7 +273,7 @@ def upsert_message_embedding(
                 embedding=embedding,
                 model=model,
                 embedded_at_ms=embedded_at_ms,
-                content_hash=content_hash,
+                embedding_input_hash=embedding_input_hash,
             )
         ],
     )
@@ -284,15 +283,15 @@ def upsert_message_embedding(
 def _prepared_write(write: ArchiveEmbeddingWrite) -> ArchiveEmbeddingWrite:
     if len(write.embedding) != EMBEDDING_DIMENSION:
         raise ValueError(f"embedding must have {EMBEDDING_DIMENSION} dimensions")
-    if len(write.content_hash) != 32:
-        raise ValueError("content_hash must be a SHA-256 value")
+    if len(write.embedding_input_hash) != 32:
+        raise ValueError("embedding_input_hash must be a SHA-256 value")
     recipe = EmbeddingRecipe.current(model=write.model, dimensions=EMBEDDING_DIMENSION)
     recipe_hash = write.recipe_hash or recipe.recipe_hash
     derivation_key = (
         write.derivation_key
         or message_embedding_derivation_key(
             message_id=write.message_id,
-            content_hash=write.content_hash,
+            embedding_input_hash=write.embedding_input_hash,
             recipe=recipe,
         ).digest()
     )
@@ -303,7 +302,7 @@ def _prepared_write(write: ArchiveEmbeddingWrite) -> ArchiveEmbeddingWrite:
         embedding=write.embedding,
         model=write.model,
         embedded_at_ms=write.embedded_at_ms,
-        content_hash=write.content_hash,
+        embedding_input_hash=write.embedding_input_hash,
         recipe_hash=recipe_hash,
         derivation_key=derivation_key,
         generation=write.generation,
@@ -311,43 +310,60 @@ def _prepared_write(write: ArchiveEmbeddingWrite) -> ArchiveEmbeddingWrite:
 
 
 def _write_message_embeddings(conn: sqlite3.Connection, writes: Sequence[ArchiveEmbeddingWrite]) -> None:
+    """Write content-addressed vectors/meta once per hash, plus per-message refs.
+
+    ``message_embeddings`` (vec0) and ``message_embeddings_meta`` are keyed by
+    ``embedding_input_hash`` and are write-once: a hash whose meta row already
+    exists is never re-inserted or deleted here (dedup — identical content
+    embeds exactly once, and a vector already proven valid for its hash stays
+    valid regardless of which message(s) currently reference it). Only
+    ``message_embedding_refs`` (message_id -> hash) is rewritten per call,
+    since that mapping tracks the *current* message set.
+    """
     for raw_write in writes:
         write = _prepared_write(raw_write)
+        hash_hex = write.embedding_input_hash.hex()
+        existing = conn.execute(
+            "SELECT 1 FROM message_embeddings_meta WHERE embedding_input_hash = ?",
+            (write.embedding_input_hash,),
+        ).fetchone()
+        if existing is None:
+            conn.execute(
+                """
+                INSERT INTO message_embeddings (embedding_input_hash, embedding, model)
+                VALUES (?, ?, ?)
+                """,
+                (hash_hex, _serialize_f32(write.embedding), write.model),
+            )
+            conn.execute(
+                """
+                INSERT INTO message_embeddings_meta (
+                    embedding_input_hash, model, dimension, embedded_at_ms,
+                    recipe_hash, output_contract_hash
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    write.embedding_input_hash,
+                    write.model,
+                    EMBEDDING_DIMENSION,
+                    write.embedded_at_ms,
+                    write.recipe_hash,
+                    None,
+                ),
+            )
         origin_value = _enum_value(write.origin)
-        conn.execute("DELETE FROM message_embeddings WHERE message_id = ?", (write.message_id,))
         conn.execute(
             """
-            INSERT INTO message_embeddings (message_id, embedding, session_id, origin)
-            VALUES (?, ?, ?, ?)
-            """,
-            (write.message_id, _serialize_f32(write.embedding), write.session_id, origin_value),
-        )
-        conn.execute(
-            """
-            INSERT INTO message_embeddings_meta (
-                message_id, model, dimension, content_hash, embedded_at_ms, needs_reindex,
-                recipe_hash, derivation_key, generation
-            ) VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?)
+            INSERT INTO message_embedding_refs (
+                message_id, session_id, origin, embedding_input_hash, embedded_at_ms
+            ) VALUES (?, ?, ?, ?, ?)
             ON CONFLICT(message_id) DO UPDATE SET
-                model = excluded.model,
-                dimension = excluded.dimension,
-                content_hash = excluded.content_hash,
-                embedded_at_ms = excluded.embedded_at_ms,
-                needs_reindex = 0,
-                recipe_hash = excluded.recipe_hash,
-                derivation_key = excluded.derivation_key,
-                generation = excluded.generation
+                session_id = excluded.session_id,
+                origin = excluded.origin,
+                embedding_input_hash = excluded.embedding_input_hash,
+                embedded_at_ms = excluded.embedded_at_ms
             """,
-            (
-                write.message_id,
-                write.model,
-                EMBEDDING_DIMENSION,
-                write.content_hash,
-                write.embedded_at_ms,
-                write.recipe_hash,
-                write.derivation_key,
-                write.generation,
-            ),
+            (write.message_id, write.session_id, origin_value, write.embedding_input_hash, write.embedded_at_ms),
         )
 
 
@@ -382,7 +398,7 @@ def complete_embedding_attempt_success(
     now_ms = int(time.time() * 1000) if completed_at_ms is None else completed_at_ms
     prepared = tuple(_prepared_write(write) for write in writes)
     message_ids: set[str] = set()
-    source_digest = EmbeddingSourceDigest()
+    input_hashes: list[bytes] = []
     for write in sorted(prepared, key=lambda item: item.message_id):
         if write.session_id != attempt.session_id:
             raise ValueError("all embedding writes must belong to the attempt session")
@@ -395,13 +411,19 @@ def complete_embedding_attempt_success(
             raise ValueError("embedding write recipe must match the owning attempt")
         expected_message_key = message_embedding_derivation_digest_from_hashes(
             message_id=write.message_id,
-            content_hash=write.content_hash,
+            embedding_input_hash=write.embedding_input_hash,
             recipe_hash=attempt.recipe_hash,
             output_contract_hash=attempt.output_contract_hash,
         )
         if write.derivation_key != expected_message_key:
             raise ValueError("embedding write key must match its message content and attempt recipe")
-        source_digest.update(write.message_id, write.content_hash)
+        input_hashes.append(write.embedding_input_hash)
+    # Digested in hash-sorted order to match the order-independent SQL
+    # aggregate (_EmbeddingSourceHashAggregate) that computes the same
+    # session source_hash at selection time.
+    source_digest = EmbeddingSourceDigest()
+    for input_hash in sorted(input_hashes):
+        source_digest.update(input_hash)
     if source_digest.digest() != attempt.source_hash:
         raise ValueError("embedding writes must cover the attempt's exact source identity")
     message_count = len(prepared)
@@ -421,19 +443,26 @@ def complete_embedding_attempt_success(
         if current is None:
             return False
 
+        # message_embeddings / message_embeddings_meta are content-addressed
+        # (keyed by embedding_input_hash) and write-once/shared across
+        # messages and sessions -- they are never deleted on session
+        # re-embed. Only this session's message_id -> hash refs are stale;
+        # drop the ones this generation no longer writes (message removed
+        # from the session, or the session shrank) before rewriting.
+        current_message_ids = {write.message_id for write in prepared}
         prior_message_ids = tuple(
             str(row[0])
             for row in conn.execute(
-                "SELECT message_id FROM message_embeddings WHERE session_id = ?",
+                "SELECT message_id FROM message_embedding_refs WHERE session_id = ?",
                 (attempt.session_id,),
             ).fetchall()
         )
-        conn.execute("DELETE FROM message_embeddings WHERE session_id = ?", (attempt.session_id,))
-        if prior_message_ids:
-            placeholders = ", ".join("?" for _ in prior_message_ids)
+        stale_message_ids = tuple(sorted(set(prior_message_ids) - current_message_ids))
+        if stale_message_ids:
+            placeholders = ", ".join("?" for _ in stale_message_ids)
             conn.execute(
-                f"DELETE FROM message_embeddings_meta WHERE message_id IN ({placeholders})",
-                prior_message_ids,
+                f"DELETE FROM message_embedding_refs WHERE message_id IN ({placeholders})",
+                stale_message_ids,
             )
         _write_message_embeddings(conn, prepared)
         updated = conn.execute(
@@ -848,12 +877,16 @@ def _failure_from_row(row: sqlite3.Row | tuple[object, ...]) -> ArchiveEmbedding
 
 
 def read_embedding_meta(conn: sqlite3.Connection, target_id: str) -> ArchiveEmbeddingMeta:
+    """Resolve one message's current vector metadata via its ref -> hash mapping."""
+
     conn.row_factory = sqlite3.Row
     row = conn.execute(
         """
-        SELECT message_id, model, dimension, content_hash, embedded_at_ms, needs_reindex
-        FROM message_embeddings_meta
-        WHERE message_id = ?
+        SELECT r.message_id AS message_id, em.model AS model, em.dimension AS dimension,
+               em.embedding_input_hash AS embedding_input_hash, em.embedded_at_ms AS embedded_at_ms
+        FROM message_embedding_refs AS r
+        JOIN message_embeddings_meta AS em ON em.embedding_input_hash = r.embedding_input_hash
+        WHERE r.message_id = ?
         """,
         (target_id,),
     ).fetchone()
@@ -863,9 +896,8 @@ def read_embedding_meta(conn: sqlite3.Connection, target_id: str) -> ArchiveEmbe
         message_id=row["message_id"],
         model=row["model"],
         dimension=row["dimension"],
-        content_hash=row["content_hash"],
+        embedding_input_hash=row["embedding_input_hash"],
         embedded_at_ms=row["embedded_at_ms"],
-        needs_reindex=bool(row["needs_reindex"]),
     )
 
 

--- a/polylogue/storage/sqlite/archive_tiers/embeddings.py
+++ b/polylogue/storage/sqlite/archive_tiers/embeddings.py
@@ -2,28 +2,60 @@
 
 from __future__ import annotations
 
-EMBEDDINGS_SCHEMA_VERSION = 3
+EMBEDDINGS_SCHEMA_VERSION = 4
 EMBEDDING_DIMENSION = 1024
 
+# v4 (polylogue-q88p, operator ruling 2026-07-20): vectors are keyed by
+# embedding_input_hash = H(model, embedder input text) -- identity-free by
+# construction, the same philosophy as the svfj block evidence hash
+# (`_block_content_hash`). v3 keyed message_embeddings/message_embeddings_meta
+# by message_id and bound freshness to messages.content_hash, which INCLUDES
+# session_id/position/variant_index; a rebuild or lineage-normalization shift
+# invalidated vectors whose underlying text never changed (the 04kl 777K-vector
+# rescue). Under v4, presence of a meta row for a given hash IS freshness --
+# there is no per-vector "stale" state anymore, and identical content across
+# forked/replayed sessions naturally dedups to one stored vector.
+#
+# embeddings.db is a rebuildable derived tier (no migration chain): a schema
+# mismatch blue-green-replaces the tier from source
+# (`polylogue ops reset --index && polylogued run`), so this is an in-place DDL
+# edit, not an additive migration.
 EMBEDDINGS_DDL = f"""
 CREATE VIRTUAL TABLE IF NOT EXISTS message_embeddings USING vec0(
-    message_id TEXT PRIMARY KEY,
+    embedding_input_hash TEXT PRIMARY KEY,
     embedding float[{EMBEDDING_DIMENSION}],
-    +session_id TEXT,
-    +origin TEXT
+    +model TEXT
 );
 
 CREATE TABLE IF NOT EXISTS message_embeddings_meta (
-    message_id      TEXT PRIMARY KEY,
-    model           TEXT NOT NULL,
-    dimension       INTEGER NOT NULL CHECK(dimension = {EMBEDDING_DIMENSION}),
-    content_hash    BLOB NOT NULL CHECK(length(content_hash) = 32),
-    embedded_at_ms  INTEGER,
-    needs_reindex   INTEGER NOT NULL DEFAULT 0 CHECK(needs_reindex IN (0, 1)),
-    recipe_hash     BLOB CHECK(recipe_hash IS NULL OR length(recipe_hash) = 32),
-    derivation_key  BLOB CHECK(derivation_key IS NULL OR length(derivation_key) = 32),
-    generation      INTEGER NOT NULL DEFAULT 0 CHECK(generation >= 0)
+    embedding_input_hash   BLOB PRIMARY KEY CHECK(length(embedding_input_hash) = 32),
+    model                  TEXT NOT NULL,
+    dimension              INTEGER NOT NULL CHECK(dimension = {EMBEDDING_DIMENSION}),
+    embedded_at_ms         INTEGER,
+    recipe_hash            BLOB CHECK(recipe_hash IS NULL OR length(recipe_hash) = 32),
+    output_contract_hash   BLOB CHECK(output_contract_hash IS NULL OR length(output_contract_hash) = 32)
 ) STRICT;
+
+-- Rebuildable message_id -> embedding_input_hash mapping. Lives in the
+-- embeddings tier (not index.db) so this rekey never bumps INDEX_SCHEMA_VERSION:
+-- the mapping is derived purely from a message's current embedder input text
+-- and this tier's own vectors, both already scoped to embeddings.db.
+-- One message has exactly one *current* embedding_input_hash; many messages
+-- (fork/resume/auto-compaction replays, or genuinely identical prose) may
+-- point at the same hash -- that convergence is the dedup win.
+CREATE TABLE IF NOT EXISTS message_embedding_refs (
+    message_id            TEXT PRIMARY KEY,
+    session_id            TEXT NOT NULL,
+    origin                TEXT NOT NULL,
+    embedding_input_hash  BLOB NOT NULL CHECK(length(embedding_input_hash) = 32),
+    embedded_at_ms        INTEGER
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_message_embedding_refs_hash
+ON message_embedding_refs(embedding_input_hash);
+
+CREATE INDEX IF NOT EXISTS idx_message_embedding_refs_session
+ON message_embedding_refs(session_id);
 
 CREATE TABLE IF NOT EXISTS embedding_status (
     session_id                 TEXT PRIMARY KEY,

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -1520,10 +1520,15 @@ def _message_content_hash(
 ) -> bytes:
     """Digest the stored message content, not just its identity.
 
-    Embedding freshness compares ``message_embeddings_meta.content_hash`` with
-    ``messages.content_hash``. The digest must therefore change when the text
-    sent to the embedder changes, even if the provider-native message id and
-    message count stay stable across a re-ingest.
+    This hash is deliberately IDENTITY-INCLUSIVE (session_id, position,
+    variant_index, provider_message_id) -- it drives row-level re-ingest/
+    dedup change detection for the ``messages`` table itself. It is no
+    longer what embedding freshness is gated on: since polylogue-q88p,
+    embeddings are keyed by ``embedding_input_hash`` (identity-FREE --
+    ``storage/embeddings/identity.py``), computed straight from the
+    embedder's input text, so a rebuild or lineage-normalization shift that
+    changes this hash without changing the actual text no longer forces a
+    wasted re-embed.
     """
 
     block_parts: list[str] = []

--- a/tests/property/test_embedding_input_hash_identity_invariant.py
+++ b/tests/property/test_embedding_input_hash_identity_invariant.py
@@ -1,0 +1,110 @@
+"""Property test: ``embedding_input_hash`` is a pure function of (model, text)
+and is invariant under every identity-bearing axis that contaminates
+``messages.content_hash`` (polylogue-q88p, operator ruling 2026-07-20).
+
+Directly contrasts the two hash functions against the SAME underlying
+message content to make the defect this bead fixes, and the fix, both
+falsifiable: ``_message_content_hash`` (the archive's existing per-message
+identity hash) is *expected* to vary when session_id/position/variant_index
+vary even though the text does not -- that is its documented job (dedup /
+re-ingest change detection at full row granularity). ``embedding_input_hash``
+must NOT vary under those same conditions -- that is the whole point of this
+bead. A test that only exercised one function would not prove the contrast;
+asserting both in the same property is the anti-vacuity guard.
+"""
+
+from __future__ import annotations
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, MaterialOrigin, MessageType
+from polylogue.sources.parsers.base_models import ParsedContentBlock, ParsedMessage
+from polylogue.storage.embeddings.identity import embedding_input_hash
+from polylogue.storage.sqlite.archive_tiers.write import _message_content_hash
+
+_TEXT = st.text(min_size=1, max_size=200).filter(lambda value: value.strip() != "")
+_MODEL = st.sampled_from(["voyage-4", "voyage-3", "voyage-3-lite", "demo-synthetic-embedding"])
+_IDENTITY_CONTEXT = st.tuples(
+    st.text(alphabet=st.characters(min_codepoint=0x21, max_codepoint=0x7E), min_size=1, max_size=20),  # session_id
+    st.integers(min_value=0, max_value=10_000),  # position
+    st.integers(min_value=0, max_value=8),  # variant_index
+    st.text(
+        alphabet=st.characters(min_codepoint=0x21, max_codepoint=0x7E), min_size=1, max_size=20
+    ),  # provider_message_id
+)
+
+
+def _content_hash_for(text: str, identity: tuple[str, int, int, str]) -> bytes:
+    session_id, position, variant_index, provider_message_id = identity
+    message = ParsedMessage(
+        provider_message_id=provider_message_id,
+        role=Role.USER,
+        text=text,
+        message_type=MessageType.MESSAGE,
+        material_origin=MaterialOrigin.HUMAN_AUTHORED,
+        blocks=[ParsedContentBlock(type=BlockType.TEXT, text=text)],
+    )
+    return _message_content_hash(session_id, message, position=position, variant_index=variant_index)
+
+
+@settings(suppress_health_check=[HealthCheck.too_slow], deadline=None)
+@given(text=_TEXT, model=_MODEL, identity_a=_IDENTITY_CONTEXT, identity_b=_IDENTITY_CONTEXT)
+def test_embedding_input_hash_ignores_identity_that_content_hash_tracks(
+    text: str, model: str, identity_a: tuple[str, int, int, str], identity_b: tuple[str, int, int, str]
+) -> None:
+    hash_a = embedding_input_hash(model=model, input_text=text)
+    hash_b = embedding_input_hash(model=model, input_text=text)
+    assert hash_a == hash_b, "embedding_input_hash must be a pure function of (model, text) alone"
+
+    content_hash_a = _content_hash_for(text, identity_a)
+    content_hash_b = _content_hash_for(text, identity_b)
+    if identity_a != identity_b:
+        # messages.content_hash is IDENTITY-CONTAMINATED by design (dedup at
+        # full-row granularity needs it); different identity contexts for
+        # the same text are expected to produce different content hashes.
+        assert content_hash_a != content_hash_b, (
+            "test setup assumption violated: distinct identity contexts must still "
+            "produce distinct legacy content hashes, or this property proves nothing"
+        )
+    # The defect this bead fixes: embedding_input_hash must be blind to every
+    # axis that content_hash tracks (session_id, position, variant_index,
+    # provider_message_id) as long as the text itself is unchanged.
+    assert hash_a == embedding_input_hash(model=model, input_text=text)
+
+
+@given(text_a=_TEXT, text_b=_TEXT, model=_MODEL)
+def test_embedding_input_hash_is_sensitive_to_text(text_a: str, text_b: str, model: str) -> None:
+    hash_a = embedding_input_hash(model=model, input_text=text_a)
+    hash_b = embedding_input_hash(model=model, input_text=text_b)
+    if text_a == text_b:
+        assert hash_a == hash_b
+    else:
+        assert hash_a != hash_b, "different embedder input text must hash differently"
+
+
+@given(text=_TEXT, model_a=_MODEL, model_b=_MODEL)
+def test_embedding_input_hash_is_sensitive_to_model(text: str, model_a: str, model_b: str) -> None:
+    hash_a = embedding_input_hash(model=model_a, input_text=text)
+    hash_b = embedding_input_hash(model=model_b, input_text=text)
+    if model_a == model_b:
+        assert hash_a == hash_b
+    else:
+        assert hash_a != hash_b, "a different model must hash differently even for identical text"
+
+
+@given(text=_TEXT, model=_MODEL)
+def test_embedding_input_hash_is_32_bytes(text: str, model: str) -> None:
+    digest = embedding_input_hash(model=model, input_text=text)
+    assert isinstance(digest, bytes)
+    assert len(digest) == 32
+
+
+@given(text=st.text(min_size=1, max_size=50), model=_MODEL)
+def test_embedding_input_hash_nfc_normalizes(text: str, model: str) -> None:
+    import unicodedata
+
+    nfd = unicodedata.normalize("NFD", text)
+    nfc = unicodedata.normalize("NFC", text)
+    assert embedding_input_hash(model=model, input_text=nfd) == embedding_input_hash(model=model, input_text=nfc)

--- a/tests/unit/archive/test_near_session_seed_execution.py
+++ b/tests/unit/archive/test_near_session_seed_execution.py
@@ -11,6 +11,7 @@ unfiltered listing.
 
 from __future__ import annotations
 
+import hashlib
 import sqlite3
 from pathlib import Path
 
@@ -99,6 +100,9 @@ def seeded_archive(tmp_path: Path) -> tuple[Path, Config, dict[str, tuple[str, s
     }
     for suffix, vector in vectors.items():
         session_id, message_id = mapping[suffix]
+        # Content-addressed (polylogue-q88p): distinguish each geometrically
+        # distinct fixture vector by its own hash, or they would dedup onto
+        # one stored vector under a shared placeholder key.
         upsert_message_embedding(
             conn,
             message_id=message_id,
@@ -107,7 +111,7 @@ def seeded_archive(tmp_path: Path) -> tuple[Path, Config, dict[str, tuple[str, s
             embedding=vector,
             model="voyage-4",
             embedded_at_ms=1_767_225_700_000,
-            content_hash=b"x" * 32,
+            embedding_input_hash=hashlib.sha256(message_id.encode()).digest(),
         )
     conn.close()
 

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import sqlite3
@@ -941,7 +942,7 @@ def _seed_orphan_embedding_row(archive_root: Path) -> tuple[str, str]:
                     embedding=[0.01] * EMBEDDING_DIMENSION,
                     model="voyage-4",
                     embedded_at_ms=1_700_000_000_000,
-                    content_hash=b"o" * 32,
+                    embedding_input_hash=hashlib.sha256(orphan_message_id.encode("utf-8")).digest(),
                 )
             ],
         )
@@ -1047,7 +1048,7 @@ def test_embedding_orphan_reconcile_cli_plain_dry_run_reports_would_remove_count
     )
 
     assert result.exit_code == 0
-    assert "Would remove:  1 meta row(s), 1 vector row(s), 1 status row(s)" in result.output
+    assert "Would remove:  1 message ref(s), 1 status row(s)" in result.output
     assert "Removed:" not in result.output
     with sqlite3.connect(cli_workspace["archive_root"] / "embeddings.db") as conn:
         assert conn.execute("SELECT COUNT(*) FROM message_embeddings_meta").fetchone()[0] == 1
@@ -1078,11 +1079,13 @@ def test_embedding_orphan_reconcile_cli_apply_removes_rows(
     assert payload["mutates"] is True
     assert payload["dry_run"] is False
     assert payload["removed_message_rows"] == 1
-    assert payload["removed_vector_rows"] == 1
+    # v4: message_embeddings/message_embeddings_meta are content-addressed and
+    # never deleted by this reconciler -- only the message_id -> hash ref is.
+    assert payload["removed_vector_rows"] == 0
     assert payload["sessions_recounted"] == 1
     with sqlite3.connect(cli_workspace["archive_root"] / "embeddings.db") as conn:
         assert (
-            conn.execute("SELECT COUNT(*) FROM message_embeddings_meta WHERE message_id = ?", (message_id,)).fetchone()[
+            conn.execute("SELECT COUNT(*) FROM message_embedding_refs WHERE message_id = ?", (message_id,)).fetchone()[
                 0
             ]
             == 0
@@ -1102,13 +1105,24 @@ def test_embedding_orphan_reconcile_cli_apply_is_bounded_by_default(
     session_id, _message_id = _seed_orphan_embedding_row(cli_workspace["archive_root"])
     embeddings_db = cli_workspace["archive_root"] / "embeddings.db"
     with sqlite3.connect(embeddings_db) as conn:
+        # v4: per-message identity for the reconciler's scan is
+        # message_embedding_refs (message_id-keyed) -- message_embeddings_meta
+        # is content-addressed and never independently orphaned, so 500
+        # distinct orphan candidates means 500 distinct refs, not meta rows.
         conn.executemany(
             """
-            INSERT INTO message_embeddings_meta (
-                message_id, model, dimension, content_hash, embedded_at_ms, needs_reindex
-            ) VALUES (?, 'voyage-4', 1024, ?, 1700000000000, 0)
+            INSERT INTO message_embedding_refs (
+                message_id, session_id, origin, embedding_input_hash, embedded_at_ms
+            ) VALUES (?, ?, 'codex-session', ?, 1700000000000)
             """,
-            [(f"{session_id}:zz-orphan-{position:03d}", b"z" * 32) for position in range(500)],
+            [
+                (
+                    f"{session_id}:zz-orphan-{position:03d}",
+                    f"{session_id}:zz-orphan-{position:03d}",
+                    hashlib.sha256(f"{session_id}:zz-orphan-{position:03d}".encode()).digest(),
+                )
+                for position in range(500)
+            ],
         )
 
     result = cli_runner.invoke(
@@ -1176,7 +1190,7 @@ def test_embedding_orphan_reconcile_cli_apply_refuses_stale_index_schema(
     assert "active index is v32, packaged index is v" in str(result.exception)
     with sqlite3.connect(cli_workspace["archive_root"] / "embeddings.db") as conn:
         assert (
-            conn.execute("SELECT COUNT(*) FROM message_embeddings_meta WHERE message_id = ?", (message_id,)).fetchone()[
+            conn.execute("SELECT COUNT(*) FROM message_embedding_refs WHERE message_id = ?", (message_id,)).fetchone()[
                 0
             ]
             == 1

--- a/tests/unit/cli/test_embed_activation.py
+++ b/tests/unit/cli/test_embed_activation.py
@@ -800,29 +800,36 @@ def _seed_embeddings_meta(archive_root: Path, *, needs_reindex: int) -> None:
     """Write a single ``message_embeddings_meta`` row into ``embeddings.db``.
 
     Native auto search intentionally does not read this table; explicit vector
-    lanes still use the configured embeddings database.
+    lanes still use the configured embeddings database. ``needs_reindex`` is
+    accepted for call-site compatibility (fresh vs. stale intent) but, like
+    the rest of this row's shape, has no bearing on the assertions below --
+    v4's ``message_embeddings_meta`` doesn't even carry a ``needs_reindex``
+    column any more (presence of a hash row IS freshness); it is threaded
+    through only so callers can still express "fresh" vs. "stale" seeding
+    intent at the call site.
     """
+    del needs_reindex
     conn = sqlite3.connect(archive_root / "embeddings.db")
     try:
         conn.executescript(
             """
             CREATE TABLE IF NOT EXISTS message_embeddings_meta (
-                message_id      TEXT PRIMARY KEY,
-                model           TEXT NOT NULL,
-                dimension       INTEGER NOT NULL,
-                content_hash    BLOB NOT NULL,
-                embedded_at_ms  INTEGER,
-                needs_reindex   INTEGER NOT NULL DEFAULT 0
+                embedding_input_hash   BLOB PRIMARY KEY,
+                model                  TEXT NOT NULL,
+                dimension              INTEGER NOT NULL,
+                embedded_at_ms         INTEGER,
+                recipe_hash            BLOB,
+                output_contract_hash   BLOB
             );
             """
         )
         conn.execute(
             """
             INSERT INTO message_embeddings_meta (
-                message_id, model, dimension, content_hash, embedded_at_ms, needs_reindex
+                embedding_input_hash, model, dimension, embedded_at_ms, recipe_hash, output_contract_hash
             ) VALUES (?, ?, ?, ?, ?, ?)
             """,
-            ("elev-1:m1", "voyage-4", 1024, b"\x00" * 32, 1, needs_reindex),
+            (b"\x00" * 32, "voyage-4", 1024, 1, None, None),
         )
         conn.commit()
     finally:

--- a/tests/unit/cli/test_embed_status_fast.py
+++ b/tests/unit/cli/test_embed_status_fast.py
@@ -13,12 +13,17 @@ from click.testing import CliRunner
 
 from polylogue.cli.commands.embed import embed_command
 from polylogue.storage.embeddings import status_payload as status_payload_mod
+from polylogue.storage.embeddings.identity import EmbeddingRecipe, EmbeddingSourceDigest, embedding_input_hash
 from polylogue.storage.embeddings.progress import (
     CatchupRunStart,
     finish_embedding_catchup_run,
     start_embedding_catchup_run,
 )
-from polylogue.storage.sqlite.archive_tiers.embedding_write import resolve_embedding_failure
+from polylogue.storage.sqlite.archive_tiers.embedding_write import (
+    begin_embedding_attempt,
+    record_embedding_failure,
+    resolve_embedding_failure,
+)
 
 
 class _Cfg:
@@ -70,7 +75,37 @@ def _seed_archive_without_embedding_ledgers(db_path: Path, *, vec_table: bool = 
         conn.commit()
 
 
+# v4 (polylogue-q88p): distinct, >=20-char prose per message so each message's
+# embedding_input_hash -- computed by archive_embeddable_messages_relation via
+# the registered SQL function from exactly this text -- is real and unique,
+# matching what production actually sends to the embedder.
+_COMPLETE_TEXT = "authored prose for the complete session message, long enough to embed"
+_PENDING_TEXT_1 = "authored prose for the first pending session message, long enough"
+_PENDING_TEXT_2 = "authored prose for the second pending session message, long enough"
+
+
+def _pending_session_source_hash() -> bytes:
+    """The exact session-level source_hash `codex-session:pending`'s 2 real
+    messages produce -- hash VALUES only, sorted, matching the production
+    aggregate (`_archive_embedding_source_hash_from_pairs`)."""
+    hashes = sorted(
+        embedding_input_hash(model="voyage-4", input_text=text) for text in (_PENDING_TEXT_1, _PENDING_TEXT_2)
+    )
+    digest = EmbeddingSourceDigest()
+    for value in hashes:
+        digest.update(value)
+    return digest.digest()
+
+
 def _seed_archive_file_set_from_archive_tiers(index_db: Path) -> None:
+    """Build a minimal but real v4-shaped index.db + embeddings.db pair.
+
+    ``message_embeddings_meta``/``message_embedding_refs`` mirror the current
+    production DDL (content-addressed by ``embedding_input_hash``, per-message
+    refs table) -- not the pre-polylogue-q88p message_id-keyed shape -- so the
+    ``--detail`` exact-pending/stale-message code paths in status_payload.py
+    (which join through ``message_embedding_refs``) exercise real behavior.
+    """
     embeddings_db = index_db.with_name("embeddings.db")
     with sqlite3.connect(index_db) as conn:
         conn.executescript(
@@ -82,6 +117,7 @@ def _seed_archive_file_set_from_archive_tiers(index_db: Path) -> None:
             CREATE TABLE messages (
                 message_id TEXT PRIMARY KEY,
                 session_id TEXT NOT NULL,
+                text TEXT,
                 role TEXT NOT NULL DEFAULT 'user',
                 message_type TEXT NOT NULL DEFAULT 'message',
                 material_origin TEXT NOT NULL DEFAULT 'human_authored',
@@ -90,15 +126,48 @@ def _seed_archive_file_set_from_archive_tiers(index_db: Path) -> None:
             );
             INSERT INTO sessions VALUES ('codex-session:complete', 1);
             INSERT INTO sessions VALUES ('codex-session:pending', 2);
-            INSERT INTO messages (message_id, session_id, content_hash)
-            VALUES ('codex-session:complete:m1', 'codex-session:complete', x'01');
-            INSERT INTO messages (message_id, session_id, content_hash)
-            VALUES ('codex-session:pending:m1', 'codex-session:pending', x'02');
-            INSERT INTO messages (message_id, session_id, content_hash)
-            VALUES ('codex-session:pending:m2', 'codex-session:pending', x'03');
             """
         )
+        conn.execute(
+            "INSERT INTO messages (message_id, session_id, text, content_hash) VALUES (?, ?, ?, x'01')",
+            ("codex-session:complete:m1", "codex-session:complete", _COMPLETE_TEXT),
+        )
+        conn.execute(
+            "INSERT INTO messages (message_id, session_id, text, content_hash) VALUES (?, ?, ?, x'02')",
+            ("codex-session:pending:m1", "codex-session:pending", _PENDING_TEXT_1),
+        )
+        conn.execute(
+            "INSERT INTO messages (message_id, session_id, text, content_hash) VALUES (?, ?, ?, x'03')",
+            ("codex-session:pending:m2", "codex-session:pending", _PENDING_TEXT_2),
+        )
         conn.commit()
+
+    from polylogue.storage.embeddings.identity import (
+        EmbeddingRecipe,
+        EmbeddingSourceDigest,
+        embedding_derivation_key,
+        embedding_input_hash,
+    )
+
+    complete_message_id = "codex-session:complete:m1"
+    complete_hash = embedding_input_hash(model="voyage-4", input_text=_COMPLETE_TEXT)
+    # Compute the real production identity chain (not a stand-in) so the
+    # `embedding_derivation_state` row this fixture writes is one the modern
+    # exact-freshness predicate (_archive_embedding_freshness_predicate)
+    # genuinely recognizes as "succeeded" for codex-session:complete -- a
+    # real v4 archive always carries this table alongside a v4-shaped
+    # message_embeddings_meta, so a fixture with one but not the other would
+    # exercise a hybrid shape production never produces (the pre-v3 fallback
+    # this table's absence used to trigger assumes the OLD message_id-keyed
+    # meta_table and errors against this one).
+    recipe = EmbeddingRecipe.current(model="voyage-4", dimensions=1024)
+    source_digest = EmbeddingSourceDigest()
+    source_digest.update(complete_hash)
+    source_hash = source_digest.digest()
+    derivation_key = embedding_derivation_key(
+        session_id="codex-session:complete", source_hash=source_hash, recipe=recipe
+    ).digest()
+
     with sqlite3.connect(embeddings_db) as conn:
         conn.executescript(
             """
@@ -106,26 +175,64 @@ def _seed_archive_file_set_from_archive_tiers(index_db: Path) -> None:
                 message_id TEXT PRIMARY KEY
             );
             CREATE TABLE message_embeddings_meta (
-                message_id TEXT PRIMARY KEY,
+                embedding_input_hash BLOB PRIMARY KEY,
                 model TEXT NOT NULL,
                 dimension INTEGER NOT NULL,
-                embedded_at_ms INTEGER NOT NULL,
-                content_hash BLOB,
-                needs_reindex INTEGER NOT NULL DEFAULT 0
+                embedded_at_ms INTEGER,
+                recipe_hash BLOB,
+                output_contract_hash BLOB
+            );
+            CREATE TABLE message_embedding_refs (
+                message_id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                origin TEXT NOT NULL,
+                embedding_input_hash BLOB NOT NULL,
+                embedded_at_ms INTEGER
             );
             CREATE TABLE embedding_status (
                 session_id TEXT PRIMARY KEY,
                 origin TEXT NOT NULL,
                 message_count_embedded INTEGER NOT NULL DEFAULT 0,
+                last_embedded_at_ms INTEGER,
                 needs_reindex INTEGER NOT NULL DEFAULT 0,
                 error_message TEXT
             );
-            INSERT INTO message_embeddings VALUES ('codex-session:complete:m1');
-            INSERT INTO message_embeddings_meta VALUES (
-                'codex-session:complete:m1', 'voyage-4', 1024, 1767225700000, x'01', 0
+            CREATE TABLE embedding_derivation_state (
+                session_id TEXT PRIMARY KEY,
+                origin TEXT NOT NULL DEFAULT '',
+                generation INTEGER NOT NULL,
+                derivation_key BLOB NOT NULL,
+                source_hash BLOB NOT NULL,
+                recipe_hash BLOB NOT NULL,
+                output_contract_hash BLOB NOT NULL,
+                attempt_state TEXT NOT NULL,
+                message_count INTEGER NOT NULL DEFAULT 0,
+                updated_at_ms INTEGER NOT NULL
             );
-            INSERT INTO embedding_status VALUES ('codex-session:complete', 'codex-session', 1, 0, NULL);
+            INSERT INTO message_embeddings VALUES ('codex-session:complete:m1');
+            INSERT INTO embedding_status (session_id, origin, message_count_embedded, last_embedded_at_ms, needs_reindex, error_message)
+            VALUES ('codex-session:complete', 'codex-session', 1, 1767225700000, 0, NULL);
             """
+        )
+        conn.execute(
+            "INSERT INTO message_embeddings_meta VALUES (?, 'voyage-4', 1024, 1767225700000, ?, ?)",
+            (complete_hash, recipe.recipe_hash, recipe.output_contract_hash),
+        )
+        conn.execute(
+            """
+            INSERT INTO message_embedding_refs (message_id, session_id, origin, embedding_input_hash, embedded_at_ms)
+            VALUES (?, 'codex-session:complete', 'codex-session', ?, 1767225700000)
+            """,
+            (complete_message_id, complete_hash),
+        )
+        conn.execute(
+            """
+            INSERT INTO embedding_derivation_state (
+                session_id, origin, generation, derivation_key, source_hash, recipe_hash,
+                output_contract_hash, attempt_state, message_count, updated_at_ms
+            ) VALUES ('codex-session:complete', 'codex-session', 1, ?, ?, ?, ?, 'succeeded', 1, 1767225700000)
+            """,
+            (derivation_key, source_hash, recipe.recipe_hash, recipe.output_contract_hash),
         )
         conn.commit()
 
@@ -328,9 +435,8 @@ def test_resolve_failure_cli_requeues_terminal_failure(tmp_path: Path) -> None:
                 resolution_note TEXT,
                 superseded_by TEXT
             );
-            INSERT INTO embedding_status VALUES (
-                'codex-session:pending', 'codex-session', 0, 0, 'Embedding generation failed: HTTP 400'
-            );
+            INSERT INTO embedding_status (session_id, origin, message_count_embedded, needs_reindex, error_message)
+            VALUES ('codex-session:pending', 'codex-session', 0, 0, 'Embedding generation failed: HTTP 400');
             INSERT INTO embedding_failures VALUES (
                 'embedding-failure:terminal', 'codex-session:pending', 'codex-session',
                 '["codex-session:pending:m1"]', 'voyage', 'voyage-4', 'provider_http_400',
@@ -390,7 +496,17 @@ def test_status_excludes_acknowledged_terminal_failure_from_retry_backlog(tmp_pa
         conn.execute("DELETE FROM sessions WHERE session_id = 'codex-session:complete'")
     with sqlite3.connect(embeddings_db) as conn:
         conn.execute("DELETE FROM message_embeddings WHERE message_id = 'codex-session:complete:m1'")
-        conn.execute("DELETE FROM message_embeddings_meta WHERE message_id = 'codex-session:complete:m1'")
+        # message_embeddings_meta is content-addressed (embedding_input_hash-
+        # keyed, v4) -- resolve via the ref, then delete both.
+        conn.execute(
+            """
+            DELETE FROM message_embeddings_meta
+            WHERE embedding_input_hash = (
+                SELECT embedding_input_hash FROM message_embedding_refs WHERE message_id = 'codex-session:complete:m1'
+            )
+            """
+        )
+        conn.execute("DELETE FROM message_embedding_refs WHERE message_id = 'codex-session:complete:m1'")
         conn.execute("DELETE FROM embedding_status WHERE session_id = 'codex-session:complete'")
     with sqlite3.connect(embeddings_db) as conn:
         conn.executescript(
@@ -411,22 +527,44 @@ def test_status_excludes_acknowledged_terminal_failure_from_retry_backlog(tmp_pa
                 resolved_at_ms INTEGER,
                 resolution_action TEXT,
                 resolution_note TEXT,
-                superseded_by TEXT
-            );
-            INSERT INTO embedding_status VALUES (
-                'codex-session:pending', 'codex-session', 0, 0, 'Embedding generation failed: HTTP 400'
-            );
-            INSERT INTO embedding_failures VALUES (
-                'embedding-failure:terminal', 'codex-session:pending', 'codex-session',
-                '["codex-session:pending:m1"]', 'voyage', 'voyage-4', 'provider_http_400',
-                'Embedding generation failed: HTTP 400', 0, 'terminal', 1800000000000, 1800000000000,
-                NULL, NULL, NULL, NULL
+                superseded_by TEXT,
+                generation INTEGER NOT NULL DEFAULT 0,
+                derivation_key BLOB,
+                source_hash BLOB,
+                recipe_hash BLOB
             );
             """
         )
+        # v4: "blocked" is read off embedding_derivation_state.attempt_state =
+        # 'failed_terminal' (the unified freshness key), not merely an
+        # embedding_status row with an error_message -- go through the real
+        # begin_embedding_attempt/record_embedding_failure write path so this
+        # fixture's terminal failure is one the modern predicate actually
+        # recognizes, exactly like a real provider-rejected session would be.
+        attempt = begin_embedding_attempt(
+            conn,
+            session_id="codex-session:pending",
+            origin="codex-session",
+            source_hash=_pending_session_source_hash(),
+            recipe=EmbeddingRecipe.current(model="voyage-4", dimensions=1024),
+            started_at_ms=1_800_000_000_000,
+        )
+        failure = record_embedding_failure(
+            conn,
+            session_id="codex-session:pending",
+            origin="codex-session",
+            message_refs=("codex-session:pending:m1",),
+            provider="voyage",
+            model="voyage-4",
+            error_class="provider_http_400",
+            error_message="Embedding generation failed: HTTP 400",
+            retryable=False,
+            occurred_at_ms=1_800_000_000_000,
+            attempt=attempt,
+        )
         resolve_embedding_failure(
             conn,
-            failure_id="embedding-failure:terminal",
+            failure_id=failure.failure_id,
             action="acknowledge",
             resolved_at_ms=1_800_000_001_000,
         )
@@ -475,6 +613,19 @@ def test_status_json_detail_does_not_derive_coverage_from_analyzed_prose_estimat
 
 
 def test_status_json_does_not_report_over_100_percent_from_retained_embedding_rows(tmp_path: Path) -> None:
+    """An inflated ``message_count_embedded`` ledger entry must never push
+    coverage past 100%.
+
+    v4: the exact-freshness predicate ties "embedded" to
+    ``embedding_status.message_count_embedded == embedding_derivation_state.
+    message_count == <current real eligible count>`` (all three, exactly) --
+    stricter than the old ">= eligible count" fallback this test originally
+    exercised. An inflated counter that disagrees with the real count now
+    demotes the session straight back to *pending* rather than being trusted
+    at face value, which is what actually prevents the >100% failure mode:
+    there is no path left where a stale/inflated ledger number can present a
+    session as embedded-and-therefore-100%-covered when it isn't.
+    """
     db_anchor = tmp_path / "custom.sqlite"
     index_db = tmp_path / "index.db"
     _seed_archive_file_set_from_archive_tiers(index_db)
@@ -491,12 +642,13 @@ def test_status_json_does_not_report_over_100_percent_from_retained_embedding_ro
             """
         )
     with sqlite3.connect(tmp_path / "embeddings.db") as conn:
+        # A content-addressed vector/meta row with no surviving ref -- e.g. the
+        # message that referenced it was removed by an index rebuild. v4 never
+        # deletes these (reconcile.py module docstring); status must not let a
+        # retained, refless row inflate coverage past 100%.
         conn.execute(
-            """
-            INSERT INTO message_embeddings_meta VALUES (
-                'orphaned-by-index-rebuild', 'voyage-4', 1024, 1767225700000, x'ff', 0
-            )
-            """
+            "INSERT INTO message_embeddings_meta VALUES (?, 'voyage-4', 1024, 1767225700000, NULL, NULL)",
+            (b"\xff" * 32,),
         )
         conn.execute(
             "UPDATE embedding_status SET message_count_embedded = 4 WHERE session_id = 'codex-session:complete'"
@@ -515,8 +667,14 @@ def test_status_json_does_not_report_over_100_percent_from_retained_embedding_ro
 
     payload = _run_status(db_anchor, "--detail", cfg=_Cfg(embedding_enabled=True, voyage_api_key="vk-live"))
 
-    assert payload["embedded_sessions"] == 1
-    assert payload["pending_sessions"] == 1
+    # codex-session:complete's inflated message_count_embedded (4) no longer
+    # matches its real eligible count (1) or its embedding_derivation_state
+    # row's message_count (1), so the exact predicate demotes it to pending
+    # instead of trusting the stale number -- coverage lands at 0%, never over
+    # 100%.
+    assert payload["embedded_sessions"] == 0
+    assert payload["pending_sessions"] == 2
+    assert payload["embedding_coverage_percent"] == 0.0
     assert payload["embedded_messages"] == 4
     assert payload["failure_count"] == 0
     assert payload["candidate_prose_messages"] == 3
@@ -671,7 +829,7 @@ def test_status_json_detail_falls_back_when_exact_pending_count_times_out(
     original_scalar = status_payload_mod._scalar_int_with_timeout
 
     def fake_scalar_int_with_timeout(conn: sqlite3.Connection, sql: str, *, timeout_ms: int) -> int | None:
-        if "LEFT JOIN embeddings.message_embeddings_meta" in sql and "LEFT JOIN embeddings.embedding_status" in sql:
+        if "LEFT JOIN embeddings.message_embedding_refs" in sql and "LEFT JOIN embeddings.embedding_status" in sql:
             return None
         return original_scalar(conn, sql, timeout_ms=timeout_ms)
 
@@ -724,7 +882,7 @@ def test_status_text_detail_does_not_claim_zero_cost_when_exact_pending_count_ti
     original_scalar = status_payload_mod._scalar_int_with_timeout
 
     def fake_scalar_int_with_timeout(conn: sqlite3.Connection, sql: str, *, timeout_ms: int) -> int | None:
-        if "LEFT JOIN embeddings.message_embeddings_meta" in sql and "LEFT JOIN embeddings.embedding_status" in sql:
+        if "LEFT JOIN embeddings.message_embedding_refs" in sql and "LEFT JOIN embeddings.embedding_status" in sql:
             return None
         return original_scalar(conn, sql, timeout_ms=timeout_ms)
 
@@ -1110,13 +1268,61 @@ def test_status_json_reports_ready_next_action(tmp_path: Path) -> None:
 def test_status_json_reports_terminal_failures_before_ready(tmp_path: Path) -> None:
     db_anchor = tmp_path / "index.db"
     _seed_archive_file_set_from_archive_tiers(db_anchor)
-    with sqlite3.connect(tmp_path / "embeddings.db") as conn:
-        conn.execute(
+    embeddings_db = tmp_path / "embeddings.db"
+    with sqlite3.connect(embeddings_db) as conn:
+        # v4: go through the real attempt/failure write path (rather than a
+        # bare embedding_status insert) so embedding_derivation_state also
+        # carries the matching 'failed_terminal' row the modern blocked-
+        # session predicate reads. record_embedding_failure requires the
+        # embedding_failures table to exist (it always records the audit
+        # row), so it's created here even though this test's focus is
+        # pending_sessions/failure_count, not the failure ledger itself.
+        conn.executescript(
             """
-            INSERT INTO embedding_status (
-                session_id, origin, message_count_embedded, needs_reindex, error_message
-            ) VALUES ('codex-session:pending', 'codex-session', 0, 0, 'Embedding generation failed: HTTP 400')
+            CREATE TABLE embedding_failures (
+                failure_id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                origin TEXT NOT NULL,
+                message_refs_json TEXT NOT NULL DEFAULT '[]',
+                provider TEXT NOT NULL,
+                model TEXT NOT NULL,
+                error_class TEXT NOT NULL,
+                error_message TEXT NOT NULL,
+                retryable INTEGER NOT NULL,
+                lifecycle_state TEXT NOT NULL,
+                created_at_ms INTEGER NOT NULL,
+                updated_at_ms INTEGER NOT NULL,
+                resolved_at_ms INTEGER,
+                resolution_action TEXT,
+                resolution_note TEXT,
+                superseded_by TEXT,
+                generation INTEGER NOT NULL DEFAULT 0,
+                derivation_key BLOB,
+                source_hash BLOB,
+                recipe_hash BLOB
+            )
             """
+        )
+        attempt = begin_embedding_attempt(
+            conn,
+            session_id="codex-session:pending",
+            origin="codex-session",
+            source_hash=_pending_session_source_hash(),
+            recipe=EmbeddingRecipe.current(model="voyage-4", dimensions=1024),
+            started_at_ms=1_800_000_000_000,
+        )
+        record_embedding_failure(
+            conn,
+            session_id="codex-session:pending",
+            origin="codex-session",
+            message_refs=("codex-session:pending:m1",),
+            provider="voyage",
+            model="voyage-4",
+            error_class="provider_http_400",
+            error_message="Embedding generation failed: HTTP 400",
+            retryable=False,
+            occurred_at_ms=1_800_000_000_000,
+            attempt=attempt,
         )
         conn.commit()
 

--- a/tests/unit/cli/test_embeddings_rescue_cli.py
+++ b/tests/unit/cli/test_embeddings_rescue_cli.py
@@ -18,18 +18,47 @@ import pytest
 from click.testing import CliRunner
 
 from polylogue.cli.click_app import cli
-from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
-from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.embeddings import EMBEDDING_DIMENSION
+from polylogue.storage.sqlite.sqlite_vec_extension import try_load_sqlite_vec
+
+# rescue.py reads a retired source tier through the OLD v3, message_id-keyed
+# shape (message_embeddings/message_embeddings_meta keyed by message_id +
+# content_hash -- see polylogue.storage.embeddings.rescue's module docstring),
+# which is deliberately NOT what the current ArchiveTier.EMBEDDINGS bootstrap
+# produces any more (that is now v4, embedding_input_hash-keyed). Build the
+# retired-tier fixture with the exact old DDL directly rather than through the
+# current bootstrap, matching tests/unit/storage/test_embedding_rescue.py.
+_RETIRED_V3_DDL = f"""
+CREATE VIRTUAL TABLE message_embeddings USING vec0(
+    message_id TEXT PRIMARY KEY,
+    embedding float[{EMBEDDING_DIMENSION}],
+    +session_id TEXT,
+    +origin TEXT
+);
+
+CREATE TABLE message_embeddings_meta (
+    message_id      TEXT PRIMARY KEY,
+    model           TEXT NOT NULL,
+    dimension       INTEGER NOT NULL,
+    content_hash    BLOB NOT NULL,
+    embedded_at_ms  INTEGER,
+    needs_reindex   INTEGER NOT NULL DEFAULT 0,
+    recipe_hash     BLOB,
+    derivation_key  BLOB,
+    generation      INTEGER NOT NULL DEFAULT 0
+);
+"""
 
 
 def _build_empty_retired_source(path: Path) -> None:
     conn = sqlite3.connect(path)
     try:
-        initialize_archive_tier(conn, ArchiveTier.EMBEDDINGS)
-    except sqlite3.OperationalError as exc:
-        if "vec0" in str(exc) or "sqlite-vec" in str(exc):
+        loaded, error = try_load_sqlite_vec(conn)
+        if not loaded:
             pytest.skip("sqlite-vec extension is unavailable")
-        raise
+            raise AssertionError("unreachable") from error
+        conn.executescript(_RETIRED_V3_DDL)
+        conn.commit()
     finally:
         conn.close()
 

--- a/tests/unit/daemon/test_embedding_orphan_reconcile_daemon.py
+++ b/tests/unit/daemon/test_embedding_orphan_reconcile_daemon.py
@@ -12,6 +12,7 @@ substrate reconciliation logic already covered directly in
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import sqlite3
 from pathlib import Path
 from unittest.mock import patch
@@ -67,7 +68,7 @@ def _build_fixture(tmp_path: Path) -> tuple[Path, Path, str, str]:
                 embedding=[0.01] * EMBEDDING_DIMENSION,
                 model="voyage-4",
                 embedded_at_ms=1_700_000_000_000,
-                content_hash=b"z" * 32,
+                embedding_input_hash=hashlib.sha256(orphan_message_id.encode("utf-8")).digest(),
             )
         ],
     )
@@ -117,13 +118,15 @@ def test_reconcile_embedding_orphans_once_removes_orphan_when_enabled(tmp_path: 
     assert result is not None
     assert result.dry_run is False
     assert result.removed_message_rows == 1
-    assert result.removed_vector_rows == 1
+    # v4: message_embeddings/message_embeddings_meta are content-addressed and
+    # never deleted by this reconciler -- only the message_id -> hash ref is.
+    assert result.removed_vector_rows == 0
 
     conn = sqlite3.connect(embeddings_db)
     try:
         assert (
             conn.execute(
-                "SELECT COUNT(*) FROM message_embeddings_meta WHERE message_id = ?", (orphan_message_id,)
+                "SELECT COUNT(*) FROM message_embedding_refs WHERE message_id = ?", (orphan_message_id,)
             ).fetchone()[0]
             == 0
         )
@@ -153,7 +156,7 @@ def test_reconcile_embedding_orphans_once_refuses_stale_index_schema(tmp_path: P
     with sqlite3.connect(embeddings_db) as conn:
         assert (
             conn.execute(
-                "SELECT COUNT(*) FROM message_embeddings_meta WHERE message_id = ?", (orphan_message_id,)
+                "SELECT COUNT(*) FROM message_embedding_refs WHERE message_id = ?", (orphan_message_id,)
             ).fetchone()[0]
             == 1
         )
@@ -181,7 +184,7 @@ def test_daemon_coordinator_owns_real_orphan_reconcile_mutation(tmp_path: Path) 
     with sqlite3.connect(embeddings_db) as conn:
         assert (
             conn.execute(
-                "SELECT COUNT(*) FROM message_embeddings_meta WHERE message_id = ?", (orphan_message_id,)
+                "SELECT COUNT(*) FROM message_embedding_refs WHERE message_id = ?", (orphan_message_id,)
             ).fetchone()[0]
             == 0
         )

--- a/tests/unit/daemon/test_embedding_readiness.py
+++ b/tests/unit/daemon/test_embedding_readiness.py
@@ -18,6 +18,7 @@ plus a mocked ``EmbedSessionOutcome`` stream for the embed loop, and
 
 from __future__ import annotations
 
+import hashlib
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -67,16 +68,37 @@ def _seed_embedding_tables(
     dimension: int,
     session_ids: tuple[str, ...] = (),
 ) -> None:
-    """Create message_embeddings_meta + embedding_status with seeded rows."""
+    """Create message_embeddings_meta + embedding_status with seeded rows.
+
+    v4: message_embeddings_meta is keyed by ``embedding_input_hash`` and
+    carries ``recipe_hash`` -- ``_reconcile_embedding_config_change``'s
+    model-change detection (``meta_recipe_changed``) reads that column
+    directly (a bare model-name mismatch alone deliberately does not trigger
+    reindex any more; the recipe hash, which embeds the model name, is the
+    monotonic signal). Seed it with the *stored* recipe's hash (computed from
+    ``model``/``dimension`` here) so a caller's subsequent "configure a
+    different model" step produces a genuine, detectable mismatch.
+
+    A model-only (non-dimension) config change only actually marks
+    ``embedding_status.needs_reindex`` for sessions whose
+    ``embedding_derivation_state`` generation advances (the bulk-mark path is
+    reserved for dimension changes, which invalidate every stored vector
+    archive-wide) -- so each seeded session also gets a derivation_state row
+    pinned to the *stored* recipe, matching what a genuinely-embedded session
+    would carry.
+    """
+    from polylogue.storage.embeddings.identity import EmbeddingRecipe
+
+    stored_recipe = EmbeddingRecipe.current(model=model, dimensions=dimension)
     conn.execute(
         """
         CREATE TABLE message_embeddings_meta (
-            message_id TEXT PRIMARY KEY,
+            embedding_input_hash BLOB PRIMARY KEY,
             model TEXT NOT NULL,
             dimension INTEGER NOT NULL,
             embedded_at_ms INTEGER,
-            content_hash TEXT,
-            needs_reindex INTEGER NOT NULL DEFAULT 0
+            recipe_hash BLOB,
+            output_contract_hash BLOB
         )
         """
     )
@@ -92,14 +114,45 @@ def _seed_embedding_tables(
         """
     )
     conn.execute(
-        "INSERT INTO message_embeddings_meta(message_id, model, dimension, embedded_at_ms) "
-        "VALUES (?, ?, ?, 1767225600000)",
-        ("msg-1", model, dimension),
+        """
+        CREATE TABLE embedding_derivation_state (
+            session_id TEXT PRIMARY KEY,
+            origin TEXT NOT NULL DEFAULT '',
+            generation INTEGER NOT NULL,
+            derivation_key BLOB NOT NULL,
+            source_hash BLOB NOT NULL,
+            recipe_hash BLOB NOT NULL,
+            output_contract_hash BLOB NOT NULL,
+            attempt_state TEXT NOT NULL,
+            message_count INTEGER NOT NULL DEFAULT 0,
+            updated_at_ms INTEGER NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO message_embeddings_meta(embedding_input_hash, model, dimension, embedded_at_ms, recipe_hash, output_contract_hash) "
+        "VALUES (?, ?, ?, 1767225600000, ?, ?)",
+        (b"\x01" * 32, model, dimension, stored_recipe.recipe_hash, stored_recipe.output_contract_hash),
     )
     for conv_id in session_ids:
         conn.execute(
             "INSERT INTO embedding_status(session_id, needs_reindex) VALUES (?, 0)",
             (conv_id,),
+        )
+        conn.execute(
+            """
+            INSERT INTO embedding_derivation_state (
+                session_id, origin, generation, derivation_key, source_hash, recipe_hash,
+                output_contract_hash, attempt_state, message_count, updated_at_ms
+            ) VALUES (?, 'codex-session', 1, ?, ?, ?, ?, 'succeeded', 1, 1767225600000)
+            """,
+            (
+                conv_id,
+                hashlib.sha256(f"{conv_id}:derivation".encode()).digest(),
+                hashlib.sha256(f"{conv_id}:source".encode()).digest(),
+                stored_recipe.recipe_hash,
+                stored_recipe.output_contract_hash,
+            ),
         )
     conn.commit()
 
@@ -121,7 +174,43 @@ def _create_vec0_table(conn: sqlite3.Connection, dimension: int) -> None:
     conn.commit()
 
 
+# v4 (polylogue-q88p): distinct, >=20-char prose per message so each
+# message's embedding_input_hash -- computed from exactly this text -- is
+# real and unique, matching what production actually sends to the embedder.
+_READINESS_COMPLETE_TEXT = "authored prose for the complete readiness session message, long enough"
+_READINESS_PENDING_TEXT_1 = "authored prose for the first pending readiness message, long enough"
+_READINESS_PENDING_TEXT_2 = "authored prose for the second pending readiness message, long enough"
+_READINESS_ERROR_TEXT = "authored prose for the failed readiness session message, long enough"
+
+
 def _seed_archive_embedding_readiness_db(path: Path) -> None:
+    """Build a real v4-shaped index.db + embeddings.db pair for readiness reads.
+
+    ``codex-session:complete`` is embedded through the real
+    begin_embedding_attempt/complete_embedding_attempt_success write path;
+    ``codex-session:error`` gets a real *retryable* failure through
+    begin_embedding_attempt/record_embedding_failure (matching this fixture's
+    original needs_reindex=1 intent -- a retryable failure stays part of the
+    pending backlog, unlike an acknowledged/terminal one, which is what
+    status_payload.py's exact freshness predicate now keys "blocked" off of
+    via embedding_derivation_state.attempt_state, not a bare embedding_status
+    error_message column).
+    """
+    from polylogue.storage.embeddings.identity import (
+        EmbeddingRecipe,
+        EmbeddingSourceDigest,
+        embedding_input_hash,
+    )
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+    from polylogue.storage.sqlite.archive_tiers.embedding_write import (
+        ArchiveEmbeddingWrite,
+        begin_embedding_attempt,
+        complete_embedding_attempt_success,
+        record_embedding_failure,
+    )
+    from polylogue.storage.sqlite.archive_tiers.embeddings import EMBEDDING_DIMENSION
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
     path.parent.mkdir(parents=True, exist_ok=True)
     embeddings_path = path.with_name("embeddings.db")
     with sqlite3.connect(path) as conn:
@@ -134,6 +223,7 @@ def _seed_archive_embedding_readiness_db(path: Path) -> None:
             CREATE TABLE messages (
                 message_id TEXT PRIMARY KEY,
                 session_id TEXT NOT NULL,
+                text TEXT,
                 role TEXT NOT NULL DEFAULT 'user',
                 message_type TEXT NOT NULL DEFAULT 'message',
                 material_origin TEXT NOT NULL DEFAULT 'human_authored',
@@ -143,47 +233,87 @@ def _seed_archive_embedding_readiness_db(path: Path) -> None:
             INSERT INTO sessions VALUES ('codex-session:complete', 1);
             INSERT INTO sessions VALUES ('codex-session:pending', 2);
             INSERT INTO sessions VALUES ('codex-session:error', 1);
-            INSERT INTO messages (message_id, session_id, content_hash)
-            VALUES ('codex-session:complete:m1', 'codex-session:complete', x'01');
-            INSERT INTO messages (message_id, session_id, content_hash)
-            VALUES ('codex-session:pending:m1', 'codex-session:pending', x'02');
-            INSERT INTO messages (message_id, session_id, content_hash)
-            VALUES ('codex-session:pending:m2', 'codex-session:pending', x'03');
-            INSERT INTO messages (message_id, session_id, content_hash)
-            VALUES ('codex-session:error:m1', 'codex-session:error', x'04');
             """
         )
-        conn.commit()
-    with sqlite3.connect(embeddings_path) as conn:
-        conn.executescript(
-            """
-            CREATE TABLE message_embeddings (
-                message_id TEXT PRIMARY KEY
-            );
-            CREATE TABLE message_embeddings_meta (
-                message_id TEXT PRIMARY KEY,
-                model TEXT NOT NULL,
-                dimension INTEGER NOT NULL,
-                embedded_at_ms INTEGER NOT NULL,
-                content_hash BLOB,
-                needs_reindex INTEGER NOT NULL DEFAULT 0
-            );
-            CREATE TABLE embedding_status (
-                session_id TEXT PRIMARY KEY,
-                origin TEXT NOT NULL,
-                message_count_embedded INTEGER NOT NULL DEFAULT 0,
-                needs_reindex INTEGER NOT NULL DEFAULT 0,
-                error_message TEXT
-            );
-            INSERT INTO message_embeddings VALUES ('codex-session:complete:m1');
-            INSERT INTO message_embeddings_meta VALUES (
-                'codex-session:complete:m1', 'voyage-4', 1024, 1767225700000, x'01', 0
-            );
-            INSERT INTO embedding_status VALUES ('codex-session:complete', 'codex-session', 1, 0, NULL);
-            INSERT INTO embedding_status VALUES ('codex-session:error', 'codex-session', 0, 1, 'voyage timeout');
-            """
+        conn.execute(
+            "INSERT INTO messages (message_id, session_id, text, content_hash) VALUES (?, ?, ?, x'01')",
+            ("codex-session:complete:m1", "codex-session:complete", _READINESS_COMPLETE_TEXT),
+        )
+        conn.execute(
+            "INSERT INTO messages (message_id, session_id, text, content_hash) VALUES (?, ?, ?, x'02')",
+            ("codex-session:pending:m1", "codex-session:pending", _READINESS_PENDING_TEXT_1),
+        )
+        conn.execute(
+            "INSERT INTO messages (message_id, session_id, text, content_hash) VALUES (?, ?, ?, x'03')",
+            ("codex-session:pending:m2", "codex-session:pending", _READINESS_PENDING_TEXT_2),
+        )
+        conn.execute(
+            "INSERT INTO messages (message_id, session_id, text, content_hash) VALUES (?, ?, ?, x'04')",
+            ("codex-session:error:m1", "codex-session:error", _READINESS_ERROR_TEXT),
         )
         conn.commit()
+
+    recipe = EmbeddingRecipe.current(model="voyage-4", dimensions=EMBEDDING_DIMENSION)
+    econn = sqlite3.connect(embeddings_path)
+    try:
+        initialize_archive_tier(econn, ArchiveTier.EMBEDDINGS)
+
+        complete_hash = embedding_input_hash(model="voyage-4", input_text=_READINESS_COMPLETE_TEXT)
+        complete_source = EmbeddingSourceDigest()
+        complete_source.update(complete_hash)
+        complete_attempt = begin_embedding_attempt(
+            econn,
+            session_id="codex-session:complete",
+            origin="codex-session",
+            source_hash=complete_source.digest(),
+            recipe=recipe,
+            started_at_ms=1_767_225_700_000,
+        )
+        complete_embedding_attempt_success(
+            econn,
+            attempt=complete_attempt,
+            writes=[
+                ArchiveEmbeddingWrite(
+                    message_id="codex-session:complete:m1",
+                    session_id="codex-session:complete",
+                    origin="codex-session",
+                    embedding=[0.01] * EMBEDDING_DIMENSION,
+                    model="voyage-4",
+                    embedded_at_ms=1_767_225_700_000,
+                    embedding_input_hash=complete_hash,
+                    recipe_hash=complete_attempt.recipe_hash,
+                    generation=complete_attempt.generation,
+                )
+            ],
+            completed_at_ms=1_767_225_700_000,
+        )
+
+        error_hash = embedding_input_hash(model="voyage-4", input_text=_READINESS_ERROR_TEXT)
+        error_source = EmbeddingSourceDigest()
+        error_source.update(error_hash)
+        error_attempt = begin_embedding_attempt(
+            econn,
+            session_id="codex-session:error",
+            origin="codex-session",
+            source_hash=error_source.digest(),
+            recipe=recipe,
+            started_at_ms=1_767_225_700_000,
+        )
+        record_embedding_failure(
+            econn,
+            session_id="codex-session:error",
+            origin="codex-session",
+            message_refs=("codex-session:error:m1",),
+            provider="voyage",
+            model="voyage-4",
+            error_class="provider_timeout",
+            error_message="voyage timeout",
+            retryable=True,
+            occurred_at_ms=1_767_225_700_000,
+            attempt=error_attempt,
+        )
+    finally:
+        econn.close()
 
 
 # ── 1. configured readiness branch ─────────────────────────────────

--- a/tests/unit/devtools/test_archive_schema_fast_forward.py
+++ b/tests/unit/devtools/test_archive_schema_fast_forward.py
@@ -248,9 +248,16 @@ def test_embedding_clone_preserves_vectors_and_installs_failure_lifecycle(tmp_pa
         conn.execute("DROP INDEX idx_embedding_failures_active")
         conn.execute("DROP TABLE embedding_failures")
         conn.execute("PRAGMA user_version = 1")
+        # v1/v2 (this helper's real historical scope, hardcoded to require
+        # user_version == 1 below) never touched message_embeddings_meta's
+        # column shape -- only the failure-lifecycle table addition
+        # differed. This test's fixture is built from the CURRENT (v4,
+        # content-addressed, polylogue-q88p) canonical DDL via
+        # initialize_archive_tier above, so the row inserted here must match
+        # that shape, not the pre-v4 message_id-keyed one.
         conn.execute(
-            "INSERT INTO message_embeddings_meta(message_id, model, dimension, content_hash) VALUES (?, ?, ?, ?)",
-            ("message:1", "fixture", 1024, b"m" * 32),
+            "INSERT INTO message_embeddings_meta(embedding_input_hash, model, dimension) VALUES (?, ?, ?)",
+            (b"m" * 32, "fixture", 1024),
         )
         conn.execute("INSERT INTO embedding_status(session_id, origin) VALUES (?, ?)", ("session:1", "chatgpt-export"))
         conn.commit()

--- a/tests/unit/security/test_excision.py
+++ b/tests/unit/security/test_excision.py
@@ -115,6 +115,7 @@ def _seed_session(
         index_conn.close()
 
     if with_embedding and with_message:
+        from polylogue.storage.embeddings.identity import embedding_input_hash
         from polylogue.storage.sqlite.sqlite_vec_extension import try_load_sqlite_vec
 
         embeddings_db = archive_root / "embeddings.db"
@@ -122,15 +123,22 @@ def _seed_session(
         emb_conn = sqlite3.connect(embeddings_db)
         try:
             try_load_sqlite_vec(emb_conn)
+            # Content-addressed (polylogue-q88p): vectors/meta are keyed by
+            # embedding_input_hash, not message_id; message_embedding_refs
+            # is the per-message mapping excision must delete from.
+            input_hash = embedding_input_hash(model="test-model", input_text=f"excision-fixture-{native_id}")
             emb_conn.execute(
-                "INSERT INTO message_embeddings (message_id, embedding, session_id, origin) "
-                "VALUES (?, ?, ?, 'codex-session')",
-                (message_id, b"\x00\x00\x80\x3f" * 1024, session_id),
+                "INSERT INTO message_embeddings (embedding_input_hash, embedding, model) VALUES (?, ?, ?)",
+                (input_hash.hex(), b"\x00\x00\x80\x3f" * 1024, "test-model"),
             )
             emb_conn.execute(
-                "INSERT INTO message_embeddings_meta (message_id, model, dimension, content_hash) "
-                "VALUES (?, 'test-model', 1024, zeroblob(32))",
-                (message_id,),
+                "INSERT INTO message_embeddings_meta (embedding_input_hash, model, dimension) VALUES (?, ?, ?)",
+                (input_hash, "test-model", 1024),
+            )
+            emb_conn.execute(
+                "INSERT INTO message_embedding_refs (message_id, session_id, origin, embedding_input_hash) "
+                "VALUES (?, ?, 'codex-session', ?)",
+                (message_id, session_id, input_hash),
             )
             emb_conn.execute(
                 "INSERT INTO embedding_status (session_id, message_count_embedded) VALUES (?, 1)",

--- a/tests/unit/storage/test_archive_tiers_embedding_write.py
+++ b/tests/unit/storage/test_archive_tiers_embedding_write.py
@@ -43,7 +43,7 @@ def test_archive_tiers_embedding_writer_upserts_vector_meta_and_status(tmp_path:
     conn = _connect(tmp_path / "embeddings.db")
     session_id = "codex-session:codex-embedding"
     message_id = f"{session_id}:m1"
-    content_hash = b"x" * 32
+    input_hash = b"x" * 32
 
     meta = upsert_message_embedding(
         conn,
@@ -53,18 +53,18 @@ def test_archive_tiers_embedding_writer_upserts_vector_meta_and_status(tmp_path:
         embedding=[0.0] * EMBEDDING_DIMENSION,
         model="voyage-4",
         embedded_at_ms=1_767_225_700_000,
-        content_hash=content_hash,
+        embedding_input_hash=input_hash,
     )
 
     assert meta == ArchiveEmbeddingMeta(
         message_id=message_id,
         model="voyage-4",
         dimension=EMBEDDING_DIMENSION,
-        content_hash=content_hash,
+        embedding_input_hash=input_hash,
         embedded_at_ms=1_767_225_700_000,
-        needs_reindex=False,
     )
     assert conn.execute("SELECT COUNT(*) FROM message_embeddings").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM message_embedding_refs").fetchone()[0] == 1
 
     # The per-message vector upsert intentionally does NOT touch
     # ``embedding_status``; that row is materialized by the session-level
@@ -101,7 +101,7 @@ def test_archive_tiers_embedding_writer_batches_message_upserts(tmp_path: Path) 
                 embedding=[0.01] * EMBEDDING_DIMENSION,
                 model="voyage-4",
                 embedded_at_ms=1_767_225_700_000,
-                content_hash=bytes([index]) * 32,
+                embedding_input_hash=bytes([index]) * 32,
             )
             for index in range(3)
         ],
@@ -111,6 +111,7 @@ def test_archive_tiers_embedding_writer_batches_message_upserts(tmp_path: Path) 
     assert transaction_events == ["BEGIN ", "COMMIT"]
     assert conn.execute("SELECT COUNT(*) FROM message_embeddings").fetchone()[0] == 3
     assert conn.execute("SELECT COUNT(*) FROM message_embeddings_meta").fetchone()[0] == 3
+    assert conn.execute("SELECT COUNT(*) FROM message_embedding_refs").fetchone()[0] == 3
 
 
 def test_archive_tiers_embedding_writer_records_reindexable_errors(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_embedding_contracts.py
+++ b/tests/unit/storage/test_embedding_contracts.py
@@ -789,10 +789,17 @@ def test_pending_archive_window_counts_only_embeddable_prose() -> None:
         pending = select_pending_archive_session_window(conn, status_table="", min_messages=1)
 
         assert [item.session_id for item in pending] == ["mixed"]
-        # Missing-status sessions use the cheap aggregate as a conservative
-        # budget estimate; exact text-floor counts are reserved for deciding
-        # whether an existing clean status row is stale.
-        assert pending[0].message_count == 4
+        # v4 (polylogue-q88p "unify embedding freshness into one monotonic
+        # key"): there is no longer a separate "cheap aggregate estimate vs.
+        # exact text-floor count" split -- _archive_embedding_freshness_
+        # predicate's exact desired_messages CTE is the ONE path, used
+        # whether or not a status table is available (a missing status_table
+        # only changes fresh_sql/blocked_sql to constants, not how message
+        # counts themselves are computed). So a status_table="" caller still
+        # gets the real embeddable-prose count (2: m-user + m-assistant),
+        # correctly excluding the context/tool-result rows even without a
+        # status ledger to consult.
+        assert pending[0].message_count == 2
     finally:
         conn.close()
 

--- a/tests/unit/storage/test_embedding_dedup.py
+++ b/tests/unit/storage/test_embedding_dedup.py
@@ -1,0 +1,163 @@
+"""Content-addressed dedup proof for the embeddings tier (polylogue-q88p).
+
+Fork/resume/auto-compaction replays and genuinely coincidental identical
+prose both produce messages with byte-identical embedder input text across
+different sessions. Content-addressing means that text is embedded exactly
+once regardless of how many messages/sessions reference it -- a real API
+cost saving in a lineage-heavy archive, and the same mechanism the 04kl
+rescue relies on when landing vectors into the new layout.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, MaterialOrigin, Provider
+from polylogue.sources.parsers.base import ParsedSession
+from polylogue.sources.parsers.base_models import ParsedContentBlock, ParsedMessage
+from polylogue.storage.embeddings.materialization import embed_archive_session_sync
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.sqlite_vec_extension import try_load_sqlite_vec
+
+_SHARED_TEXT = "This exact prose appears verbatim in two unrelated sessions."
+
+
+class _FakeVectorProvider:
+    model = "voyage-4"
+    dimension = 1024
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def _get_embeddings(self, texts: list[str], input_type: str = "document") -> list[list[float]]:
+        assert input_type == "document"
+        self.calls.append(list(texts))
+        return [[0.25] * self.dimension for _ in texts]
+
+    def upsert(self, *args: object, **kwargs: object) -> None:
+        raise AssertionError("archive materialization must use the archive embedding route")
+
+    def query(self, *args: object, **kwargs: object) -> list[tuple[str, float]]:
+        return []
+
+    def query_by_session(self, *args: object, **kwargs: object) -> list[tuple[str, float]]:
+        return []
+
+
+def _write_session(root: Path, *, native_id: str, text: str, origin: Provider = Provider.CODEX) -> str:
+    with ArchiveStore(root) as archive:
+        return archive.write_parsed(
+            ParsedSession(
+                source_name=origin,
+                provider_session_id=native_id,
+                messages=[
+                    ParsedMessage(
+                        provider_message_id="m1",
+                        role=Role.USER,
+                        text=text,
+                        blocks=[ParsedContentBlock(type=BlockType.TEXT, text=text)],
+                        material_origin=MaterialOrigin.HUMAN_AUTHORED,
+                    )
+                ],
+            )
+        )
+
+
+def _connect_vec(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    loaded, error = try_load_sqlite_vec(conn)
+    if not loaded:
+        conn.close()
+        pytest.skip(str(error) if error else "sqlite-vec extension is unavailable")
+    return conn
+
+
+def test_identical_content_across_two_sessions_embeds_once(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    session_a = _write_session(root, native_id="dedup-a", text=_SHARED_TEXT)
+    session_b = _write_session(root, native_id="dedup-b", text=_SHARED_TEXT)
+    assert session_a != session_b
+
+    index_db = root / "index.db"
+    embeddings_db = root / "embeddings.db"
+    initialize_archive_database(embeddings_db, ArchiveTier.EMBEDDINGS)
+    _connect_vec(embeddings_db).close()
+
+    provider = _FakeVectorProvider()
+    outcome_a = embed_archive_session_sync(index_db, provider, session_a)
+    outcome_b = embed_archive_session_sync(index_db, provider, session_b)
+    assert outcome_a.status == "embedded"
+    assert outcome_b.status == "embedded"
+    # Each session's embed pass still calls the provider once (per-session
+    # materialization does not consult prior vectors before calling out) --
+    # the dedup win is in STORAGE, not in avoiding this particular pass's
+    # API call. The real cost saving is a subsequent session that reaches
+    # the freshness predicate already-fresh (see
+    # test_embedding_rebuild_survival.py), or the rescue path skipping the
+    # API entirely (see test_embedding_rescue_content_addressed_layout.py).
+    assert len(provider.calls) == 2
+
+    with _connect_vec(embeddings_db) as conn:
+        vector_rows = conn.execute("SELECT COUNT(*) FROM message_embeddings").fetchone()[0]
+        meta_rows = conn.execute("SELECT COUNT(*) FROM message_embeddings_meta").fetchone()[0]
+        ref_rows = conn.execute("SELECT COUNT(*) FROM message_embedding_refs").fetchone()[0]
+        ref_session_ids = {
+            str(row[0]) for row in conn.execute("SELECT DISTINCT session_id FROM message_embedding_refs").fetchall()
+        }
+        distinct_hashes = {
+            str(row[0]) for row in conn.execute("SELECT embedding_input_hash FROM message_embedding_refs").fetchall()
+        }
+
+    assert vector_rows == 1, "identical text across two sessions must produce exactly one stored vector"
+    assert meta_rows == 1, "identical text across two sessions must produce exactly one meta row"
+    assert ref_rows == 2, "each message still gets its own message_id -> hash ref"
+    assert ref_session_ids == {session_a, session_b}
+    assert len(distinct_hashes) == 1, "both refs must point at the same content-addressed hash"
+
+
+def test_dedup_first_write_wins_the_stored_vector_bytes(tmp_path: Path) -> None:
+    """A second write for an already-known hash never overwrites the stored vector.
+
+    Anti-vacuity: if the write path re-inserted on every embed pass instead
+    of checking meta-row presence first, this test's second (different-
+    valued) provider response would clobber the first, and the assertion
+    below would fail.
+    """
+    root = tmp_path / "archive"
+    session_a = _write_session(root, native_id="dedup-first-write-a", text=_SHARED_TEXT)
+    session_b = _write_session(root, native_id="dedup-first-write-b", text=_SHARED_TEXT)
+
+    index_db = root / "index.db"
+    embeddings_db = root / "embeddings.db"
+    initialize_archive_database(embeddings_db, ArchiveTier.EMBEDDINGS)
+    _connect_vec(embeddings_db).close()
+
+    class _DistinctValueProvider(_FakeVectorProvider):
+        def __init__(self, value: float) -> None:
+            super().__init__()
+            self.value = value
+
+        def _get_embeddings(self, texts: list[str], input_type: str = "document") -> list[list[float]]:
+            self.calls.append(list(texts))
+            return [[self.value] * self.dimension for _ in texts]
+
+    first_provider = _DistinctValueProvider(0.11)
+    outcome_a = embed_archive_session_sync(index_db, first_provider, session_a)
+    assert outcome_a.status == "embedded"
+
+    second_provider = _DistinctValueProvider(0.99)
+    outcome_b = embed_archive_session_sync(index_db, second_provider, session_b)
+    assert outcome_b.status == "embedded"
+
+    with _connect_vec(embeddings_db) as conn:
+        row = conn.execute("SELECT embedding FROM message_embeddings").fetchone()
+    import struct
+
+    stored = struct.unpack("<1024f", row[0])
+    assert stored[0] == pytest.approx(0.11), "the first write's vector must survive, not the second"

--- a/tests/unit/storage/test_embedding_freshness_invariant.py
+++ b/tests/unit/storage/test_embedding_freshness_invariant.py
@@ -28,7 +28,7 @@ from polylogue.storage.derivation_identity import (
     DerivationKeyLike,
     DerivationSubject,
 )
-from polylogue.storage.embeddings.identity import EmbeddingRecipe, EmbeddingSourceDigest
+from polylogue.storage.embeddings.identity import EmbeddingRecipe, EmbeddingSourceDigest, embedding_input_hash
 from polylogue.storage.embeddings.materialization import (
     EmbedSessionOutcome,
     embed_archive_session_sync,
@@ -275,7 +275,7 @@ def test_config_change_then_old_terminal_error_cannot_clear_new_generation(
     conn.row_factory = sqlite3.Row
     try:
         source = EmbeddingSourceDigest()
-        source.update("codex-session:race:m1", b"x" * 32)
+        source.update(b"x" * 32)
         old_attempt = begin_embedding_attempt(
             conn,
             session_id="codex-session:race",
@@ -471,7 +471,7 @@ def test_unscoped_or_legacy_failure_receipt_cannot_project_over_keyed_generation
         )
 
         source = EmbeddingSourceDigest()
-        source.update("codex-session:legacy-race:m1", b"y" * 32)
+        source.update(b"y" * 32)
         attempt = begin_embedding_attempt(
             conn,
             session_id=legacy_failure.session_id,
@@ -524,6 +524,23 @@ def test_unscoped_or_legacy_failure_receipt_cannot_project_over_keyed_generation
     assert latest_receipt["derivation_key"] is None
 
 
+def _current_ref_and_vector(conn: sqlite3.Connection, session_id: str) -> tuple[str, bytes, bytes]:
+    """Resolve one session's (message_id, embedding_input_hash, vector) via the
+    v4 ref -> content-addressed row join (message_embeddings/
+    message_embeddings_meta are keyed by embedding_input_hash, not message_id,
+    so message_embedding_refs is the required message_id -> hash bridge)."""
+    row = conn.execute(
+        """
+        SELECT r.message_id, r.embedding_input_hash, m.embedding
+        FROM message_embedding_refs AS r
+        JOIN message_embeddings AS m ON m.embedding_input_hash = lower(hex(r.embedding_input_hash))
+        WHERE r.session_id = ?
+        """,
+        (session_id,),
+    ).fetchone()
+    return str(row[0]), bytes(row[1]), bytes(row[2])
+
+
 def test_same_id_full_replace_reselects_and_atomically_replaces_vector_and_meta(tmp_path: Path) -> None:
     root = tmp_path / "archive"
     session_id = _write_archive_session(root, native_id="full-replace", text=_INITIAL_TEXT)
@@ -532,15 +549,7 @@ def test_same_id_full_replace_reselects_and_atomically_replaces_vector_and_meta(
 
     conn = _open_embeddings(root / "embeddings.db")
     try:
-        old_message_id, old_hash, old_vector = conn.execute(
-            """
-            SELECT m.message_id, mm.content_hash, m.embedding
-            FROM message_embeddings AS m
-            JOIN message_embeddings_meta AS mm USING (message_id)
-            WHERE m.session_id = ?
-            """,
-            (session_id,),
-        ).fetchone()
+        old_message_id, old_input_hash, old_vector = _current_ref_and_vector(conn, session_id)
     finally:
         conn.close()
 
@@ -558,28 +567,26 @@ def test_same_id_full_replace_reselects_and_atomically_replaces_vector_and_meta(
     index_conn = sqlite3.connect(root / "index.db")
     embed_conn = _open_embeddings(root / "embeddings.db")
     try:
-        current_message_id, current_hash = index_conn.execute(
-            "SELECT message_id, content_hash FROM messages WHERE session_id = ?",
+        current_message_id = index_conn.execute(
+            "SELECT message_id FROM messages WHERE session_id = ?",
             (session_id,),
-        ).fetchone()
-        rows = embed_conn.execute(
-            """
-            SELECT m.message_id, mm.content_hash, m.embedding
-            FROM message_embeddings AS m
-            JOIN message_embeddings_meta AS mm USING (message_id)
-            WHERE m.session_id = ?
-            """,
-            (session_id,),
-        ).fetchall()
+        ).fetchone()[0]
+        new_message_id, new_input_hash, new_vector = _current_ref_and_vector(embed_conn, session_id)
     finally:
         index_conn.close()
         embed_conn.close()
 
-    assert len(rows) == 1
-    assert rows[0][0] == old_message_id == current_message_id
-    assert bytes(rows[0][1]) == bytes(current_hash)
-    assert bytes(rows[0][1]) != bytes(old_hash)
-    assert bytes(rows[0][2]) != bytes(old_vector)
+    # message_id is stable across the full-replace (same native_id/position);
+    # embedding_input_hash -- identity-free, H(model, embedder input text) --
+    # is what actually changes when the text changes, re-deriving to exactly
+    # what the production identity function computes for the new text. The
+    # vector itself is atomically replaced too (never left pointing at the
+    # stale text's embedding).
+    assert new_message_id == old_message_id == current_message_id
+    assert new_input_hash == embedding_input_hash(model="voyage-4", input_text=_CHANGED_TEXT)
+    assert old_input_hash == embedding_input_hash(model="voyage-4", input_text=_INITIAL_TEXT)
+    assert new_input_hash != old_input_hash
+    assert new_vector != old_vector
 
 
 def test_derivation_key_value_shape_is_storage_neutral_and_generation_free() -> None:

--- a/tests/unit/storage/test_embedding_orphan_reconcile.py
+++ b/tests/unit/storage/test_embedding_orphan_reconcile.py
@@ -11,6 +11,7 @@ condemns, never the ones the content-hash and quiet-window guards protect.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 from pathlib import Path
@@ -121,8 +122,15 @@ def _write_embedding(
     message_id: str,
     session_id: str,
     embedded_at_ms: int,
-    content_hash: bytes | None = None,
+    embedding_input_hash: bytes | None = None,
 ) -> None:
+    """Write one message's vector/meta/ref via the real v4 content-addressed writer.
+
+    Defaults to a hash derived from ``message_id`` (unique per message) unless
+    an explicit ``embedding_input_hash`` is supplied -- e.g. to simulate two
+    messages whose current embedder input text is identical and therefore
+    dedups onto one shared vector row.
+    """
     upsert_message_embeddings(
         conn,
         [
@@ -133,7 +141,11 @@ def _write_embedding(
                 embedding=[0.01] * EMBEDDING_DIMENSION,
                 model="voyage-4",
                 embedded_at_ms=embedded_at_ms,
-                content_hash=content_hash if content_hash is not None else (bytes([len(message_id) % 255]) * 32),
+                embedding_input_hash=(
+                    embedding_input_hash
+                    if embedding_input_hash is not None
+                    else hashlib.sha256(message_id.encode("utf-8")).digest()
+                ),
             )
         ],
     )
@@ -187,18 +199,33 @@ def test_reconcile_removes_message_orphaned_by_index_rebuild(tmp_path: Path) -> 
 
     assert report.orphan_message_rows == 1
     assert report.removed_message_rows == 1
-    assert report.removed_vector_rows == 1
+    # v4: message_embeddings/message_embeddings_meta are content-addressed and
+    # shared -- this reconciler only ever removes the orphan message_id ->
+    # hash *ref*, never the vector/meta row itself (module docstring).
+    assert report.removed_vector_rows == 0
     assert report.sessions_recounted == 1
     assert report.more_pending is False
 
     conn = sqlite3.connect(embeddings_db)
     try:
         assert (
-            conn.execute("SELECT COUNT(*) FROM message_embeddings_meta WHERE message_id = ?", (m1,)).fetchone()[0] == 1
+            conn.execute("SELECT COUNT(*) FROM message_embedding_refs WHERE message_id = ?", (m1,)).fetchone()[0] == 1
         )
         assert (
-            conn.execute("SELECT COUNT(*) FROM message_embeddings_meta WHERE message_id = ?", (m2,)).fetchone()[0] == 0
+            conn.execute("SELECT COUNT(*) FROM message_embedding_refs WHERE message_id = ?", (m2,)).fetchone()[0] == 0
         )
+        # The trivially-simplified deeper invariant behind the old (now
+        # removed) content-hash-mismatch test: an identity-present message's
+        # vector/meta row is never touched by this reconciler -- and neither
+        # is an orphaned message's, which is the new, stronger form of that
+        # guarantee (there is no content_hash column left to compare against).
+        m2_hash = hashlib.sha256(m2.encode("utf-8")).digest()
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM message_embeddings_meta WHERE embedding_input_hash = ?", (m2_hash,)
+            ).fetchone()[0]
+            == 1
+        ), "an orphaned ref's underlying vector/meta row survives untouched -- reference-counted GC is out of scope"
         status = conn.execute(
             "SELECT message_count_embedded, needs_reindex FROM embedding_status WHERE session_id = ?", (session_id,)
         ).fetchone()
@@ -266,26 +293,64 @@ def test_apply_accepts_generation_metadata_beside_external_pointer_anchor(tmp_pa
     )
 
     assert report.removed_message_rows == 1
-    assert report.removed_vector_rows == 1
+    # v4: the vector/meta row is content-addressed and never deleted by this
+    # reconciler -- only the message_id -> hash ref is removed.
+    assert report.removed_vector_rows == 0
     with _connect_embeddings(embeddings_db) as verify:
-        assert verify.execute("SELECT COUNT(*) FROM message_embeddings_meta").fetchone()[0] == 0
-        assert verify.execute("SELECT COUNT(*) FROM message_embeddings").fetchone()[0] == 0
+        assert verify.execute("SELECT COUNT(*) FROM message_embedding_refs").fetchone()[0] == 0
+        assert verify.execute("SELECT COUNT(*) FROM message_embeddings_meta").fetchone()[0] == 1
+        assert verify.execute("SELECT COUNT(*) FROM message_embeddings").fetchone()[0] == 1
 
 
-def test_reconcile_preserves_content_hash_mismatch_when_identity_present(tmp_path: Path) -> None:
-    """Content-hash guard: a message that still exists (identity present) is
-    never removed merely because its stored content_hash is stale — that is
-    0k6's re-embed territory, not this reconciler's."""
+# NOTE: the old `test_reconcile_preserves_content_hash_mismatch_when_identity_
+# present` test verified that a message which still exists in the index is
+# never removed merely because its recorded content_hash had gone stale --
+# that mismatch-tolerance mechanism doesn't exist under v4 (there is no
+# content_hash column on message_embedding_refs/message_embeddings_meta left
+# to compare; presence alone is the check). The deeper invariant it protected
+# — an identity-present message's underlying row is never disturbed by this
+# reconciler — is now folded into
+# `test_reconcile_removes_orphan_ref_but_preserves_shared_vector_and_meta_rows`
+# below, which additionally proves the *stronger* v4 claim: even an orphaned
+# message's now-refless vector/meta row is left untouched, since reference-
+# counted GC is explicitly out of scope (see reconcile.py's module docstring).
 
-    session_id = "codex-session:s2"
-    m1 = f"{session_id}:m1"
-    _connect_index(tmp_path / "index.db", sessions=[session_id], messages={session_id: [m1]})
+
+def test_reconcile_removes_orphan_ref_but_preserves_shared_vector_and_meta_rows(tmp_path: Path) -> None:
+    """v4: message_embeddings/message_embeddings_meta are content-addressed and
+    shared across messages/sessions -- removing one message's orphan ref must
+    never touch the vector/meta row a still-live message legitimately shares
+    the same hash with (dedup), nor the row belonging to an orphan alone.
+    Reference-counted vector GC is explicitly out of scope (module docstring).
+    """
+
+    live_session = "codex-session:live"
+    orphan_session = "codex-session:orphan"
+    live_id = f"{live_session}:m1"
+    orphan_id = f"{orphan_session}:m1"
+    shared_hash = b"\x42" * 32
+
+    # orphan_session/orphan_id is intentionally absent from index.db --
+    # standing in for a rebuild that dropped it while live_session survived.
+    _connect_index(tmp_path / "index.db", sessions=[live_session], messages={live_session: [live_id]})
 
     embeddings_db = tmp_path / "embeddings.db"
     conn = _connect_embeddings(embeddings_db)
-    old_hash = b"a" * 32
-    _write_embedding(conn, message_id=m1, session_id=session_id, embedded_at_ms=_OLD_MS, content_hash=old_hash)
-    _write_status(conn, session_id=session_id, message_count_embedded=1, last_embedded_at_ms=_OLD_MS)
+    _write_embedding(
+        conn, message_id=live_id, session_id=live_session, embedded_at_ms=_OLD_MS, embedding_input_hash=shared_hash
+    )
+    _write_embedding(
+        conn,
+        message_id=orphan_id,
+        session_id=orphan_session,
+        embedded_at_ms=_OLD_MS,
+        embedding_input_hash=shared_hash,
+    )
+    _write_status(conn, session_id=live_session, message_count_embedded=1, last_embedded_at_ms=_OLD_MS)
+    assert conn.execute("SELECT COUNT(*) FROM message_embeddings_meta").fetchone()[0] == 1, (
+        "both messages share one hash -- the write-once vector/meta row is written exactly once"
+    )
+    assert conn.execute("SELECT COUNT(*) FROM message_embedding_refs").fetchone()[0] == 2
     conn.close()
 
     report = reconcile_embedding_orphans(
@@ -296,16 +361,33 @@ def test_reconcile_preserves_content_hash_mismatch_when_identity_present(tmp_pat
         mutation_authority="offline-exclusive",
     )
 
-    assert report.orphan_message_rows == 0
-    assert report.removed_message_rows == 0
+    assert report.orphan_message_rows == 1
+    assert report.removed_message_rows == 1
+    assert report.removed_vector_rows == 0, "vectors are content-addressed/shared -- never deleted by this reconciler"
 
-    conn = sqlite3.connect(embeddings_db)
-    try:
-        row = conn.execute("SELECT content_hash FROM message_embeddings_meta WHERE message_id = ?", (m1,)).fetchone()
-        assert row is not None
-        assert bytes(row[0]) == old_hash, "identity-present row must be preserved untouched, hash and all"
-    finally:
-        conn.close()
+    with _connect_embeddings(embeddings_db) as conn:
+        assert (
+            conn.execute("SELECT COUNT(*) FROM message_embedding_refs WHERE message_id = ?", (orphan_id,)).fetchone()[0]
+            == 0
+        )
+        assert (
+            conn.execute("SELECT COUNT(*) FROM message_embedding_refs WHERE message_id = ?", (live_id,)).fetchone()[0]
+            == 1
+        )
+        # The shared vector/meta row survives untouched -- the live message
+        # can still resolve its embedding through it.
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM message_embeddings_meta WHERE embedding_input_hash = ?", (shared_hash,)
+            ).fetchone()[0]
+            == 1
+        )
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM message_embeddings WHERE embedding_input_hash = ?", (shared_hash.hex(),)
+            ).fetchone()[0]
+            == 1
+        )
 
 
 def test_reconcile_removes_orphan_status_for_deleted_session(tmp_path: Path) -> None:
@@ -371,7 +453,7 @@ def test_reconcile_respects_quiet_window(tmp_path: Path) -> None:
     conn = sqlite3.connect(embeddings_db)
     try:
         assert (
-            conn.execute("SELECT COUNT(*) FROM message_embeddings_meta WHERE message_id = ?", (m1,)).fetchone()[0] == 1
+            conn.execute("SELECT COUNT(*) FROM message_embedding_refs WHERE message_id = ?", (m1,)).fetchone()[0] == 1
         )
     finally:
         conn.close()
@@ -468,7 +550,7 @@ def test_reconcile_dry_run_does_not_mutate(tmp_path: Path) -> None:
     conn = sqlite3.connect(embeddings_db)
     try:
         assert (
-            conn.execute("SELECT COUNT(*) FROM message_embeddings_meta WHERE message_id = ?", (m1,)).fetchone()[0] == 1
+            conn.execute("SELECT COUNT(*) FROM message_embedding_refs WHERE message_id = ?", (m1,)).fetchone()[0] == 1
         )
     finally:
         conn.close()
@@ -571,56 +653,23 @@ def test_apply_refuses_live_v32_index_and_preserves_orphans(tmp_path: Path) -> N
         assert verify.execute("SELECT COUNT(*) FROM embedding_status").fetchone()[0] == 1
 
 
-def test_reconcile_counts_and_removes_meta_only_and_vec_only_orphans(tmp_path: Path) -> None:
-    """Real vec0/DDL proof: row-kind counts and removals must not be inferred from identity count."""
-    meta_session = "codex-session:meta-only"
-    vec_session = "codex-session:vec-only"
-    meta_id = f"{meta_session}:m1"
-    vec_id = f"{vec_session}:m1"
-    _connect_index(
-        tmp_path / "index.db",
-        sessions=[meta_session, vec_session],
-        messages={meta_session: [], vec_session: []},
-    )
-    embeddings_db = tmp_path / "embeddings.db"
-    conn = _connect_embeddings(embeddings_db)
-    _write_embedding(conn, message_id=meta_id, session_id=meta_session, embedded_at_ms=_OLD_MS)
-    _write_embedding(conn, message_id=vec_id, session_id=vec_session, embedded_at_ms=_OLD_MS)
-    _write_status(conn, session_id=meta_session, message_count_embedded=1, last_embedded_at_ms=_OLD_MS)
-    _write_status(conn, session_id=vec_session, message_count_embedded=1, last_embedded_at_ms=_OLD_MS)
-    conn.execute("DELETE FROM message_embeddings WHERE message_id = ?", (meta_id,))
-    conn.execute("DELETE FROM message_embeddings_meta WHERE message_id = ?", (vec_id,))
-    conn.commit()
-    conn.close()
-
-    inspected = inspect_embedding_orphans(tmp_path / "index.db", embeddings_db, now_ms=_NOW_MS)
-    assert inspected.scanned_message_meta_rows == 1
-    assert inspected.scanned_vector_rows == 1
-    assert inspected.orphan_message_rows == 2
-    assert inspected.orphan_message_meta_rows == 1
-    assert inspected.orphan_vector_rows == 1
-
-    applied = reconcile_embedding_orphans(
-        tmp_path / "index.db",
-        embeddings_db,
-        dry_run=False,
-        now_ms=_NOW_MS,
-        mutation_authority="offline-exclusive",
-    )
-    assert applied.removed_message_rows == 1
-    assert applied.removed_vector_rows == 1
-    assert applied.sessions_recounted == 2
-
-    with _connect_embeddings(embeddings_db) as verify:
-        assert verify.execute("SELECT COUNT(*) FROM message_embeddings_meta").fetchone()[0] == 0
-        assert verify.execute("SELECT COUNT(*) FROM message_embeddings").fetchone()[0] == 0
-        statuses = [
-            tuple(row)
-            for row in verify.execute(
-                "SELECT session_id, message_count_embedded, needs_reindex FROM embedding_status ORDER BY session_id"
-            ).fetchall()
-        ]
-    assert statuses == [(meta_session, 0, 1), (vec_session, 0, 1)]
+# NOTE: the old `test_reconcile_counts_and_removes_meta_only_and_vec_only_
+# orphans` test manually deleted rows straight out of message_embeddings /
+# message_embeddings_meta (bypassing the writer) to construct a "meta row
+# exists but vector row doesn't" / vice-versa scenario, then asserted the
+# reconciler's has_meta/has_vector row-kind counts and removals differed
+# accordingly. Under v4 that distinction is gone on both sides: the tables
+# are keyed by embedding_input_hash, not message_id (so a raw `DELETE ...
+# WHERE message_id = ?` against them no longer targets anything meaningful),
+# and `_orphan_message_rows` reports has_meta/has_vector as always-true from
+# a ref's perspective since a ref only ever points at a hash written
+# atomically with both (see reconcile.py's `_orphan_message_rows`
+# docstring) -- this reconciler doesn't distinguish or delete either kind
+# any more. The test is removed as vacuous under the new schema; its
+# "removal is scoped to real DDL, not inferred" spirit lives on in
+# `test_reconcile_removes_orphan_ref_but_preserves_shared_vector_and_meta_rows`
+# above, which proves against real vec0 + STRICT-table DDL that a ref
+# removal never touches the surviving content-addressed row.
 
 
 def test_reconcile_rolls_back_delete_recount_and_status_cleanup_then_retries(tmp_path: Path) -> None:
@@ -690,7 +739,7 @@ def test_reconcile_rolls_back_delete_recount_and_status_cleanup_then_retries(tmp
         mutation_authority="offline-exclusive",
     )
     assert retry.removed_message_rows == 2
-    assert retry.removed_vector_rows == 2
+    assert retry.removed_vector_rows == 0  # v4: vectors/meta are content-addressed, never deleted here
     assert retry.removed_status_rows == 1
     assert retry.sessions_recounted == 1
     assert retry.more_pending is False

--- a/tests/unit/storage/test_embedding_rebuild_survival.py
+++ b/tests/unit/storage/test_embedding_rebuild_survival.py
@@ -1,0 +1,169 @@
+"""Rebuild-survival proof for content-addressed embeddings (polylogue-q88p).
+
+Operator ruling 2026-07-20: vectors must be about content, not transient index
+identity. Before this change, embedding freshness was gated on
+``messages.content_hash``, which bakes in ``session_id``/``position``/
+``variant_index`` -- an index rebuild or lineage-normalization shift that
+renumbers a message (same text, different position/native id) silently
+invalidated its vector, forcing a wasted re-embed through the paid Voyage API
+(the 04kl 777K-vector incident).
+
+``embedding_input_hash = H(model, embedder input text)`` excludes every
+identity field by construction. This test proves the end-to-end consequence:
+embed a session for real (through the archive materialization route, not a
+unit-level hash comparison), then simulate an index rebuild that reassigns
+the message's provider-native id (message_id shifts) while its text is
+byte-identical, and assert the session is still classified as fully embedded
+-- zero vectors invalidated, zero re-embed API calls needed.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, MaterialOrigin, Provider
+from polylogue.sources.parsers.base import ParsedSession
+from polylogue.sources.parsers.base_models import ParsedContentBlock, ParsedMessage
+from polylogue.storage.embeddings.materialization import (
+    count_archive_embedding_session_state,
+    embed_archive_session_sync,
+    select_pending_archive_session_window,
+)
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.sqlite_vec_extension import try_load_sqlite_vec
+
+_TEXT = "This authored prose message must survive an identity-only rebuild unscathed."
+
+
+class _CountingFakeVectorProvider:
+    """Stub embedder that records every call -- proves API cost was or wasn't spent."""
+
+    model = "voyage-4"
+    dimension = 1024
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def _get_embeddings(self, texts: list[str], input_type: str = "document") -> list[list[float]]:
+        assert input_type == "document"
+        self.calls.append(list(texts))
+        return [[0.5] * self.dimension for _ in texts]
+
+    def upsert(self, *args: object, **kwargs: object) -> None:
+        raise AssertionError("archive materialization must use the archive embedding route")
+
+    def query(self, *args: object, **kwargs: object) -> list[tuple[str, float]]:
+        return []
+
+    def query_by_session(self, *args: object, **kwargs: object) -> list[tuple[str, float]]:
+        return []
+
+
+def _write_session(root: Path, *, native_id: str, message_native_id: str, text: str) -> str:
+    with ArchiveStore(root) as archive:
+        return archive.write_parsed(
+            ParsedSession(
+                source_name=Provider.CODEX,
+                provider_session_id=native_id,
+                messages=[
+                    ParsedMessage(
+                        provider_message_id=message_native_id,
+                        role=Role.USER,
+                        text=text,
+                        blocks=[ParsedContentBlock(type=BlockType.TEXT, text=text)],
+                        material_origin=MaterialOrigin.HUMAN_AUTHORED,
+                    )
+                ],
+            )
+        )
+
+
+def _connect_vec(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    loaded, error = try_load_sqlite_vec(conn)
+    if not loaded:
+        conn.close()
+        pytest.skip(str(error) if error else "sqlite-vec extension is unavailable")
+    return conn
+
+
+def test_identity_shifting_rebuild_does_not_invalidate_vector(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    session_id = _write_session(root, native_id="rebuild-survival", message_native_id="m1", text=_TEXT)
+    index_db = root / "index.db"
+    embeddings_db = root / "embeddings.db"
+    initialize_archive_database(embeddings_db, ArchiveTier.EMBEDDINGS)
+    _connect_vec(embeddings_db).close()
+
+    provider = _CountingFakeVectorProvider()
+    outcome = embed_archive_session_sync(index_db, provider, session_id)
+    assert outcome.status == "embedded"
+    assert len(provider.calls) == 1, "first embed must spend exactly one provider call"
+
+    with _connect_vec(embeddings_db) as conn:
+        meta_rows_before = conn.execute("SELECT COUNT(*) FROM message_embeddings_meta").fetchone()[0]
+        vector_rows_before = conn.execute("SELECT COUNT(*) FROM message_embeddings").fetchone()[0]
+    assert meta_rows_before == 1
+    assert vector_rows_before == 1
+
+    with _connect_vec(index_db) as conn:
+        conn.execute("ATTACH DATABASE ? AS embeddings", (str(embeddings_db),))
+        state_before = count_archive_embedding_session_state(conn, status_table="embeddings.embedding_status")
+    assert state_before.embedded_sessions == 1
+    assert state_before.pending_sessions == 0
+
+    # Simulate an index rebuild that reassigns the message's provider-native
+    # id -- e.g. lineage normalization recomputing which prefix is shared, or
+    # a provider regenerating tool/message ids on re-export. The archive
+    # write path treats this as a full-replace of the session (same native
+    # session id, differing message identity) because the OLD
+    # identity-contaminated content_hash changes even though the text is
+    # byte-identical.
+    replaced_session_id = _write_session(
+        root, native_id="rebuild-survival", message_native_id="m1-renumbered-by-rebuild", text=_TEXT
+    )
+    assert replaced_session_id == session_id
+
+    with sqlite3.connect(index_db) as conn:
+        rebuilt_message_id = conn.execute(
+            "SELECT message_id FROM messages WHERE session_id = ?", (session_id,)
+        ).fetchone()[0]
+    assert "m1-renumbered-by-rebuild" in str(rebuilt_message_id)
+
+    # The embeddings tier was never touched by the rebuild (it is a
+    # separately rebuildable, source-of-truth-independent tier) -- confirm
+    # the vector/meta rows are still exactly what the first embed wrote.
+    with _connect_vec(embeddings_db) as conn:
+        meta_rows_after = conn.execute("SELECT COUNT(*) FROM message_embeddings_meta").fetchone()[0]
+        vector_rows_after = conn.execute("SELECT COUNT(*) FROM message_embeddings").fetchone()[0]
+    assert meta_rows_after == meta_rows_before
+    assert vector_rows_after == vector_rows_before
+
+    # The load-bearing assertion: the session-level freshness predicate,
+    # which gates every real selection surface (daemon catch-up, manual
+    # backfill, convergence), must classify the rebuilt session as still
+    # fully embedded -- zero pending, zero vectors invalidated -- WITHOUT
+    # embed_archive_session_sync ever being called again.
+    with _connect_vec(index_db) as conn:
+        conn.execute("ATTACH DATABASE ? AS embeddings", (str(embeddings_db),))
+        state_after = count_archive_embedding_session_state(conn, status_table="embeddings.embedding_status")
+        pending_window = select_pending_archive_session_window(
+            conn, status_table="embeddings.embedding_status", session_ids=[session_id]
+        )
+
+    assert state_after.pending_sessions == 0, "identity-only rebuild must not mark the session pending"
+    assert state_after.embedded_sessions == 1
+    assert pending_window == [], "the rebuilt session must not appear in the pending-embedding selection window"
+
+    # Never call embed_archive_session_sync again -- if it were called and
+    # actually re-embedded, that would itself prove the bug is back (a
+    # wasted provider call for unchanged text). We assert the *selection*
+    # layer already excludes it, which is what protects production from
+    # ever making that wasted call.
+    assert len(provider.calls) == 1, "no additional provider calls were spent surviving the rebuild"

--- a/tests/unit/storage/test_embedding_rescue.py
+++ b/tests/unit/storage/test_embedding_rescue.py
@@ -7,6 +7,17 @@ retired ``embeddings.db``-shaped source file and a fresh target
 sessions/messages correctly and :func:`execute_embedding_rescue` only ever
 mutates *fully rescuable* sessions, is idempotent on rerun, and its sampled
 byte-identity verification actually catches a corrupted copy.
+
+v4 (polylogue-q88p): the retired source tier keeps the OLD v3 identity
+(``message_embeddings``/``message_embeddings_meta`` keyed by ``message_id`` +
+``content_hash`` -- see ``rescue.py`` module docstring), so its DDL/writer is
+built here directly rather than through the current ``ArchiveTier.EMBEDDINGS``
+bootstrap, which now produces the NEW v4 (``embedding_input_hash``-keyed)
+shape. The target tier this rescue writes INTO uses the real, current v4
+bootstrap -- assertions against it read through ``message_embedding_refs``
+(the message_id -> hash mapping), not a message_id column on
+``message_embeddings``/``message_embeddings_meta`` directly, since those two
+tables are content-addressed and no longer carry message identity.
 """
 
 from __future__ import annotations
@@ -18,17 +29,14 @@ from typing import NamedTuple
 
 import pytest
 
-from polylogue.core.enums import Origin
 from polylogue.storage.embeddings.identity import EmbeddingRecipe
 from polylogue.storage.embeddings.rescue import (
     execute_embedding_rescue,
     plan_embedding_rescue,
 )
+from polylogue.storage.search_providers.sqlite_vec_support import _serialize_f32
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
-from polylogue.storage.sqlite.archive_tiers.embedding_write import (
-    ArchiveEmbeddingWrite,
-    upsert_message_embeddings,
-)
+from polylogue.storage.sqlite.archive_tiers.embedding_write import read_embedding_meta
 from polylogue.storage.sqlite.archive_tiers.embeddings import EMBEDDING_DIMENSION
 from polylogue.storage.sqlite.archive_tiers.index import INDEX_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -58,6 +66,31 @@ CREATE TABLE messages (
 );
 """
 
+# OLD v3 retired-tier DDL (pre-polylogue-q88p): message_id-keyed, carries
+# content_hash directly on the meta row. Deliberately NOT the current
+# ArchiveTier.EMBEDDINGS bootstrap (which is v4, embedding_input_hash-keyed) --
+# this is exactly what a retired incident evidence file looks like.
+_RETIRED_V3_DDL = f"""
+CREATE VIRTUAL TABLE message_embeddings USING vec0(
+    message_id TEXT PRIMARY KEY,
+    embedding float[{EMBEDDING_DIMENSION}],
+    +session_id TEXT,
+    +origin TEXT
+);
+
+CREATE TABLE message_embeddings_meta (
+    message_id      TEXT PRIMARY KEY,
+    model           TEXT NOT NULL,
+    dimension       INTEGER NOT NULL,
+    content_hash    BLOB NOT NULL,
+    embedded_at_ms  INTEGER,
+    needs_reindex   INTEGER NOT NULL DEFAULT 0,
+    recipe_hash     BLOB,
+    derivation_key  BLOB,
+    generation      INTEGER NOT NULL DEFAULT 0
+);
+"""
+
 
 def _content_hash(seed: str) -> bytes:
     return (seed.encode("utf-8") * 32)[:32]
@@ -76,16 +109,37 @@ def _connect_index(path: Path, *, sessions: list[str], messages: dict[str, list[
             )
         for session_id, entries in messages.items():
             for message_id, content_hash in entries:
+                # Distinct per-message text (not the table default) so each
+                # message's embedding_input_hash -- H(model, current embedder
+                # input text) -- differs; otherwise two default-text messages
+                # would collide onto the same content-addressed hash and the
+                # write-once vector table would silently dedup them together,
+                # defeating tests that expect two independent rescued vectors.
                 conn.execute(
-                    "INSERT INTO messages (message_id, session_id, content_hash) VALUES (?, ?, ?)",
-                    (message_id, session_id, content_hash),
+                    "INSERT INTO messages (message_id, session_id, content_hash, text) VALUES (?, ?, ?, ?)",
+                    (message_id, session_id, content_hash, f"authored prose unique to {message_id}"),
                 )
         conn.commit()
     finally:
         conn.close()
 
 
+def _connect_retired_v3_tier(path: Path) -> sqlite3.Connection:
+    """Open (creating) a retired-tier file with the OLD v3, message_id-keyed DDL."""
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    loaded, error = try_load_sqlite_vec(conn)
+    if not loaded:
+        conn.close()
+        pytest.skip("sqlite-vec extension is unavailable")
+        raise AssertionError("unreachable") from error
+    conn.executescript(_RETIRED_V3_DDL)
+    conn.commit()
+    return conn
+
+
 def _connect_embeddings_tier(path: Path) -> sqlite3.Connection:
+    """Open (creating) the CURRENT v4 target embeddings tier."""
     conn = sqlite3.connect(path)
     conn.row_factory = sqlite3.Row
     try:
@@ -109,21 +163,21 @@ def _write_retired(
     content_hash: bytes,
     model: str = _MODEL,
     seed: int = 1,
+    embedded_at_ms: int = 1_700_000_000_000,
 ) -> None:
-    upsert_message_embeddings(
-        conn,
-        [
-            ArchiveEmbeddingWrite(
-                message_id=message_id,
-                session_id=session_id,
-                origin=Origin.CODEX_SESSION,
-                embedding=_vector_for(seed),
-                model=model,
-                embedded_at_ms=1_700_000_000_000,
-                content_hash=content_hash,
-            )
-        ],
+    """Write one vector directly into the OLD v3 message_id-keyed shape."""
+    conn.execute(
+        "INSERT INTO message_embeddings (message_id, embedding, session_id, origin) VALUES (?, ?, ?, ?)",
+        (message_id, _serialize_f32(_vector_for(seed)), session_id, "codex-session"),
     )
+    conn.execute(
+        """
+        INSERT INTO message_embeddings_meta (message_id, model, dimension, content_hash, embedded_at_ms)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (message_id, model, EMBEDDING_DIMENSION, content_hash, embedded_at_ms),
+    )
+    conn.commit()
 
 
 def _target_embeddings_path(tmp_path: Path) -> Path:
@@ -131,8 +185,9 @@ def _target_embeddings_path(tmp_path: Path) -> Path:
 
 
 def _connect_target_for_read(path: Path) -> sqlite3.Connection:
-    """Plain connection to the target tier with sqlite-vec loaded for reads."""
+    """Plain connection to the v4 target tier with sqlite-vec loaded for reads."""
     conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
     loaded, error = try_load_sqlite_vec(conn)
     if not loaded:
         conn.close()
@@ -176,7 +231,7 @@ class TestPlanEmbeddingRescue:
         )
 
         retired_path = tmp_path / "retired-embeddings.db"
-        retired_conn = _connect_embeddings_tier(retired_path)
+        retired_conn = _connect_retired_v3_tier(retired_path)
         _write_retired(retired_conn, message_id=full_m1, session_id=full, content_hash=hash_m1, seed=1)
         _write_retired(retired_conn, message_id=full_m2, session_id=full, content_hash=hash_m2, seed=2)
         _write_retired(retired_conn, message_id=partial_m1, session_id=partial, content_hash=hash_p1, seed=3)
@@ -213,7 +268,7 @@ class TestPlanEmbeddingRescue:
         content_hash = _content_hash("m1")
         _connect_index(tmp_path / "index.db", sessions=[session_id], messages={session_id: [(m1, content_hash)]})
         retired_path = tmp_path / "retired-embeddings.db"
-        retired_conn = _connect_embeddings_tier(retired_path)
+        retired_conn = _connect_retired_v3_tier(retired_path)
         _write_retired(retired_conn, message_id=m1, session_id=session_id, content_hash=content_hash, seed=1)
         retired_conn.close()
 
@@ -255,7 +310,7 @@ class TestExecuteEmbeddingRescue:
             },
         )
         retired_path = tmp_path / "retired-embeddings.db"
-        retired_conn = _connect_embeddings_tier(retired_path)
+        retired_conn = _connect_retired_v3_tier(retired_path)
         _write_retired(retired_conn, message_id=full_m1, session_id=full, content_hash=hash_m1, seed=1)
         _write_retired(retired_conn, message_id=full_m2, session_id=full, content_hash=hash_m2, seed=2)
         _write_retired(retired_conn, message_id=partial_m1, session_id=partial, content_hash=hash_p1, seed=3)
@@ -291,21 +346,23 @@ class TestExecuteEmbeddingRescue:
         try:
             full_m1, full_m2 = seed.full_messages
             for message_id in (full_m1, full_m2):
+                # v4: message_embeddings/message_embeddings_meta are keyed by
+                # embedding_input_hash, not message_id -- resolve through the
+                # per-message message_embedding_refs mapping (the same read
+                # path production code uses, read_embedding_meta).
                 assert (
                     conn.execute(
-                        "SELECT COUNT(*) FROM message_embeddings WHERE message_id = ?", (message_id,)
+                        "SELECT COUNT(*) FROM message_embedding_refs WHERE message_id = ?", (message_id,)
                     ).fetchone()[0]
                     == 1
                 )
-                assert (
-                    conn.execute(
-                        "SELECT COUNT(*) FROM message_embeddings_meta WHERE message_id = ?", (message_id,)
-                    ).fetchone()[0]
-                    == 1
-                )
-            # The partial session must never be written -- no vectors at all.
+                meta = read_embedding_meta(conn, message_id)
+                assert meta.message_id == message_id
+                assert meta.model == _MODEL
+                assert meta.dimension == EMBEDDING_DIMENSION
+            # The partial session must never be written -- no refs at all.
             partial_row_count = conn.execute(
-                "SELECT COUNT(*) FROM message_embeddings WHERE session_id = ?", (seed.partial,)
+                "SELECT COUNT(*) FROM message_embedding_refs WHERE session_id = ?", (seed.partial,)
             ).fetchone()[0]
             assert partial_row_count == 0
 
@@ -313,13 +370,13 @@ class TestExecuteEmbeddingRescue:
                 "SELECT message_count_embedded, needs_reindex, error_message FROM embedding_status WHERE session_id = ?",
                 (seed.full,),
             ).fetchone()
-            assert status == (2, 0, None)
+            assert tuple(status) == (2, 0, None)
 
             derivation = conn.execute(
                 "SELECT attempt_state, message_count FROM embedding_derivation_state WHERE session_id = ?",
                 (seed.full,),
             ).fetchone()
-            assert derivation == ("succeeded", 2)
+            assert tuple(derivation) == ("succeeded", 2)
         finally:
             conn.close()
 
@@ -351,11 +408,11 @@ class TestExecuteEmbeddingRescue:
         conn = _connect_target_for_read(target)
         try:
             full_m1, _full_m2 = seed.full_messages
-            row = conn.execute(
-                "SELECT embedded_at_ms FROM message_embeddings_meta WHERE message_id = ?", (full_m1,)
-            ).fetchone()
-            # Second run must not have rewritten the already-rescued vector.
-            assert row[0] == 1_800_000_000_000
+            meta = read_embedding_meta(conn, full_m1)
+            # Second run must not have rewritten the already-rescued vector:
+            # the content-addressed meta row is write-once, so its
+            # embedded_at_ms stays pinned to the first rescue's timestamp.
+            assert meta.embedded_at_ms == 1_800_000_000_000
         finally:
             conn.close()
 
@@ -370,7 +427,7 @@ class TestExecuteEmbeddingRescue:
             messages={full_a: [(m_a, hash_a)], full_b: [(m_b, hash_b)]},
         )
         retired_path = tmp_path / "retired-embeddings.db"
-        retired_conn = _connect_embeddings_tier(retired_path)
+        retired_conn = _connect_retired_v3_tier(retired_path)
         _write_retired(retired_conn, message_id=m_a, session_id=full_a, content_hash=hash_a, seed=1)
         _write_retired(retired_conn, message_id=m_b, session_id=full_b, content_hash=hash_b, seed=2)
         retired_conn.close()
@@ -415,7 +472,7 @@ class TestExecuteEmbeddingRescue:
             messages={session_id: [(message_id, content_hash)]},
         )
         retired_path = tmp_path / "retired-embeddings.db"
-        retired_conn = _connect_embeddings_tier(retired_path)
+        retired_conn = _connect_retired_v3_tier(retired_path)
         _write_retired(retired_conn, message_id=message_id, session_id=session_id, content_hash=content_hash, seed=7)
         retired_conn.close()
 

--- a/tests/unit/storage/test_embedding_rescue_content_addressed_layout.py
+++ b/tests/unit/storage/test_embedding_rescue_content_addressed_layout.py
@@ -1,0 +1,197 @@
+"""04kl rescue lands vectors directly into the v4 content-addressed layout.
+
+Operator ordering (polylogue-q88p, 2026-07-20): design the content-addressed
+keying first, then run the one-time 04kl rescue directly INTO it -- migrate
+once, not twice. The retired evidence file predates this bead and is
+structurally v3 (vectors keyed by ``message_id``, meta bound to the OLD
+identity-contaminated ``content_hash``); this test proves
+:func:`polylogue.storage.embeddings.rescue.execute_embedding_rescue`
+recomputes ``embedding_input_hash`` for each matched message from its
+*current* embedder input text and writes the rescued vector under that new
+key, plus a ``message_embedding_refs`` row -- never resurrecting the old
+message_id-keyed shape.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import struct
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, MaterialOrigin, Provider
+from polylogue.sources.parsers.base import ParsedSession
+from polylogue.sources.parsers.base_models import ParsedContentBlock, ParsedMessage
+from polylogue.storage.embeddings.identity import EmbeddingRecipe, embedding_input_hash
+from polylogue.storage.embeddings.rescue import execute_embedding_rescue, plan_embedding_rescue
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.sqlite_vec_extension import try_load_sqlite_vec
+
+_TEXT = "Retired-tier evidence prose that must be rescued into the new content-addressed layout."
+_MODEL = "voyage-4"
+_DIMENSION = 1024
+
+# The v3 retired-tier shape (pre-polylogue-q88p): vectors keyed by
+# message_id, meta bound to the OLD identity-contaminated content_hash.
+# Deliberately hand-declared here (not imported from production) because the
+# whole point of this fixture is to be the OLD, no-longer-current schema --
+# it must not silently track future changes to the live DDL.
+_RETIRED_DDL = f"""
+CREATE VIRTUAL TABLE message_embeddings USING vec0(
+    message_id TEXT PRIMARY KEY,
+    embedding float[{_DIMENSION}],
+    +session_id TEXT,
+    +origin TEXT
+);
+
+CREATE TABLE message_embeddings_meta (
+    message_id      TEXT PRIMARY KEY,
+    model           TEXT NOT NULL,
+    dimension       INTEGER NOT NULL,
+    content_hash    BLOB NOT NULL,
+    embedded_at_ms  INTEGER,
+    needs_reindex   INTEGER NOT NULL DEFAULT 0,
+    recipe_hash     BLOB,
+    derivation_key  BLOB,
+    generation      INTEGER NOT NULL DEFAULT 0
+);
+"""
+
+
+def _connect_vec(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    loaded, error = try_load_sqlite_vec(conn)
+    if not loaded:
+        conn.close()
+        pytest.skip(str(error) if error else "sqlite-vec extension is unavailable")
+    return conn
+
+
+def _write_live_session(root: Path, *, native_id: str, text: str) -> str:
+    with ArchiveStore(root) as archive:
+        return archive.write_parsed(
+            ParsedSession(
+                source_name=Provider.CODEX,
+                provider_session_id=native_id,
+                messages=[
+                    ParsedMessage(
+                        provider_message_id="m1",
+                        role=Role.USER,
+                        text=text,
+                        blocks=[ParsedContentBlock(type=BlockType.TEXT, text=text)],
+                        material_origin=MaterialOrigin.HUMAN_AUTHORED,
+                    )
+                ],
+            )
+        )
+
+
+def _build_retired_fixture(path: Path, *, message_id: str, session_id: str, content_hash: bytes) -> list[float]:
+    """Build a v3-shaped retired embeddings.db and return the stored vector."""
+    conn = _connect_vec(path)
+    try:
+        conn.executescript(_RETIRED_DDL)
+        vector = [0.42] * _DIMENSION
+        conn.execute(
+            "INSERT INTO message_embeddings (message_id, embedding, session_id, origin) VALUES (?, ?, ?, ?)",
+            (message_id, struct.pack(f"<{_DIMENSION}f", *vector), session_id, "codex-session"),
+        )
+        conn.execute(
+            """
+            INSERT INTO message_embeddings_meta (
+                message_id, model, dimension, content_hash, embedded_at_ms, needs_reindex
+            ) VALUES (?, ?, ?, ?, ?, 0)
+            """,
+            (message_id, _MODEL, _DIMENSION, content_hash, 1_700_000_000_000),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return vector
+
+
+def test_rescue_lands_vectors_into_content_addressed_layout(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    session_id = _write_live_session(archive_root, native_id="rescue-into-v4", text=_TEXT)
+    index_db = archive_root / "index.db"
+    embeddings_db = archive_root / "embeddings.db"
+
+    with sqlite3.connect(index_db) as conn:
+        row = conn.execute(
+            "SELECT message_id, content_hash FROM messages WHERE session_id = ?", (session_id,)
+        ).fetchone()
+    message_id, content_hash = str(row[0]), bytes(row[1])
+
+    retired_db = tmp_path / "embeddings.db.v2-retired-fixture"
+    retired_vector = _build_retired_fixture(
+        retired_db, message_id=message_id, session_id=session_id, content_hash=content_hash
+    )
+
+    recipe = EmbeddingRecipe.current(model=_MODEL, dimensions=_DIMENSION)
+
+    plan = plan_embedding_rescue(index_db, retired_db, recipe=recipe)
+    assert plan.counts.fully_rescuable_sessions == 1
+    assert plan.counts.rescuable_messages == 1
+    assert plan.counts.skipped_missing == 0
+    assert plan.counts.skipped_hash_mismatch == 0
+    assert plan.counts.skipped_model_mismatch == 0
+
+    report = execute_embedding_rescue(
+        index_db,
+        retired_db,
+        embeddings_db,
+        recipe=recipe,
+        mutation_authority="offline-exclusive",
+    )
+    assert report.rescued_sessions == 1
+    assert report.rescued_messages == 1
+    assert report.ok, "sampled byte-identity verification must pass"
+    assert report.verified_sample_total >= 1
+    assert report.verified_sample_ok == report.verified_sample_total
+
+    expected_hash = embedding_input_hash(model=_MODEL, input_text=_TEXT)
+
+    with _connect_vec(embeddings_db) as conn:
+        # The v4 layout: vectors keyed by embedding_input_hash, never by
+        # message_id -- assert the schema shape directly, not just counts.
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(message_embeddings_meta)").fetchall()}
+        assert "message_id" not in columns, "meta must not be message_id-keyed in the rescued layout"
+        assert "embedding_input_hash" in columns
+
+        meta_row = conn.execute(
+            "SELECT model, dimension FROM message_embeddings_meta WHERE embedding_input_hash = ?",
+            (expected_hash,),
+        ).fetchone()
+        assert meta_row is not None, "rescued vector must be keyed by the recomputed embedding_input_hash"
+        assert meta_row[0] == _MODEL
+        assert meta_row[1] == _DIMENSION
+
+        ref_row = conn.execute(
+            "SELECT session_id, origin, embedding_input_hash FROM message_embedding_refs WHERE message_id = ?",
+            (message_id,),
+        ).fetchone()
+        assert ref_row is not None, "rescue must write a message_embedding_refs row for the rescued message"
+        assert ref_row[0] == session_id
+        assert bytes(ref_row[2]) == expected_hash
+
+        vector_row = conn.execute(
+            "SELECT embedding FROM message_embeddings WHERE embedding_input_hash = ?",
+            (expected_hash.hex(),),
+        ).fetchone()
+        assert vector_row is not None
+        rescued_vector = list(struct.unpack(f"<{_DIMENSION}f", vector_row[0]))
+        assert rescued_vector == pytest.approx(retired_vector), "rescued bytes must match the retired vector exactly"
+
+    # Idempotent: a second rescue pass over an already-rescued archive is a
+    # pure no-op (the session already reads as fresh).
+    second_report = execute_embedding_rescue(
+        index_db,
+        retired_db,
+        embeddings_db,
+        recipe=recipe,
+        mutation_authority="offline-exclusive",
+    )
+    assert second_report.rescued_sessions == 0
+    assert second_report.skipped_already_fresh_sessions == 1

--- a/tests/unit/storage/test_vec.py
+++ b/tests/unit/storage/test_vec.py
@@ -258,53 +258,76 @@ def test_upsert_noop_contract(
     ids=["provider-row", "missing-provider-row"],
 )
 def test_upsert_persistence_contract(
-    mock_provider: MutableSqliteVecProvider,
+    tmp_path: Path,
     source_name: str | None,
     expected_provider: str,
 ) -> None:
-    """Upsert must filter messages, persist embeddings, and stamp provider metadata."""
+    """Upsert must filter messages, persist embeddings, and stamp provider metadata.
+
+    ``upsert`` now delegates to the canonical content-addressed write
+    primitives (polylogue-q88p), so this exercises a real sqlite-vec-backed
+    ``embeddings.db`` rather than mocked SQL -- the shape those primitives
+    write (embedding_input_hash-keyed vectors + message_embedding_refs) is
+    not expressible as raw "INSERT INTO message_embeddings" string matching
+    against a mock connection anymore.
+    """
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+    provider = MutableSqliteVecProvider(voyage_key="test-voyage-key", db_path=tmp_path / "test.db", model="voyage-4")
+    provider.dimension = 1024
+    provider._vec_available = None
+    provider._tables_ensured = False
+
+    conn = sqlite3.connect(provider.db_path)
+    try:
+        initialize_archive_tier(conn, ArchiveTier.EMBEDDINGS)
+    except sqlite3.OperationalError as exc:
+        if "vec0" in str(exc) or "sqlite-vec" in str(exc):
+            pytest.skip("sqlite-vec extension is unavailable")
+        raise
+    conn.execute("CREATE TABLE sessions (session_id TEXT PRIMARY KEY, origin TEXT)")
+    if source_name is not None:
+        conn.execute("INSERT INTO sessions (session_id, origin) VALUES (?, ?)", ("conv-1", source_name))
+    conn.commit()
+    conn.close()
+
     messages = [
         make_message(message_id="m1", text="This is a long embeddable message."),
         make_message(message_id="m2", text="short"),
         make_message(message_id="m3", text="This is another long embeddable message."),
     ]
     embeddings_called_with: list[str] = []
-    insert_calls: list[tuple[str, tuple[object, ...] | None]] = []
-    mock_provider._ensure_vec_available = MagicMock()
-    mock_provider._ensure_tables = MagicMock()
 
     def capture_embeddings(texts: list[str], input_type: str = "document") -> list[Embedding]:
         del input_type
         embeddings_called_with.extend(texts)
-        return [[0.1, 0.2] for _ in texts]
+        return [[0.1] * 1024 for _ in texts]
 
-    def capture_execute(sql: str, params: tuple[object, ...] | None = None) -> MagicMock:
-        insert_calls.append((sql, params))
-        cursor = MagicMock()
-        if "SELECT origin FROM sessions" in sql:
-            cursor.fetchone.return_value = (source_name,) if source_name is not None else None
-        return cursor
+    provider._get_embeddings = capture_embeddings
 
-    mock_provider._get_embeddings = capture_embeddings
-    connection = MagicMock()
-    connection.execute = capture_execute
-    connection.commit = MagicMock()
-    connection.close = MagicMock()
-    mock_provider._get_connection = MagicMock(return_value=connection)
-
-    mock_provider.upsert("conv-1", messages)
+    provider.upsert("conv-1", messages)
 
     assert embeddings_called_with == [
         "This is a long embeddable message.",
         "This is another long embeddable message.",
     ]
-    assert connection.commit.called
-    assert connection.close.called
-    embedding_inserts = [params for sql, params in insert_calls if "INSERT INTO message_embeddings" in sql]
-    assert len(embedding_inserts) == 2
-    assert all(expected_provider in str(params) for params in embedding_inserts)
-    status_updates = [sql for sql, _ in insert_calls if "INSERT INTO embedding_status" in sql]
-    assert len(status_updates) == 1
+
+    verify = sqlite3.connect(provider.db_path)
+    try:
+        from polylogue.storage.sqlite.sqlite_vec_extension import try_load_sqlite_vec
+
+        loaded, error = try_load_sqlite_vec(verify)
+        assert loaded, error
+        assert verify.execute("SELECT COUNT(*) FROM message_embeddings").fetchone()[0] == 2
+        assert verify.execute("SELECT COUNT(*) FROM message_embedding_refs").fetchone()[0] == 2
+        origins = {
+            str(row[0]) for row in verify.execute("SELECT DISTINCT origin FROM message_embedding_refs").fetchall()
+        }
+        assert origins == {expected_provider}
+        assert verify.execute("SELECT COUNT(*) FROM embedding_status").fetchone()[0] == 1
+    finally:
+        verify.close()
 
 
 def test_upsert_closes_connection_on_embedding_error(mock_provider: MutableSqliteVecProvider) -> None:
@@ -367,9 +390,9 @@ def test_query_route_contract(
         assert result == [("msg-1", 0.5), ("msg-2", 0.7)]
         assert connection.close.called
         if provider is None:
-            assert all("source_name = ?" not in sql for sql, _ in executed_queries)
+            assert all("r.origin = ?" not in sql for sql, _ in executed_queries)
         else:
-            assert any("source_name = ?" in sql for sql, _ in executed_queries)
+            assert any("r.origin = ?" in sql for sql, _ in executed_queries)
             assert any(provider in str(params) for _, params in executed_queries)
     else:
         assert result == []
@@ -399,6 +422,16 @@ def test_get_embedding_stats_contract(
         if operational_error:
             raise sqlite3.OperationalError("Table not found")
         if "sqlite_master" in sql and "sessions" in sql:
+            return MagicMock(fetchone=MagicMock(return_value=None))
+        # embedded_message_count_sync (polylogue-q88p) checks
+        # message_embedding_refs, then message_embeddings_meta, then
+        # message_embeddings_rowids before falling back to the raw vec0
+        # table this fixture pins its count against -- report the first
+        # three as absent so the count query lands on the same
+        # "message_embeddings" branch this fixture always exercised.
+        if "sqlite_master" in sql and (
+            "message_embedding_refs" in sql or "message_embeddings_meta" in sql or "message_embeddings_rowids" in sql
+        ):
             return MagicMock(fetchone=MagicMock(return_value=None))
         if "message_embeddings" in sql:
             return MagicMock(fetchone=MagicMock(return_value=[msg_count]))

--- a/tests/unit/storage/test_vec_session_seed.py
+++ b/tests/unit/storage/test_vec_session_seed.py
@@ -9,6 +9,7 @@ fail here rather than silently at the query surface.
 
 from __future__ import annotations
 
+import hashlib
 import sqlite3
 from pathlib import Path
 
@@ -52,6 +53,10 @@ def embeddings_db(tmp_path: Path) -> Path:
         ("sess-C", "sess-C:m1", _unit_vector(axis0=0.0, axis1=1.0)),
     ]
     for session_id, message_id, vector in seeds:
+        # Content-addressed (polylogue-q88p): each distinct stored vector
+        # needs its own embedding_input_hash, or these deliberately-distinct
+        # geometric fixtures would dedup onto a single vector and the
+        # distance assertions below would test nothing.
         upsert_message_embedding(
             conn,
             message_id=message_id,
@@ -60,7 +65,7 @@ def embeddings_db(tmp_path: Path) -> Path:
             embedding=vector,
             model="voyage-4",
             embedded_at_ms=1_767_225_700_000,
-            content_hash=b"x" * 32,
+            embedding_input_hash=hashlib.sha256(message_id.encode()).digest(),
         )
     conn.close()
     return db_path


### PR DESCRIPTION
## Summary

Content-addresses the embeddings tier: vectors are keyed by
`embedding_input_hash = SHA-256(model, normalized embedder input text)`
instead of message identity, so an index rebuild or lineage-normalization
shift can never invalidate a vector whose underlying text is unchanged.
This PR finishes a lane that died at the finish line (implementation done,
full-repo mypy clean, about to run final verification) — its entire diff
was rescued as an unverified WIP commit and is being landed here after a
full review, cleanup, and verification pass.

## Problem

`message_embeddings_meta` bound vectors to `messages.content_hash`, which
INCLUDES `session_id`/`position`/`variant_index` — identity-contaminated by
design (it drives row-level re-ingest/dedup change detection for the
`messages` table itself). An index rebuild or lineage-normalization shift
renumbers messages without changing their text, so this identity-bound
freshness gate invalidated vectors it shouldn't have — the root cause of
the 777K-vector rescue (polylogue-04kl). Vectors are about content, not
transient index identity (operator ruling 2026-07-20).

## Solution

- `embedding_input_hash(model, input_text)` (`storage/embeddings/identity.py`):
  identity-free SHA-256, same philosophy as the svfj block evidence hash.
  Derived directly from the exact string handed to the embedder (never
  re-derived from stored identity), so hash validity equals vector validity
  by construction.
- `embeddings.db` schema v3 → v4 (derived-tier DDL edit, no migration chain,
  per the repo's schema regime): `message_embeddings` (vec0) and
  `message_embeddings_meta` are now keyed by `embedding_input_hash` and are
  write-once/shared — a hash's presence in `message_embeddings_meta` IS
  freshness, there is no per-vector `needs_reindex` state anymore. New
  `message_embedding_refs` table is the rebuildable
  `message_id -> embedding_input_hash` mapping (lives in `embeddings.db`,
  not `index.db`, so this never bumps `INDEX_SCHEMA_VERSION`); it is
  rewritten per session re-embed while vector/meta rows are never deleted
  by ordinary re-embed.
- **Dedup for free**: identical embedder input text (fork/resume/
  auto-compaction replays, or genuinely coincidental duplicate prose) is
  stored exactly once regardless of how many messages/sessions reference it
  — a real Voyage API cost saving in a lineage-heavy archive.
- Every consumer updated to resolve through `message_embedding_refs` in
  both the sync and async trees: freshness predicate
  (`materialization.py`), reconcile (ref-scoped orphan cleanup only — the
  content-addressed vector/meta GC is explicitly deferred, documented as
  follow-up debt, not silently dropped), excision (reference-counted vector
  GC — excision has a privacy requirement to actually purge, unlike
  reconcile), search providers (`sqlite_vec_queries.py`/`_runtime.py`,
  which also deduplicated a second, drifted hand-rolled DDL declaration
  onto the canonical `archive_tiers/embeddings.py` DDL), daemon similarity/
  metrics, CLI maintenance/status/rescue commands, demo seed/constructs
  (stub embedders only — `voyage-4` real API is never invoked in tests or
  demo).
- **04kl rescue retargeted into the new layout**: `rescue.py` now
  recomputes `embedding_input_hash` from each matched message's *current*
  embedder input text (the old `content_hash` match is what licenses
  treating "current text" and "retired text" as identical, but the new key
  is never trusted from the retired file) and writes rescued vectors
  directly into the v4 content-addressed shape — landing once, not
  migrating twice, per the bead's stated ordering.
- Docs: `docs/architecture.md`, `docs/schema.md` updated.

### Gap found and fixed during review

`storage/embeddings/sql.py` carried a `stale_messages_sql()` function and a
`STALE_MESSAGES_SQL_LEGACY` constant, both written during the rewrite but
never wired into any caller — `status_payload.py` (the primary runtime
status surface) computes its own inline stale comparison against the
`embedding_input_hash` column its relation already projects, and the
legacy monolithic-archive reader in `embedding_stats.py` deliberately
reports 0 (no configured model available to thread through) rather than
using either helper. Grepped `polylogue/` and `tests/` to confirm zero call
sites, then removed both as dead code (separate commit
`67b07a371`).

## Verification

- `ruff format --check polylogue tests` — 2092 files already formatted
- `ruff check polylogue tests` — all checks passed
- `mypy --strict polylogue` — Success: no issues found in 1059 source files
- `devtools test` on all 20 touched test files (property + unit, including
  the rebuild-survival proof `test_embedding_rebuild_survival.py`, the
  04kl-into-v4-layout proof `test_embedding_rescue_content_addressed_layout.py`,
  and the dedup proof `test_embedding_dedup.py`) — **329 passed**
- `devtools render all --check` — exit 0, zero "out of sync" hits (grepped,
  not just the tail line)
- `devtools lab policy schema-versioning` — `derived-tier upgrade helpers
  found: 0` (this PR's embeddings v3→v4 bump is a canonical-DDL edit, not
  an illegal upgrade helper — compliant). The report's one remaining
  violation (`undeclared index schema deltas found: 1`, missing `[40]`) is
  **pre-existing on `origin/master`** — reproduced identically on a bare
  `origin/master` checkout before this branch's changes — and unrelated to
  the embeddings tier.
- `devtools verify --quick` (format + lint + mypy + render-all-check +
  topology/layering/manifests/ci-workflows/doc-commands/docs-coverage/
  test-infra-currency/test-clock-hygiene/pytest-timeout-overrides/
  degrade-loudly) — `exit_code: 0`, all 16 steps `ok`

## Ordering note (polylogue-04kl)

Per the bead's design ("design this first, then execute the one-time 04kl
rescue directly INTO the content-addressed layout, avoid double
migration"): this PR lands the keying design + rescue retargeting +
synthetic-fixture tests. The live `--yes` rescue execution against the
production archive remains coordinator-owned and run post-promote, per
04kl's own notes — not part of this PR's scope.

Ref polylogue-q88p