### PR TITLE
fix(sources): fail closed on decided ambiguous membership, not just NULL

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -1822,8 +1822,21 @@ class LiveBatchProcessor:
                             )
                             plan = archive.classify_raw_revision_cohort(logical_source_key)
                             if not plan.accepted_raw_ids:
-                                # No candidate accepted yet -- deferred, not failed.
-                                result.deferred_raw_ids[record.raw_id] = record_raw_id
+                                # classify_raw_revision_cohort is a synchronous,
+                                # purely byte-level classification (no async
+                                # conveyor revisits it) -- an empty cohort here
+                                # is a genuine, terminal rewrite/divergence
+                                # conflict, not a pending hand-off. Leave this
+                                # raw out of both raw_ids and deferred_raw_ids so
+                                # the caller's aggregation counts it as a real
+                                # failure (fail-closed), with a log line so the
+                                # cause is diagnosable.
+                                logger.warning(
+                                    "live.watcher: no unique byte-revision candidate accepted for %s "
+                                    "(logical_source_key=%s) -- surfacing as failed",
+                                    record.source_path,
+                                    logical_source_key,
+                                )
                                 continue
                             parsed_by_raw_id = self._parse_raw_revision_chain(archive, plan)
                             session_id, applied_raw_ids = archive.apply_raw_revision_replay(
@@ -1862,11 +1875,27 @@ class LiveBatchProcessor:
                         )
                     if raw_authority_complete:
                         result.raw_ids[record.raw_id] = record_raw_id
-                    else:
-                        # Census recorded, no exception -- the raw-authority
-                        # protocol's own async classification hasn't decided
-                        # this raw yet. Not a failure; see deferred_raw_ids.
+                    elif archive.raw_membership_decision_pending(source_raw_id):
+                        # Census recorded, no exception, decision IS NULL -- the
+                        # raw-authority protocol's own async classification (the
+                        # raw-materialization conveyor) hasn't arbitrated this
+                        # raw yet. Not a failure; see deferred_raw_ids.
                         result.deferred_raw_ids[record.raw_id] = record_raw_id
+                    else:
+                        # Decision is 'ambiguous'/'deferred' -- arbitration
+                        # already ran and concluded a genuine, unresolved
+                        # conflict. That is a decided outcome, not pending
+                        # state, so it must surface as a failure (fail-closed).
+                        # Leave this raw out of both raw_ids and
+                        # deferred_raw_ids so the caller's aggregation counts
+                        # it as a real failure, with a log line so the cause is
+                        # diagnosable (unlike the pre-fix silent mismark).
+                        logger.warning(
+                            "live.watcher: membership decision unresolved (ambiguous/deferred) for %s "
+                            "raw=%s -- surfacing as failed, not deferred",
+                            record.source_path,
+                            source_raw_id,
+                        )
                     result.session_ids.extend(record_session_ids)
                     result.session_count += record_session_count
                     result.message_count += record_message_count

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2856,6 +2856,39 @@ class ArchiveStore:
         )
         return row is not None and bool(row[0])
 
+    def raw_membership_decision_pending(self, raw_id: str) -> bool:
+        """Return True only when this raw's own decision is genuinely undecided.
+
+        ``raw_membership_authority_complete`` collapses three distinct
+        non-complete states into one boolean: ``decision IS NULL`` (the
+        raw-authority protocol's async classification -- the raw-materialization
+        conveyor, see ``sources/revision_backfill.py`` -- has censused this raw
+        but not yet arbitrated it), and ``decision IN ('ambiguous', 'deferred')``
+        (arbitration already ran and concluded a genuine, byte-level conflict
+        that requires new evidence to resolve, not the passage of time). Only
+        the first is a legitimate hand-off; the second is a decided outcome
+        that must surface as a failure (polylogue-emx2 vs. the fail-closed
+        invariants pinned by #2684/#2716/#2718/#2837). This predicate isolates
+        the NULL case so callers can distinguish "still pending" from "decided,
+        unresolved" instead of treating both as non-failures.
+        """
+        row = (
+            self._ensure_source_conn()
+            .execute(
+                """
+            SELECT c.status = 'complete'
+               AND EXISTS (
+                   SELECT 1 FROM raw_session_memberships AS m
+                   WHERE m.raw_id = c.raw_id AND m.decision IS NULL
+               )
+            FROM raw_membership_census AS c WHERE c.raw_id = ?
+            """,
+                (raw_id,),
+            )
+            .fetchone()
+        )
+        return row is not None and bool(row[0])
+
     def raw_revision_replay_adoptable(self, sessions: Sequence[ParsedSession]) -> bool:
         """Return whether replay may adopt an existing ungoverned session."""
         aggregate = merge_parsed_session_chunks(sessions)

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -3393,6 +3393,81 @@ def test_live_multi_session_divergence_reopens_raw_authority(tmp_path: Path) -> 
         ).fetchone() == (accepted_raw_id,)
 
 
+def test_raw_membership_decision_pending_distinguishes_null_from_ambiguous(tmp_path: Path) -> None:
+    """Pins the exact narrow scoping of the polylogue-emx2 fix (de0b2df7a regression, polylogue-lvz6 triage).
+
+    ``raw_membership_authority_complete()`` collapses three distinct
+    membership-decision states into one boolean: ``decision IS NULL``
+    (genuinely async-pending -- censused but not yet arbitrated by the
+    raw-materialization conveyor, ``sources/revision_backfill.py``) and
+    ``decision IN ('ambiguous', 'deferred')`` (arbitration already ran and
+    concluded a real conflict that needs new evidence, not time, to
+    resolve). Only the first is a legitimate "not a failure, hand off to the
+    conveyor" hand-off; the second is a decided outcome that must surface as
+    a failure -- ``LiveBatchProcessor._ingest_full_records_archive`` uses
+    ``raw_membership_decision_pending`` (not the coarse boolean alone) at
+    both of its full-ingest injection points to make exactly this
+    distinction (batch.py, the membership-governed branch and the
+    classify_raw_revision_cohort branch).
+
+    This is an archive-tier predicate test rather than a full watcher
+    end-to-end scenario because, by construction,
+    ``LiveBatchProcessor._apply_membership_sessions`` always resolves the
+    raw it just censused synchronously within the same call (both of its
+    current call sites pass ``allow_current_complete_raw=True``) -- so a
+    raw's own decision is never observed as NULL immediately after that
+    call returns. Genuinely NULL decisions persist only across the
+    conveyor's own two-phase census-then-classify split
+    (``census_historical_revision_evidence`` /
+    ``backfill_historical_revision_evidence``), which this test reproduces
+    directly against the archive tier: census without classification (NULL,
+    pending) versus census with an ambiguous classification (decided,
+    unresolved).
+    """
+    initialize_active_archive_root(tmp_path)
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="pending-vs-ambiguous",
+        messages=[ParsedMessage(provider_message_id="m0", role=Role.USER, text="hello")],
+    )
+    projection = session_revision_projection(session)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b'{"native_id":"pending-vs-ambiguous"}\n',
+            source_path=str(tmp_path / "pending-vs-ambiguous.jsonl"),
+            acquired_at_ms=1,
+        )
+        archive.replace_raw_membership_census(
+            raw_id,
+            [session],
+            parser_fingerprint="test-parser",
+            censused_at_ms=1,
+        )
+
+        # Census complete, classification never run: decision IS NULL. This
+        # is the genuinely async-pending state -- not a failure.
+        assert archive.raw_membership_authority_complete(raw_id) is False
+        assert archive.raw_membership_decision_pending(raw_id) is True
+
+        # Arbitration now runs and concludes ambiguous (a decided conflict,
+        # e.g. the conveyor found no unique growth chain). This is no longer
+        # pending -- it must surface as a failure, not defer forever.
+        archive.apply_raw_membership_classification(
+            "codex:pending-vs-ambiguous",
+            MembershipClassification((), (), (raw_id,)),
+            {raw_id: session},
+            {raw_id: projection},
+            acquired_at_ms=2,
+        )
+        assert archive.raw_membership_authority_complete(raw_id) is False
+        assert archive.raw_membership_decision_pending(raw_id) is False
+        with sqlite3.connect(tmp_path / "source.db") as conn:
+            assert conn.execute(
+                "SELECT decision FROM raw_session_memberships WHERE raw_id = ?", (raw_id,)
+            ).fetchone() == ("ambiguous",)
+
+
 def test_live_membership_reprocesses_parser_drift_without_retiring_unrelated_head(tmp_path: Path) -> None:
     """A current parse of the accepted raw is authority, even after parser drift.
 

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1653,22 +1653,35 @@ def _browser_capture_payload(*, provider_session_id: str, assistant_turn_id: str
 
 
 @pytest.mark.asyncio
-async def test_live_full_ingest_over_ambiguous_membership_defers_instead_of_failing(
+async def test_live_full_ingest_over_ambiguous_membership_fails_closed_with_diagnostic(
     workspace_env: dict[str, Path],
 ) -> None:
-    """Regression test for polylogue-emx2 (adoption idempotency). Live
-    evidence 2026-07-18: 24,626/25,324 complete-census raws in the production
-    archive had a pending (NULL/'ambiguous') membership decision --
-    classify_membership_revisions correctly refuses to pick a winner between
-    two genuinely conflicting browser-capture snapshots of the same session,
-    but before this fix the watcher's full-ingest aggregation
-    (_ingest_full_paths_sync) silently counted that outcome as a FAILED
-    file: no exception was ever raised, no log line was ever written, yet
-    the cursor was marked failed and the file was retried on every
-    subsequent catch-up sweep with no progress. This proves the fix: a raw
-    whose census completed but whose authority decision is legitimately
-    deferred to async arbitration is treated as succeeded/idempotent, not
-    failed.
+    """Regression test for polylogue-emx2 (adoption idempotency), corrected.
+
+    The original polylogue-emx2 fix (PR #3129) shipped as
+    ``raw_membership_authority_complete()``, a boolean that collapses three
+    distinct membership-decision states: ``decision IS NULL`` (genuinely
+    async-pending, arbitrated later by the raw-materialization conveyor --
+    the true motivating production scenario, 24,626/25,324 complete-census
+    raws mid-restore), and ``decision IN ('ambiguous', 'deferred')``
+    (arbitration already ran and concluded a real, byte-level conflict that
+    needs new evidence, not time, to resolve). This test's own scenario --
+    two genuinely conflicting browser-capture snapshots of one session, where
+    identity is not preserved and the content frontier does not strictly
+    grow -- produces the latter: ``classify_membership_revisions`` returns
+    ``ambiguous``, not ``accepted``, synchronously, with no exception raised.
+    The original version of this test asserted that outcome must defer
+    (not fail); that was wrong -- an ``ambiguous`` decision is a *decided*
+    conflict, not pending state, and correctly regressed 5 other watcher
+    tests (polylogue-lvz6 triage, bisected to commit de0b2df7a) that pin the
+    opposite fail-closed invariant for the same decision value
+    (#2684/#2716/#2718/#2837). This corrected version proves: the ambiguous
+    outcome now surfaces as a failed file, with a diagnostic log line (unlike
+    the pre-#3129 silence), while the first accepted snapshot's content is
+    untouched. The genuinely-NULL-must-defer case emx2 actually motivates is
+    covered separately by
+    ``test_raw_membership_decision_pending_distinguishes_null_from_ambiguous``
+    in ``tests/unit/sources/test_live_batch_support.py``.
     """
     root = workspace_env["data_root"] / "browser-capture"
     chatgpt_dir = root / "chatgpt"
@@ -1702,7 +1715,8 @@ async def test_live_full_ingest_over_ambiguous_membership_defers_instead_of_fail
         # Second snapshot: same message count/shape but a genuinely
         # different assistant turn identity -- classify_membership_revisions
         # cannot pick a winner (identity not preserved, frontier doesn't
-        # strictly grow) and correctly returns ambiguous, not accepted.
+        # strictly grow) and correctly returns ambiguous, not accepted. This
+        # is a decided conflict, not async-pending state, so it must fail.
         source_path.write_text(
             json.dumps(
                 _browser_capture_payload(
@@ -1714,20 +1728,33 @@ async def test_live_full_ingest_over_ambiguous_membership_defers_instead_of_fail
             encoding="utf-8",
         )
         second = await processor.ingest_files([source_path], emit_event=False)
-        assert second.failed_file_count == 0, "ambiguous membership decision must defer, not fail"
-        assert second.succeeded_file_count == 1
+        assert second.succeeded_file_count == 0
+        assert second.failed_file_count == 1, "a decided ambiguous membership conflict must fail closed"
 
         record = cursor.get_record(source_path)
         assert record is not None
-        assert record.failure_count == 0
+        assert record.failure_count == 1
 
-        # Idempotent re-observation: identical bytes must not be reprocessed
-        # as a fresh failure/retry.
-        third = await processor.ingest_files([source_path], emit_event=False)
-        assert third.failed_file_count == 0
-        record_after_replay = cursor.get_record(source_path)
-        assert record_after_replay is not None
-        assert record_after_replay.failure_count == 0
+        with sqlite3.connect(workspace_env["archive_root"] / "source.db") as conn:
+            decisions = conn.execute(
+                "SELECT decision FROM raw_session_memberships WHERE logical_source_key = 'chatgpt:conv-emx2' "
+                "ORDER BY raw_id"
+            ).fetchall()
+            assert decisions == [("ambiguous",), ("ambiguous",)]
+
+        # The first accepted snapshot's content remains queryable; the
+        # ambiguous second observation has no deletion authority over it.
+        with sqlite3.connect(workspace_env["archive_root"] / "index.db") as conn:
+            assert conn.execute(
+                """
+                SELECT b.search_text
+                FROM sessions AS s
+                JOIN messages AS m USING (session_id)
+                JOIN blocks AS b USING (message_id)
+                WHERE s.native_id = 'conv-emx2'
+                ORDER BY m.position, b.position
+                """
+            ).fetchall() == [("hello",), ("hi",)]
     finally:
         await archive.close()
 


### PR DESCRIPTION
## Summary

Narrows the polylogue-emx2 deferred-membership fix (PR #3129, commit
de0b2df7a) so it applies only to the genuinely async-pending case
(`decision IS NULL`), restoring the fail-closed invariant for decided
`'ambiguous'`/`'deferred'` membership conflicts that de0b2df7a's shipped
code had accidentally started treating as successes.

## Problem

The polylogue-lvz6 clean-master triage bisected 5 failing tests in
`tests/unit/sources/test_live_batch_support.py` to de0b2df7a:

- `test_rewrite_plus_growth_before_planning_fails_closed_to_full_route`
- `test_live_multi_session_divergence_reopens_raw_authority`
- `test_bundle_replay_respects_unconvertible_single_session_head[bundle_texts1-False-False]`
- `test_single_session_full_cannot_overwrite_divergent_membership_head`
- `test_append_cursor_redetects_source_rewrite_after_handoff[in-place-prefix]`

de0b2df7a's intent was narrow: treat only `raw_session_memberships.decision
IS NULL` (genuinely async-pending, arbitrated later by the
raw-materialization conveyor, `sources/revision_backfill.py`) as not-a-failure.
The shipped code used the pre-existing coarse boolean
`ArchiveStore.raw_membership_authority_complete()`, which returns `False`
for `decision IS NULL` **or** `'ambiguous'` **or** `'deferred'` -- three
distinct states collapsed into one. Net effect: genuinely divergent/ambiguous
raws (rewrites, multi-session divergence, unconvertible bundle heads,
divergent membership heads) were recorded as `SUCCEEDED` instead of `FAILED`,
defeating the fail-closed invariants pinned by #2684/#2716/#2718/#2837.

A second injection point (`classify_raw_revision_cohort(...).accepted_raw_ids`
empty, in the non-membership single-session route) was also treated as
deferred, but that classification is synchronous byte comparison with no
conveyor revisiting -- "empty" there is always terminal, never pending.

I also traced (direct DB inspection, see Verification) that de0b2df7a's own
regression test exercises `decision = 'ambiguous'`, not `NULL` -- its
assertion that this must defer was itself an instance of the bug this PR
fixes.

## Solution

- `polylogue/storage/sqlite/archive_tiers/archive.py`: new
  `ArchiveStore.raw_membership_decision_pending(raw_id)` isolates the
  `decision IS NULL` case. `raw_membership_authority_complete` had exactly
  one caller in the whole tree (audited via grep), so it stays as-is for its
  original "fully complete" semantics -- no other legitimate caller to
  preserve.
- `polylogue/sources/live/batch.py`:
  - The membership-governed injection point now branches: complete ->
    succeeded; `raw_membership_decision_pending` -> deferred (unchanged
    behavior for the true async-pending case); otherwise (decided
    `ambiguous`/`deferred`) -> falls through to the caller's existing
    failed-set aggregation in `_ingest_full_paths_sync`, now with a
    `logger.warning` (the pre-fix path failed silently, no exception, no log
    at all -- part of what made the original bug invisible in production).
  - The `classify_raw_revision_cohort` injection point drops the
    `deferred_raw_ids` branch entirely (empty accepted cohort is always
    terminal there) and logs a warning too.
- `tests/unit/sources/test_live_watcher.py`: corrected
  `test_live_full_ingest_over_ambiguous_membership_defers_instead_of_failing`
  -> `..._fails_closed_with_diagnostic`. Its two-conflicting-browser-snapshot
  scenario produces `decision = 'ambiguous'`, not `NULL` (verified by direct
  DB inspection); the original assertion that it must defer was wrong. It now
  asserts the corrected fail-closed outcome, the diagnostic log line, and that
  the first accepted snapshot's content is untouched.
- `tests/unit/sources/test_live_batch_support.py`: added
  `test_raw_membership_decision_pending_distinguishes_null_from_ambiguous`, a
  focused archive-tier regression test for the exact narrow scoping (NULL ->
  pending; ambiguous -> decided/not-pending). This is archive-tier rather than
  a full watcher scenario because `LiveBatchProcessor`'s two call sites into
  `_apply_membership_sessions` both pass `allow_current_complete_raw=True`,
  which always resolves a raw's own decision synchronously within the same
  call -- so NULL is never observed at that exact checkpoint via the live
  watcher path. Genuine NULL persistence happens only across the conveyor's
  decoupled census-then-classify phases
  (`census_historical_revision_evidence` / `backfill_historical_revision_evidence`
  in `sources/revision_backfill.py`), which this test reproduces directly.

## Verification

- `devtools test tests/unit/sources/test_live_batch_support.py tests/unit/sources/test_live_cursor_persistence.py tests/unit/sources/test_live_watcher.py` -- 160 passed (was 5 failed on clean master before this fix).
- `devtools verify --quick` -- exit 0 (format, lint, mypy --strict, render all --check, topology/layering/manifest/doc-commands/clock-hygiene/timeout/degrade-loudly gates).
- Direct DB-state inspection (ad hoc script against the archive tier, not committed) confirmed the emx2 regression test's second observation produces `raw_session_memberships.decision = 'ambiguous'` for both raws, not `NULL`, before deciding how to correct that test.
- Not run: the heavy `test` suite (skipped per-PR by CI policy, runs post-merge).

Ref polylogue-emx2
Ref polylogue-lvz6