### PR TITLE
fix(storage): permit same-raw revision CAS supersede

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/revision_application.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_application.py
@@ -15,6 +15,13 @@ from polylogue.archive.revision_replay import ApplicationDecision
 _MESSAGE_FTS_TRIGGERS = {"messages_fts_ai", "messages_fts_ad", "messages_fts_au"}
 
 
+def _hash_prefix(value: bytes | None) -> str:
+    """Short hex prefix for a content hash, safe for error messages."""
+    if value is None:
+        return "None"
+    return value.hex()[:12]
+
+
 @dataclass(frozen=True, slots=True)
 class RevisionApplicationReceipt:
     raw_id: str
@@ -192,10 +199,44 @@ def record_revision_application_sync(
                 receipt.accepted_content_hash,
             )
             if tuple(existing) != expected:
-                raise RuntimeError(f"conflicting raw revision application receipt: {receipt.decision_id}")
+                # `decision_id` hashes every decision-defining field (raw_id,
+                # session_id, decision, logical_source_key, source_revision,
+                # accepted_raw_id, accepted_source_revision) except
+                # accepted_content_hash. So a row found by decision_id can
+                # only disagree with the incoming receipt on
+                # accepted_content_hash -- a parser/derivation fix reparsing
+                # the exact same accepted raw evidence into a different
+                # content hash. The raw/session/revision identity already
+                # matched to find this row, so that is re-derivation, not a
+                # conflicting decision: update the ledger row's content hash
+                # in place. Any other field actually differing (defensive;
+                # not reachable without a decision_id hash collision) is a
+                # genuine conflict and still rejects.
+                if tuple(existing[:5]) == expected[:5]:
+                    conn.execute(
+                        "UPDATE raw_revision_applications SET accepted_content_hash = ? WHERE decision_id = ?",
+                        (receipt.accepted_content_hash, receipt.decision_id),
+                    )
+                else:
+                    raise RuntimeError(
+                        "conflicting raw revision application receipt: "
+                        f"decision_id={receipt.decision_id} logical_source_key={receipt.logical_source_key!r} "
+                        f"incoming(raw_id={receipt.raw_id!r}, session_id={receipt.session_id!r}, "
+                        f"decision={receipt.decision.value!r}, accepted_raw_id={receipt.accepted_raw_id!r}, "
+                        f"accepted_source_revision={receipt.accepted_source_revision!r}, "
+                        f"accepted_content_hash={_hash_prefix(receipt.accepted_content_hash)}) "
+                        f"existing(raw_id={existing[0]!r}, session_id={existing[1]!r}, decision={existing[2]!r}, "
+                        f"accepted_raw_id={existing[3]!r}, accepted_source_revision={existing[4]!r}, "
+                        f"accepted_content_hash={_hash_prefix(existing[5])})"
+                    )
         else:
             if receipt.decision is not ApplicationDecision.SUPERSEDED:
-                raise RuntimeError(f"conflicting raw revision application receipt: {receipt.decision_id}")
+                raise RuntimeError(
+                    "conflicting raw revision application receipt: no existing row and decision is not SUPERSEDED: "
+                    f"decision_id={receipt.decision_id} logical_source_key={receipt.logical_source_key!r} "
+                    f"raw_id={receipt.raw_id!r} session_id={receipt.session_id!r} "
+                    f"decision={receipt.decision.value!r} accepted_raw_id={receipt.accepted_raw_id!r}"
+                )
             semantic_identity = conn.execute(
                 """
                 SELECT raw_id, session_id, logical_source_key, decision,
@@ -222,7 +263,15 @@ def record_revision_application_sync(
                 receipt.accepted_content_hash,
             )
             if semantic_identity is None or tuple(semantic_identity) != expected_identity:
-                raise RuntimeError(f"conflicting raw revision application receipt: {receipt.decision_id}")
+                raise RuntimeError(
+                    "conflicting raw revision application receipt: no matching semantic-identity row for "
+                    f"SUPERSEDED replay: decision_id={receipt.decision_id} "
+                    f"logical_source_key={receipt.logical_source_key!r} raw_id={receipt.raw_id!r} "
+                    f"session_id={receipt.session_id!r} source_revision={receipt.source_revision!r} "
+                    f"accepted_source_revision={receipt.accepted_source_revision!r} "
+                    f"accepted_content_hash={_hash_prefix(receipt.accepted_content_hash)} "
+                    f"found={semantic_identity!r}"
+                )
     if receipt.accepted_raw_id is None or receipt.decision not in {
         ApplicationDecision.SELECTED_BASELINE,
         ApplicationDecision.APPLIED_APPEND,
@@ -243,10 +292,24 @@ def record_revision_application_sync(
         if receipt.accepted_frontier_kind not in {"byte", "semantic"} or receipt.accepted_frontier is None:
             raise ValueError("accepted revision receipt requires a typed frontier")
         if str(existing_head[4]) != receipt.accepted_frontier_kind:
-            raise RuntimeError("raw revision CAS rejected an incomparable accepted frontier")
+            raise RuntimeError(
+                "raw revision CAS rejected an incomparable accepted frontier: "
+                f"logical_source_key={receipt.logical_source_key!r} "
+                f"existing(session_id={existing_head[0]!r}, accepted_raw_id={existing_head[1]!r}, "
+                f"frontier_kind={existing_head[4]!r}, frontier={existing_head[5]!r}) "
+                f"incoming(session_id={receipt.session_id!r}, accepted_raw_id={receipt.accepted_raw_id!r}, "
+                f"frontier_kind={receipt.accepted_frontier_kind!r}, frontier={receipt.accepted_frontier!r})"
+            )
         existing_frontier = int(existing_head[5])
         if receipt.accepted_frontier < existing_frontier:
-            raise RuntimeError("raw revision CAS rejected an older accepted frontier")
+            raise RuntimeError(
+                "raw revision CAS rejected an older accepted frontier: "
+                f"logical_source_key={receipt.logical_source_key!r} "
+                f"existing(session_id={existing_head[0]!r}, accepted_raw_id={existing_head[1]!r}, "
+                f"frontier_kind={existing_head[4]!r}, frontier={existing_frontier}) "
+                f"incoming(session_id={receipt.session_id!r}, accepted_raw_id={receipt.accepted_raw_id!r}, "
+                f"frontier_kind={receipt.accepted_frontier_kind!r}, frontier={receipt.accepted_frontier})"
+            )
         if receipt.accepted_frontier == existing_frontier:
             existing_semantics = (existing_head[0], existing_head[3], existing_head[4], existing_head[5])
             accepted_semantics = (
@@ -255,12 +318,32 @@ def record_revision_application_sync(
                 receipt.accepted_frontier_kind,
                 receipt.accepted_frontier,
             )
-            authorized_fold = receipt.fold_authorization is not None and receipt.fold_authorization.permits(
-                existing_head, receipt
-            )
-            if existing_semantics != accepted_semantics and not authorized_fold:
-                raise RuntimeError("raw revision CAS rejected a conflicting accepted head")
-            if tuple(existing_head) == (
+            if existing_semantics != accepted_semantics:
+                authorized_fold = receipt.fold_authorization is not None and receipt.fold_authorization.permits(
+                    existing_head, receipt
+                )
+                # Same-raw re-application: the incoming receipt derives from the
+                # exact same accepted raw evidence as the existing head (equal
+                # `accepted_raw_id`) -- typically a parser/identity fix reparsing
+                # the same content-addressed blob into a different content hash
+                # and/or session_id. That is re-derivation from identical
+                # evidence, not a genuine conflict, so it supersedes the existing
+                # head. Cross-raw conflicts (a different `accepted_raw_id`
+                # claiming the same frontier with differing semantics) are real
+                # divergence and still require fold authorization to pass.
+                same_raw_supersede = receipt.accepted_raw_id == existing_head[1]
+                if not authorized_fold and not same_raw_supersede:
+                    raise RuntimeError(
+                        "raw revision CAS rejected a conflicting accepted head: "
+                        f"logical_source_key={receipt.logical_source_key!r} "
+                        f"existing(session_id={existing_head[0]!r}, accepted_raw_id={existing_head[1]!r}, "
+                        f"accepted_content_hash={_hash_prefix(existing_head[3])}, "
+                        f"frontier_kind={existing_head[4]!r}, frontier={existing_head[5]!r}) "
+                        f"incoming(session_id={receipt.session_id!r}, accepted_raw_id={receipt.accepted_raw_id!r}, "
+                        f"accepted_content_hash={_hash_prefix(receipt.accepted_content_hash)}, "
+                        f"frontier_kind={receipt.accepted_frontier_kind!r}, frontier={receipt.accepted_frontier!r})"
+                    )
+            elif tuple(existing_head) == (
                 receipt.session_id,
                 receipt.accepted_raw_id,
                 receipt.accepted_source_revision,

--- a/tests/unit/storage/test_revision_application.py
+++ b/tests/unit/storage/test_revision_application.py
@@ -103,13 +103,12 @@ def test_session_fts_proof_detects_missing_row_and_trigger_mutation() -> None:
 @pytest.mark.parametrize(
     "changes",
     [
-        {"session_id": "codex-session:other"},
-        {"accepted_content_hash": b"x" * 32},
         {"accepted_frontier": 99},
         {"accepted_frontier_kind": "semantic"},
     ],
 )
-def test_equal_frontier_cas_rejects_conflicting_semantic_state(changes: dict[str, Any]) -> None:
+def test_equal_frontier_cas_rejects_conflicting_frontier_state(changes: dict[str, Any]) -> None:
+    """(e) a genuinely older or incomparable frontier is still rejected regardless of raw identity."""
     conn = sqlite3.connect(":memory:")
     conn.executescript(INDEX_DDL)
     receipt = _receipt()
@@ -117,6 +116,77 @@ def test_equal_frontier_cas_rejects_conflicting_semantic_state(changes: dict[str
 
     with pytest.raises(RuntimeError, match="conflicting|rejected"):
         record_revision_application_sync(conn, replace(receipt, **changes), decided_at_ms=20)
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"accepted_content_hash": b"x" * 32},
+        {"session_id": "codex-session:renamed"},
+    ],
+)
+def test_equal_frontier_cas_allows_same_raw_supersede(changes: dict[str, Any]) -> None:
+    """(a)+(b) same accepted_raw_id, equal frontier, differing derived semantics.
+
+    A parser fix (differing content hash) or an identity-law fix (differing
+    session_id) re-derives from the exact same accepted raw evidence -- the
+    blob is content-addressed and unchanged, only the derivation changed. This
+    must supersede the existing head rather than raise: blocking it would make
+    every parser/identity improvement poison already-committed archives.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(INDEX_DDL)
+    receipt = _receipt()
+    record_revision_application_sync(conn, receipt, decided_at_ms=10)
+
+    reapplied = replace(receipt, **changes)
+    record_revision_application_sync(conn, reapplied, decided_at_ms=20)
+
+    row = conn.execute(
+        """
+        SELECT session_id, accepted_raw_id, accepted_content_hash
+        FROM raw_revision_heads WHERE logical_source_key = 'codex:session'
+        """
+    ).fetchone()
+    assert row == (reapplied.session_id, reapplied.accepted_raw_id, reapplied.accepted_content_hash)
+
+
+def test_equal_frontier_cas_rejects_cross_raw_conflict_without_fold_authorization() -> None:
+    """(c) a different accepted_raw_id at the same frontier is a genuine conflict and still rejects.
+
+    The error message must name both the existing and incoming accepted_raw_id
+    so a rebuild failure is diagnosable without re-running under a debugger.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(INDEX_DDL)
+    receipt = _receipt()
+    record_revision_application_sync(conn, receipt, decided_at_ms=10)
+
+    conflicting = replace(
+        receipt,
+        raw_id="raw-conflict",
+        accepted_raw_id="raw-conflict",
+        accepted_content_hash=b"z" * 32,
+    )
+    with pytest.raises(RuntimeError, match="conflicting accepted head") as excinfo:
+        record_revision_application_sync(conn, conflicting, decided_at_ms=20)
+    message = str(excinfo.value)
+    assert receipt.accepted_raw_id in message
+    assert "raw-conflict" in message
+
+
+def test_equal_frontier_cas_idempotent_same_everything_reapplication() -> None:
+    """(d) re-applying the exact same receipt at an equal frontier is a clean no-op."""
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(INDEX_DDL)
+    receipt = _receipt()
+    record_revision_application_sync(conn, receipt, decided_at_ms=10)
+    record_revision_application_sync(conn, receipt, decided_at_ms=20)
+
+    row = conn.execute(
+        "SELECT accepted_raw_id, accepted_content_hash, decided_at_ms FROM raw_revision_heads"
+    ).fetchone()
+    assert row == (receipt.accepted_raw_id, receipt.accepted_content_hash, 10)
 
 
 def test_larger_full_snapshot_supersedes_deeper_append_generation() -> None:

--- a/tests/unit/storage/test_revision_application.py
+++ b/tests/unit/storage/test_revision_application.py
@@ -171,6 +171,7 @@ def test_equal_frontier_cas_rejects_cross_raw_conflict_without_fold_authorizatio
     with pytest.raises(RuntimeError, match="conflicting accepted head") as excinfo:
         record_revision_application_sync(conn, conflicting, decided_at_ms=20)
     message = str(excinfo.value)
+    assert receipt.accepted_raw_id is not None
     assert receipt.accepted_raw_id in message
     assert "raw-conflict" in message
 


### PR DESCRIPTION
## Summary

`record_revision_application_sync` now permits a raw-revision replay to
supersede its own previous accepted head when the incoming receipt is
derived from the same `accepted_raw_id` — a re-derivation from identical
raw evidence, not a genuine conflict. Every raise in the function now
carries diagnostic context (logical source key, existing vs incoming raw
ids/session ids/frontiers, content-hash prefixes).

This unblocks resume #4 of operation ab5bad1f: resume #3 failed fast
after the #3191 parser fix because ~466 already-committed sessions'
raw evidence now reparses to a different content hash (and in some cases
a different `session_id` after identity-law fixes), and the CAS was
treating that as an unauthorized conflict.

## Problem

`polylogue/storage/sqlite/archive_tiers/revision_application.py`'s
equal-frontier CAS branch rejected any incoming receipt whose derived
semantics (`accepted_content_hash`, `session_id`) differed from the
existing `raw_revision_heads` row at the same frontier, unless a
`FullSnapshotFoldAuthorization` was present — even when the receipt's
`accepted_raw_id` was *identical* to the existing head's. The raw blob
is content-addressed and unchanged after a parser fix; only the
*derivation* (parsed content, and possibly the session_id it resolves
to) changed. Blocking same-raw re-derivation contradicts the repo's
derived-tier doctrine ("derived content re-derives from source",
`docs/architecture.md`) and means every parser or identity-law
improvement poisons already-committed archives on the next rebuild.

While reproducing this at fixture scale, a second, earlier gate with
the identical failure mode turned up: `raw_revision_applications`'
immutable-ledger check uses `decision_id` as its natural key, and
`decision_id` deliberately excludes `accepted_content_hash` from its
hash payload. So a receipt that is identical to an existing ledger row
in every decision-defining field except `accepted_content_hash` (the
pure "same raw, reparsed to a different hash" case) hit "conflicting
raw revision application receipt" *before* ever reaching the heads
CAS — same root cause, one call earlier.

## Solution

Both in `polylogue/storage/sqlite/archive_tiers/revision_application.py`:

- **Ledger check** (`raw_revision_applications`): when an existing row
  found by `decision_id` differs from the incoming receipt *only* in
  `accepted_content_hash` (the only field `decision_id`'s hash doesn't
  cover), `UPDATE` the row's `accepted_content_hash` in place instead of
  raising. Any other field actually differing is unreachable without a
  `decision_id` hash collision and still raises defensively.
- **Heads CAS** (`raw_revision_heads`, equal-frontier branch): added a
  `same_raw_supersede = receipt.accepted_raw_id == existing_head[1]`
  exemption alongside the existing fold-authorization exemption. Falls
  through to the same `UPSERT` that fold-authorized folds already use.
  **Cross-raw conflicts** (different `accepted_raw_id`, same frontier,
  differing semantics, no fold authorization) are unaffected and still
  reject — that guard protects real divergence. Older-frontier and
  incomparable-frontier-kind rejections are unaffected.
- **Error context**: all six raises in the function now include
  `logical_source_key`, existing vs incoming `accepted_raw_id`/
  `session_id`/frontier, and content-hash prefixes. A 10-hour rebuild
  died on a context-free `RuntimeError` twice this weekend.

**Async twin audit**: grepped the repo for a second CAS implementation
(`record_revision_application` without `_sync`, an `async_sqlite` tree,
etc.) — none exists. `record_revision_application_sync` is the sole
writer of `raw_revision_heads` across every call site
(`storage/sqlite/archive_tiers/archive.py`, `storage/repair.py`).

## Verification

- `devtools test tests/unit/storage/test_revision_application.py` — 12
  passed. Extended (not duplicated) with: same-raw content-hash
  supersede, same-raw session_id supersede (identity-law fix case),
  cross-raw conflict without fold authorization (asserts the message
  names both `accepted_raw_id`s), idempotent same-everything
  re-application, and a frontier-mismatch case split out of the old
  parametrized test whose other two cases this PR intentionally
  changes the expected outcome of.
- `devtools test tests/unit/sources/test_live_batch_support.py` — 63
  passed, 5 failed. Reproduced the identical 5 failures on unmodified
  master (`08cd41b34`) via a throwaway `git worktree`, confirming they
  are pre-existing and unrelated to this change (removed the worktree
  after comparison).
- `devtools test tests/unit/storage/test_repair.py
  tests/unit/storage/test_raw_revision_authority.py
  tests/unit/storage/test_duplicate_raw_identity_repair.py` — 95
  passed (broader affected-area check for the touched CAS surface).
- `devtools verify --quick` — all steps green (ruff format/check, mypy
  --strict, render all, topology/layering/closure-matrix/manifests/
  ci-workflows/doc-commands/docs-coverage/test-infra-currency/
  test-clock-hygiene/pytest-timeout-overrides/degrade-loudly).

Not run: `devtools verify --all` (full non-integration suite) — the
targeted + affected-area runs above cover the touched surface; the
per-PR CI `test` job runs post-merge on master per repo convention.

Ref ab5bad1f resume #4