### PR TITLE
fix(query): pin session-scoped index for bounded action relation

### DIFF
--- a/polylogue/storage/sqlite/action_relation.py
+++ b/polylogue/storage/sqlite/action_relation.py
@@ -8,7 +8,21 @@ def action_relation_select_sql(
     session_placeholders: str | None = None,
     empty: bool = False,
 ) -> str:
-    """Return the actions SELECT, optionally bounding every physical branch."""
+    """Return the actions SELECT, optionally bounding every physical branch.
+
+    ``INDEXED BY idx_blocks_session_position`` is pinned on every ``blocks``
+    scan whenever the relation is session-bounded. Without ``ANALYZE``
+    statistics (a brand-new archive has none -- ``ArchiveStore``'s fresh-bootstrap
+    path never seeds ``sqlite_stat1``; see ``polylogue/storage/sqlite/schema.py``
+    for the separate connection-pool bootstrap that does), SQLite's planner
+    defaults to the low-cardinality ``idx_blocks_type_tool (block_type=?)``
+    index for a `block_type = 'tool_use'` predicate -- an archive-wide scan of
+    every tool_use/tool_result block regardless of how selective the session
+    bound is (measured: a single-session query planned the same full
+    ``idx_blocks_type_tool`` scan as an unbounded one; polylogue-z9gh.2
+    F-006/F-007). The exact session id(s) are already known at SQL-generation
+    time here, so the correct index is not a matter of estimation -- pin it.
+    """
     if empty and session_placeholders is not None:
         raise ValueError("An empty action relation cannot also declare session placeholders")
     use_bound = " AND 0" if empty else f" AND u.session_id IN ({session_placeholders})" if session_placeholders else ""
@@ -18,6 +32,7 @@ def action_relation_select_sql(
     null_id_bound = (
         " AND 0" if empty else f" AND u.session_id IN ({session_placeholders})" if session_placeholders else ""
     )
+    session_index_hint = " INDEXED BY idx_blocks_session_position" if session_placeholders else ""
     return f"""
 WITH ranked_uses AS (
     SELECT
@@ -34,7 +49,7 @@ WITH ranked_uses AS (
             PARTITION BY u.session_id, u.tool_id
             ORDER BY um.position, um.variant_index, u.position
         ) AS use_rank
-    FROM blocks u
+    FROM blocks u{session_index_hint}
     JOIN messages um ON um.message_id = u.message_id
     WHERE u.block_type = 'tool_use' AND u.tool_id IS NOT NULL AND u.tool_id != ''{use_bound}
 ),
@@ -50,7 +65,7 @@ ranked_results AS (
             PARTITION BY r.session_id, r.tool_id
             ORDER BY rm.position, rm.variant_index, r.position
         ) AS result_rank
-    FROM blocks r
+    FROM blocks r{session_index_hint}
     JOIN messages rm ON rm.message_id = r.message_id
     WHERE r.block_type = 'tool_result' AND r.tool_id IS NOT NULL AND r.tool_id != ''{result_bound}
 )
@@ -88,7 +103,7 @@ SELECT
     NULL AS is_error,
     NULL AS exit_code,
     NULL AS tool_result_block_id
-FROM blocks u
+FROM blocks u{session_index_hint}
 WHERE u.block_type = 'tool_use' AND (u.tool_id IS NULL OR u.tool_id = ''){null_id_bound}
 """.strip()
 

--- a/tests/unit/storage/test_archive_tiers_archive.py
+++ b/tests/unit/storage/test_archive_tiers_archive.py
@@ -289,6 +289,102 @@ def test_exact_session_action_count_bounds_pairing_before_global_ranking(
     assert mutant_receipt.spec.semantic_result == "complete"
 
 
+def test_bounded_action_relation_plans_session_index_not_archive_wide_tool_scan(tmp_path: Path) -> None:
+    """polylogue-z9gh.2 F-006/F-007: a session-scoped ``followup_class``
+    query must not plan an archive-wide ``idx_blocks_type_tool`` scan.
+
+    ``_action_relation_for_query`` already narrows a ``session.id:X``
+    predicate to an exact session bound (``_exact_session_ids_from_predicate``)
+    for both the plain-count and the ``group by followup_class`` (needs the
+    derived follow-up relation) paths -- that part of the lowering was
+    already correct. The residual was physical: ``action_relation_select_sql``
+    had no way to force the session-scoped index, and a fresh ``ArchiveStore``
+    archive has no ``sqlite_stat1`` (its bootstrap path,
+    ``initialize_archive_tier``, never seeds planner statistics -- unlike the
+    separate connection-pool bootstrap in ``storage/sqlite/schema.py``), so
+    SQLite's planner fell back to ``idx_blocks_type_tool (block_type=?)`` --
+    an archive-wide scan of every ``tool_use``/``tool_result`` block --
+    regardless of how selective the session bound was. The exact session ids
+    are already known at SQL-generation time, so the fix pins
+    ``INDEXED BY idx_blocks_session_position`` on every bounded branch.
+    """
+    with ArchiveStore(tmp_path / "archive") as facade:
+        target_id: str | None = None
+        for i in range(8):
+            messages: list[ParsedMessage] = []
+            for j in range(3):
+                messages.append(
+                    ParsedMessage(
+                        provider_message_id=f"u{j}",
+                        role=Role.USER,
+                        blocks=[ParsedContentBlock(type=BlockType.TEXT, text="hi")],
+                    )
+                )
+                messages.append(
+                    ParsedMessage(
+                        provider_message_id=f"tu{j}",
+                        role=Role.ASSISTANT,
+                        blocks=[
+                            ParsedContentBlock(
+                                type=BlockType.TOOL_USE,
+                                tool_name="Bash",
+                                tool_id=f"t{i}-{j}",
+                                tool_input={"command": "ls"},
+                            )
+                        ],
+                    )
+                )
+                messages.append(
+                    ParsedMessage(
+                        provider_message_id=f"tr{j}",
+                        role=Role.TOOL,
+                        blocks=[
+                            ParsedContentBlock(
+                                type=BlockType.TOOL_RESULT,
+                                tool_id=f"t{i}-{j}",
+                                text="out",
+                                is_error=(j == 0),
+                            )
+                        ],
+                    )
+                )
+                messages.append(
+                    ParsedMessage(
+                        provider_message_id=f"a{j}",
+                        role=Role.ASSISTANT,
+                        blocks=[ParsedContentBlock(type=BlockType.TEXT, text="acknowledged, continuing now")],
+                    )
+                )
+            session_id = facade.write_parsed(
+                ParsedSession(source_name=Provider.CODEX, provider_session_id=f"sess-{i}", messages=messages)
+            )
+            if i == 5:
+                target_id = session_id
+        assert target_id is not None
+
+        source = parse_unit_source_expression(f"actions where session.id:{target_id} | group by followup_class | count")
+        assert source is not None
+
+        captured_sql: list[str] = []
+        facade._conn.set_trace_callback(captured_sql.append)
+        try:
+            rows = facade.query_unit_counts("action", source.pipeline.predicate, group_by=source.pipeline.group_by)
+        finally:
+            facade._conn.set_trace_callback(None)
+
+        assert rows, "expected at least one followup_class group for the target session"
+
+        aggregate_sql = next(sql for sql in reversed(captured_sql) if "group_key" in sql)
+        plan_rows = facade._conn.execute(f"EXPLAIN QUERY PLAN {aggregate_sql}").fetchall()
+        plan_details = [str(row["detail"]) for row in plan_rows]
+
+    session_scoped_block_scans = [detail for detail in plan_details if ("SEARCH u " in detail or "SEARCH r " in detail)]
+    assert session_scoped_block_scans, plan_details
+    for detail in session_scoped_block_scans:
+        assert "idx_blocks_session_position" in detail, plan_details
+        assert "idx_blocks_type_tool" not in detail, plan_details
+
+
 def test_c03_exact_session_actions_uses_real_provider_pipeline_and_planted_facts(tmp_path: Path) -> None:
     """C-03 executes generated Codex bytes through acquire→parse→index→query."""
     artifact = build_seeded_archive(cache_root=tmp_path / "seeded-artifacts")


### PR DESCRIPTION
## Summary

Fixes the polylogue-z9gh.2 F-006/F-007 residual: a session-scoped action/delegation query (e.g. `actions where session.id:X AND is_error:true`, or the `| group by followup_class | count` variant) could still plan an archive-wide `idx_blocks_type_tool` scan of every `tool_use`/`tool_result` block in the archive, instead of a cheap session-scoped index seek — even after PR #3018 (z9gh.2) replaced the old windowed-view `actions` relation with the `action_pairs`-backed one and added exact-session-id extraction from the query predicate.

## Problem

Investigation (`polylogue-z9gh` evidence matrix) flagged this residual as "unconfirmed-fixed." Root-causing it found the predicate-lowering side was already correct: `_exact_session_ids_from_predicate` / `_action_relation_for_query` (`polylogue/storage/sqlite/archive_tiers/archive.py`) already narrow a `session.id:X` predicate to an exact session bound for both the plain-count and the follow-up-relation-needing (`followup_class`) paths.

The residual was physical, not logical: `action_relation_select_sql` (`polylogue/storage/sqlite/action_relation.py`) had no way to *force* SQLite onto the session-scoped index, and a fresh `ArchiveStore`-bootstrapped archive never seeds `sqlite_stat1` — `initialize_archive_tier` (`polylogue/storage/sqlite/archive_tiers/bootstrap.py`) just runs `conn.executescript(spec.ddl)` with no `ANALYZE`/stat seeding, unlike the separate connection-pool bootstrap in `polylogue/storage/sqlite/schema.py` (`_ensure_schema`, which does seed `PLANNER_STAT1_SEED_SQL` — this is a genuinely different bootstrap path used elsewhere, not the one `ArchiveStore()` goes through). Without stats, SQLite's planner defaults to the low-cardinality `idx_blocks_type_tool (block_type=?)` index for the `block_type = 'tool_use'` predicate inside the bounded relation's ranking CTEs, regardless of how selective the session bound is. Empirically confirmed via `EXPLAIN QUERY PLAN` against a fresh archive: a single-session query planned the identical full `idx_blocks_type_tool` scan as an unbounded one.

## Solution

`action_relation_select_sql` now pins `INDEXED BY idx_blocks_session_position` on every `blocks` scan branch (`ranked_uses`, `ranked_results`, and the null-tool-id UNION ALL branch) whenever the relation is session-bounded (`session_placeholders` is set). The exact session id(s) are already known at SQL-generation time in this code path, so the correct index isn't a matter of cost estimation — it's pinned directly. The unbounded branch (used by the intentionally archive-wide flagship `actions where is_error:true | group by followup_class | count` example) is untouched.

New regression test `test_bounded_action_relation_plans_session_index_not_archive_wide_tool_scan` (`tests/unit/storage/test_archive_tiers_archive.py`) asserts via `EXPLAIN QUERY PLAN` (captured through `sqlite3.Connection.set_trace_callback` on the real `query_unit_counts` production call) that every `SEARCH u`/`SEARCH r` step in the bounded relation uses `idx_blocks_session_position`, never `idx_blocks_type_tool`. Anti-vacuity: verified the test fails with the exact pre-fix symptom (`SEARCH u USING INDEX idx_blocks_type_tool (block_type=?)`) when run against the unmodified `action_relation.py`.

### Investigated but not implemented: z9gh.3's near:/lineage: execution-layer gaps

The z9gh.3 bead (as narrowed) also names two `find`/`read`-route gaps: `near:"..."` similarity falling back to an unfiltered list, and `lineage:id:` recursive-page projection columns (`parent_refs`/`child_refs`/`continuation`) going unmaterialized. Both were investigated in depth (not skipped):

- **`near:id:`/`near:"text"`**: traced the full execution path (`polylogue/archive/query/archive_execution.py`). Current master already fails loudly (`ExpressionCompileError`) when `near:id:<ref>` needs a vector backend that isn't configured or a seed session with no stored embeddings (`_session_seed_scored`'s explicit docstring contract), and gracefully degrades to an *empty* semantic leg — not an unfiltered list — when no vector provider exists for a pure-`near:"text"` query (`_semantic_hits`'s documented #1743 graceful-degradation contract). `_archive_summaries` dispatches `plan.similar_session_id` before the text-semantic leg, correctly. A real end-to-end CLI test exists for the text-seeded leg (`test_async_execute_query_archive_uses_vector_provider_for_semantic_search`) but not for the session-seeded leg — a test-coverage gap, not a reproduced execution bug. Separately, `near:id:` used inside a `sessions where ...` scoping predicate at the `query_units`/DSL pipeline level currently raises `ExpressionCompileError("field 'near' is not supported inside Boolean SQL predicates yet")` — again fail-loud, not silent. Could not reproduce the "falls back to an unfiltered session list" symptom against current master through any of these paths; it may already have been fixed by since-landed work, similar to the stale `polylogue-2qx.2` bd state the evidence-matrix pass found and corrected.
- **`lineage:id:` recursive-page columns**: confirmed real. `lineage:id:X` *does* correctly filter session/message membership through `QueryLineagePredicate`/`_lineage_predicate_clause` (`polylogue/storage/sqlite/archive_tiers/archive.py`), but the declared "recursive-page" result semantics in the discovery corpus (`polylogue/archive/query/discovery.py`, `RECURSIVE_COLUMNS = ("session_id", "parent_refs", "child_refs", "continuation")`) promise graph-navigation columns and independent recursive pagination that the actual route never materializes — it returns a flat, non-recursively-paged row set. Building real `parent_refs`/`child_refs`/continuation-cursor graph pagination is a genuinely large, separate feature (new response shape, cycle-aware traversal, continuation state), not a surgical fix — sizing it S/M would be dishonest. Per the coordinator's explicit stop condition, this item is reported rather than force-fixed here.

No changes were made for either near:/lineage: item; recommend the polylogue-z9gh.3 bead be re-verified against current master (the near: gap) and, if still wanted, split into its own properly-scoped feature bead (the lineage: recursive-page projection) rather than carried as this residual's scope.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_archive.py -k test_bounded_action_relation_plans_session_index_not_archive_wide_tool_scan` — 1 passed.
- Anti-vacuity: same test against unmodified `action_relation.py` — fails with `SEARCH u USING INDEX idx_blocks_type_tool (block_type=?)` (the exact regression this test guards).
- `devtools test tests/unit/storage/test_archive_tiers_archive.py tests/unit/storage/test_planner_statistics_seed.py tests/unit/storage/test_delegation_facts_bulk_rebuild.py tests/unit/archive/query/test_execution_control.py` — 65 passed, 4 pre-existing failures confirmed identical on unmodified `origin/master` (unrelated to this change — tracked as `polylogue-1ldl`, a stale `>=50000 VM steps` anti-vacuity threshold in two other tests whose "archive-wide fallback" mutation stopped being expensive once PR #3018 made the `actions` view backed by the small indexed `action_pairs` table, plus a `query_units` vs `api.query_units` call-log naming mismatch in two more).
- `mypy --strict polylogue/storage/sqlite/action_relation.py tests/unit/storage/test_archive_tiers_archive.py` — clean.
- `devtools verify --quick` — exit 0, all 16 steps green.

Ref polylogue-z9gh.3, polylogue-z9gh.7