### PR TITLE
fix(sources): absorb quarantined membership head into later rebuild cohorts

### DIFF
--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -784,6 +784,18 @@ def backfill_historical_revision_evidence(
             retained_bytes = 0
             candidate_raw_ids = set(archive.raw_membership_rebuild_raw_ids(logical_key))
             candidate_raw_ids.update(membership_candidates.get(logical_key, ()))
+            # Cohort absorption: candidate selection is page-dependent, so a
+            # head written by an EARLIER page's membership cohort for this key
+            # may not be in this page's candidate set -- membership replay
+            # would then refuse to retire an "unrelated" quarantined head and
+            # kill the walk. Absorb the current quarantined head raw into the
+            # cohort so the real prefix classifier ranks it against the new
+            # members instead of any scalar comparison. Chain-governed
+            # (non-quarantined) heads are deliberately NOT absorbed --
+            # apply_raw_membership_classification yields to those.
+            head_raw_id = archive.raw_revision_head_raw_id(logical_key)
+            if head_raw_id is not None and archive._raw_revision_authority(head_raw_id) == "quarantined":
+                candidate_raw_ids.add(head_raw_id)
             for raw_id in sorted(candidate_raw_ids):
                 sessions, payload_bytes = spill.for_raw(archive, raw_id)
                 for session in sessions:


### PR DESCRIPTION
## Summary
Third and (per the loud-context guard) currently-last v42 rebuild crash class: a quarantined membership head decided on an earlier rebuild page is absent from a later page's cohort for the same logical key, so membership replay raised `cannot retire an unrelated accepted head`. The head raw is now absorbed into the cohort candidate set so the real prefix classifier ranks it — no scalar comparisons, no authority inversion (chain-governed heads are deliberately not absorbed; the #3204 yield path owns those).

## Problem
Post-#3204 the live walk died at `chatgpt:366f7d9f-…` (full context named by the new loud guard): existing head raw `ff4f5e…` (quarantined) vs a 3-raw sibling cohort that did not contain it, because `raw_membership_rebuild_raw_ids` joins on `raw_sessions.revision_authority = 'byte_proven'` and page-local candidates only cover the current page.

## Solution
One addition in `backfill_historical_revision_evidence`'s membership loop: look up the current head raw for the key; if quarantined, add it to `candidate_raw_ids` so it is spilled, parsed, and classified with the cohort. In-cohort head retirement then follows the existing, already-tested path.

## Verification
Safe-by-construction (absorption only widens classification evidence) + `devtools verify --quick` green. Honest gap: two attempts at a self-contained backfill fixture failed to reproduce the exact census-authority state — both fixture variants passed with AND without the fix (the census re-derives raw authority during the walk), so a synthetic regression test would be vacuous and was not kept. The verification artifact is the live v42 walk, which deterministically re-hits this key on resume — the pass/receipt will be posted on this PR before merge.