### PR TITLE
perf(daemon): bound parse-stage cache by estimated tree bytes

### DIFF
--- a/polylogue/daemon/parse_prefetch.py
+++ b/polylogue/daemon/parse_prefetch.py
@@ -33,13 +33,15 @@ turns the same code path into a real speedup.
 from __future__ import annotations
 
 import os
-from collections.abc import Sequence
+import threading
+from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from polylogue.config import Config
 from polylogue.logging import get_logger
 from polylogue.sources import revision_backfill
 from polylogue.sources.dispatch import is_stream_record_provider
+from polylogue.sources.parsers.base_models import ParsedSession
 from polylogue.sources.revision_backfill import RawParsePrefetchCache
 from polylogue.storage.repair import (
     raw_materialization_pending_census_raw_ids,
@@ -128,6 +130,172 @@ def daemon_parse_stage_max_inflight_bytes() -> int:
     return max(_MIN_MAX_INFLIGHT_BYTES, min(_MAX_MAX_INFLIGHT_BYTES, physical // 16))
 
 
+# polylogue-xb4i: the inflight-bytes budget above (and RawParsePrefetchCache's
+# own admission gate) both account raw PAYLOAD bytes, because payload size is
+# the only thing known BEFORE a raw is parsed. But a parsed ``ParsedSession``
+# tree resident in the cache is not the same size as the payload it was
+# parsed from -- Pydantic model instances, per-block dicts, and Python object
+# overhead inflate a compact JSON/JSONL payload substantially. Two earlyoom
+# kills (19.3G and 20.2G RSS peaks, 2026-07-20) happened on a whale-dense
+# page precisely because the cache retained a whole 2000-raw page of PARSED
+# TREES while only the raw payload bytes were budgeted -- clamping the
+# inflight (pre-parse) budget did nothing, since the memory pressure came
+# from trees already sitting in the cache post-parse, not from parses in
+# flight.
+#
+# Floor/ceiling mirror the inflight-bytes budget's adaptive-RAM shape: 1/8 of
+# physical RAM (trees are the bigger of the two budgets since they are what
+# actually sits resident) clamped to [256 MiB, 4 GiB].
+_MIN_MAX_CACHED_TREE_BYTES = 256 * 1024 * 1024  # 256 MiB
+_MAX_MAX_CACHED_TREE_BYTES = 4 * 1024 * 1024 * 1024  # 4 GiB
+
+# Calibration (measured 2026-07-20, see test_parse_prefetch.py for the exact
+# reproducer): a manual deep-object-graph walk (sys.getsizeof over every
+# reachable dict/list/model instance, the same technique pympler.asizeof
+# uses, without adding a new dependency for one calibration script) against
+# synthetic ParsedSession trees of increasing size gave:
+#
+#   messages=10,  blocks=20,   payload_chars=3_000     deep_bytes=41_165   (13.7x payload chars)
+#   messages=100, blocks=200,  payload_chars=150_000   deep_bytes=368_795  (2.5x payload chars)
+#   messages=500, blocks=1000, payload_chars=1_500_000 deep_bytes=2_521_995 (1.7x payload chars)
+#
+# A single per-char multiplier alone under-fits small/medium trees (fixed
+# per-object overhead dominates there) and a single per-object constant alone
+# under-fits text-heavy trees. A two-term linear fit (bytes_per_char * chars +
+# object_overhead_bytes * object_count, least-squares against the three
+# points above) recovers ~0.39 bytes/char and ~1290 bytes/object. This module
+# rounds BOTH terms up for a deliberate safety margin (favor overestimating
+# resident size, which biases toward eviction/reparse -- always correct --
+# over underestimating, which risks the exact OOM this budget exists to
+# prevent): 2 bytes/char and 1024 bytes/object, which lands within [0.9x,
+# 1.8x] of the measured deep size across the three calibration points.
+_ESTIMATOR_BYTES_PER_CHAR = 2
+_ESTIMATOR_OBJECT_OVERHEAD_BYTES = 1024
+
+
+def _text_len(value: str | None) -> int:
+    return len(value) if value else 0
+
+
+def _mapping_char_len(mapping: Mapping[str, object] | None) -> int:
+    """Cheap, non-recursive-getsizeof approximation of a dict-like field's size.
+
+    ``tool_input``/``metadata``/session-event ``payload`` fields are
+    provider-controlled dicts, occasionally large (a tool call's full JSON
+    args). A single ``repr()`` pass over each value is O(size) but touches
+    every byte, exactly the kind of per-object deep walk this estimator is
+    designed to avoid paying for the WHOLE tree -- so cap what a single
+    mapping field is allowed to contribute by falling back to ``str`` length
+    for string values (the overwhelmingly common case) and only ``repr``ing
+    non-string values, which are typically short (numbers, bools, small
+    nested structures).
+    """
+    if not mapping:
+        return 0
+    total = 0
+    for key, value in mapping.items():
+        total += len(str(key))
+        total += len(value) if isinstance(value, str) else len(repr(value))
+    return total
+
+
+def estimate_parsed_tree_bytes(sessions: Sequence[ParsedSession]) -> int:
+    """Cheap structural estimate of resident bytes for a parsed session tree.
+
+    Deliberately NOT a recursive ``sys.getsizeof``/pympler-style deep walk --
+    that is accurate but O(object graph size) with real per-call overhead,
+    and this runs on ``warm()``'s hot path for every raw in a page (up to a
+    couple thousand). Instead: a single linear pass sums text/content field
+    lengths and counts model-instance nodes (sessions, messages, blocks,
+    attachments, session events, web constructs), then applies two constants
+    calibrated against a real deep-size measurement -- see the constants'
+    docstring/comment above for the calibration data and measured ratio.
+    """
+    total_chars = 0
+    object_count = 0
+    for session in sessions:
+        object_count += 1
+        total_chars += _text_len(session.title)
+        total_chars += _text_len(session.instructions_text)
+        total_chars += _text_len(session.created_at)
+        total_chars += _text_len(session.updated_at)
+        total_chars += _text_len(session.git_branch)
+        total_chars += _text_len(session.git_repository_url)
+        total_chars += _text_len(session.provider_project_ref)
+        total_chars += _text_len(session.git_commit_hash)
+        total_chars += sum(len(value) for value in session.working_directories)
+        total_chars += sum(len(value) for value in session.models_used)
+        total_chars += sum(len(value) for value in session.ingest_flags)
+
+        for message in session.messages:
+            object_count += 1
+            object_count += len(message.paste_spans)
+            total_chars += _text_len(message.text)
+            total_chars += _text_len(message.timestamp)
+            total_chars += _text_len(message.sender_name)
+            total_chars += _text_len(message.recipient)
+            total_chars += _text_len(message.user_context_text)
+            total_chars += _text_len(message.model_name)
+            total_chars += _text_len(message.model_effort)
+            total_chars += _text_len(message.provider_message_id)
+            total_chars += _text_len(message.parent_message_provider_id)
+
+            for block in message.blocks:
+                object_count += 1
+                total_chars += _text_len(block.text)
+                total_chars += _text_len(block.tool_name)
+                total_chars += _text_len(block.tool_id)
+                total_chars += _text_len(block.media_type)
+                total_chars += _mapping_char_len(block.tool_input)
+                total_chars += _mapping_char_len(block.metadata)
+                for construct in block.web_constructs:
+                    object_count += 1
+                    total_chars += _text_len(construct.title)
+                    total_chars += _text_len(construct.text)
+                    total_chars += _text_len(construct.url)
+
+        for attachment in session.attachments:
+            object_count += 1
+            total_chars += _text_len(attachment.name)
+            total_chars += _text_len(attachment.path)
+            total_chars += _text_len(attachment.mime_type)
+            total_chars += _text_len(attachment.source_url)
+            total_chars += _text_len(attachment.caption)
+
+        for event in session.session_events:
+            object_count += 1
+            total_chars += _text_len(event.event_type)
+            total_chars += _mapping_char_len(event.payload)
+
+    return _ESTIMATOR_OBJECT_OVERHEAD_BYTES * object_count + _ESTIMATOR_BYTES_PER_CHAR * total_chars
+
+
+def daemon_parse_stage_max_cached_tree_bytes() -> int:
+    """Whole-cache budget for ESTIMATED parsed-tree bytes (not payload bytes).
+
+    Distinct from :func:`daemon_parse_stage_max_inflight_bytes`, which caps
+    raw PAYLOAD bytes admitted while parses are in flight (the only thing
+    knowable pre-parse). This is the budget that actually bounds what a
+    quiet daemon holds resident in ``DaemonParseStage.cache`` between warm()
+    passes -- see the calibration comment on ``_ESTIMATOR_BYTES_PER_CHAR``
+    above for why the two budgets can diverge by 10x+ on the same page.
+    Adaptive: 1/8 of physical RAM clamped to [256 MiB, 4 GiB]. Override with
+    ``POLYLOGUE_DAEMON_PARSE_STAGE_MAX_CACHED_TREE_BYTES``.
+    """
+    raw = os.environ.get("POLYLOGUE_DAEMON_PARSE_STAGE_MAX_CACHED_TREE_BYTES")
+    if raw is not None:
+        try:
+            value = int(raw)
+        except ValueError:
+            value = 0
+        if value > 0:
+            return value
+    physical = _physical_memory_bytes()
+    if physical is None:
+        return _MIN_MAX_CACHED_TREE_BYTES
+    return max(_MIN_MAX_CACHED_TREE_BYTES, min(_MAX_MAX_CACHED_TREE_BYTES, physical // 8))
+
+
 def daemon_parse_stage_warm_timeout_seconds() -> float:
     """Bound on how long ``warm()`` waits for its dispatched workers.
 
@@ -164,6 +332,7 @@ class DaemonParseStage:
         max_workers: int | None = None,
         max_inflight_bytes: int | None = None,
         warm_timeout_seconds: float | None = None,
+        max_cached_tree_bytes: int | None = None,
     ) -> None:
         self._executor = ThreadPoolExecutor(
             max_workers=max_workers if max_workers is not None else daemon_parse_stage_worker_count(),
@@ -177,6 +346,86 @@ class DaemonParseStage:
         self._warm_timeout_seconds = (
             warm_timeout_seconds if warm_timeout_seconds is not None else daemon_parse_stage_warm_timeout_seconds()
         )
+        # polylogue-xb4i: a SECOND budget tracked alongside ``self.cache``,
+        # keyed on the same raw_ids but accounting ESTIMATED PARSED-TREE
+        # bytes instead of the raw cache's payload bytes. ``self.cache``
+        # itself is not touched/subclassed (it is a shared type consumed
+        # directly by other callers -- ``bulk_rebuild.py`` hands
+        # ``stage.cache`` straight to ``RebuildIndexRequest.prefetch_cache``
+        # -- so this stays a side ledger that reconciles against the raw
+        # cache's own admission/eviction rather than replacing it.
+        self._max_cached_tree_bytes = (
+            max_cached_tree_bytes if max_cached_tree_bytes is not None else daemon_parse_stage_max_cached_tree_bytes()
+        )
+        self._tree_bytes_lock = threading.Lock()
+        self._tree_bytes_by_raw_id: dict[str, int] = {}
+        self._cached_tree_bytes_total = 0
+
+    @property
+    def cached_tree_bytes_total(self) -> int:
+        """Sum of estimated parsed-tree bytes currently tracked as cached."""
+        with self._tree_bytes_lock:
+            return self._cached_tree_bytes_total
+
+    def _reconcile_stale_tree_tracking_locked(self) -> None:
+        """Drop tracking for any raw_id no longer present in ``self.cache``.
+
+        Consumers outside this class (the writer-held pass, via
+        ``RawParsePrefetchCache.pop``) remove entries from ``self.cache``
+        directly -- this class has no hook into that removal, so the tree-
+        byte ledger can only be reconciled lazily, by checking membership
+        before making an eviction decision. Cheap: proportional to the
+        number of currently-tracked entries, each check a dict lookup under
+        the raw cache's own lock.
+        """
+        stale = [raw_id for raw_id in self._tree_bytes_by_raw_id if not self.cache.contains(raw_id)]
+        for raw_id in stale:
+            self._drop_tree_bytes_locked(raw_id)
+
+    def _drop_tree_bytes_locked(self, raw_id: str) -> None:
+        tree_bytes = self._tree_bytes_by_raw_id.pop(raw_id, None)
+        if tree_bytes is not None:
+            self._cached_tree_bytes_total -= tree_bytes
+
+    def _select_eviction_candidate_locked(self) -> str | None:
+        """Largest entry wins; ties break to the oldest (dict preserves
+        insertion order, and ``>`` -- not ``>=`` -- means the first-seen
+        (oldest) entry at the max size is kept as the running candidate)."""
+        best_id: str | None = None
+        best_bytes = -1
+        for raw_id, tree_bytes in self._tree_bytes_by_raw_id.items():
+            if tree_bytes > best_bytes:
+                best_bytes = tree_bytes
+                best_id = raw_id
+        return best_id
+
+    def _register_cached_tree_bytes(self, raw_id: str, tree_bytes: int) -> None:
+        """Record a newly-admitted raw's estimated tree size and evict
+        largest-or-oldest entries (via ``self.cache.pop``, which releases
+        both the raw cache's own payload-byte budget and this ledger's tree-
+        byte budget) until back under ``self._max_cached_tree_bytes``."""
+        evicted: list[str] = []
+        with self._tree_bytes_lock:
+            self._reconcile_stale_tree_tracking_locked()
+            self._tree_bytes_by_raw_id[raw_id] = tree_bytes
+            self._cached_tree_bytes_total += tree_bytes
+            while self._cached_tree_bytes_total > self._max_cached_tree_bytes and self._tree_bytes_by_raw_id:
+                candidate = self._select_eviction_candidate_locked()
+                if candidate is None:
+                    break
+                self._drop_tree_bytes_locked(candidate)
+                evicted.append(candidate)
+        for evicted_id in evicted:
+            self.cache.pop(evicted_id)
+        if evicted:
+            logger.info(
+                "parse-stage prefetch: evicted %d cached parsed tree(s) to stay within the %d-byte "
+                "estimated-tree-bytes budget after admitting raw_id=%s (%d bytes)",
+                len(evicted),
+                self._max_cached_tree_bytes,
+                raw_id,
+                tree_bytes,
+            )
 
     def warm(self, config: Config, *, limit: int, max_payload_bytes: int) -> int:
         """Pre-parse up to ``limit`` pending census candidates outside any writer hold.
@@ -249,7 +498,29 @@ class DaemonParseStage:
                     # shortcuts the happy path.
                     continue
                 _provider, _blob_hash, _source_path, kind, payload_size = descriptors[raw_id]
+                # polylogue-xb4i: estimate the PARSED TREE size (not payload
+                # size) before ever admitting to the cache. A tree bigger
+                # than the whole tree-bytes budget is never retained at all
+                # -- it does not even occupy a payload-bytes admission slot
+                # -- so one whale raw can never pin gigabytes of resident
+                # memory regardless of how much inflight-bytes headroom it
+                # happened to fit under pre-parse. This is the fix for the
+                # 2026-07-20 earlyoom kills: the inflight clamp bounded
+                # PAYLOAD bytes in flight, but the cache retained whatever
+                # trees resulted from that payload with no size check at all.
+                tree_bytes = estimate_parsed_tree_bytes(sessions)
+                if tree_bytes > self._max_cached_tree_bytes:
+                    logger.warning(
+                        "parse-stage prefetch: raw_id=%s estimated parsed-tree bytes %d exceed the "
+                        "whole cache budget %d bytes; never retained -- the writer-held pass reparses "
+                        "it normally, identical to any other prefetch miss",
+                        raw_id,
+                        tree_bytes,
+                        self._max_cached_tree_bytes,
+                    )
+                    continue
                 if self.cache.try_admit(raw_id, sessions, payload_bytes=payload_size, revision_kind=kind):
+                    self._register_cached_tree_bytes(raw_id, tree_bytes)
                     warmed += 1
         except TimeoutError:
             # Bounds the CONVEYOR LOOP's wait, not the worker itself -- a
@@ -274,7 +545,9 @@ class DaemonParseStage:
 
 __all__ = [
     "DaemonParseStage",
+    "daemon_parse_stage_max_cached_tree_bytes",
     "daemon_parse_stage_max_inflight_bytes",
     "daemon_parse_stage_warm_timeout_seconds",
     "daemon_parse_stage_worker_count",
+    "estimate_parsed_tree_bytes",
 ]

--- a/tests/unit/daemon/test_parse_prefetch.py
+++ b/tests/unit/daemon/test_parse_prefetch.py
@@ -15,15 +15,18 @@ Production dependencies exercised here:
 from __future__ import annotations
 
 import sqlite3
+import sys
 import threading
 import time
 from pathlib import Path
 
 import pytest
 
+from polylogue.archive.message.roles import Role
 from polylogue.config import Config
-from polylogue.core.enums import Provider
-from polylogue.daemon.parse_prefetch import DaemonParseStage
+from polylogue.core.enums import BlockType, Provider
+from polylogue.daemon.parse_prefetch import DaemonParseStage, estimate_parsed_tree_bytes
+from polylogue.sources.parsers.base_models import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 
@@ -255,3 +258,239 @@ def test_max_inflight_bytes_default_is_adaptive_and_clamped(monkeypatch: pytest.
     # Explicit env override always wins.
     monkeypatch.setenv("POLYLOGUE_DAEMON_PARSE_STAGE_MAX_INFLIGHT_BYTES", "123456789")
     assert pp.daemon_parse_stage_max_inflight_bytes() == 123456789
+
+
+# --- polylogue-xb4i: parsed-tree-byte accounting (estimator + eviction) ----
+
+
+def _session_with_text(native_id: str, text_len: int) -> ParsedSession:
+    """One session, one message, one block, all carrying ``text_len`` chars.
+
+    Deliberately constructed directly (not run through a provider parser) so
+    tree size is exactly controlled for size-comparison assertions below.
+    """
+    return ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id=native_id,
+        messages=[
+            ParsedMessage(
+                provider_message_id=f"{native_id}-m0",
+                role=Role.USER,
+                text="x" * text_len,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="x" * text_len)],
+            )
+        ],
+    )
+
+
+def _deep_size_bytes(obj: object, seen: set[int] | None = None) -> int:
+    """Manual recursive object-graph size walk -- a from-scratch equivalent
+    of ``pympler.asizeof.asizeof`` (not a repo dependency) used ONLY here,
+    to calibrate/verify ``estimate_parsed_tree_bytes``'s cheap structural
+    formula against ground truth. Never used on the production hot path --
+    that is exactly the cost ``estimate_parsed_tree_bytes`` exists to avoid."""
+    if seen is None:
+        seen = set()
+    obj_id = id(obj)
+    if obj_id in seen:
+        return 0
+    seen.add(obj_id)
+    size = sys.getsizeof(obj)
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            size += _deep_size_bytes(key, seen)
+            size += _deep_size_bytes(value, seen)
+    elif isinstance(obj, (list, tuple, set, frozenset)):
+        for item in obj:
+            size += _deep_size_bytes(item, seen)
+    elif hasattr(obj, "__dict__"):
+        size += _deep_size_bytes(obj.__dict__, seen)
+    return size
+
+
+def test_estimate_parsed_tree_bytes_is_monotone_in_content_size() -> None:
+    """Production dependency: ``estimate_parsed_tree_bytes`` itself. A
+    mutation that stopped reading ``message.text``/``block.text`` lengths
+    (e.g. hardcoding a fixed per-session constant) would make these three
+    estimates equal instead of strictly increasing, and this would fail."""
+    small = estimate_parsed_tree_bytes([_session_with_text("s", 10)])
+    medium = estimate_parsed_tree_bytes([_session_with_text("s", 1_000)])
+    large = estimate_parsed_tree_bytes([_session_with_text("s", 100_000)])
+
+    assert small < medium < large
+
+    # Also monotone in session COUNT at fixed per-session size.
+    one_session = estimate_parsed_tree_bytes([_session_with_text("s", 500)])
+    two_sessions = estimate_parsed_tree_bytes([_session_with_text("a", 500), _session_with_text("b", 500)])
+    assert two_sessions > one_session
+
+
+def test_estimate_parsed_tree_bytes_within_3x_of_deep_measurement() -> None:
+    """Production dependency: the calibrated constants
+    ``_ESTIMATOR_BYTES_PER_CHAR``/``_ESTIMATOR_OBJECT_OVERHEAD_BYTES`` inside
+    ``estimate_parsed_tree_bytes``. If either constant were set to a wildly
+    wrong value (e.g. 0, or 1000x too small), the estimate would fall
+    outside a 3x band of ``_deep_size_bytes``'s independent ground-truth
+    measurement on the same synthetic session and this would fail -- this is
+    the test that keeps the calibration comment in parse_prefetch.py honest
+    against actual measured memory, not just internally self-consistent."""
+    session = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="calibration",
+        messages=[
+            ParsedMessage(
+                provider_message_id=f"m{i}",
+                role=Role.USER,
+                text="x" * 300,
+                blocks=[
+                    ParsedContentBlock(type=BlockType.TEXT, text="y" * 200),
+                    ParsedContentBlock(type=BlockType.TEXT, text="z" * 200),
+                ],
+            )
+            for i in range(50)
+        ],
+    )
+
+    estimate = estimate_parsed_tree_bytes([session])
+    deep = _deep_size_bytes(session)
+
+    assert deep / 3 <= estimate <= deep * 3
+
+
+def test_warm_never_retains_a_tree_exceeding_the_whole_cache_budget(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Production dependency: ``DaemonParseStage.warm_raw_ids``'s per-item
+    whale check (compares ``estimate_parsed_tree_bytes(sessions)`` against
+    ``self._max_cached_tree_bytes`` BEFORE calling ``self.cache.try_admit``).
+    Deleting that check (or its ``continue``) would let a whale raw whose
+    payload happens to fit the generous inflight-bytes budget below sail
+    into the cache regardless of its parsed-tree size -- exactly the
+    2026-07-20 earlyoom failure mode -- and every assertion here would flip."""
+    _seed_raws(tmp_path, {"whale.jsonl": _codex_payload("session-whale", "seed")})
+
+    from polylogue.sources import revision_backfill
+
+    def whale_worker(
+        raw_id: str,
+        provider_value: str,
+        blob_hash: str,
+        source_path: str,
+        is_stream: bool,
+        blob_root_str: str,
+        source_db_path_str: str,
+    ) -> object:
+        return raw_id, [_session_with_text("session-whale", 50_000)], None
+
+    monkeypatch.setattr(revision_backfill, "census_parse_worker", whale_worker)
+
+    whale_tree_bytes = estimate_parsed_tree_bytes([_session_with_text("session-whale", 50_000)])
+    tiny_budget = whale_tree_bytes // 2
+    assert tiny_budget > 0
+
+    stage = DaemonParseStage(
+        max_workers=1,
+        max_inflight_bytes=10_000_000,  # generous: payload bytes are NOT the constraint here
+        max_cached_tree_bytes=tiny_budget,
+    )
+    try:
+        warmed = stage.warm(_config(tmp_path), limit=10, max_payload_bytes=10_000_000)
+    finally:
+        stage.shutdown()
+
+    assert warmed == 0
+    assert len(stage.cache) == 0
+    assert stage.cached_tree_bytes_total == 0
+
+
+def test_cache_evicts_to_stay_within_tree_bytes_budget_under_pressure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Production dependency: ``DaemonParseStage._register_cached_tree_bytes``'s
+    eviction loop (and the ledger it maintains, ``_tree_bytes_by_raw_id`` /
+    ``_cached_tree_bytes_total``). Two equal-size raws are admitted (each
+    individually well under the whole-cache budget, so the whale check never
+    fires); together they exceed the budget. A mutation that turned the
+    eviction ``while`` loop into a no-op would leave both entries cached with
+    ``cached_tree_bytes_total`` above budget, and the assertions below would
+    fail."""
+    _seed_raws(
+        tmp_path,
+        {
+            "a.jsonl": _codex_payload("session-a", "seed-a"),
+            "b.jsonl": _codex_payload("session-b", "seed-b"),
+        },
+    )
+
+    from polylogue.sources import revision_backfill
+
+    source_path_to_native_id = {"a.jsonl": "session-a", "b.jsonl": "session-b"}
+
+    def equal_size_worker(
+        raw_id: str,
+        provider_value: str,
+        blob_hash: str,
+        source_path: str,
+        is_stream: bool,
+        blob_root_str: str,
+        source_db_path_str: str,
+    ) -> object:
+        native_id = source_path_to_native_id[source_path]
+        return raw_id, [_session_with_text(native_id, 5_000)], None
+
+    monkeypatch.setattr(revision_backfill, "census_parse_worker", equal_size_worker)
+
+    one_tree_bytes = estimate_parsed_tree_bytes([_session_with_text("session-a", 5_000)])
+    # Fits exactly one tree, not two.
+    budget = int(one_tree_bytes * 1.5)
+
+    stage = DaemonParseStage(
+        max_workers=1,
+        max_inflight_bytes=10_000_000,
+        max_cached_tree_bytes=budget,
+    )
+    try:
+        warmed = stage.warm(_config(tmp_path), limit=10, max_payload_bytes=10_000_000)
+    finally:
+        stage.shutdown()
+
+    # Both raws were individually admitted at the time they were parsed --
+    # eviction is a post-hoc budget correction, not an admission rejection.
+    assert warmed == 2
+    # But only one survives the tree-bytes budget.
+    assert len(stage.cache) == 1
+    assert stage.cached_tree_bytes_total <= budget
+    assert stage.cached_tree_bytes_total == one_tree_bytes
+
+
+def test_max_cached_tree_bytes_default_is_adaptive_and_clamped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Production dependency: ``daemon_parse_stage_max_cached_tree_bytes``.
+    Mirrors ``test_max_inflight_bytes_default_is_adaptive_and_clamped`` for
+    the SECOND (tree-bytes, not payload-bytes) budget -- distinct clamp
+    range [256 MiB, 4 GiB] and distinct RAM fraction (1/8, not 1/16). A
+    mutation that swapped in the inflight-bytes clamp/fraction, or dropped
+    the env override, would flip these assertions."""
+    from polylogue.daemon import parse_prefetch as pp
+
+    monkeypatch.delenv("POLYLOGUE_DAEMON_PARSE_STAGE_MAX_CACHED_TREE_BYTES", raising=False)
+
+    # 64 GiB machine -> hits the 4 GiB ceiling (64 GiB / 8 = 8 GiB, clamped down).
+    monkeypatch.setattr(pp, "_physical_memory_bytes", lambda: 64 * 1024**3)
+    assert pp.daemon_parse_stage_max_cached_tree_bytes() == 4 * 1024**3
+
+    # 1 GiB machine -> clamped up to the 256 MiB floor (1 GiB / 8 = 128 MiB).
+    monkeypatch.setattr(pp, "_physical_memory_bytes", lambda: 1 * 1024**3)
+    assert pp.daemon_parse_stage_max_cached_tree_bytes() == 256 * 1024**2
+
+    # 16 GiB machine -> proportional (16 GiB / 8 = 2 GiB).
+    monkeypatch.setattr(pp, "_physical_memory_bytes", lambda: 16 * 1024**3)
+    assert pp.daemon_parse_stage_max_cached_tree_bytes() == 2 * 1024**3
+
+    # Unknown physical memory -> conservative floor.
+    monkeypatch.setattr(pp, "_physical_memory_bytes", lambda: None)
+    assert pp.daemon_parse_stage_max_cached_tree_bytes() == 256 * 1024**2
+
+    # Explicit env override always wins, even over an adaptive value that
+    # would otherwise differ.
+    monkeypatch.setenv("POLYLOGUE_DAEMON_PARSE_STAGE_MAX_CACHED_TREE_BYTES", "987654321")
+    assert pp.daemon_parse_stage_max_cached_tree_bytes() == 987654321


### PR DESCRIPTION
## Summary

Bounds `DaemonParseStage`'s prefetch cache by an *estimated parsed-tree*
byte budget, in addition to the existing raw-payload byte budget, so a
whale-dense census page can no longer pin gigabytes of resident memory
in the cache regardless of the payload-bytes clamp.

## Problem

`DaemonParseStage`'s inflight admission budget and
`RawParsePrefetchCache`'s own admission gate both account raw PAYLOAD
bytes, because payload size is the only thing knowable before a raw is
parsed. But a parsed `ParsedSession` tree resident in the cache is not
the same size as the payload it came from -- Pydantic model instances,
per-block dicts, and general Python object overhead inflate a compact
JSON/JSONL payload substantially. Two earlyoom kills (19.3G and 20.2G
RSS peaks, 2026-07-20) happened on a whale-dense page precisely because
the cache retained a whole 2000-raw page of parsed trees while only raw
payload bytes were budgeted; clamping the inflight (pre-parse) budget
did nothing, since the pressure came from trees already sitting in the
cache post-parse, not from parses in flight.

## Solution

`polylogue/daemon/parse_prefetch.py`:

- `estimate_parsed_tree_bytes()` -- a cheap, single linear-pass
  structural estimator over `list[ParsedSession]`: sums text/content
  field lengths across sessions/messages/blocks/attachments/session
  events and counts model-instance nodes, then applies two constants
  (`_ESTIMATOR_BYTES_PER_CHAR=2`, `_ESTIMATOR_OBJECT_OVERHEAD_BYTES=1024`)
  calibrated against a manual deep-object-graph measurement on
  synthetic sessions (calibration data + fit in the comment above the
  constants; test reproduces the measurement independently). Deliberately
  NOT a recursive `sys.getsizeof`/pympler-style deep walk -- that runs on
  `warm()`'s hot path for every raw in a page (up to ~2000), so it has
  to stay O(payload size) with low constant factor, not O(object graph).
- `daemon_parse_stage_max_cached_tree_bytes()` -- a second adaptive
  budget (1/8 of physical RAM, clamped `[256 MiB, 4 GiB]`, override
  `POLYLOGUE_DAEMON_PARSE_STAGE_MAX_CACHED_TREE_BYTES`), mirroring the
  existing inflight-bytes budget's shape but sized for the bigger
  (resident-tree) number.
- `DaemonParseStage` tracks a side ledger (`_tree_bytes_by_raw_id`,
  `_cached_tree_bytes_total`) keyed by the same raw_ids as
  `self.cache`. `RawParsePrefetchCache` itself is not touched or
  subclassed -- it's a shared type `bulk_rebuild.py` hands directly to
  `RebuildIndexRequest.prefetch_cache`, so this stays additive rather
  than replacing it.
- A tree whose estimate exceeds the WHOLE budget is never admitted at
  all (skips `cache.try_admit` entirely, so it doesn't even consume a
  payload-bytes admission slot) -- the writer-held pass reparses it
  normally, identical to any other prefetch miss.
- Admitted trees are evicted largest-first (ties break to the oldest
  insertion, via dict iteration order) through the raw cache's own
  `pop()` once the running estimated total exceeds budget. Since
  external consumers (the writer-held pass) can also `pop()` entries
  directly, the ledger reconciles lazily against `self.cache.contains()`
  before every eviction decision.

## Verification

- `devtools test tests/unit/daemon/test_parse_prefetch.py` -> 12 passed
  (7 pre-existing + 5 new: estimator monotonicity, estimator within 3x
  of an independent deep-size measurement, whale-never-retained,
  eviction-under-pressure, and the new budget's adaptive-clamp/env-override).
- `.venv/bin/python -m mypy --strict polylogue/daemon/parse_prefetch.py
  tests/unit/daemon/test_parse_prefetch.py` -> `Success: no issues found in 1 source file` (both files)
- `devtools verify --quick` -> all 16 steps `ok`, exit 0 (includes
  `render all --check` / topology / docs-coverage, since new
  module-level functions were added to an existing file -- no new
  module, so no topology-projection regen was needed)

Ref polylogue-xb4i