### PR TITLE
perf(storage): index write-path hot stages, memoize pricing catalog hash

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -786,6 +786,15 @@ CREATE TABLE IF NOT EXISTS paste_spans (
     PRIMARY KEY(message_id, position)
 ) STRICT;
 
+-- polylogue-623q: paste_spans has no index leading with session_id (its PK
+-- is (message_id, position)), so the per-session full-replace DELETE FROM
+-- paste_spans WHERE session_id = ? in _clear_session_projection_rows was a
+-- full table SCAN (verified via EXPLAIN QUERY PLAN) that gets slower every
+-- session as the table grows archive-wide -- every other projection table
+-- cleared there already has session_id as a leading PK/index column.
+CREATE INDEX IF NOT EXISTS idx_paste_spans_session
+ON paste_spans(session_id);
+
 CREATE TABLE IF NOT EXISTS price_catalogs (
     catalog_id       TEXT PRIMARY KEY,
     catalog_hash     TEXT NOT NULL,

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -511,6 +511,22 @@ CREATE INDEX IF NOT EXISTS idx_action_pairs_outcome
 ON action_pairs(is_error, exit_code, session_id, message_id)
 WHERE is_error IS NOT NULL OR exit_code IS NOT NULL;
 
+-- polylogue-623q: tool_result_block_id is ON DELETE SET NULL against
+-- blocks(block_id) but had no supporting index. SQLite must find every
+-- action_pairs row whose tool_result_block_id equals each block being
+-- deleted; without an index that is a full action_pairs table SCAN per
+-- deleted block row -- for a whale session's full-replace block DELETE
+-- (thousands of blocks) against an archive-wide action_pairs table, that is
+-- effectively O(deleted_blocks x action_pairs_row_count). Verified with a
+-- synthetic whale session (2,000 blocks) against a 32K-row action_pairs
+-- table: the single ``DELETE FROM blocks WHERE session_id = ?`` dropped
+-- from 6.87s to 0.034s (~200x) after adding this index. Partial (excludes
+-- NULL) since unpaired tool_use rows never populate this column and NULL
+-- never matches an equality FK lookup.
+CREATE INDEX IF NOT EXISTS idx_action_pairs_tool_result_block
+ON action_pairs(tool_result_block_id)
+WHERE tool_result_block_id IS NOT NULL;
+
 -- xnkf: a plain equality join on tool_id fans out when a provider re-emits
 -- the same tool_id on distinct messages (verified live: identical toolu_
 -- ids as 2 tool_use + 2 tool_result blocks at different positions, NOT

--- a/polylogue/storage/sqlite/archive_tiers/pricing_seed.py
+++ b/polylogue/storage/sqlite/archive_tiers/pricing_seed.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import hashlib
 import sqlite3
 import time
+from functools import lru_cache
 
 
 def _catalog_id() -> str:
@@ -31,8 +32,20 @@ def _catalog_id() -> str:
     return f"{CATALOG_PROVENANCE}-{CATALOG_EFFECTIVE_DATE}"
 
 
+@lru_cache(maxsize=1)
 def _catalog_hash() -> str:
-    """Stable identity of the current PRICING dict."""
+    """Stable identity of the current PRICING dict.
+
+    ``PRICING`` is a module-level dict built once at import time
+    (``polylogue.archive.semantic.pricing``) and never mutated afterward
+    (verified: no ``PRICING[...] = `` / ``.update`` / ``.pop`` write sites
+    anywhere in the codebase). Re-walking and re-hashing its ~3.5K entries on
+    every session write is pure redundant CPU work -- memoized here for the
+    lifetime of the process. ``lru_cache(maxsize=1)`` is safe across tests
+    that monkeypatch ``PRICING`` between processes/interpreters (each fresh
+    interpreter gets a fresh empty cache); within one process the dict is
+    genuinely constant, so a stale cache is not observable.
+    """
     from polylogue.archive.semantic.pricing import PRICING
 
     parts: list[str] = []
@@ -45,6 +58,7 @@ def _catalog_hash() -> str:
     return hashlib.sha256("\n".join(parts).encode()).hexdigest()
 
 
+@lru_cache(maxsize=1)
 def _effective_at_ms() -> int | None:
     """Parse CATALOG_EFFECTIVE_DATE to epoch-ms, return None on failure."""
     from polylogue.archive.semantic.pricing import CATALOG_EFFECTIVE_DATE

--- a/polylogue/storage/sqlite/runtime_indexes.py
+++ b/polylogue/storage/sqlite/runtime_indexes.py
@@ -44,6 +44,11 @@ _RUNTIME_INDEX_SQL: tuple[str, ...] = (
     CREATE INDEX IF NOT EXISTS idx_paste_spans_session
     ON paste_spans(session_id)
     """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_action_pairs_tool_result_block
+    ON action_pairs(tool_result_block_id)
+    WHERE tool_result_block_id IS NOT NULL
+    """,
 )
 
 

--- a/polylogue/storage/sqlite/runtime_indexes.py
+++ b/polylogue/storage/sqlite/runtime_indexes.py
@@ -40,6 +40,10 @@ _RUNTIME_INDEX_SQL: tuple[str, ...] = (
     ON messages(session_id, is_active_leaf)
     WHERE is_active_leaf = 1
     """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_paste_spans_session
+    ON paste_spans(session_id)
+    """,
 )
 
 

--- a/tests/unit/storage/test_pricing_chain_roundtrip.py
+++ b/tests/unit/storage/test_pricing_chain_roundtrip.py
@@ -111,7 +111,7 @@ class TestPriceCatalogSeed:
         conn.close()
 
     def test_seed_versions_changed_pricing_and_writer_uses_new_catalog(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest
     ) -> None:
         """A catalog correction preserves old evidence and prices new usage by hash."""
         conn = _make_archive(tmp_path)
@@ -123,6 +123,16 @@ class TestPriceCatalogSeed:
             model_name,
             replace(original_pricing, input_usd_per_1m=original_pricing.input_usd_per_1m + 1.0),
         )
+        # _catalog_hash() is process-lifetime memoized (polylogue-623q: PRICING
+        # is never mutated in production, so re-walking+re-hashing its ~3.5K
+        # entries on every session write was pure redundant CPU). This test is
+        # the one place that legitimately mutates PRICING mid-process via
+        # monkeypatch, so it must invalidate the memo around the mutation --
+        # both so this write observes the revised dict, and so teardown
+        # (monkeypatch reverting PRICING) doesn't leave a stale post-mutation
+        # hash cached for whichever test runs next in this process.
+        _catalog_hash.cache_clear()
+        request.addfinalizer(_catalog_hash.cache_clear)
 
         with conn:
             write_parsed_session_to_archive(


### PR DESCRIPTION
## Summary

Mechanical (no end-state row changes), zero-migration write-path throughput fixes for the archive `index.db` full-replace/rebuild path, driven by measured per-page stage timings from live v42 rebuild walks. Three fixes:

1. `idx_paste_spans_session` — the one projection table `_clear_session_projection_rows` cleared without an indexed path.
2. `functools.lru_cache` on the pricing-catalog identity hash — recomputed a SHA-256 over the ~3.5K-entry in-memory `PRICING` dict on every session write.
3. `idx_action_pairs_tool_result_block` — the dominant fix, addressing a coordinator-flagged pathological whale-session regression in `clear_projection_rows`.

## Problem

Measured per-page stage timings from a live v42 rebuild (2,000-raw page): `membership_replay.index.full_replace=31.8s`, `.full_replace.clear_projection_rows=11.1s`, `.index.model_usage_seed=8.5s`, `.full_replace.messages=7.9s`, `.full_replace.blocks=6.6s`, `.full_replace.delete_messages=4.6s`.

A follow-up live walk over a whale-dense page (500 raws) showed `clear_projection_rows` scaling pathologically with whale-session size, not just raw count: `92.7s` for 500 whale raws vs `11.1s` for 2,000 normal raws.

## Solution

**`paste_spans` index** — `_clear_session_projection_rows` deletes 10 projection tables by `session_id` before a full-session replace. `EXPLAIN QUERY PLAN` showed 9 of them hit an index (mostly their PK); `paste_spans` (PK is `(message_id, position)`, no `session_id` index) did a full table `SCAN`. Added `idx_paste_spans_session` to canonical DDL (`archive_tiers/index.py`) and to `storage/sqlite/runtime_indexes.py`'s `ensure_runtime_indexes_sync`/`async` (existing archives pick it up on next connect — no rebuild or `INDEX_SCHEMA_VERSION` bump needed, same mechanism already used for `idx_messages_active_leaf` etc).

**Pricing catalog hash memoization** — `model_usage_seed` calls `seed_price_catalog()` per session, which recomputed `_catalog_hash()` (a SHA-256 over the ~3.5K-entry in-memory `PRICING` dict) every time. `PRICING` is built once at module import and never mutated in production (grepped for write sites). Memoized `_catalog_hash()`/`_effective_at_ms()` with `functools.lru_cache(maxsize=1)`; the one test that deliberately mutates `PRICING` mid-process (`test_pricing_chain_roundtrip.py`) now clears the memo around its `monkeypatch.setitem` call (and via `request.addfinalizer`, so it doesn't leak a stale hash into later tests in the same worker process).

**`action_pairs.tool_result_block_id` index (primary fix)** — this column is `ON DELETE SET NULL` against `blocks(block_id)` but had no supporting index. Every deleted block row requires SQLite to find matching `action_pairs` rows to null out; without an index that's a full `action_pairs` table `SCAN` **per deleted block row**. For a whale session's full-replace block `DELETE` (thousands of blocks) against an archive-wide `action_pairs` table, that's `O(deleted_blocks × action_pairs_row_count)`, not `O(deleted_blocks)` — exactly the pathological whale-session scaling the coordinator flagged. `EXPLAIN QUERY PLAN` on the parent `DELETE FROM blocks` statement doesn't surface this cost (it's hidden inside the FK `SET NULL` action), so this required end-to-end profiling via `write_parsed_session_to_archive`'s own `stage_timings_s` to isolate. Added `idx_action_pairs_tool_result_block` (partial, excludes `NULL`) to both `index.py` and `runtime_indexes.py`.

## Rejected candidates (evaluated, not applied)

- **executemany for messages/blocks/projection inserts**: already `executemany` in `_write_messages`/`_write_blocks`. The `blocks_action_pairs_*` triggers that would otherwise refresh `action_pairs` per-row are already guarded by `derived_refresh_guard('session-write')` during a session write.
- **`delete_messages`**: already hits `idx_messages_session_material_origin`; every `messages(message_id)`-FK child table with a CASCADE/SET NULL action already has a supporting index (verified via `PRAGMA foreign_key_list` + `EXPLAIN QUERY PLAN` on all 9 referencing tables). No scan found.
- **`session_model_usage` skip-unchanged reseed**: skipping reseeds when the model set is unchanged needs a same-session-token-change signal beyond the model set (aggregated tokens can change without the model set changing under `merge_append`); the dominant cost there (catalog hash recompute) is already fixed with zero correctness risk, so this was left as a follow-up rather than risking a subtly wrong skip condition.

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_write.py tests/unit/storage/test_archive_tiers_ddl.py tests/unit/storage/test_revision_replay.py tests/unit/storage/test_pricing_chain_roundtrip.py tests/unit/storage/test_delegation_facts_bulk_rebuild.py tests/unit/storage/test_planner_statistics_seed.py tests/unit/storage/test_schema_policy_contracts.py tests/unit/storage/test_bulk_build_lifecycle.py` → **159 passed**
  (`tests/unit/storage/test_crud.py`, named in the original task brief, no longer exists under that path in this checkout — substituted the write/ddl/revision-replay/action_pairs-consuming equivalents that cover the touched surface)
- `mypy --strict` on all touched files → success
- `devtools verify --quick` → 16/16 steps ok (ran twice, once per commit)

### Benchmark receipts (ad hoc scripts, run manually — ``.agent/scratch/`` is gitignored, not committed)

**`paste_spans` DELETE**, synthetic 100K-row table, 2,000 session deletes:
```
NO index:   10.323s
WITH index:  0.013s   (~800x)
```

**Pricing catalog hash**, 2,000x `seed_price_catalog()` calls:
```
uncached _catalog_hash():  7.100s  (2000x _catalog_hash() alone = 6.85s)
cached   _catalog_hash():  0.247s  (~97% reduction)
```

**`action_pairs.tool_result_block_id`** — whale session (3,000 tool_use/tool_result pairs = 6,000 blocks) full-replace rewrite against a realistic archive-wide `action_pairs` population (40,000 rows from other sessions), through the real `write_parsed_session_to_archive` path, `stage_timings_s` breakdown:
```
BEFORE (no index):  full-replace total 31.4s   clear_projection_rows=30.6s
AFTER  (indexed):   full-replace total  0.86s  clear_projection_rows=0.069s
                     (~445x on the stage, ~36x overall)
```
(Before/after numbers cross-checked against the *actual unfixed main checkout* via explicit `sys.path` selection, not just a stashed diff, after discovering and correcting a `python3 <script>.py` invocation quirk where `sys.path[0]` resolves to the script's own directory rather than cwd, silently falling through to the main checkout's editable-install `polylogue` — this worktree's `bench-whale-full-replace.py` invoked directly was accidentally measuring the *unfixed* code the first several times.)

Other whale-scale stages in the same benchmark come out proportional to session size and already indexed: `blocks=0.40s`, `messages=0.21s`, `delete_messages=0.05s` for 6,000 blocks / 3,001 messages — no further scan found on any FK path off `blocks(block_id)` or `messages(message_id)`.

Ref polylogue-623q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Added database indexes to speed up session cleanup and maintenance operations.
  * Reduced repeated pricing-catalog calculations for faster catalog lookups.
* **Reliability**
  * Improved test isolation when pricing data is modified during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->