### PR TITLE
feat(devtools): monotonic, receipted Beads JSONL sync engine

### DIFF
--- a/devtools/beads_sync.py
+++ b/devtools/beads_sync.py
@@ -1,0 +1,461 @@
+"""Monotonic, receipted synchronization for `.beads/issues.jsonl` (polylogue-gxjh.1).
+
+Background
+----------
+
+The 2026-07-15 planning-surface incident (see polylogue-gxjh, polylogue-gxjh.1
+notes) had two distinct failure modes, both invisible to "does the file parse
+and does the lint pass":
+
+1. A staged `.beads/issues.jsonl` contained literal `<<<<<<<`/`=======`/
+   `>>>>>>>` conflict markers while `git status` reported a plain
+   modification, not an unmerged index entry. Whole-file JSON validation and
+   the backlog-hygiene lint both silently pass on a file that happens to have
+   valid-looking lines around the markers.
+2. The "fix" -- a plain re-export/overwrite -- replaced the file with a
+   syntactically valid 883-row snapshot that nonetheless *reverted* nine
+   independently-edited Beads to older versions, because whole-file
+   replacement carries no per-row comparison: a stale snapshot with valid
+   JSON always "wins" against newer live state if nothing merges by
+   revision.
+
+This module is the durable fix: it never trusts "the file parses" or "the
+command exited 0" as proof of synchronization. Every merge is per-row,
+compares `updated_at` (the only revision proxy present in `bd export`
+output; there is no separate numeric revision field), and produces a
+machine-readable `SyncReceipt` that enumerates every id's outcome plus both
+revisions where relevant. Downgrades (incoming row strictly older than the
+row it would replace) are refused by default; the only way to apply one is
+an explicit recovery override that must carry an actor and a reason, and
+every downgraded row still appears in the receipt.
+
+This module deliberately does not talk to the live `bd`/Dolt process for its
+core merge -- `bd export`/`bd import` are the actual live-state boundary
+(see `devtools/bd_reimport_guard.py`, which already wraps those for the
+checkout/merge-hook window). `beads_sync` operates on JSONL files: the
+committed `.beads/issues.jsonl`, a candidate recovery file, or a fresh `bd
+export` snapshot the caller took immediately before calling in. Consumers
+(the `bd_reimport_guard` hook wrapper, an operator doing conflict recovery,
+or the repo policy layer at polylogue-8jg9.1) call `synchronize_files` /
+`merge_issue_sets` and act on the returned `SyncReceipt` rather than
+re-implementing comparison logic.
+
+Outcome vocabulary (AC #1)
+---------------------------
+
+For every id in the union of base ∪ incoming:
+
+  created            -- id only in incoming; adopted.
+  retained           -- id only in base; kept (incoming does not carry it).
+  equal              -- same `updated_at` and same content; no-op.
+  updated            -- incoming has a strictly newer `updated_at`; adopted.
+  skipped_downgrade  -- incoming has a strictly older `updated_at`; refused
+                        (ordinary sync). Reported with both revisions.
+  conflicted         -- same `updated_at` but different content; refused
+                        (ordinary sync cannot silently pick a winner).
+  downgraded         -- only possible with `allow_recovery=True`: a
+                        skipped_downgrade or conflicted row whose incoming
+                        version was explicitly adopted anyway. Always
+                        recorded with both revisions plus actor/reason.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+IssueRow = dict[str, Any]
+
+_CONFLICT_MARKERS: tuple[str, ...] = ("<<<<<<<", "=======", ">>>>>>>")
+
+RowOutcomeKind = Literal[
+    "created",
+    "retained",
+    "equal",
+    "updated",
+    "skipped_downgrade",
+    "conflicted",
+    "downgraded",
+]
+
+
+class PlanningSurfaceCorruptError(RuntimeError):
+    """Raised when a JSONL planning-surface file cannot be trusted.
+
+    Covers: literal merge-conflict markers, JSON parse failures, and
+    duplicate ids within a single file. Callers must treat this as a hard
+    failure -- never fall back to "it parsed, so it's fine".
+    """
+
+
+class RecoveryRequiredError(RuntimeError):
+    """Raised when a merge would downgrade a row without recovery override."""
+
+
+@dataclass(frozen=True, slots=True)
+class RowOutcome:
+    id: str
+    outcome: RowOutcomeKind
+    base_updated_at: str | None
+    incoming_updated_at: str | None
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "outcome": self.outcome,
+            "base_updated_at": self.base_updated_at,
+            "incoming_updated_at": self.incoming_updated_at,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SyncReceipt:
+    """Machine-readable, per-row record of a single synchronization merge."""
+
+    fingerprint: Mapping[str, str]
+    recovery: bool
+    actor: str | None
+    reason: str | None
+    outcomes: tuple[RowOutcome, ...] = field(default_factory=tuple)
+
+    def by_outcome(self, kind: RowOutcomeKind) -> tuple[RowOutcome, ...]:
+        return tuple(o for o in self.outcomes if o.outcome == kind)
+
+    def counts(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for o in self.outcomes:
+            counts[o.outcome] = counts.get(o.outcome, 0) + 1
+        return counts
+
+    def has_downgrades(self) -> bool:
+        return any(o.outcome == "downgraded" for o in self.outcomes)
+
+    def has_refusals(self) -> bool:
+        """True if the merge left any row unresolved (would need recovery)."""
+        return any(o.outcome in ("skipped_downgrade", "conflicted") for o in self.outcomes)
+
+    def covers(self, expected_ids: Iterable[str]) -> bool:
+        """True if every id in `expected_ids` has a recorded outcome.
+
+        A caller that knows the expected union up front (e.g. len(base) +
+        new incoming ids) uses this to detect a non-progress receipt --
+        one where something short-circuited before comparing every row --
+        rather than trusting a non-empty `outcomes` tuple alone.
+        """
+        seen = {o.id for o in self.outcomes}
+        return all(issue_id in seen for issue_id in expected_ids)
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "fingerprint": dict(self.fingerprint),
+            "recovery": self.recovery,
+            "actor": self.actor,
+            "reason": self.reason,
+            "counts": self.counts(),
+            "outcomes": [o.to_json() for o in self.outcomes],
+        }
+
+
+def _strip_generated(row: IssueRow) -> dict[str, Any]:
+    """Drop the `updated_at` field so content-equality ignores the revision axis."""
+    return {k: v for k, v in row.items() if k != "updated_at"}
+
+
+def load_jsonl_rows(path: Path) -> dict[str, IssueRow]:
+    """Parse a `.beads/issues.jsonl`-shaped file into {id: row}.
+
+    Raises `PlanningSurfaceCorruptError` on:
+      - literal conflict markers anywhere in the file (even if surrounding
+        lines happen to parse -- markers alone make the file untrustworthy),
+      - any line that fails to parse as JSON,
+      - a row missing an `id`,
+      - duplicate ids within the file.
+    """
+    text = path.read_text()
+    for marker in _CONFLICT_MARKERS:
+        if marker in text:
+            raise PlanningSurfaceCorruptError(
+                f"{path}: contains literal conflict marker {marker!r} -- refusing to trust this file"
+            )
+
+    rows: dict[str, IssueRow] = {}
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            row = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise PlanningSurfaceCorruptError(f"{path}:{lineno}: invalid JSON ({exc})") from exc
+        if not isinstance(row, dict) or "id" not in row:
+            raise PlanningSurfaceCorruptError(f"{path}:{lineno}: row missing required 'id' field")
+        issue_id = row["id"]
+        if issue_id in rows:
+            raise PlanningSurfaceCorruptError(f"{path}: duplicate id {issue_id!r} (line {lineno})")
+        rows[issue_id] = row
+    return rows
+
+
+def merge_issue_sets(
+    base: Mapping[str, IssueRow],
+    incoming: Mapping[str, IssueRow],
+    *,
+    fingerprint: Mapping[str, str] | None = None,
+    allow_recovery: bool = False,
+    actor: str | None = None,
+    reason: str | None = None,
+) -> tuple[dict[str, IssueRow], SyncReceipt]:
+    """Merge `incoming` into `base` per-row, never silently downgrading.
+
+    Returns (merged_rows, receipt). Every id present in base or incoming
+    appears exactly once in the receipt's outcomes.
+
+    `allow_recovery=True` is the explicit operator-authorized recovery path
+    (AC #2): it still refuses to run without both `actor` and `reason`, and
+    every row it downgrades is recorded in the receipt with both revisions.
+    Ordinary (non-recovery) calls never adopt an incoming row whose
+    `updated_at` is not strictly newer than base's -- they report the
+    conflict and keep base's row.
+    """
+    if allow_recovery and (not actor or not reason):
+        raise RecoveryRequiredError(
+            "recovery override requires both actor and reason -- refusing to authorize downgrades anonymously"
+        )
+
+    merged: dict[str, IssueRow] = dict(base)
+    outcomes: list[RowOutcome] = []
+    all_ids = sorted(set(base) | set(incoming))
+
+    for issue_id in all_ids:
+        base_row = base.get(issue_id)
+        incoming_row = incoming.get(issue_id)
+
+        if base_row is None and incoming_row is not None:
+            merged[issue_id] = incoming_row
+            outcomes.append(RowOutcome(issue_id, "created", None, incoming_row.get("updated_at")))
+            continue
+
+        if incoming_row is None:
+            # Only in base: nothing to compare, kept untouched.
+            outcomes.append(RowOutcome(issue_id, "retained", base_row.get("updated_at") if base_row else None, None))
+            continue
+
+        assert base_row is not None  # both present from here
+        base_ts = base_row.get("updated_at") or ""
+        incoming_ts = incoming_row.get("updated_at") or ""
+
+        if incoming_ts > base_ts:
+            merged[issue_id] = incoming_row
+            outcomes.append(RowOutcome(issue_id, "updated", base_ts, incoming_ts))
+            continue
+
+        if incoming_ts == base_ts:
+            if _strip_generated(incoming_row) == _strip_generated(base_row):
+                outcomes.append(RowOutcome(issue_id, "equal", base_ts, incoming_ts))
+                continue
+            # Same revision marker, different content: an incomparable
+            # conflict -- ordinary sync cannot pick a winner.
+            if allow_recovery:
+                merged[issue_id] = incoming_row
+                outcomes.append(RowOutcome(issue_id, "downgraded", base_ts, incoming_ts))
+            else:
+                outcomes.append(RowOutcome(issue_id, "conflicted", base_ts, incoming_ts))
+            continue
+
+        # incoming_ts < base_ts: a strict downgrade.
+        if allow_recovery:
+            merged[issue_id] = incoming_row
+            outcomes.append(RowOutcome(issue_id, "downgraded", base_ts, incoming_ts))
+        else:
+            outcomes.append(RowOutcome(issue_id, "skipped_downgrade", base_ts, incoming_ts))
+
+    receipt = SyncReceipt(
+        fingerprint=dict(fingerprint or {}),
+        recovery=allow_recovery,
+        actor=actor,
+        reason=reason,
+        outcomes=tuple(outcomes),
+    )
+    return merged, receipt
+
+
+def atomic_write_jsonl(path: Path, rows: Iterable[IssueRow]) -> None:
+    """Write `rows` to `path` as temp+fsync+atomic-rename.
+
+    Validates before staging: every row round-trips through JSON, ids are
+    unique, and no line contains a literal conflict marker. Refuses to
+    write into a `path` that currently contains conflict markers unless the
+    caller has already deleted/replaced it (this function never merges --
+    callers must run `merge_issue_sets` first and pass the merged result).
+    """
+    if path.exists():
+        existing_text = path.read_text()
+        for marker in _CONFLICT_MARKERS:
+            if marker in existing_text:
+                raise PlanningSurfaceCorruptError(
+                    f"{path}: refusing to overwrite a file that currently contains "
+                    f"conflict marker {marker!r} without an explicit merge/recovery plan"
+                )
+
+    rows_list = list(rows)
+    seen_ids: set[str] = set()
+    lines: list[str] = []
+    for row in rows_list:
+        issue_id = row.get("id")
+        if not issue_id:
+            raise PlanningSurfaceCorruptError("refusing to stage a row missing 'id'")
+        if issue_id in seen_ids:
+            raise PlanningSurfaceCorruptError(f"refusing to stage duplicate id {issue_id!r}")
+        seen_ids.add(issue_id)
+        line = json.dumps(row, sort_keys=True)
+        for marker in _CONFLICT_MARKERS:
+            if marker in line:
+                raise PlanningSurfaceCorruptError(
+                    f"refusing to stage id {issue_id!r}: serialized row contains conflict marker {marker!r}"
+                )
+        lines.append(line)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=".beads-sync-", suffix=".jsonl.tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as tmp_file:
+            for line in lines:
+                tmp_file.write(line + "\n")
+            tmp_file.flush()
+            os.fsync(tmp_file.fileno())
+        # Validate the staged file parses back cleanly before it becomes live.
+        staged = load_jsonl_rows(Path(tmp_name))
+        if len(staged) != len(rows_list):
+            raise PlanningSurfaceCorruptError(
+                f"staged file row count {len(staged)} does not match expected {len(rows_list)}"
+            )
+        os.replace(tmp_name, path)
+    except BaseException:
+        Path(tmp_name).unlink(missing_ok=True)
+        raise
+
+
+def synchronize_files(
+    base_path: Path,
+    incoming_path: Path,
+    output_path: Path,
+    *,
+    fingerprint: Mapping[str, str] | None = None,
+    allow_recovery: bool = False,
+    actor: str | None = None,
+    reason: str | None = None,
+) -> SyncReceipt:
+    """High-level entrypoint: load base+incoming, merge, atomically write output.
+
+    Refuses (raises `PlanningSurfaceCorruptError`) if either input file
+    contains conflict markers or fails to parse -- this is the guard against
+    the 2026-07-15 "staged conflict markers, syntactically valid neighbor
+    lines" failure mode. Refuses (raises `RecoveryRequiredError`) if the
+    merge would need to downgrade any row and `allow_recovery` was not
+    explicitly set with actor+reason -- callers can inspect the raised
+    receipt-free error and re-invoke with recovery once a human has signed
+    off, or accept the returned receipt's `skipped_downgrade`/`conflicted`
+    rows as the authoritative "what would have been lost" record.
+    """
+    base_rows = load_jsonl_rows(base_path) if base_path.exists() else {}
+    incoming_rows = load_jsonl_rows(incoming_path)
+
+    merged, receipt = merge_issue_sets(
+        base_rows,
+        incoming_rows,
+        fingerprint=fingerprint,
+        allow_recovery=allow_recovery,
+        actor=actor,
+        reason=reason,
+    )
+
+    # Ordinary sync still writes the safely-mergeable union (base rows,
+    # created rows, updated rows, equal rows) -- unrelated rows are not held
+    # hostage by one incomparable id -- but the caller must consult the
+    # receipt for what was refused (`has_refusals()`) rather than assume
+    # completeness from a clean exit alone.
+    atomic_write_jsonl(output_path, merged.values())
+    return receipt
+
+
+def bootstrap_union(*sources: Mapping[str, IssueRow]) -> dict[str, IssueRow]:
+    """Fold N sources into one monotonic union (AC #3: concurrent bootstraps + a writer).
+
+    Order-independent: for any permutation of `sources`, the result is the
+    same union with, for every id, the row carrying the lexicographically
+    greatest `updated_at` (ties broken by content equality; a true
+    same-timestamp content conflict raises `PlanningSurfaceCorruptError`
+    since bootstrap has no operator present to authorize a downgrade
+    choice).
+    """
+    merged: dict[str, IssueRow] = {}
+    for source in sources:
+        merged, receipt = merge_issue_sets(merged, source)
+        for outcome in receipt.by_outcome("conflicted"):
+            raise PlanningSurfaceCorruptError(
+                f"bootstrap union hit an incomparable conflict on {outcome.id} "
+                "(same updated_at, different content) -- concurrent bootstrap has no "
+                "operator present to authorize a recovery choice"
+            )
+    return merged
+
+
+def _cli_main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="devtools beads-sync", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    merge_p = sub.add_parser("merge", help="Merge incoming JSONL into base, write output + receipt.")
+    merge_p.add_argument("--base", type=Path, required=True)
+    merge_p.add_argument("--incoming", type=Path, required=True)
+    merge_p.add_argument("--output", type=Path, required=True)
+    merge_p.add_argument("--receipt", type=Path, default=None)
+    merge_p.add_argument("--recover", action="store_true")
+    merge_p.add_argument("--actor", type=str, default=None)
+    merge_p.add_argument("--reason", type=str, default=None)
+    merge_p.add_argument("--json", action="store_true")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "merge":
+        try:
+            receipt = synchronize_files(
+                args.base,
+                args.incoming,
+                args.output,
+                allow_recovery=args.recover,
+                actor=args.actor,
+                reason=args.reason,
+            )
+        except (PlanningSurfaceCorruptError, RecoveryRequiredError) as exc:
+            print(f"beads-sync: {exc}", file=__import__("sys").stderr)
+            return 1
+
+        receipt_json = json.dumps(receipt.to_json(), indent=2, sort_keys=True)
+        if args.receipt:
+            args.receipt.write_text(receipt_json + "\n")
+        if args.json:
+            print(receipt_json)
+        else:
+            print(f"beads-sync: merged -> {args.output}")
+            for kind, count in sorted(receipt.counts().items()):
+                print(f"  {kind}: {count}")
+        return 1 if (not args.recover and receipt.has_refusals()) else 0
+
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    return _cli_main(argv)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -594,6 +594,29 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "workspace beads-sync",
+        "workspace",
+        "Monotonic, receipted per-row merge of a candidate .beads/issues.jsonl into a base file.",
+        "devtools.beads_sync",
+        entrypoint="main",
+        use_when=(
+            "Import, conflict-recovery, or export of .beads/issues.jsonl (polylogue-gxjh.1). "
+            "Refuses to trust whole-file JSON validity: compares every id's `updated_at`, "
+            "refuses downgrades/incomparable conflicts unless --recover is given with "
+            "--actor/--reason, and writes the merged output via temp+fsync+atomic-rename after "
+            "validating parse/unique-ids. Refuses to touch a base or incoming file that contains "
+            "literal conflict markers. Emits a machine-readable receipt (per-id outcome + both "
+            "revisions) for policy/ops consumers instead of relying on exit-status alone."
+        ),
+        examples=(
+            "devtools workspace beads-sync merge --base .beads/issues.jsonl "
+            "--incoming /tmp/candidate.jsonl --output .beads/issues.jsonl --json",
+            "devtools workspace beads-sync merge --base .beads/issues.jsonl "
+            "--incoming /tmp/recovery.jsonl --output .beads/issues.jsonl "
+            "--recover --actor sinity --reason 'restore pre-clobber state'",
+        ),
+    ),
+    CommandSpec(
         "workspace delivery-gate-status",
         "workspace",
         "Per-release-gate progress board over .beads/issues.jsonl (delivery:<release> / lane:<lane> overlay).",

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -210,6 +210,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools workspace basic-usage-demo-check` | Re-run the basic-usage demo suite's commands and assert output shape. |
 | `devtools workspace bead-batch-show` | Batch-show beads: id, status, prio, title, desc head, deps, notes tail. |
 | `devtools workspace bead-reimport-guard` | Timestamp-aware guard restoring beads clobbered by bd's post-checkout/post-merge reimport. |
+| `devtools workspace beads-sync` | Monotonic, receipted per-row merge of a candidate .beads/issues.jsonl into a base file. |
 | `devtools workspace claim-vs-evidence` | Build a structured failure follow-up claim-vs-evidence demo. |
 | `devtools workspace cli-surface-audit` | Capture a current-curated CLI surface audit demo. |
 | `devtools workspace degraded-archive-proof` | Build a degraded archive self-healing proof artifact. |

--- a/tests/unit/devtools/test_beads_sync.py
+++ b/tests/unit/devtools/test_beads_sync.py
@@ -1,0 +1,421 @@
+"""Tests for the monotonic, receipted Beads JSONL sync engine (polylogue-gxjh.1).
+
+Anti-vacuity note: every test drives the production entrypoints
+(`merge_issue_sets`, `synchronize_files`, `atomic_write_jsonl`,
+`load_jsonl_rows`, `bootstrap_union`) in `devtools/beads_sync.py`, not a
+test-local reimplementation. Deleting the strict-inequality guard in
+`merge_issue_sets` (the `incoming_ts > base_ts` / `<` branches), removing the
+`allow_recovery`/actor+reason requirement in `RecoveryRequiredError`, or
+removing the conflict-marker scan in `load_jsonl_rows`/`atomic_write_jsonl`
+each make a specific assertion below fail (see per-test comments).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from devtools import beads_sync as bs
+
+
+def _row(issue_id: str, updated_at: str, **extra: object) -> dict[str, object]:
+    return {"id": issue_id, "updated_at": updated_at, "title": f"title-{issue_id}", **extra}
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, object]]) -> None:
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+
+# --------------------------------------------------------------------------
+# AC #1: stale/newer/equal/incomparable outcomes, ordinary sync never downgrades
+# --------------------------------------------------------------------------
+
+
+def test_merge_outcomes_cover_created_updated_equal_skipped_conflicted() -> None:
+    base = {
+        "a": _row("a", "2026-07-10T00:00:00Z", title="a-old"),
+        "b": _row("b", "2026-07-10T00:00:00Z", title="b-same"),
+        "c": _row("c", "2026-07-12T00:00:00Z", title="c-newer-in-base"),
+        "d": _row("d", "2026-07-10T00:00:00Z", title="d-conflict-base"),
+    }
+    incoming = {
+        "a": _row("a", "2026-07-11T00:00:00Z", title="a-new"),  # strictly newer -> updated
+        "b": _row("b", "2026-07-10T00:00:00Z", title="b-same"),  # identical -> equal
+        "c": _row("c", "2026-07-09T00:00:00Z", title="c-stale"),  # older -> skipped_downgrade
+        "d": _row("d", "2026-07-10T00:00:00Z", title="d-conflict-incoming"),  # same ts, diff content
+        "e": _row("e", "2026-07-10T00:00:00Z", title="e-brand-new"),  # only incoming -> created
+    }
+
+    merged, receipt = bs.merge_issue_sets(base, incoming)
+
+    outcomes = {o.id: o.outcome for o in receipt.outcomes}
+    assert outcomes == {
+        "a": "updated",
+        "b": "equal",
+        "c": "skipped_downgrade",
+        "d": "conflicted",
+        "e": "created",
+    }
+    # Mutation check: if the `incoming_ts > base_ts` branch were changed to
+    # `>=`, "b" (equal timestamps) would report "updated" instead of "equal".
+    assert receipt.counts() == {"updated": 1, "equal": 1, "skipped_downgrade": 1, "conflicted": 1, "created": 1}
+
+    # Ordinary sync result: newer/created rows adopted, stale/conflicted rows
+    # keep the BASE version -- this is the core "cannot downgrade" guarantee.
+    assert merged["a"]["title"] == "a-new"
+    assert merged["c"]["title"] == "c-newer-in-base"  # NOT c-stale
+    assert merged["d"]["title"] == "d-conflict-base"  # NOT d-conflict-incoming
+    assert merged["e"]["title"] == "e-brand-new"
+
+    # Both revisions are present on the machine-readable outcome record.
+    skipped = receipt.by_outcome("skipped_downgrade")[0]
+    assert skipped.base_updated_at == "2026-07-12T00:00:00Z"
+    assert skipped.incoming_updated_at == "2026-07-09T00:00:00Z"
+
+
+def test_ordinary_sync_cannot_downgrade_even_when_requested_without_recovery() -> None:
+    base = {"x": _row("x", "2026-07-15T00:00:00Z", title="live-newer")}
+    incoming = {"x": _row("x", "2026-07-01T00:00:00Z", title="stale-replacement")}
+
+    merged, receipt = bs.merge_issue_sets(base, incoming)
+
+    assert merged["x"]["title"] == "live-newer"
+    assert receipt.has_refusals() is True
+    assert receipt.has_downgrades() is False
+
+
+# --------------------------------------------------------------------------
+# AC #2: explicit recovery override requires actor+reason, records every
+# downgraded row with fingerprint/actor/reason.
+# --------------------------------------------------------------------------
+
+
+def test_recovery_without_actor_or_reason_is_refused() -> None:
+    base = {"x": _row("x", "2026-07-15T00:00:00Z")}
+    incoming = {"x": _row("x", "2026-07-01T00:00:00Z")}
+
+    with pytest.raises(bs.RecoveryRequiredError):
+        bs.merge_issue_sets(base, incoming, allow_recovery=True)
+
+    with pytest.raises(bs.RecoveryRequiredError):
+        bs.merge_issue_sets(base, incoming, allow_recovery=True, actor="sinity")
+
+    with pytest.raises(bs.RecoveryRequiredError):
+        bs.merge_issue_sets(base, incoming, allow_recovery=True, reason="restore")
+
+
+def test_recovery_override_applies_downgrade_and_records_full_provenance() -> None:
+    base = {"x": _row("x", "2026-07-15T00:00:00Z", title="clobbered-bad-state")}
+    incoming = {"x": _row("x", "2026-07-01T00:00:00Z", title="known-good-recovery")}
+    fingerprint = {"project": "polylogue", "database": "dolt", "branch": "master", "source": "recovery.jsonl"}
+
+    merged, receipt = bs.merge_issue_sets(
+        base,
+        incoming,
+        fingerprint=fingerprint,
+        allow_recovery=True,
+        actor="sinity",
+        reason="restore pre-clobber state",
+    )
+
+    assert merged["x"]["title"] == "known-good-recovery"
+    assert receipt.recovery is True
+    assert receipt.actor == "sinity"
+    assert receipt.reason == "restore pre-clobber state"
+    assert dict(receipt.fingerprint) == fingerprint
+    downgraded = receipt.by_outcome("downgraded")
+    assert len(downgraded) == 1
+    assert downgraded[0].id == "x"
+    assert downgraded[0].base_updated_at == "2026-07-15T00:00:00Z"
+    assert downgraded[0].incoming_updated_at == "2026-07-01T00:00:00Z"
+    # Mutation check: if RecoveryRequiredError's guard were deleted entirely
+    # (recovery silently always-on), this test would still pass but
+    # test_recovery_without_actor_or_reason_is_refused above would fail --
+    # both must hold together to prove the guard is load-bearing.
+
+
+# --------------------------------------------------------------------------
+# AC #3: concurrent empty bootstraps + a writer yield one complete union,
+# order-independent, no lost rows.
+# --------------------------------------------------------------------------
+
+
+def test_bootstrap_union_is_order_independent_and_loses_nothing() -> None:
+    writer_a = {"1": _row("1", "2026-07-01T00:00:00Z", title="from-a")}
+    writer_b = {"2": _row("2", "2026-07-02T00:00:00Z", title="from-b")}
+    writer_c_update = {"1": _row("1", "2026-07-03T00:00:00Z", title="from-c-newer")}
+
+    orderings = [
+        (writer_a, writer_b, writer_c_update),
+        (writer_b, writer_c_update, writer_a),
+        (writer_c_update, writer_a, writer_b),
+    ]
+    results = [bs.bootstrap_union(*ordering) for ordering in orderings]
+
+    for result in results:
+        assert set(result) == {"1", "2"}
+        assert result["1"]["title"] == "from-c-newer"  # newest updated_at wins regardless of arrival order
+        assert result["2"]["title"] == "from-b"
+
+    assert results[0] == results[1] == results[2]
+
+
+def test_bootstrap_union_from_empty_base_keeps_every_row() -> None:
+    result = bs.bootstrap_union({}, {"1": _row("1", "2026-07-01T00:00:00Z")}, {"2": _row("2", "2026-07-01T00:00:00Z")})
+    assert set(result) == {"1", "2"}
+
+
+def test_bootstrap_union_raises_on_true_incomparable_conflict() -> None:
+    same_ts_different_content_a = {"1": _row("1", "2026-07-01T00:00:00Z", title="branch-a-edit")}
+    same_ts_different_content_b = {"1": _row("1", "2026-07-01T00:00:00Z", title="branch-b-edit")}
+
+    with pytest.raises(bs.PlanningSurfaceCorruptError):
+        bs.bootstrap_union(same_ts_different_content_a, same_ts_different_content_b)
+
+
+# --------------------------------------------------------------------------
+# AC #4: atomic, validated export; refuses marker-bearing/incomparable state.
+# --------------------------------------------------------------------------
+
+
+def test_atomic_write_jsonl_produces_parseable_unique_id_file(tmp_path: Path) -> None:
+    out = tmp_path / "issues.jsonl"
+    rows = [_row("a", "2026-07-01T00:00:00Z"), _row("b", "2026-07-02T00:00:00Z")]
+
+    bs.atomic_write_jsonl(out, rows)
+
+    reloaded = bs.load_jsonl_rows(out)
+    assert set(reloaded) == {"a", "b"}
+    assert out.exists()
+    # No leftover temp file.
+    assert list(tmp_path.glob(".beads-sync-*")) == []
+
+
+def test_atomic_write_jsonl_refuses_duplicate_ids(tmp_path: Path) -> None:
+    out = tmp_path / "issues.jsonl"
+    rows = [_row("a", "2026-07-01T00:00:00Z"), _row("a", "2026-07-02T00:00:00Z")]
+
+    with pytest.raises(bs.PlanningSurfaceCorruptError):
+        bs.atomic_write_jsonl(out, rows)
+    assert not out.exists()  # nothing staged on failure
+
+
+def test_atomic_write_jsonl_refuses_to_overwrite_marker_bearing_target(tmp_path: Path) -> None:
+    out = tmp_path / "issues.jsonl"
+    out.write_text('{"id": "a", "updated_at": "x"}\n<<<<<<< HEAD\n{"id": "b"}\n=======\n{"id": "c"}\n>>>>>>> branch\n')
+    original_bytes = out.read_bytes()
+
+    with pytest.raises(bs.PlanningSurfaceCorruptError):
+        bs.atomic_write_jsonl(out, [_row("a", "2026-07-01T00:00:00Z")])
+
+    # Target left byte-identical -- the refusal did not partially clobber it.
+    assert out.read_bytes() == original_bytes
+
+
+def test_load_jsonl_rows_refuses_conflict_markers_even_with_valid_json_lines(tmp_path: Path) -> None:
+    # Reproduces the 2026-07-15 shape: valid-looking JSON lines around a
+    # literal conflict marker, git reporting a plain modification.
+    path = tmp_path / "issues.jsonl"
+    path.write_text(
+        '{"id": "a", "updated_at": "2026-07-01T00:00:00Z"}\n'
+        "<<<<<<< Updated upstream\n"
+        '{"id": "b", "updated_at": "2026-07-02T00:00:00Z"}\n'
+        "=======\n"
+        '{"id": "b", "updated_at": "2026-07-03T00:00:00Z"}\n'
+        ">>>>>>> Stashed changes\n"
+    )
+
+    with pytest.raises(bs.PlanningSurfaceCorruptError, match="conflict marker"):
+        bs.load_jsonl_rows(path)
+
+
+def test_load_jsonl_rows_refuses_duplicate_ids(tmp_path: Path) -> None:
+    path = tmp_path / "issues.jsonl"
+    _write_jsonl(path, [_row("a", "2026-07-01T00:00:00Z"), _row("a", "2026-07-02T00:00:00Z")])
+
+    with pytest.raises(bs.PlanningSurfaceCorruptError, match="duplicate id"):
+        bs.load_jsonl_rows(path)
+
+
+def test_synchronize_files_refuses_marker_bearing_incoming_file(tmp_path: Path) -> None:
+    base = tmp_path / "base.jsonl"
+    incoming = tmp_path / "incoming.jsonl"
+    output = tmp_path / "out.jsonl"
+    _write_jsonl(base, [_row("a", "2026-07-01T00:00:00Z")])
+    incoming.write_text("<<<<<<< HEAD\n" + json.dumps(_row("a", "2026-07-02T00:00:00Z")) + "\n=======\n>>>>>>> x\n")
+
+    with pytest.raises(bs.PlanningSurfaceCorruptError):
+        bs.synchronize_files(base, incoming, output)
+
+    assert not output.exists()  # refusal must not stage a bad merge
+
+
+# --------------------------------------------------------------------------
+# AC #5: replay the 2026-07-15 staged-conflict / nine-horizon-bead
+# recovery scenario.
+# --------------------------------------------------------------------------
+
+
+def test_replay_2026_07_15_staged_conflict_recovery_preserves_repaired_beads(tmp_path: Path) -> None:
+    """A valid stale whole-file replacement must fail; targeted merge must
+    preserve every newer horizon-repaired row while still merging unrelated
+    (non-conflicting) rows in from the incoming file.
+    """
+    # "base" = current live state: nine repaired horizon beads at a later
+    # updated_at, plus one unrelated bead only base knows about.
+    repaired_ids = [f"polylogue-repair-{i}" for i in range(9)]
+    base_rows = {
+        issue_id: _row(issue_id, "2026-07-15T19:00:00Z", labels=["horizon:frontier"]) for issue_id in repaired_ids
+    }
+    base_rows["polylogue-unrelated-base-only"] = _row(
+        "polylogue-unrelated-base-only", "2026-07-14T00:00:00Z", title="untouched"
+    )
+
+    # "incoming" = the stale whole-file snapshot from before the repair,
+    # reintroducing legacy horizon labels, PLUS one genuinely new unrelated
+    # row that should still be adopted.
+    incoming_rows = {
+        issue_id: _row(issue_id, "2026-07-10T00:00:00Z", labels=["horizon:near"]) for issue_id in repaired_ids
+    }
+    incoming_rows["polylogue-new-from-incoming"] = _row(
+        "polylogue-new-from-incoming", "2026-07-16T00:00:00Z", title="genuinely new"
+    )
+
+    base_path = tmp_path / "base.jsonl"
+    incoming_path = tmp_path / "incoming-stale-snapshot.jsonl"
+    output_path = tmp_path / "merged.jsonl"
+    _write_jsonl(base_path, list(base_rows.values()))
+    _write_jsonl(incoming_path, list(incoming_rows.values()))
+
+    # A naive "valid stale whole-file replacement" (plain overwrite) is
+    # exactly the bug: it would silently accept the incoming file as-is.
+    # The regression is that `synchronize_files` must NOT do that --
+    # ordinary sync must refuse the downgrades and only adopt the safe rows.
+    receipt = bs.synchronize_files(base_path, incoming_path, output_path)
+
+    merged = bs.load_jsonl_rows(output_path)
+
+    # All nine repaired beads keep their newer (repaired) label state.
+    for issue_id in repaired_ids:
+        assert merged[issue_id]["labels"] == ["horizon:frontier"], issue_id
+    # Unrelated rows from both sides are present.
+    assert merged["polylogue-unrelated-base-only"]["title"] == "untouched"
+    assert merged["polylogue-new-from-incoming"]["title"] == "genuinely new"
+
+    # The receipt proves every one of the nine was a reported/refused
+    # downgrade, not a silent success.
+    downgrade_ids = {o.id for o in receipt.by_outcome("skipped_downgrade")}
+    assert downgrade_ids == set(repaired_ids)
+    assert receipt.has_downgrades() is False  # nothing was actually applied without recovery
+    created_ids = {o.id for o in receipt.by_outcome("created")}
+    assert "polylogue-new-from-incoming" in created_ids
+
+
+def test_replay_recovery_path_can_still_restore_a_deliberately_older_row(tmp_path: Path) -> None:
+    """The flip side of the incident: sometimes the recovery FILE is the
+    known-good state and current live state is the clobbered one. An
+    operator-authorized recovery merge must apply that with full receipt
+    provenance -- this is what distinguishes authorized recovery from the
+    accidental whole-file overwrite bug.
+    """
+    base_path = tmp_path / "clobbered-live.jsonl"
+    incoming_path = tmp_path / "known-good-recovery.jsonl"
+    output_path = tmp_path / "restored.jsonl"
+
+    _write_jsonl(base_path, [_row("polylogue-x", "2026-07-15T20:00:00Z", title="accidentally-reverted")])
+    _write_jsonl(incoming_path, [_row("polylogue-x", "2026-07-14T00:00:00Z", title="actually-correct-older-edit")])
+
+    receipt = bs.synchronize_files(
+        base_path,
+        incoming_path,
+        output_path,
+        allow_recovery=True,
+        actor="sinity",
+        reason="restore known-good pre-clobber row",
+    )
+
+    merged = bs.load_jsonl_rows(output_path)
+    assert merged["polylogue-x"]["title"] == "actually-correct-older-edit"
+    assert receipt.has_downgrades() is True
+    assert receipt.actor == "sinity"
+
+
+# --------------------------------------------------------------------------
+# Receipt shape / CLI smoke
+# --------------------------------------------------------------------------
+
+
+def test_receipt_to_json_round_trips_every_outcome_field() -> None:
+    base = {"a": _row("a", "2026-07-01T00:00:00Z")}
+    incoming = {"a": _row("a", "2026-07-02T00:00:00Z")}
+    _merged, receipt = bs.merge_issue_sets(base, incoming, fingerprint={"branch": "master"})
+
+    payload = receipt.to_json()
+    assert payload["fingerprint"] == {"branch": "master"}
+    assert payload["recovery"] is False
+    assert payload["counts"] == {"updated": 1}
+    assert payload["outcomes"] == [
+        {
+            "id": "a",
+            "outcome": "updated",
+            "base_updated_at": "2026-07-01T00:00:00Z",
+            "incoming_updated_at": "2026-07-02T00:00:00Z",
+        }
+    ]
+
+
+def test_covers_detects_non_progress_receipt() -> None:
+    base = {"a": _row("a", "2026-07-01T00:00:00Z")}
+    incoming = {"a": _row("a", "2026-07-02T00:00:00Z")}
+    _merged, receipt = bs.merge_issue_sets(base, incoming)
+
+    assert receipt.covers(["a"]) is True
+    assert receipt.covers(["a", "missing-id"]) is False
+
+
+def test_cli_merge_exits_nonzero_on_unresolved_refusal_without_recover(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    base_path = tmp_path / "base.jsonl"
+    incoming_path = tmp_path / "incoming.jsonl"
+    output_path = tmp_path / "out.jsonl"
+    _write_jsonl(base_path, [_row("x", "2026-07-15T00:00:00Z")])
+    _write_jsonl(incoming_path, [_row("x", "2026-07-01T00:00:00Z")])
+
+    rc = bs.main(
+        ["merge", "--base", str(base_path), "--incoming", str(incoming_path), "--output", str(output_path), "--json"]
+    )
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"] == {"skipped_downgrade": 1}
+
+
+def test_cli_merge_exits_zero_when_fully_resolved(tmp_path: Path) -> None:
+    base_path = tmp_path / "base.jsonl"
+    incoming_path = tmp_path / "incoming.jsonl"
+    output_path = tmp_path / "out.jsonl"
+    _write_jsonl(base_path, [_row("x", "2026-07-01T00:00:00Z")])
+    _write_jsonl(incoming_path, [_row("x", "2026-07-02T00:00:00Z")])
+
+    rc = bs.main(["merge", "--base", str(base_path), "--incoming", str(incoming_path), "--output", str(output_path)])
+
+    assert rc == 0
+    assert bs.load_jsonl_rows(output_path)["x"]["updated_at"] == "2026-07-02T00:00:00Z"
+
+
+def test_cli_merge_recovery_requires_actor_and_reason_flags(tmp_path: Path) -> None:
+    base_path = tmp_path / "base.jsonl"
+    incoming_path = tmp_path / "incoming.jsonl"
+    output_path = tmp_path / "out.jsonl"
+    _write_jsonl(base_path, [_row("x", "2026-07-15T00:00:00Z")])
+    _write_jsonl(incoming_path, [_row("x", "2026-07-01T00:00:00Z")])
+
+    rc = bs.main(
+        ["merge", "--base", str(base_path), "--incoming", str(incoming_path), "--output", str(output_path), "--recover"]
+    )
+
+    assert rc == 1
+    assert not output_path.exists()


### PR DESCRIPTION
## Summary

Adds `devtools/beads_sync.py`: a monotonic, per-row, receipted merge engine for `.beads/issues.jsonl`-shaped files, wired as `devtools workspace beads-sync merge`.

## Problem

The 2026-07-15 planning-surface incident showed that whole-file JSON validity and command exit status are not proof of synchronization. `.beads/issues.jsonl` was staged with literal `<<<<<<<`/`=======`/`>>>>>>>` conflict markers while `git status` reported a plain modification (not an unmerged index entry); a subsequent plain re-export produced a syntactically valid, unique-id JSONL that nonetheless silently reverted nine independently-edited Beads to older versions and reintroduced every previously repaired horizon label, while both standing backlog lints still passed. Synchronization must compare per-row revision, not trust file-level validity.

## Solution

- `merge_issue_sets()` compares every id's `updated_at` (the only revision proxy present in `bd export` output — there is no separate numeric revision field) and classifies each row: `created` / `retained` / `equal` / `updated` / `skipped_downgrade` / `conflicted` / `downgraded`. Ordinary sync never adopts a row that is not strictly newer than what it would replace; same-timestamp-different-content rows are reported as `conflicted`, never silently resolved either way.
- `RecoveryRequiredError` enforces that any downgrade requires an explicit `actor` + `reason`; every downgraded row is recorded in the resulting `SyncReceipt` with both revisions, actor, reason, and the merge fingerprint (project/database/branch/source).
- `load_jsonl_rows()` / `atomic_write_jsonl()` refuse to read or overwrite any file containing literal conflict markers, refuse duplicate ids, and write via temp+fsync+`os.replace` with a post-write parse/count validation before the target file is ever touched.
- `bootstrap_union()` folds N sources (e.g. two concurrent empty bootstraps plus a writer) into one order-independent union, raising `PlanningSurfaceCorruptError` on a true same-timestamp conflict (bootstrap has no operator present to authorize a recovery choice).
- Wired as a real `CommandSpec` (`devtools workspace beads-sync merge --base ... --incoming ... --output ... [--recover --actor ... --reason ...] [--json]`); `docs/devtools.md` regenerated.

**Scope note:** per this bead's own notes ("this bead owns... import-export, atomic conflict-aware file replacement, and synchronization receipts... do not implement a second merge algorithm here"), this PR ships the merge/receipt engine only. Consuming the receipt to gate repo policy/frontier invariants after union is the explicitly separate consumer bead `polylogue-8jg9.1`. Wiring this engine into `bd`'s own checkout/merge-hook window (currently `devtools/bd_reimport_guard.py`, a simpler live-DB before/after snapshot comparison) and full server/embedded-mode + killpoint regression coverage (AC #7) are left as follow-up integration work rather than folded into this PR — see AC matrix below.

## AC matrix (polylogue-gxjh.1)

1. **Satisfied.** Stale/newer/equal/incomparable rows produce machine-readable outcomes with both revisions (`test_merge_outcomes_cover_created_updated_equal_skipped_conflicted`); ordinary sync cannot downgrade (`test_ordinary_sync_cannot_downgrade_even_when_requested_without_recovery`).
2. **Satisfied.** Recovery override requires actor+reason and records fingerprint/actor/reason/every downgraded row (`test_recovery_without_actor_or_reason_is_refused`, `test_recovery_override_applies_downgrade_and_records_full_provenance`).
3. **Satisfied (engine-level).** `bootstrap_union()` is order-independent and loses nothing across simulated concurrent-bootstrap-plus-writer orderings (`test_bootstrap_union_is_order_independent_and_loses_nothing`, `test_bootstrap_union_from_empty_base_keeps_every_row`). Not tested against the live Dolt server's actual concurrency primitives — this module doesn't touch the live DB by design (see Solution); a true concurrent-process regression against `bd`'s server lock belongs with the hook-integration follow-up.
4. **Satisfied.** `atomic_write_jsonl` is temp+fsync+atomic-rename, validates parse/unique-ids before replacement, and refuses to overwrite a marker-bearing target (`test_atomic_write_jsonl_*`, `test_load_jsonl_rows_refuses_conflict_markers_even_with_valid_json_lines`). "Refuses ... changed-since-snapshot targets" is deferred — this module has no live-DB snapshot identity to compare against (no revision counter beyond `updated_at`); flagged as a residual gap below.
5. **Satisfied.** `test_replay_2026_07_15_staged_conflict_recovery_preserves_repaired_beads` directly replays the incident shape (nine repaired horizon beads, stale whole-file candidate) and proves the stale replacement is refused while unrelated new rows still merge in; `test_replay_recovery_path_can_still_restore_a_deliberately_older_row` covers the authorized-recovery counterpart.
6. **Deferred to polylogue-8jg9.1** (explicitly the separate consumer bead per this bead's own notes) — receipt shape is designed for that consumption (`SyncReceipt.to_json()`, `covers()` non-progress check) but this PR does not wire a post-union backlog/frontier re-check.
7. **Deferred.** Server-vs-embedded-mode coverage and killpoints around import/export are out of scope for this PR; this is a pure-Python file-level engine with no live-process kill-point surface of its own. Follow-up: wire into `devtools/bd_reimport_guard.py`'s hook window and add a killpoint regression there.

## Verification

- `devtools test tests/unit/devtools/test_beads_sync.py` — 20 passed.
- `/realm/project/polylogue/.venv/bin/python -m mypy --strict devtools/beads_sync.py devtools/command_catalog.py tests/unit/devtools/test_beads_sync.py` — no issues found in 3 source files.
- `devtools verify --quick` — 16/16 steps passed (also re-ran automatically via the pre-push hook).
- Manual CLI smoke: `devtools workspace beads-sync merge --base ... --incoming ... --output ... --json` against temp files, confirmed atomic output + correct receipt.
- Not run: full `devtools verify --all` / broader integration suite (not required for this file-scoped change; testmon-affected set is the two new/changed files above).

Ref polylogue-gxjh.1