### PR TITLE
perf(storage): extract pure prepare_session_rows for off-writer prep

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -205,6 +205,70 @@ class SessionEventWriteResult:
     wrote_provider_usage_events: bool = False
 
 
+@dataclass(frozen=True, slots=True)
+class PreparedSessionRows:
+    """Pure, off-writer-thread-computable row tuples for one session's
+    full-replace write (polylogue-623q).
+
+    Row PREPARATION -- converting a ``ParsedSession`` tree into the SQL row
+    tuples ``_replace_full_session_messages_and_blocks`` inserts -- was
+    measured happening entirely inside the writer hold (34-40s per 2,000
+    normal raws, 165-287s on whale pages) while parse-side warm workers sat
+    idle. ``prepare_session_rows`` builds this dataclass from nothing but a
+    ``ParsedSession`` (no DB connection, no archive state), so it can run on
+    a parse-prefetch worker thread; the writer then only needs to run
+    ``executemany`` against already-built tuples.
+
+    ``session_content_hash`` is ``pipeline.ids.session_content_hash(session)``
+    hex-decoded -- computed from the ORIGINAL (pre-lineage-slice) session, the
+    same value ordinary callers already pass as ``write_parsed_session_to_
+    archive(content_hash=...)``. The writer compares this against its own
+    ``content_hash`` argument before ever using the prepared rows: a session
+    whose content changed (or whose caller didn't supply a content_hash --
+    identity-only hashes never match) always falls back to preparing inline,
+    which reproduces the exact unmodified write path. A session that turns
+    out to need lineage tail-slicing (prefix-sharing composition against an
+    already-archived parent -- resolved by ``_extract_prefix_tail``, which
+    requires a live DB read the prefetch worker never had) is a SEPARATE
+    rejection condition the writer checks independently, because slicing
+    changes which messages are written without changing the session's own
+    content hash.
+    """
+
+    session_id: str
+    session_content_hash: bytes
+    message_rows: tuple[tuple[object, ...], ...]
+    block_rows: tuple[tuple[object, ...], ...]
+
+
+def prepare_session_rows(session: ParsedSession) -> PreparedSessionRows:
+    """Build ``PreparedSessionRows`` for ``session``'s full-replace write.
+
+    Pure function: normalizes messages exactly as ``write_parsed_session_to_
+    archive`` does for a non-merge-append, non-lineage-sliced write (see
+    ``_normalized_messages``), then reuses the same row-tuple builders the
+    writer itself calls (``_build_message_rows``/``_build_block_rows``) at
+    ``position_offset=0`` -- the offset every full-replace write uses. No
+    SQLite connection, network call, or filesystem access; safe to call from
+    any thread, including a parse-prefetch worker running well before (and
+    concurrently with) any writer hold.
+    """
+    from polylogue.pipeline.ids import session_content_hash as _compute_session_content_hash
+
+    origin = origin_from_provider(session.source_name)
+    session_id = archive_session_id(origin.value, session.provider_session_id)
+    messages = _normalized_messages(session.messages)
+    duplicate_native_ids = _duplicate_message_native_ids(messages)
+    message_rows = _build_message_rows(session_id, messages, duplicate_native_ids=duplicate_native_ids)
+    block_rows = _build_block_rows(session_id, messages, duplicate_native_ids=duplicate_native_ids)
+    return PreparedSessionRows(
+        session_id=session_id,
+        session_content_hash=bytes.fromhex(_compute_session_content_hash(session)),
+        message_rows=tuple(message_rows),
+        block_rows=tuple(block_rows),
+    )
+
+
 def write_parsed_session_to_archive(
     conn: sqlite3.Connection,
     session: ParsedSession,
@@ -220,8 +284,23 @@ def write_parsed_session_to_archive(
     manage_transaction: bool = True,
     bulk_fts: bool = False,
     bulk_build: bool = False,
+    prepared: PreparedSessionRows | None = None,
 ) -> str:
     """Write one parsed session into an initialized archive index DB.
+
+    ``prepared`` (polylogue-623q, default ``None``) is an optional
+    ``PreparedSessionRows`` computed off this thread (typically by the daemon
+    parse-prefetch worker via ``prepare_session_rows``). It is used ONLY when
+    ALL of the following hold, checked right before the full-replace write:
+    not ``merge_append`` (prepared rows are built for a full replace's
+    ``position_offset=0``, never an append's positive offset); lineage
+    resolution did not slice ``messages`` (a prefix-sharing composition
+    against an already-archived parent changes which messages get written,
+    and the prefetch worker never had DB access to know about that parent);
+    and ``prepared.session_content_hash`` matches this call's own
+    ``content_hash``. Any other case silently falls back to preparing rows
+    inline -- identical to ``prepared=None`` -- so passing a stale/irrelevant
+    ``prepared`` is always safe, never incorrect.
 
     By default the whole write runs in its own transaction (``with conn:``)
     committed on success. A bulk caller that wants many sessions in one
@@ -337,6 +416,20 @@ def write_parsed_session_to_archive(
     session_content_hash = (
         bytes.fromhex(content_hash) if content_hash is not None else _hash_bytes("session", origin.value, native_id)
     )
+    # polylogue-623q: only reuse rows prepared off this thread when NONE of
+    # the conditions that would make them wrong hold -- see ``prepared``'s
+    # docstring above. ``lineage_inheritance == "prefix-sharing"`` is the
+    # single signal that ``_extract_prefix_tail`` sliced ``messages`` away
+    # from what ``prepare_session_rows`` saw (it returns ``messages``
+    # unchanged in every other case, including "spawned-fresh" and no-parent).
+    prepared_rows_to_use: PreparedSessionRows | None = None
+    if (
+        prepared is not None
+        and not merge_append
+        and lineage_inheritance != "prefix-sharing"
+        and prepared.session_content_hash == session_content_hash
+    ):
+        prepared_rows_to_use = prepared
     add_timing("index.prepare", t0)
     session_counts = _session_count_values(messages)
 
@@ -467,6 +560,7 @@ def write_parsed_session_to_archive(
                     stage_timings_s=stage_timings_s,
                     stage_timing_prefix=stage_timing_prefix,
                     bulk_build=bulk_build,
+                    prepared=prepared_rows_to_use,
                 )
                 add_timing("index.full_replace", t0)
             if merge_append:
@@ -1444,33 +1538,29 @@ def rebuild_archive_messages_fts(conn: sqlite3.Connection) -> int:
     return int(row[0] if row is not None else 0)
 
 
-def _write_messages(
-    conn: sqlite3.Connection,
+def _build_message_rows(
     session_id: str,
     messages: list[ParsedMessage],
     *,
     position_offset: int = 0,
     duplicate_native_ids: frozenset[str] = frozenset(),
-) -> None:
-    """Write message rows using table-driven column specification.
+) -> list[tuple[object, ...]]:
+    """Pure row-tuple builder for the ``messages`` table (no DB access).
 
-    The messages table column spec (archive_tiers_specs.MESSAGES_SPEC) defines:
-      - writable_columns: the ordered list of columns to INSERT (29 total)
-      - The column names and placeholders are generated from the spec
-      - The tuple order is derived from the spec's writable_columns order
-
-    This consolidates the three hand-aligned duplicates (column list in INSERT,
-    placeholder string, tuple order) into a single source of truth.
+    Extracted from ``_write_messages`` (polylogue-623q) so the exact same
+    row-construction logic can run off the writer thread (see
+    ``prepare_session_rows``) and be reused verbatim by the writer via
+    ``executemany`` -- byte-identical output either way. This function
+    decides only *what* the rows are, never *whether* to write them.
     """
-    spec = archive_tiers_specs.MESSAGES_SPEC
-
-    def rows() -> Iterable[tuple[object, ...]]:
-        for fallback_position, message in enumerate(messages):
-            position = position_offset + (message.position if message.position is not None else fallback_position)
-            variant_index = message.variant_index if message.variant_index is not None else 0
-            # Build tuple in the order defined by spec.writable_columns, skipping
-            # columns with non-standard placeholders (like parent_message_id=NULL)
-            yield (
+    rows: list[tuple[object, ...]] = []
+    for fallback_position, message in enumerate(messages):
+        position = position_offset + (message.position if message.position is not None else fallback_position)
+        variant_index = message.variant_index if message.variant_index is not None else 0
+        # Build tuple in the order defined by spec.writable_columns, skipping
+        # columns with non-standard placeholders (like parent_message_id=NULL)
+        rows.append(
+            (
                 session_id,
                 _stored_message_native_id(message, duplicate_native_ids),
                 # parent_message_id: skipped (always NULL in VALUES)
@@ -1501,15 +1591,53 @@ def _write_messages(
                 _message_content_hash(session_id, message, position=position, variant_index=variant_index),
                 message.occurred_at_ms if message.occurred_at_ms is not None else _timestamp_ms(message.timestamp),
             )
+        )
+    return rows
 
-    # Generate INSERT statement from spec: column list and placeholders come from single source
-    insert_sql = f"""
+
+def _messages_insert_sql() -> str:
+    spec = archive_tiers_specs.MESSAGES_SPEC
+    return f"""
         INSERT OR REPLACE INTO messages (
             {spec.insert_column_names}
         ) VALUES ({spec.insert_placeholder_string})
         """
 
-    conn.executemany(insert_sql, rows())
+
+def _write_messages(
+    conn: sqlite3.Connection,
+    session_id: str,
+    messages: list[ParsedMessage],
+    *,
+    position_offset: int = 0,
+    duplicate_native_ids: frozenset[str] = frozenset(),
+    rows: list[tuple[object, ...]] | None = None,
+) -> None:
+    """Write message rows using table-driven column specification.
+
+    The messages table column spec (archive_tiers_specs.MESSAGES_SPEC) defines:
+      - writable_columns: the ordered list of columns to INSERT (29 total)
+      - The column names and placeholders are generated from the spec
+      - The tuple order is derived from the spec's writable_columns order
+
+    This consolidates the three hand-aligned duplicates (column list in INSERT,
+    placeholder string, tuple order) into a single source of truth.
+
+    ``rows`` (polylogue-623q), when provided, is used verbatim instead of
+    rebuilding from ``messages`` -- the caller (``_replace_full_session_
+    messages_and_blocks``) supplies this when it has an already-validated
+    ``PreparedSessionRows`` computed off the writer thread. ``messages`` is
+    still required in that case (every call site passes it regardless) so
+    this function's signature and every other caller stay unchanged.
+    """
+    if rows is None:
+        rows = _build_message_rows(
+            session_id,
+            messages,
+            position_offset=position_offset,
+            duplicate_native_ids=duplicate_native_ids,
+        )
+    conn.executemany(_messages_insert_sql(), rows)
 
 
 def _message_content_hash(
@@ -1599,44 +1727,38 @@ def _block_content_hash(
     )
 
 
-def _write_blocks(
-    conn: sqlite3.Connection,
+def _build_block_rows(
     session_id: str,
     messages: list[ParsedMessage],
     *,
     position_offset: int = 0,
     duplicate_native_ids: frozenset[str] = frozenset(),
-) -> None:
-    """Write block rows using table-driven column specification.
+) -> list[tuple[object, ...]]:
+    """Pure row-tuple builder for the ``blocks`` table (no DB access).
 
-    The blocks table column spec (archive_tiers_specs.BLOCKS_SPEC) defines:
-      - writable_columns: the ordered list of columns to INSERT (14 total)
-      - The column names and placeholders are generated from the spec
-      - The tuple order is derived from the spec's writable_columns order
-
-    This consolidates the hand-aligned duplicates into a single source of truth.
+    Extracted from ``_write_blocks`` (polylogue-623q); see
+    ``_build_message_rows`` for why this split exists.
     """
-    spec = archive_tiers_specs.BLOCKS_SPEC
-
-    def rows() -> Iterable[tuple[object, ...]]:
-        for fallback_position, message in enumerate(messages):
-            message_id = _message_id(
-                session_id,
-                message,
-                fallback_position,
-                position_offset=position_offset,
-                duplicate_native_ids=duplicate_native_ids,
-            )
-            blocks = _message_blocks(message)
-            for position, block in enumerate(blocks):
-                block_type = _block_type(block)
-                tool_input_json = _json_dumps(block.tool_input) if block.tool_input is not None else None
-                semantic_type = _semantic_type(block)
-                language = _block_language(block)
-                is_error = getattr(block, "is_error", None)
-                exit_code = getattr(block, "exit_code", None)
-                # Tuple built in order defined by spec.writable_columns
-                yield (
+    rows: list[tuple[object, ...]] = []
+    for fallback_position, message in enumerate(messages):
+        message_id = _message_id(
+            session_id,
+            message,
+            fallback_position,
+            position_offset=position_offset,
+            duplicate_native_ids=duplicate_native_ids,
+        )
+        blocks = _message_blocks(message)
+        for position, block in enumerate(blocks):
+            block_type = _block_type(block)
+            tool_input_json = _json_dumps(block.tool_input) if block.tool_input is not None else None
+            semantic_type = _semantic_type(block)
+            language = _block_language(block)
+            is_error = getattr(block, "is_error", None)
+            exit_code = getattr(block, "exit_code", None)
+            # Tuple built in order defined by spec.writable_columns
+            rows.append(
+                (
                     message_id,
                     session_id,
                     position,
@@ -1662,15 +1784,48 @@ def _write_blocks(
                         exit_code=exit_code,
                     ),
                 )
+            )
+    return rows
 
-    # Generate INSERT statement from spec: column list and placeholders from single source
-    insert_sql = f"""
+
+def _blocks_insert_sql() -> str:
+    spec = archive_tiers_specs.BLOCKS_SPEC
+    return f"""
         INSERT OR REPLACE INTO blocks (
             {spec.insert_column_names}
         ) VALUES ({spec.insert_placeholder_string})
         """
 
-    conn.executemany(insert_sql, rows())
+
+def _write_blocks(
+    conn: sqlite3.Connection,
+    session_id: str,
+    messages: list[ParsedMessage],
+    *,
+    position_offset: int = 0,
+    duplicate_native_ids: frozenset[str] = frozenset(),
+    rows: list[tuple[object, ...]] | None = None,
+) -> None:
+    """Write block rows using table-driven column specification.
+
+    The blocks table column spec (archive_tiers_specs.BLOCKS_SPEC) defines:
+      - writable_columns: the ordered list of columns to INSERT (14 total)
+      - The column names and placeholders are generated from the spec
+      - The tuple order is derived from the spec's writable_columns order
+
+    This consolidates the hand-aligned duplicates into a single source of truth.
+
+    ``rows`` (polylogue-623q): see ``_write_messages`` for the contract --
+    used verbatim when provided, otherwise built fresh from ``messages``.
+    """
+    if rows is None:
+        rows = _build_block_rows(
+            session_id,
+            messages,
+            position_offset=position_offset,
+            duplicate_native_ids=duplicate_native_ids,
+        )
+    conn.executemany(_blocks_insert_sql(), rows)
 
 
 def _write_web_constructs(
@@ -1760,6 +1915,7 @@ def _replace_full_session_messages_and_blocks(
     stage_timings_s: dict[str, float] | None = None,
     stage_timing_prefix: str = "append",
     bulk_build: bool = False,
+    prepared: PreparedSessionRows | None = None,
 ) -> None:
     """Replace one session's messages/blocks wholesale.
 
@@ -1770,6 +1926,16 @@ def _replace_full_session_messages_and_blocks(
     caller always repopulates both surfaces archive-wide exactly once at
     readiness, so per-session maintenance here is pure waste. Ordinary
     (non-bulk-build) full-session replaces are byte-for-byte unchanged.
+
+    ``prepared`` (polylogue-623q), when given, is an already-validated
+    ``PreparedSessionRows`` -- the caller (``write_parsed_session_to_archive``)
+    has already confirmed it was computed from THIS session's content hash
+    and that no lineage tail-slicing changed ``messages`` since. The message/
+    block row-building loops (the CPU-bound part of this function -- per-item
+    hashing, JSON encoding, enum lookups) are then skipped entirely in favor
+    of the precomputed tuples; only the ``executemany`` against SQLite still
+    runs on this (writer) thread. ``None`` (the default) reproduces the exact
+    prior behavior byte-for-byte.
     """
 
     def add_timing(name: str, started_at: float) -> None:
@@ -1806,6 +1972,7 @@ def _replace_full_session_messages_and_blocks(
             session_id,
             messages,
             duplicate_native_ids=duplicate_native_ids,
+            rows=list(prepared.message_rows) if prepared is not None else None,
         )
         add_timing("messages", t0)
         t0 = time.perf_counter()
@@ -1814,6 +1981,7 @@ def _replace_full_session_messages_and_blocks(
             session_id,
             messages,
             duplicate_native_ids=duplicate_native_ids,
+            rows=list(prepared.block_rows) if prepared is not None else None,
         )
         add_timing("blocks", t0)
         t0 = time.perf_counter()

--- a/tests/unit/storage/test_prepared_session_rows.py
+++ b/tests/unit/storage/test_prepared_session_rows.py
@@ -1,0 +1,304 @@
+"""polylogue-623q: ``prepare_session_rows`` extraction equivalence.
+
+Row PREPARATION (converting a ``ParsedSession`` tree into the message/block
+SQL row tuples the full-replace write path inserts) was mechanically
+extracted from the writer-hold-only ``_write_messages``/``_write_blocks``
+row-building loops into a pure ``prepare_session_rows`` function that can run
+off the writer thread (e.g. a daemon parse-prefetch worker). These tests
+prove:
+
+  1. equivalence -- writing via the inline builder and via a pre-prepared
+     ``PreparedSessionRows`` produce byte-identical ``sessions``/``messages``/
+     ``blocks`` rows for a corpus of synthetic sessions covering text,
+     tool_use/tool_result, thinking, paste, and duplicate-native-id messages;
+  2. genuine reuse -- the write path never rebuilds rows from ``messages``
+     when a valid ``prepared`` is supplied (proven by monkeypatching the
+     inline builders to raise);
+  3. stale-prepared fallback -- when the session's content changed after
+     ``prepare_session_rows`` ran (a mismatched content hash), the writer
+     ignores the stale prepared rows and builds fresh ones reflecting the
+     NEW content, not the stale one.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, MaterialOrigin, Provider
+from polylogue.pipeline.ids import session_content_hash
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.sqlite.archive_tiers import write as archive_tier_write
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.write import (
+    PreparedSessionRows,
+    prepare_session_rows,
+    write_parsed_session_to_archive,
+)
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    initialize_archive_tier(conn, ArchiveTier.INDEX)
+    return conn
+
+
+def _synthetic_sessions() -> list[ParsedSession]:
+    return [
+        ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="plain-text",
+            title="Plain text session",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="m0",
+                    role=Role.USER,
+                    text="hello there, this is a synthetic corpus message",
+                    material_origin=MaterialOrigin.HUMAN_AUTHORED,
+                    position=0,
+                ),
+                ParsedMessage(
+                    provider_message_id="m1",
+                    role=Role.ASSISTANT,
+                    text="a reply with unicode: café — 你好",
+                    material_origin=MaterialOrigin.ASSISTANT_AUTHORED,
+                    position=1,
+                ),
+            ],
+        ),
+        ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="tool-use-and-thinking",
+            title="Tool use and thinking",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="t0",
+                    role=Role.ASSISTANT,
+                    material_origin=MaterialOrigin.ASSISTANT_AUTHORED,
+                    position=0,
+                    blocks=[
+                        ParsedContentBlock(type=BlockType.THINKING, text="let me think about this"),
+                        ParsedContentBlock(
+                            type=BlockType.TOOL_USE,
+                            tool_name="Bash",
+                            tool_id="call-1",
+                            tool_input={"command": "pytest -q"},
+                        ),
+                    ],
+                ),
+                ParsedMessage(
+                    provider_message_id="t1",
+                    role=Role.TOOL,
+                    material_origin=MaterialOrigin.TOOL_RESULT,
+                    position=1,
+                    blocks=[
+                        ParsedContentBlock(
+                            type=BlockType.TOOL_RESULT,
+                            tool_id="call-1",
+                            text="1 passed",
+                            is_error=False,
+                            exit_code=0,
+                        ),
+                    ],
+                ),
+            ],
+        ),
+        ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="duplicate-native-ids",
+            title="Duplicate native ids",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="dup",
+                    role=Role.USER,
+                    text="first with a colliding native id",
+                    position=0,
+                    variant_index=0,
+                ),
+                ParsedMessage(
+                    provider_message_id="dup",
+                    role=Role.USER,
+                    text="second with a colliding native id",
+                    position=1,
+                    variant_index=1,
+                ),
+            ],
+        ),
+    ]
+
+
+def _dump_table(conn: sqlite3.Connection, table: str, order_by: str) -> list[tuple[object, ...]]:
+    rows = conn.execute(f"SELECT * FROM {table} ORDER BY {order_by}").fetchall()
+    return [tuple(row) for row in rows]
+
+
+def _write_all(conn: sqlite3.Connection, sessions: list[ParsedSession], *, prepared: bool) -> None:
+    for session in sessions:
+        chash = str(session_content_hash(session))
+        rows = prepare_session_rows(session) if prepared else None
+        write_parsed_session_to_archive(conn, session, content_hash=chash, prepared=rows)
+
+
+def test_prepared_and_inline_writes_produce_identical_rows(tmp_path: Path) -> None:
+    sessions = _synthetic_sessions()
+
+    inline_conn = _connect(tmp_path / "inline.db")
+    prepared_conn = _connect(tmp_path / "prepared.db")
+    try:
+        _write_all(inline_conn, sessions, prepared=False)
+        _write_all(prepared_conn, sessions, prepared=True)
+
+        assert _dump_table(inline_conn, "sessions", "session_id") == _dump_table(
+            prepared_conn, "sessions", "session_id"
+        )
+        assert _dump_table(inline_conn, "messages", "message_id") == _dump_table(
+            prepared_conn, "messages", "message_id"
+        )
+        assert _dump_table(inline_conn, "blocks", "block_id") == _dump_table(prepared_conn, "blocks", "block_id")
+    finally:
+        inline_conn.close()
+        prepared_conn.close()
+
+
+def test_valid_prepared_rows_are_used_verbatim_without_rebuilding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Anti-vacuity: monkeypatch the inline row builders to raise, then prove
+    a matching-content-hash write still succeeds and produces correct rows --
+    the only way that can happen is if the write path used the prepared rows
+    verbatim instead of calling ``_build_message_rows``/``_build_block_rows``.
+    """
+    session = _synthetic_sessions()[1]  # tool-use-and-thinking: exercises both tables
+    prepared = prepare_session_rows(session)
+
+    conn = _connect(tmp_path / "index.db")
+    try:
+
+        def _boom(*args: object, **kwargs: object) -> object:
+            raise AssertionError("inline row builder must not run when valid prepared rows are supplied")
+
+        monkeypatch.setattr(archive_tier_write, "_build_message_rows", _boom)
+        monkeypatch.setattr(archive_tier_write, "_build_block_rows", _boom)
+
+        session_id = write_parsed_session_to_archive(
+            conn,
+            session,
+            content_hash=str(session_content_hash(session)),
+            prepared=prepared,
+        )
+
+        stored_messages = conn.execute(
+            "SELECT native_id, has_tool_use FROM messages WHERE session_id = ? ORDER BY position",
+            (session_id,),
+        ).fetchall()
+        assert [row[0] for row in stored_messages] == ["t0", "t1"]
+        stored_blocks = conn.execute(
+            "SELECT block_type, tool_name FROM blocks b JOIN messages m ON m.message_id = b.message_id "
+            "WHERE m.session_id = ? ORDER BY m.position, b.position",
+            (session_id,),
+        ).fetchall()
+        assert ("tool_use", "Bash") in [tuple(row) for row in stored_blocks]
+    finally:
+        conn.close()
+
+
+def test_stale_prepared_rows_fall_back_to_fresh_content(tmp_path: Path) -> None:
+    """The session mutates AFTER prepare_session_rows() ran (a realistic
+    parse-prefetch race: the archive's raw changed between warm() and the
+    writer-held pass). The writer must detect the content-hash mismatch and
+    build fresh rows reflecting the NEW content -- never silently write the
+    stale prepared text.
+    """
+    original = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="mutates-after-prepare",
+        title="Mutates after prepare",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m0",
+                role=Role.USER,
+                text="the original body computed by the prefetch worker",
+                material_origin=MaterialOrigin.HUMAN_AUTHORED,
+                position=0,
+            ),
+        ],
+    )
+    stale_prepared = prepare_session_rows(original)
+
+    mutated = original.model_copy(
+        update={
+            "messages": [
+                ParsedMessage(
+                    provider_message_id="m0",
+                    role=Role.USER,
+                    text="a DIFFERENT body -- the raw changed before the writer ran",
+                    material_origin=MaterialOrigin.HUMAN_AUTHORED,
+                    position=0,
+                ),
+            ]
+        }
+    )
+    assert session_content_hash(mutated) != session_content_hash(original)
+
+    conn = _connect(tmp_path / "index.db")
+    try:
+        session_id = write_parsed_session_to_archive(
+            conn,
+            mutated,
+            content_hash=str(session_content_hash(mutated)),
+            prepared=stale_prepared,
+        )
+        stored_text = conn.execute(
+            "SELECT user_context_text FROM messages WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        # user_context_text isn't populated from .text; assert via a direct
+        # read of the composed message text using the archive's own reader.
+        del stored_text
+        from polylogue.storage.sqlite.archive_tiers.write import read_archive_session_envelope
+
+        envelope = read_archive_session_envelope(conn, session_id)
+        texts = ["".join(block.text or "" for block in message.blocks) for message in envelope.messages]
+        assert texts == ["a DIFFERENT body -- the raw changed before the writer ran"]
+    finally:
+        conn.close()
+
+
+def test_prepared_rows_are_ignored_when_no_content_hash_supplied(tmp_path: Path) -> None:
+    """``content_hash=None`` means the writer falls back to an identity-only
+    hash that can never coincide with a real ``PreparedSessionRows.session_
+    content_hash`` -- prepared rows are never (mis)used in that case."""
+    session = _synthetic_sessions()[0]
+    prepared = prepare_session_rows(session)
+
+    conn = _connect(tmp_path / "index.db")
+    try:
+        # No AssertionError from a monkeypatched builder here -- this test
+        # only proves the reuse guard degrades safely, not that the builder
+        # was skipped (it correctly is NOT skipped in this case).
+        session_id = write_parsed_session_to_archive(conn, session, prepared=prepared)
+        stored = conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()[0]
+        assert stored == len(session.messages)
+    finally:
+        conn.close()
+
+
+def test_prepare_session_rows_is_pure_and_reusable(tmp_path: Path) -> None:
+    """Calling prepare_session_rows twice on the same immutable session
+    yields identical PreparedSessionRows -- it touches no mutable state."""
+    session = _synthetic_sessions()[2]
+    first = prepare_session_rows(session)
+    second = prepare_session_rows(session)
+    assert isinstance(first, PreparedSessionRows)
+    assert first.session_content_hash == second.session_content_hash
+    assert first.message_rows == second.message_rows
+    assert first.block_rows == second.block_rows


### PR DESCRIPTION
## Summary

Extracts the CPU-bound row-tuple-building work in the full-replace write path (`write_parsed_session_to_archive` / `_replace_full_session_messages_and_blocks`) into a pure function that can run off the single-writer thread, with a cheap, always-safe validity check gating reuse.

## Problem

`write_parsed_session_to_archive`'s full-replace path converts a `ParsedSession` tree into `messages`/`blocks` SQL row tuples (enum lookups, JSON encoding of `tool_input`, per-message/per-block content hashing) entirely inside the single-writer transaction hold. Measured on the live archive: `index.full_replace.messages`/`.blocks` stage timings of 34-40s per 2,000-page rebuild pass and 165-287s on whale pages, while the daemon's 14-thread parse-prefetch pool (`polylogue/daemon/parse_prefetch.py`) sits idle ahead of the writer hold. See `bd show polylogue-623q` for the full import-performance-envelope context.

## Solution

- `polylogue/storage/sqlite/archive_tiers/write.py`: split `_write_messages`/`_write_blocks`'s inline row-building generators into pure functions `_build_message_rows`/`_build_block_rows` (no DB access — only `messages`/`session_id`/`duplicate_native_ids` in, row tuples out). `_write_messages`/`_write_blocks` gained an optional `rows=` passthrough so a caller with already-built rows skips rebuilding.
- New `PreparedSessionRows` (frozen dataclass: `session_id`, `session_content_hash`, `message_rows`, `block_rows`) and `prepare_session_rows(session: ParsedSession) -> PreparedSessionRows` — a pure function computable from nothing but a `ParsedSession`, safe to call from any thread (e.g. a parse-prefetch worker) well before any writer hold exists. `session_content_hash` is `pipeline.ids.session_content_hash(session)` — the same hash ordinary ingest callers already compute and pass as `content_hash=`.
- `write_parsed_session_to_archive` gains an optional `prepared=` parameter. Right before the full-replace write, it decides whether to reuse the supplied `PreparedSessionRows` under two independent, cheap conditions checked on the writer thread:
  1. `prepared.session_content_hash == <this call's own content_hash>` — a session whose content changed between prepare-time and write-time (or a caller that never passed `content_hash`) always falls back to inline preparation.
  2. Lineage resolution did not slice `messages` — `_extract_prefix_tail` returns `messages` unchanged in every case except real prefix-sharing composition against an already-archived parent (detected via `lineage_inheritance == "prefix-sharing"`), which the prefetch worker has no DB access to know about ahead of time.
- Any other combination transparently rebuilds rows inline; `prepared=None` (the default, every existing caller) reproduces the exact prior behavior byte-for-byte.

**Not wired in this PR:** the daemon's parse-prefetch cache (`RawParsePrefetchCache`) and the census/spill/replay pipeline in `sources/revision_backfill.py`. That pipeline's actual index writes go through `ArchiveStore.apply_raw_revision_replay`/`apply_raw_membership_classification`, which resolve mixed full-replace/append cohorts out of a pickled sqlite spill cache (`_ParsedSessionSpill`) shared between the census and replay phases across three independent budget/eviction mechanisms (inflight-bytes, tree-bytes, spill payload-bytes) plus cohort-resolution logic that decides per-raw full-vs-append semantics. Wiring `PreparedSessionRows` all the way through that machinery is a separate, larger change that can now build on this tested extraction + correctness contract rather than reinventing it. Remaining scope tracked under `polylogue-623q`.

## Verification

```
devtools test tests/unit/storage/test_prepared_session_rows.py \
  tests/unit/storage/test_revision_replay.py \
  tests/unit/storage/test_archive_tiers_write.py \
  tests/unit/storage/test_lineage_normalization.py \
  tests/unit/storage/test_bulk_build_lifecycle.py
# 126 passed in 7.71s

devtools verify --quick
# exit_code: 0 (ruff format/check, mypy --strict, render all --check,
# topology/layering/manifests/doc-commands gates)
```

New tests (`tests/unit/storage/test_prepared_session_rows.py`):
- equivalence: writing a synthetic corpus (plain text, tool_use/tool_result/thinking blocks, duplicate-native-id messages) via inline building vs. via `prepare_session_rows` produces byte-identical `sessions`/`messages`/`blocks` dumps.
- anti-vacuity reuse proof: monkeypatches `_build_message_rows`/`_build_block_rows` to raise, then proves a matching-content-hash write with `prepared=` still succeeds with correct rows — only possible if the inline builders were genuinely skipped.
- stale-prepared fallback: mutates a session's text after `prepare_session_rows()` ran, asserts the writer detects the content-hash mismatch and stores the NEW content (never the stale prepared text).
- `content_hash=None` degrades safely (prepared rows never used, since the identity-only fallback hash can't coincide with a real content hash).
- `prepare_session_rows` purity: two calls on the same immutable session produce identical output.

**Micro-benchmark** (200 synthetic sessions, 80 messages each, mixed text/tool_use/thinking blocks, `/dev/shm`, timing only the `write_parsed_session_to_archive` call):

```
targeted stage (messages+blocks) inline:   3.048s / 2.922s / 3.738s  (3 runs)
targeted stage (messages+blocks) prepared: 2.945s / 2.529s / 3.303s
targeted stage reduction:                  3.4%   / 13.4%  / 11.6%
```

Reduction is real but modest and noisy at this synthetic corpus size — `sqlite3.Connection.executemany()` itself dominates wall time on tmpfs, so the CPU-bound row-building work this extracts is a genuine but not majority share of the targeted stage here. Real corpora with richer block content (larger `tool_input` JSON payloads, more messages per session, the whale pages the bead's own numbers cite) are expected to show a larger relative share of stage time moved off the writer thread, since row-building cost scales with content complexity while the SQLite insert cost scales roughly with row count.

Ref polylogue-623q