### PR TITLE
fix(demo): force sequential parsing for deterministic demo seed

### DIFF
--- a/polylogue/demo/seed.py
+++ b/polylogue/demo/seed.py
@@ -1293,7 +1293,21 @@ async def seed_demo_archive(
 
     source_root = materialize_demo_source(archive_root, force=force)
     with _pushd(source_root):
-        result = await parse_sources_archive(archive_root, demo_source_specs(source_root))
+        # Force sequential (single-worker) parsing: the demo corpus is a
+        # handful of small, fully-controlled fixture files, so the
+        # process-pool parallel path buys no measurable throughput but
+        # exposes the fixed, small construct set to
+        # ``parse_sources_archive``'s deliberate worker-error-isolation
+        # behavior (one file's parse failure -- including a transient
+        # process-pool lifecycle failure under host resource pressure, e.g.
+        # under an 8-way xdist run -- is silently skipped rather than
+        # failing the whole ingest). A skipped demo fixture file
+        # nondeterministically undercounts a declared construct (e.g. the
+        # 3-variant browser-capture coalescing set) with no visible signal
+        # until an unrelated downstream assertion fails (polylogue-b054.1.1.1).
+        # The demo seeder needs every file every time, so it opts out of
+        # that isolation guarantee entirely instead of tolerating it.
+        result = await parse_sources_archive(archive_root, demo_source_specs(source_root), workers=1)
 
     apply_demo_post_ingest_augmentation(archive_root)
 

--- a/polylogue/pipeline/services/archive_ingest.py
+++ b/polylogue/pipeline/services/archive_ingest.py
@@ -101,7 +101,12 @@ def _parse_source_path_worker(
         publisher.discard_pending()
 
 
-async def parse_sources_archive(archive_root: Path, sources: list[Source]) -> ParseResult:
+async def parse_sources_archive(
+    archive_root: Path,
+    sources: list[Source],
+    *,
+    workers: int | None = None,
+) -> ParseResult:
     """Parse configured sources directly into archive source/index tiers.
 
     Source files are parsed across a process pool (``POLYLOGUE_INGEST_PARSE_WORKERS``)
@@ -109,12 +114,24 @@ async def parse_sources_archive(archive_root: Path, sources: list[Source]) -> Pa
     not matter: archive writes are idempotent by content hash and session links
     resolve out-of-order. Blob writes from workers are
     content-addressed and atomic, so concurrent worker writes are process-safe.
+
+    ``workers`` overrides the resolved parse worker count for this call only
+    (``None`` keeps the normal env/CPU-derived default). A parallel worker's
+    ``future.result()`` exception -- including a transient process-pool
+    lifecycle failure such as a spawn/fork failure under host resource
+    pressure -- causes that one file's session(s) to be silently skipped
+    (see the ``as_completed`` loop below); this is an intentional isolation
+    guarantee for large, uncontrolled real corpora, but it makes worker
+    count > 1 unsuitable for small, fully-controlled fixture corpora (the
+    demo seeder) where every file's content is required for deterministic
+    construct coverage and a skip is not recoverable within the same call
+    (polylogue-b054.1.1.1).
     """
     result = ParseResult()
     acquired_at_ms = int(datetime.now(UTC).timestamp() * 1000)
     threshold = _commit_batch_message_threshold()
     batched = threshold > 0
-    workers = _parse_worker_count()
+    workers = _parse_worker_count() if workers is None else workers
     blob_root = archive_root / "blob"
     from polylogue.storage.blob_publication import ArchiveBlobPublisher
 

--- a/tests/unit/demo/test_demo_seed_worker_isolation.py
+++ b/tests/unit/demo/test_demo_seed_worker_isolation.py
@@ -1,0 +1,153 @@
+"""Deterministic fault-injection proof for polylogue-b054.1.1.1.
+
+A repeated clean 8-worker testmon seed on 2026-07-16 failed once (see
+``tests/unit/demo/test_demo_seed_verify.py::test_demo_verify_reports_missing_overlays``)
+with at least one declared demo construct below its declared minimum, in a way
+that did not reproduce in isolation. ``parse_sources_archive``'s parallel
+(process-pool) branch deliberately isolates one file's parse failure --
+including a transient process-pool *lifecycle* failure such as a worker
+spawn/fork failure under host resource pressure, exactly the kind of thing an
+8-way xdist run can trigger -- by skipping that file and continuing
+(``polylogue/pipeline/services/archive_ingest.py``, the ``as_completed``
+loop's ``except Exception`` branch). That is the right behavior for a large,
+uncontrolled real corpus, but it silently undercounts a declared construct
+for the demo seeder's small, fully-controlled fixture corpus, where every
+file is required every time.
+
+This module proves the mechanism with deterministic fault injection (no
+sleeps, no retries, no reliance on genuinely reproducing host resource
+pressure), and proves the fix: ``seed_demo_archive`` now forces
+``workers=1`` for its own ``parse_sources_archive`` call, so it never engages
+the process pool -- and therefore can never hit this isolation-vs-completeness
+tradeoff -- regardless of host load or worker count.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import Future
+from pathlib import Path
+
+import pytest
+
+from polylogue.demo import evaluate_demo_constructs, seed_demo_archive
+from polylogue.demo.seed import demo_source_specs, materialize_demo_source
+from polylogue.pipeline.services import archive_ingest
+from polylogue.pipeline.services.archive_ingest import parse_sources_archive
+
+
+class _FaultInjectingPool:
+    """A drop-in ``ProcessPoolExecutor`` replacement that fails one path deterministically.
+
+    Every other submitted job actually runs the real worker function
+    in-thread (in-process, not a real subprocess -- the point here is
+    deterministic proof of the *isolation-vs-completeness* mechanism, not a
+    re-test of multiprocessing itself, which the existing process-pool tests
+    already cover).
+    """
+
+    def __init__(self, *, max_workers: int, fail_when: str) -> None:
+        self._fail_when = fail_when
+        self.failed_paths: list[str] = []
+
+    def __enter__(self) -> _FaultInjectingPool:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        return None
+
+    def submit(self, fn: object, path_str: str, *args: object, **kwargs: object) -> Future[list[tuple[object, object]]]:
+        future: Future[list[tuple[object, object]]] = Future()
+        if self._fail_when in path_str:
+            self.failed_paths.append(path_str)
+            # Simulates a worker future raising -- the same observable shape
+            # as a transient process-pool lifecycle failure (spawn/fork
+            # error, worker crash, OOM kill) under host resource pressure.
+            future.set_exception(RuntimeError("injected process-pool worker failure"))
+        else:
+            assert callable(fn)
+            try:
+                result = fn(path_str, *args, **kwargs)
+            except Exception as exc:  # pragma: no cover - defensive
+                future.set_exception(exc)
+            else:
+                future.set_result(result)
+        return future
+
+
+@pytest.mark.asyncio
+async def test_parallel_parse_worker_failure_undercounts_a_declared_construct(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Proves the vulnerability: a single injected worker failure in the
+    PARALLEL (workers>1) path silently drops one browser-capture variant and
+    the declared ``browser_capture_raw_variants`` construct (minimum 3) falls
+    to 2 -- with no other visible signal beyond the construct-coverage read.
+
+    Anti-vacuity: this exercises the real production ``parse_sources_archive``
+    parallel branch and the real ``evaluate_demo_constructs`` SQL. Removing
+    the fault injection (or raising ``max_workers`` without injecting a
+    failure) makes the construct assertion below fail, proving the assertion
+    is load-bearing on the injected fault, not a tautology.
+    """
+
+    archive_root = tmp_path / "archive"
+    source_root = materialize_demo_source(archive_root, force=True)
+    fail_path = str(source_root / "browser-capture" / "chatgpt-dom-fallback.json")
+
+    def fake_pool(*, max_workers: int) -> _FaultInjectingPool:
+        return _FaultInjectingPool(max_workers=max_workers, fail_when="chatgpt-dom-fallback.json")
+
+    monkeypatch.setattr(archive_ingest, "ProcessPoolExecutor", fake_pool)
+    monkeypatch.chdir(source_root)
+
+    result = await parse_sources_archive(archive_root, demo_source_specs(source_root), workers=2)
+
+    assert result.parse_failures == 1
+
+    coverage = {row.construct_id: row for row in evaluate_demo_constructs(archive_root)}
+    variants = coverage["browser_capture_raw_variants"]
+    assert variants.observed == 2, variants.to_payload()
+    assert variants.minimum == 3
+    assert variants.ok is False, "the injected single-file failure must undercount the construct"
+    assert fail_path  # the exact failing path is deterministic, not incidental
+
+
+@pytest.mark.asyncio
+async def test_seed_demo_archive_never_engages_the_process_pool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Proves the fix: ``seed_demo_archive`` forces sequential parsing, so it
+    can never hit the parallel-path isolation-vs-completeness tradeoff at
+    all -- regardless of host CPU count, ``POLYLOGUE_INGEST_PARSE_WORKERS``,
+    or concurrent xdist load.
+
+    Anti-vacuity: the process pool is monkeypatched to explode on
+    instantiation. If ``seed_demo_archive``'s call to ``parse_sources_archive``
+    ever passed a worker count > 1 (e.g. the ``workers=1`` argument in
+    ``polylogue/demo/seed.py::seed_demo_archive`` were removed or the demo
+    corpus were widened to reintroduce multi-worker parsing without also
+    threading an explicit ``workers=1``), the sequential branch would be
+    skipped, ``ProcessPoolExecutor`` would be constructed, and this test
+    would fail with the injected error instead of completing.
+    """
+
+    def explode(*, max_workers: int) -> object:
+        raise AssertionError(
+            f"seed_demo_archive must never construct a process pool (max_workers={max_workers}); "
+            "the demo corpus must parse sequentially for deterministic construct coverage"
+        )
+
+    monkeypatch.setattr(archive_ingest, "ProcessPoolExecutor", explode)
+    # A high, deliberately provocative env override proves this is not an
+    # accident of a low local CPU count: even an operator/CI override that
+    # would normally force heavy parallelism must not reach ProcessPoolExecutor
+    # via the demo seeder.
+    monkeypatch.setenv("POLYLOGUE_INGEST_PARSE_WORKERS", "8")
+
+    archive_root = tmp_path / "archive"
+    seed = await seed_demo_archive(archive_root, force=True, with_overlays=False)
+
+    assert seed.construct_coverage
+    failed = [row.to_payload() for row in seed.construct_coverage if not row.ok]
+    assert not failed, failed
+    assert seed.session_count > 0


### PR DESCRIPTION
## Summary

Forces the demo seeder's own `parse_sources_archive` call to sequential
(`workers=1`) parsing so it structurally can never engage the process-pool
parallel path -- eliminating a real, evidence-backed nondeterminism source
for demo construct coverage under host load (e.g. 8-way xdist).

## Problem

A repeated clean 8-worker testmon seed on 2026-07-16 failed once (Ref
polylogue-b054.1.1.1) after two green runs:
`test_demo_seed_verify.py::test_demo_verify_reports_missing_overlays`
observed at least one declared demo construct below its minimum. The exact
node and its immediate same-worker predecessors passed in isolation, ruling
out a deterministic assertion mismatch and pointing at load/ordering/process
lifecycle.

Reading `parse_sources_archive` (`polylogue/pipeline/services/archive_ingest.py`)
found the mechanism: its parallel branch submits one `ProcessPoolExecutor`
job per source file and, in the `as_completed` loop, catches any exception
from `future.result()`, increments a failure counter, logs a warning, and
*continues* -- "one bad file must not kill the run." That is the right
tradeoff for a large, uncontrolled real corpus, but the demo seeder feeds it
a tiny, fully-controlled fixture corpus (~a dozen files) where every file's
content is required for every declared construct's minimum count. A
transient process-pool lifecycle failure on exactly one file -- a
spawn/fork error or worker crash under host resource pressure, exactly what
concurrent xdist workers can cause -- silently drops that file with no
signal beyond an unrelated downstream construct-coverage assertion. This
matches the bead's diagnosis hint ("process-pool completion") and the
observed shape (non-reproducible, load-dependent, single occurrence).

## Solution

- `parse_sources_archive` gains an explicit keyword-only `workers: int |
  None = None` override (`None` preserves the existing env/CPU-derived
  default; every other call site is unaffected).
- `seed_demo_archive` now always passes `workers=1`, so the demo path never
  constructs a `ProcessPoolExecutor` regardless of host CPU count,
  `POLYLOGUE_INGEST_PARSE_WORKERS`, or concurrent xdist load. It structurally
  cannot hit the isolation-vs-completeness tradeoff described above.
- Added `tests/unit/demo/test_demo_seed_worker_isolation.py` with two
  fault-injection tests:
  1. `test_parallel_parse_worker_failure_undercounts_a_declared_construct`
     exercises the real parallel path with an injected single-file worker
     failure and proves, via the real `evaluate_demo_constructs` SQL, that
     `browser_capture_raw_variants` falls from 3 to 2 (below its declared
     minimum) -- the exact vulnerability mechanism, not a toy replica.
  2. `test_seed_demo_archive_never_engages_the_process_pool` monkeypatches
     `ProcessPoolExecutor` to raise on construction and runs the real
     `seed_demo_archive` under a provocative
     `POLYLOGUE_INGEST_PARSE_WORKERS=8` override, proving the fix. Anti-vacuity:
     reverting the `workers=1` change (verified manually) makes this test fail
     with the injected error instead of completing.

**Considered and rejected**: also switching `archive_ingest.py`'s raw
`ProcessPoolExecutor` to the shared spawn-context `process_pool_executor()`
helper used by every other process-pool call site in the codebase (a
plausible *additional* lifecycle hardening, since the raw call bypasses the
deliberate `spawn` context choice documented in `process_pool_context()`).
This broke
`test_process_pool_reingest_reserves_before_publish_and_consumes_with_source_ref`,
which relies on the *ambient default* context being `fork` on Python 3.13 so
its own fork-pinned observer process can see `BlobStore`/`ArchiveStore`
methods monkeypatched in the parent test process (inherited via `fork`,
impossible via `spawn`). That is a real, pre-existing test dependency on the
current context choice, orthogonal to this bead's scope (demo determinism,
not general process-pool context hygiene) -- reverted, left unchanged.

## Verification

- `devtools test tests/unit/demo/` -- 41 passed
- `devtools test tests/unit/pipeline/test_archive_ingest_shared_raw.py tests/unit/pipeline/test_archive_ingest_commit_batching.py tests/unit/pipeline/test_process_pool.py tests/unit/scenarios/test_demo_archive_convergence.py tests/unit/demo/` -- 58 passed (confirms no regression once the considered-and-rejected `process_pool_executor` swap was reverted)
- 5 consecutive `devtools test tests/unit/demo/ -- -n 8` runs, all green (41/41 each)
- `mypy --strict` on all three touched files -- no issues
- `devtools verify --quick` -- exit_code 0 (also ran automatically via the pre-push hook)

**Not run** (time-bounded in this session, see Residual risk): the bead's
full 20-isolated + 20-xdist repetition of the exact originally-failing node,
and two consecutive full 8-worker `devtools verify --seed-testmon
--skip-slow` runs.

## Residual risk / AC honesty

Ref polylogue-b054.1.1.1 acceptance criteria:

1. "A failing repetition reports the exact construct id..." -- **satisfied
   indirectly**: the fault-injection test reports exact construct id/observed/
   minimum for the reproduced mechanism, rather than instrumenting a live
   recurrence (none was captured this session).
2. "The evidence harness reproduces the prior failure or proves the
   implicated lifecycle race with a deterministic fault injection." --
   **satisfied**: `test_parallel_parse_worker_failure_undercounts_a_declared_construct`
   is exactly this deterministic fault injection, against the real
   production route.
3. "The underlying production/fixture lifecycle is repaired without
   retries, sleeps, test quarantine, or weakening construct coverage." --
   **satisfied**: `workers=1` is a structural elimination of the risk
   surface (no ProcessPoolExecutor is ever constructed for the demo path),
   not a retry/sleep/quarantine, and construct coverage requirements are
   unchanged.
4. "The exact node passes 20 isolated and 20 xdist repetitions, and two
   consecutive 8-worker `devtools verify --seed-testmon --skip-slow` runs
   are green." -- **deferred**: only 5 consecutive 8-worker
   `tests/unit/demo/` runs were performed in this session (time-bounded);
   the full 20+20 repetition count and the two full seed-testmon runs were
   not executed. Given the fix is a structural elimination (the failure
   mode requires `ProcessPoolExecutor` to be constructed at all, which the
   demo path now never does), the residual risk is that the original,
   never-reproduced 2026-07-16 failure had a *different* root cause that
   this change does not address. The maintainer should run the full
   repetition/seed proof before closing the bead, or accept the structural
   argument plus this session's 5x confirmation as sufficient.
5. "Cleanup receipts show no surviving process groups or temp roots." --
   **satisfied for this session's runs**: `devtools test` containment
   reports/`devtools verify --quick` completed cleanly with no reported
   leftover processes or temp roots.

Ref polylogue-b054.1.1.1