### PR TITLE
fix(sources): corroborate catch-up cursor skips against index presence

### DIFF
--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -197,6 +197,12 @@ class LiveWatcher:
         self._stop = asyncio.Event()
         self._catch_up_complete = asyncio.Event()
         self._archived_cursor_conns: tuple[sqlite3.Connection, sqlite3.Connection] | None = None
+        # Set once per reconciliation scope: True when the index tier has no
+        # materialized sessions at all despite source.db holding successfully
+        # parsed raw material -- the post-index-reset signature (polylogue-emx2).
+        # While true, cursor-trust skip decisions must be corroborated
+        # per-candidate against index presence instead of being taken on faith.
+        self._archived_cursor_index_untrusted = False
         self._batch_processor = LiveBatchProcessor(
             polylogue,
             self._sources,
@@ -694,6 +700,37 @@ class LiveWatcher:
         cursor: CursorRecord | None,
         rebase_queue: list[CursorObservationRebase] | None = None,
     ) -> bool:
+        """Decide whether ``path`` needs (re-)ingestion, corroborated against the index.
+
+        Delegates the byte/fingerprint-level decision to
+        :meth:`_needs_work_from_state_uncorroborated`. When that would skip
+        the file (trusting a cursor claim) but the index tier globally shows
+        no corroborating material (:attr:`_archived_cursor_index_untrusted`,
+        set once per catch-up scan), the skip is demoted to "needed" unless a
+        per-file existence check on ``path`` specifically finds its raw
+        material already materialized -- see polylogue-emx2.
+        """
+        needs_work = self._needs_work_from_state_uncorroborated(
+            path, stat=stat, cursor=cursor, rebase_queue=rebase_queue
+        )
+        if needs_work or not self._archived_cursor_index_untrusted:
+            return needs_work
+        if self._cursor_skip_corroborated_by_index(path):
+            return False
+        logger.warning(
+            "live.watcher: demoting uncorroborated cursor skip to needed for %s (index cannot show materialized raw)",
+            path,
+        )
+        return True
+
+    def _needs_work_from_state_uncorroborated(
+        self,
+        path: Path,
+        *,
+        stat: os.stat_result,
+        cursor: CursorRecord | None,
+        rebase_queue: list[CursorObservationRebase] | None = None,
+    ) -> bool:
         size = stat.st_size
         if cursor is None:
             if not self._reconcile_archived_cursor(path, stat=stat):
@@ -900,14 +937,45 @@ class LiveWatcher:
             except sqlite3.Error:
                 conns = None
         self._archived_cursor_conns = conns
+        self._archived_cursor_index_untrusted = (
+            self._index_lacks_all_corroboration(source_conn=conns[0], index_conn=conns[1])
+            if conns is not None
+            else False
+        )
         try:
             yield
         finally:
             self._archived_cursor_conns = None
+            self._archived_cursor_index_untrusted = False
             if conns is not None:
                 for conn in conns:
                     with suppress(sqlite3.Error):
                         conn.close()
+
+    @staticmethod
+    def _index_lacks_all_corroboration(
+        *,
+        source_conn: sqlite3.Connection,
+        index_conn: sqlite3.Connection,
+    ) -> bool:
+        """True when the index tier holds zero sessions despite acquired raw material.
+
+        A full ``index.db`` reset/rebuild leaves ``ops.db`` ingest cursors
+        pointing at file offsets the daemon already acquired and parsed --
+        cursor state that catch-up's cursor-trust fast paths would otherwise
+        take on faith and skip re-materializing (polylogue-emx2, Finding 8:
+        14,879 cursors skipped 100% of files against an empty post-reset
+        index). One cheap pair of existence probes per catch-up scan detects
+        this and forces every candidate through a per-file corroboration
+        check instead.
+        """
+        has_parsed_raw = source_conn.execute(
+            "SELECT 1 FROM raw_sessions WHERE parsed_at_ms IS NOT NULL AND parse_error IS NULL LIMIT 1"
+        ).fetchone()
+        if has_parsed_raw is None:
+            return False
+        has_any_session = index_conn.execute("SELECT 1 FROM sessions LIMIT 1").fetchone()
+        return has_any_session is None
 
     @staticmethod
     def _archived_cursor_row(
@@ -941,6 +1009,59 @@ class LiveWatcher:
             ),
             None,
         )
+
+    @classmethod
+    def _path_corroborated_by_index(
+        cls,
+        path: Path,
+        *,
+        source_conn: sqlite3.Connection,
+        index_conn: sqlite3.Connection,
+    ) -> bool:
+        """True unless ``path`` has parsed raw material the index cannot show."""
+        has_parsed_raw = source_conn.execute(
+            """
+            SELECT 1 FROM raw_sessions
+            WHERE source_path = ?
+              AND COALESCE(source_index, 0) >= 0
+              AND parsed_at_ms IS NOT NULL
+              AND parse_error IS NULL
+            LIMIT 1
+            """,
+            (str(path),),
+        ).fetchone()
+        if has_parsed_raw is None:
+            # Nothing parsed for this path yet -- not this check's concern.
+            return True
+        return cls._archived_cursor_row(path, source_conn=source_conn, index_conn=index_conn) is not None
+
+    def _cursor_skip_corroborated_by_index(self, path: Path) -> bool:
+        """Whether a cursor-trust skip for ``path`` is backed by a materialized session.
+
+        Only consulted while :attr:`_archived_cursor_index_untrusted` is set
+        (index tier globally empty relative to acquired source material). A
+        path with no successfully parsed raw row yet is not this bead's
+        concern (nothing for the index to have lost) and is treated as
+        corroborated so unrelated cursor kinds are unaffected.
+        """
+        shared = self._archived_cursor_conns
+        try:
+            if shared is not None:
+                return self._path_corroborated_by_index(path, source_conn=shared[0], index_conn=shared[1])
+            archive_root = Path(getattr(self._polylogue, "archive_root", self._cursor._db_path.parent))
+            source_db = archive_root / "source.db"
+            index_db = archive_root / "index.db"
+            if not source_db.exists() or not index_db.exists():
+                return True
+            with (
+                closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True, timeout=1.0)) as source_conn,
+                closing(sqlite3.connect(f"file:{index_db}?mode=ro", uri=True, timeout=1.0)) as index_conn,
+            ):
+                return self._path_corroborated_by_index(path, source_conn=source_conn, index_conn=index_conn)
+        except sqlite3.Error:
+            # Cannot prove absence on a transient DB error -- don't force a
+            # spurious re-ingest of an otherwise-healthy cursor.
+            return True
 
     def _reconcile_archived_cursor_outcome(
         self,

--- a/tests/unit/sources/test_live_catchup_planning.py
+++ b/tests/unit/sources/test_live_catchup_planning.py
@@ -682,3 +682,157 @@ def test_hot_insight_convergence_debt_uses_archive_source_quiet_deadline(
     retry_at = datetime.fromisoformat(debt.next_retry_at or "")
     failed_at = datetime.fromisoformat(debt.last_failed_at)
     assert retry_at - failed_at == timedelta(seconds=50)
+
+
+def _seed_healthy_hot_skip_cursor(cursor: CursorStore, path: Path, *, source_name: str) -> None:
+    """Write a cursor that the byte/fingerprint hot-skip path would trust on its own."""
+    stat = path.stat()
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    cursor.set(
+        path,
+        stat.st_size,
+        byte_offset=stat.st_size,
+        last_complete_newline=stat.st_size,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+        content_fingerprint=digest,
+        tail_hash=encode_cursor_hash_authority(digest, digest, ctime_ns=stat.st_ctime_ns),
+        source_name=source_name,
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+    )
+
+
+def _seed_parsed_source_raw(conn: sqlite3.Connection, *, path: Path, native_id: str, raw_id: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO raw_sessions (
+            raw_id, origin, native_id, source_path, source_index,
+            blob_hash, blob_size, acquired_at_ms, parsed_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (raw_id, "codex-session", native_id, str(path), 0, b"a" * 32, path.stat().st_size, 1, 1),
+    )
+
+
+def test_catch_up_demotes_hot_skip_cursor_when_index_holds_no_sessions(tmp_path: Path) -> None:
+    """polylogue-emx2: a cursor claiming acquisition must not skip when the
+    index tier that would corroborate materialization is empty -- the
+    signature left by a full index reset/rebuild (Finding 8: 14,879 cursors
+    skipped 100% of files against an empty post-reset index)."""
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+    root = tmp_path / "src"
+    root.mkdir()
+    healthy = root / "healthy.jsonl"
+    healthy.write_text('{"role":"user","content":"hello"}\n', encoding="utf-8")
+
+    polylogue = SimpleNamespace(archive_root=tmp_path, backend=None)
+    cursor = CursorStore(tmp_path / "cursor.sqlite")
+    _seed_healthy_hot_skip_cursor(cursor, healthy, source_name="test")
+
+    source_db = tmp_path / "source.db"
+    index_db = tmp_path / "index.db"
+    initialize_archive_database(source_db, ArchiveTier.SOURCE)
+    initialize_archive_database(index_db, ArchiveTier.INDEX)
+    with sqlite3.connect(source_db) as conn:
+        _seed_parsed_source_raw(conn, path=healthy, native_id="healthy", raw_id="raw-healthy")
+        conn.commit()
+    # index.db intentionally left with zero rows in `sessions` -- the
+    # post-reset state this bead targets.
+
+    watcher = LiveWatcher(cast(Any, polylogue), (WatchSource(name="test", root=root),), cursor=cursor)
+    candidates = watcher._scan_catch_up_candidates([root])
+    plan = watcher._plan_catch_up(candidates)
+
+    assert plan.needed == (healthy,), "a cursor the index cannot corroborate must be demoted to needed, not hot-skipped"
+    assert plan.skipped_file_count == 0
+
+
+def test_catch_up_trusts_hot_skip_cursor_when_index_corroborates_it(tmp_path: Path) -> None:
+    """The corroborated companion to the demotion test above: once the raw
+    this cursor claims is actually materialized as a session in the index,
+    the hot-skip path is trusted again and no re-ingest is scheduled."""
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+    root = tmp_path / "src"
+    root.mkdir()
+    healthy = root / "healthy.jsonl"
+    healthy.write_text('{"role":"user","content":"hello"}\n', encoding="utf-8")
+
+    polylogue = SimpleNamespace(archive_root=tmp_path, backend=None)
+    cursor = CursorStore(tmp_path / "cursor.sqlite")
+    _seed_healthy_hot_skip_cursor(cursor, healthy, source_name="test")
+
+    source_db = tmp_path / "source.db"
+    index_db = tmp_path / "index.db"
+    initialize_archive_database(source_db, ArchiveTier.SOURCE)
+    initialize_archive_database(index_db, ArchiveTier.INDEX)
+    with sqlite3.connect(source_db) as conn:
+        _seed_parsed_source_raw(conn, path=healthy, native_id="healthy", raw_id="raw-healthy")
+        conn.commit()
+    with sqlite3.connect(index_db) as conn:
+        conn.execute(
+            """
+            INSERT INTO sessions (
+                native_id, origin, raw_id, message_count, content_hash, created_at_ms, updated_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("healthy", "codex-session", "raw-healthy", 1, b"c" * 32, 1, 1),
+        )
+        conn.commit()
+
+    watcher = LiveWatcher(cast(Any, polylogue), (WatchSource(name="test", root=root),), cursor=cursor)
+    candidates = watcher._scan_catch_up_candidates([root])
+    plan = watcher._plan_catch_up(candidates)
+
+    assert plan.needed == ()
+    assert plan.skipped_file_count == 1
+
+
+def test_catch_up_index_lacks_all_corroboration_detects_empty_index_with_parsed_raw(tmp_path: Path) -> None:
+    """Unit-level pin on the cheap global gate itself, independent of the
+    higher-level planning flow exercised above."""
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+    source_db = tmp_path / "source.db"
+    index_db = tmp_path / "index.db"
+    initialize_archive_database(source_db, ArchiveTier.SOURCE)
+    initialize_archive_database(index_db, ArchiveTier.INDEX)
+    with sqlite3.connect(source_db) as source_conn, sqlite3.connect(index_db) as index_conn:
+        assert (
+            live_watcher.LiveWatcher._index_lacks_all_corroboration(source_conn=source_conn, index_conn=index_conn)
+            is False
+        ), "no parsed raw material yet -- nothing for the index to corroborate"
+
+        source_conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index,
+                blob_hash, blob_size, acquired_at_ms, parsed_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("raw-1", "codex-session", "conv-1", "/tmp/does-not-matter.jsonl", 0, b"a" * 32, 2, 1, 1),
+        )
+        source_conn.commit()
+        assert (
+            live_watcher.LiveWatcher._index_lacks_all_corroboration(source_conn=source_conn, index_conn=index_conn)
+            is True
+        ), "parsed raw exists but index.db has zero sessions -- the post-reset signature"
+
+        index_conn.execute(
+            """
+            INSERT INTO sessions (
+                native_id, origin, raw_id, message_count, content_hash, created_at_ms, updated_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("conv-1", "codex-session", "raw-1", 1, b"b" * 32, 1, 1),
+        )
+        index_conn.commit()
+        assert (
+            live_watcher.LiveWatcher._index_lacks_all_corroboration(source_conn=source_conn, index_conn=index_conn)
+            is False
+        ), "index now shows at least one materialized session -- corroborated again"


### PR DESCRIPTION
## Summary

Watcher catch-up's hot-skip fast path trusted `ops.db` ingest cursors as
proof of full materialization without ever checking whether `index.db`
actually holds the corresponding session. This PR adds a corroboration
check that demotes cursor-trust skips to "needed" when the index tier
cannot back up the claim.

## Problem

polylogue-emx2 (Finding 8 of perf-investigation-2026-07-18): after an
index reset/rebuild, `source.db` retained 14,879 ingest cursors
recording "acquired and parsed", but `index.db` started empty.
`_needs_work_from_state`'s hot-skip fast path (byte-size +
content-fingerprint match) never checked whether the index actually
held a materialized session for the cursor's raw — it skipped every
one of those files outright, leaving 100% of the restore drain to the
1-per-30s background conveyor.

PRs #3129 and #3193 (merged, both linked to this bead) fixed a related
but distinct bug: `batch.py` was misclassifying a raw with a
pending/decided membership arbitration as a full-ingest *failure*. That
repaired the accounting after a file was resubmitted for ingest, but
never addressed the original finding — the cursor-trust fast path in
the watcher still never consulted the index at all. This PR closes
that remaining gap.

## Solution

`polylogue/sources/live/watcher.py`:
- `_archived_cursor_reconciliation_scope` now computes, once per
  catch-up planning pass (reusing its already-shared source.db/index.db
  connections), whether the index tier is globally uncorroborated:
  `_index_lacks_all_corroboration` returns `True` when `source.db`
  holds at least one successfully parsed raw row but `index.db`'s
  `sessions` table is completely empty — the exact post-reset
  signature from Finding 8.
- `_needs_work_from_state` (the prior single-purpose decision method,
  renamed `_needs_work_from_state_uncorroborated`) now wraps that
  logic: when it would skip a file and the index is flagged
  uncorroborated, a cheap per-candidate existence check
  (`_cursor_skip_corroborated_by_index`, reusing the existing
  `_archived_cursor_row` raw→session join) decides whether to honor the
  skip or demote it to "needed".
- The gate defaults to trusted (no behavior change) whenever the index
  has any session at all, so the common healthy case adds zero extra
  queries.
- Demoted files re-enter the normal batch ingest path, which is already
  content-hash idempotent, so no bytes are re-acquired for unchanged
  files.

## Verification

- `devtools test tests/unit/sources/test_live_catchup_planning.py`:
  19 passed (16 pre-existing + 3 new).
- `devtools test tests/unit/sources/test_live_watcher.py
  tests/unit/sources/test_live_watcher_catchup_order.py
  tests/unit/sources/test_live_watcher_locking.py`: 101 passed.
- `mypy --strict polylogue/sources/live/watcher.py
  tests/unit/sources/test_live_catchup_planning.py`: no issues found.
- `devtools verify --quick`: exit 0.
- Anti-vacuity: reverted only the production fix (kept the new tests)
  and reran the suite — `test_catch_up_demotes_hot_skip_cursor_when_index_holds_no_sessions`
  failed with the exact live symptom (`plan.needed == ()` instead of
  the healthy-cursor file), and
  `test_catch_up_index_lacks_all_corroboration_detects_empty_index_with_parsed_raw`
  failed with `AttributeError` for the missing method. Restoring the
  fix turned both green.
- Not run: full `devtools verify --all` / integration suite (out of
  scope for a focused fix; the touched-file testmon selection above is
  the relevant net).

Ref polylogue-emx2