### PR TITLE
fix(sources): downgrade beads-issue maturity to proposed

### DIFF
--- a/polylogue/sources/origin_specs.py
+++ b/polylogue/sources/origin_specs.py
@@ -677,7 +677,16 @@ _ORIGIN_COMPLETENESS_MODES: dict[Origin, tuple[OriginCompletenessMode, ...]] = {
             "provider-package:beads-issue/issue-jsonl@v1",
             "issue-jsonl",
             Provider.BEADS,
-            "accepted",
+            # Kept "proposed" (not "accepted") deliberately: the detector and
+            # parser are real and admitted (OriginSpec.lifecycle="executable"
+            # above), but no schema-discovery harvesting pass has run against
+            # a real Beads repository export sample -- the wire shape is
+            # reconstructed from independent secondary sources (see
+            # polylogue/sources/parsers/beads.py), not a harvested provider-
+            # package catalog. "accepted" would require schema_package evidence
+            # this origin does not yet have, and would fail `devtools provider-
+            # completeness --check`.
+            "proposed",
             detector_paths=("polylogue/sources/parsers/beads.py", "polylogue/sources/dispatch.py"),
             raw_model_paths=("polylogue/sources/parsers/beads.py",),
             parser_paths=("polylogue/sources/parsers/beads.py",),
@@ -685,7 +694,12 @@ _ORIGIN_COMPLETENESS_MODES: dict[Origin, tuple[OriginCompletenessMode, ...]] = {
             fixture_paths=("tests/unit/sources/parsers/test_beads.py",),
             schema_paths=(),
             docs_paths=("docs/architecture.md",),
-            caveats=("Beads is a non-chat issue artifact origin.",),
+            caveats=(
+                "No schema-discovery harvesting pass has run against a real Beads repository export; "
+                "the wire shape is reconstructed from independent secondary sources (see "
+                "polylogue/sources/parsers/beads.py), not a harvested provider-package catalog. "
+                "Promote to accepted once real-sample schema evidence exists.",
+            ),
         ),
     ),
     Origin.GROK_EXPORT: (


### PR DESCRIPTION
## Summary

Downgrade `Origin.BEADS_ISSUE` maturity from "accepted" to "proposed" to resolve the provider-completeness blocker that was causing `devtools provider-completeness --check` to fail repo-wide.

## Problem

The beads-issue provider package was marked as `maturity="accepted"` with `schema_paths=()` (empty). The provider-completeness check treats an empty schema_paths as a missing schema_package, which becomes a required blocker for any "accepted" row, causing `devtools provider-completeness --check` to exit 1 with an "accepted provider-package blockers" error.

This was a pre-existing issue that predated PR #3201 (grok-export).

## Solution

Following the grok-export precedent from PR #3201, downgrade beads-issue to "proposed" maturity with an explicit caveat. The detector and parser are real and admitted (OriginSpec.lifecycle="executable"), but no schema-discovery harvesting pass has run against real Beads repository export samples. The wire shape is reconstructed from secondary sources (see polylogue/sources/parsers/beads.py), not a harvested provider-package catalog.

Changes:
- Modified `polylogue/sources/origin_specs.py`: downgrade BEADS_ISSUE completeness mode maturity from "accepted" to "proposed"
- Updated caveats to mirror grok-export wording style, explaining the schema gap and path to promotion to "accepted"

## Verification

```
python -m devtools.provider_completeness --check
```

Before: exits 1 with "accepted provider-package blockers: provider-package:beads-issue/issue-jsonl@v1: schema_package is missing"

After: exits 0 with no blockers. Status shows:
- beads-issue: proposed (previously accepted/partial)
- grok-export: proposed (unchanged)
- unknown-export: proposed (unchanged)
- 8 complete origins (unchanged)

Tests pass: `devtools test tests/unit/sources/test_origin_specs.py` — 4 tests, all passed
Type check: `mypy --strict polylogue/sources/origin_specs.py` — Success

Ref polylogue-gt3g