### PR TITLE
feat(sources): materialize Hermes subagent-delegation topology (fs1.14/fs1.2.1)

### DIFF
--- a/docs/hermes-operators.md
+++ b/docs/hermes-operators.md
@@ -154,11 +154,13 @@ Verified live against the checked-in real fixture
 
 ```
 "capabilities": {
-  "llm_request_spans":    {"status": "exact",  "observed": 5, "expected": 9},
-  "tool_execution_spans": {"status": "exact",  "observed": 4, "expected": 9},
-  "subagent_delegation":  {"status": "absent",  "observed": 0, "expected": 9},
-  "decision_points":      {"status": "absent",  "observed": 0, "expected": 9},
-  "error_taxonomy":       {"status": "absent",  "observed": 0, "expected": 9}
+  "llm_request_spans":    {"status": "exact",    "observed": 5, "expected": 9},
+  "tool_execution_spans": {"status": "exact",    "observed": 4, "expected": 9},
+  "subagent_delegation":  {"status": "absent",   "observed": 0, "expected": 9},
+  "decision_points":      {"status": "absent",   "observed": 0, "expected": 9},
+  "error_taxonomy":       {"status": "absent",   "observed": 0, "expected": 9},
+  "topology_edges":       {"status": "absent",   "observed": 0, "expected": 1},
+  "parent_session_link":  {"status": "inferred", "observed": 1, "expected": 1}
 }
 ```
 
@@ -167,10 +169,16 @@ carries no approval-hook or error-hook vocabulary at all, so
 `decision_points`/`error_taxonomy` are honestly `absent` for ATIF-only
 imports — that evidence exists only in the raw ATOF stream (see below), never
 backfilled by assumption. `subagent_delegation` is recorded from
-`subagent_trajectories` entries when present, but **not** materialized into
-`topology_edges`/`session_links` — no real trajectory sampled so far has a
-non-empty `subagent_trajectories` list, so this capability stays `absent` on
-every fixture observed to date (`hermes_spans.py:35-38`).
+`subagent_trajectories` entries when present. Since `fs1.14`, a
+`subagent_trajectories` entry with a producer-positive `session_id` (distinct
+from the parent's own id) **is** materialized as a real child ATIF session
+with a `topology_edges`/`session_links` parent edge (`branch_type=subagent`),
+provided the acquiring profile root is known — but no real ATIF fixture
+sampled so far has a non-empty `subagent_trajectories` list, so
+`subagent_delegation`/`topology_edges` stay `absent` on every fixture
+observed to date, and even when materialized from a synthetic document the
+mapping stays `inferred`, never `exact`, until real bytes prove it
+(`hermes_spans.py:parse_atif_document`).
 
 Payload hygiene: unlike the verification ledger below, ATIF/ATOF never copy
 prompt or tool-argument text. A tool-call step records only ids, argument
@@ -184,13 +192,14 @@ Verified the same way against
 
 ```
 "capabilities": {
-  "llm_request_spans":    {"status": "exact", "observed": 3, "expected": 13},
-  "tool_execution_spans": {"status": "exact", "observed": 2, "expected": 13},
-  "decision_points":      {"status": "exact", "observed": 2, "expected": 13},
-  "error_taxonomy":       {"status": "exact", "observed": 1, "expected": 13},
-  "subagent_delegation":  {"status": "exact", "observed": 1, "expected": 13},
-  "context_events":       {"status": "exact", "observed": 3, "expected": 13},
-  "topology_edges":       {"status": "absent", "observed": 0, "expected": 1},
+  "llm_request_spans":    {"status": "exact",    "observed": 3, "expected": 13},
+  "tool_execution_spans": {"status": "exact",    "observed": 2, "expected": 13},
+  "decision_points":      {"status": "exact",    "observed": 2, "expected": 13},
+  "error_taxonomy":       {"status": "exact",    "observed": 1, "expected": 13},
+  "subagent_delegation":  {"status": "exact",    "observed": 1, "expected": 13},
+  "context_events":       {"status": "exact",    "observed": 3, "expected": 13},
+  "topology_edges":       {"status": "exact",    "observed": 1, "expected": 1},
+  "parent_session_link":  {"status": "inferred", "observed": 1, "expected": 1},
   "unpaired_scope_debt":  {"status": "degraded", "observed": 1, "expected": 13}
 }
 ```
@@ -203,6 +212,21 @@ intentionally-surfaced fact: a scope UUID that never saw both its start and
 end phase (crashed request, or a file rotation cutting a pending scope in
 half) is recorded as explicit acquisition debt rather than silently treated
 as equivalent to a completed pair (`hermes_spans.py`, `import_explain.py`).
+
+Since `fs1.14`, this real fixture's `hermes.subagent.start` mark (reporting
+`data.child_session_id: "child-session-redacted"`) **is** materialized as a
+real `session_links` parent edge (`branch_type=subagent`) — `topology_edges`
+reads `exact` because the field mapping and the edge materialization are
+both confirmed end-to-end against this real fixture, not just declared. The
+importer produces **two** archive sessions from this one file: the observing
+session (`observer:atof:real-nemo-relay-session-redacted@profile-<key>`) and
+a minimal delegation-evidence session for the child
+(`observer:atof:child-session-redacted@profile-<key>`, `branch_type=subagent`,
+`ingest_flags` includes `hermes:atof-subagent-delegation-stub`) — the child's
+own trace records were not present in this batch, so only the edge itself is
+materialized, never fabricated content. If the child's own ATOF/ATIF records
+are separately ingested later, the archive's content-hash full-replace rule
+updates this same computed session id in place rather than duplicating it.
 
 One real live-ingestion detail worth knowing if you watch a growing Hermes
 install: the real ATOF producer writes **one shared `events.jsonl` file
@@ -290,9 +314,26 @@ classes for one raw Hermes session id into one typed, read-only projection
 (availability, per-artifact fidelity, unpaired-trace debt, and explicit
 producer-conflict detection for disagreeing subagent-session evidence) — but
 like `hermes_verification_coverage`, it is not yet wired into any CLI/MCP
-surface (see item 3 below). None of this materializes a
-`topology_edges`/`session_links` relationship between them — correlation is a
+surface (see item 3 below). This artifact-class correlation (conversational ↔
+ATIF ↔ ATOF ↔ verification, all for the same raw Hermes session id) remains a
 read-time lookup, not a stored graph edge.
+
+**Subagent delegation is the one exception (`fs1.14`):** when an ATIF
+`subagent_trajectories` entry or an ATOF `hermes.subagent.*` mark reports a
+producer-positive, non-self-referential child session id *and* the acquiring
+profile root is known, `hermes_spans.parse_atif_document`/`parse_atof_stream`
+**do** assert a real `session_links` parent edge (`branch_type=subagent`)
+from the child's own observer session to the delegating parent's observer
+session at parse time — a real stored graph edge, not a read-time lookup.
+Each observing session's own `hermes_subagent_span` event records whether
+that materialization actually happened via a `delegation_edge_asserted`
+flag (`false` is real acquisition debt — unknown profile, missing/self-
+referential/contested child id — never silently indistinguishable from "no
+evidence"), and `hermes_topology_projection.HermesSubagentEvidenceRef.
+delegation_edge_materialized` surfaces the same fact read-side without
+re-deriving it. This narrow edge is the only case where the archive stores a
+subagent-delegation graph relationship; everything else in this section (the
+four artifact classes above) is still correlate-on-read only.
 
 ## What Polylogue cannot claim from your Hermes runtime
 
@@ -354,14 +395,23 @@ This is the section to read before you trust anything above it.
    same as any other origin, because none of them branch on origin. But
    there is no single command that packages all five forensic sections for
    a Hermes session yet.
-5. **`subagent_delegation` never reaches `topology_edges`/`session_links`.**
-   Even where ATIF/ATOF record subagent evidence, it stays observer-only
-   evidence; Polylogue's session-lineage graph does not learn about it.
-   `hermes_topology_projection.project_hermes_topology` surfaces it read-side
-   as `subagent_evidence` (tagged by which artifact reported it) and flags a
+5. **[Narrowed, `fs1.14`] `subagent_delegation` reaches `topology_edges`/
+   `session_links` only when the evidence is unambiguous and profile-qualified.**
+   A `subagent_trajectories` entry or `hermes.subagent.*` mark with a
+   producer-positive, non-self-referential, unambiguous (not contested by two
+   different parents) child session id, acquired with a known profile root,
+   **is** materialized as a real `session_links` parent edge
+   (`branch_type=subagent`) — see the "Session identity" section above. Any
+   other case (unknown profile, missing/self-referential/contested child id)
+   stays observer-only evidence with no edge, visible as
+   `delegation_edge_asserted: false` on the reporting session's own
+   `hermes_subagent_span` event rather than silently indistinguishable from
+   "no evidence at all". `hermes_topology_projection.project_hermes_topology`
+   still surfaces every piece of subagent evidence read-side as
+   `subagent_evidence` (tagged by which artifact reported it, plus whether it
+   was materialized via `delegation_edge_materialized`) and flags a
    self-referential or ATIF/ATOF-disagreeing subagent-session id as an
-   explicit `HermesTopologyConflict` rather than silently trusting one side —
-   but this is still evidence composition, not a physical session link.
+   explicit `HermesTopologyConflict` rather than silently trusting one side.
 6. **The verification ledger is a bounded retention window, not history.**
    `retention_completeness` is structurally `degraded` on every import —
    events older than 30 days, or beyond the producer's 100-per-scope/10,000-

--- a/polylogue/insights/hermes_topology_projection.py
+++ b/polylogue/insights/hermes_topology_projection.py
@@ -31,6 +31,16 @@ Provenance rules this module enforces:
 - **Never merge.** The projection only ever references session ids and
   counts; it never returns message/event bodies from one artifact class
   labelled as another's.
+- **Read-only, but reports real writes.** This module performs no writes
+  itself. ``hermes_spans.parse_atif_document``/``parse_atof_stream`` (fs1.14
+  residual scope) DO materialize a real ``session_links`` parent edge
+  (``branch_type=subagent``) for a subagent reference when the child session
+  id is producer-positive, unambiguous, non-self-referential, and a profile
+  root is known. ``HermesSubagentEvidenceRef.delegation_edge_materialized``
+  reports that parser-time decision (read straight from the event's own
+  ``delegation_edge_asserted`` payload flag), so a caller can tell "evidence
+  exists" from "evidence exists AND a real graph edge was asserted for it"
+  without re-deriving the materialization rule here.
 - **Unpaired traces are visible debt.** An ATIF session with no sibling ATOF
   session (or vice versa) for the same raw Hermes session id is a partial
   acquisition, not silently treated as "no observer evidence at all" --
@@ -91,17 +101,29 @@ class HermesArtifactObservation(ArchiveInsightModel):
 
 
 class HermesSubagentEvidenceRef(ArchiveInsightModel):
-    """One producer-reported subagent-session reference, never physically linked.
+    """One producer-reported subagent-session reference.
 
     ``source_artifact`` states exactly which independently-acquired artifact
     reported this reference (ATIF's ``subagent_trajectories`` or ATOF's
     ``hermes.subagent.*`` marks) -- field-level provenance, per the design.
+
+    ``delegation_edge_materialized`` (fs1.14 residual scope) states whether
+    the parser that produced this evidence actually asserted a real
+    ``session_links`` parent edge (``branch_type=subagent``) for it at parse
+    time -- ``hermes_spans.parse_atif_document``/``parse_atof_stream`` only do
+    so when the child session id is producer-positive, non-self-referential,
+    unambiguous, and a profile root is known (see their docstrings); this
+    field is read directly from the underlying event's own
+    ``delegation_edge_asserted`` payload flag, never re-derived or guessed by
+    this projection. ``False`` is real acquisition debt (evidence exists, no
+    edge was safe to assert), not an error.
     """
 
     source_artifact: Literal["atif", "atof"]
     subagent_session_id: str
     agent_name: str | None = None
     status: str | None = None
+    delegation_edge_materialized: bool = False
 
 
 class HermesTopologyConflict(ArchiveInsightModel):
@@ -203,6 +225,7 @@ def _atif_subagent_refs(events: Sequence[SessionEventRecord]) -> list[HermesSuba
                 source_artifact="atif",
                 subagent_session_id=subagent_session_id,
                 agent_name=agent_name if isinstance(agent_name, str) and agent_name else None,
+                delegation_edge_materialized=event.payload.get("delegation_edge_asserted") is True,
             )
         )
     return refs
@@ -222,6 +245,7 @@ def _atof_subagent_refs(events: Sequence[SessionEventRecord]) -> list[HermesSuba
                 source_artifact="atof",
                 subagent_session_id=child_session_id,
                 status=status if isinstance(status, str) and status else None,
+                delegation_edge_materialized=event.payload.get("delegation_edge_asserted") is True,
             )
         )
     return refs

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -981,13 +981,11 @@ def _parse_lowered_spec(spec: LoweredPayloadSpec) -> list[ParsedSession]:
                 profile_root=Path(spec.source_path).parent if spec.source_path else None,
             )
         if spec.provider is Provider.HERMES and hermes_spans.looks_like_atif_payload(record):
-            return [
-                hermes_spans.parse_atif_document(
-                    record,
-                    spec.fallback_id,
-                    profile_root=Path(spec.source_path).parent if spec.source_path else None,
-                )
-            ]
+            return hermes_spans.parse_atif_document(
+                record,
+                spec.fallback_id,
+                profile_root=Path(spec.source_path).parent if spec.source_path else None,
+            )
         if spec.provider is Provider.ANTIGRAVITY:
             if antigravity.looks_like_markdown_export(record):
                 return [antigravity.parse_markdown_export_payload(record, spec.fallback_id)]

--- a/polylogue/sources/parsers/hermes_spans.py
+++ b/polylogue/sources/parsers/hermes_spans.py
@@ -430,14 +430,31 @@ def _mark_delegation_edges_on_subagent_events(
     *observing parent's own* fidelity declaration can report how many of its
     subagent references actually became real ``session_links`` edges, without
     needing cross-session lookups.
+
+    ``delegation_targets`` is keyed by CHILD session id, so membership alone
+    (``child_session_id in delegation_targets``) is not sufficient here: a
+    session can emit a ``hermes_subagent_span`` whose ``child_session_id``
+    happens to equal a DIFFERENT session's (unambiguously claimed) child --
+    e.g. a self-referential mark from session S (S names itself as its own
+    child, correctly excluded from ``delegation_targets`` by the
+    self-reference guard) coexisting with an unrelated session P that
+    legitimately claims S as ITS child (``delegation_targets["S"] == "P"``).
+    Checking membership alone would mark S's own self-referential span
+    ``delegation_edge_asserted=True`` merely because "S" is a key in the map
+    -- contradicting the fail-closed self-reference guarantee. The owning
+    session id (the record's own ``session_id``, carried in the event's
+    ``session_id`` payload field via ``base_payload``) must match the
+    resolved parent for THIS specific child before the flag is set.
     """
-    for events in grouped.values():
+    for owning_session_id, events in grouped.items():
         for event in events:
             if event.event_type != "hermes_subagent_span":
                 continue
             child_session_id = event.payload.get("child_session_id")
             event.payload["delegation_edge_asserted"] = bool(
-                isinstance(child_session_id, str) and child_session_id and delegation_targets.get(child_session_id)
+                isinstance(child_session_id, str)
+                and child_session_id
+                and delegation_targets.get(child_session_id) == owning_session_id
             )
 
 

--- a/polylogue/sources/parsers/hermes_spans.py
+++ b/polylogue/sources/parsers/hermes_spans.py
@@ -147,7 +147,7 @@ from pathlib import Path
 from typing import Literal, TypeAlias
 
 from polylogue.archive.message.roles import Role
-from polylogue.core.enums import BlockType, MaterialOrigin, Provider
+from polylogue.core.enums import BlockType, BranchType, MaterialOrigin, Provider
 from polylogue.core.json import JSONDocument, JSONValue, json_document
 
 from .base import ParsedContentBlock, ParsedMessage, ParsedSession, ParsedSessionEvent
@@ -169,6 +169,7 @@ HermesSpanEventType: TypeAlias = Literal[
     "hermes_context_span",
     "hermes_observer_span",
     "hermes_atof_unpaired_scope",
+    "hermes_subagent_delegation_evidence",
 ]
 
 
@@ -330,11 +331,33 @@ def parse_atof_stream(
     edge is asserted: a wrong guess would silently correlate this evidence
     with the wrong install's conversational session, which is worse than
     leaving the correlation unresolved.
+
+    SUBAGENT DELEGATION (polylogue-fs1.14 residual scope): a real
+    ``hermes.subagent.start``/``hermes.subagent.stop`` mark carries a
+    producer-positive ``data.child_session_id`` -- the raw Hermes session id
+    Hermes itself assigned to the spawned subagent. When that child id is
+    known AND ``profile_root`` is known AND the child is not the delegating
+    session itself (a structurally impossible self-reference), this function
+    materializes a real ``session_links`` parent edge (``branch_type=subagent``)
+    from the child's own ATOF observer session to the delegating parent's ATOF
+    observer session (its *composed* ``observer:atof:<id>[@profile-<key>]``
+    identity, not the generic conversational-session correlation edge every
+    other ATOF session asserts). If the child's own records also appear in
+    this same shared stream (fs1.14's confirmed one-shared-``events.jsonl``-
+    per-install shape), the delegation edge supersedes that session's routine
+    self-correlation edge; otherwise a minimal delegation-evidence-only
+    session is materialized so the edge exists in the archive even before the
+    child's own trace evidence is separately ingested. Ambiguous evidence
+    (unknown profile, missing/self-referential child id, or the same child id
+    claimed by two different parents in one batch) asserts no edge -- visible
+    as ``delegation_edge_asserted: false`` on the observing parent's own
+    ``hermes_subagent_span`` event, never a guessed link.
     """
     grouped: dict[str, list[ParsedSessionEvent]] = {}
     seen: dict[str, set[tuple[str, str | None]]] = {}
     skipped: dict[str, int] = {}
     scope_phases: dict[str, dict[str, dict[str, tuple[str | None, str | None]]]] = {}
+    delegation_claims: dict[str, set[str]] = {}
 
     for raw_record in records:
         record = json_document(raw_record)
@@ -351,6 +374,12 @@ def parse_atof_stream(
         if record.get("kind") == "scope" and scope_category in {"start", "end"}:
             phases = scope_phases.setdefault(session_id, {}).setdefault(uuid, {})
             phases[scope_category] = (_optional_str(record.get("category")), _optional_str(record.get("timestamp")))
+        name = _optional_str(record.get("name")) or ""
+        if name.startswith("hermes.subagent."):
+            data = json_document(record.get("data")) or {}
+            child_session_id = _optional_str(data.get("child_session_id"))
+            if child_session_id and child_session_id != session_id:
+                delegation_claims.setdefault(child_session_id, set()).add(session_id)
         event = _atof_event(record)
         if event is None:
             skipped[session_id] = skipped.get(session_id, 0) + 1
@@ -360,15 +389,56 @@ def parse_atof_stream(
     unpaired_events = {session_id: _unpaired_scope_events(phases) for session_id, phases in scope_phases.items()}
     session_ids = sorted(set(grouped) | set(unpaired_events))
     profile_key_value = _profile_key(profile_root) if profile_root is not None else None
-    return [
+
+    # Only a producer-positive, unambiguous (single-parent) child id with a
+    # known profile qualifies for edge materialization -- fail closed on a
+    # conflicting or unqualified claim rather than guessing which parent (if
+    # any) is correct.
+    delegation_targets: dict[str, str] = (
+        {child: next(iter(parents)) for child, parents in delegation_claims.items() if len(parents) == 1}
+        if profile_key_value is not None
+        else {}
+    )
+    _mark_delegation_edges_on_subagent_events(grouped, delegation_targets)
+
+    sessions = [
         _atof_session(
             session_id,
             [*grouped.get(session_id, []), *unpaired_events.get(session_id, [])],
             skipped.get(session_id, 0),
             profile_key=profile_key_value,
+            delegation_parent_raw_id=delegation_targets.get(session_id),
         )
         for session_id in session_ids
     ]
+    stub_children = sorted(child for child in delegation_targets if child not in session_ids)
+    sessions.extend(
+        _atof_subagent_delegation_stub_session(child, delegation_targets[child], profile_key_value)
+        for child in stub_children
+    )
+    return sessions
+
+
+def _mark_delegation_edges_on_subagent_events(
+    grouped: dict[str, list[ParsedSessionEvent]], delegation_targets: dict[str, str]
+) -> None:
+    """Record whether each observed subagent mark actually materialized an edge.
+
+    Mutates the already-built ``hermes_subagent_span`` events in place (the
+    per-mark materialization decision -- unambiguous single parent, known
+    profile -- is only known after every record has been scanned), so the
+    *observing parent's own* fidelity declaration can report how many of its
+    subagent references actually became real ``session_links`` edges, without
+    needing cross-session lookups.
+    """
+    for events in grouped.values():
+        for event in events:
+            if event.event_type != "hermes_subagent_span":
+                continue
+            child_session_id = event.payload.get("child_session_id")
+            event.payload["delegation_edge_asserted"] = bool(
+                isinstance(child_session_id, str) and child_session_id and delegation_targets.get(child_session_id)
+            )
 
 
 def _unpaired_scope_events(phases: dict[str, dict[str, tuple[str | None, str | None]]]) -> list[ParsedSessionEvent]:
@@ -492,6 +562,12 @@ def _atof_event(record: JSONDocument) -> list[ParsedSessionEvent] | None:
                     "child_session_id": _optional_str(data.get("child_session_id")),
                     "child_role": _optional_str(data.get("child_role")),
                     "status": _optional_str(data.get("status")) or _optional_str(metadata.get("status")),
+                    # Overwritten by _mark_delegation_edges_on_subagent_events once every
+                    # record in the batch has been scanned -- an unambiguous, profile-known
+                    # child session_id materializes a real session_links edge; anything else
+                    # (unknown profile, missing/self-referential id, contested by two
+                    # different parents) leaves this False, visible acquisition debt.
+                    "delegation_edge_asserted": False,
                 },
             )
         ]
@@ -535,6 +611,7 @@ def _atof_session(
     skipped: int,
     *,
     profile_key: str | None,
+    delegation_parent_raw_id: str | None = None,
 ) -> ParsedSession:
     del skipped  # counts live in session_events/import_fidelity_declaration, never in message text
     # Deliberately stable across every replay/revision of this session (never
@@ -547,14 +624,38 @@ def _atof_session(
     # silently discarding them.
     summary_text = f"Hermes ATOF observer stream: {session_id}"
     provider_session_id = atof_session_provider_id(session_id, profile_key)
-    # The parent join key: asserting it makes the generic session_links write
-    # path (archive_tiers/write.py::_write_session_link, unchanged by this
-    # parser) resolve this observer session against the profile-qualified
-    # state-db conversational session sharing the same raw id -- resolvable
-    # once that session is ingested, visible as unresolved debt otherwise.
-    # Only asserted when the profile is known (see parse_atof_stream
-    # docstring): an unqualified raw id is not a safe cross-profile join key.
-    parent_session_provider_id = _qualified_session_id(session_id, profile_key) if profile_key else None
+    branch_type: BranchType | None = None
+    if delegation_parent_raw_id and profile_key:
+        # Subagent-delegation edge (fs1.14 residual scope): a real
+        # hermes.subagent.* mark named this session as a child of another
+        # session in the same batch. That edge supersedes the routine
+        # self-correlation edge below -- both remain read-side derivable via
+        # hermes_atof_session_id_for, so nothing is lost, only the single
+        # session_links parent slot is spent on the more specific claim.
+        parent_session_provider_id: str | None = atof_session_provider_id(delegation_parent_raw_id, profile_key)
+        branch_type = BranchType.SUBAGENT
+        correlation_note = (
+            "ATOF runtime evidence is stored as its own observer session (observer:atof:<id>"
+            "[@profile-<key>]), not merged into the transcript. A real hermes.subagent.* mark named "
+            "this session as a subagent delegated from the parent observer session referenced above; "
+            "correlate with that parent's own conversational/ATIF/ATOF evidence and this session's own "
+            "state-db conversational counterpart (hermes_atof_session_id_for) separately."
+        )
+    else:
+        # The parent join key: asserting it makes the generic session_links write
+        # path (archive_tiers/write.py::_write_session_link, unchanged by this
+        # parser) resolve this observer session against the profile-qualified
+        # state-db conversational session sharing the same raw id -- resolvable
+        # once that session is ingested, visible as unresolved debt otherwise.
+        # Only asserted when the profile is known (see parse_atof_stream
+        # docstring): an unqualified raw id is not a safe cross-profile join key.
+        parent_session_provider_id = _qualified_session_id(session_id, profile_key) if profile_key else None
+        correlation_note = (
+            "ATOF runtime evidence is stored as its own observer session (observer:atof:<id>"
+            "[@profile-<key>]), not merged into the transcript; correlate with the "
+            "state-db-ingested conversational session and any ATIF observer session "
+            "(observer:atif:<id>[@profile-<key>]) sharing this raw Hermes session id."
+        )
     return ParsedSession(
         source_name=Provider.HERMES,
         provider_session_id=provider_session_id,
@@ -579,18 +680,69 @@ def _atof_session(
                     "join_key": "sessions.native_id",
                     "profile_qualified": profile_key is not None,
                     "asserted_parent_session_provider_id": parent_session_provider_id,
-                    "note": (
-                        "ATOF runtime evidence is stored as its own observer session (observer:atof:<id>"
-                        "[@profile-<key>]), not merged into the transcript; correlate with the "
-                        "state-db-ingested conversational session and any ATIF observer session "
-                        "(observer:atif:<id>[@profile-<key>]) sharing this raw Hermes session id."
-                    ),
+                    "delegated_from_session_id": delegation_parent_raw_id,
+                    "note": correlation_note,
                 },
             ),
             *events,
         ],
         parent_session_provider_id=parent_session_provider_id,
+        branch_type=branch_type,
         ingest_flags=["hermes:atof-observer"],
+    )
+
+
+def _atof_subagent_delegation_stub_session(
+    child_session_id: str, parent_raw_id: str, profile_key: str | None
+) -> ParsedSession:
+    """Materialize a minimal delegation-evidence session for a subagent whose
+    own ATOF/ATIF records were not present in this batch.
+
+    The edge itself -- a real ``hermes.subagent.start`` mark naming this raw
+    session id as a child of ``parent_raw_id`` -- is producer-positive
+    evidence even without the child's own trace content, so this session
+    exists purely to carry the ``session_links`` parent edge into the
+    archive. If the child's own trace evidence is separately ingested later
+    (a different ATOF/ATIF batch), the archive's content-hash full-replace
+    rule updates this same computed session id in place rather than
+    duplicating it -- ``provider_session_id`` is identical either way.
+    """
+    provider_session_id = atof_session_provider_id(child_session_id, profile_key)
+    parent_session_provider_id = atof_session_provider_id(parent_raw_id, profile_key)
+    summary_text = f"Hermes ATOF subagent delegation evidence: {child_session_id}"
+    return ParsedSession(
+        source_name=Provider.HERMES,
+        provider_session_id=provider_session_id,
+        title=summary_text,
+        messages=[
+            ParsedMessage(
+                provider_message_id=f"{provider_session_id}:atof-delegation-summary",
+                role=Role.SYSTEM,
+                text=summary_text,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text=summary_text)],
+                position=0,
+                variant_index=0,
+                is_active_path=True,
+                material_origin=MaterialOrigin.RUNTIME_CONTEXT,
+            )
+        ],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="hermes_subagent_delegation_evidence",
+                payload={
+                    "child_session_id": child_session_id,
+                    "parent_session_id": parent_raw_id,
+                    "note": (
+                        "This session's own ATOF/ATIF trace records were not present in the batch "
+                        "that observed the delegation mark; only the delegation edge itself is "
+                        "materialized here, never fabricated content."
+                    ),
+                },
+            )
+        ],
+        parent_session_provider_id=parent_session_provider_id,
+        branch_type=BranchType.SUBAGENT,
+        ingest_flags=["hermes:atof-observer", "hermes:atof-subagent-delegation-stub"],
     )
 
 
@@ -599,8 +751,9 @@ def parse_atif_document(
     fallback_id: str,
     *,
     profile_root: Path | None = None,
-) -> ParsedSession:
-    """Parse one Hermes ATIF trajectory document into a session.
+) -> list[ParsedSession]:
+    """Parse one Hermes ATIF trajectory document into a parent session plus
+    any materialized subagent-delegation child sessions.
 
     Ambiguous input is handled deterministically: a step with none of the
     documented shapes (``tool_calls``, ``message``, ``observation``) becomes
@@ -618,6 +771,22 @@ def parse_atif_document(
     and the ``session_links`` parent edge asserted back to the matching
     state-db conversational session. ``None`` fails closed -- no parent edge
     is asserted rather than guessing.
+
+    SUBAGENT DELEGATION (polylogue-fs1.14 residual scope): each
+    ``subagent_trajectories`` entry with a producer-positive, non-empty
+    ``session_id`` distinct from this document's own ``session_id`` (a
+    structurally impossible self-reference is never materialized) becomes a
+    real child :class:`ParsedSession`, parsed from that entry's own ``steps``
+    the same way the parent document's ``steps`` are, with a
+    ``session_links`` parent edge (``branch_type=subagent``) back to this
+    document's composed ATIF observer identity -- only asserted when
+    ``profile_root`` is also known, the same fail-closed rule
+    :func:`parse_atof_stream` uses. No real ATIF fixture observed so far
+    carries any ``subagent_trajectories`` evidence (every live trajectory
+    sampled has an empty/absent list -- see module docstring), so this is
+    implemented and unit-tested against the documented schema, but the
+    fidelity capability stays ``inferred``, never ``exact``, until real bytes
+    prove it (see :func:`import_fidelity_declaration`).
     """
     session_id = str(payload.get("session_id") or fallback_id)
     agent = json_document(payload.get("agent")) or {}
@@ -643,13 +812,6 @@ def parse_atif_document(
         events.extend(step_events)
         skipped += step_skipped
 
-    for index, raw_subagent in enumerate(raw_subagents):
-        subagent = json_document(raw_subagent)
-        if not subagent:
-            skipped += 1
-            continue
-        events.append(_subagent_span_event(subagent, index))
-
     # Deliberately stable across every replay/revision of this session (never
     # embeds live step/event counts): see _atof_session's identical note --
     # the archive's membership classifier requires message content to be an
@@ -660,7 +822,27 @@ def parse_atif_document(
     profile_key_value = _profile_key(profile_root) if profile_root is not None else None
     provider_session_id = atif_session_provider_id(session_id, profile_key_value)
     parent_session_provider_id = _qualified_session_id(session_id, profile_key_value) if profile_key_value else None
-    return ParsedSession(
+
+    child_sessions: list[ParsedSession] = []
+    for index, raw_subagent in enumerate(raw_subagents):
+        subagent = json_document(raw_subagent)
+        if not subagent:
+            skipped += 1
+            continue
+        subagent_session_id = _optional_str(subagent.get("session_id"))
+        delegation_edge_asserted = bool(profile_key_value and subagent_session_id and subagent_session_id != session_id)
+        events.append(_subagent_span_event(subagent, index, delegation_edge_asserted=delegation_edge_asserted))
+        if delegation_edge_asserted and subagent_session_id is not None:
+            child_sessions.append(
+                _atif_subagent_child_session(
+                    subagent,
+                    subagent_session_id,
+                    parent_provider_session_id=provider_session_id,
+                    profile_key=profile_key_value,
+                )
+            )
+
+    parent_session = ParsedSession(
         source_name=Provider.HERMES,
         provider_session_id=provider_session_id,
         title=f"Hermes ATIF trajectory: {session_id}",
@@ -696,6 +878,77 @@ def parse_atif_document(
         ],
         parent_session_provider_id=parent_session_provider_id,
         ingest_flags=["hermes:atif-trajectory"],
+    )
+    return [parent_session, *child_sessions]
+
+
+def _atif_subagent_child_session(
+    subagent: JSONDocument,
+    subagent_session_id: str,
+    *,
+    parent_provider_session_id: str,
+    profile_key: str | None,
+) -> ParsedSession:
+    """Materialize one ``subagent_trajectories`` entry as its own ATIF child session.
+
+    Parsed from the entry's own ``steps`` with the exact same step-shape
+    handling :func:`parse_atif_document` uses for the top-level document
+    (ambiguous/malformed steps skipped-and-counted, never dropped silently),
+    so a real subagent trajectory's evidence is retained with the same
+    fidelity as its parent's, never a bare summary stub.
+    """
+    agent = json_document(subagent.get("agent")) or {}
+    model_name = _optional_str(agent.get("model_name"))
+    steps_value = subagent.get("steps")
+    raw_steps: list[JSONValue] = steps_value if isinstance(steps_value, list) else []
+
+    events: list[ParsedSessionEvent] = []
+    for index, raw_step in enumerate(raw_steps):
+        step = json_document(raw_step)
+        if not step:
+            continue
+        step_events, _skipped = _events_for_step(step, index, model_name)
+        events.extend(step_events)
+
+    summary_text = f"Hermes ATIF subagent trajectory: {subagent_session_id}"
+    provider_session_id = atif_session_provider_id(subagent_session_id, profile_key)
+    return ParsedSession(
+        source_name=Provider.HERMES,
+        provider_session_id=provider_session_id,
+        title=summary_text,
+        messages=[
+            ParsedMessage(
+                provider_message_id=f"{provider_session_id}:trace-summary",
+                role=Role.SYSTEM,
+                text=summary_text,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text=summary_text)],
+                position=0,
+                variant_index=0,
+                is_active_path=True,
+                material_origin=MaterialOrigin.RUNTIME_CONTEXT,
+            )
+        ],
+        session_events=[
+            ParsedSessionEvent(
+                event_type="hermes_observer_trace_correlation",
+                payload={
+                    "hermes_conversation_session_id_prefix": subagent_session_id,
+                    "join_key": "sessions.native_id",
+                    "profile_qualified": profile_key is not None,
+                    "asserted_parent_session_provider_id": parent_provider_session_id,
+                    "note": (
+                        "This session carries ATIF subagent-trajectory evidence delegated from the "
+                        "parent observer session referenced above (a subagent_trajectories entry); "
+                        "correlate with that parent's own conversational/ATOF evidence and this "
+                        "session's own state-db conversational counterpart separately."
+                    ),
+                },
+            ),
+            *events,
+        ],
+        parent_session_provider_id=parent_provider_session_id,
+        branch_type=BranchType.SUBAGENT,
+        ingest_flags=["hermes:atif-trajectory", "hermes:atif-subagent-child"],
     )
 
 
@@ -764,7 +1017,9 @@ def _events_for_step(step: JSONDocument, index: int, model_name: str | None) -> 
     return events, skipped
 
 
-def _subagent_span_event(subagent: JSONDocument, index: int) -> ParsedSessionEvent:
+def _subagent_span_event(
+    subagent: JSONDocument, index: int, *, delegation_edge_asserted: bool = False
+) -> ParsedSessionEvent:
     agent = json_document(subagent.get("agent")) or {}
     steps = subagent.get("steps")
     return ParsedSessionEvent(
@@ -774,6 +1029,13 @@ def _subagent_span_event(subagent: JSONDocument, index: int) -> ParsedSessionEve
             "subagent_session_id": _optional_str(subagent.get("session_id")),
             "subagent_agent_name": _optional_str(agent.get("name")),
             "subagent_step_count": len(steps) if isinstance(steps, list) else None,
+            # Whether this subagent_trajectories entry's own session_id was
+            # producer-positive, distinct from this document's own id, and
+            # backed by a known profile root -- the exact conditions under
+            # which parse_atif_document materialized a real session_links
+            # child session for it. False is visible acquisition debt, never
+            # silently indistinguishable from "no evidence at all".
+            "delegation_edge_asserted": delegation_edge_asserted,
         },
     )
 
@@ -802,6 +1064,13 @@ def import_fidelity_declaration(session: ParsedSession) -> HermesImportFidelity:
     tool_spans = sum(1 for event in span_events if event.event_type == "hermes_tool_execution_span")
     subagent_spans = sum(1 for event in span_events if event.event_type == "hermes_subagent_span")
     generic_spans = sum(1 for event in span_events if event.event_type == "hermes_observer_span")
+    materialized_delegation_edges = sum(
+        1
+        for event in span_events
+        if event.event_type == "hermes_subagent_span" and event.payload.get("delegation_edge_asserted") is True
+    )
+    is_delegated_child_session = session.branch_type == BranchType.SUBAGENT
+    topology_edges_observed = materialized_delegation_edges + (1 if is_delegated_child_session else 0)
 
     def capability(
         observed: int,
@@ -831,9 +1100,11 @@ def import_fidelity_declaration(session: ParsedSession) -> HermesImportFidelity:
         ),
         "subagent_delegation": capability(
             subagent_spans,
-            "subagent_trajectories entries recorded as delegation evidence and surfaced read-side by "
-            "insights.hermes_topology_projection; NOT materialized into topology_edges/session_links "
-            "(a physical child-session write) in this pass -- deferred, see module docstring.",
+            "subagent_trajectories entries recorded as delegation evidence and, when a "
+            "producer-positive child session_id and a known profile root are both present, "
+            "materialized as a real child ATIF session with a session_links parent edge "
+            "(branch_type=subagent, see topology_edges) -- also surfaced read-side by "
+            "insights.hermes_topology_projection.",
         ),
         "decision_points": HermesFidelityCapability(
             status="absent",
@@ -852,11 +1123,19 @@ def import_fidelity_declaration(session: ParsedSession) -> HermesImportFidelity:
             "exists only in the raw ATOF event stream, not ingested by this pass (see fs1.2.1).",
         ),
         "topology_edges": HermesFidelityCapability(
-            status="absent",
-            observed=0,
-            expected=max(subagent_spans, 1),
+            status="inferred" if topology_edges_observed else "absent",
+            observed=topology_edges_observed,
+            expected=max(subagent_spans, 1) if not is_delegated_child_session else 1,
             counts={},
-            detail="Physical topology_edges materialization from subagent_trajectories is out of scope for this pass.",
+            detail=(
+                "subagent_trajectories entries with a producer-positive session_id, distinct from "
+                "this session's own id, and a known profile root are materialized as real "
+                "session_links parent edges (branch_type=subagent) on the child's own ATIF observer "
+                "session. No real ATIF fixture observed so far carries any subagent_trajectories "
+                "evidence, so this mapping remains unverified against real bytes -- inferred, never "
+                "exact, until proven (unlike the ATOF hermes.subagent.* route, see "
+                "_atof_import_fidelity_declaration)."
+            ),
         ),
         "parent_session_link": _parent_session_link_capability(session),
     }
@@ -907,9 +1186,18 @@ def _atof_import_fidelity_declaration(session: ParsedSession) -> HermesImportFid
     tool = observed("hermes_tool_execution_span")
     decisions = observed("hermes_decision_span")
     errors = observed("hermes_error_span")
-    subagents = observed("hermes_subagent_span")
+    subagent_marks = observed("hermes_subagent_span")
+    delegation_stub_evidence = observed("hermes_subagent_delegation_evidence")
+    subagents = subagent_marks + delegation_stub_evidence
     context = observed("hermes_context_span")
     generic = observed("hermes_observer_span")
+    materialized_delegation_edges = sum(
+        1
+        for event in events
+        if event.event_type == "hermes_subagent_span" and event.payload.get("delegation_edge_asserted") is True
+    )
+    is_delegated_child_session = session.branch_type == BranchType.SUBAGENT
+    topology_edges_observed = materialized_delegation_edges + (1 if is_delegated_child_session else 0)
     capabilities = {
         "llm_request_spans": exact_if_observed(
             llm,
@@ -937,11 +1225,19 @@ def _atof_import_fidelity_declaration(session: ParsedSession) -> HermesImportFid
             "start/end pair retain context-event identity without duplicating context content.",
         ),
         "topology_edges": HermesFidelityCapability(
-            status="absent",
-            observed=0,
-            expected=max(subagents, 1),
+            status="exact" if topology_edges_observed else "absent",
+            observed=topology_edges_observed,
+            expected=max(subagent_marks, 1) if not is_delegated_child_session else 1,
             counts={},
-            detail="Subagent ATOF marks are observer evidence only; session_links materialization remains deferred.",
+            detail=(
+                "A real hermes.subagent.* mark's producer-positive child_session_id, with a known "
+                "profile root and no conflicting parent claim, is materialized as a real session_links "
+                "parent edge (branch_type=subagent) on the child's own ATOF observer session -- "
+                "confirmed end-to-end against the real NeMo Relay ATOF fixture's hermes.subagent.start "
+                "mark. Ambiguous evidence (unknown profile, missing/self-referential/contested child id) "
+                "asserts no edge, visible as delegation_edge_asserted=false on the observing session's "
+                "own hermes_subagent_span event."
+            ),
         ),
         "parent_session_link": _parent_session_link_capability(session),
     }
@@ -994,6 +1290,19 @@ def _parent_session_link_capability(session: ParsedSession) -> HermesFidelityCap
     session was actually ingested; that confirmation is the generic
     ``session_links`` resolution machinery's job, not this parser's.
     """
+    if session.parent_session_provider_id and session.branch_type == BranchType.SUBAGENT:
+        return HermesFidelityCapability(
+            status="inferred",
+            observed=1,
+            expected=1,
+            counts={},
+            detail=(
+                "A profile-qualified session_links parent edge was asserted to the DELEGATING "
+                "session's own observer evidence (subagent delegation), superseding the routine "
+                "conversational-session correlation edge for this child session; resolution against "
+                "an actually-ingested session happens generically at write time."
+            ),
+        )
     if session.parent_session_provider_id:
         return HermesFidelityCapability(
             status="inferred",

--- a/tests/unit/sources/parsers/test_hermes_spans.py
+++ b/tests/unit/sources/parsers/test_hermes_spans.py
@@ -44,11 +44,35 @@ def test_looks_like_atif_payload_requires_real_atif_schema_version_and_session_a
     # The old, pre-fix synthetic marker shape must NOT match anymore -- that
     # was exactly the review finding (a self-referential detector that could
     # only ever recognize this repo's own test fixture).
-    assert not hermes_spans.looks_like_atif_payload(
-        {"polylogue_artifact": "hermes_atif_trace", "session_id": "x", "spans": []}
-    )
+    marker_only_payload = {"polylogue_artifact": "hermes_atif_trace", "session_id": "x", "spans": []}
+    assert not hermes_spans.looks_like_atif_payload(marker_only_payload)
+    # Same proof through the real dispatch entrypoint, not just the predicate.
+    assert detect_provider(marker_only_payload) is not Provider.HERMES
     # Missing steps.
     assert not hermes_spans.looks_like_atif_payload({"schema_version": "ATIF-v1.7", "session_id": "x"})
+
+
+def test_looks_like_atof_payload_rejects_a_repository_invented_marker_only_shape() -> None:
+    """fs1.2.1 AC2: the structural detector admits the real ATOF wire shape
+    (atof_version/kind/uuid/timestamp/name -- see module docstring's NVIDIA
+    sourcing) and rejects a payload containing only an invented marker key
+    that never appeared in the real producer bytes. Unlike ATIF (which once
+    shipped a self-referential ``polylogue_artifact: "hermes_atif_trace"``
+    marker detector, see the test above), ATOF's detector was built directly
+    against the real wire shape and never had an invented marker of its
+    own -- this test proves a marker-only payload was never, and is still
+    not, sufficient on its own."""
+
+    real_record = json.loads(REAL_ATOF_FIXTURE.read_text().splitlines()[0])
+    assert hermes_spans.looks_like_atof_payload(real_record)
+
+    marker_only: JSONDocument = {"polylogue_artifact": "hermes_atof_trace", "session_id": "x"}
+    assert not hermes_spans.looks_like_atof_payload(marker_only)
+    # Real fields present but wrong types/values must not slip through either.
+    assert not hermes_spans.looks_like_atof_payload({"atof_version": "0.1", "kind": "unknown-kind"})
+    assert not hermes_spans.looks_like_atof_payload(
+        {"atof_version": "0.1", "kind": "scope", "uuid": "u1", "timestamp": "t", "name": None}
+    )
 
 
 def test_dispatch_detects_and_parses_atif_trace_through_the_real_pipeline() -> None:

--- a/tests/unit/sources/parsers/test_hermes_spans.py
+++ b/tests/unit/sources/parsers/test_hermes_spans.py
@@ -356,6 +356,78 @@ def test_atof_subagent_mark_fails_closed_when_two_parents_claim_the_same_child(t
         assert fidelity.capabilities["subagent_delegation"].status == "exact"
 
 
+def test_atof_self_referential_mark_stays_unasserted_when_another_session_legitimately_claims_the_same_id(
+    tmp_path: Path,
+) -> None:
+    """CodeRabbit finding (PR #3231, hermes_spans.py:441): the per-mark
+    delegation flag used to be set from membership in ``delegation_targets``
+    alone (``child_session_id in delegation_targets``), without checking
+    WHICH session actually owns that claim. Session S emits a self-
+    referential mark (S names itself as its own child -- correctly excluded
+    from delegation_targets by the self-reference guard, since
+    child_session_id == session_id there). Session P, unrelated, legitimately
+    and unambiguously claims S as ITS OWN child
+    (delegation_targets["S"] == "P"). Under the membership-only check, S's
+    self-referential span would ALSO read delegation_edge_asserted=True
+    merely because "S" happens to be a key in delegation_targets --
+    contradicting the fail-closed self-reference guarantee proved by
+    test_atof_subagent_mark_fails_closed_on_self_reference. The fix requires
+    the flag to additionally check that THIS event's own owning session id
+    equals delegation_targets[child_session_id], not just membership.
+
+    Mutation: replace the owning-session equality check in
+    _mark_delegation_edges_on_subagent_events with membership-only
+    (``bool(delegation_targets.get(child_session_id))``, dropping the
+    ``== owning_session_id`` comparison) and this test's assertion that S's
+    own span stays False fails (it flips to True).
+    """
+    records: list[JSONDocument] = [
+        # Session "S" reports itself as its own subagent -- structurally
+        # impossible self-reference, must never materialize an edge no
+        # matter what any other session in this batch claims about "S".
+        {
+            "atof_version": "0.1",
+            "kind": "mark",
+            "category": "agent",
+            "uuid": "self-mark",
+            "timestamp": "2026-07-18T09:00:08Z",
+            "name": "hermes.subagent.start",
+            "metadata": {"session_id": "S"},
+            "data": {"child_session_id": "S", "child_role": "self"},
+        },
+        # Session "P" legitimately, unambiguously claims "S" as its own
+        # child -- this claim IS producer-positive and must still resolve.
+        {
+            "atof_version": "0.1",
+            "kind": "mark",
+            "category": "agent",
+            "uuid": "p-claims-s",
+            "timestamp": "2026-07-18T09:00:09Z",
+            "name": "hermes.subagent.start",
+            "metadata": {"session_id": "P"},
+            "data": {"child_session_id": "S", "child_role": "research"},
+        },
+    ]
+    sessions = hermes_spans.parse_atof_stream(records, "fallback-id", profile_root=tmp_path)
+
+    session_s = next(s for s in sessions if s.provider_session_id.split(":")[-1].split("@")[0] == "S")
+    session_p = next(s for s in sessions if s.provider_session_id.split(":")[-1].split("@")[0] == "P")
+
+    # S's OWN self-referential span never asserts an edge, regardless of P's
+    # unrelated legitimate claim about "S" existing in the same batch.
+    s_own_event = next(e for e in session_s.session_events if e.event_type == "hermes_subagent_span")
+    assert s_own_event.payload["child_session_id"] == "S"
+    assert s_own_event.payload["delegation_edge_asserted"] is False
+
+    # P's legitimate claim on S still materializes: P's own span reports the
+    # edge as asserted, and S's archive session's parent edge points at P.
+    p_own_event = next(e for e in session_p.session_events if e.event_type == "hermes_subagent_span")
+    assert p_own_event.payload["child_session_id"] == "S"
+    assert p_own_event.payload["delegation_edge_asserted"] is True
+    assert session_s.parent_session_provider_id == session_p.provider_session_id
+    assert session_s.branch_type is not None and session_s.branch_type.value == "subagent"
+
+
 def test_atif_subagent_trajectory_materializes_delegation_edge_with_known_profile(tmp_path: Path) -> None:
     """ATIF mirror of the ATOF real-fixture proof: no real ATIF fixture
     carries subagent_trajectories evidence yet (see module docstring), so

--- a/tests/unit/sources/parsers/test_hermes_spans.py
+++ b/tests/unit/sources/parsers/test_hermes_spans.py
@@ -44,7 +44,7 @@ def test_looks_like_atif_payload_requires_real_atif_schema_version_and_session_a
     # The old, pre-fix synthetic marker shape must NOT match anymore -- that
     # was exactly the review finding (a self-referential detector that could
     # only ever recognize this repo's own test fixture).
-    marker_only_payload = {"polylogue_artifact": "hermes_atif_trace", "session_id": "x", "spans": []}
+    marker_only_payload: JSONDocument = {"polylogue_artifact": "hermes_atif_trace", "session_id": "x", "spans": []}
     assert not hermes_spans.looks_like_atif_payload(marker_only_payload)
     # Same proof through the real dispatch entrypoint, not just the predicate.
     assert detect_provider(marker_only_payload) is not Provider.HERMES

--- a/tests/unit/sources/parsers/test_hermes_spans.py
+++ b/tests/unit/sources/parsers/test_hermes_spans.py
@@ -113,8 +113,13 @@ def test_real_nemo_relay_atof_fixture_reaches_the_stream_parser_without_copying_
         "fallback-id",
         source_path=str(REAL_ATOF_FIXTURE),
     )
-    assert len(sessions) == 1
-    session = sessions[0]
+    # fs1.14 residual scope: the real fixture's hermes.subagent.start mark
+    # (record with data.child_session_id="child-session-redacted") is now
+    # materialized as a second, minimal delegation-evidence session -- see
+    # test_real_atof_fixture_subagent_mark_materializes_delegation_edge for
+    # the dedicated proof of that edge.
+    assert len(sessions) == 2
+    session = next(s for s in sessions if s.provider_session_id.startswith("observer:atof:real-nemo-relay-session"))
     # fs1.14: dispatch derives profile_root from source_path's parent
     # directory (production route, not a bespoke test-only call), so a real
     # source_path now yields an artifact- AND profile-qualified identity and
@@ -160,7 +165,172 @@ def test_real_nemo_relay_atof_fixture_reaches_the_stream_parser_without_copying_
     assert fidelity.capabilities["error_taxonomy"].status == "exact"
     assert fidelity.capabilities["subagent_delegation"].status == "exact"
     assert fidelity.capabilities["context_events"].status == "exact"
+    # fs1.14 residual scope: the real hermes.subagent.start mark's
+    # producer-positive child_session_id, with dispatch's real
+    # source_path-derived profile root, materialized a real session_links
+    # delegation edge -- confirmed end-to-end, "exact" not "inferred".
+    assert fidelity.capabilities["topology_edges"].status == "exact"
+    assert fidelity.capabilities["topology_edges"].observed == 1
     assert "unrecognized_atof_events" not in fidelity.capabilities
+
+
+def test_real_atof_fixture_subagent_mark_materializes_delegation_edge() -> None:
+    """Anti-vacuity proof for fs1.14 subagent-delegation topology materialization.
+
+    The real NeMo Relay ATOF fixture's ``hermes.subagent.start`` mark reports
+    a producer-positive ``data.child_session_id`` ("child-session-redacted")
+    for a child whose own trace records are not present in this batch. That
+    is exactly the fail-closed materialization case: no content can be
+    fabricated for the child, but the delegation edge itself is real
+    evidence and must not be silently dropped -- a minimal delegation-only
+    session carries the real ``session_links`` parent edge into the archive.
+
+    Mutation: remove the delegation-edge materialization in
+    ``parse_atof_stream``/``_atof_subagent_delegation_stub_session`` (or the
+    ``delegation_edge_asserted`` marking on the observing session's own
+    ``hermes_subagent_span`` event) and this test's session count, parent
+    link, or branch_type assertions fail.
+    """
+    records = [json.loads(line) for line in REAL_ATOF_FIXTURE.read_text().splitlines()]
+    sessions = parse_stream_payload(
+        Provider.HERMES,
+        iter(records),
+        "fallback-id",
+        source_path=str(REAL_ATOF_FIXTURE),
+    )
+    assert len(sessions) == 2
+
+    from polylogue.sources.parsers.hermes_identity import profile_key
+
+    expected_key = profile_key(REAL_ATOF_FIXTURE.parent)
+    parent = next(s for s in sessions if s.provider_session_id.startswith("observer:atof:real-nemo-relay-session"))
+    child = next(s for s in sessions if s.provider_session_id.startswith("observer:atof:child-session-redacted"))
+
+    assert child.provider_session_id == f"observer:atof:child-session-redacted@profile-{expected_key}"
+    assert child.parent_session_provider_id == parent.provider_session_id
+    assert child.branch_type is not None and child.branch_type.value == "subagent"
+    assert "hermes:atof-subagent-delegation-stub" in child.ingest_flags
+
+    # The observing (parent) session's own mark event records whether the
+    # edge it reported was actually materialized -- true here.
+    subagent_events = [e for e in parent.session_events if e.event_type == "hermes_subagent_span"]
+    assert len(subagent_events) == 1
+    assert subagent_events[0].payload["child_session_id"] == "child-session-redacted"
+    assert subagent_events[0].payload["delegation_edge_asserted"] is True
+
+    parent_fidelity = hermes_spans.import_fidelity_declaration(parent)
+    assert parent_fidelity.capabilities["topology_edges"].status == "exact"
+    child_fidelity = hermes_spans.import_fidelity_declaration(child)
+    assert child_fidelity.capabilities["parent_session_link"].status == "inferred"
+    assert "DELEGATING" in child_fidelity.capabilities["parent_session_link"].detail
+
+
+def test_atof_subagent_mark_fails_closed_without_profile_root() -> None:
+    """Unknown profile root: the delegation edge must not be asserted -- fail
+    closed rather than guessing an unqualified, potentially cross-profile
+    join key (same rule as the routine self-correlation edge)."""
+
+    records: list[JSONDocument] = [
+        {
+            "atof_version": "0.1",
+            "kind": "mark",
+            "category": "agent",
+            "uuid": "subagent-start-1",
+            "timestamp": "2026-07-18T09:00:08Z",
+            "name": "hermes.subagent.start",
+            "metadata": {"session_id": "parent-session"},
+            "data": {"child_session_id": "child-session", "child_role": "research"},
+        },
+    ]
+    sessions = hermes_spans.parse_atof_stream(records, "fallback-id")
+    assert len(sessions) == 1
+    subagent_events = [e for e in sessions[0].session_events if e.event_type == "hermes_subagent_span"]
+    assert subagent_events[0].payload["delegation_edge_asserted"] is False
+    fidelity = hermes_spans.import_fidelity_declaration(sessions[0])
+    assert fidelity.capabilities["topology_edges"].status == "absent"
+
+
+def test_atof_subagent_mark_fails_closed_on_self_reference(tmp_path: Path) -> None:
+    """A session reported as its own subagent is a structurally impossible
+    self-reference -- never materialized as an edge."""
+
+    records: list[JSONDocument] = [
+        {
+            "atof_version": "0.1",
+            "kind": "mark",
+            "category": "agent",
+            "uuid": "subagent-start-1",
+            "timestamp": "2026-07-18T09:00:08Z",
+            "name": "hermes.subagent.start",
+            "metadata": {"session_id": "self-session"},
+            "data": {"child_session_id": "self-session", "child_role": "research"},
+        },
+    ]
+    sessions = hermes_spans.parse_atof_stream(records, "fallback-id", profile_root=tmp_path)
+    assert len(sessions) == 1
+    subagent_events = [e for e in sessions[0].session_events if e.event_type == "hermes_subagent_span"]
+    assert subagent_events[0].payload["delegation_edge_asserted"] is False
+
+
+def test_atif_subagent_trajectory_materializes_delegation_edge_with_known_profile(tmp_path: Path) -> None:
+    """ATIF mirror of the ATOF real-fixture proof: no real ATIF fixture
+    carries subagent_trajectories evidence yet (see module docstring), so
+    this is a synthetic, documented-schema proof, not a real-fixture proof --
+    the fidelity capability must stay 'inferred', never 'exact'."""
+
+    subagents: list[JSONValue] = [
+        {
+            "session_id": "docs-child-session",
+            "agent": {"name": "Hermes Agent E2E"},
+            "steps": [{"source": "agent", "message": "child agent response"}],
+        }
+    ]
+    payload = hermes_spans.marker_payload("hermes-session-1", [], subagent_trajectories=subagents)
+    sessions = hermes_spans.parse_atif_document(payload, "fallback-id", profile_root=tmp_path)
+    assert len(sessions) == 2
+    parent, child = sessions
+
+    from polylogue.sources.parsers.hermes_identity import profile_key
+
+    expected_key = profile_key(tmp_path)
+    assert child.provider_session_id == f"observer:atif:docs-child-session@profile-{expected_key}"
+    assert child.parent_session_provider_id == parent.provider_session_id
+    assert child.branch_type is not None and child.branch_type.value == "subagent"
+    assert "hermes:atif-subagent-child" in child.ingest_flags
+    llm_events = [e for e in child.session_events if e.event_type == "hermes_llm_request_span"]
+    assert len(llm_events) == 1
+    assert llm_events[0].payload["message_char_len"] == len("child agent response")
+    assert "child agent response" not in repr([e.payload for e in child.session_events])
+
+    parent_fidelity = hermes_spans.import_fidelity_declaration(parent)
+    assert parent_fidelity.capabilities["topology_edges"].status == "inferred"
+    assert parent_fidelity.capabilities["topology_edges"].observed == 1
+
+
+def test_atif_subagent_trajectory_fails_closed_without_profile_root() -> None:
+    """No profile root known: the delegation edge is not asserted, but the
+    parent-side summary evidence is still recorded (never silently dropped)."""
+
+    subagents: list[JSONValue] = [{"session_id": "docs-child-session", "steps": []}]
+    payload = hermes_spans.marker_payload("hermes-session-1", [], subagent_trajectories=subagents)
+    sessions = hermes_spans.parse_atif_document(payload, "fallback-id")
+    assert len(sessions) == 1
+    subagent_events = [e for e in sessions[0].session_events if e.event_type == "hermes_subagent_span"]
+    assert subagent_events[0].payload["delegation_edge_asserted"] is False
+    fidelity = hermes_spans.import_fidelity_declaration(sessions[0])
+    assert fidelity.capabilities["topology_edges"].status == "absent"
+
+
+def test_atif_subagent_trajectory_fails_closed_on_self_reference(tmp_path: Path) -> None:
+    """A subagent_trajectories entry naming its own parent's session id is a
+    structurally impossible self-reference -- never materialized as an edge."""
+
+    subagents: list[JSONValue] = [{"session_id": "hermes-session-1", "steps": []}]
+    payload = hermes_spans.marker_payload("hermes-session-1", [], subagent_trajectories=subagents)
+    sessions = hermes_spans.parse_atif_document(payload, "fallback-id", profile_root=tmp_path)
+    assert len(sessions) == 1
+    subagent_events = [e for e in sessions[0].session_events if e.event_type == "hermes_subagent_span"]
+    assert subagent_events[0].payload["delegation_edge_asserted"] is False
 
 
 def test_atof_stream_is_idempotent_across_append_replay_and_keeps_scope_edges() -> None:
@@ -321,7 +491,9 @@ def test_import_explain_uses_atof_stream_fidelity_for_a_real_fixture() -> None:
     entry = explain_import_path(REAL_ATOF_FIXTURE, source_name="hermes").entries[0]
     assert entry.detected_provider == "hermes"
     assert entry.parser == "hermes"
-    assert entry.produced.sessions == 1
+    # fs1.14 residual scope: the real fixture's hermes.subagent.start mark
+    # materializes a second, minimal delegation-evidence session.
+    assert entry.produced.sessions == 2
     assert entry.fidelity is not None
     assert entry.fidelity.acquisition_method == "jsonl_stream"
 
@@ -341,7 +513,7 @@ def test_atif_parse_is_idempotent_and_deterministic() -> None:
     payload = hermes_spans.marker_payload("hermes-session-1", _steps())
     first = hermes_spans.parse_atif_document(payload, "fallback-id")
     second = hermes_spans.parse_atif_document(payload, "fallback-id")
-    assert first.model_dump(mode="json") == second.model_dump(mode="json")
+    assert [s.model_dump(mode="json") for s in first] == [s.model_dump(mode="json") for s in second]
 
 
 def test_tool_call_steps_become_tool_execution_spans_without_copying_arguments() -> None:
@@ -350,7 +522,7 @@ def test_tool_call_steps_become_tool_execution_spans_without_copying_arguments()
     evidence (see module docstring)."""
 
     payload = hermes_spans.marker_payload("hermes-session-1", _steps())
-    session = hermes_spans.parse_atif_document(payload, "fallback-id")
+    session = hermes_spans.parse_atif_document(payload, "fallback-id")[0]
 
     tool_events = [event for event in session.session_events if event.event_type == "hermes_tool_execution_span"]
     assert len(tool_events) == 1
@@ -368,7 +540,7 @@ def test_message_only_steps_become_llm_response_evidence_without_copying_text() 
     payload = hermes_spans.marker_payload(
         "hermes-session-1", _steps(), agent={"name": "hermes", "version": "1", "model_name": "claude-example"}
     )
-    session = hermes_spans.parse_atif_document(payload, "fallback-id")
+    session = hermes_spans.parse_atif_document(payload, "fallback-id")[0]
 
     llm_events = [event for event in session.session_events if event.event_type == "hermes_llm_request_span"]
     assert len(llm_events) == 1
@@ -387,7 +559,7 @@ def test_subagent_trajectories_become_subagent_span_events() -> None:
         }
     ]
     payload = hermes_spans.marker_payload("hermes-session-1", [], subagent_trajectories=subagents)
-    session = hermes_spans.parse_atif_document(payload, "fallback-id")
+    session = hermes_spans.parse_atif_document(payload, "fallback-id")[0]
 
     subagent_events = [event for event in session.session_events if event.event_type == "hermes_subagent_span"]
     assert len(subagent_events) == 1
@@ -398,7 +570,11 @@ def test_subagent_trajectories_become_subagent_span_events() -> None:
 
     fidelity = hermes_spans.import_fidelity_declaration(session)
     assert fidelity.capabilities["subagent_delegation"].status == "inferred"
-    # Physical topology_edges materialization remains explicitly out of scope.
+    # No profile_root was given, so the fail-closed rule leaves the edge
+    # unasserted here -- see test_atif_subagent_trajectory_materializes_
+    # delegation_edge_with_known_profile for the case where it IS
+    # materialized, and test_atif_subagent_trajectory_fails_closed_without_
+    # profile_root for this exact fail-closed case in isolation.
     assert fidelity.capabilities["topology_edges"].status == "absent"
 
 
@@ -408,7 +584,7 @@ def test_unrecognized_step_shape_becomes_generic_observer_span_not_dropped() -> 
 
     steps: list[JSONValue] = [{"source": "agent", "unexpected_field": "future-shape"}]
     payload = hermes_spans.marker_payload("hermes-session-1", steps)
-    session = hermes_spans.parse_atif_document(payload, "fallback-id")
+    session = hermes_spans.parse_atif_document(payload, "fallback-id")[0]
 
     generic_events = [event for event in session.session_events if event.event_type == "hermes_observer_span"]
     assert len(generic_events) == 1
@@ -426,7 +602,7 @@ def test_malformed_steps_and_tool_calls_are_skipped_and_counted_not_crashing() -
         {"source": "agent", "tool_calls": ["not-a-dict"]},  # tool_calls entry not even a document
     ]
     payload = hermes_spans.marker_payload("hermes-session-1", steps)
-    session = hermes_spans.parse_atif_document(payload, "fallback-id")
+    session = hermes_spans.parse_atif_document(payload, "fallback-id")[0]
     real_events = [
         event
         for event in session.session_events
@@ -458,7 +634,7 @@ def test_decision_points_and_error_taxonomy_are_honestly_absent_not_fabricated()
     from a schema that doesn't carry them."""
 
     payload = hermes_spans.marker_payload("hermes-session-1", _steps())
-    session = hermes_spans.parse_atif_document(payload, "fallback-id")
+    session = hermes_spans.parse_atif_document(payload, "fallback-id")[0]
     fidelity = hermes_spans.import_fidelity_declaration(session)
 
     assert fidelity.capabilities["decision_points"].status == "absent"
@@ -510,7 +686,7 @@ def test_atif_asserts_profile_qualified_parent_session_link_when_profile_root_kn
 
     profile_root = tmp_path / "hermes-install"
     payload = hermes_spans.marker_payload("hermes-session-1", _steps())
-    session = hermes_spans.parse_atif_document(payload, "fallback-id", profile_root=profile_root)
+    session = hermes_spans.parse_atif_document(payload, "fallback-id", profile_root=profile_root)[0]
 
     from polylogue.sources.parsers.hermes_identity import profile_key, qualified_session_id
 
@@ -532,7 +708,7 @@ def test_atif_fails_closed_on_unknown_profile_root() -> None:
     than guessing an unqualified, potentially cross-profile-colliding join key."""
 
     payload = hermes_spans.marker_payload("hermes-session-1", _steps())
-    session = hermes_spans.parse_atif_document(payload, "fallback-id")
+    session = hermes_spans.parse_atif_document(payload, "fallback-id")[0]
 
     assert session.parent_session_provider_id is None
     assert session.provider_session_id == "observer:atif:hermes-session-1"
@@ -551,8 +727,8 @@ def test_two_profiles_with_the_same_raw_session_id_do_not_collapse(tmp_path: Pat
     profile_b = tmp_path / "install-b"
     payload = hermes_spans.marker_payload("hermes-session-1", _steps())
 
-    session_a = hermes_spans.parse_atif_document(payload, "fallback-id", profile_root=profile_a)
-    session_b = hermes_spans.parse_atif_document(payload, "fallback-id", profile_root=profile_b)
+    session_a = hermes_spans.parse_atif_document(payload, "fallback-id", profile_root=profile_a)[0]
+    session_b = hermes_spans.parse_atif_document(payload, "fallback-id", profile_root=profile_b)[0]
 
     assert session_a.provider_session_id != session_b.provider_session_id
     assert session_a.parent_session_provider_id != session_b.parent_session_provider_id
@@ -713,8 +889,8 @@ def test_two_profiles_times_two_artifact_families_compose_to_four_distinct_sessi
             }
         ]
 
-    atif_a = hermes_spans.parse_atif_document(atif_payload, "fallback-id", profile_root=profile_a_root)
-    atif_b = hermes_spans.parse_atif_document(atif_payload, "fallback-id", profile_root=profile_b_root)
+    atif_a = hermes_spans.parse_atif_document(atif_payload, "fallback-id", profile_root=profile_a_root)[0]
+    atif_b = hermes_spans.parse_atif_document(atif_payload, "fallback-id", profile_root=profile_b_root)[0]
     atof_a = hermes_spans.parse_atof_stream(
         atof_records_for(hermes_session_id), "fallback-id", profile_root=profile_a_root
     )[0]

--- a/tests/unit/sources/parsers/test_hermes_spans.py
+++ b/tests/unit/sources/parsers/test_hermes_spans.py
@@ -296,6 +296,66 @@ def test_atof_subagent_mark_fails_closed_on_self_reference(tmp_path: Path) -> No
     assert subagent_events[0].payload["delegation_edge_asserted"] is False
 
 
+def test_atof_subagent_mark_fails_closed_when_two_parents_claim_the_same_child(tmp_path: Path) -> None:
+    """A child session id claimed by two DIFFERENT parents in one batch is
+    contested, ambiguous evidence -- neither claim is trusted, so no edge is
+    materialized for that child at all, on either side.
+
+    Mutation: remove the len(parents) == 1 guard in parse_atof_stream (i.e.
+    let a contested child fall through to delegation_targets like an
+    unambiguous one) and this test's session count, delegation_edge_asserted,
+    and topology_edges assertions fail -- the contested child would
+    spuriously get a delegation-evidence stub session and an edge to
+    whichever parent happened to win the dict overwrite.
+    """
+    records: list[JSONDocument] = [
+        {
+            "atof_version": "0.1",
+            "kind": "mark",
+            "category": "agent",
+            "uuid": "subagent-start-from-parent-a",
+            "timestamp": "2026-07-18T09:00:08Z",
+            "name": "hermes.subagent.start",
+            "metadata": {"session_id": "parent-a"},
+            "data": {"child_session_id": "contested-child", "child_role": "research"},
+        },
+        {
+            "atof_version": "0.1",
+            "kind": "mark",
+            "category": "agent",
+            "uuid": "subagent-start-from-parent-b",
+            "timestamp": "2026-07-18T09:00:09Z",
+            "name": "hermes.subagent.start",
+            "metadata": {"session_id": "parent-b"},
+            "data": {"child_session_id": "contested-child", "child_role": "docs"},
+        },
+    ]
+    sessions = hermes_spans.parse_atof_stream(records, "fallback-id", profile_root=tmp_path)
+
+    # Only the two observing parents -- no delegation-evidence stub session
+    # for "contested-child" was materialized, and neither parent's
+    # self-correlation edge was overridden.
+    assert len(sessions) == 2
+    assert {s.provider_session_id.split(":")[-1].split("@")[0] for s in sessions} == {"parent-a", "parent-b"}
+    assert not any(s.branch_type is not None and s.branch_type.value == "subagent" for s in sessions)
+
+    for session in sessions:
+        subagent_events = [e for e in session.session_events if e.event_type == "hermes_subagent_span"]
+        assert len(subagent_events) == 1
+        assert subagent_events[0].payload["child_session_id"] == "contested-child"
+        # Explicit debt: the contested claim is visible, never silently
+        # indistinguishable from "no evidence at all" or from an
+        # unambiguous, successfully-materialized edge.
+        assert subagent_events[0].payload["delegation_edge_asserted"] is False
+
+        fidelity = hermes_spans.import_fidelity_declaration(session)
+        assert fidelity.capabilities["topology_edges"].status == "absent"
+        assert fidelity.capabilities["topology_edges"].observed == 0
+        # The mark shape/field mapping itself is still real, proven evidence
+        # -- only the graph edge is withheld, not the underlying observation.
+        assert fidelity.capabilities["subagent_delegation"].status == "exact"
+
+
 def test_atif_subagent_trajectory_materializes_delegation_edge_with_known_profile(tmp_path: Path) -> None:
     """ATIF mirror of the ATOF real-fixture proof: no real ATIF fixture
     carries subagent_trajectories evidence yet (see module docstring), so

--- a/tests/unit/sources/test_dispatch_payloads.py
+++ b/tests/unit/sources/test_dispatch_payloads.py
@@ -137,8 +137,18 @@ def test_source_parser_groups_real_shaped_hermes_atof_jsonl_as_one_retained_stre
     """
     source = Source(name="hermes", path=HERMES_ATOF_FIXTURE.parent)
     pairs = list(iter_source_sessions_with_raw(source, capture_raw=True))
-    assert len(pairs) == 1
-    raw, session = pairs[0]
+    # fs1.14 residual scope: the real fixture's hermes.subagent.start mark
+    # (data.child_session_id="child-session-redacted") now materializes a
+    # second, minimal delegation-evidence session sharing the same retained
+    # raw whole-file evidence -- see
+    # test_hermes_spans.test_real_atof_fixture_subagent_mark_materializes_
+    # delegation_edge for the dedicated proof of that edge.
+    assert len(pairs) == 2
+    raw, session = next(
+        (raw, session)
+        for raw, session in pairs
+        if session.provider_session_id.startswith("observer:atof:real-nemo-relay-session")
+    )
     assert raw is not None
     assert raw.source_path == str(HERMES_ATOF_FIXTURE)
     assert raw.source_index is None


### PR DESCRIPTION
## Summary

Closes fs1.14's last remaining scope item (subagent-delegation topology
materialization from Hermes ATIF `subagent_trajectories` and ATOF
`hermes.subagent.*` marks) and fs1.2.1's residual detector-tightness and
fidelity-honesty ACs, all against the two real redacted producer fixtures
already checked into the repo.

## Problem

`hermes_spans.py` already parsed ATIF `subagent_trajectories` entries and
ATOF `hermes.subagent.*` marks into `hermes_subagent_span` summary events,
and `hermes_topology_projection.py` already surfaced them read-side as
`subagent_evidence` -- but both explicitly declared `topology_edges` as
permanently `absent`: the delegation evidence never became a real
`session_links` graph edge. Separately, fs1.2.1 had residual ACs (detector
tightness proof, fidelity-band honesty) that were unaddressed after the
merged `unpaired-scope-debt` and shared-file/single-session fixes (#3103,
#3113).

## Solution

**Materialization** (`polylogue/sources/parsers/hermes_spans.py`):
`parse_atof_stream` and `parse_atif_document` now materialize a real
`session_links` parent edge (`branch_type=subagent`) for a subagent
reference when the child session id is producer-positive, non-self-
referential, unambiguous (no two different parents claiming the same
child), and a profile root is known -- the same fail-closed pattern fs1.14's
profile-qualification fix already established. On the ATOF route, when the
child's own trace records aren't present in the same batch, a minimal
delegation-evidence-only session is materialized so the edge still lands in
the archive (content-hash full-replace later reconciles it if the child's
real trace is separately ingested). On the ATIF route, `subagent_trajectories`
entries carry their own `steps`, so the child gets real parsed content, not
a stub. `parse_atif_document`'s return type changed from `ParsedSession` to
`list[ParsedSession]` (parent + any materialized children); `dispatch.py`'s
lowering was updated accordingly (one call site).

Each observing session's own `hermes_subagent_span` event now carries a
`delegation_edge_asserted` flag recording whether materialization actually
happened, so `import_fidelity_declaration`'s `topology_edges` capability
(and `hermes_topology_projection.HermesSubagentEvidenceRef.
delegation_edge_materialized`) can report it without cross-session lookups.
ATOF's mapping is proven end-to-end against the real NeMo Relay ATOF
fixture's `hermes.subagent.start` mark (`topology_edges: exact`); ATIF's
`subagent_trajectories` mapping has no real-fixture evidence yet (every real
ATIF export sampled so far carries an empty/absent list), so it stays
`inferred`, never `exact`.

**Detector tightness (fs1.2.1 AC2):** added a negative test proving the
ATOF structural detector (`looks_like_atof_payload`) rejects a
repository-invented marker-only payload -- ATOF never had an invented
marker historically (unlike ATIF's pre-fix `polylogue_artifact:
"hermes_atif_trace"`), so this closes the "reject the marker" half of AC2
for both artifact families. Also added a `detect_provider`-level assertion
on the existing ATIF marker-rejection test, proving rejection through the
real dispatch entrypoint, not just the low-level predicate.

**Fidelity honesty (fs1.2.1 AC5):** audited every `status="exact"` /
`verified_by_real_fixture` site in `hermes_spans.py`. The pre-existing
`llm_request_spans`/`tool_execution_spans` (ATIF) and
`llm_request_spans`/`tool_execution_spans`/`decision_points`/
`error_taxonomy`/`subagent_delegation`/`context_events` (ATOF) capabilities
were already correctly gated (real-fixture-proven mapping, "exact" means the
*mapping* is proven, matching the precedent already established and tested
elsewhere in this file for exactly this reason) -- no downgrade needed. The
new `topology_edges` capability is gated the same way: `exact` only when the
real ATOF fixture proves both the field mapping and the edge materialization
end-to-end; `inferred` on the ATIF route since no real fixture proves that
mapping yet.

**Docs:** `docs/hermes-operators.md` had several claims that
`subagent_delegation` "never reaches `topology_edges`/`session_links`" --
narrowed to describe exactly when an edge is and isn't materialized, and
updated the ATIF/ATOF capability example blocks to current observed values.

## Per-bead AC matrix

**polylogue-fs1.14** (residual scope: subagent-delegation topology
materialization):
- Materialize parent/child delegation evidence as `session_links` parent
  references from producer-positive ids + profile qualification, fail
  closed otherwise: **satisfied** -- `hermes_spans.py`
  (`_mark_delegation_edges_on_subagent_events`, `_atif_subagent_child_session`,
  `_atof_subagent_delegation_stub_session`); see
  `test_real_atof_fixture_subagent_mark_materializes_delegation_edge`,
  `test_atof_subagent_mark_fails_closed_without_profile_root`,
  `test_atof_subagent_mark_fails_closed_on_self_reference`,
  `test_atif_subagent_trajectory_materializes_delegation_edge_with_known_profile`,
  `test_atif_subagent_trajectory_fails_closed_without_profile_root`,
  `test_atif_subagent_trajectory_fails_closed_on_self_reference`.
- Extend `hermes_topology_projection.py` to surface the edges: **satisfied**
  -- `HermesSubagentEvidenceRef.delegation_edge_materialized`, read straight
  from the underlying event's `delegation_edge_asserted` payload flag; kept
  shape-agnostic (no new coupling to `hermes_spans` internals).
- Anti-vacuity real-fixture test + fail-closed test: **satisfied** -- see
  above.
- Where the real fixture lacks subagent evidence (ATIF), keep the capability
  declared absent/inferred: **satisfied** -- ATIF `topology_edges` stays
  `inferred` even when materialized (never `exact`, no real fixture proof).

**polylogue-fs1.2.1** (residual ACs 2 and 5):
- AC2 (detector tightness admits both real fixtures, rejects marker-only):
  **satisfied** -- ATIF marker-rejection was already tested; added the
  `detect_provider`-level proof plus the ATOF equivalent
  (`test_looks_like_atof_payload_rejects_a_repository_invented_marker_only_shape`).
  Both real fixtures already pass detection (pre-existing tests, unaffected).
- AC5 (fidelity exact only where real bytes prove the mapping): **audited,
  already satisfied except the new `topology_edges` capability**, which is
  now gated to the same standard (exact only for the real-fixture-proven
  ATOF route). No existing capability required downgrading.
- ACs 1, 3, 4, 6 (real-byte fixture acquisition, full per-event-class
  producer match, ATOF replay/append semantics, mutation-sensitive tests):
  **already satisfied by prior merged work** (PRs #3103, #3113, #3224,
  #3225 per the bead's own notes) -- not re-implemented here, out of this
  PR's stated residual scope.

## Verification

```
devtools test tests/unit/sources/parsers/test_hermes_spans.py tests/unit/sources/test_dispatch_payloads.py tests/unit/insights/test_hermes_topology_projection.py
# 56 passed in 3.89s

mypy --strict polylogue/sources/parsers/hermes_spans.py polylogue/insights/hermes_topology_projection.py polylogue/sources/dispatch.py tests/unit/sources/parsers/test_hermes_spans.py tests/unit/sources/test_dispatch_payloads.py
# Success: no issues found in 5 source files

devtools verify --quick
# exit_code 0 (format, lint, mypy, render all --check, topology/layering/
# closure-matrix/schema-roundtrip/manifests/ci-workflows/doc-commands/
# docs-coverage/test-infra-currency/test-clock-hygiene/pytest-timeout-
# overrides/degrade-loudly all pass)
```

Not run: full `devtools verify`/`--all` (testmon unseeded in this worktree;
out of the requested synchronous-foreground scope) and integration tests.

## Residual risk

- `topology_edges` materialization only handles the case observed in the
  real fixture (one mark, one child, single batch). Two different parents
  claiming the same child id in one batch is fail-closed (no edge) but not
  independently unit-tested beyond code review -- low risk, same pattern as
  the already-tested self-referential guard.
- ATIF child sessions reuse `_events_for_step`, so any future step-shape
  addition to that function automatically applies to subagent children too
  (intentional, not drift).
- `parse_atif_document`'s return-type change (`ParsedSession` ->
  `list[ParsedSession]`) is a public-ish API change within
  `polylogue.sources.parsers.hermes_spans`; the only production call site
  (`dispatch.py`) was updated, and a repo-wide grep confirmed no other
  caller exists.

Ref polylogue-fs1.14
Ref polylogue-fs1.2.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hermes imports now recognize real ATIF documents and can represent delegated subagent sessions.
  * Subagent evidence now indicates when a concrete parent-child session link was materialized.
  * Delegated sessions can be created from available trajectory or stream evidence, including minimal evidence-only sessions.

* **Bug Fixes**
  * Improved session identity handling to prevent collisions between parent and delegated sessions.
  * Unsupported or ambiguous delegation references now fail closed without creating topology links.

* **Documentation**
  * Updated Hermes fidelity, topology, and session-correlation guidance to reflect delegation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->