### PR TITLE
refactor(daemon): query-spec fast path parity + provider-usage degrade

### DIFF
--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -4005,18 +4005,48 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         much worse place to block on that than a CLI call a human can
         interrupt (polylogue-dlmv). Callers that want the full
         diagnostics can still request ``?detail=full`` explicitly.
+
+        A missing/unopenable ``index.db`` used to propagate a raw
+        ``sqlite3.OperationalError`` as an unhandled 500 (polylogue-d07y).
+        Sibling read endpoints (``/api/archive-debt``, the split-archive
+        ``/api/sessions`` fast path) degrade gracefully instead — this route
+        now returns the same typed ``route_state: degraded`` envelope shape,
+        privacy-projected like every other archive-path-bearing payload here.
         """
         origin = self._get_param(params, "origin")
         limit = self._get_int(params, "limit", 25)
         detail = self._get_param(params, "detail", "headline") or "headline"
         from polylogue.paths import archive_root as configured_archive_root
 
+        archive_root = configured_archive_root()
+
         async def _get(poly: Polylogue) -> object:
             report = await poly.provider_usage_report(origin=origin, limit=limit, detail=detail)
             return report.to_dict()
 
-        result = _web_privacy_safe_projection(self._sync_run(_get), configured_archive_root())
-        self._send_json(HTTPStatus.OK, result)
+        try:
+            result = self._sync_run(_get)
+        except (DatabaseError, sqlite3.Error) as exc:
+            logger.warning("provider-usage archive read degraded: %s", exc)
+            reason = f"Provider usage accounting is unavailable: archive index could not be read ({exc})."
+            degraded: dict[str, object] = {
+                "archive_root": str(archive_root),
+                "origin": origin,
+                "detail_level": detail,
+                "origins": [],
+                "caveats": [reason],
+                "route_state": _route_readiness_payload(
+                    "degraded",
+                    "/api/provider-usage",
+                    reason=reason,
+                    component="index_db",
+                    stale_available=False,
+                ),
+            }
+            self._send_json(HTTPStatus.OK, _web_privacy_safe_projection(degraded, archive_root))
+            return
+
+        self._send_json(HTTPStatus.OK, _web_privacy_safe_projection(result, archive_root))
 
     @daemon_safe_handler
     def _handle_query_units(self, params: dict[str, list[str]]) -> None:

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -477,16 +477,6 @@ def _web_reader_archive_root() -> Path | None:
     return root
 
 
-def _archive_origin_filter(params: dict[str, list[str]]) -> tuple[str | None, tuple[str, ...]]:
-    origin_values = params.get("origin") or []
-    if origin_values and origin_values[0]:
-        origins = tuple(
-            dict.fromkeys(token.strip() for value in origin_values for token in value.split(",") if token.strip())
-        )
-        return (origins[0] if len(origins) == 1 else None), origins
-    return None, ()
-
-
 def _utc_timestamp_json() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
@@ -578,14 +568,6 @@ def _facet_requested_optional_families(params: dict[str, list[str]]) -> set[str]
     return {family for family in requested if family in _FACET_EXPENSIVE_FAMILIES}
 
 
-def _archive_tag_filter(params: dict[str, list[str]]) -> tuple[str, ...]:
-    """Collect ``?tag=`` filters (repeated and/or comma-separated)."""
-    tags: list[str] = []
-    for value in params.get("tag") or []:
-        tags.extend(token.strip() for token in value.split(",") if token.strip())
-    return tuple(dict.fromkeys(tags))
-
-
 def _csv_values(params: dict[str, list[str]], key: str) -> tuple[str, ...]:
     """Collect repeated and/or comma-separated query-string values."""
     values: list[str] = []
@@ -598,6 +580,58 @@ def _archive_datetime_to_ms(value: datetime | None) -> int | None:
     if value is None:
         return None
     return int(value.timestamp() * 1000)
+
+
+def _archive_filter_kwargs_from_spec(
+    spec: SessionQuerySpec,
+    *,
+    since_ms: int | None,
+    until_ms: int | None,
+) -> dict[str, object]:
+    """Storage-layer filter kwargs derived from one merged ``SessionQuerySpec``.
+
+    Every key here is accepted identically by ``ArchiveStore.list_summaries``/
+    ``search_summaries``/``count_sessions``/``count_search_sessions`` — the
+    complete filter surface those four SQL entry points share (polylogue-4p1.1
+    parity test: ``tests/unit/daemon/test_web_reader.py::
+    test_archive_filter_kwargs_cover_every_storage_lowerable_spec_field``).
+    ``session_id`` is deliberately NOT included: it is passed as a separate
+    keyword by the caller because ``count_sessions`` does not accept it.
+    """
+    origins = spec.origins
+    origin = origins[0] if len(origins) == 1 else None
+    return {
+        "origin": origin,
+        "origins": origins,
+        "excluded_origins": spec.excluded_origins,
+        "tags": spec.tags,
+        "excluded_tags": spec.excluded_tags,
+        "repo_names": spec.repo_names,
+        "project_refs": spec.project_refs,
+        "has_types": spec.has_types,
+        "has_tool_use": spec.filter_has_tool_use,
+        "has_thinking": spec.filter_has_thinking,
+        "has_paste": spec.filter_has_paste,
+        "tool_terms": spec.tool_terms,
+        "excluded_tool_terms": spec.excluded_tool_terms,
+        "action_terms": spec.action_terms,
+        "excluded_action_terms": spec.excluded_action_terms,
+        "action_sequence": spec.action_sequence,
+        "action_text_terms": spec.action_text_terms,
+        "referenced_paths": spec.referenced_path,
+        "cwd_prefix": spec.cwd_prefix,
+        "typed_only": spec.typed_only,
+        "message_type": spec.message_type,
+        "title": spec.title,
+        "min_messages": spec.min_messages,
+        "max_messages": spec.max_messages,
+        "min_words": spec.min_words,
+        "max_words": spec.max_words,
+        "since_ms": since_ms,
+        "until_ms": until_ms,
+        "since_session_id": spec.since_session_id,
+        "boolean_predicate": spec.boolean_predicate,
+    }
 
 
 _SCOPE_FILTER_KEYS = frozenset(
@@ -1051,7 +1085,13 @@ def _build_query_spec_params(
     params: dict[str, list[str]],
     handler: DaemonAPIHandler,
 ) -> dict[str, object]:
-    """Build SessionQuerySpec-compatible params from HTTP query string."""
+    """Build SessionQuerySpec-compatible params from HTTP query string.
+
+    Shared by every ``/api/sessions``-style fast path (both the full-backend
+    ``_do_list`` and the split-archive ``_do_archive_session_list``,
+    polylogue-4p1.1) so a filter param is parsed once, in one place, instead
+    of being hand-mirrored per route.
+    """
     spec_params: dict[str, object] = {}
 
     for key in (
@@ -1075,12 +1115,16 @@ def _build_query_spec_params(
         if val is not None:
             spec_params[key] = val
 
-    origin = handler._get_param(params, "origin")
-    if origin is not None:
-        spec_params["origin"] = origin
-    exclude_origin = handler._get_param(params, "exclude_origin")
-    if exclude_origin is not None:
-        spec_params["exclude_origin"] = exclude_origin
+    # CSV/repeated-value fields: collect every occurrence of ``?key=a&key=b``
+    # as well as comma-joined values (``?key=a,b``) rather than only the
+    # first query-string occurrence, matching the archive route's historical
+    # ``_csv_values``/``_archive_origin_filter`` behavior.
+    origins = _csv_values(params, "origin")
+    if origins:
+        spec_params["origin"] = origins
+    excluded_origins = _csv_values(params, "exclude_origin")
+    if excluded_origins:
+        spec_params["exclude_origin"] = excluded_origins
 
     for key in (
         "tag",
@@ -1094,9 +1138,9 @@ def _build_query_spec_params(
         "tool",
         "exclude_tool",
     ):
-        val = handler._get_param(params, key)
-        if val is not None:
-            spec_params[key] = val
+        values = _csv_values(params, key)
+        if values:
+            spec_params[key] = values
 
     for key in (
         "latest",
@@ -1108,6 +1152,17 @@ def _build_query_spec_params(
     ):
         if handler._get_bool(params, key):
             spec_params[key] = True
+
+    # Public HTTP aliases for the same booleans (``has_tool_use`` /
+    # ``has_thinking`` / ``has_paste_evidence`` are the names the split-archive
+    # route and its tests use; ``filter_has_*`` are the SessionQuerySpec field
+    # names). Accept both so either param name compiles to the same filter.
+    if "filter_has_tool_use" not in spec_params and handler._get_bool(params, "has_tool_use"):
+        spec_params["filter_has_tool_use"] = True
+    if "filter_has_thinking" not in spec_params and handler._get_bool(params, "has_thinking"):
+        spec_params["filter_has_thinking"] = True
+    if "filter_has_paste" not in spec_params and handler._get_bool(params, "has_paste_evidence"):
+        spec_params["filter_has_paste"] = True
 
     for key in ("min_messages", "max_messages", "min_words", "max_words", "sample"):
         val = handler._get_param(params, key)
@@ -2930,155 +2985,82 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         offset: int,
         route: str = "/api/sessions",
     ) -> object:
-        from polylogue.archive.query.expression import compile_expression
+        from polylogue.archive.query.expression import compile_expression_into
         from polylogue.archive.query.search_hits import search_query_text
-        from polylogue.archive.query.spec import QuerySpecError, parse_query_date
+        from polylogue.archive.query.spec import QuerySpecError, SessionQuerySpec, parse_query_date
 
-        # Parse/lower only the ``query`` param through the shared expression path
+        # Build one SessionQuerySpec from every accepted HTTP query param via
+        # the shared builder (_build_query_spec_params), then route the free
+        # text ``query`` param through the shared expression parser/lowerer
         # so DSL clauses like ``origin:codex has:paste since:7d`` map to the
-        # correct ArchiveStore filter arguments rather than being passed as
-        # literal FTS text (#1860).  The ``contains`` param is a literal
-        # content-substring filter that must NOT be parsed as DSL — routing it through
-        # compile_expression() causes ExpressionCompileError when the value
-        # contains spaces or field-like tokens (#1873 Bug 7).
-        query_str = self._get_param(params, "query") or ""
-        contains_param = self._get_param(params, "contains")
-        fts_terms: tuple[str, ...]
-        if query_str:
-            spec = compile_expression(query_str)
-            # Bare words / quoted phrases become the FTS query; field clauses
-            # (origin:, tag:, since:, etc.) become structured filter args.
-            fts_terms = spec.query_terms + spec.contains_terms
-        else:
-            spec = None
-            fts_terms = ()
-        # ``?contains=`` is the literal content filter. It must still
-        # filter results, but must NOT be compiled as DSL (a value with spaces or
-        # field-like tokens would raise ExpressionCompileError, #1873 Bug 7). Wire
-        # it as a literal FTS term so ``GET /api/sessions?contains=foo`` with no
-        # ``query`` filters instead of returning the unfiltered first page.
-        if contains_param:
-            fts_terms = fts_terms + (contains_param,)
+        # correct filter fields instead of being passed as literal FTS text
+        # (#1860). This is the single spec construction path for both this
+        # split-archive fast path and the full-backend ``_do_list`` — a
+        # filter field added to SessionQuerySpec.from_params is honored here
+        # automatically instead of silently missing until this function is
+        # separately edited (polylogue-4p1.1). ``contains`` reaches
+        # ``contains_terms`` as a literal term via ``from_params`` itself, so
+        # it never risks the ExpressionCompileError a DSL-parsed value with
+        # spaces or field-like tokens would raise (#1873 Bug 7).
+        spec_query_params = _build_query_spec_params(params, self)
+        query_str = str(spec_query_params.pop("query", "") or "").strip()
+        base = SessionQuerySpec.from_params(spec_query_params)
+        spec = compile_expression_into(query_str, base) if query_str else base
+
+        fts_terms = spec.query_terms + spec.contains_terms
         fts_query = search_query_text(fts_terms)
 
-        # HTTP-param-based origin/tag filters — still honoured for backwards
-        # compatibility with callers passing ``?origin=...`` or ``?tag=...``
-        # as separate query-string parameters.
-        _, http_origins = _archive_origin_filter(params)
-        http_tags = _archive_tag_filter(params)
-
-        # Merge DSL-compiled spec filters with HTTP-param-based filters.
-        origins = tuple(dict.fromkeys((spec.origins if spec else ()) + http_origins))
-        excluded_origins = tuple(
-            dict.fromkeys((spec.excluded_origins if spec else ()) + _csv_values(params, "exclude_origin"))
-        )
-        tags = tuple(dict.fromkeys((spec.tags if spec else ()) + http_tags))
-        excluded_tags = tuple(dict.fromkeys((spec.excluded_tags if spec else ()) + _csv_values(params, "exclude_tag")))
-        origin = origins[0] if len(origins) == 1 else None
-
-        # Date filters: DSL spec takes precedence over bare HTTP params.
-        since_str = (spec.since if spec else None) or self._get_param(params, "since")
-        until_str = (spec.until if spec else None) or self._get_param(params, "until")
         # parse_query_date raises QuerySpecError (a PolylogueError carrying
         # http_status_code=400) for unparseable dates; daemon_safe_handler maps
         # it to the QueryErrorPayload-shaped 400 the other surfaces return.
-        since_dt = parse_query_date("since", since_str)
-        until_dt = parse_query_date("until", until_str)
+        since_dt = parse_query_date("since", spec.since)
+        until_dt = parse_query_date("until", spec.until)
         since_ms = _archive_datetime_to_ms(since_dt)
         until_ms = _archive_datetime_to_ms(until_dt)
 
-        # Remaining structured filters come from the compiled spec plus the
-        # stable HTTP query parameters accepted by the shared query builder.
-        # The split-archive fast path does not construct a SessionQuerySpec
-        # directly, so it must mirror those public params here.
-        has_paste = (spec.filter_has_paste if spec else False) or self._get_bool(params, "has_paste_evidence")
-        has_tool_use = (spec.filter_has_tool_use if spec else False) or self._get_bool(params, "has_tool_use")
-        has_thinking = (spec.filter_has_thinking if spec else False) or self._get_bool(params, "has_thinking")
-        repo_names = tuple(dict.fromkeys((spec.repo_names if spec else ()) + _csv_values(params, "repo")))
-        has_types = tuple(dict.fromkeys((spec.has_types if spec else ()) + _csv_values(params, "has_type")))
-        tool_terms = tuple(dict.fromkeys((spec.tool_terms if spec else ()) + _csv_values(params, "tool")))
-        excluded_tool_terms = tuple(
-            dict.fromkeys((spec.excluded_tool_terms if spec else ()) + _csv_values(params, "exclude_tool"))
-        )
-        action_terms = tuple(dict.fromkeys((spec.action_terms if spec else ()) + _csv_values(params, "action")))
-        excluded_action_terms = tuple(
-            dict.fromkeys((spec.excluded_action_terms if spec else ()) + _csv_values(params, "exclude_action"))
-        )
-        action_sequence = tuple(
-            dict.fromkeys((spec.action_sequence if spec else ()) + _csv_values(params, "action_sequence"))
-        )
-        action_text_terms = tuple(
-            dict.fromkeys((spec.action_text_terms if spec else ()) + _csv_values(params, "action_text"))
-        )
-        referenced_paths = tuple(
-            dict.fromkeys((spec.referenced_path if spec else ()) + _csv_values(params, "referenced_path"))
-        )
-        cwd_prefix = (spec.cwd_prefix if spec else None) or self._get_param(params, "cwd_prefix")
-        title = (spec.title if spec else None) or self._get_param(params, "title")
-        min_messages = (spec.min_messages if spec else None) or self._get_int(params, "min_messages", 0) or None
-        max_messages = (spec.max_messages if spec else None) or self._get_int(params, "max_messages", 0) or None
-        min_words = (spec.min_words if spec else None) or self._get_int(params, "min_words", 0) or None
-        max_words = (spec.max_words if spec else None) or self._get_int(params, "max_words", 0) or None
+        origins = spec.origins
+        origin = origins[0] if len(origins) == 1 else None
         # session_id is passed separately to list_summaries/search_summaries
         # (count_sessions does not accept this param, so it cannot go in _filter_kw).
-        spec_session_id = spec.session_id if spec else None
+        spec_session_id = spec.session_id
 
-        # Shared filter kwargs forwarded to every ArchiveStore call.
-        _filter_kw: dict[str, object] = {
-            "origin": origin,
-            "origins": origins,
-            "excluded_origins": excluded_origins,
-            "tags": tags,
-            "excluded_tags": excluded_tags,
-            "repo_names": repo_names,
-            "has_types": has_types,
-            "has_tool_use": has_tool_use,
-            "has_thinking": has_thinking,
-            "has_paste": has_paste,
-            "tool_terms": tool_terms,
-            "excluded_tool_terms": excluded_tool_terms,
-            "action_terms": action_terms,
-            "excluded_action_terms": excluded_action_terms,
-            "action_sequence": action_sequence,
-            "action_text_terms": action_text_terms,
-            "referenced_paths": referenced_paths,
-            "cwd_prefix": cwd_prefix,
-            "title": title,
-            "min_messages": min_messages,
-            "max_messages": max_messages,
-            "min_words": min_words,
-            "max_words": max_words,
-            "since_ms": since_ms,
-            "until_ms": until_ms,
-        }
+        # Every remaining structured filter is read directly off the merged
+        # spec — no per-field HTTP-param re-read for anything SessionQuerySpec
+        # already models (polylogue-4p1.1).
+        _filter_kw = _archive_filter_kwargs_from_spec(spec, since_ms=since_ms, until_ms=until_ms)
         filtered = bool(
             fts_query
             or spec_session_id
             or origin
             or origins
-            or excluded_origins
-            or tags
-            or excluded_tags
-            or repo_names
-            or has_types
-            or tool_terms
-            or excluded_tool_terms
-            or action_terms
-            or excluded_action_terms
-            or action_sequence
-            or action_text_terms
-            or referenced_paths
-            or cwd_prefix
-            or title
-            or min_messages is not None
-            or max_messages is not None
-            or min_words is not None
-            or max_words is not None
+            or spec.excluded_origins
+            or spec.tags
+            or spec.excluded_tags
+            or spec.repo_names
+            or spec.project_refs
+            or spec.has_types
+            or spec.tool_terms
+            or spec.excluded_tool_terms
+            or spec.action_terms
+            or spec.excluded_action_terms
+            or spec.action_sequence
+            or spec.action_text_terms
+            or spec.referenced_path
+            or spec.cwd_prefix
+            or spec.typed_only
+            or spec.message_type
+            or spec.title
+            or spec.min_messages is not None
+            or spec.max_messages is not None
+            or spec.min_words is not None
+            or spec.max_words is not None
             or since_dt is not None
             or until_dt is not None
-            or has_paste
-            or has_tool_use
-            or has_thinking
+            or spec.since_session_id
+            or spec.boolean_predicate is not None
+            or spec.filter_has_paste
+            or spec.filter_has_tool_use
+            or spec.filter_has_thinking
         )
 
         with archive_read_context(
@@ -3218,7 +3200,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                         for label in (
                             f"query={fts_query!r}",
                             f"origin={origin}" if origin else None,
-                            f"tags={list(tags)}" if tags else None,
+                            f"tags={list(spec.tags)}" if spec.tags else None,
                         )
                         if label is not None
                     )

--- a/tests/unit/daemon/test_web_reader.py
+++ b/tests/unit/daemon/test_web_reader.py
@@ -83,11 +83,73 @@ def test_query_spec_param_builder_uses_canonical_query_fields() -> None:
 
     result = _build_query_spec_params(params, _QueryParamBuilderHandler())  # type: ignore[arg-type]
 
-    assert result["origin"] == "codex-session"
-    assert result["exclude_origin"] == "chatgpt-export"
+    assert result["origin"] == ("codex-session",)
+    assert result["exclude_origin"] == ("chatgpt-export",)
     assert result["max_words"] == 100
     assert result["similar_session_id"] == "codex-session:seed"
     assert result["filter_has_tool_use"] is True
+
+
+def test_query_spec_param_builder_collects_repeated_csv_fields() -> None:
+    """polylogue-4p1.1: repeated ``?origin=a&origin=b`` must not lose values.
+
+    Before the split-archive fast path was collapsed onto the shared
+    ``SessionQuerySpec.from_params`` builder, ``_build_query_spec_params``
+    only read the first occurrence of a repeated query-string param
+    (``handler._get_param`` returns ``values[0]``) for origin/tag/repo/etc,
+    silently dropping every subsequent value. Removing the ``_csv_values``
+    collection in ``_build_query_spec_params`` (reverting to
+    ``handler._get_param``) reproduces that drop and fails this test.
+    """
+    from polylogue.daemon.http import _build_query_spec_params
+
+    params = {
+        "origin": ["codex-session", "claude-code-session"],
+        "tag": ["alpha", "beta,gamma"],
+        "repo": ["polylogue"],
+    }
+
+    result = _build_query_spec_params(params, _QueryParamBuilderHandler())  # type: ignore[arg-type]
+
+    assert result["origin"] == ("codex-session", "claude-code-session")
+    assert result["tag"] == ("alpha", "beta", "gamma")
+    assert result["repo"] == ("polylogue",)
+
+
+def test_archive_filter_kwargs_cover_every_storage_lowerable_spec_field() -> None:
+    """polylogue-4p1.1: the split-archive fast path must not drop a filter.
+
+    ``ArchiveStore.list_summaries``/``search_summaries``/``count_sessions``/
+    ``count_search_sessions`` accept an identical filter-kwarg surface (proven
+    below). ``_archive_filter_kwargs_from_spec`` is what
+    ``_do_archive_session_list`` calls to build that kwarg dict from the
+    merged ``SessionQuerySpec`` -- if a field is ever added to (or dropped
+    from) that storage-layer signature without also updating
+    ``_archive_filter_kwargs_from_spec``, this test fails. This is the
+    "silently absent until someone edits both sites" regression the bead
+    describes, made mechanically unrepeatable: deleting any one line from
+    ``_archive_filter_kwargs_from_spec``'s return dict (e.g. dropping
+    ``"project_refs"``) fails this assertion.
+    """
+    import inspect
+
+    from polylogue.archive.query.spec import SessionQuerySpec
+    from polylogue.daemon.http import _archive_filter_kwargs_from_spec
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    non_filter_params = {"self", "limit", "offset", "session_id", "sample", "sort", "reverse", "query"}
+    storage_methods = ("list_summaries", "search_summaries", "count_sessions", "count_search_sessions")
+    storage_filter_params = {
+        frozenset(inspect.signature(getattr(ArchiveStore, name)).parameters) - non_filter_params
+        for name in storage_methods
+    }
+    # All four SQL entry points must agree on one filter surface -- otherwise
+    # "the filter kwargs ArchiveStore accepts" is not a single well-defined set.
+    assert len(storage_filter_params) == 1, storage_filter_params
+    (expected_filter_params,) = storage_filter_params
+
+    produced = _archive_filter_kwargs_from_spec(SessionQuerySpec(), since_ms=None, until_ms=None)
+    assert expected_filter_params == set(produced)
 
 
 def test_web_reader_archive_root_rejects_schema_mismatch(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Two clustered daemon fixes on one branch:

1. **polylogue-4p1.1** — the split-archive `/api/sessions` fast path
   (`_do_archive_session_list`) now builds a `SessionQuerySpec` via the shared
   `from_params`/`compile_expression_into` pipeline instead of hand-mirroring
   every structured filter param, closing the "filter silently dropped until
   someone edits both sites" gap the bead describes.
2. **polylogue-d07y** — `/api/provider-usage` now degrades gracefully (HTTP
   200, redacted `route_state: degraded` envelope) instead of a raw 500 when
   `index.db` is missing/unopenable, matching sibling read endpoints.

## Problem

**Item 1**: `_do_archive_session_list` carried an explicit in-code comment
("the split-archive fast path does not construct a SessionQuerySpec
directly... it must mirror those public params here") documenting that it
hand-read every HTTP filter param separately from `SessionQuerySpec.from_params`
(`polylogue/archive/query/spec.py:498`). That duplication meant a filter field
added to the spec builder — or to `ArchiveStore`'s SQL filter-kwarg surface —
could silently go unenforced by this fast path. Concretely, before this
change the fast path already dropped `project_refs`, `typed_only`,
`message_type`, `since_session_id`, and `boolean_predicate` (all accepted by
`ArchiveStore.list_summaries`/`search_summaries`/`count_sessions`/
`count_search_sessions`), and only read the *first* occurrence of a repeated
HTTP param (`?origin=a&origin=b`) for `origin`/`tag`/`repo`/`tool`/`action`/etc.

**Item 2**: `tests/unit/daemon/test_web_reader.py::TestReaderAssertionEndpoint::
test_operational_web_payloads_redact_configured_archive_paths` deletes
`index.db` mid-test and hits `/api/provider-usage`, which propagated a raw
`sqlite3.OperationalError` ("unable to open database file") through
`daemon_safe_handler`'s generic 500 fallback instead of the graceful
degraded-payload path sibling endpoints (`/api/archive-debt`, the
split-archive `/api/sessions` fast path) already use. Reproduces
deterministically on unmodified master.

## Solution

**Item 1** (`polylogue/daemon/http.py`):
- `_do_archive_session_list` builds one `SessionQuerySpec` via
  `_build_query_spec_params(params, self)` → `SessionQuerySpec.from_params(...)`
  → `compile_expression_into(query_str, base)` (the same pattern `_do_list`
  already used for the full-backend path).
- New `_archive_filter_kwargs_from_spec(spec, since_ms, until_ms)` module-level
  helper derives every `ArchiveStore` filter kwarg directly from the merged
  spec — no per-field HTTP-param re-read for anything `SessionQuerySpec`
  already models.
- `_build_query_spec_params` (shared by both fast paths) now collects
  CSV/repeated-value params via `_csv_values` instead of only the first
  occurrence, and accepts the `has_tool_use`/`has_thinking`/`has_paste_evidence`
  public HTTP aliases alongside the `filter_has_*` `SessionQuerySpec` field
  names (matching the alias mapping already used by `api/archive.py` and
  `mcp/query_contracts.py`).
- Removed the now-dead `_archive_origin_filter`/`_archive_tag_filter` helpers
  the old manual-mirror code used (no remaining call sites).
- New test `test_archive_filter_kwargs_cover_every_storage_lowerable_spec_field`
  enumerates the `ArchiveStore.list_summaries`/`search_summaries`/
  `count_sessions`/`count_search_sessions` filter-kwarg signatures (proves all
  four are identical) and asserts `_archive_filter_kwargs_from_spec`'s output
  covers exactly that set — the AC-required parity test. Deleting any one line
  from that helper's return dict (e.g. `"project_refs"`) fails this test.
- `test_query_spec_param_builder_uses_canonical_query_fields` updated for the
  new tuple-shaped `origin`/`exclude_origin` builder output; new
  `test_query_spec_param_builder_collects_repeated_csv_fields` proves the
  repeated-param regression fix (fails if `_csv_values` is reverted to
  `handler._get_param`).

**Out of scope for item 1**: `exclude_text_terms`/`similar_text`/
`similar_session_id` are not SQL-lowerable by `ArchiveStore`'s filter layer
(they are CLI-side post-filter / vector-search concerns) and remain
unsupported by this fast path, matching prior behavior — this is an
intentional non-goal, not a dropped requirement.

**Item 2** (`polylogue/daemon/http.py`):
- `_handle_provider_usage` wraps the archive read in
  `try/except (DatabaseError, sqlite3.Error)`, returning HTTP 200 with a typed
  `route_state: degraded` envelope (`RouteReadinessPayload` shape, same as
  other read routes) instead of letting the exception reach
  `daemon_safe_handler`'s generic 500. The degraded payload still passes
  through `_web_privacy_safe_projection` so `archive_root` redacts to
  `"[archive]"` like every other archive-path-bearing response. A
  `logger.warning` call satisfies the `verify-degrade-loudly` gate (broad
  except-handlers need a log call or re-raise).
- No new test: the existing test names the exact regression and goes green.

## AC matrix

**polylogue-4p1.1**
| AC | Status |
| --- | --- |
| Fast path derives all structured filters from a `SessionQuerySpec` built via `from_params` (no per-field re-read for spec-modeled filters) | Satisfied |
| Test enumerates `SessionQuerySpec`/storage filter attributes and fails if the fast path drops any | Satisfied — `test_archive_filter_kwargs_cover_every_storage_lowerable_spec_field` |
| In-code "must mirror those public params here" comment and manual mirroring block removed | Satisfied |
| Render surfaces (openapi/cli-output-schemas) still verify | Satisfied — `devtools verify --quick` includes `render all --check` |

**polylogue-d07y**
| AC | Status |
| --- | --- |
| `test_operational_web_payloads_redact_configured_archive_paths` passes on master | Satisfied |
| `/api/provider-usage` with missing/unopenable `index.db` returns the degraded envelope with redacted paths, not a 500 | Satisfied |

## Verification

- `devtools test tests/unit/daemon/test_web_reader.py` → **177 passed**
  (includes the previously-failing
  `test_operational_web_payloads_redact_configured_archive_paths` and both new
  parity tests)
- `devtools test tests/unit/daemon/` → **1931 passed, 1 pre-existing failure**
  (`test_no_token_in_log_or_print_calls`; verified it reproduces identically
  on unmodified master at a different line number — an unrelated static
  line-number scan, not caused by this change)
- `devtools test tests/unit/storage/test_archive_search_contracts.py
  tests/unit/surfaces/test_search_envelope_contract.py
  tests/unit/cli/test_query_exec_laws.py tests/unit/test_read_surface_coherence.py`
  → **152 passed**
- `python3 -m mypy --strict polylogue/daemon/http.py
  tests/unit/daemon/test_web_reader.py` → `Success: no issues found in 2 source files`
- `devtools verify --quick` → `exit_code: 0` (ruff format/check, mypy, render
  all, topology, layering, closure-matrix, schema roundtrip, manifests,
  ci-workflows, doc-commands, docs-coverage, test-infra-currency,
  test-clock-hygiene, pytest-timeout-overrides, degrade-loudly all green)

Ref polylogue-4p1.1
Ref polylogue-d07y

Co-Authored-By: Claude <noreply@anthropic.com>