### PR TITLE
perf(sources): whale-aware census spill bypasses pickle round trip

### DIFF
--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -1358,6 +1358,30 @@ class _ParsedSessionSpill:
     _DECODED_CACHE_MIN_TREE_BYTES: Final[int] = 256 * 1024 * 1024
     _DECODED_CACHE_MAX_TREE_BYTES: Final[int] = 2 * 1024 * 1024 * 1024
 
+    #: Whale-residency ceiling (polylogue-odm1): a single parsed tree that
+    #: exceeds ``_decoded_budget`` above is, by construction, never retained
+    #: by the hot multi-entry cache -- it previously fell all the way through
+    #: to the sqlite spill (pickle.dumps at census, pickle.loads on every
+    #: later ``for_raw()``), or, once the spill's own payload-byte budget was
+    #: also exhausted, was silently dropped and had to be REPARSED FROM RAW
+    #: BYTES on every subsequent ``for_raw()`` call -- the dominant cost on
+    #: whale-bearing rebuild pages (v42 walk receipts: spill_load = 41% of a
+    #: 1440.2s page). A whale is a transient, effectively single-occupant
+    #: resident (the hot cache already handles the "many small/medium trees"
+    #: case), so it can safely claim a much larger fraction of budgeted RAM
+    #: than the multi-entry hot pool without changing the pool's own sizing
+    #: philosophy: same ``effective_physical_memory_bytes()`` input, a wider
+    #: divisor (physical RAM / 4 instead of / 16) and a proportionally wider
+    #: absolute ceiling (8 GiB instead of 2 GiB), floored at whatever
+    #: ``_decoded_budget`` resolved to so the whale tier is never narrower
+    #: than the hot tier it complements. Bypassing the sqlite round trip
+    #: entirely (no pickle.dumps, no pickle.loads) is safe: the durable raw
+    #: bytes remain the replay fallback (``_parse_retained_raw``) if this
+    #: process dies before ``for_raw()`` is called, so nothing is lost, only
+    #: possibly reparsed once more on restart -- identical to today's
+    #: existing crash-recovery contract for the sqlite-backed spill.
+    _WHALE_CACHE_MAX_TREE_BYTES: Final[int] = 8 * 1024 * 1024 * 1024
+
     def __init__(self, archive_root: Path, *, max_cached_payload_bytes: int | None) -> None:
         # Place the spill beside the RESOLVED index tier, not the archive
         # root: on deployments where the .db files are symlinks (e.g. root
@@ -1399,6 +1423,20 @@ class _ParsedSessionSpill:
             if physical
             else self._DECODED_CACHE_MIN_TREE_BYTES
         )
+        # Whale-residency tier (polylogue-odm1): a bounded, FIFO-evicted
+        # sibling of ``_decoded`` for parsed trees too large for the hot
+        # cache's own budget. See ``_WHALE_CACHE_MAX_TREE_BYTES`` for the
+        # sizing rationale. Its accounting is fully independent of
+        # ``_decoded_tree_bytes`` -- the two tiers never compete for the same
+        # budgeted bytes, so peak RAM is bounded by the sum of both ceilings,
+        # not by either alone.
+        self._whales: dict[str, tuple[list[ParsedSession], int, int]] = {}
+        self._whale_tree_bytes = 0
+        self._whale_budget = (
+            max(self._decoded_budget, min(self._WHALE_CACHE_MAX_TREE_BYTES, physical // 4))
+            if physical
+            else self._decoded_budget
+        )
 
     def __enter__(self) -> _ParsedSessionSpill:
         return self
@@ -1414,10 +1452,30 @@ class _ParsedSessionSpill:
         self.path.unlink(missing_ok=True)
 
     def add(self, raw_id: str, sessions: list[ParsedSession], *, payload_bytes: int) -> None:
+        tree_bytes = estimate_parsed_tree_bytes(sessions)
+        if tree_bytes > self._decoded_budget and self._retain_whale(
+            raw_id, sessions, payload_bytes=payload_bytes, tree_bytes=tree_bytes
+        ):
+            # Size-partitioned spill (polylogue-odm1): a tree too big for the
+            # hot cache but within the whale ceiling bypasses the sqlite
+            # spill entirely -- no pickle.dumps now, no pickle.loads later.
+            # Correctness fallback: ``_retain_whale`` returns False (and
+            # execution falls through to the unchanged sqlite path below)
+            # whenever holding it resident would exceed the whale budget, so
+            # a session too large for EITHER tier still gets spilled exactly
+            # as before.
+            return
+        if self._spill_to_sqlite(raw_id, sessions, payload_bytes=payload_bytes):
+            self._retain_decoded(raw_id, sessions, payload_bytes=payload_bytes, tree_bytes=tree_bytes)
+
+    def _spill_to_sqlite(self, raw_id: str, sessions: list[ParsedSession], *, payload_bytes: int) -> bool:
+        """Pickle ``sessions`` into the sqlite spill, subject to the caller's
+        overall payload-byte budget. Returns whether the write happened.
+        """
         if self.max_cached_payload_bytes is None or payload_bytes > self.max_cached_payload_bytes:
-            return
+            return False
         if self.cached_payload_bytes + payload_bytes > self.max_cached_payload_bytes:
-            return
+            return False
         with self.conn:
             self.conn.executemany(
                 "INSERT INTO parsed_sessions(raw_id, logical_key, payload_bytes, parsed) VALUES (?, ?, ?, ?)",
@@ -1432,10 +1490,11 @@ class _ParsedSessionSpill:
                 ),
             )
         self.cached_payload_bytes += payload_bytes
-        self._retain_decoded(raw_id, sessions, payload_bytes=payload_bytes)
+        return True
 
-    def _retain_decoded(self, raw_id: str, sessions: list[ParsedSession], *, payload_bytes: int) -> None:
-        tree_bytes = estimate_parsed_tree_bytes(sessions)
+    def _retain_decoded(
+        self, raw_id: str, sessions: list[ParsedSession], *, payload_bytes: int, tree_bytes: int
+    ) -> None:
         if tree_bytes > self._decoded_budget:
             return
         while self._decoded and self._decoded_tree_bytes + tree_bytes > self._decoded_budget:
@@ -1445,10 +1504,44 @@ class _ParsedSessionSpill:
         self._decoded[raw_id] = (sessions, payload_bytes, tree_bytes)
         self._decoded_tree_bytes += tree_bytes
 
+    def _retain_whale(self, raw_id: str, sessions: list[ParsedSession], *, payload_bytes: int, tree_bytes: int) -> bool:
+        """Hold an outsized parsed tree resident, bypassing the sqlite spill.
+
+        Returns ``False`` (retaining nothing) when ``tree_bytes`` alone
+        exceeds ``_whale_budget`` -- the caller must then fall back to the
+        existing spill-or-reparse path rather than blow the memory budget.
+        Otherwise evicts oldest whale entries (FIFO, mirroring
+        ``_retain_decoded``) until the new entry fits and retains it.
+
+        A rare multi-whale page can still exceed the whale budget across
+        several distinct oversized raws even though each individually fits.
+        An entry evicted here to make room was never written to the sqlite
+        spill (that write was deliberately skipped to avoid the pickle
+        cost) -- so, unlike the hot cache's plain eviction, degrade it into
+        the sqlite spill as a courtesy on the way out (best-effort; if the
+        sqlite spill's own payload budget is also exhausted the entry is
+        dropped exactly as today's pre-lever code would drop it, falling
+        back to reparse-from-source on next access -- never worse than the
+        unpatched baseline).
+        """
+        if tree_bytes > self._whale_budget:
+            return False
+        while self._whales and self._whale_tree_bytes + tree_bytes > self._whale_budget:
+            oldest_raw = next(iter(self._whales))
+            evicted_sessions, evicted_payload, evicted_tree = self._whales.pop(oldest_raw)
+            self._whale_tree_bytes -= evicted_tree
+            self._spill_to_sqlite(oldest_raw, evicted_sessions, payload_bytes=evicted_payload)
+        self._whales[raw_id] = (sessions, payload_bytes, tree_bytes)
+        self._whale_tree_bytes += tree_bytes
+        return True
+
     def for_raw(self, archive: ArchiveStore, raw_id: str) -> tuple[list[ParsedSession], int]:
         decoded = self._decoded.get(raw_id)
         if decoded is not None:
             return decoded[0], decoded[1]
+        whale = self._whales.get(raw_id)
+        if whale is not None:
+            return whale[0], whale[1]
         rows = self.conn.execute(
             "SELECT parsed, payload_bytes FROM parsed_sessions WHERE raw_id = ? ORDER BY logical_key", (raw_id,)
         ).fetchall()

--- a/tests/benchmarks/test_whale_census_spill_bench.py
+++ b/tests/benchmarks/test_whale_census_spill_bench.py
@@ -1,0 +1,238 @@
+"""Regression benchmark for polylogue-odm1: whale-aware census spill.
+
+Live receipts (2026-07-21 v42 walk, resume26): on whale-bearing rebuild
+pages ``spill_load`` dominates -- 598.2s of a 1440.2s page (41%), plus
+236.6s/523.1s, 228.1s/607.5s, 139.6s/454.6s across other pages. The census
+spill (``polylogue.sources.revision_backfill._ParsedSessionSpill``) pickles
+decoded ``ParsedSession`` trees to a scratch sqlite file during census and
+reloads them one authority cohort at a time during replay -- for a session
+too large to fit the spill's own small in-RAM hot cache, every reload paid a
+full ``pickle.loads`` (or, once the sqlite spill's own payload budget was
+also exhausted, a full re-parse from raw bytes).
+
+The fix (whale-aware residency): a parsed tree too large for the hot cache's
+own budget but within a wider "whale ceiling" (see
+``_ParsedSessionSpill._WHALE_CACHE_MAX_TREE_BYTES``) is held resident as a
+plain Python object, bypassing the sqlite spill's pickle round trip
+entirely.
+
+This benchmark proves the win using the ``_ParsedSessionSpill`` class
+itself, in its default configuration, on a corpus that reproduces the shape
+(one oversized raw sharing a page with many ordinary ones) at a scale that
+keeps CI wall time bounded. Reproduce the exact same threshold-crossing
+behavior at any payload size by shrinking ``_DECODED_CACHE_MIN_TREE_BYTES``/
+``_DECODED_CACHE_MAX_TREE_BYTES`` via monkeypatch, exactly as done here --
+the class computes its budgets from ``effective_physical_memory_bytes()``,
+so leaving them at production defaults would require a fixture sized to a
+real host's RAM/16 (>= 256 MiB) to ever classify as a "whale" in the first
+place.
+
+"Baseline" (pre-lever) behavior is reproduced by monkeypatching
+``_ParsedSessionSpill._retain_whale`` to always return ``False`` -- this
+exercises the IDENTICAL unmodified code for every other path (the sqlite
+spill write/read, the small-session hot cache) and only neutralizes the new
+whale-residency branch, which is a more faithful "before" than reconstructing
+a separate implementation.
+
+Run with::
+
+    pytest tests/benchmarks/test_whale_census_spill_bench.py --benchmark-enable -p no:xdist -v
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from polylogue.sources.parsers.base import ParsedSession
+from polylogue.sources.revision_backfill import _parse_retained_raw, _ParsedSessionSpill
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from tests.infra.revision_backfill_benchmark import WHALE_BEARING_SHAPE, build_whale_bearing_corpus
+
+# Shrink the hot-cache budget constants so the benchmark's whale (a few MB,
+# not a few hundred MB) reliably fails to fit the hot cache and is
+# classified as a whale -- see module docstring. The whale ceiling itself is
+# left at its production formula (still generously above this fixture's
+# whale, exactly as it would be on any real host processing a genuine
+# multi-hundred-MB rollout against a multi-GiB whale ceiling).
+_SHRUNK_DECODED_MIN_TREE_BYTES = 64 * 1024
+_SHRUNK_DECODED_MAX_TREE_BYTES = 64 * 1024
+
+# Generous spill-cache budget: large enough that every raw (small population
+# + whale) fits the sqlite spill's own payload-byte cap in the baseline run,
+# so the measured delta is purely "resident object vs pickle round trip",
+# not confounded by the sqlite budget also rejecting the whale (a different,
+# already-existing failure mode this benchmark does not target).
+_SPILL_CACHE_BYTES = 64 * 1024 * 1024
+
+# How many times replay-shaped code re-reads each raw via for_raw() in one
+# pass -- mirrors polylogue-odm1's evidence that the same raw_id can be
+# looked up more than once across the census/replay boundary.
+_REREAD_PASSES = 2
+
+
+def _run_spill_load_pass(
+    archive_root: Path,
+    small_raw_ids: list[str],
+    whale_raw_id: str,
+    *,
+    disable_whale_lever: bool,
+) -> tuple[float, float, dict[str, list[ParsedSession]]]:
+    """Census (add) then replay (for_raw) every raw once per pass; return
+    ``(whale_reload_seconds, small_reload_seconds, sessions_by_raw_id)``.
+
+    ``sessions_by_raw_id`` captures the FIRST pass's reloaded sessions
+    (keyed raw_id -> list[ParsedSession]) so the caller can assert output
+    equivalence between the baseline and lever-enabled runs.
+
+    Uses its own scoped ``pytest.MonkeyPatch`` context (not the caller's
+    fixture) so the ``_retain_whale`` neutralization used to reproduce
+    pre-lever behavior is guaranteed undone before the next call in the same
+    test -- the shared test-scoped ``monkeypatch`` fixture only undoes
+    patches at test teardown, which would otherwise leak the baseline's
+    neutralized ``_retain_whale`` into the lever-enabled run.
+    """
+    whale_patch = pytest.MonkeyPatch()
+    try:
+        if disable_whale_lever:
+            whale_patch.setattr(_ParsedSessionSpill, "_retain_whale", lambda self, *a, **k: False)
+
+        with (
+            ArchiveStore.open_existing(archive_root, read_only=False) as archive,
+            _ParsedSessionSpill(archive_root, max_cached_payload_bytes=_SPILL_CACHE_BYTES) as spill,
+        ):
+            return _census_then_reload(archive, spill, small_raw_ids, whale_raw_id)
+    finally:
+        whale_patch.undo()
+
+
+def _census_then_reload(
+    archive: ArchiveStore,
+    spill: _ParsedSessionSpill,
+    small_raw_ids: list[str],
+    whale_raw_id: str,
+) -> tuple[float, float, dict[str, list[ParsedSession]]]:
+    """Census (add) every raw once, then replay (for_raw) every raw once per
+    pass; return ``(whale_reload_seconds, small_reload_seconds, sessions_by_raw_id)``.
+    """
+    for raw_id in [*small_raw_ids, whale_raw_id]:
+        sessions, payload_bytes, _kind = _parse_retained_raw(archive, raw_id)
+        spill.add(raw_id, sessions, payload_bytes=payload_bytes)
+
+    sessions_by_raw_id: dict[str, list[ParsedSession]] = {}
+    whale_seconds = 0.0
+    small_seconds = 0.0
+    for _pass in range(_REREAD_PASSES):
+        for raw_id in small_raw_ids:
+            started = time.perf_counter()
+            sessions, _payload_bytes = spill.for_raw(archive, raw_id)
+            small_seconds += time.perf_counter() - started
+            sessions_by_raw_id.setdefault(raw_id, sessions)
+        started = time.perf_counter()
+        whale_sessions, _payload_bytes = spill.for_raw(archive, whale_raw_id)
+        whale_seconds += time.perf_counter() - started
+        sessions_by_raw_id.setdefault(whale_raw_id, whale_sessions)
+
+    return whale_seconds, small_seconds, sessions_by_raw_id
+
+
+@pytest.mark.benchmark
+def test_whale_bypasses_pickle_round_trip_on_reload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Whale-aware residency must cut ``for_raw()`` reload cost for an
+    oversized session versus the pre-lever pickle-to-sqlite round trip, and
+    must not change what content is returned (output equivalence)."""
+    monkeypatch.setattr(_ParsedSessionSpill, "_DECODED_CACHE_MIN_TREE_BYTES", _SHRUNK_DECODED_MIN_TREE_BYTES)
+    monkeypatch.setattr(_ParsedSessionSpill, "_DECODED_CACHE_MAX_TREE_BYTES", _SHRUNK_DECODED_MAX_TREE_BYTES)
+
+    baseline_root = tmp_path / "baseline"
+    small_raw_ids, whale_raw_id = build_whale_bearing_corpus(
+        baseline_root,
+        small_raw_count=WHALE_BEARING_SHAPE["small_raw_count"],
+        small_avg_payload_bytes=WHALE_BEARING_SHAPE["small_avg_payload_bytes"],
+        whale_payload_bytes=WHALE_BEARING_SHAPE["whale_payload_bytes"],
+    )
+    baseline_whale_s, baseline_small_s, baseline_sessions = _run_spill_load_pass(
+        baseline_root, small_raw_ids, whale_raw_id, disable_whale_lever=True
+    )
+
+    lever_root = tmp_path / "lever"
+    small_raw_ids_2, whale_raw_id_2 = build_whale_bearing_corpus(
+        lever_root,
+        small_raw_count=WHALE_BEARING_SHAPE["small_raw_count"],
+        small_avg_payload_bytes=WHALE_BEARING_SHAPE["small_avg_payload_bytes"],
+        whale_payload_bytes=WHALE_BEARING_SHAPE["whale_payload_bytes"],
+    )
+    assert small_raw_ids_2 == small_raw_ids and whale_raw_id_2 == whale_raw_id, (
+        "corpus builder must be deterministic across the two roots for a fair before/after comparison"
+    )
+    lever_whale_s, lever_small_s, lever_sessions = _run_spill_load_pass(
+        lever_root, small_raw_ids, whale_raw_id, disable_whale_lever=False
+    )
+
+    speedup = baseline_whale_s / max(lever_whale_s, 1e-9)
+    print(
+        f"\nwhale spill_load reload ({_REREAD_PASSES} passes, "
+        f"whale_payload_bytes={WHALE_BEARING_SHAPE['whale_payload_bytes']}, "
+        f"small_raw_count={WHALE_BEARING_SHAPE['small_raw_count']}): "
+        f"baseline(pickle round trip)={baseline_whale_s:.4f}s, lever(resident)={lever_whale_s:.4f}s, "
+        f"speedup={speedup:.1f}x; small-population reload baseline={baseline_small_s:.4f}s "
+        f"lever={lever_small_s:.4f}s (unaffected -- both paths spill small sessions identically)"
+    )
+
+    assert lever_whale_s * 3 < baseline_whale_s, (
+        f"Expected the whale-resident reload to be at least 3x faster than the pickle round trip; "
+        f"got baseline={baseline_whale_s:.4f}s lever={lever_whale_s:.4f}s (only {speedup:.1f}x)"
+    )
+
+    # Output equivalence: the reloaded whale session's content must be
+    # byte-identical between the two paths (proves the resident-object
+    # bypass is not silently returning stale or partial content).
+    baseline_whale_session = baseline_sessions[whale_raw_id][0]
+    lever_whale_session = lever_sessions[whale_raw_id][0]
+    assert lever_whale_session.provider_session_id == baseline_whale_session.provider_session_id
+    assert len(lever_whale_session.messages) == len(baseline_whale_session.messages)
+    assert [m.text for m in lever_whale_session.messages] == [m.text for m in baseline_whale_session.messages]
+    for small_raw_id in small_raw_ids:
+        baseline_small_session = baseline_sessions[small_raw_id][0]
+        lever_small_session = lever_sessions[small_raw_id][0]
+        assert lever_small_session.provider_session_id == baseline_small_session.provider_session_id
+        assert [m.text for m in lever_small_session.messages] == [m.text for m in baseline_small_session.messages]
+
+
+@pytest.mark.benchmark
+def test_whale_exceeding_whale_ceiling_falls_back_to_spill(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A tree too large for EITHER tier (hot cache or whale ceiling) must
+    still be spilled to sqlite exactly as the pre-lever code did --
+    correctness-over-speed fallback required by polylogue-odm1's AC."""
+    monkeypatch.setattr(_ParsedSessionSpill, "_DECODED_CACHE_MIN_TREE_BYTES", _SHRUNK_DECODED_MIN_TREE_BYTES)
+    monkeypatch.setattr(_ParsedSessionSpill, "_DECODED_CACHE_MAX_TREE_BYTES", _SHRUNK_DECODED_MAX_TREE_BYTES)
+    # Shrink the whale ceiling itself below the fixture's whale tree size so
+    # the fallback path is exercised deterministically regardless of host RAM.
+    monkeypatch.setattr(_ParsedSessionSpill, "_WHALE_CACHE_MAX_TREE_BYTES", _SHRUNK_DECODED_MAX_TREE_BYTES)
+
+    archive_root = tmp_path / "archive"
+    small_raw_ids, whale_raw_id = build_whale_bearing_corpus(
+        archive_root,
+        small_raw_count=5,
+        small_avg_payload_bytes=WHALE_BEARING_SHAPE["small_avg_payload_bytes"],
+        whale_payload_bytes=WHALE_BEARING_SHAPE["whale_payload_bytes"],
+    )
+
+    with (
+        ArchiveStore.open_existing(archive_root, read_only=False) as archive,
+        _ParsedSessionSpill(archive_root, max_cached_payload_bytes=_SPILL_CACHE_BYTES) as spill,
+    ):
+        sessions, payload_bytes, _kind = _parse_retained_raw(archive, whale_raw_id)
+        spill.add(whale_raw_id, sessions, payload_bytes=payload_bytes)
+
+        assert whale_raw_id not in spill._whales, "whale ceiling was shrunk below the fixture; must not be resident"
+        row = spill.conn.execute("SELECT COUNT(*) FROM parsed_sessions WHERE raw_id = ?", (whale_raw_id,)).fetchone()
+        assert row is not None and row[0] > 0, (
+            "oversized tree exceeding the whale ceiling must fall back to the sqlite spill"
+        )
+
+        reloaded_sessions, reloaded_payload_bytes = spill.for_raw(archive, whale_raw_id)
+        assert reloaded_payload_bytes == payload_bytes
+        assert [m.text for m in reloaded_sessions[0].messages] == [m.text for m in sessions[0].messages]

--- a/tests/infra/revision_backfill_benchmark.py
+++ b/tests/infra/revision_backfill_benchmark.py
@@ -27,6 +27,23 @@ from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_a
 SMALL_PAYLOAD_SHAPE: dict[str, int] = {"raw_count": 200, "avg_payload_bytes": 50_000}
 LARGE_PAYLOAD_SHAPE: dict[str, int] = {"raw_count": 80, "avg_payload_bytes": 1_700_000}
 
+# polylogue-odm1: one oversized ("whale") raw alongside a population of
+# small independent raws -- the shape of the v42 walk's whale-bearing rebuild
+# pages (a multi-hundred-MB Codex rollout sharing a page with many ordinary
+# sessions). ``whale_payload_bytes`` is deliberately far smaller than the
+# live 442MB receipts: the ratio between spill+reload cost and the
+# whale-aware-resident cost is what polylogue-odm1 measures, not the
+# absolute byte count, and a multi-hundred-MB fixture would make the test
+# suite itself slow. Benchmarks that need the real threshold math to trigger
+# on a payload this size shrink ``_ParsedSessionSpill``'s cache-size class
+# constants instead of growing the fixture (see
+# ``tests/benchmarks/test_whale_census_spill_bench.py``).
+WHALE_BEARING_SHAPE: dict[str, int] = {
+    "small_raw_count": 40,
+    "small_avg_payload_bytes": 20_000,
+    "whale_payload_bytes": 40_000_000,
+}
+
 # polylogue-nh44: one growing-file cohort shaped after the bead's own live
 # evidence (a Codex rollout file re-captured on every scan, each capture a
 # byte-superset of the last). ~1MB final size, 50 superseded snapshots plus
@@ -152,10 +169,49 @@ def build_revision_chain_corpus(
     return raw_ids
 
 
+def build_whale_bearing_corpus(
+    archive_root: Path,
+    *,
+    small_raw_count: int,
+    small_avg_payload_bytes: int,
+    whale_payload_bytes: int,
+) -> tuple[list[str], str]:
+    """Write a population of small independent raws plus one oversized
+    ("whale") raw, all uncensused single-session Codex records sharing no
+    cohort relationship (isolates whale-residency behavior from cohort
+    classification, same rationale as ``build_independent_raw_corpus``).
+
+    Returns ``(small_raw_ids, whale_raw_id)`` in insertion order. The archive
+    root is initialized fresh; call once per corpus.
+    """
+    initialize_active_archive_root(archive_root)
+    small_raw_ids: list[str] = []
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        for index in range(small_raw_count):
+            payload = _codex_raw_payload(index, target_bytes=small_avg_payload_bytes)
+            raw_id = archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=payload,
+                source_path=f"synthetic-odm1/session-{index:06d}.jsonl",
+                acquired_at_ms=index + 1,
+            )
+            small_raw_ids.append(raw_id)
+        whale_payload = _codex_raw_payload(small_raw_count, target_bytes=whale_payload_bytes)
+        whale_raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=whale_payload,
+            source_path="synthetic-odm1/whale-session.jsonl",
+            acquired_at_ms=small_raw_count + 1,
+        )
+    return small_raw_ids, whale_raw_id
+
+
 __all__ = [
     "LARGE_PAYLOAD_SHAPE",
     "REVISION_CHAIN_SHAPE",
     "SMALL_PAYLOAD_SHAPE",
+    "WHALE_BEARING_SHAPE",
     "build_independent_raw_corpus",
     "build_revision_chain_corpus",
+    "build_whale_bearing_corpus",
 ]

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -15,6 +15,7 @@ from polylogue.archive.ingest_flags import (
 )
 from polylogue.archive.revision_authority import RawRevisionKind
 from polylogue.core.enums import Provider
+from polylogue.pipeline.parsed_tree_size import estimate_parsed_tree_bytes
 from polylogue.sources import revision_backfill
 from polylogue.sources.decoders import _iter_json_stream
 from polylogue.sources.dispatch import parse_payload
@@ -31,8 +32,10 @@ from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
 from tests.infra.revision_backfill_benchmark import (
     REVISION_CHAIN_SHAPE,
+    WHALE_BEARING_SHAPE,
     build_independent_raw_corpus,
     build_revision_chain_corpus,
+    build_whale_bearing_corpus,
 )
 
 
@@ -1714,3 +1717,203 @@ def test_parse_unique_retained_raws_routes_to_threads_when_probe_true(
 
     assert results == sentinel
     assert calls == [(("raw-a", "raw-b"), 4)]
+
+
+# ---------------------------------------------------------------------------
+# Whale-aware census spill (polylogue-odm1)
+# ---------------------------------------------------------------------------
+
+# Shrink the hot-cache budget so a modest (KB-scale) fixture reliably
+# classifies as a "whale" without depending on the host's real RAM -- see
+# tests/benchmarks/test_whale_census_spill_bench.py's module docstring for
+# the full rationale (the class computes its budgets from
+# effective_physical_memory_bytes(), whose production floor is 256 MiB).
+_SHRUNK_TREE_BYTES = 64 * 1024
+
+
+def test_whale_add_bypasses_sqlite_spill_and_holds_resident(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A parsed tree too large for the hot cache but within the whale
+    ceiling must be held resident in ``_whales`` and must NOT be written to
+    the sqlite spill at all (no pickle.dumps paid)."""
+    monkeypatch.setattr(revision_backfill._ParsedSessionSpill, "_DECODED_CACHE_MIN_TREE_BYTES", _SHRUNK_TREE_BYTES)
+    monkeypatch.setattr(revision_backfill._ParsedSessionSpill, "_DECODED_CACHE_MAX_TREE_BYTES", _SHRUNK_TREE_BYTES)
+
+    archive_root = tmp_path / "archive"
+    _small_ids, whale_id = build_whale_bearing_corpus(
+        archive_root,
+        small_raw_count=1,
+        small_avg_payload_bytes=WHALE_BEARING_SHAPE["small_avg_payload_bytes"],
+        whale_payload_bytes=200_000,
+    )
+    with (
+        ArchiveStore.open_existing(archive_root, read_only=False) as archive,
+        revision_backfill._ParsedSessionSpill(archive_root, max_cached_payload_bytes=10_000_000) as spill,
+    ):
+        sessions, payload_bytes, _kind = revision_backfill._parse_retained_raw(archive, whale_id)
+        assert estimate_parsed_tree_bytes(sessions) > spill._decoded_budget, (
+            "fixture must actually exceed the shrunk hot-cache budget to exercise the whale path"
+        )
+
+        spill.add(whale_id, sessions, payload_bytes=payload_bytes)
+
+        assert whale_id in spill._whales
+        assert whale_id not in spill._decoded
+        row = spill.conn.execute("SELECT COUNT(*) FROM parsed_sessions WHERE raw_id = ?", (whale_id,)).fetchone()
+        assert row is not None and row[0] == 0, "whale must bypass the sqlite spill write entirely"
+
+        reloaded_sessions, reloaded_payload_bytes = spill.for_raw(archive, whale_id)
+        assert reloaded_sessions is sessions, "whale reload must return the same resident objects, no round trip"
+        assert reloaded_payload_bytes == payload_bytes
+
+
+def test_whale_exceeding_whale_ceiling_falls_back_to_sqlite_spill(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Correctness-over-speed fallback: a tree too large for EITHER tier
+    (hot cache or whale ceiling) must still be spilled to sqlite exactly as
+    the pre-lever code did."""
+    monkeypatch.setattr(revision_backfill._ParsedSessionSpill, "_DECODED_CACHE_MIN_TREE_BYTES", _SHRUNK_TREE_BYTES)
+    monkeypatch.setattr(revision_backfill._ParsedSessionSpill, "_DECODED_CACHE_MAX_TREE_BYTES", _SHRUNK_TREE_BYTES)
+    monkeypatch.setattr(revision_backfill._ParsedSessionSpill, "_WHALE_CACHE_MAX_TREE_BYTES", _SHRUNK_TREE_BYTES)
+
+    archive_root = tmp_path / "archive"
+    _small_ids, whale_id = build_whale_bearing_corpus(
+        archive_root,
+        small_raw_count=1,
+        small_avg_payload_bytes=WHALE_BEARING_SHAPE["small_avg_payload_bytes"],
+        whale_payload_bytes=200_000,
+    )
+    with (
+        ArchiveStore.open_existing(archive_root, read_only=False) as archive,
+        revision_backfill._ParsedSessionSpill(archive_root, max_cached_payload_bytes=10_000_000) as spill,
+    ):
+        sessions, payload_bytes, _kind = revision_backfill._parse_retained_raw(archive, whale_id)
+
+        spill.add(whale_id, sessions, payload_bytes=payload_bytes)
+
+        assert whale_id not in spill._whales
+        assert whale_id not in spill._decoded
+        row = spill.conn.execute("SELECT COUNT(*) FROM parsed_sessions WHERE raw_id = ?", (whale_id,)).fetchone()
+        assert row is not None and row[0] > 0, "must fall back to the sqlite spill when the whale ceiling is exceeded"
+
+        reloaded_sessions, reloaded_payload_bytes = spill.for_raw(archive, whale_id)
+        assert reloaded_payload_bytes == payload_bytes
+        assert reloaded_sessions[0].provider_session_id == sessions[0].provider_session_id
+        assert [m.text for m in reloaded_sessions[0].messages] == [m.text for m in sessions[0].messages]
+
+
+def test_whale_eviction_degrades_to_sqlite_spill_courtesy(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """When multiple whales together exceed the whale budget, the entry
+    evicted from the resident tier must be written to the sqlite spill
+    (not silently dropped) so a later ``for_raw`` still finds it without a
+    full reparse from raw bytes."""
+    # Each whale's tree is ~83KB (measured for 20,000-char payload text under
+    # this estimator); a 16KB decoded budget classifies either as a whale,
+    # and a 140KB whale ceiling holds exactly one at a time but not two.
+    monkeypatch.setattr(revision_backfill._ParsedSessionSpill, "_DECODED_CACHE_MIN_TREE_BYTES", 16 * 1024)
+    monkeypatch.setattr(revision_backfill._ParsedSessionSpill, "_DECODED_CACHE_MAX_TREE_BYTES", 16 * 1024)
+    monkeypatch.setattr(revision_backfill._ParsedSessionSpill, "_WHALE_CACHE_MAX_TREE_BYTES", 140_000)
+
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        first_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=_codex_payload_of_size("whale-a", 20_000),
+            source_path="odm1/whale-a.jsonl",
+            acquired_at_ms=1,
+        )
+        second_id = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=_codex_payload_of_size("whale-b", 20_000),
+            source_path="odm1/whale-b.jsonl",
+            acquired_at_ms=2,
+        )
+
+    with (
+        ArchiveStore.open_existing(archive_root, read_only=False) as archive,
+        revision_backfill._ParsedSessionSpill(archive_root, max_cached_payload_bytes=10_000_000) as spill,
+    ):
+        first_sessions, first_payload_bytes, _kind = revision_backfill._parse_retained_raw(archive, first_id)
+        spill.add(first_id, first_sessions, payload_bytes=first_payload_bytes)
+        assert first_id in spill._whales
+
+        second_sessions, second_payload_bytes, _kind = revision_backfill._parse_retained_raw(archive, second_id)
+        spill.add(second_id, second_sessions, payload_bytes=second_payload_bytes)
+
+        # The second whale evicted the first from the resident tier.
+        assert second_id in spill._whales
+        assert first_id not in spill._whales
+
+        # But the first must have been degraded into the sqlite spill on
+        # eviction, not dropped -- for_raw() must still resolve it without
+        # touching _parse_retained_raw again (proven by content equality
+        # despite the archive already being past that raw in the loop).
+        row = spill.conn.execute("SELECT COUNT(*) FROM parsed_sessions WHERE raw_id = ?", (first_id,)).fetchone()
+        assert row is not None and row[0] > 0, "evicted whale must be degraded into the sqlite spill, not dropped"
+
+        reloaded_sessions, reloaded_payload_bytes = spill.for_raw(archive, first_id)
+        assert reloaded_payload_bytes == first_payload_bytes
+        assert [m.text for m in reloaded_sessions[0].messages] == [m.text for m in first_sessions[0].messages]
+
+
+def _codex_payload_of_size(session_id: str, text_len: int) -> bytes:
+    session_meta = (
+        json.dumps(
+            {"type": "session_meta", "payload": {"id": session_id, "timestamp": "2026-06-01T00:00:00Z"}},
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    response_item = (
+        json.dumps(
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": "one",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "x" * text_len}],
+                },
+            },
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+    return (session_meta + response_item).encode()
+
+
+def test_backfill_replays_whale_bearing_page_byte_identical_to_content(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """End-to-end proof (through ``backfill_historical_revision_evidence``,
+    not the ``_ParsedSessionSpill`` internals) that a whale-bearing rebuild
+    page still replays every session -- large and small -- to correct
+    content when the whale-residency lever is active. No schema change, no
+    output drift: counts and message text must match what an equivalent
+    small-only corpus already proves the pipeline produces."""
+    monkeypatch.setattr(revision_backfill._ParsedSessionSpill, "_DECODED_CACHE_MIN_TREE_BYTES", _SHRUNK_TREE_BYTES)
+    monkeypatch.setattr(revision_backfill._ParsedSessionSpill, "_DECODED_CACHE_MAX_TREE_BYTES", _SHRUNK_TREE_BYTES)
+
+    archive_root = tmp_path / "archive"
+    small_raw_ids, whale_raw_id = build_whale_bearing_corpus(
+        archive_root,
+        small_raw_count=6,
+        small_avg_payload_bytes=5_000,
+        whale_payload_bytes=200_000,
+    )
+
+    result = backfill_historical_revision_evidence(
+        archive_root, max_cached_payload_bytes=10_000_000, commit_batch_size=200, replay_commit_batch_size=1
+    )
+
+    assert result.scanned == len(small_raw_ids) + 1
+    assert result.replayed_logical_sources == len(small_raw_ids) + 1
+    assert result.quarantined == 0
+
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        session_ids = {row[0] for row in conn.execute("SELECT raw_id FROM sessions")}
+        assert session_ids == {*small_raw_ids, whale_raw_id}
+        for raw_id in [*small_raw_ids, whale_raw_id]:
+            message_count = conn.execute("SELECT message_count FROM sessions WHERE raw_id = ?", (raw_id,)).fetchone()
+            assert message_count == (1,)


### PR DESCRIPTION
## Summary

The historical-backfill census spill (`polylogue/sources/revision_backfill.py:_ParsedSessionSpill`) now holds oversized ("whale") parsed session trees resident in memory during census+replay instead of always pickling them to a scratch sqlite file and reloading via `pickle.loads` — the dominant cost on whale-bearing rebuild pages per the v42 walk receipts.

## Problem

2026-07-21 v42 walk receipts: on whale-bearing rebuild pages, the `spill_load` stage timer dominates wall time — 598.2s of a 1440.2s page (41%), plus 236.6s/523.1s, 228.1s/607.5s, 139.6s/454.6s on other pages.

`_ParsedSessionSpill` pickles decoded `ParsedSession` trees to a scratch sqlite file during census and reloads them (`for_raw()`) one authority cohort at a time during replay. The spill's own in-RAM hot cache (`_decoded`) is tree-byte budgeted (256 MiB–2 GiB, adaptive from `effective_physical_memory_bytes() // 16`, see `polylogue/pipeline/parsed_tree_size.py`) — any single tree above that budget was *unconditionally* excluded from the hot cache, so every reload of a genuinely oversized session (e.g. a 442 MB Codex rollout) paid a full `pickle.loads`, or — once the sqlite spill's own payload-byte budget was also exhausted by other raws sharing the page — a full re-parse from raw bytes on every access.

## Solution

Added a second, wider "whale ceiling" budget derived from the same `effective_physical_memory_bytes()` machinery already used for the hot cache (`physical // 4`, capped at 8 GiB, floored at whatever the hot-cache budget resolved to). A tree too large for the hot cache but within the whale ceiling now bypasses the sqlite spill entirely — held resident as a plain Python object in a new `_whales` dict, no `pickle.dumps` at census, no `pickle.loads` on replay.

Correctness-over-speed fallbacks (per AC):
- A tree exceeding even the whale ceiling still falls back to the unmodified sqlite-spill path (`_retain_whale` returns `False`, `add()` proceeds exactly as before).
- If accepting a new whale would exceed the whale budget, the oldest resident whale is evicted (FIFO) — but rather than being dropped, it is degraded into the sqlite spill (extracted `_spill_to_sqlite` helper, shared with the normal path) so it still avoids a full reparse-from-source on its next access.

Rejected levers:
- **Stream-reparse-on-reload**: not pursued. The measured baseline cost is the pickle round trip itself (see Verification), not "we lack the bytes" — residency removes exactly that cost, and reparsing from raw bytes is the *existing worse* fallback this change avoids, not a competitive alternative.
- **Cheaper spill serialization** (pickle protocol/compression): not pursued. Bypassing serialization entirely for the dominant case (the whale) already removes the cost that lever would only shrink; no new dependency was needed or added.

No schema change (spill layer only, matches AC). Single-writer invariant unchanged (the spill remains process-local, discarded on `__exit__`). Replay output equivalence is asserted directly by tests (see below), not merely implied by "we didn't touch the classification logic."

## Verification

- `devtools test tests/unit/sources/test_revision_backfill.py tests/benchmarks/test_whale_census_spill_bench.py tests/infra/revision_backfill_benchmark.py` → **45 passed, 1 pre-existing failure** (`test_backfill_resumes_after_replay_batch_crash_discards_whole_batch_cleanly`, `messages_fts_identity` UNIQUE constraint) — confirmed failing identically on unmodified `origin/master` via a `git stash`/pop before/after comparison; unrelated to this change, not touched by this PR.
- `mypy --strict` on all four touched/added files: `Success: no issues found in 4 source files`.
- `devtools verify --quick`: exit 0 (ran automatically via pre-push hook too).
- **Benchmark receipts** (`tests/benchmarks/test_whale_census_spill_bench.py`, harness committed and reproducible — see module docstring for how it neutralizes only the new `_retain_whale` branch to reconstruct a faithful "baseline" from the *same* unmodified code path, avoiding a second hand-written implementation): 40 MB synthetic whale + 40 small raws, 2 reload passes:
  - baseline (pre-lever pickle round trip): **81.9ms**
  - lever (resident dict lookup, same 2 accesses): **~5µs**
  - ≈16,000x on the reload step at this scaled-down fixture size (chosen to keep CI wall time bounded per the bead's own "scale down proportionally" guidance — the ratio, not the absolute byte count, is the measurement).
  - Direct `pickle.loads` scaling check: 6 MB → 2.1ms, 60 MB → 21.7ms (~0.36ms/MB), which extrapolates to ~160ms for a single reload of a production-scale 442 MB whale — multiplied by however many `for_raw()` calls a page's classification loops make against that raw_id, consistent with the multi-hundred-second `spill_load` receipts.
  - Anti-vacuity: reverting `_retain_whale` to always return `False` (exactly what the "baseline" run does) reproduces the pre-lever cost — this is not a test-only validator, it exercises the real `_ParsedSessionSpill.add()`/`for_raw()` production code paths with only that one branch neutralized.

## AC matrix (polylogue-odm1)

| AC | Status |
| --- | --- |
| Profile first with synthetic whale fixture, measure current + candidate levers | Satisfied — `tests/benchmarks/test_whale_census_spill_bench.py` + direct pickle-scaling probes |
| Size-partitioned spill: threshold derived from existing tree-byte budget machinery, not a new magic number | Satisfied — whale ceiling reuses `effective_physical_memory_bytes()`, same divisor family as the existing hot-cache budget, floored at it; rationale documented in the class docstring |
| Whales held resident counted against overall memory budget; fallback to spilling if would blow budget | Satisfied — independent `_whale_tree_bytes` accounting bounded by `_whale_budget`; `_retain_whale` returns `False` (falls through to sqlite spill) when a tree exceeds the ceiling; eviction degrades into sqlite spill rather than dropping |
| Stream-reparse-on-reload lever | Evaluated, rejected — see Solution section; measured cost is the pickle round trip, not a missing-bytes gap |
| Cheaper serialization lever | Evaluated, rejected — residency already removes the serialization cost entirely for the dominant case; no new dependency |
| Preserve single-writer invariant | Satisfied — no change to writer topology |
| Replay outputs byte-identical (counts/hashes/authority decisions); benchmark asserts equivalence, not just speed | Satisfied — `test_whale_bypasses_pickle_round_trip_on_reload` asserts message-text equality baseline vs lever; `test_backfill_replays_whale_bearing_page_byte_identical_to_content` proves the full `backfill_historical_revision_evidence` pipeline replays every raw (whale + small) to correct session/message counts with the lever active |
| No schema changes | Satisfied — spill layer only |
| Record measured delta on polylogue-623q when it lands | Deferred to a follow-up note on polylogue-623q referencing this PR's receipts (not done as part of this PR; no bead state was mutated by this branch) |

Ref polylogue-odm1