### PR TITLE
fix(config): route direct-env config bypasses through the layered resolver

### DIFF
--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -1199,9 +1199,12 @@ def _daemon_session_query_params(
 def _daemon_disabled(*, flag: bool = False) -> bool:
     if flag:
         return True
-    if os.environ.get("POLYLOGUE_NO_DAEMON", "").lower() in {"1", "true", "yes", "on"}:
+    from polylogue.config import load_polylogue_config
+
+    settings = load_polylogue_config()
+    if settings.no_daemon:
         return True
-    return os.environ.get("POLYLOGUE_DAEMON", "").lower() == "off"
+    return settings.daemon_client_mode == "off"
 
 
 def _fetch_daemon_sessions_payload(

--- a/polylogue/cli/commands/dashboard.py
+++ b/polylogue/cli/commands/dashboard.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from urllib.request import Request, urlopen
 
 import click
@@ -43,7 +42,9 @@ def dashboard_command(env: AppEnv, status_only: bool, output_format: str) -> Non
 
 
 def _dashboard_launch_evidence() -> dict[str, object]:
-    daemon_url = os.environ.get("POLYLOGUE_DAEMON_URL", "http://127.0.0.1:8766")
+    from polylogue.config import load_polylogue_config
+
+    daemon_url = load_polylogue_config().daemon_url or "http://127.0.0.1:8766"
     status: dict[str, object] = {
         "surface": "terminal_tui",
         "launches": "Textual dashboard in the current terminal",

--- a/polylogue/cli/commands/embed.py
+++ b/polylogue/cli/commands/embed.py
@@ -344,7 +344,9 @@ def _resolve_voyage_key(env: AppEnv, explicit: str | None) -> str | None:
         return explicit
     if env.config.index_config and env.config.index_config.voyage_api_key:
         return env.config.index_config.voyage_api_key
-    return os.environ.get("VOYAGE_API_KEY") or None
+    from polylogue.config import load_polylogue_config
+
+    return load_polylogue_config().voyage_api_key
 
 
 @embed_command.command("enable")

--- a/polylogue/cli/commands/facets.py
+++ b/polylogue/cli/commands/facets.py
@@ -94,9 +94,12 @@ def _fetch_daemon_facets(
 ) -> FacetsResponse | None:
     """Use the config-matched UDS daemon for read-only facets when lossless."""
 
-    if disabled or no_idf or os.environ.get("POLYLOGUE_NO_DAEMON", "").lower() in {"1", "true", "yes", "on"}:
+    from polylogue.config import load_polylogue_config
+
+    settings = load_polylogue_config()
+    if disabled or no_idf or settings.no_daemon:
         return None
-    if os.environ.get("POLYLOGUE_DAEMON", "").lower() == "off":
+    if settings.daemon_client_mode == "off":
         return None
     from polylogue.cli.daemon_client import DaemonClient
     from polylogue.cli.shared.helpers import load_effective_config

--- a/polylogue/cli/commands/import_command.py
+++ b/polylogue/cli/commands/import_command.py
@@ -25,7 +25,6 @@ The three observable outcomes are:
 from __future__ import annotations
 
 import json
-import os
 import shutil
 import time
 from pathlib import Path
@@ -42,8 +41,6 @@ from polylogue.paths import archive_root
 if TYPE_CHECKING:
     from polylogue.demo import DemoVerifyResult
 
-_DEFAULT_DAEMON_URL = "http://127.0.0.1:8766"
-
 # Statuses that mean the daemon accepted scheduling and the work is now
 # observable through the inbox / ``polylogue ops status`` surfaces.
 _ACCEPTED_STATUSES = frozenset({"accepted", "pending", "scheduled", "queued"})
@@ -51,7 +48,9 @@ _DEMO_WAIT_POLL_INTERVAL_S = 0.25
 
 
 def _default_daemon_url() -> str:
-    return os.environ.get("POLYLOGUE_DAEMON_URL") or _DEFAULT_DAEMON_URL
+    from polylogue.config import load_polylogue_config
+
+    return load_polylogue_config().daemon_url or "http://127.0.0.1:8766"
 
 
 def _stage_for_daemon(path: Path, *, replace_existing: bool = False) -> Path:

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
 import time
 from collections.abc import Sequence
@@ -67,16 +66,16 @@ _ARCHIVE_COMPONENT_REPAIR_HINTS: dict[str, str] = {
 
 
 def _default_daemon_url() -> str:
-    """Resolve the default daemon URL.
+    """Resolve the default daemon URL through the layered config resolver.
 
-    Honours ``POLYLOGUE_DAEMON_URL`` so test fixtures can route the CLI to an
-    unreachable address and avoid contacting an operator-host ``polylogued``
-    listening at the built-in default (#1325).
+    Honours ``daemon.url`` / ``POLYLOGUE_DAEMON_URL`` (site TOML -> user TOML
+    -> env -> CLI) so test fixtures can route the CLI to an unreachable
+    address and avoid contacting an operator-host ``polylogued`` listening at
+    the built-in default (#1325).
     """
-    override = os.environ.get("POLYLOGUE_DAEMON_URL")
-    if override:
-        return override
-    return _BUILTIN_DAEMON_URL
+    from polylogue.config import load_polylogue_config
+
+    return load_polylogue_config().daemon_url or _BUILTIN_DAEMON_URL
 
 
 def _fast_count(conn: Any, sql: str, params: tuple[object, ...] = ()) -> int:
@@ -138,7 +137,9 @@ def _candidate_daemon_urls(primary_url: str) -> tuple[str, ...]:
             urls.append(normalized)
 
     add(primary_url)
-    if os.environ.get("POLYLOGUE_DAEMON_URL"):
+    from polylogue.config import load_polylogue_config
+
+    if load_polylogue_config().layer_of("daemon_url") != "default":
         return tuple(urls)
     for port in _discover_polylogued_api_ports():
         add(f"http://127.0.0.1:{port}")

--- a/polylogue/cli/commands/tutorial.py
+++ b/polylogue/cli/commands/tutorial.py
@@ -154,10 +154,11 @@ def _guided_path_needed() -> bool:
 
 def _daemon_http_alive() -> bool:
     """Best-effort daemon liveness probe with a short timeout."""
-    import os
     from urllib.request import Request, urlopen
 
-    url = os.environ.get("POLYLOGUE_DAEMON_URL", "http://127.0.0.1:8766")
+    from polylogue.config import load_polylogue_config
+
+    url = load_polylogue_config().daemon_url or "http://127.0.0.1:8766"
     try:
         req = Request(f"{url}/api/status", method="GET")
         with urlopen(req, timeout=0.5) as resp:

--- a/polylogue/daemon/backup.py
+++ b/polylogue/daemon/backup.py
@@ -692,8 +692,10 @@ def _verify_backup_result(result: BackupResult) -> None:
 
 def _backup_verification_scratch_parent(path: Path) -> Path | None:
     """Choose scratch placement near the backup to avoid root ``/tmp`` I/O."""
-    env_tmpdir = os.environ.get("POLYLOGUE_BACKUP_VERIFY_TMPDIR")
-    candidates = (path.parent, Path(env_tmpdir) if env_tmpdir else None, Path("/realm/tmp"))
+    from polylogue.config import load_polylogue_config
+
+    configured_tmpdir = load_polylogue_config().backup_verify_tmpdir
+    candidates = (path.parent, Path(configured_tmpdir) if configured_tmpdir else None, Path("/realm/tmp"))
     for candidate in candidates:
         if candidate is None:
             continue

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -2199,7 +2199,9 @@ def _live_daemon_status_payload(*, timeout: float = _LIVE_DAEMON_STATUS_TIMEOUT_
     from urllib.error import URLError
     from urllib.request import Request, urlopen
 
-    url = os.environ.get("POLYLOGUE_DAEMON_URL", "http://127.0.0.1:8766").rstrip("/")
+    from polylogue.config import load_polylogue_config
+
+    url = (load_polylogue_config().daemon_url or "http://127.0.0.1:8766").rstrip("/")
     try:
         req = Request(f"{url}/api/status", headers={"Accept": "application/json"}, method="GET")
         with urlopen(req, timeout=timeout) as resp:

--- a/polylogue/pipeline/run_stages.py
+++ b/polylogue/pipeline/run_stages.py
@@ -282,8 +282,6 @@ async def execute_embed_stage(
     """Execute the embedding stage using embed_runtime/embed_stats helpers."""
     del progress_callback
 
-    import os
-
     import click
 
     if stats_only:
@@ -308,7 +306,12 @@ async def execute_embed_stage(
             click.echo(f"  Pending:  {payload['pending_sessions']}")
         return EmbedStageOutcome(embedded_count=0, error_count=0, stats_only=True)
 
-    voyage_key = os.environ.get("VOYAGE_API_KEY")
+    index_config = getattr(config, "index_config", None)
+    voyage_key = index_config.voyage_api_key if index_config else None
+    if not voyage_key:
+        from polylogue.config import load_polylogue_config
+
+        voyage_key = load_polylogue_config().voyage_api_key
     if not voyage_key:
         click.echo("Error: VOYAGE_API_KEY environment variable not set", err=True)
         click.echo("Set it with: export VOYAGE_API_KEY=your-api-key", err=True)

--- a/polylogue/pipeline/services/archive_ingest.py
+++ b/polylogue/pipeline/services/archive_ingest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import os
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import UTC, datetime
 from pathlib import Path
@@ -45,11 +44,10 @@ POST_COMMIT_UPKEEP_REASON = "archive_ingest_commit"
 
 
 def _commit_batch_message_threshold() -> int:
-    raw = os.environ.get("POLYLOGUE_INGEST_COMMIT_BATCH_MESSAGES")
-    if raw is None:
-        return COMMIT_BATCH_MESSAGE_THRESHOLD
+    from polylogue.config import load_polylogue_config
+
     try:
-        return int(raw)
+        return load_polylogue_config().ingest_commit_batch_messages
     except ValueError:
         return COMMIT_BATCH_MESSAGE_THRESHOLD
 

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -1419,10 +1419,11 @@ async def process_ingest_batch(
     # Get validation mode from environment and Sinex authority mode from the
     # canonical config layer.  Off mode is passed through so the sync writer
     # performs no protocol encoding or outbox work.
-    validation_mode = os.environ.get("POLYLOGUE_SCHEMA_VALIDATION", "advisory")
     from polylogue.config import load_polylogue_config
 
-    publication_mode = PublicationMode.from_string(load_polylogue_config().sinex_mode)
+    _resolved_settings = load_polylogue_config()
+    validation_mode = _resolved_settings.schema_validation
+    publication_mode = PublicationMode.from_string(_resolved_settings.sinex_mode)
 
     batch_summary = await asyncio.to_thread(
         _process_ingest_batch_sync,

--- a/polylogue/sources/drive/auth.py
+++ b/polylogue/sources/drive/auth.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import shutil
 from pathlib import Path
 
@@ -60,9 +59,13 @@ def _resolve_credentials_path(ui: DriveUILike | _PromptBridge | None, config: Dr
     if configured := _configured_path(config, "credentials_path"):
         return configured
 
-    env_path = os.environ.get("POLYLOGUE_CREDENTIAL_PATH")
-    if env_path:
-        return Path(env_path).expanduser()
+    from polylogue.config import load_polylogue_config
+
+    settings = load_polylogue_config()
+    if settings.layer_of("drive_credentials_path") != "default":
+        configured_path = settings.drive_credentials_path
+        if configured_path:
+            return Path(configured_path).expanduser()
 
     default_path = default_credentials_path(config)
     if default_path.exists():
@@ -89,9 +92,13 @@ def _resolve_token_path(config: DriveConfigLike | None = None) -> Path:
     if configured := _configured_path(config, "token_path"):
         return configured
 
-    env_path = os.environ.get("POLYLOGUE_TOKEN_PATH")
-    if env_path:
-        return Path(env_path).expanduser()
+    from polylogue.config import load_polylogue_config
+
+    settings = load_polylogue_config()
+    if settings.layer_of("drive_token_path") != "default":
+        configured_path = settings.drive_token_path
+        if configured_path:
+            return Path(configured_path).expanduser()
 
     return default_token_path(config)
 

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import os
 import re
 import time
 from collections.abc import Callable, Iterable
@@ -376,12 +375,11 @@ def _full_ingest_worker_count(records: list[RawSessionRecord]) -> int:
 
 
 def _live_full_ingest_worker_limit() -> int:
-    """Resolve the daemon live full-ingest worker cap from the environment."""
-    raw_value = os.environ.get("POLYLOGUE_LIVE_FULL_INGEST_WORKERS")
-    if raw_value is None or raw_value.strip() == "":
-        return _DEFAULT_LIVE_FULL_INGEST_WORKERS
+    """Resolve the daemon live full-ingest worker cap via the layered config."""
+    from polylogue.config import load_polylogue_config
+
     try:
-        return max(1, int(raw_value))
+        return load_polylogue_config().live_full_ingest_workers
     except ValueError:
         return _DEFAULT_LIVE_FULL_INGEST_WORKERS
 

--- a/polylogue/sources/parsers/antigravity.py
+++ b/polylogue/sources/parsers/antigravity.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 import shutil
 import socket
@@ -341,9 +340,11 @@ def iter_language_server_exports(
 
 
 def discover_language_server() -> Path | None:
-    env_path = os.environ.get("POLYLOGUE_ANTIGRAVITY_LANGUAGE_SERVER")
-    if env_path:
-        path = Path(env_path).expanduser()
+    from polylogue.config import load_polylogue_config
+
+    configured_path = load_polylogue_config().antigravity_language_server
+    if configured_path:
+        path = Path(configured_path).expanduser()
         if path.is_file():
             return path
 

--- a/polylogue/storage/search_providers/__init__.py
+++ b/polylogue/storage/search_providers/__init__.py
@@ -11,7 +11,6 @@ factory — see :mod:`polylogue.storage.search_providers.hybrid` for why
 from __future__ import annotations
 
 import importlib.util
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -60,7 +59,9 @@ def create_vector_provider(
     if voyage_key is None and config and config.index_config:
         voyage_key = config.index_config.voyage_api_key
     if voyage_key is None:
-        voyage_key = os.environ.get("VOYAGE_API_KEY")
+        from polylogue.config import load_polylogue_config
+
+        voyage_key = load_polylogue_config().voyage_api_key
 
     if not voyage_key:
         return None

--- a/polylogue/ui/theme.py
+++ b/polylogue/ui/theme.py
@@ -403,41 +403,41 @@ def syntax_theme(surface: SyntaxSurface, mode: ThemeMode | None = None) -> str:
 
 
 def resolve_theme_mode() -> ThemeMode:
-    """Resolve the active theme mode honoring env, config, and auto-detection.
+    """Resolve the active theme mode honoring config layering and auto-detection.
 
-    See module docstring for precedence rules. Returns ``"dark"`` on
-    indeterminate auto-detection so the historical default is preserved.
+    See module docstring for precedence rules. ``ui.theme`` / ``POLYLOGUE_THEME``
+    is a fully layered inventory setting (default -> site TOML -> user TOML ->
+    env -> CLI); resolution goes through :func:`load_polylogue_config` so a CLI
+    override always wins over an ambient environment variable. Returns
+    ``"dark"`` on indeterminate auto-detection so the historical default is
+    preserved.
     """
-    env_value = os.environ.get("POLYLOGUE_THEME", "").strip().lower()
-    if env_value == "dark":
-        return "dark"
-    if env_value == "light":
-        return "light"
-    if env_value == "" or env_value == "auto":
-        # Try config layer; importing lazily keeps the theme module
-        # importable from anywhere without circular dependency risk.
-        try:
-            from polylogue.config import load_polylogue_config
+    # Importing lazily keeps the theme module importable from anywhere
+    # without circular dependency risk.
+    try:
+        from polylogue.config import load_polylogue_config
 
-            configured = (load_polylogue_config().theme or "").strip().lower()
-            if configured == "dark":
-                return "dark"
-            if configured == "light":
-                return "light"
-            if configured and configured != "auto":
-                return "dark"
-        except Exception:
-            pass
-        # Auto-detection: COLORFGBG="<fg>;<bg>" — bg index <8 → dark, else light.
-        fgbg = os.environ.get("COLORFGBG", "")
-        if fgbg:
-            parts = fgbg.split(";")
-            if len(parts) >= 2:
-                try:
-                    bg = int(parts[-1])
-                    return "light" if bg >= 8 else "dark"
-                except ValueError:
-                    pass
+        configured = (load_polylogue_config().theme or "").strip().lower()
+    except Exception:
+        configured = ""
+    if configured == "dark":
+        return "dark"
+    if configured == "light":
+        return "light"
+    if configured and configured != "auto":
+        return "dark"
+    # Auto-detection: COLORFGBG="<fg>;<bg>" — bg index <8 → dark, else light.
+    # COLORFGBG is a genuine external terminal-capability signal, not a
+    # polylogue-namespaced setting, so it stays a direct environment read.
+    fgbg = os.environ.get("COLORFGBG", "")
+    if fgbg:
+        parts = fgbg.split(";")
+        if len(parts) >= 2:
+            try:
+                bg = int(parts[-1])
+                return "light" if bg >= 8 else "dark"
+            except ValueError:
+                pass
     return "dark"
 
 

--- a/tests/unit/core/test_config_resolution_regression.py
+++ b/tests/unit/core/test_config_resolution_regression.py
@@ -1,0 +1,270 @@
+"""Fixture-driven regression coverage for polylogue-9gh1.
+
+The epic (config.py: close the gap between documented 5-layer precedence and
+actual runtime behavior) named three structurally distinct bug shapes found
+by the dogfood-2 round-2 config investigation (``investigations/config-resolution.md``):
+
+1. **fd2s-class (split-system delegation)** -- a setting is inventoried with a
+   ``toml_path`` (implying full 5-layer precedence) but its real runtime
+   consumer resolves the value some other way (legacy ``Config``/env-only
+   reads), so TOML precedence is silently dead for that consumer no matter how
+   many call sites get migrated to read "the config".
+2. **cxlk-class (nested-table full-replace)** -- ``_merge_toml`` treats a
+   nested TOML table as an opaque leaf value, so a later layer's partial
+   override of the table silently discards earlier-layer sibling keys instead
+   of deep-merging.
+3. **uu8r-class (direct os.environ bypass)** -- a file reads a genuinely
+   POLYLOGUE_*-namespaced, TOML-backed setting straight from
+   ``os.environ`` instead of routing through :func:`load_polylogue_config`,
+   so TOML/site/user layering never reaches that call site even though the
+   setting is fully inventoried.
+
+Each test class below pins one bug shape against a real runtime consumer (not
+a synthetic replica) and states, in its docstring, the exact mutation that
+reverts the corresponding fix and makes the test fail.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _disable_site(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Empty POLYLOGUE_SITE_CONFIG disables site discovery so tests do not
+    # accidentally read /etc/polylogue/polylogue.toml from the host.
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+
+
+class TestNestedTableDeepMergePreservesSiblings:
+    """cxlk-class: health.convergence_debt / health.cursor_lag deep-merge.
+
+    Reverted-mutation witness: replace ``_deep_merge_table``'s recursive
+    branch in ``polylogue/config.py`` with a plain
+    ``{**existing, **incoming}`` (or, equivalently, have ``_merge_toml``'s
+    ``toml_kind == "table"`` branch do ``cfg[entry.key] = dict(value)``
+    instead of ``_deep_merge_table(base, value)``) -- both tests below then
+    fail because the site layer's ``default_warning`` and family overrides
+    are silently dropped by the user layer's partial override.
+    """
+
+    def test_health_convergence_debt_retains_site_siblings_after_user_partial_override(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+        from polylogue.daemon.convergence_debt_alert import load_thresholds_from_config
+
+        _disable_site(monkeypatch)
+        site = tmp_path / "site.toml"
+        site.write_text(
+            """
+[health.convergence_debt]
+default_warning = 1
+default_error = 10
+
+[health.convergence_debt.families.claude-code-session]
+warning = 1
+error = 5
+
+[health.convergence_debt.families.chatgpt-export]
+warning = 25
+error = 200
+""",
+            encoding="utf-8",
+        )
+        user = tmp_path / "user.toml"
+        user.write_text(
+            """
+[health.convergence_debt]
+default_error = 20
+""",
+            encoding="utf-8",
+        )
+        cfg = load_polylogue_config(site_config_path=site, config_path=user)
+
+        # Raw-dict assertion: the user layer's override survives, but the
+        # site layer's sibling keys are NOT clobbered.
+        merged = cfg.raw["health_convergence_debt"]
+        assert isinstance(merged, dict)
+        assert merged["default_warning"] == 1, "site-layer default_warning was dropped by user partial override"
+        assert merged["default_error"] == 20, "user-layer override did not win"
+        assert merged["families"]["claude-code-session"] == {"warning": 1, "error": 5}
+        assert merged["families"]["chatgpt-export"] == {"warning": 25, "error": 200}
+
+        # Real-consumer assertion: the daemon alert evaluator actually reads
+        # both the tuned global default and the per-family overrides.
+        thresholds = load_thresholds_from_config(cfg)
+        assert thresholds.default_warning == 1
+        assert thresholds.default_error == 20
+        assert thresholds.for_family("claude-code-session") == (1, 5)
+        assert thresholds.for_family("chatgpt-export") == (25, 200)
+        # A family with no override still falls back to the tuned defaults,
+        # not the hardcoded module defaults.
+        assert thresholds.for_family("codex-session") == (1, 20)
+
+    def test_health_cursor_lag_retains_site_siblings_after_user_partial_override(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.config import load_polylogue_config
+        from polylogue.daemon.cursor_lag_alert import load_thresholds_from_config
+
+        _disable_site(monkeypatch)
+        site = tmp_path / "site.toml"
+        site.write_text(
+            """
+[health.cursor_lag]
+default_warning_s = 60
+default_error_s = 600
+
+[health.cursor_lag.families.claude-code-session]
+warning_s = 30
+error_s = 300
+""",
+            encoding="utf-8",
+        )
+        user = tmp_path / "user.toml"
+        user.write_text(
+            """
+[health.cursor_lag]
+default_error_s = 900
+""",
+            encoding="utf-8",
+        )
+        cfg = load_polylogue_config(site_config_path=site, config_path=user)
+
+        merged = cfg.raw["health_cursor_lag"]
+        assert isinstance(merged, dict)
+        assert merged["default_warning_s"] == 60, "site-layer default_warning_s was dropped by user partial override"
+        assert merged["default_error_s"] == 900
+        assert merged["families"]["claude-code-session"] == {"warning_s": 30, "error_s": 300}
+
+        thresholds = load_thresholds_from_config(cfg)
+        assert thresholds.default_warning_s == 60
+        assert thresholds.default_error_s == 900
+
+
+class TestDelegatedSettingsReachRealConsumers:
+    """fd2s-class: an inventoried, toml_path-bearing setting must reach the
+    real object every runtime consumer uses, not a parallel ambient-read
+    authority.
+
+    Reverted-mutation witness for the voyage_api_key test: restore
+    ``polylogue/storage/search_providers/__init__.py``'s
+    ``voyage_key = os.environ.get("VOYAGE_API_KEY")`` fallback in place of
+    ``load_polylogue_config().voyage_api_key`` -- the test then fails because
+    no ``VOYAGE_API_KEY`` env var is set (TOML-only configuration).
+    """
+
+    def test_archive_root_toml_reaches_resolved_runtime_paths(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        from polylogue.config import resolve_runtime_config
+
+        _disable_site(monkeypatch)
+        for key in ("POLYLOGUE_ARCHIVE_ROOT", "XDG_DATA_HOME"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "unused-data-home"))
+        configured_root = tmp_path / "toml-configured-archive"
+        user = tmp_path / "user.toml"
+        user.write_text(f'[archive]\nroot = "{configured_root.as_posix()}"\n', encoding="utf-8")
+
+        runtime = resolve_runtime_config(config_path=user)
+
+        assert runtime.paths.archive_root == configured_root
+        assert runtime.paths.index_db == configured_root / "index.db"
+        assert runtime.settings.layer_of("archive_root") == "user"
+
+    def test_voyage_api_key_toml_only_reaches_vector_provider_construction(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        pytest.importorskip("sqlite_vec")
+        from polylogue.storage.search_providers import create_vector_provider
+
+        _disable_site(monkeypatch)
+        monkeypatch.delenv("VOYAGE_API_KEY", raising=False)
+        user = tmp_path / "user.toml"
+        user.write_text('[embedding]\nvoyage_api_key = "toml-only-fixture-key"\n', encoding="utf-8")
+        monkeypatch.setenv("POLYLOGUE_CONFIG", str(user))
+
+        provider = create_vector_provider(db_path=tmp_path / "embeddings.db")
+
+        assert provider is not None, "vector provider construction failed even though TOML supplied a voyage key"
+        assert getattr(provider, "voyage_key", None) == "toml-only-fixture-key"
+
+
+class TestDirectEnvBypassCallersRouteThroughResolver:
+    """uu8r-class: already-inventoried settings whose real call site read
+    ``os.environ`` directly instead of the layered resolver.
+
+    Reverted-mutation witness (backup): restore
+    ``env_tmpdir = os.environ.get("POLYLOGUE_BACKUP_VERIFY_TMPDIR")`` in
+    ``polylogue/daemon/backup.py::_backup_verification_scratch_parent`` --
+    the test then fails because no environment variable is set (TOML-only
+    configuration) and the scratch parent falls back to ``/realm/tmp``
+    instead of the configured directory.
+
+    Reverted-mutation witness (antigravity): restore
+    ``env_path = os.environ.get("POLYLOGUE_ANTIGRAVITY_LANGUAGE_SERVER")`` in
+    ``polylogue/sources/parsers/antigravity.py::discover_language_server`` --
+    the test then fails because the TOML-only fixture path is never found and
+    discovery falls through to the ``shutil.which``/glob probes.
+    """
+
+    def test_backup_verify_tmpdir_toml_only_reaches_scratch_parent_resolution(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.daemon.backup import _backup_verification_scratch_parent
+
+        _disable_site(monkeypatch)
+        monkeypatch.delenv("POLYLOGUE_BACKUP_VERIFY_TMPDIR", raising=False)
+        configured_scratch = tmp_path / "toml-configured-scratch"
+        user = tmp_path / "user.toml"
+        user.write_text(f'[maintenance]\nbackup_verify_tmpdir = "{configured_scratch.as_posix()}"\n', encoding="utf-8")
+        monkeypatch.setenv("POLYLOGUE_CONFIG", str(user))
+
+        # A backup path whose own parent cannot be used (missing), so
+        # resolution must fall through to the configured scratch directory
+        # rather than the final hardcoded /realm/tmp candidate.
+        unusable_backup_path = Path("/nonexistent-root-for-test") / "backup"
+
+        result = _backup_verification_scratch_parent(unusable_backup_path)
+
+        assert result == configured_scratch
+        assert configured_scratch.is_dir()
+
+    def test_antigravity_language_server_toml_only_reaches_discovery(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        from polylogue.sources.parsers.antigravity import discover_language_server
+
+        _disable_site(monkeypatch)
+        monkeypatch.delenv("POLYLOGUE_ANTIGRAVITY_LANGUAGE_SERVER", raising=False)
+        configured_binary = tmp_path / "fixture-language-server"
+        configured_binary.write_text("#!/bin/sh\n", encoding="utf-8")
+        user = tmp_path / "user.toml"
+        user.write_text(
+            f'[sources.antigravity]\nlanguage_server = "{configured_binary.as_posix()}"\n', encoding="utf-8"
+        )
+        monkeypatch.setenv("POLYLOGUE_CONFIG", str(user))
+
+        result = discover_language_server()
+
+        assert result == configured_binary


### PR DESCRIPTION
## Summary

Lands the uu8r-class piece of the polylogue-9gh1 epic (config.py's documented 5-layer precedence vs actual runtime behavior) plus the fixture-driven regression test the epic's design requires across all three named bug shapes. The other two pieces (fd2s split-system delegation, cxlk nested-table deep-merge) were already fixed on master via PR #3079 before this branch was cut; this PR adds the regression coverage that was still missing for them and lands new fixes for the remaining env-bypass class.

## Problem

`investigations/config-resolution.md` (dogfood-2 round-2) found config.py's documented 5-layer precedence (defaults -> site TOML -> user TOML -> POLYLOGUE_* env -> CLI) silently does not hold for the whole inventoried surface, in three structurally distinct ways:

1. **fd2s-class** (split-system delegation) -- already fixed on master (PR #3079, `resolve_runtime_config`/`ResolvedRuntimeConfig`).
2. **cxlk-class** (nested-table full-replace) -- already fixed on master (`_deep_merge_table` in `polylogue/config.py:1749`).
3. **uu8r-class** (direct `os.environ` bypass) -- ~20 files read genuinely POLYLOGUE_*-namespaced, TOML-backed settings straight from `os.environ` instead of `load_polylogue_config()`, so TOML/site/user layering never reached those call sites even though every one of the settings involved was already fully inventoried in `config.py`.

None of the three bug shapes had regression coverage: `grep` for `_deep_merge_table`/`health_convergence_debt`/`ResolvedRuntimeConfig` across `tests/unit/core/test_config.py` before this PR turns up construction/precedence tests for flat scalar keys only, nothing that would fail if the nested-merge or delegation fixes were reverted.

## Solution

**Commit 1** (`fix(config): ...`) migrates 17 files' direct `os.environ.get(...)` reads for already-inventoried settings to `load_polylogue_config()` (or an already-resolved `Config`/`IndexConfig` object first, falling back to the layered resolver where one is in scope): `daemon_url` (6 call sites: `cli/commands/{dashboard,import_command,status,tutorial}.py`, `daemon/cli.py`), `no_daemon`/`daemon_client_mode` (`cli/archive_query.py`, `cli/commands/facets.py`), `voyage_api_key` (3 residual call sites: `cli/commands/embed.py`, `pipeline/run_stages.py`, `storage/search_providers/__init__.py`), `theme` (`ui/theme.py`), `backup_verify_tmpdir` (`daemon/backup.py`), `antigravity_language_server` (`sources/parsers/antigravity.py`), `drive_credentials_path`/`drive_token_path` (`sources/drive/auth.py`), `live_full_ingest_workers` (`sources/live/batch_support.py`), `schema_validation`/`ingest_commit_batch_messages` (`pipeline/services/ingest_batch/_core.py`, `pipeline/services/archive_ingest.py`).

`load_polylogue_config` remains the sole five-layer resolver per the fd2s/testsuite-diet contract -- no second resolution path was introduced.

Two non-obvious subtleties, handled explicitly:
- Some inventoried settings (`daemon_url`, `drive_credentials_path`, `drive_token_path`) have a non-empty **default-layer** value, so a bare truthiness check on the resolved value can't distinguish "explicitly configured" from "using the built-in default shape". Call sites that need that distinction (`status.py`'s daemon-port discovery skip, `drive/auth.py`'s config -> env -> XDG-default -> prompt chain) now check `PolylogueConfig.layer_of(key) != "default"` instead.
- An empty-string `POLYLOGUE_DAEMON_URL` is a valid env-layer value under `_apply_env_overrides`, but existing call sites treated an empty override as "unset, use the built-in URL" (`tests/unit/cli/commands/test_status.py::test_empty_env_var_returns_builtin`). Preserved that per-call-site behavior with an explicit `or <builtin>` rather than changing empty-string-env semantics globally.

Also fixed a latent `AttributeError` in `pipeline/run_stages.py::execute_embed_stage` (assumed `config.index_config` always exists; some test/lightweight callers pass a stand-in without it) via `getattr(config, "index_config", None)`.

**Commit 2** (`test(config): ...`) adds `tests/unit/core/test_config_resolution_regression.py`: three test classes, one per bug shape, each exercising a *real* runtime consumer (not a synthetic replica):
- `TestNestedTableDeepMergePreservesSiblings` (cxlk-class): a two-layer TOML fixture (site sets `default_warning`+`default_error`+two family overrides; user overrides only `default_error`) asserts both the raw merged dict and `daemon.convergence_debt_alert.load_thresholds_from_config` / `daemon.cursor_lag_alert.load_thresholds_from_config` retain the site layer's siblings.
- `TestDelegatedSettingsReachRealConsumers` (fd2s-class): TOML-only `archive.root` reaches `resolve_runtime_config().paths.archive_root`; TOML-only `embedding.voyage_api_key` (no env var) reaches `create_vector_provider`'s actual `SqliteVecProvider` construction.
- `TestDirectEnvBypassCallersRouteThroughResolver` (uu8r-class): TOML-only `maintenance.backup_verify_tmpdir` reaches `daemon.backup._backup_verification_scratch_parent`; TOML-only `sources.antigravity.language_server` reaches `sources.parsers.antigravity.discover_language_server`.

Each class's docstring states the exact reverted mutation that makes its test(s) fail; all were manually verified (reverted, re-ran, confirmed failure, restored).

## Verification

- `ruff check` / `ruff format --check` on all 18 touched files: clean.
- `mypy --strict` on all 18 touched files: `Success: no issues found in 18 source files`.
- `devtools test tests/unit/core/test_config_resolution_regression.py`: 6 passed.
- Manual reverted-mutation witnesses (documented in the test docstrings, executed and confirmed): reverting `_deep_merge_table` to a shallow `{**existing, **incoming}` fails both nested-table tests with `KeyError` on the dropped sibling key; reverting any of the three env-bypass fixes (`search_providers`, `backup.py`, `antigravity.py`) fails the corresponding delegated/env-bypass test; reverting `resolve_runtime_config`'s `archive_root` wiring fails the archive-root delegation test.
- `devtools test` across the touched surface's existing test files (`tests/unit/cli/test_{archive_query,dashboard_command,embed,embed_activation,embed_status_fast,import,status,tutorial}.py`, `tests/unit/cli/commands/test_status.py`, `tests/unit/cli/test_status_diagnostics.py`, `tests/unit/archive/test_facets.py`, `tests/unit/daemon/{test_backup,test_daemon_cli}.py`, `tests/unit/cli/test_backup_command.py`, `tests/unit/pipeline/{test_run_stages_runtime,test_archive_ingest_commit_batching}.py`, `tests/unit/core/{test_health_core,test_config,test_config_resolution_regression}.py`, `tests/unit/cli/test_auth.py`, `tests/unit/sources/{test_drive_auth,test_live_batch_support,test_antigravity_language_server}.py`, `tests/unit/sources/parsers/test_antigravity.py`, `tests/unit/storage/test_vec.py`, `tests/unit/cli/test_theme_aliases_help_markdown.py`): 853 passed, 5 failures -- all 5 reproduced identically with the diff reverted (`git stash`), confirming they are pre-existing/unrelated: `test_status.py::test_archive_facade_route_catalog_covers_public_async_facade` (unrelated route-catalog drift), `test_dashboard_command.py::test_dashboard_default_prints_evidence_before_launching_tui` (`ConfigError('RuntimeServices has no config projection')`, unrelated to daemon_url), and three `test_import.py` demo-fixture-world convergence failures.
- `devtools verify --quick` ran automatically via the pre-push hook: exit 0.
- Attempted a full `devtools verify --seed-testmon --skip-slow` in the background; it did not finish within a 590s budget and showed widespread failures across modules this PR does not touch, consistent with concurrent-session resource contention on this shared checkout (multiple other agent worktrees were running tests in parallel at the time) rather than this diff -- not chased further per the repo's testmon-inner-loop verification policy (targeted-file selection over blanket full-suite runs).

## AC matrix (epic polylogue-9gh1)

| AC | Status |
| --- | --- |
| Every setting inventoried with a `toml_path` respects site/user TOML precedence for its real runtime consumer (fd2s-class) | Satisfied on master via PR #3079; this PR closes 3 residual `VOYAGE_API_KEY` bypass call sites the earlier PR didn't reach and adds regression coverage |
| Nested-table settings deep-merge across layers, preserving unrelated sibling keys (cxlk-class) | Satisfied on master (`_deep_merge_table`); this PR adds the regression test that was missing |
| ~20 genuinely-bypassing files route through the layered resolver (uu8r-class) | Partially satisfied: 17 files / ~15 distinct settings migrated in this PR. Deferred-with-reason below |
| A regression test fixture exercises all three shapes | Satisfied: `tests/unit/core/test_config_resolution_regression.py`, one class per shape, real-consumer assertions, reverted-mutation witnesses documented and manually verified |

**Deferred-with-reason (uu8r remaining scope):** ~7-8 files read POLYLOGUE_*-namespaced settings that are **not yet in the config.py inventory at all** -- `POLYLOGUE_DEV_LOOP_RUN_ID`/`POLYLOGUE_DEV_LOOP_LOG_DIR` (`daemon/cli.py`, `daemon/http.py`), `POLYLOGUE_HOOK_PROVIDER` (`hooks/__init__.py`), `POLYLOGUE_RAW_AUTHORITY_COMMIT_BATCH_SIZE` (`storage/repair.py`), `POLYLOGUE_DAEMON_PARSE_STAGE_{WORKERS,MAX_INFLIGHT_BYTES,MAX_CACHED_TREE_BYTES,WARM_TIMEOUT_SECONDS}` (`daemon/parse_prefetch.py`), `POLYLOGUE_SESSION_REF` (`coordination/envelope.py`), `POLYLOGUE_REVISION_PARSE_{DISPATCH_MAX_BYTES,POOL_MIN_BYTES}` (`sources/revision_backfill.py`). These need new `ConfigInventoryEntry` rows plus a `render` regen (docs/openapi/cli-output-schemas) before a caller migration is meaningful -- a distinct, larger unit of work from routing the ~15 settings that were already inventoried but bypassed, which this PR completes. Recommend claiming the remainder directly under polylogue-uu8r.

Ref polylogue-9gh1, polylogue-uu8r

Co-Authored-By: Claude <noreply@anthropic.com>