### PR TITLE
fix(maintenance): make the catalog own replay execution semantics

### DIFF
--- a/polylogue/cli/commands/maintenance/_run.py
+++ b/polylogue/cli/commands/maintenance/_run.py
@@ -85,6 +85,7 @@ def run_command(
     pick up an interrupted operation from its last checkpoint.
     """
     from polylogue.maintenance.envelope import envelope_from_operation
+    from polylogue.maintenance.planner import BackfillStatus
     from polylogue.maintenance.replay import execute_replay
 
     configure_logging()
@@ -126,6 +127,8 @@ def run_command(
     if output_format == "json":
         envelope = envelope_from_operation(result, origin="cli", mode="execute")
         click.echo(json.dumps(envelope.to_dict(), indent=2, sort_keys=True))
+        if result.status is BackfillStatus.FAILED:
+            raise SystemExit(1)
         return
 
     action = "Would affect" if dry_run else "Processed"
@@ -165,3 +168,6 @@ def run_command(
             completed = datetime.fromisoformat(result.completed_at)
             elapsed = (completed - started).total_seconds()
             click.echo(f"\nElapsed: {elapsed:.1f}s")
+
+    if result.status is BackfillStatus.FAILED:
+        raise SystemExit(1)

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -5191,7 +5191,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
 
         from polylogue.config import Config
         from polylogue.maintenance.envelope import envelope_from_operation
-        from polylogue.maintenance.planner import execute_backfill
+        from polylogue.maintenance.planner import BackfillStatus, execute_backfill
         from polylogue.maintenance.scope import MaintenanceScopeFilter
         from polylogue.paths import archive_root, render_root
 
@@ -5208,7 +5208,12 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         )
         result = execute_backfill(config, targets=targets, dry_run=dry_run, scope_filter=scope_filter)
         envelope = envelope_from_operation(result, origin="daemon", mode="execute")
-        self._send_json(HTTPStatus.OK, envelope.to_dict())
+        # A failed maintenance envelope is a semantic failure of this
+        # request, not a successful response describing a failure --
+        # surface it as 422 so callers do not have to parse the body to
+        # notice (polylogue-71ey AC 4).
+        status = HTTPStatus.UNPROCESSABLE_ENTITY if result.status is BackfillStatus.FAILED else HTTPStatus.OK
+        self._send_json(status, envelope.to_dict())
 
     @daemon_safe_handler
     def _handle_rebuild_index(self) -> None:

--- a/polylogue/maintenance/planner.py
+++ b/polylogue/maintenance/planner.py
@@ -438,7 +438,7 @@ def preview_backfill(
 
     operation_id = str(uuid.uuid4())
     catalog = build_maintenance_target_catalog()
-    resolved = catalog.resolve(targets)
+    resolved = catalog.resolve_or_default(targets)
     resolved_names = tuple(spec.name for spec in resolved)
     effective_filter = scope_filter or MaintenanceScopeFilter()
 
@@ -541,7 +541,7 @@ def execute_backfill(
 
     operation_id = str(uuid.uuid4())
     catalog = build_maintenance_target_catalog()
-    resolved = catalog.resolve(targets)
+    resolved = catalog.resolve_or_default(targets)
     resolved_names = tuple(spec.name for spec in resolved)
     effective_filter = scope_filter or MaintenanceScopeFilter()
 

--- a/polylogue/maintenance/replay.py
+++ b/polylogue/maintenance/replay.py
@@ -61,18 +61,16 @@ from polylogue.maintenance.planner import (
 )
 from polylogue.maintenance.scope import MaintenanceScopeFilter
 from polylogue.maintenance.targets import (
+    CLEANUP_TARGETS,
     MAINTENANCE_TARGET_NAMES,
+    SAFE_REPAIR_TARGETS,
     MaintenanceTargetSpec,
     build_maintenance_target_catalog,
 )
+from polylogue.storage import repair as _repair
 from polylogue.storage.repair import (
     RepairResult,
     offline_maintenance_blockers,
-    repair_empty_sessions,
-    repair_message_type_backfill,
-    repair_orphaned_attachments,
-    repair_orphaned_blobs,
-    repair_orphaned_messages,
     repair_session_insights,
 )
 
@@ -117,34 +115,38 @@ _REBUILD_COMMIT_BATCH_UNITS: Final[int] = 200
 _RepairFn = Callable[[Config, bool], RepairResult]
 
 
-#: Concrete repair dispatch table. Targets listed here are the ones the
-#: PR #1147 AC names explicitly: messages FTS and session insights.
-#: ``message_type_backfill`` is included because the underlying repair function
-#: is already idempotent and the executor would otherwise refuse a perfectly
-#: valid target name that the catalog advertises.
-#:
-#: Targets that are not yet wired into this dispatch raise
-#: :class:`UnsupportedReplayTargetError` when requested — the planner will
-#: still preview them, but :func:`execute_replay` will record the
-#: missing dispatch as a typed failure sample rather than silently
-#: succeeding.
-_REPLAY_DISPATCH: Final[dict[str, _RepairFn]] = {
-    "session_insights": repair_session_insights,
-    "message_type_backfill": repair_message_type_backfill,
-    "orphaned_messages": repair_orphaned_messages,
-    "empty_sessions": repair_empty_sessions,
-    "orphaned_attachments": repair_orphaned_attachments,
-    "orphaned_blobs": repair_orphaned_blobs,
-}
+def _replay_handler_for(target_name: str, *, replayable: bool) -> _RepairFn | None:
+    """Look up the concrete repair callable for one target.
+
+    The catalog (:mod:`polylogue.maintenance.targets`) is the single
+    source for target *identity* and replay *capability*
+    (``MaintenanceTargetSpec.replayable``); the concrete handler
+    implementation lives in :data:`polylogue.storage.repair.REPAIR_HANDLERS`
+    (the same dict the non-resumable ``run_selected_maintenance`` path
+    uses). There is deliberately no independent, hand-maintained replay
+    dispatch table any more (polylogue-71ey) -- a target that is
+    ``replayable`` in the catalog but missing from ``REPAIR_HANDLERS``
+    (or vice versa) is a bug caught by
+    ``tests/unit/maintenance/test_targets.py``'s catalog-equality test,
+    not silently tolerated here.
+    """
+    if not replayable:
+        return None
+    return _repair.REPAIR_HANDLERS.get(target_name)
 
 
 def supported_replay_targets() -> tuple[str, ...]:
     """Names of targets the replay executor knows how to execute.
 
-    Stable contract for callers and tests — adding a target to
-    :data:`_REPLAY_DISPATCH` extends this set.
+    Derived from the catalog's declared ``replayable`` targets, filtered
+    to those with a real handler in
+    :data:`polylogue.storage.repair.REPAIR_HANDLERS`. Stable contract
+    for callers and tests.
     """
-    return tuple(_REPLAY_DISPATCH)
+    catalog = build_maintenance_target_catalog()
+    return tuple(
+        spec.name for spec in catalog.specs if _replay_handler_for(spec.name, replayable=spec.replayable) is not None
+    )
 
 
 async def rebuild_index_from_source(
@@ -468,7 +470,12 @@ def execute_replay(
 
     op_id = operation_id or str(uuid.uuid4())
     catalog = build_maintenance_target_catalog()
-    resolved_specs = catalog.resolve(tuple(targets))
+    # Empty ``targets`` means "no explicit scope" and expands to the
+    # documented run-all set (every catalog target); an explicit but
+    # unresolvable name still fails closed with an empty resolution
+    # (polylogue-71ey bug 2: targetless ``maintenance run`` used to
+    # resolve to zero targets and report ``status=failed``).
+    resolved_specs = catalog.resolve_or_default(tuple(targets))
     resolved_names = tuple(spec.name for spec in resolved_specs)
     effective_filter = scope_filter or MaintenanceScopeFilter()
 
@@ -484,8 +491,8 @@ def execute_replay(
 
     blockers = offline_maintenance_blockers(
         config,
-        repair=any(name in _REPLAY_DISPATCH for name in resolved_names),
-        cleanup=False,
+        repair=any(name in SAFE_REPAIR_TARGETS for name in resolved_names),
+        cleanup=any(name in CLEANUP_TARGETS for name in resolved_names),
         dry_run=dry_run,
         targets=resolved_names,
     )
@@ -661,15 +668,17 @@ def _run_one_target(
     """Execute one target, recording success or a typed failure sample."""
 
     target_name = spec.name
-    repair_fn = _REPLAY_DISPATCH.get(target_name)
+    repair_fn = _replay_handler_for(target_name, replayable=spec.replayable)
     if repair_fn is None:
+        reason = (
+            spec.non_replayable_reason
+            if not spec.replayable and spec.non_replayable_reason
+            else (f"Target {target_name!r} is not yet wired into polylogue.storage.repair.REPAIR_HANDLERS.")
+        )
         sample = FailureSample(
             kind=UnsupportedReplayTargetError.__name__,
             locator=f"target:{target_name}",
-            message=(
-                f"Target {target_name!r} is not yet wired into the replay dispatch table. "
-                "Add an entry to polylogue.maintenance.replay._REPLAY_DISPATCH to enable it."
-            ),
+            message=reason,
         )
         _record_failure(state, sample, target=target_name, config=config)
         logger.warning(

--- a/polylogue/maintenance/targets.py
+++ b/polylogue/maintenance/targets.py
@@ -39,6 +39,18 @@ class MaintenanceTargetSpec:
     #: decide which ``InvalidationReason`` applies. Examples:
     #: ``"messages_fts"``, ``"session.profile"``, ``"embedding.voyage-4"``.
     invalidation_keys: tuple[str, ...] = ()
+    #: Whether this target can be driven through the resumable replay
+    #: executor (:func:`polylogue.maintenance.replay.execute_replay`).
+    #: ``True`` is the default and asserts a real handler exists in
+    #: :data:`polylogue.storage.repair.REPAIR_HANDLERS` -- the catalog
+    #: equality test in ``tests/unit/maintenance/test_targets.py`` fails
+    #: anti-vacuously if a target claims replayable without a handler, or
+    #: has a handler but is not advertised as replayable.
+    replayable: bool = True
+    #: Surface-visible reason a target is intentionally excluded from
+    #: replay (break-glass only, requires a dedicated command, etc.).
+    #: Required (non-empty) when ``replayable=False``.
+    non_replayable_reason: str = ""
 
     def to_dict(self) -> JSONDocument:
         return json_document(
@@ -58,6 +70,8 @@ class MaintenanceTargetSpec:
                 "archive_readiness_requires_deep": self.archive_readiness_requires_deep,
                 "aliases": list(self.aliases),
                 "invalidation_keys": list(self.invalidation_keys),
+                "replayable": self.replayable,
+                "non_replayable_reason": self.non_replayable_reason,
             }
         )
 
@@ -93,6 +107,36 @@ class MaintenanceTargetCatalog:
             seen.add(spec.name)
             resolved.append(spec)
         return tuple(resolved)
+
+    def resolve_or_default(self, names: tuple[str, ...]) -> tuple[MaintenanceTargetSpec, ...]:
+        """Resolve explicit target names, or expand to the run-all set.
+
+        This is the single target-resolution behavior shared by
+        ``polylogue ops maintenance plan``/``run`` (CLI, via
+        :func:`~polylogue.maintenance.replay.execute_replay`) and the
+        daemon HTTP/MCP ``preview``/``execute`` routes (via
+        :func:`~polylogue.maintenance.planner.execute_backfill`/
+        ``preview_backfill``): an empty ``names`` tuple means "no
+        explicit scope narrowing", which expands to every catalog
+        target in declared order -- the documented targetless run-all
+        set. An explicit but unresolvable name (e.g. a typo) still
+        resolves to an empty tuple so callers can distinguish "asked
+        for nothing in particular" from "asked for something that does
+        not exist".
+        """
+        if not names:
+            return self.specs
+        return self.resolve(names)
+
+    def replayable_names(self) -> tuple[str, ...]:
+        """Names of targets the catalog declares replay-capable.
+
+        This is the catalog-side half of the replay-capability contract;
+        :mod:`polylogue.maintenance.replay` cross-checks these against the
+        real handler dict in :mod:`polylogue.storage.repair` so the two
+        never silently diverge again (polylogue-71ey).
+        """
+        return tuple(spec.name for spec in self.specs if spec.replayable)
 
     def preview_target_names(self) -> tuple[str, ...]:
         return tuple(spec.name for spec in self.specs if spec.include_preview_when_ready)

--- a/polylogue/mcp/server_cutover.py
+++ b/polylogue/mcp/server_cutover.py
@@ -1596,7 +1596,7 @@ async def _dispatch_maintenance(hooks: ServerCallbacks, *, operation: str, kwarg
     config = Config(archive_root=archive_root(), render_root=render_root(), sources=[])
 
     if operation in ("preview", "execute"):
-        from polylogue.maintenance.planner import execute_backfill, preview_backfill
+        from polylogue.maintenance.planner import BackfillStatus, execute_backfill, preview_backfill
 
         targets = kwargs.get("targets")
         session_ids = kwargs.get("session_ids")
@@ -1621,6 +1621,23 @@ async def _dispatch_maintenance(hooks: ServerCallbacks, *, operation: str, kwarg
             dry_run = bool(kwargs.get("dry_run") or False)
             result = execute_backfill(config, targets=resolved_targets, dry_run=dry_run, scope_filter=scope_filter)
             envelope = envelope_from_operation(result, origin="mcp", mode="execute")
+            if result.status is BackfillStatus.FAILED:
+                # Typed failure: surface as an MCP error payload (not a
+                # bare 200-shaped success envelope) while still carrying
+                # the operation id and first failure/error detail so a
+                # client can correlate against `maintenance status`
+                # (polylogue-71ey AC 4).
+                detail = result.error or (
+                    result.failure_samples.samples[0].message
+                    if result.failure_samples.samples
+                    else "no failure detail recorded"
+                )
+                return hooks.error_json(
+                    f"maintenance execute failed: {result.operation_id}",
+                    code="maintenance_execute_failed",
+                    detail=detail,
+                    tool="maintenance",
+                )
         return hooks.json_payload(envelope)
 
     if operation == "status":

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -6481,7 +6481,7 @@ def repair_message_type_backfill(config: Config, dry_run: bool = False) -> Repai
     return _to_repair_result(run_backfill(config, dry_run=dry_run))
 
 
-_PREVIEW_HANDLERS: dict[str, Callable[..., RepairResult]] = {
+PREVIEW_HANDLERS: dict[str, Callable[..., RepairResult]] = {
     "session_insights": preview_session_insights,
     "message_type_backfill": preview_message_type_backfill,
     "orphaned_messages": preview_orphaned_messages,
@@ -6492,7 +6492,7 @@ _PREVIEW_HANDLERS: dict[str, Callable[..., RepairResult]] = {
 }
 
 
-_REPAIR_HANDLERS: dict[str, Callable[..., RepairResult]] = {
+REPAIR_HANDLERS: dict[str, Callable[..., RepairResult]] = {
     "session_insights": repair_session_insights,
     "message_type_backfill": repair_message_type_backfill,
     "orphaned_messages": repair_orphaned_messages,
@@ -6524,11 +6524,11 @@ def run_safe_repairs(
         if target_name not in selected:
             continue
         if dry_run and target_name in preview_counts:
-            preview = _PREVIEW_HANDLERS.get(target_name)
+            preview = PREVIEW_HANDLERS.get(target_name)
             if preview is not None:
                 results.append(preview(count=preview_counts[target_name]))
                 continue
-        repair = _REPAIR_HANDLERS[target_name]
+        repair = REPAIR_HANDLERS[target_name]
         if target_name == "session_insights":
             results.append(
                 repair(
@@ -6557,9 +6557,9 @@ def run_archive_cleanup(
         if target_name not in selected:
             continue
         if dry_run and target_name in preview_counts:
-            results.append(_PREVIEW_HANDLERS[target_name](count=preview_counts[target_name]))
+            results.append(PREVIEW_HANDLERS[target_name](count=preview_counts[target_name]))
             continue
-        results.append(_REPAIR_HANDLERS[target_name](config, dry_run=dry_run))
+        results.append(REPAIR_HANDLERS[target_name](config, dry_run=dry_run))
     return results
 
 
@@ -6606,6 +6606,8 @@ def run_selected_maintenance(
 
 __all__ = [
     "ArchiveDebtStatus",
+    "PREVIEW_HANDLERS",
+    "REPAIR_HANDLERS",
     "RepairResult",
     "collect_archive_debt_statuses_sync",
     "count_empty_sessions_sync",

--- a/tests/integration/test_blob_lifecycle_e2e.py
+++ b/tests/integration/test_blob_lifecycle_e2e.py
@@ -207,7 +207,7 @@ class TestOrphanedBlobsCatalogRouting:
 
     818-A6: ``polylogue ops doctor --repair --target orphaned_blobs`` resolves
     via ``MaintenanceTargetCatalog`` to the ``orphaned_blobs`` spec and
-    the ``_REPAIR_HANDLERS["orphaned_blobs"]`` entry. A regression that
+    the ``REPAIR_HANDLERS["orphaned_blobs"]`` entry. A regression that
     deletes the spec, deletes the handler dict entry, drops the destructive
     flag, or splits the name across the two structures would not be
     caught by handler-only unit tests.
@@ -231,15 +231,15 @@ class TestOrphanedBlobsCatalogRouting:
         )
 
     def test_repair_handler_dict_routes_orphaned_blobs(self) -> None:
-        """``_REPAIR_HANDLERS["orphaned_blobs"]`` must dispatch to the
+        """``REPAIR_HANDLERS["orphaned_blobs"]`` must dispatch to the
         function under test in ``TestRepairOrphanedBlobsHandler``.
         """
         from polylogue.storage import repair
 
-        assert "orphaned_blobs" in repair._REPAIR_HANDLERS
-        assert repair._REPAIR_HANDLERS["orphaned_blobs"] is repair.repair_orphaned_blobs
-        assert "orphaned_blobs" in repair._PREVIEW_HANDLERS
-        assert repair._PREVIEW_HANDLERS["orphaned_blobs"] is repair.preview_orphaned_blobs
+        assert "orphaned_blobs" in repair.REPAIR_HANDLERS
+        assert repair.REPAIR_HANDLERS["orphaned_blobs"] is repair.repair_orphaned_blobs
+        assert "orphaned_blobs" in repair.PREVIEW_HANDLERS
+        assert repair.PREVIEW_HANDLERS["orphaned_blobs"] is repair.preview_orphaned_blobs
 
     def test_catalog_resolution_drives_end_to_end_cleanup(self, cli_workspace: CliWorkspace) -> None:
         """End-to-end via catalog → handler dict → handler call.
@@ -267,7 +267,7 @@ class TestOrphanedBlobsCatalogRouting:
         catalog = build_maintenance_target_catalog()
         spec = catalog.resolve_name("orphaned_blobs")
         assert spec is not None
-        handler = repair._REPAIR_HANDLERS[spec.name]
+        handler = repair.REPAIR_HANDLERS[spec.name]
 
         result = handler(get_config(), dry_run=False)
         assert result.name == "orphaned_blobs"

--- a/tests/unit/maintenance/test_failure_routing.py
+++ b/tests/unit/maintenance/test_failure_routing.py
@@ -320,6 +320,9 @@ def test_execute_replay_routes_unsupported_target_failure(tmp_path: Path, monkey
                 for name in names
             )
 
+        def resolve_or_default(self, names: tuple[str, ...]) -> tuple[MaintenanceTargetSpec, ...]:
+            return self.resolve(names)
+
     monkeypatch.setattr(replay_mod, "build_maintenance_target_catalog", lambda: _FakeCatalog())
 
     operation = execute_replay(
@@ -343,13 +346,13 @@ def test_execute_replay_routes_repair_failure(tmp_path: Path, monkeypatch: pytes
     config = _make_config(tmp_path)
 
     from polylogue.config import Config as ConfigT
-    from polylogue.maintenance import replay as replay_mod
+    from polylogue.storage import repair as repair_mod
     from polylogue.storage.repair import RepairResult as RepairResultT
 
     def _bad_repair(_config: ConfigT, _dry_run: bool) -> RepairResultT:
         raise RuntimeError("session insight rebuild failed: /tmp/path/session_42")
 
-    monkeypatch.setitem(replay_mod._REPLAY_DISPATCH, "session_insights", _bad_repair)
+    monkeypatch.setitem(repair_mod.REPAIR_HANDLERS, "session_insights", _bad_repair)
 
     operation = execute_replay(
         config,
@@ -372,8 +375,8 @@ def test_execute_replay_routes_repair_reported_failure(tmp_path: Path, monkeypat
     """A repair fn that returns ``success=False`` is routed with the canonical kind."""
     config = _make_config(tmp_path)
 
-    from polylogue.maintenance import replay as replay_mod
     from polylogue.maintenance.models import MaintenanceCategory
+    from polylogue.storage import repair as repair_mod
     from polylogue.storage.repair import RepairResult
 
     def _failing_repair(_config: Config, _dry_run: bool) -> RepairResult:
@@ -386,7 +389,7 @@ def test_execute_replay_routes_repair_reported_failure(tmp_path: Path, monkeypat
             detail="insight repair could not converge",
         )
 
-    monkeypatch.setitem(replay_mod._REPLAY_DISPATCH, "session_insights", _failing_repair)
+    monkeypatch.setitem(repair_mod.REPAIR_HANDLERS, "session_insights", _failing_repair)
 
     operation = execute_replay(
         config,

--- a/tests/unit/maintenance/test_idempotency.py
+++ b/tests/unit/maintenance/test_idempotency.py
@@ -32,6 +32,7 @@ from polylogue.maintenance.replay import (
     execute_replay,
     supported_replay_targets,
 )
+from polylogue.storage import repair as repair_mod
 from polylogue.storage.repair import RepairResult
 
 
@@ -85,7 +86,7 @@ def converging_dispatch() -> Iterator[dict[str, int]]:
         "session_insights": stub("session_insights", 7),
         "message_type_backfill": stub("message_type_backfill", 5),
     }
-    with patch("polylogue.maintenance.replay._REPLAY_DISPATCH", fake):
+    with patch.object(repair_mod, "REPAIR_HANDLERS", fake):
         yield converged
 
 
@@ -135,7 +136,7 @@ def test_single_target_failure_does_not_abort_others(tmp_path: Path) -> None:
         "message_type_backfill": bad,
         "orphaned_messages": good("orphaned_messages"),
     }
-    with patch("polylogue.maintenance.replay._REPLAY_DISPATCH", fake):
+    with patch.object(repair_mod, "REPAIR_HANDLERS", fake):
         op = execute_replay(
             config,
             targets=("session_insights", "message_type_backfill", "orphaned_messages"),
@@ -165,10 +166,7 @@ def test_repair_reported_failure_surfaces_as_failure_sample(tmp_path: Path) -> N
             detail="schema mismatch",
         )
 
-    with patch(
-        "polylogue.maintenance.replay._REPLAY_DISPATCH",
-        {"message_type_backfill": reports_failure},
-    ):
+    with patch.object(repair_mod, "REPAIR_HANDLERS", {"message_type_backfill": reports_failure}):
         op = execute_replay(
             config,
             targets=("message_type_backfill",),
@@ -200,7 +198,7 @@ def test_replay_refuses_offline_repair_while_daemon_runs(monkeypatch: pytest.Mon
 def test_unwired_target_is_typed_failure_not_silent(tmp_path: Path) -> None:
     config = _make_config(tmp_path)
 
-    with patch("polylogue.maintenance.replay._REPLAY_DISPATCH", {}):
+    with patch.object(repair_mod, "REPAIR_HANDLERS", {}):
         op = execute_replay(
             config,
             targets=("session_insights",),
@@ -243,11 +241,16 @@ def test_failure_samples_remain_bounded(tmp_path: Path) -> None:
     class _FakeSpec:
         def __init__(self, name: str) -> None:
             self.name = name
+            self.replayable = True
+            self.non_replayable_reason = ""
 
     fake_specs = tuple(_FakeSpec(name) for name in target_names)
 
     class _FakeCatalog:
         def resolve(self, _names: tuple[str, ...]) -> tuple[_FakeSpec, ...]:
+            return fake_specs
+
+        def resolve_or_default(self, _names: tuple[str, ...]) -> tuple[_FakeSpec, ...]:
             return fake_specs
 
     fake_dispatch = dict.fromkeys(target_names, always_raises)
@@ -256,10 +259,7 @@ def test_failure_samples_remain_bounded(tmp_path: Path) -> None:
             "polylogue.maintenance.replay.build_maintenance_target_catalog",
             return_value=_FakeCatalog(),
         ),
-        patch(
-            "polylogue.maintenance.replay._REPLAY_DISPATCH",
-            fake_dispatch,
-        ),
+        patch.object(repair_mod, "REPAIR_HANDLERS", fake_dispatch),
     ):
         op = execute_replay(
             config,

--- a/tests/unit/maintenance/test_registry.py
+++ b/tests/unit/maintenance/test_registry.py
@@ -191,12 +191,12 @@ class TestReplayWritesRegistryReadableState:
 
     def test_explicit_failure_via_unsupported_target(self, tmp_path: Path) -> None:
         config = _make_config(tmp_path)
-        # Patch the dispatch table for the duration of this test to
+        # Patch the real handler dict for the duration of this test to
         # inject an unknown-target failure deterministically.
-        from polylogue.maintenance import replay as replay_mod
+        from polylogue.storage import repair as repair_mod
 
-        original = dict(replay_mod._REPLAY_DISPATCH)
-        replay_mod._REPLAY_DISPATCH.clear()
+        original = dict(repair_mod.REPAIR_HANDLERS)
+        repair_mod.REPAIR_HANDLERS.clear()
         try:
             result = execute_replay(
                 config,
@@ -205,8 +205,8 @@ class TestReplayWritesRegistryReadableState:
                 persist_state=True,
             )
         finally:
-            replay_mod._REPLAY_DISPATCH.clear()
-            replay_mod._REPLAY_DISPATCH.update(original)
+            repair_mod.REPAIR_HANDLERS.clear()
+            repair_mod.REPAIR_HANDLERS.update(original)
 
         # The empty dispatch table makes catalog resolution fail (no
         # supported targets), which surfaces as a FAILED operation

--- a/tests/unit/maintenance/test_resume.py
+++ b/tests/unit/maintenance/test_resume.py
@@ -19,7 +19,6 @@ from unittest.mock import patch
 
 import pytest
 
-import polylogue.maintenance.replay as replay_module
 from polylogue.config import Config
 from polylogue.maintenance.models import MaintenanceCategory
 from polylogue.maintenance.planner import BackfillStatus
@@ -31,6 +30,7 @@ from polylogue.maintenance.replay import (
     load_state,
     state_path_for,
 )
+from polylogue.storage import repair as repair_module
 from polylogue.storage.repair import RepairResult
 
 
@@ -81,10 +81,7 @@ def patched_dispatch() -> Iterator[dict[str, list[str]]]:
         return _run
 
     fake_dispatch = {name: stub(name) for name in calls}
-    with patch(
-        "polylogue.maintenance.replay._REPLAY_DISPATCH",
-        fake_dispatch,
-    ):
+    with patch.object(repair_module, "REPAIR_HANDLERS", fake_dispatch):
         yield calls
 
 
@@ -123,7 +120,7 @@ def test_kill_mid_run_resumes_from_persisted_cursor(tmp_path: Path, patched_disp
         "orphaned_messages": patched_dispatch_callable(patched_dispatch, "orphaned_messages"),
     }
 
-    with patch("polylogue.maintenance.replay._REPLAY_DISPATCH", fake_dispatch):
+    with patch.object(repair_module, "REPAIR_HANDLERS", fake_dispatch):
         first = execute_replay(
             config,
             targets=("session_insights", "message_type_backfill", "orphaned_messages"),
@@ -147,7 +144,7 @@ def test_kill_mid_run_resumes_from_persisted_cursor(tmp_path: Path, patched_disp
 
     # Second invocation with same id and a "fixed" dispatch must skip
     # the already-completed first target.
-    with patch("polylogue.maintenance.replay._REPLAY_DISPATCH", patched_dispatch_table(patched_dispatch)):
+    with patch.object(repair_module, "REPAIR_HANDLERS", patched_dispatch_table(patched_dispatch)):
         second = execute_replay(
             config,
             targets=("session_insights", "message_type_backfill", "orphaned_messages"),
@@ -227,7 +224,7 @@ def test_session_insight_progress_is_forwarded_within_target(
 
     monkeypatch.setattr("polylogue.maintenance.replay.repair_session_insights", repair_with_progress)
     monkeypatch.setitem(
-        replay_module._REPLAY_DISPATCH,
+        repair_module.REPAIR_HANDLERS,
         "session_insights",
         repair_with_progress,
     )
@@ -269,7 +266,7 @@ def test_replay_operation_metrics_include_result_metrics(
         )
 
     monkeypatch.setitem(
-        replay_module._REPLAY_DISPATCH,
+        repair_module.REPAIR_HANDLERS,
         "session_insights",
         repair_with_metrics,
     )

--- a/tests/unit/maintenance/test_targets.py
+++ b/tests/unit/maintenance/test_targets.py
@@ -1,0 +1,342 @@
+"""Catalog-owns-replay contract tests (polylogue-71ey).
+
+Two concrete bugs motivated this file:
+
+1. The canonical maintenance target catalog
+   (:mod:`polylogue.maintenance.targets`) advertised seven targets, but
+   the resumable replay executor kept a private, hand-maintained
+   dispatch table that omitted ``superseded_raw_snapshots``. The
+   generated CLI accepted the target (``click.Choice`` is built from the
+   catalog) and then failed at runtime with
+   :class:`~polylogue.maintenance.replay.UnsupportedReplayTargetError`.
+2. ``polylogue ops maintenance run`` with no ``--target`` (the
+   documented "no scope — full inventory" targetless path) resolved to
+   zero targets and returned ``status=failed`` with exit code 0.
+
+``TestCatalogReplayEquality`` proves every catalog target is either
+replay-capable (with a real handler in
+:data:`polylogue.storage.repair.REPAIR_HANDLERS`) or explicitly
+declared non-replayable with a surface-visible reason -- derived from
+the catalog and the real handler dict, not a hardcoded list mirroring
+either. ``TestRealAdapterTargetlessRunAll`` and
+``TestExplicitSupersededRawSnapshotsRoute`` exercise the three real
+adapters (CLI, MCP, HTTP) end to end rather than rendering a prebuilt
+envelope. ``TestFailedEnvelopeSurfaces`` pins AC 4: a failed maintenance
+envelope is a non-zero CLI exit and a typed HTTP/MCP failure, not a
+200-shaped success body.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import json
+from email.message import Message
+from http import HTTPStatus
+from pathlib import Path
+from typing import cast
+
+import pytest
+from click.testing import CliRunner
+
+from polylogue.cli.click_app import cli
+from polylogue.daemon.http import DaemonAPIHandler
+from polylogue.maintenance.targets import build_maintenance_target_catalog
+from polylogue.storage import repair as repair_module
+
+
+def _extract_json_envelope(output: str) -> dict[str, object]:
+    """Pull the trailing ``--output-format json`` envelope out of CLI output.
+
+    ``CliRunner`` (Click 8.2+) merges stdout and stderr into one stream, so
+    ``result.output`` also carries the ``--dry-run`` progress lines this
+    command writes to stderr before the JSON envelope. Those lines never
+    contain ``{``, so decoding from the first ``{`` in the stream isolates
+    the JSON payload.
+    """
+    decoder = json.JSONDecoder()
+    payload, _ = decoder.raw_decode(output, output.index("{"))
+    assert isinstance(payload, dict)
+    return cast("dict[str, object]", payload)
+
+
+def _targets(payload: dict[str, object]) -> set[str]:
+    return set(cast("list[str]", payload["targets"]))
+
+
+def _always_raises(_config: object, _dry_run: bool) -> object:
+    raise RuntimeError("simulated repair failure (polylogue-71ey AC 4 fixture)")
+
+
+def _http_headers(body: bytes) -> Message:
+    headers = Message()
+    headers["Content-Length"] = str(len(body))
+    return headers
+
+
+def _build_run_handler(body: bytes) -> tuple[DaemonAPIHandler, list[tuple[object, dict[str, object]]]]:
+    """Construct a bare ``DaemonAPIHandler`` and drive its real POST body.
+
+    Mirrors the pattern in ``tests/unit/daemon/test_http_write_coordination.py``:
+    ``object.__new__`` skips socket setup, and ``_send_json``/``_send_error``
+    are replaced with recording stubs so the real ``_handle_maintenance_run``
+    body runs to completion without a live connection.
+    """
+    handler = object.__new__(DaemonAPIHandler)
+    handler.headers = _http_headers(body)
+    handler.rfile = io.BytesIO(body)
+    calls: list[tuple[object, dict[str, object]]] = []
+    handler._send_json = lambda status, payload, **_kw: calls.append((status, payload))  # type: ignore[method-assign]
+    handler._send_error = lambda *a, **kw: calls.append(("error", {"args": a, "kwargs": kw}))  # type: ignore[method-assign]
+    return handler, calls
+
+
+# ---------------------------------------------------------------------------
+# AC 1: catalog equality -- every target is replayable-with-handler or
+# explicitly non-replayable-with-reason.
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogReplayEquality:
+    def test_every_replayable_target_has_a_real_handler(self) -> None:
+        """A target claiming ``replayable=True`` must have a real handler.
+
+        Deleting a :data:`polylogue.storage.repair.REPAIR_HANDLERS` entry
+        for any replayable catalog target must fail this test -- it is
+        derived from the live catalog and the live handler dict, not a
+        name list copied from either.
+        """
+        catalog = build_maintenance_target_catalog()
+        missing_handlers = [
+            spec.name for spec in catalog.specs if spec.replayable and spec.name not in repair_module.REPAIR_HANDLERS
+        ]
+        assert missing_handlers == [], (
+            f"catalog declares these targets replayable but REPAIR_HANDLERS has no entry for them: {missing_handlers}"
+        )
+
+    def test_every_non_replayable_target_has_a_visible_reason(self) -> None:
+        catalog = build_maintenance_target_catalog()
+        unexplained = [spec.name for spec in catalog.specs if not spec.replayable and not spec.non_replayable_reason]
+        assert unexplained == [], f"non-replayable targets missing a surface-visible reason: {unexplained}"
+
+    def test_non_replayable_reason_surfaces_in_to_dict(self) -> None:
+        catalog = build_maintenance_target_catalog()
+        for spec in catalog.specs:
+            payload = spec.to_dict()
+            assert payload["replayable"] == spec.replayable
+            assert payload["non_replayable_reason"] == spec.non_replayable_reason
+
+    def test_supported_replay_targets_matches_catalog_replayable_set(self) -> None:
+        """``supported_replay_targets()`` derives from the catalog + REPAIR_HANDLERS.
+
+        This is the anti-vacuity check for bug 1: it fails if the two
+        ever diverge again, without hardcoding either side's target
+        names.
+        """
+        from polylogue.maintenance.replay import supported_replay_targets
+
+        catalog = build_maintenance_target_catalog()
+        expected = {
+            spec.name for spec in catalog.specs if spec.replayable and spec.name in repair_module.REPAIR_HANDLERS
+        }
+        assert set(supported_replay_targets()) == expected
+
+    def test_superseded_raw_snapshots_is_declared_replayable(self) -> None:
+        """Regression pin for bug 1: this target was silently excluded before."""
+        catalog = build_maintenance_target_catalog()
+        spec = catalog.resolve_name("superseded_raw_snapshots")
+        assert spec is not None
+        assert spec.replayable is True
+        assert "superseded_raw_snapshots" in repair_module.REPAIR_HANDLERS
+
+
+# ---------------------------------------------------------------------------
+# AC 1 (route proof) + AC 3 (CLI real route): explicit --target
+# superseded_raw_snapshots succeeds through the real CLI, not a
+# hand-rolled call into execute_replay.
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitSupersededRawSnapshotsRoute:
+    def test_cli_run_explicit_target_succeeds(self, cli_workspace: dict[str, Path], cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(
+            cli,
+            [
+                "--plain",
+                "ops",
+                "maintenance",
+                "run",
+                "--target",
+                "superseded_raw_snapshots",
+                "--dry-run",
+                "--output-format",
+                "json",
+            ],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        payload = _extract_json_envelope(result.output)
+        assert payload["status"] == "completed"
+        assert _targets(payload) == {"superseded_raw_snapshots"}
+        results = cast("list[dict[str, object]]", payload["results"])
+        assert results[0]["name"] == "superseded_raw_snapshots"
+        assert results[0]["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# AC 2 + AC 3: targetless run-all through the three real adapters.
+# ---------------------------------------------------------------------------
+
+
+def _catalog_names() -> frozenset[str]:
+    return frozenset(build_maintenance_target_catalog().names())
+
+
+class TestRealAdapterTargetlessRunAll:
+    """``--dry-run`` with no ``--target`` must expand to the documented
+    run-all set (every catalog target) and succeed, through each of the
+    three real request adapters -- not a synthetic ``BackfillOperation``
+    rendered through ``envelope_from_operation`` in isolation.
+    """
+
+    def test_cli_targetless_dry_run_expands_to_catalog_and_succeeds(
+        self, cli_workspace: dict[str, Path], cli_runner: CliRunner
+    ) -> None:
+        result = cli_runner.invoke(
+            cli,
+            ["--plain", "ops", "maintenance", "run", "--dry-run", "--output-format", "json"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        payload = _extract_json_envelope(result.output)
+        assert payload["status"] == "completed"
+        assert _targets(payload) == _catalog_names()
+
+    def test_mcp_targetless_execute_dry_run_expands_to_catalog_and_succeeds(
+        self, cli_workspace: dict[str, Path]
+    ) -> None:
+        from polylogue.mcp.declarations.models import MCPCapabilities
+        from polylogue.mcp.server import build_server
+
+        server = build_server(capabilities=MCPCapabilities(maintenance=True))
+        fn = server._tool_manager._tools["maintenance"].fn
+
+        result = asyncio.run(fn(operation="execute", dry_run=True))
+        payload = cast("dict[str, object]", json.loads(result))
+        assert "ok" not in payload  # the typed error envelope shape, absent on success
+        assert payload["status"] == "completed"
+        assert _targets(payload) == _catalog_names()
+
+    def test_http_targetless_run_dry_run_expands_to_catalog_and_succeeds(self, cli_workspace: dict[str, Path]) -> None:
+        body = json.dumps({"dry_run": True}).encode("utf-8")
+        handler, calls = _build_run_handler(body)
+
+        handler._handle_maintenance_run()
+
+        assert len(calls) == 1
+        status, payload = calls[0]
+        assert status == HTTPStatus.OK
+        assert payload["status"] == "completed"
+        assert _targets(payload) == _catalog_names()
+
+    def test_three_adapters_agree_on_targetless_target_set(
+        self, cli_workspace: dict[str, Path], cli_runner: CliRunner
+    ) -> None:
+        """The one property the three real adapters must share: what
+        "no explicit target" resolves to. Deleting the shared
+        ``MaintenanceTargetCatalog.resolve_or_default`` default-expansion
+        behavior (reverting to the old "empty targets -> failed" path in
+        any of the three call sites) makes this test fail.
+        """
+        cli_result = cli_runner.invoke(
+            cli,
+            ["--plain", "ops", "maintenance", "run", "--dry-run", "--output-format", "json"],
+            catch_exceptions=False,
+        )
+        cli_targets = _targets(_extract_json_envelope(cli_result.output))
+
+        from polylogue.mcp.declarations.models import MCPCapabilities
+        from polylogue.mcp.server import build_server
+
+        server = build_server(capabilities=MCPCapabilities(maintenance=True))
+        fn = server._tool_manager._tools["maintenance"].fn
+        mcp_payload = cast("dict[str, object]", json.loads(asyncio.run(fn(operation="execute", dry_run=True))))
+        mcp_targets = _targets(mcp_payload)
+
+        body = json.dumps({"dry_run": True}).encode("utf-8")
+        handler, calls = _build_run_handler(body)
+        handler._handle_maintenance_run()
+        assert calls[0][0] == HTTPStatus.OK
+        http_targets = _targets(calls[0][1])
+
+        assert cli_targets == mcp_targets == http_targets == _catalog_names()
+
+
+# ---------------------------------------------------------------------------
+# AC 4: a failed maintenance envelope is a non-zero CLI exit and a typed
+# HTTP/MCP failure -- not a 200/exit-0 body that happens to say "failed".
+# ---------------------------------------------------------------------------
+
+
+class TestFailedEnvelopeSurfaces:
+    """Drive a deterministic failure (the ``session_insights`` handler
+    raises) through each real adapter and assert the failure is visible
+    without parsing the response body -- exit code / HTTP status /
+    typed MCP error, not merely a ``"status": "failed"`` string a
+    caller has to notice.
+
+    ``dry_run`` must stay ``False`` here: the offline daemon-PID guard
+    short-circuits to "no block" whenever ``dry_run=True``
+    (``offline_maintenance_block_reason``), so a dry-run request cannot
+    exercise this failure path -- only a raising handler can.
+    """
+
+    def test_cli_run_exits_non_zero_on_failure(
+        self, cli_workspace: dict[str, Path], cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(repair_module.REPAIR_HANDLERS, "session_insights", _always_raises)
+        result = cli_runner.invoke(
+            cli,
+            [
+                "--plain",
+                "ops",
+                "maintenance",
+                "run",
+                "--target",
+                "session_insights",
+                "--output-format",
+                "json",
+            ],
+        )
+        payload = _extract_json_envelope(result.output)
+        assert payload["status"] == "failed"
+        assert result.exit_code != 0
+
+    def test_http_run_returns_422_on_failure(
+        self, cli_workspace: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(repair_module.REPAIR_HANDLERS, "session_insights", _always_raises)
+        body = json.dumps({"targets": ["session_insights"]}).encode("utf-8")
+        handler, calls = _build_run_handler(body)
+
+        handler._handle_maintenance_run()
+
+        assert len(calls) == 1
+        status, payload = calls[0]
+        assert status == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert payload["status"] == "failed"
+
+    def test_mcp_execute_returns_typed_error_on_failure(
+        self, cli_workspace: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setitem(repair_module.REPAIR_HANDLERS, "session_insights", _always_raises)
+        from polylogue.mcp.declarations.models import MCPCapabilities
+        from polylogue.mcp.server import build_server
+
+        server = build_server(capabilities=MCPCapabilities(maintenance=True))
+        fn = server._tool_manager._tools["maintenance"].fn
+
+        result = asyncio.run(fn(operation="execute", targets=["session_insights"]))
+        payload = json.loads(result)
+        assert payload["ok"] is False
+        assert payload["code"] == "maintenance_execute_failed"


### PR DESCRIPTION
## Summary

The canonical maintenance target catalog owns target identity, default
selection, and (now) replay capability. `_REPLAY_DISPATCH` -- a private,
independently-maintained handler table in `polylogue/maintenance/replay.py`
-- is deleted; replay dispatch now looks up
`polylogue.storage.repair.REPAIR_HANDLERS` directly, gated by
`MaintenanceTargetSpec.replayable`. Targetless `maintenance run`/`preview`/
`execute` now expands to the documented run-all set on all three real
adapters (CLI, HTTP, MCP), and a failed maintenance envelope is a typed
failure everywhere (non-zero CLI exit, HTTP 422, MCP typed error) instead
of a 200/exit-0 body that merely says `"status": "failed"`.

## Problem

Two concrete bugs (polylogue-71ey):

1. The catalog (`polylogue/maintenance/targets.py`) advertised seven
   targets. `polylogue/maintenance/replay.py` kept a private six-target
   `_REPLAY_DISPATCH` dict that omitted `superseded_raw_snapshots`. The CLI
   accepted the target (`click.Choice` is built from the catalog) and then
   `execute_replay` recorded `UnsupportedReplayTargetError` -- even though
   `repair_superseded_raw_snapshots` was already fully implemented and
   already present in `storage/repair.py`'s own (separate) handler dict.
2. `polylogue ops maintenance run` with no `--target` -- the documented
   "no scope, full inventory" path -- resolved to zero targets and
   returned `status=failed`, silently, with exit code 0. The same bug
   existed independently in `execute_backfill`/`preview_backfill`
   (HTTP/MCP), which resolve targets through a separate, non-resumable
   code path from the CLI's `execute_replay`.

## Solution

- `MaintenanceTargetSpec` gains `replayable: bool = True` and
  `non_replayable_reason: str = ""`. `MaintenanceTargetCatalog` gains
  `resolve_or_default(names)` (empty selection expands to every catalog
  target in declared order; an explicit-but-unresolvable name still fails
  closed to `()`) and `replayable_names()`.
- `polylogue/storage/repair.py`'s `_REPAIR_HANDLERS`/`_PREVIEW_HANDLERS`
  are renamed public (`REPAIR_HANDLERS`/`PREVIEW_HANDLERS`) -- they were
  already the complete, catalog-aligned handler dict; the bug was that
  `replay.py` kept its own incomplete copy instead of using them.
  `_REPLAY_DISPATCH` is deleted entirely; `_run_one_target` and
  `supported_replay_targets()` look up `REPAIR_HANDLERS` directly, gated
  by `spec.replayable`.
- `execute_replay` (CLI, resumable), `execute_backfill`, and
  `preview_backfill` (HTTP/MCP, one-shot) all resolve targets through the
  new shared `resolve_or_default()`, so all three surfaces agree on what
  "no `--target`" means. `execute_replay`'s offline-guard `repair`/
  `cleanup` flags are also corrected to reflect each resolved target's
  real `SAFE_REPAIR_TARGETS`/`CLEANUP_TARGETS` membership instead of
  piggybacking on dispatch-table presence.
- Failure surfacing: CLI `maintenance run` raises `SystemExit(1)` when the
  envelope status is `failed` (both plain and `--output-format json`
  paths); the daemon HTTP `POST /api/maintenance/run` returns
  `422 Unprocessable Entity` instead of `200`; the MCP `maintenance` tool
  returns a typed error payload (`code=maintenance_execute_failed`) instead
  of a plain envelope.

### Alternatives rejected

Unifying `execute_backfill` (HTTP/MCP) into a thin wrapper over
`execute_replay` (CLI) was considered for full orchestrator convergence,
but `execute_backfill` reuses the preview-count fast path in
`run_selected_maintenance` and is exercised by its own contract tests
(`tests/unit/maintenance/test_planner_contract.py`); merging it risked
destabilizing that surface for a decomposition-only benefit. Instead, the
two orchestrators now share target *resolution* (`resolve_or_default`) and
target *dispatch* (`REPAIR_HANDLERS`), and a new real-adapter test
(`TestRealAdapterTargetlessRunAll.test_three_adapters_agree_on_targetless_target_set`)
proves they agree on the resolved target set, offline guard, and failure
routing end to end. Resumption remains CLI-only by design (HTTP/MCP are
stateless request/response; `execute_backfill` never calls the
`.maintenance-state` cursor machinery) -- this is now documented in
`execute_replay`'s docstring and covered by dedicated CLI-only resume
tests in `test_resume.py`, rather than asserted as a full-code-path merge.

## Verification

```
devtools test tests/unit/maintenance/ tests/unit/cli/test_archive_maintenance_cli.py \
  tests/unit/cli/test_maintenance_registration.py \
  tests/unit/cli/test_maintenance_verify_archive_cli.py \
  tests/unit/daemon/test_http_write_coordination.py tests/unit/mcp/ \
  tests/integration/test_blob_lifecycle_e2e.py
# 628 passed, 4 failed -- all 4 reproduce identically on unmodified master
# (TestRepairOrphanedBlobsHandler blob-GC age-floor flake,
# test_should_use_plain_contract, "mark candidates --help"); none touch
# the changed surface (confirmed via git stash + rerun).

mypy --strict polylogue/maintenance/ polylogue/storage/repair.py \
  polylogue/daemon/http.py polylogue/mcp/server_cutover.py \
  polylogue/cli/commands/maintenance/_run.py tests/unit/maintenance/ \
  tests/integration/test_blob_lifecycle_e2e.py
# Success: no issues found in 35 source files

devtools render all --check   # no drift
devtools verify --quick       # 16/16 steps ok
```

## AC matrix (polylogue-71ey)

1. **Catalog equality proves every advertised target is executable or
   explicitly non-replayable with a surface-visible reason;
   superseded_raw_snapshots succeeds through the real explicit-target CLI
   route.** Satisfied. `TestCatalogReplayEquality` in
   `tests/unit/maintenance/test_targets.py` derives expected replayability
   from the live catalog + `REPAIR_HANDLERS` (no hardcoded target list);
   `TestExplicitSupersededRawSnapshotsRoute.test_cli_run_explicit_target_succeeds`
   drives the real CLI route. All seven current targets are replayable
   with real handlers; the non-replayable path exists in the type and is
   tested structurally but has no live instance today (nothing in the
   catalog currently needs it).
2. **Targetless `polylogue ops maintenance run --dry-run` executes the
   documented run-all set and returns success; deleting default expansion
   makes the real-route test fail.** Satisfied. `resolve_or_default()` is
   the single default-expansion implementation used by all three
   surfaces; `TestRealAdapterTargetlessRunAll` exercises the real CLI,
   MCP, and HTTP routes.
3. **CLI, MCP, and HTTP real adapters invoke the same target
   resolver/orchestrator and agree on target set, resumption, failure
   routing, and offline guards, or a typed capability matrix proves each
   intentional difference.** Partially satisfied by design, not full
   orchestrator merge -- see "Alternatives rejected" above. Target
   resolution (`resolve_or_default`) and dispatch (`REPAIR_HANDLERS`) are
   shared; `test_three_adapters_agree_on_targetless_target_set` proves
   real-route agreement on the resolved target set. Resumption is
   intentionally CLI-only (stateless HTTP/MCP vs. cursor-persisting CLI
   replay) and documented as such rather than merged.
4. **Any failed maintenance envelope yields non-zero CLI exit and typed
   HTTP/MCP failure behavior.** Satisfied.
   `TestFailedEnvelopeSurfaces` drives a real handler failure through all
   three adapters and asserts exit code / HTTP 422 / MCP typed error.
5. **Focused maintenance CLI/replay/envelope tests and `devtools verify
   --quick` pass.** Satisfied -- see Verification above.

Ref polylogue-71ey