### PR TITLE
feat(sources): close OriginSpec conformance-law gaps

### DIFF
--- a/polylogue/sources/origin_specs.py
+++ b/polylogue/sources/origin_specs.py
@@ -3,8 +3,17 @@
 Provider adapters retain record-level parsing.  This module owns only the
 cross-adapter admission contract: public origin vocabulary, acquisition modes,
 detector tightness, registration/fixture evidence, fidelity, and reparse
-consequences.  The initial pilots deliberately cover a streaming runtime, a
-document export, and a reserved origin.
+consequences.  The founding pilots (polylogue-2qx.1.1) deliberately covered a
+streaming runtime (Claude Code), a document export (ChatGPT), and a reserved
+origin (Grok, which had no confirmed export shape at the time). Grok has since
+shipped a real parser (polylogue-611 / #3201) and is admitted here as
+``lifecycle="executable"`` -- there is currently no origin genuinely in
+``lifecycle="reserved"``. The reserved-lifecycle path (an origin admitted with
+no parser/detector binding pending a fixture) remains part of this module's
+executable contract; ``tests/unit/sources/test_origin_specs.py`` exercises it
+with a synthetic declaration rather than a real Origin member, since every
+current public ``Origin`` token is already either executable or
+compatibility-only.
 """
 
 from __future__ import annotations
@@ -103,6 +112,14 @@ class OriginSpecDiagnostic:
     repair_command: str
 
 
+#: Provider-wire token values. A public origin name that collides with one of
+#: these would let a raw provider-wire spelling masquerade as public origin
+#: vocabulary (docs/provider-origin-identity.md's doctrine). No current
+#: ``Origin`` member collides with a ``Provider`` member; this check keeps
+#: that true as new origins are admitted.
+_PROVIDER_TOKEN_VALUES = frozenset(provider.value for provider in Provider)
+
+
 class OriginSpecRegistry:
     """Register origin declarations and reject incomplete admission edges."""
 
@@ -113,6 +130,11 @@ class OriginSpecRegistry:
     def register(self, spec: OriginSpec) -> OriginSpec:
         if spec.origin in self._by_origin:
             raise ValueError(f"duplicate OriginSpec for {spec.origin.value!r}")
+        if spec.declaration.public_name in _PROVIDER_TOKEN_VALUES:
+            raise ValueError(
+                f"{spec.origin.value}: public origin name {spec.declaration.public_name!r} leaks a "
+                "Provider-wire token; public origin vocabulary must not collide with provider-wire spelling"
+            )
         if spec.declaration.public_name != spec.origin.value:
             raise ValueError(f"{spec.origin.value}: declaration public name must equal the public Origin token")
         if not spec.acquisition_modes:
@@ -866,6 +888,41 @@ def validate_dispatch_precedence(provider_order: tuple[Provider, ...]) -> tuple[
     return tuple(sorted(diagnostics, key=lambda item: (item.origin.value, item.code)))
 
 
+def validate_stream_parser_parity(stream_record_providers: frozenset[Provider]) -> tuple[OriginSpecDiagnostic, ...]:
+    """Check that declared ``stream_parser_path`` presence matches dispatch's stream-record providers.
+
+    ``sources/dispatch.py:STREAM_RECORD_PROVIDERS`` is the current production
+    set of providers whose JSONL sources are parsed via a streaming record
+    path rather than a fully-materialized payload. An executable OriginSpec
+    whose provider wire is in that set but declares no ``stream_parser_path``
+    (or vice versa) is a stream/parser binding conflict: the declaration would
+    silently under- or over-promise streaming support relative to the actual
+    dispatch behavior it is supposed to describe.
+    """
+
+    diagnostics: list[OriginSpecDiagnostic] = []
+    for spec in ORIGIN_SPECS:
+        if spec.lifecycle != "executable":
+            continue
+        expects_stream = any(provider in stream_record_providers for provider in spec.provider_wires)
+        declares_stream = spec.stream_parser_path is not None
+        if expects_stream == declares_stream:
+            continue
+        diagnostics.append(
+            OriginSpecDiagnostic(
+                code="stream_parser_parity_mismatch",
+                message=(
+                    f"{spec.origin.value}: dispatch expects a stream parser binding ({expects_stream}) but "
+                    f"OriginSpec declares stream_parser_path={spec.stream_parser_path!r}"
+                ),
+                origin=spec.origin,
+                owner_path=spec.declaration.owner_path,
+                repair_command=spec.declaration.repair_command,
+            )
+        )
+    return tuple(sorted(diagnostics, key=lambda item: (item.origin.value, item.code)))
+
+
 __all__ = [
     "ORIGIN_SPECS",
     "ORIGIN_SPEC_REGISTRY",
@@ -879,4 +936,5 @@ __all__ = [
     "artifact_rule_for_path",
     "artifact_suffixes_for_provider",
     "validate_dispatch_precedence",
+    "validate_stream_parser_parity",
 ]

--- a/tests/unit/sources/test_origin_specs.py
+++ b/tests/unit/sources/test_origin_specs.py
@@ -7,13 +7,14 @@ from dataclasses import replace
 import pytest
 
 from polylogue.core.enums import Origin, Provider
-from polylogue.sources.dispatch import RECORD_DETECTOR_PROVIDER_ORDER
+from polylogue.sources.dispatch import RECORD_DETECTOR_PROVIDER_ORDER, STREAM_RECORD_PROVIDERS
 from polylogue.sources.origin_specs import (
     ORIGIN_SPEC_REGISTRY,
     ORIGIN_SPECS,
     OriginSpecRegistry,
     artifact_suffixes_for_provider,
     validate_dispatch_precedence,
+    validate_stream_parser_parity,
 )
 
 
@@ -76,3 +77,95 @@ def test_origin_spec_rejects_missing_fixture_and_noninjective_collision_without_
         registry.register(replace(claude, fixture_paths=()))
     with pytest.raises(ValueError, match="collision policy"):
         registry.register(replace(claude, provider_wires=(Provider.CLAUDE_CODE, Provider.DRIVE)))
+
+
+def test_origin_spec_rejects_undeclared_coverage() -> None:
+    """Production dependency: registration requires a non-empty coverage_refs.
+
+    Anti-vacuity mutation: an OriginSpec with no coverage evidence must be
+    rejected rather than silently admitted with an unproven coverage claim.
+    """
+    claude = next(spec for spec in ORIGIN_SPECS if spec.origin is Origin.CLAUDE_CODE_SESSION)
+    registry = OriginSpecRegistry()
+
+    with pytest.raises(ValueError, match="missing coverage declaration"):
+        registry.register(replace(claude, coverage_refs=()))
+
+
+def test_origin_spec_rejects_leaked_provider_token_as_public_name() -> None:
+    """Production dependency: public origin names must not collide with Provider-wire tokens.
+
+    A public origin name equal to a raw Provider-wire spelling (e.g.
+    ``"claude-code"`` instead of ``"claude-code-session"``) would let
+    provider-wire vocabulary leak onto the public origin surface, violating
+    the doctrine in docs/provider-origin-identity.md. Constructed directly
+    against a colliding declaration (bypassing the module's ``_declaration``
+    helper, which always derives ``public_name`` from ``origin.value``) since
+    no real ``Origin`` member currently collides with a ``Provider`` member.
+    """
+    claude = next(spec for spec in ORIGIN_SPECS if spec.origin is Origin.CLAUDE_CODE_SESSION)
+    registry = OriginSpecRegistry()
+    colliding = replace(claude, declaration=replace(claude.declaration, public_name=Provider.CLAUDE_CODE.value))
+
+    with pytest.raises(ValueError, match="leaks a"):
+        registry.register(colliding)
+
+
+def test_origin_spec_supports_reserved_lifecycle_without_parser_or_tightness() -> None:
+    """Production dependency: the reserved lifecycle state admits an origin with no parser yet.
+
+    ``lifecycle="reserved"`` is the state OriginSpec offers for an origin whose
+    public token is claimed but has no confirmed export shape (the original
+    Grok pilot before polylogue-611/#3201 shipped a real parser). Every
+    current ``Origin`` member is admitted as executable or compatibility-only,
+    so this proves the reserved path against a synthetic variant of a real
+    spec rather than a live production origin.
+
+    Anti-vacuity mutation: dropping ``lifecycle="reserved"`` back to
+    ``"executable"`` on this synthetic spec without also supplying
+    ``detector_tightness``/``parser_paths`` makes registration reject it
+    (see ``test_origin_specs_cover_the_public_enum_and_admission_lifecycles``'s
+    sibling executable-path checks), proving the two lifecycles are genuinely
+    different admission contracts, not a cosmetic label.
+    """
+    grok = next(spec for spec in ORIGIN_SPECS if spec.origin is Origin.GROK_EXPORT)
+    reserved_variant = replace(
+        grok,
+        lifecycle="reserved",
+        detector_tightness=None,
+        parser_paths=(),
+        stream_parser_path=None,
+        assembly_paths=(),
+    )
+    registry = OriginSpecRegistry()
+
+    registered = registry.register(reserved_variant)
+
+    assert registered.lifecycle == "reserved"
+    assert registered.parser_paths == ()
+    assert registered.detector_tightness is None
+    # The reserved variant still carries real coverage/fixture evidence --
+    # reserved means "no parser yet", not "no admission evidence at all".
+    assert registered.coverage_refs
+    assert registered.fixture_paths
+
+
+def test_origin_specs_are_parity_checked_against_stream_record_providers() -> None:
+    """Production dependency: declared stream_parser_path presence matches dispatch's stream-record set.
+
+    Anti-vacuity mutation: passing an empty stream-record-provider set makes
+    every stream-capable executable OriginSpec (Claude Code, Codex, Beads,
+    Hermes) report a ``stream_parser_parity_mismatch`` diagnostic.
+    """
+    assert validate_stream_parser_parity(STREAM_RECORD_PROVIDERS) == ()
+
+    diagnostics = validate_stream_parser_parity(frozenset())
+
+    assert {item.code for item in diagnostics} == {"stream_parser_parity_mismatch"}
+    stream_origins = {
+        spec.origin
+        for spec in ORIGIN_SPECS
+        if spec.lifecycle == "executable" and any(p in STREAM_RECORD_PROVIDERS for p in spec.provider_wires)
+    }
+    assert {item.origin for item in diagnostics} == stream_origins
+    assert stream_origins  # sanity: the production set is non-empty today


### PR DESCRIPTION
## Summary

Closes the remaining conformance-law gaps in the OriginSpec admission kernel
(`polylogue/sources/origin_specs.py`) against every clause of
`polylogue-2qx.1.1`'s acceptance criteria: a public-origin/Provider-token leak
guard, a stream/parser binding parity check against dispatch, and a live
proof of the `lifecycle="reserved"` admission path.

## Problem

`polylogue-2qx.1.1` asked for the OriginSpec admission kernel (built on the
`polylogue/declarations` DeclarationSpec kernel from `polylogue-o21.1`) plus a
conformance law where missing parser, stream/parser conflict, ambiguous
detector order, absent fixture, undeclared coverage, leaked Provider token,
and non-injective Provider-to-Origin collision each yield a source-locatable
diagnostic.

Auditing the live repo found the kernel **already exists on master** —
`polylogue/sources/origin_specs.py` landed incrementally via unrelated
feature PRs (#3051, #3087, #3088, #3092, #3201, #3228: Claude Workflow
admission, Hermes ATOF/ATIF, the Grok parser, provider_completeness
migration) without ever citing this bead, so `bd`'s tracking never reflected
it — the 2026-07-18 warroom sweep found no bead-tagged commits and reset the
bead to open even though the code was there. It already covers all 11
`Origin` tokens, consumes the declarations kernel correctly, and is wired
into `provider_completeness.py`, the artifact taxonomy, the live watcher, and
Claude Code orchestration.

Auditing it clause-by-clause against the AC found three real gaps:

1. No diagnostic caught a public origin `public_name` colliding with a raw
   `Provider`-wire token — the doctrine in
   `docs/provider-origin-identity.md` ("no provider wording on public origin
   surfaces") was enforced only indirectly (public_name must equal
   `origin.value`, and no current `Origin`/`Provider` pair happens to
   collide), with no explicit guard or diagnostic for a future collision.
2. No check parity-verified declared `stream_parser_path` presence against
   `sources/dispatch.py:STREAM_RECORD_PROVIDERS` — a stream/parser binding
   could silently drift from dispatch's actual streaming behavior with no
   diagnostic.
3. The module docstring still claimed a live "reserved origin" pilot, but
   Grok shipped a real parser (`polylogue-611`, #3201) after this bead was
   written, so no `OriginSpec` is currently `lifecycle="reserved"` and that
   admission path had no live proof.

## Solution

- Added `_PROVIDER_TOKEN_VALUES` and a guard in `OriginSpecRegistry.register()`
  that rejects a declaration whose `public_name` collides with any `Provider`
  enum value, ordered before the existing public-name/origin equality check
  so it is independently testable (a synthetic declaration can trip it
  without also tripping the equality check).
- Added `validate_stream_parser_parity()`, parity-checked against
  `sources/dispatch.py:STREAM_RECORD_PROVIDERS` the same way
  `validate_dispatch_precedence()` already parity-checks detector tightness
  order. **Zero edits to `dispatch.py`** — only a new read-only import of its
  existing `STREAM_RECORD_PROVIDERS` constant, respecting this slice's
  ownership boundary with the concurrent `ingest_worker.py`/`decoders.py`
  lane.
- Updated the module docstring to honestly state Grok's promotion from
  reserved to executable, and point at the new synthetic reserved-lifecycle
  test as the live proof of that admission path (since no real production
  `Origin` is currently reserved).
- Added five tests to `tests/unit/sources/test_origin_specs.py`: undeclared-
  coverage rejection, provider-token-leak rejection, a synthetic
  `lifecycle="reserved"` registration (built via `replace()` of the real Grok
  spec) proving the reserved admission contract requires no parser/detector
  tightness while still requiring coverage/fixture evidence, and positive
  plus negative stream/parser parity checks.

## Verification

- `devtools test tests/unit/sources/test_origin_specs.py` → 8 passed
- `devtools test tests/unit/sources/test_dispatch_ordering.py tests/unit/sources/test_dispatch_payloads.py` → 21 passed
- `devtools test -k "provider_completeness or origin_specs or dispatch_ordering"` → 26 passed
- `mypy --strict polylogue/sources/origin_specs.py tests/unit/sources/test_origin_specs.py` → Success, no issues found
- `devtools verify --quick` → exit 0 (all 16 steps ok: format, lint, mypy, render all, topology, layering, closure-matrix, schema roundtrip, manifests, ci-workflows, doc-commands, docs-coverage, test-infra-currency, test-clock-hygiene, pytest-timeout-overrides, degrade-loudly)
- No new module/file added, so no topology projection regen was required.

## AC matrix

| # | AC | Status |
| --- | --- | --- |
| 1 | `origin_specs.py` defines complete typed fields/lifecycle states, consumes `polylogue/declarations` without adding source semantics to that kernel | Satisfied (pre-existing on master; verified by reading `polylogue/declarations/*` and confirming `origin_specs.py` only wraps `DeclarationSpec`/`DeclarationRegistry`, adding no kernel-layer semantics) |
| 2 | Claude Code / ChatGPT / reserved Grok pilots derive/validate deterministic tightness, parser/assembly registration, public origin values, coverage/completeness rows, fixtures, docs, reparse consequences from one declaration each | Satisfied for Claude Code (executable, tightness 60, stream+artifact-rule bindings) and ChatGPT (executable, tightness 70). Grok itself is now executable (real parser shipped after this bead was written, #3201) rather than reserved; the reserved-lifecycle admission contract is proven live by this PR's new synthetic test rather than by a real reserved origin, since every current public `Origin` token is admitted as executable or compatibility-only |
| 3 | `dispatch.py` uses derived registration/order or is parity-checked by it; adding a synthetic executable origin requires one OriginSpec + adapter + fixtures | Satisfied — `validate_dispatch_precedence()` (pre-existing) plus this PR's new `validate_stream_parser_parity()` parity-check `dispatch.py`'s `RECORD_DETECTOR_PROVIDER_ORDER`/`STREAM_RECORD_PROVIDERS` without restructuring dispatch.py |
| 4 | Missing parser / stream-parser conflict / ambiguous or cyclic detector order / absent fixture / undeclared coverage / leaked Provider token / non-injective collision each yield a source-locatable diagnostic + repair | Satisfied — missing parser, absent fixture, and non-injective collision without policy were pre-existing `ValueError` raises (now also covered by a dedicated undeclared-coverage test in this PR); ambiguous detector order was pre-existing (`ambiguous_detector_tightness`); this PR adds the previously-missing stream/parser-conflict diagnostic (`stream_parser_parity_mismatch`) and leaked-Provider-token guard. "Cyclic" detector order has no distinct failure mode beyond ambiguous tightness, since tightness is a total order, not a graph |
| 5 | Provider stays in adapters, Origin is the public vocabulary, Gemini/Drive-style collisions require an explicit collision policy | Satisfied (pre-existing `collision_policy` field + registration guard, exercised by `aistudio-drive`'s `Provider.GEMINI`/`Provider.DRIVE` fiber) |
| 6 | Focused declaration/dispatch/public-schema/completeness/fixture/mutation/render/quick verification passes | Satisfied — see Verification section above |

`polylogue-2qx.1.2` (migrate every current origin onto OriginSpec, delete
parallel inventories) is explicitly out of this slice's scope per the bead's
own design text — it is largely already superseded in practice too (all 11
origins are already declared here and `provider_completeness.py` already
projects from `ORIGIN_SPECS`), but a formal audit of that bead's own AC
(exact-eleven-token enumeration, parallel-inventory deletion, dispatch
golden fixture) is left to whoever picks it up.

Ref polylogue-2qx.1.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented origin names from exposing internal provider terminology.
  * Added validation to ensure origin evidence is complete before registration.
  * Improved consistency checks for origins that support streaming data.
* **New Features**
  * Added support for reserved-lifecycle origins used in fixtures, including required supporting evidence without requiring parser configuration.
  * Added diagnostics for mismatches between streaming capabilities and origin configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->