### PR TITLE
fix(pipeline): route ingest_record through binary-capable Hermes SQLite detection

### DIFF
--- a/polylogue/archive/artifact_taxonomy/runtime.py
+++ b/polylogue/archive/artifact_taxonomy/runtime.py
@@ -131,6 +131,24 @@ def classify_artifact(
 ) -> ArtifactClassification:
     """Classify a payload/document into a session or sidecar cohort."""
     provider_token = Provider.from_string(provider)
+
+    # Hermes SQLite marker payloads (state.db / verification_evidence.db)
+    # must win over the path-only "SQLite evidence sidecar" classification
+    # below (polylogue-zoc3). The raw *.db path itself always classifies as
+    # a non-session sidecar (its bytes are still opaque SQLite, not a JSON
+    # marker) -- see `classify_artifact_path`'s "Hermes SQLite evidence
+    # sidecar" branch -- but once the raw payload has been decoded into the
+    # synthetic marker dict (`build_raw_payload_envelope`'s
+    # `_hermes_sqlite_marker_payload`), `source_path` still points at the
+    # same *.db filename. Checking the marker dict first, before consulting
+    # `classify_artifact_path`, keeps that positive session classification
+    # from being shadowed by the path-only sidecar rule for the exact same
+    # filename.
+    if isinstance(payload, dict):
+        marker_classification = _classify_hermes_sqlite_marker(payload, provider=provider_token)
+        if marker_classification is not None:
+            return marker_classification
+
     explicit = classify_artifact_path(source_path, provider=provider_token)
     if explicit is not None:
         return explicit
@@ -244,6 +262,41 @@ def _classify_list(
     )
 
 
+def _classify_hermes_sqlite_marker(
+    payload: JSONDocument,
+    *,
+    provider: Provider,
+) -> ArtifactClassification | None:
+    """Classify a decoded Hermes SQLite marker payload (state.db / verification_evidence.db).
+
+    Shared by `classify_artifact` (checked before the path-only sidecar rule,
+    polylogue-zoc3) and `_classify_dict` (the ordinary dict-classification
+    fallthrough), so both call sites agree on the marker shape.
+    """
+    if provider is not Provider.HERMES:
+        return None
+    artifact_marker = payload.get("polylogue_artifact")
+    if artifact_marker == _HERMES_STATE_DB_MARKER:
+        return ArtifactClassification(
+            provider=provider,
+            kind=ArtifactKind.SESSION_DOCUMENT,
+            parse_as_session=True,
+            schema_eligible=True,
+            default_priority=120,
+            reason="Hermes state.db SQLite archive marker",
+        )
+    if artifact_marker == _HERMES_VERIFICATION_DB_MARKER:
+        return ArtifactClassification(
+            provider=provider,
+            kind=ArtifactKind.SESSION_DOCUMENT,
+            parse_as_session=True,
+            schema_eligible=True,
+            default_priority=120,
+            reason="Hermes verification_evidence.db SQLite archive marker",
+        )
+    return None
+
+
 def _classify_dict(
     payload: JSONDocument,
     *,
@@ -274,25 +327,8 @@ def _classify_dict(
             reason="Antigravity language-server Markdown export",
         )
 
-    if provider is Provider.HERMES and payload.get("polylogue_artifact") == _HERMES_STATE_DB_MARKER:
-        return ArtifactClassification(
-            provider=provider,
-            kind=ArtifactKind.SESSION_DOCUMENT,
-            parse_as_session=True,
-            schema_eligible=True,
-            default_priority=120,
-            reason="Hermes state.db SQLite archive marker",
-        )
-
-    if provider is Provider.HERMES and payload.get("polylogue_artifact") == _HERMES_VERIFICATION_DB_MARKER:
-        return ArtifactClassification(
-            provider=provider,
-            kind=ArtifactKind.SESSION_DOCUMENT,
-            parse_as_session=True,
-            schema_eligible=True,
-            default_priority=120,
-            reason="Hermes verification_evidence.db SQLite archive marker",
-        )
+    if (marker_classification := _classify_hermes_sqlite_marker(payload, provider=provider)) is not None:
+        return marker_classification
 
     # Deferred import: `sources.parsers.hermes_spans` sits downstream of
     # `sources/__init__.py` (drive -> dispatch -> decoders -> decoder_zip),

--- a/polylogue/archive/raw_payload/decode.py
+++ b/polylogue/archive/raw_payload/decode.py
@@ -15,8 +15,6 @@ from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDecodeError, JSONDocument, JSONValue, is_json_value, loads
 from polylogue.sources.dispatch import detect_provider
 
-_HERMES_STATE_DB_MARKER = "hermes_state_db"
-
 WireFormat = Literal["json", "jsonl"]
 JSONRecord: TypeAlias = JSONDocument
 
@@ -289,17 +287,16 @@ def build_raw_payload_envelope(
     Python list. This avoids reading the whole file into one byte string,
     but grouped-provider parses still hold the decoded records in memory.
     """
-    if isinstance(raw_content, Path) and _looks_like_hermes_state_db(raw_content):
-        marker: JSONDocument = {"polylogue_artifact": _HERMES_STATE_DB_MARKER, "state_db_path": str(raw_content)}
-        if source_path is not None:
-            marker["profile_root"] = str(Path(source_path).parent)
-        provider = Provider.HERMES
-        return RawPayloadEnvelope(
-            payload=marker,
-            provider=provider,
-            wire_format="json",
-            artifact=classify_artifact(marker, provider=provider, source_path=source_path),
-        )
+    if isinstance(raw_content, Path):
+        hermes_marker = _hermes_sqlite_marker_payload(raw_content, source_path=source_path)
+        if hermes_marker is not None:
+            provider = Provider.HERMES
+            return RawPayloadEnvelope(
+                payload=hermes_marker,
+                provider=provider,
+                wire_format="json",
+                artifact=classify_artifact(hermes_marker, provider=provider, source_path=source_path),
+            )
     normalized_path = str(source_path or "").lower()
     prefer_jsonl = normalized_path.endswith((".jsonl", ".jsonl.txt", ".ndjson"))
     preferred_provider = payload_provider or fallback_provider
@@ -332,14 +329,33 @@ def build_raw_payload_envelope(
     )
 
 
-def _looks_like_hermes_state_db(path: Path) -> bool:
-    # Import lazily: ``dispatch`` imports the Hermes parser while this module
-    # imports ``dispatch`` for ordinary JSON provider detection. At runtime the
-    # module graph is complete, and delegating here keeps raw inspection on the
-    # same versioned structural contract as actual parsing.
-    from polylogue.sources.parsers import hermes_state
+def _hermes_sqlite_marker_payload(path: Path, *, source_path: str | Path | None) -> JSONDocument | None:
+    """Route a raw Hermes SQLite blob (state.db / verification_evidence.db) to its marker payload.
 
-    return hermes_state.looks_like_state_db_path(path)
+    Binary-capable detection BEFORE any text decode, mirroring the rebuild
+    path's provider dispatch (``sources.revision_backfill._parse_one``, which
+    probes ``looks_like_sqlite_bytes`` then the same per-artifact
+    ``looks_like_*_path`` structural checks used here). ``ingest_record``
+    (``pipeline/services/ingest_worker.py``) calls ``build_raw_payload_envelope``
+    for every raw, including binary ones, so this is the single place that
+    must recognize a SQLite-backed Hermes artifact before the generic
+    JSON/JSONL decode path runs and rejects the bytes as invalid UTF-8
+    (polylogue-zoc3: ingest and rebuild previously disagreed here for
+    ``verification_evidence.db`` raws, which only the rebuild path handled).
+
+    Import lazily: ``dispatch`` imports the Hermes parsers while this module
+    imports ``dispatch`` for ordinary JSON provider detection. At runtime the
+    module graph is complete, and delegating here keeps raw inspection on the
+    same versioned structural contract as actual parsing.
+    """
+    from polylogue.sources.parsers import hermes_state, hermes_verification
+
+    profile_root = Path(source_path).parent if source_path is not None else None
+    if hermes_state.looks_like_state_db_path(path):
+        return hermes_state.marker_payload(path, profile_root=profile_root)
+    if hermes_verification.looks_like_verification_evidence_db_path(path):
+        return hermes_verification.marker_payload(path, profile_root=profile_root)
+    return None
 
 
 __all__ = [

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -1578,7 +1578,9 @@ def _parse_one(
                     profile_root=Path(source_path).parent,
                 )
             if hermes_verification.looks_like_verification_evidence_db_path(sqlite_path):
-                return hermes_verification.parse_verification_evidence_db(sqlite_path, fallback_id=fallback_id)
+                return hermes_verification.parse_verification_evidence_db(
+                    sqlite_path, fallback_id=fallback_id, profile_root=Path(source_path).parent
+                )
     return parse_payload(
         provider,
         list(_iter_json_stream(BytesIO(payload), source_name)),

--- a/tests/unit/pipeline/test_binary_payload_parse_parity.py
+++ b/tests/unit/pipeline/test_binary_payload_parse_parity.py
@@ -1,0 +1,243 @@
+"""Binary-payload parse-route parity between ingest and rebuild (polylogue-zoc3).
+
+``ingest_record`` (``pipeline/services/ingest_worker.py``, the live daemon
+ingest worker's per-raw entry point) decoded every raw as text/JSON before
+any provider dispatch, so a Hermes raw whose payload is SQLite database
+bytes (``~/.hermes/verification_evidence.db``) failed with ``"decode: str
+is not valid UTF-8: surrogates not allowed: line 1 column 1"`` even though
+the rebuild path (``sources.revision_backfill._parse_retained_raw`` /
+``_parse_one``, used by historical backfill and the census/replay machinery)
+parses the identical raw bytes fine via ``looks_like_sqlite_bytes`` plus the
+same structural ``looks_like_*_path`` probes the parser modules expose.
+
+The fix threads the same binary-capable detection
+(``polylogue.archive.raw_payload.decode._hermes_sqlite_marker_payload``,
+built from the same ``hermes_state``/``hermes_verification`` helper
+functions ``_parse_one`` already calls) through
+``build_raw_payload_envelope`` -- the function ``ingest_record`` calls to
+decode every raw -- so both routes agree.
+
+Anti-vacuity: reverting the ``_hermes_sqlite_marker_payload`` routing in
+``polylogue/archive/raw_payload/decode.py`` (i.e. restoring the old
+state.db-only ``_looks_like_hermes_state_db`` check) makes
+``test_verification_evidence_db_parses_identically_through_ingest_and_rebuild_routes``
+fail on the ingest side with exactly the live error string:
+``decode: str is not valid UTF-8: surrogates not allowed: line 1 column 1``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from polylogue.core.enums import Provider
+from polylogue.pipeline.services.ingest_worker import ingest_record
+from polylogue.sources.revision_backfill import _parse_one
+from polylogue.storage.blob_store import BlobStore, reset_blob_store
+from polylogue.storage.runtime import RawSessionRecord
+
+
+@pytest.fixture
+def blob_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[BlobStore]:
+    root = tmp_path / "blobs"
+    store = BlobStore(root)
+    monkeypatch.setattr("polylogue.paths.blob_store_root", lambda: root)
+    reset_blob_store()
+    yield store
+    reset_blob_store()
+
+
+def _write_verification_evidence_db(path: Path) -> None:
+    """Build the live-verified verification_evidence.db schema (schema_version=1).
+
+    Mirrors ``tests/unit/sources/parsers/test_hermes_verification.py``'s
+    ``_write_verification_evidence_db`` (same table shape, redacted-placeholder
+    row values) -- kept as an independent minimal copy so this parity test does
+    not import test internals across files.
+    """
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            CREATE TABLE verification_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                cwd TEXT NOT NULL,
+                root TEXT NOT NULL,
+                command TEXT NOT NULL,
+                canonical_command TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                scope TEXT NOT NULL,
+                status TEXT NOT NULL,
+                exit_code INTEGER NOT NULL,
+                output_summary TEXT NOT NULL
+            );
+            CREATE TABLE verification_state (
+                session_id TEXT NOT NULL,
+                root TEXT NOT NULL,
+                last_event_id INTEGER,
+                last_edit_at TEXT,
+                changed_paths_json TEXT NOT NULL DEFAULT '[]',
+                PRIMARY KEY (session_id, root)
+            );
+            CREATE INDEX idx_verification_events_session_root
+                ON verification_events(session_id, root, id DESC);
+            INSERT INTO meta(key, value) VALUES ('schema_version', '1');
+            """
+        )
+        conn.execute(
+            "INSERT INTO verification_events "
+            "(created_at, session_id, cwd, root, command, canonical_command, kind, scope, status, exit_code, output_summary) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "2026-07-14T17:21:02.133901+00:00",
+                "verify-session-redacted-1",
+                "<redacted>",
+                "<redacted>",
+                "<redacted>",
+                "pytest",
+                "test",
+                "targeted",
+                "passed",
+                0,
+                "<redacted>",
+            ),
+        )
+        conn.commit()
+
+
+def _record(store: BlobStore, content: bytes, *, source_path: str) -> RawSessionRecord:
+    raw_id, blob_size = store.write_from_bytes(content)
+    return RawSessionRecord(
+        raw_id=raw_id,
+        source_name="hermes",
+        source_path=source_path,
+        payload_provider=Provider.HERMES,
+        source_index=None,
+        blob_size=blob_size,
+        acquired_at="2026-01-01T00:00:00+00:00",
+        file_mtime=None,
+    )
+
+
+def test_verification_evidence_db_parses_identically_through_ingest_and_rebuild_routes(
+    blob_store: BlobStore, tmp_path: Path
+) -> None:
+    """A raw parseable through the rebuild route is also parseable through ingest_record.
+
+    Compares produced session ``provider_session_id``s (the contract-test
+    shape the bead calls for), including the profile-qualified suffix, so a
+    regression in either route's profile-root threading also fails this test.
+    """
+    profile_dir = tmp_path / ".hermes"
+    profile_dir.mkdir(parents=True)
+    db_path = profile_dir / "verification_evidence.db"
+    _write_verification_evidence_db(db_path)
+    content = db_path.read_bytes()
+
+    # Rebuild route: the same _parse_one the backfill/census/replay machinery
+    # calls (parse_retained_raw_sessions -> _parse_one; census_parse_worker -> _parse_one).
+    rebuild_sessions = _parse_one(
+        Provider.HERMES,
+        content,
+        str(db_path),
+        payload_path=db_path,
+        archive_root=tmp_path,
+    )
+    rebuild_ids = {session.provider_session_id for session in rebuild_sessions}
+    assert rebuild_ids, "fixture must produce at least one session on the rebuild route"
+
+    # Ingest route: the live daemon worker's per-raw entry point.
+    record = _record(blob_store, content, source_path=str(db_path))
+    result = ingest_record(record, str(tmp_path / "archive"), "advisory", blob_root_str=str(blob_store.root))
+
+    assert result.error is None, result.error
+    ingest_ids = {payload.parsed_session.provider_session_id for payload in result.sessions}
+
+    assert ingest_ids == rebuild_ids
+    assert ingest_ids == {"verification:verify-session-redacted-1@profile-" + _profile_key(profile_dir)}
+
+
+def _profile_key(profile_dir: Path) -> str:
+    from polylogue.sources.parsers.hermes_identity import profile_key
+
+    return profile_key(profile_dir)
+
+
+def _write_hermes_state_db(path: Path) -> None:
+    """Minimal state.db fixture covering every column ``_has_required_tables`` checks.
+
+    Independent minimal copy of the shape
+    ``tests/unit/sources/test_parsers_local_agent.py``'s ``_write_hermes_state_db``
+    builds in full -- only the required + signature columns
+    (``hermes_state._REQUIRED_SESSION_COLUMNS`` / ``_REQUIRED_MESSAGE_COLUMNS`` /
+    ``_HERMES_SIGNATURE_*_COLUMNS``) are needed for this parity check.
+    """
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE schema_version(version INTEGER NOT NULL);
+            INSERT INTO schema_version(version) VALUES (16);
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT,
+                model_config TEXT,
+                parent_session_id TEXT,
+                started_at REAL
+            );
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_calls TEXT,
+                timestamp REAL NOT NULL,
+                observed INTEGER DEFAULT 0,
+                active INTEGER NOT NULL DEFAULT 1,
+                compacted INTEGER NOT NULL DEFAULT 0
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions (id, model_config, started_at) VALUES (?, ?, ?)",
+            ("hermes-root", "{}", 1_775_000_000.0),
+        )
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            ("hermes-root", "assistant", "hi from state.db", 1_775_000_001.0),
+        )
+        conn.commit()
+
+
+def test_state_db_still_parses_identically_through_both_routes(blob_store: BlobStore, tmp_path: Path) -> None:
+    """Regression guard: the pre-existing state.db marker route must keep working
+    after generalizing the SQLite marker helper to also recognize verification_evidence.db.
+    """
+    profile_dir = tmp_path / ".hermes"
+    profile_dir.mkdir(parents=True)
+    db_path = profile_dir / "state.db"
+    _write_hermes_state_db(db_path)
+
+    content = db_path.read_bytes()
+
+    rebuild_sessions = _parse_one(
+        Provider.HERMES,
+        content,
+        str(db_path),
+        payload_path=db_path,
+        archive_root=tmp_path,
+    )
+    rebuild_ids = {session.provider_session_id.split("@", 1)[0] for session in rebuild_sessions}
+
+    record = _record(blob_store, content, source_path=str(db_path))
+    result = ingest_record(record, str(tmp_path / "archive"), "advisory", blob_root_str=str(blob_store.root))
+
+    assert result.error is None, result.error
+    ingest_ids = {payload.parsed_session.provider_session_id.split("@", 1)[0] for payload in result.sessions}
+
+    assert ingest_ids == rebuild_ids
+    assert "hermes-root" in ingest_ids


### PR DESCRIPTION
## Summary

`ingest_record` (the live daemon's per-raw ingest worker) previously decoded
every raw as text/JSON before any provider dispatch, so Hermes raws whose
payload is SQLite database bytes failed to parse -- while the rebuild path
(historical backfill / census / replay) parsed the identical bytes fine. This
PR routes ingest_record's decode step through the same binary-capable
detection the rebuild path uses, and fixes two related parse-route divergences
found while proving parity.

## Problem

Live failure (2026-07-21, discovered during a targeted Hermes reprocess):
`parse_from_raw` -> `process_ingest_batch` -> `ingest_record`
(`polylogue/pipeline/services/ingest_worker.py`) fails all 3 Hermes
verification raws (`source_path ~/.hermes/verification_evidence.db`, SQLite
database bytes) with:

```
decode: str is not valid UTF-8: surrogates not allowed: line 1 column 1
```

The REBUILD path (`sources.revision_backfill._parse_retained_raw` /
`_parse_one`) parses these same raws fine -- the v42 walk materialized
verification sessions from them via `looks_like_sqlite_bytes` + the parser
modules' own `looks_like_*_path` structural probes, bypassing
`build_raw_payload_envelope`/`classify_artifact` entirely.

Root cause is two-layered:

1. **`polylogue/archive/raw_payload/decode.py`**: `build_raw_payload_envelope`
   (the function `ingest_record` calls to decode every raw) only special-cased
   `state.db` via `_looks_like_hermes_state_db` -- `verification_evidence.db`
   had no equivalent marker branch, so it fell through to the generic
   JSON/JSONL decode path and was rejected as invalid UTF-8.
2. **`polylogue/archive/artifact_taxonomy/runtime.py`**: even after building
   the correct marker payload, `classify_artifact()` consulted the path-only
   `classify_artifact_path()` *first*. That function's "Hermes SQLite evidence
   sidecar" filename rule for `verification_evidence.db` unconditionally
   returns `parse_as_session=False` (intended for pre-decode, path-only
   callers like schema sampling) -- and since `classify_artifact()` returns
   early on a non-`None` path classification, it shadowed the marker payload's
   positive session classification for the identical filename.

## Solution

- **`polylogue/archive/raw_payload/decode.py`**: generalized the state.db-only
  `_looks_like_hermes_state_db` branch into `_hermes_sqlite_marker_payload`,
  which now recognizes both `state.db` and `verification_evidence.db` by
  calling `hermes_state.marker_payload()` / `hermes_verification.marker_payload()`
  directly (previously the state.db marker dict was hand-built inline,
  duplicating what `hermes_state.marker_payload` already does). Binary-capable
  detection now runs before any text decode, in the same order the rebuild
  path's `_parse_one` already uses (`looks_like_sqlite_bytes` -> per-artifact
  `looks_like_*_path` probes).
- **`polylogue/archive/artifact_taxonomy/runtime.py`**: extracted the two
  Hermes SQLite marker checks (state.db / verification_evidence.db) out of
  `_classify_dict` into a shared `_classify_hermes_sqlite_marker` helper, and
  call it from `classify_artifact()` *before* consulting
  `classify_artifact_path()`. The raw `*.db` path itself still classifies as a
  non-session sidecar when passed alone (schema sampling and other path-only
  callers are unaffected); only a decoded marker *payload* now wins over the
  path-only sidecar rule.
- **`polylogue/sources/revision_backfill.py`**: while building the parity
  test, found `_parse_one`'s `verification_evidence.db` branch omitted
  `profile_root=` (unlike the adjacent `state.db` branch, which already passes
  `profile_root=Path(source_path).parent`). This meant the rebuild route
  produced an *unqualified* `verification:<raw_id>` session id while the fixed
  ingest route (via dispatch, which already threads `profile_root` from
  `spec.source_path`) produces a *profile-qualified* id -- a second, narrower
  parse-route disagreement in the exact same area. Fixed to match.

**Ownership note:** `polylogue/sources/dispatch.py` is owned by a concurrent
lane (OriginSpec work). This PR does not touch it -- the marker-payload
dispatch route (`detect_provider` / `_lower_payload_specs` /
`_parse_lowered_spec`) already fully supported `verification_evidence.db`
markers; the gap was entirely upstream of dispatch, in the envelope decode and
artifact classification steps.

## Other binary-payload providers (AC #4)

Grepped every parser module under `polylogue/sources/parsers/` for direct
`sqlite3` reads. Only `hermes_state.py` (`state.db`) and
`hermes_verification.py` (`verification_evidence.db`) read raw SQLite bytes;
both are covered by the new parity test. Antigravity's "brain-metadata"
artifact (`looks_like_brain_metadata`) is JSON, not binary -- not exposed to
this bug class. No other provider needs coverage.

## Acceptance-criteria matrix

| # | AC | Status |
| --- | --- | --- |
| 1 | Diagnose exact divergence point; reuse the rebuild path's helper instead of forking logic | Satisfied -- `_hermes_sqlite_marker_payload` calls the same `hermes_state`/`hermes_verification` `looks_like_*_path`/`marker_payload` functions `_parse_one` uses |
| 2 | Fix lives in `pipeline/services/ingest_worker.py` and/or `sources/decoders.py`; `dispatch.py` untouched or minimally flagged | Satisfied -- fix lives in `archive/raw_payload/decode.py` (the module `ingest_record` calls into) and `archive/artifact_taxonomy/runtime.py`; `dispatch.py` not touched at all |
| 3 | Contract test: raw parseable via rebuild route also parseable via `ingest_record`, comparing session native ids; anti-vacuity stated | Satisfied -- `tests/unit/pipeline/test_binary_payload_parse_parity.py`, two tests (verification_evidence.db + state.db regression guard); anti-vacuity verified live (see Verification) |
| 4 | Check other binary-payload providers | Satisfied -- only Hermes exposed; documented above |

## Verification

```
devtools test tests/unit/pipeline/test_binary_payload_parse_parity.py \
  tests/unit/pipeline/test_ingest_worker_assembly.py \
  tests/unit/sources/parsers/test_hermes_verification.py \
  tests/unit/sources/parsers/test_hermes_state.py \
  tests/unit/sources/test_revision_backfill.py \
  tests/unit/core/test_raw_payload_decode.py tests/unit/core/test_models.py \
  tests/unit/sources/test_parsers_local_agent.py tests/unit/sources/test_artifact_taxonomy.py
```
-> 270 passed, 1 pre-existing failure unrelated to this change
(`test_build_raw_payload_envelope_prefers_claude_subagent_path_over_codex_like_shape`,
reproduces identically against unmodified `master` -- Claude Code subagent
JSONL classification, no file this PR touches is involved).

```
mypy --strict polylogue/archive/raw_payload/decode.py \
  polylogue/archive/artifact_taxonomy/runtime.py \
  polylogue/sources/revision_backfill.py \
  polylogue/pipeline/services/ingest_worker.py
```
-> `Success: no issues found in 4 source files`

```
devtools verify --quick
```
-> all 16 steps `ok`, exit 0.

**Anti-vacuity**: stashed the `decode.py` routing change and re-ran the new
parity test -- it fails with the exact live error string:
`decode: str is not valid UTF-8: surrogates not allowed: line 1 column 1`.

Ref polylogue-zoc3