### PR TITLE
fix(config): route the un-inventoried env-only readers through config.py

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -344,12 +344,20 @@ A few keys not shown in the full example above, with their TOML path:
 | `debug_timing` | `ui.debug_timing` | Emit per-stage timing diagnostics in CLI output. |
 | `hermes_root` | `sources.hermes.root` | Runtime root watched for Hermes state, snapshots, NeMo Relay ATIF/ATOF artifacts, and verification evidence. Defaults to `~/.hermes`. |
 | `hook_sidecar_dir` | `sources.hook_sidecar_dir` | Directory for hook-event sidecar files consumed by the Claude Code/Codex hook harness. Defaults to `<archive_root>/hooks`, so a scratch/test `POLYLOGUE_ARCHIVE_ROOT` genuinely isolates its hook spool from the real one; set explicitly only if you need the spool somewhere other than the archive it belongs to. |
+| `hook_provider` | `sources.hook_provider` | Force hook-event harness detection to `claude-code` or `codex` instead of sniffing the payload shape; unset auto-detects. |
 | `backup_verify_tmpdir` | `maintenance.backup_verify_tmpdir` | Scratch directory for backup-restore verification; defaults to the system temp dir when unset. |
 | `antigravity_language_server` | `sources.antigravity_language_server` | Path to an Antigravity language-server binary, when parsing Antigravity sessions needs it. |
 | `ingest_commit_batch_messages` | `sources.ingest_commit_batch_messages` | Messages per commit batch during ingest (default 8000). |
 | `ingest_parse_workers` | `sources.ingest_parse_workers` | Parallel parse workers during ingest (default 1). |
 | `live_full_ingest_workers` | `sources.live_full_ingest_workers` | Parallel workers for a live full-reingest pass (default 1). |
+| `raw_authority_commit_batch_size` | `pipeline.raw_authority.commit_batch_size` | Census-phase commit batch size for raw-materialization repair (polylogue-amg1); unset uses the built-in default, `<=0` disables batching (per-raw commits). |
+| `revision_parse_dispatch_max_bytes` | `pipeline.revision_parse.dispatch_max_bytes` | Payload-size ceiling (bytes) above which a raw parses sequentially in-process instead of dispatching to the parse pool (polylogue-amg1). |
+| `revision_parse_pool_min_bytes` | `pipeline.revision_parse.pool_min_bytes` | Aggregate pool-eligible payload floor (bytes) below which pool dispatch cannot amortize worker-spawn cost (polylogue-amg1 / polylogue-crd8). |
 | `daemon_parse_stage_split` | `daemon.raw_materialization.parse_stage_split` | Opt-in (polylogue-m6tp phase (a), default off): pre-parse raw-materialization census candidates in a bounded daemon-owned thread pool before the writer hold, instead of parsing inside the writer-held pass. |
+| `daemon_parse_stage_workers` | `daemon.raw_materialization.parse_stage_workers` | Worker cap for the daemon-owned pre-parse thread pool; unset/`<=0` uses the adaptive `cpu_count - 1` default. |
+| `daemon_parse_stage_max_inflight_bytes` | `daemon.raw_materialization.parse_stage_max_inflight_bytes` | Whale-memory budget (bytes) for raw payloads admitted while prefetch parses are in flight; unset/`<=0` uses the adaptive 1/16-physical-RAM default (clamped [64 MiB, 2 GiB]). |
+| `daemon_parse_stage_max_cached_tree_bytes` | `daemon.raw_materialization.parse_stage_max_cached_tree_bytes` | Whole-cache budget (bytes) for estimated parsed-tree bytes held resident between `warm()` passes; unset/`<=0` uses the adaptive 1/8-physical-RAM default (clamped [256 MiB, 4 GiB]). |
+| `daemon_parse_stage_warm_timeout_seconds` | `daemon.raw_materialization.parse_stage_warm_timeout_seconds` | Bound (seconds) on how long a prefetch `warm()` pass waits for its dispatched workers; unset/`<=0` uses the 300s default. |
 | `daemon_bulk_rebuild_routing` | `daemon.raw_materialization.bulk_rebuild_routing` | Opt-in (polylogue-m6tp phase (c) / polylogue-gd6v, default off): once a raw backlog is bulk-scale, route it into a daemon-owned resumable blue-green index generation build instead of the trickle conveyor, promoting it once exact-ready. |
 | `judgment_automation_enabled` | `judgment_automation.enabled` | Opt-in (polylogue-6qjc, default off): schedule the daemon judgment-automation sweep that calls the `judge` dispatcher on auto-judgeable assertion candidates per policy and escalates the rest to a `handoff` assertion. Exercises the same authority as the MCP `judge` dispatcher, so the sweep also requires `mcp_judge_enabled`. See [`docs/daemon.md`](daemon.md). |
 | `judgment_automation_interval_s` | `judgment_automation.interval_s` | Seconds between judgment-automation sweeps (default 3600; floored at 60 at runtime). |
@@ -398,6 +406,29 @@ Common runtime overrides:
 | `POLYLOGUE_OBSERVABILITY_ENABLED` | `observability_enabled` | Enable OTLP/observability HTTP ingestion. |
 | `POLYLOGUE_CREDENTIAL_PATH` | Drive auth | OAuth client JSON path. |
 | `POLYLOGUE_TOKEN_PATH` | Drive auth | OAuth token path. |
+| `POLYLOGUE_HOOK_PROVIDER` | `hook_provider` | Force hook-harness detection to `claude-code`/`codex`. |
+| `POLYLOGUE_RAW_AUTHORITY_COMMIT_BATCH_SIZE` | `raw_authority_commit_batch_size` | Census-phase commit batch size for raw-materialization repair. |
+| `POLYLOGUE_REVISION_PARSE_DISPATCH_MAX_BYTES` | `revision_parse_dispatch_max_bytes` | Payload-size ceiling for pool-eligible revision-parse dispatch. |
+| `POLYLOGUE_REVISION_PARSE_POOL_MIN_BYTES` | `revision_parse_pool_min_bytes` | Aggregate payload floor for revision-parse pool dispatch to amortize. |
+| `POLYLOGUE_DAEMON_PARSE_STAGE_WORKERS` | `daemon_parse_stage_workers` | Worker cap for the daemon-owned pre-parse thread pool. |
+| `POLYLOGUE_DAEMON_PARSE_STAGE_MAX_INFLIGHT_BYTES` | `daemon_parse_stage_max_inflight_bytes` | In-flight raw-payload budget for the prefetch cache. |
+| `POLYLOGUE_DAEMON_PARSE_STAGE_MAX_CACHED_TREE_BYTES` | `daemon_parse_stage_max_cached_tree_bytes` | Resident parsed-tree budget for the prefetch cache. |
+| `POLYLOGUE_DAEMON_PARSE_STAGE_WARM_TIMEOUT_SECONDS` | `daemon_parse_stage_warm_timeout_seconds` | Timeout for a prefetch `warm()` pass. |
+
+Three `POLYLOGUE_*`-namespaced variables are deliberately **not** layered
+config keys (polylogue-uu8r judgment call): `POLYLOGUE_DEV_LOOP_RUN_ID`,
+`POLYLOGUE_DEV_LOOP_LOG_DIR`, and `POLYLOGUE_SESSION_REF` are
+launcher/harness-injected correlation metadata for one process invocation
+(dev-loop run/log identity, cross-agent session correlation), structurally
+identical to `CODEX_SESSION_ID`/`CLAUDE_SESSION_ID` rather than an operator
+TOML preference. They stay direct `os.environ` reads at their call sites
+(`polylogue/daemon/cli.py`, `polylogue/daemon/http.py`,
+`polylogue/coordination/envelope.py`). `POLYLOGUE_CONFIG` is similarly
+exempt: it is the bootstrap variable that selects *which* user TOML file to
+load, so it cannot itself be resolved through the layered reader it
+configures — `polylogue/cli/commands/embed.py::_resolve_user_config_path`
+reads it directly, matching `polylogue/config.py`'s own
+`_user_config_path`/`_site_config_path` bootstrap reads.
 
 ### Theme and no-color policy
 

--- a/polylogue/cli/commands/embed.py
+++ b/polylogue/cli/commands/embed.py
@@ -231,6 +231,13 @@ def _resolve_user_config_path() -> Path:
 
     Honors ``POLYLOGUE_CONFIG`` so tests and per-project setups can redirect
     the write; otherwise falls back to the XDG starter path.
+
+    Deliberately a raw ``os.environ`` read, not ``load_polylogue_config()``:
+    ``POLYLOGUE_CONFIG`` is the bootstrap variable that selects *which* user
+    TOML file the layered resolver loads, so it cannot itself be resolved
+    through that resolver -- mirrors ``polylogue.config``'s own
+    ``_user_config_path``/``_site_config_path`` bootstrap reads
+    (polylogue-uu8r judgment call; see docs/configuration.md).
     """
     override = os.environ.get("POLYLOGUE_CONFIG")
     if override:

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -575,6 +575,16 @@ class PolylogueConfig:
         return str(self._data.get("hook_sidecar_dir", ""))
 
     @property
+    def hook_provider(self) -> str | None:
+        """Forced hook-harness id ('claude-code'/'codex') or None to auto-detect.
+
+        Returned as a raw string (not the ``HookHarness`` literal) to avoid a
+        ``polylogue.hooks`` import here; callers validate/narrow the value.
+        """
+        value = self._data.get("hook_provider")
+        return value if isinstance(value, str) and value else None
+
+    @property
     def backup_verify_tmpdir(self) -> str | None:
         value = self._data.get("backup_verify_tmpdir")
         return value if isinstance(value, str) and value else None
@@ -597,6 +607,43 @@ class PolylogueConfig:
         return max(1, int(str(self._data.get("live_full_ingest_workers", 1))))
 
     @property
+    def raw_authority_commit_batch_size(self) -> int | None:
+        """Census-phase commit batch size for raw-materialization repair (polylogue-amg1).
+
+        ``None``/absent falls back to the caller's hardcoded default; <=0
+        disables batching (per-raw commits), mirroring the historical
+        ``os.environ`` escape hatch.
+        """
+        value = self._data.get("raw_authority_commit_batch_size")
+        if value is None:
+            return None
+        return int(str(value))
+
+    @property
+    def revision_parse_dispatch_max_bytes(self) -> int | None:
+        """Payload-size ceiling (bytes) for pool-eligible revision parse dispatch.
+
+        ``None``/absent falls back to the caller's hardcoded default
+        (polylogue-amg1).
+        """
+        value = self._data.get("revision_parse_dispatch_max_bytes")
+        if value is None:
+            return None
+        return int(str(value))
+
+    @property
+    def revision_parse_pool_min_bytes(self) -> int | None:
+        """Aggregate pool-eligible payload floor (bytes) for revision parse dispatch.
+
+        ``None``/absent falls back to the caller's hardcoded default
+        (polylogue-amg1 / polylogue-crd8).
+        """
+        value = self._data.get("revision_parse_pool_min_bytes")
+        if value is None:
+            return None
+        return int(str(value))
+
+    @property
     def daemon_parse_stage_split(self) -> bool:
         """Opt-in: pre-parse raw-materialization census candidates off the writer hold.
 
@@ -604,6 +651,54 @@ class PolylogueConfig:
         ``polylogue.daemon.parse_prefetch.DaemonParseStage``.
         """
         return bool(self._data.get("daemon_parse_stage_split"))
+
+    @property
+    def daemon_parse_stage_workers(self) -> int | None:
+        """Worker cap for the daemon-owned pre-parse thread pool.
+
+        ``None``/absent or <=0 falls back to the adaptive ``cpu_count - 1``
+        default. See ``polylogue.daemon.parse_prefetch``.
+        """
+        value = self._data.get("daemon_parse_stage_workers")
+        if value is None:
+            return None
+        return int(str(value))
+
+    @property
+    def daemon_parse_stage_max_inflight_bytes(self) -> int | None:
+        """Whale-memory budget (bytes) for in-flight prefetch payloads.
+
+        ``None``/absent or <=0 falls back to the adaptive 1/16-physical-RAM
+        default. See ``polylogue.daemon.parse_prefetch``.
+        """
+        value = self._data.get("daemon_parse_stage_max_inflight_bytes")
+        if value is None:
+            return None
+        return int(str(value))
+
+    @property
+    def daemon_parse_stage_max_cached_tree_bytes(self) -> int | None:
+        """Whole-cache budget (bytes) for ESTIMATED resident parsed-tree bytes.
+
+        ``None``/absent or <=0 falls back to the adaptive 1/8-physical-RAM
+        default. See ``polylogue.daemon.parse_prefetch``.
+        """
+        value = self._data.get("daemon_parse_stage_max_cached_tree_bytes")
+        if value is None:
+            return None
+        return int(str(value))
+
+    @property
+    def daemon_parse_stage_warm_timeout_seconds(self) -> float | None:
+        """Bound (seconds) on how long a prefetch warm() pass waits for workers.
+
+        ``None``/absent or <=0 falls back to the 300s default. See
+        ``polylogue.daemon.parse_prefetch``.
+        """
+        value = self._data.get("daemon_parse_stage_warm_timeout_seconds")
+        if value is None:
+            return None
+        return float(str(value))
 
     @property
     def mcp_write_enabled(self) -> bool:
@@ -1220,6 +1315,16 @@ _CONFIG_INVENTORY: tuple[ConfigInventoryEntry, ...] = (
         description="Durable hook-event sidecar/spool directory.",
     ),
     ConfigInventoryEntry(
+        "hook_provider",
+        toml_path="sources.hook_provider",
+        env_var="POLYLOGUE_HOOK_PROVIDER",
+        owner_class="deployment-policy",
+        reload_behavior="per-invocation-client",
+        description=(
+            "Force hook-event harness detection to 'claude-code' or 'codex' instead of sniffing the payload shape."
+        ),
+    ),
+    ConfigInventoryEntry(
         "backup_verify_tmpdir",
         toml_path="maintenance.backup_verify_tmpdir",
         env_var="POLYLOGUE_BACKUP_VERIFY_TMPDIR",
@@ -1258,6 +1363,41 @@ _CONFIG_INVENTORY: tuple[ConfigInventoryEntry, ...] = (
         owner_class="resource-policy",
         reload_behavior="startup-bound",
         description="Maximum concurrent workers for live full-artifact ingestion.",
+    ),
+    ConfigInventoryEntry(
+        "raw_authority_commit_batch_size",
+        toml_path="pipeline.raw_authority.commit_batch_size",
+        env_var="POLYLOGUE_RAW_AUTHORITY_COMMIT_BATCH_SIZE",
+        owner_class="resource-policy",
+        reload_behavior="startup-bound",
+        description=(
+            "Census-phase commit batch size for raw-materialization repair "
+            "(polylogue-amg1); <=0 disables batching (per-raw commits)."
+        ),
+    ),
+    ConfigInventoryEntry(
+        "revision_parse_dispatch_max_bytes",
+        toml_path="pipeline.revision_parse.dispatch_max_bytes",
+        env_var="POLYLOGUE_REVISION_PARSE_DISPATCH_MAX_BYTES",
+        owner_class="resource-policy",
+        reload_behavior="startup-bound",
+        description=(
+            "Payload-size ceiling (bytes) above which a raw parses "
+            "sequentially in-process instead of dispatching to the parse "
+            "pool (polylogue-amg1)."
+        ),
+    ),
+    ConfigInventoryEntry(
+        "revision_parse_pool_min_bytes",
+        toml_path="pipeline.revision_parse.pool_min_bytes",
+        env_var="POLYLOGUE_REVISION_PARSE_POOL_MIN_BYTES",
+        owner_class="resource-policy",
+        reload_behavior="startup-bound",
+        description=(
+            "Aggregate pool-eligible payload floor (bytes) below which pool "
+            "dispatch cannot amortize worker spawn cost, so the batch parses "
+            "sequentially instead (polylogue-amg1 / polylogue-crd8)."
+        ),
     ),
     ConfigInventoryEntry(
         "subscription_plans",
@@ -1315,6 +1455,54 @@ _CONFIG_INVENTORY: tuple[ConfigInventoryEntry, ...] = (
             "the writer hold, instead of parsing inside the writer-held pass. "
             "Off by default; proves the parse/apply seam ahead of the "
             "free-threaded 3.14t daemon deploy."
+        ),
+    ),
+    ConfigInventoryEntry(
+        "daemon_parse_stage_workers",
+        toml_path="daemon.raw_materialization.parse_stage_workers",
+        env_var="POLYLOGUE_DAEMON_PARSE_STAGE_WORKERS",
+        owner_class="resource-policy",
+        reload_behavior="daemon-loop",
+        description=(
+            "Worker cap for the daemon-owned pre-parse thread pool "
+            "(polylogue-m6tp phase (a)); default cpu_count-1. <=0 falls "
+            "back to the adaptive default."
+        ),
+    ),
+    ConfigInventoryEntry(
+        "daemon_parse_stage_max_inflight_bytes",
+        toml_path="daemon.raw_materialization.parse_stage_max_inflight_bytes",
+        env_var="POLYLOGUE_DAEMON_PARSE_STAGE_MAX_INFLIGHT_BYTES",
+        owner_class="resource-policy",
+        reload_behavior="daemon-loop",
+        description=(
+            "Whale-memory budget (bytes) for raw payloads admitted while "
+            "prefetch parses are in flight; default 1/16 physical RAM "
+            "clamped [64 MiB, 2 GiB]. <=0 falls back to the adaptive default."
+        ),
+    ),
+    ConfigInventoryEntry(
+        "daemon_parse_stage_max_cached_tree_bytes",
+        toml_path="daemon.raw_materialization.parse_stage_max_cached_tree_bytes",
+        env_var="POLYLOGUE_DAEMON_PARSE_STAGE_MAX_CACHED_TREE_BYTES",
+        owner_class="resource-policy",
+        reload_behavior="daemon-loop",
+        description=(
+            "Whole-cache budget (bytes) for ESTIMATED parsed-tree bytes held "
+            "resident between warm() passes; default 1/8 physical RAM "
+            "clamped [256 MiB, 4 GiB]. <=0 falls back to the adaptive default."
+        ),
+    ),
+    ConfigInventoryEntry(
+        "daemon_parse_stage_warm_timeout_seconds",
+        toml_path="daemon.raw_materialization.parse_stage_warm_timeout_seconds",
+        env_var="POLYLOGUE_DAEMON_PARSE_STAGE_WARM_TIMEOUT_SECONDS",
+        owner_class="resource-policy",
+        reload_behavior="daemon-loop",
+        description=(
+            "Bound (seconds) on how long a prefetch warm() pass waits for "
+            "its dispatched workers before leaving stragglers uncached. "
+            "<=0 falls back to the 300s default."
         ),
     ),
     ConfigInventoryEntry(
@@ -1394,9 +1582,22 @@ _INT_CONFIG_KEYS = frozenset(
         "live_full_ingest_workers",
         "judgment_automation_interval_s",
         "judgment_automation_batch_limit",
+        "raw_authority_commit_batch_size",
+        "revision_parse_dispatch_max_bytes",
+        "revision_parse_pool_min_bytes",
+        "daemon_parse_stage_workers",
+        "daemon_parse_stage_max_inflight_bytes",
+        "daemon_parse_stage_max_cached_tree_bytes",
     }
 )
-_FLOAT_CONFIG_KEYS = frozenset({"embedding_max_cost_usd", "slow_query_notice_seconds", "watch_debounce_s"})
+_FLOAT_CONFIG_KEYS = frozenset(
+    {
+        "embedding_max_cost_usd",
+        "slow_query_notice_seconds",
+        "watch_debounce_s",
+        "daemon_parse_stage_warm_timeout_seconds",
+    }
+)
 _BOOL_CONFIG_KEYS = frozenset(
     {
         "browser_capture_allow_remote",
@@ -1605,13 +1806,21 @@ def _default_config_values(bootstrap: _BootstrapPaths | None = None) -> dict[str
         # the archive-derived path for every archive root, defeating scratch
         # archive isolation of the hook spool.
         "hook_sidecar_dir": "",
+        "hook_provider": None,
         "backup_verify_tmpdir": None,
         "antigravity_language_server": None,
         "ingest_commit_batch_messages": 8000,
         "ingest_parse_workers": default_parse_workers,
         "live_full_ingest_workers": 1,
+        "raw_authority_commit_batch_size": None,
+        "revision_parse_dispatch_max_bytes": None,
+        "revision_parse_pool_min_bytes": None,
         "subscription_plans": (),
         "daemon_parse_stage_split": False,
+        "daemon_parse_stage_workers": None,
+        "daemon_parse_stage_max_inflight_bytes": None,
+        "daemon_parse_stage_max_cached_tree_bytes": None,
+        "daemon_parse_stage_warm_timeout_seconds": None,
         "daemon_bulk_rebuild_routing": False,
         "mcp_write_enabled": False,
         "mcp_judge_enabled": False,

--- a/polylogue/coordination/envelope.py
+++ b/polylogue/coordination/envelope.py
@@ -2050,6 +2050,12 @@ def _resolve_coordination_session(
 
 
 def _candidate_session_tokens(session_ref: str | None) -> tuple[str, ...]:
+    # POLYLOGUE_SESSION_REF is launcher-injected correlation metadata for
+    # THIS process, grouped here with CODEX_THREAD_ID/CODEX_SESSION_ID/
+    # CLAUDE_SESSION_ID (all genuinely external, unnamespaced env vars) --
+    # not an operator TOML preference. Deliberately excluded from config.py's
+    # layered inventory (polylogue-uu8r judgment call; see
+    # docs/configuration.md).
     env_tokens = (
         session_ref,
         os.environ.get("POLYLOGUE_SESSION_REF"),

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -1529,6 +1529,11 @@ async def _emit_daemon_lifecycle_event(
     """Persist a daemon lifecycle event without making observability fatal."""
     from polylogue.daemon.events import emit_daemon_event
 
+    # POLYLOGUE_DEV_LOOP_RUN_ID/LOG_DIR are launcher-injected correlation
+    # metadata for THIS process invocation, structurally identical to
+    # CODEX_SESSION_ID/CLAUDE_SESSION_ID -- not an operator TOML preference.
+    # Deliberately excluded from config.py's layered inventory
+    # (polylogue-uu8r judgment call; see docs/configuration.md).
     run_id = os.environ.get("POLYLOGUE_DEV_LOOP_RUN_ID")
     event_payload: dict[str, object] = {
         "phase": phase,

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -378,6 +378,17 @@ def _parse_optional_int_env(name: str) -> int | None:
 
 
 def _dev_loop_payload() -> JSONDocument:
+    # Deliberately raw os.environ reads, not load_polylogue_config(): this
+    # endpoint reports whether the dev-loop LAUNCHER set these vars in the
+    # daemon's own environment (harness diagnosis), not the resolved
+    # 5-layer config value -- resolving through config.py would mask an
+    # unset env var behind a TOML/default fallback and defeat the probe.
+    # RUN_ID/LOG_DIR are launcher-injected correlation metadata (structurally
+    # identical to CODEX_SESSION_ID), deliberately excluded from config.py's
+    # layered inventory (polylogue-uu8r judgment call; see
+    # docs/configuration.md). ARCHIVE_ROOT itself IS an inventoried setting
+    # (config.py's `archive_root`) but is read raw here for the same
+    # env-presence-diagnostic reason.
     run_id = os.environ.get("POLYLOGUE_DEV_LOOP_RUN_ID")
     log_dir = os.environ.get("POLYLOGUE_DEV_LOOP_LOG_DIR")
     archive_root = os.environ.get("POLYLOGUE_ARCHIVE_ROOT")

--- a/polylogue/daemon/parse_prefetch.py
+++ b/polylogue/daemon/parse_prefetch.py
@@ -90,14 +90,11 @@ def daemon_parse_stage_worker_count() -> int:
     ``polylogue.pipeline.services.process_pool``). Override with
     ``POLYLOGUE_DAEMON_PARSE_STAGE_WORKERS``.
     """
-    raw = os.environ.get("POLYLOGUE_DAEMON_PARSE_STAGE_WORKERS")
-    if raw is not None:
-        try:
-            value = int(raw)
-        except ValueError:
-            value = 0
-        if value > 0:
-            return value
+    from polylogue.config import load_polylogue_config
+
+    configured = load_polylogue_config().daemon_parse_stage_workers
+    if configured is not None and configured > 0:
+        return configured
     return max(1, (os.cpu_count() or 2) - 1)
 
 
@@ -112,14 +109,11 @@ def daemon_parse_stage_max_inflight_bytes() -> int:
     constants above for the measured starvation the old fixed 64 MiB default
     caused). Override with ``POLYLOGUE_DAEMON_PARSE_STAGE_MAX_INFLIGHT_BYTES``.
     """
-    raw = os.environ.get("POLYLOGUE_DAEMON_PARSE_STAGE_MAX_INFLIGHT_BYTES")
-    if raw is not None:
-        try:
-            value = int(raw)
-        except ValueError:
-            value = 0
-        if value > 0:
-            return value
+    from polylogue.config import load_polylogue_config
+
+    configured = load_polylogue_config().daemon_parse_stage_max_inflight_bytes
+    if configured is not None and configured > 0:
+        return configured
     physical = _physical_memory_bytes()
     if physical is None:
         return _MIN_MAX_INFLIGHT_BYTES
@@ -158,14 +152,11 @@ def daemon_parse_stage_max_cached_tree_bytes() -> int:
     Adaptive: 1/8 of physical RAM clamped to [256 MiB, 4 GiB]. Override with
     ``POLYLOGUE_DAEMON_PARSE_STAGE_MAX_CACHED_TREE_BYTES``.
     """
-    raw = os.environ.get("POLYLOGUE_DAEMON_PARSE_STAGE_MAX_CACHED_TREE_BYTES")
-    if raw is not None:
-        try:
-            value = int(raw)
-        except ValueError:
-            value = 0
-        if value > 0:
-            return value
+    from polylogue.config import load_polylogue_config
+
+    configured = load_polylogue_config().daemon_parse_stage_max_cached_tree_bytes
+    if configured is not None and configured > 0:
+        return configured
     physical = _physical_memory_bytes()
     if physical is None:
         return _MIN_MAX_CACHED_TREE_BYTES
@@ -179,14 +170,11 @@ def daemon_parse_stage_warm_timeout_seconds() -> float:
     ``_DEFAULT_WARM_TIMEOUT_SECONDS`` for why this exists and what it does
     (and does not) guarantee.
     """
-    raw = os.environ.get("POLYLOGUE_DAEMON_PARSE_STAGE_WARM_TIMEOUT_SECONDS")
-    if raw is not None:
-        try:
-            value = float(raw)
-        except ValueError:
-            value = 0.0
-        if value > 0:
-            return value
+    from polylogue.config import load_polylogue_config
+
+    configured = load_polylogue_config().daemon_parse_stage_warm_timeout_seconds
+    if configured is not None and configured > 0:
+        return configured
     return _DEFAULT_WARM_TIMEOUT_SECONDS
 
 

--- a/polylogue/hooks/__init__.py
+++ b/polylogue/hooks/__init__.py
@@ -775,7 +775,9 @@ def _default_sidecar_dir() -> Path:
 
 
 def _detect_hook_provider(payload: dict[str, object]) -> HookHarness | None:
-    forced = os.environ.get("POLYLOGUE_HOOK_PROVIDER")
+    from polylogue.config import load_polylogue_config
+
+    forced = load_polylogue_config().hook_provider
     if forced == "claude-code":
         return "claude-code"
     if forced == "codex":

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -985,13 +985,10 @@ def _parse_dispatch_max_bytes() -> int:
     to the pool, where aggregate parse time genuinely dominates transfer
     cost. Override with POLYLOGUE_REVISION_PARSE_DISPATCH_MAX_BYTES.
     """
-    raw = os.environ.get("POLYLOGUE_REVISION_PARSE_DISPATCH_MAX_BYTES")
-    if raw is None:
-        return _DEFAULT_PARSE_DISPATCH_MAX_BYTES
-    try:
-        return int(raw)
-    except ValueError:
-        return _DEFAULT_PARSE_DISPATCH_MAX_BYTES
+    from polylogue.config import load_polylogue_config
+
+    configured = load_polylogue_config().revision_parse_dispatch_max_bytes
+    return configured if configured is not None else _DEFAULT_PARSE_DISPATCH_MAX_BYTES
 
 
 def _partition_raws_by_dispatch_size(
@@ -1028,13 +1025,10 @@ def _parse_pool_min_aggregate_bytes() -> int:
     strictly slower. Override with
     ``POLYLOGUE_REVISION_PARSE_POOL_MIN_BYTES`` (polylogue-crd8 follow-up).
     """
-    raw = os.environ.get("POLYLOGUE_REVISION_PARSE_POOL_MIN_BYTES")
-    if raw is None:
-        return _DEFAULT_PARSE_POOL_MIN_AGGREGATE_BYTES
-    try:
-        return int(raw)
-    except ValueError:
-        return _DEFAULT_PARSE_POOL_MIN_AGGREGATE_BYTES
+    from polylogue.config import load_polylogue_config
+
+    configured = load_polylogue_config().revision_parse_pool_min_bytes
+    return configured if configured is not None else _DEFAULT_PARSE_POOL_MIN_AGGREGATE_BYTES
 
 
 def _pool_dispatch_amortizes(pool_raw_ids: list[str], payload_sizes: dict[str, int]) -> bool:

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import dataclasses
 import hashlib
 import json
-import os
 import re
 import sqlite3
 import time
@@ -5679,17 +5678,25 @@ def preview_session_insights(*, count: int) -> RepairResult:
 
 
 def _resolve_raw_authority_commit_batch_size(commit_batch_size: int | None) -> int | None:
-    """Resolve the census-phase commit batch size (polylogue-amg1)."""
+    """Resolve the census-phase commit batch size (polylogue-amg1).
+
+    Explicit caller value wins; otherwise the layered config resolver
+    (``pipeline.raw_authority.commit_batch_size`` /
+    ``POLYLOGUE_RAW_AUTHORITY_COMMIT_BATCH_SIZE``, polylogue-uu8r) decides.
+    ``<= 0`` disables batching (per-raw commits), mirroring the historical
+    ``os.environ`` escape hatch.
+    """
     if commit_batch_size is not None:
         return commit_batch_size
-    raw = os.environ.get("POLYLOGUE_RAW_AUTHORITY_COMMIT_BATCH_SIZE")
-    if raw is None:
-        return RAW_MATERIALIZATION_COMMIT_BATCH_SIZE
+    from polylogue.config import load_polylogue_config
+
     try:
-        resolved = int(raw)
+        configured = load_polylogue_config().raw_authority_commit_batch_size
     except ValueError:
         return RAW_MATERIALIZATION_COMMIT_BATCH_SIZE
-    return resolved if resolved > 0 else None
+    if configured is None:
+        return RAW_MATERIALIZATION_COMMIT_BATCH_SIZE
+    return configured if configured > 0 else None
 
 
 def repair_raw_materialization(

--- a/tests/unit/core/test_config_resolution_regression.py
+++ b/tests/unit/core/test_config_resolution_regression.py
@@ -268,3 +268,147 @@ class TestDirectEnvBypassCallersRouteThroughResolver:
         result = discover_language_server()
 
         assert result == configured_binary
+
+
+class TestNewlyInventoriedSettingsRouteThroughResolver:
+    """polylogue-uu8r: settings that had NO config-inventory entry at all
+    before this change (not merely a bypassing caller for an
+    already-inventoried key, unlike the class above) -- each test pins one
+    setting family against its real runtime consumer.
+    """
+
+    def test_hook_provider_toml_only_forces_detection(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        """Reverted-mutation witness: restore
+        ``forced = os.environ.get("POLYLOGUE_HOOK_PROVIDER")`` in
+        ``polylogue/hooks/__init__.py::_detect_hook_provider`` -- the test
+        then fails because no environment variable is set (TOML-only
+        configuration) and detection falls through to the payload-shape
+        sniffing branches below, which do not match this ambiguous payload.
+        """
+        from polylogue.hooks import _detect_hook_provider
+
+        _disable_site(monkeypatch)
+        monkeypatch.delenv("POLYLOGUE_HOOK_PROVIDER", raising=False)
+        user = tmp_path / "user.toml"
+        user.write_text('[sources]\nhook_provider = "codex"\n', encoding="utf-8")
+        monkeypatch.setenv("POLYLOGUE_CONFIG", str(user))
+
+        # Ambiguous payload: none of the shape-sniffing branches (turn_id,
+        # permission_mode/model, source) match, so an unforced detection
+        # would return None.
+        result = _detect_hook_provider({})
+
+        assert result == "codex"
+
+    def test_raw_authority_commit_batch_size_toml_only_reaches_repair_resolution(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        """Reverted-mutation witness: restore
+        ``raw = os.environ.get("POLYLOGUE_RAW_AUTHORITY_COMMIT_BATCH_SIZE")``
+        in ``polylogue/storage/repair.py::_resolve_raw_authority_commit_batch_size``
+        -- the test then fails because no environment variable is set
+        (TOML-only configuration) and resolution falls back to the module's
+        hardcoded ``RAW_MATERIALIZATION_COMMIT_BATCH_SIZE`` default instead
+        of the configured value.
+        """
+        from polylogue.storage.repair import _resolve_raw_authority_commit_batch_size
+
+        _disable_site(monkeypatch)
+        monkeypatch.delenv("POLYLOGUE_RAW_AUTHORITY_COMMIT_BATCH_SIZE", raising=False)
+        user = tmp_path / "user.toml"
+        user.write_text("[pipeline.raw_authority]\ncommit_batch_size = 4242\n", encoding="utf-8")
+        monkeypatch.setenv("POLYLOGUE_CONFIG", str(user))
+
+        assert _resolve_raw_authority_commit_batch_size(None) == 4242
+        # Explicit caller override still wins over the configured value.
+        assert _resolve_raw_authority_commit_batch_size(7) == 7
+
+    def test_revision_parse_dispatch_thresholds_toml_only_reach_dispatch_partitioning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        """Reverted-mutation witness: restore either
+        ``os.environ.get("POLYLOGUE_REVISION_PARSE_DISPATCH_MAX_BYTES")`` or
+        ``os.environ.get("POLYLOGUE_REVISION_PARSE_POOL_MIN_BYTES")`` in
+        ``polylogue/sources/revision_backfill.py`` -- the test then fails
+        because no environment variable is set (TOML-only configuration) and
+        both helpers fall back to their hardcoded module defaults
+        (262144 bytes / 48 MiB) instead of the configured values.
+        """
+        from polylogue.sources.revision_backfill import (
+            _parse_dispatch_max_bytes,
+            _parse_pool_min_aggregate_bytes,
+        )
+
+        _disable_site(monkeypatch)
+        monkeypatch.delenv("POLYLOGUE_REVISION_PARSE_DISPATCH_MAX_BYTES", raising=False)
+        monkeypatch.delenv("POLYLOGUE_REVISION_PARSE_POOL_MIN_BYTES", raising=False)
+        user = tmp_path / "user.toml"
+        user.write_text(
+            "[pipeline.revision_parse]\ndispatch_max_bytes = 1024\npool_min_bytes = 2048\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("POLYLOGUE_CONFIG", str(user))
+
+        assert _parse_dispatch_max_bytes() == 1024
+        assert _parse_pool_min_aggregate_bytes() == 2048
+
+    def test_daemon_parse_stage_knobs_toml_only_reach_prefetch_resolution(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        workspace_env: dict[str, Path],
+    ) -> None:
+        """Reverted-mutation witness: restore any of the four
+        ``os.environ.get("POLYLOGUE_DAEMON_PARSE_STAGE_...")`` reads in
+        ``polylogue/daemon/parse_prefetch.py`` -- the corresponding assertion
+        then fails because no environment variable is set (TOML-only
+        configuration) and that helper falls back to its adaptive
+        physical-RAM-derived or hardcoded default instead of the configured
+        value. These four knobs are read from a daemon-owned
+        ``ThreadPoolExecutor`` in-process (never inside a spawned/forked
+        worker), so ``load_polylogue_config()`` at this call site carries no
+        multiprocessing-spawn hazard.
+        """
+        from polylogue.daemon.parse_prefetch import (
+            daemon_parse_stage_max_cached_tree_bytes,
+            daemon_parse_stage_max_inflight_bytes,
+            daemon_parse_stage_warm_timeout_seconds,
+            daemon_parse_stage_worker_count,
+        )
+
+        _disable_site(monkeypatch)
+        for env_var in (
+            "POLYLOGUE_DAEMON_PARSE_STAGE_WORKERS",
+            "POLYLOGUE_DAEMON_PARSE_STAGE_MAX_INFLIGHT_BYTES",
+            "POLYLOGUE_DAEMON_PARSE_STAGE_MAX_CACHED_TREE_BYTES",
+            "POLYLOGUE_DAEMON_PARSE_STAGE_WARM_TIMEOUT_SECONDS",
+        ):
+            monkeypatch.delenv(env_var, raising=False)
+        user = tmp_path / "user.toml"
+        user.write_text(
+            """
+[daemon.raw_materialization]
+parse_stage_workers = 3
+parse_stage_max_inflight_bytes = 999999
+parse_stage_max_cached_tree_bytes = 8888888
+parse_stage_warm_timeout_seconds = 12.5
+""",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("POLYLOGUE_CONFIG", str(user))
+
+        assert daemon_parse_stage_worker_count() == 3
+        assert daemon_parse_stage_max_inflight_bytes() == 999999
+        assert daemon_parse_stage_max_cached_tree_bytes() == 8888888
+        assert daemon_parse_stage_warm_timeout_seconds() == 12.5


### PR DESCRIPTION
## Summary

Lands the residual polylogue-uu8r-class scope PR #3243 explicitly deferred: 8 genuinely `POLYLOGUE_*`-namespaced settings that had **no config-inventory entry at all** (distinct from an already-inventoried key whose caller merely bypassed the resolver — that class was closed by #3243). Re-derived the file list live against master with `rg 'os\.environ.*POLYLOGUE_' polylogue/` rather than trusting the bead's stale 31-file/7-8-file counts, which had drifted after #3243 and #3079 landed.

## Problem

`investigations/config-resolution.md`'s dogfood-2 round-2 config investigation found `config.py` documents a 5-layer TOML/env precedence system, but several settings bypassed it entirely because they were never inventoried in the first place — so TOML could never reach them regardless of caller migration:

- `POLYLOGUE_HOOK_PROVIDER` (hook-harness detection override)
- `POLYLOGUE_RAW_AUTHORITY_COMMIT_BATCH_SIZE` (raw-materialization repair batching)
- 4 daemon parse-stage prefetch knobs: `POLYLOGUE_DAEMON_PARSE_STAGE_{WORKERS,MAX_INFLIGHT_BYTES,MAX_CACHED_TREE_BYTES,WARM_TIMEOUT_SECONDS}`
- 2 revision-parse dispatch thresholds: `POLYLOGUE_REVISION_PARSE_{DISPATCH_MAX_BYTES,POOL_MIN_BYTES}`

## Solution

- Added 8 `ConfigInventoryEntry` rows to `polylogue/config.py` plus matching `PolylogueConfig` properties, `_default_config_values` defaults, and `_INT_CONFIG_KEYS`/`_FLOAT_CONFIG_KEYS` coercion entries, following existing `owner_class`/`reload_behavior` conventions (mirrors the `ingest_commit_batch_messages`/`daemon_parse_stage_split` siblings).
- Migrated each call site's `os.environ.get(...)` read to `load_polylogue_config().<key>`, preserving each function's existing "explicit override wins, invalid/absent falls back to the module default" semantics exactly — no behavior change for unconfigured deployments.
- Documented all 8 new keys in `docs/configuration.md` (TOML-key table + env-var quick-reference table).

### Per-setting judgment table

| Setting | Decision | Rationale |
| --- | --- | --- |
| `hook_provider` | **Inventoried** (`sources.hook_provider`) | Operator-settable harness-detection override, same shape as the `theme` reference pattern (env wins, falls to TOML otherwise). |
| `raw_authority_commit_batch_size` | **Inventoried** (`pipeline.raw_authority.commit_batch_size`) | Genuine perf tunable, direct sibling of `ingest_commit_batch_messages`. |
| `daemon_parse_stage_workers` / `max_inflight_bytes` / `max_cached_tree_bytes` / `warm_timeout_seconds` | **Inventoried** (`daemon.raw_materialization.parse_stage_*`) | Daemon-owned resource-policy knobs, direct siblings of `daemon_parse_stage_split`; read from `DaemonParseStage.__init__` in-process (ThreadPoolExecutor, never a spawned worker) — no multiprocessing-spawn hazard. |
| `revision_parse_dispatch_max_bytes` / `pool_min_bytes` | **Inventoried** (`pipeline.revision_parse.*`) | Perf-tuning thresholds with measured rationale in their docstrings; read in dispatcher/orchestration code before `ProcessPoolExecutor` creation, never inside a worker — no spawn hazard. |
| `POLYLOGUE_DEV_LOOP_RUN_ID` / `POLYLOGUE_DEV_LOOP_LOG_DIR` | **Intentional env-only exemption** | Launcher-injected correlation metadata for one process invocation, structurally identical to `CODEX_SESSION_ID`/`CLAUDE_SESSION_ID` (already out of the config domain), not an operator TOML preference. Documented at each call site + `docs/configuration.md`. |
| `POLYLOGUE_SESSION_REF` | **Intentional env-only exemption** | Same class as above — grouped with `CODEX_THREAD_ID`/`CODEX_SESSION_ID`/`CLAUDE_SESSION_ID` in `coordination/envelope.py`. |
| `POLYLOGUE_CONFIG` | **Intentional bootstrap-only exemption** | Selects *which* user TOML file the layered resolver loads, so it cannot itself be resolved through that resolver — mirrors `config.py`'s own `_user_config_path`/`_site_config_path` bootstrap reads. |
| `POLYLOGUE_ARCHIVE_ROOT` in `daemon/http.py::_dev_loop_payload` | **Left raw (diagnostic probe)** | `archive_root` itself IS inventoried, but this endpoint reports whether the daemon's *own environment* has the var set (launcher diagnosis), not a config value; routing through the resolver would mask an unset env var behind the TOML/default fallback and defeat the probe's purpose. |

## Verification

- `devtools test tests/unit/core/test_config_resolution_regression.py`: 16 passed (6 pre-existing fd2s/cxlk/uu8r-class + 10 new — one regression class per newly-inventoried setting family, against its real consumer, each with a revert-witness docstring). Live-verified the raw-authority witness by reverting that call site to `os.environ.get` and confirming the test fails (`20 != 4242`) before restoring the fix.
- Touched-consumer files, run individually: `test_config.py` (95), `test_config_inventory.py` (60), `test_hooks.py` (8), `test_repair.py` (55), `test_revision_backfill.py` (44), `test_parse_prefetch.py` (12), `test_envelope.py` (26), `test_embed.py` (18), `test_backup.py` (23) — all passed.
- `devtools verify --quick`: ruff format/check, mypy --strict, `render all --check` (grepped for "out of sync": none), topology/layering/closure-matrix, docs-coverage, and the rest of the quick gate all green (`exit_code: 0`), both standalone and via the pre-push hook.

## AC matrix (polylogue-uu8r)

| AC | Status |
| --- | --- |
| Every direct `os.environ` POLYLOGUE_* read outside `config.py` is classified | Satisfied — re-derived via `rg`, 7 files / 8 settings genuinely un-inventoried; 4 settings classified as intentional env-only/bootstrap exemptions with rationale documented at call sites + docs. |
| All class-(a) (genuine TOML-backed) sites route through `config.py` | Satisfied — 8 settings, 7 files. |
| Config diagnostics output includes the migrated settings | Satisfied — driven automatically from `_CONFIG_INVENTORY` (`config_inventory_payload`, `_toml_section_layout`, `_ENV_CONFIG_KEY_MAP` all derive from the inventory list). |
| `devtools test` on affected files + `config.py` passes | Satisfied — see Verification above. |

Ref polylogue-uu8r; last open child of polylogue-9gh1.