### PR TITLE
refactor(sources): migrate all eleven origins onto OriginSpec (polylogue-2qx.1.2)

### DIFF
--- a/docs/provider-origin-identity.md
+++ b/docs/provider-origin-identity.md
@@ -62,6 +62,30 @@ replace archive object identity.
 | Repo/workspace context | repo name, cwd, git branch, workspace, working directories | User-work context attached to a session/action/run. | Yes as filters | Use `repo`, `cwd`, `workspace`, and related fields for query/successor-context context. They are not source identity. |
 | Privacy/disclosure posture | raw-path redaction, browser capture auth, web shell raw preview policy, MCP role, export policy | What can be shown, exported, logged, or sent across a surface. | Yes as policy/status | Make disclosure explicit in route/read payloads. Do not infer safe exposure from provider, origin, or source path. |
 
+## Origin admission (`polylogue/sources/origin_specs.py`)
+
+`polylogue/sources/origin_specs.py` is the one typed admission declaration for
+every current `Origin` token (`claude-code-session`, `codex-session`,
+`gemini-cli-session`, `hermes-session`, `antigravity-session`, `beads-issue`,
+`grok-export`, `chatgpt-export`, `claude-ai-export`, `aistudio-drive`,
+`unknown-export`): lifecycle (`executable` / `reserved` / `unsupported` /
+`compatibility-only`), acquisition modes, detector tightness, parser/stream-
+parser/assembly bindings, non-injective provider-wire collision policy,
+coverage refs, fixtures, and semantic-reparse consequence. It is registered
+once, checked for exact `Origin`-enum parity at import time
+(`OriginSpecRegistry.diagnostics()`), and is the single source that
+`polylogue/sources/provider_completeness.py`'s package-mode rows and this
+doc's per-origin facts should trace back to — do not hand-maintain a second
+per-origin token list elsewhere in the codebase. Two properties this doc's
+"Current Code Invariants" below depend on are parity-checked against live
+production code rather than merely declared: `validate_dispatch_precedence`
+checks detector tightness against `sources/dispatch.py`'s actual record-shape
+branch order, and `validate_assembly_spec_parity` checks each origin's
+declared `assembly_spec_path` against the live per-provider
+`ProviderAssemblySpec` returned by `polylogue.sources.assembly.get_assembly_spec`
+(the Claude Code, Codex, and AI Studio/Drive sidecar/title/orchestration
+enrichment hook that polylogue-2qx.2/j2zz/ih67 extend).
+
 ## Current Code Invariants
 
 - `Origin` is the public archive source-origin vocabulary. Query specs,

--- a/polylogue/sources/origin_specs.py
+++ b/polylogue/sources/origin_specs.py
@@ -19,6 +19,7 @@ compatibility-only.
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import Literal
 
@@ -99,6 +100,15 @@ class OriginSpec:
     semantic_reparse: str
     artifact_rules: tuple[OriginArtifactRule, ...] = ()
     completeness_modes: tuple[OriginCompletenessMode, ...] = ()
+    #: ``"module/path.py:ClassName"`` for the ``ProviderAssemblySpec`` this
+    #: origin's provider wire binds in ``polylogue.sources.assembly.get_assembly_spec``,
+    #: or ``None`` when no sidecar/title/orchestration enrichment hook exists.
+    #: This is the one typed admission point for the assembly-layer
+    #: orchestration/title extensions that polylogue-2qx.2, polylogue-j2zz, and
+    #: polylogue-ih67 build on -- it is validated against the live
+    #: ``get_assembly_spec`` registry by :func:`validate_assembly_spec_parity`
+    #: rather than replacing that registry with a second one.
+    assembly_spec_path: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -332,6 +342,7 @@ def _claude_code_spec() -> OriginSpec:
                 path_suffixes=(".jsonl", ".ndjson"),
             ),
         ),
+        assembly_spec_path="polylogue/sources/assembly_claude_code.py:ClaudeCodeAssemblySpec",
     )
 
 
@@ -422,6 +433,7 @@ def _executable_spec(
     stream_parser_path: str | None = None,
     assembly_paths: tuple[str, ...] = (),
     fidelity_notes: tuple[str, ...] = (),
+    assembly_spec_path: str | None = None,
 ) -> OriginSpec:
     return OriginSpec(
         origin=origin,
@@ -438,6 +450,7 @@ def _executable_spec(
         coverage_refs=(f"origin:{origin.value}:admitted",),
         fidelity_notes=fidelity_notes,
         semantic_reparse=f"reparse when {origin.value} parser fingerprints change",
+        assembly_spec_path=assembly_spec_path,
     )
 
 
@@ -451,6 +464,7 @@ def _codex_spec() -> OriginSpec:
         parser_paths=("polylogue/sources/parsers/codex.py",),
         fixture_paths=("tests/unit/sources/test_parsers_codex.py", "tests/data/codex_event_stream"),
         stream_parser_path="polylogue/sources/parsers/codex.py:parse_codex_stream",
+        assembly_spec_path="polylogue/sources/assembly_codex.py:CodexAssemblySpec",
     )
 
 
@@ -548,6 +562,7 @@ def _aistudio_drive_spec() -> OriginSpec:
         coverage_refs=("origin:aistudio-drive:admitted",),
         fidelity_notes=("Provider reverse mapping remains intentionally non-injective.",),
         semantic_reparse="reparse when Drive parser fingerprints change",
+        assembly_spec_path="polylogue/sources/assembly_gemini.py:GeminiAssemblySpec",
     )
 
 
@@ -923,6 +938,46 @@ def validate_stream_parser_parity(stream_record_providers: frozenset[Provider]) 
     return tuple(sorted(diagnostics, key=lambda item: (item.origin.value, item.code)))
 
 
+def validate_assembly_spec_parity(
+    assembly_spec_resolver: Callable[[Provider], object | None],
+) -> tuple[OriginSpecDiagnostic, ...]:
+    """Check declared ``assembly_spec_path`` presence against the live assembly registry.
+
+    ``polylogue.sources.assembly.get_assembly_spec`` is the current production
+    per-provider sidecar/title/orchestration enrichment factory consumed by
+    ingest (``source_walk.py``, ``emitter.py``, ``ingest_worker.py``). This is
+    the one typed admission point polylogue-2qx.2, polylogue-j2zz, and
+    polylogue-ih67 build their assembly/orchestration/title/action extensions
+    on: a declared ``assembly_spec_path`` that must agree with whether the live
+    registry actually returns an assembly spec for the origin's provider
+    wire(s), rather than a second parallel provider-to-assembly-spec registry
+    living in this module.
+    """
+
+    diagnostics: list[OriginSpecDiagnostic] = []
+    for spec in ORIGIN_SPECS:
+        if spec.lifecycle != "executable":
+            continue
+        declares_assembly = spec.assembly_spec_path is not None
+        has_live_assembly = any(assembly_spec_resolver(provider) is not None for provider in spec.provider_wires)
+        if declares_assembly == has_live_assembly:
+            continue
+        diagnostics.append(
+            OriginSpecDiagnostic(
+                code="assembly_spec_parity_mismatch",
+                message=(
+                    f"{spec.origin.value}: live assembly registry returns a spec "
+                    f"({has_live_assembly}) but OriginSpec declares "
+                    f"assembly_spec_path={spec.assembly_spec_path!r}"
+                ),
+                origin=spec.origin,
+                owner_path=spec.declaration.owner_path,
+                repair_command=spec.declaration.repair_command,
+            )
+        )
+    return tuple(sorted(diagnostics, key=lambda item: (item.origin.value, item.code)))
+
+
 __all__ = [
     "ORIGIN_SPECS",
     "ORIGIN_SPEC_REGISTRY",
@@ -935,6 +990,7 @@ __all__ = [
     "origin_specs",
     "artifact_rule_for_path",
     "artifact_suffixes_for_provider",
+    "validate_assembly_spec_parity",
     "validate_dispatch_precedence",
     "validate_stream_parser_parity",
 ]

--- a/tests/unit/sources/test_origin_specs.py
+++ b/tests/unit/sources/test_origin_specs.py
@@ -7,12 +7,14 @@ from dataclasses import replace
 import pytest
 
 from polylogue.core.enums import Origin, Provider
+from polylogue.sources.assembly import get_assembly_spec
 from polylogue.sources.dispatch import RECORD_DETECTOR_PROVIDER_ORDER, STREAM_RECORD_PROVIDERS
 from polylogue.sources.origin_specs import (
     ORIGIN_SPEC_REGISTRY,
     ORIGIN_SPECS,
     OriginSpecRegistry,
     artifact_suffixes_for_provider,
+    validate_assembly_spec_parity,
     validate_dispatch_precedence,
     validate_stream_parser_parity,
 )
@@ -169,3 +171,42 @@ def test_origin_specs_are_parity_checked_against_stream_record_providers() -> No
     }
     assert {item.origin for item in diagnostics} == stream_origins
     assert stream_origins  # sanity: the production set is non-empty today
+
+
+def test_origin_specs_declare_the_claude_and_codex_assembly_extension_hooks() -> None:
+    """Production dependency: Claude Code and Codex admit their sidecar/title enrichment hook via OriginSpec.
+
+    This is the one typed admission point polylogue-2qx.2, polylogue-j2zz, and
+    polylogue-ih67 build their assembly/orchestration/title/action extensions
+    on, rather than a private inventory.
+    """
+    by_origin = {spec.origin: spec for spec in ORIGIN_SPECS}
+
+    assert by_origin[Origin.CLAUDE_CODE_SESSION].assembly_spec_path == (
+        "polylogue/sources/assembly_claude_code.py:ClaudeCodeAssemblySpec"
+    )
+    assert by_origin[Origin.CODEX_SESSION].assembly_spec_path == (
+        "polylogue/sources/assembly_codex.py:CodexAssemblySpec"
+    )
+    assert by_origin[Origin.AISTUDIO_DRIVE].assembly_spec_path == (
+        "polylogue/sources/assembly_gemini.py:GeminiAssemblySpec"
+    )
+    assert by_origin[Origin.GEMINI_CLI_SESSION].assembly_spec_path is None
+    assert by_origin[Origin.CHATGPT_EXPORT].assembly_spec_path is None
+
+
+def test_origin_specs_are_parity_checked_against_the_live_assembly_registry() -> None:
+    """Production dependency: declared assembly_spec_path matches polylogue.sources.assembly.get_assembly_spec.
+
+    Anti-vacuity mutation: a resolver that never returns an assembly spec makes
+    every origin that declares assembly_spec_path (Claude Code, Codex, AI
+    Studio/Drive) report a mismatch.
+    """
+    assert validate_assembly_spec_parity(get_assembly_spec) == ()
+
+    diagnostics = validate_assembly_spec_parity(lambda _provider: None)
+
+    assert {item.code for item in diagnostics} == {"assembly_spec_parity_mismatch"}
+    declared_origins = {spec.origin for spec in ORIGIN_SPECS if spec.assembly_spec_path is not None}
+    assert {item.origin for item in diagnostics} == declared_origins
+    assert declared_origins  # sanity: the production set is non-empty today


### PR DESCRIPTION
## Summary

Audits and closes the remaining gap in polylogue-2qx.1.2 ("migrate every
current origin onto OriginSpec"). Most of this bead's scope was already
shipped to `master` untagged across #3051/#3087/#3088/#3092/#3201/#3228/#3246
(closing `polylogue-2qx.1.1`'s notes confirm this). This PR verifies that
prior work end-to-end, proves the parity checks actually catch regressions
(not just pass today), and closes one concrete residual gap: a second,
un-declared provider-to-assembly-hook dispatch that Claude Code, Codex, and
AI Studio/Drive depend on.

## Problem

`polylogue/sources/origin_specs.py` already declares all eleven `Origin`
tokens with lifecycle/detector-tightness/parser/fixture/coverage bindings,
and `polylogue/sources/provider_completeness.py` already derives its rows
from `ORIGIN_SPECS` (`PACKAGE_MODE_SPECS` is a tuple comprehension over it,
parity-proven by `test_provider_completeness_is_a_projection_of_every_origin_spec`).
Dispatch-order and stream-parser-binding parity are also already
mechanically checked (`validate_dispatch_precedence`,
`validate_stream_parser_parity`) against the real production values in
`sources/dispatch.py` (`RECORD_DETECTOR_PROVIDER_ORDER`,
`STREAM_RECORD_PROVIDERS`).

What was genuinely missing: the bead's design explicitly calls for "Claude
Code and Codex specs [to] expose typed assembly/orchestration/title/action
extension hooks (consumed later by 2qx.2, j2zz, ih67) — a typed field on
the spec, not another registry." `polylogue.sources.assembly.get_assembly_spec()`
is exactly that second, un-declared provider dispatch
(`ProviderAssemblySpec` factory for `Provider.CLAUDE_CODE`/`Provider.CODEX`/
`Provider.GEMINI`) — it existed in production but had no OriginSpec
declaration or parity check, so a caller had no way to discover the hook
from `origin_specs.py` and no test would catch it drifting from the real
registry.

Also: `docs/provider-origin-identity.md` documented Provider/Origin/Source
doctrine but never pointed at `origin_specs.py` as the per-origin admission
authority a reader should trust over any hand-maintained list.

## Solution

- `polylogue/sources/origin_specs.py`: added `OriginSpec.assembly_spec_path`
  (`"module/path.py:ClassName"` or `None`) declaring which
  `ProviderAssemblySpec` a given origin's provider wire binds. Populated for
  the three origins with a real live hook: `claude-code-session` →
  `assembly_claude_code.py:ClaudeCodeAssemblySpec`, `codex-session` →
  `assembly_codex.py:CodexAssemblySpec`, `aistudio-drive` →
  `assembly_gemini.py:GeminiAssemblySpec` (its `Provider.GEMINI` wire is the
  one `get_assembly_spec` keys on). Added `validate_assembly_spec_parity()`,
  following the exact idiom of `validate_dispatch_precedence`/
  `validate_stream_parser_parity`: it checks the declared field against the
  live `get_assembly_spec(provider)` return value rather than replacing that
  registry with a second one in `origin_specs.py`.
- `tests/unit/sources/test_origin_specs.py`: two new tests — one asserting
  the three declared hook paths (and `None` for two origins without a live
  hook), one asserting `validate_assembly_spec_parity(get_assembly_spec) == ()`
  plus the mutation shape (a resolver that always returns `None` makes every
  origin that declares a hook path report `assembly_spec_parity_mismatch`).
- `docs/provider-origin-identity.md`: added an "Origin admission" section
  naming `origin_specs.py` as the per-origin declaration authority and
  pointing at both live-production parity checks.
- No parallel hand-maintained inventory was deleted, because the audit found
  none left inside my ownership (`polylogue/sources/**`) — see the residual
  below for the one still outstanding elsewhere.

### Residual found outside owned scope

`polylogue/cli/shell_completion_values.py:_ORIGIN_DESCRIPTIONS` is a
hand-maintained `dict[str, str]` of 8 of the 11 origin tokens (missing
`beads-issue`, `grok-export`, `unknown-export`) used for shell-completion
help text, and it is **not** parity-checked against `Origin`/`ORIGIN_SPECS`
the way `polylogue/agent_integration/spec.py:ORIGIN_MEANINGS` already is
(that one has a `RuntimeError` guard requiring exact `Origin`-enum order
match — already satisfies AC4, no action needed there). `cli/**` is out of
this lane's ownership (per dispatch instructions, another lane owns it
concurrently); flagging as a follow-up rather than touching it here.

## Verification

- `devtools test tests/unit/sources/test_origin_specs.py tests/unit/sources/test_provider_completeness.py` → **15 passed**
- `devtools test tests/unit/sources/ -k "origin_specs or provider_completeness or dispatch or assembly"` → **144 passed**
- `devtools test tests/unit/sources/test_parsers_props.py` (protected file) → **43 passed**
- `devtools verify --quick` → all 16 steps `ok`, `"exit_code": 0` (ruff format/check, mypy --strict, render all, topology/layering/closure-matrix, manifests, ci-workflows, doc-commands, docs-coverage, test-infra-currency, test-clock-hygiene, pytest-timeout-overrides, degrade-loudly)
- Anti-vacuity mutations, run manually then reverted (`git checkout --`), each confirmed the *existing* production dependency actually fails on the mutation before I added anything:
  - Removing `_grok_spec()` from the registration loop → `ORIGIN_SPEC_REGISTRY.diagnostics()` reports `missing_origin_spec` for `grok-export`.
  - Dropping Claude Code's `detector_tightness` below `gemini_cli_session`'s (contradicting its real last-in-branch-order position) → `validate_dispatch_precedence(RECORD_DETECTOR_PROVIDER_ORDER)` reports `dispatch_tightness_mismatch`.
  - Deleting Codex's new `assembly_spec_path` declaration → `validate_assembly_spec_parity(get_assembly_spec)` reports `assembly_spec_parity_mismatch` for `codex-session` (this is the mutation the new code in this PR is proven against).

## AC matrix (polylogue-2qx.1.2)

1. **Satisfied (pre-existing).** All eleven `Origin` tokens are declared exactly once in `ORIGIN_SPECS`; `set(by_origin) == set(Origin)` is asserted in `test_origin_specs_cover_the_public_enum_and_admission_lifecycles`, and `OriginSpecRegistry.diagnostics()` emits `missing_origin_spec` for any omission (proven above).
2. **Satisfied (pre-existing + this PR).** Every executable origin declares acquisition modes, detector/parser/stream-parser/fixture/coverage/fidelity/reparse fields; `claude-code-session` additionally declares 6 typed `OriginArtifactRule`s for its workflow/journal/transcript/sidecar/adopt-manifest/coordinator-stream family. `grok-export` is `lifecycle="executable"` today (it shipped a real parser via #3201/polylogue-611 after 2qx.1.1's pilot design assumed it would stay reserved — documented at the top of `origin_specs.py`); the `reserved` lifecycle contract itself is proven against a synthetic variant since no current `Origin` is genuinely reserved. `unknown-export` is `lifecycle="compatibility-only"` with explicit fallback semantics; `beads-issue` is executable with `issue-jsonl` acquisition and its own non-`accepted` completeness maturity caveat (no harvested schema sample yet). This PR adds the Claude/Codex/AI-Studio assembly hook declaration.
3. **Satisfied (pre-existing).** `validate_dispatch_precedence`/`validate_stream_parser_parity` parity-check tightness and stream-binding against `sources/dispatch.py`'s real `RECORD_DETECTOR_PROVIDER_ORDER`/`STREAM_RECORD_PROVIDERS`; mutation-proven above (deleting/reordering a declaration fails).
4. **Satisfied (pre-existing) for `provider_completeness.py`; this PR extends it to the assembly-hook axis.** `PACKAGE_MODE_SPECS` is a direct tuple comprehension over `ORIGIN_SPECS`, parity-proven by `test_provider_completeness_is_a_projection_of_every_origin_spec`. `agent_integration/spec.py:ORIGIN_MEANINGS` is separately parity-guarded against `Origin` at import time. **Deferred**: `cli/shell_completion_values.py:_ORIGIN_DESCRIPTIONS` remains a stale, un-parity-checked hand-maintained inventory — out of this lane's ownership (`cli/**`), flagged as a residual above rather than a named follow-up bead (small, mechanical, single-file fix for whichever lane next touches CLI completions).
5. **Satisfied (pre-existing).** `aistudio-drive`'s `provider_wires=(Provider.GEMINI, Provider.DRIVE)` with `collision_policy` is registration-enforced (`OriginSpecRegistry.register` raises `ValueError` if `len(provider_wires) > 1` without a `collision_policy`, tested in `test_origin_spec_rejects_missing_fixture_and_noninjective_collision_without_policy`); `docs/provider-origin-identity.md` already documented the non-reversal doctrine, and this PR adds the pointer from that doc to the enforcing code.
6. **Misframed — recorded honestly rather than claimed satisfied.** `polylogue-2qx.2` (Claude Code orchestration artifact admission) already closed via PR #3088, and its own close reason states it shipped as a `claude_workflow_materializer` convergence stage *without* the OriginSpec migration this bead was meant to gate — the blocking edge was explicitly force-closed as "over-blocking" because the merged implementation disproves that ordering. So AC6 as written ("Claude/Codex extension hooks are the only admission path used by 2qx.2...") cannot be retroactively true for `2qx.2`. `j2zz` (Codex child-action lowering) and `ih67` (Codex title enrichment) are still open; this PR's new `assembly_spec_path`/`validate_assembly_spec_parity` gives them a real typed admission point to consume going forward, but I did not modify `assembly_codex.py`/`ih67`/`j2zz` scope — those remain their own beads' work, not migrated by me here.

## Files touched

- `polylogue/sources/origin_specs.py`
- `tests/unit/sources/test_origin_specs.py`
- `docs/provider-origin-identity.md`

Ref polylogue-2qx.1.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance on how origin metadata is declared, validated, and kept aligned with runtime behavior.
  - Documented checks for provider completeness and assembly-related configuration.

- **Improvements**
  - Added validation to detect mismatches between declared origin capabilities and available assembly behavior.
  - Added assembly configuration metadata for Claude Code, Codex, and AI Studio origins.

- **Tests**
  - Added coverage confirming assembly declarations and runtime parity checks behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->