### PR TITLE
refactor(cli): derive origin completion descriptions from OriginSpec

### DIFF
--- a/polylogue/cli/shell_completion_values.py
+++ b/polylogue/cli/shell_completion_values.py
@@ -41,6 +41,7 @@ from polylogue.archive.query.transaction import archive_read_context
 from polylogue.cli.shell_words import completion_words
 from polylogue.core.enums import MaterialOrigin
 from polylogue.paths import active_index_db_path
+from polylogue.sources.origin_specs import ORIGIN_SPECS
 from polylogue.surfaces.action_affordances import InputUnit
 
 if TYPE_CHECKING:
@@ -48,16 +49,9 @@ if TYPE_CHECKING:
 
 ArchiveCompletionAction = Callable[["ArchiveStore"], list[CompletionItem]]
 
-_ORIGIN_DESCRIPTIONS: Final[dict[str, str]] = {
-    "chatgpt-export": "ChatGPT web exports (lab: OpenAI)",
-    "claude-ai-export": "Claude web exports (lab: Anthropic)",
-    "claude-code-session": "Claude Code local sessions (lab: Anthropic)",
-    "codex-session": "Codex CLI local sessions (lab: OpenAI)",
-    "aistudio-drive": "Google AI Studio / Drive exports (lab: Google)",
-    "gemini-cli-session": "Gemini CLI local sessions (lab: Google)",
-    "hermes-session": "Hermes agent sessions",
-    "antigravity-session": "Antigravity brain artifacts",
-}
+# Derived from the one typed origin admission inventory; do not hand-maintain
+# a second per-origin description list here.
+_ORIGIN_DESCRIPTIONS: Final[dict[str, str]] = {spec.origin.value: spec.display_description for spec in ORIGIN_SPECS}
 
 _MAX_ID_COMPLETIONS = 24
 _MAX_VALUE_COMPLETIONS = 32

--- a/polylogue/sources/origin_specs.py
+++ b/polylogue/sources/origin_specs.py
@@ -98,6 +98,10 @@ class OriginSpec:
     coverage_refs: tuple[str, ...]
     fidelity_notes: tuple[str, ...]
     semantic_reparse: str
+    #: Short operator-facing description used by user surfaces (for example
+    #: CLI ``--origin`` shell completion). Declared here so no surface keeps a
+    #: second hand-maintained per-origin description inventory.
+    display_description: str
     artifact_rules: tuple[OriginArtifactRule, ...] = ()
     completeness_modes: tuple[OriginCompletenessMode, ...] = ()
     #: ``"module/path.py:ClassName"`` for the ``ProviderAssemblySpec`` this
@@ -343,6 +347,7 @@ def _claude_code_spec() -> OriginSpec:
             ),
         ),
         assembly_spec_path="polylogue/sources/assembly_claude_code.py:ClaudeCodeAssemblySpec",
+        display_description="Claude Code local sessions (lab: Anthropic)",
     )
 
 
@@ -397,6 +402,7 @@ def _chatgpt_spec() -> OriginSpec:
         coverage_refs=("provider-package:chatgpt-export/takeout-json@v1",),
         fidelity_notes=("Browser capture remains an acquisition mode and is not a new public origin.",),
         semantic_reparse="reparse when ChatGPT document parsing fingerprints change",
+        display_description="ChatGPT web exports (lab: OpenAI)",
     )
 
 
@@ -418,6 +424,7 @@ def _grok_spec() -> OriginSpec:
             "provider_session_id/provider_message_id are synthesized from file-relative position.",
             "The export drops attachments/images by xAI's own documentation; only text turns are recoverable.",
         ),
+        display_description="Grok account-data exports (lab: xAI)",
     )
 
 
@@ -430,6 +437,7 @@ def _executable_spec(
     acquisition_modes: tuple[str, ...],
     parser_paths: tuple[str, ...],
     fixture_paths: tuple[str, ...],
+    display_description: str,
     stream_parser_path: str | None = None,
     assembly_paths: tuple[str, ...] = (),
     fidelity_notes: tuple[str, ...] = (),
@@ -451,6 +459,7 @@ def _executable_spec(
         fidelity_notes=fidelity_notes,
         semantic_reparse=f"reparse when {origin.value} parser fingerprints change",
         assembly_spec_path=assembly_spec_path,
+        display_description=display_description,
     )
 
 
@@ -465,6 +474,7 @@ def _codex_spec() -> OriginSpec:
         fixture_paths=("tests/unit/sources/test_parsers_codex.py", "tests/data/codex_event_stream"),
         stream_parser_path="polylogue/sources/parsers/codex.py:parse_codex_stream",
         assembly_spec_path="polylogue/sources/assembly_codex.py:CodexAssemblySpec",
+        display_description="Codex CLI local sessions (lab: OpenAI)",
     )
 
 
@@ -477,6 +487,7 @@ def _gemini_cli_spec() -> OriginSpec:
         acquisition_modes=("local-agent-document",),
         parser_paths=("polylogue/sources/parsers/local_agent.py",),
         fixture_paths=("tests/unit/sources/test_parsers_local_agent.py",),
+        display_description="Gemini CLI local sessions (lab: Google)",
     )
 
 
@@ -502,6 +513,7 @@ def _hermes_spec() -> OriginSpec:
             "tests/fixtures/hermes/atof/nemo_relay_atof_v0.1_real_redacted.jsonl",
         ),
         stream_parser_path="polylogue/sources/parsers/hermes_spans.py:parse_atof_stream",
+        display_description="Hermes agent sessions",
     )
 
 
@@ -517,6 +529,7 @@ def _antigravity_spec() -> OriginSpec:
             "tests/unit/sources/test_antigravity_language_server.py",
             "tests/unit/sources/parsers/test_antigravity.py",
         ),
+        display_description="Antigravity brain artifacts",
     )
 
 
@@ -530,6 +543,7 @@ def _beads_spec() -> OriginSpec:
         parser_paths=("polylogue/sources/parsers/beads.py",),
         fixture_paths=("tests/unit/sources/parsers/test_beads.py",),
         stream_parser_path="polylogue/sources/parsers/beads.py:parse_beads_stream",
+        display_description="Beads issue exports (non-chat work artifacts)",
     )
 
 
@@ -542,6 +556,7 @@ def _claude_ai_spec() -> OriginSpec:
         acquisition_modes=("export-json",),
         parser_paths=("polylogue/sources/parsers/claude/ai_parser.py",),
         fixture_paths=("tests/unit/sources/test_parsers_claude_ai_catalog.py",),
+        display_description="Claude web exports (lab: Anthropic)",
     )
 
 
@@ -563,6 +578,7 @@ def _aistudio_drive_spec() -> OriginSpec:
         fidelity_notes=("Provider reverse mapping remains intentionally non-injective.",),
         semantic_reparse="reparse when Drive parser fingerprints change",
         assembly_spec_path="polylogue/sources/assembly_gemini.py:GeminiAssemblySpec",
+        display_description="Google AI Studio / Drive exports (lab: Google)",
     )
 
 
@@ -587,6 +603,7 @@ def _unknown_spec() -> OriginSpec:
             "Fallback is explicit; browser capture resolves a provider-specific origin before archive materialization.",
         ),
         semantic_reparse="no direct parser; retain unknown evidence until a concrete source adapter is admitted",
+        display_description="Unrecognized fallback exports",
     )
 
 

--- a/tests/unit/sources/test_origin_specs.py
+++ b/tests/unit/sources/test_origin_specs.py
@@ -210,3 +210,18 @@ def test_origin_specs_are_parity_checked_against_the_live_assembly_registry() ->
     declared_origins = {spec.origin for spec in ORIGIN_SPECS if spec.assembly_spec_path is not None}
     assert {item.origin for item in diagnostics} == declared_origins
     assert declared_origins  # sanity: the production set is non-empty today
+
+
+def test_every_origin_spec_declares_a_display_description() -> None:
+    """Production dependency: CLI --origin shell completion derives its help text from OriginSpec.
+
+    Anti-vacuity: blanking a display_description (or dropping a spec) shrinks
+    the derived completion inventory below the full Origin vocabulary.
+    """
+    from polylogue.cli.shell_completion_values import _ORIGIN_DESCRIPTIONS
+
+    for spec in ORIGIN_SPECS:
+        assert spec.display_description.strip(), spec.origin.value
+
+    assert set(_ORIGIN_DESCRIPTIONS) == {origin.value for origin in Origin}
+    assert all(text.strip() for text in _ORIGIN_DESCRIPTIONS.values())


### PR DESCRIPTION
## Summary
Deletes the last hand-maintained per-origin description inventory (`cli/shell_completion_values.py:_ORIGIN_DESCRIPTIONS`, 8 of 11 origins, no parity check) by declaring a required `display_description` on `OriginSpec` and deriving the CLI completion dict from `ORIGIN_SPECS`.

## Problem
PR #3250's audit flagged this as the one remaining stale parallel origin inventory: shell completion for `--origin` silently omitted `beads-issue`, `grok-export`, and `unknown-export`, and nothing would catch future drift.

## Solution
- `OriginSpec.display_description` (required field, declared once per origin in `sources/origin_specs.py`).
- `_ORIGIN_DESCRIPTIONS` becomes a derivation over `ORIGIN_SPECS` — parity by construction.
- Regression test pins the derived inventory to the exact `Origin` enum and non-empty text; blanking a description or dropping a spec fails it.

## Verification
- `devtools test tests/unit/sources/test_origin_specs.py tests/unit/cli/test_command_aux_runtime.py` → 27 passed.
- `devtools verify --quick` → exit 0.

Ref polylogue-2qx.1.2 (residual from #3250).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ