### PR TITLE
refactor(operations): route remaining mutation families through MutationTransaction (polylogue-t46.9 phase 2)

### DIFF
--- a/docs/plans/mutation-census.yaml
+++ b/docs/plans/mutation-census.yaml
@@ -13,11 +13,14 @@
 #   - every row has a `status` in the closed vocabulary above and, for
 #     `typed-exemption`, a non-empty `reason`.
 #
-# This census is Phase 1 (t46.9/kwsb.2) scope: the two named routes (session
-# delete/excision, derived identity reset) are fully executor-routed on every
-# surface that exposes them. Every other destructive operation below is
-# inventoried honestly as `declared-not-routed` -- visible debt for the
-# Phase 2 migration named in the PR body, not a claim of completion.
+# Phase 1 (t46.9/kwsb.2) shipped the two named destructive routes (session
+# delete/excision, derived identity reset), fully executor-routed on every
+# surface that exposes them. Phase 2 adds the `reversible`-class tag,
+# metadata, and mark mutation families (role_only-strength executor routes,
+# per AC4: reversible writes must not acquire unnecessary interactive
+# confirmation). Every remaining operation below is inventoried honestly as
+# `declared-not-routed` -- visible debt for a later phase, not a claim of
+# completion.
 
 schema_version: 1
 
@@ -49,49 +52,78 @@ rows:
     adapters:
       - polylogue.cli.commands.reset.reset_command (--session/--source)
 
-  # --- Phase 2 debt: declared-not-routed --------------------------------------
-  # Reversible tag/metadata mutations. Idempotent, role-gated
-  # (write_role_required), no confirm/dry-run today; low blast radius (undo =
-  # another write) but not yet executor-routed.
+  # --- Phase 2: executor-routed (reversible class, role_only confirmation) ---
   - operation: mutate-add-tag
     spec_name: mutate-add-tag
-    status: declared-not-routed
+    status: executor-routed
+    actuator: polylogue.operations.mutation_actuators.TagAddActuator
     surfaces: [facade, mcp, api]
-    reason: >
-      Reversible write; Phase 2 candidate for a role_only-strength executor
-      route once reversible-class confirmation floors are settled.
+    adapters:
+      - polylogue.api.archive.PolylogueArchiveMixin.add_tag
+      - polylogue.mcp.server_cutover._dispatch_write (operation=add_tag, via add_tag)
 
   - operation: mutate-remove-tag
     spec_name: mutate-remove-tag
-    status: declared-not-routed
+    status: executor-routed
+    actuator: polylogue.operations.mutation_actuators.TagRemoveActuator
     surfaces: [facade, mcp, api]
+    adapters:
+      - polylogue.api.archive.PolylogueArchiveMixin.remove_tag
+      - polylogue.mcp.server_cutover._dispatch_write (operation=remove_tag, via remove_tag)
 
   - operation: mutate-bulk-tag-sessions
     spec_name: mutate-bulk-tag-sessions
-    status: declared-not-routed
+    status: executor-routed
+    actuator: polylogue.operations.mutation_actuators.BulkTagActuator
     surfaces: [mcp, api]
+    adapters:
+      - polylogue.api.archive.PolylogueArchiveMixin.bulk_tag_sessions
+      - polylogue.mcp.server_cutover._dispatch_write (operation=bulk_tag_sessions, via bulk_tag_sessions)
 
   - operation: mutate-set-metadata
     spec_name: mutate-set-metadata
-    status: declared-not-routed
+    status: executor-routed
+    actuator: polylogue.operations.mutation_actuators.MetadataSetActuator
     surfaces: [facade, mcp, api]
+    adapters:
+      - polylogue.api.archive.PolylogueArchiveMixin.set_metadata
+      - polylogue.mcp.server_cutover._dispatch_write (operation=set_metadata, via set_metadata)
 
   - operation: mutate-delete-metadata
     spec_name: mutate-delete-metadata
-    status: declared-not-routed
+    status: executor-routed
+    actuator: polylogue.operations.mutation_actuators.MetadataDeleteActuator
     surfaces: [mcp, api]
+    adapters:
+      - polylogue.api.archive.PolylogueArchiveMixin.delete_metadata
+      - polylogue.mcp.server_cutover._dispatch_write (operation=delete_metadata, via delete_metadata)
 
+  - operation: mutate-add-mark
+    spec_name: mutate-add-mark
+    status: executor-routed
+    actuator: polylogue.operations.mutation_actuators.MarkAddActuator
+    surfaces: [mcp, api]
+    adapters:
+      - polylogue.api.archive.PolylogueArchiveMixin.add_mark
+      - polylogue.mcp.server_cutover._dispatch_write (operation=add_mark, via add_mark)
+
+  - operation: mutate-remove-mark
+    spec_name: mutate-remove-mark
+    status: executor-routed
+    actuator: polylogue.operations.mutation_actuators.MarkRemoveActuator
+    surfaces: [mcp, api]
+    adapters:
+      - polylogue.api.archive.PolylogueArchiveMixin.remove_mark
+      - polylogue.mcp.server_cutover._dispatch_write (operation=remove_mark, via remove_mark)
+
+  # --- Phase 3 debt: declared-not-routed --------------------------------------
   # MCP-only mutation family with no OperationSpec entry yet (pre-existing
   # gap, not introduced by this PR). jn40's confirm-boolean sweep is the
   # interim mitigation for the destructive members of this family
   # (delete_annotation, delete_saved_view, delete_recall_pack,
-  # delete_workspace); it does not satisfy executor-routing.
-  - operation: add_mark / remove_mark
-    status: declared-not-routed
-    surfaces: [mcp]
-    adapters: [polylogue.mcp.server_cutover._dispatch_write]
-    reason: Reversible user-state write; jn40 out of scope (not in its named-ten list).
-
+  # delete_workspace); it does not satisfy executor-routing. add_mark/
+  # remove_mark are executor-routed above (t46.9 phase 2); the rest of this
+  # family remains Phase 3 debt.
   - operation: save_annotation / delete_annotation
     status: declared-not-routed
     surfaces: [mcp]
@@ -132,11 +164,6 @@ rows:
     status: declared-not-routed
     surfaces: [mcp]
     reason: User-correction overlay write; low blast radius (single-target overwrite).
-
-  - operation: delete_metadata (MCP admin alias)
-    status: declared-not-routed
-    surfaces: [mcp]
-    reason: jn40 confirm-gated (delete_metadata is in the named-ten list); not yet executor-routed.
 
   - operation: rebuild_index / update_index / rebuild_insights (maintenance_execute family)
     status: declared-not-routed

--- a/docs/test-quality-workflows.md
+++ b/docs/test-quality-workflows.md
@@ -31,9 +31,9 @@ Current registry snapshot:
 - covered declared operation targets: `46`
 - uncovered runtime paths: `thread-query-loop`, `tool-usage-query-loop`
 - uncovered runtime artifacts: `thread_results`, `tool_usage_results`
-- uncovered runtime operations: `mutate-add-tag`, `mutate-bulk-tag-sessions`, `mutate-delete-metadata`, `mutate-delete-session`, `mutate-identity-reset`, `mutate-remove-tag`, `mutate-session-excision`, `mutate-set-metadata`, `query-threads`, `query-tool-usage`
+- uncovered runtime operations: `mutate-add-mark`, `mutate-add-tag`, `mutate-bulk-tag-sessions`, `mutate-delete-metadata`, `mutate-delete-session`, `mutate-identity-reset`, `mutate-remove-mark`, `mutate-remove-tag`, `mutate-session-excision`, `mutate-set-metadata`, `query-threads`, `query-tool-usage`
 - uncovered maintenance targets: `empty_sessions`, `message_type_backfill`, `orphaned_attachments`, `orphaned_messages`, `superseded_raw_snapshots`
-- uncovered declared operation targets: `mutate-add-tag`, `mutate-bulk-tag-sessions`, `mutate-delete-metadata`, `mutate-delete-session`, `mutate-identity-reset`, `mutate-remove-tag`, `mutate-session-excision`, `mutate-set-metadata`, `query-threads`, `query-tool-usage`
+- uncovered declared operation targets: `mutate-add-mark`, `mutate-add-tag`, `mutate-bulk-tag-sessions`, `mutate-delete-metadata`, `mutate-delete-session`, `mutate-identity-reset`, `mutate-remove-mark`, `mutate-remove-tag`, `mutate-session-excision`, `mutate-set-metadata`, `query-threads`, `query-tool-usage`
 
 Inspect the full authored map with:
 

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -5509,21 +5509,44 @@ class PolylogueArchiveMixin:
         Returns a ``TagMutationResult`` with:
         - ``outcome="added"`` if the tag was newly added
         - ``outcome="no_op"`` if the tag was already present
+
+        Routed through ``OperationExecutor``/``TagAddActuator`` (t46.9 phase
+        2): the real mutation is still ``ArchiveStore.add_user_tags``, but
+        every surface (this facade method, reached by CLI's
+        ``apply_modifiers``/query-mutation path and MCP's
+        ``write(operation='add_tag')``) now shares one preview/authorize/
+        receipt contract instead of calling the primitive independently.
         """
+        from polylogue.operations.mutation_actuators import TagAddActuator, TagAddArgs
+        from polylogue.operations.mutation_transaction import OperationExecutor
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
         from polylogue.surfaces.payloads import TagMutationResult
 
         with ArchiveStore.open_existing(_active_archive_root(self.config), read_only=False) as archive:
+            actuator = TagAddActuator()
+            executor = OperationExecutor()
+            args = TagAddArgs(
+                archive=archive, session_id=session_id, tag=tag, author_ref=author_ref, author_kind=author_kind
+            )
             try:
-                resolved_v1 = archive.resolve_session_id(session_id)
-                changed = archive.add_user_tags(
-                    (resolved_v1,),
-                    (tag,),
-                    author_ref=author_ref,
-                    author_kind=author_kind,
+                plan = executor.prepare(actuator, args)
+                authorization = executor.authorize(
+                    actuator,
+                    plan,
+                    actor="facade",
+                    role="write",
+                    capability="archive.add_tag",
+                    confirmation_strength="role_only",
                 )
+                receipt = executor.execute(actuator, plan, authorization, args)
             except KeyError:
+                # Covers both the initial resolve (session never existed) and
+                # EXECUTE's fresh-PREPARE revalidation (session deleted by a
+                # concurrent actor between AUTHORIZE and EXECUTE) -- both
+                # collapse to the same "session not found" outcome for this
+                # reversible-class operation.
                 raise SessionNotFoundError(session_id) from None
+        changed = receipt.affected_count
         return TagMutationResult(
             outcome="added" if changed else "no_op",
             detail=None if changed else "already_present",
@@ -5535,16 +5558,33 @@ class PolylogueArchiveMixin:
         Returns a ``TagMutationResult`` with:
         - ``outcome="removed"`` if the tag was removed
         - ``outcome="not_present"`` if the tag was not present
+
+        Routed through ``OperationExecutor``/``TagRemoveActuator`` (t46.9
+        phase 2); see :meth:`add_tag` for the shared-contract rationale.
         """
+        from polylogue.operations.mutation_actuators import TagRemoveActuator, TagRemoveArgs
+        from polylogue.operations.mutation_transaction import OperationExecutor
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
         from polylogue.surfaces.payloads import TagMutationResult
 
         with ArchiveStore.open_existing(_active_archive_root(self.config), read_only=False) as archive:
+            actuator = TagRemoveActuator()
+            executor = OperationExecutor()
+            args = TagRemoveArgs(archive=archive, session_id=session_id, tag=tag)
             try:
-                resolved_v1 = archive.resolve_session_id(session_id)
-                changed = archive.remove_user_tags((resolved_v1,), (tag,))
+                plan = executor.prepare(actuator, args)
+                authorization = executor.authorize(
+                    actuator,
+                    plan,
+                    actor="facade",
+                    role="write",
+                    capability="archive.remove_tag",
+                    confirmation_strength="role_only",
+                )
+                receipt = executor.execute(actuator, plan, authorization, args)
             except KeyError:
                 raise SessionNotFoundError(session_id) from None
+        changed = receipt.affected_count
         return TagMutationResult(
             outcome="removed" if changed else "not_present",
             detail=None if changed else "tag_not_present",
@@ -5585,7 +5625,12 @@ class PolylogueArchiveMixin:
         validated before any store call (raising
         :class:`~polylogue.surfaces.payloads.MetadataKeyValidationError`),
         and the ``unchanged`` detail token is the shared ``value_unchanged``.
+
+        Routed through ``OperationExecutor``/``MetadataSetActuator`` (t46.9
+        phase 2); see :meth:`add_tag` for the shared-contract rationale.
         """
+        from polylogue.operations.mutation_actuators import MetadataSetActuator, MetadataSetArgs
+        from polylogue.operations.mutation_transaction import OperationExecutor
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
         from polylogue.surfaces.payloads import (
             MetadataKeyValidationError,
@@ -5598,11 +5643,24 @@ class PolylogueArchiveMixin:
             raise MetadataKeyValidationError(validation_error)
 
         with ArchiveStore.open_existing(_active_archive_root(self.config), read_only=False) as archive:
+            actuator = MetadataSetActuator()
+            executor = OperationExecutor()
+            args = MetadataSetArgs(archive=archive, session_id=session_id, key=key, value=value)
             try:
-                resolved = archive.resolve_session_id(session_id)
-                changed = archive.set_user_metadata((resolved,), ((key, value),))
+                plan = executor.prepare(actuator, args)
+                authorization = executor.authorize(
+                    actuator,
+                    plan,
+                    actor="facade",
+                    role="write",
+                    capability="archive.set_metadata",
+                    confirmation_strength="role_only",
+                )
+                receipt = executor.execute(actuator, plan, authorization, args)
             except KeyError:
                 raise SessionNotFoundError(session_id) from None
+        changed = receipt.affected_count
+        resolved = str(plan.context["session_id"])
         return MetadataMutationResult(
             outcome="set" if changed else "unchanged",
             session_id=resolved,
@@ -5616,7 +5674,13 @@ class PolylogueArchiveMixin:
         Follows the centralized mutation contract (#862): the key is
         validated before any store call, and the missing-key detail token is
         the shared ``key_not_found``.
+
+        Routed through ``OperationExecutor``/``MetadataDeleteActuator``
+        (t46.9 phase 2); see :meth:`add_tag` for the shared-contract
+        rationale.
         """
+        from polylogue.operations.mutation_actuators import MetadataDeleteActuator, MetadataDeleteArgs
+        from polylogue.operations.mutation_transaction import OperationExecutor
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
         from polylogue.surfaces.payloads import (
             MetadataKeyValidationError,
@@ -5629,11 +5693,24 @@ class PolylogueArchiveMixin:
             raise MetadataKeyValidationError(validation_error)
 
         with ArchiveStore.open_existing(_active_archive_root(self.config), read_only=False) as archive:
+            actuator = MetadataDeleteActuator()
+            executor = OperationExecutor()
+            args = MetadataDeleteArgs(archive=archive, session_id=session_id, key=key)
             try:
-                resolved = archive.resolve_session_id(session_id)
-                changed = archive.delete_user_metadata(resolved, key)
+                plan = executor.prepare(actuator, args)
+                authorization = executor.authorize(
+                    actuator,
+                    plan,
+                    actor="facade",
+                    role="write",
+                    capability="archive.delete_metadata",
+                    confirmation_strength="role_only",
+                )
+                receipt = executor.execute(actuator, plan, authorization, args)
             except KeyError:
                 raise SessionNotFoundError(session_id) from None
+        changed = receipt.affected_count
+        resolved = str(plan.context["session_id"])
         return MetadataMutationResult(
             outcome="deleted" if changed else "not_found",
             session_id=resolved,
@@ -5654,7 +5731,12 @@ class PolylogueArchiveMixin:
         Validation (empty inputs and size limits) is enforced inside the
         :class:`ArchiveMutationsMixin` so every surface sees the same
         behavior.
+
+        Routed through ``OperationExecutor``/``BulkTagActuator`` (t46.9 phase
+        2); see :meth:`add_tag` for the shared-contract rationale.
         """
+        from polylogue.operations.mutation_actuators import BulkTagActuator, BulkTagArgs
+        from polylogue.operations.mutation_transaction import OperationExecutor
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
         from polylogue.surfaces.payloads import BulkTagMutationResult
 
@@ -5668,28 +5750,33 @@ class PolylogueArchiveMixin:
             raise ValueError(f"bulk_tag_sessions supports at most {max_sessions} session_ids")
         if len(tags) > max_tags:
             raise ValueError(f"bulk_tag_sessions supports at most {max_tags} tags")
-        affected_count = 0
+
         with ArchiveStore.open_existing(_active_archive_root(self.config), read_only=False) as archive:
-            for session_id in session_ids:
-                try:
-                    resolved = archive.resolve_session_id(session_id)
-                except KeyError:
-                    continue
-                if (
-                    archive.add_user_tags(
-                        (resolved,),
-                        tuple(tags),
-                        author_ref=author_ref,
-                        author_kind=author_kind,
-                    )
-                    > 0
-                ):
-                    affected_count += 1
+            actuator = BulkTagActuator()
+            executor = OperationExecutor()
+            args = BulkTagArgs(
+                archive=archive,
+                session_ids=tuple(session_ids),
+                tags=tuple(tags),
+                author_ref=author_ref,
+                author_kind=author_kind,
+            )
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator,
+                plan,
+                actor="facade",
+                role="write",
+                capability="archive.bulk_tag_sessions",
+                confirmation_strength="role_only",
+            )
+            receipt = executor.execute(actuator, plan, authorization, args)
+        domain_receipt = receipt.domain_receipt
         return BulkTagMutationResult(
-            session_count=len(session_ids),
-            tag_count=len(tags),
-            affected_count=affected_count,
-            skipped_count=len(session_ids) - affected_count,
+            session_count=int(cast("int", domain_receipt["session_count"])),
+            tag_count=int(cast("int", domain_receipt["tag_count"])),
+            affected_count=int(cast("int", domain_receipt["affected_count"])),
+            skipped_count=int(cast("int", domain_receipt["skipped_count"])),
         )
 
     # ------------------------------------------------------------------
@@ -5812,8 +5899,17 @@ class PolylogueArchiveMixin:
 
         Returns ``True`` if the mark was newly added, ``False`` if it already
         existed.
+
+        Routed through ``OperationExecutor``/``MarkAddActuator`` (t46.9 phase
+        2: the first MCP no-spec mutation family to gain executor routing).
+        Target resolution stays here (async, may consult insight-derived
+        indexes) and runs once before the actuator sees an already-resolved
+        ``target_type``/``target_id`` pair, mirroring
+        ``IdentityResetActuator``'s pattern.
         """
         from polylogue.core.user_state_targets import validate_mark_type
+        from polylogue.operations.mutation_actuators import MarkAddActuator, MarkArgs
+        from polylogue.operations.mutation_transaction import OperationExecutor
 
         mark_type = validate_mark_type(mark_type)
         target = await self._resolve_user_state_target(
@@ -5825,7 +5921,25 @@ class PolylogueArchiveMixin:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
         with ArchiveStore.open_existing(_active_archive_root(self.config), read_only=False) as archive:
-            return archive.add_mark(str(target["target_type"]), str(target["target_id"]), mark_type)
+            actuator = MarkAddActuator()
+            executor = OperationExecutor()
+            args = MarkArgs(
+                archive=archive,
+                target_type=str(target["target_type"]),
+                target_id=str(target["target_id"]),
+                mark_type=mark_type,
+            )
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator,
+                plan,
+                actor="facade",
+                role="write",
+                capability="archive.add_mark",
+                confirmation_strength="role_only",
+            )
+            receipt = executor.execute(actuator, plan, authorization, args)
+        return receipt.status == "applied"
 
     async def remove_mark(
         self,
@@ -5836,8 +5950,14 @@ class PolylogueArchiveMixin:
         target_id: str | None = None,
         message_id: str | None = None,
     ) -> bool:
-        """Remove a mark from a session or message. Returns ``True`` if removed."""
+        """Remove a mark from a session or message. Returns ``True`` if removed.
+
+        Routed through ``OperationExecutor``/``MarkRemoveActuator`` (t46.9
+        phase 2); see :meth:`add_mark` for the shared-contract rationale.
+        """
         from polylogue.core.user_state_targets import validate_mark_type
+        from polylogue.operations.mutation_actuators import MarkArgs, MarkRemoveActuator
+        from polylogue.operations.mutation_transaction import OperationExecutor
 
         mark_type = validate_mark_type(mark_type)
         target = await self._resolve_user_state_target(
@@ -5849,7 +5969,25 @@ class PolylogueArchiveMixin:
         from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
         with ArchiveStore.open_existing(_active_archive_root(self.config), read_only=False) as archive:
-            return archive.remove_mark(str(target["target_type"]), str(target["target_id"]), mark_type)
+            actuator = MarkRemoveActuator()
+            executor = OperationExecutor()
+            args = MarkArgs(
+                archive=archive,
+                target_type=str(target["target_type"]),
+                target_id=str(target["target_id"]),
+                mark_type=mark_type,
+            )
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator,
+                plan,
+                actor="facade",
+                role="write",
+                capability="archive.remove_mark",
+                confirmation_strength="role_only",
+            )
+            receipt = executor.execute(actuator, plan, authorization, args)
+        return receipt.status == "applied"
 
     async def list_marks(
         self,

--- a/polylogue/operations/mutation_actuators.py
+++ b/polylogue/operations/mutation_actuators.py
@@ -1,11 +1,20 @@
-"""Domain actuators for the two t46.9/kwsb.2 named routes.
+"""Domain actuators for the t46.9/kwsb.2 named routes.
 
 Each actuator wraps exactly one existing low-level mutation primitive
 (``ArchiveStore.delete_sessions``, ``security.excision``, the identity-reset
-tombstone helpers) behind the :class:`~polylogue.operations.mutation_transaction
-.MutationActuator` protocol. Actuators own target resolution and the real
-mutation; they never enforce authorization -- every surface drives them
-through :class:`~polylogue.operations.mutation_transaction.OperationExecutor`.
+tombstone helpers, the ``ArchiveStore`` tag/metadata/mark writers) behind the
+:class:`~polylogue.operations.mutation_transaction.MutationActuator` protocol.
+Actuators own target resolution and the real mutation; they never enforce
+authorization -- every surface drives them through
+:class:`~polylogue.operations.mutation_transaction.OperationExecutor`.
+
+Phase 1 (PR #3249) shipped ``SessionDeleteActuator``/``SessionExcisionActuator``/
+``IdentityResetActuator`` for the ``delete``/``excise``/``reset`` destructive
+classes, all requiring ``confirm_flag``-strength authorization. Phase 2
+(polylogue-t46.9/polylogue-kwsb.2) adds the ``reversible``-class tag, metadata,
+and mark actuators below: their ``required_confirmation`` is ``role_only`` --
+AC4 requires reversible writes not acquire unnecessary interactive
+confirmation, since undo is another write through the same actuator.
 """
 
 from __future__ import annotations
@@ -324,11 +333,429 @@ def _resolve_existing_session_ids(archive_root: Path, session_ids: tuple[str, ..
         conn.close()
 
 
+# ---------------------------------------------------------------------------
+# Tag mutations (mutate-add-tag / mutate-remove-tag / mutate-bulk-tag-sessions)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class TagAddArgs:
+    """Shared prepare/apply argument shape for single-session tag add."""
+
+    archive: ArchiveStore
+    session_id: str
+    tag: str
+    author_ref: str | None = None
+    author_kind: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TagAddActuator:
+    """Actuator for ``mutate-add-tag``: reversible user.db tag assertion.
+
+    Real production mutation: ``ArchiveStore.add_user_tags`` -- the same
+    primitive ``PolylogueArchiveMixin.add_tag`` (reached by CLI's
+    ``apply_modifiers``/query-mutation path and MCP's
+    ``write(operation='add_tag')``) already calls. Undo is
+    ``mutate-remove-tag`` through the same primitive family, so this is
+    ``reversible``-class and requires only ``role_only`` confirmation (AC4).
+    """
+
+    operation: str = "mutate-add-tag"
+    destructive_class: DestructiveClass = "reversible"
+    required_confirmation: ConfirmationStrength = "role_only"
+
+    def prepare(self, args: TagAddArgs) -> MutationPlan:
+        resolved = args.archive.resolve_session_id(args.session_id)
+        return build_plan(
+            operation=self.operation,
+            destructive_class="reversible",
+            target_refs=(make_target_ref("session", resolved),),
+            affected_tiers=("user",),
+            reversible=True,
+            context={"session_id": resolved, "tag": args.tag},
+        )
+
+    def apply(self, plan: MutationPlan, args: TagAddArgs) -> MutationReceipt:
+        session_id = str(plan.context["session_id"])
+        tag = str(plan.context["tag"])
+        changed = args.archive.add_user_tags(
+            (session_id,), (tag,), author_ref=args.author_ref, author_kind=args.author_kind
+        )
+        status: MutationTargetStatus = "applied" if changed else "already_satisfied"
+        return MutationReceipt(
+            operation=self.operation,
+            plan_hash=plan.plan_hash,
+            status=status,
+            target_refs=plan.target_refs,
+            affected_count=changed,
+            detail=None if changed else "already_present",
+            receipt_ref=None,
+            applied_at=plan.prepared_at,
+            domain_receipt={"changed": changed},
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TagRemoveArgs:
+    """Shared prepare/apply argument shape for single-session tag remove."""
+
+    archive: ArchiveStore
+    session_id: str
+    tag: str
+
+
+@dataclass(frozen=True, slots=True)
+class TagRemoveActuator:
+    """Actuator for ``mutate-remove-tag``: reversible user.db tag retraction.
+
+    Real production mutation: ``ArchiveStore.remove_user_tags`` -- marks the
+    tag assertion deleted rather than physically removing it, so this is
+    itself reversible via ``mutate-add-tag``.
+    """
+
+    operation: str = "mutate-remove-tag"
+    destructive_class: DestructiveClass = "reversible"
+    required_confirmation: ConfirmationStrength = "role_only"
+
+    def prepare(self, args: TagRemoveArgs) -> MutationPlan:
+        resolved = args.archive.resolve_session_id(args.session_id)
+        return build_plan(
+            operation=self.operation,
+            destructive_class="reversible",
+            target_refs=(make_target_ref("session", resolved),),
+            affected_tiers=("user",),
+            reversible=True,
+            context={"session_id": resolved, "tag": args.tag},
+        )
+
+    def apply(self, plan: MutationPlan, args: TagRemoveArgs) -> MutationReceipt:
+        session_id = str(plan.context["session_id"])
+        tag = str(plan.context["tag"])
+        changed = args.archive.remove_user_tags((session_id,), (tag,))
+        status: MutationTargetStatus = "applied" if changed else "already_satisfied"
+        return MutationReceipt(
+            operation=self.operation,
+            plan_hash=plan.plan_hash,
+            status=status,
+            target_refs=plan.target_refs,
+            affected_count=changed,
+            detail=None if changed else "tag_not_present",
+            receipt_ref=None,
+            applied_at=plan.prepared_at,
+            domain_receipt={"changed": changed},
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BulkTagArgs:
+    """Shared prepare/apply argument shape for multi-session bulk tagging."""
+
+    archive: ArchiveStore
+    session_ids: tuple[str, ...]
+    tags: tuple[str, ...]
+    author_ref: str | None = None
+    author_kind: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class BulkTagActuator:
+    """Actuator for ``mutate-bulk-tag-sessions``: reversible multi-target tagging.
+
+    Real production mutation: ``ArchiveStore.add_user_tags`` applied per
+    resolved session, mirroring ``PolylogueArchiveMixin.bulk_tag_sessions``'s
+    existing skip-unresolved behavior -- ``prepare`` only plans sessions that
+    resolve against live state right now, same pattern as
+    ``SessionDeleteActuator``.
+    """
+
+    operation: str = "mutate-bulk-tag-sessions"
+    destructive_class: DestructiveClass = "reversible"
+    required_confirmation: ConfirmationStrength = "role_only"
+
+    def prepare(self, args: BulkTagArgs) -> MutationPlan:
+        resolved: list[str] = []
+        for session_id in dict.fromkeys(args.session_ids):
+            try:
+                resolved.append(args.archive.resolve_session_id(session_id))
+            except KeyError:
+                continue
+        return build_plan(
+            operation=self.operation,
+            destructive_class="reversible",
+            target_refs=tuple(make_target_ref("session", sid) for sid in resolved),
+            affected_tiers=("user",),
+            reversible=True,
+            context={
+                "session_ids": resolved,
+                "tags": list(args.tags),
+                "requested_session_count": len(args.session_ids),
+            },
+        )
+
+    def apply(self, plan: MutationPlan, args: BulkTagArgs) -> MutationReceipt:
+        session_ids: tuple[str, ...] = tuple(cast("list[str]", plan.context.get("session_ids") or ()))
+        tags: tuple[str, ...] = tuple(cast("list[str]", plan.context.get("tags") or ()))
+        requested_count = int(cast("int", plan.context.get("requested_session_count") or len(session_ids)))
+        affected = 0
+        for session_id in session_ids:
+            if (
+                args.archive.add_user_tags(
+                    (session_id,), tags, author_ref=args.author_ref, author_kind=args.author_kind
+                )
+                > 0
+            ):
+                affected += 1
+        status: MutationTargetStatus = "applied" if affected else "already_satisfied"
+        return MutationReceipt(
+            operation=self.operation,
+            plan_hash=plan.plan_hash,
+            status=status,
+            target_refs=plan.target_refs,
+            affected_count=affected,
+            detail=None if affected else "no_sessions_changed",
+            receipt_ref=None,
+            applied_at=plan.prepared_at,
+            domain_receipt={
+                "session_count": requested_count,
+                "tag_count": len(tags),
+                "affected_count": affected,
+                "skipped_count": requested_count - affected,
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Metadata mutations (mutate-set-metadata / mutate-delete-metadata)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class MetadataSetArgs:
+    """Shared prepare/apply argument shape for session metadata set."""
+
+    archive: ArchiveStore
+    session_id: str
+    key: str
+    value: object
+
+
+@dataclass(frozen=True, slots=True)
+class MetadataSetActuator:
+    """Actuator for ``mutate-set-metadata``: reversible user.db metadata write.
+
+    Real production mutation: ``ArchiveStore.set_user_metadata``. Key
+    validation (``validate_metadata_key``) stays in the adapter layer, run
+    before the actuator is constructed, matching the existing
+    ``PolylogueArchiveMixin.set_metadata`` contract.
+    """
+
+    operation: str = "mutate-set-metadata"
+    destructive_class: DestructiveClass = "reversible"
+    required_confirmation: ConfirmationStrength = "role_only"
+
+    def prepare(self, args: MetadataSetArgs) -> MutationPlan:
+        resolved = args.archive.resolve_session_id(args.session_id)
+        return build_plan(
+            operation=self.operation,
+            destructive_class="reversible",
+            target_refs=(make_target_ref("session", resolved),),
+            affected_tiers=("user",),
+            reversible=True,
+            context={"session_id": resolved, "key": args.key, "value": args.value},
+        )
+
+    def apply(self, plan: MutationPlan, args: MetadataSetArgs) -> MutationReceipt:
+        session_id = str(plan.context["session_id"])
+        key = str(plan.context["key"])
+        value = plan.context["value"]
+        changed = args.archive.set_user_metadata((session_id,), ((key, value),))
+        status: MutationTargetStatus = "applied" if changed else "already_satisfied"
+        return MutationReceipt(
+            operation=self.operation,
+            plan_hash=plan.plan_hash,
+            status=status,
+            target_refs=plan.target_refs,
+            affected_count=changed,
+            detail=None if changed else "value_unchanged",
+            receipt_ref=None,
+            applied_at=plan.prepared_at,
+            domain_receipt={"changed": changed},
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MetadataDeleteArgs:
+    """Shared prepare/apply argument shape for session metadata delete."""
+
+    archive: ArchiveStore
+    session_id: str
+    key: str
+
+
+@dataclass(frozen=True, slots=True)
+class MetadataDeleteActuator:
+    """Actuator for ``mutate-delete-metadata``: reversible user.db metadata retraction.
+
+    Real production mutation: ``ArchiveStore.delete_user_metadata``, which
+    marks the metadata assertion deleted (undo = ``mutate-set-metadata``).
+    """
+
+    operation: str = "mutate-delete-metadata"
+    destructive_class: DestructiveClass = "reversible"
+    required_confirmation: ConfirmationStrength = "role_only"
+
+    def prepare(self, args: MetadataDeleteArgs) -> MutationPlan:
+        resolved = args.archive.resolve_session_id(args.session_id)
+        return build_plan(
+            operation=self.operation,
+            destructive_class="reversible",
+            target_refs=(make_target_ref("session", resolved),),
+            affected_tiers=("user",),
+            reversible=True,
+            context={"session_id": resolved, "key": args.key},
+        )
+
+    def apply(self, plan: MutationPlan, args: MetadataDeleteArgs) -> MutationReceipt:
+        session_id = str(plan.context["session_id"])
+        key = str(plan.context["key"])
+        changed = args.archive.delete_user_metadata(session_id, key)
+        status: MutationTargetStatus = "applied" if changed else "already_satisfied"
+        return MutationReceipt(
+            operation=self.operation,
+            plan_hash=plan.plan_hash,
+            status=status,
+            target_refs=plan.target_refs,
+            affected_count=changed,
+            detail=None if changed else "key_not_found",
+            receipt_ref=None,
+            applied_at=plan.prepared_at,
+            domain_receipt={"changed": changed},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Mark mutations (mutate-add-mark / mutate-remove-mark) -- the first
+# MCP no-spec mutation family (census "add_mark / remove_mark" row) to gain
+# an OperationSpec and executor route.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class MarkArgs:
+    """Shared prepare/apply argument shape for mark add/remove.
+
+    ``target_type``/``target_id`` are resolved once by the caller (mirroring
+    ``IdentityResetActuator``'s "resolve once, preview and mutate the
+    identical set" pattern) via
+    ``PolylogueArchiveMixin._resolve_user_state_target`` before the actuator
+    ever runs -- a mark target can be a session, message, or block, and that
+    resolution is async (may consult insight-derived indexes), while
+    ``MutationActuator.prepare``/``apply`` are synchronous.
+    """
+
+    archive: ArchiveStore
+    target_type: str
+    target_id: str
+    mark_type: str
+
+
+@dataclass(frozen=True, slots=True)
+class MarkAddActuator:
+    """Actuator for ``mutate-add-mark``: reversible user.db mark assertion.
+
+    Real production mutation: ``ArchiveStore.add_mark``, the same primitive
+    ``PolylogueArchiveMixin.add_mark`` (reached by MCP's
+    ``write(operation='add_mark')``) already calls. Undo is
+    ``mutate-remove-mark``.
+    """
+
+    operation: str = "mutate-add-mark"
+    destructive_class: DestructiveClass = "reversible"
+    required_confirmation: ConfirmationStrength = "role_only"
+
+    def prepare(self, args: MarkArgs) -> MutationPlan:
+        return build_plan(
+            operation=self.operation,
+            destructive_class="reversible",
+            target_refs=(f"{args.target_type}:{args.target_id}",),
+            affected_tiers=("user",),
+            reversible=True,
+            context={"target_type": args.target_type, "target_id": args.target_id, "mark_type": args.mark_type},
+        )
+
+    def apply(self, plan: MutationPlan, args: MarkArgs) -> MutationReceipt:
+        added = args.archive.add_mark(args.target_type, args.target_id, args.mark_type)
+        status: MutationTargetStatus = "applied" if added else "already_satisfied"
+        return MutationReceipt(
+            operation=self.operation,
+            plan_hash=plan.plan_hash,
+            status=status,
+            target_refs=plan.target_refs,
+            affected_count=1 if added else 0,
+            detail=None if added else "already_present",
+            receipt_ref=None,
+            applied_at=plan.prepared_at,
+            domain_receipt={"added": added},
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MarkRemoveActuator:
+    """Actuator for ``mutate-remove-mark``: reversible user.db mark retraction.
+
+    Real production mutation: ``ArchiveStore.remove_mark`` (undo =
+    ``mutate-add-mark``).
+    """
+
+    operation: str = "mutate-remove-mark"
+    destructive_class: DestructiveClass = "reversible"
+    required_confirmation: ConfirmationStrength = "role_only"
+
+    def prepare(self, args: MarkArgs) -> MutationPlan:
+        return build_plan(
+            operation=self.operation,
+            destructive_class="reversible",
+            target_refs=(f"{args.target_type}:{args.target_id}",),
+            affected_tiers=("user",),
+            reversible=True,
+            context={"target_type": args.target_type, "target_id": args.target_id, "mark_type": args.mark_type},
+        )
+
+    def apply(self, plan: MutationPlan, args: MarkArgs) -> MutationReceipt:
+        removed = args.archive.remove_mark(args.target_type, args.target_id, args.mark_type)
+        status: MutationTargetStatus = "applied" if removed else "already_satisfied"
+        return MutationReceipt(
+            operation=self.operation,
+            plan_hash=plan.plan_hash,
+            status=status,
+            target_refs=plan.target_refs,
+            affected_count=1 if removed else 0,
+            detail=None if removed else "not_present",
+            receipt_ref=None,
+            applied_at=plan.prepared_at,
+            domain_receipt={"removed": removed},
+        )
+
+
 __all__ = [
+    "BulkTagActuator",
+    "BulkTagArgs",
     "IdentityResetActuator",
     "IdentityResetArgs",
+    "MarkAddActuator",
+    "MarkArgs",
+    "MarkRemoveActuator",
+    "MetadataDeleteActuator",
+    "MetadataDeleteArgs",
+    "MetadataSetActuator",
+    "MetadataSetArgs",
     "SessionDeleteActuator",
     "SessionDeleteArgs",
     "SessionExcisionActuator",
     "SessionExcisionArgs",
+    "TagAddActuator",
+    "TagAddArgs",
+    "TagRemoveActuator",
+    "TagRemoveArgs",
 ]

--- a/polylogue/operations/specs.py
+++ b/polylogue/operations/specs.py
@@ -547,7 +547,10 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
     OperationSpec(
         name="mutate-add-tag",
         kind=OperationKind.MAINTENANCE,
-        description="Add a tag to one session. Idempotent — returns unchanged when the tag is already present.",
+        description=(
+            "Add a tag to one session. Idempotent — returns unchanged when the tag is already present. "
+            "Routed through OperationExecutor/TagAddActuator (reversible class, role_only confirmation)."
+        ),
         consumes=("sessions", "assertions"),
         produces=("assertions",),
         path_targets=("tag-mutation-loop",),
@@ -555,51 +558,65 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
             "polylogue.storage.repository.archive.repository_writes.RepositoryWriteMixin.add_tag",
             "polylogue.api.archive.PolylogueArchiveMixin.add_tag",
             "polylogue.mcp.server_cutover._dispatch_write",
+            "polylogue.operations.mutation_actuators.TagAddActuator",
         ),
         surfaces=("facade", "mcp", "api"),
         mutates_state=True,
         idempotent=True,
         effects=("DbRead", "DbWrite"),
         safety_guards=("write_role_required",),
-        executor_status="declared-not-routed",
+        executor_status="executor-routed",
     ),
     OperationSpec(
         name="mutate-remove-tag",
         kind=OperationKind.MAINTENANCE,
-        description="Remove a tag from one session. Idempotent — returns not-found when the tag is absent.",
+        description=(
+            "Remove a tag from one session. Idempotent — returns not-found when the tag is absent. "
+            "Routed through OperationExecutor/TagRemoveActuator (reversible class, role_only confirmation)."
+        ),
         consumes=("sessions", "assertions"),
         produces=("assertions",),
         path_targets=("tag-mutation-loop",),
         code_refs=(
             "polylogue.api.archive.PolylogueArchiveMixin.remove_tag",
             "polylogue.mcp.server_cutover._dispatch_write",
+            "polylogue.operations.mutation_actuators.TagRemoveActuator",
         ),
         surfaces=("facade", "mcp", "api"),
         mutates_state=True,
         idempotent=True,
         effects=("DbRead", "DbWrite"),
         safety_guards=("write_role_required",),
-        executor_status="declared-not-routed",
+        executor_status="executor-routed",
     ),
     OperationSpec(
         name="mutate-bulk-tag-sessions",
         kind=OperationKind.MAINTENANCE,
-        description="Apply tags to multiple sessions in one transaction. Returns affected and skipped counts.",
+        description=(
+            "Apply tags to multiple sessions in one transaction. Returns affected and skipped counts. "
+            "Routed through OperationExecutor/BulkTagActuator (reversible class, role_only confirmation)."
+        ),
         consumes=("sessions", "assertions"),
         produces=("assertions",),
         path_targets=("tag-mutation-loop",),
-        code_refs=("polylogue.mcp.server_cutover._dispatch_write",),
+        code_refs=(
+            "polylogue.mcp.server_cutover._dispatch_write",
+            "polylogue.operations.mutation_actuators.BulkTagActuator",
+        ),
         surfaces=("mcp", "api"),
         mutates_state=True,
         idempotent=True,
         effects=("DbRead", "DbWrite"),
         safety_guards=("write_role_required",),
-        executor_status="declared-not-routed",
+        executor_status="executor-routed",
     ),
     OperationSpec(
         name="mutate-set-metadata",
         kind=OperationKind.MAINTENANCE,
-        description="Set a metadata key on one session. Idempotent — returns unchanged when the value matches.",
+        description=(
+            "Set a metadata key on one session. Idempotent — returns unchanged when the value matches. "
+            "Routed through OperationExecutor/MetadataSetActuator (reversible class, role_only confirmation)."
+        ),
         consumes=("sessions", "assertions"),
         produces=("assertions",),
         path_targets=("metadata-mutation-loop",),
@@ -607,28 +624,82 @@ RUNTIME_OPERATION_SPECS: tuple[OperationSpec, ...] = (
             "polylogue.storage.repository.archive.repository_writes.RepositoryWriteMixin.update_metadata",
             "polylogue.api.archive.PolylogueArchiveMixin.update_metadata",
             "polylogue.mcp.server_cutover._dispatch_write",
+            "polylogue.operations.mutation_actuators.MetadataSetActuator",
         ),
         surfaces=("facade", "mcp", "api"),
         mutates_state=True,
         idempotent=True,
         effects=("DbRead", "DbWrite"),
         safety_guards=("write_role_required",),
-        executor_status="declared-not-routed",
+        executor_status="executor-routed",
     ),
     OperationSpec(
         name="mutate-delete-metadata",
         kind=OperationKind.MAINTENANCE,
-        description="Delete a metadata key from one session. Idempotent — returns not-found when the key is absent.",
+        description=(
+            "Delete a metadata key from one session. Idempotent — returns not-found when the key is absent. "
+            "Routed through OperationExecutor/MetadataDeleteActuator (reversible class, role_only confirmation)."
+        ),
         consumes=("sessions", "assertions"),
         produces=("assertions",),
         path_targets=("metadata-mutation-loop",),
-        code_refs=("polylogue.mcp.server_cutover._dispatch_write",),
+        code_refs=(
+            "polylogue.mcp.server_cutover._dispatch_write",
+            "polylogue.operations.mutation_actuators.MetadataDeleteActuator",
+        ),
         surfaces=("mcp", "api"),
         mutates_state=True,
         idempotent=True,
         effects=("DbRead", "DbWrite"),
         safety_guards=("write_role_required",),
-        executor_status="declared-not-routed",
+        executor_status="executor-routed",
+    ),
+    OperationSpec(
+        name="mutate-add-mark",
+        kind=OperationKind.MAINTENANCE,
+        description=(
+            "Add a mark (star/pin/archive) to a session, message, or block. Idempotent — returns unchanged "
+            "when the mark is already present. Routed through OperationExecutor/MarkAddActuator (reversible "
+            "class, role_only confirmation); the first MCP no-spec mutation family (t46.9 phase 2) to gain "
+            "an OperationSpec and executor route."
+        ),
+        consumes=("sessions", "assertions"),
+        produces=("assertions",),
+        path_targets=("mark-mutation-loop",),
+        code_refs=(
+            "polylogue.api.archive.PolylogueArchiveMixin.add_mark",
+            "polylogue.mcp.server_cutover._dispatch_write",
+            "polylogue.operations.mutation_actuators.MarkAddActuator",
+        ),
+        surfaces=("mcp", "api"),
+        mutates_state=True,
+        idempotent=True,
+        effects=("DbRead", "DbWrite"),
+        safety_guards=("write_role_required",),
+        executor_status="executor-routed",
+    ),
+    OperationSpec(
+        name="mutate-remove-mark",
+        kind=OperationKind.MAINTENANCE,
+        description=(
+            "Remove a mark from a session, message, or block. Idempotent — returns unchanged when the mark "
+            "is absent. Routed through OperationExecutor/MarkRemoveActuator (reversible class, role_only "
+            "confirmation)."
+        ),
+        consumes=("sessions", "assertions"),
+        produces=("assertions",),
+        path_targets=("mark-mutation-loop",),
+        code_refs=(
+            "polylogue.api.archive.PolylogueArchiveMixin.remove_mark",
+            "polylogue.mcp.server_cutover._dispatch_write",
+            "polylogue.operations.mutation_actuators.MarkRemoveActuator",
+        ),
+        surfaces=("mcp", "api"),
+        mutates_state=True,
+        idempotent=True,
+        effects=("DbRead", "DbWrite"),
+        safety_guards=("write_role_required",),
+        executor_status="executor-routed",
     ),
     OperationSpec(
         name="mutate-delete-session",

--- a/tests/unit/operations/test_mutation_actuators.py
+++ b/tests/unit/operations/test_mutation_actuators.py
@@ -1,12 +1,22 @@
 """Real-dependency tests for the t46.9/kwsb.2 named-route actuators.
 
-Anti-vacuity: these drive ``SessionDeleteActuator``/``IdentityResetActuator``
-against a real seeded ``index.db``/``user.db`` pair (real schema, real SQL),
-not a toy replica. ``test_session_delete_actuator_removes_the_session_row``
-fails if ``SessionDeleteActuator.apply`` stops calling
-``ArchiveStore.delete_sessions``; ``test_identity_reset_actuator_suppresses_
-and_deletes`` fails if ``IdentityResetActuator.apply`` stops writing the
-``user.db`` suppression row or stops deleting the ``index.db`` session row.
+Anti-vacuity: these drive the actuators against a real seeded
+``index.db``/``user.db`` pair (real schema, real SQL), not a toy replica.
+``test_session_delete_actuator_removes_the_session_row`` fails if
+``SessionDeleteActuator.apply`` stops calling ``ArchiveStore.delete_sessions``;
+``test_identity_reset_actuator_suppresses_and_deletes`` fails if
+``IdentityResetActuator.apply`` stops writing the ``user.db`` suppression row
+or stops deleting the ``index.db`` session row.
+
+Phase 2 (t46.9/kwsb.2) additions below (``TagAddActuator``/``TagRemoveActuator``/
+``BulkTagActuator``/``MetadataSetActuator``/``MetadataDeleteActuator``/
+``MarkAddActuator``/``MarkRemoveActuator``) drive the real
+``ArchiveStore.add_user_tags``/``remove_user_tags``/``set_user_metadata``/
+``delete_user_metadata``/``add_mark``/``remove_mark`` primitives against the
+same real ``user.db`` schema, and additionally prove AC4 (reversible writes
+do not require interactive confirmation): every ``role_only``-strength
+``authorize`` call below succeeds where the phase-1 delete/reset actuators
+above require ``confirm_flag`` and refuse ``role_only``.
 """
 
 from __future__ import annotations
@@ -17,10 +27,23 @@ from pathlib import Path
 import pytest
 
 from polylogue.operations.mutation_actuators import (
+    BulkTagActuator,
+    BulkTagArgs,
     IdentityResetActuator,
     IdentityResetArgs,
+    MarkAddActuator,
+    MarkArgs,
+    MarkRemoveActuator,
+    MetadataDeleteActuator,
+    MetadataDeleteArgs,
+    MetadataSetActuator,
+    MetadataSetArgs,
     SessionDeleteActuator,
     SessionDeleteArgs,
+    TagAddActuator,
+    TagAddArgs,
+    TagRemoveActuator,
+    TagRemoveArgs,
 )
 from polylogue.operations.mutation_transaction import ConfirmationRequiredError, OperationExecutor, PlanStaleError
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -177,3 +200,337 @@ class TestIdentityResetActuator:
         assert plan.target_refs == ()
         with sqlite3.connect(archive_root / "index.db") as conn:
             assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 1
+
+
+class TestTagAddActuator:
+    def test_full_lifecycle_writes_the_tag_assertion(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        session_id = _seed_archive_session(archive_root, native_id="tag-add")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            actuator = TagAddActuator()
+            executor = OperationExecutor()
+            args = TagAddArgs(archive=archive, session_id=session_id, tag="Review")
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator, plan, actor="test", role="write", capability="test", confirmation_strength="role_only"
+            )
+            receipt = executor.execute(actuator, plan, authorization, args)
+
+        assert receipt.status == "applied"
+        assert receipt.affected_count == 1
+        with sqlite3.connect(archive_root / "user.db") as conn:
+            rows = conn.execute("SELECT key FROM assertions WHERE kind = 'tag' AND status != 'deleted'").fetchall()
+        assert [r[0] for r in rows] == ["review"]
+
+    def test_duplicate_add_is_already_satisfied(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        session_id = _seed_archive_session(archive_root, native_id="tag-dup")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            actuator = TagAddActuator()
+            executor = OperationExecutor()
+            args = TagAddArgs(archive=archive, session_id=session_id, tag="dup")
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator, plan, actor="test", role="write", capability="test", confirmation_strength="role_only"
+            )
+            executor.execute(actuator, plan, authorization, args)
+            # Second round trip against the same live state.
+            plan2 = executor.prepare(actuator, args)
+            authorization2 = executor.authorize(
+                actuator, plan2, actor="test", role="write", capability="test", confirmation_strength="role_only"
+            )
+            receipt2 = executor.execute(actuator, plan2, authorization2, args)
+
+        assert receipt2.status == "already_satisfied"
+        assert receipt2.affected_count == 0
+
+    def test_nonexistent_session_raises_keyerror_at_prepare(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        _seed_archive_session(archive_root, native_id="tag-real")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            actuator = TagAddActuator()
+            args = TagAddArgs(archive=archive, session_id="codex-session:typo", tag="x")
+            with pytest.raises(KeyError):
+                actuator.prepare(args)
+
+
+class TestTagRemoveActuator:
+    def test_full_lifecycle_marks_the_tag_deleted(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        session_id = _seed_archive_session(archive_root, native_id="tag-remove")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            archive.add_user_tags((session_id,), ("keep",))
+            actuator = TagRemoveActuator()
+            executor = OperationExecutor()
+            args = TagRemoveArgs(archive=archive, session_id=session_id, tag="KEEP")
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator, plan, actor="test", role="write", capability="test", confirmation_strength="role_only"
+            )
+            receipt = executor.execute(actuator, plan, authorization, args)
+
+        assert receipt.status == "applied"
+        with sqlite3.connect(archive_root / "user.db") as conn:
+            status = conn.execute("SELECT status FROM assertions WHERE kind = 'tag'").fetchone()[0]
+        assert status == "deleted"
+
+    def test_missing_tag_is_already_satisfied(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        session_id = _seed_archive_session(archive_root, native_id="tag-remove-missing")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            actuator = TagRemoveActuator()
+            executor = OperationExecutor()
+            args = TagRemoveArgs(archive=archive, session_id=session_id, tag="absent")
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator, plan, actor="test", role="write", capability="test", confirmation_strength="role_only"
+            )
+            receipt = executor.execute(actuator, plan, authorization, args)
+
+        assert receipt.status == "already_satisfied"
+        assert receipt.detail == "tag_not_present"
+
+
+class TestBulkTagActuator:
+    def test_skips_unresolved_sessions_and_tags_the_rest(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        session_id = _seed_archive_session(archive_root, native_id="bulk")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            actuator = BulkTagActuator()
+            executor = OperationExecutor()
+            args = BulkTagArgs(archive=archive, session_ids=(session_id, "does-not-exist"), tags=("a", "b"))
+            plan = executor.prepare(actuator, args)
+            assert plan.target_refs == (f"session:{session_id}",)
+            authorization = executor.authorize(
+                actuator, plan, actor="test", role="write", capability="test", confirmation_strength="role_only"
+            )
+            receipt = executor.execute(actuator, plan, authorization, args)
+
+        assert receipt.status == "applied"
+        assert receipt.domain_receipt["affected_count"] == 1
+        assert receipt.domain_receipt["session_count"] == 2
+        assert receipt.domain_receipt["skipped_count"] == 1
+        with sqlite3.connect(archive_root / "user.db") as conn:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM assertions WHERE kind = 'tag' AND status != 'deleted'"
+            ).fetchone()[0]
+        assert count == 2
+
+
+class TestMetadataSetActuator:
+    def test_full_lifecycle_writes_the_metadata_assertion(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        session_id = _seed_archive_session(archive_root, native_id="meta-set")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            actuator = MetadataSetActuator()
+            executor = OperationExecutor()
+            args = MetadataSetArgs(archive=archive, session_id=session_id, key="priority", value="high")
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator, plan, actor="test", role="write", capability="test", confirmation_strength="role_only"
+            )
+            receipt = executor.execute(actuator, plan, authorization, args)
+
+        assert receipt.status == "applied"
+        with sqlite3.connect(archive_root / "user.db") as conn:
+            row = conn.execute("SELECT key, value_json FROM assertions WHERE kind = 'metadata'").fetchone()
+        assert row[0] == "priority"
+        assert "high" in row[1]
+
+    def test_unchanged_value_is_already_satisfied(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        session_id = _seed_archive_session(archive_root, native_id="meta-unchanged")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            archive.set_user_metadata((session_id,), (("status", "open"),))
+            actuator = MetadataSetActuator()
+            executor = OperationExecutor()
+            args = MetadataSetArgs(archive=archive, session_id=session_id, key="status", value="open")
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator, plan, actor="test", role="write", capability="test", confirmation_strength="role_only"
+            )
+            receipt = executor.execute(actuator, plan, authorization, args)
+
+        assert receipt.status == "already_satisfied"
+        assert receipt.detail == "value_unchanged"
+
+
+class TestMetadataDeleteActuator:
+    def test_full_lifecycle_marks_the_metadata_deleted(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        session_id = _seed_archive_session(archive_root, native_id="meta-delete")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            archive.set_user_metadata((session_id,), (("status", "open"),))
+            actuator = MetadataDeleteActuator()
+            executor = OperationExecutor()
+            args = MetadataDeleteArgs(archive=archive, session_id=session_id, key="status")
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator, plan, actor="test", role="write", capability="test", confirmation_strength="role_only"
+            )
+            receipt = executor.execute(actuator, plan, authorization, args)
+
+        assert receipt.status == "applied"
+        with sqlite3.connect(archive_root / "user.db") as conn:
+            status = conn.execute("SELECT status FROM assertions WHERE kind = 'metadata'").fetchone()[0]
+        assert status == "deleted"
+
+    def test_missing_key_is_already_satisfied(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        session_id = _seed_archive_session(archive_root, native_id="meta-delete-missing")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            actuator = MetadataDeleteActuator()
+            executor = OperationExecutor()
+            args = MetadataDeleteArgs(archive=archive, session_id=session_id, key="absent")
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator, plan, actor="test", role="write", capability="test", confirmation_strength="role_only"
+            )
+            receipt = executor.execute(actuator, plan, authorization, args)
+
+        assert receipt.status == "already_satisfied"
+        assert receipt.detail == "key_not_found"
+
+
+class TestMarkActuators:
+    def test_add_then_remove_round_trips_through_user_db(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        session_id = _seed_archive_session(archive_root, native_id="mark")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            executor = OperationExecutor()
+
+            add_actuator = MarkAddActuator()
+            add_args = MarkArgs(archive=archive, target_type="session", target_id=session_id, mark_type="star")
+            add_plan = executor.prepare(add_actuator, add_args)
+            add_authorization = executor.authorize(
+                add_actuator, add_plan, actor="test", role="write", capability="test", confirmation_strength="role_only"
+            )
+            add_receipt = executor.execute(add_actuator, add_plan, add_authorization, add_args)
+            assert add_receipt.status == "applied"
+
+            with sqlite3.connect(archive_root / "user.db") as conn:
+                status = conn.execute("SELECT status FROM assertions WHERE kind = 'mark'").fetchone()[0]
+            assert status != "deleted"
+
+            remove_actuator = MarkRemoveActuator()
+            remove_plan = executor.prepare(remove_actuator, add_args)
+            remove_authorization = executor.authorize(
+                remove_actuator,
+                remove_plan,
+                actor="test",
+                role="write",
+                capability="test",
+                confirmation_strength="role_only",
+            )
+            remove_receipt = executor.execute(remove_actuator, remove_plan, remove_authorization, add_args)
+            assert remove_receipt.status == "applied"
+
+            with sqlite3.connect(archive_root / "user.db") as conn:
+                status = conn.execute("SELECT status FROM assertions WHERE kind = 'mark'").fetchone()[0]
+            assert status == "deleted"
+
+    def test_duplicate_add_is_already_satisfied(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        session_id = _seed_archive_session(archive_root, native_id="mark-dup")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            executor = OperationExecutor()
+            actuator = MarkAddActuator()
+            args = MarkArgs(archive=archive, target_type="session", target_id=session_id, mark_type="pin")
+            plan = executor.prepare(actuator, args)
+            authorization = executor.authorize(
+                actuator, plan, actor="test", role="write", capability="test", confirmation_strength="role_only"
+            )
+            executor.execute(actuator, plan, authorization, args)
+
+            plan2 = executor.prepare(actuator, args)
+            authorization2 = executor.authorize(
+                actuator, plan2, actor="test", role="write", capability="test", confirmation_strength="role_only"
+            )
+            receipt2 = executor.execute(actuator, plan2, authorization2, args)
+
+        assert receipt2.status == "already_satisfied"
+
+
+class TestReversibleActuatorsAcceptTheWeakestConfirmation:
+    """AC4: reversible writes must not require confirm_flag/bound_token."""
+
+    def test_role_only_never_raises_confirmation_required(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        session_id = _seed_archive_session(archive_root, native_id="ac4")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            executor = OperationExecutor()
+
+            tag_actuator = TagAddActuator()
+            tag_args = TagAddArgs(archive=archive, session_id=session_id, tag="t")
+            tag_plan = executor.prepare(tag_actuator, tag_args)
+            executor.authorize(
+                tag_actuator, tag_plan, actor="test", role="write", capability="test", confirmation_strength="role_only"
+            )
+
+            metadata_actuator = MetadataSetActuator()
+            metadata_args = MetadataSetArgs(archive=archive, session_id=session_id, key="k", value="v")
+            metadata_plan = executor.prepare(metadata_actuator, metadata_args)
+            executor.authorize(
+                metadata_actuator,
+                metadata_plan,
+                actor="test",
+                role="write",
+                capability="test",
+                confirmation_strength="role_only",
+            )
+
+            mark_actuator = MarkAddActuator()
+            mark_args = MarkArgs(archive=archive, target_type="session", target_id=session_id, mark_type="star")
+            mark_plan = executor.prepare(mark_actuator, mark_args)
+            # None of the three role_only authorize calls above raised
+            # ConfirmationRequiredError -- that is the AC4 assertion.
+            executor.authorize(
+                mark_actuator,
+                mark_plan,
+                actor="test",
+                role="write",
+                capability="test",
+                confirmation_strength="role_only",
+            )
+
+    def test_delete_class_actuator_refuses_role_only(self, tmp_path: Path) -> None:
+        """Contrast: the phase-1 delete actuator still requires confirm_flag."""
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        session_id = _seed_archive_session(archive_root, native_id="ac4-contrast")
+
+        with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+            executor = OperationExecutor()
+            actuator = SessionDeleteActuator()
+            args = SessionDeleteArgs(archive=archive, session_ids=(session_id,))
+            plan = executor.prepare(actuator, args)
+            with pytest.raises(ConfirmationRequiredError):
+                executor.authorize(
+                    actuator, plan, actor="test", role="write", capability="test", confirmation_strength="role_only"
+                )


### PR DESCRIPTION
## Summary

Phase 2 of the t46.9/kwsb.2 mutation-executor migration: routes the
`reversible`-class tag, metadata, and mark mutation families through
`OperationExecutor`/`MutationActuator` (the PREPARE → AUTHORIZE → EXECUTE
lifecycle shipped in phase 1, PR #3249), replacing per-surface direct calls
to the underlying `ArchiveStore` primitives.

## Problem

`docs/plans/mutation-census.yaml` (phase 1) inventoried `mutate-add-tag`,
`mutate-remove-tag`, `mutate-bulk-tag-sessions`, `mutate-set-metadata`, and
`mutate-delete-metadata` as `declared-not-routed`: CLI (query-mutation path),
MCP (`write(operation=...)`), and the Python API facade each reached
`ArchiveStore.add_user_tags`/`remove_user_tags`/`set_user_metadata`/
`delete_user_metadata` independently, with no shared preview/authorize/
receipt contract and no `OperationSpec`-level executor status beyond
"declared". Separately, `add_mark`/`remove_mark` was a genuine MCP-only
mutation family with **no `OperationSpec` at all** — invisible to the t46.9
AC1 inventory.

## Solution

**New actuators** (`polylogue/operations/mutation_actuators.py`):
`TagAddActuator`, `TagRemoveActuator`, `BulkTagActuator`,
`MetadataSetActuator`, `MetadataDeleteActuator`, `MarkAddActuator`,
`MarkRemoveActuator`. Each wraps exactly one existing `ArchiveStore`
primitive unchanged (`add_user_tags`/`remove_user_tags`/`set_user_metadata`/
`delete_user_metadata`/`add_mark`/`remove_mark`) and declares
`destructive_class="reversible"` + `required_confirmation="role_only"` —
the AC4 floor: reversible writes (undo = another write through the same
actuator) must not force an interactive confirm ceremony, unlike phase 1's
`confirm_flag`-gated delete/excise/reset actuators.

**Routing** (`polylogue/api/archive.py`): `PolylogueArchiveMixin.add_tag`,
`remove_tag`, `bulk_tag_sessions`, `set_metadata`, `delete_metadata`,
`add_mark`, `remove_mark` now construct the actuator + `OperationExecutor`
and drive PREPARE → AUTHORIZE → EXECUTE instead of calling the archive
primitive directly. This is the single choke point every surface already
funneled through (CLI's `apply_modifiers`/query-mutation path and
`query_verbs.py`, MCP's `write(operation=...)` dispatch, and direct API
callers), so routing it there covers all three surfaces in one place —
mirroring how phase 1 routed `delete_session_safe`.

**Specs** (`polylogue/operations/specs.py`): flipped the five existing
tag/metadata specs' `executor_status` to `executor-routed`, and added two
new specs, `mutate-add-mark`/`mutate-remove-mark` (previously absent from
the catalog entirely) — the first MCP no-spec mutation family to gain both
an `OperationSpec` and an executor route.

**Census** (`docs/plans/mutation-census.yaml`): moved the seven rows above
from `declared-not-routed` to `executor-routed` with actuator/adapter
citations, and removed a stale duplicate `delete_metadata (MCP admin alias)`
row that named the exact same code path as `mutate-delete-metadata` (there
is only one `delete_metadata` code path in `mcp/server_cutover.py`).

**Race-window fix** (`polylogue/api/archive.py`): widened the
`KeyError → SessionNotFoundError` conversion in `add_tag`/`remove_tag`/
`set_metadata`/`delete_metadata` to wrap AUTHORIZE+EXECUTE as well as
PREPARE. `OperationExecutor.execute` re-resolves the plan via a fresh
`actuator.prepare()` call before mutating; if a session is deleted by a
concurrent actor between AUTHORIZE and EXECUTE, that fresh PREPARE now
raises `KeyError` inside the same `try` block instead of leaking an
untyped exception past the facade boundary.

### Routing matrix

| Family | Spec | Actuator | Surfaces | Census state |
| --- | --- | --- | --- | --- |
| add tag | `mutate-add-tag` | `TagAddActuator` | facade, mcp, api | executor-routed |
| remove tag | `mutate-remove-tag` | `TagRemoveActuator` | facade, mcp, api | executor-routed |
| bulk tag | `mutate-bulk-tag-sessions` | `BulkTagActuator` | mcp, api | executor-routed |
| set metadata | `mutate-set-metadata` | `MetadataSetActuator` | facade, mcp, api | executor-routed |
| delete metadata | `mutate-delete-metadata` | `MetadataDeleteActuator` | mcp, api | executor-routed |
| add mark | `mutate-add-mark` (new) | `MarkAddActuator` | mcp, api | executor-routed |
| remove mark | `mutate-remove-mark` (new) | `MarkRemoveActuator` | mcp, api | executor-routed |

### AC coverage (t46.9)

- **AC1** (one inventory covers every mutation): extended — `add_mark`/
  `remove_mark` now have `OperationSpec` entries where previously they had
  none; the census/spec cross-check test (`test_mutation_census.py`) stays
  green and honest.
- **AC5** (internal actors use declared capabilities through the executor):
  not touched this phase — no daemon/maintenance internal actor was in
  scope here.
- **AC8** (jn40 confirm booleans retained only as interim compat): not
  affected — none of the seven migrated operations were in jn40's
  confirm-gated list (only `delete_session`/`delete_annotation`/
  `delete_saved_view`/`delete_recall_pack`/`delete_workspace`/
  `maintenance_execute` family are), so there was no confirm boolean to
  remove or reduce here.

## Verification

```
devtools test tests/unit/operations/test_mutation_actuators.py \
  tests/unit/operations/test_mutation_census.py \
  tests/unit/operations/test_mutations.py \
  tests/unit/api/test_facade_contracts.py
# 307 passed

devtools test tests/unit/mcp/test_mcp_edge_cases.py tests/unit/mcp/test_contract_evidence.py \
  tests/unit/mcp/test_privileged_tools.py tests/unit/mcp/test_tool_discovery.py
# 60 passed

devtools verify --quick
# exit_code: 0 (ruff format/check, mypy --strict, render all --check all clean)
```

Anti-vacuity (`tests/unit/operations/test_mutation_actuators.py`): each new
actuator is driven against a real seeded `index.db`/`user.db` pair (real
schema, real SQL) and asserts on the actual `assertions` table rows —
e.g. `TestTagAddActuator::test_full_lifecycle_writes_the_tag_assertion`
fails if `TagAddActuator.apply` stops calling `ArchiveStore.add_user_tags`.
`TestReversibleActuatorsAcceptTheWeakestConfirmation` directly contrasts a
`role_only` AUTHORIZE succeeding for the new reversible actuators against
`SessionDeleteActuator` (phase 1) refusing the identical `role_only`
strength with `ConfirmationRequiredError` — the AC4 evidence.

`devtools test tests/unit/cli/test_verb_cardinality.py -k
test_guard_dry_run_and_deleted_sets_are_identical_and_unlimited` fails
identically on unmodified `master` (`git stash` before/after) — pre-existing
"no running event loop" / `RuntimeServices` `ConfigError`, unrelated to this
change; not touched here.

Not run: full `devtools verify --all` (reserved for a final pre-merge pass
per repo convention; the touched surface's affected-area tests above plus
`--quick` gate cover this change).

## Remaining polylogue-t46.9 / polylogue-kwsb.2 scope

Named as Phase 3 debt in the census, not attempted in this PR:

- `save_annotation`/`delete_annotation`, `save_saved_view`/
  `delete_saved_view`, `save_recall_pack`/`delete_recall_pack`,
  `save_workspace`/`delete_workspace` — `delete_*` members are jn40
  confirm-gated at the MCP layer; not yet executor-routed.
- `record_correction`/`clear_corrections`, `capture_assertion_candidate`,
  `blackboard_post`, `import_annotation_batch` — additive/low-blast-radius
  writes, still `declared-not-routed`.
- `rebuild_index`/`update_index`/`rebuild_insights` (`maintenance_execute`
  family) — internal idempotent-rebuild maintenance, jn40 confirm-gated.
- `ops reset --database/--index/--blob/--assets/--cache/--auth` (file-tier
  deletion) — census still asks whether to extend `MutationPlan`'s
  target-ref vocabulary to file-tier targets or keep this a typed exemption
  permanently; no decision made in this PR.
- `bound_token` confirmation-strength adoption and durable audit-row
  persistence — untouched, as scoped by the task brief.

Ref polylogue-t46.9
Ref polylogue-kwsb.2