### PR TITLE
fix(nix): make HM module PATH install optional via installPackage

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -43,6 +43,18 @@ in
       description = "The polylogue package to use.";
     };
 
+    installPackage = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Whether to add ``package`` to ``home.packages`` (user PATH).
+        Disable when the daemon runs a different build than the
+        interactive CLI on PATH — e.g. a free-threaded 3.14t daemon
+        alongside a standard-CPython CLI wrapper — so the two packages
+        do not collide on ``bin/polylogue`` in the profile.
+      '';
+    };
+
     autoStart = mkOption {
       type = types.bool;
       default = true;
@@ -78,7 +90,7 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    home.packages = [ cfg.package ];
+    home.packages = lib.mkIf cfg.installPackage [ cfg.package ];
 
     xdg.configFile = lib.mkIf useXdg {
       ${xdgRelPath} = {


### PR DESCRIPTION
## Summary
Adds `programs.polylogued.installPackage` (default `true`) gating the `home.packages = [ cfg.package ]` line in the Home Manager module.

## Problem
Deploying the free-threaded 3.14t daemon (Ref polylogue-dcz5) while keeping the standard-CPython CLI wrapper on the user PATH fails the HM `buildEnv`: `polylogue-cli/bin/polylogue` and `python3.14t-polylogue/bin/polylogue` are conflicting subpaths. Hit live on the sinnix switch 2026-07-21 (build failed pre-activation; system unchanged).

## Solution
Additive option, default preserves existing behavior for all consumers. Site config sets `installPackage = false` when the daemon build differs from the PATH CLI.

## Verification
- `nix eval .#homeManagerModules` — module set evaluates.
- `nix build .#polylogue-freethreaded --no-link` — target package builds.
- End-to-end proof is the sinnix switch consuming this via flake-input bump (receipt to land on polylogue-dcz5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to control whether the Polylogued package is installed in the user’s Home Manager profile.
  * Package installation is enabled by default, preserving existing behavior.
  * The Polylogued configuration and user service continue to work unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->