### PR TITLE
fix(storage): keep equivalents quarantined-ambiguous when no head is accepted

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -3265,7 +3265,18 @@ class ArchiveStore:
         conn = self._ensure_source_conn()
         decided_at_ms = int(datetime.now(UTC).timestamp() * 1000)
         decisions: dict[str, str] = dict.fromkeys(classification.ambiguous_raw_ids, "ambiguous")
-        decisions.update(dict.fromkeys(classification.equivalent_raw_ids, "superseded_equivalent"))
+        # "superseded_equivalent" asserts an accepted chain superseded the
+        # member. With no accepted head, equivalence collapses back into the
+        # unresolved cohort: labeling it superseded (and, downstream,
+        # byte_proven) fabricates authority for a head that was never written
+        # -- 914 headless-but-"byte_proven" logical sources on the 2026-07-20
+        # rebuild walk came from exactly this mislabel.
+        decisions.update(
+            dict.fromkeys(
+                classification.equivalent_raw_ids,
+                "superseded_equivalent" if classification.accepted_raw_ids else "ambiguous",
+            )
+        )
         for raw_id in classification.accepted_raw_ids[:-1]:
             decisions[raw_id] = "superseded_prefix"
         session_id: str | None = None

--- a/tests/unit/storage/test_revision_replay.py
+++ b/tests/unit/storage/test_revision_replay.py
@@ -237,6 +237,87 @@ def test_membership_reselection_reuses_equivalent_superseded_receipt(tmp_path: P
         assert matching_receipts is not None and tuple(matching_receipts) == (1,)
 
 
+def test_headless_cohort_keeps_equivalents_quarantined_ambiguous(tmp_path: Path) -> None:
+    """No accepted head means no fabricated supersession authority.
+
+    Production dependency: ``apply_raw_membership_classification``'s
+    membership write-back. Mutation that must fail this test: labeling
+    ``equivalent_raw_ids`` as ``superseded_equivalent``/``byte_proven`` when
+    ``accepted_raw_ids`` is empty (the pre-fix behavior that produced 914
+    headless-but-byte_proven logical sources on the 2026-07-20 rebuild).
+    """
+    initialize_active_archive_root(tmp_path)
+
+    def session_with(text: str) -> ParsedSession:
+        return ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="session",
+            messages=[ParsedMessage(provider_message_id="m0", role=Role.USER, text=text)],
+        )
+
+    branch_a = session_with("alpha")
+    branch_b = session_with("beta")
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+
+        def add_member(raw_id: str, session: ParsedSession) -> MembershipRevision:
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=raw_id.encode(),
+                source_path=f"{raw_id}.jsonl",
+                acquired_at_ms=1,
+                raw_id=raw_id,
+            )
+            archive.replace_raw_membership_census(
+                raw_id,
+                [session],
+                parser_fingerprint="test-parser",
+                censused_at_ms=1,
+            )
+            return MembershipRevision(raw_id, session_revision_projection(session))
+
+        members = [
+            add_member("branch-a", branch_a),
+            add_member("branch-a-dup", branch_a),
+            add_member("branch-b", branch_b),
+        ]
+        classification = classify_membership_revisions(members)
+        assert classification.accepted_raw_ids == ()
+        assert classification.equivalent_raw_ids
+
+        session_by_raw = {"branch-a": branch_a, "branch-a-dup": branch_a, "branch-b": branch_b}
+        archive.apply_raw_membership_classification(
+            "codex:session",
+            classification,
+            session_by_raw,
+            {raw_id: session_revision_projection(session) for raw_id, session in session_by_raw.items()},
+            acquired_at_ms=1,
+        )
+
+        head = archive._conn.execute(
+            "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = 'codex:session'"
+        ).fetchone()
+        assert head is None
+
+        membership_rows = (
+            archive._ensure_source_conn()
+            .execute(
+                """
+            SELECT raw_id, decision, revision_authority
+            FROM raw_session_memberships
+            WHERE logical_source_key = 'codex:session'
+            ORDER BY raw_id
+            """
+            )
+            .fetchall()
+        )
+        assert [tuple(row) for row in membership_rows] == [
+            ("branch-a", "ambiguous", "quarantined"),
+            ("branch-a-dup", "ambiguous", "quarantined"),
+            ("branch-b", "ambiguous", "quarantined"),
+        ]
+
+
 def test_replay_defers_gap_and_quarantines_unproven_evidence() -> None:
     candidates = [
         _candidate("base", RawRevisionKind.FULL, 1),


### PR DESCRIPTION
## Summary
When `classify_membership_revisions` refuses to pick a head (`accepted_raw_ids=()`), the membership write-back no longer labels `equivalent_raw_ids` as `superseded_equivalent`/`byte_proven` — they collapse back into the unresolved cohort as `ambiguous`/`quarantined`.

## Problem
Live-archive forensics (Ref polylogue-yla8; report `.agent/reports/byte-headless-914-investigation-2026-07-21.md`) found 914 logical sources (155,816 max messages) whose memberships read `byte_proven`/`superseded_equivalent` yet have **no** `raw_revision_heads` row, no application receipt, and no session — supersession authority fabricated for a head that was never written. Introduced by 6a579d090 (#2684, 2026-07-11); the 2026-07-20 rebuild walk amplified it (93% of the cohort decided in one hour).

## Solution
One-line gate in `apply_raw_membership_classification`'s decisions construction: equivalents map to `superseded_equivalent` only when `accepted_raw_ids` is non-empty. The authority ternary then keeps them `quarantined` automatically. Comment documents the incident.

## Verification
- `devtools test tests/unit/storage/test_revision_replay.py` → 23 passed.
- New `test_headless_cohort_keeps_equivalents_quarantined_ambiguous`: all-ambiguous cohort with duplicate content → no head row, every member `('ambiguous','quarantined')`. Anti-vacuity: with the fix stashed, the test fails (pre-fix labeling) — verified.
- `devtools test tests/unit/storage/test_no_string_interpolated_sql.py` (archive.py self-audit) → pass.
- `devtools verify --quick` → exit 0.

Note: repairing the existing mislabeled rows on the live archive is a separate coordinator-owned step (re-census after this merges).

Ref polylogue-yla8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QUsH3Rhq6oAZpYPWcsZqnZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of conflicting revision branches when no accepted version exists.
  * Keeps affected records marked as ambiguous and quarantined instead of incorrectly treating them as superseded.

* **Tests**
  * Added coverage to verify that headless revision groups retain their ambiguous status and do not produce an accepted revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->