### PR TITLE
fix(storage): classify oversized quarantine-repair targets instead of aborting the batch

### DIFF
--- a/polylogue/storage/raw_reconciler.py
+++ b/polylogue/storage/raw_reconciler.py
@@ -1043,9 +1043,9 @@ def _apply_strategy(
         _inspect_browser_capture_origin_strategy,
         _inspect_duplicate_raw_identity,
         _inspect_quarantined_accepted_raw,
+        _partition_quarantined_raw_repair_blob_budget,
         _stage_browser_origin_copy_forward_source,
         _stage_quarantined_census_cohort,
-        _validate_quarantined_raw_repair_blob_budget,
         _verify_browser_origin_copy_forward_source_stage,
     )
 
@@ -1166,7 +1166,13 @@ def _apply_strategy(
             _attach_repair_index(source_conn, index_db)
             source_conn.execute("BEGIN IMMEDIATE")
             try:
-                _validate_quarantined_raw_repair_blob_budget(source_conn, [item.raw_id])
+                # Apply-side stays fail-closed: an authorized plan whose single
+                # target trips the blob budget must abort, not silently skip.
+                _, budget_excluded = _partition_quarantined_raw_repair_blob_budget(source_conn, [item.raw_id])
+                if budget_excluded:
+                    raise RuntimeError(
+                        f"quarantine repair blob budget refused {item.raw_id}: {budget_excluded[0].reason}"
+                    )
                 quarantine_locked = _inspect_quarantined_accepted_raw(root, item.raw_id, conn=source_conn)
                 if _quarantine_strategy_witness(quarantine_locked) != item.strategy_witness:
                     raise RuntimeError("quarantine strategy proof changed after plan authorization")

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -304,8 +304,22 @@ def _attach_repair_index(conn: sqlite3.Connection, index_db: Path) -> None:
     conn.execute("ATTACH DATABASE ? AS index_tier", (f"file:{index_db}?mode=ro",))
 
 
-def _validate_quarantined_raw_repair_blob_budget(conn: sqlite3.Connection, raw_ids: list[str]) -> None:
-    """Reject a bounded repair set before any retained blob is loaded into memory."""
+def _partition_quarantined_raw_repair_blob_budget(
+    conn: sqlite3.Connection, raw_ids: list[str]
+) -> tuple[list[str], list[QuarantinedAcceptedRawRepairItem]]:
+    """Split a repair set into (inspectable, budget-excluded) before any
+    retained blob is loaded into memory.
+
+    Live incident 2026-07-22: a single 298 MB codex whale raw over the
+    256 MiB per-target limit made this check (then a hard ``RuntimeError``)
+    abort the daemon's entire raw-authority frontier convergence pass every
+    cycle — one oversized target poisoned the whole batch, so NOTHING on the
+    frontier could converge. Whale targets and aggregate-budget overflow are
+    per-target *classifications* (typed ineligible items the caller reports
+    and retries/escalates), never batch-fatal exceptions. The memory-safety
+    guarantee is unchanged: excluded targets are returned before any blob
+    load happens.
+    """
     rows = conn.execute(
         """
         SELECT raw_id, blob_size FROM raw_sessions
@@ -313,16 +327,34 @@ def _validate_quarantined_raw_repair_blob_budget(conn: sqlite3.Connection, raw_i
         """,
         (json.dumps(raw_ids),),
     ).fetchall()
-    oversized = [
-        str(row["raw_id"]) for row in rows if int(row["blob_size"]) > _QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES
-    ]
-    if oversized:
-        raise RuntimeError(
-            "quarantined accepted raw repair exceeds the per-target retained-blob limit: " + ", ".join(oversized)
-        )
-    total = sum(int(row["blob_size"]) for row in rows)
-    if total > _QUARANTINED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES:
-        raise RuntimeError("quarantined accepted raw repair exceeds the aggregate retained-blob limit")
+    sizes = {str(row["raw_id"]): int(row["blob_size"]) for row in rows}
+    inspectable: list[str] = []
+    excluded: list[QuarantinedAcceptedRawRepairItem] = []
+    total = 0
+    for raw_id in raw_ids:
+        size = sizes.get(raw_id)
+        if size is not None and size > _QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES:
+            excluded.append(
+                _quarantined_raw_item(
+                    raw_id,
+                    f"retained blob ({size} bytes) exceeds the per-target repair limit "
+                    f"({_QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES} bytes)",
+                )
+            )
+            continue
+        if size is not None and total + size > _QUARANTINED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES:
+            # Retryable in a later batch, not a property of the target itself.
+            excluded.append(
+                _quarantined_raw_item(
+                    raw_id,
+                    "deferred: aggregate retained-blob repair budget exhausted by earlier targets in this batch",
+                )
+            )
+            continue
+        if size is not None:
+            total += size
+        inspectable.append(raw_id)
+    return inspectable, excluded
 
 
 def _proof_digest(item: QuarantinedAcceptedRawRepairItem) -> str:
@@ -1149,8 +1181,12 @@ def inspect_quarantined_accepted_raws(
         raise RuntimeError("source or index tier is missing")
     with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as conn:
         _attach_repair_index(conn, index_db)
-        _validate_quarantined_raw_repair_blob_budget(conn, raw_ids)
-        return tuple(_inspect_quarantined_accepted_raw(archive_root, raw_id, conn=conn) for raw_id in raw_ids)
+        inspectable, excluded = _partition_quarantined_raw_repair_blob_budget(conn, raw_ids)
+        by_id = {item.raw_id: item for item in excluded}
+        by_id.update(
+            {raw_id: _inspect_quarantined_accepted_raw(archive_root, raw_id, conn=conn) for raw_id in inspectable}
+        )
+        return tuple(by_id[raw_id] for raw_id in raw_ids)
 
 
 def _browser_origin_ineligible(raw_id: str, reason: str) -> BrowserCaptureOriginRepairItem:

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -331,7 +331,15 @@ def _partition_quarantined_raw_repair_blob_budget(
     inspectable: list[str] = []
     excluded: list[QuarantinedAcceptedRawRepairItem] = []
     total = 0
-    for raw_id in raw_ids:
+    # Aggregate admission runs smallest-first (review finding on this PR):
+    # it maximizes how many targets each cycle inspects, guarantees a small
+    # target can never be starved by a larger earlier one, and naturally
+    # latches — once one target overflows the aggregate budget, every later
+    # (larger-or-equal) target overflows too, so "exhausted" is truthful for
+    # the whole deferred tail. Ties/unknown sizes keep input order (stable
+    # sort; unknown sizes cost 0 and are admitted for downstream typed
+    # missing-row reporting).
+    for raw_id in sorted(raw_ids, key=lambda rid: sizes.get(rid, 0)):
         size = sizes.get(raw_id)
         if size is not None and size > _QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES:
             excluded.append(
@@ -347,7 +355,7 @@ def _partition_quarantined_raw_repair_blob_budget(
             excluded.append(
                 _quarantined_raw_item(
                     raw_id,
-                    "deferred: aggregate retained-blob repair budget exhausted by earlier targets in this batch",
+                    "deferred: aggregate retained-blob repair budget exhausted by smaller targets in this batch",
                 )
             )
             continue

--- a/tests/unit/storage/test_quarantine_repair_budget.py
+++ b/tests/unit/storage/test_quarantine_repair_budget.py
@@ -1,0 +1,87 @@
+"""Quarantined-accepted-raw repair blob-budget classification.
+
+Live incident 2026-07-22: a single 298 MB codex whale raw over the 256 MiB
+per-target limit made the budget check (then a hard ``RuntimeError``) abort
+the daemon's entire raw-authority frontier convergence pass every cycle --
+one oversized target poisoned the whole batch. The budget is now a
+per-target *partition*: oversized targets come back as typed ineligible
+items, aggregate overflow defers the tail, and every other target stays
+inspectable.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from polylogue.storage.repair import (
+    _QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES,
+    _QUARANTINED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES,
+    _partition_quarantined_raw_repair_blob_budget,
+)
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    connection = sqlite3.connect(":memory:")
+    connection.row_factory = sqlite3.Row
+    # Only the two columns the partition reads; the real raw_sessions schema
+    # is exercised by the archive-tier test suite.
+    connection.execute("CREATE TABLE raw_sessions (raw_id TEXT PRIMARY KEY, blob_size INTEGER NOT NULL)")
+    return connection
+
+
+def _seed(connection: sqlite3.Connection, sizes: dict[str, int]) -> None:
+    connection.executemany(
+        "INSERT INTO raw_sessions (raw_id, blob_size) VALUES (?, ?)",
+        list(sizes.items()),
+    )
+
+
+def test_oversized_whale_is_excluded_not_batch_fatal(conn: sqlite3.Connection) -> None:
+    whale = "a" * 64
+    small = "b" * 64
+    _seed(conn, {whale: _QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES + 1, small: 1024})
+
+    inspectable, excluded = _partition_quarantined_raw_repair_blob_budget(conn, [whale, small])
+
+    assert inspectable == [small]
+    assert [item.raw_id for item in excluded] == [whale]
+    assert excluded[0].status == "ineligible"
+    assert "per-target repair limit" in excluded[0].reason
+
+
+def test_aggregate_overflow_defers_tail_targets(conn: sqlite3.Connection) -> None:
+    # Three targets each just under the per-target cap; the third pushes the
+    # running total over the aggregate cap and must be deferred, not raise.
+    size = _QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES - 1
+    assert 3 * size > _QUARANTINED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES
+    ids = ["1" * 64, "2" * 64, "3" * 64]
+    _seed(conn, dict.fromkeys(ids, size))
+
+    inspectable, excluded = _partition_quarantined_raw_repair_blob_budget(conn, ids)
+
+    assert inspectable == ids[:2]
+    assert [item.raw_id for item in excluded] == [ids[2]]
+    assert "deferred" in excluded[0].reason
+
+
+def test_within_budget_set_is_fully_inspectable(conn: sqlite3.Connection) -> None:
+    ids = ["c" * 64, "d" * 64]
+    _seed(conn, dict.fromkeys(ids, 4096))
+
+    inspectable, excluded = _partition_quarantined_raw_repair_blob_budget(conn, ids)
+
+    assert inspectable == ids
+    assert excluded == []
+
+
+def test_unknown_raw_id_stays_inspectable_for_downstream_typed_reporting(conn: sqlite3.Connection) -> None:
+    """A raw id with no raw_sessions row is not a budget question -- the
+    inspect path itself reports it as a typed 'raw row is missing' item."""
+    missing = "e" * 64
+    inspectable, excluded = _partition_quarantined_raw_repair_blob_budget(conn, [missing])
+
+    assert inspectable == [missing]
+    assert excluded == []

--- a/tests/unit/storage/test_quarantine_repair_budget.py
+++ b/tests/unit/storage/test_quarantine_repair_budget.py
@@ -67,6 +67,25 @@ def test_aggregate_overflow_defers_tail_targets(conn: sqlite3.Connection) -> Non
     assert "deferred" in excluded[0].reason
 
 
+def test_small_late_target_is_never_starved_by_large_earlier_ones(conn: sqlite3.Connection) -> None:
+    """Admission is smallest-first: a small target listed after two large ones
+    is still inspected, and the deferred tail is the largest target -- so a
+    stable input order can never permanently starve small targets."""
+    big_a, big_b, small = "a" * 64, "b" * 64, "c" * 64
+    big_size = _QUARANTINED_ACCEPTED_RAW_REPAIR_BLOB_LIMIT_BYTES
+    # Two per-target-cap blobs fill the aggregate budget exactly; the small
+    # target's 1024 bytes tip whichever big one is admitted last over the edge.
+    assert 2 * big_size == _QUARANTINED_ACCEPTED_RAW_REPAIR_TOTAL_BLOB_LIMIT_BYTES
+    _seed(conn, {big_a: big_size, big_b: big_size, small: 1024})
+
+    inspectable, excluded = _partition_quarantined_raw_repair_blob_budget(conn, [big_a, big_b, small])
+
+    assert small in inspectable
+    assert len(inspectable) == 2
+    assert [item.raw_id for item in excluded] == [big_b]
+    assert "deferred" in excluded[0].reason
+
+
 def test_within_budget_set_is_fully_inspectable(conn: sqlite3.Connection) -> None:
     ids = ["c" * 64, "d" * 64]
     _seed(conn, dict.fromkeys(ids, 4096))


### PR DESCRIPTION
## Summary
The raw-authority frontier convergence pass no longer dies wholesale when a whale raw exceeds the quarantine-repair blob budget: oversized targets come back as typed ineligible items, aggregate overflow defers the batch tail, and every other target proceeds.

## Problem
First convergence cycle after the #3259 deploy (2026-07-22 02:00:58, live journal): `RuntimeError: quarantined accepted raw repair exceeds the per-target retained-blob limit: 0a2517ba9224b6733…` — a single 298.4 MB codex raw (`codex:019d4eea-2068-7852-a2e4-4f4ce000abe7`) over the 256 MiB per-target cap. `inspect_quarantined_accepted_raws` validated the whole chunk with a batch-fatal raise, so `_converge_raw_authority_frontier` burned ~42s and aborted every cycle; nothing on the frontier could converge. Same fail-closed-blocks-whales family as polylogue-t93b (operator ruling: whales must converge through the daemon).

## Solution
- `polylogue/storage/repair.py`: `_validate_quarantined_raw_repair_blob_budget` → `_partition_quarantined_raw_repair_blob_budget`, returning `(inspectable, excluded)` where excluded entries are typed `QuarantinedAcceptedRawRepairItem`s (`ineligible`, reason with byte counts; aggregate overflow → retryable `deferred:` reason). Memory-safety guarantee unchanged: exclusion is decided before any blob load. `inspect_quarantined_accepted_raws` merges excluded items back in input order.
- `polylogue/storage/raw_reconciler.py`: the apply-side (`REFINE_QUARANTINE`, single authorized target) stays fail-closed — budget refusal raises there, since an authorized plan must not silently skip.

The oversized whale target itself remains unrepaired-by-this-path by design; its escalation route is the t93b whale-pass family.

## Verification
- `devtools test tests/unit/storage/test_quarantine_repair_budget.py` — 4 passed (oversized→typed-ineligible, aggregate-overflow→deferred tail, in-budget→all inspectable, missing-row passthrough).
- `devtools verify --quick` — exit 0 (pre-push hook; mypy caught and drove the reconciler apply-side adaptation).

Ref polylogue-t93b, polylogue-yla8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quarantined raw-data repair now continues processing eligible items when individual records exceed repair limits.
  * Oversized or deferred records are clearly reported as ineligible instead of causing the entire inspection to fail.
  * Repair processing preserves the original item order and provides specific deferral reasons.

* **Tests**
  * Added coverage for per-record limits, aggregate budget overflow, fully eligible batches, and missing records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->