### PR TITLE
fix(storage): guard-gated bulk delete_sessions — one-pass derived maintenance instead of per-row trigger detonation

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -138,6 +138,12 @@ from polylogue.sources.dispatch import merge_parsed_session_chunks
 from polylogue.sources.parsers.base import ParsedSession
 from polylogue.storage.fts.fts_lifecycle import repair_message_fts_index_sync
 from polylogue.storage.fts.session_repair import repair_session_fts_if_needed_sync
+from polylogue.storage.fts.sql import (
+    FTS_BULK_SESSION_WRITE_GUARD,
+    delete_session_identity_rows_sql,
+    delete_session_rows_sql,
+    trigram_delete_session_rows_sql,
+)
 from polylogue.storage.insights.session.records import SessionProfileRecord
 from polylogue.storage.insights.session.runtime import (
     SESSION_INSIGHT_MATERIALIZATION_TYPES,
@@ -6901,6 +6907,48 @@ class ArchiveStore:
 
         User-tier overlays are intentionally left in ``user.db``; the user
         overlay orphan checker owns follow-up visibility for those durable rows.
+
+        polylogue-meoz: a plain per-session ``DELETE FROM sessions`` detonates
+        the per-row derived-refresh triggers -- ``blocks_action_pairs_ad``
+        (gated on the ``'session-write'`` guard, see ``index.py``) fires once
+        per deleted ``blocks`` row (both the explicit block cascade and the FK
+        ``ON DELETE CASCADE`` from ``messages``/``sessions`` still invoke AFTER
+        DELETE triggers per row) and, on each firing, deletes+rebuilds the
+        *entire session's* ``action_pairs`` via two window-function scans and
+        re-derives ``delegation_facts``. Live incident 2026-07-21: deleting 91
+        sessions ran 3h, 375GB reads, zero commit, before being killed.
+        ``messages_fts``/``blocks_command_trigram`` are external-content FTS5
+        tables with no FK cascade at all, so those triggers would fire and
+        maintain per-row postings unless suppressed the same way.
+
+        This mirrors ``_bulk_fts_session_guard``'s delete-then-guard-then-
+        mutate shape (``write.py``): explicit session-scoped FTS/identity/
+        trigram deletes run first (while ``blocks`` rows still exist -- the
+        trigram table needs the OLD text to locate its postings), then BOTH
+        ``derived_refresh_guard`` rows are set for the whole batch --
+        ``'session-write'`` (suppresses ``blocks_action_pairs_a{i,d,u}`` and
+        the ``delegation_facts`` triggers) and ``'fts-bulk-session-write'``
+        (suppresses the ``messages_fts``/``blocks_command_trigram`` trigger
+        BODIES, redundant here since those rows are already gone, but kept for
+        parity with the guard contract and defense-in-depth against any block
+        row that slips past the explicit pre-delete). ``action_pairs``/
+        ``delegation_facts`` are also explicitly cleared by session id --
+        belt-and-suspenders alongside the ``ON DELETE CASCADE`` FKs those
+        tables already carry against ``sessions``/``blocks``, and it keeps the
+        post-condition legible without depending on cascade timing. The
+        physical ``sessions``/``messages``/``blocks`` rows are then removed by
+        one ``DELETE FROM sessions`` per id, relying on indexed FK cascades
+        (not per-row trigger logic) for the tree removal; guard rows are
+        cleared and the transaction commits once for the whole batch.
+
+        The per-row ``query_unit_frame_{sessions,messages,blocks}_delete``
+        epoch-bump triggers (``index.py``) are NOT gated by either guard --
+        they still fire once per deleted row. Each firing is a single
+        primary-key ``UPDATE query_unit_frame_state SET epoch = epoch + 1
+        WHERE singleton = 1`` against a one-row table, not a window-function
+        rebuild, so it is O(1) per row rather than O(session_size) per row;
+        left ungated deliberately rather than folding a third guard in for a
+        cost that was never implicated by the incident.
         """
         resolved_session_ids = tuple(dict.fromkeys(self.resolve_session_id(session_id) for session_id in session_ids))
         if not resolved_session_ids:
@@ -6912,8 +6960,29 @@ class ArchiveStore:
         try:
             with conn:
                 for session_id in resolved_session_ids:
-                    cursor = conn.execute("DELETE FROM sessions WHERE session_id = ?", (session_id,))
-                    deleted += max(int(cursor.rowcount), 0)
+                    # Must run before the blocks rows are removed below --
+                    # external-content FTS5 deletion needs the OLD text/rowid
+                    # mapping to locate the postings to remove.
+                    conn.execute(delete_session_rows_sql(1), (session_id,))
+                    conn.execute(delete_session_identity_rows_sql(1), (session_id,))
+                    conn.execute(trigram_delete_session_rows_sql(), (session_id,))
+                conn.execute("INSERT OR REPLACE INTO derived_refresh_guard(guard_name) VALUES ('session-write')")
+                conn.execute(
+                    "INSERT OR REPLACE INTO derived_refresh_guard(guard_name) VALUES (?)",
+                    (FTS_BULK_SESSION_WRITE_GUARD,),
+                )
+                try:
+                    for session_id in resolved_session_ids:
+                        conn.execute("DELETE FROM action_pairs WHERE session_id = ?", (session_id,))
+                        conn.execute("DELETE FROM delegation_facts WHERE parent_session_id = ?", (session_id,))
+                        cursor = conn.execute("DELETE FROM sessions WHERE session_id = ?", (session_id,))
+                        deleted += max(int(cursor.rowcount), 0)
+                finally:
+                    conn.execute("DELETE FROM derived_refresh_guard WHERE guard_name = 'session-write'")
+                    conn.execute(
+                        "DELETE FROM derived_refresh_guard WHERE guard_name = ?",
+                        (FTS_BULK_SESSION_WRITE_GUARD,),
+                    )
         finally:
             conn.close()
         return deleted

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -6902,6 +6902,29 @@ class ArchiveStore:
         finally:
             user_conn.close()
 
+    def _trigram_trigger_is_guarded(self, conn: sqlite3.Connection) -> bool:
+        """Whether the live ``blocks_command_trigram_ad`` trigger honors the
+        bulk-write guard (CodeRabbit #3263 P1).
+
+        ``CREATE TRIGGER IF NOT EXISTS`` (index.py's additive-DDL convention)
+        never replaces an already-created same-name trigger, so an archive
+        last rebuilt before the guard clause was added to this trigger (#3259)
+        keeps its old, ungated body forever -- reopening it does not upgrade
+        it. Setting ``FTS_BULK_SESSION_WRITE_GUARD`` and relying on the guard
+        to suppress that trigger during the block cascade below would be a
+        silent no-op on such an archive: the old trigger fires anyway and
+        reissues an FTS5 ``'delete'`` command for a trigram row this method's
+        own explicit pre-delete already removed, which raises "database disk
+        image is malformed" and rolls back the whole batch. Checked once per
+        call (cheap: one indexed sqlite_master lookup) rather than assumed
+        from ``INDEX_SCHEMA_VERSION`` alone, since the guard clause landed
+        without its own version bump (additive/inert until this method).
+        """
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'trigger' AND name = 'blocks_command_trigram_ad'"
+        ).fetchone()
+        return row is not None and row["sql"] is not None and "derived_refresh_guard" in row["sql"]
+
     def delete_sessions(self, session_ids: tuple[str, ...]) -> int:
         """Delete rebuildable archive sessions by id.
 
@@ -6956,21 +6979,29 @@ class ArchiveStore:
         conn = sqlite3.connect(self.index_db_path)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA foreign_keys = ON")
+        trigram_guarded = self._trigram_trigger_is_guarded(conn)
         deleted = 0
         try:
             with conn:
                 for session_id in resolved_session_ids:
                     # Must run before the blocks rows are removed below --
                     # external-content FTS5 deletion needs the OLD text/rowid
-                    # mapping to locate the postings to remove.
+                    # mapping to locate the postings to remove. Only safe to
+                    # do explicitly when the live trigger will honor the
+                    # guard below; on an archive whose trigger predates it,
+                    # skip this and let that same (ungated) trigger clean up
+                    # trigram rows per-block during the cascade delete, same
+                    # as before this method existed.
                     conn.execute(delete_session_rows_sql(1), (session_id,))
                     conn.execute(delete_session_identity_rows_sql(1), (session_id,))
-                    conn.execute(trigram_delete_session_rows_sql(), (session_id,))
+                    if trigram_guarded:
+                        conn.execute(trigram_delete_session_rows_sql(), (session_id,))
                 conn.execute("INSERT OR REPLACE INTO derived_refresh_guard(guard_name) VALUES ('session-write')")
-                conn.execute(
-                    "INSERT OR REPLACE INTO derived_refresh_guard(guard_name) VALUES (?)",
-                    (FTS_BULK_SESSION_WRITE_GUARD,),
-                )
+                if trigram_guarded:
+                    conn.execute(
+                        "INSERT OR REPLACE INTO derived_refresh_guard(guard_name) VALUES (?)",
+                        (FTS_BULK_SESSION_WRITE_GUARD,),
+                    )
                 try:
                     for session_id in resolved_session_ids:
                         conn.execute("DELETE FROM action_pairs WHERE session_id = ?", (session_id,))
@@ -6979,10 +7010,11 @@ class ArchiveStore:
                         deleted += max(int(cursor.rowcount), 0)
                 finally:
                     conn.execute("DELETE FROM derived_refresh_guard WHERE guard_name = 'session-write'")
-                    conn.execute(
-                        "DELETE FROM derived_refresh_guard WHERE guard_name = ?",
-                        (FTS_BULK_SESSION_WRITE_GUARD,),
-                    )
+                    if trigram_guarded:
+                        conn.execute(
+                            "DELETE FROM derived_refresh_guard WHERE guard_name = ?",
+                            (FTS_BULK_SESSION_WRITE_GUARD,),
+                        )
         finally:
             conn.close()
         return deleted

--- a/tests/unit/storage/test_bulk_delete_guarded.py
+++ b/tests/unit/storage/test_bulk_delete_guarded.py
@@ -1,0 +1,318 @@
+"""Regression: ``ArchiveStore.delete_sessions`` must not detonate per-row
+derived-refresh triggers (polylogue-meoz).
+
+Background: a plain per-session ``DELETE FROM sessions`` fires
+``blocks_action_pairs_ad`` once per deleted ``blocks`` row (both the explicit
+cascade and the FK ``ON DELETE CASCADE`` invoke AFTER DELETE triggers per
+row); each firing deletes+rebuilds the *entire session's* ``action_pairs`` via
+two window-function scans and re-derives ``delegation_facts``. Live incident
+2026-07-21: deleting 91 sessions ran 3h, 375GB reads, zero commit, before
+being killed.
+
+The fix wraps the delete in both ``derived_refresh_guard`` rows
+(``'session-write'``, ``'fts-bulk-session-write'``) and performs the derived
+maintenance explicitly, one pass, mirroring ``_bulk_fts_session_guard``'s
+delete-then-guard-then-mutate shape (``write.py``).
+
+These tests prove: (a) FTS/identity/trigram coherence after a bulk delete
+through the PRODUCT delete API; (b) ``action_pairs``/``delegation_facts`` rows
+for the deleted sessions are gone; (c) anti-vacuity -- a *canary* trigger
+carrying the exact same ``WHEN NOT EXISTS (... derived_refresh_guard ...)``
+condition as the real ``blocks_action_pairs_ad``/``blocks_command_trigram_ad``
+triggers never fires during the delete. ``sqlite3.Connection.set_trace_callback``
+was tried first and rejected: it only reports the outer statement text
+(``DELETE FROM sessions ...``), never the SQL text executed *inside* a
+trigger body, so it cannot distinguish a guarded delete from an unguarded one
+-- verified empirically against a minimal repro before choosing the canary
+approach.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, Provider
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+# Mirrors the exact WHEN-clause guard names the real triggers gate on (see
+# ``blocks_action_pairs_ad`` and ``blocks_command_trigram_ad`` in
+# ``storage/sqlite/archive_tiers/index.py``).
+_SESSION_WRITE_GUARD = "session-write"
+_FTS_BULK_GUARD = "fts-bulk-session-write"
+
+
+def _install_canary_triggers(conn: sqlite3.Connection) -> None:
+    """Install AFTER-DELETE canary triggers on ``blocks`` carrying the exact
+    same guard WHEN-clauses as the real ``blocks_action_pairs_ad`` and
+    ``blocks_command_trigram_ad`` production triggers.
+
+    A canary fires precisely when the corresponding expensive real trigger
+    body would also have fired for that row -- so a nonzero canary count
+    after ``delete_sessions`` directly proves the per-row rebuild machinery
+    was NOT suppressed, without needing to inspect trigger-body SQL text
+    (which SQLite's trace callback does not expose).
+    """
+    conn.execute("CREATE TABLE IF NOT EXISTS _canary_counts (name TEXT PRIMARY KEY, n INTEGER NOT NULL)")
+    conn.execute("INSERT OR REPLACE INTO _canary_counts (name, n) VALUES ('session_write', 0), ('fts_bulk', 0)")
+    conn.execute(
+        f"""
+        CREATE TRIGGER IF NOT EXISTS _canary_action_pairs_ad
+        AFTER DELETE ON blocks
+        WHEN NOT EXISTS (SELECT 1 FROM derived_refresh_guard WHERE guard_name = '{_SESSION_WRITE_GUARD}')
+        BEGIN
+            UPDATE _canary_counts SET n = n + 1 WHERE name = 'session_write';
+        END;
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE TRIGGER IF NOT EXISTS _canary_trigram_ad
+        AFTER DELETE ON blocks
+        WHEN old.block_type = 'tool_use' AND old.tool_detail_text != ' '
+         AND NOT EXISTS (SELECT 1 FROM derived_refresh_guard WHERE guard_name = '{_FTS_BULK_GUARD}')
+        BEGIN
+            UPDATE _canary_counts SET n = n + 1 WHERE name = 'fts_bulk';
+        END;
+        """
+    )
+    conn.commit()
+
+
+def _canary_counts(conn: sqlite3.Connection) -> dict[str, int]:
+    return dict(conn.execute("SELECT name, n FROM _canary_counts").fetchall())
+
+
+def _trigram_ghost_posting_count(conn: sqlite3.Connection) -> int:
+    """Indexed trigram rows whose content-table (``blocks``) row is gone."""
+    return int(
+        conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM blocks_command_trigram_docsize AS d
+            LEFT JOIN blocks AS b ON b.rowid = d.id
+            WHERE b.rowid IS NULL
+            """
+        ).fetchone()[0]
+    )
+
+
+def _fts_identity_orphan_count(conn: sqlite3.Connection) -> int:
+    """``messages_fts_identity`` ledger rows whose ``blocks`` row is gone."""
+    return int(
+        conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM messages_fts_identity AS i
+            LEFT JOIN blocks AS b ON b.rowid = i.rowid
+            WHERE b.rowid IS NULL
+            """
+        ).fetchone()[0]
+    )
+
+
+def _fts_docsize_ghost_count(conn: sqlite3.Connection) -> int:
+    """``messages_fts`` (contentless) docsize rows whose ``blocks`` row is gone."""
+    return int(
+        conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM messages_fts_docsize AS d
+            LEFT JOIN blocks AS b ON b.rowid = d.id
+            WHERE b.rowid IS NULL
+            """
+        ).fetchone()[0]
+    )
+
+
+def _tool_session(provider_session_id: str, *, n_pairs: int) -> ParsedSession:
+    """A session with ``n_pairs`` tool_use/tool_result pairs across distinct
+    messages -- enough indexable blocks that a per-row trigger regression
+    would fire (and be traced) multiple times, not just once."""
+    messages: list[ParsedMessage] = [
+        ParsedMessage(
+            provider_message_id="m0",
+            role=Role.USER,
+            text="please run some commands",
+            position=0,
+            variant_index=0,
+            is_active_path=True,
+            is_active_leaf=False,
+            blocks=[ParsedContentBlock(type=BlockType.TEXT, text="please run some commands")],
+        )
+    ]
+    for i in range(n_pairs):
+        tool_id = f"tool-{provider_session_id}-{i}"
+        messages.append(
+            ParsedMessage(
+                provider_message_id=f"use-{i}",
+                role=Role.ASSISTANT,
+                text=f"running command {i}",
+                position=2 * i + 1,
+                variant_index=0,
+                is_active_path=True,
+                is_active_leaf=False,
+                blocks=[
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_USE,
+                        tool_name="Bash",
+                        tool_id=tool_id,
+                        tool_input={"command": f"echo pair-{i}"},
+                    )
+                ],
+            )
+        )
+        messages.append(
+            ParsedMessage(
+                provider_message_id=f"result-{i}",
+                role=Role.TOOL,
+                text=f"pair-{i}",
+                position=2 * i + 2,
+                variant_index=0,
+                is_active_path=True,
+                is_active_leaf=False,
+                blocks=[
+                    ParsedContentBlock(
+                        type=BlockType.TOOL_RESULT,
+                        tool_id=tool_id,
+                        text=f"pair-{i}",
+                        is_error=False,
+                        exit_code=0,
+                    )
+                ],
+            )
+        )
+    return ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id=provider_session_id,
+        title=provider_session_id,
+        messages=messages,
+    )
+
+
+def test_delete_sessions_bulk_leaves_fts_trigram_and_action_pairs_coherent(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    session_ids: list[str] = []
+    with ArchiveStore(root) as facade:
+        for i in range(3):
+            session_ids.append(facade.write_parsed(_tool_session(f"bulk-delete-{i}", n_pairs=4)))
+
+    index_db_path = root / "index.db"
+    conn = sqlite3.connect(index_db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        # Sanity: the sessions actually produced action_pairs, indexable FTS
+        # rows, and trigram-indexed tool_use blocks before the delete -- a
+        # test that starts from an already-empty state would prove nothing.
+        action_pairs_before = conn.execute(
+            "SELECT COUNT(*) FROM action_pairs WHERE session_id IN ({})".format(", ".join("?" for _ in session_ids)),
+            session_ids,
+        ).fetchone()[0]
+        assert action_pairs_before == 3 * 4  # one action_pairs row per tool_use/tool_result pair
+        fts_rows_before = conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0]
+        assert fts_rows_before > 0
+        trigram_rows_before = conn.execute("SELECT COUNT(*) FROM blocks_command_trigram_docsize").fetchone()[0]
+        assert trigram_rows_before == 3 * 4  # one indexed tool_use block per pair
+
+        # Manually seed a delegation_facts row so the explicit
+        # ``DELETE FROM delegation_facts WHERE parent_session_id = ?``
+        # ``delete_sessions`` now issues has something real to remove --
+        # exercising a genuine production statement, not a mock.
+        conn.execute(
+            """
+            INSERT INTO delegation_facts (
+                delegation_id, parent_session_id, mapping_state, result_status, parent_origin
+            ) VALUES (?, ?, 'mapped', 'ok', 'codex-session')
+            """,
+            (f"deleg-{session_ids[0]}", session_ids[0]),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with ArchiveStore(root) as facade:
+        deleted = facade.delete_sessions(tuple(session_ids))
+
+    assert deleted == 3
+
+    conn = sqlite3.connect(index_db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        remaining_sessions = conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE session_id IN ({})".format(", ".join("?" for _ in session_ids)),
+            session_ids,
+        ).fetchone()[0]
+        assert remaining_sessions == 0
+
+        # (a) FTS coherence: no dangling docsize/identity/trigram postings.
+        assert conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] == 0
+        assert _fts_docsize_ghost_count(conn) == 0
+        assert conn.execute("SELECT COUNT(*) FROM messages_fts_identity").fetchone()[0] == 0
+        assert _fts_identity_orphan_count(conn) == 0
+        assert conn.execute("SELECT COUNT(*) FROM blocks_command_trigram_docsize").fetchone()[0] == 0
+        assert _trigram_ghost_posting_count(conn) == 0
+
+        # (b) action_pairs / delegation_facts rows for the deleted sessions
+        # are gone.
+        remaining_action_pairs = conn.execute(
+            "SELECT COUNT(*) FROM action_pairs WHERE session_id IN ({})".format(", ".join("?" for _ in session_ids)),
+            session_ids,
+        ).fetchone()[0]
+        assert remaining_action_pairs == 0
+        remaining_delegation_facts = conn.execute(
+            "SELECT COUNT(*) FROM delegation_facts WHERE parent_session_id IN ({})".format(
+                ", ".join("?" for _ in session_ids)
+            ),
+            session_ids,
+        ).fetchone()[0]
+        assert remaining_delegation_facts == 0
+
+        # Guard rows must never leak past the transaction they protected.
+        assert conn.execute("SELECT COUNT(*) FROM derived_refresh_guard").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_delete_sessions_bulk_never_fires_unguarded_per_row_canary(tmp_path: Path) -> None:
+    """Anti-vacuity: install canary triggers carrying the exact WHEN-clause
+    guard conditions of the real ``blocks_action_pairs_ad`` /
+    ``blocks_command_trigram_ad`` triggers, then prove neither one fires
+    during a bulk ``delete_sessions`` call through the PRODUCT API.
+
+    What would make this fail: removing (or narrowing the scope of) either
+    ``INSERT OR REPLACE INTO derived_refresh_guard(...)`` call this PR adds to
+    ``ArchiveStore.delete_sessions``. With the ``'session-write'`` guard
+    absent, ``blocks_action_pairs_ad`` (and this test's mirroring canary)
+    fires once per deleted ``blocks`` row; with ``'fts-bulk-session-write'``
+    absent, ``blocks_command_trigram_ad`` (and its canary) fires once per
+    deleted tool_use block. Either regression flips the corresponding canary
+    count from 0 to a positive number equal to the number of blocks deleted
+    while that guard was unset.
+    """
+    root = tmp_path / "archive"
+    session_ids: list[str] = []
+    with ArchiveStore(root) as facade:
+        for i in range(2):
+            session_ids.append(facade.write_parsed(_tool_session(f"canary-delete-{i}", n_pairs=3)))
+
+    index_db_path = root / "index.db"
+    setup_conn = sqlite3.connect(index_db_path)
+    try:
+        _install_canary_triggers(setup_conn)
+    finally:
+        setup_conn.close()
+
+    with ArchiveStore(root) as facade:
+        deleted = facade.delete_sessions(tuple(session_ids))
+    assert deleted == 2
+
+    verify_conn = sqlite3.connect(index_db_path)
+    try:
+        counts = _canary_counts(verify_conn)
+    finally:
+        verify_conn.close()
+    assert counts == {"session_write": 0, "fts_bulk": 0}, (
+        f"unguarded per-row trigger canary fired during bulk delete: {counts}"
+    )

--- a/tests/unit/storage/test_bulk_delete_guarded.py
+++ b/tests/unit/storage/test_bulk_delete_guarded.py
@@ -316,3 +316,66 @@ def test_delete_sessions_bulk_never_fires_unguarded_per_row_canary(tmp_path: Pat
     assert counts == {"session_write": 0, "fts_bulk": 0}, (
         f"unguarded per-row trigger canary fired during bulk delete: {counts}"
     )
+
+
+def _downgrade_trigram_trigger_to_ungated(conn: sqlite3.Connection) -> None:
+    """Replace ``blocks_command_trigram_ad`` with its pre-#3259 body: the same
+    delete logic, but with the ``derived_refresh_guard`` WHEN-clause removed.
+
+    Simulates an archive last rebuilt before the guard clause was added to
+    this trigger -- ``CREATE TRIGGER IF NOT EXISTS`` never upgrades an
+    existing same-name trigger, so such an archive keeps exactly this body
+    forever without a real rebuild.
+    """
+    conn.execute("DROP TRIGGER blocks_command_trigram_ad")
+    conn.execute(
+        """
+        CREATE TRIGGER blocks_command_trigram_ad
+        AFTER DELETE ON blocks
+        WHEN old.block_type = 'tool_use' AND old.tool_detail_text != ' '
+        BEGIN
+            INSERT INTO blocks_command_trigram(blocks_command_trigram, rowid, tool_detail_text)
+            VALUES ('delete', old.rowid, old.tool_detail_text);
+        END;
+        """
+    )
+    conn.commit()
+
+
+def test_delete_sessions_bulk_falls_back_safely_on_pre_guard_archive(tmp_path: Path) -> None:
+    """Regression (CodeRabbit #3263 P1): on an archive whose trigram trigger
+    predates the bulk-write guard, ``delete_sessions`` must not rely on that
+    guard -- doing so double-deletes each trigram posting (the explicit
+    pre-delete, then the ungated trigger firing again during the cascade),
+    which FTS5 reports as "database disk image is malformed" and rolls back
+    the whole batch."""
+    root = tmp_path / "archive"
+    session_ids: list[str] = []
+    with ArchiveStore(root) as facade:
+        for i in range(2):
+            session_ids.append(facade.write_parsed(_tool_session(f"legacy-delete-{i}", n_pairs=3)))
+
+    index_db_path = root / "index.db"
+    setup_conn = sqlite3.connect(index_db_path)
+    try:
+        _downgrade_trigram_trigger_to_ungated(setup_conn)
+    finally:
+        setup_conn.close()
+
+    with ArchiveStore(root) as facade:
+        deleted = facade.delete_sessions(tuple(session_ids))
+    assert deleted == 2
+
+    conn = sqlite3.connect(index_db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        remaining_sessions = conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE session_id IN ({})".format(", ".join("?" for _ in session_ids)),
+            session_ids,
+        ).fetchone()[0]
+        assert remaining_sessions == 0
+        assert conn.execute("SELECT COUNT(*) FROM blocks_command_trigram_docsize").fetchone()[0] == 0
+        assert _trigram_ghost_posting_count(conn) == 0
+        assert conn.execute("SELECT COUNT(*) FROM derived_refresh_guard").fetchone()[0] == 0
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

`ArchiveStore.delete_sessions` (the product bulk-delete API used by the CLI
`delete` verb and `SessionDeleteActuator`) now wraps its whole batch in the
same `derived_refresh_guard` rows the bulk session-write path already uses,
and performs the derived FTS/trigram/action_pairs/delegation_facts
maintenance explicitly, one pass, instead of relying on unsuppressed
per-row triggers.

## Problem

`delete_sessions` issued a plain per-session `DELETE FROM sessions`.
`blocks_action_pairs_ad` (`storage/sqlite/archive_tiers/index.py`) fires
once per deleted `blocks` row — both the explicit block cascade and the FK
`ON DELETE CASCADE` from `messages`/`sessions` still invoke AFTER DELETE
triggers per row — and each firing deletes+rebuilds the **entire session's**
`action_pairs` via two window-function scans and re-derives
`delegation_facts`. Live incident 2026-07-21: deleting 91 sessions ran 3h,
375GB reads, zero commit, before being killed.

The bulk session-write path already suppresses this class of cost via
`derived_refresh_guard` rows (`'session-write'`, `'fts-bulk-session-write'`),
see `_bulk_fts_session_guard` in `write.py` (bead polylogue-crd8's fix for
the analogous whale-lineage-prefix-delete stall). `delete_sessions` never set
either guard.

## Solution

`ArchiveStore.delete_sessions` (`polylogue/storage/sqlite/archive_tiers/archive.py`):

1. For each session id, explicit session-scoped deletes run first, while the
   `blocks` rows still exist (external-content FTS5 needs the OLD text to
   locate its postings): `messages_fts` / `messages_fts_identity`
   (`delete_session_rows_sql` / `delete_session_identity_rows_sql`) and
   `blocks_command_trigram` (`trigram_delete_session_rows_sql`, landed in
   #3259).
2. Both `derived_refresh_guard` rows are set for the whole batch —
   `'session-write'` (suppresses `blocks_action_pairs_a{i,d,u}` and the
   `delegation_facts` triggers) and `'fts-bulk-session-write'` (suppresses
   the `messages_fts`/`blocks_command_trigram` trigger bodies — redundant
   here since those rows are already gone by step 1, kept for guard-contract
   parity and defense-in-depth).
3. `action_pairs` and `delegation_facts` are explicitly cleared by session
   id — belt-and-suspenders alongside the `ON DELETE CASCADE` FKs those
   tables already carry against `sessions`/`blocks`; this keeps the
   post-condition legible without depending on cascade-ordering.
4. `DELETE FROM sessions` per id relies on indexed FK cascades (not per-row
   trigger logic) for physical `messages`/`blocks` tree removal; guard rows
   are cleared and the transaction commits once for the whole batch.

This mirrors `_bulk_fts_session_guard`'s delete-then-guard-then-mutate shape.

**Epoch triggers audit** (per bead's ask): `query_unit_frame_{sessions,
messages,blocks}_delete` fire per deleted row, ungated by either guard. Left
deliberately ungated — each firing is a single primary-key `UPDATE
query_unit_frame_state SET epoch = epoch + 1 WHERE singleton = 1` against a
one-row table (O(1) per row), not a window-function rebuild, so this was
never implicated by the incident and folding a third guard in for a
zero-measured cost isn't warranted.

**Async path** (`repository/archive/writes/sessions.py` ->
`delete_session_via_backend` -> `queries/sessions_writes.py`'s
`delete_session_sql`): unaffected by this fix and left unchanged. It deletes
**exactly one session per call/transaction** — there is no loop batching N
session ids into a single transaction, so the "91 sessions in one
transaction" incident shape does not reproduce there. (A single very-large
session could still see a bounded version of the same per-block trigger cost
for its own row count — that's the pre-existing, already-tracked crd8
concern for whale *writes*, not a bulk-*delete* regression, and out of this
bead's scope.)

## Verification

- `devtools test tests/unit/storage/test_bulk_delete_guarded.py tests/unit/storage/test_bulk_fts_prefix_reextract.py`
  -> `9 passed`
- **Anti-vacuity proof**: `sqlite3.Connection.set_trace_callback` was tried
  first and rejected — it only reports the outer statement text (`DELETE
  FROM sessions ...`), never SQL executed *inside* a trigger body (verified
  empirically against a minimal repro). Instead, the new
  `test_delete_sessions_bulk_never_fires_unguarded_per_row_canary` installs
  canary triggers on `blocks` carrying the **exact same WHEN-clause guard
  conditions** as the real `blocks_action_pairs_ad` /
  `blocks_command_trigram_ad` triggers. With the fix reverted (`git stash`
  on `archive.py` only, canary test re-run), the canaries fire
  `{'session_write': 14, 'fts_bulk': 6}` for 2 sessions x 3 tool pairs each
  — i.e. the per-row rebuild machinery *would* have detonated. With the fix
  restored, both counts are `0`. What would make this test fail: removing
  or narrowing the scope of either `INSERT OR REPLACE INTO
  derived_refresh_guard(...)` call this PR adds.
- `devtools verify --quick` -> `exit_code: 0` (ruff format/check, mypy
  --strict, `render all --check`, topology/layering/manifests/doc-commands/
  docs-coverage/test-clock-hygiene/pytest-timeout-overrides/degrade-loudly)
- `tests/unit/storage/test_archive_tiers_archive.py::test_exact_session_action_count_bounds_pairing_before_global_ranking`
  fails identically with the fix reverted (`git stash` on `archive.py` only)
  — confirmed pre-existing and unrelated to this change, not touched by this
  PR.
- Not run: full `devtools verify --all` / broad directory pytest (repo
  convention is testmon-affected + focused files, not blanket runs).

Ref polylogue-meoz. Relates to polylogue-crd8 (same `derived_refresh_guard`
mechanism, different write path — whale prefix-delete during ingest vs. bulk
session delete via the product API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)