### PR TITLE
fix(storage): resolve whale stream safety for expanded members (#3268)

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -3619,6 +3619,13 @@ class RawMaterializationCandidates:
     byte_authority_pending: int = 0
     expanded_raw_ids: tuple[str, ...] = ()
     expanded_blob_bytes: dict[str, int] = field(default_factory=dict)
+    # Origin/source_path for EVERY member of an expanded authority component,
+    # including already-materialized non-candidate members that raw_origins /
+    # raw_source_paths (candidate-only) omit. Without these, the whale-pass
+    # stream-safety check judged a fully stream-safe codex component non-safe
+    # because its non-candidate members resolved to origin=None (polylogue-t93b).
+    expanded_origins: dict[str, str] = field(default_factory=dict)
+    expanded_source_paths: dict[str, str] = field(default_factory=dict)
     authority_components: tuple[tuple[str, ...], ...] = ()
     missing_blob_raw_ids: tuple[str, ...] = ()
     adoption_deferred_raw_ids: tuple[str, ...] = ()
@@ -3700,6 +3707,8 @@ def _raw_materialization_candidate_ids(
     byte_authority_pending_raw_ids: list[str] = []
     expanded_raw_ids: tuple[str, ...] = ()
     expanded_blob_bytes: dict[str, int] = {}
+    expanded_origins: dict[str, str] = {}
+    expanded_source_paths: dict[str, str] = {}
     authority_components: tuple[tuple[str, ...], ...] = ()
     with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as conn:
         conn.row_factory = sqlite3.Row
@@ -3892,13 +3901,14 @@ def _raw_materialization_candidate_ids(
         expanded_raw_ids = tuple(sorted({raw_id for component in authority_components for raw_id in component}))
         if expanded_raw_ids:
             placeholders = ",".join("?" for _ in expanded_raw_ids)
-            expanded_blob_bytes = {
-                str(row[0]): int(row[1] or 0)
-                for row in conn.execute(
-                    f"SELECT raw_id, blob_size FROM raw_sessions WHERE raw_id IN ({placeholders})",
-                    expanded_raw_ids,
-                )
-            }
+            for row in conn.execute(
+                f"SELECT raw_id, blob_size, origin, source_path FROM raw_sessions WHERE raw_id IN ({placeholders})",
+                expanded_raw_ids,
+            ):
+                rid = str(row[0])
+                expanded_blob_bytes[rid] = int(row[1] or 0)
+                expanded_origins[rid] = str(row[2] or "")
+                expanded_source_paths[rid] = str(row[3] or "")
     return RawMaterializationCandidates(
         raw_ids=raw_ids,
         missing_blobs=missing_blobs,
@@ -3916,6 +3926,8 @@ def _raw_materialization_candidate_ids(
         byte_authority_pending=byte_authority_pending,
         expanded_raw_ids=expanded_raw_ids,
         expanded_blob_bytes=expanded_blob_bytes,
+        expanded_origins=expanded_origins,
+        expanded_source_paths=expanded_source_paths,
         authority_components=authority_components,
         missing_blob_raw_ids=tuple(sorted(missing_blob_raw_ids)),
         adoption_deferred_raw_ids=tuple(sorted(adoption_deferred_raw_ids)),
@@ -4016,9 +4028,15 @@ def raw_materialization_readonly_descriptors(
 def _raw_materialization_stream_safe(candidates: RawMaterializationCandidates, raw_id: str) -> bool:
     from polylogue.sources.dispatch import is_stream_record_provider
 
-    origin = Origin.from_string(candidates.raw_origins.get(raw_id))
-    provider = provider_from_origin(origin)
-    return is_stream_record_provider(candidates.raw_source_paths.get(raw_id), provider)
+    # Fall back to the expanded (full-component) maps for already-materialized
+    # non-candidate members, which raw_origins/raw_source_paths (candidate-only)
+    # omit -- mirroring _raw_materialization_component_blob_bytes. Without this a
+    # fully stream-safe codex whale component reads origin=None for its
+    # non-candidate members and is wrongly judged non-stream-safe (polylogue-t93b).
+    origin_token = candidates.expanded_origins.get(raw_id, candidates.raw_origins.get(raw_id))
+    source_path = candidates.expanded_source_paths.get(raw_id, candidates.raw_source_paths.get(raw_id))
+    provider = provider_from_origin(Origin.from_string(origin_token))
+    return is_stream_record_provider(source_path, provider)
 
 
 def _raw_materialization_component_stream_safe(

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -2913,6 +2913,28 @@ def test_raw_materialization_whale_pass_candidate_selects_stream_safe_blocked_co
     )
 
 
+def test_stream_safe_resolves_non_candidate_component_members_via_expanded_maps() -> None:
+    """A component's already-materialized (non-candidate) members are absent from
+    raw_origins/raw_source_paths (candidate-only) but present in the expanded
+    maps. Stream-safety must resolve them there, not read origin=None and judge a
+    fully stream-safe codex component non-safe -- the bug that made the daemon
+    whale pass skip the 6.33GB codex witness component (polylogue-t93b)."""
+    candidates = repair_mod.RawMaterializationCandidates(
+        raw_ids=["cand"],
+        missing_blobs=0,
+        already_parsed=0,
+        raw_origins={"cand": "codex-session"},
+        raw_source_paths={"cand": "/c/rollout-2026-a.jsonl"},
+        expanded_origins={"cand": "codex-session", "noncand": "codex-session"},
+        expanded_source_paths={"cand": "/c/rollout-2026-a.jsonl", "noncand": "/c/rollout-2026-b.jsonl"},
+    )
+    # Candidate member: stream-safe as before.
+    assert repair_mod._raw_materialization_stream_safe(candidates, "cand") is True
+    # Non-candidate member present ONLY in the expanded maps must ALSO be
+    # judged by its real codex origin -- True, not False from a missing lookup.
+    assert repair_mod._raw_materialization_stream_safe(candidates, "noncand") is True
+
+
 def test_raw_materialization_whale_pass_candidate_excludes_non_stream_safe_component(tmp_path: Path) -> None:
     from polylogue.core.enums import Provider
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore


### PR DESCRIPTION
## Summary

Allow the daemon whale pass to recognize stream-safe authority components when some expanded members have already materialized.

## Problem

The live 6.33 GiB Codex witness component was rejected by the whale-pass eligibility check even though its members are stream-safe. The check consulted candidate-only identity maps, so already-materialized members resolved as unknown and made the component appear unsafe.

## Solution

`polylogue/storage/repair.py` now records origin and source path for every expanded authority-component member and falls back to those maps during stream-safety evaluation. The focused regression test exercises a member present only in the expanded maps.

Ref polylogue-t93b.

## Verification

- `devtools test tests/unit/storage/test_repair.py -k 'stream_safe or whale_pass_candidate'` — 3 passed.
- `uv run mypy --strict polylogue/storage/repair.py` — Success: no issues found.
- `devtools verify --quick` — completed successfully.
- Pre-push quick baseline — format, lint, mypy, rendering, topology, layering, schema roundtrip, manifests, CI workflow, documentation, and test-infrastructure gates passed.

## Acceptance criteria

- Satisfied: the live whale component is no longer incorrectly excluded because an expanded, already-materialized member lacks candidate-map identity.
- Remaining `polylogue-t93b` scope: daemon deployment must converge the live witness and emit its receipt.