### PR TITLE
fix(repair): refresh planner stats before raw replay

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -6380,8 +6380,12 @@ def repair_raw_materialization(
     # raw materialization into a full rebuild.
     with closing(sqlite3.connect(archive_root / "index.db", timeout=60)) as planner_conn:
         planner_conn.execute("PRAGMA busy_timeout = 60000")
-        planner_conn.execute("ANALYZE blocks")
-        planner_conn.commit()
+        # A freshly reset index uses representative bootstrap statistics.
+        # ``ANALYZE blocks`` on an empty table deletes that seed and brings
+        # back the broad action-pair plan this refresh is meant to prevent.
+        if planner_conn.execute("SELECT 1 FROM blocks LIMIT 1").fetchone() is not None:
+            planner_conn.execute("ANALYZE blocks")
+            planner_conn.commit()
 
     executable_raw_ids = raw_ids
     metrics["raw_materialization_executed_count"] = float(len(executable_raw_ids))

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -6370,6 +6370,19 @@ def repair_raw_materialization(
 
     from polylogue.sources.revision_backfill import RevisionBackfillResult, backfill_historical_revision_evidence
 
+    # ``action_pairs_refresh_sql`` is session-scoped, but on an index tier
+    # whose planner statistics were lost during an interrupted generation
+    # transition SQLite can choose the broad ``idx_blocks_type_tool`` scan
+    # instead.  Replaying several authority components then becomes an
+    # archive-wide read for every session replacement.  Refresh only the
+    # writer-hot table before this bounded live pass; this is the same
+    # planner invariant seeded for a fresh index bootstrap, without turning
+    # raw materialization into a full rebuild.
+    with closing(sqlite3.connect(archive_root / "index.db", timeout=60)) as planner_conn:
+        planner_conn.execute("PRAGMA busy_timeout = 60000")
+        planner_conn.execute("ANALYZE blocks")
+        planner_conn.commit()
+
     executable_raw_ids = raw_ids
     metrics["raw_materialization_executed_count"] = float(len(executable_raw_ids))
     replay_parts: list[RevisionBackfillResult] = []


### PR DESCRIPTION
## Summary
Refresh SQLite statistics for the writer-hot blocks table before a bounded raw-materialization replay.

## Problem
An interrupted index-generation transition left the live raw replay path without representative planner statistics. SQLite chose an archive-wide action-pair scan for each session replacement, producing sustained multi-gigabyte reads without a plan receipt.

## Solution
Run ANALYZE blocks before selected authority components are replayed. This restores the existing session-scoped planner invariant without changing source authority or durable replay semantics.

## Verification
Focused planner and fixed-point tests passed: 3 passed, 63 deselected.

Ref polylogue-t93b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of raw materialization repair by refreshing database planning statistics before replay.
  * Reduced the likelihood of delays or lock-related failures during repair operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->