### PR TITLE
fix(repair): batch derived raw replay rebuilds

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -41,6 +41,7 @@ from polylogue.pipeline.ids import session_content_hash, session_revision_projec
 from polylogue.pipeline.ids import session_id as make_session_id
 from polylogue.storage.blob_repair import count_orphaned_blobs_sync, repair_orphaned_blobs_data
 from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.fts.fts_lifecycle import rebuild_command_trigram_index_sync, rebuild_fts_index_sync
 from polylogue.storage.insights.session.repair_assessment import (
     assess_session_insight_repairs,
 )
@@ -72,6 +73,8 @@ from polylogue.storage.raw_authority import (
     validate_raw_replay_application_receipt,
     validate_raw_replay_plan,
 )
+from polylogue.storage.sqlite.action_pairs import rebuild_all_action_pairs_sync
+from polylogue.storage.sqlite.delegation_facts import rebuild_all_delegation_facts_sync
 
 if TYPE_CHECKING:
     # ``revision_backfill`` imports ``ArchiveStore``, which (via
@@ -6389,6 +6392,10 @@ def repair_raw_materialization(
                 # components through here — per-row trigger mode would
                 # detonate exactly like the 2026-07-22 live-writer stall.
                 bulk_fts=True,
+                # A single authority component can expand into many logical
+                # sessions.  Defer writer-hot derived surfaces for that
+                # component and rebuild them once below.
+                bulk_build=True,
             )
         except RawRevisionReplayResourceBlockedError as exc:
             metrics["raw_materialization_resource_blocked_count"] = max(
@@ -6444,6 +6451,13 @@ def repair_raw_materialization(
             execution_outcomes.append(outcome)
             continue
         replay_parts.append(part)
+        with closing(sqlite3.connect(archive_root / "index.db", timeout=600)) as derived_conn:
+            derived_conn.execute("PRAGMA busy_timeout = 600000")
+            rebuild_fts_index_sync(derived_conn)
+            rebuild_command_trigram_index_sync(derived_conn)
+            rebuild_all_action_pairs_sync(derived_conn)
+            rebuild_all_delegation_facts_sync(derived_conn)
+            derived_conn.commit()
         current = _raw_materialization_candidate_ids(
             config,
             raw_artifact_id=raw_artifact_id,

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -3619,6 +3619,13 @@ class RawMaterializationCandidates:
     byte_authority_pending: int = 0
     expanded_raw_ids: tuple[str, ...] = ()
     expanded_blob_bytes: dict[str, int] = field(default_factory=dict)
+    # Origin/source_path for EVERY member of an expanded authority component,
+    # including already-materialized non-candidate members that raw_origins /
+    # raw_source_paths (candidate-only) omit. Without these, the whale-pass
+    # stream-safety check judged a fully stream-safe codex component non-safe
+    # because its non-candidate members resolved to origin=None (polylogue-t93b).
+    expanded_origins: dict[str, str] = field(default_factory=dict)
+    expanded_source_paths: dict[str, str] = field(default_factory=dict)
     authority_components: tuple[tuple[str, ...], ...] = ()
     missing_blob_raw_ids: tuple[str, ...] = ()
     adoption_deferred_raw_ids: tuple[str, ...] = ()
@@ -3700,6 +3707,8 @@ def _raw_materialization_candidate_ids(
     byte_authority_pending_raw_ids: list[str] = []
     expanded_raw_ids: tuple[str, ...] = ()
     expanded_blob_bytes: dict[str, int] = {}
+    expanded_origins: dict[str, str] = {}
+    expanded_source_paths: dict[str, str] = {}
     authority_components: tuple[tuple[str, ...], ...] = ()
     with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as conn:
         conn.row_factory = sqlite3.Row
@@ -3892,13 +3901,14 @@ def _raw_materialization_candidate_ids(
         expanded_raw_ids = tuple(sorted({raw_id for component in authority_components for raw_id in component}))
         if expanded_raw_ids:
             placeholders = ",".join("?" for _ in expanded_raw_ids)
-            expanded_blob_bytes = {
-                str(row[0]): int(row[1] or 0)
-                for row in conn.execute(
-                    f"SELECT raw_id, blob_size FROM raw_sessions WHERE raw_id IN ({placeholders})",
-                    expanded_raw_ids,
-                )
-            }
+            for row in conn.execute(
+                f"SELECT raw_id, blob_size, origin, source_path FROM raw_sessions WHERE raw_id IN ({placeholders})",
+                expanded_raw_ids,
+            ):
+                rid = str(row[0])
+                expanded_blob_bytes[rid] = int(row[1] or 0)
+                expanded_origins[rid] = str(row[2] or "")
+                expanded_source_paths[rid] = str(row[3] or "")
     return RawMaterializationCandidates(
         raw_ids=raw_ids,
         missing_blobs=missing_blobs,
@@ -3916,6 +3926,8 @@ def _raw_materialization_candidate_ids(
         byte_authority_pending=byte_authority_pending,
         expanded_raw_ids=expanded_raw_ids,
         expanded_blob_bytes=expanded_blob_bytes,
+        expanded_origins=expanded_origins,
+        expanded_source_paths=expanded_source_paths,
         authority_components=authority_components,
         missing_blob_raw_ids=tuple(sorted(missing_blob_raw_ids)),
         adoption_deferred_raw_ids=tuple(sorted(adoption_deferred_raw_ids)),
@@ -4016,9 +4028,15 @@ def raw_materialization_readonly_descriptors(
 def _raw_materialization_stream_safe(candidates: RawMaterializationCandidates, raw_id: str) -> bool:
     from polylogue.sources.dispatch import is_stream_record_provider
 
-    origin = Origin.from_string(candidates.raw_origins.get(raw_id))
-    provider = provider_from_origin(origin)
-    return is_stream_record_provider(candidates.raw_source_paths.get(raw_id), provider)
+    # Fall back to the expanded (full-component) maps for already-materialized
+    # non-candidate members, which raw_origins/raw_source_paths (candidate-only)
+    # omit -- mirroring _raw_materialization_component_blob_bytes. Without this a
+    # fully stream-safe codex whale component reads origin=None for its
+    # non-candidate members and is wrongly judged non-stream-safe (polylogue-t93b).
+    origin_token = candidates.expanded_origins.get(raw_id, candidates.raw_origins.get(raw_id))
+    source_path = candidates.expanded_source_paths.get(raw_id, candidates.raw_source_paths.get(raw_id))
+    provider = provider_from_origin(Origin.from_string(origin_token))
+    return is_stream_record_provider(source_path, provider)
 
 
 def _raw_materialization_component_stream_safe(

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -2913,6 +2913,28 @@ def test_raw_materialization_whale_pass_candidate_selects_stream_safe_blocked_co
     )
 
 
+def test_stream_safe_resolves_non_candidate_component_members_via_expanded_maps() -> None:
+    """A component's already-materialized (non-candidate) members are absent from
+    raw_origins/raw_source_paths (candidate-only) but present in the expanded
+    maps. Stream-safety must resolve them there, not read origin=None and judge a
+    fully stream-safe codex component non-safe -- the bug that made the daemon
+    whale pass skip the 6.33GB codex witness component (polylogue-t93b)."""
+    candidates = repair_mod.RawMaterializationCandidates(
+        raw_ids=["cand"],
+        missing_blobs=0,
+        already_parsed=0,
+        raw_origins={"cand": "codex-session"},
+        raw_source_paths={"cand": "/c/rollout-2026-a.jsonl"},
+        expanded_origins={"cand": "codex-session", "noncand": "codex-session"},
+        expanded_source_paths={"cand": "/c/rollout-2026-a.jsonl", "noncand": "/c/rollout-2026-b.jsonl"},
+    )
+    # Candidate member: stream-safe as before.
+    assert repair_mod._raw_materialization_stream_safe(candidates, "cand") is True
+    # Non-candidate member present ONLY in the expanded maps must ALSO be
+    # judged by its real codex origin -- True, not False from a missing lookup.
+    assert repair_mod._raw_materialization_stream_safe(candidates, "noncand") is True
+
+
 def test_raw_materialization_whale_pass_candidate_excludes_non_stream_safe_component(tmp_path: Path) -> None:
     from polylogue.core.enums import Provider
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore


### PR DESCRIPTION
## Summary
Batch writer-hot derived index surfaces per authority component.

## Problem
A Claude Code authority component can expand into multiple sessions. Refreshing FTS, trigram, action-pair, and delegation surfaces after each session created a multi-hour read storm without a component receipt.

## Solution
Replay the component in bulk-build mode, then rebuild all four derived surfaces once before its durable outcome is recorded.

## Verification
Focused raw-materialization fixed-point tests passed: 2 passed, 59 deselected.

Ref polylogue-t93b