### PR TITLE
fix(fts): reconcile global debt in one pass

### DIFF
--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -1432,45 +1432,11 @@ def repair_messages_fts_surface(db_path: Path) -> bool:
             from polylogue.storage.fts.dangling_repair import configure_bounded_repair_connection
             from polylogue.storage.fts.freshness import READY, record_fts_surface_state_sync
             from polylogue.storage.fts.fts_lifecycle import (
-                delete_excess_message_rows_batched_sync,
-                insert_missing_message_rows_batched_sync,
+                reconcile_message_fts_rows_once_sync,
             )
 
             configure_bounded_repair_connection(conn)
-            progress_windows = 0
-            inserted_total = 0
-
-            def progress(lower: int, upper: int, inserted: int) -> None:
-                nonlocal inserted_total, progress_windows
-                progress_windows += 1
-                inserted_total += inserted
-                if inserted or progress_windows % 20 == 0:
-                    logger.info(
-                        "fts: archive messages_fts repair window rowid=(%d,%d] inserted=%d total_inserted=%d",
-                        lower,
-                        upper,
-                        inserted,
-                        inserted_total,
-                    )
-
-            deleted_total = 0
-
-            def excess_progress(deleted: int) -> None:
-                nonlocal deleted_total
-                deleted_total += deleted
-                if deleted:
-                    logger.info(
-                        "fts: archive messages_fts deleted excess rows deleted=%d total_deleted=%d",
-                        deleted,
-                        deleted_total,
-                    )
-
-            delete_excess_message_rows_batched_sync(conn, progress_callback=excess_progress)
-            insert_missing_message_rows_batched_sync(
-                conn,
-                measure_counts=False,
-                progress_callback=progress,
-            )
+            inserted_total, deleted_total = reconcile_message_fts_rows_once_sync(conn)
             record_fts_surface_state_sync(
                 conn,
                 surface="messages_fts",

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -33,9 +33,11 @@ from polylogue.storage.fts.sql import (
     insert_all_message_rows_sql,
     insert_all_trigram_rows_sql,
     insert_missing_message_rows_range_sql,
+    insert_missing_message_rows_sql,
     insert_session_identity_rows_sql,
     insert_session_rows_sql,
     message_identity_mismatch_sql,
+    repair_all_message_identity_rows_sql,
     repair_message_identity_rows_range_sql,
 )
 
@@ -523,6 +525,27 @@ def delete_excess_message_rows_batched_sync(
         if len(rowids) < batch_rows:
             break
     return deleted_total
+
+
+def reconcile_message_fts_rows_once_sync(conn: sqlite3.Connection) -> tuple[int, int]:
+    """Reconcile the global message FTS surface with bounded scan count.
+
+    The old numeric-rowid window loop is safe for compact tables, but a live
+    archive can retain a sparse rowid space after many full replacements.
+    Each window then repeats an expensive join against the FTS docsize shadow
+    table.  A global debt repair is already an explicit maintenance action, so
+    use one set-based missing-row pass and one set-based identity pass instead.
+    Existing excess rows are still removed through the contentless-FTS-safe
+    batched delete primitive.
+    """
+    ensure_fts_index_sync(conn)
+    deleted = delete_excess_message_rows_batched_sync(conn)
+    before = conn.total_changes
+    conn.execute(insert_missing_message_rows_sql())
+    inserted = max(0, conn.total_changes - before)
+    if _blocks_content_hash_available_sync(conn):
+        conn.execute(repair_all_message_identity_rows_sql())
+    return inserted, deleted
 
 
 def rebuild_session_insight_fts_sync(conn: sqlite3.Connection) -> None:
@@ -1139,6 +1162,7 @@ __all__ = [
     "repair_fts_index_async",
     "repair_fts_index_sync",
     "repair_message_fts_index_sync",
+    "reconcile_message_fts_rows_once_sync",
     "reset_message_fts_index_sync",
     "replace_fts_rows_for_messages_sync",
     "restore_message_fts_triggers_sync",

--- a/polylogue/storage/fts/sql.py
+++ b/polylogue/storage/fts/sql.py
@@ -392,6 +392,34 @@ def repair_message_identity_rows_range_sql() -> str:
     """
 
 
+def repair_all_message_identity_rows_sql() -> str:
+    """Return the set-based identity-ledger reconciliation statement.
+
+    Global recovery must not turn sparse SQLite rowids into millions of
+    numeric windows.  This is the same conflict policy as
+    :func:`repair_message_identity_rows_range_sql`, but evaluates the archive
+    once while the caller owns a global FTS repair transaction.
+    """
+    return f"""
+        INSERT INTO messages_fts_identity (rowid, block_id, source_hash, recipe_id)
+        SELECT b.rowid, b.block_id, b.content_hash, '{FTS_MESSAGES_IDENTITY_RECIPE_ID}'
+        FROM blocks AS b
+        JOIN messages_fts_docsize AS d ON d.id = b.rowid
+        WHERE b.search_text != ''
+        ON CONFLICT(rowid) DO UPDATE SET
+            block_id = excluded.block_id,
+            source_hash = excluded.source_hash,
+            recipe_id = excluded.recipe_id
+        WHERE messages_fts_identity.block_id != excluded.block_id
+           OR messages_fts_identity.source_hash IS NOT excluded.source_hash
+           OR messages_fts_identity.recipe_id != excluded.recipe_id
+        ON CONFLICT(block_id) DO UPDATE SET
+            rowid = excluded.rowid,
+            source_hash = excluded.source_hash,
+            recipe_id = excluded.recipe_id
+    """
+
+
 def message_identity_mismatch_sql() -> str:
     """Exact rowid+block_id+source+recipe identity CONFLICT check for ``messages_fts``.
 
@@ -536,6 +564,7 @@ __all__ = [
     "insert_session_rows_sql",
     "message_identity_mismatch_sql",
     "repair_message_identity_rows_range_sql",
+    "repair_all_message_identity_rows_sql",
     "trigram_delete_session_rows_sql",
     "trigram_insert_session_rows_sql",
 ]

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -41,6 +41,7 @@ from polylogue.pipeline.ids import session_content_hash, session_revision_projec
 from polylogue.pipeline.ids import session_id as make_session_id
 from polylogue.storage.blob_repair import count_orphaned_blobs_sync, repair_orphaned_blobs_data
 from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.fts.fts_lifecycle import rebuild_command_trigram_index_sync, rebuild_fts_index_sync
 from polylogue.storage.insights.session.repair_assessment import (
     assess_session_insight_repairs,
 )
@@ -72,6 +73,8 @@ from polylogue.storage.raw_authority import (
     validate_raw_replay_application_receipt,
     validate_raw_replay_plan,
 )
+from polylogue.storage.sqlite.action_pairs import rebuild_all_action_pairs_sync
+from polylogue.storage.sqlite.delegation_facts import rebuild_all_delegation_facts_sync
 
 if TYPE_CHECKING:
     # ``revision_backfill`` imports ``ArchiveStore``, which (via
@@ -6389,6 +6392,10 @@ def repair_raw_materialization(
                 # components through here — per-row trigger mode would
                 # detonate exactly like the 2026-07-22 live-writer stall.
                 bulk_fts=True,
+                # A single authority component can expand into many logical
+                # sessions.  Defer writer-hot derived surfaces for that
+                # component and rebuild them once below.
+                bulk_build=True,
             )
         except RawRevisionReplayResourceBlockedError as exc:
             metrics["raw_materialization_resource_blocked_count"] = max(
@@ -6444,6 +6451,13 @@ def repair_raw_materialization(
             execution_outcomes.append(outcome)
             continue
         replay_parts.append(part)
+        with closing(sqlite3.connect(archive_root / "index.db", timeout=600)) as derived_conn:
+            derived_conn.execute("PRAGMA busy_timeout = 600000")
+            rebuild_fts_index_sync(derived_conn)
+            rebuild_command_trigram_index_sync(derived_conn)
+            rebuild_all_action_pairs_sync(derived_conn)
+            rebuild_all_delegation_facts_sync(derived_conn)
+            derived_conn.commit()
         current = _raw_materialization_candidate_ids(
             config,
             raw_artifact_id=raw_artifact_id,

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -3619,6 +3619,13 @@ class RawMaterializationCandidates:
     byte_authority_pending: int = 0
     expanded_raw_ids: tuple[str, ...] = ()
     expanded_blob_bytes: dict[str, int] = field(default_factory=dict)
+    # Origin/source_path for EVERY member of an expanded authority component,
+    # including already-materialized non-candidate members that raw_origins /
+    # raw_source_paths (candidate-only) omit. Without these, the whale-pass
+    # stream-safety check judged a fully stream-safe codex component non-safe
+    # because its non-candidate members resolved to origin=None (polylogue-t93b).
+    expanded_origins: dict[str, str] = field(default_factory=dict)
+    expanded_source_paths: dict[str, str] = field(default_factory=dict)
     authority_components: tuple[tuple[str, ...], ...] = ()
     missing_blob_raw_ids: tuple[str, ...] = ()
     adoption_deferred_raw_ids: tuple[str, ...] = ()
@@ -3700,6 +3707,8 @@ def _raw_materialization_candidate_ids(
     byte_authority_pending_raw_ids: list[str] = []
     expanded_raw_ids: tuple[str, ...] = ()
     expanded_blob_bytes: dict[str, int] = {}
+    expanded_origins: dict[str, str] = {}
+    expanded_source_paths: dict[str, str] = {}
     authority_components: tuple[tuple[str, ...], ...] = ()
     with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as conn:
         conn.row_factory = sqlite3.Row
@@ -3892,13 +3901,14 @@ def _raw_materialization_candidate_ids(
         expanded_raw_ids = tuple(sorted({raw_id for component in authority_components for raw_id in component}))
         if expanded_raw_ids:
             placeholders = ",".join("?" for _ in expanded_raw_ids)
-            expanded_blob_bytes = {
-                str(row[0]): int(row[1] or 0)
-                for row in conn.execute(
-                    f"SELECT raw_id, blob_size FROM raw_sessions WHERE raw_id IN ({placeholders})",
-                    expanded_raw_ids,
-                )
-            }
+            for row in conn.execute(
+                f"SELECT raw_id, blob_size, origin, source_path FROM raw_sessions WHERE raw_id IN ({placeholders})",
+                expanded_raw_ids,
+            ):
+                rid = str(row[0])
+                expanded_blob_bytes[rid] = int(row[1] or 0)
+                expanded_origins[rid] = str(row[2] or "")
+                expanded_source_paths[rid] = str(row[3] or "")
     return RawMaterializationCandidates(
         raw_ids=raw_ids,
         missing_blobs=missing_blobs,
@@ -3916,6 +3926,8 @@ def _raw_materialization_candidate_ids(
         byte_authority_pending=byte_authority_pending,
         expanded_raw_ids=expanded_raw_ids,
         expanded_blob_bytes=expanded_blob_bytes,
+        expanded_origins=expanded_origins,
+        expanded_source_paths=expanded_source_paths,
         authority_components=authority_components,
         missing_blob_raw_ids=tuple(sorted(missing_blob_raw_ids)),
         adoption_deferred_raw_ids=tuple(sorted(adoption_deferred_raw_ids)),
@@ -4016,9 +4028,15 @@ def raw_materialization_readonly_descriptors(
 def _raw_materialization_stream_safe(candidates: RawMaterializationCandidates, raw_id: str) -> bool:
     from polylogue.sources.dispatch import is_stream_record_provider
 
-    origin = Origin.from_string(candidates.raw_origins.get(raw_id))
-    provider = provider_from_origin(origin)
-    return is_stream_record_provider(candidates.raw_source_paths.get(raw_id), provider)
+    # Fall back to the expanded (full-component) maps for already-materialized
+    # non-candidate members, which raw_origins/raw_source_paths (candidate-only)
+    # omit -- mirroring _raw_materialization_component_blob_bytes. Without this a
+    # fully stream-safe codex whale component reads origin=None for its
+    # non-candidate members and is wrongly judged non-stream-safe (polylogue-t93b).
+    origin_token = candidates.expanded_origins.get(raw_id, candidates.raw_origins.get(raw_id))
+    source_path = candidates.expanded_source_paths.get(raw_id, candidates.raw_source_paths.get(raw_id))
+    provider = provider_from_origin(Origin.from_string(origin_token))
+    return is_stream_record_provider(source_path, provider)
 
 
 def _raw_materialization_component_stream_safe(

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -2913,6 +2913,28 @@ def test_raw_materialization_whale_pass_candidate_selects_stream_safe_blocked_co
     )
 
 
+def test_stream_safe_resolves_non_candidate_component_members_via_expanded_maps() -> None:
+    """A component's already-materialized (non-candidate) members are absent from
+    raw_origins/raw_source_paths (candidate-only) but present in the expanded
+    maps. Stream-safety must resolve them there, not read origin=None and judge a
+    fully stream-safe codex component non-safe -- the bug that made the daemon
+    whale pass skip the 6.33GB codex witness component (polylogue-t93b)."""
+    candidates = repair_mod.RawMaterializationCandidates(
+        raw_ids=["cand"],
+        missing_blobs=0,
+        already_parsed=0,
+        raw_origins={"cand": "codex-session"},
+        raw_source_paths={"cand": "/c/rollout-2026-a.jsonl"},
+        expanded_origins={"cand": "codex-session", "noncand": "codex-session"},
+        expanded_source_paths={"cand": "/c/rollout-2026-a.jsonl", "noncand": "/c/rollout-2026-b.jsonl"},
+    )
+    # Candidate member: stream-safe as before.
+    assert repair_mod._raw_materialization_stream_safe(candidates, "cand") is True
+    # Non-candidate member present ONLY in the expanded maps must ALSO be
+    # judged by its real codex origin -- True, not False from a missing lookup.
+    assert repair_mod._raw_materialization_stream_safe(candidates, "noncand") is True
+
+
 def test_raw_materialization_whale_pass_candidate_excludes_non_stream_safe_component(tmp_path: Path) -> None:
     from polylogue.core.enums import Provider
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore


### PR DESCRIPTION
## Summary\n\nReplaces sparse-rowid FTS debt reconciliation with a set-based single-pass repair.\n\n## Problem\n\nLive recovery traced the FTS debt worker repeatedly scanning the 27 GiB active index through numeric rowid windows. The stale-ledger recovery starved the pending raw-authority replay without producing a durable FTS receipt.\n\n## Solution\n\nGlobal FTS debt retains contentless-FTS-safe excess deletion, then reconciles missing FTS rows and their identity ledger with one set-based pass each.\n\n## Verification\n\n-  — 51 passed.\n- Pre-push {
  "timestamp": "2026-07-23T11:22:09.622434+00:00",
  "git_head": "f7819d8057dba12fe46584b779bb838627a77e71",
  "tier": "quick",
  "run_id": "20260723T112139Z-quick-2591035-e6957bff",
  "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff",
  "steps": [
    {
      "name": "ruff format",
      "duration_s": 0.01,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/01-ruff-format"
    },
    {
      "name": "ruff check",
      "duration_s": 0.01,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/02-ruff-check"
    },
    {
      "name": "mypy",
      "duration_s": 0.63,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/03-mypy"
    },
    {
      "name": "render all",
      "duration_s": 9.03,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/04-render-all"
    },
    {
      "name": "verify topology",
      "duration_s": 0.46,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/05-verify-topology"
    },
    {
      "name": "verify layering",
      "duration_s": 3.82,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/06-verify-layering"
    },
    {
      "name": "verify closure-matrix",
      "duration_s": 0.29,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/07-verify-closure-matrix"
    },
    {
      "name": "lab schema roundtrip",
      "duration_s": 0.88,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/08-lab-schema-roundtrip"
    },
    {
      "name": "verify manifests",
      "duration_s": 1.72,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/09-verify-manifests"
    },
    {
      "name": "verify ci-workflows",
      "duration_s": 0.34,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/10-verify-ci-workflows"
    },
    {
      "name": "verify doc-commands",
      "duration_s": 2.54,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/11-verify-doc-commands"
    },
    {
      "name": "verify docs-coverage",
      "duration_s": 2.41,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/12-verify-docs-coverage"
    },
    {
      "name": "verify test-infra-currency",
      "duration_s": 0.38,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/13-verify-test-infra-currency"
    },
    {
      "name": "verify test-clock-hygiene",
      "duration_s": 2.21,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/14-verify-test-clock-hygiene"
    },
    {
      "name": "verify pytest-timeout-overrides",
      "duration_s": 3.97,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/15-verify-pytest-timeout-overrides"
    },
    {
      "name": "verify degrade-loudly",
      "duration_s": 1.21,
      "exit": 0,
      "run_id": "20260723T112139Z-quick-2591035-e6957bff",
      "artifact_dir": ".cache/verify/runs/20260723T112139Z-quick-2591035-e6957bff/steps/16-verify-degrade-loudly"
    }
  ],
  "total_duration_s": 30.18,
  "exit_code": 0
} — completed successfully before branch publication.\n\nRef polylogue-t93b