### PR TITLE
fix(memory): honor nested cgroup limits (#3273)

### DIFF
--- a/polylogue/pipeline/parsed_tree_size.py
+++ b/polylogue/pipeline/parsed_tree_size.py
@@ -146,14 +146,59 @@ def estimate_parsed_tree_bytes(sessions: Sequence[ParsedSession]) -> int:
     )
 
 
+def _cgroup_memory_limit_paths(
+    *,
+    cgroup_v2_root: Path = Path("/sys/fs/cgroup"),
+    cgroup_v1_root: Path = Path("/sys/fs/cgroup/memory"),
+    proc_cgroup_path: Path = Path("/proc/self/cgroup"),
+) -> tuple[Path, ...]:
+    """Return memory-limit files from this process's cgroup ancestry.
+
+    Reading only ``/sys/fs/cgroup/memory.max`` sees the host/root cgroup on
+    systemd hosts. A transient service's real limit is normally on a nested
+    path recorded in ``/proc/self/cgroup``; include it and every ancestor so
+    the caller can select the tightest finite limit.
+    """
+
+    paths: list[Path] = [cgroup_v2_root / "memory.max", cgroup_v1_root / "memory.limit_in_bytes"]
+    try:
+        memberships = proc_cgroup_path.read_text().splitlines()
+    except OSError:
+        return tuple(paths)
+
+    for membership in memberships:
+        try:
+            hierarchy, controllers, relative_path = membership.split(":", 2)
+        except ValueError:
+            continue
+        if hierarchy == "0" and not controllers:
+            root, limit_name = cgroup_v2_root, "memory.max"
+        elif "memory" in controllers.split(","):
+            root, limit_name = cgroup_v1_root, "memory.limit_in_bytes"
+        else:
+            continue
+        parts = tuple(part for part in relative_path.split("/") if part)
+        if any(part in {".", ".."} for part in parts):
+            continue
+        current = root.joinpath(*parts)
+        while True:
+            paths.append(current / limit_name)
+            if current == root:
+                break
+            current = current.parent
+
+    return tuple(dict.fromkeys(paths))
+
+
 def effective_physical_memory_bytes() -> int | None:
     """Physical RAM available to THIS process: host RAM capped by cgroup limit.
 
     Under a container/systemd cgroup memory limit, ``SC_PHYS_PAGES`` reports
     host RAM; sizing an adaptive cache from it starves a memory-limited
     process. Reads cgroup v2 ``memory.max`` (and legacy v1
-    ``memory.limit_in_bytes``) and returns the minimum of host RAM and any
-    finite limit; ``None`` when neither is knowable.
+    ``memory.limit_in_bytes``) across the process's cgroup ancestry and
+    returns the minimum of host RAM and any finite limit; ``None`` when
+    neither is knowable.
     """
 
     physical: int | None
@@ -164,7 +209,7 @@ def effective_physical_memory_bytes() -> int | None:
     except (ValueError, OSError, AttributeError):
         physical = None
     limits = []
-    for path in ("/sys/fs/cgroup/memory.max", "/sys/fs/cgroup/memory/memory.limit_in_bytes"):
+    for path in _cgroup_memory_limit_paths():
         try:
             raw = Path(path).read_text().strip()
         except OSError:

--- a/tests/unit/pipeline/test_parsed_tree_size.py
+++ b/tests/unit/pipeline/test_parsed_tree_size.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from polylogue.pipeline import parsed_tree_size
+
+
+def test_cgroup_v2_limit_paths_include_nested_service_ancestry(tmp_path: Path) -> None:
+    cgroup_root = tmp_path / "cgroup"
+    service = cgroup_root / "user.slice" / "user-1000.slice" / "worker.service"
+    service.mkdir(parents=True)
+    membership = tmp_path / "self-cgroup"
+    membership.write_text("0::/user.slice/user-1000.slice/worker.service\n")
+
+    paths = parsed_tree_size._cgroup_memory_limit_paths(
+        cgroup_v2_root=cgroup_root,
+        cgroup_v1_root=tmp_path / "cgroup-v1-memory",
+        proc_cgroup_path=membership,
+    )
+
+    assert service / "memory.max" in paths
+    assert cgroup_root / "user.slice" / "memory.max" in paths
+    assert cgroup_root / "memory.max" in paths
+
+
+def test_effective_memory_caps_host_ram_to_nested_cgroup_limit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    limit_path = tmp_path / "worker-memory.max"
+    limit_path.write_text(str(10 * 1024**3))
+    monkeypatch.setattr(os, "sysconf", lambda key: 32 * 1024**3 if key == "SC_PHYS_PAGES" else 1)
+    monkeypatch.setattr(parsed_tree_size, "_cgroup_memory_limit_paths", lambda: (limit_path,))
+
+    assert parsed_tree_size.effective_physical_memory_bytes() == 10 * 1024**3


### PR DESCRIPTION
## Summary

Caps adaptive parsed-session cache sizing to the current process's actual cgroup hierarchy, including nested systemd service limits.

## Problem

The cache-sizing helper read only root cgroup files. For a rebuild worker constrained by a nested 10 GiB systemd limit, it instead observed host RAM and could admit an 8 GiB whale cache alongside normal replay overhead.

## Solution

- Discover v2 and v1 memory-limit files from proc self cgroup membership through the process ancestry.
- Select the tightest finite limit together with host physical RAM.
- Add focused tests for nested v2 discovery and the production cap calculation.

## Verification

- Focused parsed-tree sizing tests: 2 passed.
- Quick verification: format, lint, mypy, generated-surface, layering, schema, and policy gates passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved effective memory detection for environments with nested container or cgroup limits.
  * Memory usage now respects the most restrictive finite limit across the full cgroup hierarchy, preventing overestimation.

* **Tests**
  * Added coverage for nested cgroup ancestry and memory limits.
  * Added validation that effective memory is capped below available host RAM when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->