### PR TITLE
docs: make the README reader-first

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <a href="https://sinity.github.io/polylogue/"><img src="https://img.shields.io/badge/docs-live-2563eb" alt="Live documentation"></a>
 </p>
 
+<!-- public-claim:category.local-evidence-system -->
 Polylogue keeps AI conversations and coding-agent runs from several tools in one
 local archive. It ingests supported histories from ChatGPT, Claude and Claude
 Code, Codex, Gemini, Hermes, and other sources, then normalizes them into one

--- a/README.md
+++ b/README.md
@@ -9,87 +9,103 @@
   <a href="https://sinity.github.io/polylogue/"><img src="https://img.shields.io/badge/docs-live-2563eb" alt="Live documentation"></a>
 </p>
 
-<!-- public-claim:category.local-evidence-system -->
-**Polylogue archives your AI conversations and coding-agent runs — in one place, on your machine.**
+Polylogue keeps AI conversations and coding-agent runs from several tools in one
+local archive. It ingests supported histories from ChatGPT, Claude and Claude
+Code, Codex, Gemini, Hermes, and other sources, then normalizes them into one
+model of sessions, messages, content blocks, tool calls and results, branches,
+subagents, usage, and costs.
 
-Every AI tool keeps its history in its own format and its own corner: Claude
-Code writes JSONL under `~/.claude`, Codex under `~/.codex`, while ChatGPT and
-Claude web expose export archives. Polylogue ingests supported histories into a
-set of SQLite files you own, normalizes them into one model — sessions,
-messages, content blocks, tool calls and results — and serves them through a
-query-first CLI, an MCP server for agents, a local HTTP reader, and a Python
-API.
+The archive stays on your machine. You can search it from the CLI, read it over
+a local HTTP interface, query it from Python, or expose it to agents through
+MCP.
 
-```mermaid
-flowchart LR
-    subgraph sources[" "]
-        direction TB
-        A["Claude Code · Codex · Gemini CLI<br/>live JSONL, watched as you work"]
-        B["ChatGPT · Claude · Grok · AI Studio<br/>export zips, browser capture"]
-    end
-    sources -->|"ingest"| S[("source.db<br/><i>raw bytes, durable</i>")]
-    S -->|"parse + derive"| I[("index.db<br/><i>one normalized model,<br/>rebuildable</i>")]
-    U[("user.db<br/><i>your notes & judgments,<br/>durable</i>")] --- I
-    I --> CLI["CLI<br/><code>find … then …</code>"]
-    I --> MCP["MCP server<br/>for agents"]
-    I --> HTTP["local HTTP<br/>reader"]
-    I --> PY["Python<br/>API"]
+The author's live archive currently contains more than **18,000 sessions and
+4.7 million messages**, covering several providers and work dating back to
+2022. The session count is a verified July 2026 figure after a repair stopped
+counting hook events as standalone sessions. The hook records and their payloads
+were retained and linked to their parent sessions.
+
+[Getting started](docs/getting-started.md) | [Live documentation](https://sinity.github.io/polylogue/) | [Architecture](docs/architecture.md) | [CLI reference](docs/cli-reference.md)
+
+## What Polylogue is for
+
+AI work is usually split across vendor exports, JSONL logs, browser captures,
+and tool-specific directories. Even when the data is available, each source has
+a different model of messages, tool use, branches, and usage.
+
+Polylogue provides one place to:
+
+- search conversations and coding sessions across providers;
+- inspect tool calls and their recorded outcomes;
+- follow forks, resumes, subagents, and compaction lineage;
+- distinguish human-authored material from injected runtime context;
+- compile context from earlier work for a new agent session;
+- calculate usage and cost without collapsing incompatible token lanes;
+- attach notes, tags, corrections, and judgments without modifying source data.
+
+## Quick start
+
+Install one of the packaged releases:
+
+```bash
+pipx install polylogue
+# or
+uv tool install polylogue
+# or
+brew tap sinity/polylogue && brew install polylogue
+# or
+nix run github:Sinity/polylogue -- --help
 ```
 
-## See it work
+Detect local sources and start the daemon:
 
-Every block below is a real command against the author's own archive —
-currently **18,000+ sessions and 4.7 million messages** of live history,
-covering multiple providers and reaching back to 2022. The session figure is a
-verified July 2026 snapshot after a repair stopped counting hook events as
-standalone sessions; the hook evidence and retained payloads were preserved and
-linked to their parent sessions. Output is trimmed with `...` where noted;
-nothing is invented.
-
-Start wide: dated sessions per year. This grouping omits sessions without a
-usable start timestamp; hook events are attached evidence and are not counted
-as sessions:
-
-```console
-$ polylogue find 'since:2015-01-01' then analyze --by year
-2026: 13537
-2025: 2270
-2024: 737
-2023: 683
-2022: 25
+```bash
+polylogue init
+polylogued run
 ```
 
-Search it. One query hits Codex and Claude Code sessions at once — here, a
-recurring clock-hygiene lint check landing in both:
+Import a one-off export:
 
-```console
-$ polylogue --limit 4 find 'repo:polylogue "with host-clock calls"'
-1. claude-code-session  sure, I'm going AFK. Do not halt. Remember the word indefinitely. Do start by ex...  test files scanned: 618 files [with host-clock calls]: 23 allowlisted: 23 violations: 0
-2. claude-code-session  3b0038ec-234c-44b8-bb88-fe222b44fe0f:agent-a97318edcffaac69d  test files scanned: 738 files [with host-clock calls]: 22 allowlisted: 26 violations: 0
-3. claude-code-session  8dab1c19-ef6f-4f49-b4c1-cd9084c1b582  test files scanned: 894 files [with host-clock calls]: 27 allowlisted: 31 violations: 0 "total_duration_s": 28.98, "exit_code": 0 }
-4. codex-session  019e1a5c-0abe-71e1-8adf-8ae8d4cc71a6  Chunk ID: 7b81ce Wall time: 0.0000 seconds Process exited with code 0 Original token count: 22 Output: test files scanned: 598 files [with host-clock calls]: 23 allowlisted: 23 violations: 0
+```bash
+polylogue import ~/Downloads/chatgpt-export.zip
+polylogue import some-file.json --explain
 ```
 
-Read one back as a transcript — real coding-agent sessions carry a lot of
-injected system/skill context before the actual exchange, so this excerpt
-trims that noise down to the assistant's opening move on a real task:
+Run a query:
 
-```console
-$ polylogue find 'id:codex-session:019f4b85-1e4a-7060-a8c3-36e4b4175ff2' then read --view transcript
-# 019f4b85-1e4a-7060-a8c3-36e4b4175ff2
-...
-## assistant
-I'll independently map the bead's acceptance criteria to the branch diff, then
-trace each persistence and reparse path into its production implementation and
-focused tests. I'll treat passing tests as evidence only after checking that
-they exercise the claimed failure modes.
-...
+```bash
+polylogue find 'repo:polylogue since:7d' then analyze --facets
+polylogue --origin claude-code-session find "migration" then read --view messages
+polylogue find 'actions where tool:shell AND command:pytest' then read
 ```
 
-Query tool activity as data, not text. Tool calls are paired with their
-results, and failure comes from the provider's `exit_code`/`is_error`
-structure — not from grepping prose for the word "error" — so this is every
-tool that ever failed across this repo's own coding sessions, ranked:
+`polylogue init` writes a starter `polylogue.toml` from the sources found on the
+machine. `polylogued run` imports those sources and continues watching the live
+ones.
+
+## Supported sources
+
+| Source | Origin | Typical input |
+|---|---|---|
+| Claude Code | `claude-code-session` | watched JSONL under `~/.claude/projects` |
+| Codex CLI | `codex-session` | watched sessions under `~/.codex/sessions` |
+| ChatGPT | `chatgpt-export` | export archive or opt-in browser capture |
+| Claude web | `claude-ai-export` | export archive or opt-in browser capture |
+| Gemini and AI Studio | `aistudio-drive` | Drive or AI Studio export |
+| Gemini CLI | `gemini-cli-session` | watched local session data |
+| Hermes | `hermes-session` | runtime-root ATIF or ATOF artifacts |
+| Antigravity | `antigravity-session` | exported session data |
+
+Each parser preserves the detail present in its source, including roles, prose,
+thinking blocks, tool calls and results, attachments, and session metadata.
+Provider-specific caveats are documented in
+[docs/provider-origin-identity.md](docs/provider-origin-identity.md).
+
+## A real archive query
+
+Tool execution is stored as structured data. A failed tool result comes from the
+provider's `exit_code` or `is_error` field when one exists. Polylogue does not
+guess failure by searching assistant prose for words such as "error".
 
 ```console
 $ polylogue "actions where session.repo:polylogue AND is_error:true | group by tool | count"
@@ -101,9 +117,7 @@ tool=exec_command count=149
 ...
 ```
 
-The same structure answers sharper questions. Every `pytest` invocation any
-agent ever ran here, split by its **actual exit status** — including the
-honest `unknown` lane for results the provider never reported:
+The same data can separate successful, failed, and unreported `pytest` results:
 
 ```console
 $ polylogue "actions where tool:Bash AND command:pytest | group by is_error | count"
@@ -112,91 +126,58 @@ is_error=1 count=1039
 is_error=unknown count=115
 ```
 
-That is the product: the AI-work evidence your configured tools exposed, in one
-queryable place, with tool activity modeled as work rather than chat.
+These examples use the author's live archive. Output is shortened where shown.
 
-## Use it on your own history
+## Storage model
 
-```bash
-polylogue init      # detects Claude Code, Codex, Gemini CLI, Hermes, Antigravity under $HOME; writes polylogue.toml
-polylogued run      # the daemon: ingests what init found, then keeps watching as you work
-```
+Polylogue uses five SQLite databases and a SHA-256 content-addressed blob store
+under one local archive root.
 
-`polylogue init` records the sources present on your machine;
-`polylogued run` ingests them and stays running — new sessions appear in the
-archive as your tools write them. One-off files (a ChatGPT export zip, a
-downloaded conversation) go through the same pipeline:
+> Source evidence and user-authored judgments are durable. Search indexes,
+> embeddings, analytics, and other derived data can be rebuilt.
 
-```bash
-polylogue import ~/Downloads/chatgpt-export.zip
-polylogue import some-file.json --explain   # show detection/parse decisions without importing
-```
-
-| You use | Origin | How it arrives |
+| File | Contents | Durability |
 |---|---|---|
-| Claude Code | `claude-code-session` | daemon watches `~/.claude/projects` |
-| Codex CLI | `codex-session` | daemon watches `~/.codex/sessions` |
-| ChatGPT (web) | `chatgpt-export` | export zip, or opt-in browser capture |
-| Claude (web) | `claude-ai-export` | export zip, or opt-in browser capture |
-| Gemini / AI Studio | `aistudio-drive` | Drive / AI Studio exports |
-| Gemini CLI | `gemini-cli-session` | daemon watch |
-| Hermes (Nous) | `hermes-session` | runtime-root import (ATIF/ATOF artifacts) |
-| Antigravity | `antigravity-session` | export import |
-
-Each origin is captured at full fidelity — roles, prose, thinking, tool calls
-and results, attachments, session metadata — as far as the source provides
-them. Per-origin detail: [docs/provider-origin-identity.md](docs/provider-origin-identity.md).
-
-## What the archive is
-
-Five SQLite files plus a SHA-256 content-addressed blob store, under one
-local directory. Ingestion flows raw bytes → parsed model → derived indexes;
-one rule decides what must survive:
-
-> **Source evidence and your own judgments are durable. Everything derived —
-> search indexes, analytics, embeddings — is rebuildable from source.**
-
-| File | Holds | Durability |
-|---|---|---|
-| `source.db` | raw acquired artifacts, hook events | durable |
-| `index.db` | sessions, messages, blocks, actions, lineage, FTS, analytics | rebuildable |
+| `source.db` | acquired source artifacts and hook records | durable |
+| `index.db` | normalized sessions, messages, blocks, actions, lineage, FTS, analytics | rebuildable |
 | `embeddings.db` | optional semantic-search vectors | rebuildable |
-| `user.db` | your notes, tags, corrections, judgments | durable |
-| `ops.db` | daemon cursors and telemetry | disposable |
+| `user.db` | notes, tags, corrections, candidates, and judgments | durable |
+| `ops.db` | daemon cursors, convergence state, and telemetry | disposable |
 
-Modelling decisions that make queries trustworthy:
+Several modeling choices are important for trustworthy queries:
 
-- **Tool outcomes are structural.** `tool_result_is_error` and
-  `tool_result_exit_code` come from provider structure; unknown stays `NULL`
-  instead of being guessed from prose.
-- **Role ≠ authorship.** Providers encode injected runtime context as
-  `role=user` messages; a separate `material_origin` column keeps
-  human-authored text distinct from protocol noise, so "what did I actually
-  write" and cost accounting stay honest.
-- **Forks don't double-count.** Forks, resumes, subagents, and compaction
-  physically replay a parent's prefix in the raw logs. The archive stores
-  only the divergent tail plus a branch point and recomposes on read — so
-  token totals and transcripts count copied history once.
-- **Cost is modeled per lane.** Provider-reported usage, cached-token lanes,
-  reasoning tokens, catalog prices, and subscription-credit views stay
-  separate (Codex "input" is ~mostly cache reads; adding lanes together
-  silently inflates spend).
+- **Tool outcomes remain structural.** Unknown status stays unknown instead of
+  being inferred from text.
+- **Message role and authorship are separate.** Injected context may arrive as a
+  `user` message even though a human did not write it.
+- **Copied prefixes are counted once.** Forks, resumes, subagents, and compaction
+  may replay parent history in raw logs. Polylogue stores lineage and the
+  divergent tail rather than treating every copy as new work.
+- **Usage lanes remain separate.** Provider-reported input, cache reads,
+  reasoning tokens, catalog prices, and subscription-credit views are not added
+  together unless the calculation is valid.
+
+See [docs/data-model.md](docs/data-model.md) and
+[docs/architecture.md](docs/architecture.md) for the full model.
 
 ## Interfaces
 
-The CLI is query-first — `find QUERY then ACTION`, with a real query grammar
-(fielded predicates, booleans, date ranges, pipeline stages):
+### CLI
+
+The CLI is query-first and supports field filters, booleans, date ranges, action
+queries, and pipelines:
 
 ```bash
 polylogue find 'repo:polylogue since:7d' then analyze --facets
-polylogue --origin claude-code-session find "migration" then read --view messages
-polylogue find 'actions where tool:shell AND command:pytest' then read
 polylogue find "urgent" then mark --tag-add review
+polylogue find 'actions where tool:shell AND command:pytest' then read
 ```
 
-**Agents** get the same archive over MCP — `polylogue-mcp` is a standalone
-stdio server, read-only by default. Write access requires an explicit configured
-role and remains authorization- and confirmation-gated:
+### MCP
+
+`polylogue-mcp` exposes the archive over stdio. It is read-only by default.
+Write access requires an explicitly configured role and remains subject to
+authorization and confirmation rules.
 
 ```json
 {
@@ -206,37 +187,29 @@ role and remains authorization- and confirmation-gated:
 }
 ```
 
-An agent with this block can search its own past sessions, resume prior
-work with compiled context, and audit what previous runs actually did. Setup
-and role details: [docs/mcp-integration.md](docs/mcp-integration.md).
+See [docs/mcp-integration.md](docs/mcp-integration.md).
 
-**The daemon** (`polylogued run`) also serves a local HTTP reader and
-metrics; **Python** callers get an async API over the same storage
-([docs/data-model.md](docs/data-model.md)). Semantic search is an explicit
-opt-in (`--semantic`) that requires configuring an embedding provider —
-that is the only path where any text leaves your machine, and
-`polylogue ops embed preflight` shows the cost before anything is sent.
+### HTTP and Python
 
-## Install
+`polylogued run` serves a local HTTP reader and metrics endpoint. Python callers
+can use the asynchronous API over the same archive.
 
-```bash
-pipx install polylogue          # or: uv tool install polylogue
-brew tap sinity/polylogue && brew install polylogue
-nix run github:Sinity/polylogue -- --help
-```
+Semantic search is optional. It requires an embedding provider, and it is the
+only normal path that sends archive text outside the machine. Run
+`polylogue ops embed preflight` to inspect the work and estimated cost before
+sending anything.
 
-All three routes ship the same three commands: `polylogue`, `polylogued`,
-`polylogue-mcp`. Source checkout, NixOS/Home Manager modules, and
-verification: [docs/installation.md](docs/installation.md).
+## Demo data
 
-No accounts, no personal data, no API keys — `demo seed` builds a small
-synthetic archive through the real ingestion path, so the commands above
-work against something before you point Polylogue at your own history:
+You can exercise the real ingestion and query paths without importing personal
+data:
 
 ```bash
-polylogue demo seed      # writes a synthetic archive to POLYLOGUE_ARCHIVE_ROOT
-polylogue demo verify    # checks it round-tripped correctly
+polylogue demo seed
+polylogue demo verify
 ```
+
+The demo writes a small synthetic archive to `POLYLOGUE_ARCHIVE_ROOT`.
 
 <!-- BEGIN GENERATED: docs-surface -->
 ## Documentation
@@ -264,19 +237,20 @@ Start with the task-oriented guides below; [docs/README.md](docs/README.md) sepa
 
 ## Status
 
-Pre-1.0, under heavy daily dogfooding against the author's own multi-year,
-multi-tool archive. The deterministic demo world, the normalized model, and
-the CLI/MCP/HTTP/Python surfaces are real and tested; interfaces may still
-change between releases. Roadmap lives in the committed
-[Beads](https://github.com/steveyegge/beads) graph
-([web board](https://sinity.github.io/polylogue/main/beads/), or `bd ready`
-locally) — not in GitHub Issues.
+Polylogue is pre-1.0 and used daily against the author's multi-year archive.
+The deterministic demo, normalized model, CLI, MCP, HTTP, and Python interfaces
+are implemented and tested. Interfaces may still change between releases.
+
+The roadmap lives in the committed
+[Beads](https://github.com/steveyegge/beads) graph. Browse the
+[web board](https://sinity.github.io/polylogue/main/beads/) or run `bd ready`
+locally.
 
 ## Development
 
 ```bash
-devtools status          # repo state and next steps
-devtools verify --quick  # format + lint + types + generated-surface check
+devtools status
+devtools verify --quick
 ```
 
 See [CONTRIBUTING.md](CONTRIBUTING.md), [TESTING.md](TESTING.md), and
@@ -284,10 +258,13 @@ See [CONTRIBUTING.md](CONTRIBUTING.md), [TESTING.md](TESTING.md), and
 
 ## Security
 
-Polylogue assumes a trusted single-user machine. The daemon binds to
-loopback; protected routes use bearer tokens; browser capture is opt-in with
-its own token. The archive contains whatever your sessions contain — source
-code, secrets, personal conversations — so treat it like the private data it
-is: use disk encryption, and read [docs/security.md](docs/security.md) and
-[docs/daemon-threat-model.md](docs/daemon-threat-model.md) before exposing
+Polylogue assumes a trusted single-user machine. The daemon binds to loopback,
+protected routes use bearer tokens, and browser capture is opt-in with its own
+token. The archive may contain source code, credentials, and personal
+conversations. Use disk encryption and read [docs/security.md](docs/security.md)
+and [docs/daemon-threat-model.md](docs/daemon-threat-model.md) before exposing
 anything beyond localhost.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- lead with the archive's actual purpose and verified live scale
- replace internal terminology with plain descriptions where possible
- shorten the demonstration section while keeping real archive queries
- explain storage, lineage, authorship, usage, and MCP rules in reader-facing language
- remove em dashes and product-copy phrasing

## Verification

Documentation-only change. The branch changes only `README.md`. Commands and counts were retained from the current public interfaces and verified live-archive snapshot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the README with clearer project positioning and quick-start guidance.
  * Expanded documentation for supported sources, storage, data modeling, and query examples.
  * Clarified CLI, MCP, HTTP, and Python interfaces, including semantic search and authorization behavior.
  * Added sections covering demo data, project status, development, security, and licensing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->