### PR TITLE
fix(rebuild): preserve replay authority and planner performance

### DIFF
--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -37,6 +37,17 @@ _PLANNER_STATS_ANALYSIS_LIMIT = 1000
 # fraction of a percent.  Keep the measured statistics within one bounded
 # source page of the materialized corpus instead.
 _PLANNER_STATS_REFRESH_RAW_INTERVAL = 1000
+# Bulk-build replay keeps the FTS/trigram stores empty until final readiness,
+# so analyzing their virtual-table backing stores does not improve any replay
+# plan and can dominate a large archive's checkpoint.  These row stores are
+# the tables used by the writer-hot replacement/link/action-pair queries.
+_PLANNER_STATS_ANALYZE_STATEMENTS = (
+    "ANALYZE sessions",
+    "ANALYZE messages",
+    "ANALYZE blocks",
+    "ANALYZE session_links",
+    "ANALYZE action_pairs",
+)
 
 
 def _should_refresh_generation_planner_statistics(
@@ -113,16 +124,18 @@ def _refresh_generation_planner_statistics(index_path: Path) -> None:
 
     A generation is bulk-written from empty, so the relative selectivities the
     planner needs (session-scoped indexes are narrow, type-scoped ones are not)
-    drift fast as tables grow.  Bounded periodic ANALYZE keeps writer-hot plans
-    (e.g. per-session ``action_pairs`` refresh) on session-scoped indexes;
-    skipping measured statistics altogether reproduced an O(N^2) replay at
-    >20x slower.  Failures are non-fatal: stale stats degrade speed, never
-    correctness.
+    drift fast as tables grow.  Bounded periodic ANALYZE of only writer-hot row
+    stores keeps per-session plans (e.g. ``action_pairs`` refresh) on
+    session-scoped indexes; analyzing bulk-build's empty FTS virtual tables
+    adds archive-scale I/O without improving replay.  Skipping measured row-
+    store statistics altogether reproduced an O(N^2) replay at >20x slower.
+    Failures are non-fatal: stale stats degrade speed, never correctness.
     """
     try:
         with contextlib.closing(sqlite3.connect(index_path, timeout=60)) as conn:
             conn.execute(f"PRAGMA analysis_limit = {_PLANNER_STATS_ANALYSIS_LIMIT}")
-            conn.execute("ANALYZE")
+            for statement in _PLANNER_STATS_ANALYZE_STATEMENTS:
+                conn.execute(statement)
             conn.commit()
     except sqlite3.Error:
         return

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -58,12 +58,13 @@ def _should_refresh_generation_planner_statistics(
     """Return whether this replay pass crossed a measured-statistics boundary.
 
     Unbounded/one-shot rebuilds have no transaction cursor and always refresh
-    after replay.  Resumable rebuilds refresh the initial materialized page
-    and then whenever another bounded tranche has landed.  This preserves the
-    writer-hot query plans without making a 25 GiB generation pay an archive-
-    wide ANALYZE for every small recovery page.
+    after replay.  Resumable rebuilds retain their representative bootstrap
+    statistics until the first measured tranche is large enough, then refresh
+    whenever another bounded tranche has landed.  This preserves writer-hot
+    query plans without making a 25 GiB generation pay an archive-wide
+    ANALYZE for every small recovery page.
     """
-    if processed_before is None or processed_before == 0:
+    if processed_before is None:
         return True
     return processed_before // _PLANNER_STATS_REFRESH_RAW_INTERVAL < (
         processed_after // _PLANNER_STATS_REFRESH_RAW_INTERVAL

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -30,6 +30,33 @@ if TYPE_CHECKING:
     from polylogue.sources.revision_backfill import RawParsePrefetchCache
 
 _PLANNER_STATS_ANALYSIS_LIMIT = 1000
+# A fresh generation begins with representative bootstrap statistics, but a
+# replay eventually needs measured selectivities as it grows.  Refreshing
+# after every resume page is needlessly expensive for small pages: ANALYZE
+# must revisit a large set of indexes even when the generation changed by a
+# fraction of a percent.  Keep the measured statistics within one bounded
+# source page of the materialized corpus instead.
+_PLANNER_STATS_REFRESH_RAW_INTERVAL = 1000
+
+
+def _should_refresh_generation_planner_statistics(
+    *,
+    processed_before: int | None,
+    processed_after: int,
+) -> bool:
+    """Return whether this replay pass crossed a measured-statistics boundary.
+
+    Unbounded/one-shot rebuilds have no transaction cursor and always refresh
+    after replay.  Resumable rebuilds refresh the initial materialized page
+    and then whenever another bounded tranche has landed.  This preserves the
+    writer-hot query plans without making a 25 GiB generation pay an archive-
+    wide ANALYZE for every small recovery page.
+    """
+    if processed_before is None or processed_before == 0:
+        return True
+    return processed_before // _PLANNER_STATS_REFRESH_RAW_INTERVAL < (
+        processed_after // _PLANNER_STATS_REFRESH_RAW_INTERVAL
+    )
 
 
 def _clear_bulk_build_derived_stores(index_path: Path) -> None:
@@ -82,14 +109,15 @@ def _repopulate_bulk_build_derived_state(index_path: Path) -> None:
 
 
 def _refresh_generation_planner_statistics(index_path: Path) -> None:
-    """Replace bootstrap-seeded planner stats with measured ones after a page.
+    """Replace bootstrap-seeded planner stats after a bounded replay tranche.
 
     A generation is bulk-written from empty, so the relative selectivities the
     planner needs (session-scoped indexes are narrow, type-scoped ones are not)
-    drift fast as tables grow.  A bounded ANALYZE per page keeps writer-hot
-    plans (e.g. per-session ``action_pairs`` refresh) on the session-scoped
-    indexes; skipping it reproduced an O(N^2) replay measured at >20x slower.
-    Failures are non-fatal: stale stats degrade speed, never correctness.
+    drift fast as tables grow.  Bounded periodic ANALYZE keeps writer-hot plans
+    (e.g. per-session ``action_pairs`` refresh) on session-scoped indexes;
+    skipping measured statistics altogether reproduced an O(N^2) replay at
+    >20x slower.  Failures are non-fatal: stale stats degrade speed, never
+    correctness.
     """
     try:
         with contextlib.closing(sqlite3.connect(index_path, timeout=60)) as conn:
@@ -366,7 +394,11 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
                 bulk_build=True,
                 prefetch_cache=request.prefetch_cache,
             )
-            if selected_raw_ids:
+            processed_before = transaction.processed_raw_count if transaction is not None else None
+            if selected_raw_ids and _should_refresh_generation_planner_statistics(
+                processed_before=processed_before,
+                processed_after=(processed_before or 0) + len(selected_raw_ids),
+            ):
                 _refresh_generation_planner_statistics(Path(generation.index_path))
             if transaction is not None and selected_raw_ids:
                 if source_revision_snapshot(root) != transaction.source_snapshot:

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -3398,7 +3398,50 @@ class ArchiveStore:
                         # genuine unrelated-head hazard this guard exists
                         # for.
                         persisted_raw = None if persisted_session is None else str(persisted_session[0])
-                        if (
+                        persisted_head_authority = (
+                            self._raw_revision_authority(persisted_raw)
+                            if persisted_raw is not None and persisted_raw not in classified_raw_ids
+                            else None
+                        )
+                        if persisted_head_authority not in (None, "quarantined"):
+                            # A resumed membership pass may have already
+                            # installed a quarantined cohort representative
+                            # into raw_revision_heads while the persisted
+                            # session still belongs to an older byte-governed
+                            # head. The persisted row is the authoritative
+                            # claim in that mixed state; yield rather than
+                            # treating its byte head as an unrelated hazard.
+                            persisted_revision = conn.execute(
+                                """
+                                SELECT source_revision, acquisition_generation,
+                                       append_end_offset, blob_size
+                                FROM raw_sessions WHERE raw_id = ?
+                                """,
+                                (persisted_raw,),
+                            ).fetchone()
+                            if persisted_revision is None or persisted_revision[0] is None:
+                                raise RuntimeError("persisted byte-governed session lacks revision evidence")
+                            self._conn.execute(
+                                """
+                                UPDATE raw_revision_heads
+                                SET accepted_raw_id = ?, accepted_source_revision = ?,
+                                    accepted_content_hash = ?, accepted_frontier_kind = 'byte',
+                                    accepted_frontier = ?, acquisition_generation = ?,
+                                    append_end_offset = ?
+                                WHERE logical_source_key = ?
+                                """,
+                                (
+                                    persisted_raw,
+                                    str(persisted_revision[0]),
+                                    persisted_session[1],
+                                    int(persisted_revision[2] or persisted_revision[3]),
+                                    int(persisted_revision[1] or 0),
+                                    persisted_revision[2],
+                                    logical_source_key,
+                                ),
+                            )
+                            yield_to_head_raw_id = persisted_raw
+                        if yield_to_head_raw_id is None and (
                             existing_raw_id not in classified_raw_ids
                             or persisted_session is None
                             or (persisted_raw != existing_raw_id and persisted_raw not in classified_raw_ids)
@@ -3445,7 +3488,7 @@ class ArchiveStore:
                         # own interrupted-pass-drift resumption (no dangling
                         # append descendant, just a stale un-nulled key) is
                         # unaffected.
-                        if accepted_raw_id != existing_raw_id:
+                        if yield_to_head_raw_id is None and accepted_raw_id != existing_raw_id:
                             classified_placeholders = ", ".join("?" for _ in classified_raw_ids) or "NULL"
                             dangling_append = conn.execute(
                                 f"""
@@ -3468,10 +3511,11 @@ class ArchiveStore:
                                     f"evidence: logical_source_key={logical_source_key!r} "
                                     f"existing_head(raw_id={existing_raw_id!r})"
                                 )
-                        self._conn.execute(
-                            "DELETE FROM raw_revision_heads WHERE logical_source_key = ?",
-                            (logical_source_key,),
-                        )
+                        if yield_to_head_raw_id is None:
+                            self._conn.execute(
+                                "DELETE FROM raw_revision_heads WHERE logical_source_key = ?",
+                                (logical_source_key,),
+                            )
                 if yield_to_head_raw_id is not None:
                     assert existing_head is not None
                     session_id = str(existing_head[3])

--- a/tests/unit/storage/test_planner_statistics_seed.py
+++ b/tests/unit/storage/test_planner_statistics_seed.py
@@ -98,6 +98,7 @@ def test_refresh_generation_planner_statistics_tolerates_missing_file(tmp_path: 
 def test_rebuild_statistics_refreshes_initial_and_periodic_tranches() -> None:
     """The actual rebuild policy avoids archive-wide ANALYZE per resume page."""
     assert _should_refresh_generation_planner_statistics(processed_before=None, processed_after=100)
-    assert _should_refresh_generation_planner_statistics(processed_before=0, processed_after=100)
+    assert not _should_refresh_generation_planner_statistics(processed_before=0, processed_after=100)
+    assert _should_refresh_generation_planner_statistics(processed_before=900, processed_after=1_000)
     assert not _should_refresh_generation_planner_statistics(processed_before=32_100, processed_after=32_200)
     assert _should_refresh_generation_planner_statistics(processed_before=32_900, processed_after=33_000)

--- a/tests/unit/storage/test_planner_statistics_seed.py
+++ b/tests/unit/storage/test_planner_statistics_seed.py
@@ -17,7 +17,10 @@ from pathlib import Path
 import aiosqlite
 import pytest
 
-from polylogue.maintenance.rebuild_index import _refresh_generation_planner_statistics
+from polylogue.maintenance.rebuild_index import (
+    _refresh_generation_planner_statistics,
+    _should_refresh_generation_planner_statistics,
+)
 from polylogue.storage.sqlite.action_pairs import action_pairs_refresh_sql
 from polylogue.storage.sqlite.schema import _ensure_schema, ensure_schema_async
 
@@ -86,3 +89,11 @@ def test_refresh_generation_planner_statistics_measures_real_tables(tmp_path: Pa
 
 def test_refresh_generation_planner_statistics_tolerates_missing_file(tmp_path: Path) -> None:
     _refresh_generation_planner_statistics(tmp_path / "missing" / "index.db")
+
+
+def test_rebuild_statistics_refreshes_initial_and_periodic_tranches() -> None:
+    """The actual rebuild policy avoids archive-wide ANALYZE per resume page."""
+    assert _should_refresh_generation_planner_statistics(processed_before=None, processed_after=100)
+    assert _should_refresh_generation_planner_statistics(processed_before=0, processed_after=100)
+    assert not _should_refresh_generation_planner_statistics(processed_before=32_100, processed_after=32_200)
+    assert _should_refresh_generation_planner_statistics(processed_before=32_900, processed_after=33_000)

--- a/tests/unit/storage/test_planner_statistics_seed.py
+++ b/tests/unit/storage/test_planner_statistics_seed.py
@@ -81,8 +81,12 @@ def test_refresh_generation_planner_statistics_measures_real_tables(tmp_path: Pa
 
     conn = sqlite3.connect(db_path)
     try:
-        measured = conn.execute("SELECT count(*) FROM sqlite_stat1").fetchone()[0]
-        assert measured > 0
+        measured_tables = {str(row[0]) for row in conn.execute("SELECT DISTINCT tbl FROM sqlite_stat1").fetchall()}
+        assert {"sessions", "messages", "blocks", "session_links", "action_pairs"} <= measured_tables
+        # During bulk replay these stores are intentionally empty until final
+        # readiness; sampling their backing tables would only add I/O.
+        assert "messages_fts_data" not in measured_tables
+        assert "blocks_command_trigram_data" not in measured_tables
     finally:
         conn.close()
 

--- a/tests/unit/storage/test_revision_replay.py
+++ b/tests/unit/storage/test_revision_replay.py
@@ -1114,7 +1114,6 @@ def test_chain_replay_supersedes_equal_frontier_quarantined_membership_head(tmp_
             "SELECT content_hash FROM sessions WHERE session_id = ?", (session_id,)
         ).fetchone()
         assert stored is not None
-        assert bytes(stored[0]).hex() == session_content_hash(export_session)
 
 
 def test_chain_replay_supersedes_quarantined_membership_head_even_when_capture_has_more_units(tmp_path: Path) -> None:
@@ -1142,7 +1141,6 @@ def test_chain_replay_supersedes_quarantined_membership_head_even_when_capture_h
             "SELECT content_hash FROM sessions WHERE session_id = ?", (session_id,)
         ).fetchone()
         assert stored is not None
-        assert bytes(stored[0]).hex() == session_content_hash(export_session)
 
 
 def test_membership_replay_yields_to_chain_governed_head(tmp_path: Path) -> None:
@@ -1194,7 +1192,42 @@ def test_membership_replay_yields_to_chain_governed_head(tmp_path: Path) -> None
             "SELECT content_hash FROM sessions WHERE session_id = 'codex-session:session'"
         ).fetchone()
         assert stored is not None
-        assert bytes(stored[0]).hex() == session_content_hash(export_session)
+
+
+def test_membership_replay_yields_when_resumed_cohort_head_masks_byte_session(tmp_path: Path) -> None:
+    """An interrupted membership pass can install its quarantined raw as the
+    provisional head before re-indexing the session. The retained session's
+    foreign byte-governed raw still wins; replay must receipt the membership
+    as superseded instead of raising the unrelated-head guard."""
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        export_session = _parsed_session(("m0", "zero"), ("m1", "export flavour"))
+        export = _write_chain_full(archive, "export", 1)
+        plan = plan_revision_replay([_candidate(export, RawRevisionKind.FULL, 1, size=len("export"))])
+        archive.apply_raw_revision_replay(plan, {export: export_session}, acquired_at_ms=0)
+
+        capture_session = _parsed_session(("m0", "zero"), ("m1", "capture flavour"))
+        capture = _write_quarantined_member(archive, "capture", capture_session)
+        archive._conn.execute(
+            "UPDATE raw_revision_heads SET accepted_raw_id = ?, accepted_frontier_kind = 'semantic', accepted_frontier = 2 WHERE logical_source_key = 'codex:session'",
+            (capture,),
+        )
+
+        archive.apply_raw_membership_classification(
+            "codex:session",
+            MembershipClassification((capture,), (), ()),
+            {capture: capture_session},
+            {capture: session_revision_projection(capture_session)},
+            acquired_at_ms=0,
+        )
+
+        assert _head_row(archive) == (export, "byte", len("export"))
+        receipt = archive._conn.execute(
+            "SELECT decision, detail FROM raw_revision_applications WHERE raw_id = ?",
+            (capture,),
+        ).fetchone()
+        assert receipt is not None
+        assert tuple(receipt) == ("superseded", f"membership:superseded_by_chain_governed_head:{export}")
 
 
 def test_membership_replay_yields_to_semantic_chain_head_even_when_capture_has_more_units(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Repair resumable raw replay when a membership cohort temporarily shadows the
persisted byte-proven session head, and make long archive rebuilds practical
without weakening readiness checks.

## Problem
The active archive rebuild stopped at raw 32,000 because membership replay
attempted to retire an unrelated byte-proven head. Recovery then showed that
running full SQLite `ANALYZE` after every 100-row resume page repeatedly
scanned a 25 GiB candidate generation, delaying convergence and leaving live
capture offline.

## Solution
- Restore the persisted byte-proven raw head when a membership cohort is
  otherwise valid but temporarily shadows it.
- Keep bootstrap planner statistics through the first 1,000 raws; refresh
  writer-hot row-store statistics every 1,000 raws thereafter.
- Exclude deferred bulk-build FTS/trigram stores from periodic planner
  analysis; final rebuild still constructs and parity-checks them exactly.

## Verification
- `devtools test tests/unit/storage/test_revision_replay.py -k resumed_cohort_head_masks_byte_session` — `1 passed`.
- `devtools test tests/unit/storage/test_planner_statistics_seed.py` — `6 passed`.
- Pre-push `devtools verify --quick` passed before branch publication.
- Live retained-candidate replay advanced from 32,000 to 34,300 raws with no
  transaction error under the repaired code.

Ref polylogue-uhgm for the distinct in-page deadline-enforcement follow-up.