### PR TITLE
fix(rebuild): target stale thread materializations

### DIFF
--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -118,7 +118,7 @@ def _repopulate_bulk_build_derived_state(index_path: Path) -> dict[str, float]:
     with contextlib.closing(sqlite3.connect(index_path, timeout=600)) as conn:
         conn.execute("PRAGMA busy_timeout = 600000")
         started_at = time.perf_counter()
-        rebuild_fts_index_sync(conn, resume_from_empty_message_index=True)
+        rebuild_fts_index_sync(conn)
         timings_s["fts"] = time.perf_counter() - started_at
         started_at = time.perf_counter()
         rebuild_command_trigram_index_sync(conn)


### PR DESCRIPTION
## Summary

Repair thread-only insight debt without an archive-wide aggregate refresh, and expose precise timings for terminal index-rebuild stages.

## Problem

A full replay left four sessions with stale thread materialization markers because null source sort keys were replaced by a thread high-water mark. The repair planner excluded thread markers from targeted candidates and could classify thread-only debt as already ready. Terminal bulk derived rebuilds had no stage-level visibility.

## Solution

Preserve null sort keys, include thread markers in candidate selection, rebuild only affected roots, and log FTS/trigram/action-pair/delegation/parity/readiness/promotion durations.

## Verification

-  — 1 passed
-  — 3 passed
-  — 1 passed
- {
  "timestamp": "2026-07-26T10:36:07.775809+00:00",
  "git_head": "1a001af05afa3b1045fe199fc99d58f68124d687",
  "tier": "quick",
  "run_id": "20260726T103537Z-quick-358301-4b0619a3",
  "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3",
  "steps": [
    {
      "name": "ruff format",
      "duration_s": 0.01,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/01-ruff-format"
    },
    {
      "name": "ruff check",
      "duration_s": 0.01,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/02-ruff-check"
    },
    {
      "name": "mypy",
      "duration_s": 0.55,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/03-mypy"
    },
    {
      "name": "render all",
      "duration_s": 8.59,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/04-render-all"
    },
    {
      "name": "verify topology",
      "duration_s": 0.46,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/05-verify-topology"
    },
    {
      "name": "verify layering",
      "duration_s": 3.9,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/06-verify-layering"
    },
    {
      "name": "verify closure-matrix",
      "duration_s": 0.3,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/07-verify-closure-matrix"
    },
    {
      "name": "lab schema roundtrip",
      "duration_s": 0.91,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/08-lab-schema-roundtrip"
    },
    {
      "name": "verify manifests",
      "duration_s": 1.78,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/09-verify-manifests"
    },
    {
      "name": "verify ci-workflows",
      "duration_s": 0.35,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/10-verify-ci-workflows"
    },
    {
      "name": "verify doc-commands",
      "duration_s": 2.62,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/11-verify-doc-commands"
    },
    {
      "name": "verify docs-coverage",
      "duration_s": 2.5,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/12-verify-docs-coverage"
    },
    {
      "name": "verify test-infra-currency",
      "duration_s": 0.39,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/13-verify-test-infra-currency"
    },
    {
      "name": "verify test-clock-hygiene",
      "duration_s": 2.24,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/14-verify-test-clock-hygiene"
    },
    {
      "name": "verify pytest-timeout-overrides",
      "duration_s": 3.96,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/15-verify-pytest-timeout-overrides"
    },
    {
      "name": "verify degrade-loudly",
      "duration_s": 1.23,
      "exit": 0,
      "run_id": "20260726T103537Z-quick-358301-4b0619a3",
      "artifact_dir": ".cache/verify/runs/20260726T103537Z-quick-358301-4b0619a3/steps/16-verify-degrade-loudly"
    }
  ],
  "total_duration_s": 30.09,
  "exit_code": 0
} — passed

No tracker file is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved archive replay handling to preserve the correct accepted revision when quarantined records temporarily appear as the session head.
  - Preserved missing session sort keys during thread insight rebuilding.
  - Improved targeted session-insight repair readiness and reporting.

- **Performance & Diagnostics**
  - Added stage-level rebuild timing and completion diagnostics.
  - Planner statistics now refresh periodically and target core tables for more efficient analysis.

- **Reliability**
  - Added regression coverage for archive replay, insight rebuilding, planner statistics, and derived-state timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->