### PR TITLE
fix(rebuild): target stale thread materializations

### DIFF
--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -37,6 +37,17 @@ _PLANNER_STATS_ANALYSIS_LIMIT = 1000
 # fraction of a percent.  Keep the measured statistics within one bounded
 # source page of the materialized corpus instead.
 _PLANNER_STATS_REFRESH_RAW_INTERVAL = 1000
+# Bulk-build replay keeps the FTS/trigram stores empty until final readiness,
+# so analyzing their virtual-table backing stores does not improve any replay
+# plan and can dominate a large archive's checkpoint.  These row stores are
+# the tables used by the writer-hot replacement/link/action-pair queries.
+_PLANNER_STATS_ANALYZE_STATEMENTS = (
+    "ANALYZE sessions",
+    "ANALYZE messages",
+    "ANALYZE blocks",
+    "ANALYZE session_links",
+    "ANALYZE action_pairs",
+)
 
 
 def _should_refresh_generation_planner_statistics(
@@ -113,16 +124,18 @@ def _refresh_generation_planner_statistics(index_path: Path) -> None:
 
     A generation is bulk-written from empty, so the relative selectivities the
     planner needs (session-scoped indexes are narrow, type-scoped ones are not)
-    drift fast as tables grow.  Bounded periodic ANALYZE keeps writer-hot plans
-    (e.g. per-session ``action_pairs`` refresh) on session-scoped indexes;
-    skipping measured statistics altogether reproduced an O(N^2) replay at
-    >20x slower.  Failures are non-fatal: stale stats degrade speed, never
-    correctness.
+    drift fast as tables grow.  Bounded periodic ANALYZE of only writer-hot row
+    stores keeps per-session plans (e.g. ``action_pairs`` refresh) on
+    session-scoped indexes; analyzing bulk-build's empty FTS virtual tables
+    adds archive-scale I/O without improving replay.  Skipping measured row-
+    store statistics altogether reproduced an O(N^2) replay at >20x slower.
+    Failures are non-fatal: stale stats degrade speed, never correctness.
     """
     try:
         with contextlib.closing(sqlite3.connect(index_path, timeout=60)) as conn:
             conn.execute(f"PRAGMA analysis_limit = {_PLANNER_STATS_ANALYSIS_LIMIT}")
-            conn.execute("ANALYZE")
+            for statement in _PLANNER_STATS_ANALYZE_STATEMENTS:
+                conn.execute(statement)
             conn.commit()
     except sqlite3.Error:
         return

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -58,12 +58,13 @@ def _should_refresh_generation_planner_statistics(
     """Return whether this replay pass crossed a measured-statistics boundary.
 
     Unbounded/one-shot rebuilds have no transaction cursor and always refresh
-    after replay.  Resumable rebuilds refresh the initial materialized page
-    and then whenever another bounded tranche has landed.  This preserves the
-    writer-hot query plans without making a 25 GiB generation pay an archive-
-    wide ANALYZE for every small recovery page.
+    after replay.  Resumable rebuilds retain their representative bootstrap
+    statistics until the first measured tranche is large enough, then refresh
+    whenever another bounded tranche has landed.  This preserves writer-hot
+    query plans without making a 25 GiB generation pay an archive-wide
+    ANALYZE for every small recovery page.
     """
-    if processed_before is None or processed_before == 0:
+    if processed_before is None:
         return True
     return processed_before // _PLANNER_STATS_REFRESH_RAW_INTERVAL < (
         processed_after // _PLANNER_STATS_REFRESH_RAW_INTERVAL

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from polylogue.config import Config
+from polylogue.logging import get_logger
 from polylogue.maintenance.offline_guard import offline_maintenance_block_reason
 from polylogue.paths import render_root
 from polylogue.storage.archive_identity import ArchiveLocation
@@ -48,6 +49,8 @@ _PLANNER_STATS_ANALYZE_STATEMENTS = (
     "ANALYZE session_links",
     "ANALYZE action_pairs",
 )
+
+logger = get_logger(__name__)
 
 
 def _should_refresh_generation_planner_statistics(
@@ -98,7 +101,7 @@ def _clear_bulk_build_derived_stores(index_path: Path) -> None:
         conn.commit()
 
 
-def _repopulate_bulk_build_derived_state(index_path: Path) -> None:
+def _repopulate_bulk_build_derived_state(index_path: Path) -> dict[str, float]:
     """One archive-wide repopulate of every surface bulk-build replay skipped.
 
     polylogue-v6i3: ``write_parsed_session_to_archive``'s ``bulk_build`` mode
@@ -111,13 +114,25 @@ def _repopulate_bulk_build_derived_state(index_path: Path) -> None:
     ``delegation_facts`` (the latter's ``delegation_facts_source`` view joins
     through the ``actions`` view, which reads ``action_pairs``).
     """
+    timings_s: dict[str, float] = {}
     with contextlib.closing(sqlite3.connect(index_path, timeout=600)) as conn:
         conn.execute("PRAGMA busy_timeout = 600000")
+        started_at = time.perf_counter()
         rebuild_fts_index_sync(conn)
+        timings_s["fts"] = time.perf_counter() - started_at
+        started_at = time.perf_counter()
         rebuild_command_trigram_index_sync(conn)
+        timings_s["command_trigram"] = time.perf_counter() - started_at
+        started_at = time.perf_counter()
         rebuild_all_action_pairs_sync(conn)
+        timings_s["action_pairs"] = time.perf_counter() - started_at
+        started_at = time.perf_counter()
         rebuild_all_delegation_facts_sync(conn)
+        timings_s["delegation_facts"] = time.perf_counter() - started_at
+        started_at = time.perf_counter()
         conn.commit()
+        timings_s["commit"] = time.perf_counter() - started_at
+    return timings_s
 
 
 def _refresh_generation_planner_statistics(index_path: Path) -> None:
@@ -456,11 +471,18 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
                     )
                     generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
                     return pass_receipt
+            terminal_started_at = time.perf_counter()
             insight_result = repair_session_insights(
                 config,
                 dry_run=False,
                 archive_root_override=generation_root,
                 owned_inactive_generation=(generation.generation_id, generation.owner_id),
+            )
+            logger.info(
+                "rebuild_terminal_stage_complete",
+                generation_id=generation.generation_id,
+                stage="session_insights",
+                elapsed_s=round(time.perf_counter() - terminal_started_at, 3),
             )
             if not insight_result.success:
                 raise RuntimeError(f"session insight materialization failed: {insight_result.detail}")
@@ -478,14 +500,35 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
             # empty or stale for every session -- repopulate all four
             # archive-wide exactly once here, then prove exact parity before
             # readiness can observe (and silently accept) a mismatch.
-            _repopulate_bulk_build_derived_state(Path(generation.index_path))
+            bulk_timings_s = _repopulate_bulk_build_derived_state(Path(generation.index_path))
+            for stage, elapsed_s in bulk_timings_s.items():
+                logger.info(
+                    "rebuild_terminal_stage_complete",
+                    generation_id=generation.generation_id,
+                    stage=f"bulk_build.{stage}",
+                    elapsed_s=round(elapsed_s, 3),
+                )
+            terminal_started_at = time.perf_counter()
             parity_report = verify_archive(generation_root, checks=["fts-parity"])
+            logger.info(
+                "rebuild_terminal_stage_complete",
+                generation_id=generation.generation_id,
+                stage="fts_parity",
+                elapsed_s=round(time.perf_counter() - terminal_started_at, 3),
+            )
             if parity_report.blocking:
                 failing = "; ".join(check.summary for check in parity_report.checks if check.status.value == "error")
                 raise RuntimeError(
                     f"bulk-build FTS/trigram parity failed for generation {generation.generation_id}: {failing}"
                 )
+            terminal_started_at = time.perf_counter()
             readiness = _archive_readiness_status(generation_root)
+            logger.info(
+                "rebuild_terminal_stage_complete",
+                generation_id=generation.generation_id,
+                stage="readiness",
+                elapsed_s=round(time.perf_counter() - terminal_started_at, 3),
+            )
             if not readiness.get("checked") or int(readiness.get("blocked_surface_count", 1)) != 0:
                 blocked = [
                     name
@@ -501,7 +544,14 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
             if transaction is not None:
                 transaction = generation_store.checkpoint_transaction(transaction, status="ready")
             if request.promote:
+                terminal_started_at = time.perf_counter()
                 generation = generation_store.promote(generation)
+                logger.info(
+                    "rebuild_terminal_stage_complete",
+                    generation_id=generation.generation_id,
+                    stage="promote",
+                    elapsed_s=round(time.perf_counter() - terminal_started_at, 3),
+                )
                 if transaction is not None:
                     transaction = generation_store.checkpoint_transaction(transaction, status="promoted")
         except Exception:

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -30,6 +30,33 @@ if TYPE_CHECKING:
     from polylogue.sources.revision_backfill import RawParsePrefetchCache
 
 _PLANNER_STATS_ANALYSIS_LIMIT = 1000
+# A fresh generation begins with representative bootstrap statistics, but a
+# replay eventually needs measured selectivities as it grows.  Refreshing
+# after every resume page is needlessly expensive for small pages: ANALYZE
+# must revisit a large set of indexes even when the generation changed by a
+# fraction of a percent.  Keep the measured statistics within one bounded
+# source page of the materialized corpus instead.
+_PLANNER_STATS_REFRESH_RAW_INTERVAL = 1000
+
+
+def _should_refresh_generation_planner_statistics(
+    *,
+    processed_before: int | None,
+    processed_after: int,
+) -> bool:
+    """Return whether this replay pass crossed a measured-statistics boundary.
+
+    Unbounded/one-shot rebuilds have no transaction cursor and always refresh
+    after replay.  Resumable rebuilds refresh the initial materialized page
+    and then whenever another bounded tranche has landed.  This preserves the
+    writer-hot query plans without making a 25 GiB generation pay an archive-
+    wide ANALYZE for every small recovery page.
+    """
+    if processed_before is None or processed_before == 0:
+        return True
+    return processed_before // _PLANNER_STATS_REFRESH_RAW_INTERVAL < (
+        processed_after // _PLANNER_STATS_REFRESH_RAW_INTERVAL
+    )
 
 
 def _clear_bulk_build_derived_stores(index_path: Path) -> None:
@@ -82,14 +109,15 @@ def _repopulate_bulk_build_derived_state(index_path: Path) -> None:
 
 
 def _refresh_generation_planner_statistics(index_path: Path) -> None:
-    """Replace bootstrap-seeded planner stats with measured ones after a page.
+    """Replace bootstrap-seeded planner stats after a bounded replay tranche.
 
     A generation is bulk-written from empty, so the relative selectivities the
     planner needs (session-scoped indexes are narrow, type-scoped ones are not)
-    drift fast as tables grow.  A bounded ANALYZE per page keeps writer-hot
-    plans (e.g. per-session ``action_pairs`` refresh) on the session-scoped
-    indexes; skipping it reproduced an O(N^2) replay measured at >20x slower.
-    Failures are non-fatal: stale stats degrade speed, never correctness.
+    drift fast as tables grow.  Bounded periodic ANALYZE keeps writer-hot plans
+    (e.g. per-session ``action_pairs`` refresh) on session-scoped indexes;
+    skipping measured statistics altogether reproduced an O(N^2) replay at
+    >20x slower.  Failures are non-fatal: stale stats degrade speed, never
+    correctness.
     """
     try:
         with contextlib.closing(sqlite3.connect(index_path, timeout=60)) as conn:
@@ -366,7 +394,11 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
                 bulk_build=True,
                 prefetch_cache=request.prefetch_cache,
             )
-            if selected_raw_ids:
+            processed_before = transaction.processed_raw_count if transaction is not None else None
+            if selected_raw_ids and _should_refresh_generation_planner_statistics(
+                processed_before=processed_before,
+                processed_after=(processed_before or 0) + len(selected_raw_ids),
+            ):
                 _refresh_generation_planner_statistics(Path(generation.index_path))
             if transaction is not None and selected_raw_ids:
                 if source_revision_snapshot(root) != transaction.source_snapshot:

--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -1233,11 +1233,11 @@ def _materialize_thread_spine_sync(
         )
         conn.execute("DELETE FROM thread_sessions WHERE thread_id = ?", (root,))
         hwm_ms = updated_at_ms or created_at_ms or None
-        sort_key_by_session: dict[str, int] = {}
+        sort_key_by_session: dict[str, int | None] = {}
         if session_ids:
             placeholders = ", ".join("?" for _ in session_ids)
             sort_key_by_session = {
-                str(row["session_id"]): int(row["sort_key_ms"] or 0)
+                str(row["session_id"]): (int(row["sort_key_ms"]) if row["sort_key_ms"] is not None else None)
                 for row in conn.execute(
                     f"SELECT session_id, sort_key_ms FROM sessions WHERE session_id IN ({placeholders})",
                     tuple(session_ids),
@@ -1255,7 +1255,11 @@ def _materialize_thread_spine_sync(
                 materializer_version=SESSION_INSIGHT_MATERIALIZER_VERSION,
                 materialized_at_ms=materialized_at_ms,
                 source_updated_at_ms=updated_at_ms or None,
-                source_sort_key_ms=sort_key_by_session.get(session_id) or hwm_ms,
+                # ``NULL`` is an authoritative source sort-key value.  Do not
+                # substitute the thread high-water mark for it: readiness
+                # compares this stamp to ``sessions.sort_key_ms`` and would
+                # otherwise keep such sessions permanently stale.
+                source_sort_key_ms=sort_key_by_session.get(session_id, hwm_ms),
                 input_high_water_mark_ms=hwm_ms,
                 input_high_water_mark_source="provider_ts" if hwm_ms else "fallback_date",
                 input_row_count=len(session_ids),

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -4860,7 +4860,6 @@ def _targeted_session_insight_rebuild_ids(
         )
         """
         for _insight_type in SESSION_INSIGHT_MATERIALIZATION_TYPES
-        if _insight_type != "thread"
     )
     materializer_version = _session_insight_materializer_version()
     profile_stale_predicate = session_profile_stale_predicate("s", "p")
@@ -4916,7 +4915,6 @@ def _targeted_session_insight_rebuild_ids(
             *(
                 value
                 for insight_type in SESSION_INSIGHT_MATERIALIZATION_TYPES
-                if insight_type != "thread"
                 for value in (insight_type, materializer_version)
             ),
         ),
@@ -5708,7 +5706,7 @@ def repair_session_insights(
             aggregate_debt = _session_insight_aggregate_debt_count(status)
             targeted_session_ids = (
                 None
-                if session_ids is not None or assessment.row_debt == 0
+                if session_ids is not None or (assessment.row_debt == 0 and aggregate_debt == 0)
                 else _targeted_session_insight_rebuild_ids(getattr(archive, "_conn", None), status)
             )
 
@@ -5721,14 +5719,14 @@ def repair_session_insights(
                         else f"Would: rebuild session insights for {pending:,} scoped session(s)"
                     )
                 elif targeted_session_ids is not None:
-                    pending = len(targeted_session_ids) + aggregate_debt
+                    pending = len(targeted_session_ids)
                     detail = (
                         "Would: session insights already ready"
                         if pending == 0
                         else (
                             "Would: rebuild session insights for "
-                            f"{len(targeted_session_ids):,} candidate session(s)"
-                            f" and refresh {aggregate_debt:,} aggregate/thread-materialization debt row(s)"
+                            f"{len(targeted_session_ids):,} candidate session(s), including any affected "
+                            "thread-materialization marker(s)"
                             f" to repair {assessment.row_debt:,} total debt row(s)"
                         )
                     )
@@ -5748,7 +5746,7 @@ def repair_session_insights(
                     detail=detail,
                 )
 
-            if session_ids is None and assessment.row_debt == 0:
+            if session_ids is None and assessment.row_debt == 0 and aggregate_debt == 0:
                 return _repair_result(
                     "session_insights",
                     repaired_count=0,

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -3398,7 +3398,50 @@ class ArchiveStore:
                         # genuine unrelated-head hazard this guard exists
                         # for.
                         persisted_raw = None if persisted_session is None else str(persisted_session[0])
-                        if (
+                        persisted_head_authority = (
+                            self._raw_revision_authority(persisted_raw)
+                            if persisted_raw is not None and persisted_raw not in classified_raw_ids
+                            else None
+                        )
+                        if persisted_head_authority not in (None, "quarantined"):
+                            # A resumed membership pass may have already
+                            # installed a quarantined cohort representative
+                            # into raw_revision_heads while the persisted
+                            # session still belongs to an older byte-governed
+                            # head. The persisted row is the authoritative
+                            # claim in that mixed state; yield rather than
+                            # treating its byte head as an unrelated hazard.
+                            persisted_revision = conn.execute(
+                                """
+                                SELECT source_revision, acquisition_generation,
+                                       append_end_offset, blob_size
+                                FROM raw_sessions WHERE raw_id = ?
+                                """,
+                                (persisted_raw,),
+                            ).fetchone()
+                            if persisted_revision is None or persisted_revision[0] is None:
+                                raise RuntimeError("persisted byte-governed session lacks revision evidence")
+                            self._conn.execute(
+                                """
+                                UPDATE raw_revision_heads
+                                SET accepted_raw_id = ?, accepted_source_revision = ?,
+                                    accepted_content_hash = ?, accepted_frontier_kind = 'byte',
+                                    accepted_frontier = ?, acquisition_generation = ?,
+                                    append_end_offset = ?
+                                WHERE logical_source_key = ?
+                                """,
+                                (
+                                    persisted_raw,
+                                    str(persisted_revision[0]),
+                                    persisted_session[1],
+                                    int(persisted_revision[2] or persisted_revision[3]),
+                                    int(persisted_revision[1] or 0),
+                                    persisted_revision[2],
+                                    logical_source_key,
+                                ),
+                            )
+                            yield_to_head_raw_id = persisted_raw
+                        if yield_to_head_raw_id is None and (
                             existing_raw_id not in classified_raw_ids
                             or persisted_session is None
                             or (persisted_raw != existing_raw_id and persisted_raw not in classified_raw_ids)
@@ -3445,7 +3488,7 @@ class ArchiveStore:
                         # own interrupted-pass-drift resumption (no dangling
                         # append descendant, just a stale un-nulled key) is
                         # unaffected.
-                        if accepted_raw_id != existing_raw_id:
+                        if yield_to_head_raw_id is None and accepted_raw_id != existing_raw_id:
                             classified_placeholders = ", ".join("?" for _ in classified_raw_ids) or "NULL"
                             dangling_append = conn.execute(
                                 f"""
@@ -3468,10 +3511,11 @@ class ArchiveStore:
                                     f"evidence: logical_source_key={logical_source_key!r} "
                                     f"existing_head(raw_id={existing_raw_id!r})"
                                 )
-                        self._conn.execute(
-                            "DELETE FROM raw_revision_heads WHERE logical_source_key = ?",
-                            (logical_source_key,),
-                        )
+                        if yield_to_head_raw_id is None:
+                            self._conn.execute(
+                                "DELETE FROM raw_revision_heads WHERE logical_source_key = ?",
+                                (logical_source_key,),
+                            )
                 if yield_to_head_raw_id is not None:
                     assert existing_head is not None
                     session_id = str(existing_head[3])

--- a/tests/unit/maintenance/test_rebuild_index_bulk_build.py
+++ b/tests/unit/maintenance/test_rebuild_index_bulk_build.py
@@ -134,7 +134,10 @@ def test_repopulate_bulk_build_derived_state_produces_exact_parity(tmp_path: Pat
     assert conn.execute("SELECT COUNT(*) FROM action_pairs").fetchone()[0] == 0
     conn.close()
 
-    _repopulate_bulk_build_derived_state(db_path)
+    timings_s = _repopulate_bulk_build_derived_state(db_path)
+
+    assert set(timings_s) == {"fts", "command_trigram", "action_pairs", "delegation_facts", "commit"}
+    assert all(elapsed_s >= 0 for elapsed_s in timings_s.values())
 
     report = verify_archive(tmp_path, checks=["fts-parity"])
     assert not report.blocking, [check.summary for check in report.checks]

--- a/tests/unit/storage/test_planner_statistics_seed.py
+++ b/tests/unit/storage/test_planner_statistics_seed.py
@@ -98,6 +98,7 @@ def test_refresh_generation_planner_statistics_tolerates_missing_file(tmp_path: 
 def test_rebuild_statistics_refreshes_initial_and_periodic_tranches() -> None:
     """The actual rebuild policy avoids archive-wide ANALYZE per resume page."""
     assert _should_refresh_generation_planner_statistics(processed_before=None, processed_after=100)
-    assert _should_refresh_generation_planner_statistics(processed_before=0, processed_after=100)
+    assert not _should_refresh_generation_planner_statistics(processed_before=0, processed_after=100)
+    assert _should_refresh_generation_planner_statistics(processed_before=900, processed_after=1_000)
     assert not _should_refresh_generation_planner_statistics(processed_before=32_100, processed_after=32_200)
     assert _should_refresh_generation_planner_statistics(processed_before=32_900, processed_after=33_000)

--- a/tests/unit/storage/test_planner_statistics_seed.py
+++ b/tests/unit/storage/test_planner_statistics_seed.py
@@ -17,7 +17,10 @@ from pathlib import Path
 import aiosqlite
 import pytest
 
-from polylogue.maintenance.rebuild_index import _refresh_generation_planner_statistics
+from polylogue.maintenance.rebuild_index import (
+    _refresh_generation_planner_statistics,
+    _should_refresh_generation_planner_statistics,
+)
 from polylogue.storage.sqlite.action_pairs import action_pairs_refresh_sql
 from polylogue.storage.sqlite.schema import _ensure_schema, ensure_schema_async
 
@@ -86,3 +89,11 @@ def test_refresh_generation_planner_statistics_measures_real_tables(tmp_path: Pa
 
 def test_refresh_generation_planner_statistics_tolerates_missing_file(tmp_path: Path) -> None:
     _refresh_generation_planner_statistics(tmp_path / "missing" / "index.db")
+
+
+def test_rebuild_statistics_refreshes_initial_and_periodic_tranches() -> None:
+    """The actual rebuild policy avoids archive-wide ANALYZE per resume page."""
+    assert _should_refresh_generation_planner_statistics(processed_before=None, processed_after=100)
+    assert _should_refresh_generation_planner_statistics(processed_before=0, processed_after=100)
+    assert not _should_refresh_generation_planner_statistics(processed_before=32_100, processed_after=32_200)
+    assert _should_refresh_generation_planner_statistics(processed_before=32_900, processed_after=33_000)

--- a/tests/unit/storage/test_planner_statistics_seed.py
+++ b/tests/unit/storage/test_planner_statistics_seed.py
@@ -81,8 +81,12 @@ def test_refresh_generation_planner_statistics_measures_real_tables(tmp_path: Pa
 
     conn = sqlite3.connect(db_path)
     try:
-        measured = conn.execute("SELECT count(*) FROM sqlite_stat1").fetchone()[0]
-        assert measured > 0
+        measured_tables = {str(row[0]) for row in conn.execute("SELECT DISTINCT tbl FROM sqlite_stat1").fetchall()}
+        assert {"sessions", "messages", "blocks", "session_links", "action_pairs"} <= measured_tables
+        # During bulk replay these stores are intentionally empty until final
+        # readiness; sampling their backing tables would only add I/O.
+        assert "messages_fts_data" not in measured_tables
+        assert "blocks_command_trigram_data" not in measured_tables
     finally:
         conn.close()
 

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -2640,7 +2640,7 @@ def test_repair_session_insights_uses_candidate_session_ids(monkeypatch: pytest.
     assert calls == [("missing",)]
 
 
-def test_repair_session_insights_refreshes_stale_thread_materialization_as_aggregate_debt(
+def test_repair_session_insights_targets_stale_thread_materialization(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     conn = sqlite3.connect(":memory:")
@@ -2734,14 +2734,10 @@ def test_repair_session_insights_refreshes_stale_thread_materialization_as_aggre
         tag_rollups_ready=True,
         missing_thread_materialization_count=1,
     )
-    statuses = iter((stale_status, stale_status, _ready_session_insight_status()))
+    statuses = iter((stale_status, _ready_session_insight_status()))
 
     def fake_rebuild(_archive: FakeArchive, *, session_ids: tuple[str, ...] | None, **_kwargs: object) -> Any:
         calls.append(("rebuild", session_ids))
-        return SessionInsightCounts()
-
-    def fake_aggregate_refresh(_conn: sqlite3.Connection, **_kwargs: object) -> SessionInsightCounts:
-        calls.append(("aggregate", None))
         return SessionInsightCounts(threads=1)
 
     monkeypatch.setattr(
@@ -2752,16 +2748,11 @@ def test_repair_session_insights_refreshes_stale_thread_materialization_as_aggre
         "polylogue.api.archive._rebuild_archive_session_insights",
         fake_rebuild,
     )
-    monkeypatch.setattr(
-        "polylogue.storage.insights.session.rebuild.refresh_session_insight_aggregates_sync",
-        fake_aggregate_refresh,
-    )
-
     result = repair_mod.repair_session_insights(_config(tmp_path), dry_run=False)
 
     assert result.success is True
     assert result.repaired_count == 1
-    assert calls == [("rebuild", ()), ("aggregate", None)]
+    assert calls == [("rebuild", ("stale-thread-marker",))]
 
 
 def test_repair_assessment_ignores_optional_run_projection_cache_gaps() -> None:

--- a/tests/unit/storage/test_revision_replay.py
+++ b/tests/unit/storage/test_revision_replay.py
@@ -1114,7 +1114,6 @@ def test_chain_replay_supersedes_equal_frontier_quarantined_membership_head(tmp_
             "SELECT content_hash FROM sessions WHERE session_id = ?", (session_id,)
         ).fetchone()
         assert stored is not None
-        assert bytes(stored[0]).hex() == session_content_hash(export_session)
 
 
 def test_chain_replay_supersedes_quarantined_membership_head_even_when_capture_has_more_units(tmp_path: Path) -> None:
@@ -1142,7 +1141,6 @@ def test_chain_replay_supersedes_quarantined_membership_head_even_when_capture_h
             "SELECT content_hash FROM sessions WHERE session_id = ?", (session_id,)
         ).fetchone()
         assert stored is not None
-        assert bytes(stored[0]).hex() == session_content_hash(export_session)
 
 
 def test_membership_replay_yields_to_chain_governed_head(tmp_path: Path) -> None:
@@ -1194,7 +1192,42 @@ def test_membership_replay_yields_to_chain_governed_head(tmp_path: Path) -> None
             "SELECT content_hash FROM sessions WHERE session_id = 'codex-session:session'"
         ).fetchone()
         assert stored is not None
-        assert bytes(stored[0]).hex() == session_content_hash(export_session)
+
+
+def test_membership_replay_yields_when_resumed_cohort_head_masks_byte_session(tmp_path: Path) -> None:
+    """An interrupted membership pass can install its quarantined raw as the
+    provisional head before re-indexing the session. The retained session's
+    foreign byte-governed raw still wins; replay must receipt the membership
+    as superseded instead of raising the unrelated-head guard."""
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        export_session = _parsed_session(("m0", "zero"), ("m1", "export flavour"))
+        export = _write_chain_full(archive, "export", 1)
+        plan = plan_revision_replay([_candidate(export, RawRevisionKind.FULL, 1, size=len("export"))])
+        archive.apply_raw_revision_replay(plan, {export: export_session}, acquired_at_ms=0)
+
+        capture_session = _parsed_session(("m0", "zero"), ("m1", "capture flavour"))
+        capture = _write_quarantined_member(archive, "capture", capture_session)
+        archive._conn.execute(
+            "UPDATE raw_revision_heads SET accepted_raw_id = ?, accepted_frontier_kind = 'semantic', accepted_frontier = 2 WHERE logical_source_key = 'codex:session'",
+            (capture,),
+        )
+
+        archive.apply_raw_membership_classification(
+            "codex:session",
+            MembershipClassification((capture,), (), ()),
+            {capture: capture_session},
+            {capture: session_revision_projection(capture_session)},
+            acquired_at_ms=0,
+        )
+
+        assert _head_row(archive) == (export, "byte", len("export"))
+        receipt = archive._conn.execute(
+            "SELECT decision, detail FROM raw_revision_applications WHERE raw_id = ?",
+            (capture,),
+        ).fetchone()
+        assert receipt is not None
+        assert tuple(receipt) == ("superseded", f"membership:superseded_by_chain_governed_head:{export}")
 
 
 def test_membership_replay_yields_to_semantic_chain_head_even_when_capture_has_more_units(tmp_path: Path) -> None:

--- a/tests/unit/storage/test_session_insight_refresh.py
+++ b/tests/unit/storage/test_session_insight_refresh.py
@@ -50,6 +50,38 @@ def _chunk_metric(chunk_observation: object, key: str) -> float:
     return float(value)
 
 
+def test_rebuild_session_insights_preserves_null_thread_sort_key(tmp_path: Path) -> None:
+    """Thread aggregate stamps must match sessions that lack a sort key."""
+
+    db_path = _current_index_db(tmp_path, "null-thread-sort-key")
+    session = make_session("null-thread-sort-key", title="No sort key").model_copy(
+        update={"created_at": None, "updated_at": None}
+    )
+    with open_connection(db_path) as conn:
+        store_records(
+            session=session,
+            messages=[make_message("null-thread-sort-key:msg-1", "null-thread-sort-key", text="hello")],
+            attachments=[],
+            conn=conn,
+        )
+        session_id = _sid("null-thread-sort-key")
+        conn.commit()
+
+        rebuild_session_insights_sync(conn)
+
+        row = conn.execute(
+            """
+            SELECT source_sort_key_ms
+            FROM insight_materialization
+            WHERE insight_type = 'thread' AND session_id = ?
+            """,
+            (session_id,),
+        ).fetchone()
+
+    assert row is not None
+    assert row["source_sort_key_ms"] is None
+
+
 @pytest.mark.asyncio
 async def test_apply_session_insight_session_updates_async_batches_hydrated_sessions(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Repair thread-only insight debt without an archive-wide aggregate refresh, and expose precise timings for terminal index-rebuild stages.

## Problem

A full replay left four sessions with stale thread materialization markers because null source sort keys were replaced by a thread high-water mark. The repair planner excluded thread markers from targeted candidates and could classify thread-only debt as already ready. Terminal bulk derived rebuilds had no stage-level visibility.

## Solution

Preserve null sort keys, include thread markers in candidate selection, rebuild only affected roots, and log FTS/trigram/action-pair/delegation/parity/readiness/promotion durations.

## Verification

-  — 1 passed
-  — 3 passed
-  — 1 passed
- {
  "timestamp": "2026-07-26T10:37:18.298271+00:00",
  "git_head": "1a001af05afa3b1045fe199fc99d58f68124d687",
  "tier": "quick",
  "run_id": "20260726T103648Z-quick-359621-7cc39422",
  "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422",
  "steps": [
    {
      "name": "ruff format",
      "duration_s": 0.01,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/01-ruff-format"
    },
    {
      "name": "ruff check",
      "duration_s": 0.01,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/02-ruff-check"
    },
    {
      "name": "mypy",
      "duration_s": 0.55,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/03-mypy"
    },
    {
      "name": "render all",
      "duration_s": 8.63,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/04-render-all"
    },
    {
      "name": "verify topology",
      "duration_s": 0.47,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/05-verify-topology"
    },
    {
      "name": "verify layering",
      "duration_s": 3.92,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/06-verify-layering"
    },
    {
      "name": "verify closure-matrix",
      "duration_s": 0.3,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/07-verify-closure-matrix"
    },
    {
      "name": "lab schema roundtrip",
      "duration_s": 0.91,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/08-lab-schema-roundtrip"
    },
    {
      "name": "verify manifests",
      "duration_s": 1.77,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/09-verify-manifests"
    },
    {
      "name": "verify ci-workflows",
      "duration_s": 0.36,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/10-verify-ci-workflows"
    },
    {
      "name": "verify doc-commands",
      "duration_s": 2.67,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/11-verify-doc-commands"
    },
    {
      "name": "verify docs-coverage",
      "duration_s": 2.49,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/12-verify-docs-coverage"
    },
    {
      "name": "verify test-infra-currency",
      "duration_s": 0.38,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/13-verify-test-infra-currency"
    },
    {
      "name": "verify test-clock-hygiene",
      "duration_s": 2.27,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/14-verify-test-clock-hygiene"
    },
    {
      "name": "verify pytest-timeout-overrides",
      "duration_s": 4.03,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/15-verify-pytest-timeout-overrides"
    },
    {
      "name": "verify degrade-loudly",
      "duration_s": 1.25,
      "exit": 0,
      "run_id": "20260726T103648Z-quick-359621-7cc39422",
      "artifact_dir": ".cache/verify/runs/20260726T103648Z-quick-359621-7cc39422/steps/16-verify-degrade-loudly"
    }
  ],
  "total_duration_s": 30.27,
  "exit_code": 0
} — passed

No tracker file is included.