### PR TITLE
fix(rebuild): target stale thread materializations

### DIFF
--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from polylogue.config import Config
+from polylogue.logging import get_logger
 from polylogue.maintenance.offline_guard import offline_maintenance_block_reason
 from polylogue.paths import render_root
 from polylogue.storage.archive_identity import ArchiveLocation
@@ -48,6 +49,8 @@ _PLANNER_STATS_ANALYZE_STATEMENTS = (
     "ANALYZE session_links",
     "ANALYZE action_pairs",
 )
+
+logger = get_logger(__name__)
 
 
 def _should_refresh_generation_planner_statistics(
@@ -98,7 +101,7 @@ def _clear_bulk_build_derived_stores(index_path: Path) -> None:
         conn.commit()
 
 
-def _repopulate_bulk_build_derived_state(index_path: Path) -> None:
+def _repopulate_bulk_build_derived_state(index_path: Path) -> dict[str, float]:
     """One archive-wide repopulate of every surface bulk-build replay skipped.
 
     polylogue-v6i3: ``write_parsed_session_to_archive``'s ``bulk_build`` mode
@@ -111,13 +114,25 @@ def _repopulate_bulk_build_derived_state(index_path: Path) -> None:
     ``delegation_facts`` (the latter's ``delegation_facts_source`` view joins
     through the ``actions`` view, which reads ``action_pairs``).
     """
+    timings_s: dict[str, float] = {}
     with contextlib.closing(sqlite3.connect(index_path, timeout=600)) as conn:
         conn.execute("PRAGMA busy_timeout = 600000")
+        started_at = time.perf_counter()
         rebuild_fts_index_sync(conn)
+        timings_s["fts"] = time.perf_counter() - started_at
+        started_at = time.perf_counter()
         rebuild_command_trigram_index_sync(conn)
+        timings_s["command_trigram"] = time.perf_counter() - started_at
+        started_at = time.perf_counter()
         rebuild_all_action_pairs_sync(conn)
+        timings_s["action_pairs"] = time.perf_counter() - started_at
+        started_at = time.perf_counter()
         rebuild_all_delegation_facts_sync(conn)
+        timings_s["delegation_facts"] = time.perf_counter() - started_at
+        started_at = time.perf_counter()
         conn.commit()
+        timings_s["commit"] = time.perf_counter() - started_at
+    return timings_s
 
 
 def _refresh_generation_planner_statistics(index_path: Path) -> None:
@@ -456,11 +471,18 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
                     )
                     generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
                     return pass_receipt
+            terminal_started_at = time.perf_counter()
             insight_result = repair_session_insights(
                 config,
                 dry_run=False,
                 archive_root_override=generation_root,
                 owned_inactive_generation=(generation.generation_id, generation.owner_id),
+            )
+            logger.info(
+                "rebuild_terminal_stage_complete",
+                generation_id=generation.generation_id,
+                stage="session_insights",
+                elapsed_s=round(time.perf_counter() - terminal_started_at, 3),
             )
             if not insight_result.success:
                 raise RuntimeError(f"session insight materialization failed: {insight_result.detail}")
@@ -478,14 +500,35 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
             # empty or stale for every session -- repopulate all four
             # archive-wide exactly once here, then prove exact parity before
             # readiness can observe (and silently accept) a mismatch.
-            _repopulate_bulk_build_derived_state(Path(generation.index_path))
+            bulk_timings_s = _repopulate_bulk_build_derived_state(Path(generation.index_path))
+            for stage, elapsed_s in bulk_timings_s.items():
+                logger.info(
+                    "rebuild_terminal_stage_complete",
+                    generation_id=generation.generation_id,
+                    stage=f"bulk_build.{stage}",
+                    elapsed_s=round(elapsed_s, 3),
+                )
+            terminal_started_at = time.perf_counter()
             parity_report = verify_archive(generation_root, checks=["fts-parity"])
+            logger.info(
+                "rebuild_terminal_stage_complete",
+                generation_id=generation.generation_id,
+                stage="fts_parity",
+                elapsed_s=round(time.perf_counter() - terminal_started_at, 3),
+            )
             if parity_report.blocking:
                 failing = "; ".join(check.summary for check in parity_report.checks if check.status.value == "error")
                 raise RuntimeError(
                     f"bulk-build FTS/trigram parity failed for generation {generation.generation_id}: {failing}"
                 )
+            terminal_started_at = time.perf_counter()
             readiness = _archive_readiness_status(generation_root)
+            logger.info(
+                "rebuild_terminal_stage_complete",
+                generation_id=generation.generation_id,
+                stage="readiness",
+                elapsed_s=round(time.perf_counter() - terminal_started_at, 3),
+            )
             if not readiness.get("checked") or int(readiness.get("blocked_surface_count", 1)) != 0:
                 blocked = [
                     name
@@ -501,7 +544,14 @@ async def rebuild_index_from_source(request: RebuildIndexRequest) -> RebuildInde
             if transaction is not None:
                 transaction = generation_store.checkpoint_transaction(transaction, status="ready")
             if request.promote:
+                terminal_started_at = time.perf_counter()
                 generation = generation_store.promote(generation)
+                logger.info(
+                    "rebuild_terminal_stage_complete",
+                    generation_id=generation.generation_id,
+                    stage="promote",
+                    elapsed_s=round(time.perf_counter() - terminal_started_at, 3),
+                )
                 if transaction is not None:
                     transaction = generation_store.checkpoint_transaction(transaction, status="promoted")
         except Exception:

--- a/polylogue/storage/insights/session/rebuild.py
+++ b/polylogue/storage/insights/session/rebuild.py
@@ -1233,11 +1233,11 @@ def _materialize_thread_spine_sync(
         )
         conn.execute("DELETE FROM thread_sessions WHERE thread_id = ?", (root,))
         hwm_ms = updated_at_ms or created_at_ms or None
-        sort_key_by_session: dict[str, int] = {}
+        sort_key_by_session: dict[str, int | None] = {}
         if session_ids:
             placeholders = ", ".join("?" for _ in session_ids)
             sort_key_by_session = {
-                str(row["session_id"]): int(row["sort_key_ms"] or 0)
+                str(row["session_id"]): (int(row["sort_key_ms"]) if row["sort_key_ms"] is not None else None)
                 for row in conn.execute(
                     f"SELECT session_id, sort_key_ms FROM sessions WHERE session_id IN ({placeholders})",
                     tuple(session_ids),
@@ -1255,7 +1255,11 @@ def _materialize_thread_spine_sync(
                 materializer_version=SESSION_INSIGHT_MATERIALIZER_VERSION,
                 materialized_at_ms=materialized_at_ms,
                 source_updated_at_ms=updated_at_ms or None,
-                source_sort_key_ms=sort_key_by_session.get(session_id) or hwm_ms,
+                # ``NULL`` is an authoritative source sort-key value.  Do not
+                # substitute the thread high-water mark for it: readiness
+                # compares this stamp to ``sessions.sort_key_ms`` and would
+                # otherwise keep such sessions permanently stale.
+                source_sort_key_ms=sort_key_by_session.get(session_id, hwm_ms),
                 input_high_water_mark_ms=hwm_ms,
                 input_high_water_mark_source="provider_ts" if hwm_ms else "fallback_date",
                 input_row_count=len(session_ids),

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -4860,7 +4860,6 @@ def _targeted_session_insight_rebuild_ids(
         )
         """
         for _insight_type in SESSION_INSIGHT_MATERIALIZATION_TYPES
-        if _insight_type != "thread"
     )
     materializer_version = _session_insight_materializer_version()
     profile_stale_predicate = session_profile_stale_predicate("s", "p")
@@ -4916,7 +4915,6 @@ def _targeted_session_insight_rebuild_ids(
             *(
                 value
                 for insight_type in SESSION_INSIGHT_MATERIALIZATION_TYPES
-                if insight_type != "thread"
                 for value in (insight_type, materializer_version)
             ),
         ),
@@ -5708,7 +5706,7 @@ def repair_session_insights(
             aggregate_debt = _session_insight_aggregate_debt_count(status)
             targeted_session_ids = (
                 None
-                if session_ids is not None or assessment.row_debt == 0
+                if session_ids is not None or (assessment.row_debt == 0 and aggregate_debt == 0)
                 else _targeted_session_insight_rebuild_ids(getattr(archive, "_conn", None), status)
             )
 
@@ -5721,14 +5719,14 @@ def repair_session_insights(
                         else f"Would: rebuild session insights for {pending:,} scoped session(s)"
                     )
                 elif targeted_session_ids is not None:
-                    pending = len(targeted_session_ids) + aggregate_debt
+                    pending = len(targeted_session_ids)
                     detail = (
                         "Would: session insights already ready"
                         if pending == 0
                         else (
                             "Would: rebuild session insights for "
-                            f"{len(targeted_session_ids):,} candidate session(s)"
-                            f" and refresh {aggregate_debt:,} aggregate/thread-materialization debt row(s)"
+                            f"{len(targeted_session_ids):,} candidate session(s), including any affected "
+                            "thread-materialization marker(s)"
                             f" to repair {assessment.row_debt:,} total debt row(s)"
                         )
                     )
@@ -5748,7 +5746,7 @@ def repair_session_insights(
                     detail=detail,
                 )
 
-            if session_ids is None and assessment.row_debt == 0:
+            if session_ids is None and assessment.row_debt == 0 and aggregate_debt == 0:
                 return _repair_result(
                     "session_insights",
                     repaired_count=0,

--- a/tests/unit/maintenance/test_rebuild_index_bulk_build.py
+++ b/tests/unit/maintenance/test_rebuild_index_bulk_build.py
@@ -134,7 +134,10 @@ def test_repopulate_bulk_build_derived_state_produces_exact_parity(tmp_path: Pat
     assert conn.execute("SELECT COUNT(*) FROM action_pairs").fetchone()[0] == 0
     conn.close()
 
-    _repopulate_bulk_build_derived_state(db_path)
+    timings_s = _repopulate_bulk_build_derived_state(db_path)
+
+    assert set(timings_s) == {"fts", "command_trigram", "action_pairs", "delegation_facts", "commit"}
+    assert all(elapsed_s >= 0 for elapsed_s in timings_s.values())
 
     report = verify_archive(tmp_path, checks=["fts-parity"])
     assert not report.blocking, [check.summary for check in report.checks]

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -2640,7 +2640,7 @@ def test_repair_session_insights_uses_candidate_session_ids(monkeypatch: pytest.
     assert calls == [("missing",)]
 
 
-def test_repair_session_insights_refreshes_stale_thread_materialization_as_aggregate_debt(
+def test_repair_session_insights_targets_stale_thread_materialization(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     conn = sqlite3.connect(":memory:")
@@ -2734,14 +2734,10 @@ def test_repair_session_insights_refreshes_stale_thread_materialization_as_aggre
         tag_rollups_ready=True,
         missing_thread_materialization_count=1,
     )
-    statuses = iter((stale_status, stale_status, _ready_session_insight_status()))
+    statuses = iter((stale_status, _ready_session_insight_status()))
 
     def fake_rebuild(_archive: FakeArchive, *, session_ids: tuple[str, ...] | None, **_kwargs: object) -> Any:
         calls.append(("rebuild", session_ids))
-        return SessionInsightCounts()
-
-    def fake_aggregate_refresh(_conn: sqlite3.Connection, **_kwargs: object) -> SessionInsightCounts:
-        calls.append(("aggregate", None))
         return SessionInsightCounts(threads=1)
 
     monkeypatch.setattr(
@@ -2752,16 +2748,11 @@ def test_repair_session_insights_refreshes_stale_thread_materialization_as_aggre
         "polylogue.api.archive._rebuild_archive_session_insights",
         fake_rebuild,
     )
-    monkeypatch.setattr(
-        "polylogue.storage.insights.session.rebuild.refresh_session_insight_aggregates_sync",
-        fake_aggregate_refresh,
-    )
-
     result = repair_mod.repair_session_insights(_config(tmp_path), dry_run=False)
 
     assert result.success is True
     assert result.repaired_count == 1
-    assert calls == [("rebuild", ()), ("aggregate", None)]
+    assert calls == [("rebuild", ("stale-thread-marker",))]
 
 
 def test_repair_assessment_ignores_optional_run_projection_cache_gaps() -> None:

--- a/tests/unit/storage/test_session_insight_refresh.py
+++ b/tests/unit/storage/test_session_insight_refresh.py
@@ -50,6 +50,38 @@ def _chunk_metric(chunk_observation: object, key: str) -> float:
     return float(value)
 
 
+def test_rebuild_session_insights_preserves_null_thread_sort_key(tmp_path: Path) -> None:
+    """Thread aggregate stamps must match sessions that lack a sort key."""
+
+    db_path = _current_index_db(tmp_path, "null-thread-sort-key")
+    session = make_session("null-thread-sort-key", title="No sort key").model_copy(
+        update={"created_at": None, "updated_at": None}
+    )
+    with open_connection(db_path) as conn:
+        store_records(
+            session=session,
+            messages=[make_message("null-thread-sort-key:msg-1", "null-thread-sort-key", text="hello")],
+            attachments=[],
+            conn=conn,
+        )
+        session_id = _sid("null-thread-sort-key")
+        conn.commit()
+
+        rebuild_session_insights_sync(conn)
+
+        row = conn.execute(
+            """
+            SELECT source_sort_key_ms
+            FROM insight_materialization
+            WHERE insight_type = 'thread' AND session_id = ?
+            """,
+            (session_id,),
+        ).fetchone()
+
+    assert row is not None
+    assert row["source_sort_key_ms"] is None
+
+
 @pytest.mark.asyncio
 async def test_apply_session_insight_session_updates_async_batches_hydrated_sessions(
     tmp_path: Path,


### PR DESCRIPTION
## Summary

Repair thread-only insight debt without an archive-wide aggregate refresh, and expose precise timings for terminal index-rebuild stages.

## Problem

A full replay left four sessions with stale thread materialization markers because null source sort keys were replaced by a thread high-water mark. The repair planner excluded thread markers from targeted candidates and could classify thread-only debt as already ready. Terminal bulk derived rebuilds had no stage-level visibility.

## Solution

Preserve null sort keys, include thread markers in candidate selection, rebuild only affected roots, and log FTS/trigram/action-pair/delegation/parity/readiness/promotion durations.

## Verification

-  — 1 passed
-  — 3 passed
-  — 1 passed
- {
  "timestamp": "2026-07-26T10:41:22.763948+00:00",
  "git_head": "56ae168a17b9aaf2c230b2400e8214821dc23f77",
  "tier": "quick",
  "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
  "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32",
  "steps": [
    {
      "name": "ruff format",
      "duration_s": 0.01,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/01-ruff-format"
    },
    {
      "name": "ruff check",
      "duration_s": 0.01,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/02-ruff-check"
    },
    {
      "name": "mypy",
      "duration_s": 0.56,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/03-mypy"
    },
    {
      "name": "render all",
      "duration_s": 8.73,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/04-render-all"
    },
    {
      "name": "verify topology",
      "duration_s": 0.48,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/05-verify-topology"
    },
    {
      "name": "verify layering",
      "duration_s": 3.91,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/06-verify-layering"
    },
    {
      "name": "verify closure-matrix",
      "duration_s": 0.31,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/07-verify-closure-matrix"
    },
    {
      "name": "lab schema roundtrip",
      "duration_s": 0.93,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/08-lab-schema-roundtrip"
    },
    {
      "name": "verify manifests",
      "duration_s": 1.8,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/09-verify-manifests"
    },
    {
      "name": "verify ci-workflows",
      "duration_s": 0.36,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/10-verify-ci-workflows"
    },
    {
      "name": "verify doc-commands",
      "duration_s": 2.66,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/11-verify-doc-commands"
    },
    {
      "name": "verify docs-coverage",
      "duration_s": 2.53,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/12-verify-docs-coverage"
    },
    {
      "name": "verify test-infra-currency",
      "duration_s": 0.39,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/13-verify-test-infra-currency"
    },
    {
      "name": "verify test-clock-hygiene",
      "duration_s": 2.25,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/14-verify-test-clock-hygiene"
    },
    {
      "name": "verify pytest-timeout-overrides",
      "duration_s": 4.06,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/15-verify-pytest-timeout-overrides"
    },
    {
      "name": "verify degrade-loudly",
      "duration_s": 1.24,
      "exit": 0,
      "run_id": "20260726T104052Z-quick-362916-2ee4fd32",
      "artifact_dir": ".cache/verify/runs/20260726T104052Z-quick-362916-2ee4fd32/steps/16-verify-degrade-loudly"
    }
  ],
  "total_duration_s": 30.5,
  "exit_code": 0
} — passed

No tracker file is included.