### PR TITLE
perf(rebuild): checkpoint bulk FTS materialization

### DIFF
--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -118,7 +118,7 @@ def _repopulate_bulk_build_derived_state(index_path: Path) -> dict[str, float]:
     with contextlib.closing(sqlite3.connect(index_path, timeout=600)) as conn:
         conn.execute("PRAGMA busy_timeout = 600000")
         started_at = time.perf_counter()
-        rebuild_fts_index_sync(conn)
+        rebuild_fts_index_sync(conn, resume_from_empty_message_index=True)
         timings_s["fts"] = time.perf_counter() - started_at
         started_at = time.perf_counter()
         rebuild_command_trigram_index_sync(conn)

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -355,16 +355,26 @@ def rebuild_messages_fts_identity_sync(conn: sqlite3.Connection) -> None:
     conn.execute(insert_all_message_identity_rows_sql())
 
 
-def rebuild_fts_index_sync(conn: sqlite3.Connection) -> None:
+def rebuild_fts_index_sync(
+    conn: sqlite3.Connection,
+    *,
+    resume_from_empty_message_index: bool = False,
+) -> None:
     """Rebuild the full FTS index from persisted archive rows.
 
-    ``messages_fts`` is contentless, so it must be cleared with
-    ``delete-all`` and repopulated from the canonical message/content-block
-    projection.
+    ``messages_fts`` is contentless, so the ordinary path clears it and
+    repopulates it from the canonical message/content-block projection. An
+    owned bulk-build generation may opt into ``resume_from_empty_message_index``:
+    its FTS store is known to have been cleared before replay, so the existing
+    paged missing-row writer can commit each chunk and resume an interrupted
+    terminal pass without redoing already materialized FTS rows.
     """
     ensure_fts_index_sync(conn)
-    rebuild_messages_fts_content_sync(conn)
-    rebuild_messages_fts_identity_sync(conn)
+    if resume_from_empty_message_index:
+        insert_missing_message_rows_batched_sync(conn)
+    else:
+        rebuild_messages_fts_content_sync(conn)
+        rebuild_messages_fts_identity_sync(conn)
     _rebuild_session_work_events_fts_sync(conn)
     _rebuild_threads_fts_sync(conn)
     from polylogue.storage.fts.freshness import record_fts_invariant_snapshot_sync

--- a/tests/unit/storage/test_fts_repair_sql.py
+++ b/tests/unit/storage/test_fts_repair_sql.py
@@ -99,6 +99,31 @@ def test_missing_fts_repair_commits_and_checkpoints_batches(test_conn: sqlite3.C
     assert len(checkpoints) == 3
 
 
+def test_bulk_fts_rebuild_resumes_from_committed_missing_rows(test_conn: sqlite3.Connection) -> None:
+    """The bulk-generation mode keeps already committed FTS rows on retry."""
+    restore_fts_triggers_sync(test_conn)
+    for index in range(3):
+        _seed_text_block(
+            test_conn,
+            native_session_id=f"conv-bulk-resume-{index}",
+            native_message_id=f"msg-bulk-resume-{index}",
+            text=f"bulk resume needle {index}",
+        )
+    test_conn.execute("DELETE FROM messages_fts")
+    test_conn.execute("DELETE FROM messages_fts_identity")
+
+    inserted = insert_missing_message_fts_rows_sync(test_conn, batch_rows=1)
+    assert inserted == 3
+    identity_before = test_conn.execute("SELECT COUNT(*) FROM messages_fts_identity").fetchone()[0]
+
+    rebuild_fts_index_sync(test_conn, resume_from_empty_message_index=True)
+
+    source_rows = test_conn.execute("SELECT COUNT(*) FROM blocks WHERE search_text != ''").fetchone()[0]
+    assert test_conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] == source_rows
+    assert test_conn.execute("SELECT COUNT(*) FROM messages_fts_identity").fetchone()[0] == source_rows
+    assert identity_before == source_rows
+
+
 def test_excess_fts_repair_deletes_orphan_docsize_rows(test_conn: sqlite3.Connection) -> None:
     restore_fts_triggers_sync(test_conn)
     message_id = _seed_text_block(


### PR DESCRIPTION
## Summary

Make bulk-generation FTS finalization commit and resume in bounded rowid windows.

## Problem

Live full-corpus finalization localized an hour-long uncheckpointed contentless FTS insert. A retry would discard all completed FTS work.

## Solution

The bulk-generation caller now opts into the existing missing-row batch materializer. Its docsize and identity-ledger rows commit together per range, so a retry fills only remaining FTS rows. Ordinary full rebuild callers retain replacement semantics.

## Verification

- focused FTS-resume test: 2 passed
- bulk rebuild test: 3 passed
- bulk lifecycle test: 2 passed
- devtools verify --quick: passed

No tracker file is included.