### PR TITLE
perf(storage): defer FTS repair off the live-ingest write path

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -518,13 +518,20 @@ async def _run_drive_source_catchup_safely() -> int:
         return 0
 
 
-async def _periodic_drive_source_catchup() -> None:
+async def _periodic_drive_source_catchup(
+    *,
+    catch_up_complete: asyncio.Event | None = None,
+) -> None:
     """Periodically converge remote Drive sources such as AiStudio exports.
 
-    The first pass runs immediately in the background: Drive catch-up is
-    serial network I/O and must never sit between daemon startup and the
-    local convergence loops or the live watcher.
+    The first pass normally runs immediately in the background.  A live
+    watcher supplies ``catch_up_complete`` so fresh local session evidence
+    gets the single archive writer before remote download/index work.  The
+    gate is deliberately absent for maintenance-only callers.
     """
+    if catch_up_complete is not None:
+        await catch_up_complete.wait()
+
     while True:
         coordinator = daemon_write_coordinator()
         changed = await coordinator.run("maintenance.drive_catchup", _run_drive_source_catchup_safely)
@@ -2055,7 +2062,7 @@ async def run_daemon_services(
                 periodic_fts_identity_drift_recompute(catch_up_complete=catch_up_complete_gate),
             ]
             if enable_source_catchup:
-                periodic_loops.append(_periodic_drive_source_catchup())
+                periodic_loops.append(_periodic_drive_source_catchup(catch_up_complete=catch_up_complete_gate))
             maintenance_tasks.extend(asyncio.create_task(loop) for loop in periodic_loops)
             _db = _active_index_db_path()
             # While the watcher's initial source catch-up is still running,

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -778,16 +778,27 @@ async def _maybe_route_daemon_bulk_rebuild(counts: RawMaterializationCounts) -> 
     return True
 
 
-async def _periodic_raw_materialization_convergence() -> None:
+async def _periodic_raw_materialization_convergence(
+    *,
+    catch_up_complete: asyncio.Event | None = None,
+) -> None:
     """Continuously converge durable raw source rows into the index tier.
 
-    Deliberately ungated on watcher catch-up: the candidates live in the
-    local durable ``source.db``, so materializing them has no acquisition
-    precondition. When a backlog exists (e.g. after an index rebuild) the
-    loop bursts through bounded passes back-to-back — yielding the writer
-    between passes — instead of waiting a full interval per pass, which
-    would stretch a large drain into weeks.
+    A daemon-owned live watcher supplies ``catch_up_complete``.  Its initial
+    acquisition must get the single writer first: a raw-frontier census can
+    inspect the entire durable archive before its bounded replay begins, and
+    otherwise delays fresh Codex/Claude/browser evidence behind unrelated
+    recovery work.  Callers without a watcher deliberately pass no gate, so
+    maintenance-only use still begins immediately.
+
+    Once the gate is open, a backlog (e.g. after an index rebuild) bursts
+    through bounded passes back-to-back — yielding the writer between passes
+    — instead of waiting a full interval per pass, which would stretch a large
+    drain into weeks.
     """
+    if catch_up_complete is not None:
+        await catch_up_complete.wait()
+
     census_mode = False
     while True:
         if _browser_capture_spool_has_pending_files():
@@ -2029,7 +2040,7 @@ async def run_daemon_services(
                 logger.info("daemon: configured source catch-up disabled for this run")
             catch_up_complete_gate = asyncio.Event() if enable_watch else None
             periodic_loops = [
-                _periodic_raw_materialization_convergence(),
+                _periodic_raw_materialization_convergence(catch_up_complete=catch_up_complete_gate),
                 _periodic_session_insight_convergence_after(catch_up_complete_gate),
                 _periodic_convergence_check(sources, catch_up_complete=catch_up_complete_gate),
                 _periodic_wal_checkpoint(),

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -118,7 +118,7 @@ def _repopulate_bulk_build_derived_state(index_path: Path) -> dict[str, float]:
     with contextlib.closing(sqlite3.connect(index_path, timeout=600)) as conn:
         conn.execute("PRAGMA busy_timeout = 600000")
         started_at = time.perf_counter()
-        rebuild_fts_index_sync(conn)
+        rebuild_fts_index_sync(conn, resume_from_empty_message_index=True)
         timings_s["fts"] = time.perf_counter() - started_at
         started_at = time.perf_counter()
         rebuild_command_trigram_index_sync(conn)

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -565,14 +565,21 @@ class LiveBatchProcessor:
                     current_source=source_name,
                     current_path=source_paths[0] if source_paths else None,
                 )
-                _converged_paths, elapsed, timings, convergence_debt = await self._run_sync(
-                    "watcher.live_ingest.full_convergence",
-                    self._converge_paths,
-                    full_result.succeeded,
-                )
-                convergence_time_s += elapsed
-                release_process_memory()
-                _accumulate_stage_timings(stage_timings, timings)
+                convergence_debt: list[ConvergenceDebt] = []
+                if full_result.changed_session_count:
+                    _converged_paths, elapsed, timings, convergence_debt = await self._run_sync(
+                        "watcher.live_ingest.full_convergence",
+                        self._converge_paths,
+                        full_result.succeeded,
+                    )
+                    convergence_time_s += elapsed
+                    release_process_memory()
+                    _accumulate_stage_timings(stage_timings, timings)
+                elif full_result.succeeded:
+                    logger.info(
+                        "live.watcher: skipping full convergence for %d source observation(s) without session changes",
+                        len(full_result.succeeded),
+                    )
                 debt_by_source_path = debt_by_path(convergence_debt)
                 for path in full_result.succeeded:
                     succeeded_paths.add(path)

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -2130,9 +2130,16 @@ class LiveBatchProcessor:
                 acquired_at_ms=acquired_at_ms,
                 stage_timings_s=stage_timings_s,
                 stage_timing_prefix="full",
+                defer_fts=True,
             )
             if membership_session_id is not None:
                 session_ids.append(membership_session_id)
+                self._cursor.record_convergence_debt(
+                    stage="fts",
+                    subject_type="session_id",
+                    subject_id=membership_session_id,
+                    error="live membership ingest deferred FTS to preserve writer availability",
+                )
                 session_count += 1
                 message_count += len(member_sessions[classification.accepted_raw_ids[-1]].messages)
         return (

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -220,14 +220,14 @@ def _captured_jsonl_ends_at_record_boundary(
 @dataclass(slots=True)
 class _ArchiveFullWriteResult:
     raw_ids: dict[str, str] = field(default_factory=dict)
-    # polylogue-emx2: a raw whose membership census completed but whose
-    # authority decision is still pending (arbitration deferred to the async
-    # raw-materialization conveyor) is a hand-off, not a failure. Bytes are
-    # durably acquired; only the classification decision is outstanding.
-    # Tracked separately from raw_ids so the aggregation layer in
-    # _ingest_full_paths_sync can treat re-observation of these files as
-    # idempotent (cursor succeeded, no retry churn) instead of silently
-    # counting them as full-ingest failures with no exception ever raised.
+    # A raw whose membership census does not produce an accepted session is
+    # still a durably acquired, successfully parsed source observation. The
+    # decision can be pending for the materialization conveyor or already
+    # resolved as ambiguous/deferred. Neither state is a transient source-file
+    # failure: retrying identical bytes burns the live catch-up budget without
+    # supplying new authority evidence. Track it separately from ``raw_ids``
+    # so the cursor records the observation as complete while the durable raw
+    # membership state remains queryable and a later file change reopens it.
     deferred_raw_ids: dict[str, str] = field(default_factory=dict)
     session_ids: list[str] = field(default_factory=list)
     session_count: int = 0
@@ -1947,17 +1947,19 @@ class LiveBatchProcessor:
                         # raw yet. Not a failure; see deferred_raw_ids.
                         result.deferred_raw_ids[record.raw_id] = record_raw_id
                     else:
-                        # Decision is 'ambiguous'/'deferred' -- arbitration
-                        # already ran and concluded a genuine, unresolved
-                        # conflict. That is a decided outcome, not pending
-                        # state, so it must surface as a failure (fail-closed).
-                        # Leave this raw out of both raw_ids and
-                        # deferred_raw_ids so the caller's aggregation counts
-                        # it as a real failure, with a log line so the cause is
-                        # diagnosable (unlike the pre-fix silent mismark).
-                        logger.warning(
-                            "live.watcher: membership decision unresolved (ambiguous/deferred) for %s "
-                            "raw=%s -- surfacing as failed, not deferred",
+                        # A decided ambiguous/deferred classification is
+                        # fail-closed for materialization, but it is not a
+                        # failed acquisition or parse. Re-running the exact
+                        # same source path cannot resolve a content conflict;
+                        # it only makes every daemon restart re-read the same
+                        # historical bytes. Preserve the durable unresolved
+                        # decision and make the live cursor idempotent. Any
+                        # changed observation returns through full ingest and
+                        # may supply the evidence needed to arbitrate it.
+                        result.deferred_raw_ids[record.raw_id] = record_raw_id
+                        logger.info(
+                            "live.watcher: membership decision remains unresolved for %s "
+                            "raw=%s; preserving durable authority debt without retrying unchanged bytes",
                             record.source_path,
                             source_raw_id,
                         )

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -1831,6 +1831,13 @@ class LiveBatchProcessor:
                                     acquired_at_ms=acquired_at_ms,
                                     stage_timings_s=record_timings,
                                     stage_timing_prefix="full",
+                                    defer_fts=True,
+                                )
+                                self._cursor.record_convergence_debt(
+                                    stage="fts",
+                                    subject_type="session_id",
+                                    subject_id=session_id,
+                                    error="live full ingest deferred FTS to preserve writer availability",
                                 )
                                 record_session_ids.append(session_id)
                                 record_session_count = 1

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -53,8 +53,14 @@ _PARSER_FINGERPRINT = "live-batched-v2"
 # One bounded writer hold per hook-spool drain batch; the drain loops until
 # the backlog is gone, releasing the writer between batches.
 _HOOK_SPOOL_DRAIN_BATCH_LIMIT = 250
-_CATCH_UP_MAX_BATCH_FILES = 50
-_CATCH_UP_MAX_BATCH_BYTES = 64 * 1024 * 1024
+# A catch-up writer owns the only archive writer for the whole chunk.  The
+# former 50-file/64-MiB envelope held it for 14+ minutes on the real archive,
+# starving fresh watcher events.  Keep historical convergence fair by
+# yielding after a handful of files; one individually large source still owns
+# one bounded logical-session write, but cannot be bundled with dozens more.
+_CATCH_UP_MAX_BATCH_FILES = 4
+_CATCH_UP_MAX_BATCH_BYTES = 16 * 1024 * 1024
+_CATCH_UP_HOT_FILE_AGE_S = 60.0 * 60.0
 _INCOMPLETE_APPEND_PROBE_BYTES = 64 * 1024 * 1024
 # Filesystem notifications are the real-time delivery path.  This sweep is a
 # recovery mechanism for notifications missed while the daemon was unavailable
@@ -334,65 +340,82 @@ class LiveWatcher:
 
     async def _catch_up(self, roots: list[Path]) -> None:
         candidates = self._scan_catch_up_candidates(roots)
+        if not candidates:
+            await self._drain_hook_spool()
+            return
+
+        now = time.time()
+        hot_candidates = tuple(
+            candidate for candidate in candidates if now - candidate.stat.st_mtime <= _CATCH_UP_HOT_FILE_AGE_S
+        )
+        hot_paths = {candidate.path for candidate in hot_candidates}
+        cold_candidates = tuple(candidate for candidate in candidates if candidate.path not in hot_paths)
+        if hot_candidates:
+            logger.info(
+                "live.watcher: prioritizing %d recently modified source file(s) before backlog catch-up",
+                len(hot_candidates),
+            )
+        for group in (hot_candidates, cold_candidates):
+            if self._stop.is_set() or not group:
+                break
+            await self._catch_up_candidates(group)
+        await self._drain_hook_spool()
+
+    async def _catch_up_candidates(self, candidates: tuple[CandidateSourceFile, ...]) -> None:
+        """Plan and ingest one priority class of catch-up candidates."""
         plan_holder: list[CatchUpPlan] = []
 
         async def prepare_catch_up() -> None:
             await self._run_writer_sync("watcher.catch_up.cursor_initialize", self._cursor.initialize)
-            if not candidates:
-                return
             logger.info("live.watcher: catch-up scan over %d file(s)", len(candidates))
             plan_holder.append(self._plan_catch_up(candidates))
 
         await self._run_coordinated("watcher.catch_up.prefilter", prepare_catch_up)
-        if plan_holder:
-            plan = plan_holder[0]
-        else:
-            plan = CatchUpPlan(candidates=(), needed=(), skipped_file_count=0, needed_bytes=0)
-
-        if plan.needed:
-            candidate_by_path = {candidate.path: candidate for candidate in plan.candidates}
-            chunks = tuple(self._chunk_catch_up_paths(plan.needed, candidate_by_path))
+        plan = plan_holder[0]
+        if not plan.needed:
+            return
+        candidate_by_path = {candidate.path: candidate for candidate in plan.candidates}
+        chunks = tuple(self._chunk_catch_up_paths(plan.needed, candidate_by_path))
+        logger.info(
+            "live.watcher: catch-up ingesting %d file(s) (%.1f MB), skipped=%d, chunks=%d",
+            len(plan.needed),
+            plan.needed_bytes / 1e6,
+            plan.skipped_file_count,
+            len(chunks),
+        )
+        for index, chunk in enumerate(chunks, start=1):
+            if self._stop.is_set():
+                break
+            chunk_bytes = sum(candidate_by_path[path].stat.st_size for path in chunk)
             logger.info(
-                "live.watcher: catch-up ingesting %d file(s) (%.1f MB), skipped=%d, chunks=%d",
-                len(plan.needed),
-                plan.needed_bytes / 1e6,
-                plan.skipped_file_count,
+                "live.watcher: catch-up chunk %d/%d ingesting %d file(s) (%.1f MB)",
+                index,
                 len(chunks),
+                len(chunk),
+                chunk_bytes / 1e6,
             )
-            for index, chunk in enumerate(chunks, start=1):
-                if self._stop.is_set():
-                    break
-                chunk_bytes = sum(candidate_by_path[path].stat.st_size for path in chunk)
-                logger.info(
-                    "live.watcher: catch-up chunk %d/%d ingesting %d file(s) (%.1f MB)",
-                    index,
-                    len(chunks),
-                    len(chunk),
-                    chunk_bytes / 1e6,
+            chunk_index = index
+            chunk_paths = list(chunk)
+
+            async def ingest_chunk(
+                chunk_index: int = chunk_index,
+                chunk_paths: list[Path] = chunk_paths,
+            ) -> None:
+                metrics = await self._ingest_files(
+                    chunk_paths,
+                    queued_file_count=len(plan.candidates) if chunk_index == 1 else len(chunk_paths),
+                    skipped_file_count=plan.skipped_file_count if chunk_index == 1 else 0,
                 )
-                chunk_index = index
-                chunk_paths = list(chunk)
+                if metrics is not None:
+                    _log_ingest_metrics(f"live.watcher: catch-up chunk {chunk_index}/{len(chunks)}", metrics)
+                    if (
+                        getattr(metrics, "succeeded_file_count", 0) == 0
+                        and getattr(metrics, "failed_file_count", 0) == 0
+                    ):
+                        self._defer_unaccounted_failed_retries(chunk_paths)
 
-                async def ingest_chunk(
-                    chunk_index: int = chunk_index,
-                    chunk_paths: list[Path] = chunk_paths,
-                ) -> None:
-                    metrics = await self._ingest_files(
-                        chunk_paths,
-                        queued_file_count=len(plan.candidates) if chunk_index == 1 else len(chunk_paths),
-                        skipped_file_count=plan.skipped_file_count if chunk_index == 1 else 0,
-                    )
-                    if metrics is not None:
-                        _log_ingest_metrics(f"live.watcher: catch-up chunk {chunk_index}/{len(chunks)}", metrics)
-                        if (
-                            getattr(metrics, "succeeded_file_count", 0) == 0
-                            and getattr(metrics, "failed_file_count", 0) == 0
-                        ):
-                            self._defer_unaccounted_failed_retries(chunk_paths)
-
-                await self._run_coordinated("watcher.catch_up.chunk", ingest_chunk)
-            self._schedule_failed_retry_scan()
-        await self._drain_hook_spool()
+            await self._run_coordinated("watcher.catch_up.chunk", ingest_chunk)
+        self._schedule_failed_retry_scan()
 
     async def _drain_hook_spool(self) -> None:
         """Acknowledge hook envelopes only after their source-tier write commits.

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -39,6 +39,8 @@ from polylogue.storage.fts.sql import (
     message_identity_mismatch_sql,
     repair_all_message_identity_rows_sql,
     repair_message_identity_rows_range_sql,
+    trigram_delete_session_rows_sql,
+    trigram_insert_session_rows_sql,
 )
 
 _chunked = chunked
@@ -670,6 +672,15 @@ def repair_message_fts_index_sync(
         conn.execute(delete_session_identity_rows_sql(len(chunk)), params)
         conn.execute(insert_session_rows_sql(len(chunk)), params)
         conn.execute(insert_session_identity_rows_sql(len(chunk)), params)
+        # A deferred full-replace deletes a session's blocks_command_trigram
+        # postings at write time (using the old block text) but skips the
+        # matching reinsert, so this repair is the only catch-up: reissue the
+        # delete (a no-op unless something re-populated it) then repopulate
+        # from the current blocks table. Trigram SQL is session-scoped, not
+        # chunked like the calls above.
+        for session_id in chunk:
+            conn.execute(trigram_delete_session_rows_sql(), (session_id,))
+            conn.execute(trigram_insert_session_rows_sql(), (session_id,))
     if not record_exact_snapshot:
         return
     from polylogue.storage.fts.freshness import record_fts_invariant_snapshot_sync

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -650,7 +650,23 @@ def repair_message_fts_index_sync(
         return
     for chunk in chunked(list(session_ids), size=500):
         params = tuple(chunk)
-        conn.execute(delete_session_rows_sql(len(chunk)), params)
+        # FTS5 cannot efficiently plan ``rowid IN (SELECT ...)``: even when
+        # the subquery is session-indexed, SQLite scans the entire virtual
+        # table to evaluate the delete.  First use the ordinary docsize shadow
+        # table to identify rows that are actually indexed (preserving the
+        # malformed-index guard in ``delete_session_rows_sql``), then issue
+        # direct rowid deletes that FTS5 can seek.
+        rowids = conn.execute(
+            f"""
+            SELECT b.rowid
+            FROM blocks AS b INDEXED BY idx_blocks_session_position
+            JOIN messages_fts_docsize AS d ON d.id = b.rowid
+            WHERE b.session_id IN ({", ".join("?" for _ in chunk)})
+            """,
+            params,
+        ).fetchall()
+        if rowids:
+            conn.executemany("DELETE FROM messages_fts WHERE rowid = ?", rowids)
         conn.execute(delete_session_identity_rows_sql(len(chunk)), params)
         conn.execute(insert_session_rows_sql(len(chunk)), params)
         conn.execute(insert_session_identity_rows_sql(len(chunk)), params)

--- a/polylogue/storage/fts/fts_lifecycle.py
+++ b/polylogue/storage/fts/fts_lifecycle.py
@@ -355,16 +355,26 @@ def rebuild_messages_fts_identity_sync(conn: sqlite3.Connection) -> None:
     conn.execute(insert_all_message_identity_rows_sql())
 
 
-def rebuild_fts_index_sync(conn: sqlite3.Connection) -> None:
+def rebuild_fts_index_sync(
+    conn: sqlite3.Connection,
+    *,
+    resume_from_empty_message_index: bool = False,
+) -> None:
     """Rebuild the full FTS index from persisted archive rows.
 
-    ``messages_fts`` is contentless, so it must be cleared with
-    ``delete-all`` and repopulated from the canonical message/content-block
-    projection.
+    ``messages_fts`` is contentless, so the ordinary path clears it and
+    repopulates it from the canonical message/content-block projection. An
+    owned bulk-build generation may opt into ``resume_from_empty_message_index``:
+    its FTS store is known to have been cleared before replay, so the existing
+    paged missing-row writer can commit each chunk and resume an interrupted
+    terminal pass without redoing already materialized FTS rows.
     """
     ensure_fts_index_sync(conn)
-    rebuild_messages_fts_content_sync(conn)
-    rebuild_messages_fts_identity_sync(conn)
+    if resume_from_empty_message_index:
+        insert_missing_message_rows_batched_sync(conn)
+    else:
+        rebuild_messages_fts_content_sync(conn)
+        rebuild_messages_fts_identity_sync(conn)
     _rebuild_session_work_events_fts_sync(conn)
     _rebuild_threads_fts_sync(conn)
     from polylogue.storage.fts.freshness import record_fts_invariant_snapshot_sync

--- a/polylogue/storage/fts/sql.py
+++ b/polylogue/storage/fts/sql.py
@@ -498,10 +498,10 @@ def trigram_delete_session_rows_sql() -> str:
         INSERT INTO blocks_command_trigram(blocks_command_trigram, rowid, tool_detail_text)
         SELECT 'delete', b.rowid, b.tool_detail_text
         FROM blocks AS b
+        JOIN blocks_command_trigram_docsize AS d ON d.id = b.rowid
         WHERE b.session_id = ?
           AND b.block_type = 'tool_use'
           AND b.tool_detail_text != ' '
-          AND b.rowid IN (SELECT id FROM blocks_command_trigram_docsize)
     """
 
 

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1558,6 +1558,7 @@ class ArchiveStore:
         revision_authoritative: bool = False,
         bulk_fts: bool = False,
         bulk_build: bool = False,
+        defer_fts_rebuild: bool = False,
     ) -> ArchiveRawParsedWriteResult:
         session_id = str(make_session_id(session.source_name, session.provider_session_id))
         content_hash = str(session_content_hash(session))
@@ -1590,6 +1591,7 @@ class ArchiveStore:
                 manage_transaction=manage_transaction,
                 bulk_fts=bulk_fts,
                 bulk_build=bulk_build,
+                defer_fts_rebuild=defer_fts_rebuild,
             )
             return ArchiveRawParsedWriteResult(
                 raw_id=raw_id,
@@ -3199,6 +3201,7 @@ class ArchiveStore:
                     revision_authoritative=True,
                     bulk_fts=bulk_fts,
                     bulk_build=bulk_build,
+                    defer_fts_rebuild=not bulk_build,
                 )
                 if stage_timings_s is not None:
                     key = f"{stage_timing_prefix}.index_parsed_write"
@@ -3710,6 +3713,7 @@ class ArchiveStore:
         revision_authoritative: bool = False,
         bulk_fts: bool = False,
         bulk_build: bool = False,
+        defer_fts_rebuild: bool = False,
     ) -> ArchiveRawParsedWriteResult:
         provider = Provider.from_string(session.source_name)
         try:
@@ -3724,6 +3728,7 @@ class ArchiveStore:
                 revision_authoritative=revision_authoritative,
                 bulk_fts=bulk_fts,
                 bulk_build=bulk_build,
+                defer_fts_rebuild=defer_fts_rebuild,
             )
         except Exception as exc:
             self.finalize_raw_parse_state(raw_id, state=self._raw_parse_failure_state(provider, exc))

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -3091,6 +3091,7 @@ class ArchiveStore:
         manage_transaction: bool = True,
         bulk_fts: bool = False,
         bulk_build: bool = False,
+        defer_fts: bool = False,
     ) -> tuple[str, tuple[str, ...]]:
         """Apply a proven chain and atomically receipt its exact index state.
 
@@ -3214,9 +3215,23 @@ class ArchiveStore:
                 "UPDATE sessions SET content_hash = ? WHERE session_id = ?",
                 (aggregate_content_hash, session_id),
             )
-            if not bulk_build:
+            if not bulk_build and not defer_fts:
                 repair_message_fts_index_sync(self._conn, [session_id], record_exact_snapshot=False)
-            assert_session_fts_exact_sync(self._conn, session_id, bulk_build=bulk_build)
+            if defer_fts:
+                from polylogue.storage.fts.freshness import STALE, record_fts_surface_state_sync
+
+                record_fts_surface_state_sync(
+                    self._conn,
+                    surface="messages_fts",
+                    state=STALE,
+                    detail="live authoritative replay deferred targeted session FTS repair",
+                )
+            assert_session_fts_exact_sync(
+                self._conn,
+                session_id,
+                bulk_build=bulk_build,
+                allow_pending=defer_fts,
+            )
             stored = self._conn.execute(
                 "SELECT content_hash FROM sessions WHERE session_id = ?", (session_id,)
             ).fetchone()

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -3311,6 +3311,7 @@ class ArchiveStore:
         manage_transaction: bool = True,
         bulk_fts: bool = False,
         bulk_build: bool = False,
+        defer_fts: bool = False,
     ) -> str | None:
         """Apply one semantic member head and persist every membership decision.
 
@@ -3575,14 +3576,29 @@ class ArchiveStore:
                         revision_authoritative=True,
                         bulk_fts=bulk_fts,
                         bulk_build=bulk_build,
+                        defer_fts_rebuild=not bulk_build,
                     )
                     if stage_timings_s is not None:
                         key = f"{stage_timing_prefix}.index_parsed_write"
                         stage_timings_s[key] = stage_timings_s.get(key, 0.0) + (time.perf_counter() - index_started)
                     session_id = result.session_id
-                    if not bulk_build:
+                    if not bulk_build and not defer_fts:
                         repair_message_fts_index_sync(self._conn, [session_id], record_exact_snapshot=False)
-                    assert_session_fts_exact_sync(self._conn, session_id, bulk_build=bulk_build)
+                    if defer_fts:
+                        from polylogue.storage.fts.freshness import STALE, record_fts_surface_state_sync
+
+                        record_fts_surface_state_sync(
+                            self._conn,
+                            surface="messages_fts",
+                            state=STALE,
+                            detail="live membership replay deferred targeted session FTS repair",
+                        )
+                    assert_session_fts_exact_sync(
+                        self._conn,
+                        session_id,
+                        bulk_build=bulk_build,
+                        allow_pending=defer_fts,
+                    )
                     stored = self._conn.execute(
                         "SELECT content_hash FROM sessions WHERE session_id = ?", (session_id,)
                     ).fetchone()

--- a/polylogue/storage/sqlite/archive_tiers/revision_application.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_application.py
@@ -98,7 +98,13 @@ class FullSnapshotFoldAuthorization:
         )
 
 
-def assert_session_fts_exact_sync(conn: sqlite3.Connection, session_id: str, *, bulk_build: bool = False) -> None:
+def assert_session_fts_exact_sync(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    bulk_build: bool = False,
+    allow_pending: bool = False,
+) -> None:
     """Fail unless the current session's indexable blocks have exact FTS rows.
 
     ``bulk_build`` (polylogue-v6i3, default ``False``): a bulk-generation-
@@ -119,7 +125,7 @@ def assert_session_fts_exact_sync(conn: sqlite3.Connection, session_id: str, *, 
     }
     if not _MESSAGE_FTS_TRIGGERS.issubset(triggers):
         raise RuntimeError("raw revision application requires canonical message FTS triggers")
-    if bulk_build:
+    if bulk_build or allow_pending:
         return
     expected, indexed = conn.execute(
         """

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -39,11 +39,7 @@ from polylogue.sources.parsers.base import (
     ParsedSession,
     ParsedSessionEvent,
 )
-from polylogue.storage.fts.fts_lifecycle import (
-    message_fts_triggers_present_sync,
-    restore_message_fts_triggers_sync,
-    suspend_message_fts_triggers_sync,
-)
+from polylogue.storage.fts.fts_lifecycle import message_fts_triggers_present_sync
 from polylogue.storage.fts.pl_fold import pl_fold_sql_expr
 from polylogue.storage.fts.sql import (
     FTS_BULK_SESSION_WRITE_GUARD,
@@ -1934,8 +1930,7 @@ def _replace_full_session_messages_and_blocks(
     """Replace one session's messages/blocks wholesale.
 
     ``bulk_build`` (polylogue-v6i3, default ``False``) skips this function's
-    own scoped ``messages_fts`` delete/suspend-trigger/insert/restore dance
-    and its ``action_pairs`` refresh entirely -- see
+    own scoped derived-index refresh and its ``action_pairs`` refresh entirely -- see
     ``write_parsed_session_to_archive``'s docstring for why: a bulk-build
     caller always repopulates both surfaces archive-wide exactly once at
     readiness, so per-session maintenance here is pure waste. Ordinary
@@ -1974,10 +1969,25 @@ def _replace_full_session_messages_and_blocks(
         # docstring for why this non-bulk full-session-replace fast path must
         # keep messages_fts_identity paired with messages_fts.
         conn.execute(delete_session_identity_rows_sql(1), (session_id,))
+        # Full replacement also deletes and recreates tool-use blocks.  The
+        # trigram external-content index must be cleared while their old text
+        # is still available, before the guard below suppresses its per-row
+        # triggers.  Leaving it trigger-maintained made a live 18 MB Codex
+        # transcript spend minutes performing thousands of individual FTS5
+        # updates under the sole writer lock.
+        conn.execute(trigram_delete_session_rows_sql(), (session_id,))
         add_timing("fts_delete", t0)
         t0 = time.perf_counter()
-        suspend_message_fts_triggers_sync(conn)
-        add_timing("fts_suspend", t0)
+        # Keep the canonical triggers structurally present and gate both the
+        # message and trigram bodies for the whole replacement.  This is the
+        # same protocol used for guarded lineage rewrites, but here it covers
+        # the session's own delete and insert as well.
+        conn.execute(
+            "INSERT OR REPLACE INTO derived_refresh_guard(guard_name) VALUES (?)",
+            (FTS_BULK_SESSION_WRITE_GUARD,),
+        )
+        add_timing("fts_guard", t0)
+    replacement_complete = False
     try:
         t0 = time.perf_counter()
         _clear_session_projection_rows(conn, session_id)
@@ -2015,18 +2025,22 @@ def _replace_full_session_messages_and_blocks(
             duplicate_native_ids=duplicate_native_ids,
         )
         add_timing("web_constructs", t0)
-        if use_scoped_fts_rebuild:
-            t0 = time.perf_counter()
-            conn.execute(insert_session_rows_sql(1), (session_id,))
-            # polylogue-miwv: identity-ledger companion, same chunk params as
-            # the messages_fts insert above.
-            conn.execute(insert_session_identity_rows_sql(1), (session_id,))
-            add_timing("fts_insert", t0)
+        replacement_complete = True
     finally:
         if use_scoped_fts_rebuild:
             t0 = time.perf_counter()
-            restore_message_fts_triggers_sync(conn)
-            add_timing("fts_restore", t0)
+            if replacement_complete:
+                conn.execute(insert_session_rows_sql(1), (session_id,))
+                # polylogue-miwv: identity-ledger companion, same chunk params
+                # as the messages_fts insert above.
+                conn.execute(insert_session_identity_rows_sql(1), (session_id,))
+                conn.execute(trigram_insert_session_rows_sql(), (session_id,))
+                add_timing("fts_insert", t0)
+            conn.execute(
+                "DELETE FROM derived_refresh_guard WHERE guard_name = ?",
+                (FTS_BULK_SESSION_WRITE_GUARD,),
+            )
+            add_timing("fts_guard_clear", t0)
 
 
 def _refresh_session_counts(conn: sqlite3.Connection, session_id: str) -> None:

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -284,6 +284,7 @@ def write_parsed_session_to_archive(
     manage_transaction: bool = True,
     bulk_fts: bool = False,
     bulk_build: bool = False,
+    defer_fts_rebuild: bool = False,
     prepared: PreparedSessionRows | None = None,
 ) -> str:
     """Write one parsed session into an initialized archive index DB.
@@ -328,6 +329,11 @@ def write_parsed_session_to_archive(
     daemon writes (and ``bulk_fts=True`` used alone, e.g. in
     ``tests/unit/storage/test_bulk_fts_prefix_reextract.py``) keep those
     surfaces exactly in sync after every write, unchanged.
+
+    ``defer_fts_rebuild`` is for an authoritative raw-revision replay that
+    owns one targeted repair and exactness proof after its writes. It avoids
+    rebuilding the same session's FTS surfaces twice in the same transaction.
+    Direct callers retain the immediate-ready default.
     """
     t0 = time.perf_counter()
 
@@ -560,6 +566,7 @@ def write_parsed_session_to_archive(
                     stage_timings_s=stage_timings_s,
                     stage_timing_prefix=stage_timing_prefix,
                     bulk_build=bulk_build,
+                    defer_fts_rebuild=defer_fts_rebuild,
                     prepared=prepared_rows_to_use,
                 )
                 add_timing("index.full_replace", t0)
@@ -1925,6 +1932,7 @@ def _replace_full_session_messages_and_blocks(
     stage_timings_s: dict[str, float] | None = None,
     stage_timing_prefix: str = "append",
     bulk_build: bool = False,
+    defer_fts_rebuild: bool = False,
     prepared: PreparedSessionRows | None = None,
 ) -> None:
     """Replace one session's messages/blocks wholesale.
@@ -2029,7 +2037,7 @@ def _replace_full_session_messages_and_blocks(
     finally:
         if use_scoped_fts_rebuild:
             t0 = time.perf_counter()
-            if replacement_complete:
+            if replacement_complete and not defer_fts_rebuild:
                 conn.execute(insert_session_rows_sql(1), (session_id,))
                 # polylogue-miwv: identity-ledger companion, same chunk params
                 # as the messages_fts insert above.

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -1972,19 +1972,23 @@ def _replace_full_session_messages_and_blocks(
     if use_scoped_fts_rebuild:
         t0 = time.perf_counter()
         conn.execute(delete_session_rows_sql(1), (session_id,))
+        add_timing("fts_messages_delete", t0)
         # polylogue-miwv: identity-ledger companion, same chunk params as the
         # messages_fts delete above -- see message_identity_mismatch_sql's
         # docstring for why this non-bulk full-session-replace fast path must
         # keep messages_fts_identity paired with messages_fts.
+        t0 = time.perf_counter()
         conn.execute(delete_session_identity_rows_sql(1), (session_id,))
+        add_timing("fts_identity_delete", t0)
         # Full replacement also deletes and recreates tool-use blocks.  The
         # trigram external-content index must be cleared while their old text
         # is still available, before the guard below suppresses its per-row
         # triggers.  Leaving it trigger-maintained made a live 18 MB Codex
         # transcript spend minutes performing thousands of individual FTS5
         # updates under the sole writer lock.
+        t0 = time.perf_counter()
         conn.execute(trigram_delete_session_rows_sql(), (session_id,))
-        add_timing("fts_delete", t0)
+        add_timing("fts_trigram_delete", t0)
         t0 = time.perf_counter()
         # Keep the canonical triggers structurally present and gate both the
         # message and trigram bodies for the whole replacement.  This is the

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -1142,6 +1142,37 @@ def test_periodic_raw_materialization_convergence_waits_for_watcher_catch_up(
     assert calls == ["drain"]
 
 
+def test_periodic_drive_source_catchup_waits_for_watcher_catch_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote Drive work cannot monopolize startup ahead of local sessions."""
+    from polylogue.daemon import cli as daemon_cli
+
+    calls: list[str] = []
+
+    async def fake_run(_actor: str, _func: object, *_args: object, **_kwargs: object) -> int:
+        calls.append("drive")
+        raise asyncio.CancelledError
+
+    async def exercise() -> None:
+        catch_up_complete = asyncio.Event()
+        monkeypatch.setattr(
+            daemon_cli,
+            "daemon_write_coordinator",
+            lambda: SimpleNamespace(run=fake_run),
+        )
+        task = asyncio.create_task(daemon_cli._periodic_drive_source_catchup(catch_up_complete=catch_up_complete))
+        await asyncio.sleep(0)
+        assert calls == []
+        catch_up_complete.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(exercise())
+
+    assert calls == ["drive"]
+
+
 def test_periodic_raw_materialization_bursts_through_backlog(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3552,7 +3583,9 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
         stack.enter_context(patch.object(daemon_cli, "_periodic_health_check", lambda: fake_loop("health")))
         stack.enter_context(patch.object(daemon_cli, "_periodic_db_optimize", lambda: fake_loop("optimize")))
         stack.enter_context(patch.object(daemon_cli, "_periodic_status_snapshot_refresh", lambda: fake_loop("status")))
-        stack.enter_context(patch.object(daemon_cli, "_periodic_drive_source_catchup", lambda: fake_loop("drive")))
+        stack.enter_context(
+            patch.object(daemon_cli, "_periodic_drive_source_catchup", lambda **_kwargs: fake_loop("drive"))
+        )
         stack.enter_context(
             patch(
                 "polylogue.daemon.embedding_backlog.periodic_embedding_backlog_check",

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -1109,6 +1109,39 @@ def test_periodic_raw_materialization_convergence_starts_without_catch_up(
     assert calls == ["drain"]
 
 
+def test_periodic_raw_materialization_convergence_waits_for_watcher_catch_up(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Initial live acquisition keeps the writer ahead of frontier recovery."""
+    from polylogue.daemon import cli as daemon_cli
+
+    calls: list[str] = []
+
+    async def fake_run_sync(_actor: str, _func: object, *_args: object, **_kwargs: object) -> object:
+        calls.append("drain")
+        raise asyncio.CancelledError
+
+    async def exercise() -> None:
+        catch_up_complete = asyncio.Event()
+        monkeypatch.setattr(
+            daemon_cli,
+            "daemon_write_coordinator",
+            lambda: SimpleNamespace(run_sync=fake_run_sync),
+        )
+        task = asyncio.create_task(
+            daemon_cli._periodic_raw_materialization_convergence(catch_up_complete=catch_up_complete)
+        )
+        await asyncio.sleep(0)
+        assert calls == []
+        catch_up_complete.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(exercise())
+
+    assert calls == ["drain"]
+
+
 def test_periodic_raw_materialization_bursts_through_backlog(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3500,7 +3533,7 @@ def test_run_daemon_services_waits_for_fts_startup_before_watcher() -> None:
             patch.object(
                 daemon_cli,
                 "_periodic_raw_materialization_convergence",
-                lambda: fake_loop("raw-materialization"),
+                lambda **_kwargs: fake_loop("raw-materialization"),
             )
         )
         stack.enter_context(

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -4055,6 +4055,10 @@ def test_bulk_rebuild_routing_resumable_transaction_drives_pass_even_below_thres
 
     class FakeResolved:
         daemon_bulk_rebuild_routing = True
+        daemon_parse_stage_workers = None
+        daemon_parse_stage_max_inflight_bytes = None
+        daemon_parse_stage_max_cached_tree_bytes = None
+        daemon_parse_stage_warm_timeout_seconds = None
 
     calls: list[dict[str, object]] = []
 

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -366,8 +366,8 @@ def test_full_ingest_writes_archive_with_route_observability(
         "full.index.full_replace.clear_projection_rows",
         "full.index.full_replace.messages",
         "full.index.full_replace.blocks",
-        "full.index.full_replace.fts_insert",
     }.issubset(result.stage_timings_s)
+    assert cursor.list_convergence_debt(limit=10)[0].stage == "fts"
     with sqlite3.connect(source_db) as conn:
         raw_state = conn.execute("SELECT parsed_at_ms, parse_error FROM raw_sessions").fetchone()
         assert raw_state is not None
@@ -2681,6 +2681,9 @@ def test_incomplete_full_jsonl_capture_retries_without_losing_split_record(tmp_p
             ("message-0",),
             ("message-1",),
         ]
+        from polylogue.storage.fts.fts_lifecycle import repair_message_fts_index_sync
+
+        repair_message_fts_index_sync(conn, ["codex-session:split-record"], record_exact_snapshot=False)
         assert conn.execute(
             "SELECT b.search_text FROM messages_fts AS f JOIN blocks AS b ON b.rowid = f.rowid ORDER BY b.message_id"
         ).fetchall() == [("zero",), ("one",)]

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -3331,8 +3331,10 @@ def test_live_multi_session_divergence_reopens_raw_authority(tmp_path: Path) -> 
     accepted_raw_id = first_result.raw_fingerprints[first]
 
     second_result = processor._ingest_full_paths_sync([second], source_name="inbox")
-    assert second_result.failed == [second]
-    assert second_result.succeeded == []
+    # The divergent authority remains unresolved, but this source file was
+    # acquired and parsed. Its unchanged bytes must not become a retry loop.
+    assert second_result.failed == []
+    assert second_result.succeeded == [second]
     with sqlite3.connect(tmp_path / "source.db") as conn:
         assert conn.execute("SELECT COUNT(*) FROM raw_session_memberships WHERE decision = 'ambiguous'").fetchone() == (
             2,
@@ -3940,8 +3942,12 @@ def test_bundle_replay_respects_unconvertible_single_session_head(
 
     result = processor._ingest_full_paths_sync([older_bundle], source_name="codex")
 
-    assert result.failed == ([] if succeeds else [older_bundle])
-    assert result.succeeded == ([older_bundle] if succeeds else [])
+    # A same-size divergent membership result is a decided authority conflict
+    # with a complete source observation; attempted replacement through live
+    # append evidence raises instead and must remain retryable.
+    cursor_complete = succeeds or bundle_texts == ("base", "different")
+    assert result.failed == ([] if cursor_complete else [older_bundle])
+    assert result.succeeded == ([older_bundle] if cursor_complete else [])
     with sqlite3.connect(index_db) as conn:
         assert conn.execute("SELECT message_count FROM sessions WHERE native_id = 'shared'").fetchone() == (2,)
         head_after = conn.execute(

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -3543,10 +3543,13 @@ def test_live_third_raw_reunifies_with_backfill_retired_siblings(tmp_path: Path)
 
     # The genuine three-way content divergence still correctly refuses to
     # pick a winner -- reunification recovers a real resolution when one
-    # exists, it does not fabricate one.
+    # exists, it does not fabricate one. The source observation itself was
+    # acquired and parsed successfully, so its cursor is complete rather than
+    # retried as a transient file failure; the durable membership decision
+    # remains ambiguous/fail-closed.
     assert by_path[str(third)] == "ambiguous"
-    assert third_result.failed == [third]
-    assert third_result.succeeded == []
+    assert third_result.failed == []
+    assert third_result.succeeded == [third]
 
 
 def test_raw_membership_decision_pending_distinguishes_null_from_ambiguous(tmp_path: Path) -> None:
@@ -3558,13 +3561,13 @@ def test_raw_membership_decision_pending_distinguishes_null_from_ambiguous(tmp_p
     raw-materialization conveyor, ``sources/revision_backfill.py``) and
     ``decision IN ('ambiguous', 'deferred')`` (arbitration already ran and
     concluded a real conflict that needs new evidence, not time, to
-    resolve). Only the first is a legitimate "not a failure, hand off to the
-    conveyor" hand-off; the second is a decided outcome that must surface as
-    a failure -- ``LiveBatchProcessor._ingest_full_records_archive`` uses
-    ``raw_membership_decision_pending`` (not the coarse boolean alone) at
-    both of its full-ingest injection points to make exactly this
-    distinction (batch.py, the membership-governed branch and the
-    classify_raw_revision_cohort branch).
+    resolve). The first is a conveyor hand-off; the second is a durable
+    fail-closed materialization outcome. Neither is a transient source-file
+    failure, so the live cursor must not re-read unchanged bytes for either
+    state. ``LiveBatchProcessor._ingest_full_records_archive`` uses
+    ``raw_membership_decision_pending`` (not the coarse boolean alone) to
+    preserve this distinction in its durable raw-authority state while both
+    paths remain cursor-idempotent.
 
     This is an archive-tier predicate test rather than a full watcher
     end-to-end scenario because, by construction,
@@ -4006,8 +4009,12 @@ def test_single_session_full_cannot_overwrite_divergent_membership_head(
     assert processor._ingest_full_paths_sync([bundle], source_name="codex").failed == []
     divergent_result = processor._ingest_full_paths_sync([divergent], source_name="codex")
 
-    assert divergent_result.succeeded == []
-    assert divergent_result.failed == [divergent]
+    # Divergence remains fail-closed for the materialized head, but the source
+    # bytes were acquired and parsed successfully. Treating this as a cursor
+    # success prevents each daemon restart from reprocessing the same decided
+    # conflict until the file actually changes.
+    assert divergent_result.succeeded == [divergent]
+    assert divergent_result.failed == []
     with sqlite3.connect(index_db) as conn:
         assert conn.execute(
             """

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -32,6 +32,7 @@ from polylogue.sources.live.batch_support import (
     _AppendPlan,
     _AppendResult,
     _detect_provider_from_path_sample,
+    _FullIngestResult,
     _parse_path_as_session_artifact,
     encode_cursor_hash_authority,
     sha256_range_from_path,
@@ -4306,6 +4307,54 @@ def test_live_raw_compaction_ignores_cursor_db_without_source_db(tmp_path: Path)
     with cursor._connect() as conn:
         rows = conn.execute("SELECT raw_id FROM raw_sessions").fetchall()
     assert rows == [("raw-old",)]
+
+
+@pytest.mark.asyncio
+async def test_live_full_ingest_skips_convergence_without_session_changes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cursor-only raw observation must not rerun global workflow materializers."""
+    root = tmp_path / "sessions"
+    root.mkdir()
+    path = root / "unchanged.json"
+    path.write_text("{}", encoding="utf-8")
+    cursor = CursorStore(tmp_path / "live.sqlite")
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=cursor._db_path))),
+        (WatchSource(name="sessions", root=root, suffixes=(".json",)),),
+        cursor=cursor,
+        parser_fingerprint="test-parser",
+    )
+    convergence_calls: list[list[Path]] = []
+
+    async def fake_full_ingest(
+        paths: list[Path], *, source_name: str, heartbeat: object | None = None, attempt_id: str | None = None
+    ) -> _FullIngestResult:
+        del source_name, heartbeat, attempt_id
+        return _FullIngestResult(
+            succeeded=paths,
+            failed=[],
+            source_payload_read_bytes=0,
+            raw_fingerprints={path: "raw-unchanged"},
+            changed_session_count=0,
+        )
+
+    def record_convergence(paths: list[Path]) -> tuple[set[Path], float, dict[str, float], list[object]]:
+        convergence_calls.append(paths)
+        return set(paths), 0.0, {}, []
+
+    monkeypatch.setattr(processor, "_append_plan", lambda _path, *, cursor: None)
+    monkeypatch.setattr(processor, "_ingest_full_paths", fake_full_ingest)
+    monkeypatch.setattr(processor, "_converge_paths", record_convergence)
+    monkeypatch.setattr(processor, "_record_full_cursor", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(processor, "_compact_superseded_raw_snapshots", lambda _paths: None)
+
+    metrics = await processor.ingest_files([path], emit_event=False)
+
+    assert convergence_calls == []
+    assert metrics.succeeded_file_count == 1
+    assert metrics.changed_session_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/sources/test_live_catchup_planning.py
+++ b/tests/unit/sources/test_live_catchup_planning.py
@@ -4,7 +4,6 @@ import asyncio
 import hashlib
 import os
 import sqlite3
-import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -339,6 +338,7 @@ def test_catch_up_ingests_needed_files_in_bounded_chunks(
 def test_catch_up_ingests_recent_source_before_historical_backlog(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    frozen_clock: FrozenClock,
 ) -> None:
     """A live session does not wait behind a full historical catch-up plan."""
     root = tmp_path / "src"
@@ -356,7 +356,7 @@ def test_catch_up_ingests_recent_source_before_historical_backlog(
         cast(Any, SimpleNamespace(archive_root=tmp_path, backend=None)),
         (WatchSource(name="test", root=root),),
     )
-    monkeypatch.setattr(time, "time", lambda: now)
+    frozen_clock.set_time(now)
     monkeypatch.setattr(live_watcher, "_CATCH_UP_MAX_BATCH_FILES", 1)
 
     calls: list[list[Path]] = []

--- a/tests/unit/sources/test_live_catchup_planning.py
+++ b/tests/unit/sources/test_live_catchup_planning.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import os
 import sqlite3
+import time
 from datetime import datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -355,7 +356,7 @@ def test_catch_up_ingests_recent_source_before_historical_backlog(
         cast(Any, SimpleNamespace(archive_root=tmp_path, backend=None)),
         (WatchSource(name="test", root=root),),
     )
-    monkeypatch.setattr(live_watcher.time, "time", lambda: now)
+    monkeypatch.setattr(time, "time", lambda: now)
     monkeypatch.setattr(live_watcher, "_CATCH_UP_MAX_BATCH_FILES", 1)
 
     calls: list[list[Path]] = []

--- a/tests/unit/sources/test_live_catchup_planning.py
+++ b/tests/unit/sources/test_live_catchup_planning.py
@@ -335,6 +335,41 @@ def test_catch_up_ingests_needed_files_in_bounded_chunks(
     assert retry_scan_calls == [3]
 
 
+def test_catch_up_ingests_recent_source_before_historical_backlog(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A live session does not wait behind a full historical catch-up plan."""
+    root = tmp_path / "src"
+    root.mkdir()
+    historical = root / "historical.jsonl"
+    current = root / "current.jsonl"
+    historical.write_text('{"role":"user","content":"old"}\n')
+    current.write_text('{"role":"user","content":"live"}\n')
+    now = 1_800_000_000.0
+    os.utime(
+        historical, (now - live_watcher._CATCH_UP_HOT_FILE_AGE_S - 1, now - live_watcher._CATCH_UP_HOT_FILE_AGE_S - 1)
+    )
+    os.utime(current, (now, now))
+    watcher = LiveWatcher(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=None)),
+        (WatchSource(name="test", root=root),),
+    )
+    monkeypatch.setattr(live_watcher.time, "time", lambda: now)
+    monkeypatch.setattr(live_watcher, "_CATCH_UP_MAX_BATCH_FILES", 1)
+
+    calls: list[list[Path]] = []
+
+    async def fake_ingest_files(paths: list[Path], **_kwargs: object) -> None:
+        calls.append(paths)
+
+    watcher._ingest_files = fake_ingest_files  # type: ignore[assignment,method-assign]
+
+    asyncio.run(watcher._catch_up([root]))
+
+    assert calls == [[current], [historical]]
+
+
 def test_catch_up_does_not_immediately_requeue_failed_paths(tmp_path: Path) -> None:
     root = tmp_path / "src"
     root.mkdir()

--- a/tests/unit/storage/test_bulk_fts_prefix_reextract.py
+++ b/tests/unit/storage/test_bulk_fts_prefix_reextract.py
@@ -305,6 +305,58 @@ def test_bulk_fts_trigram_survives_guarded_prefix_delete(tmp_path: Path) -> None
     conn.close()
 
 
+def test_full_replace_bulk_guard_rebuilds_both_fts_surfaces(tmp_path: Path) -> None:
+    """A normal full replacement must batch both FTS surfaces, not just lineage deletes.
+
+    The production live-ingest path uses a full replacement for a changed
+    Codex JSONL.  This exercises its own tool-use delete/insert cycle and
+    proves the guard's explicit rebuild leaves messages FTS, trigram search,
+    and the guard state coherent.
+    """
+    conn = _connect(tmp_path / "index.db")
+    original = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="full-replace",
+        title="before",
+        messages=[_tool_msg("m0", Role.ASSISTANT, "before", 0, "rg before-command")],
+    )
+    session_id = write_parsed_session_to_archive(conn, original)
+    replacement = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="full-replace",
+        title="after",
+        messages=[_tool_msg("m1", Role.ASSISTANT, "after", 0, "pytest after-command")],
+    )
+    assert write_parsed_session_to_archive(conn, replacement) == session_id
+
+    assert_session_fts_exact_sync(conn, session_id)
+    assert _trigram_ghost_posting_count(conn) == 0
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM blocks WHERE session_id = ? AND rowid IN "
+            "(SELECT rowid FROM blocks_command_trigram WHERE tool_detail_text LIKE '%after-command%')",
+            (session_id,),
+        ).fetchone()[0]
+        == 1
+    )
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM blocks WHERE session_id = ? AND rowid IN "
+            "(SELECT rowid FROM blocks_command_trigram WHERE tool_detail_text LIKE '%before-command%')",
+            (session_id,),
+        ).fetchone()[0]
+        == 0
+    )
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM derived_refresh_guard WHERE guard_name = ?",
+            (FTS_BULK_SESSION_WRITE_GUARD,),
+        ).fetchone()[0]
+        == 0
+    )
+    conn.close()
+
+
 def test_bulk_fts_guard_row_cleared_even_on_exception(tmp_path: Path) -> None:
     """A failure mid-guard must not leave the dedicated guard row set."""
     conn = _connect(tmp_path / "index.db")

--- a/tests/unit/storage/test_bulk_fts_prefix_reextract.py
+++ b/tests/unit/storage/test_bulk_fts_prefix_reextract.py
@@ -37,6 +37,7 @@ from polylogue.archive.message.roles import Role
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.core.enums import BlockType, Provider
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.fts.fts_lifecycle import repair_message_fts_index_sync
 from polylogue.storage.fts.sql import FTS_BULK_SESSION_WRITE_GUARD
 from polylogue.storage.sqlite.archive_tiers import write as _write_module
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
@@ -351,6 +352,64 @@ def test_full_replace_bulk_guard_rebuilds_both_fts_surfaces(tmp_path: Path) -> N
         conn.execute(
             "SELECT COUNT(*) FROM derived_refresh_guard WHERE guard_name = ?",
             (FTS_BULK_SESSION_WRITE_GUARD,),
+        ).fetchone()[0]
+        == 0
+    )
+    conn.close()
+
+
+def test_deferred_full_replace_trigram_survives_catchup_repair(tmp_path: Path) -> None:
+    """Regression: a deferred full-replace must not permanently drop trigram postings.
+
+    ``defer_fts_rebuild=True`` skips the immediate re-insert (the live-ingest
+    perf path -- polylogue-6mvg) and instead marks FTS stale for the existing
+    session-scoped convergence-debt retry. ``repair_message_fts_index_sync``
+    is that catch-up's only repair call, so it must repopulate
+    ``blocks_command_trigram`` too, not just ``messages_fts``.
+    """
+    conn = _connect(tmp_path / "index.db")
+    original = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="deferred-full-replace",
+        title="before",
+        messages=[_tool_msg("m0", Role.ASSISTANT, "before", 0, "rg before-command")],
+    )
+    session_id = write_parsed_session_to_archive(conn, original)
+    replacement = ParsedSession(
+        source_name=Provider.CODEX,
+        provider_session_id="deferred-full-replace",
+        title="after",
+        messages=[_tool_msg("m1", Role.ASSISTANT, "after", 0, "pytest after-command")],
+    )
+    assert write_parsed_session_to_archive(conn, replacement, defer_fts_rebuild=True) == session_id
+
+    # Deferred: the replacement's trigram posting is not yet present.
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM blocks WHERE session_id = ? AND rowid IN "
+            "(SELECT rowid FROM blocks_command_trigram WHERE tool_detail_text LIKE '%after-command%')",
+            (session_id,),
+        ).fetchone()[0]
+        == 0
+    )
+
+    repair_message_fts_index_sync(conn, [session_id], record_exact_snapshot=False)
+
+    assert_session_fts_exact_sync(conn, session_id)
+    assert _trigram_ghost_posting_count(conn) == 0
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM blocks WHERE session_id = ? AND rowid IN "
+            "(SELECT rowid FROM blocks_command_trigram WHERE tool_detail_text LIKE '%after-command%')",
+            (session_id,),
+        ).fetchone()[0]
+        == 1
+    )
+    assert (
+        conn.execute(
+            "SELECT COUNT(*) FROM blocks WHERE session_id = ? AND rowid IN "
+            "(SELECT rowid FROM blocks_command_trigram WHERE tool_detail_text LIKE '%before-command%')",
+            (session_id,),
         ).fetchone()[0]
         == 0
     )

--- a/tests/unit/storage/test_fts_repair_sql.py
+++ b/tests/unit/storage/test_fts_repair_sql.py
@@ -99,6 +99,31 @@ def test_missing_fts_repair_commits_and_checkpoints_batches(test_conn: sqlite3.C
     assert len(checkpoints) == 3
 
 
+def test_bulk_fts_rebuild_resumes_from_committed_missing_rows(test_conn: sqlite3.Connection) -> None:
+    """The bulk-generation mode keeps already committed FTS rows on retry."""
+    restore_fts_triggers_sync(test_conn)
+    for index in range(3):
+        _seed_text_block(
+            test_conn,
+            native_session_id=f"conv-bulk-resume-{index}",
+            native_message_id=f"msg-bulk-resume-{index}",
+            text=f"bulk resume needle {index}",
+        )
+    test_conn.execute("DELETE FROM messages_fts")
+    test_conn.execute("DELETE FROM messages_fts_identity")
+
+    inserted = insert_missing_message_fts_rows_sync(test_conn, batch_rows=1)
+    assert inserted == 3
+    identity_before = test_conn.execute("SELECT COUNT(*) FROM messages_fts_identity").fetchone()[0]
+
+    rebuild_fts_index_sync(test_conn, resume_from_empty_message_index=True)
+
+    source_rows = test_conn.execute("SELECT COUNT(*) FROM blocks WHERE search_text != ''").fetchone()[0]
+    assert test_conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0] == source_rows
+    assert test_conn.execute("SELECT COUNT(*) FROM messages_fts_identity").fetchone()[0] == source_rows
+    assert identity_before == source_rows
+
+
 def test_excess_fts_repair_deletes_orphan_docsize_rows(test_conn: sqlite3.Connection) -> None:
     restore_fts_triggers_sync(test_conn)
     message_id = _seed_text_block(

--- a/tests/unit/storage/test_fts_repair_sql.py
+++ b/tests/unit/storage/test_fts_repair_sql.py
@@ -67,6 +67,36 @@ def test_incremental_fts_repair_deletes_via_block_rowid(test_conn: sqlite3.Conne
     assert "SEARCH blocks USING" in plan
 
 
+def test_incremental_fts_repair_uses_direct_fts_rowid_deletes(test_conn: sqlite3.Connection) -> None:
+    """A changed session must not make FTS5 scan the whole archive to delete."""
+    restore_fts_triggers_sync(test_conn)
+    message_id = _seed_text_block(
+        test_conn,
+        native_session_id="conv-message-repair-direct-delete",
+        native_message_id="msg-message-repair-direct-delete",
+        text="direct FTS rowid delete needle",
+    )
+    session_id = "unknown-export:conv-message-repair-direct-delete"
+
+    traced: list[str] = []
+    test_conn.set_trace_callback(traced.append)
+    try:
+        repair_message_fts_index_sync(test_conn, [session_id], record_exact_snapshot=False)
+    finally:
+        test_conn.set_trace_callback(None)
+
+    delete_statements = [sql for sql in traced if sql.startswith("DELETE FROM messages_fts")]
+    assert delete_statements == [
+        "DELETE FROM messages_fts WHERE rowid = "
+        + str(
+            test_conn.execute(
+                "SELECT rowid FROM blocks WHERE message_id = ?",
+                (message_id,),
+            ).fetchone()[0]
+        )
+    ]
+
+
 def test_global_missing_fts_sql_is_rowid_bounded() -> None:
     sql = " ".join(insert_missing_message_rows_range_sql().split())
 

--- a/tests/unit/storage/test_fts_repair_sql.py
+++ b/tests/unit/storage/test_fts_repair_sql.py
@@ -17,6 +17,7 @@ from polylogue.storage.fts.sql import (
     delete_session_rows_sql,
     insert_missing_message_rows_range_sql,
     insert_session_rows_sql,
+    trigram_delete_session_rows_sql,
 )
 
 
@@ -65,6 +66,23 @@ def test_incremental_fts_repair_deletes_via_block_rowid(test_conn: sqlite3.Conne
         )
     )
     assert "SEARCH blocks USING" in plan
+
+
+def test_session_trigram_cleanup_seeks_docsize_by_block_rowid(test_conn: sqlite3.Connection) -> None:
+    """Guarded full replacement must not scan trigram FTS docsize globally."""
+    sql = " ".join(trigram_delete_session_rows_sql().split())
+    assert "JOIN blocks_command_trigram_docsize AS d ON d.id = b.rowid" in sql
+    assert "IN (SELECT id FROM blocks_command_trigram_docsize)" not in sql
+
+    plan = "\n".join(
+        row[3]
+        for row in test_conn.execute(
+            f"EXPLAIN QUERY PLAN {trigram_delete_session_rows_sql()}",
+            ("test:conv1",),
+        )
+    )
+    assert "SEARCH b USING INDEX idx_blocks_session_position" in plan
+    assert "SEARCH d USING INTEGER PRIMARY KEY" in plan
 
 
 def test_incremental_fts_repair_uses_direct_fts_rowid_deletes(test_conn: sqlite3.Connection) -> None:


### PR DESCRIPTION
## Summary

Continuation of the resumable-bulk-FTS perf line (#3281): moves message FTS/trigram repair off the sole-writer hot path for live ingest, catch-up, and membership replay, and adds daemon catch-up ordering fixes found along the way.

## Problem

A 19 MB live Codex session held the sole writer for over 31 minutes doing targeted FTS repair inline, even though its raw acquisition and canonical session projection were already durable. Membership-governed replay and full-replace paths had the same shape: FTS teardown/rebuild ran synchronously inside the write transaction, and some of it duplicated work the post-write repair pass would redo anyway. Separately, catch-up ordering let historical backlog starve live sources, and unresolved-but-decided membership conflicts were mis-counted as retryable failures, causing repeated reparsing on daemon restart.

## Solution

- Live authoritative replay, membership replay, and full-replace paths now commit canonical state, mark FTS stale, and queue the existing session-scoped FTS convergence debt instead of repairing inline.
- Eliminate a duplicate authoritative-replay FTS rebuild that ran once inline and again in the deferred repair.
- FTS trigram/session cleanup seeks rows by canonical block rowid join instead of a virtual-table `IN` subquery.
- Full-replace FTS teardown timing is now split into distinct stages (message FTS / identity-ledger / trigram deletes) for observability.
- Full ingest convergence is skipped entirely for cursor-only observations that didn't change a session.
- Decided-but-unresolved membership conflicts are preserved as cursor-complete raw authority debt instead of retried as transient failures.
- Daemon catch-up now prioritizes live sources over historical backlog, and defers Drive catch-up until local capture completes.
- `rebuild_index` bulk FTS materialization checkpoints progress (base for #3281, rebased here after that merge).

## Verification

- `devtools verify --quick` — pass (ruff format/check, mypy, render all, topology/layering/closure-matrix/manifests/ci-workflows/doc-commands/docs-coverage/test-infra-currency/test-clock-hygiene/pytest-timeout-overrides/degrade-loudly).
- `devtools test tests/unit/sources/test_live_batch_support.py tests/unit/sources/test_live_catchup_planning.py tests/unit/storage/test_revision_replay.py tests/unit/storage/test_fts_identity_ledger.py tests/unit/storage/test_fts_repair_sql.py tests/unit/storage/test_bulk_fts_prefix_reextract.py tests/unit/daemon/test_daemon_cli.py` — all passing (see individual commit messages for per-commit pass counts).

Ref polylogue-6mvg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup ordering so background synchronization begins only after watcher catch-up completes.
  * Prioritized recently updated source files during catch-up while continuing to process historical backlog.
  * Reduced unnecessary convergence work when ingestion produces no session changes.
  * Preserved unresolved membership decisions for later handling instead of incorrectly marking ingestion as failed.
  * Improved search index rebuilding and cleanup to prevent stale or missing results during bulk updates and session replacement.

* **Tests**
  * Added coverage for catch-up ordering, deferred convergence, membership outcomes, and search index consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->