### PR TITLE
fix(devtools): repair verify-quick gate broken by tracker-authority merge

### DIFF
--- a/devtools/docs_surface.py
+++ b/devtools/docs_surface.py
@@ -216,6 +216,12 @@ DOCS_REFERENCE_ENTRIES: tuple[DocsEntry, ...] = (
     _entry(
         "Release Checklist", "release.md", "Cut-time packaging, installed-artifact, and publish checks.", "operations"
     ),
+    _entry(
+        "Tracker Authority",
+        "tracker-authority.md",
+        "GitHub and Beads authority split, and the reconciliation script that checks it.",
+        "operations",
+    ),
     # Evidence and product
     _entry(
         "Demos and Proofs",

--- a/devtools/reconcile_tracker_authority.py
+++ b/devtools/reconcile_tracker_authority.py
@@ -65,6 +65,8 @@ def _export_live_rows() -> dict[str, dict[str, Any]]:
 
 def _load_manifest(path: Path) -> dict[str, Any]:
     payload = json.loads(path.read_text())
+    if not isinstance(payload, dict):
+        raise ValueError(f"tracker authority manifest is not a JSON object: {type(payload).__name__}")
     if payload.get("version") != 1:
         raise ValueError(f"unsupported manifest version: {payload.get('version')!r}")
     bindings = payload.get("bindings")
@@ -156,13 +158,10 @@ def _apply_binding(row: dict[str, Any], binding: dict[str, Any], *, timestamp: s
 
 
 def _write_candidate(rows: dict[str, dict[str, Any]]) -> Path:
-    handle = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False)
-    path = Path(handle.name)
-    try:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as handle:
+        path = Path(handle.name)
         for issue_id in sorted(rows):
             handle.write(json.dumps(rows[issue_id], sort_keys=True) + "\n")
-    finally:
-        handle.close()
     return path
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,7 @@ Start with **Guides** for a task, **Reference** for a surface contract, and **Ar
 | [Test Quality Workflows](test-quality-workflows.md) | Executable mutation-campaign and benchmark registries. |
 | [Visual Evidence](visual-evidence.md) | Synthetic reader DOM/media evidence lanes and local screenshot boundaries. |
 | [Release Checklist](release.md) | Cut-time packaging, installed-artifact, and publish checks. |
+| [Tracker Authority](tracker-authority.md) | GitHub and Beads authority split, and the reconciliation script that checks it. |
 
 ## Demos, Evidence, and Product
 


### PR DESCRIPTION
## Summary

`devtools verify --quick` (and its `render all --check`/lint/mypy components) currently fails on `master` HEAD itself.

## Problem

The tracker-authority PR that merged earlier today added `docs/tracker-authority.md` and `devtools/reconcile_tracker_authority.py` without ever registering the doc in `devtools/docs_surface.py`'s registry, and the script fails both `ruff check` (SIM115: unpaired `NamedTemporaryFile` open/close) and `mypy --strict` (`_load_manifest` returns `Any` from a `dict[str, Any]`-typed function). None of this was caught pre-merge — GitHub's squash-merge button doesn't run the local pre-push hook, so nothing exercised the quick gate against the final merged tree. Discovered while rebasing an unrelated worktree onto master and finding `devtools verify --quick` red at HEAD with no local changes.

## Solution

- Registered "Tracker Authority" in `docs_surface.py`'s operations tier and regenerated `docs/README.md`.
- `_write_candidate` now opens its temp file with a context manager instead of an unpaired open/finally-close.
- `_load_manifest` narrows `json.loads()`'s result with an `isinstance(payload, dict)` check before returning it as `dict[str, Any]`.

## Verification

- `devtools test tests/unit/devtools/test_render_docs_surface.py` — 5 passed.
- `devtools verify --quick` — pass (confirmed failing at HEAD before this change, exit 1 via `render all` reporting the unindexed doc, plus the ruff/mypy findings).