### PR TITLE
fix(storage): auto-resolve stale-plan blockers, no operator judgment needed

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -1044,6 +1044,19 @@ def _drain_raw_materialization_once(
     )
     if recover:
         raw_authority.recover_interrupted_frontier(config)
+    # polylogue-d7im: a stale-plan blocker requires no operator judgment (it
+    # is a pure TOCTOU race between a census and its apply, already
+    # recomputed unattended in the crash-recovery path above) but, left
+    # unresolved, unresolved_raw_replay_blockers makes repair_materialization
+    # below fail closed for the WHOLE archive, not just the affected raw.
+    # Clear these automatically before every pass instead of waiting for a
+    # manual raw-authority-blocker-resolve invocation.
+    auto_resolved = raw_authority.auto_resolve_stale_plan_blockers(config)
+    if auto_resolved:
+        logger.info(
+            "raw authority: auto-resolved %d stale-plan blocker(s) before raw materialization",
+            auto_resolved,
+        )
     try:
         result = raw_authority.repair_materialization(
             config,

--- a/polylogue/product/raw_authority.py
+++ b/polylogue/product/raw_authority.py
@@ -69,6 +69,20 @@ def recover_interrupted_frontier(config: Config) -> tuple[str, ...]:
     return recover_interrupted_raw_authority_frontier(config)
 
 
+def auto_resolve_stale_plan_blockers(config: Config) -> int:
+    """Clear every unresolved stale-plan blocker automatically (polylogue-d7im).
+
+    See ``storage.raw_authority.auto_resolve_stale_plan_blockers`` for why
+    this is safe to run unattended: a stale-plan blocker requires no
+    judgment content, and this is the one non-frontier blocker kind
+    ``repair_materialization`` checks archive-wide before doing any repair
+    work at all (``unresolved_raw_replay_blockers``).
+    """
+    from polylogue.storage.raw_authority import auto_resolve_stale_plan_blockers as _auto_resolve
+
+    return _auto_resolve(config.archive_root)
+
+
 def repair_materialization(
     config: Config,
     *,

--- a/polylogue/storage/raw_authority.py
+++ b/polylogue/storage/raw_authority.py
@@ -1765,6 +1765,82 @@ def resolve_raw_authority_blocker(
     )
 
 
+#: Fixed, non-arbitrary resolution text for automatic stale-plan clearing.
+#: Distinguishes an automated clearing pass's receipts from an operator's own
+#: free-text resolution in ``raw_authority_blockers.resolution`` (searchable).
+AUTO_STALE_PLAN_RESOLUTION = (
+    "automatic: stale plan superseded by current evidence, no operator judgment required (polylogue-d7im)"
+)
+
+
+def auto_resolve_stale_plan_blockers(archive_root: Path) -> int:
+    """Clear every unresolved ``stale_plan`` blocker automatically.
+
+    polylogue-d7im: ``resolve_raw_authority_blocker``'s non-frontier
+    (``stale_plan``) branch does not consult its ``resolution`` argument for
+    anything beyond a non-empty-string check (see that function) -- it only
+    recomputes the plan from current evidence via :func:`build_raw_replay_plan`
+    (a pure read/snapshot, no writes) and tombstones the blocked state so the
+    ordinary convergence pipeline can retry the same raws. There is no
+    judgment content a human/agent could supply that changes this outcome:
+    unlike a ``frontier_judgment`` blocker (which requires an accepted
+    assertion + disposition -- unaffected, this function only ever touches
+    the non-frontier kind), a stale plan is a pure TOCTOU race between a
+    census and its apply, already recomputed unattended in the equivalent
+    crash-recovery path (:func:`recover_interrupted_raw_authority_censuses`).
+
+    This closes the actual harm a stale-plan blocker causes today:
+    ``unresolved_raw_replay_blockers`` (the gate ``repair_materialization``
+    checks every pass) counts ANY unresolved stale-plan blocker archive-wide
+    and, if nonzero, skips repair for every other raw too -- so one stale
+    plan on one component halted ordinary materialization for the whole
+    archive until someone ran the manual CLI with a throwaway
+    acknowledgment string. Called from the daemon's own periodic
+    materialization loop before ``repair_materialization``, so this replaces
+    "wait indefinitely for an operator" with "clear automatically on the
+    very next pass" -- the write is a plain tombstone-and-resolve, not a
+    re-materialization, so a component whose recomputed plan is still not
+    fully settled simply falls through to the ordinary retryable/blocked
+    paths on the next pass rather than being force-applied.
+
+    Returns the number of blockers cleared. Individual failures (a blocker
+    resolved by a concurrent caller between listing and resolving) are
+    logged and skipped rather than aborting the whole batch.
+    """
+    source_db = archive_root / "source.db"
+    if not source_db.is_file():
+        return 0
+    with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as conn:
+        exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='raw_authority_blockers'"
+        ).fetchone()
+        if exists is None:
+            return 0
+        blocker_ids = tuple(
+            str(row[0])
+            for row in conn.execute(
+                """
+                SELECT b.blocker_id
+                FROM raw_authority_blockers AS b
+                JOIN raw_authority_plans AS p ON p.plan_id = b.plan_id
+                WHERE b.resolved_at_ms IS NULL
+                  AND COALESCE(json_extract(p.authority_witness_json, '$.schema'), '') !=
+                      'polylogue.raw-authority-frontier-plan.v1'
+                """
+            ).fetchall()
+        )
+    resolved_count = 0
+    for blocker_id in blocker_ids:
+        try:
+            resolve_raw_authority_blocker(archive_root, blocker_id, resolution=AUTO_STALE_PLAN_RESOLUTION)
+            resolved_count += 1
+        except (KeyError, RuntimeError):
+            # Already resolved by a concurrent caller, or changed underfoot
+            # between listing and resolving -- not this pass's problem.
+            continue
+    return resolved_count
+
+
 def reject_stale_raw_replay_plan(
     archive_root: Path,
     census_id: str,
@@ -1973,6 +2049,7 @@ def prune_orphaned_index_revision_seeds(
 
 
 __all__ = [
+    "AUTO_STALE_PLAN_RESOLUTION",
     "RAW_AUTHORITY_CENSUS_QUERY_PREFIX",
     "RAW_AUTHORITY_DETAIL_CHUNK_CHARS",
     "RAW_AUTHORITY_DETAIL_QUERY_PREFIX",
@@ -1983,6 +2060,7 @@ __all__ = [
     "RawReplayPlan",
     "RawReplayPlanOutcome",
     "RawReplayPlanStatus",
+    "auto_resolve_stale_plan_blockers",
     "build_raw_replay_plan",
     "build_raw_replay_plans",
     "describe_raw_authority_blocker",

--- a/tests/unit/storage/test_raw_authority_ledger.py
+++ b/tests/unit/storage/test_raw_authority_ledger.py
@@ -19,9 +19,11 @@ from polylogue.storage import raw_authority as raw_authority_mod
 from polylogue.storage import repair as repair_mod
 from polylogue.storage.archive_readiness import raw_materialization_readiness_snapshot, raw_materialization_ready
 from polylogue.storage.raw_authority import (
+    AUTO_STALE_PLAN_RESOLUTION,
     RawReplayPlan,
     RawReplayPlanOutcome,
     RawReplayPlanStatus,
+    auto_resolve_stale_plan_blockers,
     build_raw_replay_plans,
     finalize_raw_authority_census,
     read_raw_authority_census,
@@ -253,6 +255,108 @@ def test_stale_plan_persists_blocker_before_automatic_replay_refuses_work(tmp_pa
     assert refused.success is False
     assert refused.metrics["raw_materialization_unresolved_blocker_count"] == 1.0
     assert raw_materialization_ready(raw_materialization_readiness_snapshot(tmp_path)) is False
+
+
+def test_auto_resolve_stale_plan_blockers_unblocks_materialization_unattended(tmp_path: Path) -> None:
+    """polylogue-d7im: one stale-plan blocker halts repair_materialization
+    archive-wide (unresolved_raw_replay_blockers counts it), even though
+    resolving it requires no operator judgment -- it only recomputes the
+    plan from current evidence, exactly as an unattended crash-recovery pass
+    already does elsewhere. auto_resolve_stale_plan_blockers must clear it
+    without any human-supplied resolution text, and repair must proceed
+    on the very next call."""
+    initialize_active_archive_root(tmp_path)
+    raw_id = _write_codex_raw(tmp_path, native_id="stale2", source_path="stale2.jsonl", acquired_at_ms=1)
+    census_historical_revision_evidence(tmp_path, selected_raw_ids=[raw_id])
+    plan = build_raw_replay_plans(tmp_path, ((raw_id,),))[0]
+    census = record_raw_authority_census(
+        tmp_path,
+        (plan,),
+        selected_plan_ids={plan.plan_id},
+        mode="apply",
+        quiescent=True,
+        scope={"test": "stale-auto-resolve"},
+        residual={},
+    )
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute("UPDATE raw_sessions SET source_path = 'moved-after-plan-2.jsonl' WHERE raw_id = ?", (raw_id,))
+        conn.commit()
+    valid, observed = validate_raw_replay_plan(tmp_path, plan)
+    assert valid is False
+    reject_stale_raw_replay_plan(tmp_path, census.census_id, plan, observed)
+
+    refused = repair_raw_materialization(_config(tmp_path))
+    assert refused.success is False
+
+    resolved_count = auto_resolve_stale_plan_blockers(tmp_path)
+
+    assert resolved_count == 1
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert (
+            conn.execute("SELECT COUNT(*) FROM raw_authority_blockers WHERE resolved_at_ms IS NULL").fetchone()[0] == 0
+        )
+        resolution = conn.execute(
+            "SELECT json_extract(resolution, '$.operator_resolution') FROM raw_authority_blockers"
+        ).fetchone()[0]
+        assert resolution == AUTO_STALE_PLAN_RESOLUTION
+
+    proceeds = repair_raw_materialization(_config(tmp_path))
+    assert proceeds.metrics.get("raw_materialization_unresolved_blocker_count", 0.0) == 0.0
+
+    # Idempotent: nothing left to clear on a second call.
+    assert auto_resolve_stale_plan_blockers(tmp_path) == 0
+
+
+def test_auto_resolve_stale_plan_blockers_never_touches_frontier_judgment_blockers(tmp_path: Path) -> None:
+    """Frontier-judgment blockers require an accepted assertion id +
+    disposition (enforced inside resolve_raw_authority_blocker itself);
+    auto_resolve_stale_plan_blockers must only ever query non-frontier
+    (stale_plan) blockers, never attempt -- and therefore never accidentally
+    satisfy -- a judgment-gated one."""
+    initialize_active_archive_root(tmp_path)
+    raw_id = _write_codex_raw(tmp_path, native_id="judgment", source_path="judgment.jsonl", acquired_at_ms=1)
+    census_historical_revision_evidence(tmp_path, selected_raw_ids=[raw_id])
+    base_plan = build_raw_replay_plans(tmp_path, ((raw_id,),))[0]
+    frontier_plan = RawReplayPlan(
+        plan_id=base_plan.plan_id,
+        input_digest=base_plan.input_digest,
+        input_raw_ids=base_plan.input_raw_ids,
+        logical_keys=base_plan.logical_keys,
+        authority_witness=json_document({"schema": "polylogue.raw-authority-frontier-plan.v1"}),
+        source_preconditions=base_plan.source_preconditions,
+        index_preconditions=base_plan.index_preconditions,
+    )
+    census = record_raw_authority_census(
+        tmp_path,
+        (frontier_plan,),
+        selected_plan_ids={frontier_plan.plan_id},
+        mode="apply",
+        quiescent=True,
+        scope={"test": "frontier-judgment"},
+        residual={},
+    )
+    reject_stale_raw_replay_plan(
+        tmp_path,
+        census.census_id,
+        frontier_plan,
+        json_document({"judgment_assertion_id": "assertion:unaccepted"}),
+    )
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        blocker_id = conn.execute(
+            "SELECT blocker_id FROM raw_authority_blockers WHERE resolved_at_ms IS NULL"
+        ).fetchone()[0]
+
+    resolved_count = auto_resolve_stale_plan_blockers(tmp_path)
+
+    assert resolved_count == 0
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        assert (
+            conn.execute(
+                "SELECT COUNT(*) FROM raw_authority_blockers WHERE blocker_id = ? AND resolved_at_ms IS NULL",
+                (blocker_id,),
+            ).fetchone()[0]
+            == 1
+        )
 
 
 def test_interrupted_census_has_no_partial_plan_visibility_and_retries_once(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

A single stale-plan raw-authority blocker halts `repair_materialization` for the **entire archive**, not just the affected raw — and resolving it requires only a throwaway acknowledgment string that is never actually checked. This closes that gap: stale-plan blockers now clear automatically on the daemon's next materialization pass.

## Problem

`unresolved_raw_replay_blockers` — the gate `repair_materialization` checks every ~30s pass before doing any repair work — counts every unresolved *non-frontier* (`stale_plan`) blocker archive-wide. If nonzero, the whole pass fails closed with `success=False`, for every raw, not just the one behind the blocker. The function's own docstring states the design intent is the opposite: "one missing or conflicting authority must not starve unrelated, independently proven raw components" — that's exactly why frontier-schema blockers are excluded from this count, but a plain `stale_plan` blocker (a TOCTOU race between a census and its apply) isn't, and does exactly the thing the docstring says shouldn't happen.

Worse, clearing it manually via `raw-authority-blocker-resolve` turns out to add nothing: for a non-frontier blocker, `resolve_raw_authority_blocker` only checks the `resolution` string is non-empty, then recomputes the plan from current evidence via `build_raw_replay_plan` (a pure read/snapshot — no writes) and tombstones the blocked state. No judgment content changes that outcome. The equivalent crash-recovery path (`recover_interrupted_raw_authority_censuses`) already performs the same recompute completely unattended. Verified directly with a real stale-plan fixture: reproduced the archive-wide stall, confirmed the "resolution" text is never inspected beyond a truthiness check.

## Solution

- New `auto_resolve_stale_plan_blockers(archive_root)` in `storage/raw_authority.py`: clears every unresolved `stale_plan` blocker automatically, using the exact same non-frontier-only query `unresolved_raw_replay_blockers` uses, so it never touches a `frontier_judgment` blocker (those still require their accepted-assertion-id + disposition gate, enforced inside `resolve_raw_authority_blocker` itself).
- Wired into the daemon's existing periodic raw-materialization loop (`_drain_raw_materialization_once`), right before `repair_materialization` runs, so a stale plan clears on the very next tick instead of waiting on a manual CLI invocation.
- Product-boundary wrapper in `product/raw_authority.py` following the module's existing convention.

## Verification

- `devtools test tests/unit/storage/test_raw_authority_ledger.py tests/unit/daemon/test_daemon_cli.py tests/unit/storage/test_repair.py tests/unit/product/` — 255 passed, including:
  - a regression reproducing the exact archive-wide-halt scenario and proving auto-resolve clears it and lets repair proceed,
  - an idempotency check (nothing left to clear on a second call),
  - a negative test proving `frontier_judgment` blockers are never touched by this function.
- `devtools verify --quick` — pass.

Ref polylogue-d7im