### PR TITLE
perf(daemon): run periodic FTS merge every 60s instead of 300s

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -392,19 +392,37 @@ def _configure_fts_automerge_sync(db: Path) -> None:
         conn.close()
 
 
+#: Live incident 2026-07-27: a long-running ingest/append pass can hold the
+#: sole-writer lock for 14+ minutes straight (observed: 860s for one live
+#: watcher catch-up chunk). At the previous 300s interval this starved the
+#: merge task outright during exactly the backlog conditions it exists to
+#: help with -- messages_fts_data grew to 700K+ rows (steady state is far
+#: lower) before a merge got a turn, and unmerged segment bloat itself makes
+#: every subsequent per-block FTS5 insert slower, which lengthens the next
+#: writer hold and starves the merge task further: a genuine, self-
+#: reinforcing degradation spiral, not merely a slow one-off pass. Shortening
+#: the interval does not touch the per-call work bound (still the same small,
+#: bounded 500-work-unit / 2-4 MiB chunk -- the merge pass itself must never
+#: become a long writer hold, see fts_automerge.py) -- it only asks for the
+#: writer's turn more often, so once contention eases the backlog clears
+#: roughly 5x faster than before. This does not fix worst-case starvation
+#: (a single 14-minute hold still blocks every queued actor including this
+#: one) -- see polylogue-de2a for the harder writer-fairness question.
+_FTS_MERGE_INTERVAL_SECONDS = 60
+
+
 async def _periodic_fts_merge() -> None:
-    """Run a bounded FTS5 merge every 5 minutes to amortise segment cost (#1851).
+    """Run a bounded FTS5 merge every 60s to amortise segment cost (#1851).
 
     With automerge=0, level-0 FTS5 segments accumulate over time.  This
     periodic pass merges them in bounded 500-work-unit chunks so query
     performance stays good without ever paying the full merge cost in a
-    single write transaction.  The 5-minute interval matches the WAL
-    checkpoint loop so the two share the same maintenance cadence.
+    single write transaction.
     """
     from polylogue.daemon.fts_automerge import run_periodic_fts_merge_sync
 
     while True:
-        await asyncio.sleep(300)
+        await asyncio.sleep(_FTS_MERGE_INTERVAL_SECONDS)
         db = _active_index_db_path()
         if not db.exists():
             continue


### PR DESCRIPTION
## Summary

Shortens the FTS5 periodic-merge interval from 300s to 60s to break a self-reinforcing degradation spiral discovered live while investigating why PR #3287's stale-plan auto-resolve hadn't taken effect after deploy.

## Problem

Live incident, 2026-07-27: a single live-watcher catch-up append held the daemon's sole-writer lock for 860 seconds (14+ minutes) parsing/writing one modest (~7MB, 547-block) session. At the previous 300s merge interval this starved `_periodic_fts_merge` during exactly the backlog conditions it exists to help with.

Root cause chain, verified against the live archive (not speculation):
1. `messages_fts` runs with `automerge=0` (`fts_automerge.py`, #1851) — segment consolidation depends entirely on the periodic merge task, bounded to a small 500-work-unit (2-4 MiB) chunk per call by design.
2. `messages_fts_data` (the FTS5 shadow table) had grown to 705,281 rows live — far past steady state, consistent with the merge task being starved for an extended period.
3. Unmerged segment bloat degrades per-block FTS5 insert cost (a documented FTS5 characteristic), so ordinary append writes get progressively slower.
4. Slower writes → longer writer holds → less chance the merge task ever gets a turn → more bloat. Self-reinforcing, not a one-off slow pass.

## Solution

Interval 300s → 60s. The per-call work bound is unchanged — still the same deliberately small, bounded chunk (the merge pass itself must never become a long writer hold). This only asks for the writer's turn 5x more often, so once contention eases the backlog clears roughly 5x faster.

**Not a complete fix**: a single very long writer hold still blocks every queued actor regardless of how often they ask. The harder question — writer-lock fairness/priority, or bounding how long a single ingest pass can hold the lock without yielding — is tracked separately as polylogue-de2a, deliberately out of scope for this narrow, low-risk cadence change.

## Verification

- `devtools test tests/unit/daemon/test_daemon_cli.py` — 116 passed.
- `devtools verify --quick` — pass.

Ref polylogue-de2a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Full-text search maintenance now runs every 60 seconds, helping search indexes stay up to date more frequently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->