### PR TITLE
perf(daemon): give maintenance actors priority over bulk-ingest waiters

### DIFF
--- a/polylogue/daemon/write_coordinator.py
+++ b/polylogue/daemon/write_coordinator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import contextvars
+import heapq
 import threading
 import time
 import weakref
@@ -28,6 +29,91 @@ P = ParamSpec("P")
 T = TypeVar("T")
 WritePhase = Literal["queued", "acquired", "released"]
 WriteOutcome = Literal["success", "error", "cancelled"]
+
+# Bulk-ingest actors (live watcher catch-up/append batches) re-queue almost
+# immediately after each release, so under sustained backlog a strict-FIFO
+# gate lets them monopolize admission indefinitely: a periodic maintenance
+# actor (FTS merge, WAL checkpoint, convergence) that only wakes every N
+# seconds could be stuck behind an ever-refilling line of ingest waiters
+# (polylogue-de2a, live incident 2026-07-26: a 14-minute single hold plus
+# continuous re-queueing starved FTS merge long enough for messages_fts_data
+# to balloon to 705K rows). Everything except "watcher.*" actors is treated
+# as maintenance/interactive and admitted ahead of any queued watcher actor,
+# bounding worst-case maintenance wait to "current hold + at most one more
+# already-queued ingest hold" instead of "current hold + unbounded backlog".
+_BULK_INGEST_PRIORITY = 1
+_DEFAULT_PRIORITY = 0
+
+
+def _actor_priority(actor: str) -> int:
+    """Classify a writer actor for queue-admission ordering, not execution order.
+
+    This only changes which *queued* request is admitted next when several are
+    waiting; it does not preempt an actor that already holds the gate.
+    """
+    if actor.startswith("watcher."):
+        return _BULK_INGEST_PRIORITY
+    return _DEFAULT_PRIORITY
+
+
+class _PriorityGate:
+    """Single-holder async gate admitting the lowest-priority queued waiter first.
+
+    Mirrors ``asyncio.Lock``'s cancellation-safety shape (a waiter removes
+    itself from the wait set in all cases; a cancelled-after-woken waiter
+    re-triggers the wake so the grant is never silently dropped) but orders
+    waiters by ``(priority, sequence)`` instead of pure FIFO.
+    """
+
+    def __init__(self) -> None:
+        self._locked = False
+        self._waiters: list[tuple[int, int, asyncio.Future[None]]] = []
+        self._sequence = 0
+
+    @property
+    def locked(self) -> bool:
+        return self._locked
+
+    async def acquire(self, priority: int) -> None:
+        if not self._locked and not self._waiters:
+            self._locked = True
+            return
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future[None] = loop.create_future()
+        self._sequence += 1
+        entry = (priority, self._sequence, fut)
+        heapq.heappush(self._waiters, entry)
+        try:
+            await fut
+        except asyncio.CancelledError:
+            self._discard(entry)
+            if not self._locked:
+                self._wake_next()
+            raise
+        self._discard(entry)
+        self._locked = True
+
+    def release(self) -> None:
+        if not self._locked:
+            raise RuntimeError("_PriorityGate.release() called while not held")
+        self._locked = False
+        self._wake_next()
+
+    def _discard(self, entry: tuple[int, int, asyncio.Future[None]]) -> None:
+        try:
+            self._waiters.remove(entry)
+        except ValueError:
+            return
+        heapq.heapify(self._waiters)
+
+    def _wake_next(self) -> None:
+        while self._waiters:
+            _, _, fut = self._waiters[0]
+            if fut.done():
+                heapq.heappop(self._waiters)
+                continue
+            fut.set_result(None)
+            return
 
 
 @dataclass(frozen=True, slots=True)
@@ -97,7 +183,7 @@ class DaemonWriteCoordinator:
     """
 
     def __init__(self, *, observer: WriteEventObserver | None = None) -> None:
-        self._lock = asyncio.Lock()
+        self._lock = _PriorityGate()
         self._observer = observer
         self._sequence = 0
         self._active_actor: str | None = None
@@ -164,7 +250,7 @@ class DaemonWriteCoordinator:
 
     async def _execute(self, request: _WriteRequest, operation: Callable[[], Awaitable[T]]) -> T:
         try:
-            await self._lock.acquire()
+            await self._lock.acquire(_actor_priority(request.actor))
         except BaseException:
             self._remove_queued(request.sequence)
             raise

--- a/tests/unit/daemon/test_write_coordinator.py
+++ b/tests/unit/daemon/test_write_coordinator.py
@@ -16,8 +16,47 @@ from polylogue.daemon.write_coordinator import (
     DaemonWriteCoordinator,
     DaemonWriteEvent,
     DaemonWriteThreadBridge,
+    _actor_priority,
+    _PriorityGate,
     daemon_write_telemetry_payload,
 )
+
+
+def test_actor_priority_classifies_bulk_ingest_below_everything_else() -> None:
+    assert _actor_priority("watcher.catch_up.chunk") == 1
+    assert _actor_priority("watcher.live_batch") == 1
+    assert _actor_priority("maintenance.fts_merge") == 0
+    assert _actor_priority("maintenance.wal_checkpoint") == 0
+    assert _actor_priority("startup.fts_automerge") == 0
+    assert _actor_priority("daemon.lifecycle.heartbeat") == 0
+    # Exact "watcher" (no trailing segment) is not the bulk-ingest convention.
+    assert _actor_priority("watcher") == 0
+
+
+@pytest.mark.asyncio
+async def test_priority_gate_wake_survives_cancellation_before_resume() -> None:
+    """Reproduce the exact race a stdlib-Lock-shaped gate must survive: a
+    waiter is woken (its future gets a result) but is cancelled before it
+    resumes past ``await``. The grant must be forwarded, not dropped."""
+    gate = _PriorityGate()
+    await gate.acquire(0)  # first caller takes the gate synchronously
+
+    async def waiter() -> None:
+        await gate.acquire(0)
+
+    task = asyncio.create_task(waiter())
+    await asyncio.sleep(0)  # let it enqueue
+    assert gate.locked
+
+    gate.release()  # wakes the queued waiter's future (call_soon, not yet resumed)
+    task.cancel()  # cancel before the event loop resumes the woken task
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The grant must not be stranded: a fresh acquirer still succeeds.
+    successor = asyncio.create_task(gate.acquire(0))
+    await asyncio.wait_for(successor, timeout=1.0)
+    assert gate.locked
 
 
 @pytest.mark.asyncio
@@ -131,6 +170,102 @@ async def test_coordinator_serializes_fifo_without_writer_overlap() -> None:
     assert [event.actor for event in released] == call_order
     assert all(event.wait_seconds is not None and event.hold_seconds is not None for event in released)
     assert all(event.outcome == "success" for event in released)
+
+
+@pytest.mark.asyncio
+async def test_maintenance_actor_jumps_ahead_of_queued_bulk_ingest_actors() -> None:
+    """polylogue-de2a: a continuously-refilling watcher backlog must not starve
+    periodic maintenance. A queued ``maintenance.*``/other actor is admitted
+    before an earlier-queued ``watcher.*`` actor, though never before an
+    already-admitted one (queue-admission fairness only, not preemption)."""
+    queued = {
+        actor: asyncio.Event()
+        for actor in ("watcher.catch_up.chunk", "watcher.catch_up.chunk.2", "maintenance.fts_merge")
+    }
+    call_order: list[str] = []
+
+    def observe(event: DaemonWriteEvent) -> None:
+        if event.phase == "queued" and event.actor in queued:
+            queued[event.actor].set()
+
+    coordinator = DaemonWriteCoordinator(observer=observe)
+    release_owner = asyncio.Event()
+    owner_entered = asyncio.Event()
+
+    async def owner() -> None:
+        owner_entered.set()
+        await release_owner.wait()
+
+    async def tracked(actor: str) -> str:
+        call_order.append(actor)
+        return actor
+
+    owner_task = asyncio.create_task(coordinator.run("owner", owner))
+    await owner_entered.wait()
+
+    # Two watcher chunks queue first (as a continuously-refilling backlog
+    # would), then a maintenance actor queues last.
+    first_watcher = asyncio.create_task(
+        coordinator.run("watcher.catch_up.chunk", lambda: tracked("watcher.catch_up.chunk"))
+    )
+    await queued["watcher.catch_up.chunk"].wait()
+    second_watcher = asyncio.create_task(
+        coordinator.run("watcher.catch_up.chunk.2", lambda: tracked("watcher.catch_up.chunk.2"))
+    )
+    await queued["watcher.catch_up.chunk.2"].wait()
+    maintenance = asyncio.create_task(
+        coordinator.run("maintenance.fts_merge", lambda: tracked("maintenance.fts_merge"))
+    )
+    await queued["maintenance.fts_merge"].wait()
+
+    assert coordinator.snapshot().active_actor == "owner"
+    release_owner.set()
+    await asyncio.gather(owner_task, first_watcher, second_watcher, maintenance)
+
+    # Maintenance queued last but is admitted before either watcher waiter;
+    # among the two same-priority watcher waiters, arrival order still wins.
+    assert call_order == ["maintenance.fts_merge", "watcher.catch_up.chunk", "watcher.catch_up.chunk.2"]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_priority_waiter_does_not_strand_the_grant() -> None:
+    """Cancelling a still-queued higher-priority waiter must not drop the
+    gate: the next (lower-priority) waiter still gets admitted afterward."""
+    queued_maintenance = asyncio.Event()
+    queued_watcher = asyncio.Event()
+
+    def observe(event: DaemonWriteEvent) -> None:
+        if event.phase == "queued" and event.actor == "maintenance.wal_checkpoint":
+            queued_maintenance.set()
+        if event.phase == "queued" and event.actor == "watcher.catch_up.chunk":
+            queued_watcher.set()
+
+    coordinator = DaemonWriteCoordinator(observer=observe)
+    release_owner = asyncio.Event()
+    owner_entered = asyncio.Event()
+
+    async def owner() -> None:
+        owner_entered.set()
+        await release_owner.wait()
+
+    owner_task = asyncio.create_task(coordinator.run("owner", owner))
+    await owner_entered.wait()
+
+    maintenance_task = asyncio.create_task(coordinator.run("maintenance.wal_checkpoint", _unexpected_operation))
+    await queued_maintenance.wait()
+    watcher_task = asyncio.create_task(coordinator.run("watcher.catch_up.chunk", _return_ready))
+    await queued_watcher.wait()
+
+    # Cancel the higher-priority waiter while it is still queued (owner has
+    # not released yet), then release: the lower-priority watcher waiter must
+    # still be admitted, and the gate must not be left stuck.
+    maintenance_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await maintenance_task
+    release_owner.set()
+    await owner_task
+    assert await watcher_task == "ready"
+    assert await coordinator.run("next", _return_ready) == "ready"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `DaemonWriteCoordinator` serialized every writer through a plain `asyncio.Lock` (strict FIFO). Replaced it with a `_PriorityGate` that admits queued waiters by `(priority, arrival order)` instead of pure FIFO.
- Every actor name outside the existing `watcher.*` naming convention (`maintenance.*`, `startup.*`, `daemon.lifecycle.*`, etc.) is classified as higher priority and admitted ahead of any queued `watcher.*` waiter.

## Problem
Under a sustained live-watcher catch-up backlog, `watcher.*` chunk requests re-queue almost immediately after each release, so a periodic maintenance actor (FTS merge, WAL checkpoint, raw-materialization convergence) that only wakes every N seconds could get stuck behind an ever-refilling line of ingest waiters. This starved `polylogue-de2a`'s `auto_resolve_stale_plan_blockers` pass (`polylogue-d7im`) and let `messages_fts_data` balloon to 705K rows during a live incident (2026-07-26): a single 14-minute ingest hold plus continuous re-queueing left FTS merge with no turn for an extended period.

## Solution
Priority-ordered admission bounds worst-case maintenance latency to "current hold + at most one more already-queued ingest hold" instead of "current hold + unbounded backlog". This only reorders *queued* admission - it does **not** preempt an actor that already holds the gate, so it does not fix the separate (larger, riskier) problem of a single ingest pass holding the gate for minutes; that remains tracked in `polylogue-de2a` as the harder writer-preemption/internal-chunking fix.

The gate mirrors `asyncio.Lock`'s cancellation-safety shape (a cancelled waiter always removes itself and, if not yet re-locked, forwards the wake to the next waiter) so a waiter cancelled exactly as it's woken never strands the grant - covered by a dedicated test reproducing the race deterministically (`release()` then `task.cancel()` with no intervening `await`).

## Verification
- `tests/unit/daemon/test_write_coordinator.py`: 17 tests (3 new - actor-priority classification, priority-ordered admission under a simulated refilling backlog, wake-then-cancel race)
- Full `tests/unit/daemon/` suite: 1950 passed, 1 pre-existing unrelated failure (`test_no_token_in_log_or_print_calls`, a static scan flagging `http.py`/`browser_capture/server.py`, untouched by this change)
- `mypy --strict polylogue/daemon/write_coordinator.py`: clean
- `ruff check` + `format`: clean
- pre-push quick gate: all 16 checks green

Ref polylogue-de2a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Prioritized write operations so maintenance activity can proceed ahead of queued bulk-ingest work.
  * Preserved fair access for operations already in progress.
  * Improved reliability when queued write operations are cancelled, preventing the write queue from becoming stuck.
* **Tests**
  * Added coverage for priority ordering, cancellation handling, and continued coordinator availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->