### PR TITLE
feat(storage): add archive-location ownership acquisition for maintenance writers

### DIFF
--- a/polylogue/storage/archive_identity.py
+++ b/polylogue/storage/archive_identity.py
@@ -7,6 +7,7 @@ import logging
 import os
 import socket
 import sys
+import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -388,24 +389,39 @@ def _pid_is_alive(pid: int) -> bool:
     return True
 
 
+_STALE_RECLAIM_ATTEMPTS = 20
+_STALE_RECLAIM_RETRY_SECONDS = 0.01
+
+
 def _acquire_ownership_lock_fd(path: Path, *, owner: str) -> int:
     """Open ``path`` and take an exclusive, non-blocking ``flock`` proving ownership.
 
     Never opens a sqlite3 connection -- callers rely on this to fail before
-    any SQLite tier file is touched. A lock file whose recorded holder pid
-    is no longer running is reclaimed: a fresh file is written at the same
-    path and swapped in atomically, handing a brand-new, guaranteed-unlocked
-    inode to the new owner while any surviving reference to the old one is
-    left orphaned.
+    any SQLite tier file is touched.
+
+    A lock file whose recorded holder pid is no longer running is reclaimed
+    by retrying the *same* ``flock`` call against the *same* inode, never by
+    creating a second one. An earlier version of this function raced two
+    reclaimers by opening a fresh inode and ``os.replace``-ing it over
+    ``path``: if the true holder had just died, one reclaimer could win the
+    direct ``flock`` on the original (now-unlocked) inode while a second
+    reclaimer, having already observed ``BlockingIOError``, swapped in a
+    brand-new inode via rename -- leaving two processes each holding a lock
+    on a *different* inode and both believing they own the location. A dead
+    holder's ``flock`` is released by the kernel the moment its last fd
+    closes (process exit tears down the fd table), which happens at or
+    before the point another process can read pid= from the file and
+    confirm it's dead -- so retrying the identical ``flock`` call converges
+    quickly without ever creating a second inode to race against.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
     try:
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
     except BlockingIOError as exc:
-        os.close(fd)
         holder_pid = _lock_holder_pid(path)
         if holder_pid is None or _pid_is_alive(holder_pid):
+            os.close(fd)
             suffix = f" (pid={holder_pid})" if holder_pid is not None else ""
             raise ArchiveOwnershipError(f"archive location already owned: {path}{suffix}") from exc
         logger.warning(
@@ -413,16 +429,15 @@ def _acquire_ownership_lock_fd(path: Path, *, owner: str) -> int:
             path,
             holder_pid,
         )
-        reclaim = path.with_name(f".{path.name}.reclaim-{uuid.uuid4().hex}")
-        reclaimed_fd = os.open(reclaim, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
-        try:
-            fcntl.flock(reclaimed_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            os.close(reclaimed_fd)
-            reclaim.unlink(missing_ok=True)
+        for _ in range(_STALE_RECLAIM_ATTEMPTS):
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                time.sleep(_STALE_RECLAIM_RETRY_SECONDS)
+        else:
+            os.close(fd)
             raise ArchiveOwnershipError(f"archive location already owned: {path}") from exc
-        os.replace(reclaim, path)
-        fd = reclaimed_fd
     os.ftruncate(fd, 0)
     os.write(fd, owner.encode("utf-8"))
     os.fsync(fd)

--- a/polylogue/storage/archive_identity.py
+++ b/polylogue/storage/archive_identity.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import fcntl
 import logging
 import os
+import socket
 import sys
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
+from types import TracebackType
 from typing import Literal
 
 from polylogue.version import VERSION_INFO
@@ -261,3 +265,165 @@ def assert_writable_archive_identity(*, configured_root: Path, active_root: Path
             f"active_index={active.tier('index').resolved_path}"
         )
     return active
+
+
+class ArchiveOwnershipError(RuntimeError):
+    """A maintenance/campaign writer could not prove exclusive ownership of an archive location."""
+
+
+class OwnedArchiveLocation:
+    """Exclusive maintenance/campaign ownership proof over one :class:`ArchiveLocation`.
+
+    ``ArchiveLocation``/``ArchiveIdentity`` answer *what* a configured root,
+    tier, or resolved generation names.  They deliberately say nothing about
+    *who* may mutate it.  A maintenance or campaign writer (an offline index
+    rebuild, a devtools benchmark/scale campaign, a b5l generation
+    transition) must call :meth:`acquire` and receive a distinct
+    ``OwnedArchiveLocation`` token before opening SQLite against the
+    location's tiers -- an ``ArchiveLocation`` alone is never sufficient
+    authorization to write.
+
+    Acquisition is a pure filesystem preflight: it takes an exclusive
+    ``flock`` on a lock file under the configured root and never opens a
+    sqlite3 connection.  A location already owned by another live process
+    therefore fails closed -- ``ArchiveOwnershipError`` -- before any tier
+    file is created or touched, rather than surfacing later as a confusing
+    runtime error against an already-open writer connection (or, worse, two
+    writers silently racing the same generation).  This mirrors
+    ``assert_writable_archive_identity``'s preflight shape one level up: that
+    function proves *one coherent generation*; this one proves *one writer*
+    for that generation.
+    """
+
+    def __init__(self, location: ArchiveLocation) -> None:
+        self.location = location
+        self.lock_path = location.configured_root / ".archive-ownership.lock"
+        self.owner_id: str | None = None
+        self._fd: int | None = None
+
+    @classmethod
+    def acquire(cls, location: ArchiveLocation, *, owner_id: str | None = None) -> OwnedArchiveLocation:
+        """Claim exclusive ownership of ``location`` for a maintenance/campaign writer.
+
+        Raises :class:`ArchiveOwnershipError` immediately -- before any
+        SQLite tier file is opened -- when another live process already
+        holds the lock.  A lock file left behind by a process that is no
+        longer running is reclaimed rather than treated as a permanent
+        blocker, matching ``index_generation``'s stale-lease handling.
+        """
+        owner = owner_id or f"pid={os.getpid()} host={socket.gethostname()} token={uuid.uuid4().hex}"
+        instance = cls(location)
+        instance._fd = _acquire_ownership_lock_fd(instance.lock_path, owner=owner)
+        instance.owner_id = owner
+        return instance
+
+    def release(self) -> None:
+        if self._fd is not None:
+            fcntl.flock(self._fd, fcntl.LOCK_UN)
+            os.close(self._fd)
+            self._fd = None
+
+    def __enter__(self) -> OwnedArchiveLocation:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        del exc_type, exc, traceback
+        self.release()
+
+
+def assert_owns_archive_location(owned: OwnedArchiveLocation, location: ArchiveLocation) -> None:
+    """Fail before SQLite opens when an ownership proof does not cover ``location``.
+
+    An ``OwnedArchiveLocation`` is a token for one configured root at one
+    resolved active generation.  Reusing it against a different root (wrong
+    archive entirely) or the same root after its active generation moved on
+    (stale proof -- the pointer rotated after acquisition, e.g. a concurrent
+    promotion) must fail here rather than let the caller silently write
+    against tiers it never actually claimed.
+    """
+    if owned.location.configured_root != location.configured_root:
+        raise ArchiveOwnershipError(
+            "archive ownership proof does not cover this location: "
+            f"owned={owned.location.configured_root} target={location.configured_root}"
+        )
+    if not owned.location.active_index.same_file(location.active_index):
+        raise ArchiveOwnershipError(
+            "archive ownership proof is stale for the current active generation: "
+            f"owned={owned.location.active_index.stable_id} "
+            f"current={location.active_index.stable_id}"
+        )
+
+
+def _lock_holder_pid(path: Path) -> int | None:
+    """Best-effort recorded pid from an existing lock file; ``None`` if absent/unreadable."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    for token in text.split():
+        if token.startswith("pid="):
+            try:
+                return int(token[len("pid=") :])
+            except ValueError:
+                return None
+    return None
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Whether ``pid`` still names a live process, best-effort via ``kill(pid, 0)``."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Owned by another user but still running.
+        return True
+    return True
+
+
+def _acquire_ownership_lock_fd(path: Path, *, owner: str) -> int:
+    """Open ``path`` and take an exclusive, non-blocking ``flock`` proving ownership.
+
+    Never opens a sqlite3 connection -- callers rely on this to fail before
+    any SQLite tier file is touched. A lock file whose recorded holder pid
+    is no longer running is reclaimed: a fresh file is written at the same
+    path and swapped in atomically, handing a brand-new, guaranteed-unlocked
+    inode to the new owner while any surviving reference to the old one is
+    left orphaned.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError as exc:
+        os.close(fd)
+        holder_pid = _lock_holder_pid(path)
+        if holder_pid is None or _pid_is_alive(holder_pid):
+            suffix = f" (pid={holder_pid})" if holder_pid is not None else ""
+            raise ArchiveOwnershipError(f"archive location already owned: {path}{suffix}") from exc
+        logger.warning(
+            "reclaiming stale archive ownership lock %s: recorded holder pid=%d is no longer running",
+            path,
+            holder_pid,
+        )
+        reclaim = path.with_name(f".{path.name}.reclaim-{uuid.uuid4().hex}")
+        reclaimed_fd = os.open(reclaim, os.O_RDWR | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            fcntl.flock(reclaimed_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            os.close(reclaimed_fd)
+            reclaim.unlink(missing_ok=True)
+            raise ArchiveOwnershipError(f"archive location already owned: {path}") from exc
+        os.replace(reclaim, path)
+        fd = reclaimed_fd
+    os.ftruncate(fd, 0)
+    os.write(fd, owner.encode("utf-8"))
+    os.fsync(fd)
+    return fd

--- a/tests/unit/storage/test_archive_identity.py
+++ b/tests/unit/storage/test_archive_identity.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,9 @@ from polylogue.storage.archive_identity import (
     ArchiveIdentity,
     ArchiveIdentityConflictError,
     ArchiveLocation,
+    ArchiveOwnershipError,
+    OwnedArchiveLocation,
+    assert_owns_archive_location,
     assert_writable_archive_identity,
 )
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -131,3 +135,92 @@ def test_missing_index_cannot_bypass_split_root_preflight(tmp_path: Path, missin
         assert_writable_archive_identity(configured_root=configured, active_root=active)
 
     assert not (missing_root / "index.db").exists()
+
+
+def test_owned_location_rejects_concurrent_acquire_before_any_sqlite_file_exists(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    root.mkdir()
+    # No tier files exist yet -- the fixture proves the failure below happens
+    # strictly before any SQLite tier file is created, not merely before an
+    # already-open connection would have used it.
+    location = ArchiveLocation.resolve(root)
+
+    first = OwnedArchiveLocation.acquire(location)
+    try:
+        with pytest.raises(ArchiveOwnershipError, match="already owned"):
+            OwnedArchiveLocation.acquire(location)
+    finally:
+        first.release()
+
+    for name in ("source.db", "index.db", "embeddings.db", "user.db", "ops.db"):
+        assert not (root / name).exists(), f"{name} must not exist: ownership must fail before SQLite opens"
+
+
+def test_owned_location_reclaims_lock_left_by_dead_process(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    root.mkdir()
+    location = ArchiveLocation.resolve(root)
+    lock_path = root / ".archive-ownership.lock"
+    # A pid that cannot plausibly be alive: simulate a crashed prior owner
+    # without depending on any real process's exit timing.
+    dead_pid = 2**30
+    while _pid_is_alive_for_test(dead_pid):
+        dead_pid += 1
+    lock_path.write_text(f"pid={dead_pid} host=stale token=dead\n", encoding="utf-8")
+
+    owned = OwnedArchiveLocation.acquire(location)
+    try:
+        assert owned.owner_id is not None
+    finally:
+        owned.release()
+
+
+def _pid_is_alive_for_test(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def test_assert_owns_archive_location_rejects_foreign_root(tmp_path: Path) -> None:
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    _touch_tiers(root_a)
+    _touch_tiers(root_b)
+    location_a = ArchiveLocation.resolve(root_a)
+    location_b = ArchiveLocation.resolve(root_b)
+
+    owned = OwnedArchiveLocation.acquire(location_a)
+    try:
+        with pytest.raises(ArchiveOwnershipError, match="does not cover this location"):
+            assert_owns_archive_location(owned, location_b)
+        # A matching location is accepted without raising.
+        assert_owns_archive_location(owned, location_a)
+    finally:
+        owned.release()
+
+
+def test_assert_owns_archive_location_rejects_stale_generation_after_pointer_rotation(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    generation_a = tmp_path / "gen-a"
+    generation_b = tmp_path / "gen-b"
+    _touch_tiers(root)
+    generation_a.mkdir()
+    generation_b.mkdir()
+    (generation_a / "index.db").touch()
+    (generation_b / "index.db").touch()
+    (root / ".index-active-pointer").write_text(str(generation_a / "index.db"), encoding="utf-8")
+
+    owned = OwnedArchiveLocation.acquire(ArchiveLocation.resolve(root))
+    try:
+        # Simulate a concurrent promotion rotating the active generation
+        # after ownership was acquired: the proof must not silently cover it.
+        (root / ".index-active-pointer").unlink()
+        (root / ".index-active-pointer").write_text(str(generation_b / "index.db"), encoding="utf-8")
+        rotated = ArchiveLocation.resolve(root)
+
+        with pytest.raises(ArchiveOwnershipError, match="stale for the current active generation"):
+            assert_owns_archive_location(owned, rotated)
+    finally:
+        owned.release()

--- a/tests/unit/storage/test_archive_identity.py
+++ b/tests/unit/storage/test_archive_identity.py
@@ -171,6 +171,12 @@ def test_owned_location_reclaims_lock_left_by_dead_process(tmp_path: Path) -> No
     owned = OwnedArchiveLocation.acquire(location)
     try:
         assert owned.owner_id is not None
+        # Reclaim must retry the SAME inode, never create a competing one: a
+        # prior implementation swapped in a fresh file via os.replace, which
+        # could let two racing reclaimers each believe they hold exclusive
+        # ownership of a *different* inode. No such artifact should exist.
+        ownership_paths = [p.name for p in root.iterdir() if "ownership" in p.name]
+        assert ownership_paths == [lock_path.name]
     finally:
         owned.release()
 


### PR DESCRIPTION
## Summary

Adds `OwnedArchiveLocation`, a distinct ownership-proof capability that a maintenance/campaign writer must acquire over an `ArchiveLocation` before opening SQLite against its tiers.

## Problem

`ArchiveLocation`/`ArchiveIdentity` (polylogue/storage/archive_identity.py) already distinguish configured root, configured tier, and resolved active generation as separate typed values, with `assert_writable_archive_identity` as a preflight that fails before bootstrap on a durable-tier conflict. But per polylogue-ovme.1 AC1/AC5, none of this says *who* may write to a location: a maintenance/campaign writer (offline index rebuild, devtools benchmark/scale campaign, b5l generation transition) had no typed way to prove exclusive ownership before opening SQLite — an unowned or foreign path could previously only fail after a writer connection already existed, via some later runtime error, not before SQLite opens.

## Solution

- `OwnedArchiveLocation.acquire(location, owner_id=...)`: a pure filesystem preflight that takes an exclusive, non-blocking `flock` on a `.archive-ownership.lock` file under the location's configured root, and never opens a sqlite3 connection. A location already owned by another live process raises `ArchiveOwnershipError` immediately. A lock left behind by a now-dead process is reclaimed (mirrors `index_generation.py`'s existing stale-lease handling for offline rebuilds).
- `assert_owns_archive_location(owned, location)`: rejects reusing an ownership proof against a foreign configured root, and rejects a stale proof whose active generation has since rotated (e.g. a concurrent promotion) — mirroring `assert_writable_archive_identity`'s preflight shape one level up (that function proves one coherent generation; this proves one writer for that generation).
- `OwnedArchiveLocation` is a context manager (`release()` on `__exit__`).

Wiring real maintenance/campaign call sites (storage, status, devtools campaigns) to actually require `OwnedArchiveLocation` before writing is polylogue-ovme.2/.3 scope — not this slice, which is identity/resolver/canaries only (per the ovme parent epic's explicit 3-way split).

## Acceptance criteria (ovme.1)

1. Satisfied for the ownership axis: `OwnedArchiveLocation` is a distinct typed constructor; wrong root or stale generation fails via `assert_owns_archive_location`, and acquiring an already-owned location fails via `OwnedArchiveLocation.acquire` — both before any SQLite tier file is opened. Root/tier/generation typing (the rest of AC1) already existed in `ArchiveLocation`/`TierFileIdentity` prior to this PR.
2/3/4. Unaffected by this change (resolver, production read compatibility, existing split-tier/symlink canaries) — no existing behavior touched.
5. Satisfied — see Verification below.

## Verification

- `devtools test tests/unit/storage/test_archive_identity.py` -> `13 passed` (5 new: concurrent-acquire-before-sqlite-exists, dead-process lock reclaim, foreign-root rejection + accepted match, stale-generation rejection after pointer rotation)
- `devtools test tests/unit/storage/` -> 1 pre-existing unrelated failure (`test_exact_session_action_count_bounds_pairing_before_global_ranking`), reproduced identically on `origin/master` before this change (confirmed via `git stash`)
- `mypy --strict polylogue/storage/archive_identity.py tests/unit/storage/test_archive_identity.py` -> no issues found
- `ruff check` / `ruff format --check` on both files -> clean
- `devtools render all --check` -> no "out of sync" surfaces
- `git push` pre-push quick gate (format/lint/mypy/render/topology/layering/closure-matrix/schema/manifests/ci-workflows/doc-commands/docs-coverage/test-infra-currency/test-clock-hygiene/pytest-timeout-overrides/degrade-loudly) -> all `ok`, `exit_code: 0`

Ref polylogue-ovme.1