### PR TITLE
fix(sources): enrich Codex titles from state_5.sqlite thread titles

### DIFF
--- a/polylogue/sources/assembly.py
+++ b/polylogue/sources/assembly.py
@@ -38,6 +38,7 @@ class _ClaudeCodeSidecarData(TypedDict, total=False):
 class _CodexSidecarData(TypedDict, total=False):
     thread_names: CodexThreadNames
     history_titles: CodexHistoryTitles
+    state_titles: CodexHistoryTitles
 
 
 class SidecarData(_ClaudeCodeSidecarData, _CodexSidecarData, total=False):

--- a/polylogue/sources/assembly_codex.py
+++ b/polylogue/sources/assembly_codex.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from collections.abc import Callable, Mapping
 from pathlib import Path
 
@@ -122,6 +123,47 @@ def _parse_history_file(history_path: Path) -> dict[str, str]:
     return titles
 
 
+def _parse_codex_state_titles(sessions_root: Path) -> dict[str, str]:
+    """Read ``threads.title`` from the live Codex ``state_5.sqlite`` store.
+
+    On modern Codex installs ``state_5.sqlite`` (a live SQLite database in
+    WAL mode) is a richer, more actively maintained successor of
+    ``session_index.jsonl`` — it can carry a curated ``threads.title`` even
+    when ``session_index.jsonl`` no longer exists. Codex itself may hold this
+    file open for writing at any time, so treat it as an unreliable, optional
+    evidence source: any failure (missing file, lock contention, schema
+    drift, corruption) degrades to an empty mapping rather than raising.
+    """
+    state_path = sessions_root.parent / "state_5.sqlite"
+    if not state_path.exists():
+        return {}
+    return _cached_parse(state_path, _parse_state_db_file)
+
+
+def _parse_state_db_file(state_path: Path) -> dict[str, str]:
+    titles: dict[str, str] = {}
+    try:
+        # mode=ro avoids ever taking a write lock; WAL mode lets us read
+        # concurrently with a live Codex writer. A short timeout keeps a
+        # momentarily-locked file from stalling ingest.
+        conn = sqlite3.connect(f"file:{state_path}?mode=ro", uri=True, timeout=1.0)
+    except sqlite3.Error as exc:
+        logger.debug("Failed to open Codex state_5.sqlite: %s", exc)
+        return {}
+    try:
+        try:
+            rows = conn.execute("SELECT id, title FROM threads").fetchall()
+        except sqlite3.Error as exc:
+            logger.debug("Failed to query Codex state_5.sqlite threads: %s", exc)
+            return {}
+        for thread_id, title in rows:
+            if isinstance(thread_id, str) and thread_id and isinstance(title, str) and title.strip():
+                titles[thread_id] = title.strip()
+    finally:
+        conn.close()
+    return titles
+
+
 def _title_preview(text: str) -> str | None:
     """First non-empty line, bounded, or None when nothing usable remains."""
     for line in text.strip().splitlines():
@@ -143,6 +185,7 @@ class CodexAssemblySpec:
         """
         thread_names: dict[str, str] = {}
         history_titles: dict[str, str] = {}
+        state_titles: dict[str, str] = {}
         seen_roots: set[Path] = set()
         for path in source_paths:
             # Walk up to find the sessions root
@@ -151,16 +194,22 @@ class CodexAssemblySpec:
                     seen_roots.add(parent)
                     thread_names.update(_parse_codex_session_index(parent))
                     history_titles.update(_parse_codex_history(parent))
+                    state_titles.update(_parse_codex_state_titles(parent))
                     break
-        return {"thread_names": thread_names, "history_titles": history_titles}
+        return {
+            "thread_names": thread_names,
+            "history_titles": history_titles,
+            "state_titles": state_titles,
+        }
 
     def enrich_session(
         self,
         conv: ParsedSession,
         sidecar_data: SidecarData,
     ) -> ParsedSession:
-        """Resolve a Codex title: thread name → authored history → first
-        human-authored message → leave the native id.
+        """Resolve a Codex title: thread name → authored history →
+        state_5.sqlite thread title → first human-authored message → leave
+        the native id.
 
         A ``role=user`` row alone never becomes a title: Codex runtime
         context and operator protocol rows share that role, so only
@@ -169,6 +218,7 @@ class CodexAssemblySpec:
         """
         thread_names: CodexThreadNames = sidecar_data.get("thread_names", {})
         history_titles: CodexHistoryTitles = sidecar_data.get("history_titles", {})
+        state_titles: CodexHistoryTitles = sidecar_data.get("state_titles", {})
         cid = conv.provider_session_id
 
         # 1. Provider thread name — authoritative, may replace a stale title.
@@ -200,7 +250,23 @@ class CodexAssemblySpec:
                     }
                 )
 
-        # 3. First human-authored message in the parsed session.
+        # 3. state_5.sqlite live thread title — a richer, more actively
+        # maintained sibling of session_index.jsonl (which some modern
+        # Codex installs no longer even write). Only fills the gap left by
+        # thread name / authored history above; it never overrides an
+        # authored-history title already resolved in step 2.
+        state_text = state_titles.get(cid)
+        if state_text:
+            preview = _title_preview(state_text)
+            if preview:
+                return conv.model_copy(
+                    update={
+                        "title": preview,
+                        "title_source": TitleSource.ORIGIN,
+                    }
+                )
+
+        # 4. First human-authored message in the parsed session.
         for msg in conv.messages:
             if msg.material_origin is not MaterialOrigin.HUMAN_AUTHORED:
                 continue
@@ -215,7 +281,7 @@ class CodexAssemblySpec:
                     }
                 )
 
-        # 4. Nothing enrichable — the native id stands.
+        # 5. Nothing enrichable — the native id stands.
         return conv
 
 
@@ -235,4 +301,5 @@ __all__ = [
     "CodexAssemblySpec",
     "_parse_codex_history",
     "_parse_codex_session_index",
+    "_parse_codex_state_titles",
 ]

--- a/tests/unit/sources/test_assembly.py
+++ b/tests/unit/sources/test_assembly.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
@@ -12,7 +13,12 @@ from polylogue.archive.session.branch_type import BranchType
 from polylogue.core.enums import MaterialOrigin, Provider, TitleSource
 from polylogue.sources.assembly import SidecarData, get_assembly_spec
 from polylogue.sources.assembly_claude_code import ClaudeCodeAssemblySpec
-from polylogue.sources.assembly_codex import CodexAssemblySpec, _parse_codex_history, _parse_codex_session_index
+from polylogue.sources.assembly_codex import (
+    CodexAssemblySpec,
+    _parse_codex_history,
+    _parse_codex_session_index,
+    _parse_codex_state_titles,
+)
 from polylogue.sources.assembly_gemini import GeminiAssemblySpec
 from polylogue.sources.parsers.base import ParsedAttachment, ParsedMessage, ParsedSession, ParsedSessionEvent
 from polylogue.sources.parsers.claude.index import (
@@ -78,10 +84,12 @@ def _parsed_session(
 def _thread_sidecars(
     thread_names: dict[str, str] | None = None,
     history_titles: dict[str, str] | None = None,
+    state_titles: dict[str, str] | None = None,
 ) -> SidecarData:
     return {
         "thread_names": {} if thread_names is None else thread_names,
         "history_titles": {} if history_titles is None else history_titles,
+        "state_titles": {} if state_titles is None else state_titles,
     }
 
 
@@ -782,3 +790,206 @@ class TestCodexHistoryTitles:
         sessions_root = tmp_path / ".codex" / "sessions"
         sessions_root.mkdir(parents=True)
         assert _parse_codex_history(sessions_root) == {}
+
+
+# ---------------------------------------------------------------------------
+# Codex state_5.sqlite live thread titles (polylogue-ih67)
+# ---------------------------------------------------------------------------
+
+
+def _write_codex_state_db(codex_dir: Path, rows: list[tuple[str, str]]) -> Path:
+    """Create a minimal ``state_5.sqlite`` with a ``threads(id, title)`` table."""
+    state_path = codex_dir / "state_5.sqlite"
+    conn = sqlite3.connect(state_path)
+    try:
+        conn.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT NOT NULL DEFAULT '')")
+        conn.executemany("INSERT INTO threads (id, title) VALUES (?, ?)", rows)
+        conn.commit()
+    finally:
+        conn.close()
+    return state_path
+
+
+class TestCodexStateTitles:
+    def test_discover_sidecars_includes_state_titles(self, tmp_path: Path) -> None:
+        codex_dir = tmp_path / ".codex"
+        sessions_dir = codex_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        session_file = sessions_dir / "thread-1" / "session.jsonl"
+        session_file.parent.mkdir()
+        session_file.touch()
+        _write_codex_state_db(
+            codex_dir,
+            [("thread-1", "Live-DB curated title"), ("thread-2", ""), ("thread-3", "  ")],
+        )
+
+        sidecar_data = CodexAssemblySpec().discover_sidecars([session_file])
+
+        assert sidecar_data["state_titles"] == {"thread-1": "Live-DB curated title"}
+
+    def test_discover_sidecars_handles_missing_state_db(self, tmp_path: Path) -> None:
+        codex_dir = tmp_path / ".codex"
+        sessions_dir = codex_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        session_file = sessions_dir / "thread-1" / "session.jsonl"
+        session_file.parent.mkdir()
+        session_file.touch()
+
+        sidecar_data = CodexAssemblySpec().discover_sidecars([session_file])
+
+        assert sidecar_data["state_titles"] == {}
+
+    def test_discover_sidecars_handles_malformed_state_db(self, tmp_path: Path) -> None:
+        """A non-SQLite file at the expected path degrades to empty, never raises."""
+        codex_dir = tmp_path / ".codex"
+        sessions_dir = codex_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        session_file = sessions_dir / "thread-1" / "session.jsonl"
+        session_file.parent.mkdir()
+        session_file.touch()
+        (codex_dir / "state_5.sqlite").write_bytes(b"not a sqlite file at all")
+
+        sidecar_data = CodexAssemblySpec().discover_sidecars([session_file])
+
+        assert sidecar_data["state_titles"] == {}
+
+    def test_discover_sidecars_handles_schema_mismatch(self, tmp_path: Path) -> None:
+        """A state_5.sqlite without the expected threads/title shape degrades to empty."""
+        codex_dir = tmp_path / ".codex"
+        sessions_dir = codex_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        session_file = sessions_dir / "thread-1" / "session.jsonl"
+        session_file.parent.mkdir()
+        session_file.touch()
+        state_path = codex_dir / "state_5.sqlite"
+        conn = sqlite3.connect(state_path)
+        try:
+            conn.execute("CREATE TABLE unrelated_table (foo TEXT)")
+            conn.commit()
+        finally:
+            conn.close()
+
+        sidecar_data = CodexAssemblySpec().discover_sidecars([session_file])
+
+        assert sidecar_data["state_titles"] == {}
+
+    def test_discover_sidecars_handles_locked_state_db(self, tmp_path: Path) -> None:
+        """A concurrently write-locked state_5.sqlite degrades to empty, never raises."""
+        codex_dir = tmp_path / ".codex"
+        sessions_dir = codex_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        session_file = sessions_dir / "thread-1" / "session.jsonl"
+        session_file.parent.mkdir()
+        session_file.touch()
+        state_path = _write_codex_state_db(codex_dir, [("thread-1", "Curated title")])
+
+        # Hold an exclusive write lock (default rollback-journal mode, not
+        # WAL) to simulate Codex mid-write while we attempt a read.
+        locker = sqlite3.connect(state_path, timeout=0)
+        locker.execute("BEGIN EXCLUSIVE")
+        try:
+            sidecar_data = CodexAssemblySpec().discover_sidecars([session_file])
+            assert sidecar_data["state_titles"] == {}
+        finally:
+            locker.rollback()
+            locker.close()
+
+    def test_state_title_fills_gap_when_no_thread_name_or_history(self) -> None:
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(Provider.CODEX, "thread-1", "thread-1", [])
+        sidecar_data = _thread_sidecars(state_titles={"thread-1": "Curated live title"})
+
+        enriched = spec.enrich_session(conv, sidecar_data)
+
+        assert enriched.title == "Curated live title"
+        assert enriched.title_source == TitleSource.ORIGIN
+
+    def test_thread_name_beats_state_title(self) -> None:
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(Provider.CODEX, "thread-1", "thread-1", [])
+        sidecar_data = _thread_sidecars(
+            thread_names={"thread-1": "Named thread"},
+            state_titles={"thread-1": "Curated live title"},
+        )
+
+        enriched = spec.enrich_session(conv, sidecar_data)
+
+        assert enriched.title == "Named thread"
+
+    def test_history_title_beats_state_title(self) -> None:
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(Provider.CODEX, "thread-1", "thread-1", [])
+        sidecar_data = _thread_sidecars(
+            history_titles={"thread-1": "History opening prompt"},
+            state_titles={"thread-1": "Curated live title"},
+        )
+
+        enriched = spec.enrich_session(conv, sidecar_data)
+
+        assert enriched.title == "History opening prompt"
+
+    def test_state_title_beats_first_message_fallback(self) -> None:
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(
+            Provider.CODEX,
+            "thread-1",
+            "thread-1",
+            [_authored_message("m1", "message body that would otherwise win")],
+        )
+        sidecar_data = _thread_sidecars(state_titles={"thread-1": "Curated live title"})
+
+        enriched = spec.enrich_session(conv, sidecar_data)
+
+        assert enriched.title == "Curated live title"
+        assert enriched.title_source == TitleSource.ORIGIN
+
+    def test_state_title_uses_first_line_bounded(self) -> None:
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(Provider.CODEX, "thread-1", "thread-1", [])
+        long_first_line = "C" * 100
+        sidecar_data = _thread_sidecars(state_titles={"thread-1": f"\n\n{long_first_line}\nsecond line"})
+
+        enriched = spec.enrich_session(conv, sidecar_data)
+
+        assert enriched.title == "C" * 80 + "..."
+
+    def test_state_title_never_replaces_real_title(self) -> None:
+        spec = CodexAssemblySpec()
+        conv = _parsed_session(Provider.CODEX, "thread-1", "A real existing title", [])
+        sidecar_data = _thread_sidecars(state_titles={"thread-1": "Curated live title"})
+
+        result = spec.enrich_session(conv, sidecar_data)
+
+        assert result is conv
+
+    def test_parse_codex_state_titles_missing_file(self, tmp_path: Path) -> None:
+        sessions_root = tmp_path / ".codex" / "sessions"
+        sessions_root.mkdir(parents=True)
+        assert _parse_codex_state_titles(sessions_root) == {}
+
+    def test_state_titles_cache_invalidates_on_file_change(self, tmp_path: Path) -> None:
+        import os
+
+        codex_dir = tmp_path / ".codex"
+        sessions_dir = codex_dir / "sessions"
+        sessions_dir.mkdir(parents=True)
+        session_file = sessions_dir / "thread-1" / "session.jsonl"
+        session_file.parent.mkdir()
+        session_file.touch()
+        state_path = _write_codex_state_db(codex_dir, [("thread-1", "first version")])
+        spec = CodexAssemblySpec()
+
+        first = spec.discover_sidecars([session_file])["state_titles"]
+        assert first == {"thread-1": "first version"}
+
+        conn = sqlite3.connect(state_path)
+        try:
+            conn.execute("UPDATE threads SET title = ? WHERE id = ?", ("rewritten", "thread-1"))
+            conn.commit()
+        finally:
+            conn.close()
+        stat = state_path.stat()
+        os.utime(state_path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+
+        second = spec.discover_sidecars([session_file])["state_titles"]
+        assert second == {"thread-1": "rewritten"}


### PR DESCRIPTION
## Summary

Adds `state_5.sqlite` `threads.title` as a Codex title-discovery source in `polylogue/sources/assembly_codex.py`, alongside the existing `session_index.jsonl` and `history.jsonl` sidecars.

## Problem

Codex title discovery only ever read `session_index.jsonl` (thread name) and `history.jsonl` (earliest authored prompt). Modern Codex installs maintain a richer, live `threads.title` column in `~/.codex/state_5.sqlite` that is not read anywhere in the archive. On the operator's live install, `session_index.jsonl` no longer even exists, while `state_5.sqlite` has 2771/3054 non-empty `threads.title` rows — a large body of curated title evidence the archive currently ignores, leaving those sessions to fall back to a first-message heuristic or the bare native UUID.

This is the `state_5.sqlite` slice of `polylogue-ih67` ("Enrich Codex titles from authored history in canonical ingest"), named explicitly as remaining scope in that bead's 2026-07-18 note: *"(c) state_5.sqlite threads.title as an additional discovery source (richer than session_index.jsonl on live installs — copy-first, it is live-locked)"*.

## Solution

- `polylogue/sources/assembly_codex.py`: new `_parse_codex_state_titles(sessions_root)` / `_parse_state_db_file(state_path)` pair that opens `state_5.sqlite` (found at `sessions_root.parent / "state_5.sqlite"`, same convention as `history.jsonl`) via a **read-only URI connection** (`mode=ro`, 1s timeout) and reads `threads.id` / `threads.title`. Any failure — missing file, lock contention, malformed file, missing/renamed table — is caught and degrades to an empty mapping; it never raises, since Codex may hold this WAL-mode database open for writing at any time.
- Wired into the existing sidecar cache (`_cached_parse`, `(mtime_ns, size)` fingerprint — same pattern already used for `history.jsonl`) and into `discover_sidecars`'s returned `SidecarData` as a new `state_titles` key (added to the `_CodexSidecarData` TypedDict in `assembly.py`).
- `enrich_session`'s resolution chain gains a new step 3, inserted **after** thread name (`session_index.jsonl`, step 1) and authored history (`history.jsonl`, step 2), and **before** the first-human-authored-message fallback (now step 4): it only fills the gap those two leave (missing title or bare native id) and never overrides a title either of them already resolved. New chain: thread name → authored history → state_5.sqlite title → first human-authored message → native id.
- Not in scope for this slice (tracked on `polylogue-ih67`): acquiring sidecars as raw authority evidence for subprocess-safe replay (AC#3/4 on the bead), persisted `TitleSource`/ref/confidence provenance columns, and the corpus-wide before/after UUID-title census (AC#6).

## Verification

- `devtools test tests/unit/sources/test_assembly.py tests/unit/sources/test_codex_event_stream_contract.py tests/unit/sources/test_parsers_codex.py tests/unit/sources/test_parsers_codex_catalog.py tests/unit/sources/test_origin_specs.py` → `188 passed in 5.80s`
- New tests cover: discovery from a real fixture `threads(id, title)` sqlite table; missing file; malformed (non-sqlite) file; schema mismatch (no `threads`/`title`); a concurrently write-locked database (`BEGIN EXCLUSIVE` from a second connection) — all degrade to `{}` without raising; resolution precedence (thread name beats state title, history beats state title, state title beats first-message fallback, state title never overrides a real existing title); first-line/80-char truncation; mtime/size cache invalidation on live update.
- `mypy --strict polylogue/sources/assembly.py polylogue/sources/assembly_codex.py tests/unit/sources/test_assembly.py` → `Success: no issues found in 3 source files`
- `ruff check` + `ruff format --check` on the same three files → clean
- `devtools render all --check` → `OK` (no topology/doc drift; no new module added)
- Pre-push quick verification baseline (ruff format/check, mypy, render all, topology/layering/closure-matrix/manifests/ci-workflows/doc-commands/docs-coverage/test-infra-currency/test-clock-hygiene/pytest-timeout-overrides/degrade-loudly) → all `ok`

Ref polylogue-ih67