### PR TITLE
feat(devtools): compare seed/incident workload receipts like-for-like

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -35,6 +35,7 @@ VERIFICATION_LAB_COMMAND_NAMES: tuple[str, ...] = (
     "lab schema list",
     "lab schema promote",
     "lab schema roundtrip",
+    "lab seed-receipt-compare",
     "lab snapshot read-surface",
     "lab test-economics",
     "lab testmon-proof",
@@ -440,6 +441,22 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=(
             "devtools lab pytest-witness-repetitions",
             "devtools lab pytest-witness-repetitions --attempts 2 --xdist-workers 3 --json",
+        ),
+    ),
+    CommandSpec(
+        "lab seed-receipt-compare",
+        "verification lab",
+        "Compare two workload receipts for a clean, like-for-like seed/incident proof (polylogue-b054.1.1.3).",
+        "devtools.seed_receipt_compare",
+        use_when=(
+            "Judge a seed-testmon or focused pytest run's resource receipt against a named baseline "
+            "receipt (e.g. a prior incident) — confirms both runs share workload identity and terminated "
+            "cleanly, then scores wall-time speedup and peak-PSS ceiling targets, naming a blocker and "
+            "linked follow-up for any unmet target instead of silently dropping it."
+        ),
+        examples=(
+            "devtools lab seed-receipt-compare --baseline incident.json --candidate current.json",
+            "devtools lab seed-receipt-compare --baseline incident.json --candidate current.json --json",
         ),
     ),
     CommandSpec(

--- a/devtools/seed_receipt_compare.py
+++ b/devtools/seed_receipt_compare.py
@@ -1,0 +1,362 @@
+"""Like-for-like comparison of two workload receipts (polylogue-b054.1.1.3).
+
+``devtools verify`` and ``devtools test`` already emit a real ``WorkloadReceipt``
+(``polylogue/scenarios/workload.py``) for every managed pytest step, embedded
+under ``metadata["workload_receipt"]`` and persisted to each step's
+``postmortem.json``. PR #2934/#2980 extended that receipt with per-process-tree
+and cgroup RSS/PSS/swap/read/write accounting, but nothing yet *used* two such
+receipts together to answer the question the resource accounting exists to
+answer: "is this run clean, comparable to a named baseline, and within its
+declared physical envelope?"
+
+This module closes that gap. It does not invent a new sampling mechanism —
+it reads the receipts PR #2934/#2980 already produce and:
+
+1. Confirms the two runs are actually comparable ("like-for-like"): the same
+   declared workload/family/input identity, and both terminated
+   ``succeeded`` — a partial, failed, or cancelled run cannot anchor or be
+   judged against a physical-envelope target.
+2. Evaluates a small set of declared comparison targets (wall-time speedup
+   relative to the baseline, an absolute peak-PSS ceiling) against the
+   observed ``execute``-phase measures, using the same
+   :class:`~polylogue.scenarios.workload.BudgetVerdict` vocabulary the rest of
+   the workload-receipt system already uses — ``pass``, ``exceeded``, or
+   ``measurement-unavailable`` (never a fabricated pass when a measure was not
+   captured).
+3. Names an explicit blocker and a linked follow-up reference for every
+   unmet target, so an unmet 2x/peak-memory target is durable evidence
+   instead of a silently-dropped aspiration (polylogue-b054.1.1 AC5/AC8).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from polylogue.scenarios.workload import BudgetMeasure, BudgetVerdict
+
+#: The follow-up that owns closing the still-outstanding memory-amplification
+#: gap identified while proving polylogue-b054.1.1's own 2x/<3GiB target
+#: (see that bead's notes, 2026-07-16).
+DEFAULT_FOLLOW_UP_REF = "polylogue-b054.1.1.2"
+
+_GIB = 1024**3
+
+
+class ComparisonTargetKind(str, Enum):
+    """How a target's ``limit`` relates the candidate to the baseline."""
+
+    #: candidate <= baseline * limit (e.g. limit=0.5 asserts a 2x speedup).
+    MAX_RATIO_OF_BASELINE = "max-ratio-of-baseline"
+    #: candidate <= limit, independent of the baseline's own value.
+    MAX_ABSOLUTE = "max-absolute"
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptComparisonTarget:
+    """One declared comparison budget over a workload receipt's phase measure."""
+
+    measure: BudgetMeasure
+    kind: ComparisonTargetKind
+    limit: float
+    phase: str = "execute"
+    follow_up_ref: str | None = None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "measure": self.measure.value,
+            "kind": self.kind.value,
+            "limit": self.limit,
+            "phase": self.phase,
+            "follow_up_ref": self.follow_up_ref,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptComparisonResult:
+    """Verdict for one declared target after comparing baseline vs candidate."""
+
+    measure: BudgetMeasure
+    kind: ComparisonTargetKind
+    phase: str
+    limit: float
+    baseline_value: float | None
+    candidate_value: float | None
+    ratio: float | None
+    verdict: BudgetVerdict
+    blocker: str | None
+    follow_up_ref: str | None
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "measure": self.measure.value,
+            "kind": self.kind.value,
+            "phase": self.phase,
+            "limit": self.limit,
+            "baseline_value": self.baseline_value,
+            "candidate_value": self.candidate_value,
+            "ratio": self.ratio,
+            "verdict": self.verdict.value,
+            "blocker": self.blocker,
+            "follow_up_ref": self.follow_up_ref,
+        }
+
+
+def default_seed_comparison_targets(
+    *,
+    follow_up_ref: str = DEFAULT_FOLLOW_UP_REF,
+    speedup_ratio: float = 0.5,
+    peak_pss_ceiling_bytes: float = 3 * _GIB,
+) -> tuple[ReceiptComparisonTarget, ...]:
+    """Return the polylogue-b054.1.1 seed-comparison targets (2x wall, <3GiB peak PSS).
+
+    ``speedup_ratio=0.5`` means the candidate's wall time must be at most half
+    the baseline's — i.e. at least a 2x speedup, matching the target recorded
+    in polylogue-b054.1.1's own acceptance criteria.
+    """
+    return (
+        ReceiptComparisonTarget(
+            measure=BudgetMeasure.WALL_MS,
+            kind=ComparisonTargetKind.MAX_RATIO_OF_BASELINE,
+            limit=speedup_ratio,
+            phase="execute",
+            follow_up_ref=follow_up_ref,
+        ),
+        ReceiptComparisonTarget(
+            measure=BudgetMeasure.PEAK_PSS_BYTES,
+            kind=ComparisonTargetKind.MAX_ABSOLUTE,
+            limit=peak_pss_ceiling_bytes,
+            phase="execute",
+            follow_up_ref=follow_up_ref,
+        ),
+    )
+
+
+def _phase(receipt: Mapping[str, Any], phase: str) -> Mapping[str, Any] | None:
+    phases = receipt.get("phases")
+    if not isinstance(phases, list):
+        return None
+    for candidate_phase in phases:
+        if isinstance(candidate_phase, dict) and candidate_phase.get("name") == phase:
+            return candidate_phase
+    return None
+
+
+def _measure_value(receipt: Mapping[str, Any], *, phase: str, measure: BudgetMeasure) -> float | None:
+    observed_phase = _phase(receipt, phase)
+    if observed_phase is None:
+        return None
+    value = observed_phase.get(measure.value)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def identity_mismatches(baseline: Mapping[str, Any], candidate: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return every field that keeps two receipts from being like-for-like.
+
+    Comparable receipts must declare the identical workload/family identity
+    and the identical input digest (``spec.inputs[*].input_id`` is a content
+    hash of the workload's command/selection) — otherwise a ratio between the
+    two measures nothing.
+    """
+    raw_baseline_spec = baseline.get("spec")
+    raw_candidate_spec = candidate.get("spec")
+    baseline_spec: dict[str, Any] = raw_baseline_spec if isinstance(raw_baseline_spec, dict) else {}
+    candidate_spec: dict[str, Any] = raw_candidate_spec if isinstance(raw_candidate_spec, dict) else {}
+    mismatches: list[str] = []
+    for field in ("workload_id", "family_id", "measurement_scope"):
+        baseline_value = baseline_spec.get(field)
+        candidate_value = candidate_spec.get(field)
+        if baseline_value != candidate_value:
+            mismatches.append(f"{field}: baseline={baseline_value!r} candidate={candidate_value!r}")
+    baseline_inputs = tuple(item.get("input_id") for item in baseline_spec.get("inputs", []) if isinstance(item, dict))
+    candidate_inputs = tuple(
+        item.get("input_id") for item in candidate_spec.get("inputs", []) if isinstance(item, dict)
+    )
+    if baseline_inputs != candidate_inputs:
+        mismatches.append(f"inputs: baseline={baseline_inputs!r} candidate={candidate_inputs!r}")
+    return tuple(mismatches)
+
+
+def evaluate_target(
+    baseline: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    target: ReceiptComparisonTarget,
+) -> ReceiptComparisonResult:
+    """Score one declared target without inventing a verdict for missing data."""
+    baseline_value = _measure_value(baseline, phase=target.phase, measure=target.measure)
+    candidate_value = _measure_value(candidate, phase=target.phase, measure=target.measure)
+
+    ratio = None
+    if baseline_value is not None and candidate_value is not None and baseline_value != 0:
+        ratio = candidate_value / baseline_value
+
+    if baseline_value is None or candidate_value is None:
+        verdict = BudgetVerdict.MEASUREMENT_UNAVAILABLE
+    elif target.kind is ComparisonTargetKind.MAX_RATIO_OF_BASELINE:
+        effective_limit = baseline_value * target.limit
+        verdict = BudgetVerdict.PASS if candidate_value <= effective_limit else BudgetVerdict.EXCEEDED
+    else:
+        verdict = BudgetVerdict.PASS if candidate_value <= target.limit else BudgetVerdict.EXCEEDED
+
+    blocker: str | None = None
+    if verdict is BudgetVerdict.EXCEEDED:
+        if target.kind is ComparisonTargetKind.MAX_RATIO_OF_BASELINE:
+            blocker = (
+                f"{target.measure.value} on phase {target.phase!r}: candidate={candidate_value!r} "
+                f"baseline={baseline_value!r} ratio={ratio!r} exceeds the declared "
+                f"max-ratio-of-baseline target {target.limit!r}"
+            )
+        else:
+            blocker = (
+                f"{target.measure.value} on phase {target.phase!r}: candidate={candidate_value!r} "
+                f"exceeds the declared absolute ceiling {target.limit!r}"
+            )
+
+    return ReceiptComparisonResult(
+        measure=target.measure,
+        kind=target.kind,
+        phase=target.phase,
+        limit=target.limit,
+        baseline_value=baseline_value,
+        candidate_value=candidate_value,
+        ratio=ratio,
+        verdict=verdict,
+        blocker=blocker,
+        follow_up_ref=target.follow_up_ref if verdict is BudgetVerdict.EXCEEDED else None,
+    )
+
+
+def compare_receipts(
+    baseline: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    targets: Sequence[ReceiptComparisonTarget] | None = None,
+) -> dict[str, Any]:
+    """Compare two workload receipts and score every declared target.
+
+    Returns a JSON-serializable dict; ``like_for_like`` is ``False`` whenever
+    the two receipts do not share workload identity or either run did not
+    terminate ``succeeded`` — a dirty or mismatched pair cannot license any
+    budget verdict below, regardless of what the individual measures say.
+    """
+    resolved_targets = tuple(targets) if targets is not None else default_seed_comparison_targets()
+    mismatches = identity_mismatches(baseline, candidate)
+    baseline_status = baseline.get("status")
+    candidate_status = candidate.get("status")
+    clean = baseline_status == "succeeded" and candidate_status == "succeeded"
+    like_for_like = not mismatches and clean
+
+    results = tuple(evaluate_target(baseline, candidate, target) for target in resolved_targets)
+    exceeded = tuple(result for result in results if result.verdict is BudgetVerdict.EXCEEDED)
+
+    return {
+        "like_for_like": like_for_like,
+        "identity_mismatches": list(mismatches),
+        "baseline_status": baseline_status,
+        "candidate_status": candidate_status,
+        "targets_met": like_for_like and not exceeded,
+        "results": [result.to_payload() for result in results],
+    }
+
+
+def _unwrap_receipt(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Accept either a bare workload receipt or a wrapping postmortem.json."""
+    workload_receipt = payload.get("workload_receipt")
+    if isinstance(workload_receipt, dict):
+        return workload_receipt
+    return payload
+
+
+def load_receipt(path: Path) -> Mapping[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected a JSON object, got {type(payload).__name__}")
+    return _unwrap_receipt(payload)
+
+
+def _render_text(comparison: Mapping[str, Any]) -> str:
+    lines: list[str] = []
+    if comparison["like_for_like"]:
+        lines.append("like-for-like: yes")
+    else:
+        lines.append("like-for-like: NO")
+        for mismatch in comparison["identity_mismatches"]:
+            lines.append(f"  identity mismatch: {mismatch}")
+        if comparison["baseline_status"] != "succeeded":
+            lines.append(f"  baseline run did not succeed: status={comparison['baseline_status']!r}")
+        if comparison["candidate_status"] != "succeeded":
+            lines.append(f"  candidate run did not succeed: status={comparison['candidate_status']!r}")
+    for result in comparison["results"]:
+        marker = {"pass": "PASS", "exceeded": "EXCEEDED", "measurement-unavailable": "N/A"}[result["verdict"]]
+        lines.append(
+            f"[{marker}] {result['measure']} ({result['phase']}): "
+            f"baseline={result['baseline_value']!r} candidate={result['candidate_value']!r} "
+            f"ratio={result['ratio']!r} limit={result['limit']!r} kind={result['kind']}"
+        )
+        if result["blocker"]:
+            lines.append(f"    blocker: {result['blocker']}")
+            lines.append(f"    follow-up: {result['follow_up_ref']}")
+    lines.append(f"targets_met: {comparison['targets_met']}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare a baseline and candidate workload receipt (devtools verify/test "
+            "postmortem.json or a bare workload_receipt payload) for a clean, "
+            "like-for-like seed/incident comparison (polylogue-b054.1.1.3)."
+        )
+    )
+    parser.add_argument("--baseline", required=True, type=Path, help="Path to the baseline receipt JSON.")
+    parser.add_argument("--candidate", required=True, type=Path, help="Path to the candidate receipt JSON.")
+    parser.add_argument(
+        "--follow-up-ref",
+        default=DEFAULT_FOLLOW_UP_REF,
+        help="Tracking-item reference cited on any unmet target (default: %(default)s).",
+    )
+    parser.add_argument(
+        "--speedup-ratio",
+        type=float,
+        default=0.5,
+        help="Maximum candidate/baseline wall-time ratio to pass (default 0.5 = 2x speedup).",
+    )
+    parser.add_argument(
+        "--peak-pss-ceiling-mb",
+        type=float,
+        default=3 * 1024.0,
+        help="Absolute peak-PSS ceiling in MiB (default 3072 MiB = 3 GiB).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the complete comparison as JSON.")
+    args = parser.parse_args(argv)
+
+    baseline = load_receipt(args.baseline)
+    candidate = load_receipt(args.candidate)
+    targets = default_seed_comparison_targets(
+        follow_up_ref=args.follow_up_ref,
+        speedup_ratio=args.speedup_ratio,
+        peak_pss_ceiling_bytes=args.peak_pss_ceiling_mb * 1024 * 1024,
+    )
+    comparison = compare_receipts(baseline, candidate, targets)
+
+    if args.json:
+        print(json.dumps(comparison, indent=2))
+    else:
+        print(_render_text(comparison))
+
+    if not comparison["like_for_like"]:
+        return 2
+    if not comparison["targets_met"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -70,6 +70,7 @@ They are not a proof ledger or end-user archive workflow.
 | `devtools lab schema list` | Inspect committed provider schema package catalogs without presenting them as normal archive usage. |
 | `devtools lab schema promote` | Turn reviewed schema evidence clusters into committed provider schema packages. |
 | `devtools lab schema roundtrip` | Close the schema inference-validation loop: package manifests must roundtrip through typed models, and every supported element schema must be reachable from the runtime registry. |
+| `devtools lab seed-receipt-compare` | Judge a seed-testmon or focused pytest run's resource receipt against a named baseline receipt (e.g. a prior incident) — confirms both runs share workload identity and terminated cleanly, then scores wall-time speedup and peak-PSS ceiling targets, naming a blocker and linked follow-up for any unmet target instead of silently dropping it. |
 | `devtools lab snapshot read-surface` | Freeze archive read-surface behavior before archive work, then compare candidate archives against the captured envelope baseline. |
 | `devtools lab test-economics` | Decide where test-writing effort or test-suite pruning actually pays off, by cross-referencing coverage percent, historical fix-commit density, testmon wall-time cost exposure, and testmon selection fan-out per top-level package. |
 | `devtools lab testmon-proof` | Validate the affected-test harness itself: a disposable copy of a real Polylogue module and existing route test is seeded, semantically mutated, edge-severed, restored, and checked for bounded unrelated-change selection. |
@@ -159,6 +160,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools lab schema list` | List committed schema packages, versions, and evidence manifests. |
 | `devtools lab schema promote` | Promote a schema evidence cluster into a registered package version. |
 | `devtools lab schema roundtrip` | Verify committed provider schema packages reload and roundtrip cleanly. |
+| `devtools lab seed-receipt-compare` | Compare two workload receipts for a clean, like-for-like seed/incident proof (polylogue-b054.1.1.3). |
 | `devtools lab smoke` | Run direct archive and reader smoke sets. |
 | `devtools lab snapshot read-surface` | Capture and compare archive read-surface snapshots. |
 | `devtools lab test-economics` | Report per-package coverage/fix-density/test-cost economics (polylogue-9e5.11). |

--- a/tests/unit/devtools/test_seed_receipt_compare.py
+++ b/tests/unit/devtools/test_seed_receipt_compare.py
@@ -1,0 +1,277 @@
+"""Contract tests for the like-for-like seed/incident receipt comparison (polylogue-b054.1.1.3)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from devtools.seed_receipt_compare import (
+    ComparisonTargetKind,
+    ReceiptComparisonTarget,
+    compare_receipts,
+    default_seed_comparison_targets,
+    identity_mismatches,
+    load_receipt,
+    main,
+)
+from polylogue.scenarios.workload import (
+    BudgetMeasure,
+    BudgetVerdict,
+    MeasurementScope,
+    WorkloadEnvelopeSpec,
+    WorkloadInputRef,
+    WorkloadPhaseObservation,
+    WorkloadReceipt,
+    WorkloadRunStatus,
+)
+
+_GIB = 1024**3
+
+
+def _receipt(
+    *,
+    wall_ms: float,
+    peak_pss_bytes: int | None,
+    status: WorkloadRunStatus = WorkloadRunStatus.SUCCEEDED,
+    workload_id: str = "verify:pytest focused",
+    input_id: str = "pytest-selection:sha256:same-selection",
+) -> dict[str, object]:
+    """Build a real WorkloadReceipt payload (the exact shape devtools verify emits)."""
+    spec = WorkloadEnvelopeSpec(
+        workload_id=workload_id,
+        family_id="verify-pytest",
+        version=1,
+        inputs=(WorkloadInputRef(input_id=input_id),),
+        phases=("execute", "quiescent"),
+        measurement_scope=MeasurementScope.PROCESS_TREE,
+    )
+    execute_unavailable = () if peak_pss_bytes is not None else ("peak_pss_bytes",)
+    receipt = WorkloadReceipt.from_observations(
+        spec=spec,
+        status=status,
+        build_id="git:deadbeef",
+        runtime_id="python:3.12.0",
+        archive_id=None,
+        generation_id=None,
+        frame_id=None,
+        phases=(
+            WorkloadPhaseObservation(
+                name="execute",
+                wall_ms=wall_ms,
+                peak_pss_bytes=peak_pss_bytes,
+                unavailable=execute_unavailable,
+            ),
+            WorkloadPhaseObservation(name="quiescent", quiescent=True),
+        ),
+    )
+    return dict(receipt.to_payload())
+
+
+def test_identical_receipts_are_like_for_like_and_meet_default_targets() -> None:
+    baseline = _receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB)
+    candidate = _receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB)
+
+    comparison = compare_receipts(baseline, candidate)
+
+    assert comparison["like_for_like"] is True
+    assert comparison["identity_mismatches"] == []
+    # Same wall time as baseline is NOT a 2x speedup, so the default target is unmet.
+    wall_result = next(r for r in comparison["results"] if r["measure"] == "wall_ms")
+    assert wall_result["verdict"] == "exceeded"
+    assert wall_result["ratio"] == pytest.approx(1.0)
+    assert wall_result["blocker"] is not None
+    assert wall_result["follow_up_ref"] == "polylogue-b054.1.1.2"
+    assert comparison["targets_met"] is False
+
+
+def test_real_two_x_speedup_and_low_memory_meets_default_targets() -> None:
+    baseline = _receipt(wall_ms=20_000, peak_pss_bytes=2 * _GIB)
+    candidate = _receipt(wall_ms=9_000, peak_pss_bytes=1 * _GIB)
+
+    comparison = compare_receipts(baseline, candidate)
+
+    assert comparison["like_for_like"] is True
+    assert comparison["targets_met"] is True
+    wall_result = next(r for r in comparison["results"] if r["measure"] == "wall_ms")
+    assert wall_result["verdict"] == "pass"
+    assert wall_result["ratio"] == pytest.approx(0.45)
+    pss_result = next(r for r in comparison["results"] if r["measure"] == "peak_pss_bytes")
+    assert pss_result["verdict"] == "pass"
+
+
+def test_peak_pss_regression_is_flagged_with_blocker_and_follow_up() -> None:
+    baseline = _receipt(wall_ms=20_000, peak_pss_bytes=2 * _GIB)
+    candidate = _receipt(wall_ms=9_000, peak_pss_bytes=4 * _GIB)
+
+    comparison = compare_receipts(baseline, candidate)
+
+    assert comparison["like_for_like"] is True
+    assert comparison["targets_met"] is False
+    pss_result = next(r for r in comparison["results"] if r["measure"] == "peak_pss_bytes")
+    assert pss_result["verdict"] == "exceeded"
+    assert "peak_pss_bytes" in pss_result["blocker"]
+    assert pss_result["follow_up_ref"] == "polylogue-b054.1.1.2"
+
+
+def test_missing_measure_is_measurement_unavailable_not_a_fabricated_pass() -> None:
+    baseline = _receipt(wall_ms=20_000, peak_pss_bytes=2 * _GIB)
+    candidate = _receipt(wall_ms=9_000, peak_pss_bytes=None)
+
+    comparison = compare_receipts(baseline, candidate)
+
+    pss_result = next(r for r in comparison["results"] if r["measure"] == "peak_pss_bytes")
+    assert pss_result["verdict"] == "measurement-unavailable"
+    assert pss_result["candidate_value"] is None
+    assert pss_result["blocker"] is None
+    # A measurement gap does not, by itself, block the overall comparison.
+    assert comparison["targets_met"] is True
+
+
+def test_mismatched_workload_identity_is_not_like_for_like() -> None:
+    baseline = _receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB, workload_id="verify:pytest focused")
+    candidate = _receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB, workload_id="verify:pytest seed-testmon")
+
+    comparison = compare_receipts(baseline, candidate)
+
+    assert comparison["like_for_like"] is False
+    assert any("workload_id" in mismatch for mismatch in comparison["identity_mismatches"])
+    # A mismatched pair cannot license a target verdict.
+    assert comparison["targets_met"] is False
+
+
+def test_mismatched_input_selection_is_not_like_for_like() -> None:
+    baseline = _receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB, input_id="pytest-selection:sha256:aaa")
+    candidate = _receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB, input_id="pytest-selection:sha256:bbb")
+
+    mismatches = identity_mismatches(baseline, candidate)
+
+    assert any("inputs" in mismatch for mismatch in mismatches)
+
+
+def test_unclean_baseline_run_is_not_like_for_like_even_with_matching_identity() -> None:
+    baseline = _receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB, status=WorkloadRunStatus.FAILED)
+    candidate = _receipt(wall_ms=5_000, peak_pss_bytes=1 * _GIB)
+
+    comparison = compare_receipts(baseline, candidate)
+
+    assert comparison["like_for_like"] is False
+    assert comparison["baseline_status"] == "failed"
+    assert comparison["targets_met"] is False
+
+
+def test_unclean_candidate_run_is_not_like_for_like() -> None:
+    baseline = _receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB)
+    candidate = _receipt(wall_ms=5_000, peak_pss_bytes=1 * _GIB, status=WorkloadRunStatus.INTERRUPTED)
+
+    comparison = compare_receipts(baseline, candidate)
+
+    assert comparison["like_for_like"] is False
+    assert comparison["candidate_status"] == "interrupted"
+
+
+def test_custom_targets_override_the_default_seed_comparison_contract() -> None:
+    baseline = _receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB)
+    candidate = _receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB)
+    lenient_targets = (
+        ReceiptComparisonTarget(
+            measure=BudgetMeasure.WALL_MS,
+            kind=ComparisonTargetKind.MAX_RATIO_OF_BASELINE,
+            limit=1.5,
+            follow_up_ref="polylogue-example-follow-up",
+        ),
+    )
+
+    comparison = compare_receipts(baseline, candidate, lenient_targets)
+
+    assert comparison["targets_met"] is True
+    assert len(comparison["results"]) == 1
+
+
+def test_default_seed_comparison_targets_are_2x_wall_and_3gib_peak_pss() -> None:
+    targets = default_seed_comparison_targets()
+
+    wall_target = next(t for t in targets if t.measure is BudgetMeasure.WALL_MS)
+    pss_target = next(t for t in targets if t.measure is BudgetMeasure.PEAK_PSS_BYTES)
+    assert wall_target.kind is ComparisonTargetKind.MAX_RATIO_OF_BASELINE
+    assert wall_target.limit == pytest.approx(0.5)
+    assert pss_target.kind is ComparisonTargetKind.MAX_ABSOLUTE
+    assert pss_target.limit == pytest.approx(3 * _GIB)
+
+
+def test_load_receipt_unwraps_a_postmortem_json_payload(tmp_path: Path) -> None:
+    receipt = _receipt(wall_ms=1_000, peak_pss_bytes=1 * _GIB)
+    postmortem = tmp_path / "postmortem.json"
+    postmortem.write_text(json.dumps({"diagnosis": None, "workload_receipt": receipt}), encoding="utf-8")
+
+    loaded = load_receipt(postmortem)
+
+    assert loaded["status"] == "succeeded"
+    assert loaded == receipt
+
+
+def test_load_receipt_accepts_a_bare_workload_receipt_payload(tmp_path: Path) -> None:
+    receipt = _receipt(wall_ms=1_000, peak_pss_bytes=1 * _GIB)
+    bare = tmp_path / "receipt.json"
+    bare.write_text(json.dumps(receipt), encoding="utf-8")
+
+    assert load_receipt(bare) == receipt
+
+
+def test_cli_exits_zero_when_like_for_like_and_targets_met(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    baseline = tmp_path / "baseline.json"
+    candidate = tmp_path / "candidate.json"
+    baseline.write_text(json.dumps(_receipt(wall_ms=20_000, peak_pss_bytes=2 * _GIB)), encoding="utf-8")
+    candidate.write_text(json.dumps(_receipt(wall_ms=9_000, peak_pss_bytes=1 * _GIB)), encoding="utf-8")
+
+    exit_code = main(["--baseline", str(baseline), "--candidate", str(candidate), "--json"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["targets_met"] is True
+
+
+def test_cli_exits_one_when_a_target_is_unmet(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    baseline = tmp_path / "baseline.json"
+    candidate = tmp_path / "candidate.json"
+    baseline.write_text(json.dumps(_receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB)), encoding="utf-8")
+    candidate.write_text(json.dumps(_receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB)), encoding="utf-8")
+
+    exit_code = main(["--baseline", str(baseline), "--candidate", str(candidate)])
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "EXCEEDED" in out
+    assert "blocker" in out
+    assert "polylogue-b054.1.1.2" in out
+
+
+def test_cli_exits_two_when_receipts_are_not_like_for_like(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    baseline = tmp_path / "baseline.json"
+    candidate = tmp_path / "candidate.json"
+    baseline.write_text(
+        json.dumps(_receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB, workload_id="verify:pytest focused")),
+        encoding="utf-8",
+    )
+    candidate.write_text(
+        json.dumps(_receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB, workload_id="verify:pytest seed-testmon")),
+        encoding="utf-8",
+    )
+
+    exit_code = main(["--baseline", str(baseline), "--candidate", str(candidate)])
+
+    out = capsys.readouterr().out
+    assert exit_code == 2
+    assert "like-for-like: NO" in out
+
+
+def test_evaluate_budgets_verdict_vocabulary_is_reused_verbatim() -> None:
+    """The comparison must reuse BudgetVerdict, not invent a parallel vocabulary."""
+    baseline = _receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB)
+    candidate = _receipt(wall_ms=10_000, peak_pss_bytes=1 * _GIB)
+
+    comparison = compare_receipts(baseline, candidate)
+
+    verdicts = {result["verdict"] for result in comparison["results"]}
+    assert verdicts <= {verdict.value for verdict in BudgetVerdict}


### PR DESCRIPTION
## Summary

Adds `devtools lab seed-receipt-compare`, a tool that compares two workload
receipts (the `WorkloadReceipt` already emitted by `devtools verify`/`devtools
test` under each pytest step's `postmortem.json`) for a clean, like-for-like
seed/incident proof — the specific gap left open in polylogue-b054.1.1.3's own
notes after PR #2934 and #2980.

## Problem

polylogue-b054.1.1.3 landed explicit seed-node outcomes (PR #2934, commit
23e8b2933) and process-tree/cgroup RSS/PSS/swap/read/write accounting (PR
#2934, then PR #2980 / commit 33960c93b adding cgroup path, current/peak
memory, swap current, and read/write-byte deltas). Per the bead's own notes,
this "advances per-run attribution but does not yet prove the full AC
comparison/budget contract" — kept open scope was specifically "cgroup-level
counters [done], clean like-for-like incident comparison, and full AC proof."

AC5 of the bead states: "A like-for-like clean seed comparison against the
incident baseline is recorded; any unmet 2x target names a measured phase
blocker and linked follow-up." Nothing in the codebase actually compared two
receipts — the resource data existed but was never used to answer the
question it exists to answer.

## Solution

`devtools/seed_receipt_compare.py` (registered as `devtools lab
seed-receipt-compare`):

- Reads the existing `WorkloadReceipt` payload (`polylogue/scenarios/
  workload.py`) from a bare receipt JSON or a `postmortem.json` wrapper — no
  new sampling mechanism, purely a consumer of what PR #2934/#2980 already
  produce.
- `identity_mismatches()` confirms two receipts share `workload_id`,
  `family_id`, `measurement_scope`, and input digest (`spec.inputs[*]
  .input_id`, a content hash of the pytest command/selection) — a mismatched
  pair (e.g. different `-n` worker count, different test selection) is
  explicitly refused as not comparable, even when its raw numbers look
  favorable.
- `compare_receipts()` additionally requires both runs to have terminated
  `succeeded` — a partial/failed/interrupted run cannot anchor or be judged
  against a physical envelope.
- `evaluate_target()` scores declared comparison targets against the
  observed `execute`-phase measures, reusing `BudgetVerdict`
  (`pass`/`exceeded`/`measurement-unavailable`) verbatim from
  `polylogue/scenarios/workload.py` rather than inventing a parallel
  vocabulary — a missing measurement is never silently treated as a pass.
- `default_seed_comparison_targets()` declares the two targets recorded in
  polylogue-b054.1.1's own AC8: candidate wall time <= 50% of baseline (a 2x
  speedup) and peak PSS <= 3 GiB. Every unmet target carries an explicit
  blocker string and cites `polylogue-b054.1.1.2` (the follow-up that already
  owns the outstanding memory-amplification gap) — both configurable via CLI
  flags/kwargs.
- CLI (`main()`): `--baseline`/`--candidate` receipt paths, `--follow-up-ref`,
  `--speedup-ratio`, `--peak-pss-ceiling-mb`, `--json`. Exit codes: `0` clean
  pass, `1` like-for-like but a target unmet, `2` not like-for-like (invalid
  comparison).

Registered in `devtools/command_catalog.py` (`VERIFICATION_LAB_COMMAND_NAMES`
+ `CommandSpec`) and rendered into `docs/devtools.md`.

## Verification

- `devtools test tests/unit/devtools/test_seed_receipt_compare.py
  tests/unit/devtools/test_command_catalog.py` — 21 passed. Tests build
  fixture receipts through the real `WorkloadReceipt.from_observations`
  constructor (not hand-rolled dicts) and cover: identical-receipt comparison
  (like-for-like, unmet speedup target correctly flagged since it's the same
  workload, not an actual speedup), a real 2x-speedup + low-memory pass, a
  peak-PSS regression with blocker+follow-up, a missing-measurement case
  (`measurement-unavailable`, not a fabricated pass), mismatched
  workload/input identity, unclean baseline/candidate runs, custom target
  overrides, `postmortem.json`-wrapped vs bare receipt loading, and all three
  CLI exit codes.
- `uv run mypy --strict devtools/seed_receipt_compare.py
  devtools/command_catalog.py tests/unit/devtools/test_seed_receipt_compare.py`
  — no issues found in 3 source files.
- `uv run ruff check` / `ruff format --check` on the same files — clean.
- `devtools render devtools-reference` — regenerated `docs/devtools.md`.
- `devtools verify --quick` — exit 0 (16/16 steps), both before commit and
  again via the pre-push hook.
- **Real-receipt proof** (not synthetic-only, per the bead's own
  anti-vacuity spirit): ran `devtools test tests/unit/devtools/test_verify.py
  --deselect
  tests/unit/devtools/test_verify.py::test_lab_verify_runs_every_registered_lab_policy_command
  -n 0` twice (identical invocations) and fed the two real `postmortem.json`
  receipts to `python -m devtools.seed_receipt_compare`:
  `like-for-like: yes`; it correctly flags the 2x wall-time target as
  `EXCEEDED` (ratio ~0.96 — expected, since rerunning the identical workload
  is not itself a speedup) with the blocker text and
  `polylogue-b054.1.1.2` follow-up printed; the peak-PSS target `PASS`es.
  Re-ran the comparison against a third real receipt from the same selection
  at `-n 4` instead of `-n 0`: correctly reports `like-for-like: NO` (mismatched
  input digest) even though the raw wall time looks faster — proving the tool
  refuses to certify an apples-to-oranges "speedup" instead of taking the
  bait on a favorable-looking but incomparable number.
- Unrelated, reproduced identically on master HEAD `4241316e0` without this
  change: `test_lab_verify_runs_every_registered_lab_policy_command` fails
  because `lab policy bead-graph` is registered but not run by `devtools
  verify --lab` — pre-existing baseline debt, not touched by this PR.

## Scope note / AC honesty

This closes the specific residual named in polylogue-b054.1.1.3's own notes
("cgroup-level counters [done via #2980], clean like-for-like incident
comparison, and full AC proof") with a comparison *mechanism* plus a real
demonstration of it against genuine `devtools test` receipts. It does not
re-run the full historical seed-testmon incident (the 2026-07-15/16 baseline
referenced in polylogue-b054.1.1) end-to-end — that specific 2x/<3GiB target
for the *full* seed-testmon corpus is already tracked and explicitly deferred
to `polylogue-b054.1.1.2` per polylogue-b054.1.1's own notes ("Operator
preference is to retain throughput ... Follow-up polylogue-b054.1.1.2 owns
memory-amplification profiling/reduction without throughput loss"). This PR
gives that follow-up (and any future incident postmortem) a real tool to
produce that comparison and cite the blocker precisely, rather than
re-litigating the memory-amplification investigation itself here.

Ref polylogue-b054.1.1.3