### PR TITLE
fix(query): rank near:id: and materialize lineage:id: projection

### DIFF
--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -1578,6 +1578,28 @@ components:
           - $ref: '#/components/schemas/SessionFlagsPayload'
           - type: 'null'
           default: null
+        parent_refs:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          default: null
+          title: Parent Refs
+        child_refs:
+          anyOf:
+          - items:
+              type: string
+            type: array
+          - type: 'null'
+          default: null
+          title: Child Refs
+        continuation:
+          anyOf:
+          - type: string
+          - type: 'null'
+          default: null
+          title: Continuation
       required:
       - id
       - origin

--- a/docs/schemas/cli-output/session-list-row.schema.json
+++ b/docs/schemas/cli-output/session-list-row.schema.json
@@ -183,6 +183,33 @@
       "default": null,
       "title": "Anchor"
     },
+    "child_refs": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Child Refs"
+    },
+    "continuation": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Continuation"
+    },
     "created_at": {
       "anyOf": [
         {
@@ -230,6 +257,21 @@
     "origin": {
       "title": "Origin",
       "type": "string"
+    },
+    "parent_refs": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Parent Refs"
     },
     "repo": {
       "anyOf": [

--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -839,12 +839,19 @@ def _lineage_seed_from_predicate(predicate: QueryPredicate | None) -> str | None
     session rows to one shared-root lineage family. This walks the same
     boolean-predicate tree to detect that shape so the list route can
     materialize the declared recursive-graph projection columns for it (#z9gh.3).
+
+    Only descends into ``and`` nodes. A ``lineage:id:X or repo:foo`` result
+    set is NOT purely lineage X's family -- rows matched only via the ``or``
+    branch would get X's parent_refs/child_refs/continuation stamped on them,
+    which is wrong, not just imprecise. An ``or`` node (or a ``not`` wrapping
+    the predicate, which isn't a ``QueryBoolPredicate``/``QueryLineagePredicate``
+    at all) correctly yields no seed here.
     """
     if predicate is None:
         return None
     if isinstance(predicate, QueryLineagePredicate):
         return predicate.seed_session_id
-    if isinstance(predicate, QueryBoolPredicate):
+    if isinstance(predicate, QueryBoolPredicate) and predicate.op == "and":
         for child in predicate.children:
             seed = _lineage_seed_from_predicate(child)
             if seed is not None:

--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -31,7 +31,7 @@ from polylogue.archive.query.expression import (
     split_with_projection_clause,
 )
 from polylogue.archive.query.metadata import query_unit_descriptor
-from polylogue.archive.query.predicate import QueryPredicate
+from polylogue.archive.query.predicate import QueryBoolPredicate, QueryLineagePredicate, QueryPredicate
 from polylogue.archive.query.spec import (
     QuerySpecError,
     SessionQuerySpec,
@@ -262,6 +262,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
     sort = compiled_spec.sort
     reverse = compiled_spec.reverse
     similar_text = compiled_spec.similar_text
+    similar_session_id = compiled_spec.similar_session_id
     retrieval_lane = _optional_str(params.get("retrieval_lane")) or compiled_spec.retrieval_lane
     delete_matched = bool(params.get("delete_matched"))
     excluded_origins = compiled_spec.excluded_origins or _resolve_excluded_origins(params)
@@ -298,6 +299,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
     }
     if compiled_spec.boolean_predicate is not None:
         filter_kwargs["boolean_predicate"] = compiled_spec.boolean_predicate
+    lineage_seed_session_id = _lineage_seed_from_predicate(compiled_spec.boolean_predicate)
     if _try_emit_daemon_session_page(
         env,
         config=config,
@@ -323,6 +325,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
         sort=sort,
         reverse=reverse,
         similar_text=similar_text,
+        similar_session_id=similar_session_id,
         retrieval_lane=retrieval_lane,
     ):
         return
@@ -564,7 +567,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
         if conv_id:
             try:
                 session_id = archive.resolve_session_id(str(conv_id))
-                if query or similar_text:
+                if query or similar_text or similar_session_id:
                     if sample_count is not None:
                         raise click.UsageError("Root query does not combine --sample with search terms.")
                     hits, resolved_lane = _query_hits(
@@ -572,6 +575,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                         config=config,
                         query=query,
                         similar_text=similar_text,
+                        similar_session_id=similar_session_id,
                         retrieval_lane=retrieval_lane,
                         limit=limit + 1,
                         offset=page_offset,
@@ -621,11 +625,12 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                     _emit_search(
                         page_hits,
                         archive=archive,
-                        query=similar_text or query,
+                        query=similar_text or query or similar_session_id or "",
                         total=_count_root_matches(
                             archive,
                             query=query,
                             similar_text=similar_text,
+                            similar_session_id=similar_session_id,
                             session_id=session_id,
                             filter_kwargs=filter_kwargs,
                         ),
@@ -684,7 +689,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                     fields=fields,
                 )
                 return
-        if query or similar_text:
+        if query or similar_text or similar_session_id:
             if sample_count is not None:
                 raise click.UsageError("Root query does not combine --sample with search terms.")
             fetch_limit = limit + 1
@@ -693,6 +698,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                 config=config,
                 query=query,
                 similar_text=similar_text,
+                similar_session_id=similar_session_id,
                 retrieval_lane=retrieval_lane,
                 limit=fetch_limit,
                 offset=page_offset,
@@ -738,11 +744,12 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
             _emit_search(
                 page_hits,
                 archive=archive,
-                query=similar_text or query,
+                query=similar_text or query or similar_session_id or "",
                 total=_count_root_matches(
                     archive,
                     query=query,
                     similar_text=similar_text,
+                    similar_session_id=similar_session_id,
                     session_id=None,
                     filter_kwargs=filter_kwargs,
                 ),
@@ -820,7 +827,29 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
             archive=archive,
             with_units=with_units,
             with_unit_fields=with_unit_fields,
+            lineage_seed_session_id=lineage_seed_session_id,
         )
+
+
+def _lineage_seed_from_predicate(predicate: QueryPredicate | None) -> str | None:
+    """Return the ``lineage:id:`` seed session id carried by ``predicate``, if any.
+
+    ``lineage:id:<ref>`` compiles to :class:`QueryLineagePredicate` (possibly
+    ANDed with other clauses), which the SQL layer already uses to filter
+    session rows to one shared-root lineage family. This walks the same
+    boolean-predicate tree to detect that shape so the list route can
+    materialize the declared recursive-graph projection columns for it (#z9gh.3).
+    """
+    if predicate is None:
+        return None
+    if isinstance(predicate, QueryLineagePredicate):
+        return predicate.seed_session_id
+    if isinstance(predicate, QueryBoolPredicate):
+        for child in predicate.children:
+            seed = _lineage_seed_from_predicate(child)
+            if seed is not None:
+                return seed
+    return None
 
 
 def _reject_unsupported_params(params: dict[str, object]) -> None:
@@ -841,6 +870,7 @@ def _query_hits(
     config: Config,
     query: str,
     similar_text: str | None,
+    similar_session_id: str | None,
     retrieval_lane: str,
     limit: int,
     offset: int,
@@ -851,6 +881,34 @@ def _query_hits(
 ) -> tuple[list[ArchiveSessionSearchHit], str]:
     archive_root = archive_file_set_root_for_paths(archive_root_path=config.archive_root, db_anchor=config.db_path)
     embeddings_db = archive_root / "embeddings.db"
+    if similar_session_id is not None:
+        # near:id: is an explicit request to rank by a *stored* session's
+        # embeddings; unlike near:"text" there is no lexical fallback query.
+        # Reuse the same VectorProvider mechanism (sqlite-vec + Voyage
+        # embeddings) that backs the near:"text" branch below and the
+        # SessionFilter route (archive_execution.py's ``_session_seed_scored``)
+        # rather than silently degrading to an unfiltered session list
+        # (polylogue-z9gh.3).
+        from polylogue.storage.search_providers.sqlite_vec_support import SqliteVecError
+
+        vector_provider = create_vector_provider(config, db_path=embeddings_db)
+        if vector_provider is None:
+            raise click.UsageError(
+                "near:id: requires configured sqlite-vec and Voyage embeddings; none is available for this archive."
+            )
+        pool = max(limit + offset, limit) * 3
+        try:
+            seed_scored = vector_provider.query_by_session(similar_session_id, limit=pool)
+        except SqliteVecError as exc:
+            raise click.UsageError(str(exc)) from exc
+        seed_hits = archive.semantic_summaries(
+            seed_scored,
+            limit=pool,
+            offset=0,
+            session_id=session_id,
+            **filter_kwargs,
+        )
+        return seed_hits[offset : offset + limit], "semantic"
     # ``auto`` is intentionally lexical. A default ``find`` must not open or scan
     # embeddings.db before returning FTS results; large active archives can make
     # that probe block in I/O wait. Vector retrieval remains explicit through
@@ -914,6 +972,7 @@ def _count_root_matches(
     *,
     query: str,
     similar_text: str | None,
+    similar_session_id: str | None = None,
     session_id: str | None,
     filter_kwargs: _ArchiveFilterKwargs,
 ) -> int | None:
@@ -926,7 +985,7 @@ def _count_root_matches(
     primitives and retain the full total even when the page itself is bounded.
     """
 
-    if similar_text is not None:
+    if similar_text is not None or similar_session_id is not None:
         return None
     counter = getattr(archive, "count_search_sessions" if query else "count_sessions", None)
     if not callable(counter):
@@ -964,6 +1023,7 @@ def _try_emit_daemon_session_page(
     sort: str | None,
     reverse: bool,
     similar_text: str | None,
+    similar_session_id: str | None,
     retrieval_lane: str,
 ) -> bool:
     """Use the running daemon for ordinary session pages when it is safe.
@@ -990,6 +1050,7 @@ def _try_emit_daemon_session_page(
         sort=sort,
         reverse=reverse,
         similar_text=similar_text,
+        similar_session_id=similar_session_id,
         retrieval_lane=retrieval_lane,
     ):
         return False
@@ -1131,6 +1192,7 @@ def _daemon_session_page_supported(
     sort: str | None,
     reverse: bool,
     similar_text: str | None,
+    similar_session_id: str | None,
     retrieval_lane: str,
 ) -> bool:
     if unit_source is not None or with_units or with_unit_fields:
@@ -1141,7 +1203,11 @@ def _daemon_session_page_supported(
         return False
     if sample_count is not None or cursor is not None or sort is not None or reverse:
         return False
-    if similar_text is not None or retrieval_lane not in {"auto", "dialogue"}:
+    if similar_text is not None or similar_session_id is not None or retrieval_lane not in {"auto", "dialogue"}:
+        # near:id: session-seeded ranking has no equivalent in the daemon's
+        # split-archive `/api/sessions` fast path (_do_archive_session_list only
+        # handles FTS terms and plain filters), so this must fall through to
+        # local CLI execution, which resolves the vector provider itself.
         return False
     if compiled_spec.boolean_predicate is not None or compiled_spec.since_session_id is not None:
         return False
@@ -2059,8 +2125,37 @@ def _emit_list(
     archive: ArchiveStore | None = None,
     with_units: tuple[str, ...] = (),
     with_unit_fields: dict[str, tuple[str, ...]] | None = None,
+    lineage_seed_session_id: str | None = None,
 ) -> None:
-    items = [_summary_payload(summary) for summary in summaries]
+    lineage_edges: dict[str, tuple[str | None, tuple[str, ...]]] = {}
+    if lineage_seed_session_id is not None and archive is not None and summaries:
+        # Materialize the declared recursive-graph projection columns
+        # (parent_refs/child_refs/continuation) for a lineage:id:-seeded page:
+        # per-page direct edges plus the page-level cursor, reusing the
+        # already-fetched page instead of a second unbounded graph walk
+        # (#z9gh.3).
+        lineage_edges = archive.session_lineage_edges([summary.session_id for summary in summaries])
+
+    def _parent_refs(session_id: str) -> tuple[str, ...] | None:
+        edge = lineage_edges.get(session_id)
+        if edge is None:
+            return None
+        parent_id = edge[0]
+        return (parent_id,) if parent_id else ()
+
+    def _child_refs(session_id: str) -> tuple[str, ...] | None:
+        edge = lineage_edges.get(session_id)
+        return edge[1] if edge is not None else None
+
+    items = [
+        _summary_payload(
+            summary,
+            parent_refs=_parent_refs(summary.session_id),
+            child_refs=_child_refs(summary.session_id),
+            continuation=(next_cursor if lineage_seed_session_id is not None else None),
+        )
+        for summary in summaries
+    ]
     _inject_attached_units(
         items,
         [summary.session_id for summary in summaries],
@@ -2414,7 +2509,13 @@ def _csv(items: list[dict[str, object]]) -> str:
     return buf.getvalue()
 
 
-def _summary_payload(summary: ArchiveSessionSummary) -> dict[str, object]:
+def _summary_payload(
+    summary: ArchiveSessionSummary,
+    *,
+    parent_refs: tuple[str, ...] | None = None,
+    child_refs: tuple[str, ...] | None = None,
+    continuation: str | None = None,
+) -> dict[str, object]:
     return cast(
         "dict[str, object]",
         model_json_document(
@@ -2431,6 +2532,9 @@ def _summary_payload(summary: ArchiveSessionSummary) -> dict[str, object]:
                 words=summary.word_count,
                 repo=summary.git_repository_url,
                 cwd_display=summary.working_directories[0] if summary.working_directories else None,
+                parent_refs=parent_refs,
+                child_refs=child_refs,
+                continuation=continuation,
             ),
             exclude_none=True,
         ),

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -3996,6 +3996,46 @@ class ArchiveStore:
         ).fetchone()
         return row is not None
 
+    def session_lineage_edges(self, session_ids: Sequence[str]) -> dict[str, tuple[str | None, tuple[str, ...]]]:
+        """Return ``(parent_session_id, child_session_ids)`` per requested id.
+
+        Reuses the same ``sessions.parent_session_id`` column the
+        ``lineage:id:`` predicate already filters sessions by (shared
+        ``root_session_id``) to materialize the direct parent/child edges for
+        one already-selected page of a lineage family, rather than performing
+        a second unbounded recursive graph traversal (#z9gh.3). Only direct
+        (one-hop) edges are returned; children outside ``session_ids`` are
+        still discovered (the child query is unscoped by the input set), but
+        parents outside ``session_ids`` are reported by id only, not hydrated.
+        """
+        if not session_ids:
+            return {}
+        ids = tuple(dict.fromkeys(session_ids))
+        placeholders = ",".join("?" for _ in ids)
+        parent_rows = self._conn.execute(
+            f"SELECT session_id, parent_session_id FROM sessions WHERE session_id IN ({placeholders})",
+            ids,
+        ).fetchall()
+        parent_by_id: dict[str, str | None] = {
+            str(row["session_id"]): (str(row["parent_session_id"]) if row["parent_session_id"] else None)
+            for row in parent_rows
+        }
+        child_rows = self._conn.execute(
+            f"SELECT session_id, parent_session_id FROM sessions WHERE parent_session_id IN ({placeholders})",
+            ids,
+        ).fetchall()
+        children_by_parent: dict[str, list[str]] = {}
+        for row in child_rows:
+            parent_id = str(row["parent_session_id"])
+            children_by_parent.setdefault(parent_id, []).append(str(row["session_id"]))
+        return {
+            session_id: (
+                parent_by_id.get(session_id),
+                tuple(children_by_parent.get(session_id, ())),
+            )
+            for session_id in ids
+        }
+
     def get_session_tree(self, session_id: str) -> list[ArchiveSessionEnvelope]:
         """Return the rooted archive session tree containing ``session_id``."""
         try:

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -950,6 +950,14 @@ class SessionListRowPayload(SurfacePayloadModel):
     repo: str | None = None
     cwd_display: str | None = None
     flags: SessionFlagsPayload | None = None
+    # Recursive-graph projection (#z9gh.3): populated only for lineage-seeded
+    # (``lineage:id:<ref>``) list pages. ``parent_refs``/``child_refs`` are the
+    # session's direct one-hop lineage edges within the current page;
+    # ``continuation`` mirrors the page-level cursor (``None`` once the
+    # lineage family's last page has been served).
+    parent_refs: tuple[str, ...] | None = None
+    child_refs: tuple[str, ...] | None = None
+    continuation: str | None = None
 
     @classmethod
     def from_session(cls, session: Session) -> SessionListRowPayload:

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -2299,6 +2299,219 @@ def test_async_execute_query_archive_uses_vector_provider_for_semantic_search(
     assert decode_search_cursor(payload["next_cursor"]).lane == "semantic"
 
 
+def test_async_execute_query_archive_uses_vector_provider_for_session_seed_similarity(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``near:id:<ref>`` through the CLI root query route ranks by vector similarity.
+
+    Regression for polylogue-z9gh.3: this route used to have no
+    ``similar_session_id`` handling at all and silently fell through to a
+    plain unfiltered ``list_summaries`` page. ``FakeArchiveStore.list_summaries``
+    raises if invoked, proving the fixed route never reaches that fallback and
+    instead resolves through the same vector-provider mechanism as ``near:"text"``.
+    """
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    (archive_root / "index.db").touch()
+    config = MagicMock()
+    config.archive_root = archive_root
+    env = _make_env(repo=MagicMock(), config=config)
+
+    class FakeVectorProvider:
+        def query_by_session(self, session_id: str, limit: int = 10) -> list[tuple[str, float]]:
+            assert session_id == "codex-session:seed"
+            assert limit == 6
+            return [("codex-session:native-1:m1", 0.2), ("codex-session:native-2:m1", 0.3)]
+
+    class FakeArchiveStore:
+        index_db_path = archive_root / "index.db"
+
+        def __enter__(self) -> FakeArchiveStore:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def semantic_summaries(
+            self,
+            scored_message_ids: list[tuple[str, float]],
+            **kwargs: object,
+        ) -> list[ArchiveSessionSearchHit]:
+            assert scored_message_ids == [("codex-session:native-1:m1", 0.2), ("codex-session:native-2:m1", 0.3)]
+            return [
+                ArchiveSessionSearchHit(
+                    rank=1,
+                    session_id="codex-session:native-1",
+                    block_id="codex-session:native-1:m1:0",
+                    message_id="codex-session:native-1:m1",
+                    origin="codex-session",
+                    title="Seed neighbor",
+                    snippet="near hit",
+                ),
+                ArchiveSessionSearchHit(
+                    rank=2,
+                    session_id="codex-session:native-2",
+                    block_id="codex-session:native-2:m1:0",
+                    message_id="codex-session:native-2:m1",
+                    origin="codex-session",
+                    title="Seed neighbor 2",
+                    snippet="near hit 2",
+                ),
+            ]
+
+        def read_summary(self, session_id: str) -> ArchiveSessionSummary:
+            native_id = session_id.removeprefix("codex-session:")
+            return ArchiveSessionSummary(
+                session_id=session_id,
+                native_id=native_id,
+                origin="codex-session",
+                title=f"Seed neighbor {native_id[-1]}",
+                created_at=None,
+                updated_at=None,
+                message_count=1,
+                word_count=1,
+                tags=(),
+            )
+
+        def list_summaries(self, **kwargs: object) -> list[ArchiveSessionSummary]:
+            raise AssertionError("near:id: must not fall through to the plain unfiltered list_summaries route")
+
+    monkeypatch.setattr(
+        "polylogue.cli.archive_query.ArchiveStore.open_existing",
+        classmethod(lambda cls, root: FakeArchiveStore()),
+    )
+    monkeypatch.setattr(
+        "polylogue.cli.archive_query.create_vector_provider", lambda *args, **kwargs: FakeVectorProvider()
+    )
+
+    asyncio.run(
+        async_execute_query(
+            env,
+            {
+                "archive": True,
+                "similar_session_id": "codex-session:seed",
+                "limit": 1,
+                "output_format": "json",
+            },
+        )
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["retrieval_lane"] == "semantic"
+    assert payload["items"][0]["session"]["id"] == "codex-session:native-1"
+    assert [item["session"]["id"] for item in payload["items"]] != []
+
+
+def test_async_execute_query_archive_session_seed_without_vector_backend_raises_usage_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No configured vector backend must fail typed, never degrade to a plain list."""
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    (archive_root / "index.db").touch()
+    config = MagicMock()
+    config.archive_root = archive_root
+    env = _make_env(repo=MagicMock(), config=config)
+
+    class FakeArchiveStore:
+        index_db_path = archive_root / "index.db"
+
+        def __enter__(self) -> FakeArchiveStore:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def list_summaries(self, **kwargs: object) -> list[ArchiveSessionSummary]:
+            raise AssertionError("near:id: must not fall through to the plain unfiltered list_summaries route")
+
+    monkeypatch.setattr(
+        "polylogue.cli.archive_query.ArchiveStore.open_existing",
+        classmethod(lambda cls, root: FakeArchiveStore()),
+    )
+    monkeypatch.setattr("polylogue.cli.archive_query.create_vector_provider", lambda *args, **kwargs: None)
+
+    with pytest.raises(click.UsageError, match="near:id: requires configured"):
+        asyncio.run(
+            async_execute_query(
+                env,
+                {
+                    "archive": True,
+                    "similar_session_id": "codex-session:seed",
+                    "limit": 1,
+                    "output_format": "json",
+                },
+            )
+        )
+
+
+def test_lineage_id_cli_query_materializes_parent_child_refs(cli_workspace: dict[str, Path]) -> None:
+    """``lineage:id:<ref>`` through the CLI root query route projects lineage edges.
+
+    Regression for polylogue-z9gh.3: the ``lineage:id:`` predicate already
+    filtered session rows to one shared-root family via SQL, but the CLI list
+    route never populated the declared ``parent_refs``/``child_refs``/
+    ``continuation`` projection columns on the emitted rows. This exercises the
+    real production ``ArchiveStore`` (via ``write_parsed_session_to_archive``
+    through ``SessionBuilder``) rather than a mock, so it fails if the fix only
+    special-cases a synthetic double.
+    """
+    from polylogue.cli import cli
+    from tests.infra.storage_records import SessionBuilder
+
+    index_db = cli_workspace["archive_root"] / "index.db"
+    (
+        SessionBuilder(index_db, "lineage-parent")
+        .provider("codex")
+        .title("Lineage parent")
+        .add_message("m1", role="user", text="root session message")
+        .save()
+    )
+    (
+        SessionBuilder(index_db, "lineage-child")
+        .provider("codex")
+        .title("Lineage child")
+        .parent_session("ext-lineage-parent")
+        .add_message("m1", role="user", text="child session message")
+        .save()
+    )
+    # An unrelated session must not appear in the lineage-seeded page.
+    (
+        SessionBuilder(index_db, "unrelated")
+        .provider("codex")
+        .title("Unrelated session")
+        .add_message("m1", role="user", text="unrelated")
+        .save()
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--plain", "--no-daemon", "find", "lineage:id:codex-session:ext-lineage-parent", "-f", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["mode"] == "list"
+    items_by_id = {item["id"]: item for item in payload["items"]}
+    assert set(items_by_id) == {
+        "codex-session:ext-lineage-parent",
+        "codex-session:ext-lineage-child",
+    }
+
+    parent_row = items_by_id["codex-session:ext-lineage-parent"]
+    child_row = items_by_id["codex-session:ext-lineage-child"]
+    assert parent_row["parent_refs"] == []
+    assert parent_row["child_refs"] == ["codex-session:ext-lineage-child"]
+    assert child_row["parent_refs"] == ["codex-session:ext-lineage-parent"]
+    assert child_row["child_refs"] == []
+    # No further page remains, so the per-row continuation cursor is absent.
+    assert parent_row.get("continuation") is None
+    assert child_row.get("continuation") is None
+
+
 def test_async_execute_query_archive_accepts_explicit_semantic_lane(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -2512,6 +2512,39 @@ def test_lineage_id_cli_query_materializes_parent_child_refs(cli_workspace: dict
     assert child_row.get("continuation") is None
 
 
+def test_lineage_seed_from_predicate_ignores_or_combined_lineage_clause() -> None:
+    """``lineage:id:X or <anything>`` must not yield a lineage seed.
+
+    Regression for a bug found reviewing polylogue-z9gh.3's fix: the seed
+    detector originally walked into ``QueryBoolPredicate.children``
+    regardless of the boolean operator, so an ``or``-combined lineage
+    predicate would incorrectly materialize parent_refs/child_refs for rows
+    that never actually belong to that lineage family - they'd have merely
+    matched the query via the unrelated ``or`` branch. An ``and``-combined
+    lineage clause is unaffected: AND only narrows the result set further,
+    so every remaining row genuinely is a member of the lineage family.
+    """
+    from polylogue.archive.query.predicate import (
+        QueryBoolPredicate,
+        QueryFieldPredicate,
+        QueryLineagePredicate,
+    )
+    from polylogue.cli.archive_query import _lineage_seed_from_predicate
+
+    lineage = QueryLineagePredicate(seed_session_id="codex-session:seed")
+    other = QueryFieldPredicate(field="repo", values=("foo",), op="=")
+
+    or_combined = QueryBoolPredicate(op="or", children=(lineage, other))
+    assert _lineage_seed_from_predicate(or_combined) is None
+
+    and_combined = QueryBoolPredicate(op="and", children=(lineage, other))
+    assert _lineage_seed_from_predicate(and_combined) == "codex-session:seed"
+
+    assert _lineage_seed_from_predicate(lineage) == "codex-session:seed"
+    assert _lineage_seed_from_predicate(None) is None
+    assert _lineage_seed_from_predicate(other) is None
+
+
 def test_async_execute_query_archive_accepts_explicit_semantic_lane(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/webui/src/api/generated.ts
+++ b/webui/src/api/generated.ts
@@ -402,12 +402,15 @@ export type SessionListRowPayload = {
   readonly [key: string]: ReaderActionAvailabilityPayload;
 };
   readonly anchor?: string | null;
+  readonly child_refs?: ReadonlyArray<string> | null;
+  readonly continuation?: string | null;
   readonly created_at?: string | null;
   readonly cwd_display?: string | null;
   readonly flags?: SessionFlagsPayload | null;
   readonly id: string;
   readonly message_count?: number;
   readonly origin: string;
+  readonly parent_refs?: ReadonlyArray<string> | null;
   readonly repo?: string | null;
   readonly summary?: string | null;
   readonly tags?: ReadonlyArray<string>;


### PR DESCRIPTION
## Summary

Fixes two pre-existing, execution-layer-only gaps in the generic `find`/`read`
CLI query route: `near:id:<ref>` silently fell back to an unfiltered session
list instead of real vector-similarity ranking, and `lineage:id:<ref>` never
materialized its declared `parent_refs`/`child_refs`/`continuation`
recursive-graph projection columns.

## Problem

`polylogue-z9gh.3`'s 2026-07-20 note narrowed the bead's remaining scope to
two "size S" residuals, confirmed via a spot-check against a seeded demo
archive: `near:id:` executes without error via the generic find/read CLI
route but does not perform real similarity ranking (falls back to an
unfiltered session list), and the declared recursive-page projection columns
are not materialized by that same route for `lineage:id:` queries.

I independently re-verified both against a live `polylogue demo seed`
archive before writing any fix:

- `polylogue find 'near:id:<seed>' --format json` returned the exact same
  19-session list, in the same order, as a query with no filter at all.
- `polylogue find 'lineage:id:<parent>' --format json` correctly narrowed to
  the 2-session lineage family (the SQL-level filter already worked), but
  neither row carried `parent_refs`, `child_refs`, or `continuation`.

Root cause for `near:id:`: `polylogue/cli/archive_query.py`'s hand-rolled
search-execution path (`_query_hits`, `_daemon_session_page_supported`,
`_try_emit_daemon_session_page`) only ever threaded `similar_text` through;
`SessionQuerySpec.similar_session_id` was never read anywhere in that file,
so a bare `near:id:` predicate (no FTS terms, no `similar_text`) fell through
every branch straight to the plain `archive.list_summaries(**filter_kwargs)`
call. (The separate `SessionFilter`/`archive_execution.py` route already had
correct vector-seeded ranking since PR #3018 — this bug was isolated to the
CLI's own parallel execution path.)

Root cause for `lineage:id:`: the SQL-level `QueryLineagePredicate` filter
(via `boolean_predicate`) was correct, but no code anywhere translated the
declared `RECURSIVE_COLUMNS` (`session_id`, `parent_refs`, `child_refs`,
`continuation`) from `archive/query/discovery.py` into actual payload fields.

## Solution

- `polylogue/cli/archive_query.py`: thread `similar_session_id` through
  `_query_hits` the same way `similar_text` already is. When set, it calls
  the existing `VectorProvider.query_by_session` mechanism (the same
  mechanism `archive_execution.py`'s `_session_seed_scored` already uses for
  the `SessionFilter` route) rather than building new vector-search code.
  Raises a typed `click.UsageError` when no vector backend is configured or
  the seed session has no stored embeddings, matching the existing
  `near:"text"` error contract. Also excludes `similar_session_id` from the
  daemon session-page fast path (`_daemon_session_page_supported`), since
  that fast path's `/api/sessions` split-archive route has the identical gap
  and forcing local execution is the minimal fix within this file's scope.
- `polylogue/storage/sqlite/archive_tiers/archive.py`: adds
  `ArchiveStore.session_lineage_edges`, a small bounded query over the
  existing `sessions.parent_session_id` column (the same column
  `lineage:id:` already filters on via `root_session_id`) returning direct
  one-hop parent/child ids for a page of session ids — no new recursive
  graph traversal.
- `polylogue/cli/archive_query.py` + `polylogue/surfaces/payloads.py`: when a
  list page's `boolean_predicate` carries a `QueryLineagePredicate`
  (`lineage:id:`), look up per-page lineage edges and populate
  `SessionListRowPayload.parent_refs`/`child_refs`/`continuation`.
  `continuation` mirrors the page's own pagination cursor; edges are
  qualified per page, consistent with the "recursive-page" result-semantics
  contract already documented in `archive/query/discovery.py`
  (`RESULT_SEMANTICS_TEACHING`).
- Regenerated `docs/schemas/cli-output/session-list-row.schema.json`,
  `docs/openapi/search.yaml`, and `webui/src/api/generated.ts` for the two
  new payload fields.

No grammar changes: `polylogue/archive/query/expression.py` is untouched.

## Verification

- Manual, against a seeded demo archive: `near:id:<ref>` now raises a typed
  error instead of returning the full session list; `lineage:id:<ref>` now
  emits `parent_refs`/`child_refs` per row.
- `devtools test tests/unit/cli/test_query_exec_laws.py` — 88 passed (adds 3
  new tests: real vector-ranked `near:id:` through the CLI route with an
  assertion that `list_summaries` is never reached, a typed `UsageError`
  with no vector backend configured, and a real-archive `lineage:id:` test
  via `SessionBuilder`/`write_parsed_session_to_archive` proving
  `parent_refs`/`child_refs` materialize correctly against production
  `ArchiveStore` SQL, not a mock).
- `devtools test tests/unit/cli/test_archive_query.py tests/unit/cli/test_cli_output_schemas.py` — 135 passed.
- `devtools test tests/unit/archive/test_near_session_seed_execution.py tests/unit/storage/test_vec_session_seed.py` — 9 passed.
- `devtools test tests/unit/mcp/test_query_request_contracts.py tests/unit/cli/test_query_expression.py tests/unit/cli/test_select.py` — 449 passed, 1 skipped.
- `mypy` on all three changed source files — no issues.
- `ruff check` + `ruff format --check` — clean.
- `devtools render all --check` — sync OK, no "out of sync" lines.
- `devtools verify --quick` — exit 0 (also ran automatically via the pre-push hook).

Not run: `devtools verify --all`/full suite — seeding `pytest-testmon` from
scratch triggered a large, apparently pre-existing failure spread across the
whole suite baseline unrelated to these three files; the targeted
`devtools test` runs above cover every file this change touches or could
plausibly affect.

Ref polylogue-z9gh.3