### PR TITLE
feat(daemon): surface GIL/free-threaded runtime mode in status

### DIFF
--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -1482,6 +1482,13 @@ def _show_daemon_status(env: AppEnv, status: dict[str, Any], *, compact: bool = 
                 desc = comp.get("description", "")
                 env.ui.console.print(f"  [{state_color}]●[/{state_color}] {name}: {desc}")
 
+    # Runtime (polylogue-dcz5): free-threaded (3.14t+) vs GIL-enabled.
+    gil_enabled = status.get("gil_enabled")
+    if gil_enabled is not None:
+        mode_text = "free-threaded (GIL disabled)" if gil_enabled is False else "GIL enabled"
+        mode_color = "green" if gil_enabled is False else "dim"
+        env.ui.console.print(f"  Runtime: [{mode_color}]{mode_text}[/{mode_color}]")
+
     # Live ingest. The status payload carries LiveIngestAttemptSummary, which
     # exposes running_count + per-attempt worker progress in `recent` — it has
     # no top-level completed_count/total_count, so the previous keys always read
@@ -1578,6 +1585,7 @@ def _compact_status_payload(status: dict[str, Any], *, source: str) -> dict[str,
         "messages",
         "raw_records",
         "next_action",
+        "gil_enabled",
     ):
         if key in status:
             payload[key] = status[key]

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 import sqlite3
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -406,6 +407,9 @@ class DaemonStatus(BaseModel):
     raw_failure_samples: list[RawFailureSample] = Field(default_factory=list)
     raw_detection_warnings: int = 0
     health: DaemonHealth = Field(default_factory=DaemonHealth)
+    # Whether the running interpreter has the GIL enabled; False means a
+    # free-threaded (PEP 703) build such as 3.14t (polylogue-dcz5).
+    gil_enabled: bool = True
     checked_at: str = ""
     # Memory pressure — surfaced from the most recent running live ingest attempt
     rss_current_mb: float | None = None
@@ -1013,6 +1017,19 @@ def _safe_float(value: object, *, default: float = 0.0) -> float:
         except ValueError:
             return default
     return default
+
+
+def _gil_enabled() -> bool:
+    """Whether the running interpreter has the GIL enabled (polylogue-dcz5).
+
+    ``sys._is_gil_enabled`` exists only on Python 3.13+ builds capable of
+    running free-threaded (PEP 703); interpreters predating it never had a
+    disableable GIL, so the safe fallback is ``True`` (GIL enabled).
+    """
+    checker = getattr(sys, "_is_gil_enabled", None)
+    if checker is None:
+        return True
+    return bool(checker())
 
 
 def _fmt_bytes(value: int) -> str:
@@ -2396,6 +2413,7 @@ def build_daemon_status(
         rss_current_mb=rss_current_mb,
         rss_peak_mb=rss_peak_mb,
         cgroup_memory_current_mb=cgroup_memory_current_mb,
+        gil_enabled=_gil_enabled(),
         checked_at=datetime.now(UTC).isoformat(),
     )
 

--- a/polylogue/daemon/status_snapshot.py
+++ b/polylogue/daemon/status_snapshot.py
@@ -225,7 +225,11 @@ def _disk_free_bytes(path: Path) -> int:
 
 def _minimal_status_payload(*, refresh_in_progress: bool = False, refresh_error: str | None = None) -> JSONDocument:
     """Return a request-safe status envelope with no archive-scale scans."""
-    from polylogue.daemon.status import _check_daemon_liveness, browser_capture_status_public_payload
+    from polylogue.daemon.status import (
+        _check_daemon_liveness,
+        _gil_enabled,
+        browser_capture_status_public_payload,
+    )
 
     dbf = active_index_db_path()
     wal = dbf.with_suffix(".db-wal")
@@ -246,6 +250,7 @@ def _minimal_status_payload(*, refresh_in_progress: bool = False, refresh_error:
         "daemon": "polylogued",
         "daemon_liveness": _check_daemon_liveness(),
         "checked_at": now,
+        "gil_enabled": _gil_enabled(),
         "component_state": {
             "watcher": _component_state_from_flag(runtime.watcher_enabled),
             "api": _component_state_from_flag(runtime.api_enabled, default_when_unknown="running"),

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+import sys
 from datetime import timedelta
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -454,6 +455,50 @@ def test_daemon_status_honors_explicit_disabled_browser_capture(
 
     assert status.browser_capture_active is False
     assert status.component_state.browser_capture == "stopped"
+
+
+def test_daemon_status_reports_gil_disabled_on_free_threaded_interpreter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """polylogue-dcz5: free-threaded (3.14t) builds must report gil_enabled=False."""
+    monkeypatch.setattr(sys, "_is_gil_enabled", lambda: False, raising=False)
+
+    status = build_daemon_status(sources=())
+
+    assert status.gil_enabled is False
+
+
+def test_daemon_status_reports_gil_enabled_on_standard_interpreter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A standard (non-free-threaded) 3.13+ build reports gil_enabled=True."""
+    monkeypatch.setattr(sys, "_is_gil_enabled", lambda: True, raising=False)
+
+    status = build_daemon_status(sources=())
+
+    assert status.gil_enabled is True
+
+
+def test_daemon_status_gil_enabled_falls_back_true_without_gil_checker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interpreters predating ``sys._is_gil_enabled`` (pre-3.13) never had a
+    disableable GIL, so the fallback must be the safe default: enabled."""
+    monkeypatch.delattr(sys, "_is_gil_enabled", raising=False)
+
+    status = build_daemon_status(sources=())
+
+    assert status.gil_enabled is True
+
+
+def test_minimal_status_payload_reports_gil_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The pre-refresh minimal snapshot also carries gil_enabled (cheap fact,
+    no archive I/O required — matches sys._is_gil_enabled()'s cost profile)."""
+    monkeypatch.setattr(sys, "_is_gil_enabled", lambda: False, raising=False)
+
+    payload = get_status_snapshot_payload()
+
+    assert payload["gil_enabled"] is False
 
 
 def test_daemon_status_check_health_failure_reports_error_not_ok(


### PR DESCRIPTION
## Summary

Adds a `gil_enabled` field to the daemon status payload so operators can see whether `polylogued` is running under a standard GIL-enabled interpreter or a free-threaded (PEP 703, Python 3.13+) build such as 3.14t.

## Problem

`polylogue-dcz5` ("Deploy polylogued on Python 3.14t (free-threaded) and gate runtime") requires the daemon status surface to show the interpreter's runtime mode before a production deploy decision can be verified end-to-end. No status/observability field existed anywhere for this.

## Solution

- `polylogue/daemon/status.py`: new `_gil_enabled()` helper — calls `sys._is_gil_enabled()` when present (Python 3.13+), falls back to `True` on older interpreters that never had a disableable GIL. New `DaemonStatus.gil_enabled: bool = True` field, wired into `build_daemon_status()`'s return.
- `polylogue/daemon/status_snapshot.py`: `_minimal_status_payload()` (the pre-refresh/refreshing fallback dict) also reports `gil_enabled` — it's a cheap, no-I/O fact matching that function's cost profile, reusing the module's existing deferred-import pattern from `polylogue.daemon.status`.
- `polylogue/cli/commands/status.py`: `_show_daemon_status()` renders a `Runtime: ...` line; `gil_enabled` added to `_compact_status_payload()`'s key allowlist so it survives `polylogue ops status --json` without `--full`.
- Daemon HTTP `/api/status` reads from the same snapshot builders, so no separate wiring was needed there. Grepped for MCP consumers of `DaemonStatus` — none found, so no MCP surface change needed.

## Verification

- `mypy --strict polylogue/daemon/status.py polylogue/daemon/status_snapshot.py polylogue/cli/commands/status.py` → clean.
- `ruff check` + `ruff format --check` on touched files → clean.
- `devtools test tests/unit/daemon/test_daemon_status.py` → 61 passed, including 4 new tests: GIL-disabled (free-threaded), GIL-enabled (standard), `sys._is_gil_enabled` attribute-absent fallback, and minimal-snapshot payload inclusion.
- `devtools test tests/unit/cli/test_status.py` → 1 pre-existing failure (`test_archive_facade_route_catalog_covers_public_async_facade`, a `hermes_integration_health` route-catalog mismatch), confirmed identical with this diff stashed out — unrelated to this change.
- `devtools render all --check` → no drift.
- Pre-push hook (`devtools verify --quick`: format + lint + mypy + render-all-check) → exit 0.

## Self-review note

CodeRabbit is rate-limited on every PR this session, so I self-reviewed the diff directly: 4 files touched, matches the plan exactly, no stray edits, no unrelated `.beads/*` churn included (those pre-existing dirty files were stashed separately and are not part of this branch).

## Scope

This covers AC item 2 of 4 on `polylogue-dcz5` ("daemon status surface shows free-threaded runtime"). Explicitly out of scope for this repo/PR: the sinnix-side package pin bump + `switch`/`test-vm`, recorded 7mtf-style benchmark numbers proving parallel fan-out, and rollback documentation — all real deploy coordination outside this repo.

Ref polylogue-dcz5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daemon status now displays whether the runtime uses the GIL or free-threaded execution.
  * Compact status output includes the runtime mode for machine-readable monitoring.
  * Status reporting remains compatible with standard Python runtimes when detailed runtime detection is unavailable.

* **Tests**
  * Added coverage for free-threaded, standard, and fallback runtime detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->