### PR TITLE
test(schemas): prove schema-generation cancellation and shuffle-order equivalence

### DIFF
--- a/tests/infra/schema_generation_cancellation_probe.py
+++ b/tests/infra/schema_generation_cancellation_probe.py
@@ -1,0 +1,108 @@
+"""Subprocess target for the schema-generation cancellation-equivalence proof.
+
+``devtools/schema_generate.py`` reports its own resume semantics as
+``restart_from_acquisition``: a killed run's private ``ObservationJournal`` is
+always removed, so there is no partial-resume state to diverge from a fresh
+run. This script lets a test prove that claim empirically against the real
+``generate_provider_schema`` entrypoint (not just the raw journal cleanup
+contract already covered by ``test_journal_cleanup_runs_for_real_terminated_process``):
+
+1. Write a small deterministic synthetic ChatGPT archive once (idempotent
+   across repeated invocations against the same ``--archive-root``).
+2. Optionally pause right after the ``observe_and_cluster`` phase starts
+   (``--pause-after-observe``) so the parent can send SIGTERM mid-run and
+   confirm the journal directory is empty afterward.
+3. Run generation to completion and print the resulting schema (minus the
+   wall-clock-dependent ``x-polylogue-generated-at`` field) as JSON, so the
+   parent can diff an uninterrupted reference run against an
+   interrupted-then-restarted run on the same archive.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+
+def _payload(index: int) -> bytes:
+    document = {
+        "title": f"synthetic conversation {index}",
+        "conversation_id": f"conversation-{index}",
+        "mapping": {
+            f"node-{index}": {
+                "id": f"node-{index}",
+                "message": {
+                    "author": {"role": "user" if index % 2 == 0 else "assistant"},
+                    "content": {"content_type": "text", "parts": [f"message {index}"]},
+                },
+            }
+        },
+    }
+    return json.dumps(document, sort_keys=True).encode("utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--archive-root", type=Path, required=True)
+    parser.add_argument("--count", type=int, default=6)
+    parser.add_argument("--pause-after-observe", action="store_true")
+    args = parser.parse_args(argv)
+
+    archive_root = args.archive_root.resolve()
+    os.environ["POLYLOGUE_ARCHIVE_ROOT"] = str(archive_root)
+    os.environ["XDG_CACHE_HOME"] = str(archive_root.parent / "cache")
+    os.environ["XDG_CONFIG_HOME"] = str(archive_root.parent / "config")
+    os.environ["XDG_DATA_HOME"] = str(archive_root.parent / "data")
+    os.environ["XDG_STATE_HOME"] = str(archive_root.parent / "state")
+
+    from polylogue.core.enums import Provider
+    from polylogue.core.json import JSONDocument
+    from polylogue.schemas.generation.workflow import generate_provider_schema
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    if not (archive_root / "index.db").exists():
+        with ArchiveStore(archive_root) as archive:
+            for index in range(args.count):
+                archive.write_raw_payload(
+                    provider=Provider.CHATGPT,
+                    payload=_payload(index),
+                    source_path=f"/synthetic/chatgpt/session-{index}.json",
+                    acquired_at_ms=1_700_000_000_000 + index,
+                    raw_id=f"synthetic-raw-{index}",
+                )
+
+    def on_progress(phase: str, payload: JSONDocument) -> None:
+        if args.pause_after_observe and phase == "observe_and_cluster" and payload.get("state") == "started":
+            print("PAUSED", flush=True)
+            time.sleep(10)
+
+    result = generate_provider_schema(
+        "chatgpt",
+        db_path=archive_root / "index.db",
+        progress_callback=on_progress if args.pause_after_observe else None,
+    )
+    schema = dict(result.schema or {})
+    schema.pop("x-polylogue-generated-at", None)
+    print(
+        json.dumps(
+            {
+                "success": result.success,
+                "error": result.error,
+                "sample_count": result.sample_count,
+                "cluster_count": result.cluster_count,
+                "package_count": result.package_count,
+                "default_version": result.default_version,
+                "schema": schema,
+            },
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+    return 0 if result.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/core/test_schema_observation_journal.py
+++ b/tests/unit/core/test_schema_observation_journal.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import random
 import signal
 import sqlite3
 import stat
@@ -15,6 +16,7 @@ from pathlib import Path
 
 import pytest
 
+from polylogue.core.json import JSONDocument
 from polylogue.scenarios import (
     MeasurementScope,
     WorkloadEnvelopeSpec,
@@ -24,11 +26,13 @@ from polylogue.scenarios import (
     WorkloadRunStatus,
 )
 from polylogue.schemas.generation import observation_journal as observation_journal_module
+from polylogue.schemas.generation.models import _ProviderBundle
 from polylogue.schemas.generation.observation_journal import (
     ObservationJournal,
     recover_stale_journals,
 )
 from polylogue.schemas.generation.replay import MembershipSessionIds
+from polylogue.schemas.generation.workflow import _build_provider_bundle
 from polylogue.schemas.observation import SchemaUnit
 from polylogue.schemas.workload_tiers import WorkloadScaleTier
 
@@ -584,3 +588,172 @@ def test_single_jsonl_10x_replays_all_records_without_10x_python_memory(tmp_path
     assert ten_x.peak_journal_bytes > 0
     assert one_x.receipt.cleanup_complete is True
     assert ten_x.receipt.cleanup_complete is True
+
+
+def _shuffle_probe_units() -> list[SchemaUnit]:
+    """One structurally homogeneous cluster/package, small enough to hand-verify."""
+    return [
+        SchemaUnit(
+            cluster_payload={"id": str(index), "text": f"message-{index}"},
+            schema_samples=[{"id": str(index), "text": f"message-{index}"}],
+            artifact_kind="session_document",
+            session_id=f"conv-{index}",
+            raw_id=f"raw-{index}",
+            source_path=f"/private/source-{index}.json",
+            bundle_scope=f"scope-{index}",
+            observed_at=f"2026-07-01T00:{index:02d}:00+00:00",
+            exact_structure_id="structure-uniform",
+            profile_tokens=("field:id", "field:text"),
+        )
+        for index in range(6)
+    ]
+
+
+def _strip_generated_at(schema: JSONDocument) -> JSONDocument:
+    return {key: value for key, value in schema.items() if key != "x-polylogue-generated-at"}
+
+
+def _generate_from_units(units: list[SchemaUnit], db_root: Path) -> _ProviderBundle:
+    """Run the real production bundle builder over a fixed, ordered unit list.
+
+    Mirrors the monkeypatch technique already used by
+    ``test_build_provider_bundle_captures_element_windows_and_bundle_scopes``
+    in tests/unit/core/test_schema_generation.py: ``iter_schema_units`` is the
+    one production seam between DB sampling and cluster/package assembly, so
+    patching it is the standard way to feed the real
+    ``_build_provider_bundle``/``ObservationJournal`` pipeline a deterministic,
+    order-controlled corpus without touching a database.
+    """
+    import polylogue.schemas.sampling as sampling_module
+
+    original = sampling_module.iter_schema_units
+    sampling_module.iter_schema_units = lambda *args, **kwargs: iter(units)
+    try:
+        return _build_provider_bundle(
+            "chatgpt",
+            db_path=db_root / "unused.db",
+            max_samples=None,
+            privacy_config=None,
+        )
+    finally:
+        sampling_module.iter_schema_units = original
+
+
+def test_shuffled_sample_order_yields_identical_schema_and_package_assignment(tmp_path: Path) -> None:
+    """AC polylogue-1xc.14.1.1 #5: shuffled input order must not change output.
+
+    Feeds the identical unit multiset through the real production bundle
+    builder (``_build_provider_bundle``, the sole entrypoint
+    ``generate_provider_schema``/``generate_all_schemas`` use) in two
+    different orders and asserts the resulting schema content, package
+    identity, and cluster-manifest identities are the same regardless of
+    presentation order -- the design note for this bead explicitly requires
+    "deterministic ordering and identities so small-corpus outputs match the
+    in-memory reference."
+    """
+    canonical = _shuffle_probe_units()
+    shuffled = list(canonical)
+    random.Random(1234).shuffle(shuffled)
+    assert [unit.raw_id for unit in shuffled] != [unit.raw_id for unit in canonical]
+
+    canonical_bundle = _generate_from_units(canonical, tmp_path)
+    shuffled_bundle = _generate_from_units(shuffled, tmp_path)
+
+    assert canonical_bundle.catalog is not None
+    assert shuffled_bundle.catalog is not None
+    assert len(canonical_bundle.catalog.packages) == 1
+    assert len(shuffled_bundle.catalog.packages) == 1
+    canonical_package = canonical_bundle.catalog.packages[0]
+    shuffled_package = shuffled_bundle.catalog.packages[0]
+
+    assert canonical_package.anchor_profile_family_id == shuffled_package.anchor_profile_family_id
+    assert canonical_package.profile_family_ids == shuffled_package.profile_family_ids
+    assert canonical_package.sample_count == shuffled_package.sample_count == 6
+    assert canonical_package.bundle_scope_count == shuffled_package.bundle_scope_count == 6
+    assert canonical_package.first_seen == shuffled_package.first_seen
+    assert canonical_package.last_seen == shuffled_package.last_seen
+    assert canonical_bundle.catalog.default_version == shuffled_bundle.catalog.default_version
+    assert canonical_bundle.catalog.latest_version == shuffled_bundle.catalog.latest_version
+
+    canonical_schemas = {
+        version: {kind: _strip_generated_at(schema) for kind, schema in kinds.items()}
+        for version, kinds in canonical_bundle.package_schemas.items()
+    }
+    shuffled_schemas = {
+        version: {kind: _strip_generated_at(schema) for kind, schema in kinds.items()}
+        for version, kinds in shuffled_bundle.package_schemas.items()
+    }
+    assert set(canonical_schemas) == set(shuffled_schemas) == {"v1"}
+    assert canonical_schemas["v1"] == shuffled_schemas["v1"]
+
+    assert canonical_bundle.manifest is not None
+    assert shuffled_bundle.manifest is not None
+    canonical_cluster = canonical_bundle.manifest.clusters[0]
+    shuffled_cluster = shuffled_bundle.manifest.clusters[0]
+    assert sorted(canonical_cluster.exact_structure_ids) == sorted(shuffled_cluster.exact_structure_ids)
+    assert canonical_cluster.bundle_scope_count == shuffled_cluster.bundle_scope_count == 6
+
+
+def test_generation_cancellation_restarts_from_scratch_and_matches_uninterrupted_run(tmp_path: Path) -> None:
+    """AC polylogue-1xc.14.1.1 #2/#6: cancellation must be equivalent to a fresh run.
+
+    ``devtools/schema_generate.py``'s own generation receipt reports resume
+    status as ``"restart_from_acquisition"`` because "the private observation
+    journal is intentionally removed after interruption" -- there is no
+    partial-resume state that could diverge. This proves that claim
+    empirically through the real ``generate_provider_schema`` entrypoint
+    (not just the raw journal-cleanup contract already covered by
+    ``test_journal_cleanup_runs_for_real_terminated_process``): killing a run
+    mid-observation and then re-running against the same, unmodified archive
+    produces the same schema as an uninterrupted reference run.
+    """
+    probe = Path(__file__).resolve().parents[2] / "infra" / "schema_generation_cancellation_probe.py"
+    assert probe.exists()
+    archive_root = tmp_path / "archive"
+    cache_root = tmp_path / "cache"
+    env = {**os.environ, "XDG_CACHE_HOME": str(cache_root)}
+
+    def _run(*, pause: bool) -> subprocess.CompletedProcess[str] | subprocess.Popen[str]:
+        args = [sys.executable, str(probe), "--archive-root", str(archive_root)]
+        if pause:
+            args.append("--pause-after-observe")
+            return subprocess.Popen(
+                args,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        return subprocess.run(args, env=env, capture_output=True, text=True, timeout=30)
+
+    reference = _run(pause=False)
+    assert isinstance(reference, subprocess.CompletedProcess)
+    assert reference.returncode == 0, reference.stderr
+    reference_payload = json.loads(reference.stdout)
+    assert reference_payload["success"] is True
+    assert reference_payload["sample_count"] > 0
+
+    process = _run(pause=True)
+    assert isinstance(process, subprocess.Popen)
+    try:
+        assert process.stdout is not None
+        assert process.stdout.readline().strip() == "PAUSED"
+        process.terminate()
+        assert process.wait(timeout=10) == 128 + signal.SIGTERM
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)
+
+    journal_root = cache_root / "polylogue" / "schema-observation-journals"
+    assert not list(journal_root.glob("run-*.sqlite3*"))
+
+    restarted = _run(pause=False)
+    assert isinstance(restarted, subprocess.CompletedProcess)
+    assert restarted.returncode == 0, restarted.stderr
+    restarted_payload = json.loads(restarted.stdout)
+    assert restarted_payload["success"] is True
+    assert restarted_payload["schema"] == reference_payload["schema"]
+    assert restarted_payload["sample_count"] == reference_payload["sample_count"]
+    assert restarted_payload["default_version"] == reference_payload["default_version"]
+    assert not list(journal_root.glob("run-*.sqlite3*"))


### PR DESCRIPTION
## Summary

Adds the two production-route tests needed to close the remaining proof gap on polylogue-1xc.14.1.1 ("Make schema inference replayable and memory-bounded"): cancellation equivalence for the real `generate_provider_schema` entrypoint, and shuffled-input-order equivalence for the real `_build_provider_bundle` pipeline. Both run against synthetic/demo data only.

## Problem

polylogue-1xc.14.1.1 landed heavy hardening for the `ObservationJournal` full-corpus pipeline (#2968, #2971, #2973: bounded batch commits, selective-membership replay, Hermes terminal-ledger accounting) with a 1x/10x memory-bound proof already in place. Two AC items were still unproven going into this pass:

- AC #2/#6 ("cancellation"): `grep -rn cancel polylogue/schemas/generation/observation_journal.py polylogue/schemas/generation/provider_bundle.py` returns zero hits. The existing tests (`test_journal_cleanup_runs_for_sigterm`, `test_journal_cleanup_runs_for_real_terminated_process`) only prove that a raw, low-level `ObservationJournal.append_unit` call cleans up on SIGTERM — they never exercise the real `generate_provider_schema` entrypoint, and none of them prove a killed-then-restarted run produces the *same output* as an uninterrupted run (the actual "equivalence" claim in the bead's own notes: "cancellation proof" listed as remaining scope).
- AC #5 ("shuffled input order produces the same schemas, package assignments, profiles, and identities"): `grep -rl shuffle tests/unit/` returns nothing anywhere under the schema test tree. This clause was simply untested.

## Solution

- `tests/infra/schema_generation_cancellation_probe.py` (new): a subprocess target that writes a small deterministic synthetic ChatGPT archive once (idempotent across repeated invocations against the same `--archive-root`, so it can be reused for the reference and restarted runs without re-seeding), then calls the real `generate_provider_schema`. With `--pause-after-observe` it installs a `progress_callback` that prints `PAUSED` right after the `observe_and_cluster` phase starts and sleeps, giving the parent a deterministic, non-flaky window to send SIGTERM mid-run.
- `tests/unit/core/test_schema_observation_journal.py`:
  - `test_generation_cancellation_restarts_from_scratch_and_matches_uninterrupted_run`: runs the probe to completion once (reference), then runs it again with `--pause-after-observe`, SIGTERMs it once `PAUSED` is observed, asserts the journal directory is empty afterward (same contract as the existing terminated-process test, now through the *real* generation entrypoint), then reruns to completion and asserts the resulting schema/sample_count/default_version are identical to the reference run. This empirically proves `devtools/schema_generate.py`'s own resume-receipt claim ("the private observation journal is intentionally removed after interruption" / `restart_from_acquisition`) actually holds for real generation, not just for a synthetic `ObservationJournal.append_unit` call.
  - `test_shuffled_sample_order_yields_identical_schema_and_package_assignment`: feeds an identical `SchemaUnit` multiset through the real `_build_provider_bundle` in two different orders, using the same `iter_schema_units` monkeypatch technique already established by `test_build_provider_bundle_captures_element_windows_and_bundle_scopes` in `test_schema_generation.py`. Asserts schema content (minus the wall-clock `x-polylogue-generated-at` field), package identity (`anchor_profile_family_id`, `profile_family_ids`, `sample_count`, `bundle_scope_count`, `first_seen`/`last_seen`), catalog version selection, and cluster-manifest identities (`exact_structure_ids`, `bundle_scope_count`) are all order-invariant.

### Not addressed in this PR

AC #5 also contains a separate clause: "Small known-answer provider bundles are byte/content equivalent to the reference algorithm except for newly declared profile metadata." I looked for what "the reference algorithm" refers to and could not find an unambiguous, non-fabricated interpretation: `generate_schema_from_samples` (the older genson-based helper) uses a structurally different shape-inference algorithm than `_generate_cluster_schema` (the production path's custom `observed_structure_schema`/`merge_observed_structure_schemas`), so comparing them would not be a meaningful equivalence proof — it would just assert two different algorithms disagree. The other candidate reading (the bead's own description mentions `list(iter_schema_units(...))` as the naive/eager alternative to the journal-backed streaming path) would require building a full parallel non-journal reference pipeline for cluster/package/catalog assembly purely for this test — a nontrivial, test-only duplicate implementation that risks becoming exactly the kind of toy replica the project's testing conventions reject. I left this alone rather than fabricate a shaky test; it's called out explicitly in the `bd update` note on polylogue-1xc.14.1.1 (kept open, not closed, because of this gap).

## Verification

```
devtools test tests/unit/core/test_schema_observation_journal.py tests/infra/schema_generation_cancellation_probe.py
# 17 passed

mypy polylogue
# Success: no issues found in 1078 source files

ruff check tests/unit/core/test_schema_observation_journal.py tests/infra/schema_generation_cancellation_probe.py
ruff format --check tests/unit/core/test_schema_observation_journal.py tests/infra/schema_generation_cancellation_probe.py
# All checks passed! / 2 files already formatted

devtools render all --check
# OK: site sources render and generated local links resolve. (test-only files, no topology drift)
```

`devtools test tests/unit/core/test_schema_generation.py` shows 6 pre-existing `sqlite3.OperationalError: database is locked` setup errors under `-n 2` xdist — reproduced identically on an unmodified checkout of this file before any of my changes, so it is pre-existing environment flakiness unrelated to this diff (not caused or fixed here).

The pre-push `devtools verify --quick` gate (format + lint + mypy + render-all-check) ran automatically on push and passed (exit_code 0).

Ref polylogue-1xc.14.1.1