### PR TITLE
feat(usage): reconcile per-session token/cost evidence for one case

### DIFF
--- a/polylogue/storage/usage.py
+++ b/polylogue/storage/usage.py
@@ -10,12 +10,13 @@ from __future__ import annotations
 import json
 import sqlite3
 from collections import Counter, defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Final, Literal, cast
 
+from polylogue.archive.semantic.cost_records import ModelUsageTotals
 from polylogue.archive.semantic.pricing import (
     CATALOG_EFFECTIVE_DATE,
     CATALOG_PROVENANCE,
@@ -32,11 +33,14 @@ from polylogue.archive.semantic.subscription_pricing import (
 from polylogue.core.enums import Origin, Provider
 from polylogue.core.evidence_value import (
     CoverageExclusion,
+    EvidenceObservation,
     EvidenceValue,
     FactFamilySpec,
     FrameCoverage,
     FreshnessProvenance,
+    MeasurementAuthority,
     TemporalProvenance,
+    refine_evidence_value,
     sum_evidence_values,
 )
 from polylogue.core.refs import ObjectRef
@@ -117,6 +121,74 @@ USAGE_LANE_CATALOG_COST_FAMILY: Final = FactFamilySpec(
     allowed_states=frozenset({"known", "unknown"}),
     allowed_authorities=frozenset({"catalog-derived"}),
     authority_precedence=("catalog-derived",),
+)
+
+
+_SESSION_USAGE_RECONCILED_TOKENS_DEFINITION_REF: Final = ObjectRef(
+    kind="insight",
+    object_id="session-usage-reconciled-total-tokens:v1",
+)
+SESSION_USAGE_RECONCILED_TOKENS_FAMILY: Final = FactFamilySpec(
+    family="usage.session_reconciled_total_tokens",
+    owner="polylogue.storage.usage",
+    source_adapter="build_session_usage_reconciliation",
+    public_field="session_usage_reconciliation.reconciled_tokens_evidence",
+    renderer_label="reconciled session total tokens",
+    value_schema="integer",
+    unit="tokens",
+    grain="session",
+    denominator="canonical per-session token sources (session_model_usage rollup, session_profiles estimate)",
+    definition_ref=_SESSION_USAGE_RECONCILED_TOKENS_DEFINITION_REF,
+    required_axes=frozenset(
+        {
+            "value_state",
+            "measurement_authority",
+            "evidence_refs",
+            "definition_ref",
+            "temporal",
+            "enumeration",
+            "coverage",
+            "freshness",
+        }
+    ),
+    allowed_states=frozenset({"known", "unknown"}),
+    allowed_authorities=frozenset({"provider-reported", "structural", "model-derived"}),
+    authority_precedence=("provider-reported", "structural", "model-derived"),
+)
+
+_SESSION_USAGE_RECONCILED_COST_DEFINITION_REF: Final = ObjectRef(
+    kind="insight",
+    object_id="session-usage-reconciled-catalog-cost:v1",
+)
+SESSION_USAGE_RECONCILED_COST_FAMILY: Final = FactFamilySpec(
+    family="usage.session_reconciled_catalog_cost",
+    owner="polylogue.storage.usage",
+    source_adapter="build_session_usage_reconciliation",
+    public_field="session_usage_reconciliation.reconciled_cost_evidence",
+    renderer_label="reconciled session catalog-equivalent cost",
+    value_schema="number",
+    unit="USD",
+    grain="session",
+    denominator=(
+        "canonical per-session cost sources (fresh catalog price of the reconciled tokens, "
+        "legacy session_profiles/cost-insight total)"
+    ),
+    definition_ref=_SESSION_USAGE_RECONCILED_COST_DEFINITION_REF,
+    required_axes=frozenset(
+        {
+            "value_state",
+            "measurement_authority",
+            "evidence_refs",
+            "definition_ref",
+            "temporal",
+            "enumeration",
+            "coverage",
+            "freshness",
+        }
+    ),
+    allowed_states=frozenset({"known", "unknown"}),
+    allowed_authorities=frozenset({"provider-reported", "catalog-derived", "model-derived"}),
+    authority_precedence=("provider-reported", "catalog-derived", "model-derived"),
 )
 
 
@@ -2075,11 +2147,361 @@ def _int(value: object) -> int:
     return 0
 
 
+# --------------------------------------------------------------------------
+# Per-session usage/cost reconciliation (polylogue-f2qv.6, first slice)
+#
+# A single session can carry three disagreeing answers for "how many tokens
+# / how much did this cost": the exact session_model_usage rollup, the
+# (possibly stale) session_profiles estimate, and the per-session cost
+# insight -- which today reads its number off that same profile row rather
+# than off session_model_usage. This section reconciles those three sources
+# into one canonical snapshot using EvidenceValue authority ordering: the
+# exact rollup wins when it disagrees with the profile estimate, and the
+# superseded lower-authority value is preserved (never dropped, never
+# averaged) as a labeled contribution on the reconciled EvidenceValue.
+#
+# Scope note: this reconciles ONE session at a time from already-loaded
+# values. It does not (yet) wire a corpus-wide census, a materializer/insight
+# registry entry, or contradiction-debt recording -- see polylogue-f2qv.6 for
+# the remaining scope.
+# --------------------------------------------------------------------------
+
+
+def _session_usage_fact_ref(session_id: str, metric: str) -> ObjectRef:
+    return ObjectRef(kind="insight", object_id=f"session-usage-reconciled:{session_id}:{metric}")
+
+
+def _session_usage_source_ref(session_id: str, source: str) -> ObjectRef:
+    return ObjectRef(kind="insight", object_id=f"session-usage-source:{session_id}:{source}")
+
+
+def _cost_provenance_authority(
+    provenance: str,
+) -> Literal["provider-reported", "catalog-derived", "model-derived"]:
+    """Classify a legacy ``cost_provenance``/``cost_is_estimated`` label.
+
+    Mirrors ``_usage_lane_authority`` above: an exact/provider-reported label
+    is treated as authoritative money, a prior catalog-priced computation is
+    ``catalog-derived``, and anything estimated/unknown is the weakest,
+    ``model-derived`` tier -- the same tier a stale profile estimate carries.
+    """
+
+    if provenance in {"exact", "provider_reported"}:
+        return "provider-reported"
+    if provenance in {"priced", "origin_reported", "catalog_priced"}:
+        return "catalog-derived"
+    return "model-derived"
+
+
+def _sum_model_usage_tokens(rows: Sequence[ModelUsageTotals]) -> int:
+    return sum(row.input_tokens + row.output_tokens + row.cache_read_tokens + row.cache_write_tokens for row in rows)
+
+
+def _model_usage_tokens_evidence(
+    session_id: str,
+    rows: Sequence[ModelUsageTotals],
+    *,
+    observed_at: str,
+) -> EvidenceValue[int]:
+    fact_ref = _session_usage_fact_ref(session_id, "exact-total-tokens")
+    source_ref = _session_usage_source_ref(session_id, "session_model_usage")
+    known = bool(rows)
+    return EvidenceValue(
+        family=SESSION_USAGE_RECONCILED_TOKENS_FAMILY.family,
+        fact_ref=fact_ref,
+        value_state="known" if known else "unknown",
+        value=_sum_model_usage_tokens(rows) if known else None,
+        measurement_authority=("provider-reported",),
+        weakest_measurement_authority="provider-reported",
+        evidence_refs=(source_ref,),
+        definition_ref=SESSION_USAGE_RECONCILED_TOKENS_FAMILY.definition_ref,
+        temporal=TemporalProvenance.from_source(observed_at=observed_at, time_source="materialization_ts"),
+        enumeration="census",
+        coverage=FrameCoverage(
+            intended_frame=f"session {session_id} reconciled total tokens",
+            grain=SESSION_USAGE_RECONCILED_TOKENS_FAMILY.grain,
+            denominator=SESSION_USAGE_RECONCILED_TOKENS_FAMILY.denominator,
+            intended_count=1,
+            observed_count=1 if known else 0,
+            supported_count=1 if known else 0,
+            complete=known,
+        ),
+        freshness=FreshnessProvenance(state="fresh", evaluated_at=observed_at),
+    )
+
+
+def _profile_tokens_evidence(
+    session_id: str,
+    *,
+    total_input_tokens: int,
+    total_output_tokens: int,
+    total_cache_read_tokens: int,
+    total_cache_write_tokens: int,
+    cost_provenance: str,
+    observed_at: str,
+) -> EvidenceValue[int]:
+    fact_ref = _session_usage_fact_ref(session_id, "exact-total-tokens")
+    source_ref = _session_usage_source_ref(session_id, "session_profiles")
+    total = total_input_tokens + total_output_tokens + total_cache_read_tokens + total_cache_write_tokens
+    known = total > 0
+    authority = _cost_provenance_authority(cost_provenance)
+    # session_profiles token totals are never themselves provider-reported
+    # money; the strongest a profile token total can claim is the same
+    # authority its own model-rollup fallback in cost_compute.py would carry.
+    token_authority: MeasurementAuthority = "structural" if authority == "provider-reported" else "model-derived"
+    return EvidenceValue(
+        family=SESSION_USAGE_RECONCILED_TOKENS_FAMILY.family,
+        fact_ref=fact_ref,
+        value_state="known" if known else "unknown",
+        value=total if known else None,
+        measurement_authority=(token_authority,),
+        weakest_measurement_authority=token_authority,
+        evidence_refs=(source_ref,),
+        definition_ref=SESSION_USAGE_RECONCILED_TOKENS_FAMILY.definition_ref,
+        temporal=TemporalProvenance.from_source(observed_at=observed_at, time_source="materialization_ts"),
+        enumeration="census",
+        coverage=FrameCoverage(
+            intended_frame=f"session {session_id} reconciled total tokens",
+            grain=SESSION_USAGE_RECONCILED_TOKENS_FAMILY.grain,
+            denominator=SESSION_USAGE_RECONCILED_TOKENS_FAMILY.denominator,
+            intended_count=1,
+            observed_count=1 if known else 0,
+            supported_count=1 if known else 0,
+            complete=known,
+        ),
+        freshness=FreshnessProvenance(state="fresh", evaluated_at=observed_at),
+    )
+
+
+def _catalog_cost_evidence(
+    session_id: str,
+    *,
+    tokens_evidence: EvidenceValue[int],
+    normalized_model: str | None,
+    observed_at: str,
+) -> EvidenceValue[float]:
+    fact_ref = _session_usage_fact_ref(session_id, "catalog-api-equivalent-cost")
+    source_ref = _session_usage_source_ref(session_id, "reconciled_tokens_repriced")
+    catalog_ref = ObjectRef(kind="insight", object_id=f"pricing-catalog:{CATALOG_EFFECTIVE_DATE}")
+    priceable = tokens_evidence.value_state == "known" and normalized_model is not None and normalized_model in PRICING
+    value: float | None = None
+    exclusions: tuple[CoverageExclusion, ...] = ()
+    if priceable:
+        assert tokens_evidence.value is not None  # narrowed by value_state == "known" above
+        value = round(
+            estimate_cost(input_tokens=int(tokens_evidence.value), output_tokens=0, model=normalized_model or ""),
+            6,
+        )
+    elif tokens_evidence.value_state != "known":
+        exclusions = (CoverageExclusion(subject_ref=source_ref, reason="reconciled-tokens-unknown"),)
+    else:
+        exclusions = (CoverageExclusion(subject_ref=source_ref, reason="unpriced-model"),)
+    return EvidenceValue(
+        family=SESSION_USAGE_RECONCILED_COST_FAMILY.family,
+        fact_ref=fact_ref,
+        value_state="known" if priceable else "unknown",
+        value=value,
+        measurement_authority=("catalog-derived",),
+        weakest_measurement_authority="catalog-derived",
+        evidence_refs=(source_ref, catalog_ref),
+        definition_ref=SESSION_USAGE_RECONCILED_COST_FAMILY.definition_ref,
+        temporal=TemporalProvenance.from_source(observed_at=observed_at, time_source="materialization_ts"),
+        enumeration="census",
+        coverage=FrameCoverage(
+            intended_frame=f"session {session_id} reconciled catalog-equivalent cost",
+            grain=SESSION_USAGE_RECONCILED_COST_FAMILY.grain,
+            denominator=SESSION_USAGE_RECONCILED_COST_FAMILY.denominator,
+            intended_count=1,
+            observed_count=1 if priceable else 0,
+            supported_count=1 if priceable else 0,
+            complete=priceable,
+            exclusions=exclusions,
+        ),
+        freshness=FreshnessProvenance(state="fresh", evaluated_at=observed_at),
+    )
+
+
+def _legacy_cost_evidence(
+    session_id: str,
+    *,
+    cost_usd: float,
+    cost_provenance: str,
+    observed_at: str,
+) -> EvidenceValue[float]:
+    fact_ref = _session_usage_fact_ref(session_id, "catalog-api-equivalent-cost")
+    source_ref = _session_usage_source_ref(session_id, "cost_insight")
+    known = cost_usd > 0
+    authority = _cost_provenance_authority(cost_provenance)
+    exclusions: tuple[CoverageExclusion, ...] = ()
+    if not known:
+        exclusions = (CoverageExclusion(subject_ref=source_ref, reason="no_tokens"),)
+    return EvidenceValue(
+        family=SESSION_USAGE_RECONCILED_COST_FAMILY.family,
+        fact_ref=fact_ref,
+        value_state="known" if known else "unknown",
+        value=round(cost_usd, 6) if known else None,
+        measurement_authority=(authority,),
+        weakest_measurement_authority=authority,
+        evidence_refs=(source_ref,),
+        definition_ref=SESSION_USAGE_RECONCILED_COST_FAMILY.definition_ref,
+        temporal=TemporalProvenance.from_source(observed_at=observed_at, time_source="materialization_ts"),
+        enumeration="census",
+        coverage=FrameCoverage(
+            intended_frame=f"session {session_id} reconciled catalog-equivalent cost",
+            grain=SESSION_USAGE_RECONCILED_COST_FAMILY.grain,
+            denominator=SESSION_USAGE_RECONCILED_COST_FAMILY.denominator,
+            intended_count=1,
+            observed_count=1 if known else 0,
+            supported_count=1 if known else 0,
+            complete=known,
+            exclusions=exclusions,
+        ),
+        freshness=FreshnessProvenance(state="fresh", evaluated_at=observed_at),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class SessionUsageReconciliation:
+    """One canonical per-session usage/cost snapshot reconciling three sources.
+
+    polylogue-f2qv.6 (first slice): a single live session can show three
+    incompatible answers -- ``session_model_usage`` reports the exact
+    provider-derived rollup, ``session_profiles`` persists a token estimate
+    that can go stale, and the per-session cost insight reads its dollar
+    figure off that same profile row. This snapshot reconciles the token
+    lane (``session_model_usage`` vs ``session_profiles``) and the money
+    lane (a fresh catalog reprice of the winning tokens vs the legacy
+    persisted cost) independently, through EvidenceValue authority ordering
+    (provider-reported > structural/catalog-derived > model-derived).
+
+    Nothing is discarded: every input source survives as a labeled
+    ``contributions`` entry on the reconciled EvidenceValue, so a caller can
+    always see which sources agreed, which were superseded, and why.
+    """
+
+    session_id: str
+    model_usage_tokens_evidence: EvidenceValue[int]
+    profile_tokens_evidence: EvidenceValue[int]
+    reconciled_tokens_evidence: EvidenceValue[int]
+    catalog_cost_evidence: EvidenceValue[float]
+    legacy_cost_evidence: EvidenceValue[float]
+    reconciled_cost_evidence: EvidenceValue[float]
+
+    def superseded_token_observations(self) -> tuple[EvidenceObservation[int], ...]:
+        """Leaf token observations that lost to a stronger-authority source."""
+        winning_value = self.reconciled_tokens_evidence.value
+        return tuple(
+            observation
+            for observation in self.reconciled_tokens_evidence.contributions
+            if observation.value_state != "known" or observation.value != winning_value
+        )
+
+    def superseded_cost_observations(self) -> tuple[EvidenceObservation[float], ...]:
+        """Leaf cost observations that lost to a stronger-authority source."""
+        winning_value = self.reconciled_cost_evidence.value
+        return tuple(
+            observation
+            for observation in self.reconciled_cost_evidence.contributions
+            if observation.value_state != "known" or observation.value != winning_value
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "session_id": self.session_id,
+            "model_usage_tokens_evidence": self.model_usage_tokens_evidence.to_dict(),
+            "profile_tokens_evidence": self.profile_tokens_evidence.to_dict(),
+            "reconciled_tokens_evidence": self.reconciled_tokens_evidence.to_dict(),
+            "catalog_cost_evidence": self.catalog_cost_evidence.to_dict(),
+            "legacy_cost_evidence": self.legacy_cost_evidence.to_dict(),
+            "reconciled_cost_evidence": self.reconciled_cost_evidence.to_dict(),
+        }
+
+
+def build_session_usage_reconciliation(
+    session_id: str,
+    *,
+    observed_at: str,
+    model_usage_rows: Sequence[ModelUsageTotals] = (),
+    profile_total_input_tokens: int = 0,
+    profile_total_output_tokens: int = 0,
+    profile_total_cache_read_tokens: int = 0,
+    profile_total_cache_write_tokens: int = 0,
+    profile_cost_usd: float = 0.0,
+    profile_cost_provenance: str = "unknown",
+    reconciled_model: str | None = None,
+) -> SessionUsageReconciliation:
+    """Reconcile the three per-session usage/cost sources into one snapshot.
+
+    This is a pure function over already-loaded values: callers read
+    ``session_model_usage`` rows (``ModelUsageTotals``, e.g. via
+    ``polylogue.storage.sqlite.queries.model_usage``), the ``session_profiles``
+    row's token/cost columns, and the cost-insight row it currently derives
+    from (``_session_cost_insight_from_archive_row`` reads the same
+    ``session_profiles`` columns), then hand them here. This function owns
+    only the reconciliation policy -- authority ordering and conflict
+    preservation -- not the storage reads.
+
+    ``reconciled_model`` is the normalized model name used to reprice the
+    winning token evidence against the catalog; pass the model the winning
+    source actually reports (the dominant model on multi-model sessions) so
+    the fresh catalog cost is computed against the tokens that won, not an
+    arbitrary source's tokens.
+    """
+
+    model_usage_evidence = _model_usage_tokens_evidence(session_id, model_usage_rows, observed_at=observed_at)
+    profile_evidence = _profile_tokens_evidence(
+        session_id,
+        total_input_tokens=profile_total_input_tokens,
+        total_output_tokens=profile_total_output_tokens,
+        total_cache_read_tokens=profile_total_cache_read_tokens,
+        total_cache_write_tokens=profile_total_cache_write_tokens,
+        cost_provenance=profile_cost_provenance,
+        observed_at=observed_at,
+    )
+    reconciled_tokens = refine_evidence_value(
+        model_usage_evidence,
+        profile_evidence,
+        spec=SESSION_USAGE_RECONCILED_TOKENS_FAMILY,
+    )
+
+    catalog_cost = _catalog_cost_evidence(
+        session_id,
+        tokens_evidence=reconciled_tokens,
+        normalized_model=reconciled_model,
+        observed_at=observed_at,
+    )
+    legacy_cost = _legacy_cost_evidence(
+        session_id,
+        cost_usd=profile_cost_usd,
+        cost_provenance=profile_cost_provenance,
+        observed_at=observed_at,
+    )
+    reconciled_cost = refine_evidence_value(
+        catalog_cost,
+        legacy_cost,
+        spec=SESSION_USAGE_RECONCILED_COST_FAMILY,
+    )
+
+    return SessionUsageReconciliation(
+        session_id=session_id,
+        model_usage_tokens_evidence=model_usage_evidence,
+        profile_tokens_evidence=profile_evidence,
+        reconciled_tokens_evidence=reconciled_tokens,
+        catalog_cost_evidence=catalog_cost,
+        legacy_cost_evidence=legacy_cost,
+        reconciled_cost_evidence=reconciled_cost,
+    )
+
+
 __all__ = [
     "OriginUsageReport",
     "ProviderUsageCoverage",
     "ProviderUsageReport",
+    "SESSION_USAGE_RECONCILED_COST_FAMILY",
+    "SESSION_USAGE_RECONCILED_TOKENS_FAMILY",
+    "SessionUsageReconciliation",
     "UsageCounters",
+    "build_session_usage_reconciliation",
     "provider_usage_coverage_matrix",
     "provider_usage_report_for_archive_root",
     "provider_usage_report_from_connection",

--- a/polylogue/storage/usage.py
+++ b/polylogue/storage/usage.py
@@ -2277,6 +2277,10 @@ def _catalog_cost_evidence(
     session_id: str,
     *,
     tokens_evidence: EvidenceValue[int],
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+    cache_write_tokens: int,
     normalized_model: str | None,
     observed_at: str,
 ) -> EvidenceValue[float]:
@@ -2288,8 +2292,19 @@ def _catalog_cost_evidence(
     exclusions: tuple[CoverageExclusion, ...] = ()
     if priceable:
         assert tokens_evidence.value is not None  # narrowed by value_state == "known" above
+        # Price each token category at its own catalog rate -- input, output,
+        # and cache read/write are priced very differently (output is
+        # typically several times an input token's rate), so collapsing the
+        # reconciled *total* into a single input_tokens argument would
+        # systematically misprice any session with real output/cache volume.
         value = round(
-            estimate_cost(input_tokens=int(tokens_evidence.value), output_tokens=0, model=normalized_model or ""),
+            estimate_cost(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+                model=normalized_model or "",
+            ),
             6,
         )
     elif tokens_evidence.value_state != "known":
@@ -2464,9 +2479,32 @@ def build_session_usage_reconciliation(
         spec=SESSION_USAGE_RECONCILED_TOKENS_FAMILY,
     )
 
+    # The reconciled EvidenceValue carries only the combined total, so
+    # re-derive which source actually won to reprice using ITS per-category
+    # breakdown -- input/output/cache tokens have different catalog rates,
+    # and estimate_cost needs them split, not summed (see _catalog_cost_evidence).
+    if (
+        reconciled_tokens.value_state == "known"
+        and model_usage_evidence.value_state == "known"
+        and reconciled_tokens.value == model_usage_evidence.value
+    ):
+        winning_input_tokens = sum(row.input_tokens for row in model_usage_rows)
+        winning_output_tokens = sum(row.output_tokens for row in model_usage_rows)
+        winning_cache_read_tokens = sum(row.cache_read_tokens for row in model_usage_rows)
+        winning_cache_write_tokens = sum(row.cache_write_tokens for row in model_usage_rows)
+    else:
+        winning_input_tokens = profile_total_input_tokens
+        winning_output_tokens = profile_total_output_tokens
+        winning_cache_read_tokens = profile_total_cache_read_tokens
+        winning_cache_write_tokens = profile_total_cache_write_tokens
+
     catalog_cost = _catalog_cost_evidence(
         session_id,
         tokens_evidence=reconciled_tokens,
+        input_tokens=winning_input_tokens,
+        output_tokens=winning_output_tokens,
+        cache_read_tokens=winning_cache_read_tokens,
+        cache_write_tokens=winning_cache_write_tokens,
         normalized_model=reconciled_model,
         observed_at=observed_at,
     )

--- a/tests/unit/storage/test_session_usage_reconciliation.py
+++ b/tests/unit/storage/test_session_usage_reconciliation.py
@@ -15,7 +15,7 @@ contribution rather than silently discarding it.
 from __future__ import annotations
 
 from polylogue.archive.semantic.cost_records import ModelUsageTotals
-from polylogue.archive.semantic.pricing import PRICING, _normalize_model
+from polylogue.archive.semantic.pricing import PRICING, _normalize_model, estimate_cost
 from polylogue.storage.usage import (
     SESSION_USAGE_RECONCILED_COST_FAMILY,
     SESSION_USAGE_RECONCILED_TOKENS_FAMILY,
@@ -112,11 +112,31 @@ def test_reconciled_cost_prefers_fresh_catalog_price_over_stale_zero() -> None:
     assert reconciliation.legacy_cost_evidence.value_state == "unknown"
     assert reconciliation.legacy_cost_evidence.value is None
 
-    # A fresh catalog reprice of the winning (exact) token evidence is known.
+    # A fresh catalog reprice of the winning (exact) token evidence is known,
+    # and prices EACH category at its own rate rather than collapsing
+    # input/output/cache into one combined total priced as pure input --
+    # output and cache-read tokens are priced very differently from input,
+    # so that shortcut would systematically misprice any real session.
     assert reconciliation.catalog_cost_evidence.value_state == "known"
     assert reconciliation.catalog_cost_evidence.value is not None
     assert reconciliation.catalog_cost_evidence.value > 0.0
     assert _NORMALIZED_MODEL in PRICING
+    expected_cost = round(
+        estimate_cost(
+            input_tokens=_EXACT_UNCACHED_INPUT,
+            output_tokens=_EXACT_OUTPUT,
+            cache_read_tokens=_EXACT_CACHE_READ,
+            cache_write_tokens=0,
+            model=_NORMALIZED_MODEL,
+        ),
+        6,
+    )
+    mispriced_as_pure_input = round(
+        estimate_cost(input_tokens=_EXACT_TOTAL, output_tokens=0, model=_NORMALIZED_MODEL),
+        6,
+    )
+    assert expected_cost != mispriced_as_pure_input, "fixture must exercise a model with non-uniform per-category rates"
+    assert reconciliation.catalog_cost_evidence.value == expected_cost
 
     reconciled_cost = reconciliation.reconciled_cost_evidence
     assert reconciled_cost.value_state == "known"

--- a/tests/unit/storage/test_session_usage_reconciliation.py
+++ b/tests/unit/storage/test_session_usage_reconciliation.py
@@ -1,0 +1,181 @@
+"""Per-session usage/cost reconciliation (polylogue-f2qv.6, first slice).
+
+Reproduces the bead's concrete disagreement: one Codex session where
+``session_model_usage`` reports an exact rollup of 64,561 uncached input +
+723,456 cache read + 7,776 output tokens (795,793 total), the
+``session_profiles`` row persists a stale 4,031-token estimate, and the
+per-session cost insight (which reads its number off that same profile row)
+reports zero/unavailable. ``build_session_usage_reconciliation`` must pick
+the exact rollup as the winning token value -- not average the two numbers,
+not arbitrarily prefer whichever was passed first -- and must keep the
+superseded profile estimate visible as a labeled, lower-authority
+contribution rather than silently discarding it.
+"""
+
+from __future__ import annotations
+
+from polylogue.archive.semantic.cost_records import ModelUsageTotals
+from polylogue.archive.semantic.pricing import PRICING, _normalize_model
+from polylogue.storage.usage import (
+    SESSION_USAGE_RECONCILED_COST_FAMILY,
+    SESSION_USAGE_RECONCILED_TOKENS_FAMILY,
+    build_session_usage_reconciliation,
+)
+
+_OBSERVED_AT = "2026-07-15T00:00:00+00:00"
+
+# The bead's exact reported numbers for the disagreeing live Codex session.
+_EXACT_UNCACHED_INPUT = 64_561
+_EXACT_CACHE_READ = 723_456
+_EXACT_OUTPUT = 7_776
+_EXACT_TOTAL = _EXACT_UNCACHED_INPUT + _EXACT_CACHE_READ + _EXACT_OUTPUT
+
+_STALE_PROFILE_ESTIMATE_TOKENS = 4_031
+
+_MODEL = "gpt-5.1-codex"
+_NORMALIZED_MODEL = _normalize_model(_MODEL)
+
+
+def _model_usage_rows() -> tuple[ModelUsageTotals, ...]:
+    return (
+        ModelUsageTotals(
+            model_name=_MODEL,
+            input_tokens=_EXACT_UNCACHED_INPUT,
+            output_tokens=_EXACT_OUTPUT,
+            cache_read_tokens=_EXACT_CACHE_READ,
+            cache_write_tokens=0,
+        ),
+    )
+
+
+def test_exact_rollup_wins_over_stale_profile_estimate() -> None:
+    """The exact session_model_usage rollup wins, not the stale estimate."""
+
+    reconciliation = build_session_usage_reconciliation(
+        "codex-session:disagreeing-example",
+        observed_at=_OBSERVED_AT,
+        model_usage_rows=_model_usage_rows(),
+        profile_total_input_tokens=_STALE_PROFILE_ESTIMATE_TOKENS,
+        profile_total_output_tokens=0,
+        profile_total_cache_read_tokens=0,
+        profile_total_cache_write_tokens=0,
+        profile_cost_usd=0.0,
+        profile_cost_provenance="heuristic_estimated",
+        reconciled_model=_NORMALIZED_MODEL,
+    )
+
+    # The three raw sources disagree exactly as the bead describes.
+    assert reconciliation.model_usage_tokens_evidence.value == _EXACT_TOTAL
+    assert reconciliation.profile_tokens_evidence.value == _STALE_PROFILE_ESTIMATE_TOKENS
+    assert reconciliation.model_usage_tokens_evidence.value != reconciliation.profile_tokens_evidence.value
+
+    # The reconciled snapshot is not an average or an arbitrary pick: it is
+    # exactly the exact-rollup value, carrying provider-reported authority.
+    reconciled = reconciliation.reconciled_tokens_evidence
+    assert reconciled.value_state == "known"
+    assert reconciled.value == _EXACT_TOTAL
+    assert reconciled.value != round((_EXACT_TOTAL + _STALE_PROFILE_ESTIMATE_TOKENS) / 2)
+    assert "provider-reported" in reconciled.measurement_authority
+    SESSION_USAGE_RECONCILED_TOKENS_FAMILY.require(reconciled)
+
+    # The superseded profile estimate is preserved, not dropped, and is
+    # labeled with its own (weaker) authority so a reader can see why it lost.
+    superseded = reconciliation.superseded_token_observations()
+    assert len(superseded) == 1
+    assert superseded[0].value == _STALE_PROFILE_ESTIMATE_TOKENS
+    assert superseded[0].value_state == "known"
+    assert superseded[0].measurement_authority == ("model-derived",)
+
+    # All source evidence is discoverable on the reconciled value's contributions.
+    contribution_values = {observation.value for observation in reconciled.contributions}
+    assert contribution_values == {_EXACT_TOTAL, _STALE_PROFILE_ESTIMATE_TOKENS}
+
+
+def test_reconciled_cost_prefers_fresh_catalog_price_over_stale_zero() -> None:
+    """A legacy zero/unavailable cost insight does not survive reconciliation
+    when a fresh catalog reprice of the winning tokens is available."""
+
+    reconciliation = build_session_usage_reconciliation(
+        "codex-session:disagreeing-example",
+        observed_at=_OBSERVED_AT,
+        model_usage_rows=_model_usage_rows(),
+        profile_total_input_tokens=_STALE_PROFILE_ESTIMATE_TOKENS,
+        profile_total_output_tokens=0,
+        profile_total_cache_read_tokens=0,
+        profile_total_cache_write_tokens=0,
+        profile_cost_usd=0.0,
+        profile_cost_provenance="heuristic_estimated",
+        reconciled_model=_NORMALIZED_MODEL,
+    )
+
+    # The legacy cost-insight source is exactly the bug's "zero and unavailable".
+    assert reconciliation.legacy_cost_evidence.value_state == "unknown"
+    assert reconciliation.legacy_cost_evidence.value is None
+
+    # A fresh catalog reprice of the winning (exact) token evidence is known.
+    assert reconciliation.catalog_cost_evidence.value_state == "known"
+    assert reconciliation.catalog_cost_evidence.value is not None
+    assert reconciliation.catalog_cost_evidence.value > 0.0
+    assert _NORMALIZED_MODEL in PRICING
+
+    reconciled_cost = reconciliation.reconciled_cost_evidence
+    assert reconciled_cost.value_state == "known"
+    assert reconciled_cost.value == reconciliation.catalog_cost_evidence.value
+    assert "catalog-derived" in reconciled_cost.measurement_authority
+    SESSION_USAGE_RECONCILED_COST_FAMILY.require(reconciled_cost)
+
+    superseded = reconciliation.superseded_cost_observations()
+    assert any(observation.value_state == "unknown" for observation in superseded)
+
+
+def test_agreeing_sources_reconcile_without_conflict() -> None:
+    """When session_profiles already reflects the exact rollup (post self-heal),
+    reconciliation reports a clean agreement, not a spurious conflict."""
+
+    rows = _model_usage_rows()
+    reconciliation = build_session_usage_reconciliation(
+        "codex-session:agreeing-example",
+        observed_at=_OBSERVED_AT,
+        model_usage_rows=rows,
+        profile_total_input_tokens=_EXACT_UNCACHED_INPUT,
+        profile_total_output_tokens=_EXACT_OUTPUT,
+        profile_total_cache_read_tokens=_EXACT_CACHE_READ,
+        profile_total_cache_write_tokens=0,
+        profile_cost_usd=0.05,
+        profile_cost_provenance="provider_reported",
+        reconciled_model=_NORMALIZED_MODEL,
+    )
+
+    reconciled = reconciliation.reconciled_tokens_evidence
+    assert reconciled.value == _EXACT_TOTAL
+    assert reconciled.conflicts == ()
+    assert reconciliation.superseded_token_observations() == ()
+
+
+def test_no_model_usage_rows_falls_back_to_profile_estimate_labeled_as_weak() -> None:
+    """With no session_model_usage rows at all, the only known source is the
+    profile estimate -- reconciliation must still surface it, correctly
+    labeled with model-derived (not provider-reported) authority."""
+
+    reconciliation = build_session_usage_reconciliation(
+        "codex-session:no-rollup-example",
+        observed_at=_OBSERVED_AT,
+        model_usage_rows=(),
+        profile_total_input_tokens=_STALE_PROFILE_ESTIMATE_TOKENS,
+        profile_total_output_tokens=0,
+        profile_total_cache_read_tokens=0,
+        profile_total_cache_write_tokens=0,
+        profile_cost_usd=0.0,
+        profile_cost_provenance="heuristic_estimated",
+        reconciled_model=_NORMALIZED_MODEL,
+    )
+
+    assert reconciliation.model_usage_tokens_evidence.value_state == "unknown"
+    reconciled = reconciliation.reconciled_tokens_evidence
+    assert reconciled.value_state == "known"
+    assert reconciled.value == _STALE_PROFILE_ESTIMATE_TOKENS
+    # The only known contributor is the profile estimate, so the weakest
+    # (and here, sole substantive) authority behind the value is honestly
+    # labeled model-derived -- never upgraded to provider-reported just
+    # because an *unknown* session_model_usage observation was also present.
+    assert reconciled.weakest_measurement_authority == "model-derived"


### PR DESCRIPTION
## Summary

First slice of polylogue-f2qv.6 ("Reconcile profiles and costs to exact
provider usage"): adds `build_session_usage_reconciliation()` and
`SessionUsageReconciliation` to `polylogue/storage/usage.py`, reconciling
one session's three disagreeing usage/cost sources into a single canonical
EvidenceValue-backed snapshot.

## Problem

polylogue-f2qv.6 reports that a single live Codex session can show three
incompatible answers:

- `session_model_usage` (exact rollup): 64,561 uncached input + 723,456
  cache read + 7,776 output tokens (795,793 total)
- `session_profiles`: a stale 4,031-token estimate
- the per-session cost insight: zero / unavailable

The cost insight reads its number off the `session_profiles` row
(`_session_cost_insight_from_archive_row` in
`polylogue/storage/sqlite/archive_tiers/archive.py`), so a stale profile
silently produces a stale-and-wrong cost too. Across the operator's full
Codex census, zero profiles matched their session's exact rollup at the
time this bead was filed.

## Solution

- Two new `FactFamilySpec` declarations, `SESSION_USAGE_RECONCILED_TOKENS_FAMILY`
  and `SESSION_USAGE_RECONCILED_COST_FAMILY`, at session grain, following
  the same EvidenceValue pattern this module already uses for archive-level
  pricing-lane evidence (`USAGE_LANE_EXACT_TOKENS_FAMILY` /
  `USAGE_LANE_CATALOG_COST_FAMILY`, landed under polylogue-cuxz.2).
- `build_session_usage_reconciliation(...)` is a pure function over
  already-loaded values (no storage reads). It builds an `EvidenceValue`
  for the `session_model_usage` rollup (authority `provider-reported`) and
  one for the `session_profiles` estimate (authority `structural` or
  `model-derived`, driven by the profile's own `cost_provenance` label),
  then reconciles them with `refine_evidence_value` -- the shared
  cuxz.2 primitive that picks the strongest-authority value on
  disagreement (never an average, never insertion-order) while keeping
  every input as a labeled `contributions` entry.
- The money lane is reconciled independently, per the bead's own design
  note ("disjoint token-lane authority separate from monetary price
  authority"): a fresh catalog reprice of the *winning* token evidence
  (authority `catalog-derived`) is reconciled against the legacy persisted
  cost (authority derived the same way as the token side).
- `SessionUsageReconciliation.superseded_token_observations()` /
  `superseded_cost_observations()` expose exactly which lower-authority
  inputs lost and why, rather than burying them.

## Scope (first slice, not the full bead)

This satisfies **one** reconciliation case with a real test, not the bead's
full acceptance criteria. Explicitly **not** done here (see the bead note
added alongside this PR):

- No storage-layer wiring: nothing in `storage/insights/session/rebuild.py`,
  `storage/sqlite/archive_tiers/archive.py`, or the insight registry calls
  this function yet -- `session_model_usage`, `session_profiles`, and the
  cost insight still disagree in the live archive today.
- No daemon convergence / contradiction-debt integration.
- No corpus-wide census proving "zero unexplained profile contradictions."
- Broader EvidenceValue family/surface migration remains polylogue-cuxz.3.

## Verification

```
devtools test polylogue/storage/usage.py \
  tests/unit/storage/test_session_usage_reconciliation.py \
  tests/unit/storage/test_provider_usage_report.py \
  tests/unit/storage/test_session_profile_model_usage_consistency.py
# -> 25 passed

mypy --strict polylogue/storage/usage.py tests/unit/storage/test_session_usage_reconciliation.py
# -> Success: no issues found in 2 source files

devtools verify --quick
# -> exit_code: 0
```

Ref polylogue-f2qv.6

Co-Authored-By: Claude <noreply@anthropic.com>