### PR TITLE
feat(devtools): register recovered bead-cluster as a workspace command

### DIFF
--- a/devtools/bead_cluster.py
+++ b/devtools/bead_cluster.py
@@ -1,0 +1,605 @@
+"""bead-cluster: execution-frontier clustering for polylogue Beads.
+
+Implements polylogue-2yax: reads bd ready (or a supplied JSON export), extracts
+file/package/resource footprints from each bead's design+notes+ac text, builds
+an overlap and dependency graph, and emits:
+
+  - FRONTIER-READY   -- horizon:frontier, no blocking deps -> claim now
+  - BLOCKED          -- has unmet hard dependencies
+  - IN-PROGRESS       -- already claimed
+  - DESIGN-HORIZON    -- mid/vision horizon, not yet executable
+
+For frontier-ready beads it computes:
+  - OVERLAPPING clusters  -> one branch/PR sweep (share context, single rewrite pass)
+  - DISJOINT sets         -> safe to run as parallel lanes / separate worktrees
+  - CONTENTION points     -> same migration tier/slot, same generated surface, same DB
+
+Usage:
+    # From repo root, using live bd output:
+    devtools workspace bead-cluster
+
+    # Read a pre-exported JSON (e.g. bd ready --json --limit 0 > ready.json):
+    devtools workspace bead-cluster --input ready.json
+
+    # Include all open beads (not just ready):
+    devtools workspace bead-cluster --all-open
+
+    # Machine-readable JSON output:
+    devtools workspace bead-cluster --json
+
+    # Filter to a priority ceiling:
+    devtools workspace bead-cluster --max-priority 1
+
+    # Replay-validate against the 2026-07-13 migration-slot collision:
+    devtools workspace bead-cluster --validate-roster
+
+Notes:
+  Footprints are extracted heuristically -- they are ADVISORY. A missing or
+  ambiguous footprint lowers readiness and is reported as NEEDS-CONFIRM.
+  Never treat inferred footprints as correctness proof.
+
+History: originally shipped 2026-07-16 as .agent/tools/bead-cluster.py
+(commit 49182a7f2) but never registered as a devtools CommandSpec, so it was
+invisible to `devtools --help` / `render devtools-reference` / the repo's
+catalog-completeness checks. PR #3188 (2026-07-20) classified the unregistered
+file as dead code ("no live references") and deleted it. polylogue-1ebm
+recovers it here, registered, so the analysis is discoverable again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+BeadDict = dict[str, Any]
+
+# ---------------------------------------------------------------------------
+# Footprint extraction
+# ---------------------------------------------------------------------------
+
+# Regex: file paths mentioning known project trees
+_FILE_PAT = re.compile(
+    r"(?:polylogue|tests|\.agent|docs|storage|pipeline|daemon|cli|mcp"
+    r"|browser[_-]extension|browser_capture|coordination|archive|insights"
+    r"|context|core|hooks|maintenance|artifacts)"
+    r"/[\w./\-]+\.(?:py|ts|js|yaml|yml|md|json|sql|html)",
+    re.IGNORECASE,
+)
+
+# Regex: migration slot references  e.g. "migration 008", "slot 008", "NNN_"
+_MIGRATION_PAT = re.compile(r"\b(?:migration|slot)\s*[#]?(\d{3,4})\b|(\d{3})_\w+\.sql", re.IGNORECASE)
+
+# Regex: generated surface families
+_GENERATED_SURFACES = {
+    "topology-status.md": "generated:topology-status",
+    "topology-target.yaml": "generated:topology-target",
+    "cli-reference.md": "generated:cli-reference",
+    "openapi/": "generated:openapi",
+}
+
+# Area label -> primary package(s)
+_AREA_TO_PACKAGES: dict[str, list[str]] = {
+    "area:lineage": ["storage/sqlite/", "polylogue/archive/"],
+    "area:storage": ["storage/sqlite/", "polylogue/storage/"],
+    "area:daemon": ["polylogue/daemon/"],
+    "area:ingest": ["pipeline/", "polylogue/daemon/"],
+    "area:mcp": ["polylogue/mcp/"],
+    "area:query": ["polylogue/archive/query/", "polylogue/storage/search/"],
+    "area:cli": ["polylogue/cli/"],
+    "area:browser": ["browser-extension/", "polylogue/browser_capture/"],
+    "area:sources": ["polylogue/pipeline/", "polylogue/core/"],
+    "area:context": ["polylogue/context/"],
+    "area:substrate": ["polylogue/storage/"],
+    "area:analytics": ["polylogue/cost/", "polylogue/insights/"],
+    "area:perf": ["polylogue/archive/query/", "polylogue/storage/"],
+    "area:coordination": ["polylogue/coordination/"],
+    "area:web": ["browser-extension/"],
+    "area:sinex": ["polylogue/coordination/"],
+    "area:test": ["tests/"],
+    "area:audit": ["devtools/", ".agent/"],
+    "area:devtools": ["devtools/"],
+    "area:ops": ["polylogue/maintenance/"],
+    "area:architecture": [],
+    "area:beads": [".beads/", ".agent/"],
+    "area:capture": ["browser-extension/", "polylogue/browser_capture/"],
+}
+
+
+# Top-level package dirs that are too broad to use as overlap discriminators.
+# Nearly every bead touches these, so they would collapse the entire frontier
+# into one mega-cluster if used as clustering keys.
+_BROAD_PACKAGES: frozenset[str] = frozenset(
+    {
+        "tests/",
+        "polylogue/storage/",
+        "polylogue/archive/",
+        "polylogue/",
+        ".agent/",
+        ".agent/scratch/",
+        "storage/sqlite/",
+        "pipeline/",
+        "docs/",
+    }
+)
+
+
+@dataclass
+class Footprint:
+    files: list[str] = field(default_factory=list)
+    packages: list[str] = field(default_factory=list)
+    areas: list[str] = field(default_factory=list)
+    migration_slots: list[str] = field(default_factory=list)
+    generated_surfaces: list[str] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not (self.files or self.packages or self.areas)
+
+    def overlap_keys(self) -> set[str]:
+        """Keys used to detect footprint overlap between beads.
+
+        Uses concrete file paths and specific sub-package dirs only.
+        Broad roots (tests/, polylogue/storage/, etc.) are excluded -- they
+        would collapse the entire frontier into one mega-cluster.
+        Area labels are metadata, not clustering keys.
+        Migration slots belong in contention_keys only.
+        """
+        keys: set[str] = set()
+        # Exact file paths (most discriminating)
+        keys.update(self.files)
+        # Package dirs: exclude broad shared roots
+        for pkg in self.packages:
+            if pkg not in _BROAD_PACKAGES:
+                keys.add(pkg)
+        return keys
+
+    def contention_keys(self) -> set[str]:
+        keys: set[str] = set()
+        keys.update(f"migration:{s}" for s in self.migration_slots)
+        keys.update(self.generated_surfaces)
+        return keys
+
+
+def _extract_footprint(item: BeadDict) -> Footprint:
+    text = " ".join(filter(None, [item.get("design", ""), item.get("notes", ""), item.get("acceptance_criteria", "")]))
+    labels: list[str] = item.get("labels", [])
+
+    # Raw file paths (most specific footprint signal)
+    raw_files = list(dict.fromkeys(_FILE_PAT.findall(text)))  # deduplicate, preserve order
+
+    # Package families: second path segment (e.g. polylogue/mcp/, tests/unit/)
+    packages: set[str] = set()
+    for f in raw_files:
+        parts = f.split("/")
+        if len(parts) >= 3:
+            # Use the two-level prefix for specificity
+            packages.add(f"{parts[0]}/{parts[1]}/")
+        elif len(parts) == 2:
+            packages.add(f"{parts[0]}/{parts[1]}/")
+        elif parts:
+            packages.add(parts[0] + "/")
+
+    # Only fall back to area->package mapping when NO files found at all.
+    # When files ARE found, area->package would add broad roots that over-merge.
+    if not raw_files:
+        for label in labels:
+            for pkg in _AREA_TO_PACKAGES.get(label, []):
+                packages.add(pkg)
+
+    # Area labels -- stored for display and metadata, NOT used as overlap keys.
+    areas: list[str] = [lbl for lbl in labels if lbl.startswith("area:")]
+
+    # Migration slots
+    migration_slots: list[str] = []
+    for m in _MIGRATION_PAT.finditer(text):
+        slot = m.group(1) or m.group(2)
+        if slot:
+            migration_slots.append(slot)
+
+    # Generated surfaces
+    gen_surfaces: list[str] = []
+    for key, tag in _GENERATED_SURFACES.items():
+        if key in text:
+            gen_surfaces.append(tag)
+
+    return Footprint(
+        files=raw_files,
+        packages=sorted(packages),
+        areas=areas,
+        migration_slots=list(dict.fromkeys(migration_slots)),
+        generated_surfaces=gen_surfaces,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bead classification
+# ---------------------------------------------------------------------------
+
+FRONTIER_LABELS = {"horizon:frontier"}
+VISION_LABELS = {"horizon:vision"}
+MID_LABELS = {"horizon:mid"}
+
+
+def _horizon(item: BeadDict) -> str:
+    labels = set(item.get("labels", []))
+    if labels & FRONTIER_LABELS:
+        return "frontier"
+    if labels & VISION_LABELS:
+        return "vision"
+    if labels & MID_LABELS:
+        return "mid"
+    return "unset"
+
+
+def _classify(item: BeadDict) -> str:
+    status = item.get("status", "open")
+    if status in ("in_progress", "claimed"):
+        return "IN-PROGRESS"
+    dep_count = item.get("dependency_count", 0)
+    if dep_count and dep_count > 0:
+        return "BLOCKED"
+    h = _horizon(item)
+    if h == "frontier":
+        return "FRONTIER-READY"
+    if h in ("vision", "mid"):
+        return "DESIGN-HORIZON"
+    # No horizon label -- treat as frontier-ready if P0/P1, else design-horizon
+    prio = item.get("priority", 4)
+    return "FRONTIER-READY" if prio <= 1 else "DESIGN-HORIZON"
+
+
+# ---------------------------------------------------------------------------
+# Overlap graph + clustering
+# ---------------------------------------------------------------------------
+
+
+def _build_overlap_graph(beads: list[BeadDict], footprints: dict[str, Footprint]) -> dict[str, set[str]]:
+    """Return adjacency map: id -> set of overlapping ids."""
+    # Build inverted index: overlap_key -> list of bead ids
+    key_to_ids: dict[str, list[str]] = defaultdict(list)
+    for b in beads:
+        bid = b["id"]
+        for key in footprints[bid].overlap_keys():
+            key_to_ids[key].append(bid)
+
+    adj: dict[str, set[str]] = {b["id"]: set() for b in beads}
+    for ids in key_to_ids.values():
+        if len(ids) > 1:
+            for i, a in enumerate(ids):
+                for other in ids[i + 1 :]:
+                    adj[a].add(other)
+                    adj[other].add(a)
+    return adj
+
+
+def _connected_components(ids: list[str], adj: dict[str, set[str]]) -> list[set[str]]:
+    visited: set[str] = set()
+    components: list[set[str]] = []
+    for start in ids:
+        if start in visited:
+            continue
+        component: set[str] = set()
+        stack = [start]
+        while stack:
+            node = stack.pop()
+            if node in visited:
+                continue
+            visited.add(node)
+            component.add(node)
+            for neighbor in adj.get(node, set()):
+                if neighbor in ids and neighbor not in visited:
+                    stack.append(neighbor)
+        components.append(component)
+    return components
+
+
+def _find_contention(beads: list[BeadDict], footprints: dict[str, Footprint]) -> list[dict[str, Any]]:
+    """Return list of contention events (migration slot / generated surface collisions)."""
+    key_to_ids: dict[str, list[str]] = defaultdict(list)
+    for b in beads:
+        for key in footprints[b["id"]].contention_keys():
+            key_to_ids[key].append(b["id"])
+    events: list[dict[str, Any]] = []
+    for key, ids in key_to_ids.items():
+        if len(ids) > 1:
+            events.append({"key": key, "beads": ids})
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Output rendering
+# ---------------------------------------------------------------------------
+
+
+def _short(s: str, n: int = 70) -> str:
+    return s[:n] + "..." if len(s) > n else s
+
+
+def _render_human(
+    all_beads: list[BeadDict],
+    footprints: dict[str, Footprint],
+    frontier_clusters: list[set[str]],
+    contention: list[dict[str, Any]],
+    design_horizon: list[BeadDict],
+    blocked: list[BeadDict],
+    in_progress: list[BeadDict],
+) -> None:
+    id_to_bead = {b["id"]: b for b in all_beads}
+
+    print("=" * 72)
+    print("POLYLOGUE EXECUTION FRONTIER CLUSTERS")
+    print("=" * 72)
+    print()
+
+    # In-progress first (context)
+    if in_progress:
+        print(f"-- IN-PROGRESS ({len(in_progress)}) -----------------------------------------------")
+        for b in sorted(in_progress, key=lambda x: x.get("priority", 4)):
+            print(f"  {b['id']:25s} P{b['priority']}  {_short(b['title'])}")
+        print()
+
+    # Frontier clusters
+    print(f"-- FRONTIER-READY CLUSTERS ({len(frontier_clusters)} clusters) ------------------------")
+    for i, cluster in enumerate(
+        sorted(frontier_clusters, key=lambda c: min(id_to_bead[bid].get("priority", 4) for bid in c))
+    ):
+        members = sorted(cluster, key=lambda bid: id_to_bead[bid].get("priority", 4))
+        min_p = id_to_bead[members[0]].get("priority", 4)
+        shape = "SWEEP (overlapping)" if len(cluster) > 1 else "SOLO"
+        print(f"\n  Cluster {i + 1}  [{shape}]  min-P{min_p}")
+        for bid in members:
+            b = id_to_bead[bid]
+            fp = footprints[bid]
+            needsconf = "  [NEEDS-CONFIRM: no footprint]" if fp.is_empty else ""
+            print(f"    {bid:30s} P{b['priority']}  {_short(b['title'], 55)}{needsconf}")
+            if fp.packages:
+                pkgs = ", ".join(fp.packages[:4])
+                if len(fp.packages) > 4:
+                    pkgs += f" +{len(fp.packages) - 4}"
+                print(f"      pkgs: {pkgs}")
+            if fp.migration_slots:
+                print(f"      migration slots: {', '.join(fp.migration_slots)}")
+            if fp.generated_surfaces:
+                print(f"      generated surfaces: {', '.join(fp.generated_surfaces)}")
+        # Parallel hint
+        if len(cluster) > 1:
+            print("    -> Execute as one branch/PR sweep (shared file footprint)")
+    print()
+
+    # Contention warnings
+    if contention:
+        print(f"-- CONTENTION WARNINGS ({len(contention)}) -------------------------------------")
+        for ev in contention:
+            print(f"  {ev['key']}")
+            for bid in ev["beads"]:
+                b = id_to_bead.get(bid, {})
+                print(f"    {bid:30s} {_short(b.get('title', '?'), 50)}")
+        print()
+
+    # Blocked
+    if blocked:
+        print(f"-- BLOCKED ({len(blocked)}) -----------------------------------------------------")
+        for b in sorted(blocked, key=lambda x: x.get("priority", 4)):
+            ndeps = b.get("dependency_count", "?")
+            print(f"  {b['id']:25s} P{b['priority']}  [{ndeps} dep]  {_short(b['title'])}")
+        print()
+
+    # Design-horizon summary (just counts)
+    if design_horizon:
+        by_h: dict[str, int] = defaultdict(int)
+        for b in design_horizon:
+            by_h[_horizon(b)] += 1
+        horizon_str = "  ".join(f"{h}:{c}" for h, c in sorted(by_h.items()))
+        print(f"-- DESIGN-HORIZON ({len(design_horizon)})  [{horizon_str}]  (not shown -- use --all-open to list)")
+        print()
+
+    # Disjoint parallel-safe set across all clusters
+    solo_clusters = [c for c in frontier_clusters if len(c) == 1]
+    disjoint_frontier = [next(iter(c)) for c in solo_clusters]
+    if len(disjoint_frontier) > 1:
+        print(f"-- SAFE PARALLEL LANES ({len(disjoint_frontier)} solo beads, disjoint footprints) --")
+        for bid in sorted(disjoint_frontier, key=lambda b: id_to_bead[b].get("priority", 4)):
+            b = id_to_bead[bid]
+            print(f"  {bid:25s} P{b['priority']}  {_short(b['title'])}")
+        print()
+
+    print("Advisory: footprints are extracted heuristically. Verify on claim.")
+
+
+def _render_json(
+    all_beads: list[BeadDict],
+    footprints: dict[str, Footprint],
+    frontier_clusters: list[set[str]],
+    contention: list[dict[str, Any]],
+    design_horizon: list[BeadDict],
+    blocked: list[BeadDict],
+    in_progress: list[BeadDict],
+) -> None:
+    id_to_bead = {b["id"]: b for b in all_beads}
+
+    clusters_out: list[dict[str, Any]] = []
+    for cluster in sorted(frontier_clusters, key=lambda c: min(id_to_bead[bid].get("priority", 4) for bid in c)):
+        members = sorted(cluster, key=lambda bid: id_to_bead[bid].get("priority", 4))
+        shape = "sweep" if len(cluster) > 1 else "solo"
+        clusters_out.append(
+            {
+                "shape": shape,
+                "min_priority": min(id_to_bead[bid].get("priority", 4) for bid in members),
+                "beads": [
+                    {
+                        "id": bid,
+                        "priority": id_to_bead[bid].get("priority"),
+                        "title": id_to_bead[bid].get("title"),
+                        "footprint": {
+                            "packages": footprints[bid].packages,
+                            "files": footprints[bid].files[:8],
+                            "areas": footprints[bid].areas,
+                            "migration_slots": footprints[bid].migration_slots,
+                            "generated_surfaces": footprints[bid].generated_surfaces,
+                            "needs_confirm": footprints[bid].is_empty,
+                        },
+                    }
+                    for bid in members
+                ],
+            }
+        )
+
+    out = {
+        "frontier_clusters": clusters_out,
+        "contention": contention,
+        "blocked": [
+            {
+                "id": b["id"],
+                "priority": b.get("priority"),
+                "title": b["title"],
+                "dep_count": b.get("dependency_count", 0),
+            }
+            for b in blocked
+        ],
+        "in_progress": [{"id": b["id"], "priority": b.get("priority"), "title": b["title"]} for b in in_progress],
+        "design_horizon_count": len(design_horizon),
+    }
+    json.dump(out, sys.stdout, indent=2)
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Roster validation (AC3: predict the 2026-07-13 migration-slot collision)
+# ---------------------------------------------------------------------------
+
+# The hand-built LANES dict from the retired fanout_gen_prompts.py encoded two
+# lanes both touching migration slot 008 -- the tool should have flagged them.
+ROSTER_2026_07_13_KNOWN_COLLISION = {
+    "lane_a": "storage-rebuild-bytes",  # touched migrations/source/008_*.sql
+    "lane_b": "schema-write-audit",  # also touched migrations/source/008_*.sql
+    "slot": "008",
+    "note": "Two fanout PR lanes collided on durable-tier migration slot 008; "
+    "the hand roster missed it; bead-cluster must predict it.",
+}
+
+
+def _validate_roster(beads: list[BeadDict], footprints: dict[str, Footprint]) -> None:
+    print("=== ROSTER VALIDATION: 2026-07-13 migration-slot collision ===")
+    print()
+    slot = ROSTER_2026_07_13_KNOWN_COLLISION["slot"]
+    slot_beads = [b for b in beads if slot in footprints[b["id"]].migration_slots]
+    if len(slot_beads) >= 2:
+        print(f"  PREDICTED: {len(slot_beads)} beads share migration slot {slot}:")
+        for b in slot_beads:
+            print(f"    {b['id']}: {_short(b['title'])}")
+    elif len(slot_beads) == 1:
+        print(f"  PARTIAL: only 1 bead mentions slot {slot} (live roster may differ from 2026-07-13)")
+        print(f"    {slot_beads[0]['id']}: {_short(slot_beads[0]['title'])}")
+    else:
+        print(f"  NOT-DETECTED in current roster: no beads mention slot {slot}")
+        print("    (Either the collision lanes are merged/closed, or footprint extraction")
+        print("     missed the migration reference. Verify with: grep -r '008_' storage/sqlite/migrations/)")
+    print()
+    print(f"  Note: {ROSTER_2026_07_13_KNOWN_COLLISION['note']}")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def _parse_json_stream(text: str) -> Any:
+    """Parse a JSON value from ``text``, tolerating trailing non-JSON text.
+
+    bd's ``--json`` output can be followed by a plain-text pagination notice
+    on stdout (e.g. ``Showing 100 of 391 ready issues...``) when a command's
+    default ``--limit`` truncates the result set. ``json.loads`` rejects the
+    trailing text outright, so decode only the leading JSON value.
+    """
+    decoder = json.JSONDecoder()
+    value, _end = decoder.raw_decode(text)
+    return value
+
+
+def _load_beads(args: argparse.Namespace) -> list[BeadDict]:
+    if args.input:
+        with open(args.input) as f:
+            return list(json.load(f))
+
+    cmd = (
+        ["bd", "list", "--status=open", "--json", "--limit", "0"]
+        if args.all_open
+        else ["bd", "ready", "--json", "--limit", "0"]
+    )
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"ERROR running bd: {result.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        return list(_parse_json_stream(result.stdout))
+    except json.JSONDecodeError as exc:
+        print(f"ERROR parsing bd output: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--input", "-i", metavar="FILE", help="Read beads from JSON file instead of bd")
+    parser.add_argument("--all-open", action="store_true", help="Include all open beads (not just ready)")
+    parser.add_argument("--json", action="store_true", dest="json_out", help="Machine-readable JSON output")
+    parser.add_argument(
+        "--max-priority", type=int, default=4, metavar="N", help="Only show beads at priority <= N (default: 4)"
+    )
+    parser.add_argument(
+        "--validate-roster", action="store_true", help="Replay-validate 2026-07-13 collision prediction"
+    )
+    args = parser.parse_args(argv)
+
+    all_beads = _load_beads(args)
+
+    # Filter by priority ceiling
+    if args.max_priority < 4:
+        all_beads = [b for b in all_beads if b.get("priority", 4) <= args.max_priority]
+
+    # Extract footprints
+    footprints: dict[str, Footprint] = {b["id"]: _extract_footprint(b) for b in all_beads}
+
+    # Classify
+    frontier_beads = [b for b in all_beads if _classify(b) == "FRONTIER-READY"]
+    blocked = [b for b in all_beads if _classify(b) == "BLOCKED"]
+    in_progress = [b for b in all_beads if _classify(b) == "IN-PROGRESS"]
+    design_horizon = [b for b in all_beads if _classify(b) == "DESIGN-HORIZON"]
+
+    # Overlap graph over frontier-ready beads only
+    adj = _build_overlap_graph(frontier_beads, footprints)
+    frontier_clusters = _connected_components([b["id"] for b in frontier_beads], adj)
+
+    # Contention (migration slots / generated surfaces) across ALL frontier beads
+    contention = _find_contention(frontier_beads, footprints)
+
+    # Roster validation
+    if args.validate_roster:
+        _validate_roster(all_beads, footprints)
+
+    if args.json_out:
+        _render_json(all_beads, footprints, frontier_clusters, contention, design_horizon, blocked, in_progress)
+    else:
+        _render_human(
+            all_beads,
+            footprints,
+            frontier_clusters,
+            contention,
+            design_horizon,
+            blocked,
+            in_progress,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -593,6 +593,29 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools workspace bead-batch-show polylogue-kapb polylogue-2yax",),
     ),
     CommandSpec(
+        "workspace bead-cluster",
+        "workspace",
+        "Footprint/overlap/contention clustering of ready Beads (execution frontier).",
+        "devtools.bead_cluster",
+        use_when=(
+            "Before dispatching a batch of ready beads, see which ones share a file/package "
+            "footprint (cluster into one branch/PR sweep) vs. which are genuinely disjoint "
+            "(safe to run as parallel worktree lanes), and flag contention -- beads that touch "
+            "the same durable migration slot or the same generated surface even without an "
+            "exact file-path overlap. Answers a different question than "
+            "`workspace delivery-gate-status` (gate-progress board): this is footprint/overlap "
+            "clustering over the same live bead data, not gate percentage. Footprints are "
+            "advisory -- verify on claim."
+        ),
+        examples=(
+            "devtools workspace bead-cluster",
+            "devtools workspace bead-cluster --json",
+            "devtools workspace bead-cluster --all-open",
+            "devtools workspace bead-cluster --max-priority 1",
+            "devtools workspace bead-cluster --input ready.json --validate-roster",
+        ),
+    ),
+    CommandSpec(
         "workspace bead-reimport-guard",
         "workspace",
         "Monotonic, receipted guard/reconcile/export for bd's JSONL synchronization.",

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -211,6 +211,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools workspace archive-schema-fast-forward` | Clone-forward the v35 archive tiers without raw replay. |
 | `devtools workspace basic-usage-demo-check` | Re-run the basic-usage demo suite's commands and assert output shape. |
 | `devtools workspace bead-batch-show` | Batch-show beads: id, status, prio, title, desc head, deps, notes tail. |
+| `devtools workspace bead-cluster` | Footprint/overlap/contention clustering of ready Beads (execution frontier). |
 | `devtools workspace bead-reimport-guard` | Monotonic, receipted guard/reconcile/export for bd's JSONL synchronization. |
 | `devtools workspace claim-vs-evidence` | Build a structured failure follow-up claim-vs-evidence demo. |
 | `devtools workspace cli-surface-audit` | Capture a current-curated CLI surface audit demo. |

--- a/tests/unit/devtools/test_bead_cluster.py
+++ b/tests/unit/devtools/test_bead_cluster.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from devtools import bead_cluster
+
+
+def _bead(
+    bead_id: str,
+    *,
+    title: str = "untitled",
+    priority: int = 2,
+    status: str = "open",
+    dependency_count: int = 0,
+    labels: list[str] | None = None,
+    design: str = "",
+    notes: str = "",
+    acceptance_criteria: str = "",
+) -> dict[str, Any]:
+    return {
+        "id": bead_id,
+        "title": title,
+        "priority": priority,
+        "status": status,
+        "dependency_count": dependency_count,
+        "labels": labels or [],
+        "design": design,
+        "notes": notes,
+        "acceptance_criteria": acceptance_criteria,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Footprint extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_footprint_finds_file_paths_and_packages() -> None:
+    bead = _bead(
+        "polylogue-a",
+        design="Touch polylogue/mcp/server.py and tests/unit/mcp/test_server.py.",
+    )
+    fp = bead_cluster._extract_footprint(bead)
+    assert "polylogue/mcp/server.py" in fp.files
+    assert "tests/unit/mcp/test_server.py" in fp.files
+    assert "polylogue/mcp/" in fp.packages
+    assert "tests/unit/" in fp.packages
+
+
+def test_extract_footprint_falls_back_to_area_labels_when_no_files() -> None:
+    bead = _bead("polylogue-a", design="no file paths here", labels=["area:mcp"])
+    fp = bead_cluster._extract_footprint(bead)
+    assert "polylogue/mcp/" in fp.packages
+    assert fp.files == []
+
+
+def test_extract_footprint_area_labels_ignored_once_files_present() -> None:
+    # Area labels should NOT be added once concrete files are found -- otherwise
+    # broad area->package roots would over-merge clusters.
+    bead = _bead(
+        "polylogue-a",
+        design="Touch polylogue/mcp/server.py.",
+        labels=["area:storage"],
+    )
+    fp = bead_cluster._extract_footprint(bead)
+    assert "storage/sqlite/" not in fp.packages
+    assert "polylogue/storage/" not in fp.packages
+
+
+def test_extract_footprint_finds_migration_slots_and_generated_surfaces() -> None:
+    bead = _bead(
+        "polylogue-a",
+        design="Add migration 008_add_col.sql; regenerate topology-status.md too.",
+    )
+    fp = bead_cluster._extract_footprint(bead)
+    assert "008" in fp.migration_slots
+    assert "generated:topology-status" in fp.generated_surfaces
+
+
+def test_footprint_overlap_keys_exclude_broad_packages() -> None:
+    fp = bead_cluster.Footprint(files=[], packages=["polylogue/storage/", "polylogue/mcp/"])
+    assert "polylogue/storage/" not in fp.overlap_keys()
+    assert "polylogue/mcp/" in fp.overlap_keys()
+
+
+def test_footprint_is_empty_when_no_signal() -> None:
+    assert bead_cluster.Footprint().is_empty
+    assert not bead_cluster.Footprint(packages=["polylogue/mcp/"]).is_empty
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def test_classify_in_progress_takes_priority() -> None:
+    bead = _bead("polylogue-a", status="in_progress", labels=["horizon:frontier"])
+    assert bead_cluster._classify(bead) == "IN-PROGRESS"
+
+
+def test_classify_blocked_when_dependency_count_positive() -> None:
+    bead = _bead("polylogue-a", dependency_count=2, labels=["horizon:frontier"])
+    assert bead_cluster._classify(bead) == "BLOCKED"
+
+
+def test_classify_frontier_ready_from_horizon_label() -> None:
+    bead = _bead("polylogue-a", labels=["horizon:frontier"])
+    assert bead_cluster._classify(bead) == "FRONTIER-READY"
+
+
+def test_classify_design_horizon_from_mid_or_vision_label() -> None:
+    assert bead_cluster._classify(_bead("polylogue-a", labels=["horizon:mid"])) == "DESIGN-HORIZON"
+    assert bead_cluster._classify(_bead("polylogue-b", labels=["horizon:vision"])) == "DESIGN-HORIZON"
+
+
+def test_classify_unlabeled_high_priority_defaults_to_frontier_ready() -> None:
+    bead = _bead("polylogue-a", priority=1, labels=[])
+    assert bead_cluster._classify(bead) == "FRONTIER-READY"
+
+
+def test_classify_unlabeled_low_priority_defaults_to_design_horizon() -> None:
+    bead = _bead("polylogue-a", priority=3, labels=[])
+    assert bead_cluster._classify(bead) == "DESIGN-HORIZON"
+
+
+# ---------------------------------------------------------------------------
+# Overlap graph + clustering
+# ---------------------------------------------------------------------------
+
+
+def test_build_overlap_graph_links_beads_sharing_a_package() -> None:
+    beads = [
+        _bead("polylogue-a", design="Touch polylogue/mcp/server.py."),
+        _bead("polylogue-b", design="Touch polylogue/mcp/dispatch.py."),
+        _bead("polylogue-c", design="Touch polylogue/cli/click_app.py."),
+    ]
+    footprints = {b["id"]: bead_cluster._extract_footprint(b) for b in beads}
+    adj = bead_cluster._build_overlap_graph(beads, footprints)
+    assert "polylogue-b" in adj["polylogue-a"]
+    assert "polylogue-c" not in adj["polylogue-a"]
+
+
+def test_connected_components_groups_transitively_linked_beads() -> None:
+    adj = {
+        "a": {"b"},
+        "b": {"a", "c"},
+        "c": {"b"},
+        "d": set(),
+    }
+    components = bead_cluster._connected_components(["a", "b", "c", "d"], adj)
+    component_sets = {frozenset(c) for c in components}
+    assert frozenset({"a", "b", "c"}) in component_sets
+    assert frozenset({"d"}) in component_sets
+
+
+def test_find_contention_flags_shared_migration_slot() -> None:
+    beads = [
+        _bead("polylogue-a", design="Add migration 008_add_col.sql"),
+        _bead("polylogue-b", design="Add migration 008_other.sql"),
+        _bead("polylogue-c", design="Add migration 009_third.sql"),
+    ]
+    footprints = {b["id"]: bead_cluster._extract_footprint(b) for b in beads}
+    contention = bead_cluster._find_contention(beads, footprints)
+    events = {ev["key"]: set(ev["beads"]) for ev in contention}
+    assert events["migration:008"] == {"polylogue-a", "polylogue-b"}
+    assert "migration:009" not in events
+
+
+# ---------------------------------------------------------------------------
+# Roster-collision validation (AC3)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_roster_detects_known_collision(capsys: pytest.CaptureFixture[str]) -> None:
+    beads = [
+        _bead("polylogue-lane-a", design="touches migration 008_x.sql"),
+        _bead("polylogue-lane-b", design="touches migration 008_y.sql"),
+    ]
+    footprints = {b["id"]: bead_cluster._extract_footprint(b) for b in beads}
+    bead_cluster._validate_roster(beads, footprints)
+    out = capsys.readouterr().out
+    assert "PREDICTED" in out
+    assert "polylogue-lane-a" in out
+    assert "polylogue-lane-b" in out
+
+
+def test_validate_roster_reports_not_detected_when_absent(capsys: pytest.CaptureFixture[str]) -> None:
+    beads = [_bead("polylogue-a", design="no migrations mentioned")]
+    footprints = {b["id"]: bead_cluster._extract_footprint(b) for b in beads}
+    bead_cluster._validate_roster(beads, footprints)
+    out = capsys.readouterr().out
+    assert "NOT-DETECTED" in out
+
+
+# ---------------------------------------------------------------------------
+# JSON stream parsing (tolerates bd's trailing pagination notice)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_json_stream_ignores_trailing_pagination_notice() -> None:
+    text = '[{"id": "polylogue-a"}]\nShowing 1 of 2 ready issues. Use --limit 0 for all.\n'
+    value = bead_cluster._parse_json_stream(text)
+    assert value == [{"id": "polylogue-a"}]
+
+
+def test_parse_json_stream_plain_json_still_works() -> None:
+    text = '[{"id": "polylogue-a"}]'
+    assert bead_cluster._parse_json_stream(text) == [{"id": "polylogue-a"}]
+
+
+# ---------------------------------------------------------------------------
+# _load_beads / subprocess invocation
+# ---------------------------------------------------------------------------
+
+
+def test_load_beads_from_input_file(tmp_path: Path) -> None:
+    path = tmp_path / "ready.json"
+    path.write_text(json.dumps([{"id": "polylogue-a"}]))
+    args = argparse.Namespace(input=str(path), all_open=False)
+    assert bead_cluster._load_beads(args) == [{"id": "polylogue-a"}]
+
+
+def test_load_beads_calls_bd_ready_with_unbounded_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, list[str]] = {}
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        seen["cmd"] = cmd
+        return MagicMock(returncode=0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    args = argparse.Namespace(input=None, all_open=False)
+    assert bead_cluster._load_beads(args) == []
+    assert seen["cmd"] == ["bd", "ready", "--json", "--limit", "0"]
+
+
+def test_load_beads_all_open_calls_bd_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, list[str]] = {}
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        seen["cmd"] = cmd
+        return MagicMock(returncode=0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    args = argparse.Namespace(input=None, all_open=True)
+    assert bead_cluster._load_beads(args) == []
+    assert seen["cmd"] == ["bd", "list", "--status=open", "--json", "--limit", "0"]
+
+
+def test_load_beads_tolerates_trailing_pagination_notice(monkeypatch: pytest.MonkeyPatch) -> None:
+    stdout = '[{"id": "polylogue-a"}]\nShowing 1 of 2 ready issues. Use --limit 0 for all.\n'
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: MagicMock(returncode=0, stdout=stdout, stderr=""))
+    args = argparse.Namespace(input=None, all_open=False)
+    assert bead_cluster._load_beads(args) == [{"id": "polylogue-a"}]
+
+
+def test_load_beads_exits_nonzero_on_bd_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: MagicMock(returncode=1, stdout="", stderr="bd: no workspace")
+    )
+    args = argparse.Namespace(input=None, all_open=False)
+    with pytest.raises(SystemExit):
+        bead_cluster._load_beads(args)
+
+
+# ---------------------------------------------------------------------------
+# main() end-to-end over --input
+# ---------------------------------------------------------------------------
+
+
+def test_main_json_output_clusters_overlapping_beads(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    beads = [
+        _bead(
+            "polylogue-a",
+            priority=1,
+            labels=["horizon:frontier"],
+            design="Touch polylogue/mcp/server.py.",
+        ),
+        _bead(
+            "polylogue-b",
+            priority=2,
+            labels=["horizon:frontier"],
+            design="Touch polylogue/mcp/dispatch.py.",
+        ),
+        _bead(
+            "polylogue-c",
+            priority=1,
+            labels=["horizon:frontier"],
+            design="Touch polylogue/cli/click_app.py.",
+        ),
+        _bead("polylogue-blocked", priority=1, dependency_count=1, labels=["horizon:frontier"]),
+        _bead("polylogue-wip", status="in_progress"),
+        _bead("polylogue-vision", labels=["horizon:vision"]),
+    ]
+    path = tmp_path / "ready.json"
+    path.write_text(json.dumps(beads))
+
+    rc = bead_cluster.main(["--input", str(path), "--json"])
+    assert rc == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    cluster_ids = {frozenset(m["id"] for m in c["beads"]) for c in payload["frontier_clusters"]}
+    assert frozenset({"polylogue-a", "polylogue-b"}) in cluster_ids
+    assert frozenset({"polylogue-c"}) in cluster_ids
+    assert [b["id"] for b in payload["blocked"]] == ["polylogue-blocked"]
+    assert [b["id"] for b in payload["in_progress"]] == ["polylogue-wip"]
+    assert payload["design_horizon_count"] == 1
+
+
+def test_main_human_output_renders_sections(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    beads = [
+        _bead("polylogue-a", priority=1, labels=["horizon:frontier"], design="Touch polylogue/mcp/server.py."),
+    ]
+    path = tmp_path / "ready.json"
+    path.write_text(json.dumps(beads))
+
+    rc = bead_cluster.main(["--input", str(path)])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "FRONTIER-READY CLUSTERS" in out
+    assert "polylogue-a" in out
+
+
+def test_main_max_priority_filters_lower_priority_beads(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    beads = [
+        _bead("polylogue-hi", priority=1, labels=["horizon:frontier"]),
+        _bead("polylogue-lo", priority=3, labels=["horizon:frontier"]),
+    ]
+    path = tmp_path / "ready.json"
+    path.write_text(json.dumps(beads))
+
+    rc = bead_cluster.main(["--input", str(path), "--json", "--max-priority", "1"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    all_ids = {m["id"] for c in payload["frontier_clusters"] for m in c["beads"]}
+    assert all_ids == {"polylogue-hi"}


### PR DESCRIPTION
## Summary
Recovers `.agent/tools/bead-cluster.py` (deleted by PR #3188's over-broad dead-code sweep) as a properly registered `devtools workspace bead-cluster` command.

## Problem
`.agent/tools/bead-cluster.py` (commit `49182a7f2`, implementing polylogue-2yax) performed footprint/overlap/contention clustering of ready Beads -- a genuinely distinct question from `devtools workspace delivery-gate-status` (a gate-progress board over the same bead data). It was never registered as a `CommandSpec`, so it was invisible to `devtools --help`, `render devtools-reference`, and the repo's catalog-completeness checks (polylogue-utf/polylogue-o21). polylogue-1ebm was filed 2026-07-16 to close that gap.

Four days later, PR #3188 (`9e9e33950`, "chore(devtools): migrate .agent/scripts + .agent/tools into devtools", Ref polylogue-kapb) classified the unregistered file as dead ("no live references") and deleted it along with two genuinely-dead scripts, without cross-referencing this still-open bead's own investigation.

## Solution
- Recovered the pre-deletion version via `git show 9e9e33950^:.agent/tools/bead-cluster.py`.
- Ported it to `devtools/bead_cluster.py`, preserving the clustering algorithm exactly: footprint extraction (file paths / packages / migration slots / generated surfaces from design+notes+AC text), overlap-key based connected-component clustering, contention detection, and the `--validate-roster` replay check.
- Registered as `devtools workspace bead-cluster` via a new `CommandSpec` in `devtools/command_catalog.py`, with a `use_when` explicitly distinguishing it from `delivery-gate-status`.
- Fixed two bugs discovered while making it work against the current `bd` CLI:
  1. `bd ready --json` truncates at 100 results and appends a plain-text pagination notice ("Showing 100 of 391 ready issues...") to stdout, which broke `json.loads`. Now passes `--limit 0` and parses via `json.JSONDecoder().raw_decode` to tolerate trailing text defensively.
  2. `main()` previously returned `None`; the `CommandSpec` dispatch contract requires an `int` return.
- Added full `mypy --strict` typing (`dict` -> `dict[str, Any]`, etc).
- Added `tests/unit/devtools/test_bead_cluster.py` covering footprint extraction, classification, overlap-graph clustering, contention detection, roster validation, the trailing-notice-tolerant JSON parser, `_load_beads` subprocess invocation (mocked, following `test_bead_batch_show.py`'s pattern), and end-to-end `main()` over `--input` fixtures.

## Verification
- `devtools test tests/unit/devtools/test_bead_cluster.py tests/unit/devtools/test_command_catalog.py` -- 32 passed.
- `mypy --strict devtools/bead_cluster.py devtools/command_catalog.py tests/unit/devtools/test_bead_cluster.py` -- no issues.
- `ruff check` / `ruff format --check` on touched files -- clean.
- `devtools render devtools-reference` -- regenerated `docs/devtools.md` with the new command entry.
- `devtools verify --quick` -- exit_code 0 (ran on both commit and push).
- Ran the command against this repo's real live Beads workspace (read-only): `devtools workspace bead-cluster --max-priority 1`, `--json`, and `--validate-roster` all produced sensible clustering/contention output over actual `bd ready` data, not just mocks.

Ref polylogue-1ebm