### PR TITLE
docs(sources): fix false Pydantic-validation claim in dispatch.py comment

### DIFF
--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -177,8 +177,10 @@ def _detect_provider_from_record(record: PayloadRecord) -> Provider | None:
         return Provider.ANTIGRAVITY
     if beads.looks_like(record):
         return Provider.BEADS
-    # Specific type-level checks first (Codex, Claude Code use Pydantic
-    # validation), then weaker dict-key checks (ChatGPT, Claude AI, Gemini).
+    # Specific type-level checks first (Codex uses Pydantic validation;
+    # Claude Code uses a dict-key/type shape check, not Pydantic, despite
+    # ClaudeCodeRecord existing as a separate typed parse-time model), then
+    # weaker dict-key checks (ChatGPT, Claude AI, Gemini).
     if codex.looks_like([dict(record)]):
         return Provider.CODEX
     if claude.looks_like_code([dict(record)]):


### PR DESCRIPTION
## Summary
Fixes `polylogue-kj0u`.

## Problem
`dispatch.py`'s provider-detection comment claimed Claude Code detection uses Pydantic validation alongside Codex. It does not — the actual detector (`claude.looks_like_code`, `sources/parsers/claude/code_detection.py`) is a pure dict-key/type-shape check. `ClaudeCodeRecord` (`sources/providers/claude_code_record.py`) is a real Pydantic model, but confirmed dead-in-production: grepped for `ClaudeCodeRecord(` — every instantiation site is in `tests/`, none in `code_parser.py` (the live parse path).

## Solution
Corrected the comment to accurately describe Claude Code detection as a dict-key/type shape check, while noting `ClaudeCodeRecord` exists as a separate (currently unused-in-production) typed parse-time model.

## Verification
`mypy --strict` / `ruff check`/`format` clean. `devtools verify --quick` green via pre-push hook.

Ref polylogue-kj0u

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified internal documentation describing how provider records are identified, including the distinction between validation approaches.

- **Chores**
  - Closed a stale security-documentation tracking issue after confirming the repository already contains the relevant security guidance and links.

- **Other**
  - No user-facing functionality or behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->