### PR TITLE
fix(sources): cap aggregate uncompressed size across zip entries

### DIFF
--- a/polylogue/sources/decoder_zip.py
+++ b/polylogue/sources/decoder_zip.py
@@ -22,6 +22,22 @@ logger = get_logger(__name__)
 MAX_COMPRESSION_RATIO = 1000
 MAX_UNCOMPRESSED_SIZE = 10 * 1024 * 1024 * 1024
 
+#: Aggregate ceiling (bytes) on the sum of declared ``file_size`` across every
+#: entry admitted from a single ZIP archive (polylogue-lqxx). The per-entry
+#: cap above bounds one entry but does nothing to stop a "zip bomb by many
+#: entries": thousands of entries each just under the 10 GiB per-entry cap
+#: would still sum to an unbounded total. 64 GiB is chosen to comfortably
+#: exceed any real single-archive GDPR/Takeout export this repo has observed
+#: (the largest full raw corpus recorded across this operator's *entire*
+#: archive history, spanning every session ever ingested, is ~52.1 GiB --
+#: see `sources/revision_backfill.py`'s newest-revision-raws comment) while
+#: still bounding aggregate decompression well below the terabyte-scale
+#: totals a many-small-entries zip bomb would otherwise reach. It is also in
+#: the same order of magnitude as the daemon's other whole-pass resource
+#: envelopes (e.g. the whale-pass `raw_authority_whale_payload_bytes`
+#: default of 8 GiB for a *single* stream-safe-gated component).
+MAX_AGGREGATE_UNCOMPRESSED_SIZE = 64 * 1024 * 1024 * 1024
+
 #: Chunk size used when bounding ZIP entry decompression. Read in fixed
 #: windows so a malicious entry cannot allocate more than this much extra
 #: memory beyond the running total before the ceiling check fires.
@@ -97,7 +113,7 @@ def open_bounded_zip_entry(
 class ZipEntryValidator:
     """Validate ZIP entries for security and relevance."""
 
-    __slots__ = ("_provider_hint", "_cursor_state", "_zip_path", "_session_only")
+    __slots__ = ("_provider_hint", "_cursor_state", "_zip_path", "_session_only", "_aggregate_total")
 
     def __init__(
         self,
@@ -111,6 +127,7 @@ class ZipEntryValidator:
         self._cursor_state = cursor_state
         self._zip_path = zip_path
         self._session_only = session_only
+        self._aggregate_total = 0
 
     def filter_entries(self, entries: list[zipfile.ZipInfo]) -> Iterable[zipfile.ZipInfo]:
         """Yield safe, relevant entries and record failures in cursor state."""
@@ -158,6 +175,32 @@ class ZipEntryValidator:
                     )
                     if path_classification is not None and not path_classification.parse_as_session:
                         continue
+
+                # Aggregate cap: the per-entry check above bounds one entry,
+                # but a zip bomb built from many entries each just under the
+                # per-entry cap would otherwise sum to an unbounded total.
+                # Check the running total of declared uncompressed sizes
+                # against MAX_AGGREGATE_UNCOMPRESSED_SIZE before yielding, so
+                # rejection happens from central-directory metadata alone --
+                # before any entry is opened/decompressed.
+                projected_total = self._aggregate_total + info.file_size
+                if projected_total > MAX_AGGREGATE_UNCOMPRESSED_SIZE:
+                    logger.warning(
+                        "Skipping %s in %s: aggregate uncompressed size %d would exceed the %d-byte archive-wide limit",
+                        name,
+                        self._zip_path,
+                        projected_total,
+                        MAX_AGGREGATE_UNCOMPRESSED_SIZE,
+                    )
+                    _record_cursor_failure(
+                        self._cursor_state,
+                        f"{self._zip_path}:{name}",
+                        f"Aggregate uncompressed size {projected_total} exceeds archive-wide limit "
+                        f"{MAX_AGGREGATE_UNCOMPRESSED_SIZE}",
+                    )
+                    continue
+
+                self._aggregate_total = projected_total
                 yield info
 
 
@@ -249,6 +292,7 @@ def process_zip(
 
 
 __all__ = [
+    "MAX_AGGREGATE_UNCOMPRESSED_SIZE",
     "MAX_COMPRESSION_RATIO",
     "MAX_UNCOMPRESSED_SIZE",
     "ZipBombError",

--- a/polylogue/sources/decoders.py
+++ b/polylogue/sources/decoders.py
@@ -14,6 +14,7 @@ from polylogue.sources.decoder_json import (
     iter_json_stream_with,
 )
 from polylogue.sources.decoder_zip import (
+    MAX_AGGREGATE_UNCOMPRESSED_SIZE,
     MAX_COMPRESSION_RATIO,
     MAX_UNCOMPRESSED_SIZE,
 )
@@ -42,6 +43,7 @@ __all__ = [
     "_ZipEntryValidator",
     "_zip_entry_provider_hint",
     "_process_zip",
+    "MAX_AGGREGATE_UNCOMPRESSED_SIZE",
     "MAX_COMPRESSION_RATIO",
     "MAX_UNCOMPRESSED_SIZE",
 ]

--- a/tests/unit/sources/test_decoders.py
+++ b/tests/unit/sources/test_decoders.py
@@ -15,6 +15,7 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from polylogue.sources.decoders import (
+    MAX_AGGREGATE_UNCOMPRESSED_SIZE,
     MAX_UNCOMPRESSED_SIZE,
     _decode_json_bytes,
     _iter_json_stream,
@@ -308,3 +309,63 @@ class TestZipEntryValidator:
         failed_files: list[CursorFailurePayload] = cursor_state.get("failed_files", [])
         assert cursor_state["failed_count"] >= 1
         assert len(failed_files) >= 1
+
+    def test_aggregate_size_limit_rejects_many_entries_under_per_entry_cap(self) -> None:
+        """A zip bomb built from many entries, each individually under
+        MAX_UNCOMPRESSED_SIZE, is rejected once their SUM would exceed
+        MAX_AGGREGATE_UNCOMPRESSED_SIZE (polylogue-lqxx).
+
+        Each entry here is deliberately just 1 byte under the per-entry
+        cap, so this proves the aggregate check fires on its own -- the
+        existing per-entry check alone would accept every single one of
+        these entries.
+        """
+        cursor_state = _seeded_cursor_state()
+        validator = _ZipEntryValidator(
+            "chatgpt",
+            cursor_state=cursor_state,
+            zip_path=Path("bomb.zip"),
+        )
+        per_entry_size = MAX_UNCOMPRESSED_SIZE - 1
+        assert per_entry_size <= MAX_UNCOMPRESSED_SIZE  # sanity: never trips the per-entry cap
+
+        # 7 entries * (10 GiB - 1 byte) ~= 70 GiB, comfortably over the
+        # 64 GiB aggregate cap, while no single entry is oversized.
+        entry_count = (MAX_AGGREGATE_UNCOMPRESSED_SIZE // per_entry_size) + 2
+        entries = [
+            self._make_zip_info(f"conversation_{i}.json", file_size=per_entry_size, compress_size=per_entry_size)
+            for i in range(entry_count)
+        ]
+
+        accepted = list(validator.filter_entries(entries))
+
+        # Every accepted entry was individually under the per-entry cap
+        # (proven above), yet not all entries were accepted -- the
+        # aggregate check, not the per-entry check, did the rejecting.
+        assert len(accepted) < entry_count
+        assert sum(info.file_size for info in accepted) <= MAX_AGGREGATE_UNCOMPRESSED_SIZE
+
+        failed_files: list[CursorFailurePayload] = cursor_state.get("failed_files", [])
+        assert cursor_state["failed_count"] >= 1
+        assert any("Aggregate uncompressed size" in failure["error"] for failure in failed_files)
+
+    def test_aggregate_size_limit_allows_archive_comfortably_under_cap(self) -> None:
+        """Multiple entries whose sum stays well under the aggregate cap
+        all decode successfully -- no regression for legitimate
+        multi-file exports."""
+        validator = _ZipEntryValidator(
+            "chatgpt",
+            cursor_state=None,
+            zip_path=Path("normal_export.zip"),
+        )
+        # 3 entries of 1 GiB each = 3 GiB total, far under both the 10 GiB
+        # per-entry cap and the 64 GiB aggregate cap.
+        one_gib = 1024 * 1024 * 1024
+        entries = [
+            self._make_zip_info(f"conversation_{i}.json", file_size=one_gib, compress_size=one_gib) for i in range(3)
+        ]
+
+        accepted = list(validator.filter_entries(entries))
+
+        assert len(accepted) == 3
+        assert sum(info.file_size for info in accepted) == 3 * one_gib


### PR DESCRIPTION
## Summary

`ZipEntryValidator.filter_entries` (`polylogue/sources/decoder_zip.py`) enforced a 10 GiB *per-entry* uncompressed-size cap (`MAX_UNCOMPRESSED_SIZE`) but tracked no running total across an archive's entries, leaving a zip-bomb-by-many-entries path open. This adds a genuine aggregate cap.

## Problem

A crafted (or corrupted) zip with thousands of entries each just under the 10 GiB per-entry cap would sum to an unbounded total, and the decoder would process all of them -- flagged by the 2026-06-28 fanout audit as polylogue-lqxx (LOW/security).

## Solution

- New `MAX_AGGREGATE_UNCOMPRESSED_SIZE = 64 GiB` constant in `polylogue/sources/decoder_zip.py`. Justification: the largest real single-archive size this repo has evidence for is the *entire* raw corpus across this operator's whole archive history (~52.1 GiB, per `sources/revision_backfill.py`'s newest-revision-raws comment) -- a single GDPR/Takeout zip export is far smaller than that -- while 64 GiB stays well below the terabyte-scale totals a many-small-entries zip bomb would otherwise reach. It's also the same order of magnitude as the daemon's other whole-pass resource envelopes (e.g. the whale-pass default of 8 GiB for one stream-safe-gated component).
- `ZipEntryValidator` now tracks a running `_aggregate_total` of admitted entries' declared `file_size` and rejects (via the same `_record_cursor_failure` path used by the existing per-entry/ratio checks) once the projected total would exceed the cap. This fires against zip central-directory metadata alone, before any entry is opened/decompressed -- same timing as the existing per-entry check, which is otherwise untouched.
- Re-exported the new constant from `polylogue/sources/decoders.py` alongside the existing `MAX_*` constants for symmetry with the compat re-export the tests already import through.

**Not touched:** `polylogue/sources/import_explain.py`'s `_zip_entry_skip_reason` duplicates the per-entry ratio/size checks for the `import --explain` dry-run preview but has no aggregate check either -- a preview could still say "will import" for entries a real `process_zip` run now rejects on aggregate grounds. Left as-is; scoped to the actual decode path per polylogue-lqxx's acceptance criteria.

## Verification

- `devtools test tests/unit/sources/test_decoders.py` -> 25 passed, including two new cases: many entries each individually under the per-entry cap but summing past the aggregate cap are rejected (and `cursor_state` records the aggregate-specific failure reason), and an archive comfortably under the aggregate cap still decodes every entry (no regression).
- `mypy --strict polylogue/sources/decoder_zip.py polylogue/sources/decoders.py` -> no issues found
- `ruff check` / `ruff format --check` on all three touched files -> clean
- `devtools render all --check` -> no drift
- `devtools verify --quick` (pre-push hook) -> exit 0

Ref polylogue-lqxx

🤖 Generated with [Claude Code](https://claude.com/claude-code)