### PR TITLE
chore(cleanup): delete re-verified dead-code kill-list from 9e5.15 audit

### DIFF
--- a/docs/plans/docs-coverage-baseline.yaml
+++ b/docs/plans/docs-coverage-baseline.yaml
@@ -16,16 +16,6 @@
 
 gaps:
   cli:
-    - name: 'agents conflicts'
-      reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
-    - name: 'agents current'
-      reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
-    - name: 'agents handoff'
-      reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
-    - name: 'agents overlap'
-      reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
-    - name: 'agents self'
-      reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
     - name: 'agents status'
       reason: "pre-existing gap at gate introduction (polylogue-3tl.9); needs a doc entry, not baseline growth"
     - name: 'agents work-item'

--- a/polylogue/archive/artifact_taxonomy/support.py
+++ b/polylogue/archive/artifact_taxonomy/support.py
@@ -31,10 +31,6 @@ _HOOK_EVENT_KEYS = frozenset({"event_type", "session_id", "timestamp", "provider
 _BEADS_INTERACTION_KEYS = frozenset({"id", "kind", "created_at", "issue_id", "extra"})
 
 
-def path_only_sidecars() -> dict[str, str]:
-    return _PATH_ONLY_SIDECARS
-
-
 def path_only_sidecar_reason(name: str) -> str | None:
     lowered = name.lower()
     if lowered in _PATH_ONLY_SIDECARS:

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -138,7 +138,6 @@ from polylogue.archive.query.metadata import (
     structural_query_units,
     terminal_query_source_list,
     terminal_query_source_pairs,
-    terminal_query_unit,
 )
 from polylogue.archive.query.predicate import (
     QueryBoolPredicate,
@@ -1644,13 +1643,6 @@ def _is_boolean_expression(expression: str) -> bool:
     return ":" in expression and bool(re.search(r"\b(?:and|or|not)\b", expression, re.IGNORECASE))
 
 
-def _source_where_unit(source: str) -> QueryUnitName:
-    unit = terminal_query_unit(source.strip().lower())
-    if unit is not None:
-        return unit
-    raise ExpressionCompileError(f"unsupported query source {source!r}", field=None)
-
-
 def _transform_boolean_predicate(expression: str) -> QueryPredicate:
     try:
         tree = _QUERY_PARSER.parse(expression, start="boolean_query")
@@ -1935,11 +1927,6 @@ def _canonicalize_with_projection(tail: str) -> tuple[tuple[str, ...], dict[str,
             else:
                 field_map[descriptor.unit] = fields
     return tuple(canonical), field_map
-
-
-def _canonicalize_with_units(tail: str) -> tuple[str, ...]:
-    units, _fields = _canonicalize_with_projection(tail)
-    return units
 
 
 def _split_with_projection_clause(expression: str) -> tuple[str, tuple[str, ...], dict[str, tuple[str, ...]]]:
@@ -2914,10 +2901,6 @@ def _parse_relative_date(value: str) -> str:
         return f"{num_str} {unit_map[unit_char]} ago"
     # Otherwise pass through (ISO date or natural language) and let parse_date validate
     return value
-
-
-def _merge_tuples(existing: tuple[str, ...], new_values: tuple[str, ...]) -> tuple[str, ...]:
-    return existing + new_values
 
 
 @dataclass

--- a/polylogue/archive/query/plan.py
+++ b/polylogue/archive/query/plan.py
@@ -19,26 +19,19 @@ from polylogue.archive.query.retrieval import (
     actions_ready,
     can_use_action_stats_with,
     candidate_record_query,
-    candidate_record_query_for,
     fetch_record_query_for,
-    search_limit,
     should_batch_post_filter_fetch,
     uses_actions,
 )
 from polylogue.archive.query.runtime import (
     apply_common_filters,
     apply_full_filters,
-    matches_action_sequence,
-    matches_action_terms,
-    matches_action_text_terms,
-    matches_referenced_path,
-    matches_tool_terms,
     plan_can_count_in_sql,
     plan_can_use_action_stats,
     plan_has_post_filters,
     plan_needs_content_loading,
 )
-from polylogue.archive.query.sorting import SortKey, finalize_results, sort_generic, sort_sessions, sort_summaries
+from polylogue.archive.query.sorting import finalize_results, sort_sessions, sort_summaries
 from polylogue.archive.query.support import session_has_branches
 from polylogue.storage.query_models import SessionRecordQuery
 
@@ -184,21 +177,6 @@ class SessionQueryPlan:
     def can_use_action_stats(self) -> bool:
         return plan_can_use_action_stats(self)
 
-    def _matches_referenced_path(self, session: Session) -> bool:
-        return matches_referenced_path(self, session)
-
-    def _matches_action_terms(self, session: Session) -> bool:
-        return matches_action_terms(self, session)
-
-    def _matches_tool_terms(self, session: Session) -> bool:
-        return matches_tool_terms(self, session)
-
-    def _matches_action_sequence(self, session: Session) -> bool:
-        return matches_action_sequence(self, session)
-
-    def _matches_action_text_terms(self, session: Session) -> bool:
-        return matches_action_text_terms(self, session)
-
     def _apply_common_filters(
         self,
         items: builtins.list[_FilterableT],
@@ -209,9 +187,6 @@ class SessionQueryPlan:
 
     def _apply_full_filters(self, sessions: list[Session], *, sql_pushed: bool) -> list[Session]:
         return apply_full_filters(self, sessions, sql_pushed=sql_pushed)
-
-    def _sort_generic(self, items: list[_T], key_fn: Callable[[_T], SortKey]) -> list[_T]:
-        return sort_generic(self, items, key_fn)
 
     def _sort_sessions(self, sessions: list[Session]) -> list[Session]:
         return sort_sessions(self, sessions)
@@ -240,20 +215,11 @@ class SessionQueryPlan:
     async def can_use_action_stats_with(self, repository: SessionQueryRuntimeStore) -> bool:
         return await can_use_action_stats_with(self, repository)
 
-    async def _candidate_record_query_for(
-        self,
-        repository: SessionQueryRuntimeStore,
-    ) -> tuple[SessionRecordQuery, bool]:
-        return await candidate_record_query_for(self, repository)
-
     async def fetch_record_query_for(self, repository: SessionQueryRuntimeStore) -> SessionRecordQuery:
         return await fetch_record_query_for(self, repository)
 
     def _should_batch_post_filter_fetch(self) -> bool:
         return should_batch_post_filter_fetch(self)
-
-    def _search_limit(self) -> int:
-        return search_limit(self)
 
     async def list(self, config: Config) -> list[Session]:
         from polylogue.archive.query.archive_execution import list_archive

--- a/polylogue/archive/semantic/models.py
+++ b/polylogue/archive/semantic/models.py
@@ -7,7 +7,6 @@ from datetime import datetime
 
 from polylogue.archive.actions.actions import Action
 from polylogue.archive.viewport.viewports import ReasoningTrace, ToolCall
-from polylogue.core.json import JSONDocument, json_document
 
 
 @dataclass(frozen=True, slots=True)
@@ -54,20 +53,6 @@ class ProjectionSemanticFacts:
     tool_messages: int
     renderable_role_counts: dict[str, int]
 
-    def to_evidence_input(self) -> JSONDocument:
-        return json_document(
-            {
-                "total_messages": self.total_messages,
-                "renderable_messages": self.renderable_messages,
-                "timestamped_renderable_messages": self.timestamped_renderable_messages,
-                "attachment_count": self.attachment_count,
-                "empty_messages": self.empty_messages,
-                "thinking_messages": self.thinking_messages,
-                "tool_messages": self.tool_messages,
-                "renderable_role_counts": self.renderable_role_counts,
-            }
-        )
-
 
 @dataclass(frozen=True, slots=True)
 class SessionSemanticFacts:
@@ -97,29 +82,6 @@ class SessionSemanticFacts:
     wall_duration_ms: int
     message_facts: tuple[MessageSemanticFacts, ...]
 
-    def to_evidence_input(self) -> JSONDocument:
-        return json_document(
-            {
-                "session_id": self.session_id,
-                "origin": self.origin,
-                "title": self.title,
-                "date": self.date,
-                "total_messages": self.total_messages,
-                "text_messages": self.text_messages,
-                "message_ids": list(self.message_ids),
-                "text_message_ids": list(self.text_message_ids),
-                "text_role_counts": self.text_role_counts,
-                "timestamped_text_messages": self.timestamped_text_messages,
-                "timestamped_messages": self.timestamped_messages,
-                "untimestamped_messages": self.untimestamped_messages,
-                "timestamp_coverage": self.timestamp_coverage,
-                "attachment_count": self.attachment_count,
-                "thinking_messages": self.thinking_messages,
-                "tool_messages": self.tool_messages,
-                "branch_messages": self.branch_messages,
-            }
-        )
-
 
 @dataclass(frozen=True, slots=True)
 class SummarySemanticFacts:
@@ -130,19 +92,6 @@ class SummarySemanticFacts:
     messages: int
     tags: tuple[str, ...]
     summary: str | None
-
-    def to_evidence_input(self) -> JSONDocument:
-        return json_document(
-            {
-                "session_id": self.session_id,
-                "origin": self.origin,
-                "title": self.title,
-                "date": self.date,
-                "messages": self.messages,
-                "tags": list(self.tags),
-                "summary": self.summary,
-            }
-        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -162,26 +111,6 @@ class StreamSemanticFacts:
     message_roles: tuple[str, ...]
     message_limit: int | None
 
-    def to_evidence_input(self) -> JSONDocument:
-        return json_document(
-            {
-                "session_id": self.session_id,
-                "origin": self.origin,
-                "title": self.title,
-                "date": self.date,
-                "text_messages": self.text_messages,
-                "text_message_ids": list(self.text_message_ids),
-                "text_role_counts": self.text_role_counts,
-                "timestamped_text_messages": self.timestamped_text_messages,
-                "attachment_count": self.attachment_count,
-                "thinking_messages": self.thinking_messages,
-                "tool_messages": self.tool_messages,
-                "branch_messages": self.branch_messages,
-                "message_roles": list(self.message_roles),
-                "message_limit": self.message_limit,
-            }
-        )
-
 
 @dataclass(frozen=True, slots=True)
 class MCPDetailSemanticFacts:
@@ -199,25 +128,6 @@ class MCPDetailSemanticFacts:
     tool_messages: int
     branch_messages: int
 
-    def to_evidence_input(self) -> JSONDocument:
-        return json_document(
-            {
-                "session_id": self.session_id,
-                "origin": self.origin,
-                "title": self.title,
-                "created_at": self.created_at,
-                "updated_at": self.updated_at,
-                "messages": self.messages,
-                "message_ids": list(self.message_ids),
-                "role_counts": self.role_counts,
-                "timestamped_messages": self.timestamped_messages,
-                "attachment_count": self.attachment_count,
-                "thinking_messages": self.thinking_messages,
-                "tool_messages": self.tool_messages,
-                "branch_messages": self.branch_messages,
-            }
-        )
-
 
 @dataclass(frozen=True, slots=True)
 class MCPSummarySemanticFacts:
@@ -229,20 +139,6 @@ class MCPSummarySemanticFacts:
     updated_at: str | None
     tags: tuple[str, ...]
     summary: str | None
-
-    def to_evidence_input(self) -> JSONDocument:
-        return json_document(
-            {
-                "session_id": self.session_id,
-                "origin": self.origin,
-                "title": self.title,
-                "messages": self.messages,
-                "created_at": self.created_at,
-                "updated_at": self.updated_at,
-                "tags": list(self.tags),
-                "summary": self.summary,
-            }
-        )
 
 
 __all__ = [

--- a/polylogue/cli/commands/agents.py
+++ b/polylogue/cli/commands/agents.py
@@ -107,46 +107,11 @@ def status_command(cwd: Path | None, limit: int, json_output: bool, output_forma
     _emit("status", cwd, limit, json_output, output_format, detail)
 
 
-@agents_command.command("self")
-@_format_options
-def self_command(cwd: Path | None, limit: int, json_output: bool, output_format: str, detail: bool) -> None:
-    """Show this agent's repo, process, and current work-item projection."""
-    _emit("self", cwd, limit, json_output, output_format, detail)
-
-
 @agents_command.command("work-item")
 @_format_options
 def work_item_command(cwd: Path | None, limit: int, json_output: bool, output_format: str, detail: bool) -> None:
     """Show the current work item projection."""
     _emit("work-item", cwd, limit, json_output, output_format, detail)
-
-
-@agents_command.command("current")
-@_format_options
-def current_command(cwd: Path | None, limit: int, json_output: bool, output_format: str, detail: bool) -> None:
-    """Alias for ``work-item``."""
-    _emit("work-item", cwd, limit, json_output, output_format, detail)
-
-
-@agents_command.command("conflicts")
-@_format_options
-def conflicts_command(cwd: Path | None, limit: int, json_output: bool, output_format: str, detail: bool) -> None:
-    """Show overlap/resource awareness; same-file activity is not a blocker."""
-    _emit("conflicts", cwd, limit, json_output, output_format, detail)
-
-
-@agents_command.command("overlap")
-@_format_options
-def overlap_command(cwd: Path | None, limit: int, json_output: bool, output_format: str, detail: bool) -> None:
-    """Alias for ``conflicts``."""
-    _emit("conflicts", cwd, limit, json_output, output_format, detail)
-
-
-@agents_command.command("handoff")
-@_format_options
-def handoff_command(cwd: Path | None, limit: int, json_output: bool, output_format: str, detail: bool) -> None:
-    """Show supported live handoff references for the current repo."""
-    _emit("handoff", cwd, limit, json_output, output_format, detail)
 
 
 __all__ = ["agents_command"]

--- a/polylogue/storage/repository/archive/sessions.py
+++ b/polylogue/storage/repository/archive/sessions.py
@@ -107,9 +107,6 @@ class RepositoryArchiveSessionMixin:
         full_id = await self.resolve_id(session_id) or session_id
         return await self.get(str(full_id))
 
-    async def get_eager(self, session_id: str) -> Session | None:
-        return await self.get(session_id)
-
     async def get_messages(self, session_id: str) -> list[MessageRecord]:
         return await self.queries.get_messages(session_id)
 


### PR DESCRIPTION
## Summary

Executes polylogue-k7m7: independently re-verify and delete the ~30-symbol dead-code kill-list produced by polylogue-9e5.15's 2026-07-09 vulture+coverage+affordance-usage audit. Every symbol was re-checked against the current tree (not blindly trusted from a ~2.5-week-old audit) before deletion.

## Problem

polylogue-9e5.15 intersected three signals (vulture static analysis, coverage.py 0%-function data, CLI/MCP affordance-usage telemetry) and manually call-site-verified a ~30-symbol kill-list, documented in `.agent/handoffs/polylogue-deep-research-2026-07-09/2026-07-09-codebase-structure-audit.md` section 2. That audit was explicitly split into an audit half (closed) and an execution half (this PR, polylogue-k7m7) because a lot can land between finding dead code and deleting it.

## Solution

For every symbol on the list: fresh `rg` call-site search across `polylogue/`, `tests/`, `docs/`; check for test/CLI-registration/MCP-registration/generated-doc references; and for one ambiguous case (a Protocol-declared method), a full-repo `mypy --strict` run with the symbol removed to empirically confirm no structural-typing consumer exists.

**Deleted (still genuinely dead):**
- `polylogue/cli/commands/agents.py`: `self_command`, `current_command`, `conflicts_command`, `overlap_command`, `handoff_command` — 5 untested, uncalled CLI subcommand wrappers. `agents status`/`agents work-item` remain; the underlying `CoordinationView` substrate and MCP surface are untouched, only these CLI aliasing wrappers are gone.
- `polylogue/archive/semantic/models.py`: `to_evidence_input` on all 6 semantic-facts dataclasses (zero call sites anywhere) + the now-unused `JSONDocument`/`json_document` import.
- `polylogue/archive/query/plan.py`: 8 one-line `SessionQueryPlan` wrapper methods (`_matches_referenced_path`, `_matches_action_terms`, `_matches_tool_terms`, `_matches_action_sequence`, `_matches_action_text_terms`, `_sort_generic`, `_candidate_record_query_for`, `_search_limit`) that only forwarded to free functions already called directly by their real callers, plus the resulting unused imports (`candidate_record_query_for`, `search_limit`, the `matches_*` family, `sort_generic`, `SortKey`).
- `polylogue/archive/query/expression.py`: `_merge_tuples`, `_canonicalize_with_units`, `_source_where_unit` (zero callers) + the unused `terminal_query_unit` import.
- `polylogue/archive/artifact_taxonomy/support.py`: `path_only_sidecars` (one-line dict-returning wrapper, zero callers; `path_only_sidecar_reason`, which reads the same dict directly, stays).
- `polylogue/storage/repository/archive/sessions.py`: `get_eager`.

**Skipped — found to have changed since the 2026-07-09 audit (not deleted):**
- The 3 `cli/query_verbs.py` mark-candidate commands (`reject`/`defer`/`supersede_mark_candidate_command`) **no longer exist at all** — already deleted by PR #3138 (2026-07-19), which consolidated the `mark candidates` subcommand group into the root `judge` command. No action needed; this half of the audit's finding is stale in a "already resolved" direction.
- The `polylogue/api/archive.py` half of the audit's "`get_eager` pair" is also already gone — removed by the #2900 control-center decomposition. Only the `storage/repository/archive/sessions.py` half still existed and was deleted above.
- `get_eager` is now declared as a required method on two `@runtime_checkable` Protocols (`SessionQueryRuntimeStore`, `SessionOutputStore` in `polylogue/core/protocols.py`), added by PR #2906 (2026-07-15, after the audit) when those protocols' methods were inlined from a deleted shared base. This looked exactly like the "grew a new reference since the audit" case the bead warned about, so I verified it empirically rather than assuming either way: a full-repo `mypy --strict` run with the concrete `sessions.py` method removed reports zero errors, and grepping for `.get_eager(` call sites and getattr/dynamic-dispatch patterns found none — the two Protocol declarations themselves are never structurally checked against a real `SessionRepository` instance anywhere in production code today. I deleted the concrete method (documented above) but left the two Protocol declarations untouched (out of this sweep's scope). This leaves the Protocols describing a method their only real implementer no longer provides — worth revisiting if `plan_execution.py`/`query_actions.py` (themselves apparently production-unreferenced, test-only-exercised query scaffolding using these exact Protocols) are ever wired into a live call path.

## Verification

- `python -m mypy --strict polylogue` → `Success: no issues found in 1082 source files` (run after every deletion step, including a throwaway pre-deletion probe specifically for the `get_eager` question).
- `ruff check polylogue` → `All checks passed!`; `ruff format --check polylogue` → `1082 files already formatted`.
- `devtools test` against the ~40 test files that import the touched modules: **11 failed, 291 passed**. Confirmed via `git stash` + re-run against `origin/master` with the identical test-file set that all 11 failures are **pre-existing and unrelated** (same test names, same assertion messages, same line numbers, with or without this diff).
- `devtools render all --check` → exit 0, no `out of sync` entries (grepped per the repo's own gotcha about the tail line lying).
- `devtools verify --quick` (pre-push hook) → all 16 steps green (ruff format/check, mypy, render all, topology, layering, closure-matrix, schema roundtrip, manifests, ci-workflows, doc-commands, docs-coverage, test-infra-currency, test-clock-hygiene, pytest-timeout-overrides, degrade-loudly).

Ref polylogue-k7m7