### PR TITLE
refactor(devtools): unify read-only SQLite opens on one canonical helper

### DIFF
--- a/devtools/archive_schema_fast_forward.py
+++ b/devtools/archive_schema_fast_forward.py
@@ -26,6 +26,7 @@ from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_
 from polylogue.storage.sqlite.archive_tiers.embeddings import EMBEDDINGS_DDL, EMBEDDINGS_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.index import INDEX_DDL, INDEX_SCHEMA_VERSION
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from polylogue.storage.sqlite.migration_runner import migrate_archive_tier
 from polylogue.storage.sqlite.sqlite_vec_extension import try_load_sqlite_vec
 
@@ -122,7 +123,7 @@ def _open_immutable_readonly(path: Path) -> sqlite3.Connection:
     """
     resolved = path.resolve(strict=True)
     _require_no_sidecars(resolved)
-    return sqlite3.connect(f"{resolved.as_uri()}?mode=ro&immutable=1", uri=True)
+    return open_readonly_connection(resolved, immutable=True)
 
 
 def _table_names(conn: sqlite3.Connection) -> tuple[str, ...]:

--- a/devtools/cost_reconciliation_probe.py
+++ b/devtools/cost_reconciliation_probe.py
@@ -15,6 +15,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Literal
 
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
 ProbeStatus = Literal["pass", "fail", "skip"]
 _MAX_PLAUSIBLE_CODEX_THREAD_TOKENS = 2_000_000
 
@@ -60,7 +62,7 @@ def _archive_root_default() -> Path:
 
 
 def _open_ro(path: Path) -> sqlite3.Connection:
-    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    conn = open_readonly_connection(path)
     conn.row_factory = sqlite3.Row
     return conn
 

--- a/devtools/degraded_archive_proof.py
+++ b/devtools/degraded_archive_proof.py
@@ -18,6 +18,7 @@ from polylogue.demo import seed_demo_archive, verify_demo_archive
 from polylogue.storage.fts.dangling_repair import configure_bounded_repair_connection, repair_stale_fts_rows
 from polylogue.storage.fts.freshness import STALE, record_fts_surface_state_sync
 from polylogue.storage.fts.fts_lifecycle import message_fts_search_readiness_sync
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from polylogue.storage.sqlite.maintenance import maybe_optimize_archive_tiers
 from polylogue.storage.sqlite.wal_checkpoint import maybe_checkpoint_archive_wals
 
@@ -63,7 +64,7 @@ def _index_db(root: Path) -> Path:
 
 
 def _fts_ready(root: Path) -> bool:
-    with sqlite3.connect(f"file:{_index_db(root)}?mode=ro", uri=True) as conn:
+    with open_readonly_connection(_index_db(root)) as conn:
         return bool(message_fts_search_readiness_sync(conn)["ready"])
 
 

--- a/devtools/deployment_smoke.py
+++ b/devtools/deployment_smoke.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from polylogue.browser_capture.identity import legacy_browser_capture_native_id
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
 _CURRENT_USER = getpass.getuser()
 _HOME = Path.home()
@@ -511,7 +512,7 @@ def _probe_browser_capture_archive(*, archive_root: Path) -> BrowserCaptureArchi
         error = "index_db_missing"
     if error is None and latest_raw_id is not None and index_db_path.exists():
         try:
-            with sqlite3.connect(f"file:{index_db_path}?mode=ro", uri=True) as conn:
+            with open_readonly_connection(index_db_path) as conn:
                 row = conn.execute(
                     """
                     SELECT session_id, native_id, title, message_count

--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -32,6 +32,7 @@ from polylogue.storage.sqlite.archive_tiers.archive_init import (
     initialize_archive_tier_files,
 )
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
 DEFAULT_API_PORT = 8766
 DEFAULT_BROWSER_CAPTURE_PORT = 8765
@@ -2644,7 +2645,7 @@ def _archive_status(archive: Path) -> dict[str, object]:
         status["error"] = "index.db missing"
         return status
     try:
-        with sqlite3.connect(f"file:{index_db}?mode=ro", uri=True) as conn:
+        with open_readonly_connection(index_db) as conn:
             user_version = int(conn.execute("PRAGMA user_version").fetchone()[0] or 0)
             status["user_version"] = user_version
             sessions_exists = (
@@ -2670,7 +2671,7 @@ def _read_sqlite_user_version(path: Path) -> int | None:
     if not path.exists():
         return None
     try:
-        with sqlite3.connect(f"file:{path}?mode=ro", uri=True) as conn:
+        with open_readonly_connection(path) as conn:
             return int(conn.execute("PRAGMA user_version").fetchone()[0] or 0)
     except sqlite3.Error:
         return None

--- a/devtools/failure_context.py
+++ b/devtools/failure_context.py
@@ -22,6 +22,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TESTMON_DB = REPO_ROOT / ".cache" / "testmon" / "testmondata"
 WITNESS_DIR = REPO_ROOT / "tests" / "witnesses"
@@ -38,7 +40,7 @@ def _testmon_dependencies(failure_id: str) -> list[str]:
     if not TESTMON_DB.exists():
         return []
     try:
-        conn = sqlite3.connect(f"file:{TESTMON_DB}?mode=ro", uri=True)
+        conn = open_readonly_connection(TESTMON_DB)
     except sqlite3.Error:
         return []
     try:

--- a/devtools/index_fast_forward.py
+++ b/devtools/index_fast_forward.py
@@ -33,6 +33,7 @@ from polylogue.storage.fts.fts_lifecycle import (
 )
 from polylogue.storage.fts.pl_fold import pl_fold, pl_fold_sql_expr
 from polylogue.storage.sqlite.archive_tiers.index import INDEX_DDL
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from polylogue.storage.sqlite.lifecycle import IndexFastForwardPlan, index_fast_forward_plan
 
 FAST_FORWARD_FROM_VERSION = 32
@@ -266,7 +267,7 @@ def _deployed_plan(source_version: int) -> IndexFastForwardPlan | None:
 
 def plan_index(path: Path) -> dict[str, object]:
     identity = file_identity(path)
-    with sqlite3.connect(f"file:{identity.resolved_path}?mode=ro", uri=True, timeout=30.0) as conn:
+    with open_readonly_connection(identity.resolved_path, timeout=30.0) as conn:
         metrics = _database_metrics(conn)
         counts = _table_counts(conn)
         fts = {
@@ -869,14 +870,12 @@ def _require_unchanged_identity(path: Path, expected: object, *, label: str) -> 
 
 
 def _quick_check_only(db_path: Path) -> list[str]:
-    with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=120.0) as conn:
-        conn.execute("PRAGMA query_only = ON")
+    with open_readonly_connection(db_path, timeout=120.0) as conn:
         return [str(row[0]) for row in conn.execute("PRAGMA quick_check").fetchall()]
 
 
 def _runtime_version_sanity(db_path: Path) -> dict[str, object]:
-    with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=120.0) as conn:
-        conn.execute("PRAGMA query_only = ON")
+    with open_readonly_connection(db_path, timeout=120.0) as conn:
         version = int(conn.execute("PRAGMA user_version").fetchone()[0])
         schema_probe = conn.execute(
             "SELECT COUNT(*) FROM sqlite_master "

--- a/devtools/index_v37_fast_forward.py
+++ b/devtools/index_v37_fast_forward.py
@@ -27,6 +27,7 @@ from polylogue.config import Config
 from polylogue.maintenance.offline_guard import running_daemon_pid
 from polylogue.storage.index_generation import IndexGenerationStore, RebuildLease, source_revision_snapshot
 from polylogue.storage.sqlite.archive_tiers.index import INDEX_DDL, INDEX_SCHEMA_VERSION
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from polylogue.storage.sqlite.runtime_indexes import ensure_runtime_indexes_sync
 
 FROM_VERSION = 36
@@ -319,7 +320,7 @@ def _inspect_clean_database(path: Path, *, expected_version: int) -> tuple[dict[
         sidecar = Path(f"{path.resolve(strict=True)}{suffix}")
         if sidecar.exists() and sidecar.stat().st_size:
             raise IndexV37FastForwardError(f"non-empty SQLite sidecar blocks fast-forward: {sidecar}")
-    with closing(sqlite3.connect(f"file:{path.resolve(strict=True)}?mode=ro&immutable=1", uri=True)) as conn:
+    with closing(open_readonly_connection(path.resolve(strict=True), immutable=True)) as conn:
         version = int(conn.execute("PRAGMA user_version").fetchone()[0])
         if version != expected_version:
             raise IndexV37FastForwardError(f"expected index v{expected_version}, found v{version}")
@@ -375,7 +376,7 @@ def _transform_clone(path: Path, *, before_rootpages: dict[str, int], canonical:
         if conn.total_changes - changes_before != repaired_orphan_native_ids:
             raise IndexV37FastForwardError("v37 clone transformation changed rows outside the declared repair")
     _checkpoint_stopped_database(path, label="prepared clone")
-    with closing(sqlite3.connect(f"file:{path}?mode=ro&immutable=1", uri=True)) as conn:
+    with closing(open_readonly_connection(path, immutable=True)) as conn:
         checks = _checks(conn)
         after_schema = _schema_objects(conn)
         after_rootpages = _schema_rootpages(conn)

--- a/devtools/read_package.py
+++ b/devtools/read_package.py
@@ -18,6 +18,7 @@ from typing import Any, Literal, TextIO
 import yaml
 
 from polylogue.paths import archive_root
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
 
 @dataclass(frozen=True, slots=True)
@@ -161,7 +162,7 @@ def _read_package_freshness(session_ref: str, *, generated_at: str) -> dict[str,
         return payload
 
     try:
-        with sqlite3.connect(f"file:{index_db}?mode=ro", uri=True, timeout=5.0) as conn:
+        with open_readonly_connection(index_db) as conn:
             conn.row_factory = sqlite3.Row
             schema_version = int(conn.execute("PRAGMA user_version").fetchone()[0])
             payload["archive_cursor"] = {

--- a/devtools/render_demo_corpus_datasheet.py
+++ b/devtools/render_demo_corpus_datasheet.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import shutil
-import sqlite3
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -14,6 +13,7 @@ from devtools.command_catalog import control_plane_command
 from devtools.render_support import write_if_changed
 from polylogue.demo import DemoSeedResult, DemoVerifyResult, seed_demo_archive, verify_demo_archive
 from polylogue.scenarios import DEMO_CORPUS_FAMILIES
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from polylogue.storage.sqlite.run_projection_relations import (
     context_snapshot_relation_sql,
     observed_event_relation_sql,
@@ -50,7 +50,7 @@ def _code_list(items: tuple[str, ...]) -> str:
 
 
 def _measure_archive(archive_root: Path) -> DemoCorpusMeasurement:
-    with sqlite3.connect(f"file:{archive_root / 'index.db'}?mode=ro", uri=True) as conn:
+    with open_readonly_connection(archive_root / "index.db") as conn:
         origins = tuple(
             str(row[0]) for row in conn.execute("SELECT DISTINCT origin FROM sessions ORDER BY origin").fetchall()
         )

--- a/devtools/scale_regression_probe.py
+++ b/devtools/scale_regression_probe.py
@@ -34,6 +34,7 @@ from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
 from polylogue.storage.sqlite.connection import open_connection
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from polylogue.storage.sqlite.run_projection_relations import run_relation_sql
 
 
@@ -137,7 +138,7 @@ def _check_message_budget_chunking(root: Path) -> ScaleRegressionCheck:
         del amount
         if desc is not None and desc.startswith("rebuild:"):
             return
-        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True) as probe:
+        with open_readonly_connection(db_path) as probe:
             probe.row_factory = sqlite3.Row
             rows = probe.execute(
                 "SELECT session_id, title FROM session_profiles WHERE session_id IN (?, ?, ?)",

--- a/devtools/schema_generate.py
+++ b/devtools/schema_generate.py
@@ -15,6 +15,7 @@ from polylogue.config import get_config
 from polylogue.core.json import JSONDocument
 from polylogue.schemas.operator.models import SchemaInferRequest
 from polylogue.schemas.operator.workflow import infer_schema
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
 
 def _process_resources() -> JSONDocument:
@@ -44,7 +45,7 @@ def _source_input_summary(index_path: Path) -> JSONDocument:
     if not source_path.exists():
         return {"source_db_bytes": None, "raw_row_count": None, "raw_blob_bytes": None}
     try:
-        with sqlite3.connect(f"file:{source_path}?mode=ro", uri=True) as connection:
+        with open_readonly_connection(source_path) as connection:
             row = connection.execute("SELECT COUNT(*), COALESCE(SUM(blob_size), 0) FROM raw_sessions").fetchone()
         return {
             "source_db_bytes": source_path.stat().st_size,

--- a/devtools/self_verify.py
+++ b/devtools/self_verify.py
@@ -6,7 +6,6 @@ import argparse
 import asyncio
 import hashlib
 import json
-import sqlite3
 import subprocess
 import sys
 from collections.abc import Mapping, Sequence
@@ -21,6 +20,7 @@ from polylogue.archive.query.spec import SessionQuerySpec, clamp_query_limit
 from polylogue.core.json import JSONDocument, JSONValue, require_json_document
 from polylogue.paths import active_index_db_path as default_db_path
 from polylogue.paths import archive_root
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 from polylogue.surfaces.payloads import (
     SessionListRowPayload,
     SessionMessagePayload,
@@ -64,7 +64,7 @@ def _git_head() -> str:
 def _schema_version(db_path: Path) -> int | None:
     if not db_path.exists():
         return None
-    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn = open_readonly_connection(db_path)
     try:
         row = conn.execute("PRAGMA user_version").fetchone()
         return int(row[0]) if row else None

--- a/devtools/test_economics_report.py
+++ b/devtools/test_economics_report.py
@@ -84,6 +84,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _POLYLOGUE_ROOT = _REPO_ROOT / "polylogue"
 _DEFAULT_TESTMON_DB = _REPO_ROOT / ".cache" / "testmon" / "testmondata"
@@ -225,9 +227,7 @@ def compute_test_economics(
     if not testmon_db_path.exists():
         return {}, {}, f"no testmon database found at {testmon_db_path}; wall-time/fan-out left null"
 
-    import sqlite3
-
-    con = sqlite3.connect(f"file:{testmon_db_path}?mode=ro", uri=True)
+    con = open_readonly_connection(testmon_db_path)
     try:
         cur = con.cursor()
         cur.execute(

--- a/polylogue/storage/sqlite/connection_profile.py
+++ b/polylogue/storage/sqlite/connection_profile.py
@@ -235,14 +235,31 @@ def open_daemon_connection(
     return conn
 
 
-def open_readonly_connection(path: str | Path, *, timeout: float = READ_DB_TIMEOUT) -> sqlite3.Connection:
+def open_readonly_connection(
+    path: str | Path,
+    *,
+    timeout: float = READ_DB_TIMEOUT,
+    immutable: bool = False,
+) -> sqlite3.Connection:
     """Open a read-only SQLite connection with canonical read pragmas applied.
 
     Uses ``file:...?mode=ro`` URI mode to guarantee no write locks are taken.
     Returns ``None`` / raises ``sqlite3.OperationalError`` if the database file
     does not exist.
+
+    ``immutable`` additionally sets SQLite's ``immutable=1`` URI parameter,
+    which tells SQLite the file is guaranteed not to change for the lifetime
+    of the connection: it skips locking and WAL/journal presence checks, and
+    will not create a ``-shm``/``-wal`` sidecar itself. This is only correct
+    against a verified-stable snapshot (e.g. a stopped-daemon clone the caller
+    has already confirmed has no WAL/SHM/journal sidecars) -- never against a
+    database a live process (such as ``polylogued``) might still be writing.
+    Callers passing ``immutable=True`` own that precondition check; this
+    helper does not perform it, since the check is specific to how the caller
+    obtained the snapshot.
     """
-    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=timeout)
+    suffix = "?mode=ro&immutable=1" if immutable else "?mode=ro"
+    conn = sqlite3.connect(f"file:{path}{suffix}", uri=True, timeout=timeout)
     try:
         for stmt in READ_CONNECTION_PRAGMA_STATEMENTS:
             conn.execute(stmt)


### PR DESCRIPTION
## Summary

Migrates all 18 devtools/ call sites that hand-rolled `sqlite3.connect()` for
read-only archive/testmon access onto the repo's existing canonical helper,
`open_readonly_connection` (`polylogue/storage/sqlite/connection_profile.py`),
extended with an `immutable: bool = False` parameter for the two call sites
that genuinely need `immutable=1`.

## Problem

At least 18 `devtools/` files hand-rolled their own `sqlite3.connect()` call
for opening the archive read-only, with real, risk-bearing divergence:
timeout varied across default/5.0/30.0/120.0, two sites additionally set
`PRAGMA query_only = ON` manually, and two sites set `immutable=1`. This is
inconsistent locking/timeout/immutability semantics across tools that all
claim to be "read-only" — a real risk, not style noise (polylogue-ykhy).

Investigation found the repo already has the natural shared-utility home:
`open_readonly_connection` in `polylogue/storage/sqlite/connection_profile.py`,
already correctly used by 6 other devtools files (`archive_space_report.py`,
`affordance_usage.py`, `temporal_archive_aggregates.py`, `claim_vs_evidence.py`,
`lineage_validation.py`, `daemon_workload_probe.py`). Most of the divergence
was simply files that never adopted it, not a missing abstraction.

## Solution

- Extended `open_readonly_connection()` with `immutable: bool = False`
  (default preserves behavior for its 30+ existing callers). The docstring
  states the precondition explicitly: `immutable=1` is only correct against a
  verified-stable snapshot; callers requesting it own that precondition
  check.
- Migrated all 18 `mode=ro` call sites across 14 files onto the helper:
  `degraded_archive_proof.py`, `index_v37_fast_forward.py` (x2, `immutable=True`),
  `index_fast_forward.py` (x3), `archive_schema_fast_forward.py`
  (`immutable=True`), `cost_reconciliation_probe.py`, `scale_regression_probe.py`,
  `deployment_smoke.py`, `self_verify.py`, `render_demo_corpus_datasheet.py`,
  `read_package.py`, `dev_loop.py` (x2), `schema_generate.py`,
  `failure_context.py`, `test_economics_report.py`.
- **`immutable=1` kept, not spread**: verified both existing `immutable=1`
  sites (`index_v37_fast_forward.py`, `archive_schema_fast_forward.py`) each
  explicitly check for zero WAL/SHM/journal sidecars on a stopped-daemon
  clone immediately before opening immutable — genuinely load-bearing, not
  copy-paste drift. Did not add `immutable=True` anywhere else.
- **Timeout overrides kept where justified**: `index_fast_forward.py`'s
  `plan_index` (30s) and `_quick_check_only`/`_runtime_version_sanity` (120s)
  read a potentially-live archive under daemon lock contention — plausible,
  deliberate. Dropped their now-redundant manual `PRAGMA query_only = ON`
  since the helper's `READ_CONNECTION_PRAGMA_STATEMENTS` already sets it.
- **One variant unified as accidental**: `read_package.py`'s explicit
  `timeout=5.0` was byte-for-byte the canonical `READ_DB_TIMEOUT` default —
  collapsed to no override (behavior-identical).

### Behavior change flagged honestly

`archive_schema_fast_forward.py`'s `_open_immutable_readonly` previously built
its URI via `resolved.as_uri()` (percent-encoded). The canonical helper uses
plain `f"file:{path}"` string interpolation — the same pattern already used
by all 30+ pre-existing `open_readonly_connection` callers in this codebase.
This drops percent-encoding for paths containing reserved URI characters
(space, `#`, `?`). This is an existing, accepted risk already shared by every
other caller of the canonical helper, not a new risk introduced by this PR;
flagging it rather than silently reformatting the connection semantics.

### Explicitly not touched

- `row_factory = sqlite3.Row` assignments (`cost_reconciliation_probe.py`,
  `scale_regression_probe.py`, `read_package.py`, ...) — query ergonomics
  applied by the caller after open, not a connection-open semantic.
- The many other `sqlite3.connect()` calls in these same files that open
  **read-write** connections (`index_v37_fast_forward.py`'s clone-transform
  writer, `degraded_archive_proof.py`'s scenario setup, `scale_regression_probe.py`'s
  seed writer, etc.) — out of scope, not read-only opens.
- `turso_probe.py`'s `file:...?mode=ro` strings use the `turso` library, not
  `sqlite3.connect()` — deliberately probing a different backend's URI
  behavior.
- `ATTACH DATABASE (...'?mode=ro')` statements in `pipeline_probe/result.py`
  and `daemon_workload_probe.py` attach a sibling tier to an **already-open**
  connection, not a new `connect()` call — different mechanism, out of scope.

## Verification

- `ruff check devtools polylogue` / `ruff format --check devtools polylogue`: all checks passed, 1250 files already formatted
- `mypy polylogue devtools` (strict): `Success: no issues found in 1250 source files`
- `devtools render all --check`: exit 0, no `out of sync` surfaces
- `devtools test` on all 14 touched files' own test modules plus adjacent
  coverage (`test_archive_tiers_self_verify.py`, `test_index_fast_forward_executor.py`,
  `test_index_fast_forward_lifecycle.py`, `test_index_v37_fast_forward.py`,
  `test_status.py`, `test_convergence_stages.py`, `test_daemon_status.py`,
  `test_mcp_call_log.py`, `test_ingest_batch_wal_checkpoint.py`,
  `test_blob_gc_generation_gate.py`, `test_archive_tiers_assertions.py`,
  `test_repair_blobs.py`, `test_session_insight_parallel_fanout.py`,
  `test_wal_journal_size_limit.py`, `test_daemon_cli.py`): 149 + 360 passed.
  14 pre-existing failures in `test_index_v37_fast_forward.py` /
  `test_index_fast_forward_lifecycle.py` (schema-drift assertions unrelated
  to connection opening) and 1 in `test_status.py` (async facade
  route-catalog coverage) reproduce identically on `origin/master` before
  this change — confirmed via `git stash` A/B comparison.
- `git push` ran the pre-push `devtools verify --quick` gate: exit 0.

Ref polylogue-ykhy