### PR TITLE
fix: add aggregate zip-size cap to import --explain preview

### DIFF
--- a/polylogue/sources/import_explain.py
+++ b/polylogue/sources/import_explain.py
@@ -552,7 +552,12 @@ def _explain_zip(
     try:
         with zipfile.ZipFile(path) as archive:
             for info in archive.infolist():
-                skip_reason, aggregate_total = _zip_entry_skip_reason(info, aggregate_total=aggregate_total)
+                skip_reason, aggregate_total = _zip_entry_skip_reason(
+                    info,
+                    aggregate_total=aggregate_total,
+                    zip_path=path,
+                    provider_hint=provider_hint,
+                )
                 if skip_reason is not None:
                     skipped.append(
                         ImportSkippedRowPayload(
@@ -612,17 +617,25 @@ def _explain_zip(
     )
 
 
-def _zip_entry_skip_reason(info: zipfile.ZipInfo, *, aggregate_total: int) -> tuple[str | None, int]:
+def _zip_entry_skip_reason(
+    info: zipfile.ZipInfo,
+    *,
+    aggregate_total: int,
+    zip_path: Path,
+    provider_hint: Provider,
+) -> tuple[str | None, int]:
     """Return a skip reason (if any) plus the aggregate-total that should
     carry forward to the next entry.
 
-    Mirrors ``ZipEntryValidator.filter_entries`` in ``decoder_zip.py``: an
-    entry that fails the extension/ratio/per-entry-size checks never
-    contributes to the running aggregate total (the real decode path only
-    accumulates entries that clear every earlier check), and the aggregate
-    check itself -- evaluated last, from central-directory metadata alone --
-    is what decides whether *this* entry's size gets added to the total that
-    subsequent entries are checked against.
+    Mirrors ``ZipEntryValidator.filter_entries`` in ``decoder_zip.py`` (which
+    ``process_zip`` always constructs with ``session_only=True``): an entry
+    that fails the extension/ratio/per-entry-size checks, or that classifies
+    as a non-session artifact (sidecar/metadata), never contributes to the
+    running aggregate total -- the real decode path only accumulates entries
+    that clear every earlier check AND are actually parsed as a session. The
+    aggregate check itself -- evaluated last, from central-directory metadata
+    alone -- is what decides whether *this* entry's size gets added to the
+    total that subsequent entries are checked against.
     """
     if info.is_dir() or not info.filename.lower().endswith(_SUPPORTED_ENTRY_SUFFIXES):
         return "unsupported ZIP entry", aggregate_total
@@ -630,6 +643,9 @@ def _zip_entry_skip_reason(info: zipfile.ZipInfo, *, aggregate_total: int) -> tu
         return f"zip entry compression ratio {info.file_size / info.compress_size:.1f} exceeds limit", aggregate_total
     if info.file_size > MAX_UNCOMPRESSED_SIZE:
         return f"zip entry file size {info.file_size} exceeds limit", aggregate_total
+    path_classification = classify_artifact_path(f"{zip_path}:{info.filename}", provider=provider_hint)
+    if path_classification is not None and not path_classification.parse_as_session:
+        return path_classification.reason or "not a session artifact", aggregate_total
     projected_total = aggregate_total + info.file_size
     if projected_total > MAX_AGGREGATE_UNCOMPRESSED_SIZE:
         return (

--- a/polylogue/sources/import_explain.py
+++ b/polylogue/sources/import_explain.py
@@ -17,6 +17,7 @@ from polylogue.core.enums import Provider
 from polylogue.core.json import JSONValue
 from polylogue.core.sources import origin_from_provider
 from polylogue.sources.decoder_zip import (
+    MAX_AGGREGATE_UNCOMPRESSED_SIZE,
     MAX_COMPRESSION_RATIO,
     MAX_UNCOMPRESSED_SIZE,
     ZipBombError,
@@ -547,10 +548,11 @@ def _explain_zip(
         ),
         _evidence("zip.container", matched=True, reason="ZIP container"),
     ]
+    aggregate_total = 0
     try:
         with zipfile.ZipFile(path) as archive:
             for info in archive.infolist():
-                skip_reason = _zip_entry_skip_reason(info)
+                skip_reason, aggregate_total = _zip_entry_skip_reason(info, aggregate_total=aggregate_total)
                 if skip_reason is not None:
                     skipped.append(
                         ImportSkippedRowPayload(
@@ -610,14 +612,32 @@ def _explain_zip(
     )
 
 
-def _zip_entry_skip_reason(info: zipfile.ZipInfo) -> str | None:
+def _zip_entry_skip_reason(info: zipfile.ZipInfo, *, aggregate_total: int) -> tuple[str | None, int]:
+    """Return a skip reason (if any) plus the aggregate-total that should
+    carry forward to the next entry.
+
+    Mirrors ``ZipEntryValidator.filter_entries`` in ``decoder_zip.py``: an
+    entry that fails the extension/ratio/per-entry-size checks never
+    contributes to the running aggregate total (the real decode path only
+    accumulates entries that clear every earlier check), and the aggregate
+    check itself -- evaluated last, from central-directory metadata alone --
+    is what decides whether *this* entry's size gets added to the total that
+    subsequent entries are checked against.
+    """
     if info.is_dir() or not info.filename.lower().endswith(_SUPPORTED_ENTRY_SUFFIXES):
-        return "unsupported ZIP entry"
+        return "unsupported ZIP entry", aggregate_total
     if info.compress_size > 0 and (info.file_size / info.compress_size) > MAX_COMPRESSION_RATIO:
-        return f"zip entry compression ratio {info.file_size / info.compress_size:.1f} exceeds limit"
+        return f"zip entry compression ratio {info.file_size / info.compress_size:.1f} exceeds limit", aggregate_total
     if info.file_size > MAX_UNCOMPRESSED_SIZE:
-        return f"zip entry file size {info.file_size} exceeds limit"
-    return None
+        return f"zip entry file size {info.file_size} exceeds limit", aggregate_total
+    projected_total = aggregate_total + info.file_size
+    if projected_total > MAX_AGGREGATE_UNCOMPRESSED_SIZE:
+        return (
+            f"aggregate uncompressed size {projected_total} exceeds archive-wide limit "
+            f"{MAX_AGGREGATE_UNCOMPRESSED_SIZE}",
+            aggregate_total,
+        )
+    return None, projected_total
 
 
 def _explain_bytes(

--- a/tests/unit/cli/test_import_explain.py
+++ b/tests/unit/cli/test_import_explain.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 from pytest import MonkeyPatch
 
 from polylogue.cli.click_app import cli
+from polylogue.core.enums import Provider
 from polylogue.sources import decoder_zip as decoder_zip_module
 from polylogue.sources import import_explain as import_explain_module
 from polylogue.sources.decoder_zip import ZipEntryValidator
@@ -166,6 +167,75 @@ def test_import_explain_zip_rejects_aggregate_over_cap_before_read(
     assert accepted_names == {"entry_0.json"}
     rejected_by_preview = {row.source_path.split(":", 1)[1] for row in aggregate_skips if row.source_path is not None}
     assert rejected_by_preview == set(entry_names) - accepted_names
+
+
+def test_import_explain_zip_excludes_non_session_artifact_from_aggregate(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A non-session-classified entry must not count toward the preview's
+    aggregate total (CodeRabbit finding on PR #3317): ``process_zip`` always
+    constructs ``ZipEntryValidator`` with ``session_only=True``, which
+    excludes non-session-classified entries from the running total entirely
+    (they ``continue`` before the aggregate check in ``decoder_zip.py``).
+    The preview must apply the identical exclusion, or it can wrongly
+    predict an aggregate-cap rejection a real import would never hit.
+
+    Uses a monkeypatched ``classify_artifact_path`` rather than a real
+    ``OriginArtifactRule`` path pattern: every current rule's regex requires
+    a ``/``-anchored match (``(?:^|/)workflows/...``), but zip-embedded
+    entry paths are built as ``f"{zip_path}:{name}"`` (colon-joined), which
+    no existing rule matches -- confirmed separately and filed as
+    polylogue-<followup> (session_only exclusion is effectively unreachable
+    for zip archives today, a distinct pre-existing gap in decoder_zip.py
+    itself, not something this fix can or should paper over). This test
+    isolates and proves the exclusion LOGIC in ``_zip_entry_skip_reason``
+    independent of that separate path-matching gap.
+    """
+    from polylogue.archive.artifact_taxonomy.models import ArtifactClassification, ArtifactKind
+
+    archive = tmp_path / "workflow.zip"
+    session_bytes = b'{"a": 1}'
+    non_session_bytes = b'{"run": "snapshot"}' * 1000
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("session.json", session_bytes)
+        zf.writestr("run.json", non_session_bytes)
+    # Cap sits between the session entry alone and session+non-session
+    # combined -- if the non-session entry wrongly counted, this would
+    # falsely reject the accepted session entry too.
+    monkeypatch.setattr(
+        import_explain_module,
+        "MAX_AGGREGATE_UNCOMPRESSED_SIZE",
+        len(session_bytes) + len(non_session_bytes) // 2,
+    )
+
+    def fake_classify(source_path: object, *, provider: object) -> ArtifactClassification | None:
+        if str(source_path).endswith(":run.json"):
+            return ArtifactClassification(
+                provider=Provider.CLAUDE_CODE,
+                kind=ArtifactKind.WORKFLOW_RUN_SNAPSHOT,
+                parse_as_session=False,
+                schema_eligible=False,
+                default_priority=0,
+                reason="non-session workflow snapshot (test fixture)",
+            )
+        return None
+
+    monkeypatch.setattr(import_explain_module, "classify_artifact_path", fake_classify)
+
+    payload = explain_import_path(archive, source_name="claude-code")
+
+    assert not any("aggregate uncompressed size" in row.reason for row in payload.skipped)
+    non_session_skips = [row for row in payload.skipped if row.source_path == f"{archive}:run.json"]
+    assert len(non_session_skips) == 1
+    assert non_session_skips[0].reason == "non-session workflow snapshot (test fixture)"
+    # session.json is separately skipped as "metadata-oriented document" (its
+    # trivial fixture bytes aren't a real session shape) -- but crucially
+    # NOT for an aggregate-size reason, which is the only thing this test
+    # proves: run.json's bytes never reached the running aggregate total.
+    session_skips = [row for row in payload.skipped if row.source_path == f"{archive}:session.json"]
+    assert len(session_skips) == 1
+    assert "aggregate uncompressed size" not in session_skips[0].reason
 
 
 def test_import_explain_zip_allows_archive_comfortably_under_aggregate_cap(

--- a/tests/unit/cli/test_import_explain.py
+++ b/tests/unit/cli/test_import_explain.py
@@ -9,7 +9,9 @@ from click.testing import CliRunner
 from pytest import MonkeyPatch
 
 from polylogue.cli.click_app import cli
+from polylogue.sources import decoder_zip as decoder_zip_module
 from polylogue.sources import import_explain as import_explain_module
+from polylogue.sources.decoder_zip import ZipEntryValidator
 from polylogue.sources.import_explain import explain_import_path
 
 
@@ -126,3 +128,60 @@ def test_import_explain_zip_rejects_oversized_member_before_read(
     assert skipped_path is not None
     assert skipped_path.endswith("oversized.zip:big.json")
     assert "file size" in payload.skipped[0].reason
+
+
+def test_import_explain_zip_rejects_aggregate_over_cap_before_read(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A zip whose entries are each individually under the per-entry cap but
+    whose running total would exceed MAX_AGGREGATE_UNCOMPRESSED_SIZE must be
+    reported by the --explain preview the same way a real ``import`` run
+    rejects it (polylogue-it3u): before this fix, the preview only checked
+    the old per-entry ratio/size limits and would wrongly claim every entry
+    here "will import".
+    """
+    archive = tmp_path / "aggregate.zip"
+    entry_bytes = b'{"a": 1}'
+    entry_names = [f"entry_{i}.json" for i in range(3)]
+    with zipfile.ZipFile(archive, "w") as zf:
+        for name in entry_names:
+            zf.writestr(name, entry_bytes)
+    monkeypatch.setattr(import_explain_module, "MAX_AGGREGATE_UNCOMPRESSED_SIZE", len(entry_bytes))
+    monkeypatch.setattr(decoder_zip_module, "MAX_AGGREGATE_UNCOMPRESSED_SIZE", len(entry_bytes))
+
+    payload = explain_import_path(archive)
+
+    aggregate_skips = [row for row in payload.skipped if "aggregate uncompressed size" in row.reason]
+    assert [row.source_path for row in aggregate_skips] == [
+        f"{archive}:entry_1.json",
+        f"{archive}:entry_2.json",
+    ]
+
+    # Cross-check against the real decode-path validator over the exact same
+    # entries: the preview's accepted/rejected split must match it exactly.
+    with zipfile.ZipFile(archive) as zf:
+        validator = ZipEntryValidator("chatgpt", cursor_state=None, zip_path=archive)
+        accepted_names = {info.filename for info in validator.filter_entries(zf.infolist())}
+    assert accepted_names == {"entry_0.json"}
+    rejected_by_preview = {row.source_path.split(":", 1)[1] for row in aggregate_skips if row.source_path is not None}
+    assert rejected_by_preview == set(entry_names) - accepted_names
+
+
+def test_import_explain_zip_allows_archive_comfortably_under_aggregate_cap(
+    tmp_path: Path,
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Multiple small entries whose sum stays well under the aggregate cap
+    are all reported importable -- no regression for legitimate multi-file
+    exports."""
+    archive = tmp_path / "normal.zip"
+    entry_bytes = b'{"a": 1}'
+    with zipfile.ZipFile(archive, "w") as zf:
+        for i in range(3):
+            zf.writestr(f"entry_{i}.json", entry_bytes)
+    monkeypatch.setattr(import_explain_module, "MAX_AGGREGATE_UNCOMPRESSED_SIZE", len(entry_bytes) * 10)
+
+    payload = explain_import_path(archive)
+
+    assert not any("aggregate uncompressed size" in row.reason for row in payload.skipped)


### PR DESCRIPTION
## Summary
Brings the `import --explain` dry-run zip preview into agreement with the real `process_zip` decode path on aggregate uncompressed-size rejections.

## Problem
PR #3314 added `MAX_AGGREGATE_UNCOMPRESSED_SIZE` (64 GiB) to `ZipEntryValidator.filter_entries` in `polylogue/sources/decoder_zip.py`, tracking a running total of declared uncompressed sizes across all entries in a zip and rejecting entries whose admission would push that total over the cap — closing a zip-bomb-by-many-entries gap that the pre-existing per-entry ratio/size cap didn't cover.

`polylogue/sources/import_explain.py`'s `_zip_entry_skip_reason` (the `import --explain` dry-run preview path) duplicates the old per-entry ratio/size checks but was never updated with the aggregate check. This is a preview/reality drift, not a security hole (the real decode path is already protected): the preview could report an entry "will import" for a case a real `import` run now rejects on aggregate grounds.

## Solution
- `import_explain.py` now imports `MAX_AGGREGATE_UNCOMPRESSED_SIZE` from `decoder_zip.py` (no redefinition).
- `_zip_entry_skip_reason` takes/returns a running `aggregate_total`, threaded through `_explain_zip`'s entry loop in the same iteration order the real `process_zip`/`ZipEntryValidator.filter_entries` path uses.
- Check order mirrors the real validator exactly: extension/ratio/per-entry-size checks first — entries that fail those never contribute to the running total (matching `ZipEntryValidator`) — then the aggregate check against central-directory metadata alone, before any entry bytes are read.

## Verification
- `devtools test tests/unit/cli/test_import_explain.py tests/unit/sources/test_decoders.py` → 34 passed
- `mypy` (via pre-push quick gate) → no issues
- `ruff check` / `ruff format --check` (via pre-push quick gate) → clean
- New tests in `tests/unit/cli/test_import_explain.py`:
  - `test_import_explain_zip_rejects_aggregate_over_cap_before_read` — builds a zip with 3 entries each individually under the per-entry cap whose sum exceeds a monkeypatched aggregate cap, confirms the preview reports the correct entries as skipped for the aggregate reason, and cross-checks the accepted/rejected split against a real `ZipEntryValidator.filter_entries` run over the same entries to prove they agree exactly.
  - `test_import_explain_zip_allows_archive_comfortably_under_aggregate_cap` — a small archive well under the cap reports no aggregate-cap skips (regression guard).

Ref polylogue-it3u

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ZIP import previews now enforce the archive-wide uncompressed size limit.
  * Entries exceeding the combined size limit are clearly identified as skipped.
  * ZIP entry filtering now more closely matches import decoding behavior.

* **Tests**
  * Added coverage for archives exceeding the aggregate size limit.
  * Added coverage confirming valid small archives remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->