### PR TITLE
fix(storage): declare index schema v40 query-unit-frame delta

### DIFF
--- a/polylogue/storage/sqlite/lifecycle.py
+++ b/polylogue/storage/sqlite/lifecycle.py
@@ -233,6 +233,51 @@ INDEX_DELTA_DECLARATIONS: tuple[IndexDeltaDeclaration, ...] = (
         classes=(DerivedDeltaClass.SEMANTIC_REPARSE,),
     ),
     IndexDeltaDeclaration(
+        version=40,
+        # Adds query_unit_frame_state (polylogue-z9gh.9, PR #3068): a
+        # singleton, trigger-maintained epoch counter that composes with the
+        # user-tier assertion epoch to bind query-unit continuation resumes
+        # to the exact archive snapshot they were issued against. Insert,
+        # update, and delete triggers on session_links, sessions, messages,
+        # blocks, session_tags, session_profiles, and delegation_facts each
+        # bump the counter -- every table already exists at v39 and gains
+        # only a maintenance trigger, so no row is reparsed or reshaped. The
+        # table itself starts at epoch=0 via INSERT OR IGNORE. A clone can
+        # therefore create the table and its 21 triggers verbatim from
+        # canonical INDEX_DDL with no semantic reparse of raw evidence.
+        classes=(DerivedDeltaClass.INDEX_ONLY,),
+        operations=(
+            FastForwardOperation(
+                name="v40-query-unit-frame-state",
+                kind=FastForwardOperationKind.REPLACE_TABLE,
+                objects=(
+                    ("table", "query_unit_frame_state"),
+                    ("trigger", "query_unit_frame_session_links_insert"),
+                    ("trigger", "query_unit_frame_session_links_update"),
+                    ("trigger", "query_unit_frame_session_links_delete"),
+                    ("trigger", "query_unit_frame_sessions_insert"),
+                    ("trigger", "query_unit_frame_sessions_update"),
+                    ("trigger", "query_unit_frame_sessions_delete"),
+                    ("trigger", "query_unit_frame_messages_insert"),
+                    ("trigger", "query_unit_frame_messages_update"),
+                    ("trigger", "query_unit_frame_messages_delete"),
+                    ("trigger", "query_unit_frame_blocks_insert"),
+                    ("trigger", "query_unit_frame_blocks_update"),
+                    ("trigger", "query_unit_frame_blocks_delete"),
+                    ("trigger", "query_unit_frame_session_tags_insert"),
+                    ("trigger", "query_unit_frame_session_tags_update"),
+                    ("trigger", "query_unit_frame_session_tags_delete"),
+                    ("trigger", "query_unit_frame_session_profiles_insert"),
+                    ("trigger", "query_unit_frame_session_profiles_update"),
+                    ("trigger", "query_unit_frame_session_profiles_delete"),
+                    ("trigger", "query_unit_frame_delegation_facts_insert"),
+                    ("trigger", "query_unit_frame_delegation_facts_update"),
+                    ("trigger", "query_unit_frame_delegation_facts_delete"),
+                ),
+            ),
+        ),
+    ),
+    IndexDeltaDeclaration(
         version=41,
         # action_pairs stops materializing tool_input/output_text text
         # copies (polylogue-2i2w) -- every tool interaction existed ~3x on


### PR DESCRIPTION
## Summary

Adds the missing `IndexDeltaDeclaration(version=40, ...)` entry to `polylogue/storage/sqlite/lifecycle.py`'s `INDEX_DELTA_DECLARATIONS` registry so `devtools lab policy schema-versioning` recognizes the index-tier v39→v40 schema bump.

## Problem

`devtools lab policy schema-versioning` was failing on master: "undeclared index schema deltas found: 1, missing: [40]". PR #3068 ("bind query_units continuations to the archive epoch", polylogue-z9gh.9) bumped `INDEX_SCHEMA_VERSION` from 39 to 40 -- adding the `query_unit_frame_state` table plus its insert/update/delete triggers on `session_links`, `sessions`, `messages`, `blocks`, `session_tags`, `session_profiles`, and `delegation_facts` -- but never added the matching `IndexDeltaDeclaration`. `INDEX_DELTA_DECLARATIONS` jumped straight from `version=39` to `version=41` (the latter added by a later, unrelated PR for polylogue-2i2w), silently skipping 40.

## Solution

Added `IndexDeltaDeclaration(version=40, classes=(DerivedDeltaClass.INDEX_ONLY,), operations=(...))` describing the actual v40 delta: one `FastForwardOperation` (`kind=REPLACE_TABLE`) whose `objects` list the `query_unit_frame_state` table and all 21 `query_unit_frame_*` triggers, matching exactly what df8683767 (#3068) added to `INDEX_DDL`. No canonical DDL, executor, or runtime behavior changes -- this is a declaration-only fix; the schema itself already exists and is deployed.

## Verification

- `devtools lab policy schema-versioning` before: `undeclared index schema deltas found: 1` / `missing: [40]`; after: `undeclared index schema deltas found: 0` / `Schema evolution policy intact.`
- `devtools test tests/unit/storage/test_index_fast_forward_lifecycle.py tests/unit/storage/test_index_fast_forward_executor.py`: the two tests this fix targets (`test_current_index_schema_has_a_complete_delta_declaration`, `test_schema_policy_rejects_an_index_bump_without_a_delta_declaration`) now pass. Two unrelated pre-existing failures remain (`test_nonsemantic_delta_without_operations_is_rejected`, `test_delta_without_a_declared_class_is_rejected`) -- confirmed via `git stash` to already fail identically on master, caused by a separate latent bug where `invalid_versions` flags every declaration with `version > current_version` regardless of the v40 gap. Out of scope here.
- `mypy --strict polylogue/storage/sqlite/lifecycle.py`: no issues
- `ruff check` / `ruff format --check` on the touched file: clean
- `devtools render all --check`: no drift
- `devtools verify --quick` (pre-push hook): passed

Ref polylogue-5h5y

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added a storage upgrade that introduces query-unit frame state tracking.
  * Improved synchronization of session, message, block, tag, profile, and delegation changes through automatic database updates.
  * Existing data is upgraded automatically when the application applies the new storage version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->