### PR TITLE
fix(sources): classify zip entries on relative path, not zip:name

### DIFF
--- a/polylogue/sources/decoder_zip.py
+++ b/polylogue/sources/decoder_zip.py
@@ -169,8 +169,19 @@ class ZipEntryValidator:
 
             if lower_name.endswith((".json", ".jsonl", ".jsonl.txt", ".ndjson")):
                 if self._session_only:
+                    # Classify on the bare intra-archive relative path, not
+                    # the zip-container-prefixed ``{zip_path}:{name}`` form.
+                    # Every ``OriginArtifactRule.path_pattern`` is anchored
+                    # ``(?:^|/)`` to match a relative filesystem-style path
+                    # (the same convention every non-zip caller of
+                    # ``classify_artifact_path`` already uses, e.g.
+                    # ``sources/live/batch_support.py``): the character
+                    # immediately before a rule's leading path segment must be
+                    # ``/`` or start-of-string. Prefixing with the zip path
+                    # inserts a ``:`` there instead, so no rule could ever
+                    # match and this exclusion was dead code (polylogue-dc1k).
                     path_classification = classify_artifact_path(
-                        f"{self._zip_path}:{name}",
+                        name,
                         provider=self._provider_hint,
                     )
                     if path_classification is not None and not path_classification.parse_as_session:

--- a/polylogue/sources/import_explain.py
+++ b/polylogue/sources/import_explain.py
@@ -643,7 +643,13 @@ def _zip_entry_skip_reason(
         return f"zip entry compression ratio {info.file_size / info.compress_size:.1f} exceeds limit", aggregate_total
     if info.file_size > MAX_UNCOMPRESSED_SIZE:
         return f"zip entry file size {info.file_size} exceeds limit", aggregate_total
-    path_classification = classify_artifact_path(f"{zip_path}:{info.filename}", provider=provider_hint)
+    # Classify on the bare intra-archive relative path (matches
+    # ``ZipEntryValidator.filter_entries``'s identical fix, polylogue-dc1k):
+    # every ``OriginArtifactRule.path_pattern`` is anchored ``(?:^|/)``, so a
+    # ``{zip_path}:{name}`` prefix put a ``:`` immediately before the pattern
+    # instead of ``/``/start-of-string and no rule could ever match.
+    del zip_path
+    path_classification = classify_artifact_path(info.filename, provider=provider_hint)
     if path_classification is not None and not path_classification.parse_as_session:
         return path_classification.reason or "not a session artifact", aggregate_total
     projected_total = aggregate_total + info.file_size

--- a/tests/unit/cli/test_import_explain.py
+++ b/tests/unit/cli/test_import_explain.py
@@ -181,16 +181,14 @@ def test_import_explain_zip_excludes_non_session_artifact_from_aggregate(
     The preview must apply the identical exclusion, or it can wrongly
     predict an aggregate-cap rejection a real import would never hit.
 
-    Uses a monkeypatched ``classify_artifact_path`` rather than a real
-    ``OriginArtifactRule`` path pattern: every current rule's regex requires
-    a ``/``-anchored match (``(?:^|/)workflows/...``), but zip-embedded
-    entry paths are built as ``f"{zip_path}:{name}"`` (colon-joined), which
-    no existing rule matches -- confirmed separately and filed as
-    polylogue-<followup> (session_only exclusion is effectively unreachable
-    for zip archives today, a distinct pre-existing gap in decoder_zip.py
-    itself, not something this fix can or should paper over). This test
-    isolates and proves the exclusion LOGIC in ``_zip_entry_skip_reason``
-    independent of that separate path-matching gap.
+    Uses a monkeypatched ``classify_artifact_path`` (isolating the exclusion
+    LOGIC in ``_zip_entry_skip_reason`` from real ``OriginArtifactRule``
+    matching, which is covered separately) matching on the bare intra-archive
+    relative path -- both ``_zip_entry_skip_reason`` and
+    ``ZipEntryValidator.filter_entries`` classify on that bare path, not a
+    ``{zip_path}:{name}`` prefix (polylogue-dc1k: every rule's ``(?:^|/)``-anchored
+    pattern only matches after start-of-string or ``/``, never after the ``:``
+    a container prefix would insert).
     """
     from polylogue.archive.artifact_taxonomy.models import ArtifactClassification, ArtifactKind
 
@@ -210,7 +208,7 @@ def test_import_explain_zip_excludes_non_session_artifact_from_aggregate(
     )
 
     def fake_classify(source_path: object, *, provider: object) -> ArtifactClassification | None:
-        if str(source_path).endswith(":run.json"):
+        if str(source_path) == "run.json":
             return ArtifactClassification(
                 provider=Provider.CLAUDE_CODE,
                 kind=ArtifactKind.WORKFLOW_RUN_SNAPSHOT,

--- a/tests/unit/sources/test_decoders.py
+++ b/tests/unit/sources/test_decoders.py
@@ -369,3 +369,44 @@ class TestZipEntryValidator:
 
         assert len(accepted) == 3
         assert sum(info.file_size for info in accepted) == 3 * one_gib
+
+    def test_session_only_excludes_non_session_artifact_via_real_classification(self) -> None:
+        """``session_only=True`` (what ``process_zip`` always passes in
+        production) must actually exclude a real non-session artifact via a
+        genuine, non-monkeypatched ``classify_artifact_path`` call.
+
+        Regression test for polylogue-dc1k: every ``OriginArtifactRule.path_pattern``
+        in ``origin_specs.py`` is anchored ``(?:^|/)``, but the entry was
+        classified on ``f"{zip_path}:{name}"`` -- the character immediately
+        before the pattern's leading segment was ``:``, never ``/`` or
+        start-of-string, so no rule could ever match and this exclusion was
+        dead code for every zip import. Builds a *real* zip (not a bare
+        ``ZipInfo``) so the entries here are exactly what ``zf.infolist()``
+        would hand ``filter_entries`` in production.
+        """
+        buffer = io.BytesIO()
+        with zipfile.ZipFile(buffer, "w") as zf:
+            # Matches the "workflow_run" OriginArtifactRule for claude-code
+            # (parse_policy="fact" -> parse_as_session=False): must be excluded.
+            zf.writestr("workflows/run.json", json.dumps({"run_id": "abc"}))
+            # Matches the "agent_transcript" OriginArtifactRule for claude-code
+            # (parse_policy="session" -> parse_as_session=True): must survive.
+            zf.writestr("subagents/agent-1.jsonl", json.dumps({"type": "user"}) + "\n")
+            # No OriginArtifactRule matches this path at all (classify_artifact_path
+            # returns None): must also survive -- session_only only excludes on an
+            # affirmative non-session classification, never on "unclassified".
+            zf.writestr("sessions.json", json.dumps({"conversations": []}))
+        buffer.seek(0)
+
+        with zipfile.ZipFile(buffer) as zf:
+            validator = _ZipEntryValidator(
+                "claude-code",
+                cursor_state=_seeded_cursor_state(),
+                zip_path=Path("export.zip"),
+                session_only=True,
+            )
+            accepted = [info.filename for info in validator.filter_entries(zf.infolist())]
+
+        assert "workflows/run.json" not in accepted
+        assert "subagents/agent-1.jsonl" in accepted
+        assert "sessions.json" in accepted


### PR DESCRIPTION
## Summary

`ZipEntryValidator.filter_entries`'s (and `import_explain.py`'s mirroring
`_zip_entry_skip_reason`'s) `session_only=True` exclusion of non-session
artifacts from zip imports was dead code for every provider: it classified
entries on `f"{zip_path}:{name}"`, but every `OriginArtifactRule.path_pattern`
in `origin_specs.py` is anchored `(?:^|/)`, so a `:` immediately before a
rule's leading path segment could never match. Fixed by classifying on the
bare intra-archive relative path instead.

## Problem

`process_zip` (`decoder_zip.py`) always constructs `ZipEntryValidator` with
`session_only=True`. When set, `filter_entries` was supposed to exclude
non-session-classified entries (workflow snapshots, agent sidecar metadata,
etc.) bundled inside a zip export before they're parsed as sessions:

```python
path_classification = classify_artifact_path(
    f"{self._zip_path}:{name}", provider=self._provider_hint,
)
if path_classification is not None and not path_classification.parse_as_session:
    continue
```

Every current `OriginArtifactRule.path_pattern` requires a slash-anchored
match, e.g. `r"(?:^|/)workflows/[^/]+\.json$"`. Confirmed empirically:
`classify_artifact_path("/tmp/export.zip:workflows/run.json", provider=Provider.CLAUDE_CODE)`
returns `None` -- the character immediately before `workflows` is `:`, never
`/` or start-of-string. So this exclusion branch could never fire, for any
provider, for any zip import: non-session artifacts silently fell through to
normal parsing instead of being excluded. `import_explain.py`'s
`_zip_entry_skip_reason` (added in #3317 to mirror this exact call) had the
identical bug.

## Solution

Checked how every *non-zip* caller of `classify_artifact_path` builds its
source path (`sources/live/batch_support.py`, `source_parsing.py`,
`pipeline/services/archive_ingest.py`, `storage/artifacts/inspection.py`,
`schemas/sampling_db.py`): all of them pass a real filesystem path (a `Path`
or a plain string), never a container-prefixed compound path. The
`(?:^|/)`-anchored rules were clearly designed for that convention.

Chose fix option **(a)** from the bead (build the classification path
without the zip_path prefix) over option (b) (add a zip-aware `:`-anchored
pattern variant), because (a) is the only option consistent with how every
other caller already works — (b) would have created a second, zip-only path
convention living alongside the existing relative-path one in
`origin_specs.py`, for no benefit.

- `polylogue/sources/decoder_zip.py`: `ZipEntryValidator.filter_entries` now
  classifies on the bare `name` (the intra-archive relative path from
  `zipfile.ZipInfo.filename`) instead of `f"{self._zip_path}:{name}"`.
- `polylogue/sources/import_explain.py`: `_zip_entry_skip_reason` now
  classifies on the bare `info.filename` instead of `f"{zip_path}:{info.filename}"`.
  The `zip_path` parameter is no longer needed for classification (kept on
  the signature for the caller's symmetry with other skip-reason helpers,
  explicitly `del`eted at the top of the function body).
- `tests/unit/cli/test_import_explain.py`:
  `test_import_explain_zip_excludes_non_session_artifact_from_aggregate`'s
  monkeypatched `fake_classify` matcher was written against the old
  `":run.json"` suffix convention, and its docstring explicitly documented
  this exact gap as a known, separate, *unfixed* issue ("polylogue-<followup>
  ... not something this fix can or should paper over") -- that followup is
  this PR. Updated the matcher to the bare `"run.json"` path and rewrote the
  docstring.
- `tests/unit/sources/test_decoders.py`: added
  `test_session_only_excludes_non_session_artifact_via_real_classification`,
  which builds a real in-memory zip (`workflows/run.json`,
  `subagents/agent-1.jsonl`, `sessions.json`) and drives it through
  `ZipEntryValidator.filter_entries(session_only=True)` with a genuine,
  non-monkeypatched `classify_artifact_path` call against real
  `OriginArtifactRule`s for `claude-code`. No existing test exercised
  `session_only=True`'s exclusion branch against a real classification call
  before this. Confirmed the new test fails against the pre-fix
  `decoder_zip.py` (`workflows/run.json` wrongly survives) and passes
  against the fix, while a genuine session-shaped entry
  (`subagents/agent-1.jsonl`) and an unclassified entry (`sessions.json`)
  both still survive (no regression).

## Verification

- `devtools test tests/unit/sources/test_decoders.py` -> 26 passed
- `devtools test tests/unit/cli/test_import_explain.py tests/unit/sources/test_source_laws.py tests/unit/sources/test_hermes_import_explain.py tests/unit/sources/test_decoders.py` -> 165 passed
- `mypy --strict polylogue/sources/decoder_zip.py polylogue/sources/import_explain.py` -> Success: no issues found in 2 source files
- `ruff check` / `ruff format --check` on all touched files -> clean
- `devtools verify --quick` -> exit_code 0 (also ran automatically via the pre-push hook)
- Manually confirmed the new fixture test fails on the pre-fix `decoder_zip.py` (via `git stash` of that one file) and passes on the fix.

Not run: the broader `devtools verify --all` full non-integration suite (out of scope for a focused fix; the affected-area tests above cover every call site of `classify_artifact_path` from a zip context).

Ref polylogue-dc1k