### PR TITLE
perf(ui): defer questionary/pygments imports off the CLI status path

### DIFF
--- a/polylogue/ui/facade.py
+++ b/polylogue/ui/facade.py
@@ -7,7 +7,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import questionary
 from rich import box
 from rich.console import Console
 from rich.theme import Theme
@@ -113,6 +112,8 @@ class ConsoleFacade:
             if not value:
                 return default
             return value.lower() in {"y", "yes"}
+        import questionary
+
         result = questionary.confirm(prompt, default=default).ask()
         return default if result is None else result
 
@@ -138,6 +139,8 @@ class ConsoleFacade:
                     if 1 <= selected <= len(options):
                         return options[selected - 1]
                 self.console.print("Enter a number corresponding to your choice.")
+        import questionary
+
         if len(options) > 12:
             result: str | None = questionary.autocomplete(prompt, choices=options, match_middle=True).ask()
         else:
@@ -156,6 +159,8 @@ class ConsoleFacade:
             except EOFError:
                 return default
             return value or default
+        import questionary
+
         result: str | None = questionary.text(prompt, default=default or "").ask()
         return result if result else default
 

--- a/polylogue/ui/facade_rendering.py
+++ b/polylogue/ui/facade_rendering.py
@@ -5,15 +5,10 @@ from __future__ import annotations
 import difflib
 from typing import Literal
 
-from pygments import highlight
-from pygments.formatters import Terminal256Formatter
-from pygments.lexers import get_lexer_by_name
 from rich.align import Align
 from rich.box import Box
 from rich.console import Console, RenderableType
-from rich.markdown import Markdown
 from rich.panel import Panel
-from rich.syntax import Syntax
 from rich.text import Text
 
 from polylogue.ui.facade_console import ConsoleLike
@@ -95,6 +90,8 @@ def render_markdown(console: ConsoleLike, *, plain: bool, panel_box: Box, conten
         console.print(content)
         return
 
+    from rich.markdown import Markdown
+
     md = Markdown(content, style="summary.text")
     _render_panel(
         console,
@@ -109,6 +106,8 @@ def render_code(console: ConsoleLike, *, plain: bool, panel_box: Box, code: str,
     if plain:
         console.print(code)
         return
+
+    from rich.syntax import Syntax
 
     syntax = Syntax(code, language, theme=syntax_theme("terminal_code"), line_numbers=True)
     _render_panel(
@@ -145,6 +144,10 @@ def render_diff(
 
     try:
         if isinstance(console, Console):
+            from pygments import highlight
+            from pygments.formatters import Terminal256Formatter
+            from pygments.lexers import get_lexer_by_name
+
             with console.pager():
                 lexer = get_lexer_by_name("diff")
                 highlighted = highlight(diff_text, lexer, Terminal256Formatter(style=syntax_theme("terminal_diff")))
@@ -153,6 +156,8 @@ def render_diff(
             console.print(diff_text)
     except (ImportError, AttributeError):
         if isinstance(console, Console):
+            from rich.syntax import Syntax
+
             syntax = Syntax(diff_text, "diff", theme=syntax_theme("terminal_diff"))
             console.print(syntax)
         else:


### PR DESCRIPTION
## Summary
Fixes a real, measured slice of `polylogue-8s70`'s command-body import tax.

## Problem
`polylogue status`/`agents status` pay an import tax that `polylogue --help` never reaches (`--help` short-circuits before the command callback runs). Prior work (PR #3166) cut `status` from ~2.05s to ~1.47s by localizing `storage.repair`/`sources.dispatch` imports, but a fresh `python -X importtime` pass on `polylogue status --format json` against an empty archive root showed it had regressed back to ~1.84-1.90s, tracing a distinct, previously unnoticed 300-400ms branch: `polylogue.ui` → `polylogue.ui.facade` → `questionary` → `prompt_toolkit`, plus a smaller `pygments`/`rich.markdown`/`rich.syntax` branch in `facade_rendering.py`.

Both are imported unconditionally at module top level even though:
- `questionary` is only called inside `ConsoleFacade.confirm`/`choose`/`input`'s non-plain (interactive TTY) branches — `--format json` output never reaches them.
- `pygments`/`rich.markdown.Markdown`/`rich.syntax.Syntax` are only used inside `render_markdown`/`render_code`/`render_diff`, not by plain status printing.

## Solution
Moved both import sets from module top level into the specific methods/functions that use them, matching this repo's existing local-import convention. No behavior change — confirmed via `tests/unit/ui` (which monkeypatches `questionary` attributes directly on the shared module object; imports are idempotent).

## Verification
- `python -X importtime -m polylogue status --format json`: `polylogue.ui` cumulative import cost 408ms → 92ms; questionary/prompt_toolkit/pygments/rich.markdown/rich.syntax now show 0 occurrences on this command's trace (994 → 716 modules imported total).
- `time polylogue status --format json` (empty archive root, cold subprocess, `POLYLOGUE_DAEMON_URL` forced to a closed port, 3+ runs): ~1.84-1.90s → ~1.52-1.54s.
- `polylogue --help`: unaffected, ~0.45-0.46s; `devtools bench help-latency`: all 14 required targets still green.
- `polylogue agents status --format json`: unaffected (~1.48-1.50s) — that command's import trace never touched questionary/prompt_toolkit, confirming this is a targeted fix, not a blanket sweep.
- `ruff check`/`format --check` clean; `mypy --strict` clean on both files.
- `devtools test tests/unit/ui`: 115 passed.
- `devtools test tests/unit/cli/test_status.py tests/unit/cli/commands/test_status.py tests/unit/cli/test_status_diagnostics.py tests/unit/cli/test_embed_status_fast.py`: 1 pre-existing failure (`test_archive_facade_route_catalog_covers_public_async_facade`), independently re-confirmed identical on `origin/master` before merging this PR — unrelated async facade route-catalog coverage gap, not touched by this change.

## AC honesty
The bead's original AC (<700ms cold-CLI budget) is still not met. Remaining ~1.1s is dominated by the readiness/capability → `storage.repair` and `insights.archive`/`archive_rollups` chains, which prior investigation (recorded on the bead) already found to be a genuine, non-trivially-fixable pydantic-model-construction cost rather than an eager-import artifact — unchanged by this PR. This PR closes a previously undiscovered, cleanly avoidable slice (the interactive UI stack) found via a fresh importtime pass.

Ref polylogue-8s70