### PR TITLE
test(storage): stop lifecycle report tests drifting with new declarations

### DIFF
--- a/tests/unit/storage/test_index_fast_forward_lifecycle.py
+++ b/tests/unit/storage/test_index_fast_forward_lifecycle.py
@@ -102,10 +102,18 @@ def test_nonsemantic_delta_without_operations_is_rejected(monkeypatch: pytest.Mo
         version=37,
         classes=(DerivedDeltaClass.INDEX_ONLY,),
     )
+    # Isolate to declarations at or below 36 (the versions this plan actually
+    # needs) rather than the live module tuple: the live tuple keeps growing
+    # past 37 as later schema versions get declared, and every one of those
+    # would otherwise leak into invalid_versions via the
+    # `declaration.version > current_version` check below.
+    base_declarations = tuple(
+        declaration for declaration in lifecycle.INDEX_DELTA_DECLARATIONS if declaration.version <= 36
+    )
     monkeypatch.setattr(
         lifecycle,
         "INDEX_DELTA_DECLARATIONS",
-        (*lifecycle.INDEX_DELTA_DECLARATIONS, empty_declaration),
+        (*base_declarations, empty_declaration),
     )
 
     report = lifecycle.index_delta_declaration_report(37)
@@ -128,10 +136,14 @@ def test_delta_without_a_declared_class_is_rejected(monkeypatch: pytest.MonkeyPa
             ),
         ),
     )
+    # Same isolation rationale as test_nonsemantic_delta_without_operations_is_rejected above.
+    base_declarations = tuple(
+        declaration for declaration in lifecycle.INDEX_DELTA_DECLARATIONS if declaration.version <= 36
+    )
     monkeypatch.setattr(
         lifecycle,
         "INDEX_DELTA_DECLARATIONS",
-        (*lifecycle.INDEX_DELTA_DECLARATIONS, unclassified_declaration),
+        (*base_declarations, unclassified_declaration),
     )
 
     assert lifecycle.index_delta_declaration_report(37)["invalid_versions"] == (37,)
@@ -143,6 +155,15 @@ def test_schema_policy_rejects_an_index_bump_without_a_delta_declaration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The real lab command must fail before an undeclared bump reaches CI."""
+    # Isolate to declarations at or below the current (pre-bump) schema
+    # version: index_delta_declaration_report's missing_versions accumulates
+    # over the whole expected range, so any future currently-undeclared gap
+    # elsewhere in the live tuple would otherwise leak into this assertion
+    # alongside the version this test deliberately leaves undeclared.
+    complete_declarations = tuple(
+        declaration for declaration in lifecycle.INDEX_DELTA_DECLARATIONS if declaration.version <= INDEX_SCHEMA_VERSION
+    )
+    monkeypatch.setattr(lifecycle, "INDEX_DELTA_DECLARATIONS", complete_declarations)
     monkeypatch.setattr(schema_policy, "INDEX_SCHEMA_VERSION", INDEX_SCHEMA_VERSION + 1)
 
     exit_code = schema_policy.main(["--json"])


### PR DESCRIPTION
## Summary

Fixes 3 tests in `tests/unit/storage/test_index_fast_forward_lifecycle.py` that hardcoded exact literal `invalid_versions`/`missing_versions` results computed against the *real*, ever-growing module-level `INDEX_DELTA_DECLARATIONS` tuple in `polylogue/storage/sqlite/lifecycle.py`.

## Problem

`test_nonsemantic_delta_without_operations_is_rejected` and `test_delta_without_a_declared_class_is_rejected` monkeypatched by appending a synthetic declaration onto the *live* `INDEX_DELTA_DECLARATIONS` tuple, then asserted `invalid_versions == (37,)`. `index_delta_declaration_report()` flags any declaration whose version exceeds the version under test (`current_version=37` in these tests), so every schema version declared since these tests were written (38, 39, 41, 42, 43) widened the actual result to `(38, 39, 41, 42, 43, 37)`, breaking the literal assertion.

`test_schema_policy_rejects_an_index_bump_without_a_delta_declaration` asserted `missing_versions == [INDEX_SCHEMA_VERSION + 1]`, but `missing_versions` accumulates across the *whole* expected range (`compatibility_floor+1 .. current_version`), so any currently-undeclared gap elsewhere in the live tuple (e.g. the v40 gap that existed before polylogue-5h5y/#3319) leaked into the same assertion.

These were real, ongoing test-staleness bugs — correct when the declarations tuple was short, silently masking/breaking indefinitely as more versions get declared.

## Solution

All three tests now build an **isolated** declarations tuple — filtered from the live `INDEX_DELTA_DECLARATIONS` to only the versions each test actually needs (`<= 36` for the first two, `<= INDEX_SCHEMA_VERSION` for the third) — before monkeypatching `lifecycle.INDEX_DELTA_DECLARATIONS`, instead of splicing a synthetic declaration onto the unbounded live tuple.

This matches the isolation convention already used elsewhere in the same file: `test_semantic_delta_routes_a_plan_away_from_sql_fast_forward` and `test_plan_orders_declarations_before_validating_contiguity` both fully replace `lifecycle.INDEX_DELTA_DECLARATIONS` with a small, self-contained fixture rather than layering onto the live tuple. Only `lifecycle.py`'s test file changed — no production code touched.

## Verification

- `devtools test tests/unit/storage/test_index_fast_forward_lifecycle.py` → `9 passed`
- `mypy --strict tests/unit/storage/test_index_fast_forward_lifecycle.py` → `Success: no issues found in 1 source file`
- `ruff check` / `ruff format --check` on the touched file → clean
- Pre-push quick verification baseline (format/lint/mypy/render/topology/layering/closure-matrix/schema-roundtrip/manifests/etc.) → all green

**Future-proofing proof (per polylogue-z2fj step 5):** temporarily added a throwaway `IndexDeltaDeclaration(version=44, ...)` to the real module-level `INDEX_DELTA_DECLARATIONS` tuple in `lifecycle.py` and reran the suite. All 3 fixed tests still passed **unchanged** — their isolated fixtures ignore versions beyond what each test needs, so the extra declaration never leaked in. The only failure was `test_current_index_schema_has_a_complete_delta_declaration`, which is expected/correct: a declaration beyond the current `INDEX_SCHEMA_VERSION` is itself an invalid state per the report's own semantics (`declaration.version > current_version`), not a test bug this PR is scoped to fix. Reverted the throwaway declaration afterward — `lifecycle.py` has zero diff in the final PR.

Ref polylogue-z2fj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved lifecycle validation tests to remain reliable as additional schema declarations are introduced.
  * Preserved coverage for rejecting invalid or undeclared index version changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->