### PR TITLE
feat(devtools): gate new hash producer call sites behind a registry lint

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -1302,6 +1302,20 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools verify degrade-loudly", "devtools verify degrade-loudly --json"),
     ),
     CommandSpec(
+        "verify hash-boundary-census",
+        "verification",
+        "Verify every hashlib/core.hashing call site in polylogue/ is registered in the hash-boundary registry.",
+        "devtools.verify_hash_boundary_census",
+        use_when=(
+            "Enforce the hash-boundary census follow-up (polylogue-okpn, docs/audits/"
+            "2026-07-09-hash-boundary-census.md): a new hashlib.sha256/sha1/md5/blake2*/sha3_* call "
+            "or a new hash_text/hash_text_short/hash_payload/hash_bytes/hash_file call site must be "
+            "registered (path/function/call/classification/note) in "
+            "docs/plans/hash-boundary-registry.yaml, or the lint fails."
+        ),
+        examples=("devtools verify hash-boundary-census", "devtools verify hash-boundary-census --json"),
+    ),
+    CommandSpec(
         "release verify-distribution",
         "release",
         "Verify wheel/sdist installed artifacts expose only supported runtime entrypoints.",

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -1771,6 +1771,7 @@ def build_verify_steps(
                 ("verify test-clock-hygiene", _devtools_cmd("verify test-clock-hygiene")),
                 ("verify pytest-timeout-overrides", _devtools_cmd("verify pytest-timeout-overrides")),
                 ("verify degrade-loudly", _devtools_cmd("verify degrade-loudly")),
+                ("verify hash-boundary-census", _devtools_cmd("verify hash-boundary-census")),
             ]
         )
 

--- a/devtools/verify_hash_boundary_census.py
+++ b/devtools/verify_hash_boundary_census.py
@@ -1,0 +1,338 @@
+"""Lint: new hashlib/core.hashing call sites must register in the hash-boundary registry.
+
+Background (polylogue-okpn, follow-up to the polylogue-9e5.6 census at
+``docs/audits/2026-07-09-hash-boundary-census.md``): that audit hand-classified
+every digest producer call site in ``polylogue/`` (42 direct ``hashlib.*``
+calls + 23 ``core.hashing`` helper calls at the time) into content-hash/
+integrity-drift checks, identifier-generation-only sites, and a couple of
+other one-off uses (HMAC signatures, redaction digests, re-hashing an
+already-hashed value). The audit's own "Register-or-fail lint" section
+deferred building the mechanical gate to this follow-up, flagging three open
+design questions:
+
+1. **Registry format** -- a dedicated machine-readable YAML that the lint
+   diffs against, not a lint that regexes the prose census markdown table.
+   This follows the same convention as
+   ``docs/plans/degrade-loudly-allowlist.yaml`` (AST-discovered sites keyed
+   by path/function/occurrence, not line number, with a human-written
+   rationale) and ``docs/plans/docs-coverage-baseline.yaml`` (a grandfathered
+   baseline of pre-existing gaps at gate introduction, tagged as tracked debt
+   rather than silently re-legitimized).
+2. **Classification granularity** -- pure ID-generation sites (a hash used
+   only to derive a stable identifier / uniqueness key, never compared for
+   drift) get the lighter ``identifier`` tag rather than being forced through
+   the same shape a ``content-hash`` drift-check site needs. A residual
+   ``other`` tag covers the handful of sites that are neither (HMAC
+   signatures, redaction digests, re-hashing an already-hashed value). A
+   ``baseline-unclassified`` tag grandfathers real call sites that exist in
+   the codebase today but were not part of the 65-site 2026-07-09 census and
+   have not yet been individually re-audited -- this is tracked debt, not a
+   rubber stamp; see the registry file's own header.
+3. **Cost** -- this is a static AST scan of ``polylogue/`` plus a YAML diff,
+   the same cost class as ``verify_degrade_loudly.py`` (~15s warm gate
+   budget), so it is wired into ``devtools verify --quick`` alongside it.
+
+Scan scope: every call to ``hashlib.sha256``/``sha1``/``md5``/``blake2b``/
+``blake2s``/``sha3_*``/``sha512``/``sha224``/``sha384`` anywhere in
+``polylogue/`` *except* their four definitional uses inside
+``polylogue/core/hashing.py`` itself (those calls ARE the implementation of
+``hash_text``/``hash_payload``/``hash_bytes``/``hash_file`` -- registering
+them separately from the helpers they define would double-count the same
+producer), plus every call to ``hash_text``/``hash_text_short``/
+``hash_payload``/``hash_bytes``/``hash_file`` anywhere else in ``polylogue/``
+(the helper-call sites). Tests are excluded (matching the audit's own scope).
+
+The registry is keyed by ``(path, function qualname, call name, occurrence
+index within that function+call-name)`` -- not line number -- so it survives
+unrelated line-shift churn, exactly like the degrade-loudly allowlist. A new
+call site with no matching registry entry fails the lint with an actionable
+message naming the exact site and the registry file to edit. A registry entry
+matching no current call site also fails (stale-entry check), so the
+registry cannot silently accumulate dead rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - yaml is a hard repo dep
+    yaml = None  # type: ignore[assignment]
+
+from devtools import repo_root as _get_root
+
+ROOT = _get_root()
+TARGET_DIR = "polylogue"
+REGISTRY_PATH = ROOT / "docs" / "plans" / "hash-boundary-registry.yaml"
+
+# The four current core.hashing helpers, plus hash_bytes (added after the
+# 2026-07-09 census). Calls to these OUTSIDE core/hashing.py are helper-call
+# sites; calls to hashlib.* INSIDE core/hashing.py are the helpers' own
+# implementation and are excluded from the direct-hashlib scan below.
+_HELPER_NAMES = {"hash_text", "hash_text_short", "hash_payload", "hash_bytes", "hash_file"}
+_HASHLIB_ALGOS = {
+    "sha256",
+    "sha1",
+    "md5",
+    "sha512",
+    "sha224",
+    "sha384",
+    "blake2b",
+    "blake2s",
+    "sha3_224",
+    "sha3_256",
+    "sha3_384",
+    "sha3_512",
+    "shake_128",
+    "shake_256",
+}
+_HASHING_DEFINITION_FILE = "polylogue/core/hashing.py"
+
+_ALLOWED_CLASSIFICATIONS = {"content-hash", "identifier", "other", "baseline-unclassified"}
+
+
+@dataclass(frozen=True, slots=True)
+class Site:
+    path: str
+    function: str
+    call: str
+    occurrence: int
+    lineno: int
+
+    @property
+    def key(self) -> tuple[str, str, str, int]:
+        return (self.path, self.function, self.call, self.occurrence)
+
+
+class _FunctionScopeVisitor(ast.NodeVisitor):
+    """Walk a module tracking enclosing function qualnames and per-function
+    occurrence counters for hashlib/core.hashing call sites."""
+
+    def __init__(self, relpath: str, *, is_hashing_definition_file: bool) -> None:
+        self.relpath = relpath
+        self._is_hashing_definition_file = is_hashing_definition_file
+        self._stack: list[str] = ["<module>"]
+        self._occurrence: dict[str, int] = {}
+        self.sites: list[Site] = []
+
+    def _qualname(self) -> str:
+        return ".".join(self._stack)
+
+    def _visit_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        self._stack.append(node.name)
+        self.generic_visit(node)
+        self._stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def _record(self, call_name: str, lineno: int) -> None:
+        qualname = self._qualname()
+        occ_key = f"{qualname}::{call_name}"
+        occurrence = self._occurrence.get(occ_key, 0)
+        self._occurrence[occ_key] = occurrence + 1
+        self.sites.append(
+            Site(path=self.relpath, function=qualname, call=call_name, occurrence=occurrence, lineno=lineno)
+        )
+
+    def visit_Call(self, node: ast.Call) -> None:
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr in _HASHLIB_ALGOS:
+            value = func.value
+            if isinstance(value, ast.Name) and value.id == "hashlib" and not self._is_hashing_definition_file:
+                self._record(f"hashlib.{func.attr}", node.lineno)
+        elif isinstance(func, ast.Name) and func.id in _HELPER_NAMES and not self._is_hashing_definition_file:
+            self._record(func.id, node.lineno)
+        self.generic_visit(node)
+
+
+def _scan_file(path: Path, *, root: Path) -> list[Site]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+    relpath = str(path.relative_to(root))
+    visitor = _FunctionScopeVisitor(relpath, is_hashing_definition_file=relpath == _HASHING_DEFINITION_FILE)
+    visitor.visit(tree)
+    return visitor.sites
+
+
+def _scan_repo(*, root: Path) -> list[Site]:
+    sites: list[Site] = []
+    base = root / TARGET_DIR
+    if not base.exists():
+        return sites
+    for path in sorted(base.rglob("*.py")):
+        if "test" in path.parts:
+            continue
+        sites.extend(_scan_file(path, root=root))
+    return sites
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryEntry:
+    path: str
+    function: str
+    call: str
+    occurrence: int
+    classification: str
+    note: str
+
+    @property
+    def key(self) -> tuple[str, str, str, int]:
+        return (self.path, self.function, self.call, self.occurrence)
+
+
+@dataclass(frozen=True, slots=True)
+class RegistryError:
+    message: str
+
+
+def _load_registry(registry_path: Path) -> tuple[list[RegistryEntry], list[RegistryError]]:
+    if not registry_path.exists():
+        return [], []
+    if yaml is None:
+        raise RuntimeError("PyYAML is required to read the hash-boundary registry")
+    data = yaml.safe_load(registry_path.read_text(encoding="utf-8")) or {}
+    raw_entries = data.get("entries", []) or []
+    entries: list[RegistryEntry] = []
+    errors: list[RegistryError] = []
+    for raw in raw_entries:
+        if not isinstance(raw, dict):
+            errors.append(RegistryError(f"registry entry is not a mapping: {raw!r}"))
+            continue
+        classification = str(raw.get("classification", ""))
+        if classification not in _ALLOWED_CLASSIFICATIONS:
+            errors.append(
+                RegistryError(
+                    f"{raw.get('path')}::{raw.get('function')}::{raw.get('call')} has unknown "
+                    f"classification {classification!r} (must be one of {sorted(_ALLOWED_CLASSIFICATIONS)})"
+                )
+            )
+            continue
+        entries.append(
+            RegistryEntry(
+                path=str(raw.get("path", "")),
+                function=str(raw.get("function", "")),
+                call=str(raw.get("call", "")),
+                occurrence=int(raw.get("occurrence", 0)),
+                classification=classification,
+                note=str(raw.get("note", "")),
+            )
+        )
+    return entries, errors
+
+
+def _format_report(
+    *,
+    sites: list[Site],
+    registry: list[RegistryEntry],
+    unregistered: list[Site],
+    stale: list[RegistryEntry],
+    malformed: list[RegistryError],
+    root: Path,
+    registry_path: Path,
+) -> str:
+    rel_registry = registry_path.relative_to(root) if registry_path.is_relative_to(root) else registry_path
+    lines = [
+        f"hash producer call sites scanned in {TARGET_DIR}/: {len(sites)}",
+        f"registered: {len(registry)}",
+        f"unregistered (new ungoverned hash sites): {len(unregistered)}",
+        f"stale registry entries: {len(stale)}",
+        f"malformed registry entries: {len(malformed)}",
+    ]
+    if unregistered:
+        lines.append("")
+        lines.append("Hash call sites with no registry entry:")
+        for site in sorted(unregistered, key=lambda s: (s.path, s.lineno)):
+            lines.append(
+                f"  {site.path}:{site.lineno} in {site.function}() call={site.call} "
+                f"(occurrence {site.occurrence}) -- add an entry to {rel_registry} with "
+                "classification (content-hash | identifier | other) and a one-line note "
+                "on producer + consumer (polylogue-okpn)."
+            )
+    if stale:
+        lines.append("")
+        lines.append("Registry entries that no longer match a current call site (remove them):")
+        for entry in sorted(stale, key=lambda e: (e.path, e.function)):
+            lines.append(f"  {entry.path} :: {entry.function}() call={entry.call} [occurrence {entry.occurrence}]")
+    if malformed:
+        lines.append("")
+        lines.append("Malformed registry entries:")
+        for error in malformed:
+            lines.append(f"  {error.message}")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    parser.add_argument("--root", type=Path, default=ROOT, help="Repository root to scan.")
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=None,
+        help="Registry YAML path (defaults to <root>/docs/plans/hash-boundary-registry.yaml).",
+    )
+    args = parser.parse_args(argv)
+
+    root: Path = args.root.resolve()
+    default_registry = root / "docs" / "plans" / "hash-boundary-registry.yaml"
+    registry_path: Path = (args.registry or default_registry).resolve()
+
+    sites = _scan_repo(root=root)
+    registry, malformed = _load_registry(registry_path)
+    registered_keys = {entry.key for entry in registry}
+    site_keys = {site.key for site in sites}
+
+    unregistered = [site for site in sites if site.key not in registered_keys]
+    stale = [entry for entry in registry if entry.key not in site_keys]
+
+    ok = not unregistered and not stale and not malformed
+
+    if args.json:
+        payload = {
+            "sites_scanned": len(sites),
+            "registered": len(registry),
+            "violations": [
+                {"path": s.path, "line": s.lineno, "function": s.function, "call": s.call}
+                for s in sorted(unregistered, key=lambda s: (s.path, s.lineno))
+            ],
+            "stale_registry_entries": [
+                {"path": e.path, "function": e.function, "call": e.call, "occurrence": e.occurrence}
+                for e in sorted(stale, key=lambda e: (e.path, e.function))
+            ],
+            "malformed_registry_entries": [e.message for e in malformed],
+            "ok": ok,
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print(
+            _format_report(
+                sites=sites,
+                registry=registry,
+                unregistered=unregistered,
+                stale=stale,
+                malformed=malformed,
+                root=root,
+                registry_path=registry_path,
+            )
+        )
+
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -180,6 +180,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools verify doc-commands` | Verify README/docs command examples resolve to live polylogue, polylogued, and devtools commands. |
 | `devtools verify docs-coverage` | Verify every public CLI command, MCP tool, config key, and stable daemon route is named in the docs tree. |
 | `devtools verify evidence` | Render the pytest-first evidence dashboard or a changed-path trace. |
+| `devtools verify hash-boundary-census` | Verify every hashlib/core.hashing call site in polylogue/ is registered in the hash-boundary registry. |
 | `devtools verify layering` | Check inter-package imports against declared layering rules from docs/plans/layering.yaml. |
 | `devtools verify manifests` | Verify internal consistency across all docs/plans/*.yaml manifest files. |
 | `devtools verify public-claims` | Verify generated public-claim views, preset parity, sanitized refs, coverage markers, and retired copy. |

--- a/docs/plans/hash-boundary-registry.yaml
+++ b/docs/plans/hash-boundary-registry.yaml
@@ -1,0 +1,1180 @@
+# Hash-boundary registry (polylogue-okpn)
+#
+# Machine-readable companion to docs/audits/2026-07-09-hash-boundary-census.md,
+# checked by `devtools verify hash-boundary-census` (wired into
+# `devtools verify --quick`). Every hashlib.sha256/sha1/md5/blake2*/sha3_*
+# call and every core.hashing helper call (hash_text/hash_text_short/
+# hash_payload/hash_bytes/hash_file) in polylogue/ must have a matching entry
+# here, or the lint fails -- this is what keeps new hash usage from silently
+# appearing ungoverned outside the audit's inventory.
+#
+# Format: keyed by (path, function qualname, call, occurrence-within-function)
+# -- not line number -- so unrelated line-shift churn elsewhere in the file
+# doesn't require re-numbering entries (same convention as
+# docs/plans/degrade-loudly-allowlist.yaml). `occurrence` counts repeated
+# calls to the same function/call-name pair within one enclosing function,
+# starting at 0.
+#
+# classification (one of):
+#   content-hash            -- the digest's inputs are compared for drift/
+#                               integrity/dedup (a real, reachable decision
+#                               is gated on match/mismatch).
+#   identifier               -- the digest is used only to derive a stable
+#                               identifier / uniqueness key (PK, dedup key,
+#                               cache/lookup key); never compared for drift.
+#                               A lighter contract than content-hash: no
+#                               "consumer comparison" is expected.
+#   other                    -- neither of the above: HMAC/auth-token
+#                               digests, redaction/masked-display aids,
+#                               informational one-shot checksums, or a
+#                               re-hash of an already-hashed value.
+#   baseline-unclassified    -- TRACKED DEBT: a real call site that exists in
+#                               the codebase today but was not part of the
+#                               2026-07-09 census and has not yet been
+#                               individually re-audited. This is a
+#                               grandfathered gap, not a rubber stamp (same
+#                               convention as docs/plans/docs-coverage-
+#                               baseline.yaml) -- new call sites must be
+#                               properly classified, not added here.
+#
+# Seeded 2026-07-27 (polylogue-okpn) from a full re-scan of polylogue/ against
+# the 2026-07-09 census: 65 sites carry the census's own classification
+# (content-hash / identifier / other), the remainder reflect new hash usage
+# added since the census and are classified by direct source inspection
+# where the producer/consumer shape was unambiguous at a glance.
+
+entries:
+- path: polylogue/agent_integration/assets.py
+  function: '<module>.agent_asset_digest'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'deterministic digest of packaged agent assets, used to detect installed-vs-packaged drift.'
+- path: polylogue/agent_integration/installer.py
+  function: '<module>._sha256_bytes'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'backs _state_integrity''s installed-agent-state integrity check.'
+- path: polylogue/annotations/schema.py
+  function: '<module>.definition_fingerprint'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'compared by storage/sqlite/archive_tiers/user_annotations.py''s _schema_from_row (actual_fingerprint != stored_fingerprint) -- schema-definition drift check.'
+- path: polylogue/annotations/write.py
+  function: '<module>.assertion_id_for_ontology_candidate'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'deterministic assertion id, PK-style.'
+- path: polylogue/annotations/write.py
+  function: '<module>.assertion_id_for_ontology_governance'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'deterministic assertion id, PK-style.'
+- path: polylogue/annotations/write.py
+  function: '<module>.assertion_id_for_schema_annotation'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'deterministic assertion id, PK-style.'
+- path: polylogue/api/archive.py
+  function: '<module>._archive_capture_assertion_candidate'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'capture_fingerprint compared against existing_fingerprint to decide candidate-assertion idempotency (identity= branch is id-construction; fingerprint compare is content-hash).'
+- path: polylogue/api/archive.py
+  function: '<module>._archive_capture_assertion_candidate'
+  call: hashlib.sha256
+  occurrence: 1
+  classification: content-hash
+  note: 'capture_fingerprint compared against existing_fingerprint to decide candidate-assertion idempotency (identity= branch is id-construction; fingerprint compare is content-hash).'
+- path: polylogue/api/archive.py
+  function: '<module>._archive_capture_assertion_candidate'
+  call: hashlib.sha256
+  occurrence: 2
+  classification: content-hash
+  note: 'capture_fingerprint compared against existing_fingerprint to decide candidate-assertion idempotency (identity= branch is id-construction; fingerprint compare is content-hash).'
+- path: polylogue/archive/actions/fields.py
+  function: '<module>.make_action_id'
+  call: hash_text_short
+  occurrence: 0
+  classification: identifier
+  note: 'actions view row identity; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/archive/query/execution_control.py
+  function: '<module>.create'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'query_ref cache/log correlation key.'
+- path: polylogue/archive/query/source_freshness.py
+  function: '<module>.aggregate_named_source_byte_lag'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'source-freshness insight object_id key.'
+- path: polylogue/archive/query/source_freshness.py
+  function: '<module>.project_named_source_freshness'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'source-freshness insight object_id key.'
+- path: polylogue/archive/query/transaction.py
+  function: '<module>.decode'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'compares expected_checksum != checksum via hmac.compare_digest -- continuation-token tamper check.'
+- path: polylogue/archive/query/transaction.py
+  function: '<module>.encode'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'checksum written into the continuation token for later decode() comparison.'
+- path: polylogue/archive/query/transaction.py
+  function: '<module>.query_ref'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'query continuation reference key.'
+- path: polylogue/archive/query/transaction.py
+  function: '<module>.result_ref'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'result continuation reference key.'
+- path: polylogue/browser_capture/actions.py
+  function: '<module>._request_sha256'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'action idempotency-key derivation, not compared for drift.'
+- path: polylogue/browser_capture/actions.py
+  function: '<module>.enqueue_action'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'attachment id fallback derived from a digest prefix.'
+- path: polylogue/browser_capture/actions.py
+  function: '<module>.read_action_attachment'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'compares hashlib.sha256(content).hexdigest() != attachment.sha256 -- attachment integrity check.'
+- path: polylogue/browser_capture/capture_jobs.py
+  function: '<module>._census_legacy_orphans'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'legacy-orphan record identity digest.'
+- path: polylogue/browser_capture/capture_jobs.py
+  function: '<module>.canonical_digest'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'generic canonical-digest helper used for capture-job change detection.'
+- path: polylogue/browser_capture/capture_jobs.py
+  function: '<module>.capture_job_scope_namespace'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'capture-job scope namespace key, not compared for drift.'
+- path: polylogue/browser_capture/pairing.py
+  function: '<module>.mint_pairing_code'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'pairing-code secret hash, verified via hmac.compare_digest -- auth/secret domain, not content drift.'
+- path: polylogue/browser_capture/pairing.py
+  function: '<module>.redeem_pairing_code'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'pairing-code secret hash, verified via hmac.compare_digest -- auth/secret domain, not content drift.'
+- path: polylogue/browser_capture/receiver.py
+  function: '<module>.capture_artifact_path'
+  call: hash_text_short
+  occurrence: 0
+  classification: identifier
+  note: 'session id disambiguation on capture; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/browser_capture/receiver.py
+  function: '<module>.capture_dedup_content_hash'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'explicit content-hash dedup key for browser-capture payloads.'
+- path: polylogue/browser_capture/server.py
+  function: '<module>._read_json_body'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'stored as _request_content_hash for capture-request dedup.'
+- path: polylogue/cli/query_verbs.py
+  function: '<module>.mark_verb._apply_marks'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'note-annotation id derived from a digest, PK-style.'
+- path: polylogue/context/compiler.py
+  function: '<module>.compile_query_unit_context_segment'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: '''query-unit:'' + digest -- context segment ref; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/context/compiler.py
+  function: '<module>.context_image_sha256'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'context-image identity digest, cache/lookup key; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/context/compiler.py
+  function: '<module>.context_snapshot_record_from_image'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: '''context-snapshot:'' + digest -- snapshot ref; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/core/query_identity.py
+  function: '<module>._canonical_sort_key'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: 'deterministic sort-key stabilizer for commutative plan children.'
+- path: polylogue/core/query_identity.py
+  function: '<module>.query_hash_for_plan'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: 'expanded-query-plan identity/cache key.'
+- path: polylogue/core/security.py
+  function: '<module>.sanitize_path'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'masked-value display aid for a blocked path -- redaction, not a comparison.'
+- path: polylogue/core/security.py
+  function: '<module>.sanitize_path'
+  call: hashlib.sha256
+  occurrence: 1
+  classification: other
+  note: 'masked-value display aid for a blocked path -- redaction, not a comparison.'
+- path: polylogue/daemon/backup.py
+  function: '<module>._canonical_json_sha256'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'backup manifest integrity digest.'
+- path: polylogue/daemon/backup.py
+  function: '<module>._receipt_evidence'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'manifest_sha256 recorded in the backup verification receipt.'
+- path: polylogue/daemon/backup.py
+  function: '<module>._sha256_file'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'backup file integrity digest.'
+- path: polylogue/daemon/backup.py
+  function: '<module>._verify_archive_file_set_backup'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'compares payload_hash == blob_hash -- restored-blob integrity check.'
+- path: polylogue/daemon/convergence_standing_queries.py
+  function: '<module>._materialize_promoted_finding_drifts'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: '''finding-'' + digest -- deterministic finding id.'
+- path: polylogue/daemon/convergence_standing_queries.py
+  function: '<module>._materialize_watch_evaluation'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: 'rank_hash recorded alongside the watch evaluation snapshot, same id-construction family.'
+- path: polylogue/daemon/convergence_standing_queries.py
+  function: '<module>._watch_result_set_id'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: '''watch-'' + digest -- deterministic result-set id.'
+- path: polylogue/daemon/convergence_standing_queries.py
+  function: '<module>._watch_result_set_id'
+  call: hash_payload
+  occurrence: 1
+  classification: identifier
+  note: '''watch-'' + digest -- deterministic result-set id.'
+- path: polylogue/daemon/http.py
+  function: '<module>._handle_status'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'HTTP ETag cache-validator key, not a content-drift comparison.'
+- path: polylogue/daemon/judgment_automation.py
+  function: '<module>._handoff_assertion_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'deterministic handoff assertion id, PK-style.'
+- path: polylogue/daemon/user_state_http.py
+  function: '<module>._default_annotation_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'default id when the operator omits one; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/daemon/user_state_http.py
+  function: '<module>._default_saved_view_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'default id when the operator omits one; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/daemon/web_auth.py
+  function: '<module>._token_digest'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'session-token digest -- auth domain, not content drift.'
+- path: polylogue/daemon/webui.py
+  function: '<module>.read_asset'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'static-asset ETag/cache key.'
+- path: polylogue/insights/claude_workflow_evidence.py
+  function: '<module>.project_claude_workflow_evidence'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'structured-result ObjectRef identity key.'
+- path: polylogue/insights/claude_workflow_evidence.py
+  function: '<module>.project_claude_workflow_evidence'
+  call: hashlib.sha256
+  occurrence: 1
+  classification: identifier
+  note: 'structured-result ObjectRef identity key.'
+- path: polylogue/insights/claude_workflow_evidence.py
+  function: '<module>.project_claude_workflow_evidence.add_claim'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'work-claim ObjectRef identity key.'
+- path: polylogue/insights/claude_workflow_evidence.py
+  function: '<module>.project_claude_workflow_evidence.add_edge'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'work-edge ObjectRef identity key.'
+- path: polylogue/insights/claude_workflow_materializer.py
+  function: '<module>._corpus_snapshot'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'context-snapshot ObjectRef identity key.'
+- path: polylogue/insights/judgment/blinding.py
+  function: '<module>.blind_items'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: 'blinding-receipt item-order hash, an audit-trail id, not a drift comparison.'
+- path: polylogue/insights/judgment/comparative.py
+  function: '<module>._deterministic_judgment_id'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: 'deterministic judgment id, PK-style.'
+- path: polylogue/insights/judgment/elicitation.py
+  function: '<module>.select_next'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: 'elicitation receipt id, PK-style.'
+- path: polylogue/insights/judgment/rankers.py
+  function: '<module>.ranker_hash'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: 'ranker identity/reference key.'
+- path: polylogue/insights/measurement/canon.py
+  function: '<module>.content_ref'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: 'evidence content-ref id for citation.'
+- path: polylogue/insights/transforms.py
+  function: '<module>._candidate_ref'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'stable evidence-ref id for citation; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/material_protocol/v1/encode.py
+  function: '<module>._content_digest'
+  call: hash_bytes
+  occurrence: 0
+  classification: content-hash
+  note: 'revision content digest written to the manifest for later verify.py comparison.'
+- path: polylogue/material_protocol/v1/encode.py
+  function: '<module>._pack_head'
+  call: hash_bytes
+  occurrence: 0
+  classification: content-hash
+  note: 'head-segment sha256 written to the manifest for later verify.py comparison.'
+- path: polylogue/material_protocol/v1/encode.py
+  function: '<module>._pack_head'
+  call: hash_bytes
+  occurrence: 1
+  classification: content-hash
+  note: 'head-segment sha256 written to the manifest for later verify.py comparison.'
+- path: polylogue/material_protocol/v1/encode.py
+  function: '<module>._pack_segments'
+  call: hash_bytes
+  occurrence: 0
+  classification: content-hash
+  note: 'segment sha256 written to the manifest for later verify.py comparison.'
+- path: polylogue/material_protocol/v1/encode.py
+  function: '<module>._pack_segments'
+  call: hash_bytes
+  occurrence: 1
+  classification: content-hash
+  note: 'segment sha256 written to the manifest for later verify.py comparison.'
+- path: polylogue/material_protocol/v1/encode.py
+  function: '<module>.encode_appended_revision'
+  call: hash_bytes
+  occurrence: 0
+  classification: content-hash
+  note: 'compares candidate_sha != expected_anchor.sha256 -- append-only-edit detection.'
+- path: polylogue/material_protocol/v1/origin_vocab.py
+  function: '<module>.current_origin_vocabulary_digest'
+  call: hash_bytes
+  occurrence: 0
+  classification: content-hash
+  note: 'origin-vocabulary version digest, compared against a manifest-declared vocabulary version.'
+- path: polylogue/material_protocol/v1/verify.py
+  function: '<module>._check_segment'
+  call: hash_bytes
+  occurrence: 0
+  classification: content-hash
+  note: 'compares actual_sha != descriptor.sha256 -- segment integrity check.'
+- path: polylogue/material_protocol/v1/verify.py
+  function: '<module>._walk_records'
+  call: hash_bytes
+  occurrence: 0
+  classification: content-hash
+  note: 'per-record sha256 recorded for anchor resolution/comparison.'
+- path: polylogue/material_protocol/v1/verify.py
+  function: '<module>.resolve_anchor'
+  call: hash_bytes
+  occurrence: 0
+  classification: content-hash
+  note: 'compares actual_sha != anchor.sha256 -- manifest anchor integrity check.'
+- path: polylogue/material_protocol/v1/verify.py
+  function: '<module>.verify_revision'
+  call: hash_bytes
+  occurrence: 0
+  classification: content-hash
+  note: 'compares actual_content_sha != manifest.content_digest -- revision content integrity check.'
+- path: polylogue/mcp/call_log.py
+  function: '<module>._outbox_root'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'archive-identity namespace directory key.'
+- path: polylogue/operations/mutation_transaction.py
+  function: '<module>.compute_plan_hash'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'mutation-plan identity/reference key.'
+- path: polylogue/pipeline/ids.py
+  function: '<module>._attachment_hash_payload'
+  call: hash_bytes
+  occurrence: 0
+  classification: content-hash
+  note: 'feeds session_content_hash (2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md), Table 1 row 1).'
+- path: polylogue/pipeline/ids.py
+  function: '<module>._content_block_payload'
+  call: hash_payload
+  occurrence: 0
+  classification: content-hash
+  note: 'feeds session_content_hash (2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md), Table 1 row 1).'
+- path: polylogue/pipeline/ids.py
+  function: '<module>._session_hash_components'
+  call: hash_payload
+  occurrence: 0
+  classification: content-hash
+  note: 'feeds session_content_hash (2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md), Table 1 row 1).'
+- path: polylogue/pipeline/ids.py
+  function: '<module>._session_tree_hash'
+  call: hash_payload
+  occurrence: 0
+  classification: content-hash
+  note: 'feeds session_content_hash (2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md), Table 1 row 1).'
+- path: polylogue/pipeline/ids.py
+  function: '<module>.session_revision_projection'
+  call: hash_payload
+  occurrence: 0
+  classification: content-hash
+  note: 'feeds session_content_hash / revision projection (2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md), Table 1 row 1).'
+- path: polylogue/pipeline/ids.py
+  function: '<module>.session_revision_projection'
+  call: hash_payload
+  occurrence: 1
+  classification: content-hash
+  note: 'feeds session_content_hash / revision projection (2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md), Table 1 row 1).'
+- path: polylogue/pipeline/ids.py
+  function: '<module>.session_revision_projection'
+  call: hash_payload
+  occurrence: 2
+  classification: content-hash
+  note: 'feeds session_content_hash / revision projection (2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md), Table 1 row 1).'
+- path: polylogue/scenarios/workload.py
+  function: '<module>._identity'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'scenario workload identity key.'
+- path: polylogue/schemas/field_stats/distributions.py
+  function: '<module>.observe'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'hash used for consistent-hash sampling-bucket assignment, not identity or drift detection.'
+- path: polylogue/schemas/generation/dynamic_keys.py
+  function: '<module>.merge_observed_structure_schemas'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'schema-identity digest used as a dedup set key (seen_identities).'
+- path: polylogue/schemas/generation/workload_profiles.py
+  function: '<module>.workload_profile_identity'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'workload-profile identity key.'
+- path: polylogue/schemas/observation_identity.py
+  function: '<module>.bundle_scope_identity'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'bundle-scope identity key, same family as fingerprint_hash but not itself compared.'
+- path: polylogue/schemas/observation_identity.py
+  function: '<module>.fingerprint_hash'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'compared via fingerprint_hash(...) == request.cluster_id -- schema-cluster grouping equality gate; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 10.'
+- path: polylogue/schemas/promotion_audit.py
+  function: '<module>._secret_findings'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'masked-value display digest for a promotion-audit finding -- redaction aid, not a comparison.'
+- path: polylogue/schemas/synthetic/build_batch.py
+  function: '<module>._planted_artifact_facts'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'synthetic corpus raw_sha256 fact, informational identity, not compared.'
+- path: polylogue/schemas/synthetic/core.py
+  function: '<module>._select_structural_variant'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'structural-variant identity key for synthetic corpus generation.'
+- path: polylogue/security/excision.py
+  function: '<module>._receipt_assertion_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'deterministic excision-receipt assertion id, PK-style.'
+- path: polylogue/security/lifecycle.py
+  function: '<module>._request_assertion_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'deterministic excision-request assertion id, PK-style.'
+- path: polylogue/security/secret_scan.py
+  function: '<module>.scan_text_for_secret_candidates'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'secret-candidate span fingerprint, used to build a stable id, not compared.'
+- path: polylogue/security/secret_scan.py
+  function: '<module>.secret_candidate_assertion_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'deterministic secret-candidate assertion id (idempotent re-scan), PK-style.'
+- path: polylogue/sinex/material_adapter.py
+  function: '<module>._parsed_attachment_input'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'attachment blob-sha identity, same family as blob content-addressing.'
+- path: polylogue/sinex/material_adapter.py
+  function: '<module>.encode_parsed_session_publication'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'manifest_digest later reconciled/compared by obligations.py''s load_payload.'
+- path: polylogue/sinex/models.py
+  function: '<module>.request_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'publication request identity key.'
+- path: polylogue/sinex/obligations.py
+  function: '<module>._validate_payload'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'compares actual_manifest_digest != payload.manifest_digest -- publication payload integrity check.'
+- path: polylogue/sinex/obligations.py
+  function: '<module>.load_payload'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'compares stored digest/size against recomputed values -- staged manifest/segment reconciliation check.'
+- path: polylogue/sinex/obligations.py
+  function: '<module>.load_payload'
+  call: hashlib.sha256
+  occurrence: 1
+  classification: content-hash
+  note: 'compares stored digest/size against recomputed values -- staged manifest/segment reconciliation check.'
+- path: polylogue/sinex/obligations.py
+  function: '<module>.stage_payload'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'segment digest used as an INSERT OR IGNORE dedup key.'
+- path: polylogue/sinex/obligations.py
+  function: '<module>.stage_payload_async'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'segment digest used as an INSERT OR IGNORE dedup key.'
+- path: polylogue/sinex/transport.py
+  function: '<module>.publish_revision'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'streaming manifest digest, same reconciliation family as obligations.py.'
+- path: polylogue/sources/live/batch_support.py
+  function: '<module>.fingerprint_file'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'cursor fingerprint, compared to detect truncation/rotation; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 8.'
+- path: polylogue/sources/live/batch_support.py
+  function: '<module>.sha256_range_from_path'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'range fingerprint, same cursor-integrity family as fingerprint_file/tail_hash_from_path.'
+- path: polylogue/sources/live/batch_support.py
+  function: '<module>.tail_hash_and_last_complete_newline_from_path'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'tail-window fingerprint, same family as tail_hash_from_path; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 8.'
+- path: polylogue/sources/live/batch_support.py
+  function: '<module>.tail_hash_and_last_complete_newline_from_path'
+  call: hashlib.sha256
+  occurrence: 1
+  classification: content-hash
+  note: 'tail-window fingerprint, same family as tail_hash_from_path; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 8.'
+- path: polylogue/sources/live/batch_support.py
+  function: '<module>.tail_hash_and_last_complete_newline_from_path'
+  call: hashlib.sha256
+  occurrence: 2
+  classification: content-hash
+  note: 'tail-window fingerprint, same family as tail_hash_from_path; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 8.'
+- path: polylogue/sources/live/batch_support.py
+  function: '<module>.tail_hash_from_path'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'tail-window fingerprint compared to detect append-only growth vs. rewrite; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 8.'
+- path: polylogue/sources/live/batch_support.py
+  function: '<module>.tail_hash_from_path'
+  call: hashlib.sha256
+  occurrence: 1
+  classification: content-hash
+  note: 'tail-window fingerprint compared to detect append-only growth vs. rewrite; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 8.'
+- path: polylogue/sources/parsers/base_support.py
+  function: '<module>._make_attachment_id'
+  call: hash_text
+  occurrence: 0
+  classification: identifier
+  note: 'attachment id fallback; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/sources/parsers/codex.py
+  function: '<module>._sanitize_codex_data_url'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'digest shown inline in sanitized placeholder text for an omitted image -- display aid, not compared.'
+- path: polylogue/sources/parsers/drive_support_attachments.py
+  function: '<module>._attachment_from_inline_data'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: 'attachment dedup key; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/sources/parsers/drive_support_attachments.py
+  function: '<module>._attachment_from_inline_data'
+  call: hash_text_short
+  occurrence: 0
+  classification: identifier
+  note: 'attachment dedup key; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/sources/parsers/drive_support_attachments.py
+  function: '<module>.attachment_from_file_data'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: 'attachment dedup key; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/sources/parsers/drive_support_attachments.py
+  function: '<module>.attachment_from_file_data'
+  call: hash_text_short
+  occurrence: 0
+  classification: identifier
+  note: 'attachment dedup key; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/sources/parsers/drive_support_attachments.py
+  function: '<module>.attachment_from_youtube_video'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: 'attachment dedup key; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/sources/parsers/hermes_identity.py
+  function: '<module>.profile_key'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'profile identity key derivation.'
+- path: polylogue/sources/sqlite_snapshot.py
+  function: '<module>.hermes_profile_raw_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'raw-id key derivation for a Hermes SQLite profile.'
+- path: polylogue/sources/sqlite_snapshot.py
+  function: '<module>.sqlite_source_revision'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'filesystem-state fingerprint for a SQLite source, same family as batch_support.py''s fingerprint_file.'
+- path: polylogue/storage/artifacts/inspection.py
+  function: '<module>.artifact_observation_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'observation-sample identity; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/storage/backup_attestation.py
+  function: '<module>.sign_verification_receipt'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'HMAC-attestation key-id metadata, part of the signing chain (not a content-drift check).'
+- path: polylogue/storage/backup_attestation.py
+  function: '<module>.tier_attestation_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'backup-tier resource identity key.'
+- path: polylogue/storage/backup_attestation.py
+  function: '<module>.verify_verification_receipt'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'HMAC-attestation key-id comparison, part of the signing chain (not a content-drift check).'
+- path: polylogue/storage/blob_integrity.py
+  function: '<module>._raw_backed_recovery_action'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'blob repair recompute-and-compare; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 7.'
+- path: polylogue/storage/blob_integrity.py
+  function: '<module>._restore_expected_hash_from_path'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'blob repair recompute-and-compare; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 7.'
+- path: polylogue/storage/blob_integrity.py
+  function: '<module>._restore_expected_hash_from_source_span'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'blob repair recompute-and-compare; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 7.'
+- path: polylogue/storage/blob_integrity.py
+  function: '<module>._restore_expected_hash_from_source_span'
+  call: hashlib.sha256
+  occurrence: 1
+  classification: content-hash
+  note: 'blob repair recompute-and-compare; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 7.'
+- path: polylogue/storage/blob_integrity.py
+  function: '<module>.replace_raw_backed_blob_reference_debt_from_source'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'blob repair recompute-and-compare; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 7.'
+- path: polylogue/storage/blob_store.py
+  function: '<module>.prepare_from_bytes'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'content-addressing: the digest becomes the blob''s own storage key; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 6.'
+- path: polylogue/storage/blob_store.py
+  function: '<module>.prepare_from_fileobj'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'content-addressing key derivation; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 6.'
+- path: polylogue/storage/blob_store.py
+  function: '<module>.prepare_from_path'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'content-addressing key derivation; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 6.'
+- path: polylogue/storage/blob_store.py
+  function: '<module>.verify'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 're-derives and compares against the expected hash_hex -- blob integrity check; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 6.'
+- path: polylogue/storage/blob_store.py
+  function: '<module>.verify_all'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'bulk blob integrity check; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 6.'
+- path: polylogue/storage/derivation_identity.py
+  function: '<module>._digest'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'derivation-key composition helper, not a drift comparison.'
+- path: polylogue/storage/derivation_identity.py
+  function: '<module>.compose_derivation_key_digest'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'derivation-key composition, PK-style identity.'
+- path: polylogue/storage/embeddings/identity.py
+  function: '<module>.__init__'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'feeds message_embeddings_meta.content_hash freshness comparison; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 2.'
+- path: polylogue/storage/embeddings/identity.py
+  function: '<module>.embedding_input_hash'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'feeds message_embeddings_meta.content_hash freshness comparison; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 2.'
+- path: polylogue/storage/index_generation.py
+  function: '<module>.source_revision_snapshot'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'streaming digest over source.db rows used as an index-generation change-detection fingerprint.'
+- path: polylogue/storage/insights/session/timeline_rows.py
+  function: '<module>._event_id'
+  call: hash_text
+  occurrence: 0
+  classification: identifier
+  note: 'work-event row identity; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/storage/insights/session/timeline_rows.py
+  function: '<module>.phase_id'
+  call: hash_text
+  occurrence: 0
+  classification: identifier
+  note: 'session-phase row identity; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/storage/raw_authority.py
+  function: '<module>._digest'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'raw-authority reconciliation digest, compared for fixed-point convergence.'
+- path: polylogue/storage/raw_authority.py
+  function: '<module>.read_raw_authority_detail'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'compares document_sha256 != requested_revision -- offset-continuation validity check.'
+- path: polylogue/storage/raw_reconciler.py
+  function: '<module>._digest'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'raw reconciliation digest, compared for fixed-point convergence.'
+- path: polylogue/storage/repair.py
+  function: '<module>._authority_rows_digest'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'fixed-point comparison digest over authority row state.'
+- path: polylogue/storage/repair.py
+  function: '<module>._browser_canonical_authority_conflict_witness'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'comparison-style evidence-packet digest for authority-conflict witnesses.'
+- path: polylogue/storage/repair.py
+  function: '<module>._browser_canonical_authority_conflict_witness'
+  call: hashlib.sha256
+  occurrence: 1
+  classification: content-hash
+  note: 'comparison-style evidence-packet digest for authority-conflict witnesses.'
+- path: polylogue/storage/repair.py
+  function: '<module>._browser_origin_copy_raw_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'deterministic raw-id construction for browser-origin copy-forward, not compared.'
+- path: polylogue/storage/repair.py
+  function: '<module>._browser_origin_item_digest'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'comparison-style digest of composed repair-item state.'
+- path: polylogue/storage/repair.py
+  function: '<module>._canonical_browser_origin_head_is_exact'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'blob integrity + session-hash recompute-and-compare.'
+- path: polylogue/storage/repair.py
+  function: '<module>._canonical_browser_origin_head_is_semantically_equivalent'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'blob integrity + session-hash recompute-and-compare.'
+- path: polylogue/storage/repair.py
+  function: '<module>._canonical_browser_origin_head_is_semantically_equivalent'
+  call: hashlib.sha256
+  occurrence: 1
+  classification: content-hash
+  note: 'blob integrity + session-hash recompute-and-compare.'
+- path: polylogue/storage/repair.py
+  function: '<module>._duplicate_raw_identity_proof_digest'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'fixed-point comparison digest for duplicate-raw-identity proof state.'
+- path: polylogue/storage/repair.py
+  function: '<module>._inspect_browser_capture_origin_mismatch'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'blob integrity recompute-and-compare against declared source evidence.'
+- path: polylogue/storage/repair.py
+  function: '<module>._inspect_duplicate_raw_identity'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'blob integrity recompute-and-compare.'
+- path: polylogue/storage/repair.py
+  function: '<module>._inspect_quarantined_accepted_raw'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'blob integrity recompute-and-compare against accepted_revision.'
+- path: polylogue/storage/repair.py
+  function: '<module>._proof_digest'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'fixed-point comparison digest over proof state.'
+- path: polylogue/storage/repair.py
+  function: '<module>._raw_authority_residual'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'fixed-point comparison digest for idempotency check of residual debt.'
+- path: polylogue/storage/repair.py
+  function: '<module>._revision_application_decision_id_is_exact'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'recomputes decision_id and compares to the stored value -- fixed-point check.'
+- path: polylogue/storage/repair.py
+  function: '<module>._stageable_quarantined_census_cohort'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'blob integrity recompute-and-compare against candidate_blob_hash.'
+- path: polylogue/storage/repair.py
+  function: '<module>._verify_browser_origin_copy_forward_source_stage'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'blob integrity recompute-and-compare before copy-forward.'
+- path: polylogue/storage/repair.py
+  function: '<module>.record_browser_canonical_authority_conflict_blockers'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'deterministic blocker-assertion id construction, not compared.'
+- path: polylogue/storage/runtime/__init__.py
+  function: '<module>._make_ref_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: '''ref-'' + digest -- deterministic reference id.'
+- path: polylogue/storage/runtime/archive/records.py
+  function: '<module>.make_id'
+  call: hash_text
+  occurrence: 0
+  classification: identifier
+  note: 'synthetic block-id fallback; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/storage/sqlite/archive_tiers/archive.py
+  function: '<module>._raw_revision_payload_digest_and_size'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'raw revision content digest consumed by raw-authority/repair reconciliation.'
+- path: polylogue/storage/sqlite/archive_tiers/pricing_seed.py
+  function: '<module>._catalog_hash'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'vacuous producer per census -- computed but never read back anywhere (polylogue-w379 tracks the fix); 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 4.'
+- path: polylogue/storage/sqlite/archive_tiers/revision_application.py
+  function: '<module>.decision_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'recomputed and compared for equality by repair.py''s _revision_application_decision_id_is_exact -- fixed-point decision-state check.'
+- path: polylogue/storage/sqlite/archive_tiers/source_write.py
+  function: '<module>.deterministic_blob_hash'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'PK/uniqueness key for raw_sessions blob addressing; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 5.'
+- path: polylogue/storage/sqlite/archive_tiers/source_write.py
+  function: '<module>.deterministic_history_sidecar_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'PK/uniqueness key for history-sidecar rows; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 1 row 5.'
+- path: polylogue/storage/sqlite/archive_tiers/source_write.py
+  function: '<module>.deterministic_raw_session_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'PK/uniqueness key for raw_sessions rows, same family as deterministic_blob_hash.'
+- path: polylogue/storage/sqlite/archive_tiers/user_annotations.py
+  function: '<module>._schema_from_row'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'compares actual_fingerprint != stored_fingerprint -- annotation-schema definition drift check.'
+- path: polylogue/storage/sqlite/archive_tiers/user_write.py
+  function: '<module>._deterministic_id'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'generic deterministic id-from-parts helper, PK/uniqueness consumer.'
+- path: polylogue/storage/sqlite/archive_tiers/write.py
+  function: '<module>._attachment_position'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'attachment ordering key derived from a digest, not a drift comparison.'
+- path: polylogue/storage/sqlite/archive_tiers/write.py
+  function: '<module>._hash_bytes'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'shared local hex-digest helper backing _message_content_hash/_block_content_hash -- message/block content-hash consumed by embedding-freshness (materialization.py) and citation-anchor drift checks (block_anchor.py); census Table 1 rows 2-3.'
+- path: polylogue/storage/sqlite/archive_tiers/write.py
+  function: '<module>._message_signature_from_blocks'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'per-block signature feeding message content-hash composition (write.py); census Table 1 row 2.'
+- path: polylogue/storage/sqlite/migration_runner.py
+  function: '<module>._canonical_json_sha256'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'migration manifest integrity digest.'
+- path: polylogue/storage/sqlite/migration_runner.py
+  function: '<module>._sha256_file'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'migration backup-file integrity digest.'
+- path: polylogue/storage/sqlite/queries/artifacts.py
+  function: '<module>._materialize_hook_events'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: '''hook:'' + digest -- deterministic hook-event row id.'
+- path: polylogue/storage/sqlite/queries/raw_writes.py
+  function: '<module>.save_raw_session'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 're-hashes an already-hashed blob_hash value when its byte length is not 32 -- a sharding/bucketing transform, not a fresh content hash (flagged as unverified-in-depth by the 2026-07-09 census).'
+- path: polylogue/storage/sqlite/query_objects.py
+  function: '<module>.membership_merkle_root'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: 'merkle-style aggregate key over a result-set membership list, used as a cache/lookup key.'
+- path: polylogue/storage/sqlite/query_objects.py
+  function: '<module>.membership_merkle_root'
+  call: hash_payload
+  occurrence: 1
+  classification: identifier
+  note: 'merkle-style aggregate key over a result-set membership list, used as a cache/lookup key.'
+- path: polylogue/storage/sqlite/query_objects.py
+  function: '<module>.membership_merkle_root'
+  call: hash_payload
+  occurrence: 2
+  classification: identifier
+  note: 'merkle-style aggregate key over a result-set membership list, used as a cache/lookup key.'
+- path: polylogue/storage/sqlite/query_objects.py
+  function: '<module>.put_result_set'
+  call: hash_payload
+  occurrence: 0
+  classification: identifier
+  note: 'result-set row identity key.'
+- path: polylogue/surfaces/payloads.py
+  function: '<module>._delegation_preview'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'digest of a truncated text preview -- informational display aid, not compared.'
+- path: polylogue/surfaces/payloads.py
+  function: '<module>.from_document'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'informational sha256 of truncated JSON payload metadata, not compared.'
+- path: polylogue/surfaces/payloads.py
+  function: '<module>.from_invalid_ref'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'informational sha256 of an oversized/invalid ref for diagnostics, not compared.'
+- path: polylogue/surfaces/payloads.py
+  function: '<module>.from_oversized_ref'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'informational sha256 for diagnostics, not compared.'
+- path: polylogue/surfaces/payloads.py
+  function: '<module>.from_text'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: other
+  note: 'informational sha256 of truncated text payload metadata, not compared.'
+- path: polylogue/surfaces/payloads.py
+  function: '<module>.search_cursor_request_identity'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'search-cursor pagination identity key.'

--- a/tests/unit/devtools/test_verify_hash_boundary_census.py
+++ b/tests/unit/devtools/test_verify_hash_boundary_census.py
@@ -1,0 +1,246 @@
+"""Tests for the hash-boundary registry lint (polylogue-okpn).
+
+The lint is the register-or-fail mechanism the 2026-07-09 hash-boundary
+census (docs/audits/2026-07-09-hash-boundary-census.md) deferred as a
+follow-up: a new hashlib.*/core.hashing call site must be registered in
+docs/plans/hash-boundary-registry.yaml, or the gate fails. These tests prove
+it catches a new unregistered call site, accepts a registered one, and
+rejects a stale registry entry, using synthetic fixture trees (not the real
+repo, so a future edit to real source can't accidentally make this test
+vacuous).
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from devtools import verify_hash_boundary_census
+
+
+def _write(root: Path, relative: str, content: str) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(content), encoding="utf-8")
+
+
+def _run_json(root: Path, capsys: pytest.CaptureFixture[str], *, registry: Path | None = None) -> dict[str, Any]:
+    args = ["--json", "--root", str(root)]
+    if registry is not None:
+        args += ["--registry", str(registry)]
+    rc = verify_hash_boundary_census.main(args)
+    payload: dict[str, Any] = json.loads(capsys.readouterr().out)
+    payload["_rc"] = rc
+    return payload
+
+
+def test_flags_new_unregistered_hashlib_call(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(
+        tmp_path,
+        "polylogue/storage/example_write.py",
+        """
+        import hashlib
+
+
+        def compute_digest(value):
+            return hashlib.sha256(value.encode()).hexdigest()
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys)
+
+    assert payload["_rc"] == 1
+    assert payload["ok"] is False
+    violations = payload["violations"]
+    assert len(violations) == 1
+    assert violations[0]["path"] == "polylogue/storage/example_write.py"
+    assert violations[0]["function"] == "<module>.compute_digest"
+    assert violations[0]["call"] == "hashlib.sha256"
+
+
+def test_flags_new_unregistered_hashing_helper_call(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(
+        tmp_path,
+        "polylogue/storage/example_ids.py",
+        """
+        from polylogue.core.hashing import hash_text
+
+
+        def make_id(value):
+            return hash_text(value)
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys)
+
+    assert payload["_rc"] == 1
+    violations = payload["violations"]
+    assert len(violations) == 1
+    assert violations[0]["call"] == "hash_text"
+
+
+def test_registered_site_passes_with_matching_entry(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(
+        tmp_path,
+        "polylogue/storage/example_write.py",
+        """
+        import hashlib
+
+
+        def compute_digest(value):
+            return hashlib.sha256(value.encode()).hexdigest()
+        """,
+    )
+    registry = tmp_path / "docs" / "plans" / "hash-boundary-registry.yaml"
+    _write(
+        tmp_path,
+        "docs/plans/hash-boundary-registry.yaml",
+        """
+        entries:
+        - path: polylogue/storage/example_write.py
+          function: <module>.compute_digest
+          call: hashlib.sha256
+          occurrence: 0
+          classification: identifier
+          note: 'test fixture registration'
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys, registry=registry)
+
+    assert payload["_rc"] == 0
+    assert payload["ok"] is True
+    assert payload["registered"] == 1
+    assert payload["violations"] == []
+    assert payload["stale_registry_entries"] == []
+
+
+def test_stale_registry_entry_is_rejected(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A registry entry with no matching call site (the call was removed, or
+    edited) must fail the gate too -- otherwise the registry only ever grows
+    and stops meaning anything."""
+    _write(
+        tmp_path,
+        "polylogue/storage/example_write.py",
+        """
+        def compute_digest(value):
+            return value
+        """,
+    )
+    registry = tmp_path / "docs" / "plans" / "hash-boundary-registry.yaml"
+    _write(
+        tmp_path,
+        "docs/plans/hash-boundary-registry.yaml",
+        """
+        entries:
+        - path: polylogue/storage/example_write.py
+          function: <module>.compute_digest
+          call: hashlib.sha256
+          occurrence: 0
+          classification: identifier
+          note: 'no longer matches any call site in this function'
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys, registry=registry)
+
+    assert payload["_rc"] == 1
+    assert payload["ok"] is False
+    assert len(payload["stale_registry_entries"]) == 1
+    assert payload["stale_registry_entries"][0]["function"] == "<module>.compute_digest"
+
+
+def test_unknown_classification_is_rejected(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write(
+        tmp_path,
+        "polylogue/storage/example_write.py",
+        """
+        import hashlib
+
+
+        def compute_digest(value):
+            return hashlib.sha256(value.encode()).hexdigest()
+        """,
+    )
+    registry = tmp_path / "docs" / "plans" / "hash-boundary-registry.yaml"
+    _write(
+        tmp_path,
+        "docs/plans/hash-boundary-registry.yaml",
+        """
+        entries:
+        - path: polylogue/storage/example_write.py
+          function: <module>.compute_digest
+          call: hashlib.sha256
+          occurrence: 0
+          classification: not-a-real-tag
+          note: 'bad classification'
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys, registry=registry)
+
+    assert payload["_rc"] == 1
+    assert payload["ok"] is False
+    assert len(payload["malformed_registry_entries"]) == 1
+
+
+def test_hashing_definition_file_own_hashlib_calls_are_excluded(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """core/hashing.py's own hashlib calls implement the helpers themselves
+    and must not be double-counted as separate producer sites."""
+    _write(
+        tmp_path,
+        "polylogue/core/hashing.py",
+        """
+        import hashlib
+
+
+        def hash_text(text):
+            return hashlib.sha256(text.encode()).hexdigest()
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys)
+
+    assert payload["_rc"] == 0
+    assert payload["sites_scanned"] == 0
+
+
+def test_files_under_a_test_directory_component_are_excluded(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Matches the scanner's ``"test" in path.parts`` exclusion (same rule as
+    verify_degrade_loudly.py) -- a path component that is exactly ``test``."""
+    _write(
+        tmp_path,
+        "polylogue/storage/test/fixture.py",
+        """
+        import hashlib
+
+
+        def make_fixture_digest():
+            return hashlib.sha256(b"x").hexdigest()
+        """,
+    )
+
+    payload = _run_json(tmp_path, capsys)
+
+    assert payload["_rc"] == 0
+    assert payload["sites_scanned"] == 0
+
+
+def test_real_repo_registry_is_internally_consistent(capsys: pytest.CaptureFixture[str]) -> None:
+    """The committed docs/plans/hash-boundary-registry.yaml must currently
+    match the real repo exactly -- no unregistered sites, no stale entries.
+    This is the gate that runs in ``devtools verify --quick``."""
+    assert verify_hash_boundary_census.main(["--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["violations"] == []
+    assert payload["stale_registry_entries"] == []
+    assert payload["malformed_registry_entries"] == []


### PR DESCRIPTION
## Summary

Builds the register-or-fail lint that the 2026-07-09 hash-boundary census
(docs/audits/2026-07-09-hash-boundary-census.md, polylogue-9e5.6) deferred to
a follow-up: a new `hashlib.sha256`/`sha1`/`md5`/`blake2*`/`sha3_*` call or a
new `hash_text`/`hash_text_short`/`hash_payload`/`hash_bytes`/`hash_file` call
site in `polylogue/` must now be registered in a machine-readable registry, or
`devtools verify --quick` fails.

## Problem

The census's own "Register-or-fail lint" section named three open design
questions rather than building the check in that pass: registry format
(prose markdown table vs. a dedicated machine-readable file), whether
ID-generation-only sites need the same schema as content-hash drift checks,
and how to keep the check cheap enough for the pre-push `--quick` gate.
Without the gate, new hash usage can silently appear ungoverned outside the
census's inventory.

## Solution

- **Registry format**: `docs/plans/hash-boundary-registry.yaml`, keyed by
  `(path, function qualname, call, occurrence-within-function)` — not line
  number, so unrelated line-shift churn doesn't require re-numbering
  entries. This follows the exact convention already established by
  `docs/plans/degrade-loudly-allowlist.yaml` (AST-discovered sites, one-line
  rationale per entry) rather than having the lint regex the prose census
  table.
- **Classification granularity**: four tags —
  - `content-hash`: the digest's inputs are compared for drift/integrity/
    dedup and a real, reachable decision is gated on match/mismatch.
  - `identifier`: the digest derives only a stable identifier/uniqueness
    key, never compared for drift — a deliberately lighter contract than
    `content-hash`, resolving the bead's second open question.
  - `other`: HMAC/auth-token digests, redaction/display aids, informational
    one-shot checksums, or a re-hash of an already-hashed value.
  - `baseline-unclassified`: grandfathered tracked debt, following the same
    convention as `docs/plans/docs-coverage-baseline.yaml` — new call sites
    must be properly classified, not added here as a rubber stamp.
- **`devtools/verify_hash_boundary_census.py`**: AST scan of `polylogue/`
  (excluding tests and `core/hashing.py`'s own definitional hashlib calls,
  which implement the helpers rather than constituting separate producer
  sites) for the call shapes above, diffed against the registry. Fails on
  any unregistered site (actionable message naming the exact `file:line`)
  or any stale registry entry (so the registry can't silently accumulate
  dead rows). Wired into `devtools verify --quick` next to
  `verify degrade-loudly` — same cost class (~2.6s warm vs. ~1.2s for
  degrade-loudly).
- **Registry seeding**: a fresh AST re-scan against current master found
  189 producer call sites (grown from the census's 65 — real feature work
  landed across storage/repair, backup attestation, the SinEx material
  protocol, etc. in the 18 days since the census). All 189 were classified
  by direct source inspection during this PR (zero `baseline-unclassified`
  fallbacks needed) rather than mass-registered as debt.

## Verification

- `python -m devtools.verify_hash_boundary_census --json` → 189 scanned, 189
  registered, 0 unregistered, 0 stale, 0 malformed.
- Injected a temporary unregistered `hashlib.sha256` call into
  `polylogue/core/security.py` → lint fails with the exact `file:line` and a
  fix-it message naming the registry path; reverting the injection makes it
  pass again (both the failure and recovery paths were exercised manually
  before being captured as fixture-based tests).
- `devtools test tests/unit/devtools/test_verify_hash_boundary_census.py` →
  8 passed (new hashlib call, new helper call, registered-site pass,
  stale-entry rejection, unknown-classification rejection,
  `core/hashing.py`-definition exclusion, test-directory exclusion, and a
  real-registry-consistency check mirroring the committed state).
- `devtools render all --check` → all surfaces sync OK.
- `devtools verify --quick` → exit 0; `verify hash-boundary-census` step is
  2.58s of a 45.09s total run.
- `ruff format --check` / `ruff check` / `mypy --strict` on touched files →
  clean.

Ref polylogue-okpn