### PR TITLE
docs(sources): document Drive/Gemini detector canonicalization

### DIFF
--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -149,6 +149,24 @@ def is_stream_record_provider(source_path: str | None, provider: str | Provider 
 
 
 def _looks_like_gemini_mapping(record: PayloadRecord) -> bool:
+    """Detect the Drive/Gemini chunked-prompt shape (polylogue-zkmi).
+
+    Despite the name, this is not a separate Gemini-specific check layered
+    on top of an unused Drive detector: ``drive.py`` owns the single
+    structural detector (``looks_like``) for the ``chunkedPrompt``/``chunks``
+    shape shared by both wire families, and this function is that detector's
+    sole call site in auto-detection. The result is intentionally always
+    surfaced as ``Provider.GEMINI`` here, never ``Provider.DRIVE``:
+    ``Provider.GEMINI`` and ``Provider.DRIVE`` are a non-injective fiber over
+    the same ``Origin.AISTUDIO_DRIVE`` (see ``core/sources.py``'s
+    ``_PROVIDER_TO_ORIGIN``/``provider_from_origin`` notes), and ``GEMINI``
+    is the documented canonical member of that fiber, so auto-detection has
+    no shape-based reason to distinguish them. ``Provider.DRIVE`` remains a
+    reachable value elsewhere -- pre-existing raw rows and explicit source
+    configs, see ``revision_backfill._PATH_INDEPENDENT_PARSE_PROVIDERS`` and
+    ``live/batch_support._large_non_jsonl_path_can_stream`` -- it is simply
+    never *produced* by this detector.
+    """
     return drive.looks_like(record)
 
 

--- a/polylogue/sources/parsers/drive.py
+++ b/polylogue/sources/parsers/drive.py
@@ -421,7 +421,12 @@ def has_chunk_container(payload: object) -> bool:
 
 
 def looks_like(payload: object) -> bool:
-    """Return True if payload looks like a Drive / Gemini chunkedPrompt export."""
+    """Return True if payload looks like a Drive / Gemini chunkedPrompt export.
+
+    Called from ``dispatch._looks_like_gemini_mapping`` -- that is this
+    detector's sole auto-detection call site (polylogue-zkmi); it is not
+    dead code despite the differently-named wrapper.
+    """
     record = json_document(payload)
     prompt = json_document(record.get("chunkedPrompt"))
     if prompt and _looks_like_chunks(prompt.get("chunks"), allow_empty=True):


### PR DESCRIPTION
## Summary

Investigates and closes the documentation gap flagged by polylogue-zkmi: adds
docstrings explaining that `drive.looks_like()` IS wired into auto-detection
(the bead's premise had gone stale) and why the wrapper always reports
`Provider.GEMINI`.

## Problem

polylogue-zkmi flagged `drive.looks_like()` (`polylogue/sources/parsers/drive.py`)
as dead code never called from `_detect_provider_from_record()`
(`polylogue/sources/dispatch.py`), implying every Drive-format file is detected
as Gemini and only re-routed to Drive during parsing.

That premise no longer matches the code. PR #3044 (commit `1d3145afa5`,
2026-07-17 — one day after the bead was filed) already changed
`_looks_like_gemini_mapping()` to delegate to `drive.looks_like()` instead of
duplicating its shape check inline:

```python
def _looks_like_gemini_mapping(record: PayloadRecord) -> bool:
    return drive.looks_like(record)
```

So `drive.looks_like()` runs on every record via this call site — it is not
dead code, just reachable through a confusingly-named wrapper. I also checked
`parse_drive_payload()` (the "re-detection during parsing" the bead
referenced): it does not re-detect Drive vs Gemini either — it reuses
whatever provider was already resolved and only calls `detect_provider()`
recursively for nested sub-records. There is no "Gemini-first, Drive-later"
behavior anywhere in current code.

## Solution

What remained genuinely undocumented: `_looks_like_gemini_mapping()` always
reports `Provider.GEMINI`, never `Provider.DRIVE`, even though the shape
check it delegates to lives in `drive.py`. This is intentional:
`Provider.GEMINI` and `Provider.DRIVE` are a non-injective fiber over the
same `Origin.AISTUDIO_DRIVE` (`core/sources.py`'s `_PROVIDER_TO_ORIGIN` /
`provider_from_origin`), and `GEMINI` is the documented canonical member, so
shape-based auto-detection has no reason to distinguish them.
`Provider.DRIVE` remains reachable elsewhere — pre-existing raw rows and
explicit source configs (`revision_backfill._PATH_INDEPENDENT_PARSE_PROVIDERS`,
`live/batch_support._large_non_jsonl_path_can_stream`) — it is simply never
*produced* by this detector.

Added docstrings at both ends of the call (`dispatch.py`'s
`_looks_like_gemini_mapping`, `drive.py`'s `looks_like`) explaining the
delegation, the call site, and the canonicalization rationale. This matches
the bead's acceptance criteria option to "document the design as intentional
at the call site" rather than rewire detection or delete anything — no
behavior change.

## Verification

- `devtools test tests/unit/sources/test_dispatch_ordering.py tests/unit/sources/test_gemini_chunked_prompt_contract.py tests/unit/sources/test_parsers_props.py tests/unit/sources/test_parser_crashlessness.py` → 93 passed
- `devtools verify --quick` → exit 0 (format, lint, mypy --strict, render all --check, and all other quick-gate checks green)

Ref polylogue-zkmi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for automatic detection of Drive/Gemini chunked-prompt payloads.
  * Documented how detection maps payloads to the Gemini provider.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->