### PR TITLE
refactor(api): delete 3 zero/tests-only facade methods

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -1732,44 +1732,6 @@ def _archive_judge_assertion_candidates(
         raise RuntimeError(f"failed to judge assertion candidates: {exc}") from exc
 
 
-def _archive_emit_pathology_assertions(
-    config: Config,
-    findings_by_session: Mapping[str, Sequence[Any]],
-) -> int:
-    """Upsert pathology findings as candidate assertions in ``user.db`` (#2383).
-
-    Returns the number of candidate assertion rows written. Idempotent: the
-    deterministic assertion id means re-emitting identical findings updates the
-    same candidate rows rather than duplicating them.
-    """
-
-    from polylogue.storage.sqlite.archive_tiers.user_write import (
-        upsert_pathology_findings_as_assertions,
-    )
-
-    if not findings_by_session:
-        return 0
-    user_db = _active_archive_root(config) / "user.db"
-    if not user_db.exists():
-        raise ValueError("assertion user tier is not initialized")
-    emitted = 0
-    try:
-        conn = open_connection(user_db)
-        conn.row_factory = sqlite3.Row
-        try:
-            for session_id, findings in findings_by_session.items():
-                if not findings:
-                    continue
-                envelopes = upsert_pathology_findings_as_assertions(conn, session_id, list(findings))
-                emitted += len(envelopes)
-            conn.commit()
-        finally:
-            conn.close()
-    except sqlite3.Error as exc:
-        raise RuntimeError(f"failed to emit pathology assertions: {exc}") from exc
-    return emitted
-
-
 def _archive_count_table_rows(conn: Any, table_name: str) -> int | None:
     row = conn.execute(
         "SELECT 1 FROM sqlite_master WHERE type IN ('table', 'view') AND name = ? LIMIT 1",
@@ -2491,69 +2453,6 @@ class PolylogueArchiveMixin:
             if digest is not None:
                 projections.append(digest.run_projection)
         return compile_pathology_report(projections)
-
-    async def materialize_pathology_assertions(
-        self,
-        spec: SessionQuerySpec | None = None,
-        *,
-        limit: int | None = None,
-    ) -> int:
-        """Emit pathology findings as candidate assertions queryable via #2006 (#2383).
-
-        Runs the deterministic detectors over a matched session scope (the same
-        path :meth:`pathology_report` uses) and upserts each finding as a private,
-        non-injected ``AssertionKind.PATHOLOGY`` candidate in ``user.db``. The
-        candidates are then queryable through the standard assertion-claims surface
-        (``list_assertion_claims(kinds="pathology")``) and promotable through the
-        existing accept/reject/defer lifecycle (Ref #2182) — nothing is
-        auto-injected into agent context. Returns the number of candidate rows
-        written. Idempotent by deterministic assertion id. The analysis cap
-        defaults to 200 sessions.
-        """
-        from polylogue.insights.pathology import detect_session_pathologies
-
-        cap = limit if limit is not None and limit > 0 else 200
-        summaries = await run_archive_read(
-            _active_archive_root(self.config),
-            operation="insights.pathology_assertions.scope",
-            arguments={"spec": spec, "limit": cap},
-            work=lambda archive: (
-                _archive_list_summaries_for_spec(archive, spec, default_limit=1_000_000)
-                if spec is not None and spec.has_filters()
-                else archive.list_summaries(limit=1_000_000)
-            ),
-            page_size=cap,
-            projection="session-scope",
-            workload_class="scan",
-        )
-
-        session_ids: list[str] = []
-        seen: set[str] = set()
-        for summary in summaries:
-            if summary.session_id in seen:
-                continue
-            seen.add(summary.session_id)
-            session_ids.append(summary.session_id)
-
-        matched = len(session_ids)
-        analyzed_ids = session_ids[:cap]
-        if matched > cap:
-            logger.warning(
-                "materialize_pathology_assertions truncated: matched=%d cap=%d dropped=%d dropped_preview=%s",
-                matched,
-                cap,
-                matched - cap,
-                session_ids[cap : cap + 5],
-            )
-        findings_by_session: dict[str, list[Any]] = {}
-        for sid in analyzed_ids:
-            digest = await self._session_digest(sid)
-            if digest is None:
-                continue
-            findings = detect_session_pathologies(digest.run_projection)
-            if findings:
-                findings_by_session[sid] = findings
-        return _archive_emit_pathology_assertions(self.config, findings_by_session)
 
     async def portfolio_bundle(
         self,
@@ -4208,27 +4107,17 @@ class PolylogueArchiveMixin:
                 rows.append(row)
         return rows
 
-    async def get_actions(self, session_id: str) -> tuple[Action, ...]:
-        """Derive a session's actions from its content blocks.
-
-        ``index.db`` exposes an ``actions`` view; these actions
-        are derived on read from the session's tool-use/tool-result blocks —
-        the same source the archive materializer hashed into durable rows.
-        Returns an empty tuple when the session is absent.
-        """
-        session = await self.get_session(session_id)
-        if session is None:
-            return ()
-        return _actions_for_session(session)
-
     async def get_actions_batch(
         self,
         session_ids: builtins.list[str],
     ) -> dict[str, tuple[Action, ...]]:
-        """Batch counterpart of :meth:`get_actions`.
+        """Derive actions for a batch of sessions from their content blocks.
 
-        Missing sessions are omitted from the result mapping, mirroring
-        the archive repository batch reader.
+        ``index.db`` exposes an ``actions`` view; these actions are derived on
+        read from each session's tool-use/tool-result blocks — the same
+        source the archive materializer hashed into durable rows. Missing
+        sessions are omitted from the result mapping, mirroring the archive
+        repository batch reader.
         """
         sessions = await self.get_sessions(session_ids)
         return {str(session.id): _actions_for_session(session) for session in sessions}
@@ -6138,16 +6027,6 @@ class PolylogueArchiveMixin:
             operation="user_state.view.get",
             arguments={"view_id": view_id},
             work=lambda archive: archive.get_view(view_id),
-            projection="saved-view",
-        )
-
-    async def get_view_by_name(self, name: str) -> dict[str, str] | None:
-        """Get a saved view by name."""
-        return await run_archive_read(
-            _active_archive_root(self.config),
-            operation="user_state.view_by_name.get",
-            arguments={"name": name},
-            work=lambda archive: archive.get_view_by_name(name),
             projection="saved-view",
         )
 

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -335,7 +335,6 @@ _ARCHIVE_FACADE_ROUTES: dict[str, tuple[str, str, str]] = {
     ),
     "find_stuck_session_latency_profile_insights": ("archive_routed", "index", "reads latency profiles from index.db"),
     "explain_query_expression": ("archive_routed", "index", "explains query DSL parsing and lowering"),
-    "get_actions": ("archive_direct", "index", "derives actions from index.db content blocks"),
     "get_actions_batch": (
         "archive_direct",
         "index",
@@ -366,7 +365,6 @@ _ARCHIVE_FACADE_ROUTES: dict[str, tuple[str, str, str]] = {
     "get_stats_by": ("archive_direct", "index", "groups session counts from index.db"),
     "get_thread": ("archive_routed", "index", "reads session topology from index.db"),
     "get_view": ("archive_routed", "user", "reads saved views through user.db"),
-    "get_view_by_name": ("archive_routed", "user", "reads saved views through user.db"),
     "get_thread_insight": ("archive_routed", "index", "reads work threads from index.db"),
     "get_workspace": ("archive_routed", "user", "reads workspaces through user.db"),
     "health_check": ("archive_routed", "index", "returns archive tier/index readiness"),
@@ -415,11 +413,6 @@ _ARCHIVE_FACADE_ROUTES: dict[str, tuple[str, str, str]] = {
     "post_blackboard_note": ("archive_routed", "user", "writes blackboard notes through user.db"),
     "postmortem_bundle": ("archive_routed", "index", "compiles postmortem bundles from archive-routed session reads"),
     "pathology_report": ("archive_routed", "index", "compiles pathology reports from archive-routed projections"),
-    "materialize_pathology_assertions": (
-        "archive_routed",
-        "user",
-        "writes pathology candidate assertions through user.db",
-    ),
     "portfolio_bundle": ("archive_routed", "index", "builds portfolio bundles from archive-routed session reads"),
     "provider_usage_report": ("archive_routed", "index", "delegates to the provider usage report archive helper"),
     "parse_sources": ("archive_routed", "source", "writes source.db and index.db directly"),

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -97,7 +97,6 @@ READ_BY_ID_EMPTY_METHODS: frozenset[str] = frozenset(
         "get_session_tree",
         "get_raw_artifacts_for_session",
         "bulk_get_messages",
-        "get_actions",
     }
 )
 
@@ -206,7 +205,6 @@ BESPOKE_METHODS: frozenset[str] = frozenset(
         "get_annotation",
         "save_view",
         "get_view",
-        "get_view_by_name",
         "delete_view",
         "save_workspace",
         "get_workspace",
@@ -259,7 +257,6 @@ BESPOKE_METHODS: frozenset[str] = frozenset(
         "session_correlation_payload",
         # Pathology and portfolio read methods added in recent PRs.
         "pathology_report",
-        "materialize_pathology_assertions",
         "portfolio_bundle",
         # Session analysis primitives sunk from the MCP-only surface into the
         # shared facade (#1691 / polylogue-9e5.24) -- covered by
@@ -1633,12 +1630,12 @@ async def test_list_assertion_claims_filters_lifecycle_claims(tmp_path: Path) ->
         await archive.close()
 
 
-async def test_get_actions_derives_from_archive_blocks(tmp_path: Path) -> None:
-    """``get_actions`` derives tool invocations from content blocks.
+async def test_get_actions_batch_derives_from_archive_blocks(tmp_path: Path) -> None:
+    """``get_actions_batch`` derives tool invocations from content blocks.
 
     Archives have no materialized ``actions`` table; the facade
     rebuilds actions on read from the session's tool-use blocks. This pins that
-    derivation contract (single, batch, and the missing-id empty cases).
+    derivation contract (batch and the missing-id empty cases).
     """
     archive = _archive(tmp_path)
     with ArchiveStore(archive.config.archive_root) as archive_db:
@@ -1669,14 +1666,10 @@ async def test_get_actions_derives_from_archive_blocks(tmp_path: Path) -> None:
         assert len(summaries) == 1
         native_id = str(summaries[0].id)
 
-        actions = await archive.get_actions(native_id)
-        assert [action.tool_name for action in actions] == ["Bash"]
-
         batch = await archive.get_actions_batch([native_id])
-        assert batch[native_id] == actions
+        assert [action.tool_name for action in batch[native_id]] == ["Bash"]
 
-        # Unknown IDs: empty tuple, and omitted from the batch mapping.
-        assert await archive.get_actions("nonexistent") == ()
+        # Unknown IDs are omitted from the batch mapping.
         assert await archive.get_actions_batch(["nonexistent"]) == {}
     finally:
         await archive.close()
@@ -5110,7 +5103,6 @@ async def test_archive_tiers_api_reader_artifacts_write_user_tier(tmp_path: Path
         view_renamed_id = await archive.save_view("view-v2", "Needs Review", '{"provider":"codex","tag":"second"}')
         view = await archive.get_view("view-v1")
         replaced_view = await archive.get_view("view-v2")
-        view_by_name = await archive.get_view_by_name("Needs Review")
         views = await archive.list_views()
 
         pack_created = await archive.create_recall_pack(
@@ -5159,7 +5151,6 @@ async def test_archive_tiers_api_reader_artifacts_write_user_tier(tmp_path: Path
         assert view_renamed_id is False
         assert view is None
         assert replaced_view is not None
-        assert view_by_name == replaced_view
         assert views == [replaced_view]
         assert json.loads(replaced_view["query_json"]) == {"provider": "codex", "tag": "second"}
         assert pack_created is True


### PR DESCRIPTION
## Summary
Deletes 3 confirmed-dead `Polylogue` facade methods and documents keep-with-rationale for 2 borderline candidates, per a fresh re-verification against current master (the prior audit was over two weeks old and this repo has had significant churn since).

## Problem
`polylogue-9e5.14` flagged 5 facade methods with weak/no call sites:
`materialize_pathology_assertions` (zero consumers), `get_actions` (tests-only), `get_view_by_name` (tests-only), plus two borderline cases `export_otel` and `bulk_get_messages` needing individual review before deciding. `polylogue-kzld` asked for a fresh re-verification (not trusting the audit) and action per method.

## Solution
- **`materialize_pathology_assertions`** — deleted. Confirmed zero call sites anywhere including tests; the only hit was a name literal in a `KNOWN_METHODS` contract-test enumeration set, not an invocation. Its private helper `_archive_emit_pathology_assertions` (sole caller) was deleted too. The underlying storage primitive `upsert_pathology_findings_as_assertions` has independent callers (`storage/repair.py`) and its own dedicated tests, so it is untouched.
- **`get_actions`** — deleted. Confirmed tests-only in production code: `get_actions_batch` is the only production-reachable sibling (used by `cli/query_semantic.py`) and does not call `get_actions` internally — they're independent implementations sharing a private `_actions_for_session` helper. Trimmed the shared contract test to exercise only the batch path plus the missing-id empty case; the block-derivation contract itself remains fully covered.
- **`get_view_by_name`** (facade-level, `api/archive.py`) — deleted, tests-only (1 test call site). Important nuance found during re-verification: `ArchiveStore.get_view_by_name` at the storage tier is a *different* method with the same name, called from `operations/mutation_actuators.py`'s `SavedViewSaveActuator` (collision detection on view rename) — that one is genuinely load-bearing production code and was left completely untouched.
- **`export_otel`** (borderline) — **kept**. It backs a dedicated 239-line `telemetry/otel_projection.py` module, is documented as an intentional architecture decision in `docs/search.md` (outbound OTel-shaped projection, worked example included), and is the concrete implementation surface for the open, tracked bead `polylogue-wmj` ("OTel GenAI trace export lane"). This reads as a young library feature awaiting its first consumer, not orphaned scaffolding — added ~5 weeks ago with full behavioral test coverage, not merely enumerated in a contract list.
- **`bulk_get_messages`** (borderline) — **kept**. Its "one internal caller" (`polylogue/api/sync/sessions.py`'s `SyncSessionQueriesMixin.bulk_get_messages`) is the public sync-API wrapper actually invoked in production by `sinity-lynchpin`'s `lynchpin/sources/polylogue.py:conversation_transcripts()` via `_polylogue_client().bulk_get_messages(...)`. Genuinely load-bearing external-consumer code, not dead.

## Verification
- `ruff check` / `ruff format --check` on all 3 touched files: clean.
- `mypy --strict polylogue/api/archive.py polylogue/cli/commands/status.py`: `Success: no issues found in 2 source files`.
- `devtools test tests/unit/api/test_facade_contracts.py`: `277 passed`.
- `devtools test tests/unit/cli/commands/test_status.py`: `92 passed`.
- `devtools render all --check`: all surfaces `sync OK`, no `out of sync` lines.
- `devtools verify --quick`: `exit_code: 0` (all 17 steps green), also ran again automatically via the pre-push hook.

Ref polylogue-kzld