### PR TITLE
fix(storage): scope duplicate-raw-identity proof to its own logical key

### DIFF
--- a/polylogue/storage/raw_reconciler.py
+++ b/polylogue/storage/raw_reconciler.py
@@ -497,6 +497,7 @@ def _classify_frontier(
                 blob_store.root.parent,
                 raw_id,
                 duplicate_siblings[0],
+                str(row["logical_source_key"]),
             )
         if duplicate_item.status not in {"eligible", "already_repaired"}:
             raise RuntimeError(f"duplicate alias lacks an exact strategy proof: {duplicate_item.reason}")
@@ -1111,20 +1112,25 @@ def _apply_strategy(
         canonical_ids = tuple(raw_id for raw_id in item.input_raw_ids if raw_id != item.raw_id)
         if len(canonical_ids) != 1:
             raise RuntimeError("duplicate-alias plan does not identify exactly one canonical twin")
+        if item.logical_source_key is None:
+            raise RuntimeError("duplicate-alias plan is missing the logical source key it was proven against")
+        logical_source_key = item.logical_source_key
         with RebuildLease(root), closing(sqlite3.connect(f"file:{index_db}?mode=rw", uri=True)) as conn:
             conn.row_factory = sqlite3.Row
             conn.execute("PRAGMA foreign_keys = ON")
             conn.execute("ATTACH DATABASE ? AS source", (f"file:{source_db}?mode=ro",))
             conn.execute("BEGIN IMMEDIATE")
             try:
-                duplicate_locked = _inspect_duplicate_raw_identity(conn, root, item.raw_id, canonical_ids[0])
+                duplicate_locked = _inspect_duplicate_raw_identity(
+                    conn, root, item.raw_id, canonical_ids[0], logical_source_key
+                )
                 if _duplicate_strategy_witness(duplicate_locked) != item.strategy_witness:
                     raise RuntimeError("duplicate strategy proof changed after plan authorization")
                 if duplicate_locked.status == "eligible":
                     _apply_duplicate_raw_identity_repair(conn, duplicate_locked)
                 elif duplicate_locked.status != "already_repaired":
                     raise RuntimeError(f"duplicate strategy lost its exact proof: {duplicate_locked.reason}")
-                after = _inspect_duplicate_raw_identity(conn, root, item.raw_id, canonical_ids[0])
+                after = _inspect_duplicate_raw_identity(conn, root, item.raw_id, canonical_ids[0], logical_source_key)
                 if after.status != "already_repaired":
                     raise RuntimeError("duplicate strategy did not reach its typed terminal postcondition")
                 conn.commit()

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -3390,7 +3390,11 @@ def _duplicate_raw_identity_proof_digest(item: DuplicateRawIdentityRepairItem) -
 
 
 def _inspect_duplicate_raw_identity(
-    conn: sqlite3.Connection, archive_root: Path, stale_raw_id: str, canonical_raw_id: str
+    conn: sqlite3.Connection,
+    archive_root: Path,
+    stale_raw_id: str,
+    canonical_raw_id: str,
+    logical_source_key: str,
 ) -> DuplicateRawIdentityRepairItem:
     """Prove one ``(stale, canonical)`` raw pair is the exact pre-/post-#2729 duplicate shape.
 
@@ -3398,9 +3402,26 @@ def _inspect_duplicate_raw_identity(
     deterministic id its own recorded fields predict under its own scheme
     (``native_id``-inclusive for the stale raw, ``native_id=NULL`` for the
     canonical raw -- see ``deterministic_raw_session_id``, #2729); the stale
-    raw must be the *current* accepted head and session pointer; and the
-    canonical raw must be a genuinely dangling duplicate -- not itself an
-    accepted head or session pointer anywhere. Read-only; never mutates state.
+    raw must be the *current* accepted head and session pointer *for
+    ``logical_source_key``*; and the canonical raw must be a genuinely
+    dangling duplicate -- not itself an accepted head or session pointer
+    anywhere. Read-only; never mutates state.
+
+    ``logical_source_key`` disambiguates which accepted-head row this proof is
+    about. A single physical raw acquisition (one ``raw_id`` under the old
+    native-id-inclusive scheme) can legitimately be the accepted head for
+    *several* logical source keys/sessions at once -- forked/subagent/resumed
+    sessions replay the same parent JSONL, so their materialization can each
+    independently accept the identical raw as their own head (polylogue-ihc8).
+    Looking the head up by ``accepted_raw_id`` alone is ambiguous in that case
+    -- ``fetchone()`` would silently pick an arbitrary one of the matching
+    logical source keys, proving (and later "already-repairing") a witness for
+    a *different* session than the one the caller is actually folding. The
+    fold itself is inherently per-session (it repoints exactly one
+    ``sessions.raw_id``), so every lookup below that reads the stale raw's own
+    head is scoped to this specific key; only the *canonical* raw's head/
+    session checks stay unscoped, since canonical eligibility genuinely is a
+    global "not claimed by anyone yet" fact.
     """
     from polylogue.storage.sqlite.archive_tiers.source_write import deterministic_raw_session_id
 
@@ -3462,17 +3483,21 @@ def _inspect_duplicate_raw_identity(
         """
         SELECT logical_source_key, session_id, accepted_source_revision, accepted_content_hash,
                accepted_frontier_kind, accepted_frontier, decided_at_ms
-        FROM raw_revision_heads WHERE accepted_raw_id = ?
+        FROM raw_revision_heads WHERE accepted_raw_id = ? AND logical_source_key = ?
         """,
-        (stale_raw_id,),
+        (stale_raw_id, logical_source_key),
     ).fetchone()
     canonical_head = conn.execute(
         "SELECT logical_source_key FROM raw_revision_heads WHERE accepted_raw_id = ?", (canonical_raw_id,)
     ).fetchone()
 
     if stale_head is None:
-        if canonical_head is not None:
-            head_key = str(canonical_head["logical_source_key"])
+        # Canonical must be the accepted head of *this* logical source key,
+        # not merely of some other key this same physical raw also happens to
+        # serve (see the fan-out note in the docstring above) -- otherwise a
+        # fold performed for a sibling session would be misreported as having
+        # already repaired this one.
+        if canonical_head is not None and str(canonical_head["logical_source_key"]) == logical_source_key:
             session = conn.execute(
                 "SELECT session_id, raw_id FROM sessions WHERE raw_id = ?", (canonical_raw_id,)
             ).fetchone()
@@ -3488,7 +3513,7 @@ def _inspect_duplicate_raw_identity(
                 SELECT 1 FROM raw_revision_applications
                 WHERE raw_id = ? AND logical_source_key = ? AND decision = ? AND accepted_raw_id = ?
                 """,
-                (stale_raw_id, head_key, ApplicationDecision.SUPERSEDED.value, canonical_raw_id),
+                (stale_raw_id, logical_source_key, ApplicationDecision.SUPERSEDED.value, canonical_raw_id),
             ).fetchone()
             if session is not None and stale_superseded is not None:
                 return DuplicateRawIdentityRepairItem(
@@ -3497,9 +3522,9 @@ def _inspect_duplicate_raw_identity(
                     status="already_repaired",
                     reason="",
                     session_id=str(session["session_id"]),
-                    logical_source_key=head_key,
+                    logical_source_key=logical_source_key,
                 )
-        return ineligible("stale raw is not the currently accepted head of any logical source key")
+        return ineligible("stale raw is not the currently accepted head of this logical source key")
     if canonical_head is not None:
         return ineligible("canonical raw is already an accepted head; not a dangling duplicate")
     session = conn.execute(

--- a/tests/unit/storage/test_duplicate_raw_identity_repair.py
+++ b/tests/unit/storage/test_duplicate_raw_identity_repair.py
@@ -398,3 +398,200 @@ def test_unified_frontier_recovers_crash_after_outcome_before_postflight(
 def _rows(root: Path, tier: str, table: str, where: str, params: tuple[object, ...]) -> list[tuple[object, ...]]:
     with closing(sqlite3.connect(root / f"{tier}.db")) as conn:
         return sorted(conn.execute(f"SELECT * FROM {table} WHERE {where}", params).fetchall())
+
+
+def _seed_duplicate_raw_fanout(root: Path) -> tuple[str, str, tuple[tuple[str, str], ...]]:
+    """Seed one stale raw shared as the accepted head across TWO sessions.
+
+    Reproduces polylogue-ihc8: forked/subagent/resumed sessions can physically
+    replay the identical parent evidence, so the exact same pre-#2729
+    native-id-inclusive ``raw_id`` can legitimately be the accepted head of
+    *more than one* logical source key/session at once. Only one canonical
+    (native_id=NULL) duplicate raw exists for the shared content, so at most
+    one of the sessions can ever be folded onto it -- the other must be
+    provably distinguished from "already repaired", not silently
+    misclassified as if it were the one that got folded.
+    """
+    initialize_active_archive_root(root)
+    payload = json.dumps({"marker": "duplicate-raw-fanout-fixture"}).encode()
+    source_path = "codex-session/carryover-fanout.jsonl"
+    legacy_native_id = "legacy-native-id-fanout"
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        canonical_raw_id = archive.write_raw_payload(
+            provider=Provider.CODEX, payload=payload, source_path=source_path, acquired_at_ms=2
+        )
+        source_conn = archive._ensure_source_conn()
+        row = source_conn.execute(
+            """
+            SELECT origin, capture_mode, source_path, source_index, blob_hash, blob_size
+            FROM raw_sessions WHERE raw_id = ?
+            """,
+            (canonical_raw_id,),
+        ).fetchone()
+        origin, capture_mode, stored_source_path, source_index, blob_hash, blob_size = row
+        stale_raw_id = deterministic_raw_session_id(
+            str(origin), str(stored_source_path), int(source_index), bytes(blob_hash), native_id=legacy_native_id
+        )
+        blob_hash_hex = bytes(blob_hash).hex()
+        source_conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, capture_mode, native_id, source_path, source_index,
+                blob_hash, blob_size, acquired_at_ms,
+                revision_kind, source_revision, baseline_raw_id, acquisition_generation, revision_authority
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'full', ?, ?, 0, 'byte_proven')
+            """,
+            (
+                stale_raw_id,
+                origin,
+                capture_mode,
+                legacy_native_id,
+                stored_source_path,
+                source_index,
+                blob_hash,
+                blob_size,
+                1,
+                blob_hash_hex,
+                stale_raw_id,
+            ),
+        )
+        source_conn.execute(
+            """
+            INSERT INTO blob_refs (blob_hash, ref_id, ref_type, source_path, size_bytes, acquired_at_ms)
+            VALUES (?, ?, 'raw_payload', ?, ?, ?)
+            """,
+            (blob_hash, stale_raw_id, stored_source_path, blob_size, 1),
+        )
+        source_conn.commit()
+
+        heads: list[tuple[str, str]] = []
+        for suffix in ("a", "b"):
+            session = ParsedSession(
+                source_name=Provider.CODEX,
+                provider_session_id=f"fanout-session-{suffix}",
+                messages=[ParsedMessage(provider_message_id="m1", role=Role.USER, text=f"hello-{suffix}")],
+            )
+            _stored, session_id = archive.write_parsed_for_retained_raw(
+                session,
+                raw_id=stale_raw_id,
+                source_path=source_path,
+                acquired_at_ms=1,
+                revision_authoritative=True,
+            )
+            logical_source_key = f"codex:fanout-session-{suffix}"
+            accepted_hash = bytes.fromhex(session_content_hash(session))
+            record_revision_application_sync(
+                archive._conn,
+                RevisionApplicationReceipt(
+                    raw_id=stale_raw_id,
+                    session_id=session_id,
+                    logical_source_key=logical_source_key,
+                    source_revision=blob_hash_hex,
+                    acquisition_generation=0,
+                    decision=ApplicationDecision.SELECTED_BASELINE,
+                    accepted_raw_id=stale_raw_id,
+                    accepted_source_revision=blob_hash_hex,
+                    accepted_content_hash=accepted_hash,
+                    accepted_frontier_kind="byte",
+                    accepted_frontier=blob_size,
+                    baseline_raw_id=stale_raw_id,
+                    detail=f"pre-#2729 duplicate-raw fanout fixture ({suffix})",
+                ),
+                decided_at_ms=1,
+            )
+            heads.append((session_id, logical_source_key))
+        archive.commit()
+        return stale_raw_id, canonical_raw_id, tuple(heads)
+
+
+def test_duplicate_alias_witness_is_scoped_to_its_own_session_not_a_fanout_sibling(tmp_path: Path) -> None:
+    """polylogue-ihc8 regression: classification must not cross-contaminate siblings.
+
+    Before the fix, ``_inspect_duplicate_raw_identity`` looked up the stale
+    raw's accepted-head row by ``accepted_raw_id`` alone. When that raw_id was
+    the accepted head of two different logical source keys (the fanout
+    shape), ``fetchone()`` picked one arbitrarily -- so the frontier item
+    classified for session A could carry a strategy witness describing
+    session B's head instead of its own.
+    """
+    stale_raw_id, canonical_raw_id, heads = _seed_duplicate_raw_fanout(tmp_path)
+    (session_a, key_a), (session_b, key_b) = heads
+
+    census = inspect_raw_authority_frontier(_config(tmp_path))
+    duplicate_items = [
+        item
+        for item in census.items
+        if item.raw_id == stale_raw_id and item.state is RawAuthorityFrontierState.DUPLICATE_ALIAS
+    ]
+    assert len(duplicate_items) == 2
+    by_key = {item.logical_source_key: item for item in duplicate_items}
+    assert set(by_key) == {key_a, key_b}
+    for logical_source_key, session_id in ((key_a, session_a), (key_b, session_b)):
+        item = by_key[logical_source_key]
+        assert item.actuator is RawAuthorityActuator.FOLD_DUPLICATE_ALIAS
+        assert item.session_id == session_id
+        # The strategy witness bound to THIS item must describe THIS item's
+        # own session/key -- not whichever sibling an unscoped lookup happened
+        # to find first.
+        assert item.strategy_witness["session_id"] == session_id
+        assert item.strategy_witness["logical_source_key"] == logical_source_key
+        assert item.strategy_witness["canonical_raw_id"] == canonical_raw_id
+    assert by_key[key_a].plan_id != by_key[key_b].plan_id
+
+
+def test_duplicate_alias_fold_reaches_terminal_postcondition_under_fanout(tmp_path: Path) -> None:
+    """polylogue-ihc8 regression: applying one fanout sibling must not corrupt the other.
+
+    Before the fix, applying the plan for one sibling's head could instead
+    repoint a *different* sibling's head (whichever the ambiguous
+    ``accepted_raw_id``-only lookup happened to find), so the typed re-inspect
+    postcondition then failed every retry with the exact plan hash unchanged
+    -- an infinite non-converging RuntimeError loop (observed live: 7
+    identical failures over 90 minutes for one plan, matching this exact
+    shape). With the fix, each sibling's plan folds its own head only; this is
+    verified from both directions -- whichever sibling is selected reaches the
+    canonical twin, and the untouched sibling's own head/session pointer is
+    provably unaffected.
+    """
+    for selected, other in (("a", "b"), ("b", "a")):
+        stale_raw_id, canonical_raw_id, heads = _seed_duplicate_raw_fanout(tmp_path / selected)
+        by_suffix = dict(zip(("a", "b"), heads, strict=True))
+        selected_session, selected_key = by_suffix[selected]
+        other_session, other_key = by_suffix[other]
+
+        preview = inspect_raw_authority_frontier(_config(tmp_path / selected))
+        duplicate_items = {
+            item.logical_source_key: item
+            for item in preview.items
+            if item.raw_id == stale_raw_id and item.state is RawAuthorityFrontierState.DUPLICATE_ALIAS
+        }
+        plan_id = duplicate_items[selected_key].plan_id
+
+        report = apply_raw_authority_frontier(
+            _config(tmp_path / selected),
+            preview_census_id=preview.census_id,
+            selected_plan_ids=(plan_id,),
+        )
+
+        assert report.selected_plan_count == report.executed_plan_count == 1
+        assert report.retryable_plan_count == 0
+
+        with sqlite3.connect(tmp_path / selected / "index.db") as conn:
+            assert conn.execute(
+                "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = ?",
+                (selected_key,),
+            ).fetchone() == (canonical_raw_id,)
+            assert conn.execute("SELECT raw_id FROM sessions WHERE session_id = ?", (selected_session,)).fetchone() == (
+                canonical_raw_id,
+            )
+            # The other fanout sibling's own head/session pointer must be
+            # untouched -- the ambiguity bug repointed whichever sibling an
+            # unscoped lookup happened to find, which could corrupt this row
+            # instead of the one actually selected.
+            assert conn.execute(
+                "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = ?",
+                (other_key,),
+            ).fetchone() == (stale_raw_id,)
+            assert conn.execute("SELECT raw_id FROM sessions WHERE session_id = ?", (other_session,)).fetchone() == (
+                stale_raw_id,
+            )


### PR DESCRIPTION
## Summary

Fixes a live, recurring `polylogued` failure: `fold_duplicate_alias` raw-authority repair kept raising `RuntimeError: duplicate strategy did not reach its typed terminal postcondition` for the same plan hash on every retry, never converging (observed 7 identical failures over 90 minutes for one plan, 1 for another).

## Problem

`_inspect_duplicate_raw_identity` (`polylogue/storage/repair.py`) proves a `(stale_raw_id, canonical_raw_id)` pair is an exact pre-/post-#2729 duplicate-fold shape, and looked up the stale raw's accepted-head row with `SELECT ... FROM raw_revision_heads WHERE accepted_raw_id = ?` — scoped only by raw id, not by which session/logical source key the caller actually cares about.

Correlating the two failing plan hashes to live data (read-only, via `mode=ro` connections against `/realm/db/polylogue`) showed why that's ambiguous: the same physical raw acquisition (one `raw_id` under the old native-id-inclusive scheme) is legitimately the accepted head of **four different sessions simultaneously** — forked/subagent/resumed Claude Code sessions replay the identical parent JSONL evidence, so each session's own materialization can independently accept that raw as its head. `fetchone()` on the unscoped query picked an arbitrary one of those four sessions. The frontier item classified for session `896c6b64-...` ended up carrying a strategy witness describing session `560a3328-...`'s head instead of its own — directly confirmed: the item's own `index_preconditions.logical_source_key` was `896c6b64-...` while its `strategy_witness.logical_source_key` was `560a3328-...`.

At apply time this meant the fold repointed the *wrong* session's head inside the transaction; the re-inspect (also unscoped) then found a different remaining row still pointing at the stale raw, saw the canonical now claimed, and returned `"ineligible"` instead of `"already_repaired"` — tripping the typed postcondition check and rolling back the whole transaction. Since nothing ever committed, the same plan hash and error recurred identically on every retry, exactly matching the 90-minute log pattern.

This is an application-logic bug (a missing scope key), not a design gap requiring a new terminal status — `"already_repaired"` only needed disambiguation.

## Solution

- `_inspect_duplicate_raw_identity` (`polylogue/storage/repair.py`) now takes a required `logical_source_key` parameter and scopes the stale raw's accepted-head lookup and the `"already_repaired"` session/superseded-receipt checks to that key. The canonical raw's head/session checks stay unscoped — "not claimed by anyone yet" is genuinely global, not per-session.
- The three call sites in `polylogue/storage/raw_reconciler.py` (`_classify_frontier`, and both `_apply_strategy` inspect calls for `FOLD_DUPLICATE_ALIAS`) now pass the frontier row's/item's own `logical_source_key`.
- Added `_seed_duplicate_raw_fanout` and two regression tests in `tests/unit/storage/test_duplicate_raw_identity_repair.py` reproducing the exact fan-out shape (one stale raw shared as accepted head by two sessions, one canonical twin available): one proves classification no longer cross-contaminates the strategy witness between siblings, the other proves applying either sibling's plan folds only that sibling and leaves the other's head/session pointer untouched. Both new tests fail against the pre-fix code with the *exact* same `"did not reach its typed terminal postcondition"` RuntimeError observed live (verified by temporarily reverting the fix and re-running).

Did not perform any live write against `/realm/db/polylogue` — all live-archive reads used explicit `mode=ro` URI connections; the fix ships in code for the daemon to pick up on its next deploy.

## Verification

- `devtools test tests/unit/storage/test_duplicate_raw_identity_repair.py` → 9 passed (2 new tests confirmed to fail against pre-fix code).
- `devtools test tests/unit/storage/test_repair.py tests/unit/storage/test_quarantined_accepted_raw_repair.py tests/unit/storage/test_browser_capture_origin_repair.py tests/unit/storage/test_raw_authority_ledger.py tests/unit/storage/test_quarantine_repair_budget.py tests/unit/devtools/test_raw_authority_scale_proof.py tests/unit/devtools/test_raw_authority_restart_proof.py` → 141 passed, no regressions.
- `mypy --strict polylogue/storage/repair.py polylogue/storage/raw_reconciler.py` → Success, no issues.
- `ruff check` / `ruff format --check` on all touched files → clean.
- `devtools render all --check` → no drift.
- `devtools verify --quick` ran clean on push (pre-push hook, exit 0).
- Did not run `devtools verify --all` (out of scope for this focused fix).

Ref polylogue-ihc8