### PR TITLE
feat(insights): implement production GitHub PR effect adapter

### DIFF
--- a/polylogue/cli/commands/reconcile_work_effects.py
+++ b/polylogue/cli/commands/reconcile_work_effects.py
@@ -66,6 +66,12 @@ def _render_plain(summary_dict: dict[str, object]) -> None:
     default=None,
     help="Beads interaction ledger (.beads/interactions.jsonl) to read issue-state effects from.",
 )
+@click.option(
+    "--github-repo",
+    "github_repo",
+    default=None,
+    help="'owner/name' GitHub repo to read PR lifecycle effects from via the gh CLI.",
+)
 @click.option("--since", default=None, help="Lower effect time bound (ISO or relative date).")
 @click.option("--until", default=None, help="Upper effect time bound (ISO or relative date).")
 @click.option(
@@ -86,19 +92,28 @@ def reconcile_work_effects_command(
     graph_id: str,
     repo_path: Path,
     beads_jsonl: Path | None,
+    github_repo: str | None,
     since: str | None,
     until: str | None,
     apply: bool,
     output_format: str,
 ) -> None:
-    """Attach observed git/Beads repository effects to a stored work-evidence graph.
+    """Attach observed git/GitHub/Beads repository effects to a stored work-evidence graph.
 
-    Reads commit history from --repo and, if given, issue-state changes from
-    --beads-jsonl. Claims are only linked to an effect through an explicit
-    shared work-item id in their text -- never through time or file
-    proximity. Without --yes this only reports what would change.
+    Reads commit history from --repo, PR lifecycle state from --github-repo
+    (via the gh CLI), and, if given, issue-state changes from --beads-jsonl.
+    Claims are only linked to an effect through an explicit shared work-item
+    id in their text -- never through time or file proximity. Without --yes
+    this only reports what would change. A --github-repo the gh CLI cannot
+    reach (no auth, no network, not installed) shows up as an "adapter
+    unavailable: github" line rather than silently omitting PR effects.
     """
-    from polylogue.insights.work_effects import BeadsIssueEffectAdapter, GitCommitEffectAdapter, RepositoryEffectAdapter
+    from polylogue.insights.work_effects import (
+        BeadsIssueEffectAdapter,
+        GitCommitEffectAdapter,
+        GitHubPullRequestEffectAdapter,
+        RepositoryEffectAdapter,
+    )
     from polylogue.operations.work_effect_reconciliation import (
         WorkEffectReconciliationSummary,
         WorkEvidenceGraphNotFoundError,
@@ -113,6 +128,8 @@ def reconcile_work_effects_command(
     adapters: list[RepositoryEffectAdapter] = [GitCommitEffectAdapter(repo_path=repo_path)]
     if beads_jsonl is not None:
         adapters.append(BeadsIssueEffectAdapter(jsonl_path=beads_jsonl))
+    if github_repo is not None:
+        adapters.append(GitHubPullRequestEffectAdapter(repo=github_repo))
 
     async def _run() -> WorkEffectReconciliationSummary:
         async with SessionRepository(db_path=active_index_db_path()) as repository:

--- a/polylogue/insights/work_effects.py
+++ b/polylogue/insights/work_effects.py
@@ -7,18 +7,28 @@ the missing production half -- adapters that read *independent* repository
 evidence and a conservative matcher that turns shared identifiers into
 judgments, so the reconciler is no longer fed by hand in tests only.
 
-Two adapters are concrete and read-only:
+Three adapters are concrete and read-only:
 
 - :class:`GitCommitEffectAdapter` reads ``git log`` for a local checkout.
 - :class:`BeadsIssueEffectAdapter` reads a Beads ``interactions.jsonl``
   ledger (the same append-only shape ``sources/parsers/beads.py`` ingests).
+- :class:`GitHubPullRequestEffectAdapter` shells out to the ``gh`` CLI (the
+  same subprocess pattern ``insights.correlation_view._enrich_with_github_api``
+  already uses) to read PR lifecycle state -- number, title, body, open/
+  merged/closed state, and merge commit -- for one ``owner/name`` repo.
 
-A third, :class:`GitHubPullRequestEffectAdapter`, is declared but not
-implemented: PR lifecycle/review/merge evidence needs live network or ``gh``
-CLI access this module does not assume is available (auth, rate limits,
-sandboxed/cloud lanes with no egress). Calling its ``collect`` fails
-explicitly with :class:`EffectAdapterUnavailableError` -- an honest "not wired
-yet", never a silent empty result that would read as "no PRs found".
+``gh`` access is genuinely unavailable in some lanes (no network egress,
+missing binary, no ``gh auth login``). Rather than special-case those lanes,
+every failure mode -- missing executable, auth/network error, a non-zero
+``gh`` exit, unparseable output -- raises :class:`EffectAdapterUnavailableError`
+explicitly, exactly like the other two adapters do for their own missing
+inputs. ``collect_repository_effects`` already isolates one adapter's failure
+from the others, so a lane with no GitHub access still gets git/Beads
+effects and an honest "github: <reason>" entry in ``unavailable`` -- never a
+silent empty result that would read as "no PRs found". PR
+review/approval-level granularity (per-reviewer decisions, not just PR
+lifecycle state) is deliberately out of scope here -- see
+polylogue-1vpm.6.2 for that follow-on.
 
 Judgment derivation (``derive_direct_identifier_judgments``) never uses time
 or file-path proximity -- that heuristic already exists as a *candidate-only*
@@ -281,24 +291,51 @@ def _file_identity(path: Path) -> str:
     return sha256(str(Path(path).resolve()).encode("utf-8")).hexdigest()[:16]
 
 
-# ── GitHub adapter (typed stub -- honest degradation) ────────────────
+# ── GitHub PR adapter ─────────────────────────────────────────────────
+
+#: `gh pr list --json` fields this adapter needs. Kept as an explicit tuple
+#: (not `--json '*'`) so a `gh` version that drops/renames a field breaks
+#: loudly at the `_run_gh` non-zero-exit / JSON-decode boundary instead of
+#: silently starving one label of context.
+_PR_JSON_FIELDS: Final = (
+    "number",
+    "title",
+    "body",
+    "state",
+    "url",
+    "createdAt",
+    "updatedAt",
+    "closedAt",
+    "mergedAt",
+    "mergeCommit",
+)
 
 
 @dataclass(frozen=True, slots=True)
 class GitHubPullRequestEffectAdapter:
-    """Declared, pluggable placeholder for PR lifecycle/review/merge effects.
+    """Reads pull-request lifecycle effects from GitHub via the ``gh`` CLI.
 
-    Not implemented in this pass: GitHub PR evidence needs live network or
-    ``gh`` CLI access (auth, rate limits, no egress in cloud/CI lanes) this
-    module deliberately does not assume. ``collect`` always raises
-    :class:`EffectAdapterUnavailableError` -- an honest "not wired yet" rather than
-    a silent empty result indistinguishable from "no PRs found". The type
-    exists so a real ``gh``/GitHub-API-backed adapter can be dropped in later
-    without changing the reconciliation call sites.
+    Read-only: a single ``gh pr list --repo <repo> --state all`` call per
+    ``collect()``, the same subprocess-shelling pattern already used by
+    ``insights.correlation_view._enrich_with_github_api`` elsewhere in this
+    repo. Every PR ``gh`` returns (open, merged, or closed -- ``--state all``)
+    becomes one effect carrying its number, title, body, lifecycle state, and
+    merge commit, so identifier matching against a PR's title/body works the
+    same way it already does for git commit subjects and Beads interactions.
+
+    ``limit`` bounds one ``gh`` call's page size (``gh`` itself paginates
+    beyond it only if asked); ``since_ms``/``until_ms`` are applied
+    client-side against each PR's most recent known lifecycle timestamp
+    (merged, else closed, else updated, else created) after the page is
+    fetched -- ``gh pr list`` has no native time-range filter for arbitrary
+    bounds without changing the query shape into GitHub's search syntax.
     """
 
     repo: str  # "owner/name"
     authority: EffectAuthority = "github"
+    limit: int = 200
+    gh_path: str = "gh"
+    timeout_s: int = 45
 
     def collect(
         self,
@@ -306,10 +343,115 @@ class GitHubPullRequestEffectAdapter:
         since_ms: int | None = None,
         until_ms: int | None = None,
     ) -> tuple[ObservedRepositoryEffect, ...]:
-        raise EffectAdapterUnavailableError(
-            f"GitHub PR effect adapter for {self.repo!r} is not implemented "
-            "(requires network/gh CLI access); see polylogue-1vpm.6.2 follow-up"
+        output = _run_gh(
+            self.gh_path,
+            [
+                "pr",
+                "list",
+                "--repo",
+                self.repo,
+                "--state",
+                "all",
+                "--limit",
+                str(self.limit),
+                "--json",
+                ",".join(_PR_JSON_FIELDS),
+            ],
+            timeout_s=self.timeout_s,
         )
+        try:
+            records = json.loads(output)
+        except json.JSONDecodeError as exc:
+            raise EffectAdapterUnavailableError(
+                f"gh pr list for {self.repo!r} returned output that is not valid JSON"
+            ) from exc
+        if not isinstance(records, list):
+            raise EffectAdapterUnavailableError(
+                f"gh pr list for {self.repo!r} returned an unexpected JSON shape ({type(records).__name__})"
+            )
+
+        snapshot_ref = ObjectRef(
+            kind="context-snapshot",
+            object_id=f"github:{self.repo}@{sha256(output.encode('utf-8')).hexdigest()[:16]}",
+        )
+        effects: list[ObservedRepositoryEffect] = []
+        for record in records:
+            if not isinstance(record, dict) or record.get("number") is None:
+                continue
+            number = record["number"]
+            occurred_at_ms = _first_present_ms(record, ("mergedAt", "closedAt", "updatedAt", "createdAt"))
+            if since_ms is not None and (occurred_at_ms is None or occurred_at_ms < since_ms):
+                continue
+            if until_ms is not None and (occurred_at_ms is None or occurred_at_ms > until_ms):
+                continue
+            effects.append(
+                ObservedRepositoryEffect(
+                    ref=ObjectRef(kind="github-pr", object_id=f"{self.repo}#{number}"),
+                    label=_pull_request_label(self.repo, record),
+                    authority="github",
+                    evidence_ref=ObjectRef(kind="artifact", object_id=f"github-pr:{self.repo}:{number}"),
+                    repository_snapshot_ref=snapshot_ref,
+                    occurred_at_ms=occurred_at_ms,
+                )
+            )
+        return tuple(effects)
+
+
+def _run_gh(gh_path: str, args: Sequence[str], *, timeout_s: int) -> str:
+    """Run one ``gh`` subcommand and return its captured stdout.
+
+    Every failure mode raises :class:`EffectAdapterUnavailableError` with a
+    reason a caller can log or surface verbatim -- missing binary, auth/
+    network failure (non-zero exit with ``gh``'s own stderr), and timeout are
+    all distinguishable from "gh ran and found nothing".
+    """
+    command = [gh_path, *args]
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise EffectAdapterUnavailableError(
+            f"{gh_path!r} executable not found on PATH -- install the GitHub CLI to collect PR effects"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise EffectAdapterUnavailableError(f"{' '.join(command)} timed out after {timeout_s}s") from exc
+    except OSError as exc:
+        raise EffectAdapterUnavailableError(f"{' '.join(command)} failed to start: {exc}") from exc
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip() or "(no stderr output)"
+        raise EffectAdapterUnavailableError(f"{' '.join(command)} exited {completed.returncode}: {stderr}")
+    return completed.stdout
+
+
+def _first_present_ms(record: dict[str, object], fields: Sequence[str]) -> int | None:
+    for field in fields:
+        value = record.get(field)
+        if isinstance(value, str) and value:
+            parsed = _parse_iso_ms(value)
+            if parsed is not None:
+                return parsed
+    return None
+
+
+def _pull_request_label(repo: str, record: dict[str, object]) -> str:
+    number = record.get("number")
+    title = str(record.get("title") or "").strip()
+    state = str(record.get("state") or "").upper()
+    label = f"{repo}#{number} [{state}] {title}".strip()
+    merge_commit = record.get("mergeCommit")
+    if isinstance(merge_commit, dict):
+        merge_sha = merge_commit.get("oid")
+        if isinstance(merge_sha, str) and merge_sha:
+            label = f"{label} (merge {merge_sha[:12]})"
+    body = str(record.get("body") or "").strip()
+    if body:
+        label = f"{label}\n{body}"
+    return label
 
 
 # ── Collection + judgment derivation ─────────────────────────────────

--- a/tests/unit/cli/test_reconcile_work_effects_command.py
+++ b/tests/unit/cli/test_reconcile_work_effects_command.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from click.testing import CliRunner
@@ -112,6 +113,64 @@ def test_yes_flag_persists_reconciled_graph(
     assert stored is not None
     assert any(node.kind == "effect" for node in stored.nodes)
     assert any(edge.kind == "claimed" for edge in stored.edges)
+
+
+def test_github_repo_flag_wires_in_pr_effects(
+    tmp_path: Path,
+    _seeded_graph: WorkEvidenceGraph,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--github-repo reaches the real GitHubPullRequestEffectAdapter.collect
+    (only the OS-level `gh` subprocess call is faked -- no live GitHub
+    network/auth access in this test suite)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _init_git_repo(repo, message="unrelated plain commit")
+
+    pr_records = [
+        {
+            "number": 7,
+            "title": "fix: land it (Ref polylogue-1vpm.6.2)",
+            "body": "",
+            "state": "MERGED",
+            "url": "https://github.com/Sinity/polylogue/pull/7",
+            "createdAt": "2026-07-10T09:00:00Z",
+            "updatedAt": "2026-07-10T10:00:00Z",
+            "closedAt": "2026-07-10T10:00:00Z",
+            "mergedAt": "2026-07-10T10:00:00Z",
+            "mergeCommit": {"oid": "deadbeef"},
+        }
+    ]
+
+    real_run = subprocess.run
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str] | MagicMock:
+        if cmd[:1] == ["gh"]:
+            return MagicMock(returncode=0, stdout=json.dumps(pr_records), stderr="")
+        return real_run(cmd, **kwargs)  # type: ignore[call-overload, no-any-return]
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = CliRunner().invoke(
+        reconcile_work_effects_command,
+        [
+            "--graph-id",
+            _seeded_graph.graph_id,
+            "--repo",
+            str(repo),
+            "--github-repo",
+            "Sinity/polylogue",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["effect_count_by_authority"] == {"git": 1, "github": 1}
+    assert payload["claims_evaluated"] == 1
+    assert payload["adapter_failures"] == []
 
 
 def test_unknown_graph_id_is_a_usage_error(tmp_path: Path, workspace_env: dict[str, Path]) -> None:

--- a/tests/unit/insights/test_work_effects.py
+++ b/tests/unit/insights/test_work_effects.py
@@ -9,8 +9,10 @@ Removing the git/Beads I/O, or the direct-identifier restriction in
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -158,21 +160,153 @@ def test_beads_issue_adapter_ignores_non_interaction_lines(tmp_path: Path) -> No
     assert effects[0].ref.object_id == "proj-1:int-x"
 
 
-# ── GitHubPullRequestEffectAdapter (honest stub) ─────────────────────
+# ── GitHubPullRequestEffectAdapter ────────────────────────────────────
+
+_PR_RECORDS = [
+    {
+        "number": 42,
+        "title": "fix: land the effect (Ref polylogue-1vpm.6.2)",
+        "body": "Closes the reconciliation gap.",
+        "state": "MERGED",
+        "url": "https://github.com/Sinity/polylogue/pull/42",
+        "createdAt": "2026-07-10T09:00:00Z",
+        "updatedAt": "2026-07-10T10:00:00Z",
+        "closedAt": "2026-07-10T10:00:00Z",
+        "mergedAt": "2026-07-10T10:00:00Z",
+        "mergeCommit": {"oid": "abc123def456abc123def456abc123def456abc1"},
+    },
+    {
+        "number": 43,
+        "title": "docs: unrelated cleanup",
+        "body": "",
+        "state": "OPEN",
+        "url": "https://github.com/Sinity/polylogue/pull/43",
+        "createdAt": "2026-07-11T09:00:00Z",
+        "updatedAt": "2026-07-11T09:00:00Z",
+        "closedAt": None,
+        "mergedAt": None,
+        "mergeCommit": None,
+    },
+]
 
 
-def test_github_adapter_fails_explicitly_instead_of_returning_empty() -> None:
+def _fake_gh_run(stdout: str = "", returncode: int = 0, stderr: str = "") -> MagicMock:
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_github_adapter_reads_real_gh_cli_output_shape(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Anti-vacuity: exercises the adapter's own gh-invocation and JSON-decode
+    path, not a stand-in double -- only the OS-level subprocess boundary
+    (there is no real GitHub network access in this test suite) is faked."""
+    seen: dict[str, list[str]] = {}
+
+    def fake_run(cmd: list[str], **kwargs: object) -> MagicMock:
+        seen["cmd"] = cmd
+        return _fake_gh_run(stdout=json.dumps(_PR_RECORDS))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
     adapter = GitHubPullRequestEffectAdapter(repo="Sinity/polylogue")
+    effects = adapter.collect()
 
-    with pytest.raises(EffectAdapterUnavailableError, match="Sinity/polylogue"):
-        adapter.collect()
+    assert seen["cmd"][:4] == ["gh", "pr", "list", "--repo"]
+    assert "Sinity/polylogue" in seen["cmd"]
+    assert len(effects) == 2
+    assert {effect.authority for effect in effects} == {"github"}
+    merged, opened = sorted(effects, key=lambda e: e.ref.object_id)
+    assert merged.ref == ObjectRef(kind="github-pr", object_id="Sinity/polylogue#42")
+    assert "polylogue-1vpm.6.2" in merged.label
+    assert "abc123def456" in merged.label
+    assert merged.occurred_at_ms is not None
+    assert opened.ref.object_id == "Sinity/polylogue#43"
+    assert opened.occurred_at_ms is not None
+    assert effects[0].repository_snapshot_ref.kind == "context-snapshot"
 
 
-def test_collect_repository_effects_records_adapter_failures_without_losing_others(tmp_path: Path) -> None:
+def test_github_adapter_time_bounds_exclude_out_of_window_prs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_gh_run(stdout=json.dumps(_PR_RECORDS)))
+
+    adapter = GitHubPullRequestEffectAdapter(repo="Sinity/polylogue")
+    all_effects = adapter.collect()
+    assert len(all_effects) == 2
+
+    far_future_ms = max(e.occurred_at_ms for e in all_effects if e.occurred_at_ms is not None) + 1000 * 60 * 60 * 24
+    assert adapter.collect(since_ms=far_future_ms) == ()
+
+
+def test_github_adapter_raises_explicitly_when_gh_binary_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*_a: object, **_k: object) -> MagicMock:
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(EffectAdapterUnavailableError, match="not found on PATH"):
+        GitHubPullRequestEffectAdapter(repo="Sinity/polylogue").collect()
+
+
+def test_github_adapter_raises_explicitly_on_nonzero_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **k: _fake_gh_run(returncode=1, stderr="gh: authentication required"),
+    )
+
+    with pytest.raises(EffectAdapterUnavailableError, match="authentication required"):
+        GitHubPullRequestEffectAdapter(repo="Sinity/polylogue").collect()
+
+
+def test_github_adapter_raises_explicitly_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(*_a: object, **_k: object) -> MagicMock:
+        raise subprocess.TimeoutExpired(cmd="gh", timeout=45)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(EffectAdapterUnavailableError, match="timed out"):
+        GitHubPullRequestEffectAdapter(repo="Sinity/polylogue").collect()
+
+
+def test_github_adapter_raises_explicitly_on_malformed_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_gh_run(stdout="not json"))
+
+    with pytest.raises(EffectAdapterUnavailableError, match="not valid JSON"):
+        GitHubPullRequestEffectAdapter(repo="Sinity/polylogue").collect()
+
+
+def test_github_adapter_judgments_link_pr_effects_by_shared_identifier(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _fake_gh_run(stdout=json.dumps(_PR_RECORDS)))
+
+    effects = GitHubPullRequestEffectAdapter(repo="Sinity/polylogue").collect()
+    matching_claim = _claim_node("claim:matches-pr", "Claude Workflow finalResult: closed polylogue-1vpm.6.2")
+    graph = WorkEvidenceGraph(graph_id="g", corpus_snapshot_ref=_SNAPSHOT, nodes=(matching_claim,), edges=())
+
+    judgments = derive_direct_identifier_judgments(graph, effects)
+
+    assert len(judgments) == 1
+    [judgment] = judgments
+    assert judgment.claim_ref == matching_claim.ref
+    assert judgment.effect_ref == ObjectRef(kind="github-pr", object_id="Sinity/polylogue#42")
+    assert judgment.evaluation == "supported"
+
+
+def test_collect_repository_effects_records_adapter_failures_without_losing_others(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()
     _init_git_repo(repo)
     _commit(repo, filename="a.txt", message="plain commit, no bead ref")
+
+    # Only fake the `gh` invocation; let git's own subprocess calls (made by
+    # both the adapter under test and the `_commit`/`_init_git_repo` fixture
+    # helpers) run for real -- this isolates "no gh CLI" from "no git".
+    real_run = subprocess.run
+
+    def selective_fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if cmd[:1] == ["gh"]:
+            raise FileNotFoundError("gh")
+        return real_run(cmd, **kwargs)  # type: ignore[call-overload, no-any-return]
+
+    monkeypatch.setattr(subprocess, "run", selective_fake_run)
 
     result = collect_repository_effects(
         (
@@ -185,7 +319,7 @@ def test_collect_repository_effects_records_adapter_failures_without_losing_othe
     assert result.effects[0].authority == "git"
     assert len(result.unavailable) == 1
     assert result.unavailable[0].authority == "github"
-    assert "Sinity/polylogue" in result.unavailable[0].reason
+    assert "not found on PATH" in result.unavailable[0].reason
 
 
 # ── derive_direct_identifier_judgments ────────────────────────────────


### PR DESCRIPTION
## Summary

Implements the GitHub half of polylogue-z9gh's remaining gap #1
("production git/GitHub/Beads effect adapters"). Git and Beads effect
adapters were already production-real as of the #3049 checkpoint;
`GitHubPullRequestEffectAdapter` was a typed stub whose `collect()` always
raised `EffectAdapterUnavailableError`. It now shells out to the `gh` CLI to
read real PR lifecycle state.

## Problem

`polylogue-z9gh`'s notes explicitly mark the bead NOT TERMINAL, naming three
remaining gaps. Gap #1 ("production git/GitHub/Beads effect adapters") was
only two-thirds real: `reconcile_work_effects` had a working
`GitCommitEffectAdapter` (real `git log`) and `BeadsIssueEffectAdapter` (real
`.beads/interactions.jsonl` parse), but the GitHub adapter was a declared
placeholder that could never corroborate a claim like "opened/merged PR #N"
against actual GitHub state. `polylogue-1vpm.6.2`'s investigation confirmed
no GitHub effect adapter existed at all prior to this PR.

## Solution

- `polylogue/insights/work_effects.py`: `GitHubPullRequestEffectAdapter.collect()`
  now runs `gh pr list --repo <owner/name> --state all --json number,title,body,
  state,url,createdAt,updatedAt,closedAt,mergedAt,mergeCommit` (the same
  subprocess-shelling pattern `insights.correlation_view._enrich_with_github_api`
  already uses elsewhere in this repo) and turns each PR into one
  `ObservedRepositoryEffect` (ref `github-pr:<repo>#<number>`, label combining
  number/state/title/merge-sha/body so `derive_direct_identifier_judgments`'
  existing shared-work-item-id matching links claims to PRs the same way it
  already links commits and Beads interactions). `since_ms`/`until_ms` filter
  client-side against each PR's most recent known lifecycle timestamp.
  Every failure mode -- missing `gh` binary, non-zero exit (auth/network/rate
  limit), timeout, unparseable JSON -- raises `EffectAdapterUnavailableError`
  explicitly, matching the existing git/Beads adapters' "never a silent empty
  result" contract; `collect_repository_effects` already isolates one
  adapter's failure from the others.
- `polylogue/cli/commands/reconcile_work_effects.py`: new `--github-repo`
  option wires the adapter into the `reconcile-work-effects` CLI alongside
  the existing `--repo`/`--beads-jsonl`.
- Module docstring updated: "two adapters concrete, one stub" -> "three
  adapters concrete."

**Explicitly out of scope**: per-reviewer PR review/approval-level
granularity (as opposed to PR lifecycle state itself) -- tracked separately
at `polylogue-1vpm.6.2`.

## Verification

```
devtools test tests/unit/insights/test_work_effects.py tests/unit/cli/test_reconcile_work_effects_command.py
# 23 passed in 4.58s

mypy --strict polylogue/insights/work_effects.py polylogue/cli/commands/reconcile_work_effects.py \
  tests/unit/insights/test_work_effects.py tests/unit/cli/test_reconcile_work_effects_command.py
# Success: no issues found in 4 source files

ruff check / ruff format --check <same files>
# clean

devtools render all --check
# no drift

devtools verify --quick
# exit_code 0 (format+lint+mypy+render-all-check+manifests+ci-workflows+
# doc-commands+docs-coverage+test-infra-currency+test-clock-hygiene+
# pytest-timeout-overrides+degrade-loudly+hash-boundary-census)
```

New adapter tests mock only the OS-level `gh` subprocess boundary (no live
GitHub network/auth access in this test suite, per repo convention) while
covering: real gh-JSON-shape decode, time-window filtering, missing-binary,
non-zero-exit, timeout, malformed-JSON, and end-to-end identifier-judgment
linking. The existing git-commit/Beads-ledger tests are untouched and
continue to exercise real subprocess/file I/O.

## Scope honesty (z9gh AC / bead notes)

This PR delivers **z9gh gap #1 only** ("production git/GitHub/Beads effect
adapters" -- now fully real for all three sources). It does **not** address
z9gh's other two named NOT TERMINAL gaps:

- Gap #2: source-to-graph incident materialization -- untouched.
- Gap #3: the real paged/cancelled/cold-model MCP continuity replay --
  untouched.

z9gh should stay open; its bead notes are being updated with this account
separately (not via this PR).

Ref polylogue-z9gh

Co-Authored-By: Claude <noreply@anthropic.com>