### PR TITLE
feat(browser-capture): add explicit-approval attention category for destructive submits

### DIFF
--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -2196,6 +2196,19 @@ async function updateBrowserAction(actionId, ownerInstanceId, patch) {
   });
 }
 
+// The operator's explicit approve/decline decision on an action the receiver
+// is holding at "awaiting_approval" (polylogue-yyvg.7). Unlike
+// updateBrowserAction this carries no lease -- an awaiting_approval action
+// has never been leased, and approving it is what makes it claimable for the
+// first time.
+async function decideBrowserActionApproval(actionId, decision) {
+  const ownerInstanceId = await browserActionExecutorId();
+  return postJson(`/v1/browser-actions/${encodeURIComponent(actionId)}/approval`, {
+    extension_instance_id: ownerInstanceId,
+    decision,
+  });
+}
+
 async function browserActionAttachmentBytes(action) {
   const settings = await receiverSettings();
   const attachments = [];
@@ -3240,6 +3253,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
     if (message.type === "polylogue.browserActions.poll") {
       sendResponse({ ok: true, ...(await pollBrowserActions()) });
+      return;
+    }
+    if (message.type === "polylogue.browserActions.approval") {
+      const result = await decideBrowserActionApproval(message.actionId, message.decision);
+      if (message.decision === "approve") void pollBrowserActions();
+      sendResponse({ ok: true, action: result.action });
       return;
     }
   })().catch(async (error) => {

--- a/browser-extension/src/operator_status.js
+++ b/browser-extension/src/operator_status.js
@@ -496,10 +496,12 @@
   // time (polylogue-yyvg.7 AC3). This is a strict typed priority list, not a
   // free-form aggregation: auth/pairing mismatch (the receiver cannot be
   // trusted) outranks an unconfirmed action outcome (a stuck submit, never
-  // auto-retried), which outranks a typed capability mismatch on queued
-  // work, which outranks a hard archive failure on the current conversation.
-  // Anything else is healthy/automatic and returns null — silence is the
-  // correct answer far more often than not.
+  // auto-retried), which outranks a browser action explicitly held for
+  // operator approval (a genuinely destructive submit that must not
+  // auto-resolve either way), which outranks a typed capability mismatch on
+  // queued work, which outranks a hard archive failure on the current
+  // conversation. Anything else is healthy/automatic and returns null —
+  // silence is the correct answer far more often than not.
   function computeAttention({
     conversationState = null,
     pairing = null,
@@ -552,6 +554,24 @@
       };
     }
 
+    // A submit_once reply posts one real, provider-visible turn into an
+    // EXISTING conversation with no automatic undo (polylogue-yyvg.7). The
+    // receiver holds it at "awaiting_approval" instead of dispatching it, so
+    // this is the one attention category the popup must never auto-resolve:
+    // the operator explicitly approves or declines, there is no third option.
+    const awaitingApproval = (Array.isArray(browserActions) ? browserActions : [])
+      .find((action) => action?.status === "awaiting_approval");
+    if (awaitingApproval) {
+      return {
+        kind: "explicit_approval_required",
+        tone: "bad",
+        headline: "A browser action needs your explicit approval before it submits",
+        detail: "This will post a real reply into an existing conversation. Review the request, then approve or decline it.",
+        actionId: "browser-action-approval",
+        actionLabel: "Review request",
+      };
+    }
+
     const capabilityItem = (Array.isArray(workItems) ? workItems : [])
       .find((item) => ["capability_mismatch", "receiver_contract_incompatible"].includes(item?.raw?.cooldown_reason));
     if (capabilityItem) {
@@ -597,6 +617,7 @@
     operatorStatusForState,
     operatorStatusLabel,
     pendingBrowserActionCount,
+    providerLabel,
     receiverPairingPresentation,
   });
 })(globalThis);

--- a/browser-extension/src/popup.html
+++ b/browser-extension/src/popup.html
@@ -330,6 +330,18 @@
           <div id="asset-failures" class="log-meta conversation-only"></div>
         </section>
 
+        <section id="browser-action-approval" tabindex="-1" hidden aria-labelledby="browser-action-approval-heading">
+          <div class="section-head"><strong id="browser-action-approval-heading">Browser action approval</strong></div>
+          <div class="surface-card">
+            <div id="browser-action-approval-summary" class="pairing-id">--</div>
+            <p id="browser-action-approval-detail" class="log-meta">This will post a real reply into an existing conversation. It stays held until you decide.</p>
+          </div>
+          <div class="controls">
+            <button id="browser-action-approve" class="primary"><span class="button-label">Approve</span><span class="button-status"></span></button>
+            <button id="browser-action-decline" class="danger"><span class="button-label">Decline</span><span class="button-status"></span></button>
+          </div>
+        </section>
+
         <section aria-labelledby="receiver-heading">
           <div class="section-head"><strong id="receiver-heading">Paired receiver</strong><span id="receiver-health" class="state-chip neutral">--</span></div>
           <div class="surface-card">

--- a/browser-extension/src/popup.js
+++ b/browser-extension/src/popup.js
@@ -531,6 +531,45 @@ function renderAttention(attention) {
   }
 }
 
+function renderBrowserActionApproval(browserActions) {
+  const section = document.getElementById("browser-action-approval");
+  if (!section) return;
+  const action = (Array.isArray(browserActions) ? browserActions : [])
+    .find((item) => item?.status === "awaiting_approval");
+  section.hidden = !action;
+  if (!action) return;
+  section.dataset.actionId = action.action_id;
+  const summary = document.getElementById("browser-action-approval-summary");
+  if (summary) {
+    const provider = operatorStatusApi.providerLabel
+      ? operatorStatusApi.providerLabel(action.provider)
+      : action.provider;
+    const preview = String(action.text || "").slice(0, 160);
+    summary.textContent = `${provider} · reply into ${action.target?.conversation_id || "existing conversation"}: "${preview}"`;
+  }
+}
+
+document.getElementById("browser-action-approve")?.addEventListener("click", async () => {
+  const actionId = document.getElementById("browser-action-approval")?.dataset.actionId;
+  if (!actionId) return;
+  await withAction("browser-action-approve", async () => {
+    await chrome.runtime.sendMessage({ type: "polylogue.browserActions.approval", actionId, decision: "approve" });
+    await render();
+  }, { busy: "Approving", ok: "Approved" });
+});
+
+document.getElementById("browser-action-decline")?.addEventListener("click", async () => {
+  const actionId = document.getElementById("browser-action-approval")?.dataset.actionId;
+  if (!actionId) return;
+  const confirmed = typeof globalThis.confirm !== "function"
+    || globalThis.confirm("Decline this browser action? It will not be submitted and cannot be resumed.");
+  if (!confirmed) return;
+  await withAction("browser-action-decline", async () => {
+    await chrome.runtime.sendMessage({ type: "polylogue.browserActions.approval", actionId, decision: "decline" });
+    await render();
+  }, { busy: "Declining", ok: "Declined" });
+});
+
 async function loadMissionSnapshot() {
   try {
     const result = await chrome.runtime.sendMessage({ type: "polylogue.missionControl.status", refresh: false });
@@ -625,6 +664,7 @@ async function render() {
   if (pendingActionCountNode) {
     pendingActionCountNode.textContent = String(operatorStatusApi.pendingBrowserActionCount(browserActions));
   }
+  renderBrowserActionApproval(browserActions);
   const extensionBuild = document.getElementById("extension-build");
   if (extensionBuild) {
     const runtime = mission?.extension;

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -2252,6 +2252,81 @@ describe("browser action polling", () => {
   });
 });
 
+describe("browser action explicit-approval decision (polylogue-yyvg.7)", () => {
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    await loadBackground({
+      polylogueReceiverPairing: {
+        state: "online",
+        receiver_id: "rx-approval-test",
+        api_schema: "polylogue-browser-capture/v1",
+      },
+    });
+  });
+
+  it("posts an explicit approve decision and wakes the poll loop, never auto-declining", async () => {
+    let approvalBody = null;
+    globalThis.fetch = vi.fn(async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      if (String(url).endsWith("/v1/status")) {
+        return responseJson({ ok: true, receiver_id: "rx-approval-test", api_schema: "polylogue-browser-capture/v1" });
+      }
+      if (String(url).endsWith("/v1/browser-actions/action-held-1/approval")) {
+        approvalBody = JSON.parse(options.body);
+        return responseJson({ action: { action_id: "action-held-1", status: "queued" } });
+      }
+      if (String(url).includes("/v1/browser-actions?claim_by=")) {
+        return responseJson({ actions: [] });
+      }
+      return responseJson({ error: "unexpected_receiver_request" }, { ok: false, status: 500 });
+    });
+
+    const response = await sendRuntimeMessage({
+      type: "polylogue.browserActions.approval",
+      actionId: "action-held-1",
+      decision: "approve",
+    });
+
+    expect(response.ok).toBe(true);
+    expect(response.action).toMatchObject({ action_id: "action-held-1", status: "queued" });
+    expect(approvalBody).toMatchObject({ decision: "approve" });
+    expect(approvalBody.extension_instance_id).toBeTruthy();
+    // Approving must never send a decline, and it should wake the claim loop
+    // so the now-queued action is picked up without waiting for the next alarm.
+    expect(approvalBody.decision).not.toBe("decline");
+    await vi.waitFor(() => expect(
+      fetchCalls.some((call) => String(call.url).includes("/v1/browser-actions?claim_by=")),
+    ).toBe(true));
+  });
+
+  it("posts an explicit decline decision without ever polling for a claim", async () => {
+    let approvalBody = null;
+    globalThis.fetch = vi.fn(async (url, options = {}) => {
+      fetchCalls.push({ url, options });
+      if (String(url).endsWith("/v1/status")) {
+        return responseJson({ ok: true, receiver_id: "rx-approval-test", api_schema: "polylogue-browser-capture/v1" });
+      }
+      if (String(url).endsWith("/v1/browser-actions/action-held-2/approval")) {
+        approvalBody = JSON.parse(options.body);
+        return responseJson({ action: { action_id: "action-held-2", status: "cancelled" } });
+      }
+      return responseJson({ error: "unexpected_receiver_request" }, { ok: false, status: 500 });
+    });
+
+    const response = await sendRuntimeMessage({
+      type: "polylogue.browserActions.approval",
+      actionId: "action-held-2",
+      decision: "decline",
+    });
+
+    expect(response.ok).toBe(true);
+    expect(response.action).toMatchObject({ action_id: "action-held-2", status: "cancelled" });
+    expect(approvalBody).toMatchObject({ decision: "decline" });
+    expect(fetchCalls.some((call) => String(call.url).includes("claim_by="))).toBe(false);
+  });
+});
+
 describe("provider-neutral browser action worker", () => {
   beforeEach(async () => {
     vi.restoreAllMocks();

--- a/browser-extension/tests/operator_status.test.js
+++ b/browser-extension/tests/operator_status.test.js
@@ -271,6 +271,20 @@ describe("shared operator status vocabulary", () => {
       detail: "submit channel ended without a receipt",
     });
 
+    const awaitingApproval = api.computeAttention({
+      browserActions: [
+        { status: "submitted" },
+        { status: "awaiting_approval", approval_reason: "destructive_submit" },
+      ],
+      workItems: [{ title: "ChatGPT reply", raw: { cooldown_reason: "capability_mismatch" } }],
+    });
+    expect(awaitingApproval).toMatchObject({
+      kind: "explicit_approval_required",
+      tone: "bad",
+      actionId: "browser-action-approval",
+      actionLabel: "Review request",
+    });
+
     const capabilityMismatch = api.computeAttention({
       workItems: [{ title: "ChatGPT reply", cooldown: "model unavailable", raw: { cooldown_reason: "capability_mismatch" } }],
     });
@@ -290,6 +304,22 @@ describe("shared operator status vocabulary", () => {
       health: { status: "dev_override_stale" },
     });
     expect(devOverrideStale).toMatchObject({ kind: "dev_override_stale", tone: "bad", actionId: "reset-pairing" });
+  });
+
+  it("ranks an unconfirmed action outcome above explicit-approval, and explicit-approval above a capability mismatch", () => {
+    const outcomeBeatsApproval = api.computeAttention({
+      browserActions: [
+        { status: "outcome_unknown", last_error: "no receipt" },
+        { status: "awaiting_approval", approval_reason: "destructive_submit" },
+      ],
+    });
+    expect(outcomeBeatsApproval).toMatchObject({ kind: "action_outcome_unknown" });
+
+    const approvalBeatsCapability = api.computeAttention({
+      browserActions: [{ status: "awaiting_approval", approval_reason: "destructive_submit" }],
+      workItems: [{ title: "ChatGPT reply", raw: { cooldown_reason: "capability_mismatch" } }],
+    });
+    expect(approvalBeatsCapability).toMatchObject({ kind: "explicit_approval_required" });
   });
 
   it("counts only browser actions still awaiting a receipt as pending", () => {

--- a/browser-extension/tests/popup.test.js
+++ b/browser-extension/tests/popup.test.js
@@ -79,6 +79,12 @@ function installDom() {
       <span id="cost-tokens" class="conversation-only"></span>
       <span id="assets" class="conversation-only"></span>
       <div id="asset-failures" class="conversation-only"></div>
+      <section id="browser-action-approval" hidden>
+        <div id="browser-action-approval-summary"></div>
+        <p id="browser-action-approval-detail"></p>
+        <button id="browser-action-approve"><span class="button-status"></span></button>
+        <button id="browser-action-decline"><span class="button-status"></span></button>
+      </section>
       <span id="receiver-health"></span>
       <span id="receiver-pairing-status"></span>
       <span id="receiver-pairing-detail"></span>
@@ -300,6 +306,158 @@ describe("popup capture", () => {
     // No actionId is offered for an outcome_unknown action -- there is no safe
     // one-click resolution, only "Details" (progressive disclosure, not a button).
     expect(globalThis.document.getElementById("attention-action").hidden).toBe(true);
+  });
+
+  it("holds a destructive submit_once reply for explicit operator approval and renders one primary action", async () => {
+    await loadPopup({}, [CHATGPT_TAB], async (message) => {
+      if (message.type === "polylogue.browserActions.status") {
+        return {
+          ok: true,
+          actions: [
+            {
+              action_id: "a-reply-1",
+              status: "awaiting_approval",
+              approval_reason: "destructive_submit",
+              provider: "chatgpt",
+              text: "Here is the reply Polylogue would post on your behalf.",
+              target: { conversation_id: "conversation-1" },
+            },
+          ],
+        };
+      }
+      return { ok: true };
+    });
+
+    await vi.waitFor(() => expect(globalThis.document.getElementById("attention-section").hidden).toBe(false));
+    expect(globalThis.document.getElementById("attention-heading").textContent)
+      .toBe("A browser action needs your explicit approval before it submits");
+    const actionButton = globalThis.document.getElementById("attention-action");
+    expect(actionButton.hidden).toBe(false);
+    expect(actionButton.querySelector(".button-label").textContent).toBe("Review request");
+
+    // The primary action opens diagnostics and focuses the approval panel --
+    // it never auto-approves or auto-declines on its own.
+    const diagnostics = globalThis.document.getElementById("diagnostics");
+    diagnostics.open = false;
+    actionButton.dispatchEvent(new globalThis.window.Event("click", { bubbles: true }));
+    expect(diagnostics.open).toBe(true);
+
+    const panel = globalThis.document.getElementById("browser-action-approval");
+    expect(panel.hidden).toBe(false);
+    expect(panel.dataset.actionId).toBe("a-reply-1");
+    expect(globalThis.document.getElementById("browser-action-approval-summary").textContent)
+      .toContain("conversation-1");
+  });
+
+  it("sends an explicit approve decision only when the operator clicks Approve", async () => {
+    let decisionCalls = [];
+    await loadPopup({}, [CHATGPT_TAB], async (message) => {
+      if (message.type === "polylogue.browserActions.status") {
+        return {
+          ok: true,
+          actions: [{
+            action_id: "a-reply-2",
+            status: "awaiting_approval",
+            approval_reason: "destructive_submit",
+            provider: "chatgpt",
+            text: "reply text",
+            target: { conversation_id: "conversation-2" },
+          }],
+        };
+      }
+      if (message.type === "polylogue.browserActions.approval") {
+        decisionCalls.push(message);
+        return { ok: true, action: { action_id: message.actionId, status: "queued" } };
+      }
+      return { ok: true };
+    });
+
+    await vi.waitFor(() => expect(globalThis.document.getElementById("browser-action-approval").hidden).toBe(false));
+    globalThis.document.getElementById("browser-action-approve")
+      .dispatchEvent(new globalThis.window.Event("click", { bubbles: true }));
+
+    await vi.waitFor(() => expect(decisionCalls).toHaveLength(1));
+    expect(decisionCalls[0]).toMatchObject({
+      type: "polylogue.browserActions.approval",
+      actionId: "a-reply-2",
+      decision: "approve",
+    });
+  });
+
+  it("sends an explicit decline decision, and never a silent approve, when the operator clicks Decline", async () => {
+    let decisionCalls = [];
+    await loadPopup({}, [CHATGPT_TAB], async (message) => {
+      if (message.type === "polylogue.browserActions.status") {
+        return {
+          ok: true,
+          actions: [{
+            action_id: "a-reply-3",
+            status: "awaiting_approval",
+            approval_reason: "destructive_submit",
+            provider: "chatgpt",
+            text: "reply text",
+            target: { conversation_id: "conversation-3" },
+          }],
+        };
+      }
+      if (message.type === "polylogue.browserActions.approval") {
+        decisionCalls.push(message);
+        return { ok: true, action: { action_id: message.actionId, status: "cancelled" } };
+      }
+      return { ok: true };
+    });
+
+    await vi.waitFor(() => expect(globalThis.document.getElementById("browser-action-approval").hidden).toBe(false));
+    vi.stubGlobal("confirm", vi.fn(() => true));
+    try {
+      globalThis.document.getElementById("browser-action-decline")
+        .dispatchEvent(new globalThis.window.Event("click", { bubbles: true }));
+
+      await vi.waitFor(() => expect(decisionCalls).toHaveLength(1));
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    expect(decisionCalls[0]).toMatchObject({
+      type: "polylogue.browserActions.approval",
+      actionId: "a-reply-3",
+      decision: "decline",
+    });
+    expect(decisionCalls.every((call) => call.decision !== "approve")).toBe(true);
+  });
+
+  it("does not send any approval decision when the operator cancels the decline confirmation", async () => {
+    let decisionCalls = [];
+    await loadPopup({}, [CHATGPT_TAB], async (message) => {
+      if (message.type === "polylogue.browserActions.status") {
+        return {
+          ok: true,
+          actions: [{
+            action_id: "a-reply-4",
+            status: "awaiting_approval",
+            approval_reason: "destructive_submit",
+            provider: "chatgpt",
+            text: "reply text",
+            target: { conversation_id: "conversation-4" },
+          }],
+        };
+      }
+      if (message.type === "polylogue.browserActions.approval") {
+        decisionCalls.push(message);
+        return { ok: true, action: { action_id: message.actionId, status: "cancelled" } };
+      }
+      return { ok: true };
+    });
+
+    await vi.waitFor(() => expect(globalThis.document.getElementById("browser-action-approval").hidden).toBe(false));
+    vi.stubGlobal("confirm", vi.fn(() => false));
+    try {
+      globalThis.document.getElementById("browser-action-decline")
+        .dispatchEvent(new globalThis.window.Event("click", { bubbles: true }));
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 20));
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    expect(decisionCalls).toHaveLength(0);
   });
 
   it("renders DOM fallback with concrete next action", async () => {

--- a/docs/browser-capture.md
+++ b/docs/browser-capture.md
@@ -17,7 +17,7 @@ The receiver listens on `127.0.0.1:8765` by default and accepts the route contra
 - `GET /v1/status` -> `BrowserCaptureReceiverStatusPayload`
 - `GET /v1/archive-state?provider=chatgpt&provider_session_id=...` -> `BrowserCaptureArchiveStatePayload`
 - `POST /v1/browser-captures` with `BrowserCaptureEnvelope` -> `BrowserCaptureAcceptedPayload` or `BrowserCaptureErrorPayload`
-- `GET/POST /v1/browser-actions...` -> provider-neutral draft/submit intents, leases, exact receipts, and explicit uncertain-submit reconciliation
+- `GET/POST /v1/browser-actions...` -> provider-neutral draft/submit intents, leases, exact receipts, explicit uncertain-submit reconciliation, and explicit operator approval for destructive submits
 
 `/v1/archive-state` reports archive visibility, not just receiver spool
 presence. Its `state`/`lifecycle` field is one of:

--- a/polylogue/browser_capture/actions.py
+++ b/polylogue/browser_capture/actions.py
@@ -21,6 +21,7 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 from polylogue.browser_capture.models import (
+    BrowserActionApprovalDecisionRequest,
     BrowserActionAttachment,
     BrowserActionEvent,
     BrowserActionIntent,
@@ -245,6 +246,20 @@ def _request_sha256(request: BrowserActionRequest) -> str:
     return hashlib.sha256(dumps_bytes(payload, sort_keys=True)).hexdigest()
 
 
+def _approval_reason_for(request: BrowserActionRequest) -> str | None:
+    """Return why a request must be held for explicit operator approval, if any.
+
+    ``submit_once`` on ``conversation.reply`` posts one real, provider-visible
+    turn into an EXISTING conversation with no automatic undo -- the operator
+    may not be watching that conversation when the extension would otherwise
+    dispatch it automatically. ``conversation.create`` (a fresh conversation)
+    and ``stage_only`` (never submits) are not gated here.
+    """
+    if request.submit_policy == "submit_once" and request.operation == "conversation.reply":
+        return "destructive_submit"
+    return None
+
+
 def list_actions(*, spool_path: Path | None = None) -> list[BrowserActionIntent]:
     root = action_root(spool_path)
     if not root.exists():
@@ -282,7 +297,7 @@ def enqueue_action(
             if existing.request_sha256 == request_sha256:
                 return existing
             raise BrowserActionConflictError("browser action identity already exists with different input")
-    active_statuses = {"queued", "leased", "preparing", "submit_intent"}
+    active_statuses = {"awaiting_approval", "queued", "leased", "preparing", "submit_intent"}
     if sum(action.status in active_statuses for action in list_actions(spool_path=spool_path)) >= ACTION_MAX_ACTIVE:
         raise BrowserActionQuotaError("active browser action quota exceeded")
 
@@ -315,6 +330,7 @@ def enqueue_action(
         decoded.append((attachment, content))
 
     now = _now()
+    approval_reason = _approval_reason_for(request)
     action = BrowserActionIntent(
         action_id=action_id,
         idempotency_key=idempotency_key,
@@ -327,10 +343,20 @@ def enqueue_action(
         attachments=attachments,
         presentation=request.presentation,
         submit_policy=request.submit_policy,
+        status="awaiting_approval" if approval_reason else "queued",
+        phase="awaiting_approval" if approval_reason else "queued",
         created_at=_iso(now),
         updated_at=_iso(now),
+        requires_operator_approval=approval_reason is not None,
+        approval_reason=approval_reason,  # type: ignore[arg-type]
+        approval_requested_at=_iso(now) if approval_reason else None,
     )
-    _event(action, "created", "queued")
+    _event(
+        action,
+        "awaiting_approval" if approval_reason else "created",
+        action.phase,
+        detail=f"held for explicit operator approval: {approval_reason}" if approval_reason else None,
+    )
     try:
         for attachment, content in decoded:
             _atomic_write(_action_dir(root, action_id) / "attachments" / attachment.attachment_id, content)
@@ -540,6 +566,46 @@ def reconcile_action(
     return action
 
 
+@_serialized
+def decide_action_approval(
+    action_id: str,
+    request: BrowserActionApprovalDecisionRequest,
+    *,
+    spool_path: Path | None = None,
+) -> BrowserActionIntent | None:
+    """Record the operator's explicit approve/decline decision.
+
+    Approving turns an ``awaiting_approval`` action into an ordinary
+    ``queued`` one -- the same automatic claim/dispatch path any other
+    action follows from that point. Declining is terminal (``cancelled``):
+    it never becomes claimable, so no provider submission can ever occur for
+    it. Deciding on any action not currently ``awaiting_approval`` is a
+    conflict, not a silent no-op -- a decision must land on the exact hold it
+    was made against.
+    """
+    root = action_root(spool_path)
+    action = _read_action(_action_path(root, action_id))
+    if action is None:
+        return None
+    if action.status != "awaiting_approval":
+        raise BrowserActionConflictError("only an awaiting_approval browser action can record an approval decision")
+    now = _now()
+    action.updated_at = _iso(now)
+    if request.decision == "approve":
+        action.status = "queued"
+        action.phase = "queued"
+        action.approved_at = _iso(now)
+        action.approved_by = request.extension_instance_id
+        _event(action, "approved", action.phase, detail=request.detail, owner=request.extension_instance_id)
+    else:
+        action.status = "cancelled"
+        action.phase = "declined"
+        action.declined_at = _iso(now)
+        _event(action, "declined", action.phase, detail=request.detail, owner=request.extension_instance_id)
+    _write_action(root, action)
+    return action
+
+
 def read_action_attachment(
     action_id: str,
     attachment_id: str,
@@ -569,6 +635,7 @@ __all__ = [
     "action_root",
     "browser_action_capabilities",
     "claim_action",
+    "decide_action_approval",
     "enqueue_action",
     "get_action",
     "list_actions",

--- a/polylogue/browser_capture/models.py
+++ b/polylogue/browser_capture/models.py
@@ -399,6 +399,7 @@ BrowserActionProvider = Literal["chatgpt", "claude"]
 BrowserActionOperation = Literal["conversation.create", "conversation.reply"]
 BrowserActionSubmitPolicy = Literal["stage_only", "submit_once"]
 BrowserActionStatus = Literal[
+    "awaiting_approval",
     "queued",
     "leased",
     "preparing",
@@ -410,6 +411,21 @@ BrowserActionStatus = Literal[
     "failed",
     "cancelled",
 ]
+#: Why a browser action is held at ``awaiting_approval`` instead of being
+#: claimable immediately after enqueue. Only ``destructive_submit`` is wired
+#: to a real trigger today (polylogue-yyvg.7): a ``submit_once`` action whose
+#: operation is ``conversation.reply`` posts one real, provider-visible turn
+#: into an EXISTING conversation the operator may not currently be watching,
+#: with no automatic undo. That is the "explicit submit/destructive approval"
+#: category the redesign's AC3 names and the popup previously had no data to
+#: back. A second AC3-named category, "destructive conflict", is deliberately
+#: NOT modeled here: the receiver's ``claim_action`` already serializes to one
+#: in-flight action at a time (see its "any(...) return None" guard below), so
+#: there is no genuine two-actions-racing-for-one-resource scenario in the
+#: current architecture to attach it to. Adding a value for it now would be an
+#: unbacked, unfireable enum member; a future bead should add it once a real
+#: collision scenario exists (e.g. multi-instance orchestration).
+BrowserActionApprovalReason = Literal["destructive_submit"]
 BrowserActionOutcome = Literal[
     "progress",
     "drafted",
@@ -555,6 +571,15 @@ class BrowserActionIntent(BaseModel):
     retry_after_seconds: int | None = Field(default=None, ge=1, le=86_400)
     receipt: BrowserActionReceipt | None = None
     events: list[BrowserActionEvent] = Field(default_factory=list)
+    #: True once this action was ever held for explicit operator approval
+    #: (stays True after approve/decline -- it is a historical fact, not a
+    #: live gate; the live gate is ``status == "awaiting_approval"``).
+    requires_operator_approval: bool = False
+    approval_reason: BrowserActionApprovalReason | None = None
+    approval_requested_at: str | None = None
+    approved_at: str | None = None
+    approved_by: str | None = None
+    declined_at: str | None = None
 
 
 class BrowserActionUpdateRequest(BaseModel):
@@ -572,6 +597,19 @@ class BrowserActionReconcileRequest(BaseModel):
     resolution: Literal["submitted", "drafted"]
     detail: str = Field(min_length=1, max_length=4_000)
     receipt: BrowserActionReceipt
+
+
+class BrowserActionApprovalDecisionRequest(BaseModel):
+    """The operator's explicit approve/decline decision on a held action.
+
+    Unlike ``BrowserActionUpdateRequest``, this does not require a lease --
+    an ``awaiting_approval`` action has never been leased, and approving one
+    is exactly what makes it claimable for the first time.
+    """
+
+    extension_instance_id: str = Field(min_length=1, max_length=128)
+    decision: Literal["approve", "decline"]
+    detail: str | None = Field(default=None, max_length=4_000)
 
 
 class BrowserActionListPayload(BaseModel):
@@ -619,6 +657,8 @@ __all__ = [
     "BrowserBackfillCheckpointPayload",
     "BrowserBackfillCheckpointRecord",
     "BrowserBackfillCheckpointRequest",
+    "BrowserActionApprovalDecisionRequest",
+    "BrowserActionApprovalReason",
     "BrowserActionAttachment",
     "BrowserActionAttachmentInput",
     "BrowserActionCapabilitiesPayload",

--- a/polylogue/browser_capture/route_contracts.py
+++ b/polylogue/browser_capture/route_contracts.py
@@ -33,6 +33,7 @@ BrowserCaptureRouteKind = Literal[
     "browser_action_attachment",
     "browser_action_update",
     "browser_action_reconcile",
+    "browser_action_approval",
     "capture_job_capabilities",
     "capture_job_create",
     "capture_job_discover",
@@ -161,6 +162,16 @@ BROWSER_CAPTURE_ROUTE_CONTRACTS: tuple[BrowserCaptureRouteContract, ...] = (
         "BrowserActionReconcileRequest",
         "BrowserActionPayload | BrowserCaptureErrorPayload",
         "Explicitly binds provider evidence to an outcome_unknown action; never retries it implicitly.",
+    ),
+    BrowserCaptureRouteContract(
+        "POST",
+        "/v1/browser-actions/{action_id}/approval",
+        "browser_action_approval",
+        "bearer_if_web_origin",
+        "BrowserActionApprovalDecisionRequest",
+        "BrowserActionPayload | BrowserCaptureErrorPayload",
+        "Records the operator's explicit approve/decline decision on an awaiting_approval action; "
+        "approve makes it claimable for the first time, decline is terminal.",
     ),
     BrowserCaptureRouteContract(
         "GET",

--- a/polylogue/browser_capture/server.py
+++ b/polylogue/browser_capture/server.py
@@ -24,6 +24,7 @@ from polylogue.browser_capture.actions import (
     BrowserActionStateError,
     browser_action_capabilities,
     claim_action,
+    decide_action_approval,
     enqueue_action,
     get_action,
     list_actions,
@@ -34,6 +35,7 @@ from polylogue.browser_capture.actions import (
 from polylogue.browser_capture.capture_jobs import CaptureJobError, registry_for_receiver
 from polylogue.browser_capture.models import (
     BROWSER_CAPTURE_EXTENSION_ORIGIN_WILDCARD,
+    BrowserActionApprovalDecisionRequest,
     BrowserActionCapabilitiesPayload,
     BrowserActionListPayload,
     BrowserActionPayload,
@@ -472,6 +474,10 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
             action_id = path[len("/v1/browser-actions/") : -len("/reconcile")]
             self._browser_action_reconcile(action_id)
             return
+        if path.startswith("/v1/browser-actions/") and path.endswith("/approval"):
+            action_id = path[len("/v1/browser-actions/") : -len("/approval")]
+            self._browser_action_approval(action_id)
+            return
         if path in {"/v1/capture-jobs", "/v1/capture-jobs/discover"} or (
             path.startswith("/v1/capture-jobs/") and path.endswith(("/adopt", "/update"))
         ):
@@ -689,6 +695,31 @@ class BrowserCaptureHandler(BaseHTTPRequestHandler):
             return
         except (OSError, BrowserActionStateError) as exc:
             logger.warning("browser_capture.action_reconcile_failed", request_id=self._request_id(), error=repr(exc))
+            self._safe_error(HTTPStatus.INTERNAL_SERVER_ERROR, "write_failed")
+            return
+        if action is None:
+            self._safe_error(HTTPStatus.NOT_FOUND, "unknown_browser_action")
+            return
+        self._send_json(HTTPStatus.OK, BrowserActionPayload(action=action).model_dump(mode="json"))
+
+    def _browser_action_approval(self, action_id: str) -> None:
+        payload = self._read_json_body()
+        if payload is None:
+            return
+        try:
+            request = BrowserActionApprovalDecisionRequest.model_validate(payload)
+            action = decide_action_approval(action_id, request, spool_path=self.server.config.spool_path)
+        except ValidationError:
+            self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_browser_action_approval")
+            return
+        except BrowserActionConflictError:
+            self._safe_error(HTTPStatus.CONFLICT, "browser_action_approval_conflict")
+            return
+        except ValueError:
+            self._safe_error(HTTPStatus.BAD_REQUEST, "invalid_browser_action_id")
+            return
+        except (OSError, BrowserActionStateError) as exc:
+            logger.warning("browser_capture.action_approval_failed", request_id=self._request_id(), error=repr(exc))
             self._safe_error(HTTPStatus.INTERNAL_SERVER_ERROR, "write_failed")
             return
         if action is None:

--- a/tests/unit/browser_capture/test_actions.py
+++ b/tests/unit/browser_capture/test_actions.py
@@ -20,6 +20,7 @@ from polylogue.browser_capture.actions import (
     BrowserActionLeaseError,
     BrowserActionQuotaError,
     claim_action,
+    decide_action_approval,
     enqueue_action,
     get_action,
     read_action_attachment,
@@ -27,6 +28,7 @@ from polylogue.browser_capture.actions import (
     update_action,
 )
 from polylogue.browser_capture.models import (
+    BrowserActionApprovalDecisionRequest,
     BrowserActionAttachmentInput,
     BrowserActionPresentation,
     BrowserActionReceipt,
@@ -236,6 +238,119 @@ def test_reply_and_project_target_are_explicit(tmp_path: Path) -> None:
     assert action.target.project_ref == "g-p-project"
 
 
+def test_submit_once_reply_is_held_for_explicit_operator_approval(tmp_path: Path) -> None:
+    # polylogue-yyvg.7: a submit_once conversation.reply posts one real,
+    # provider-visible turn into an EXISTING conversation with no automatic
+    # undo, so it must never be automatically claimable straight off enqueue.
+    action = enqueue_action(
+        _request(operation="conversation.reply", conversation_id="conversation-1"),
+        receiver_id=_RECEIVER_ID,
+        spool_path=tmp_path,
+    )
+    assert action.status == "awaiting_approval"
+    assert action.phase == "awaiting_approval"
+    assert action.requires_operator_approval is True
+    assert action.approval_reason == "destructive_submit"
+    assert action.approval_requested_at is not None
+    assert action.approved_at is None
+    assert action.declined_at is None
+    assert claim_action("extension-one", spool_path=tmp_path) is None
+
+
+def test_submit_once_create_is_not_held_for_approval(tmp_path: Path) -> None:
+    # A fresh conversation is lower-consequence than replying into an
+    # existing one the operator may not be watching -- only conversation.reply
+    # is gated (regression guard for the default request fixture, which is
+    # conversation.create + submit_once and must remain immediately claimable).
+    action = enqueue_action(_request(), receiver_id=_RECEIVER_ID, spool_path=tmp_path)
+    assert action.status == "queued"
+    assert action.requires_operator_approval is False
+    assert action.approval_reason is None
+    claimed = claim_action("extension-one", spool_path=tmp_path)
+    assert claimed is not None and claimed.action_id == action.action_id
+
+
+def test_stage_only_reply_is_not_held_for_approval(tmp_path: Path) -> None:
+    # A staged draft never submits to the provider on its own -- only
+    # submit_once replies carry the un-undoable consequence that needs an
+    # explicit decision.
+    action = enqueue_action(
+        _request(operation="conversation.reply", conversation_id="conversation-1", submit_policy="stage_only"),
+        receiver_id=_RECEIVER_ID,
+        spool_path=tmp_path,
+    )
+    assert action.status == "queued"
+    assert action.requires_operator_approval is False
+
+
+def test_approving_a_held_action_makes_it_claimable(tmp_path: Path) -> None:
+    action = enqueue_action(
+        _request(operation="conversation.reply", conversation_id="conversation-1"),
+        receiver_id=_RECEIVER_ID,
+        spool_path=tmp_path,
+    )
+    decided = decide_action_approval(
+        action.action_id,
+        BrowserActionApprovalDecisionRequest(
+            extension_instance_id="extension-one",
+            decision="approve",
+            detail="operator reviewed the reply text and target conversation",
+        ),
+        spool_path=tmp_path,
+    )
+    assert decided is not None
+    assert decided.status == "queued"
+    assert decided.approved_at is not None
+    assert decided.approved_by == "extension-one"
+    # The historical fact that this went through approval is preserved even
+    # though the live gate (status) has moved on.
+    assert decided.requires_operator_approval is True
+    assert decided.approval_reason == "destructive_submit"
+
+    claimed = claim_action("extension-two", spool_path=tmp_path)
+    assert claimed is not None and claimed.action_id == action.action_id
+
+
+def test_declining_a_held_action_is_terminal_and_never_claimable(tmp_path: Path) -> None:
+    action = enqueue_action(
+        _request(operation="conversation.reply", conversation_id="conversation-1"),
+        receiver_id=_RECEIVER_ID,
+        spool_path=tmp_path,
+    )
+    decided = decide_action_approval(
+        action.action_id,
+        BrowserActionApprovalDecisionRequest(
+            extension_instance_id="extension-one",
+            decision="decline",
+            detail="wrong conversation target",
+        ),
+        spool_path=tmp_path,
+    )
+    assert decided is not None
+    assert decided.status == "cancelled"
+    assert decided.declined_at is not None
+    assert claim_action("extension-one", spool_path=tmp_path) is None
+    # A second decision against an already-decided action is a conflict, not
+    # a silent no-op -- it must land on the exact hold it was made against.
+    with pytest.raises(BrowserActionConflictError):
+        decide_action_approval(
+            action.action_id,
+            BrowserActionApprovalDecisionRequest(extension_instance_id="extension-one", decision="approve"),
+            spool_path=tmp_path,
+        )
+
+
+def test_deciding_on_an_action_that_was_never_held_is_a_conflict(tmp_path: Path) -> None:
+    action = enqueue_action(_request(), receiver_id=_RECEIVER_ID, spool_path=tmp_path)
+    assert action.status == "queued"
+    with pytest.raises(BrowserActionConflictError):
+        decide_action_approval(
+            action.action_id,
+            BrowserActionApprovalDecisionRequest(extension_instance_id="extension-one", decision="approve"),
+            spool_path=tmp_path,
+        )
+
+
 def test_pre_submit_lease_is_replaceable_but_submit_intent_is_quarantined(
     tmp_path: Path,
     frozen_clock: FrozenClock,
@@ -403,6 +518,12 @@ def test_reply_receipt_must_match_the_requested_conversation(tmp_path: Path) -> 
         receiver_id=_RECEIVER_ID,
         spool_path=tmp_path,
     )
+    assert action.status == "awaiting_approval"
+    decide_action_approval(
+        action.action_id,
+        BrowserActionApprovalDecisionRequest(extension_instance_id="extension-one", decision="approve"),
+        spool_path=tmp_path,
+    )
     claimed = claim_action("extension-one", spool_path=tmp_path) or pytest.fail("action was not claimed")
     wrong_receipt = _receipt(action.action_id).model_copy(
         update={
@@ -512,6 +633,54 @@ def test_http_contract_create_claim_attachment_update_and_read(tmp_path: Path) -
         assert json.loads(content)["action"]["receipt"]["provider_turn_id"] == "turn-user-1"
 
 
+def test_http_contract_approval_gates_a_destructive_reply_until_the_operator_decides(tmp_path: Path) -> None:
+    with _receiver(tmp_path) as (host, port):
+        status, content, _ = _http(
+            host,
+            port,
+            "POST",
+            "/v1/browser-actions",
+            body=_request(operation="conversation.reply", conversation_id="conversation-1").model_dump(mode="json"),
+        )
+        assert status == HTTPStatus.ACCEPTED
+        created = json.loads(content)["action"]
+        assert created["status"] == "awaiting_approval"
+        assert created["requires_operator_approval"] is True
+        assert created["approval_reason"] == "destructive_submit"
+
+        # Not claimable while the decision is pending.
+        status, content, _ = _http(host, port, "GET", "/v1/browser-actions?claim_by=extension-one")
+        assert status == HTTPStatus.OK
+        assert json.loads(content)["actions"] == []
+
+        status, content, _ = _http(
+            host,
+            port,
+            "POST",
+            f"/v1/browser-actions/{created['action_id']}/approval",
+            body={"extension_instance_id": "extension-one", "decision": "approve"},
+        )
+        assert status == HTTPStatus.OK
+        approved = json.loads(content)["action"]
+        assert approved["status"] == "queued"
+        assert approved["approved_by"] == "extension-one"
+
+        status, content, _ = _http(host, port, "GET", "/v1/browser-actions?claim_by=extension-one")
+        assert status == HTTPStatus.OK
+        assert json.loads(content)["actions"][0]["action_id"] == created["action_id"]
+
+        # Deciding again on an already-decided action is a conflict.
+        status, content, _ = _http(
+            host,
+            port,
+            "POST",
+            f"/v1/browser-actions/{created['action_id']}/approval",
+            body={"extension_instance_id": "extension-one", "decision": "decline"},
+        )
+        assert status == HTTPStatus.CONFLICT
+        assert json.loads(content)["error"] == "browser_action_approval_conflict"
+
+
 def test_http_contract_rejects_noncanonical_action_ids(tmp_path: Path) -> None:
     with _receiver(tmp_path) as (host, port):
         for method, path, body in (
@@ -573,7 +742,9 @@ def test_route_contracts_cover_every_browser_action_route() -> None:
         "browser_action_attachment",
         "browser_action_update",
         "browser_action_reconcile",
+        "browser_action_approval",
     } <= kinds
     assert browser_capture_route_contract_for("GET", "/v1/browser-actions/action-1") is not None
     assert browser_capture_route_contract_for("POST", "/v1/browser-actions/action-1/events") is not None
     assert browser_capture_route_contract_for("POST", "/v1/browser-actions/action-1/reconcile") is not None
+    assert browser_capture_route_contract_for("POST", "/v1/browser-actions/action-1/approval") is not None


### PR DESCRIPTION
## Summary

Implements the "explicit-approval attention categories" scope item named in polylogue-yyvg.7's notes: a submit_once `conversation.reply` browser action now requires an explicit operator approve/decline decision before the receiver will ever hand it out for dispatch, and the popup surfaces this as a new, distinctly-rendered attention category.

## Problem

polylogue-yyvg.7 AC3 names five popup attention categories ("typed auth/pairing mismatch, action outcome_unknown, explicit submit/destructive approval, provider capability mismatch, or destructive conflict"). Prior work (PR #3126) implemented the first, second, fourth, and a fifth stand-in (`archive_failed`), but explicitly left "explicit submit/destructive approval" unimplemented because no backing data model existed: `dispatchBrowserAction` in `background.js` would lease and execute a `submit_once` action the instant the poll loop claimed it, with zero operator gate — even though such an action posts one real, provider-visible turn into an EXISTING conversation the operator may not currently be watching, with no automatic undo.

## Solution

- **`polylogue/browser_capture/models.py`**: `BrowserActionStatus` gains `"awaiting_approval"`. `BrowserActionIntent` gains `requires_operator_approval`, `approval_reason` (`BrowserActionApprovalReason = Literal["destructive_submit"]`), `approval_requested_at`, `approved_at`, `approved_by`, `declined_at`. New `BrowserActionApprovalDecisionRequest`.
- **`polylogue/browser_capture/actions.py`**: `enqueue_action` holds a `submit_once` + `conversation.reply` request at `status="awaiting_approval"` instead of `"queued"` — `claim_action` only ever looks at `"queued"`, so it is never leased until decided. New `decide_action_approval`: approve transitions to `"queued"` (claimable for the first time); decline is terminal (`"cancelled"`); deciding twice, or deciding on an action that was never held, is a `BrowserActionConflictError`, not a silent no-op.
- **`polylogue/browser_capture/server.py` + `route_contracts.py`**: new `POST /v1/browser-actions/{action_id}/approval` route, wired through the same auth/error-mapping pattern as the existing `/reconcile` route.
- **`browser-extension/src/operator_status.js`**: `computeAttention` gets a new `explicit_approval_required` branch, ranked between `action_outcome_unknown` and `capability_mismatch` per AC3's stated order. Exports `providerLabel` for reuse in the popup preview.
- **`browser-extension/src/popup.html` + `popup.js`**: a "Browser action approval" panel inside the existing progressive-disclosure `<details id="diagnostics">` (no AC4 duplication), with Approve/Decline buttons and a text preview (provider, target conversation, first 160 chars of the reply). The attention item's single primary action is "Review request" — it opens diagnostics and focuses the panel; it never auto-approves or auto-declines. Decline requires an extra `confirm()`.
- **`browser-extension/src/background.js`**: `decideBrowserActionApproval` posts the decision to the new route and, only on approve, wakes the existing poll loop so the now-queued action is picked up without waiting for the next alarm.

### Deliberately not modeled: `destructive_conflict`

AC3 also names "destructive conflict" as a category. I looked for a real trigger and didn't find one: `claim_action` already serializes to exactly one in-flight action at a time (`if any(status in {leased, preparing, submit_intent})`: return None`), so there is no genuine two-actions-racing-for-the-same-resource scenario in the current architecture to attach a "conflict" decision to. Adding an enum value with no real firing condition would be an unbacked, unfireable category — left as an explicit, documented gap in `models.py` for a future bead once a genuine collision scenario exists (e.g. multi-instance orchestration).

### Out of scope (per task assignment)

The sibling yyvg.7 item "live offline-recovery proof" needs a live browser fixture and was explicitly excluded from this task's scope — untouched here.

## Verification

- `devtools test tests/unit/browser_capture/` → **153 passed** (was 143 before this change; 10 new/modified tests cover: awaiting_approval gating on enqueue, `conversation.create` and `stage_only` remaining unaffected, approve/decline transitions, conflict on re-deciding an already-decided or never-held action, and a full HTTP round trip through the new route).
- `devtools test tests/unit/daemon/test_route_contracts.py` → 1 pre-existing unrelated failure (`test_rebuild_index_handler_forwards_resumable_pass_options_through_writer_bridge`), reproduced identically on `origin/master` before this change (confirmed via `git stash`).
- `mypy polylogue/browser_capture/{models,actions,server,route_contracts}.py` → `Success: no issues found in 4 source files`.
- `devtools verify --quick` → exit 0 (format, lint, mypy, render-all-check, topology/layering/closure-matrix, schema roundtrip, manifests, docs) — ran clean both pre-commit and pre-push.
- `cd browser-extension && npx vitest run` → 354/355 passed (added 8 new tests across `operator_status.test.js`, `popup.test.js`, `background.test.js`); the 1 failure (`build.mjs` packaged-service-worker backfill fixture) reproduces identically on `origin/master` before this change (confirmed via `git stash`) and is unrelated to browser actions.
- `cd browser-extension && npm run lint && npm run validate` → clean.

### Not verified (needs a live browser; explicitly out of scope for this task)

Visual rendering of the new diagnostics panel in a real popup, and an actual end-to-end trigger→popup-display proof against a real ChatGPT session with a genuine `submit_once` reply. The data model, state-transition logic, HTTP contract, and DOM-wiring logic are all covered by the automated tests above; the live-browser proof is a separate, already-tracked yyvg.7 item.

Ref polylogue-yyvg.7