### PR TITLE
fix(query): add pre-parse nesting-depth guard against transformer DoS

### DIFF
--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -198,6 +198,20 @@ class UnsupportedSessionTerminalActionError(ExpressionCompileError):
     """Raised when a session-source terminal action is not supported."""
 
 
+class QueryDepthExceededError(ExpressionCompileError):
+    """Raised when a query expression's parenthesis nesting is too deep to parse safely.
+
+    The Boolean grammar's ``expr`` rule is recursive (``"(" expr ")"``), so an
+    adversarially deep run of nested parens drives Lark's post-parse
+    ``Transformer.transform()`` walk (a stock mutually-recursive tree-walker
+    with no depth guard of its own) into a Python ``RecursionError`` -- a
+    cheap way to burn real CPU on the shared daemon/MCP/HTTP query surface
+    (polylogue-u0dm). This error is raised by a linear, quote-aware scan over
+    the raw expression *before* the Lark parse/transform is attempted, so a
+    rejected expression costs a bounded scan rather than a partial parse.
+    """
+
+
 #: Recognized ``has:`` sub-tokens that map to boolean spec flags.
 #: Other values pass through to ``has_types``.
 _HAS_BOOL_MAP: dict[str, str] = {
@@ -1643,7 +1657,71 @@ def _is_boolean_expression(expression: str) -> bool:
     return ":" in expression and bool(re.search(r"\b(?:and|or|not)\b", expression, re.IGNORECASE))
 
 
+#: Maximum parenthesis nesting depth accepted by the Boolean grammar's
+#: recursive ``expr`` rule. Comfortably covers any legitimate hand- or
+#: tool-authored query (real Boolean queries in this codebase nest at most a
+#: handful of levels deep) while sitting well below Python's default
+#: recursion limit (1000), so a rejection never risks tripping a
+#: ``RecursionError`` of its own inside the cheap preflight scan itself.
+_MAX_QUERY_NESTING_DEPTH = 64
+
+
+def _expression_nesting_depth(expression: str) -> int:
+    """Return the maximum parenthesis nesting depth of *expression*.
+
+    A linear, single-pass scan over the raw text -- no Lark grammar,
+    tokenization, or recursion of its own. Quoted string literals (and
+    backslash-escaped characters within them) are skipped so that
+    parentheses appearing inside quoted text, such as
+    ``fts:"note (see appendix)"``, are not counted as structural nesting
+    (mirrors the quote/escape handling in :func:`_split_pipeline_stages`).
+    """
+
+    depth = 0
+    max_depth = 0
+    in_quote = False
+    escaped = False
+    for char in expression:
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\" and in_quote:
+            escaped = True
+            continue
+        if char == '"':
+            in_quote = not in_quote
+            continue
+        if in_quote:
+            continue
+        if char == "(":
+            depth += 1
+            if depth > max_depth:
+                max_depth = depth
+        elif char == ")":
+            depth = max(0, depth - 1)
+    return max_depth
+
+
+def _check_query_nesting_depth(expression: str) -> None:
+    """Reject over-deep parenthesis nesting before the Lark parse is attempted.
+
+    Raises:
+        QueryDepthExceededError: if *expression* nests parentheses deeper than
+            :data:`_MAX_QUERY_NESTING_DEPTH`.
+    """
+
+    depth = _expression_nesting_depth(expression)
+    if depth > _MAX_QUERY_NESTING_DEPTH:
+        raise QueryDepthExceededError(
+            f"query expression nesting depth {depth} exceeds the maximum of "
+            f"{_MAX_QUERY_NESTING_DEPTH}; simplify the expression by reducing "
+            "nested parenthesized groups",
+            field=None,
+        )
+
+
 def _transform_boolean_predicate(expression: str) -> QueryPredicate:
+    _check_query_nesting_depth(expression)
     try:
         tree = _QUERY_PARSER.parse(expression, start="boolean_query")
     except UnexpectedInput as exc:

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import time
 from pathlib import Path
 from typing import Any, cast
 
@@ -28,8 +29,10 @@ import pytest
 from click.testing import CliRunner
 
 from polylogue.archive.query.expression import (
+    _MAX_QUERY_NESTING_DEPTH,
     EXPRESSION_FIELD_REGISTRY,
     ExpressionCompileError,
+    QueryDepthExceededError,
     QueryUnitPipeline,
     QueryUnitSessionScopeStage,
     QueryUnitSource,
@@ -513,6 +516,90 @@ class TestExplainExpression:
         lowering_plan = cast(dict[str, Any], payload["lowering_plan"])
         assert lowering_plan["pipeline"] == unit_source["pipeline"]
         assert lowering_plan["pipeline_stages"] == unit_source["pipeline_stages"]
+
+
+class TestQueryNestingDepthGuard:
+    """polylogue-u0dm: reject adversarial nesting cheaply, before Lark parse/transform.
+
+    ``sessions where (((...)))`` recurses through the Boolean grammar's
+    ``expr`` rule, and Lark's stock ``Transformer.transform()`` walk has no
+    depth guard of its own -- deep-enough nesting previously spent real CPU
+    (~0.83s observed for n=250) building a parse tree only to blow Python's
+    recursion limit during the transform walk. The fix short-circuits with a
+    linear, quote-aware scan before the parse is even attempted.
+    """
+
+    def test_reasonable_nesting_still_parses(self) -> None:
+        # One level below the ceiling: legitimate deep-but-bounded nesting
+        # (e.g. programmatically generated queries) must not false-positive.
+        depth = _MAX_QUERY_NESTING_DEPTH - 1
+        expression = "sessions where " + "(" * depth + "repo:polylogue" + ")" * depth
+
+        spec = compile_expression(expression)
+
+        assert spec.boolean_predicate is not None
+
+    def test_nesting_at_the_ceiling_still_parses(self) -> None:
+        expression = (
+            "sessions where " + "(" * _MAX_QUERY_NESTING_DEPTH + "repo:polylogue" + ")" * _MAX_QUERY_NESTING_DEPTH
+        )
+
+        spec = compile_expression(expression)
+
+        assert spec.boolean_predicate is not None
+
+    def test_quoted_parens_do_not_count_toward_depth(self) -> None:
+        # Parens inside a quoted FTS phrase are literal text, not structural
+        # nesting -- a long run of them must not trip the guard.
+        quoted_parens = "(" * (_MAX_QUERY_NESTING_DEPTH * 2)
+        expression = f'sessions where ~"note {quoted_parens} appendix"'
+
+        spec = compile_expression(expression)
+
+        assert spec.boolean_predicate is not None
+
+    def test_excessive_nesting_raises_purpose_built_error_not_generic_fallback(self) -> None:
+        depth = _MAX_QUERY_NESTING_DEPTH + 1
+        expression = "sessions where " + "(" * depth + "repo:polylogue" + ")" * depth
+
+        with pytest.raises(QueryDepthExceededError, match=r"nesting depth \d+ exceeds the maximum") as exc_info:
+            compile_expression(expression)
+
+        # Purpose-built subclass of the module's typed compile-error base,
+        # not the base ``ExpressionCompileError`` (which would indicate the
+        # generic fallback path) and not a bare ``RecursionError``.
+        assert isinstance(exc_info.value, ExpressionCompileError)
+        assert type(exc_info.value) is QueryDepthExceededError
+
+    def test_adversarial_bomb_payload_rejected_cheaply(self) -> None:
+        # The exact shape reported in polylogue-u0dm: ~245 bytes, n=250
+        # nesting levels, previously costing ~0.83s CPU to hit
+        # ``RecursionError`` inside the transform walk.
+        n = 250
+        payload = "sessions where " + "(" * n + "repo:polylogue" + ")" * n
+
+        started = time.perf_counter()
+        with pytest.raises(QueryDepthExceededError):
+            compile_expression(payload)
+        elapsed = time.perf_counter() - started
+
+        # A fast rejection, not a slow one: generous ceiling still an order
+        # of magnitude below the previously observed ~0.83s RecursionError cost.
+        assert elapsed < 0.1
+
+    def test_depth_guard_covers_pipeline_stage_and_unit_source_entry_points(self) -> None:
+        # `_transform_boolean_predicate` is the single choke point for every
+        # Boolean-grammar entry (top-level `sessions where`, pipeline stages,
+        # and `<unit> where` terminal sources) -- exercise the non-top-level
+        # paths directly so a future refactor that adds a new bypass is caught.
+        n = _MAX_QUERY_NESTING_DEPTH + 1
+        bomb = "(" * n + "repo:polylogue" + ")" * n
+
+        with pytest.raises(QueryDepthExceededError):
+            compile_expression(f"messages where {bomb}")
+
+        with pytest.raises(QueryDepthExceededError):
+            compile_expression(f"sessions where {bomb} | count")
 
 
 class TestBooleanQueryExpression:


### PR DESCRIPTION
## Summary
Adds a cheap, quote-aware preflight scan that rejects adversarially deep parenthesis nesting in query-DSL Boolean expressions *before* the Lark parse/transform is attempted, closing a resource-amplification vector on the shared daemon/MCP/HTTP query surface.

## Problem
The Boolean query grammar's `expr` rule (`polylogue/archive/query/expression.py`) is recursive (`"(" expr ")"`), and Lark's stock `Transformer.transform()` walk used by `_BooleanQueryTransformer` has no depth guard of its own. A ~245-byte payload of n=250 nested parens drives that walk into a Python `RecursionError`.

This was already contained (a clean one-line CLI error via `machine_main.py`'s broad `PolylogueError` handler — no traceback, no process corruption across repeated bomb/good-query cycles), but it surfaced as the generic unexpected-error fallback rather than a purpose-built diagnostic, and cost a repeatable ~0.83s CPU per payload — a cheap, trivially-discoverable amplification vector for anyone hitting the shared query surface with adversarial nesting.

## Solution
- Added `_expression_nesting_depth`: a linear, single-pass scan over the raw expression text that tracks max parenthesis nesting depth, respecting quoted string literals and backslash escapes (mirrors the existing quote/escape handling already used by `_split_pipeline_stages`) so parens inside `~"note (see appendix)"`-style quoted text are not counted as structural nesting.
- Added `_check_query_nesting_depth`, called at the top of `_transform_boolean_predicate` — the single choke point through which every Boolean-grammar entry path reaches the Lark parser (top-level `sessions where`, pipeline stages via `_session_source_predicate`, and `<unit> where` terminal sources via `_parse_plain_unit_source_expression`). Verified each of these three call sites subclasses through this one function, so no bypass exists today.
- New `_MAX_QUERY_NESTING_DEPTH = 64` ceiling: comfortably above any real hand- or tool-authored query, well below Python's default recursion limit (1000).
- New `QueryDepthExceededError(ExpressionCompileError)` — a purpose-built typed error, not the generic unexpected-error fallback. Because it subclasses `ExpressionCompileError`, the existing CLI (`PolylogueError` handler in `machine_main.py`), MCP (`server_support.py`), and HTTP (`daemon/http.py`) error paths already catch it correctly — no new plumbing needed.
- The compact (non-Boolean) query grammar has no recursive paren rule today, so it isn't independently vulnerable, but `_is_boolean_expression` routes any expression starting with `(` (or containing `exists <unit>(`, `seq(`, etc.) into the guarded Boolean path regardless.

## Verification
- `devtools test tests/unit/cli/test_query_expression.py` → 430 passed, 1 skipped. 6 new tests in `TestQueryNestingDepthGuard`:
  - reasonable nesting (ceiling − 1) and nesting exactly at the ceiling still parse (no false positive)
  - parentheses inside a quoted FTS phrase don't count toward depth
  - the n=250 bomb payload from the bug report is rejected in well under 0.1s (previously ~0.83s to `RecursionError`) with the typed `QueryDepthExceededError`, asserting `type(...) is QueryDepthExceededError` (not the base `ExpressionCompileError`, not a bare `RecursionError`)
  - the guard fires from the pipeline-stage (`sessions where ... | count`) and unit-source (`messages where ...`) entry points too, not just the top-level path
- `devtools verify --quick` → exit_code 0 (ruff format, ruff check, mypy --strict, render all --check) — also re-ran automatically via the pre-push hook.
- Manual timing: adversarial n=250 nested-paren payload previously ~0.83s CPU to `RecursionError`; now rejected in ~0.00023s.
- Not run: `devtools verify --seed-testmon` (full-suite testmon seed) — this is optional first-time infra for the testmon inner loop, not a required gate; the focused file run + quick gate above are the project's required local verification for a change of this shape.

Ref polylogue-u0dm