### PR TITLE
feat(devloop): close remaining polylogue-5en gaps (stale-run detection, MCP recipe)

### DIFF
--- a/devtools/dev_loop.py
+++ b/devtools/dev_loop.py
@@ -370,8 +370,9 @@ def _dev_loop_suggested_env(
     api_port: int,
     browser_capture_port: int,
     run_id: str,
+    commit: str | None = None,
 ) -> dict[str, str]:
-    return {
+    env = {
         "POLYLOGUE_ARCHIVE_ROOT": str(archive),
         "POLYLOGUE_API_PORT": str(api_port),
         "POLYLOGUE_BROWSER_CAPTURE_PORT": str(browser_capture_port),
@@ -382,6 +383,14 @@ def _dev_loop_suggested_env(
         "XDG_DATA_HOME": str(run_log_dir / "xdg-data"),
         "XDG_STATE_HOME": str(run_log_dir / "xdg-state"),
     }
+    # Recorded so the running daemon can detect the stale-run-dir trap: if the
+    # checkout's HEAD moves (branch switch, pull, rebase) after launch, Python
+    # has already imported the old code into the running process's memory --
+    # `git branch --show-current` on disk no longer reflects what the daemon
+    # is actually serving. See `_dev_loop_payload` in `polylogue/daemon/http.py`.
+    if commit:
+        env["POLYLOGUE_DEV_LOOP_LAUNCH_COMMIT"] = commit
+    return env
 
 
 def _preflight_suggested_env(preflight: dict[str, Any]) -> dict[str, str]:
@@ -401,6 +410,7 @@ def _preflight_suggested_env(preflight: dict[str, Any]) -> dict[str, str]:
         api_port=int(api_status["port"]),
         browser_capture_port=int(receiver_status["port"]),
         run_id=str(preflight["run_id"]),
+        commit=(str(commit_value) if (commit_value := preflight.get("commit")) else None),
     )
 
 
@@ -3098,6 +3108,7 @@ def build_dev_loop_status(
         api_port=api_port,
         browser_capture_port=browser_capture_port,
         run_id=run_id,
+        commit=commit,
     )
     if prepare:
         archive.mkdir(parents=True, exist_ok=True)

--- a/docs/dev-loop.md
+++ b/docs/dev-loop.md
@@ -173,6 +173,37 @@ event stream together with `polylogued.launch.json` and `polylogued.log` to
 diagnose whether a branch-local failure happened during API/receiver readiness
 or inside the daemon itself.
 
+### Stale-run-dir detection
+
+Switching branches, pulling, or rebasing on disk after the branch-local daemon
+started does **not** change what code it is actually running: Python already
+imported the old modules into the live process. `git branch --show-current`
+on a fresh preflight will happily report the new branch while the running
+daemon keeps serving the old one — restart is required, not just a re-run of
+`devtools workspace dev-loop`.
+
+The launcher records the commit it started at as `POLYLOGUE_DEV_LOOP_LAUNCH_COMMIT`
+in the daemon's own environment (part of `suggested_env`/`polylogued.env.json`).
+`GET /api/dev-loop` re-derives the checkout's live HEAD on every call and
+compares it against that launch-time commit:
+
+```json
+{
+  "run_id": "...",
+  "launch_commit": "abc1234",
+  "current_commit": "def5678",
+  "stale": true
+}
+```
+
+The web shell's `dev:` chip (`renderDevLoopChip` in `web_shell.py`) reads the
+same payload and switches to the `q-stale` quality class with a `(stale)`
+label and a tooltip naming both commits when they diverge — this is the
+"daemon + web" stale warning named in polylogue-5en's acceptance criteria.
+`stale` is always `false` when no launch commit was recorded (e.g. a
+production/non-dev-loop daemon, or a non-git checkout), so the field never
+false-positives outside a dev-loop run.
+
 Once the daemon passes its schema preflight, it also writes durable
 `daemon.lifecycle` rows to the existing `ops.db` daemon event ledger. These
 rows carry the same dev-loop run id when `POLYLOGUE_DEV_LOOP_RUN_ID` is set and
@@ -376,6 +407,33 @@ auth, verifies that an unauthenticated capture is rejected, verifies that an
 authenticated synthetic capture is accepted, and reports the written spool
 artifact. It uses the branch-local run directory and does not talk to the
 deployed `polylogued.service`.
+
+**Concurrent spool/dedup proof.** The receiver's write path is designed for
+two extension instances (or two receiver processes sharing one spool root)
+racing to post the same conversation snapshot: they must converge on exactly
+one spool artifact, never corrupt it, and never overshoot the spool quota.
+This is exercised by real concurrency, not a toy replica:
+
+- `tests/unit/browser_capture/test_receiver.py::test_concurrent_new_session_writes_never_exceed_the_quota` —
+  20 threads racing distinct new sessions against a quota of 5 must produce at
+  most 5 files, proving `_check_spool_quota` + `_SPOOL_WRITE_LOCK` close the
+  TOCTOU window.
+- `tests/unit/daemon/test_browser_capture_instance_attribution.py::test_multiple_receiver_processes_deduplicate_without_corrupting_spool` —
+  two separate OS processes (`multiprocessing`, `spawn` context) posting the
+  same content-hash-equivalent envelope under two different
+  `extension_instance_id`s must leave exactly one artifact on disk, proving the
+  advisory `flock` (`_spool_file_lock`) serializes writers beyond one receiver
+  process.
+- `tests/unit/daemon/test_browser_capture_instance_attribution.py::test_concurrent_extension_instances_deduplicate_without_corrupting_spool` —
+  the same race within one process (`ThreadPoolExecutor`) followed by an actual
+  archive ingest, proving the deduplicated capture also converges to one
+  archived session.
+
+Run them together for the branch-local proof:
+
+```bash
+devtools test tests/unit/browser_capture/test_receiver.py tests/unit/daemon/test_browser_capture_instance_attribution.py
+```
 
 For service-worker-to-receiver coverage, run the extension smoke:
 
@@ -628,6 +686,65 @@ back to Sinnix. Never point a branch daemon at the live archive directory.
 
    The branch run never touches the live archive or the deployed unit beyond
    the explicit stop/start above — both remain operator actions.
+
+## MCP Server
+
+The MCP server (`polylogue.mcp.cli:main`, console script `polylogue-mcp`) is a
+standalone stdio process — it is not part of `polylogued` and has no port to
+isolate. It resolves its archive root through the same 5-layer config as the
+CLI (see `docs/configuration.md`), so a branch-local instance is just that
+process launched with the branch-local archive root in its environment:
+
+```bash
+POLYLOGUE_ARCHIVE_ROOT=.local/dev-archive \
+  python -c "from polylogue.mcp.cli import main; main()"
+```
+
+or, from an installed console script:
+
+```bash
+POLYLOGUE_ARCHIVE_ROOT=.local/dev-archive polylogue-mcp
+```
+
+**Do not edit the operator's registered `.mcp.json`/`~/.claude.json` MCP server
+entry to point at a branch checkout** — that is the "prod-registered" instance
+other agent sessions rely on, and clobbering it mid-session breaks their
+archive access. Instead:
+
+- run the branch-local process directly and drive it with a raw stdio client
+  (or `mcp` inspector tooling) for interactive debugging; or
+- register a **second**, distinctly-named MCP server entry in a project-local
+  or throwaway client config (e.g. `.mcp.dev-loop.json`, not committed) that
+  points `command`/`args`/`env` at the branch checkout's interpreter and
+  `POLYLOGUE_ARCHIVE_ROOT`; or
+- exercise tool behavior directly in Python via `polylogue.mcp.server.build_server`,
+  which is exactly what `tests/unit/mcp/` and `tests/infra/mcp.py` already do —
+  the fastest branch-local MCP loop for verifying a tool contract change is
+  usually a focused `devtools test tests/unit/mcp/...` run, not a live client.
+
+There is no shared server-side state to isolate between two branch-local MCP
+instances: `build_server`/`_get_server` hold an in-process singleton scoped to
+one Python process, and the MCP call log
+(`polylogue/mcp/call_log.py::start_mcp_call_log`) resolves its spool path
+through the same per-process resolved config, so it follows whatever archive
+root that process's `POLYLOGUE_ARCHIVE_ROOT` names. Two branch-local `polylogue-mcp`
+processes pointed at two different `.local/dev-archive` roots (one per
+worktree) cannot cross-talk; nothing before this needed to be built, only
+documented.
+
+## Surface Isolation Summary
+
+Deliverable table for polylogue-5en: what isolates two concurrent branch-local
+dev loops from each other and from the deployed system, per surface.
+
+| Surface | Isolation unit | Cross-talk guard | Stale-code detection |
+| --- | --- | --- | --- |
+| Daemon (`polylogued run`) | `POLYLOGUE_ARCHIVE_ROOT` + API/receiver ports (`--isolated-ports` or explicit `--api-port`/`--browser-capture-port`) | Preflight refuses to launch onto an already-occupied port; `system_service` check warns when the deployed unit is active without isolated ports | `GET /api/dev-loop` `stale` field (launch commit vs. live checkout HEAD); see above |
+| Web shell | Served by the branch-local daemon process on its own port; no separate process | Same as daemon (one HTTP server serves both) | Same `dev:` chip, same `stale` field |
+| CLI/TUI capture | `--capture-cli`/`--tui-plan` write under `.cache/dev-loop/<run-id>/{terminal,tui}/`, keyed by the run id (which embeds branch+commit+ports) | Two branches produce two different run ids and therefore two different artifact directories; nothing is shared | N/A — each capture is a point-in-time transcript, not a long-lived process |
+| Browser-capture receiver | Its own port (`--browser-capture-port`) and spool path (`--browser-capture-spool`, defaults under the run's `XDG_DATA_HOME`) | Advisory `flock` on the spool root (`_spool_file_lock`) serializes writers even across processes; the `_SPOOL_WRITE_LOCK` + quota check are also process-serialized (see the concurrent spool/dedup tests below) | Not applicable — the receiver is a pure function of each request; there is no in-memory model to go stale |
+| Browser extension | Configured via receiver URL/token at load time (`--browser-plan`, `--extension-smoke`, `--browser-smoke`) | Each branch's plan/smoke uses that branch's receiver port; loading the extension unpacked from a different worktree simply targets a different receiver URL | Reload the unpacked extension after a code change; MV3 does not hot-reload either |
+| MCP server (`polylogue-mcp`) | `POLYLOGUE_ARCHIVE_ROOT` in the process's own environment; stdio transport, no shared port | Each branch runs its own process; `build_server`'s singleton and the MCP call log are process-local and follow that process's resolved config (see "MCP Server" above) | Restart the process after a code change; there is no daemon-style live payload to compare commits (stdio has no persistent debug endpoint) |
 
 ## Current Boundary
 

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -377,6 +377,30 @@ def _parse_optional_int_env(name: str) -> int | None:
         return None
 
 
+def _dev_loop_current_commit(cwd: str) -> str | None:
+    """Return the checkout's current short HEAD commit, or ``None`` if unknown.
+
+    Used only to detect the stale-run-dir trap (see ``_dev_loop_payload``);
+    never raises on a non-git checkout, missing ``git``, or a slow/hung call.
+    """
+    import subprocess
+
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
 def _dev_loop_payload() -> JSONDocument:
     # Deliberately raw os.environ reads, not load_polylogue_config(): this
     # endpoint reports whether the dev-loop LAUNCHER set these vars in the
@@ -393,6 +417,16 @@ def _dev_loop_payload() -> JSONDocument:
     log_dir = os.environ.get("POLYLOGUE_DEV_LOOP_LOG_DIR")
     archive_root = os.environ.get("POLYLOGUE_ARCHIVE_ROOT")
     enabled = any((run_id, log_dir))
+    # Stale-run-dir trap (devloop-runtime memory, polylogue-5en): a branch
+    # switch/pull/rebase on disk after this process was launched does NOT
+    # change what code is actually running -- Python already imported the
+    # old modules. `launch_commit` is the HEAD the launcher recorded at
+    # start; `current_commit` is read fresh from the checkout on every call.
+    # A mismatch means this daemon is serving stale code and must be
+    # restarted, not just re-preflighted.
+    launch_commit = os.environ.get("POLYLOGUE_DEV_LOOP_LAUNCH_COMMIT")
+    current_commit = _dev_loop_current_commit(os.getcwd()) if launch_commit else None
+    stale = bool(launch_commit and current_commit and launch_commit != current_commit)
     return {
         "ok": True,
         "enabled": enabled,
@@ -403,6 +437,9 @@ def _dev_loop_payload() -> JSONDocument:
         "browser_capture_port": _parse_optional_int_env("POLYLOGUE_BROWSER_CAPTURE_PORT"),
         "pid": os.getpid(),
         "cwd": os.getcwd(),
+        "launch_commit": launch_commit,
+        "current_commit": current_commit,
+        "stale": stale,
     }
 
 

--- a/polylogue/daemon/web_shell.py
+++ b/polylogue/daemon/web_shell.py
@@ -1387,13 +1387,20 @@ function renderDevLoopChip(payload) {
   var runId = payload.run_id || 'local';
   var label = String(runId);
   if (label.length > 14) label = label.slice(0, 11) + '...';
-  el.textContent = 'dev: ' + label;
-  setChipQuality(el, 'partial');
+  var stale = !!payload.stale;
+  el.textContent = 'dev: ' + label + (stale ? ' (stale)' : '');
+  setChipQuality(el, stale ? 'stale' : 'partial');
   var details = [];
   if (payload.archive_root) details.push('archive ' + payload.archive_root);
   if (payload.log_dir) details.push('logs ' + payload.log_dir);
   if (payload.api_port) details.push('api :' + payload.api_port);
   if (payload.browser_capture_port) details.push('capture :' + payload.browser_capture_port);
+  if (stale) {
+    details.push(
+      'STALE: running commit ' + (payload.launch_commit || '?') + ' but checkout is now at '
+      + (payload.current_commit || '?') + ' -- restart the branch-local daemon'
+    );
+  }
   el.title = 'Branch-local dev loop'
     + (payload.run_id ? ' ' + payload.run_id : '')
     + (details.length ? '; ' + details.join('; ') : '');

--- a/tests/unit/daemon/test_daemon_http_contracts.py
+++ b/tests/unit/daemon/test_daemon_http_contracts.py
@@ -619,11 +619,57 @@ class TestPrivacyContract:
             "browser_capture_port": 8875,
             "pid": os.getpid(),
             "cwd": os.getcwd(),
+            "launch_commit": None,
+            "current_commit": None,
+            "stale": False,
         }
         serialized = json.dumps(payload)
         assert "SECRET-DEV-LOOP-TOKEN" not in serialized
         assert "SECRET-ENV-DUMP-CANARY" not in serialized
         assert "POLYLOGUE_TEST_SENTINEL_ENV_DO_NOT_DUMP" not in serialized
+
+    def test_dev_loop_payload_reports_stale_when_launch_commit_differs_from_current_commit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """polylogue-5en: the stale-run-dir trap.
+
+        Switching branches on disk after the daemon started does not change
+        what code the process is actually running -- Python already imported
+        the old modules. The daemon must detect and surface the mismatch
+        between the commit recorded at launch and the checkout's live HEAD.
+        """
+        import polylogue.daemon.http as http_mod
+
+        monkeypatch.setenv("POLYLOGUE_DEV_LOOP_RUN_ID", "dev-run-stale")
+        monkeypatch.setenv("POLYLOGUE_DEV_LOOP_LAUNCH_COMMIT", "aaa1111")
+        monkeypatch.setattr(http_mod, "_dev_loop_current_commit", lambda cwd: "bbb2222")
+
+        handler = _make_handler("GET", "/api/dev-loop")
+        _, send_json = _capture_responses(handler)
+        handler.do_GET()
+
+        _, payload = send_json.call_args.args
+        assert payload["launch_commit"] == "aaa1111"
+        assert payload["current_commit"] == "bbb2222"
+        assert payload["stale"] is True
+
+    def test_dev_loop_payload_is_not_stale_when_launch_and_current_commit_match(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import polylogue.daemon.http as http_mod
+
+        monkeypatch.setenv("POLYLOGUE_DEV_LOOP_RUN_ID", "dev-run-fresh")
+        monkeypatch.setenv("POLYLOGUE_DEV_LOOP_LAUNCH_COMMIT", "ccc3333")
+        monkeypatch.setattr(http_mod, "_dev_loop_current_commit", lambda cwd: "ccc3333")
+
+        handler = _make_handler("GET", "/api/dev-loop")
+        _, send_json = _capture_responses(handler)
+        handler.do_GET()
+
+        _, payload = send_json.call_args.args
+        assert payload["stale"] is False
 
     def test_dev_loop_payload_is_disabled_without_launcher_metadata(
         self,
@@ -635,6 +681,7 @@ class TestPrivacyContract:
             "POLYLOGUE_ARCHIVE_ROOT",
             "POLYLOGUE_API_PORT",
             "POLYLOGUE_BROWSER_CAPTURE_PORT",
+            "POLYLOGUE_DEV_LOOP_LAUNCH_COMMIT",
         ):
             monkeypatch.delenv(name, raising=False)
 
@@ -647,6 +694,7 @@ class TestPrivacyContract:
         assert payload["enabled"] is False
         assert payload["run_id"] is None
         assert payload["log_dir"] is None
+        assert payload["stale"] is False
 
     def test_status_payload_does_not_leak_secrets(
         self,

--- a/tests/unit/devtools/test_dev_loop.py
+++ b/tests/unit/devtools/test_dev_loop.py
@@ -157,6 +157,7 @@ def test_build_dev_loop_status_uses_branch_local_paths_and_warnings(
     assert payload["suggested_env"]["POLYLOGUE_ARCHIVE_ROOT"] == str(repo / ".local" / "dev-archive")
     assert payload["suggested_env"]["POLYLOGUE_DAEMON_URL"] == "http://127.0.0.1:9999"
     assert payload["suggested_env"]["POLYLOGUE_DEV_LOOP_RUN_ID"] == payload["run_id"]
+    assert payload["suggested_env"]["POLYLOGUE_DEV_LOOP_LAUNCH_COMMIT"] == payload["commit"]
     assert payload["suggested_env"]["XDG_DATA_HOME"].endswith("/xdg-data")
     assert payload["archive_status"]["index_db_exists"] is False
     assert payload["archive_status"]["schema_ready"] is False


### PR DESCRIPTION
## Summary

Closes out the remaining acceptance criteria on polylogue-5en (branch-local
daemon/web/extension/MCP dev loops). Auditing current `master` against the
bead's AC found the daemon/web/extension/receiver dev loop was already
comprehensively built and tested; two concrete gaps remained, both fixed here.

## Problem

polylogue-5en's acceptance criteria require: "Each surface
(daemon/web/extension/MCP) has a documented branch-local recipe that two
concurrent branches can run without cross-talk; stale-run-dir detection warns
in at least the daemon + web cases." Its delivery-upgrade note additionally
names three residual proofs: extension smoke, concurrent spool/dedup test,
capture-gap event fixture.

Auditing the repo found:
- The three named proofs (extension smoke, concurrent spool/dedup, capture-gap
  fixture) already exist and pass — see Verification below.
- `devtools/dev_loop.py` and `docs/dev-loop.md` had **zero** mention of the MCP
  server — no branch-local recipe existed for it at all.
- Nothing detected the documented "known trap": a branch-local daemon keeps
  serving code from the commit it launched under even after the checkout
  switches branches, because Python already imported the old modules.

## Solution

- `devtools/dev_loop.py`: the launcher now records the launch-time commit as
  `POLYLOGUE_DEV_LOOP_LAUNCH_COMMIT` in the daemon's suggested/actual
  environment.
- `polylogue/daemon/http.py`: `GET /api/dev-loop` re-derives the checkout's
  live HEAD on every call and reports `launch_commit`, `current_commit`, and a
  `stale` bool when they diverge. Never false-positives when no launch commit
  was recorded (production daemon, non-git checkout).
- `polylogue/daemon/web_shell.py`: the `dev:` status chip renders the
  `q-stale` quality class with a `(stale)` label and a tooltip naming both
  commits when `stale` is true.
- `docs/dev-loop.md`: added a "Stale-run-dir detection" section, an "MCP
  Server" section documenting the branch-local recipe (run
  `polylogue-mcp`/`polylogue.mcp.cli:main` with a branch-local
  `POLYLOGUE_ARCHIVE_ROOT`; never edit the operator's registered `.mcp.json`
  entry — that's the "prod-registered" instance other sessions rely on), the
  requested surface-isolation deliverable table (daemon/web/CLI-TUI/receiver/
  extension/MCP × isolation unit × cross-talk guard × stale-code detection),
  and a citation of the existing concurrent spool/dedup proof tests next to
  the receiver-smoke docs.

(An earlier revision of this branch also carried a `type: ignore` band-aid for
an unrelated pre-existing mypy failure in `test_timestamp_guards.py`; that has
been dropped after rebasing onto master, which now has the proper root-cause
fix from #3332. This PR's diff no longer touches that file.)

## Verification

```
devtools test tests/unit/devtools/test_dev_loop.py \
  tests/unit/browser_capture/test_receiver.py \
  tests/unit/daemon/test_browser_capture_instance_attribution.py \
  tests/unit/daemon/test_daemon_http_contracts.py \
  tests/unit/daemon/test_web_reader.py
-> 284 passed
```

`mypy --strict` on all touched Python files: clean.
`devtools verify --quick` (post-rebase onto latest master): exit 0.

The bead's three named residual proofs are pre-existing and green:
- Extension smoke: `devtools workspace dev-loop --extension-smoke` +
  `tests/unit/devtools/test_dev_loop.py`.
- Concurrent spool/dedup: `test_concurrent_new_session_writes_never_exceed_the_quota`,
  `test_multiple_receiver_processes_deduplicate_without_corrupting_spool`,
  `test_concurrent_extension_instances_deduplicate_without_corrupting_spool`.
- Capture-gap event fixture: `polylogue/demo/seed.py::_write_demo_browser_capture_gap_sources`,
  `polylogue/demo/constructs.py::capture_gap_events`, exercised by
  `tests/unit/demo/test_demo_seed_verify.py`, `tests/unit/storage/test_archive_tiers_archive.py`,
  `tests/unit/storage/test_archive_tiers_write.py`, `tests/unit/scenarios/test_corpus.py`,
  `tests/integration/test_demo_daemon_convergence.py`.

Ref polylogue-5en

🤖 Generated with [Claude Code](https://claude.com/claude-code)