### PR TITLE
fix(storage): terminalize no-progress raw replay plans instead of looping

### DIFF
--- a/polylogue/storage/raw_authority.py
+++ b/polylogue/storage/raw_authority.py
@@ -741,6 +741,58 @@ def raw_replay_plan_deferred_for_envelope(archive_root: Path, *, max_payload_byt
         }
 
 
+RAW_REPLAY_NO_PROGRESS_REASON = (
+    "authority component executed a selected plan and produced zero replayed, "
+    "quarantined, or deferred outcomes -- accepted plan made no typed progress"
+)
+
+
+def raw_replay_plan_no_progress_plan_ids(archive_root: Path) -> set[str]:
+    """Return plan ids whose most recent selected execution made zero typed progress.
+
+    hjpx's core execution-completeness gap: ``repair_raw_materialization`` can
+    classify a raw as a replayable/selected authority component, hand it to
+    ``backfill_historical_revision_evidence``, and get back
+    ``replayed_logical_sources=0`` with no quarantine or adoption-deferral
+    either -- i.e. the plan executed without raising, but nothing durable
+    happened, and the same immutable plan id would otherwise be reselected
+    forever (a bug this bead's earlier passes describe as "accepted plan
+    never executes"). ``_raw_replay_plan_outcome`` now types that exact
+    first occurrence as ``TERMINAL`` (not ``RETRYABLE``) with
+    ``RAW_REPLAY_NO_PROGRESS_REASON`` instead of silently looping; this
+    function lets the caller exclude the SAME unchanged plan id from
+    automatic reselection afterward, mirroring
+    ``raw_replay_plan_deferred_for_envelope``'s envelope-scoped exclusion. A
+    changed source/index precondition mints a new plan id (see
+    ``validate_raw_replay_plan``) and is immediately eligible again; only the
+    exact plan that already proved it cannot make progress is held out.
+    """
+    source_db = archive_root / "source.db"
+    if not source_db.is_file():
+        return set()
+    with closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)) as conn:
+        exists = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='raw_authority_census_plans'"
+        ).fetchone()
+        if exists is None:
+            return set()
+        return {
+            str(row[0])
+            for row in conn.execute(
+                """
+                SELECT cp.plan_id
+                FROM raw_authority_census_plans AS cp
+                JOIN raw_authority_censuses AS c ON c.census_id = cp.census_id
+                WHERE cp.selected = 1
+                  AND cp.outcome_status = 'terminal'
+                  AND cp.reason = ?
+                  AND c.lifecycle_status IN ('completed', 'interrupted')
+                """,
+                (RAW_REPLAY_NO_PROGRESS_REASON,),
+            )
+        }
+
+
 def unresolved_raw_authority_blockers(archive_root: Path) -> int:
     source_db = archive_root / "source.db"
     if not source_db.is_file():

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -55,6 +55,7 @@ from polylogue.storage.message_type_backfill import (
     count_unclassified_message_type_sync,
 )
 from polylogue.storage.raw_authority import (
+    RAW_REPLAY_NO_PROGRESS_REASON,
     RawAuthorityCensusReceipt,
     RawReplayPlan,
     RawReplayPlanOutcome,
@@ -65,6 +66,7 @@ from polylogue.storage.raw_authority import (
     raw_replay_application_receipt,
     raw_replay_plan_deferred_for_envelope,
     raw_replay_plan_last_attempts,
+    raw_replay_plan_no_progress_plan_ids,
     record_raw_authority_census,
     record_raw_replay_outcome,
     recover_interrupted_raw_authority_censuses,
@@ -4211,6 +4213,7 @@ def _raw_authority_residual(
     *,
     census_pending_raw_ids: tuple[str, ...] = (),
     resource_blocked_plan_ids: tuple[str, ...] = (),
+    no_progress_plan_ids: tuple[str, ...] = (),
 ) -> dict[str, object]:
     """Return identity-sensitive residual debt for fixed-point comparison."""
     census_pending_digest = hashlib.sha256(
@@ -4229,6 +4232,11 @@ def _raw_authority_residual(
         "census_pending_raw_count": len(census_pending_raw_ids),
         "census_pending_raw_digest": census_pending_digest,
         "resource_blocked_plan_ids": list(resource_blocked_plan_ids),
+        # hjpx AC1/AC5: plans that executed and made zero typed progress are
+        # durable non-executable debt, distinct from a resource-envelope
+        # defer -- they must appear in residual so two quiescent passes
+        # cannot silently claim fixed point while one sits unresolved.
+        "no_progress_plan_ids": list(no_progress_plan_ids),
     }
 
 
@@ -4249,7 +4257,14 @@ def _raw_authority_postflight_snapshot(
             > max_payload_bytes
         )
     )
-    return plans, _raw_authority_residual(candidates, resource_blocked_plan_ids=blocked_plan_ids)
+    no_progress_plan_ids = tuple(
+        sorted(raw_replay_plan_no_progress_plan_ids(archive_root).intersection(plan.plan_id for plan in plans))
+    )
+    return plans, _raw_authority_residual(
+        candidates,
+        resource_blocked_plan_ids=blocked_plan_ids,
+        no_progress_plan_ids=no_progress_plan_ids,
+    )
 
 
 def _raw_authority_candidates_for_scope(
@@ -4295,12 +4310,37 @@ def _raw_replay_plan_outcome(
     plan: RawReplayPlan,
     *,
     remaining: RawMaterializationCandidates,
+    no_progress: bool = False,
 ) -> RawReplayPlanOutcome:
-    """Conserve one selected component into an explicit post-pass state."""
+    """Conserve one selected component into an explicit post-pass state.
+
+    ``no_progress`` (hjpx AC1) is set by the caller only after an actual
+    execution attempt (``backfill_historical_revision_evidence`` returned
+    without raising) whose own ``RevisionBackfillResult`` reported zero
+    replayed, quarantined, AND adoption-deferred outcomes for this exact
+    component.  Ordinarily a component still present in ``remaining`` is
+    ``RETRYABLE`` -- plausibly transient (lock contention, a sibling
+    component's turn) and worth another pass.  But an executed plan that
+    produced literally no typed side effect and still remains a candidate is
+    the "accepted plan never executes" defect this bead targets: retrying it
+    automatically forever is indistinguishable from silent limbo.  Type it
+    ``TERMINAL`` instead so it surfaces as durable debt requiring
+    investigation and stops being silently reselected (see
+    ``raw_replay_plan_no_progress_plan_ids``).
+    """
     plan_id = plan.plan_id
     component = plan.input_raw_ids
     remaining_ids = set(remaining.expanded_raw_ids) | set(remaining.raw_ids)
     if remaining_ids.intersection(component):
+        if no_progress:
+            return RawReplayPlanOutcome(
+                plan_id,
+                component,
+                RawReplayPlanStatus.TERMINAL,
+                RAW_REPLAY_NO_PROGRESS_REASON,
+                "durable debt: inspect authority/membership state directly; "
+                "do not retry automatically until source or index preconditions change",
+            )
         return RawReplayPlanOutcome(
             plan_id,
             component,
@@ -4392,13 +4432,16 @@ def _raw_replay_plan_outcomes(
     plans: Sequence[RawReplayPlan],
     *,
     remaining: RawMaterializationCandidates,
+    no_progress: bool = False,
 ) -> tuple[RawReplayPlanOutcome, ...]:
     if not plans:
         return ()
     with closing(sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True)) as conn:
         conn.row_factory = sqlite3.Row
         conn.execute("ATTACH DATABASE ? AS index_tier", (str(archive_root / "index.db"),))
-        return tuple(_raw_replay_plan_outcome(conn, plan, remaining=remaining) for plan in plans)
+        return tuple(
+            _raw_replay_plan_outcome(conn, plan, remaining=remaining, no_progress=no_progress) for plan in plans
+        )
 
 
 def _raw_replay_conservation_metrics(
@@ -6109,8 +6152,12 @@ def repair_raw_materialization(
     all_blocked_component_raw_ids = {raw_id for component in all_blocked_components for raw_id in component}
     resource_blocked_candidate_raw_ids = set(candidate_raw_ids).intersection(all_blocked_component_raw_ids)
     deferred_plan_ids = raw_replay_plan_deferred_for_envelope(archive_root, max_payload_bytes=max_payload_bytes)
+    no_progress_plan_ids = raw_replay_plan_no_progress_plan_ids(archive_root)
     admissible_components = [
-        component for component in ordered_components if plan_by_component[component].plan_id not in deferred_plan_ids
+        component
+        for component in ordered_components
+        if plan_by_component[component].plan_id not in deferred_plan_ids
+        and plan_by_component[component].plan_id not in no_progress_plan_ids
     ]
     selected_components = (
         admissible_components[:raw_artifact_limit] if raw_artifact_limit is not None else admissible_components
@@ -6194,6 +6241,8 @@ def repair_raw_materialization(
         metrics["raw_materialization_non_stream_safe_oversized_count"] = float(len(oversized_non_stream_safe_raw_ids))
     if deferred_plan_ids:
         metrics["raw_materialization_deferred_plan_count"] = float(len(deferred_plan_ids))
+    if no_progress_plan_ids:
+        metrics["raw_materialization_no_progress_plan_count"] = float(len(no_progress_plan_ids))
     scope = _raw_authority_scope(
         raw_artifact_id=raw_artifact_id,
         provider=provider,
@@ -6202,7 +6251,7 @@ def repair_raw_materialization(
         raw_artifact_limit=raw_artifact_limit,
         max_payload_bytes=max_payload_bytes,
     )
-    if not dry_run and not selected_components and deferred_plan_ids:
+    if not dry_run and not selected_components and (deferred_plan_ids or no_progress_plan_ids):
         retained_census_receipt = latest_raw_authority_census_receipt(archive_root, scope=scope)
         if retained_census_receipt is None:
             # v1 receipts predate envelope identity.  They are safe to reuse
@@ -6213,15 +6262,26 @@ def repair_raw_materialization(
             retained_census_receipt = latest_raw_authority_census_receipt(archive_root, scope=legacy_scope)
         if retained_census_receipt is None:
             raise RuntimeError("resource-deferred raw replay lacks a completed durable census receipt")
+        detail = "Raw materialization has no newly admissible authority components"
+        if deferred_plan_ids:
+            detail += (
+                f"; {len(deferred_plan_ids):,} unchanged plan(s) remain deferred for "
+                f"the {_format_bytes(max_payload_bytes)} envelope"
+            )
+        if no_progress_plan_ids:
+            detail += (
+                f"; {len(no_progress_plan_ids):,} unchanged plan(s) remain terminal after making zero "
+                "typed progress and require investigation before retry"
+            )
         return _internal_derived_repair_result(
             "raw_materialization",
             repaired_count=0,
-            success=True,
-            detail=(
-                "Raw materialization has no newly admissible authority components; "
-                f"{len(deferred_plan_ids):,} unchanged plan(s) remain deferred for "
-                f"the {_format_bytes(max_payload_bytes)} envelope"
-            ),
+            # A no-progress plan is durable, investigation-requiring debt --
+            # unlike a resource-envelope defer, it is never expected to
+            # self-resolve without evidence changing, so it must not report
+            # success while it is the sole reason nothing was selected.
+            success=not no_progress_plan_ids,
+            detail=detail,
             metrics=metrics,
             census_receipt=retained_census_receipt,
         )
@@ -6230,12 +6290,14 @@ def repair_raw_materialization(
         plan_by_component[component].plan_id
         for component in ordered_components
         if not all_blocked_component_raw_ids.intersection(component)
+        and plan_by_component[component].plan_id not in no_progress_plan_ids
     }
     residual = _raw_authority_residual(
         candidates,
         resource_blocked_plan_ids=tuple(
             sorted(plan_by_component[component].plan_id for component in all_blocked_components)
         ),
+        no_progress_plan_ids=tuple(sorted(no_progress_plan_ids.intersection(plan.plan_id for plan in plans))),
     )
     census_receipt = record_raw_authority_census(
         archive_root,
@@ -6506,7 +6568,13 @@ def repair_raw_materialization(
             source_family=source_family,
             source_root=source_root,
         )
-        component_outcomes = _raw_replay_plan_outcomes(archive_root, [plan], remaining=current)
+        # hjpx AC1: an executed plan that produced zero replayed, quarantined,
+        # AND adoption-deferred outcomes made no typed progress at all --
+        # distinct from ordinary partial progress on a multi-key component.
+        # ``_raw_replay_plan_outcome`` types this TERMINAL (not RETRYABLE) so
+        # it stops being silently reselected forever.
+        no_progress = part.replayed_logical_sources == 0 and part.quarantined == 0 and part.adoption_deferred == 0
+        component_outcomes = _raw_replay_plan_outcomes(archive_root, [plan], remaining=current, no_progress=no_progress)
         for outcome in component_outcomes:
             application_receipt = raw_replay_application_receipt(archive_root, plan)
             receipted = dataclasses.replace(outcome, application_receipt=application_receipt)
@@ -6586,6 +6654,12 @@ def repair_raw_materialization(
     metrics["raw_materialization_plan_carried_forward_count"] = float(carried_forward_count)
     metrics["raw_materialization_plan_outcome_count"] = float(plan_count)
     metrics["raw_materialization_plan_conservation_error_count"] = float(conservation_error_count)
+    no_progress_outcome_count = sum(
+        outcome.status is RawReplayPlanStatus.TERMINAL and outcome.reason == RAW_REPLAY_NO_PROGRESS_REASON
+        for outcome in plan_outcomes
+    )
+    if no_progress_outcome_count:
+        metrics["raw_materialization_no_progress_count"] = float(no_progress_outcome_count)
     success = (
         not remaining.raw_ids
         and remaining.missing_blobs == 0
@@ -6593,6 +6667,7 @@ def repair_raw_materialization(
         and remaining.adoption_deferred == 0
         and remaining.byte_authority_pending == 0
         and conservation_error_count == 0
+        and no_progress_outcome_count == 0
         and not any(outcome.status is RawReplayPlanStatus.REJECTED_STALE for outcome in plan_outcomes)
         and (
             raw_artifact_id is None
@@ -6607,6 +6682,11 @@ def repair_raw_materialization(
         f"Replayed {replay.replayed_logical_sources:,} logical source(s) through typed revision authority; "
         f"{len(remaining.raw_ids):,} replay candidate(s) remain"
     )
+    if no_progress_outcome_count:
+        detail += (
+            f"; {no_progress_outcome_count:,} authority component(s) executed with zero typed progress and "
+            "are now terminal, requiring investigation before retry"
+        )
     if replay.quarantined:
         detail += f"; {replay.quarantined:,} ambiguous/legacy revision(s) quarantined"
     if replay.adoption_deferred:

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -1085,6 +1085,120 @@ def test_raw_materialization_ordinary_replay_reaches_two_call_fixed_point(tmp_pa
     assert receipts_after_first
 
 
+def test_raw_materialization_no_progress_component_terminalizes_instead_of_looping(tmp_path: Path) -> None:
+    """polylogue-hjpx AC1: an accepted plan that executes with zero typed
+    progress must not be silently re-selected forever.
+
+    Reproduces the exact production-shaped defect this bead names: a raw is
+    classified as a replayable/selected authority component by
+    ``repair_raw_materialization``, but its logical cohort has no unique
+    byte-proven full baseline (a genuinely orphaned ``append``-kind row with
+    no sibling ``full`` row for the same ``logical_source_key``) and no
+    membership evidence either -- so ``backfill_historical_revision_evidence``
+    runs its full census/replay pipeline without raising, yet returns
+    ``replayed_logical_sources=0`` with zero quarantine or adoption-deferral
+    too. Before this fix that raw was typed ``RETRYABLE`` forever: identical
+    selection, identical zero-progress execution, every pass, with no durable
+    signal distinguishing it from a plausible transient retry. It must
+    instead terminalize on the first no-progress execution and stop being
+    automatically reselected on the next pass.
+    """
+    config = _config(tmp_path)
+    initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
+    initialize_archive_database(tmp_path / "index.db", ArchiveTier.INDEX)
+    payload = b"""{
+      "id": "orphan-append",
+      "title": "orphan append",
+      "create_time": 1,
+      "update_time": 2,
+      "mapping": {
+        "message-1": {
+          "id": "message-1",
+          "parent": null,
+          "children": [],
+          "message": {
+            "id": "message-1",
+            "author": {"role": "user"},
+            "create_time": 2,
+            "content": {"content_type": "text", "parts": ["orphan"]}
+          }
+        }
+      },
+      "current_node": "message-1"
+    }"""
+    raw_id, blob_size = BlobStore(tmp_path / "blob").write_from_bytes(payload)
+    logical_source_key = "chatgpt-export:orphan-append"
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        source_conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash,
+                blob_size, acquired_at_ms, logical_source_key, revision_kind,
+                source_revision, revision_authority, acquisition_generation
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                raw_id,
+                "chatgpt-export",
+                "orphan-append",
+                "orphan-append.json",
+                0,
+                bytes.fromhex(raw_id),
+                blob_size,
+                1,
+                logical_source_key,
+                # An 'append'-kind row with no sibling 'full' row for the same
+                # logical_source_key: classify_raw_revision_cohort's full_rows
+                # query is empty (no 'full' rows at all), so plan_revision_
+                # replay's proven_full list is also empty regardless of this
+                # row's own authority -- accepted_raw_ids is (). The fallback
+                # to membership governance (convertible_full_revision_raw_ids)
+                # then refuses too, since not every row for this key is
+                # 'full'. No branch ever touches this raw.
+                "append",
+                "orphan-append-rev-1",
+                "quarantined",
+                0,
+            ),
+        )
+        source_conn.commit()
+
+    first = repair_mod.repair_raw_materialization(config)
+    assert first.success is False
+    assert first.repaired_count == 0
+    assert first.metrics.get("raw_materialization_no_progress_count") == 1.0
+    assert "zero typed progress" in first.detail
+    assert first.metrics["raw_materialization_remaining_candidate_count"] == 1.0
+
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        terminal_rows_after_first = source_conn.execute(
+            "SELECT COUNT(*) FROM raw_authority_census_plans WHERE outcome_status = 'terminal'"
+        ).fetchone()[0]
+    assert terminal_rows_after_first == 1
+
+    second = repair_mod.repair_raw_materialization(config)
+    # The stalled plan must not be reselected: no second execution attempt,
+    # so the metric that only appears when a component is actually selected
+    # for this pass is absent, and the terminal receipt count is unchanged
+    # (not doubled by a second no-progress execution of the same plan).
+    assert second.metrics.get("raw_materialization_selected_executable_component_count", 0.0) == 0.0
+    assert second.metrics.get("raw_materialization_no_progress_plan_count") == 1.0
+    # The raw remains honestly visible as unresolved debt, not silently
+    # reported as converged (this pass takes the "nothing newly admissible"
+    # early-return branch, which reports the base candidate count rather
+    # than a post-execution "remaining" count).
+    assert second.metrics["raw_materialization_candidate_count"] == 1.0
+    assert second.success is False
+
+    with sqlite3.connect(tmp_path / "source.db") as source_conn:
+        terminal_rows_after_second = source_conn.execute(
+            "SELECT COUNT(*) FROM raw_authority_census_plans WHERE outcome_status = 'terminal'"
+        ).fetchone()[0]
+    # Exactly one terminal receipt total: the plan was not re-executed and
+    # re-terminalized a second time.
+    assert terminal_rows_after_second == terminal_rows_after_first
+
+
 def test_raw_materialization_uses_authority_replay_not_legacy_batch_parser(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Fixes the core execution-completeness gap named in polylogue-hjpx AC1: `repair_raw_materialization` can classify a raw as a replayable/selected authority component, hand it to `backfill_historical_revision_evidence`, and get back `replayed_logical_sources=0` with no exception -- the plan executes but makes zero durable typed progress, and (before this PR) the exact same plan is silently reselected and re-executed forever with no signal distinguishing it from ordinary transient retry.

## Problem

`_raw_replay_plan_outcome` classified any component still present in the post-pass candidate set as `RETRYABLE`, regardless of whether the just-completed execution attempt made any progress at all. A cohort with no unique byte-proven full baseline AND no membership evidence (e.g. an orphaned `append`-kind raw with no sibling `full` row for its `logical_source_key`) hits an empty-fallback path in both `classify_raw_revision_cohort` and `classify_membership_revisions` -- nothing ever touches it.

Reproduced directly against unmodified master with a synthetic fixture (temp archive only, no live data): 4 consecutive `repair_raw_materialization` passes each reported `plan_retryable_count=1.0`, `plan_terminal_count=0.0` -- identical zero progress, forever.

## Solution

- `polylogue/storage/raw_authority.py`: added `RAW_REPLAY_NO_PROGRESS_REASON` + `raw_replay_plan_no_progress_plan_ids()`, mirroring the existing `raw_replay_plan_deferred_for_envelope` pattern. Deliberately reused the existing `TERMINAL` status rather than adding a new enum value -- that would require an additive migration widening the `outcome_status` CHECK constraint on the durable `source.db` tier (durable tiers need a backup-manifest-gated migration per this repo's schema regime), and `TERMINAL`'s existing semantics ("inspect durable authority debt; do not replay without new evidence") already fit exactly.
- `polylogue/storage/repair.py`: `_raw_replay_plan_outcome`/`_raw_replay_plan_outcomes` take a `no_progress` flag, set only after an actual execution attempt whose `RevisionBackfillResult` reported zero replayed, quarantined, AND adoption-deferred outcomes. When set, the outcome is `TERMINAL` instead of `RETRYABLE`. `repair_raw_materialization` excludes no-progress plan ids from admissible/executable component selection (same treatment as resource-envelope deferrals), threads the new state through `_raw_authority_residual`/`_raw_authority_postflight_snapshot` for fixed-point identity, and surfaces it in metrics/detail/`success` so the debt stays honestly visible rather than silently reported as converged.
- `tests/unit/storage/test_repair.py`: new fixture reproducing the exact failure (fails on unmodified master) and its fix (terminalizes on first no-progress execution; not reselected or re-executed on a second pass; raw stays visible as unresolved candidate debt).
- `tests/unit/core/test_timestamp_guards.py`: unrelated one-line `# type: ignore[arg-type]` fix for a pre-existing mypy/hypothesis stub mismatch that was blocking the pre-push hook for any branch (confirmed via `git stash` against unmodified master); separate commit, no behavior change.

## What this does NOT close

hjpx has 7 AC items and ~2 months of history; this PR is a continuation, not a closure.

- **AC1** (core execution-completeness gap): addressed.
- **AC2** (plan conservation into one explicit outcome) / **AC5** (residual debt visible across two quiescent passes): contributed to -- no-progress plans are now conserved into a typed terminal outcome and threaded into residual identity.
- **AC3** (fair bounded scheduling across many components), **AC4** (transient lock/resource retry -- already substantially covered by the earlier hjpx.1 kernel), **AC6** (sanitized scale fixture matching the 2026-07-15 shape), **AC7** (live-apply preflight) remain open and untouched by this PR.

No live archive was touched. Every fixture in this PR is a synthetic temp-directory archive, per this bead's explicit safety constraint (no live apply without verified backup + quiescent census + operator sign-off).

## Verification

- `devtools test tests/unit/sources/test_revision_backfill.py` -> 44 passed
- `devtools test -k raw_materialization` -> 115 passed
- `devtools test -k raw_authority` -> 81 passed
- `devtools test tests/unit/core/test_timestamp_guards.py` -> 96 passed
- `mypy --strict` on all changed files -> success, no issues
- `ruff check` / `ruff format --check` on all changed files -> clean
- `devtools render all --check` -> exit 0, no drift
- `devtools verify --quick` -> exit 0 (green push gate)
- **Anti-vacuity**: reverted `repair.py`/`raw_authority.py` via `git stash` and reran the new fixture directly against unmodified master -- confirmed 4 consecutive `repair_raw_materialization` passes all report `plan_retryable_count=1.0`, `plan_terminal_count=0.0` (the exact infinite-loop defect); with the fix restored, pass 1 terminalizes once and passes 2-4 show zero re-execution (verified via `backfill_historical_revision_evidence`'s own stage-timing log line appearing exactly once across all 4 passes)

Ref polylogue-hjpx