### PR TITLE
docs(ops): add quarterly restore-drill runbook, file live-tier backup gap

### DIFF
--- a/docs/archive-backup.md
+++ b/docs/archive-backup.md
@@ -88,3 +88,137 @@ Blob garbage collection is dry-run-first work. A safe GC report must prove:
 
 Do not delete blobs based only on filesystem age, directory mtime, or absence
 from `index.db`. `source.db` is the authority for raw evidence reachability.
+
+## Quarterly Restore Drill Runbook (polylogue-4be)
+
+First real drill executed 2026-07-27. This is the repeatable procedure for the
+next quarterly run — an untested backup is a hypothesis, not a capability, so
+this drill must actually restore bytes from the real backup stores into a
+scratch location and verify them, not just check that a job "ran".
+
+**Safety invariants**: restore only into a fresh scratch directory (never the
+live archive root, never `polylogued.service`'s data, never this repo's
+`.beads/`); treat borg repos and reflink source directories as read-only for
+the whole drill; delete the scratch restore once verified.
+
+### 1. Durable tier from Borg (`source.db`/`user.db`)
+
+The operator's `sinnix` host backs up `/realm` into the Borg repo at
+`/outer-realm/backup/borg-realm-v2` (btrbk snapshot -> `borgbackup-job-realm`
+drain, see sinnix `modules/backup.nix`). List archives and restore only the
+target files (not a whole directory — a directory extract can pull in a
+multi-GB blob store and stall):
+
+```bash
+export BORG_PASSCOMMAND="cat /run/agenix/borg-passphrase"
+export BORG_CACHE_DIR=/persist/root/.cache/borg
+REPO="file:///outer-realm/backup/borg-realm-v2"
+
+# List recent archives (needs root — repo dir is 0700 root:root)
+sudo env BORG_PASSCOMMAND="$BORG_PASSCOMMAND" BORG_CACHE_DIR="$BORG_CACHE_DIR" \
+  borg list --last 5 --format '{archive}{NL}' "$REPO"
+
+ARCHIVE="<pick latest realm-realm.* archive>"
+mkdir -p /realm/tmp/restore-drill-$(date +%Y%m%d)/borg-restore
+cd /realm/tmp/restore-drill-$(date +%Y%m%d)/borg-restore
+
+# Extract only the specific durable-tier file paths inside the archive —
+# never extract a whole directory without checking its size first.
+sudo env BORG_PASSCOMMAND="$BORG_PASSCOMMAND" BORG_CACHE_DIR="$BORG_CACHE_DIR" \
+  borg extract --list "$REPO::$ARCHIVE" \
+  "<relative/path/to>/user.db" "<relative/path/to>/source.db"
+
+sudo chown -R "$USER":"$USER" /realm/tmp/restore-drill-$(date +%Y%m%d)
+```
+
+Verify:
+
+```bash
+sqlite3 <restored>/user.db "PRAGMA integrity_check;"     # must print exactly "ok"
+sqlite3 <restored>/user.db "PRAGMA user_version; SELECT count(*) FROM assertions;"
+sqlite3 <restored>/source.db "PRAGMA integrity_check;"
+sqlite3 <restored>/source.db "PRAGMA user_version; SELECT count(*) FROM raw_sessions;"
+
+# Sane-lag comparison against the live archive (restored counts must be <=
+# live counts, and the gap should track the age of the chosen archive):
+sqlite3 /realm/db/polylogue/user.db "SELECT count(*) FROM assertions;"
+sqlite3 /realm/db/polylogue/source.db "SELECT count(*) FROM raw_sessions;"
+```
+
+**Negative control (deliberately corrupted restore must fail loudly)** —
+flip a few bytes past the SQLite header and confirm `integrity_check` reports
+corruption, not `ok`:
+
+```bash
+cp <restored>/user.db /tmp/corrupt-test.db
+python3 -c "
+with open('/tmp/corrupt-test.db', 'r+b') as f:
+    f.seek(4096); d = f.read(64); f.seek(4096)
+    f.write(bytes(b ^ 0xFF for b in d))
+"
+sqlite3 /tmp/corrupt-test.db "PRAGMA integrity_check;"   # must report errors, exit 11
+```
+
+2026-07-27 result: extracting `inbox/polylogue-backups/polylogue-archive-20260710T162633Z/{user,source}.db`
+(a receipt-verified pre-deploy backup snapshot, not the live-tier path — see
+gap below) from archive `realm-realm.20260727T163001+0200` took **29.4s**.
+Both files passed `integrity_check = ok`; `user.db` carried 1 assertion at
+schema `user_version=4`, `source.db` carried 17,839 `raw_sessions` rows at
+`user_version=3` — both older than live (`user_version=10`/95 assertions and
+`user_version=13`/41,233 raw_sessions respectively), consistent with this
+snapshot's 17-day age. The corruption negative control correctly failed with
+`database disk image is malformed (11)`.
+
+**CRITICAL FINDING — the live durable tier currently has NO Borg coverage.**
+`/realm/db/polylogue` (where `source.db`/`user.db` actually live; `/realm/data/captures/polylogue/*.db`
+are symlinks to it) was converted to its own nested Btrfs subvolume on
+2026-07-06 (`btrfs subvolume list /realm` shows `ID 3862 ... path db/polylogue`).
+btrbk/Borg snapshot the **parent** `/realm` subvolume only; a nested
+subvolume shows up as an **empty directory** in every snapshot and archive —
+confirmed directly: `borg list <latest realm archive> db/polylogue` returns
+only the empty directory entry itself, zero children. This is the exact same
+class of gap `sinex`'s blob repository hit before `borgbackup-job-sinex-blobs`
+was added, and that `state/machine-telemetry`/`db/machine-telemetry` hit
+before `machine-telemetry-sqlite-backup.service` was added (see sinnix
+`modules/services/machine-telemetry.nix`). Polylogue's durable tiers have no
+equivalent dedicated job. The drill above only worked because an older,
+already-durable pre-deploy backup snapshot happened to sit under
+`/realm/inbox/polylogue-backups/` (itself not a nested subvolume, so it *is*
+covered) — the actual live `user.db`/`source.db` files have been unbacked-up
+since 2026-07-06. Tracked as a new bead; see notes on polylogue-4be.
+
+### 2. Beads workspace from reflink snapshot
+
+Pre-migration reflink snapshots of this repo's Dolt-backed Beads workspace
+live under `/realm/tmp/beads-backup-<repo>-<pid>/`. Restore is a plain
+`cp --reflink=always` (fast, copy-on-write, no borg involved) into scratch,
+then open it directly with the `dolt` CLI — no need to reconstruct a full
+`.beads/` tree, the noms data directory alone is a valid Dolt database:
+
+```bash
+cp --reflink=always -a /realm/tmp/beads-backup-polylogue-<pid>/polylogue \
+  /realm/tmp/restore-drill-$(date +%Y%m%d)/beads-restore
+
+cd /realm/tmp/restore-drill-$(date +%Y%m%d)/beads-restore
+dolt sql -q "show databases;"                 # must list the restored db
+dolt sql -q "use \`beads-restore\`; show tables;"
+dolt sql -q "use \`beads-restore\`; select count(*) from issues;"
+dolt sql -q "use \`beads-restore\`; select count(*) from dolt_log;"  # commit history intact
+```
+
+2026-07-27 result: reflinking `/realm/tmp/beads-backup-polylogue-0007/polylogue`
+(290 MB apparent, birth 2026-07-13) took **0.007s** (confirms true reflink,
+not a byte copy). The restored database opened cleanly under `dolt` 2.1.9,
+listed all 26 expected tables (`issues`, `dependencies`, `wisps`, `events`,
+...), reported **713 issues** and **6,274** `dolt_log` commits. Sane-lag
+check: live `bd count` currently reports 1,108 issues — restored count is
+lower and consistent with 14 days of growth since the snapshot.
+
+### Cleanup
+
+Delete the scratch restore once both verifications are captured — do not
+leave multi-hundred-MB restored copies in `/realm/tmp/`:
+
+```bash
+rm -rf /realm/tmp/restore-drill-$(date +%Y%m%d)
+```


### PR DESCRIPTION
## Summary

Executed the first real restore drill of this operator's backup infrastructure (polylogue-4be) and wrote the resulting runbook into `docs/archive-backup.md`. Along the way, discovered and filed a real gap: the live archive's durable tiers currently have zero Borg backup coverage.

## Problem

polylogue-4be asked for the first real restore drill against this operator's backup infrastructure (btrbk/Borg + Dolt reflink snapshots) — none of it had ever been exercised end-to-end. An untested backup is a hypothesis, not a capability.

## Solution

Ran two real, timed restores into scratch locations (never touching the live archive, `.beads/`, or any backup store destructively):

1. **Durable tier from Borg**: extracted a real pre-deploy backup snapshot (`user.db`/`source.db`) from the `borg-realm-v2` repository. 29.4s. `PRAGMA integrity_check = ok` on both; schema versions and row counts sane vs. the (much newer) live archive. A deliberate byte-corruption negative control correctly failed `integrity_check` (exit 11), proving the check actually detects damage.
2. **Beads workspace from reflink**: `cp --reflink=always` of a pre-migration Dolt snapshot (0.007s — proves true copy-on-write, not a byte copy). Opened directly with the `dolt` CLI: 26 tables, 713 issues, 6,274 commits, all correct.

Both procedures, exact commands, and timing are now documented in `docs/archive-backup.md`'s new "Quarterly Restore Drill Runbook" section, including the negative-control recipe, so the next quarterly run doesn't have to re-derive anything.

**Critical finding**: the live archive's actual on-disk location, `/realm/db/polylogue`, was converted to its own nested Btrfs subvolume on 2026-07-06. btrbk/`borgbackup-job-realm` only snapshot the parent `/realm` subvolume — a nested subvolume is invisible to that snapshot. Verified directly: `borg list <latest realm archive> db/polylogue` returns only an empty directory entry with zero children. The live durable tiers (`user.db` irreplaceable, `source.db` rebuild-root) have had **no Borg coverage since 2026-07-06**. This is the same failure class `sinex`'s blob repository and `state/machine-telemetry` hit before dedicated backup jobs were added for each. Filed as `polylogue-2a6d` (linked discovered-from polylogue-4be) rather than fixed in this PR, since the fix belongs in `sinnix` (a dedicated backup job bypassing the nested-subvolume gap), not this repo.

## Verification

- `PRAGMA integrity_check` = `ok` on both restored durable-tier files (`user.db`, `source.db`)
- `dolt sql` query battery against the restored reflink workspace (table list, issue count, commit count)
- Deliberate byte-corruption negative control correctly failed `integrity_check` with exit 11
- `devtools verify --quick` → 17/17 steps green (run `20260727T170424Z-quick-83026-c3f25d64`)
- Full account, timing, and AC-by-AC assessment recorded in polylogue-4be's notes

Ref polylogue-4be, polylogue-2a6d

🤖 Generated with [Claude Code](https://claude.com/claude-code)