### PR TITLE
test(storage): re-arm stale global-first anti-vacuity VM-step canary

### DIFF
--- a/tests/unit/archive/query/test_execution_control.py
+++ b/tests/unit/archive/query/test_execution_control.py
@@ -694,6 +694,7 @@ def test_exact_session_multi_aggregate_work_is_not_amplified_by_irrelevant_growt
     from polylogue.archive.query.expression import parse_unit_source_expression
     from polylogue.archive.query.unit_results import query_unit_rows
     from polylogue.core.enums import BlockType, Origin
+    from polylogue.storage.sqlite.action_relation import action_relation_select_sql
     from polylogue.surfaces.payloads import QueryUnitAggregateEnvelope
 
     root = tmp_path / "archive"
@@ -764,9 +765,25 @@ def test_exact_session_multi_aggregate_work_is_not_amplified_by_irrelevant_growt
     bounded_ctx = QueryExecutionContext.create(query_text="c03-bounded", workload_class="scan", timeout_s=10.0)
     bounded = execute(bounded_ctx)
 
+    # polylogue-1ldl: renaming the relation to the plain ``actions`` compat
+    # VIEW used to reproduce the pre-z9gh.2 "global-first" cost (a
+    # windowed-CTE recomputation over the entire archive). Since PR #3018
+    # (z9gh.2), ``actions`` is a cheap re-join over the small, indexed,
+    # pre-materialized ``action_pairs`` table (session_id leads its index),
+    # so this rename no longer forces any meaningfully different/expensive
+    # path -- the canary silently stopped discriminating anything. The
+    # actually-expensive "global-first" path this mutation means to exercise
+    # still exists in ``action_relation_select_sql``'s unbounded branch
+    # (``session_placeholders=None``), which recomputes the tool_use/
+    # tool_result window-function pairing across every block in the archive
+    # instead of reading the materialized table. Force that branch directly.
     monkeypatch.setattr(
         "polylogue.storage.sqlite.archive_tiers.archive._action_relation_for_query",
-        lambda **_kwargs: ("", "actions", []),
+        lambda **_kwargs: (
+            f"WITH actions_global_recompute AS ({action_relation_select_sql(session_placeholders=None)})",
+            "actions_global_recompute",
+            [],
+        ),
     )
     mutant_ctx = QueryExecutionContext.create(query_text="c03-global-first", workload_class="scan", timeout_s=10.0)
     mutant = execute(mutant_ctx)

--- a/tests/unit/storage/test_archive_tiers_archive.py
+++ b/tests/unit/storage/test_archive_tiers_archive.py
@@ -25,6 +25,7 @@ from polylogue.sources.parsers.base import (
     ParsedPasteEvidence,
     ParsedSession,
 )
+from polylogue.storage.sqlite.action_relation import action_relation_select_sql
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveQueryUnitAggregateRow, ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.user_write import (
     assertion_id_for_session_metadata,
@@ -247,9 +248,30 @@ def test_exact_session_action_count_bounds_pairing_before_global_ranking(
             contradictory_rows = facade.query_unit_counts("action", contradictory_source.predicate)
         finally:
             facade._conn.set_progress_handler(None, 0)
+        # polylogue-1ldl: mutating this to fall back to the plain ``actions``
+        # compatibility VIEW used to reproduce the pre-z9gh.2 "global-first"
+        # cost -- that view used to be a windowed-CTE recomputation over the
+        # *entire* archive. Since PR #3018 (z9gh.2), ``actions`` is instead a
+        # cheap re-join over the small, indexed, pre-materialized
+        # ``action_pairs`` table (session_id is the leading index column), so
+        # renaming the relation to ``actions`` no longer forces any
+        # meaningfully different/expensive path (measured: 0 VM steps at this
+        # data scale -- an anti-vacuity check that no longer discriminates
+        # anything). The genuinely expensive "global-first" path that this
+        # canary means to guard against still exists in
+        # ``action_relation_select_sql`` -- it is the branch taken when no
+        # session bound is supplied (``session_placeholders=None``), which
+        # recomputes the tool_use/tool_result window-function pairing across
+        # every block in the archive rather than reading the materialized
+        # table. Force that branch directly so the mutation again reproduces
+        # real archive-wide work.
         monkeypatch.setattr(
             "polylogue.storage.sqlite.archive_tiers.archive._action_relation_for_query",
-            lambda **_kwargs: ("", "actions", []),
+            lambda **_kwargs: (
+                f"WITH actions_global_recompute AS ({action_relation_select_sql(session_placeholders=None)})",
+                "actions_global_recompute",
+                [],
+            ),
         )
         mutant_rows, global_first_vm_steps = measure_query()
 


### PR DESCRIPTION
## Summary

Fixes a stale VM-step anti-vacuity mutation in two archive query tests (polylogue-1ldl) and verifies a previously-stale live-batch assertion (polylogue-5202) is already resolved on master by an unrelated prior PR.

## Problem

**polylogue-1ldl**: `test_exact_session_action_count_bounds_pairing_before_global_ranking` (tests/unit/storage/test_archive_tiers_archive.py) and `test_exact_session_multi_aggregate_work_is_not_amplified_by_irrelevant_growth` (tests/unit/archive/query/test_execution_control.py) each monkeypatch `_action_relation_for_query` to fall back to the plain `"actions"` relation name, simulating pre-z9gh.2 "global-first" behavior, and assert the resulting query costs `>= 50000` SQLite VM steps as an anti-vacuity control. Since PR #3018 (z9gh.2) replaced the old windowed-CTE `actions` compatibility view with one backed by the small, pre-materialized, session_id-indexed `action_pairs` table, renaming the relation to `"actions"` no longer forces any meaningfully different/expensive path — both tests measured 0/400 VM steps for the "mutant" query, well under the 50000 threshold. The canary had silently stopped discriminating the exact regression it exists to catch.

**polylogue-5202**: `test_live_multi_session_divergence_reopens_raw_authority` (tests/unit/sources/test_live_batch_support.py) was reported failing with a stale `failed == [second]` assertion predating PR #3129's deferred-membership semantics change. Investigation found the assertions were already updated to the current-correct `failed == [] / succeeded == [second]` shape by PR #3282 (commit 4120c40c2, merged 2026-07-26, Ref polylogue-6mvg) as part of unrelated FTS-repair-deferral work. The test already passes on current master with no further code change needed.

## Solution

- Replaced the now-inert `lambda **_kwargs: ("", "actions", [])` mutation at both polylogue-1ldl sites with one that forces the actually-expensive "global-first" branch that still exists in `action_relation_select_sql(session_placeholders=None)` — the unbounded windowed tool_use/tool_result pairing recomputation across every block in the archive, instead of a read against the materialized `action_pairs` table. Verified this reproduces genuinely archive-wide cost (measured 53500 VM steps for the count-only path vs 400 bounded).
- Added inline comments at both mutation sites recording what changed (#3018) and why the old mutation stopped discriminating.
- No code change for polylogue-5202 — verified its test and the broader `raw_materialization`/`raw_authority` selection are green on master, and closing the bead by reference to PR #3282.
- Filed polylogue-0twa for an unrelated, pre-existing stale `query_units` vs `api.query_units` call-log naming assertion noticed in the same test file (out of scope for this PR).

## Verification

- `devtools test tests/unit/storage/test_archive_tiers_archive.py tests/unit/archive/query/test_execution_control.py` → 60 passed, 2 failed (pre-existing, out-of-scope polylogue-0twa naming mismatch; both polylogue-1ldl tests pass)
- `devtools test -k "raw_materialization or raw_authority"` → 198 passed (includes polylogue-5202's test)
- `ruff check` / `ruff format --check` on both changed files → clean
- `mypy --strict` on both changed files → no issues
- `devtools render all --check` → no drift
- pre-push `devtools verify --quick` → all steps ok

Ref polylogue-1ldl, polylogue-5202