### PR TITLE
fix: page explain(subject=result/recovery) instead of infinite retry

### DIFF
--- a/polylogue/mcp/server.py
+++ b/polylogue/mcp/server.py
@@ -68,17 +68,19 @@ def build_server(
     hooks = ServerCallbacks(
         json_payload=_json_payload,
         clamp_limit=_clamp_limit,
-        safe_call=lambda fn_name, fn, *, session_id=None, session_ids=(): _safe_call(
+        safe_call=lambda fn_name, fn, *, session_id=None, session_ids=(), arguments=None: _safe_call(
             fn_name,
             fn,
             session_id=session_id,
             session_ids=session_ids,
+            arguments=arguments,
         ),
-        async_safe_call=lambda fn_name, fn, *, session_id=None, session_ids=(): _async_safe_call(
+        async_safe_call=lambda fn_name, fn, *, session_id=None, session_ids=(), arguments=None: _async_safe_call(
             fn_name,
             fn,
             session_id=session_id,
             session_ids=session_ids,
+            arguments=arguments,
         ),
         error_json=lambda message, **extra: _error_json(message, **extra),
         get_config=lambda: _get_config(),

--- a/polylogue/mcp/server_cutover.py
+++ b/polylogue/mcp/server_cutover.py
@@ -680,8 +680,18 @@ def register_cutover_read_tools(mcp: ToolRegistrar, hooks: ServerCallbacks) -> N
         subject: Literal["query", "capability", "ref", "result", "recovery"],
         expression: str | None = None,
         ref: str | None = None,
+        offset: int = 0,
     ) -> str:
-        """Explain parser grammar, capabilities, refs, result semantics, or recovery."""
+        """Explain parser grammar, capabilities, refs, result semantics, or recovery.
+
+        ``offset`` skips this many entries into the ``result``/``recovery``
+        examples catalog or the ``capability`` read-view list before paging;
+        it exists so a budget-exceeded continuation can advance through the
+        full catalog instead of repeating the same oversized call
+        (polylogue-3k30). It is ignored for ``query``/``ref`` subjects, which
+        never return list-shaped bodies.
+        """
+        offset = max(0, offset)
 
         async def run() -> str:
             if subject == "query":
@@ -700,26 +710,36 @@ def register_cutover_read_tools(mcp: ToolRegistrar, hooks: ServerCallbacks) -> N
                 )
             from polylogue.archive.query.discovery import RESULT_SEMANTICS_TEACHING, query_discovery_examples
 
-            read_views: list[object] = []
             if subject == "capability":
-                read_views = list(await hooks.get_polylogue().list_read_view_profiles())
+                all_read_views = list(await hooks.get_polylogue().list_read_view_profiles())
                 return hooks.json_payload(
-                    MCPRootPayload(root={"subject": subject, "read_views": read_views, "total": len(read_views)})
+                    MCPRootPayload(
+                        root={
+                            "subject": subject,
+                            "read_views": all_read_views[offset:],
+                            "total": len(all_read_views),
+                            "offset": offset,
+                        }
+                    )
                 )
+            all_examples = query_discovery_examples()
             return hooks.json_payload(
                 MCPRootPayload(
                     root={
                         "subject": subject,
                         "result_semantics": RESULT_SEMANTICS_TEACHING,
-                        "examples": query_discovery_examples(),
+                        "examples": all_examples[offset:],
                         "recovery": "Use a q2 continuation alone to resume an exhaustive query page.",
-                        "read_views": read_views,
-                        "total": len(read_views),
+                        "read_views": [],
+                        "total": len(all_examples),
+                        "offset": offset,
                     }
                 )
             )
 
-        return await hooks.async_safe_call("explain", run)
+        return await hooks.async_safe_call(
+            "explain", run, arguments={"subject": subject, "expression": expression, "ref": ref, "offset": offset}
+        )
 
     async def context(
         intent: str,

--- a/polylogue/mcp/server_support.py
+++ b/polylogue/mcp/server_support.py
@@ -95,6 +95,7 @@ class SafeCallHook(Protocol):
         *,
         session_id: str | None = None,
         session_ids: tuple[str, ...] = (),
+        arguments: Mapping[str, object] | None = None,
     ) -> str: ...
 
 
@@ -106,6 +107,7 @@ class AsyncSafeCallHook(Protocol):
         *,
         session_id: str | None = None,
         session_ids: tuple[str, ...] = (),
+        arguments: Mapping[str, object] | None = None,
     ) -> Awaitable[str]: ...
 
 
@@ -178,8 +180,23 @@ def _compact_metadata(
     return value
 
 
-def _fallback_response_arguments(fn_name: str, session_id: str | None) -> dict[str, object]:
-    """Return replayable identifiers carried by the safe-call contract."""
+def _fallback_response_arguments(
+    fn_name: str,
+    session_id: str | None,
+    *,
+    arguments: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """Return replayable arguments carried by the safe-call contract.
+
+    ``arguments``, when the tool body supplies its own bound call arguments
+    (subject, offset, expression, ...), is authoritative: it is the only way
+    a continuation can replay a non-session-scoped tool call without losing
+    the arguments that made the original call meaningful (polylogue-3k30).
+    Falling back to synthesizing from ``session_id`` alone only covers the
+    narrow set of session-scoped tools in ``_SESSION_ID_ARGUMENT_NAMES``.
+    """
+    if arguments is not None:
+        return dict(arguments)
     if session_id is None:
         return {}
     return {_SESSION_ID_ARGUMENT_NAMES.get(fn_name, "session_id"): session_id}
@@ -247,6 +264,9 @@ def _serialize_payload(payload: BaseModel, *, exclude_none: bool) -> str:
 
 def _bounded_item_page(payload: BaseModel, *, exclude_none: bool) -> tuple[BaseModel, int] | None:
     """Find the largest useful prefix that fits the transport budget."""
+    root = getattr(payload, "root", None)
+    if isinstance(root, dict):
+        return _bounded_root_dict_page(payload, root, exclude_none=exclude_none)
     item_field = "items"
     raw_items = getattr(payload, item_field, None)
     if not isinstance(raw_items, (tuple, list)):
@@ -276,6 +296,46 @@ def _bounded_item_page(payload: BaseModel, *, exclude_none: bool) -> tuple[BaseM
             # the retained prefix instead, so never expose a stale cursor.
             updates["next_cursor"] = None
         candidate = payload.model_copy(update=updates)
+        size = len(_serialize_payload(candidate, exclude_none=exclude_none).encode("utf-8"))
+        if size <= MCP_RESPONSE_BUDGET_BYTES - MCP_RESPONSE_ENVELOPE_HEADROOM_BYTES:
+            best = (candidate, count)
+            low = count + 1
+        else:
+            high = count - 1
+    return best
+
+
+def _bounded_root_dict_page(
+    payload: BaseModel, root: Mapping[str, object], *, exclude_none: bool
+) -> tuple[BaseModel, int] | None:
+    """Bound the dominant list field of a dict-rooted MCP payload (polylogue-3k30).
+
+    A dict-rooted payload (:class:`~polylogue.mcp.payloads.MCPRootPayload`)
+    is not covered by the attribute-based search above -- ``getattr(payload,
+    "items")`` never resolves through a pydantic ``RootModel`` to its
+    ``root`` dict. Worse, such a payload can carry *multiple* list-valued
+    keys at once (e.g. ``explain(subject="result")``'s ``result_semantics``/
+    ``examples``/``read_views``), so a single hardcoded field name would not
+    generalize even if attribute lookup worked. Trimming picks the single
+    largest list field and binary-searches its prefix exactly like the
+    attribute-based path, leaving every smaller sibling list untouched --
+    in every observed shape exactly one field is responsible for exceeding
+    the budget, so bounding it alone is sufficient.
+    """
+    list_fields: dict[str, tuple[object, ...]] = {
+        key: tuple(value) for key, value in root.items() if isinstance(value, (list, tuple)) and value
+    }
+    if not list_fields:
+        return None
+    item_field = max(list_fields, key=lambda key: len(list_fields[key]))
+    items = list_fields[item_field]
+    low, high = 1, len(items)
+    best: tuple[BaseModel, int] | None = None
+    while low <= high:
+        count = (low + high) // 2
+        candidate_root = dict(root)
+        candidate_root[item_field] = items[:count]
+        candidate = payload.model_copy(update={"root": candidate_root})
         size = len(_serialize_payload(candidate, exclude_none=exclude_none).encode("utf-8"))
         if size <= MCP_RESPONSE_BUDGET_BYTES - MCP_RESPONSE_ENVELOPE_HEADROOM_BYTES:
             best = (candidate, count)
@@ -498,6 +558,7 @@ def _safe_call(
     *,
     session_id: str | None = None,
     session_ids: tuple[str, ...] = (),
+    arguments: Mapping[str, object] | None = None,
 ) -> str: ...
 
 
@@ -508,6 +569,7 @@ def _safe_call(
     *,
     session_id: str | None = None,
     session_ids: tuple[str, ...] = (),
+    arguments: Mapping[str, object] | None = None,
 ) -> str | None: ...
 
 
@@ -518,6 +580,7 @@ def _safe_call(
     *,
     session_id: str | None = None,
     session_ids: tuple[str, ...] = (),
+    arguments: Mapping[str, object] | None = None,
 ) -> TResult | str: ...
 
 
@@ -527,6 +590,7 @@ def _safe_call(
     *,
     session_id: str | None = None,
     session_ids: tuple[str, ...] = (),
+    arguments: Mapping[str, object] | None = None,
 ) -> TResult | str:
     """Call ``fn()`` and return its result, or a typed error JSON on failure.
 
@@ -540,10 +604,18 @@ def _safe_call(
     Every call is first durably spooled, then idempotently delivered to the
     ``ops.db`` MCP call-log table, keyed by ``fn_name`` and the optional
     ``session_id`` the caller passes when the tool is session-scoped.
+
+    ``arguments``, when the tool body passes its own bound call arguments,
+    is what a budget-exceeded continuation replays (polylogue-3k30) --
+    without it, a non-session-scoped tool's continuation can only fall back
+    to the empty/session-id-only reconstruction in
+    :func:`_fallback_response_arguments`, silently dropping arguments such as
+    ``subject``/``offset`` and making the continuation repeat the identical
+    oversized call forever instead of progressing.
     """
     started_at_ms = _now_ms()
     try:
-        with _response_context(fn_name, _fallback_response_arguments(fn_name, session_id)):
+        with _response_context(fn_name, _fallback_response_arguments(fn_name, session_id, arguments=arguments)):
             result = fn()
     except Exception as exc:
         logger.exception("MCP tool %s failed", fn_name)
@@ -577,6 +649,7 @@ async def _async_safe_call(
     *,
     session_id: str | None = None,
     session_ids: tuple[str, ...] = (),
+    arguments: Mapping[str, object] | None = None,
 ) -> str: ...
 
 
@@ -587,6 +660,7 @@ async def _async_safe_call(
     *,
     session_id: str | None = None,
     session_ids: tuple[str, ...] = (),
+    arguments: Mapping[str, object] | None = None,
 ) -> str | None: ...
 
 
@@ -597,6 +671,7 @@ async def _async_safe_call(
     *,
     session_id: str | None = None,
     session_ids: tuple[str, ...] = (),
+    arguments: Mapping[str, object] | None = None,
 ) -> TResult | str: ...
 
 
@@ -606,11 +681,12 @@ async def _async_safe_call(
     *,
     session_id: str | None = None,
     session_ids: tuple[str, ...] = (),
+    arguments: Mapping[str, object] | None = None,
 ) -> TResult | str:
     """Async counterpart of :func:`_safe_call`. Same isolation and call-log contract."""
     started_at_ms = _now_ms()
     try:
-        with _response_context(fn_name, _fallback_response_arguments(fn_name, session_id)):
+        with _response_context(fn_name, _fallback_response_arguments(fn_name, session_id, arguments=arguments)):
             result = await fn()
     except Exception as exc:
         logger.exception("MCP tool %s failed", fn_name)

--- a/tests/unit/mcp/test_explain_catalog_pagination.py
+++ b/tests/unit/mcp/test_explain_catalog_pagination.py
@@ -1,0 +1,142 @@
+"""Regression coverage for polylogue-3k30.
+
+``explain(subject="result")``/``explain(subject="recovery")`` serialize the
+full ``QUERY_DISCOVERY_EXAMPLES`` catalog (106 examples, ~82.5KB) inside one
+``MCPRootPayload`` -- comfortably over ``MCP_RESPONSE_BUDGET_BYTES`` (25000).
+
+Before the fix, two independent defects compounded into an unrecoverable
+loop:
+
+1. ``_bounded_item_page`` only searched for a *single* attribute named
+   ``items``/``messages``/``hits`` on the payload. ``MCPRootPayload`` is a
+   pydantic ``RootModel`` wrapping a plain dict, so none of those attributes
+   ever resolved (``getattr(payload, "items", None)`` is always ``None``),
+   and the dict in question additionally carries multiple list-valued keys
+   (``result_semantics``, ``examples``, ``read_views``) even if attribute
+   lookup had worked. The trimmer therefore always returned ``page=None``.
+2. The synthesized continuation for a budget-exceeded response came from
+   ``_fallback_response_arguments(fn_name, session_id)``, which only knows
+   ``session_id`` -- for a non-session-scoped tool call like
+   ``explain(subject="result")`` it returns ``{}``, silently dropping
+   ``subject`` entirely. Retrying ``continuation.tool``/
+   ``continuation.arguments`` therefore replayed the identical oversized,
+   argument-losing call forever.
+
+This module exercises the real, wired MCP ``explain`` tool (not a
+hand-rolled replica) end-to-end through as many continuation hops as it
+takes, and asserts every example in the catalog is retrieved exactly once.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from tests.infra.mcp import MCPServerUnderTest, invoke_surface
+
+
+def _explain_examples_via_continuation(
+    mcp_server: MCPServerUnderTest, *, subject: str, max_steps: int = 20
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Drive ``explain(subject=...)`` through continuations to exhaustion.
+
+    Returns ``(examples, steps)`` where ``steps`` records each hop's raw
+    envelope body for assertions on progress/argument preservation.
+    """
+    fn = mcp_server._tool_manager._tools["explain"].fn
+    examples: list[dict[str, Any]] = []
+    steps: list[dict[str, Any]] = []
+    call_kwargs: dict[str, Any] = {"subject": subject}
+
+    for _ in range(max_steps):
+        raw = invoke_surface(fn, **call_kwargs)
+        body = json.loads(raw)
+        steps.append(body)
+        if body.get("budget_exceeded"):
+            page = body["page"]
+            assert page is not None, (
+                f"budget-exceeded response returned no bounded page at all "
+                f"(the original zero-progress defect): {body!r}"
+            )
+            examples.extend(page["examples"])
+            continuation = body["continuation"]
+            assert continuation is not None, f"budget-exceeded response has no continuation: {body!r}"
+            assert continuation["tool"] == "explain", f"continuation routes to the wrong tool: {continuation!r}"
+            call_kwargs = dict(continuation["arguments"])
+            continue
+        examples.extend(body["examples"])
+        return examples, steps
+
+    pytest.fail(f"explain(subject={subject!r}) did not terminate within {max_steps} continuation hops")
+
+
+class TestExplainCatalogPagination:
+    """``explain(subject="result"|"recovery")`` pages through continuation."""
+
+    @pytest.mark.parametrize("subject", ["result", "recovery"])
+    def test_full_catalog_is_retrieved_exactly_once(self, mcp_server: MCPServerUnderTest, subject: str) -> None:
+        from polylogue.archive.query.discovery import QUERY_DISCOVERY_EXAMPLES
+
+        examples, steps = _explain_examples_via_continuation(mcp_server, subject=subject)
+
+        # More than one hop proves the response really did exceed the byte
+        # budget (this is not exercising some already-small payload).
+        assert len(steps) > 1, "expected the oversized catalog to require multiple continuation hops"
+
+        keys = [example["key"] for example in examples]
+        assert len(keys) == len(QUERY_DISCOVERY_EXAMPLES), (
+            f"expected every one of {len(QUERY_DISCOVERY_EXAMPLES)} examples, got {len(keys)}"
+        )
+        assert len(set(keys)) == len(keys), "continuation retrieved a duplicate example"
+        assert set(keys) == {example.key for example in QUERY_DISCOVERY_EXAMPLES}, (
+            "continuation retrieved a different example set than the declared catalog (skip/mismatch)"
+        )
+
+    def test_continuation_preserves_subject_and_advances_offset(self, mcp_server: MCPServerUnderTest) -> None:
+        """The defect's second half: continuation must not drop ``subject``."""
+        fn = mcp_server._tool_manager._tools["explain"].fn
+        raw = invoke_surface(fn, subject="result")
+        body = json.loads(raw)
+
+        assert body["budget_exceeded"] is True, "expected the full catalog to exceed the MCP response budget"
+        continuation = body["continuation"]
+        assert continuation is not None
+
+        arguments = continuation["arguments"]
+        assert arguments.get("subject") == "result", (
+            f"continuation dropped the original 'subject' argument -- retrying would repeat the identical "
+            f"oversized call forever: {arguments!r}"
+        )
+        offset = arguments.get("offset")
+        assert isinstance(offset, int) and offset > 0, f"continuation did not advance an offset: {arguments!r}"
+
+        returned = len(body["page"]["examples"])
+        assert offset == returned, (
+            f"offset should equal items consumed on this page: offset={offset} returned={returned}"
+        )
+
+    def test_non_progressing_call_never_repeats_the_oversized_response(self, mcp_server: MCPServerUnderTest) -> None:
+        """Following the continuation chain must not revisit offset=0."""
+        fn = mcp_server._tool_manager._tools["explain"].fn
+        seen_offsets: list[int] = []
+        call_kwargs: dict[str, Any] = {"subject": "result"}
+        for _ in range(20):
+            raw = invoke_surface(fn, **call_kwargs)
+            body = json.loads(raw)
+            seen_offsets.append(call_kwargs.get("offset", 0))
+            if not body.get("budget_exceeded"):
+                break
+            call_kwargs = dict(body["continuation"]["arguments"])
+        assert seen_offsets == sorted(set(seen_offsets)), (
+            f"continuation chain revisited an earlier offset (non-progressing loop): {seen_offsets!r}"
+        )
+        assert len(seen_offsets) > 1
+
+    def test_response_budget_exceeded_page_fits_the_transport_budget(self, mcp_server: MCPServerUnderTest) -> None:
+        from polylogue.mcp.server_support import MCP_RESPONSE_BUDGET_BYTES
+
+        fn = mcp_server._tool_manager._tools["explain"].fn
+        raw = invoke_surface(fn, subject="result")
+        assert len(raw.encode("utf-8")) <= MCP_RESPONSE_BUDGET_BYTES


### PR DESCRIPTION
## Summary

Fixes `explain(subject="result"|"recovery")` returning `page=null` /
`returned_items=0` with a continuation that silently drops `subject`,
making the query-discovery catalog unrecoverable through the MCP
discovery surface. Generalizes the response-budget trimmer to handle
dict-rooted payloads with multiple list fields, and threads real call
arguments through to continuations for non-session-scoped tools.

## Problem

`explain(subject="result"|"recovery")` serializes the full
`QUERY_DISCOVERY_EXAMPLES` catalog (106 examples, ~82.5KB) inside one
`MCPRootPayload`, well over `MCP_RESPONSE_BUDGET_BYTES` (25000). Two
compounding defects made this unrecoverable rather than merely large:

1. `_bounded_item_page` (`polylogue/mcp/server_support.py`) only checked
   `payload.items`/`.messages`/`.hits` via `getattr`. `MCPRootPayload` is a
   pydantic `RootModel` wrapping a plain dict, so none of those attributes
   ever resolve, and the dict additionally carries multiple list-valued
   keys (`result_semantics`, `examples`, `read_views`) that a single
   hardcoded field name could never generalize to anyway. The trimmer
   always returned `page=None`.
2. The synthesized continuation came from
   `_fallback_response_arguments(fn_name, session_id)`, which only knows
   `session_id`. For a non-session-scoped call like
   `explain(subject="result")` it returned `{}`, silently dropping
   `subject` -- retrying `continuation.tool`/`continuation.arguments`
   replayed the identical oversized, argument-losing call forever. A
   cold model relying purely on the shipped MCP discovery surface
   (`list_tools` + `explain`) could not retrieve the query-discovery
   catalog at all.

Discovered while building the polylogue-z9gh gap #3 cold-model MCP
continuity replay harness (`devtools/cold_model_continuity_replay.py`).

## Solution

- **`_bounded_item_page`** now detects a dict-rooted `RootModel` payload
  and delegates to a new `_bounded_root_dict_page` helper, which picks the
  single largest list-valued key in the root dict and binary-searches its
  prefix the same way the existing attribute-based path does for
  `items`/`messages`/`hits`, leaving smaller sibling lists untouched. This
  is a clean generalization (not an `explain`-only special case): any
  current or future dict-rooted MCP payload with multiple list fields
  gets correct budget trimming for free.
- **`_fallback_response_arguments`/`_safe_call`/`_async_safe_call`** (plus
  the `SafeCallHook`/`AsyncSafeCallHook` protocols and `server.py`'s hook
  wiring) gained an explicit `arguments` parameter so a tool body can hand
  its own bound call arguments to the response-context continuation
  machinery, instead of the session-id-only fallback that only covers
  session-scoped tools.
- **`explain()`** (`polylogue/mcp/server_cutover.py`) gained an `offset`
  parameter that windows the `examples`/`read_views` lists before
  serialization, and now passes
  `{subject, expression, ref, offset}` as its safe-call arguments so a
  budget-exceeded continuation replays with `subject` preserved and
  `offset` advanced by the count actually returned on the prior page.
  `total` (previously an unrelated `len(read_views)`, always 0 for the
  `result`/`recovery` subjects) now correctly reports the full catalog
  size.

### Alternative considered

A dedicated per-`explain` pagination path restructuring the response
shape was the fallback plan (AC1 option b), but the generic
`_bounded_root_dict_page` generalization turned out no more complex and
also silently fixes at least one other pre-existing dict-rooted payload
(`abandoned`/maintenance `{"items": [...], "total": ...}` shapes) that was
never actually reachable by the old attribute-based trimmer either.

## Verification

- `devtools test tests/unit/mcp/` -> **193 passed**, including the 5 new
  tests in `tests/unit/mcp/test_explain_catalog_pagination.py`, which
  drive the real wired `explain` tool through continuation to exhaustion
  for both `subject="result"` and `subject="recovery"`, asserting all 106
  examples are retrieved exactly once with no duplicates/skips, and that
  the continuation's `offset` strictly advances.
- Reproduced the pre-fix defect directly: stashed the three production
  file changes (test file left in place) and reran the new test module --
  4 of 5 tests failed with `page: None`, `continuation.arguments: {}`,
  confirming the test exercises the exact described failure before the
  fix restores it green.
- `devtools verify --quick` -> exit 0 (format, lint, `mypy --strict`,
  `render all --check`, layering/closure-matrix/manifests/doc-commands/
  docs-coverage/test-infra-currency/clock-hygiene/timeout-overrides/
  degrade-loudly/hash-boundary-census). Ran automatically on `git push`
  via the pre-push hook as well.
- Not run: full `devtools verify --all` (reserved for harness/dependency
  changes or a final pre-merge diagnostic per repo convention); per-PR CI
  skips the heavy `test` suite by design (runs post-merge on master), so
  the `devtools test tests/unit/mcp/` run above is the actual test
  evidence for this PR.

## Acceptance criteria (polylogue-3k30)

1. **Satisfied.** `explain(subject="result"|"recovery")` pages its
   `examples` list with a continuation that preserves `subject` (and
   `expression`/`ref`) and advances `offset`.
2. **Satisfied, generally.** `_fallback_response_arguments` now accepts an
   explicit `arguments` override; `explain` supplies it. The mechanism is
   general (any tool body can opt in), not an `explain`-only patch, though
   only `explain` was migrated to use it in this PR -- other
   non-session-scoped tools whose continuations may still fall back to
   `{}` are unaffected by this change and are not claimed as fixed here.
3. **Satisfied.** Regression test calls the real MCP `explain` tool for
   the full catalog and asserts every example is retrievable through
   continuation; verified to fail pre-fix.

Ref polylogue-3k30
