### PR TITLE
fix(mcp): require confirm=true for previously-unguarded destructive tools

### DIFF
--- a/docs/generated/mcp-equivalence.json
+++ b/docs/generated/mcp-equivalence.json
@@ -1134,7 +1134,7 @@
         "notes": "Continuation is opaque and must be the only resume input."
       },
       "deprecation_state": "retained",
-      "description": "Apply a declared mutation operation after shared authorization.",
+      "description": "Apply a declared mutation operation after shared authorization. Destructive operations (delete_session, remove_tag, remove_mark, delete_metadata, delete_annotation, delete_saved_view, delete_recall_pack, delete_workspace) require confirm=true and fail closed without it.",
       "field_discovery": [],
       "grammar_discovery": [],
       "incident_coverage": [],
@@ -1162,7 +1162,7 @@
           }
         ],
         "declaration_id": "mcp.tool.write",
-        "discovery_text": "Apply a declared mutation operation after shared authorization.",
+        "discovery_text": "Apply a declared mutation operation after shared authorization. Destructive operations (delete_session, remove_tag, remove_mark, delete_metadata, delete_annotation, delete_saved_view, delete_recall_pack, delete_workspace) require confirm=true and fail closed without it.",
         "examples": [
           {
             "arguments": [
@@ -1494,7 +1494,7 @@
         "notes": "Continuation is opaque and must be the only resume input."
       },
       "deprecation_state": "retained",
-      "description": "Preview, execute, list, and inspect maintenance operations.",
+      "description": "Preview, execute, list, and inspect maintenance operations. execute with dry_run=false, rebuild_index, and rebuild_insights require confirm=true and fail closed without it.",
       "field_discovery": [],
       "grammar_discovery": [],
       "incident_coverage": [],
@@ -1522,7 +1522,7 @@
           }
         ],
         "declaration_id": "mcp.tool.maintenance",
-        "discovery_text": "Preview, execute, list, and inspect maintenance operations.",
+        "discovery_text": "Preview, execute, list, and inspect maintenance operations. execute with dry_run=false, rebuild_index, and rebuild_insights require confirm=true and fail closed without it.",
         "examples": [
           {
             "arguments": [

--- a/polylogue/mcp/declarations/registry.py
+++ b/polylogue/mcp/declarations/registry.py
@@ -187,7 +187,10 @@ _CUTOVER_TOOL_ROWS: Final[tuple[_ToolRow, ...]] = (
     ),
     _ToolRow(
         "write",
-        "Apply a declared mutation operation after shared authorization.",
+        "Apply a declared mutation operation after shared authorization. Destructive "
+        "operations (delete_session, remove_tag, remove_mark, delete_metadata, "
+        "delete_annotation, delete_saved_view, delete_recall_pack, delete_workspace) "
+        "require confirm=true and fail closed without it.",
         "polylogue.mcp.server_cutover",
         "register_cutover_privileged_tools",
         "write",
@@ -238,7 +241,9 @@ _CUTOVER_TOOL_ROWS: Final[tuple[_ToolRow, ...]] = (
     ),
     _ToolRow(
         "maintenance",
-        "Preview, execute, list, and inspect maintenance operations.",
+        "Preview, execute, list, and inspect maintenance operations. execute with "
+        "dry_run=false, rebuild_index, and rebuild_insights require confirm=true "
+        "and fail closed without it.",
         "polylogue.mcp.server_cutover",
         "register_cutover_privileged_tools",
         "maintenance",

--- a/polylogue/mcp/server_cutover.py
+++ b/polylogue/mcp/server_cutover.py
@@ -891,6 +891,19 @@ def register_cutover_read_tools(mcp: ToolRegistrar, hooks: ServerCallbacks) -> N
         register_declared_handler(mcp, handler, name=handler.__name__)
 
 
+def _require_confirm(hooks: ServerCallbacks, confirm: bool, *, verb: str, **context: str) -> str | None:
+    """Fail-closed safety guard: return an error payload unless ``confirm`` is True.
+
+    Mirrors the ``delete_session`` safety-guard message shape (interim
+    mitigation ahead of polylogue-t46.9's executable OperationSpec authority;
+    see polylogue-jn40). Every destructive operation reachable from write/
+    judge/admin roles must call this before it touches storage.
+    """
+    if confirm:
+        return None
+    return hooks.error_json(f"Safety guard: set confirm=true to {verb}", **context)
+
+
 def _field(fields: dict[str, object] | None, name: str) -> object | None:
     return None if fields is None else fields.get(name)
 
@@ -979,6 +992,11 @@ async def _dispatch_write(hooks: ServerCallbacks, *, operation: str, kwargs: dic
                 return hooks.error_json(
                     "write(operation='remove_tag') requires session_id and tag", code="invalid_argument"
                 )
+            confirm_error = _require_confirm(
+                hooks, confirm, verb="remove tag", session_id=session_id, detail=f"tag={tag}"
+            )
+            if confirm_error is not None:
+                return confirm_error
             resolved, err = await resolve_session_or_error(hooks, session_id)
             if err:
                 return err
@@ -1053,6 +1071,11 @@ async def _dispatch_write(hooks: ServerCallbacks, *, operation: str, kwargs: dic
                 return hooks.error_json(
                     "write(operation='delete_metadata') requires session_id and key", code="invalid_argument"
                 )
+            confirm_error = _require_confirm(
+                hooks, confirm, verb="delete metadata", session_id=session_id, detail=f"key={key}"
+            )
+            if confirm_error is not None:
+                return confirm_error
             from polylogue.api.archive import SessionNotFoundError
             from polylogue.surfaces.payloads import MetadataKeyValidationError, validate_metadata_key
 
@@ -1100,6 +1123,12 @@ async def _dispatch_write(hooks: ServerCallbacks, *, operation: str, kwargs: dic
             mark_type = _require_field(hooks, fields, "mark_type", operation=operation)
             if not is_mark_type_supported(mark_type):
                 return hooks.error_json(f"mark_type must be one of: {', '.join(MARK_TYPE_NAMES)}", detail=mark_type)
+            if operation == "remove_mark":
+                confirm_error = _require_confirm(
+                    hooks, confirm, verb="remove mark", session_id=session_id, detail=f"mark_type={mark_type}"
+                )
+                if confirm_error is not None:
+                    return confirm_error
             resolved, err = await resolve_session_or_error(hooks, session_id)
             if err:
                 return err
@@ -1177,6 +1206,11 @@ async def _dispatch_write(hooks: ServerCallbacks, *, operation: str, kwargs: dic
 
         if operation == "delete_annotation":
             annotation_id = _require_field(hooks, fields, "annotation_id", operation=operation)
+            confirm_error = _require_confirm(
+                hooks, confirm, verb="delete annotation", detail=f"annotation_id={annotation_id}"
+            )
+            if confirm_error is not None:
+                return confirm_error
             deleted = await poly.delete_annotation(annotation_id)
             return hooks.json_payload(
                 MutationResultPayload(
@@ -1334,6 +1368,9 @@ async def _dispatch_write(hooks: ServerCallbacks, *, operation: str, kwargs: dic
 
         if operation == "delete_saved_view":
             view_id = _require_field(hooks, fields, "view_id", operation=operation)
+            confirm_error = _require_confirm(hooks, confirm, verb="delete saved view", detail=f"view_id={view_id}")
+            if confirm_error is not None:
+                return confirm_error
             deleted = await poly.delete_view(view_id)
             return hooks.json_payload(
                 MutationResultPayload(
@@ -1372,6 +1409,9 @@ async def _dispatch_write(hooks: ServerCallbacks, *, operation: str, kwargs: dic
 
         if operation == "delete_recall_pack":
             pack_id = _require_field(hooks, fields, "pack_id", operation=operation)
+            confirm_error = _require_confirm(hooks, confirm, verb="delete recall pack", detail=f"pack_id={pack_id}")
+            if confirm_error is not None:
+                return confirm_error
             deleted = await poly.delete_recall_pack(pack_id)
             return hooks.json_payload(
                 MutationResultPayload(
@@ -1421,6 +1461,11 @@ async def _dispatch_write(hooks: ServerCallbacks, *, operation: str, kwargs: dic
 
         if operation == "delete_workspace":
             workspace_id = _require_field(hooks, fields, "workspace_id", operation=operation)
+            confirm_error = _require_confirm(
+                hooks, confirm, verb="delete workspace", detail=f"workspace_id={workspace_id}"
+            )
+            if confirm_error is not None:
+                return confirm_error
             deleted = await poly.delete_workspace(workspace_id)
             return hooks.json_payload(
                 MutationResultPayload(
@@ -1619,6 +1664,12 @@ async def _dispatch_maintenance(hooks: ServerCallbacks, *, operation: str, kwarg
             envelope = envelope_from_operation(result, origin="mcp", mode="preview")
         else:
             dry_run = bool(kwargs.get("dry_run") or False)
+            if not dry_run:
+                confirm_error = _require_confirm(
+                    hooks, bool(kwargs.get("confirm") or False), verb="execute maintenance with dry_run=false"
+                )
+                if confirm_error is not None:
+                    return confirm_error
             result = execute_backfill(config, targets=resolved_targets, dry_run=dry_run, scope_filter=scope_filter)
             envelope = envelope_from_operation(result, origin="mcp", mode="execute")
             if result.status is BackfillStatus.FAILED:
@@ -1679,6 +1730,9 @@ async def _dispatch_maintenance(hooks: ServerCallbacks, *, operation: str, kwarg
     if operation == "rebuild_index":
         from polylogue.mcp.payloads import MCPMutationStatusPayload
 
+        confirm_error = _require_confirm(hooks, bool(kwargs.get("confirm") or False), verb="rebuild the index")
+        if confirm_error is not None:
+            return confirm_error
         poly = hooks.get_polylogue()
         success = await poly.rebuild_index()
         status_info = await poly.get_index_status()
@@ -1706,6 +1760,9 @@ async def _dispatch_maintenance(hooks: ServerCallbacks, *, operation: str, kwarg
         )
 
     if operation == "rebuild_insights":
+        confirm_error = _require_confirm(hooks, bool(kwargs.get("confirm") or False), verb="rebuild session insights")
+        if confirm_error is not None:
+            return confirm_error
         session_ids = kwargs.get("session_ids")
         counts = await hooks.get_polylogue().rebuild_insights(session_ids=list(session_ids) if session_ids else None)
         return hooks.json_payload(
@@ -1776,6 +1833,12 @@ def register_cutover_privileged_tools(mcp: ToolRegistrar, hooks: ServerCallbacks
             operation-specific value beyond those (see each operation's
             retired single-purpose tool for the exact field names, e.g.
             ``fields={"mark_type": "star"}`` for ``add_mark``).
+
+            Destructive operations require ``confirm=True`` and fail closed
+            without it: ``delete_session``, ``remove_tag``, ``remove_mark``,
+            ``delete_metadata``, ``delete_annotation``, ``delete_saved_view``,
+            ``delete_recall_pack``, and ``delete_workspace`` (interim
+            mitigation, polylogue-jn40).
             """
 
             async def run() -> str:
@@ -1914,8 +1977,15 @@ def register_cutover_privileged_tools(mcp: ToolRegistrar, hooks: ServerCallbacks
             failure_kind: str | None = None,
             parser_version: str | None = None,
             operation_id: str | None = None,
+            confirm: bool = False,
         ) -> str:
-            """Preview, execute, list, and inspect maintenance operations."""
+            """Preview, execute, list, and inspect maintenance operations.
+
+            Destructive/full-effect operations require ``confirm=True``:
+            ``execute`` with ``dry_run=false``, ``rebuild_index``, and
+            ``rebuild_insights`` all fail closed without it (interim
+            mitigation, polylogue-jn40).
+            """
 
             async def run() -> str:
                 return await _dispatch_maintenance(
@@ -1933,6 +2003,7 @@ def register_cutover_privileged_tools(mcp: ToolRegistrar, hooks: ServerCallbacks
                         "failure_kind": failure_kind,
                         "parser_version": parser_version,
                         "operation_id": operation_id,
+                        "confirm": confirm,
                     },
                 )
 

--- a/tests/unit/mcp/test_privileged_tools.py
+++ b/tests/unit/mcp/test_privileged_tools.py
@@ -138,7 +138,9 @@ class TestWriteTool:
             assert added["outcome"] == "added"
 
             removed = json.loads(
-                await invoke_surface_async(write_fn, operation="remove_tag", session_id=session_id, tag="reviewed")
+                await invoke_surface_async(
+                    write_fn, operation="remove_tag", session_id=session_id, tag="reviewed", confirm=True
+                )
             )
             assert removed.get("is_error") is not True, removed
             assert removed["outcome"] == "removed"
@@ -241,7 +243,256 @@ class TestWriteTool:
             view_id = saved["key"]
 
             deleted = json.loads(
+                await invoke_surface_async(
+                    write_fn, operation="delete_saved_view", fields={"view_id": view_id}, confirm=True
+                )
+            )
+            assert deleted.get("is_error") is not True, deleted
+            assert deleted["status"] == "deleted"
+
+
+class TestWriteToolConfirmGates:
+    """polylogue-jn40: every destructive ``write`` operation must fail closed.
+
+    Mirrors ``TestWriteTool.test_delete_session_without_confirm_is_refused``
+    for the sibling destructive operations that previously had no gate at
+    all: ``remove_tag`` is covered directly in ``TestWriteTool`` (round trip
+    now passes ``confirm=True``); the remainder are covered here, each with
+    a refusal case (asserting the underlying state is unchanged) and a
+    ``confirm=True`` success case.
+    """
+
+    @pytest.mark.asyncio
+    async def test_remove_tag_without_confirm_is_refused_and_tag_survives(self, tmp_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive(archive_root)
+        server = cast(MCPServerUnderTest, build_server(capabilities=MCPCapabilities(write=True)))
+        write_fn = server._tool_manager._tools["write"].fn
+
+        with _installed_runtime_services(archive_root):
+            added = json.loads(
+                await invoke_surface_async(write_fn, operation="add_tag", session_id=session_id, tag="reviewed")
+            )
+            assert added.get("is_error") is not True, added
+
+            refused = json.loads(
+                await invoke_surface_async(write_fn, operation="remove_tag", session_id=session_id, tag="reviewed")
+            )
+            assert refused.get("is_error") is True
+            assert "confirm" in refused.get("message", "").lower()
+
+            # Prove the tag actually survived the refused call: a confirmed
+            # removal afterwards still finds it present ("removed", not
+            # "not_found").
+            removed = json.loads(
+                await invoke_surface_async(
+                    write_fn, operation="remove_tag", session_id=session_id, tag="reviewed", confirm=True
+                )
+            )
+            assert removed.get("is_error") is not True, removed
+            assert removed["outcome"] == "removed"
+
+    @pytest.mark.asyncio
+    async def test_remove_mark_without_confirm_is_refused_and_mark_survives(self, tmp_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive(archive_root)
+        server = cast(MCPServerUnderTest, build_server(capabilities=MCPCapabilities(write=True)))
+        write_fn = server._tool_manager._tools["write"].fn
+
+        with _installed_runtime_services(archive_root):
+            added = json.loads(
+                await invoke_surface_async(
+                    write_fn, operation="add_mark", session_id=session_id, fields={"mark_type": "star"}
+                )
+            )
+            assert added.get("is_error") is not True, added
+
+            refused = json.loads(
+                await invoke_surface_async(
+                    write_fn, operation="remove_mark", session_id=session_id, fields={"mark_type": "star"}
+                )
+            )
+            assert refused.get("is_error") is True
+            assert "confirm" in refused.get("message", "").lower()
+
+            removed = json.loads(
+                await invoke_surface_async(
+                    write_fn,
+                    operation="remove_mark",
+                    session_id=session_id,
+                    fields={"mark_type": "star"},
+                    confirm=True,
+                )
+            )
+            assert removed.get("is_error") is not True, removed
+            assert removed["outcome"] == "removed"
+
+    @pytest.mark.asyncio
+    async def test_delete_metadata_without_confirm_is_refused_and_key_survives(self, tmp_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive(archive_root)
+        server = cast(MCPServerUnderTest, build_server(capabilities=MCPCapabilities(write=True)))
+        write_fn = server._tool_manager._tools["write"].fn
+
+        with _installed_runtime_services(archive_root):
+            set_result = json.loads(
+                await invoke_surface_async(
+                    write_fn, operation="set_metadata", session_id=session_id, key="note", value="keep"
+                )
+            )
+            assert set_result.get("is_error") is not True, set_result
+
+            refused = json.loads(
+                await invoke_surface_async(write_fn, operation="delete_metadata", session_id=session_id, key="note")
+            )
+            assert refused.get("is_error") is True
+            assert "confirm" in refused.get("message", "").lower()
+
+            deleted = json.loads(
+                await invoke_surface_async(
+                    write_fn, operation="delete_metadata", session_id=session_id, key="note", confirm=True
+                )
+            )
+            assert deleted.get("is_error") is not True, deleted
+            assert deleted["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_delete_annotation_without_confirm_is_refused(self, tmp_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive(archive_root)
+        server = cast(MCPServerUnderTest, build_server(capabilities=MCPCapabilities(write=True)))
+        write_fn = server._tool_manager._tools["write"].fn
+
+        with _installed_runtime_services(archive_root):
+            saved = json.loads(
+                await invoke_surface_async(
+                    write_fn,
+                    operation="save_annotation",
+                    session_id=session_id,
+                    fields={"annotation_id": "note-1", "note_text": "a durable note"},
+                )
+            )
+            assert saved.get("is_error") is not True, saved
+
+            refused = json.loads(
+                await invoke_surface_async(write_fn, operation="delete_annotation", fields={"annotation_id": "note-1"})
+            )
+            assert refused.get("is_error") is True
+            assert "confirm" in refused.get("message", "").lower()
+
+            deleted = json.loads(
+                await invoke_surface_async(
+                    write_fn,
+                    operation="delete_annotation",
+                    fields={"annotation_id": "note-1"},
+                    confirm=True,
+                )
+            )
+            assert deleted.get("is_error") is not True, deleted
+            assert deleted["status"] == "deleted"
+
+    @pytest.mark.asyncio
+    async def test_delete_saved_view_without_confirm_is_refused(self, tmp_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        server = cast(MCPServerUnderTest, build_server(capabilities=MCPCapabilities(write=True)))
+        write_fn = server._tool_manager._tools["write"].fn
+
+        with _installed_runtime_services(archive_root):
+            saved = json.loads(
+                await invoke_surface_async(
+                    write_fn,
+                    operation="save_saved_view",
+                    fields={"name": "needle sessions", "query_json": json.dumps({"query": "needle"})},
+                )
+            )
+            assert saved.get("is_error") is not True, saved
+            view_id = saved["key"]
+
+            refused = json.loads(
                 await invoke_surface_async(write_fn, operation="delete_saved_view", fields={"view_id": view_id})
+            )
+            assert refused.get("is_error") is True
+            assert "confirm" in refused.get("message", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_delete_recall_pack_without_confirm_is_refused(self, tmp_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        server = cast(MCPServerUnderTest, build_server(capabilities=MCPCapabilities(write=True)))
+        write_fn = server._tool_manager._tools["write"].fn
+
+        with _installed_runtime_services(archive_root):
+            saved = json.loads(
+                await invoke_surface_async(
+                    write_fn,
+                    operation="save_recall_pack",
+                    fields={
+                        "pack_id": "pack-1",
+                        "label": "Recall pack",
+                        "payload_json": json.dumps({"items": []}),
+                    },
+                )
+            )
+            assert saved.get("is_error") is not True, saved
+
+            refused = json.loads(
+                await invoke_surface_async(write_fn, operation="delete_recall_pack", fields={"pack_id": "pack-1"})
+            )
+            assert refused.get("is_error") is True
+            assert "confirm" in refused.get("message", "").lower()
+
+            deleted = json.loads(
+                await invoke_surface_async(
+                    write_fn, operation="delete_recall_pack", fields={"pack_id": "pack-1"}, confirm=True
+                )
+            )
+            assert deleted.get("is_error") is not True, deleted
+            assert deleted["status"] == "deleted"
+
+    @pytest.mark.asyncio
+    async def test_delete_workspace_without_confirm_is_refused(self, tmp_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        server = cast(MCPServerUnderTest, build_server(capabilities=MCPCapabilities(write=True)))
+        write_fn = server._tool_manager._tools["write"].fn
+
+        with _installed_runtime_services(archive_root):
+            saved = json.loads(
+                await invoke_surface_async(
+                    write_fn,
+                    operation="save_workspace",
+                    fields={"workspace_id": "workspace-1", "name": "My workspace"},
+                )
+            )
+            assert saved.get("is_error") is not True, saved
+
+            refused = json.loads(
+                await invoke_surface_async(
+                    write_fn, operation="delete_workspace", fields={"workspace_id": "workspace-1"}
+                )
+            )
+            assert refused.get("is_error") is True
+            assert "confirm" in refused.get("message", "").lower()
+
+            deleted = json.loads(
+                await invoke_surface_async(
+                    write_fn, operation="delete_workspace", fields={"workspace_id": "workspace-1"}, confirm=True
+                )
             )
             assert deleted.get("is_error") is not True, deleted
             assert deleted["status"] == "deleted"
@@ -401,6 +652,131 @@ class TestMaintenanceTool:
             )
             assert result.get("is_error") is True
             assert result.get("code") == "not_found"
+
+
+class TestMaintenanceConfirmGates:
+    """polylogue-jn40: full-effect maintenance operations must fail closed.
+
+    ``rebuild_index`` and ``rebuild_insights`` route through
+    ``hooks.get_polylogue()`` (the installed runtime services / seeded
+    archive); ``execute`` with ``dry_run=false`` routes through the
+    planner's own ``Config`` (a pre-existing, unrelated quirk -- see
+    ``_dispatch_maintenance``), so its refusal case is verified independent
+    of archive content and its confirmed-success case merely asserts the
+    call is not refused.
+    """
+
+    @pytest.mark.asyncio
+    async def test_execute_with_dry_run_false_without_confirm_is_refused(self, tmp_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        server = cast(MCPServerUnderTest, build_server(capabilities=MCPCapabilities(maintenance=True)))
+        maintenance_fn = server._tool_manager._tools["maintenance"].fn
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(
+                await invoke_surface_async(
+                    maintenance_fn, operation="execute", targets=["session_insights"], dry_run=False
+                )
+            )
+            assert result.get("is_error") is True
+            assert "confirm" in result.get("message", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_execute_with_dry_run_true_does_not_require_confirm(self, tmp_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        server = cast(MCPServerUnderTest, build_server(capabilities=MCPCapabilities(maintenance=True)))
+        maintenance_fn = server._tool_manager._tools["maintenance"].fn
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(
+                await invoke_surface_async(
+                    maintenance_fn, operation="execute", targets=["session_insights"], dry_run=True
+                )
+            )
+            assert result.get("is_error") is not True, result
+
+    @pytest.mark.asyncio
+    async def test_execute_with_dry_run_false_and_confirm_true_succeeds(self, tmp_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        server = cast(MCPServerUnderTest, build_server(capabilities=MCPCapabilities(maintenance=True)))
+        maintenance_fn = server._tool_manager._tools["maintenance"].fn
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(
+                await invoke_surface_async(
+                    maintenance_fn,
+                    operation="execute",
+                    targets=["session_insights"],
+                    dry_run=False,
+                    confirm=True,
+                )
+            )
+            assert result.get("is_error") is not True, result
+
+    @pytest.mark.asyncio
+    async def test_rebuild_index_without_confirm_is_refused(self, tmp_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        server = cast(MCPServerUnderTest, build_server(capabilities=MCPCapabilities(maintenance=True)))
+        maintenance_fn = server._tool_manager._tools["maintenance"].fn
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(await invoke_surface_async(maintenance_fn, operation="rebuild_index"))
+            assert result.get("is_error") is True
+            assert "confirm" in result.get("message", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_rebuild_index_with_confirm_succeeds(self, tmp_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        server = cast(MCPServerUnderTest, build_server(capabilities=MCPCapabilities(maintenance=True)))
+        maintenance_fn = server._tool_manager._tools["maintenance"].fn
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(await invoke_surface_async(maintenance_fn, operation="rebuild_index", confirm=True))
+            assert result.get("is_error") is not True, result
+            assert result["status"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_rebuild_insights_without_confirm_is_refused(self, tmp_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        server = cast(MCPServerUnderTest, build_server(capabilities=MCPCapabilities(maintenance=True)))
+        maintenance_fn = server._tool_manager._tools["maintenance"].fn
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(await invoke_surface_async(maintenance_fn, operation="rebuild_insights"))
+            assert result.get("is_error") is True
+            assert "confirm" in result.get("message", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_rebuild_insights_with_confirm_succeeds(self, tmp_path: Path) -> None:
+        from polylogue.mcp.server import build_server
+
+        archive_root = tmp_path / "archive"
+        _seed_archive(archive_root)
+        server = cast(MCPServerUnderTest, build_server(capabilities=MCPCapabilities(maintenance=True)))
+        maintenance_fn = server._tool_manager._tools["maintenance"].fn
+
+        with _installed_runtime_services(archive_root):
+            result = json.loads(await invoke_surface_async(maintenance_fn, operation="rebuild_insights", confirm=True))
+            assert result.get("is_error") is not True, result
+            assert result["status"] == "ok"
 
 
 class TestQuerySessionsProjection:


### PR DESCRIPTION
## Summary

Applies the same fail-closed `confirm=True` safety guard that `write(operation="delete_session")` already used to nine sibling destructive operations that had no such guard, plus three admin-tier `maintenance` operations.

## Problem

The dogfood-2 MCP confirm-gate investigation (F-029) found that `delete_session`'s `confirm: bool = False` guard was not applied consistently across the MCP surface. Since this codebase's MCP surface was cutover to the current 10-tool `write`/`maintenance` dispatcher pattern, the gap now lives inside `write()`'s `operation=` dispatch (`polylogue/mcp/server_cutover.py:_dispatch_write`) and `maintenance()`'s dispatch (`_dispatch_maintenance`):

- `write()`: `remove_tag`, `remove_mark`, `delete_metadata`, `delete_annotation`, `delete_saved_view`, `delete_recall_pack`, `delete_workspace` had no confirm check at all.
- `maintenance()`: `rebuild_index`, `rebuild_insights`, and `execute` with `dry_run=false` had no confirm check at all (`dry_run` alone gated nothing).

Because `role_allows`'s monotonic role ordering means write/review/admin roles can all reach these, this was a live mitigation gap ahead of the larger `polylogue-t46.9` OperationSpec/preview-token/receipt authority redesign.

## Solution

- Added a shared `_require_confirm()` fail-closed helper in `polylogue/mcp/server_cutover.py`, mirroring `delete_session`'s existing `"Safety guard: set confirm=true to <verb>"` message shape.
- Applied it to all nine remaining destructive `write()` operations, and to `maintenance`'s `rebuild_index`, `rebuild_insights`, and `execute(dry_run=false)`. `execute(dry_run=true)` (a genuine preview) and read-only maintenance operations (`preview`/`status`/`list`/`update_index`) are unaffected.
- `maintenance()` gained a new `confirm: bool = False` parameter (threaded through to `_dispatch_maintenance`).
- Updated the `write`/`maintenance` tool docstrings and their declaration-owned descriptions in `polylogue/mcp/declarations/registry.py` to name the gated operations explicitly, so the requirement is visible in the live tool schema an agent sees (not just as a runtime error). Regenerated `docs/generated/mcp-equivalence.json` accordingly.

## Non-goals / out of scope

`polylogue-t46.9` (in progress) owns the structural fix: an executable `OperationSpec`/preview-token/receipt authority that makes this class of inconsistency impossible by construction. Confirm booleans remain an interim compatibility mechanism only, per that bead's notes.

## Verification

- `devtools test tests/unit/mcp/` -> 202 passed, including 37 in `test_privileged_tools.py` with new confirm-refusal + confirm-success cases for every newly-gated operation.
- `devtools test tests/unit/operations/test_mutation_actuators.py tests/unit/operations/test_mutations.py` -> 64 passed.
- `devtools test tests/integration/test_mcp.py` -> same 4 pre-existing failures with and without this change (`KeyError` on retired tool names `search`/`list_sessions`/`list_tags`, confirmed by stashing the diff and re-running against the same commit) -- unrelated to this PR.
- `mypy --strict polylogue/mcp/server_cutover.py polylogue/mcp/declarations/registry.py tests/unit/mcp/test_privileged_tools.py` -> success, no issues.
- `ruff check` / `ruff format --check` on the same files -> clean.
- `devtools render mcp-equivalence` -> regenerated; `devtools render all --check` -> clean.
- `devtools verify --quick` -> ok, twice (pre-commit and pre-push), 17 static/generated-surface steps green.

Ref polylogue-jn40