### PR TITLE
test: fix stale query_units call-log naming assertions

### DIFF
--- a/tests/unit/archive/query/test_execution_control.py
+++ b/tests/unit/archive/query/test_execution_control.py
@@ -494,7 +494,7 @@ async def test_api_query_units_routes_through_execution_control(
         await archive.close()
 
     assert isinstance(envelope, QueryUnitEnvelope)
-    assert seen == ["api.query_units"]
+    assert seen == ["query_units"]
 
 
 async def test_api_multi_aggregate_receipt_reports_real_work_selection_and_delivery(
@@ -545,7 +545,7 @@ async def test_api_multi_aggregate_receipt_reports_real_work_selection_and_deliv
     assert [(row.count, row.group_key) for row in envelope.items]
     assert len(seen) == 1
     ctx = seen[0]
-    assert ctx.owner_ref == "api.query_units"
+    assert ctx.owner_ref == "query_units"
     assert ctx.workload_class == "scan"
     assert ctx.receipt.state == "completed"
     assert ctx.receipt.selected_rows_exact == 3


### PR DESCRIPTION
## Summary
Fixes two tests in `tests/unit/archive/query/test_execution_control.py` that asserted a stale operation name in the execution-control call log.

## Problem
`test_api_query_units_routes_through_execution_control` and `test_api_multi_aggregate_receipt_reports_real_work_selection_and_delivery` assert the execution-control call log / `owner_ref` records the operation as `"api.query_units"`. Current production code (`query_units_transaction_request` in `polylogue/archive/query/transaction.py`) sets `operation="query_units"` — no `api.` prefix.

Investigation (see polylogue-0twa): the constructor's docstring states it is "the single constructor shared by the API, MCP, and daemon HTTP adapters so the three surfaces cannot drift into building the request differently" (introduced in #3068, `feat(query): bind query_units continuations to the archive epoch`). An `api.`-prefixed name would be incorrect given the name is intentionally shared across non-API surfaces too. This is a stale test assertion, not a production regression.

## Solution
Updated both assertions from `"api.query_units"` to `"query_units"`. No production code changed.

## Verification
- `devtools test tests/unit/archive/query/test_execution_control.py` -> 23 passed
- `mypy --strict tests/unit/archive/query/test_execution_control.py` -> Success
- `ruff check` / `ruff format --check` on the changed file -> clean
- Pre-push quick verification baseline (format/lint/mypy/render-all/layering/etc.) -> all ok

Ref polylogue-0twa

🤖 Generated with [Claude Code](https://claude.com/claude-code)