### PR TITLE
fix: pin raw-artifact parsed_at fixture to frozen clock

### DIFF
--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -51,6 +51,7 @@ from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.user_write import upsert_assertion
+from tests.infra.frozen_clock import FrozenClock
 from tests.infra.storage_records import db_setup
 
 # ---------------------------------------------------------------------------
@@ -4152,8 +4153,19 @@ async def test_archive_tiers_api_delete_uses_index_tier_and_keeps_user_overlay(t
         await archive.close()
 
 
-async def test_archive_tiers_api_raw_artifacts_read_source_tier(tmp_path: Path) -> None:
-    """Raw artifact facade reads ``source.db`` rows."""
+@pytest.mark.frozen_clock_modules("polylogue.storage.sqlite.archive_tiers.archive")
+async def test_archive_tiers_api_raw_artifacts_read_source_tier(tmp_path: Path, frozen_clock: FrozenClock) -> None:
+    """Raw artifact facade reads ``source.db`` rows and their parse-lifecycle timestamp.
+
+    ``write_raw_and_parsed`` finalizes a raw row's ``parsed_at`` the instant the
+    parsed write commits (``ArchiveStore._raw_parse_success_state``, which reads
+    ``datetime.now(UTC)`` in this module -- frozen here so the exact value is
+    assertable rather than dodged). A raw row whose parse is deliberately
+    deferred (``finalize_raw_parse=False``, e.g. a membership cohort still
+    awaiting a sibling replay decision) must keep ``parsed_at`` absent until a
+    later finalize call, distinguishing acquired-only from parsed raw rows
+    (polylogue-2kvn).
+    """
     from polylogue.archive.message.roles import Role
     from polylogue.core.enums import BlockType
     from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
@@ -4172,6 +4184,20 @@ async def test_archive_tiers_api_raw_artifacts_read_source_tier(tmp_path: Path) 
             )
         ],
     )
+    acquired_only_payload = b'{"session":"raw-artifact-v1-acquired-only"}'
+    acquired_only_session = ParsedSession(
+        source_name=Provider.DRIVE,
+        provider_session_id="api-raw-artifact-drive-v1-acquired-only",
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.USER,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="acquired-only target")],
+            )
+        ],
+    )
+    frozen_clock.set_time(1_780_000_000)
+    expected_parsed_at = frozen_clock.now().isoformat().replace("+00:00", "Z")
     try:
         with ArchiveStore(archive.config.archive_root) as archive_db:
             raw_id, session_id = archive_db.write_raw_and_parsed(
@@ -4180,8 +4206,18 @@ async def test_archive_tiers_api_raw_artifacts_read_source_tier(tmp_path: Path) 
                 source_path="/tmp/raw-artifact-drive-v1.json",
                 acquired_at_ms=1_770_000_000_000,
             )
+            acquired_only_raw_id, acquired_only_session_id = archive_db.write_raw_and_parsed(
+                acquired_only_session,
+                payload=acquired_only_payload,
+                source_path="/tmp/raw-artifact-drive-v1-acquired-only.json",
+                acquired_at_ms=1_770_000_000_000,
+                finalize_raw_parse=False,
+            )
 
         artifacts, total = await archive.get_raw_artifacts_for_session(session_id)
+        acquired_only_artifacts, acquired_only_total = await archive.get_raw_artifacts_for_session(
+            acquired_only_session_id
+        )
         missing_artifacts, missing_total = await archive.get_raw_artifacts_for_session("missing-session")
 
         assert total == 1
@@ -4191,7 +4227,15 @@ async def test_archive_tiers_api_raw_artifacts_read_source_tier(tmp_path: Path) 
         assert artifacts[0]["source_path"] == "/tmp/raw-artifact-drive-v1.json"
         assert artifacts[0]["blob_size"] == len(payload)
         assert artifacts[0]["acquired_at"] == "2026-02-02T02:40:00Z"
+        assert artifacts[0]["parsed_at"] == expected_parsed_at
         assert artifacts[0]["validation_status"] is None
+
+        assert acquired_only_total == 1
+        assert len(acquired_only_artifacts) == 1
+        assert acquired_only_artifacts[0]["raw_id"] == acquired_only_raw_id
+        assert acquired_only_artifacts[0]["acquired_at"] == "2026-02-02T02:40:00Z"
+        assert acquired_only_artifacts[0]["parsed_at"] is None
+
         assert missing_artifacts == []
         assert missing_total == 0
     finally:


### PR DESCRIPTION
## Summary

Pins `test_archive_tiers_api_raw_artifacts_read_source_tier` to a frozen clock so it asserts the exact `raw_sessions.parsed_at` value instead of dodging the assertion, and adds a regression case that distinguishes an acquired-only raw row from a parsed one.

## Problem

polylogue-2kvn reported that `write_parsed` now populates `raw_sessions.parsed_at`, while the test asserted `parsed_at=None`, causing a deterministic failure in isolation. On the current branch tip the test no longer asserts `parsed_at` at all — it was quietly dropped from the assertion list at some point, because the value comes from `ArchiveStore._raw_parse_success_state` (`polylogue/storage/sqlite/archive_tiers/archive.py`), which reads real `datetime.now(UTC)` — non-deterministic and therefore unassertable as written.

The bead's acceptance criteria required classifying the intended contract: is `parsed_at` authoritative after `write_parsed`, or should it stay absent? And whichever way, the exact node must pass and a regression must distinguish acquired-only from parsed raw rows.

## Solution

Classified `parsed_at` as the intended authoritative contract by design: it's set exactly once, at the parsed write that commits it (raw-artifact lifecycle: `acquired_at` at raw commit, `parsed_at` at parse finalize, never rewritten by later materialize/index activity). No production write needed repair — only the test fixture was under-specified.

- `tests/unit/api/test_facade_contracts.py`: added `@pytest.mark.frozen_clock_modules("polylogue.storage.sqlite.archive_tiers.archive")` + the `frozen_clock` fixture, set a known frozen time, and asserted the exact ISO `parsed_at` string on the finalized raw+parsed write.
- Added a second `write_raw_and_parsed(..., finalize_raw_parse=False)` call (the deferred-cohort-member path used when a membership replay still has undecided siblings) and asserted its `parsed_at` stays `None` — this is the acquired-only vs. parsed distinguishing regression the AC calls for.

## Verification

- `devtools test tests/unit/api/test_facade_contracts.py -k test_archive_tiers_api_raw_artifacts_read_source_tier` → 1 passed
- `devtools test tests/unit/api/test_facade_contracts.py` → 277 passed
- **Anti-vacuity (both reverted before commit):**
  - Removing the `frozen_clock_modules` marker made the `parsed_at` assertion fail against real wall-clock time (`'2026-07-27T20:40:52...Z' != '2026-05-28T20:26:40Z'`), proving the frozen clock is load-bearing.
  - Forcing `_index_parsed_for_retained_raw` to always finalize (ignoring `finalize_raw_parse=False`) made the acquired-only assertion fail (`parsed_at` was no longer `None`), proving the deferred-finalize regression is load-bearing.
- `mypy tests/unit/api/test_facade_contracts.py` → Success, no issues
- `ruff check` / `ruff format --check` → clean
- `devtools render all --check` → OK, no drift
- `git push` pre-push quick gate (format/lint/mypy/render/topology/layering/closure-matrix/schema-roundtrip/manifests/ci-workflows/doc-commands/docs-coverage/test-infra-currency/test-clock-hygiene/pytest-timeout-overrides/degrade-loudly/hash-boundary-census) → all passed

Ref polylogue-2kvn
