### PR TITLE
refactor(cli): route reconcile/materialize commands through AppEnv.repository

### DIFF
--- a/polylogue/cli/commands/materialize_incident_evidence.py
+++ b/polylogue/cli/commands/materialize_incident_evidence.py
@@ -9,6 +9,7 @@ import click
 
 from polylogue.api.sync.bridge import run_coroutine_sync
 from polylogue.archive.query.spec import QuerySpecError, parse_query_date
+from polylogue.cli.shared.types import AppEnv
 
 
 def _parse_time_bound(field: str, value: str | None) -> datetime | None:
@@ -66,7 +67,9 @@ def _render_plain(payload: dict[str, object]) -> None:
     show_default=True,
     help="Output format.",
 )
+@click.pass_obj
 def materialize_incident_evidence_command(
+    env: AppEnv,
     session_ids: tuple[str, ...],
     repo_names: tuple[str, ...],
     since: str | None,
@@ -96,8 +99,7 @@ def materialize_incident_evidence_command(
         NoIncidentSessionsFoundError,
         materialize_incident_work_evidence,
     )
-    from polylogue.paths import active_index_db_path, archive_root
-    from polylogue.storage.repository import SessionRepository
+    from polylogue.paths import archive_root
 
     since_bound = _parse_time_bound("since", since)
     until_bound = _parse_time_bound("until", until)
@@ -122,13 +124,12 @@ def materialize_incident_evidence_command(
         resolved_session_ids.extend(run_coroutine_sync(_select()))
 
     async def _run() -> IncidentEvidenceMaterializationResult:
-        async with SessionRepository(db_path=active_index_db_path()) as repository:
-            return await materialize_incident_work_evidence(
-                repository,
-                session_ids=resolved_session_ids,
-                graph_id=graph_id,
-                apply=apply,
-            )
+        return await materialize_incident_work_evidence(
+            env.repository,
+            session_ids=resolved_session_ids,
+            graph_id=graph_id,
+            apply=apply,
+        )
 
     try:
         result = run_coroutine_sync(_run())

--- a/polylogue/cli/commands/reconcile_work_effects.py
+++ b/polylogue/cli/commands/reconcile_work_effects.py
@@ -9,6 +9,7 @@ import click
 
 from polylogue.api.sync.bridge import run_coroutine_sync
 from polylogue.archive.query.spec import QuerySpecError, parse_query_date
+from polylogue.cli.shared.types import AppEnv
 
 
 def _parse_time_bound(field: str, value: str | None) -> int | None:
@@ -88,7 +89,9 @@ def _render_plain(summary_dict: dict[str, object]) -> None:
     show_default=True,
     help="Output format.",
 )
+@click.pass_obj
 def reconcile_work_effects_command(
+    env: AppEnv,
     graph_id: str,
     repo_path: Path,
     beads_jsonl: Path | None,
@@ -119,8 +122,6 @@ def reconcile_work_effects_command(
         WorkEvidenceGraphNotFoundError,
         reconcile_graph_repository_effects,
     )
-    from polylogue.paths import active_index_db_path
-    from polylogue.storage.repository import SessionRepository
 
     since_ms = _parse_time_bound("since", since)
     until_ms = _parse_time_bound("until", until)
@@ -132,15 +133,14 @@ def reconcile_work_effects_command(
         adapters.append(GitHubPullRequestEffectAdapter(repo=github_repo))
 
     async def _run() -> WorkEffectReconciliationSummary:
-        async with SessionRepository(db_path=active_index_db_path()) as repository:
-            return await reconcile_graph_repository_effects(
-                repository,
-                graph_id=graph_id,
-                adapters=adapters,
-                since_ms=since_ms,
-                until_ms=until_ms,
-                apply=apply,
-            )
+        return await reconcile_graph_repository_effects(
+            env.repository,
+            graph_id=graph_id,
+            adapters=adapters,
+            since_ms=since_ms,
+            until_ms=until_ms,
+            apply=apply,
+        )
 
     try:
         summary = run_coroutine_sync(_run())

--- a/tests/unit/architecture/test_surface_storage_boundary.py
+++ b/tests/unit/architecture/test_surface_storage_boundary.py
@@ -18,11 +18,6 @@ Allow-list:
 * ``polylogue/cli/shared/types.py`` — typed property exposed to CLI
   commands that legitimately need the repository handle while the
   remaining bypasses are moved.
-* ``polylogue/cli/commands/reconcile_work_effects.py`` and
-  ``polylogue/cli/commands/materialize_incident_evidence.py`` — construct
-  ``SessionRepository`` directly rather than through ``AppEnv.repository``;
-  neither command is yet wired into the ``pass_obj``/``AppEnv`` context-object
-  pattern other CLI commands use. Tracked by polylogue-a7uk.
 
 This list should shrink over time; do not add new entries without
 filing a follow-up issue.
@@ -49,8 +44,6 @@ ALLOWED: frozenset[Path] = frozenset(
         REPO_ROOT / "polylogue" / "api" / "archive.py",
         REPO_ROOT / "polylogue" / "api" / "ingest.py",
         REPO_ROOT / "polylogue" / "cli" / "shared" / "types.py",
-        REPO_ROOT / "polylogue" / "cli" / "commands" / "reconcile_work_effects.py",
-        REPO_ROOT / "polylogue" / "cli" / "commands" / "materialize_incident_evidence.py",
     }
 )
 

--- a/tests/unit/cli/test_materialize_incident_evidence_command.py
+++ b/tests/unit/cli/test_materialize_incident_evidence_command.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from polylogue.api.sync.bridge import run_coroutine_sync
-from polylogue.cli.commands.materialize_incident_evidence import materialize_incident_evidence_command
+from polylogue.cli import cli
 from polylogue.insights.work_evidence import WorkEvidenceGraph
 from polylogue.paths import active_index_db_path
 from polylogue.storage.repository import SessionRepository
@@ -54,8 +54,17 @@ def test_dry_run_reports_json_summary_without_persisting(workspace_env: dict[str
     session_id = _seed_incident_session(workspace_env)
 
     result = CliRunner().invoke(
-        materialize_incident_evidence_command,
-        ["--session-id", session_id, "--graph-id", "incident:cli-demo", "--output-format", "json"],
+        cli,
+        [
+            "ops",
+            "materialize-incident-evidence",
+            "--session-id",
+            session_id,
+            "--graph-id",
+            "incident:cli-demo",
+            "--output-format",
+            "json",
+        ],
         catch_exceptions=False,
     )
 
@@ -77,8 +86,18 @@ def test_yes_flag_persists_materialized_graph(workspace_env: dict[str, Path]) ->
     session_id = _seed_incident_session(workspace_env)
 
     result = CliRunner().invoke(
-        materialize_incident_evidence_command,
-        ["--session-id", session_id, "--graph-id", "incident:cli-apply-demo", "--yes", "--output-format", "json"],
+        cli,
+        [
+            "ops",
+            "materialize-incident-evidence",
+            "--session-id",
+            session_id,
+            "--graph-id",
+            "incident:cli-apply-demo",
+            "--yes",
+            "--output-format",
+            "json",
+        ],
         catch_exceptions=False,
     )
 
@@ -96,8 +115,15 @@ def test_yes_flag_persists_materialized_graph(workspace_env: dict[str, Path]) ->
 
 def test_unknown_session_id_reports_usage_error(workspace_env: dict[str, Path]) -> None:
     result = CliRunner().invoke(
-        materialize_incident_evidence_command,
-        ["--session-id", "codex-session:does-not-exist", "--graph-id", "incident:cli-missing"],
+        cli,
+        [
+            "ops",
+            "materialize-incident-evidence",
+            "--session-id",
+            "codex-session:does-not-exist",
+            "--graph-id",
+            "incident:cli-missing",
+        ],
     )
     assert result.exit_code != 0
     assert "no sessions found" in str(result.output) or (

--- a/tests/unit/cli/test_reconcile_work_effects_command.py
+++ b/tests/unit/cli/test_reconcile_work_effects_command.py
@@ -15,7 +15,7 @@ import pytest
 from click.testing import CliRunner
 
 from polylogue.api.sync.bridge import run_coroutine_sync
-from polylogue.cli.commands.reconcile_work_effects import reconcile_work_effects_command
+from polylogue.cli import cli
 from polylogue.core.refs import ObjectRef
 from polylogue.insights.work_evidence import WorkEvidenceGraph, WorkEvidenceNode
 from polylogue.paths import active_index_db_path
@@ -74,8 +74,17 @@ def test_dry_run_reports_json_summary_without_persisting(
     _init_git_repo(repo, message="fix: land it (Ref polylogue-1vpm.6.2)")
 
     result = CliRunner().invoke(
-        reconcile_work_effects_command,
-        ["--graph-id", _seeded_graph.graph_id, "--repo", str(repo), "--output-format", "json"],
+        cli,
+        [
+            "ops",
+            "reconcile-work-effects",
+            "--graph-id",
+            _seeded_graph.graph_id,
+            "--repo",
+            str(repo),
+            "--output-format",
+            "json",
+        ],
         catch_exceptions=False,
     )
 
@@ -98,8 +107,18 @@ def test_yes_flag_persists_reconciled_graph(
     _init_git_repo(repo, message="fix: land it (Ref polylogue-1vpm.6.2)")
 
     result = CliRunner().invoke(
-        reconcile_work_effects_command,
-        ["--graph-id", _seeded_graph.graph_id, "--repo", str(repo), "--yes", "--output-format", "json"],
+        cli,
+        [
+            "ops",
+            "reconcile-work-effects",
+            "--graph-id",
+            _seeded_graph.graph_id,
+            "--repo",
+            str(repo),
+            "--yes",
+            "--output-format",
+            "json",
+        ],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
@@ -152,8 +171,10 @@ def test_github_repo_flag_wires_in_pr_effects(
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     result = CliRunner().invoke(
-        reconcile_work_effects_command,
+        cli,
         [
+            "ops",
+            "reconcile-work-effects",
             "--graph-id",
             _seeded_graph.graph_id,
             "--repo",
@@ -179,8 +200,8 @@ def test_unknown_graph_id_is_a_usage_error(tmp_path: Path, workspace_env: dict[s
     _init_git_repo(repo, message="irrelevant")
 
     result = CliRunner().invoke(
-        reconcile_work_effects_command,
-        ["--graph-id", "claude-workflow:does-not-exist", "--repo", str(repo)],
+        cli,
+        ["ops", "reconcile-work-effects", "--graph-id", "claude-workflow:does-not-exist", "--repo", str(repo)],
     )
 
     assert result.exit_code != 0


### PR DESCRIPTION
## Summary
Routes `reconcile_work_effects_command` and `materialize_incident_evidence_command` through the standard `AppEnv.repository` / `@click.pass_obj` context-object pattern instead of constructing `SessionRepository(db_path=active_index_db_path())` directly, removing a tracked architecture-boundary allow-list exception.

## Problem
Both commands (from PR #3199/#3327 and PR #3336) imported `SessionRepository` directly from `polylogue.storage.repository` and constructed it manually instead of going through `AppEnv.repository` — the pattern every other CLI command uses. `tests/unit/architecture/test_surface_storage_boundary.py` had to special-case both files in its `ALLOWED` set rather than fix the violation (tracked by polylogue-a7uk).

## Solution
- Added `@click.pass_obj` to both commands, with `env: AppEnv` as the first parameter.
- Replaced the manual `async with SessionRepository(db_path=active_index_db_path()) as repository:` construction with `env.repository`, which resolves to the same cached repository via `RuntimeServices.get_repository()` (same underlying archive path).
- Removed the now-unneeded allow-list entries in `test_surface_storage_boundary.py`.
- Updated both commands' CLI tests (`test_reconcile_work_effects_command.py`, `test_materialize_incident_evidence_command.py`) to invoke through the real `cli` root group (`ops reconcile-work-effects` / `ops materialize-incident-evidence`) instead of the bare leaf command, matching `test_excise.py`'s existing pattern — this is what lets the root callback build a properly runtime-resolved `AppEnv` (an ad hoc `AppEnv()` constructed directly in a test has no resolved database path).

## Verification
- `devtools test tests/unit/cli/test_reconcile_work_effects_command.py tests/unit/cli/test_materialize_incident_evidence_command.py tests/unit/architecture/test_surface_storage_boundary.py` → 162 passed
- `mypy --strict polylogue/cli/commands/reconcile_work_effects.py polylogue/cli/commands/materialize_incident_evidence.py` → Success: no issues found in 2 source files
- `ruff check` / `ruff format --check` on all changed files → clean
- `devtools render all --check` → no "out of sync" surfaces
- Pre-push hook (`devtools verify --quick`) passed on push

Ref polylogue-a7uk