### PR TITLE
fix: defer sibling full-revision retirement instead of quarantining raw

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -127,6 +127,7 @@ from polylogue.sources.sqlite_snapshot import (
 )
 from polylogue.storage.blob_store import BlobStore
 from polylogue.storage.runtime import RawSessionRecord
+from polylogue.storage.sqlite.archive_tiers.archive import ActiveByteRevisionChainError
 from polylogue.storage.sqlite.archive_tiers.bootstrap import (
     ARCHIVE_TIER_SPECS,
 )
@@ -2177,14 +2178,35 @@ class LiveBatchProcessor:
                     raise RuntimeError(
                         f"full revision {revision_raw_id}:{logical_source_key} no longer parses uniquely"
                     )
-                archive.replace_raw_membership_census(
-                    revision_raw_id,
-                    retained_sessions,
-                    parser_fingerprint=self._current_parser_fingerprint(),
-                    censused_at_ms=acquired_at_ms,
-                    detail=HISTORICAL_NON_PREFIX_GOVERNANCE_DETAIL,
-                    retire_full_revision_governance=True,
-                )
+                try:
+                    archive.replace_raw_membership_census(
+                        revision_raw_id,
+                        retained_sessions,
+                        parser_fingerprint=self._current_parser_fingerprint(),
+                        censused_at_ms=acquired_at_ms,
+                        detail=HISTORICAL_NON_PREFIX_GOVERNANCE_DETAIL,
+                        retire_full_revision_governance=True,
+                    )
+                except ActiveByteRevisionChainError:
+                    # polylogue-lpen: another raw's predecessor_raw_id/
+                    # baseline_raw_id still points at revision_raw_id, so it
+                    # cannot be retired out of byte-revision governance yet.
+                    # This is expected, transient sibling-discovery-ordering
+                    # contention (the same class as polylogue-52l2/hm2f, on
+                    # the retire leg instead of the accept-cohort leg), not a
+                    # failure of the raw currently being ingested
+                    # (source_raw_id). Defer this specific sibling's
+                    # retirement to a later tick -- once the dependent chain
+                    # resolves, convertible_full_revision_raw_ids will surface
+                    # it again -- instead of letting the exception propagate
+                    # up and quarantine the unrelated raw being processed.
+                    logger.warning(
+                        "live.watcher: deferring full-revision retirement of %s (%s): "
+                        "active byte-revision chain dependent still present",
+                        revision_raw_id,
+                        logical_source_key,
+                    )
+                    continue
             member_sessions: dict[str, Any] = {}
             projections: dict[str, Any] = {}
             revisions: list[MembershipRevision] = []

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -271,6 +271,26 @@ from polylogue.storage.sqlite.runtime_indexes import ensure_runtime_indexes_sync
 from polylogue.storage.table_existence import table_exists as _table_exists
 
 
+class ActiveByteRevisionChainError(RuntimeError):
+    """Raised when a full-revision raw still has a live byte-chain dependent.
+
+    ``replace_raw_membership_census(..., retire_full_revision_governance=True)``
+    refuses to retire a raw out of byte-revision governance while another raw's
+    ``predecessor_raw_id``/``baseline_raw_id`` still points at it -- retiring it
+    would orphan that dependent's chain. This is expected, transient
+    contention (polylogue-lpen): the dependent raw simply hasn't been
+    discovered/ingested yet, or its own membership transition is still in
+    flight. Callers should defer the retirement of *this specific* raw and
+    retry on a later tick once the dependent chain resolves, not treat it as a
+    fatal error for whatever unrelated raw happened to trigger the sibling
+    retirement sweep. A distinct exception type (rather than a bare
+    ``RuntimeError``) lets callers narrowly catch this expected-contention
+    case without also swallowing the other, genuinely-buggy
+    ``RuntimeError``s this method raises (missing census raw, non-full raw
+    misrouted into full-revision retirement).
+    """
+
+
 @dataclass(slots=True)
 class _UsageTimelineAccumulator:
     bucket: str
@@ -2650,7 +2670,9 @@ class ArchiveStore:
                     (raw_id, raw_id, raw_id),
                 ).fetchone()
                 if dependent is not None:
-                    raise RuntimeError("an active byte-revision chain cannot move to membership governance")
+                    raise ActiveByteRevisionChainError(
+                        "an active byte-revision chain cannot move to membership governance"
+                    )
                 conn.execute(
                     """
                     UPDATE raw_sessions
@@ -13035,4 +13057,10 @@ def _month_bucket_end_ms(bucket: str) -> int:
     return int(end.timestamp() * 1000)
 
 
-__all__ = ["ArchiveFileQueryRow", "ArchiveStore", "ArchiveSessionSearchHit", "ArchiveSessionSummary"]
+__all__ = [
+    "ActiveByteRevisionChainError",
+    "ArchiveFileQueryRow",
+    "ArchiveStore",
+    "ArchiveSessionSearchHit",
+    "ArchiveSessionSummary",
+]

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -3613,6 +3613,185 @@ def test_live_third_raw_reunifies_with_backfill_retired_siblings(tmp_path: Path)
         ).fetchone() == (None,)
 
 
+def test_membership_sweep_defers_sibling_retirement_instead_of_quarantining_current_raw(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """polylogue-lpen: an active byte-revision chain must not poison an unrelated raw.
+
+    Root cause (11 of 73 live ``claude-code-session`` parse-failed raws, found
+    via ``polylogue ops debt list``): ``_apply_membership_sessions`` sweeps
+    *every* full-only raw sharing a logical identity
+    (``archive.convertible_full_revision_raw_ids``) and unconditionally tries
+    to retire each one out of byte-revision governance
+    (``replace_raw_membership_census(..., retire_full_revision_governance=
+    True)``), as a side effect of processing some entirely different,
+    currently-ingesting raw (``source_raw_id``). It never checks whether a
+    candidate still has a live byte-chain dependent -- another raw whose
+    ``predecessor_raw_id``/``baseline_raw_id`` points at it -- before
+    attempting the retirement; that invariant is enforced only deeper inside
+    ``replace_raw_membership_census``, which raises
+    ``ActiveByteRevisionChainError`` (a ``RuntimeError``) when it finds one.
+    Pre-fix, that exception propagated all the way up through
+    ``_apply_membership_sessions`` into the live-watcher's blanket
+    ``except Exception`` (``sources/live/batch.py``), which called
+    ``archive.mark_raw_parse_failed`` on ``source_raw_id`` -- the CURRENT,
+    unrelated raw -- permanently quarantining it even though it had nothing
+    to do with the chain conflict.
+
+    Fixture: raw_a (baseline) and raw_b (a genuine byte-extension of raw_a's
+    bytes) form a real byte-proven full-revision chain for ``codex:shared``
+    via ``classify_raw_revision_cohort`` -- raw_b's ``predecessor_raw_id``
+    durably points at raw_a, exactly the "active byte-revision chain"
+    dependency ``replace_raw_membership_census`` refuses to break. A third,
+    unrelated raw (raw_c) then triggers ``_apply_membership_sessions`` for
+    the same logical identity (mirroring the live "no accepted chain but no
+    retired siblings either" / multi-session bundle call sites). The
+    retirement sweep order is pinned (raw_a before raw_b) so the parent is
+    always attempted while its dependent is still live, regardless of
+    raw_id hash ordering.
+    """
+    initialize_active_archive_root(tmp_path)
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_a = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b'{"a":1}\n',
+            source_path=str(tmp_path / "a.jsonl"),
+            acquired_at_ms=1,
+        )
+        archive.bind_raw_revision(
+            raw_a,
+            RawRevisionEnvelope(
+                "codex:shared", RawRevisionKind.FULL, "rev-a", 0, authority=RawRevisionAuthority.QUARANTINED
+            ),
+        )
+        raw_b = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b'{"a":1}\n{"b":2}\n',
+            source_path=str(tmp_path / "b.jsonl"),
+            acquired_at_ms=2,
+        )
+        archive.bind_raw_revision(
+            raw_b,
+            RawRevisionEnvelope(
+                "codex:shared", RawRevisionKind.FULL, "rev-b", 0, authority=RawRevisionAuthority.QUARANTINED
+            ),
+        )
+        archive.classify_raw_revision_cohort("codex:shared")
+        archive.commit()
+        raw_c = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b'{"c":1}\n',
+            source_path=str(tmp_path / "c.jsonl"),
+            acquired_at_ms=3,
+        )
+        archive.commit()
+
+    # Sanity: the byte chain really was proven, and raw_b really is a live
+    # dependent of raw_a -- this is the exact condition the fixture claims.
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        rows = dict(
+            conn.execute(
+                "SELECT raw_id, predecessor_raw_id FROM raw_sessions WHERE logical_source_key = 'codex:shared'"
+            ).fetchall()
+        )
+    assert rows[raw_a] is None
+    assert rows[raw_b] == raw_a
+
+    def session(native_id: str, *texts: str) -> ParsedSession:
+        return ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id=native_id,
+            messages=[
+                ParsedMessage(provider_message_id=f"{native_id}-{index}", role=Role.USER, text=text)
+                for index, text in enumerate(texts)
+            ],
+        )
+
+    session_a = session("shared", "base")
+    session_b = session("shared", "base", "extra")
+    session_c = session("shared", "base")
+    sessions_by_raw_id = {raw_a: session_a, raw_b: session_b}
+
+    index_db = tmp_path / "index.db"
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db))),
+        (WatchSource(name="codex", root=tmp_path),),
+        cursor=CursorStore(index_db),
+        parser_fingerprint="test-parser",
+    )
+    monkeypatch.setattr(
+        processor,
+        "_parse_retained_raw_sessions",
+        lambda _archive, raw_id: [sessions_by_raw_id[raw_id]],
+    )
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        # Confirm the lower-level invariant still fails closed on its own --
+        # the fix belongs in the caller's handling of this, not in silently
+        # dropping the check.
+        with pytest.raises(archive_tier_module.ActiveByteRevisionChainError):
+            archive.replace_raw_membership_census(
+                raw_a,
+                [session_a],
+                parser_fingerprint="test-parser",
+                censused_at_ms=10,
+                retire_full_revision_governance=True,
+            )
+        archive.rollback()
+
+        # Pin the sweep order to (parent, child) regardless of raw_id hash
+        # ordering, so the parent is always attempted while its dependent
+        # (raw_b) is still live.
+        monkeypatch.setattr(archive, "convertible_full_revision_raw_ids", lambda _key: (raw_a, raw_b))
+
+        # Mirror every production call site: source_raw_id is always censused
+        # (without retiring anything) immediately before
+        # ``_apply_membership_sessions`` is invoked.
+        archive.replace_raw_membership_census(
+            raw_c,
+            [session_c],
+            parser_fingerprint="test-parser",
+            censused_at_ms=10,
+        )
+
+        with caplog.at_level("WARNING", logger="polylogue.sources.live.batch"):
+            session_ids, session_count, message_count, complete = processor._apply_membership_sessions(
+                archive,
+                raw_c,
+                [session_c],
+                acquired_at_ms=10,
+                allow_current_complete_raw=True,
+            )
+        archive.commit()
+
+    # The unrelated raw_c ingest completes -- it is not poisoned by raw_a's
+    # unresolved sibling-retirement conflict.
+    assert session_count == 1
+    assert message_count >= 1
+    assert any("deferring" in record.message and raw_a in record.message for record in caplog.records)
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        # raw_a's dependent (raw_b) was still live when its retirement was
+        # attempted -- deferred, not retired: its byte-chain evidence survives
+        # intact for a later tick to retry once raw_b resolves.
+        assert conn.execute(
+            "SELECT logical_source_key, revision_authority FROM raw_sessions WHERE raw_id = ?",
+            (raw_a,),
+        ).fetchone() == ("codex:shared", "byte_proven")
+        # raw_b had no live dependent of its own -- it retired successfully.
+        assert conn.execute(
+            "SELECT logical_source_key, revision_authority FROM raw_sessions WHERE raw_id = ?",
+            (raw_b,),
+        ).fetchone() == (None, "quarantined")
+        # raw_c itself never failed -- no parse_error was ever recorded for it.
+        assert conn.execute(
+            "SELECT parse_error FROM raw_sessions WHERE raw_id = ?",
+            (raw_c,),
+        ).fetchone() == (None,)
+
+
 def test_raw_membership_decision_pending_distinguishes_null_from_ambiguous(tmp_path: Path) -> None:
     """Pins the exact narrow scoping of the polylogue-emx2 fix (de0b2df7a regression, polylogue-lvz6 triage).
 


### PR DESCRIPTION
## Summary

Fixes the root cause behind 11 of 73 live `claude-code-session` raws
permanently stuck as `debt:raw-materialization:claude-code-session:parse-failed`
(found via `polylogue ops debt list`), all carrying
`RuntimeError: an active byte-revision chain cannot move to membership
governance`.

## Problem

`LiveBatchProcessor._apply_membership_sessions`
(`polylogue/sources/live/batch.py`) sweeps every full-only raw sharing a
logical identity (`archive.convertible_full_revision_raw_ids`) and
unconditionally tries to retire each one out of byte-revision governance
(`replace_raw_membership_census(..., retire_full_revision_governance=True)`),
as a side effect of processing some entirely different, currently-ingesting
raw (`source_raw_id`). It never checks whether a sweep candidate still has a
live byte-chain dependent -- another raw whose `predecessor_raw_id`/
`baseline_raw_id` points at it -- before attempting the retirement; that
invariant is enforced only deeper inside `replace_raw_membership_census`,
which raises when it finds one.

Pre-fix, that `RuntimeError` propagated all the way up through
`_apply_membership_sessions` into the live watcher's blanket
`except Exception`, which called `archive.mark_raw_parse_failed` on
`source_raw_id` -- the CURRENT, unrelated raw being ingested -- permanently
quarantining it (`validation_status` stays NULL/`unknown` forever since
parse never completes, and nothing re-triggers reparse once `parse_error`
is set and validation was never reached).

This is the same class of incremental-discovery-ordering race documented
and partly fixed for polylogue-52l2/polylogue-hm2f (byte-revision cohort
acceptance), but on the retire-sibling leg rather than the accept-cohort
leg.

## Solution

- `polylogue/storage/sqlite/archive_tiers/archive.py`: introduced
  `ActiveByteRevisionChainError` (a distinct `RuntimeError` subclass),
  raised in place of the bare `RuntimeError` at the exact site that detects
  a live byte-chain dependent. A distinct type lets callers narrowly catch
  this expected, transient contention without also swallowing the method's
  other, genuinely-buggy `RuntimeError`s (missing census raw, non-full raw
  misrouted into full-revision retirement).
- `polylogue/sources/live/batch.py`: `_apply_membership_sessions` now wraps
  the per-sibling `replace_raw_membership_census(...,
  retire_full_revision_governance=True)` call in a narrow
  `except ActiveByteRevisionChainError`, logs a warning, and continues to
  the next candidate instead of letting the exception propagate. The
  sibling's own census write already rolled back in its own transaction, so
  nothing is left inconsistent; a later tick retries once the dependent
  chain resolves (once the dependent itself retires or resolves, the
  `predecessor_raw_id` link that blocked this raw's retirement disappears).

Non-goal (per bead notes, left as durable/expected debt): the other
`claude-code-session` parse-failed shapes in the same debt row (stale
`.pre-enrich` snapshot JSONL fragments, CAS-rejected superseded captures)
are legitimate fail-closed outcomes, not code bugs, and were intentionally
not touched. Also out of scope: the write-path non-session-artifact
classification gap for `hermes-session`/`unknown-export` sidecar files
(flagged in the bead as a separate follow-up).

## Verification

- New regression test
  `test_membership_sweep_defers_sibling_retirement_instead_of_quarantining_current_raw`
  (`tests/unit/sources/test_live_batch_support.py`) builds a synthetic
  byte-proven full-revision chain (raw_a baseline, raw_b a genuine byte
  extension of raw_a, chained via the real `classify_raw_revision_cohort`)
  plus a third, unrelated raw, then calls `_apply_membership_sessions`
  directly with the sibling sweep order pinned to (raw_a, raw_b) so the
  parent is always attempted while its dependent is still live. Manually
  confirmed the test fails pre-fix (reverted the try/except locally, reran,
  observed `ActiveByteRevisionChainError` escape uncaught and fail the
  test), then restored the fix and reran green.
- `devtools test tests/unit/sources/test_live_batch_support.py
  tests/unit/storage/test_archive_readiness.py tests/unit/storage/test_repair.py
  tests/unit/storage/test_revision_replay.py` -- **179 passed**.
- `devtools verify --quick` -- **exit 0** (ruff format, ruff check, mypy
  --strict, render all --check all clean).
- No live mutation was performed against `/realm/db/polylogue` (irreplaceable
  personal archive; verified backup taken 2026-07-27T19:56:07Z) -- fixed and
  verified entirely against synthetic in-memory/tmp-path fixtures.

Ref polylogue-lpen