### PR TITLE
perf(storage): skip re-indexing already-applied append-chain positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,7 @@ normal path that sends archive text outside the machine. Run
 
 Live site: <https://sinity.github.io/polylogue/>.
 
-Start with the task-oriented guides below. The complete documentation map is in
-[docs/README.md](docs/README.md).
+Start with the task-oriented guides below. The complete documentation map is in [docs/README.md](docs/README.md).
 
 | Document | Description |
 |----------|-------------|

--- a/devtools/render_docs_surface.py
+++ b/devtools/render_docs_surface.py
@@ -58,9 +58,7 @@ def _render_table(entries: tuple[DocsEntry, ...], *, from_dir: str = "") -> str:
 
 def _render_readme_table(entries: tuple[DocsEntry, ...]) -> str:
     lines = ["| Document | Description |", "|----------|-------------|"]
-    lines.extend(
-        f"| [{entry.title}]({entry.path}) | {README_DOC_DESCRIPTIONS[entry.title]} |" for entry in entries
-    )
+    lines.extend(f"| [{entry.title}]({entry.path}) | {README_DOC_DESCRIPTIONS[entry.title]} |" for entry in entries)
     return "\n".join(lines)
 
 

--- a/polylogue/sources/live/append_ingest.py
+++ b/polylogue/sources/live/append_ingest.py
@@ -197,6 +197,17 @@ def _ingest_append_plans_archive(
                         acquired_at_ms=acquired_at_ms,
                         stage_timings_s=timings,
                         stage_timing_prefix="append",
+                        # polylogue-de2a: this is the live watcher's hot
+                        # per-append path -- called again for every tiny
+                        # append a still-open session receives. Re-indexing
+                        # (not re-parsing) every already-applied historical
+                        # position on every call is what made the writer
+                        # gate's hold time grow with the session's total
+                        # accumulated append count instead of the size of
+                        # just this append (see apply_raw_revision_replay's
+                        # skip_already_applied docstring for the full
+                        # evidence chain).
+                        skip_already_applied=True,
                     )
                     _add_timing(timings, "append.raw_and_index_write", t0)
                     succeeded.append(plan)

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -3099,6 +3099,7 @@ class ArchiveStore:
         bulk_fts: bool = False,
         bulk_build: bool = False,
         defer_fts: bool = False,
+        skip_already_applied: bool = False,
     ) -> tuple[str, tuple[str, ...]]:
         """Apply a proven chain and atomically receipt its exact index state.
 
@@ -3129,6 +3130,29 @@ class ArchiveStore:
         relaxes ``assert_session_fts_exact_sync`` to its trigger-presence-only
         check, since the bulk-build caller repopulates ``messages_fts``
         archive-wide exactly once at readiness instead.
+
+        ``skip_already_applied`` (polylogue-de2a, default ``False`` so every
+        existing caller is byte-for-byte unchanged) skips the index write --
+        not the parse, not the bookkeeping/receipt writes -- for every
+        ``plan.accepted_raw_ids`` entry at or before the logical source's
+        current ``raw_revision_heads.accepted_raw_id``. Without this, every
+        single live append replays the WHOLE accumulated chain from its
+        proven baseline through every previously accepted append: each of
+        those historical positions is already durably indexed from an
+        earlier call, so re-running ``_index_parsed_for_retained_raw`` for
+        them is redundant ``INSERT OR REPLACE`` churn against ``messages``/
+        ``blocks`` that re-triggers their ``messages_fts`` insert triggers
+        for content that never changed. A long-lived session accumulating N
+        small live appends over its lifetime pays O(N) redundant historical
+        writes on its Nth append and O(N^2) cumulatively over its life --
+        this is the confirmed root cause of the multi-minute/multi-hour
+        writer-gate holds in polylogue-de2a (observed 860s and 9297s single
+        holds), which in turn starved every other periodic write actor (FTS
+        merge, WAL checkpoint) for the entire hold. Only the live append
+        path opts in; the backfill/restore/membership replay paths keep the
+        full self-healing re-apply (their content may predate a parser fix
+        and legitimately need every historical position rewritten, and they
+        run far less often than a live append).
         """
         if not plan.accepted_raw_ids:
             raise ValueError("cannot apply a revision plan without an accepted chain")
@@ -3160,6 +3184,21 @@ class ArchiveStore:
                    FROM raw_revision_heads WHERE logical_source_key = ?""",
                 (plan.logical_source_key,),
             ).fetchone()
+            # Captured before any clearing below (the quarantined-membership
+            # fold path nulls ``existing_head`` further down): the previous
+            # run's accepted tip is exactly the boundary between "already
+            # durably indexed" and "new tail" for THIS byte chain. If it
+            # isn't present in the current chain at all (a fresh chain, a
+            # cleared/superseded membership head, or a discontinuity), the
+            # lookup below naturally falls back to "no skip" -- every
+            # position gets indexed, identical to today's behavior.
+            previously_accepted_raw_id = str(existing_head[1]) if existing_head is not None else None
+            already_indexed_upto = -1
+            if skip_already_applied and previously_accepted_raw_id is not None:
+                try:
+                    already_indexed_upto = plan.accepted_raw_ids.index(previously_accepted_raw_id)
+                except ValueError:
+                    already_indexed_upto = -1
             accepted_frontier_kind = (
                 "semantic" if existing_head is not None and str(existing_head[4]) == "semantic" else "byte"
             )
@@ -3196,6 +3235,15 @@ class ArchiveStore:
                 )
                 existing_head = None
             for position, raw_id in enumerate(plan.accepted_raw_ids):
+                if position <= already_indexed_upto:
+                    # Already durably written by an earlier accepted replay
+                    # of this exact byte chain (see ``skip_already_applied``
+                    # above) -- its session_id is deterministic from its own
+                    # parsed content, so recover it without re-running the
+                    # write.
+                    parsed = parsed_by_raw_id[raw_id]
+                    session_ids.add(str(make_session_id(parsed.source_name, parsed.provider_session_id)))
+                    continue
                 index_started = time.perf_counter()
                 result = self._index_parsed_for_retained_raw(
                     parsed_by_raw_id[raw_id],

--- a/tests/unit/storage/test_revision_replay.py
+++ b/tests/unit/storage/test_revision_replay.py
@@ -1276,3 +1276,231 @@ def test_membership_replay_yields_to_semantic_chain_head_even_when_capture_has_m
         ).fetchone()
         assert stored is not None
         assert bytes(stored[0]).hex() == session_content_hash(export_session)
+
+
+def test_skip_already_applied_indexes_only_new_tail_of_append_chain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """polylogue-de2a: the live watcher's per-append replay must not re-index
+    every historical append on every new one.
+
+    Simulates the exact live-watcher shape: baseline arrives, then two more
+    appends arrive one at a time, each replaying the WHOLE accumulated chain
+    (as the real ``append_ingest.py`` hot path always does -- it always
+    passes ``parsed_by_raw_id`` for the entire ``plan.accepted_raw_ids``).
+    With ``skip_already_applied=True``, only the newly accepted tail raw_id
+    should reach ``_index_parsed_for_retained_raw`` on the 2nd and 3rd calls
+    -- not the whole chain again. Without the fix, every call re-indexes
+    every position, an O(n) cost per append that made the daemon's writer
+    gate hold for minutes to hours as a session's append count grew
+    (confirmed root cause; see ``apply_raw_revision_replay``'s
+    ``skip_already_applied`` docstring).
+    """
+    initialize_active_archive_root(tmp_path)
+
+    def parsed(*messages: tuple[str, str]) -> ParsedSession:
+        return ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="session",
+            messages=[
+                ParsedMessage(provider_message_id=message_id, role=Role.USER, text=text)
+                for message_id, text in messages
+            ],
+        )
+
+    indexed_raw_ids: list[str] = []
+    original = ArchiveStore._index_parsed_for_retained_raw
+
+    def spy(self: ArchiveStore, session: ParsedSession, *, raw_id: str, **kwargs: object) -> object:
+        indexed_raw_ids.append(raw_id)
+        return original(self, session, raw_id=raw_id, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(ArchiveStore, "_index_parsed_for_retained_raw", spy)
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        baseline = archive.write_raw_payload(
+            provider=Provider.CODEX, payload=b"a" * 10, source_path="session.jsonl", acquired_at_ms=1
+        )
+        archive.bind_raw_revision(
+            baseline,
+            RawRevisionEnvelope(
+                "codex:session", RawRevisionKind.FULL, "full-0", 0, authority=RawRevisionAuthority.BYTE_PROVEN
+            ),
+        )
+        plan0 = archive.classify_raw_revision_cohort("codex:session")
+        archive.apply_raw_revision_replay(
+            plan0, {baseline: parsed(("m0", "zero"))}, acquired_at_ms=0, skip_already_applied=True
+        )
+        assert indexed_raw_ids == [baseline]
+        indexed_raw_ids.clear()
+
+        append_one = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b"b" * 5,
+            source_path="session.jsonl",
+            source_index=-1,
+            acquired_at_ms=2,
+        )
+        archive.bind_raw_revision(
+            append_one,
+            RawRevisionEnvelope(
+                "codex:session",
+                RawRevisionKind.APPEND,
+                append_source_revision("full-0", hashlib.sha256(b"b" * 5).hexdigest()),
+                1,
+                predecessor_source_revision="full-0",
+                predecessor_raw_id=baseline,
+                baseline_raw_id=baseline,
+                append_start_offset=10,
+                append_end_offset=15,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
+            ),
+        )
+        plan1 = archive.classify_raw_revision_cohort("codex:session")
+        assert plan1.accepted_raw_ids == (baseline, append_one)
+        # The real live-watcher hot path always reparses+passes the FULL
+        # accepted chain (see append_ingest.py), not just the new tail.
+        archive.apply_raw_revision_replay(
+            plan1,
+            {baseline: parsed(("m0", "zero")), append_one: parsed(("m1", "one"))},
+            acquired_at_ms=0,
+            skip_already_applied=True,
+        )
+        # Only the NEW tail position was actually indexed -- the baseline
+        # was already durably written by the first call above.
+        assert indexed_raw_ids == [append_one]
+        indexed_raw_ids.clear()
+
+        append_two = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b"c" * 5,
+            source_path="session.jsonl",
+            source_index=-1,
+            acquired_at_ms=3,
+        )
+        archive.bind_raw_revision(
+            append_two,
+            RawRevisionEnvelope(
+                "codex:session",
+                RawRevisionKind.APPEND,
+                append_source_revision(
+                    append_source_revision("full-0", hashlib.sha256(b"b" * 5).hexdigest()),
+                    hashlib.sha256(b"c" * 5).hexdigest(),
+                ),
+                2,
+                predecessor_source_revision=append_source_revision("full-0", hashlib.sha256(b"b" * 5).hexdigest()),
+                predecessor_raw_id=append_one,
+                baseline_raw_id=baseline,
+                append_start_offset=15,
+                append_end_offset=20,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
+            ),
+        )
+        plan2 = archive.classify_raw_revision_cohort("codex:session")
+        assert plan2.accepted_raw_ids == (baseline, append_one, append_two)
+        archive.apply_raw_revision_replay(
+            plan2,
+            {
+                baseline: parsed(("m0", "zero")),
+                append_one: parsed(("m1", "one")),
+                append_two: parsed(("m2", "two")),
+            },
+            acquired_at_ms=0,
+            skip_already_applied=True,
+        )
+        # Again: only the newest position, not the two already-applied ones.
+        assert indexed_raw_ids == [append_two]
+        indexed_raw_ids.clear()
+
+        # Correctness is unaffected by skipping the already-applied writes:
+        # every message from every accepted position is still present.
+        rows = archive._conn.execute(
+            "SELECT block_type, search_text FROM blocks JOIN messages USING (message_id)"
+            " WHERE messages.session_id = 'codex-session:session' ORDER BY messages.position"
+        ).fetchall()
+        texts = [str(row[1]) for row in rows]
+        assert any("zero" in text for text in texts)
+        assert any("one" in text for text in texts)
+        assert any("two" in text for text in texts)
+
+        head = archive._conn.execute(
+            "SELECT accepted_raw_id FROM raw_revision_heads WHERE logical_source_key = 'codex:session'"
+        ).fetchone()
+        assert head is not None
+        assert head[0] == append_two
+
+
+def test_skip_already_applied_default_false_still_reindexes_whole_chain(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Backfill/restore/membership callers do not pass ``skip_already_applied``
+    and must keep today's full self-healing re-apply of every historical
+    position -- only the live-append hot path opts into the fast tail-only
+    mode.
+    """
+    initialize_active_archive_root(tmp_path)
+
+    def parsed(*messages: tuple[str, str]) -> ParsedSession:
+        return ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="session",
+            messages=[
+                ParsedMessage(provider_message_id=message_id, role=Role.USER, text=text)
+                for message_id, text in messages
+            ],
+        )
+
+    indexed_raw_ids: list[str] = []
+    original = ArchiveStore._index_parsed_for_retained_raw
+
+    def spy(self: ArchiveStore, session: ParsedSession, *, raw_id: str, **kwargs: object) -> object:
+        indexed_raw_ids.append(raw_id)
+        return original(self, session, raw_id=raw_id, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(ArchiveStore, "_index_parsed_for_retained_raw", spy)
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        baseline = archive.write_raw_payload(
+            provider=Provider.CODEX, payload=b"a" * 10, source_path="session.jsonl", acquired_at_ms=1
+        )
+        archive.bind_raw_revision(
+            baseline,
+            RawRevisionEnvelope(
+                "codex:session", RawRevisionKind.FULL, "full-0", 0, authority=RawRevisionAuthority.BYTE_PROVEN
+            ),
+        )
+        plan0 = archive.classify_raw_revision_cohort("codex:session")
+        archive.apply_raw_revision_replay(plan0, {baseline: parsed(("m0", "zero"))}, acquired_at_ms=0)
+        indexed_raw_ids.clear()
+
+        append_one = archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=b"b" * 5,
+            source_path="session.jsonl",
+            source_index=-1,
+            acquired_at_ms=2,
+        )
+        archive.bind_raw_revision(
+            append_one,
+            RawRevisionEnvelope(
+                "codex:session",
+                RawRevisionKind.APPEND,
+                append_source_revision("full-0", hashlib.sha256(b"b" * 5).hexdigest()),
+                1,
+                predecessor_source_revision="full-0",
+                predecessor_raw_id=baseline,
+                baseline_raw_id=baseline,
+                append_start_offset=10,
+                append_end_offset=15,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
+            ),
+        )
+        plan1 = archive.classify_raw_revision_cohort("codex:session")
+        archive.apply_raw_revision_replay(
+            plan1,
+            {baseline: parsed(("m0", "zero")), append_one: parsed(("m1", "one"))},
+            acquired_at_ms=0,
+        )
+        # Default (no skip): the whole chain is re-indexed, exactly as before
+        # this fix -- pinning that non-opted-in callers are unaffected.
+        assert indexed_raw_ids == [baseline, append_one]


### PR DESCRIPTION
## Summary

Fixes the confirmed root cause of polylogue-de2a's multi-minute/multi-hour
daemon writer-gate holds: `apply_raw_revision_replay` re-indexes every
historical raw revision in a session's append chain on every single new
live append, not just the new tail. This PR adds an opt-in fast path that
skips re-writing (not re-parsing) already-durably-applied positions.

## Problem

polylogue-de2a was opened after observing the live daemon's watcher
`catch-up.chunk` actor hold the sole-writer lock for 860 seconds (14+
minutes) processing a single modest (~7MB, 547-block) session append, and
in a more extreme case, 9297 seconds (2.6 hours) for one append. While
held, every other periodic daemon actor (FTS merge, WAL checkpoint,
convergence) was starved for the entire duration, since
`DaemonWriteCoordinator` serializes all writers through one gate with no
preemption of an already-admitted holder.

Two prior fast-follows in this bead (PR #3288: shortened the FTS-merge
interval 300s -> 60s; PR #3289: gave maintenance actors queue-admission
priority over watcher actors) mitigated recovery speed and worst-case
starvation bound, but neither fixes an already-admitted single hold
running for minutes to hours.

Root-causing this session with a direct SQL-level trace of
`apply_raw_revision_replay` (`polylogue/storage/sqlite/archive_tiers/archive.py`):
its write loop (`for position, raw_id in enumerate(plan.accepted_raw_ids)`)
calls `_index_parsed_for_retained_raw` -> `write_parsed_session_to_archive`
for **every** raw_id in the accepted chain, every single call --
including every historical append already durably applied by an earlier
successful replay. `messages`/`blocks` writes use `INSERT OR REPLACE`,
which re-fires `messages_fts` insert triggers even for byte-identical
content that never changed. The live watcher's per-append hot path
(`polylogue/sources/live/append_ingest.py`) always builds
`parsed_by_raw_id` for the **entire** accepted chain (not just the new
tail), so a long-lived session accumulating N small live appends over its
life pays O(N) redundant historical writes on its Nth append and O(N^2)
cumulatively -- exactly the self-reinforcing FTS-segment-bloat spiral this
bead's live evidence already pointed to (`messages_fts_data` at 705K rows).

## Solution

- `apply_raw_revision_replay` gains `skip_already_applied: bool = False`
  (default preserves today's behavior for every existing caller).
  When `True`, it captures the logical source's current
  `raw_revision_heads.accepted_raw_id` *before* any clearing (the
  quarantined-membership-fold path can null it later in the same call),
  finds that raw_id's position in `plan.accepted_raw_ids`, and skips the
  index write for every position at or before it -- only the new tail
  gets written. `session_id` for a skipped position is derived
  deterministically from its already-parsed content
  (`make_session_id(parsed.source_name, parsed.provider_session_id)`)
  instead of the write result.
- Only `append_ingest.py`'s live per-append call site opts in
  (`skip_already_applied=True`). The backfill/restore/membership-classification
  call sites (`revision_backfill.py`, `batch.py`) keep the full
  self-healing re-apply unchanged -- their content may predate a parser
  fix and legitimately need every historical position rewritten, and they
  run far less often than a live append.
- Reparsing (`parse_retained_raw_sessions`) is intentionally left
  unchanged -- the aggregate content hash and semantic frontier still need
  every position's parsed content merged. Only the expensive SQL/FTS
  **write** is skipped for already-applied positions.
- Small mechanical drift-fix commit first: `devtools/render_docs_surface.py`
  had drifted from the current ruff formatter (unrelated pre-existing
  issue on master), which blocked the pre-push hook's
  `devtools verify --quick` for every branch; fixed with
  `ruff format` + `devtools render docs-surface` (no logic change).

## Verification

- `devtools test tests/unit/storage/test_revision_replay.py` -- 26 passed,
  including two new tests added by this PR:
  - `test_skip_already_applied_indexes_only_new_tail_of_append_chain`:
    simulates three sequential live appends onto a growing chain (mirroring
    `append_ingest.py`'s real shape, which always replays the whole
    accumulated chain), spies on `_index_parsed_for_retained_raw` calls, and
    proves only the newest tail position is ever indexed on the 2nd/3rd
    calls -- plus asserts final message content and the recorded head are
    correct.
  - `test_skip_already_applied_default_false_still_reindexes_whole_chain`:
    pins that callers not opting in still re-index every position,
    unchanged.
- `devtools test tests/unit/storage/ tests/unit/sources/test_live_*.py tests/unit/sources/test_revision_backfill.py`
  -- 267 passed.
- `devtools verify --quick` -- format + lint + `mypy --strict` +
  `render all --check`, exit 0.
- `mypy --strict` (standalone) on the two touched production files --
  "Success: no issues found in 2 source files".
- Two integration-test failures were investigated and confirmed
  pre-existing on unmodified `origin/master` (verified via `git stash`
  before/after this change, identical failure both ways, unrelated to
  this fix): `tests/integration/test_append_cohort_memory.py`'s two tests
  (a `replay_raw_blob.read_all`/`historical_full_blob.read_all` counter
  mismatch unrelated to indexing) and
  `tests/integration/test_live_read_amplification.py::TestRestartedCursorReconcile::test_missing_cursor_reconciles_archived_prefix_for_append`.

## Remaining polylogue-de2a scope

This PR removes the dominant cost driver that produced the observed
860s/9297s pathological holds, but does not add a genuine
preemption/yield mechanism for an already-admitted single-actor writer
hold in general -- a mid-hold SQLite transaction cannot safely release the
coordinator's async gate without also releasing the real DB-level write
lock, so that harder problem (an unrelated, genuinely slow single stage
blocking maintenance for its whole duration) remains open if it ever
recurs from a different cause. Left open with this note; not closing the
bead from this PR alone.

Ref polylogue-de2a