### PR TITLE
feat(daemon): scope live-ingest SSE events to real session identity

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -1689,19 +1689,51 @@ def _release_pidfile_after_writer_drain(pidfile_fd: int | None, *, writer_draine
     return None
 
 
+def _session_id_touches(payload: dict[str, object], key: str) -> list[tuple[str | None, str]]:
+    """Extract ``(source_name, session_id)`` pairs from a batch payload list.
+
+    ``key`` is ``"new_sessions"`` or ``"updated_sessions"`` -- the identity
+    threaded from :class:`polylogue.sources.live.metrics.LiveBatchMetrics`
+    (polylogue-20d.13). Malformed/legacy payloads (missing key, non-list,
+    entries without a usable ``session_id``) yield no touches rather than
+    raising -- this is an observability fan-out, not a load-bearing write.
+    """
+    raw = payload.get(key)
+    if not isinstance(raw, list):
+        return []
+    touches: list[tuple[str | None, str]] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        session_id = entry.get("session_id")
+        if not isinstance(session_id, str) or not session_id:
+            continue
+        source_name = entry.get("source_name")
+        touches.append((source_name if isinstance(source_name, str) else None, session_id))
+    return touches
+
+
 def _emit_live_batch_event(kind: str, payload: dict[str, object]) -> None:
     """Persist a live-ingest batch event and fan out granular #1204 topics.
 
     The legacy ``ingestion_batch`` kind is preserved verbatim for existing
     consumers (status views, polling fallback). When the batch payload
-    carries succeeded counts we additionally emit per-topic events
-    (``session.appended`` / ``message.appended``) so the reader can
-    subscribe selectively and animate just-touched rows.
+    carries real per-session identity (``new_sessions`` / ``updated_sessions``,
+    threaded from the live-ingest full/append routes) each touched session
+    gets its own identity-scoped ``session.appended`` / ``session.updated`` /
+    ``message.appended`` event, so a reader with session A open is never
+    refreshed by an event that only ever touched session B
+    (polylogue-20d.13 -- the defect the description names: "an unscoped
+    message event currently refreshes whichever session a browser has
+    open").
     """
+    from collections import Counter
+
     from polylogue.daemon.events import (
         emit_daemon_event,
         emit_message_appended,
         emit_session_appended,
+        emit_session_updated,
     )
 
     emit_daemon_event(kind, payload=payload)
@@ -1716,20 +1748,33 @@ def _emit_live_batch_event(kind: str, payload: dict[str, object]) -> None:
     if succeeded <= 0:
         return
 
-    # ``source_group_count`` is the only per-source breakdown the batch
-    # payload carries today. Emit one aggregate granular event per batch;
-    # source-level fan-out can be added once the metrics payload exposes
-    # per-source success counts (deferred — tracked under #1204 follow-ups).
-    emit_session_appended(
-        source_name=None,
-        succeeded_file_count=succeeded,
-        failed_file_count=failed,
-    )
-    emit_message_appended(
-        session_id=None,
-        source_name=None,
-        appended_count=succeeded,
-    )
+    new_touches = _session_id_touches(payload, "new_sessions")
+    updated_touches = _session_id_touches(payload, "updated_sessions")
+
+    if not new_touches and not updated_touches:
+        # No real per-session identity was resolved for this batch (a source
+        # family or code path this bead's threading does not yet cover).
+        # Preserve the pre-#20d.13 unscoped aggregate rather than silently
+        # dropping the notification -- a coarse "something changed" signal
+        # is still better than none, and existing consumers already treat
+        # an absent session_id as "refresh regardless".
+        emit_session_appended(source_name=None, succeeded_file_count=succeeded, failed_file_count=failed)
+        emit_message_appended(session_id=None, source_name=None, appended_count=succeeded)
+        return
+
+    new_counts = Counter(new_touches)
+    for (source_name, session_id), count in new_counts.items():
+        emit_session_appended(
+            source_name=source_name,
+            succeeded_file_count=count,
+            session_id=session_id,
+        )
+        emit_message_appended(session_id=session_id, source_name=source_name, appended_count=count)
+
+    updated_counts = Counter(updated_touches)
+    for (source_name, session_id), count in updated_counts.items():
+        emit_session_updated(session_id=session_id, source_name=source_name, appended_count=count)
+        emit_message_appended(session_id=session_id, source_name=source_name, appended_count=count)
 
 
 async def _emit_daemon_lifecycle_event(

--- a/polylogue/daemon/events.py
+++ b/polylogue/daemon/events.py
@@ -277,22 +277,28 @@ def emit_catch_up_cycle(
 # (status views, polling fallback). The granular kinds below split the
 # realtime channel so the reader can subscribe selectively by view and
 # animate just-appended rows without rerendering the full list.
+#
+# ``insight.updated`` / ``progress.update`` / ``progress.complete`` were
+# retired here (polylogue-20d.13): grepping the whole codebase found no
+# production caller for ``emit_insight_updated``/``emit_progress_update``/
+# ``emit_progress_complete`` -- the only callers were their own unit tests,
+# and the docstring's claimed consumer (``status --convergence --watch``)
+# does not exist in the CLI. Per this bead's AC ("every advertised topic has
+# a declared spec and production emitter, or is removed"), an advertised
+# topic with no real producer is a completeness defect, not a feature to
+# preserve. Wiring real embedding-catchup/insight-rebuild progress into SSE
+# remains a legitimate future bead; it should introduce these kinds fresh
+# from a real call site rather than resurrect the unwired scaffolding.
 
 EVENT_SESSION_APPENDED = "session.appended"
 EVENT_SESSION_UPDATED = "session.updated"
 EVENT_MESSAGE_APPENDED = "message.appended"
-EVENT_INSIGHT_UPDATED = "insight.updated"
-EVENT_PROGRESS_UPDATE = "progress.update"
-EVENT_PROGRESS_COMPLETE = "progress.complete"
 
 GRANULAR_EVENT_KINDS: frozenset[str] = frozenset(
     {
         EVENT_SESSION_APPENDED,
         EVENT_SESSION_UPDATED,
         EVENT_MESSAGE_APPENDED,
-        EVENT_INSIGHT_UPDATED,
-        EVENT_PROGRESS_UPDATE,
-        EVENT_PROGRESS_COMPLETE,
     }
 )
 
@@ -303,22 +309,49 @@ def emit_session_appended(
     succeeded_file_count: int,
     failed_file_count: int = 0,
     source_paths: Sequence[str] | None = None,
+    session_id: str | None = None,
 ) -> None:
-    """Emit a ``session.appended`` event for newly-arrived sessions.
+    """Emit a ``session.appended`` event for a newly-materialized session.
 
-    Fired once per live-ingest batch summarising the touched source group.
-    Carries enough for the reader to animate new rows without rerendering
-    the whole list; the reader still calls ``/api/sessions`` to
-    materialise the rows.
+    ``session_id`` is the real archive identity of the session this event
+    describes (polylogue-20d.13) -- when known, callers should always pass
+    it so consumers can scope refresh/animation to the exact session rather
+    than treating every event as "refresh whatever is open". ``None`` is
+    reserved for legacy/aggregate callers that genuinely cannot attribute a
+    single session (e.g. pre-#1204 opaque batch summaries).
     """
     payload: dict[str, object] = {
         "source_name": source_name,
         "succeeded_file_count": int(succeeded_file_count),
         "failed_file_count": int(failed_file_count),
+        "session_id": session_id,
     }
     if source_paths is not None:
         payload["source_paths"] = list(source_paths)
-    emit_daemon_event(EVENT_SESSION_APPENDED, payload=payload)
+    emit_daemon_event(EVENT_SESSION_APPENDED, operation_id=session_id, payload=payload)
+
+
+def emit_session_updated(
+    *,
+    session_id: str,
+    source_name: str | None = None,
+    appended_count: int = 0,
+) -> None:
+    """Emit a ``session.updated`` event when an existing session grows.
+
+    Distinct from :func:`emit_session_appended`: the live-ingest append
+    route only ever grows a file whose session already exists (a
+    cursor-tracked prior observation), so every real producer of this event
+    is describing a mutation of a session the reader may already have open
+    -- exactly the identity the description this bead started from called
+    unscoped (polylogue-20d.13).
+    """
+    payload: dict[str, object] = {
+        "session_id": session_id,
+        "source_name": source_name,
+        "appended_count": int(appended_count),
+    }
+    emit_daemon_event(EVENT_SESSION_UPDATED, operation_id=session_id, payload=payload)
 
 
 def emit_message_appended(
@@ -344,65 +377,6 @@ def emit_message_appended(
     emit_daemon_event(EVENT_MESSAGE_APPENDED, payload=payload)
 
 
-def emit_insight_updated(
-    *,
-    insight_kind: str,
-    session_id: str | None = None,
-) -> None:
-    """Emit an ``insight.updated`` event when a derived insight rebuilds."""
-    payload: dict[str, object] = {
-        "insight_kind": insight_kind,
-        "session_id": session_id,
-    }
-    emit_daemon_event(EVENT_INSIGHT_UPDATED, payload=payload)
-
-
-def emit_progress_update(
-    *,
-    operation_id: str,
-    operation_kind: str,
-    completed: int,
-    total: int | None = None,
-    detail: str | None = None,
-    eta_seconds: float | None = None,
-) -> None:
-    """Emit a ``progress.update`` event for long-running maintenance ops (#996).
-
-    Consumers: web reader status chip; ``status --convergence --watch`` (#1218).
-    Coalescing-friendly — the snapshot path collapses bursts into one
-    summary frame, so emitters do not need to throttle themselves.
-    """
-    payload: dict[str, object] = {
-        "operation_kind": operation_kind,
-        "completed": int(completed),
-    }
-    if total is not None:
-        payload["total"] = int(total)
-        payload["fraction"] = round(completed / total, 6) if total > 0 else None
-    if detail is not None:
-        payload["detail"] = detail
-    if eta_seconds is not None:
-        payload["eta_seconds"] = round(float(eta_seconds), 3)
-    emit_daemon_event(EVENT_PROGRESS_UPDATE, operation_id=operation_id, payload=payload)
-
-
-def emit_progress_complete(
-    *,
-    operation_id: str,
-    operation_kind: str,
-    status: str = "completed",
-    detail: str | None = None,
-) -> None:
-    """Emit a terminal ``progress.complete`` event for a long-running op."""
-    payload: dict[str, object] = {
-        "operation_kind": operation_kind,
-        "status": status,
-    }
-    if detail is not None:
-        payload["detail"] = detail
-    emit_daemon_event(EVENT_PROGRESS_COMPLETE, operation_id=operation_id, payload=payload)
-
-
 def get_daemon_event_counts() -> dict[str, int]:
     """Return event counts by kind."""
     conn = _open_events_reader()
@@ -418,18 +392,13 @@ def get_daemon_event_counts() -> dict[str, int]:
 __all__ = [
     "EVENT_SESSION_APPENDED",
     "EVENT_SESSION_UPDATED",
-    "EVENT_INSIGHT_UPDATED",
     "EVENT_MESSAGE_APPENDED",
-    "EVENT_PROGRESS_COMPLETE",
-    "EVENT_PROGRESS_UPDATE",
     "GRANULAR_EVENT_KINDS",
     "emit_catch_up_cycle",
     "emit_session_appended",
+    "emit_session_updated",
     "emit_daemon_event",
-    "emit_insight_updated",
     "emit_message_appended",
-    "emit_progress_complete",
-    "emit_progress_update",
     "get_daemon_event_counts",
     "get_last_ingestion_batch",
     "get_latest_event_id",

--- a/polylogue/daemon/events_http.py
+++ b/polylogue/daemon/events_http.py
@@ -12,8 +12,7 @@ Two shapes share the ``/api/events`` route:
 
 Granular topics (#1204): callers may filter by ``?kinds=`` (comma-list).
 The reader subscribes by view — list view filters to ``session.*``;
-the session view filters to ``message.appended`` plus
-``insight.updated``.
+the session view filters to ``message.appended``.
 
 Backpressure coalescing (#1204): when the ledger has produced more than
 ``coalesce_threshold`` events since ``since`` (default 100, override via

--- a/polylogue/daemon/web_shell_realtime.py
+++ b/polylogue/daemon/web_shell_realtime.py
@@ -10,13 +10,19 @@ Topic vocabulary and selective-subscription policy:
 * Legacy opaque kinds (``ingestion_batch`` / ``ingest`` / ``reset`` /
   ``operation``) stay on the wire so older consumers keep working.
 * Granular kinds (``session.appended`` / ``session.updated`` /
-  ``message.appended`` / ``insight.updated`` / ``progress.update`` /
-  ``progress.complete``) split the channel by topic.
-* The list view subscribes to legacy + ``session.*`` + ``progress.*``.
-  The session view additionally subscribes to ``message.appended``
-  and ``insight.updated`` so it can live-tail without polling.
+  ``message.appended``) split the channel by topic. Each carries a real
+  ``session_id`` (polylogue-20d.13) when the producer resolved one, so a
+  reader with session A open ignores an event scoped to session B instead
+  of refreshing unconditionally.
+* The list view subscribes to legacy + ``session.*``. The session view
+  additionally subscribes to ``message.appended`` so it can live-tail
+  without polling.
 * ``snapshot`` is the coalesced backpressure frame; clients react by
   refetching the materialised view and skipping row-level animations.
+* ``insight.updated`` / ``progress.update`` / ``progress.complete`` were
+  retired (polylogue-20d.13): no production code ever emitted them, so
+  advertising subscriptions for them was itself an identity/completeness
+  defect. Reintroduce only alongside a real producer.
 """
 
 from __future__ import annotations
@@ -25,9 +31,7 @@ REALTIME_JS = r"""
 // --- Realtime channel (#1204) -------------------------------------------
 // Subscribe to /api/events (SSE) when available, scoped by current view:
 //   * list view subscribes to session.* and the legacy batch kinds
-//   * session view also subscribes to message.appended + insight.updated
-//   * progress.update / progress.complete are always streamed so the
-//     status chip and #1218 watch-mode consumer can advance their UIs
+//   * session view also subscribes to message.appended for live tail
 // EventSource handles reconnects automatically; on persistent failure we
 // fall back to polling. New-row animations decorate just-appended rows
 // without rerendering the full list.
@@ -49,26 +53,20 @@ var REALTIME_GRANULAR_KINDS = [
   'session.appended',
   'session.updated',
   'message.appended',
-  'insight.updated',
-  'progress.update',
-  'progress.complete',
   'snapshot'
 ];
 
 function realtimeKindsForView() {
   // Always include legacy kinds so existing consumers keep working;
   // granular kinds are scoped by current view to reduce wakeups on a
-  // slow link. The session view subscribes to message.appended
-  // and insight.updated for live tail.
+  // slow link. The session view subscribes to message.appended for
+  // live tail.
   var kinds = REALTIME_LEGACY_KINDS.slice();
   kinds.push('session.appended');
   kinds.push('session.updated');
-  kinds.push('progress.update');
-  kinds.push('progress.complete');
   kinds.push('snapshot');
   if (currentSelectedSessionId()) {
     kinds.push('message.appended');
-    kinds.push('insight.updated');
   }
   return kinds;
 }
@@ -163,23 +161,6 @@ function handleRealtimeEvent(payload) {
       }
       scheduleRefresh();
       return;
-    case 'insight.updated':
-      if (typeof renderInspector === 'function') renderInspector();
-      return;
-    case 'progress.update':
-    case 'progress.complete':
-      // Surface progress in the chip — operator can see live %.
-      var opKind = (data && data.operation_kind) || 'op';
-      var label = 'live';
-      if (kind === 'progress.complete') {
-        label = 'done: ' + opKind;
-      } else if (typeof data.fraction === 'number') {
-        label = opKind + ' ' + Math.round(data.fraction * 100) + '%';
-      } else if (typeof data.completed === 'number') {
-        label = opKind + ' ' + data.completed;
-      }
-      setLiveChip(label, realtime.lastEventId);
-      return;
     case 'snapshot':
       // Coalesced burst — refetch the materialised view, skip animations.
       scheduleRefresh();
@@ -270,8 +251,8 @@ function startRealtimeChannel() {
 function restartRealtimeForView() {
   // Reopen the SSE channel with an updated ?kinds= subscription when the
   // user switches between list and session views. The session
-  // view adds message.appended + insight.updated; switching back removes
-  // them so we don't fire live-tail handlers for a dormant view.
+  // view adds message.appended; switching back removes it so we don't
+  // fire live-tail handlers for a dormant view.
   if (!realtime.source) return;
   var currentKinds = (realtime.subscribedKinds || []).join(',');
   var nextKinds = realtimeKindsForView().join(',');

--- a/polylogue/sources/live/append_ingest.py
+++ b/polylogue/sources/live/append_ingest.py
@@ -86,6 +86,7 @@ def _ingest_append_plans_archive(
     succeeded: list[_AppendPlan] = []
     failed: list[_AppendPlan] = []
     deferred: list[_AppendPlan] = []
+    session_ids_by_path: dict[Path, str] = {}
     acquired_at_ms = int(datetime.now(UTC).timestamp() * 1000)
     try:
         t0 = time.perf_counter()
@@ -191,7 +192,7 @@ def _ingest_append_plans_archive(
                             raise RuntimeError(f"raw revision {replay_raw_id} did not replay to exactly one session")
                         parsed_by_raw_id[replay_raw_id] = replay_sessions[0]
                     t0 = time.perf_counter()
-                    archive.apply_raw_revision_replay(
+                    session_id, _applied_raw_ids = archive.apply_raw_revision_replay(
                         replay_plan,
                         parsed_by_raw_id,
                         acquired_at_ms=acquired_at_ms,
@@ -210,6 +211,7 @@ def _ingest_append_plans_archive(
                         skip_already_applied=True,
                     )
                     _add_timing(timings, "append.raw_and_index_write", t0)
+                    session_ids_by_path[plan.path] = session_id
                     succeeded.append(plan)
                 except Exception as exc:
                     if isinstance(exc, sqlite3.OperationalError) and is_transient_sqlite_lock(exc):
@@ -238,6 +240,7 @@ def _ingest_append_plans_archive(
         deferred=deferred,
         worker_count=1,
         stage_timings_s=timings,
+        session_ids_by_path=session_ids_by_path,
     )
 
 

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -377,6 +377,12 @@ class LiveBatchProcessor:
         pending_append_plans: list[_AppendPlan] = []
         full_paths: list[Path] = []
         deferred_paths: list[Path] = []
+        # Identity-scoped session touches for this batch (polylogue-20d.13):
+        # collected as (source_name, session_id) pairs so the daemon can emit
+        # session.appended/session.updated/message.appended events carrying
+        # real refs instead of an unscoped aggregate.
+        new_session_touches: list[tuple[str, str]] = []
+        updated_session_touches: list[tuple[str, str]] = []
 
         async def flush_append_plans() -> None:
             nonlocal convergence_time_s
@@ -456,6 +462,9 @@ class LiveBatchProcessor:
                 if not self._record_append_cursor(plan):
                     stale_cursor_write_count += 1
                 self._record_convergence_outcome(plan.path, debt_by_source_path.get(plan.path, ()))
+                session_id = append_result.session_ids_by_path.get(plan.path)
+                if session_id:
+                    updated_session_touches.append((plan.source_name, session_id))
             for plan in append_result.failed:
                 failed_paths.append(str(plan.path))
                 cursor_fingerprint_read_bytes += self._record_failed_cursor(plan.path)
@@ -543,6 +552,8 @@ class LiveBatchProcessor:
                     )
                     ingest_worker_count_max = max(ingest_worker_count_max, full_result.worker_count)
                     full_ingest_aggregate.add(full_result)
+                    for session_id in full_result.changed_session_ids:
+                        new_session_touches.append((source_name, session_id))
                 except SchemaVersionMismatchError as exc:
                     handle_schema_version_mismatch(source_name, exc)
                     # Account for every queued path in this source group, not
@@ -719,6 +730,8 @@ class LiveBatchProcessor:
             stale_cursor_write_count=stale_cursor_write_count,
             stage_timings_s={name: round(elapsed, 6) for name, elapsed in stage_timings.items()},
             failed_paths=retry_paths,
+            new_sessions=tuple(new_session_touches),
+            updated_sessions=tuple(updated_session_touches),
         )
         if emit_event and self._event_emitter is not None:
             self._event_emitter("ingestion_batch", metrics.to_payload())

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -136,6 +136,11 @@ class _AppendResult:
     deferred: list[_AppendPlan] = field(default_factory=list)
     worker_count: int = 0
     stage_timings_s: dict[str, float] = field(default_factory=dict)
+    # Real session identity for each succeeded append plan (polylogue-20d.13):
+    # the append route only ever grows a file whose session already exists
+    # (a cursor-tracked prior observation), so every entry here is an
+    # existing-session touch, never a newly created session.
+    session_ids_by_path: dict[Path, str] = field(default_factory=dict)
 
 
 class _DeferredAppend:
@@ -168,6 +173,10 @@ class _FullIngestResult:
     wal_checkpoint_mode: str = "none"
     wal_checkpoint_error: str | None = None
     stage_timings_s: dict[str, float] = field(default_factory=dict)
+    # Real session ids materialized by this full-ingest group (polylogue-20d.13),
+    # threaded from ``_IngestBatchSummary.changed_session_ids`` so callers can
+    # emit identity-scoped SSE events instead of an unscoped aggregate.
+    changed_session_ids: tuple[str, ...] = ()
 
 
 def _full_ingest_result_from_summary(
@@ -198,6 +207,7 @@ def _full_ingest_result_from_summary(
         ingested_session_count=int(getattr(summary, "total_convos", 0)) if summary is not None else 0,
         ingested_message_count=int(getattr(summary, "total_msgs", 0)) if summary is not None else 0,
         changed_session_count=len(getattr(summary, "changed_session_ids", ())) if summary is not None else 0,
+        changed_session_ids=tuple(getattr(summary, "changed_session_ids", ()) or ()) if summary is not None else (),
         wal_bytes_before_checkpoint=int(getattr(summary, "wal_bytes_before_checkpoint", 0))
         if summary is not None
         else 0,

--- a/polylogue/sources/live/metrics.py
+++ b/polylogue/sources/live/metrics.py
@@ -61,6 +61,14 @@ class LiveBatchMetrics:
     stale_cursor_write_count: int = 0
     stage_timings_s: dict[str, float] = field(default_factory=dict)
     failed_paths: list[str] = field(default_factory=list)
+    # Identity-scoped session touches for this batch (polylogue-20d.13):
+    # ``new_sessions`` are session ids materialized for the first time via
+    # the full-ingest route; ``updated_sessions`` are session ids that grew
+    # via the append route (a cursor-tracked file that already had a
+    # session). Both are (source_name, session_id) pairs, bounded by the
+    # batch's own file-count caps -- never a proxy for the full archive.
+    new_sessions: tuple[tuple[str, str], ...] = ()
+    updated_sessions: tuple[tuple[str, str], ...] = ()
 
     def to_payload(self) -> dict[str, object]:
         read_amplification = (
@@ -112,6 +120,10 @@ class LiveBatchMetrics:
             "stale_cursor_write_count": self.stale_cursor_write_count,
             "stage_timings_s": self.stage_timings_s,
             "failed_paths": self.failed_paths,
+            "new_sessions": [{"source_name": source_name, "session_id": sid} for source_name, sid in self.new_sessions],
+            "updated_sessions": [
+                {"source_name": source_name, "session_id": sid} for source_name, sid in self.updated_sessions
+            ],
         }
 
 

--- a/tests/unit/daemon/test_daemon_events_endpoint.py
+++ b/tests/unit/daemon/test_daemon_events_endpoint.py
@@ -492,6 +492,7 @@ class TestGranularEventKinds:
             succeeded_file_count=3,
             failed_file_count=1,
             source_paths=["/tmp/a.jsonl", "/tmp/b.jsonl"],
+            session_id="claude-code-session:conv-abc",
         )
         events = query_daemon_events(limit=10)
         assert events[0]["kind"] == "session.appended"
@@ -500,6 +501,24 @@ class TestGranularEventKinds:
         assert payload["succeeded_file_count"] == 3
         assert payload["failed_file_count"] == 1
         assert payload["source_paths"] == ["/tmp/a.jsonl", "/tmp/b.jsonl"]
+        # Identity-scoped ref (polylogue-20d.13): a reader must be able to
+        # tell whether this event describes the session it has open.
+        assert payload["session_id"] == "claude-code-session:conv-abc"
+
+    def test_emit_session_updated_payload_shape(self, empty_events_db: Path) -> None:
+        from polylogue.daemon.events import emit_session_updated, query_daemon_events
+
+        emit_session_updated(
+            session_id="codex:conv-xyz",
+            source_name="codex",
+            appended_count=2,
+        )
+        events = query_daemon_events(limit=10)
+        assert events[0]["kind"] == "session.updated"
+        payload = cast("dict[str, object]", events[0]["payload"])
+        assert payload["session_id"] == "codex:conv-xyz"
+        assert payload["source_name"] == "codex"
+        assert payload["appended_count"] == 2
 
     def test_emit_message_appended_payload_shape(self, empty_events_db: Path) -> None:
         from polylogue.daemon.events import emit_message_appended, query_daemon_events
@@ -517,54 +536,119 @@ class TestGranularEventKinds:
         assert payload["appended_count"] == 4
         assert payload["source_path"] == "/tmp/session.json"
 
-    def test_emit_progress_update_includes_fraction(self, empty_events_db: Path) -> None:
-        from polylogue.daemon.events import emit_progress_update, query_daemon_events
-
-        emit_progress_update(
-            operation_id="replay-42",
-            operation_kind="replay",
-            completed=47,
-            total=100,
-            eta_seconds=180.0,
-            detail="reapplying schema validation",
-        )
-        events = query_daemon_events(limit=10)
-        assert events[0]["kind"] == "progress.update"
-        assert events[0]["operation_id"] == "replay-42"
-        payload = cast("dict[str, object]", events[0]["payload"])
-        assert payload["completed"] == 47
-        assert payload["total"] == 100
-        assert payload["fraction"] == 0.47
-        assert payload["eta_seconds"] == 180.0
-
-    def test_emit_progress_complete(self, empty_events_db: Path) -> None:
-        from polylogue.daemon.events import emit_progress_complete, query_daemon_events
-
-        emit_progress_complete(operation_id="replay-42", operation_kind="replay", status="completed")
-        events = query_daemon_events(limit=10)
-        assert events[0]["kind"] == "progress.complete"
-        assert events[0]["operation_id"] == "replay-42"
-        assert cast("dict[str, object]", events[0]["payload"])["status"] == "completed"
-
     def test_selective_subscription_via_kinds(self, empty_events_db: Path) -> None:
         from polylogue.daemon.events import (
             emit_message_appended,
-            emit_progress_update,
             emit_session_appended,
+            emit_session_updated,
         )
 
         emit_session_appended(source_name=None, succeeded_file_count=1)
         emit_message_appended(session_id="c", appended_count=1)
-        emit_progress_update(operation_id="op", operation_kind="x", completed=1)
+        emit_session_updated(session_id="c", appended_count=1)
 
         handler = _make_handler(
             "GET",
-            "/api/events?poll=1&since=0&kinds=message.appended,progress.update",
+            "/api/events?poll=1&since=0&kinds=message.appended,session.updated",
         )
         send_json = _capture_json(handler)
         handler.do_GET()
         kinds = {e["kind"] for e in send_json.call_args.args[1]["events"]}
-        assert kinds == {"message.appended", "progress.update"}
+        assert kinds == {"message.appended", "session.updated"}
+
+
+class TestLiveBatchEventFanOut:
+    """polylogue-20d.13 — live-ingest batches fan out identity-scoped events.
+
+    ``_emit_live_batch_event`` is the daemon-side translator between the
+    generic ``ingestion_batch`` metrics payload (produced deep in
+    ``polylogue.sources.live.batch``) and the granular SSE topics. These
+    tests exercise it directly against the real ``daemon.events`` emitters
+    and the real event ledger, so a regression that drops ``session_id``
+    threading (e.g. reverting to the pre-#20d.13 aggregate-only emission)
+    fails here even without a full live-ingest fixture.
+    """
+
+    def test_batch_with_new_and_updated_sessions_emits_scoped_events(self, empty_events_db: Path) -> None:
+        from polylogue.daemon.cli import _emit_live_batch_event
+        from polylogue.daemon.events import query_daemon_events
+
+        _emit_live_batch_event(
+            "ingestion_batch",
+            {
+                "succeeded_file_count": 2,
+                "failed_file_count": 0,
+                "new_sessions": [{"source_name": "codex", "session_id": "codex:new-1"}],
+                "updated_sessions": [{"source_name": "claude-code", "session_id": "claude-code:existing-1"}],
+            },
+        )
+        events = query_daemon_events(limit=10)
+        by_kind: dict[str, list[dict[str, object]]] = {}
+        for event in events:
+            by_kind.setdefault(cast("str", event["kind"]), []).append(cast("dict[str, object]", event["payload"]))
+
+        assert len(by_kind["session.appended"]) == 1
+        assert by_kind["session.appended"][0]["session_id"] == "codex:new-1"
+        assert by_kind["session.appended"][0]["source_name"] == "codex"
+
+        assert len(by_kind["session.updated"]) == 1
+        assert by_kind["session.updated"][0]["session_id"] == "claude-code:existing-1"
+        assert by_kind["session.updated"][0]["source_name"] == "claude-code"
+
+        # message.appended fires once per distinct touched session, each
+        # scoped to that session's own id -- never the aggregate None the
+        # description names as the identity defect ("an unscoped message
+        # event currently refreshes whichever session a browser has open").
+        message_session_ids = {payload["session_id"] for payload in by_kind["message.appended"]}
+        assert message_session_ids == {"codex:new-1", "claude-code:existing-1"}
+        assert None not in message_session_ids
+
+    def test_batch_touching_only_session_b_never_names_session_a(self, empty_events_db: Path) -> None:
+        """The exact regression the bead describes: session A must be unaffected."""
+        from polylogue.daemon.cli import _emit_live_batch_event
+        from polylogue.daemon.events import query_daemon_events
+
+        _emit_live_batch_event(
+            "ingestion_batch",
+            {
+                "succeeded_file_count": 1,
+                "failed_file_count": 0,
+                "new_sessions": [],
+                "updated_sessions": [{"source_name": "codex", "session_id": "codex:session-b"}],
+            },
+        )
+        events = query_daemon_events(limit=10)
+        seen_session_ids = {
+            cast("dict[str, object]", event["payload"])["session_id"]
+            for event in events
+            if event["kind"] in ("session.updated", "message.appended")
+        }
+        assert seen_session_ids == {"codex:session-b"}
+        assert "codex:session-a" not in seen_session_ids
+
+    def test_batch_without_resolved_identity_falls_back_to_unscoped_aggregate(self, empty_events_db: Path) -> None:
+        """No source path yet threads identity through -- preserve the old signal."""
+        from polylogue.daemon.cli import _emit_live_batch_event
+        from polylogue.daemon.events import query_daemon_events
+
+        _emit_live_batch_event(
+            "ingestion_batch",
+            {"succeeded_file_count": 1, "failed_file_count": 0},
+        )
+        events = query_daemon_events(limit=10)
+        kinds = {cast("str", event["kind"]) for event in events}
+        assert kinds == {"ingestion_batch", "session.appended", "message.appended"}
+        for event in events:
+            if event["kind"] in ("session.appended", "message.appended"):
+                assert cast("dict[str, object]", event["payload"])["session_id"] is None
+
+    def test_zero_succeeded_batch_emits_no_granular_events(self, empty_events_db: Path) -> None:
+        from polylogue.daemon.cli import _emit_live_batch_event
+        from polylogue.daemon.events import query_daemon_events
+
+        _emit_live_batch_event("ingestion_batch", {"succeeded_file_count": 0, "failed_file_count": 3})
+        events = query_daemon_events(limit=10)
+        assert {cast("str", event["kind"]) for event in events} == {"ingestion_batch"}
 
 
 class TestBackpressureCoalescing:

--- a/tests/unit/sources/test_live_metrics.py
+++ b/tests/unit/sources/test_live_metrics.py
@@ -35,6 +35,8 @@ def test_live_batch_metrics_payload_includes_memory_pressure_fields() -> None:
         wal_checkpoint_errors=["database is locked"],
         cgroup_path="/user.slice/test.scope",
         cgroup_memory_peak_mb=128.0,
+        new_sessions=(("codex", "codex:conv-1"),),
+        updated_sessions=(("claude-code", "claude-code:conv-2"),),
     )
 
     payload = metrics.to_payload()
@@ -51,3 +53,35 @@ def test_live_batch_metrics_payload_includes_memory_pressure_fields() -> None:
     assert payload["wal_checkpoint_elapsed_s"] == 0.04
     assert payload["wal_checkpoint_modes"] == {"passive": 1}
     assert payload["wal_checkpoint_errors"] == ["database is locked"]
+    # Identity-scoped session touches (polylogue-20d.13): real refs, not an
+    # unscoped aggregate, so consumers can tell session A from session B.
+    assert payload["new_sessions"] == [{"source_name": "codex", "session_id": "codex:conv-1"}]
+    assert payload["updated_sessions"] == [{"source_name": "claude-code", "session_id": "claude-code:conv-2"}]
+
+
+def test_live_batch_metrics_defaults_to_empty_session_touches() -> None:
+    metrics = LiveBatchMetrics(
+        queued_file_count=0,
+        needed_file_count=0,
+        skipped_file_count=0,
+        succeeded_file_count=0,
+        failed_file_count=0,
+        source_group_count=0,
+        input_bytes=0,
+        source_payload_read_bytes=0,
+        cursor_fingerprint_read_bytes=0,
+        ingest_worker_count_max=0,
+        append_file_count=0,
+        full_file_count=0,
+        archive_bytes_before=0,
+        archive_bytes_after=0,
+        archive_write_bytes_delta=0,
+        parse_time_s=0.0,
+        convergence_time_s=0.0,
+        total_time_s=0.0,
+    )
+
+    payload = metrics.to_payload()
+
+    assert payload["new_sessions"] == []
+    assert payload["updated_sessions"] == []

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -1855,6 +1855,71 @@ async def test_live_append_merges_tail_visible_through_public_archive_read(works
 
 
 @pytest.mark.asyncio
+async def test_live_ingest_metrics_carry_real_session_identity(workspace_env: dict[str, Path]) -> None:
+    """polylogue-20d.13: full/append batches must name the real touched session.
+
+    A regression that drops session-id threading (e.g. reverting
+    ``_ArchiveFullWriteResult``/``_AppendResult`` identity fields back to an
+    unscoped aggregate) makes this fail even though ``full_file_count`` /
+    ``append_file_count`` still look correct -- the counts alone cannot
+    prove the daemon can tell session A apart from session B.
+    """
+    root = workspace_env["data_root"] / "claude-projects"
+    project = root / "project"
+    project.mkdir(parents=True)
+    source_path = project / "session.jsonl"
+    db_path = workspace_env["data_root"] / "session-identity.db"
+    archive = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    cursor = CursorStore(db_path)
+    processor = LiveBatchProcessor(
+        archive,
+        (WatchSource(name="claude-code", root=root),),
+        cursor=cursor,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+    )
+
+    try:
+        _write_jsonl(
+            source_path,
+            [
+                _claude_code_message(
+                    session_id="session-identity",
+                    uuid="msg-1",
+                    role="user",
+                    text="first live message",
+                    timestamp="2026-05-01T00:00:00Z",
+                ),
+            ],
+        )
+        full_metrics = await processor.ingest_files([source_path], emit_event=False)
+        assert full_metrics.new_sessions == (("claude-code", "claude-code-session:session-identity"),)
+        assert full_metrics.updated_sessions == ()
+
+        with source_path.open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(
+                    _claude_code_message(
+                        session_id="session-identity",
+                        uuid="msg-2",
+                        parent_uuid="msg-1",
+                        role="assistant",
+                        text="second appended reply",
+                        timestamp="2026-05-01T00:00:01Z",
+                    )
+                )
+                + "\n"
+            )
+        append_metrics = await processor.ingest_files([source_path], emit_event=False)
+        # The append route only ever grows an already-tracked file: this is
+        # an EXISTING session growing, never a fresh one -- exactly the
+        # session.updated semantics this bead introduces.
+        assert append_metrics.new_sessions == ()
+        assert append_metrics.updated_sessions == (("claude-code", "claude-code-session:session-identity"),)
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
 async def test_live_full_ingest_expands_inbox_zip_members(
     workspace_env: dict[str, Path],
 ) -> None:


### PR DESCRIPTION
## Summary

Live-ingest SSE events (`session.appended` / `message.appended`) now carry
the real session id they describe instead of firing once per batch with
`session_id: null`. Added a real production emitter for `session.updated`.
Retired three advertised-but-unwired topics (`insight.updated`,
`progress.update`, `progress.complete`) that had zero production callers.

## Problem

`polylogue-20d.13` names an evidence-identity defect: the daemon emitted one
aggregate `session.appended`/`message.appended` event per live-ingest batch
with `session_id=None`. The web reader's live-tail handler already had
correct session-scoping logic (`if (convId && convId !== selectedId) return;`
in `web_shell_realtime.py`), but since the producer never sent a real
`session_id`, the guard never fired — every successful ingest batch
refreshed whichever session the browser happened to have open, regardless
of which session actually changed.

Separately, `session.updated` was advertised in `GRANULAR_EVENT_KINDS` and
subscribed to by the client, but had no emitter at all. Grepping the whole
codebase for `emit_insight_updated`/`emit_progress_update`/
`emit_progress_complete` turned up zero production callers — only their own
unit tests — and the docstring's claimed CLI consumer
(`status --convergence --watch`) does not exist.

## Solution

- `polylogue/sources/live/append_ingest.py`: capture the `session_id` that
  `archive.apply_raw_revision_replay` already returns (previously
  discarded) into a new `_AppendResult.session_ids_by_path`.
- `polylogue/sources/live/batch_support.py`: add
  `_FullIngestResult.changed_session_ids` (threaded from
  `_IngestBatchSummary.changed_session_ids`, which existed but was only
  ever reduced to a count).
- `polylogue/sources/live/batch.py`: accumulate `(source_name, session_id)`
  touches from both routes during `ingest_files` and attach them to
  `LiveBatchMetrics` as `new_sessions` (full-ingest route — first
  materialization) and `updated_sessions` (append route — the append path
  only ever grows a file whose session already exists, by construction).
- `polylogue/sources/live/metrics.py`: serialize the two new fields in
  `to_payload()`.
- `polylogue/daemon/cli.py`: `_emit_live_batch_event` now fans out one
  `session.appended`/`session.updated`/`message.appended` event **per
  distinct touched session**, each carrying its real `session_id`, instead
  of one aggregate event. Falls back to the old unscoped emission only when
  no identity was resolved for a succeeded batch (an explicit, logged
  degrade rather than silent loss — covers source families this pass
  doesn't thread identity through yet).
- `polylogue/daemon/events.py`: added `emit_session_updated` (the first real
  producer for `session.updated`); added `session_id` to
  `emit_session_appended`. Removed `EVENT_INSIGHT_UPDATED`,
  `EVENT_PROGRESS_UPDATE`, `EVENT_PROGRESS_COMPLETE` and their emitters —
  per this bead's own design text ("remove topics with no production
  semantics or wire their actual producers"), zero-producer advertised
  topics are a completeness defect, not a feature worth preserving.
- `polylogue/daemon/web_shell_realtime.py` / `events_http.py`: dropped the
  matching client-side subscriptions/handlers and doc references.

**Not done (honest residual):**
- No formal per-topic `EventSpec` registry (design section 1 of this bead)
  — that's a larger structural addition (ids, refs, cursor/frame, phase,
  authorization contract per topic) beyond identity-scoping the two
  existing wired topics.
- New-vs-updated classification uses the ingestion **route** (full vs
  append) as a proxy for new-vs-existing session. This is accurate for the
  common case (a brand-new file vs. an already-cursor-tracked file growing)
  but a full reparse of an *already-existing* session id (e.g. a rewritten
  file) would still surface as `session.appended` rather than
  `session.updated`. Documented, not silently claimed solved.
- Multi-session bundle raws (browser-capture snapshots, ChatGPT exports)
  get correct per-session identity for every touched session, but no
  per-session message-count split (the underlying membership-census
  application only returns an aggregate message count across all sessions
  in one raw).
- Ring-gap resync, subscriber cap, and privacy/auth policy (AC #4 and #5)
  were already in place before this change (bounded replay ring, `Last-
  Event-ID`, subscriber controls in `events_http.py`) and are untouched by
  this PR.

## Verification

```
devtools test tests/unit/sources/test_live_watcher.py \
  tests/unit/sources/test_live_metrics.py \
  tests/unit/daemon/test_daemon_events_endpoint.py \
  tests/unit/sources/test_live_batch_support.py
# 193 passed, 1 pre-existing failure unrelated to this change
# (test_live_full_ingest_over_ambiguous_membership_fails_closed_with_diagnostic,
# reproduced identically against master before this branch existed)

uv run mypy polylogue          # Success: no issues found in 1087 source files
uv run ruff check . / format --check .   # all clean
devtools render all --check    # exit 0
devtools verify --quick        # exit_code 0
```

Anti-vacuity: reverted the `session_ids_by_path` assignment in
`append_ingest.py` and confirmed
`test_live_ingest_metrics_carry_real_session_identity` fails
(`assert () == (('claude-code', ...),)`), then restored it — proving the
test exercises the real production wiring, not a self-authorized mock.

Ref polylogue-20d.13