### PR TITLE
fix: retry seeded-archive journal-mode flip past a same-process zombie lock

### DIFF
--- a/tests/infra/workload_artifacts.py
+++ b/tests/infra/workload_artifacts.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import fcntl
+import gc
 import hashlib
 import json
 import os
@@ -17,6 +18,7 @@ import shutil
 import sqlite3
 import stat
 import subprocess
+import time
 import uuid
 from collections.abc import Iterable, Iterator
 from dataclasses import asdict, dataclass
@@ -259,21 +261,70 @@ def _archive_files(root: Path) -> tuple[dict[str, object], ...]:
     return tuple(entries)
 
 
+def _journal_mode_delete_with_retry(conn: sqlite3.Connection, *, name: str) -> None:
+    """Flip WAL to a DELETE-journal snapshot, tolerant of a same-process zombie closer.
+
+    CPython's ``sqlite3`` module closes connections via ``sqlite3_close_v2``
+    (not the older non-``_v2`` API): a connection whose last statement/cursor
+    hasn't been finalized yet becomes a "zombie" that keeps SQLite's
+    per-process shared pager-cache entry for that file alive until the
+    lingering ``Cursor``/``Connection`` object is actually garbage-collected.
+    While a zombie is pending, ``PRAGMA journal_mode=DELETE`` on a *different*
+    (fully legitimate, single) connection to the same file raises
+    ``sqlite3.OperationalError: database is locked`` -- SQLite reports this
+    specific condition as ``SQLITE_LOCKED`` (a same-process/shared-cache
+    conflict), which, unlike plain ``SQLITE_BUSY``, is **not** retried by
+    ``sqlite3``'s own busy-timeout/busy-handler mechanism, so a plain
+    ``timeout=`` connect argument cannot absorb it (polylogue-lbgc).
+
+    Confirmed empirically: two genuinely separate OS processes building the
+    same corpus key concurrently (an isolated ``cache_root``, no pytest)
+    serialize cleanly through the ``build_seeded_archive`` file lock with no
+    error. The failure reproduces only under real system load (pytest-xdist
+    workers plus a busy machine), which is exactly when CPython's cyclic GC
+    is more likely to have deferred collecting a zombie connection/cursor
+    from earlier in this same worker process's own write pipeline. Forcing a
+    ``gc.collect()`` finalizes any such zombie so its shared-cache slot is
+    actually released, then a short bounded retry absorbs the remaining
+    scheduling jitter.
+    """
+    deadline = time.monotonic() + 5.0
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            mode = conn.execute("PRAGMA journal_mode=DELETE").fetchone()
+        except sqlite3.OperationalError as exc:
+            if "locked" not in str(exc).lower() or time.monotonic() >= deadline:
+                raise
+            gc.collect()
+            time.sleep(min(0.05 * attempt, 0.5))
+            continue
+        if mode != ("delete",):
+            raise RuntimeError(f"could not close seeded archive tier {name} into a snapshot")
+        return
+
+
 def _sqlite_integrity(root: Path) -> None:
+    """Validate + collapse each tier's journal to a snapshot, one connection at a time.
+
+    Uses ``contextlib.closing`` (the idiom already used for this same
+    connection-lifecycle footgun in ``polylogue/storage/raw_reconciler.py``)
+    so each connection is actually closed, not merely committed/rolled back
+    the way a bare ``with sqlite3.connect(...) as conn:`` would leave it.
+    """
     checked: list[str] = []
     for name in _ARCHIVE_DB_NAMES:
         path = root / name
         if not path.exists():
             continue
-        with sqlite3.connect(path) as conn:
+        with contextlib.closing(sqlite3.connect(path)) as conn, conn:
             quick = conn.execute("PRAGMA quick_check").fetchone()
             foreign = conn.execute("PRAGMA foreign_key_check").fetchall()
             if quick != ("ok",) or foreign:
                 raise RuntimeError(f"invalid seeded archive tier {name}")
             conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-            mode = conn.execute("PRAGMA journal_mode=DELETE").fetchone()
-            if mode != ("delete",):
-                raise RuntimeError(f"could not close seeded archive tier {name} into a snapshot")
+            _journal_mode_delete_with_retry(conn, name=name)
         checked.append(name)
     for name in checked:
         for suffix in ("-wal", "-shm"):
@@ -293,7 +344,7 @@ def _remove_tree(path: Path) -> None:
 
 
 def _validate_facts(root: Path, facts: tuple[SyntheticArtifactFacts, ...]) -> None:
-    with sqlite3.connect(root / "index.db") as conn:
+    with contextlib.closing(sqlite3.connect(root / "index.db")) as conn:
         session_ids = {str(row[0]) for row in conn.execute("SELECT session_id FROM sessions")}
         tool_ids = {
             str(row[0]) for row in conn.execute("SELECT DISTINCT tool_id FROM blocks WHERE tool_id IS NOT NULL")

--- a/tests/unit/infra/test_workload_artifacts.py
+++ b/tests/unit/infra/test_workload_artifacts.py
@@ -2,13 +2,21 @@
 
 from __future__ import annotations
 
+import gc
 import os
+import sqlite3
+import time
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from polylogue.storage.archive_readiness import raw_materialization_readiness_snapshot, raw_materialization_ready
-from tests.infra.workload_artifacts import build_seeded_archive, clone_seeded_archive
+from tests.infra.workload_artifacts import (
+    _journal_mode_delete_with_retry,
+    build_seeded_archive,
+    clone_seeded_archive,
+)
 
 
 def test_seeded_archive_publishes_valid_immutable_real_pipeline_artifact(tmp_path: Path) -> None:
@@ -80,3 +88,89 @@ def test_seeded_archive_failure_never_publishes_partial_staging(
     cache_root = tmp_path / "cache"
     assert not list((cache_root / "artifacts").iterdir())
     assert not list((cache_root / ".staging").iterdir())
+
+
+class _FlakyLockConnection:
+    """Fakes ``PRAGMA journal_mode=DELETE`` raising a transient same-process lock.
+
+    Mirrors CPython's ``sqlite3_close_v2`` zombie-connection footgun
+    (polylogue-lbgc): a not-yet-finalized cursor/connection from earlier in
+    the same worker process keeps SQLite's per-process shared pager-cache
+    entry alive, so ``PRAGMA journal_mode=DELETE`` on a legitimate connection
+    raises ``sqlite3.OperationalError: database is locked`` until that zombie
+    is garbage-collected.
+    """
+
+    def __init__(self, *, locked_attempts: int) -> None:
+        self.locked_attempts = locked_attempts
+        self.attempts = 0
+
+    def execute(self, sql: str) -> _FlakyLockConnection:
+        assert sql == "PRAGMA journal_mode=DELETE"
+        self.attempts += 1
+        if self.attempts <= self.locked_attempts:
+            raise sqlite3.OperationalError("database is locked")
+        return self
+
+    def fetchone(self) -> tuple[str]:
+        return ("delete",)
+
+
+def test_journal_mode_delete_retry_survives_a_transient_same_process_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Anti-vacuity: reverting to a bare ``conn.execute(...)`` call (no retry/gc.collect)
+    makes this fail on the very first simulated lock, since there would be no
+    mechanism left to absorb it."""
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+    gc_collect_calls = 0
+
+    def fake_collect() -> int:
+        nonlocal gc_collect_calls
+        gc_collect_calls += 1
+        return 0
+
+    monkeypatch.setattr(gc, "collect", fake_collect)
+
+    conn = _FlakyLockConnection(locked_attempts=2)
+    _journal_mode_delete_with_retry(conn, name="index.db")  # type: ignore[arg-type]
+
+    assert conn.attempts == 3
+    assert gc_collect_calls == 2
+
+
+def test_journal_mode_delete_does_not_retry_non_lock_operational_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-lock OperationalError (e.g. real corruption/IO error) must propagate
+    immediately -- retrying it would hide a genuine failure, not a transient
+    same-process race."""
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(time, "sleep", sleep_calls.append)
+
+    class _BrokenConnection:
+        def execute(self, sql: str) -> Any:
+            raise sqlite3.OperationalError("disk I/O error")
+
+    with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+        _journal_mode_delete_with_retry(_BrokenConnection(), name="index.db")  # type: ignore[arg-type]
+
+    assert sleep_calls == []
+
+
+def test_journal_mode_delete_reraises_lock_once_deadline_elapses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A persistent (non-transient) same-process lock must still surface as a
+    real failure rather than retry forever; the fake clock jumps straight past
+    the deadline so the test doesn't need to sleep for real."""
+    clock = iter([0.0, 10.0, 10.0])
+    monkeypatch.setattr(time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(time, "sleep", lambda _seconds: None)
+
+    class _AlwaysLockedConnection:
+        def execute(self, sql: str) -> Any:
+            raise sqlite3.OperationalError("database is locked")
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        _journal_mode_delete_with_retry(_AlwaysLockedConnection(), name="index.db")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Fixes an intermittent `sqlite3.OperationalError: database is locked` in the shared, cached, real-pipeline seeded-archive test artifact builder when a named corpus cache is cold and must build fresh under `devtools test`'s xdist parallelism.

## Problem

`build_seeded_archive()`'s `_sqlite_integrity()` raised `sqlite3.OperationalError: database is locked` at the `PRAGMA journal_mode=DELETE` step, breaking `tests/unit/cli/test_plain_cli_snapshots.py` and `tests/unit/core/test_schema_generation.py` on a cold cache under `pytest -n 2`.

Root cause, confirmed via an instrumented reproduction (dumping `/proc/self/fd` and live `sqlite3.Connection` objects at the exact failure point):

- The existing per-corpus-key `fcntl.flock` already serializes concurrent builds correctly *across processes* — two genuinely separate OS processes building the same corpus key against an isolated `cache_root` complete cleanly every time, with no error.
- The failure only reproduces under real system load (xdist workers + a busy machine). CPython's `sqlite3` module closes connections via `sqlite3_close_v2`, which defers releasing a connection's shared per-process pager-cache slot until any not-yet-finalized cursor/statement is actually garbage-collected. Under load, cyclic GC runs more often lag behind, so a "zombie" connection from earlier in the same worker process's own write pipeline can still hold the file's shared-cache slot when `_sqlite_integrity` tries to flip `journal_mode` on a separate, legitimate connection.
- SQLite reports this same-process conflict as `SQLITE_LOCKED`, which — unlike `SQLITE_BUSY` — is **not** retried by sqlite3's own busy-timeout/busy-handler, so a plain `connect(timeout=...)` cannot absorb it.

## Solution

`tests/infra/workload_artifacts.py`:
- `_sqlite_integrity` / `_validate_facts` now use `contextlib.closing` around each `sqlite3.connect` call. A bare `with sqlite3.connect(path) as conn:` only commits/rolls back the transaction — it never calls `.close()` (the same footgun already worked around in `polylogue/storage/raw_reconciler.py`). This is real (proven via the `gc.get_objects()` dump showing multiple live, un-closed `Connection` objects), but on its own was not sufficient to eliminate the race.
- New `_journal_mode_delete_with_retry` forces `gc.collect()` (to finalize any zombie connection) and bounded-retries the `journal_mode=DELETE` flip for up to 5s specifically when the error is "database is locked"; any other `OperationalError` still propagates immediately (no masking of genuine corruption/IO failures).

`tests/unit/infra/test_workload_artifacts.py`:
- 3 new unit tests exercise `_journal_mode_delete_with_retry` directly against fake connections: retry-then-succeed, non-lock errors propagate without retrying, and a persistent lock still raises once the deadline elapses.
- Anti-vacuity verified locally: reverting the retry to the old bare `conn.execute(...)` call made the retry-survives test fail on the very first simulated lock.

## Verification

- Reproduced pre-fix: cleared `/realm/tmp/polylogue-seeded-artifacts` and ran `pytest tests/unit/cli/test_plain_cli_snapshots.py -q -n 2` against a cold cache -> reliably reproduced `1 passed variant + 8 errors: database is locked` (matching the bead's own repro).
- Post-fix: same cold-cache + `-n 2` command run 4 times -> `24 passed` every time (0 flakes).
- `devtools test tests/unit/infra/test_workload_artifacts.py` -> `7 passed` (includes the 3 new regression tests).
- `mypy --strict tests/infra/workload_artifacts.py tests/unit/infra/test_workload_artifacts.py` -> `Success: no issues found`.
- `ruff check` / `ruff format --check` on both files -> clean.
- `devtools verify --quick` -> `exit_code: 0` (format/lint/mypy/render-all-check + repo policy checks).
- `devtools render all --check` -> no "out of sync" surfaces, exit 0.

Ref polylogue-lbgc

🤖 Generated with [Claude Code](https://claude.com/claude-code)