### PR TITLE
fix(sources): split chatgpt detection into document and fragment tiers

### DIFF
--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -203,7 +203,11 @@ def _detect_provider_from_record(record: PayloadRecord) -> Provider | None:
         return Provider.CODEX
     if claude.looks_like_code([dict(record)]):
         return Provider.CLAUDE_CODE
-    if chatgpt.looks_like(record):
+    # A single record here may be an intentionally partial ChatGPT fragment
+    # (e.g. one line of a streamed JSONL sniff), not a whole assembled
+    # export document, so this uses the fragment-level check rather than
+    # ``chatgpt.looks_like``'s document-identity requirements (polylogue-t0ta).
+    if chatgpt.looks_like_fragment(record):
         return Provider.CHATGPT
     if claude.looks_like_ai(record):
         return Provider.CLAUDE_AI
@@ -232,7 +236,11 @@ def _detect_provider_from_sequence(payloads: PayloadSequence) -> Provider | None
             return Provider.HERMES
         if beads.looks_like(first_record):
             return Provider.BEADS
-        if is_json_document(first_record.get("mapping")):
+        # The first record of a *sequence* is a whole assembled document
+        # (e.g. one conversation from a ChatGPT bundle array), not a
+        # partial per-line fragment, so this uses the strict document-level
+        # check rather than ``looks_like_fragment`` (polylogue-t0ta).
+        if chatgpt.looks_like(first_record):
             return Provider.CHATGPT
         if isinstance(first_record.get("chat_messages"), list):
             return Provider.CLAUDE_AI
@@ -718,7 +726,10 @@ def _lower_drive_like_payload(
         return [_local_agent_document_spec(Provider.GEMINI_CLI, record, fallback_id)]
     if _record_messages(record) is not None:
         return [_generic_messages_spec(provider, record, fallback_id)]
-    if chatgpt.looks_like(record):
+    # This handles one already-lowered record, not a whole document/list, so
+    # it uses the fragment-level check rather than requiring document-identity
+    # fields (polylogue-t0ta) -- consistent with ``_detect_provider_from_record``.
+    if chatgpt.looks_like_fragment(record):
         return [_single_record_spec(Provider.CHATGPT, record, fallback_id)]
     if _looks_like_chunked_session(record):
         return [_chunked_prompt_spec(provider, record, fallback_id)]
@@ -772,7 +783,9 @@ def _lower_fallback_payload(
         return []
     if _record_messages(record) is not None:
         return [_generic_messages_spec(provider, record, fallback_id)]
-    if chatgpt.looks_like(record):
+    # Same rationale as the fallback branch in ``_lower_drive_like_payload``
+    # above: one record, not a whole document, so fragment-level detection.
+    if chatgpt.looks_like_fragment(record):
         return [_single_record_spec(Provider.CHATGPT, record, fallback_id)]
     if _looks_like_chunked_session(record):
         return [_chunked_prompt_spec(provider, record, fallback_id)]

--- a/polylogue/sources/parsers/chatgpt.py
+++ b/polylogue/sources/parsers/chatgpt.py
@@ -6,11 +6,14 @@ import re
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 
+from pydantic import ValidationError
+
 from polylogue.archive.message.artifacts import classify_material_origin, classify_text_message_type
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
 from polylogue.core.enums import BlockType, Provider, SessionKind, WebConstructType
 from polylogue.core.timestamps import parse_timestamp
+from polylogue.sources.providers.chatgpt_session_models import ChatGPTNode
 
 from .base import (
     ParsedAttachment,
@@ -833,10 +836,112 @@ def extract_messages_from_mapping(
     return (messages, attachments)
 
 
-def looks_like(payload: object) -> bool:
+def _mapping_nodes_are_valid(mapping: Mapping[str, object]) -> bool:
+    """Pydantic-validate every ``mapping`` entry against the typed node shape.
+
+    Requires the full ``ChatGPTNode`` shape, including a real ``id`` field
+    (and, transitively, a real ``message.id`` when a message is present).
+    This is the whole-document check's node validator -- see
+    ``_mapping_node_shape_is_plausible`` for the lighter fragment-level
+    check.
+    """
+    for node in mapping.values():
+        if not isinstance(node, dict):
+            return False
+        try:
+            ChatGPTNode.model_validate(node)
+        except ValidationError:
+            return False
+    return True
+
+
+def _mapping_node_shape_is_plausible(mapping: Mapping[str, object]) -> bool:
+    """Loosely validate mapping-node shape for fragment-level detection.
+
+    A per-record fragment (one JSONL line, or one already-lowered record
+    passed without the surrounding document -- see ``looks_like_fragment``)
+    routinely omits the ``id``/``message.id`` fields ``ChatGPTNode`` treats
+    as mandatory: those fields duplicate identity the caller already knows
+    from the mapping key / conversation context, so real per-record
+    fragments do not always repeat them. Full ``ChatGPTNode`` Pydantic
+    validation is therefore too strict for this tier. This instead checks
+    the shape ``ChatGPTNode``/``ChatGPTMessage`` actually constrain
+    structurally: every node is a dict, and when a node carries a
+    ``message`` it is a dict with an ``author`` dict (the one field every
+    real ChatGPT message node has, fragment or not). This still rejects an
+    arbitrary dict-with-a-``mapping``-key payload from an unrelated
+    provider (empty nodes, non-dict nodes, malformed ``message``/``author``
+    shapes), which is what the original bare ``isinstance(mapping, dict)``
+    check silently accepted.
+    """
+    for node in mapping.values():
+        if not isinstance(node, dict):
+            return False
+        message = node.get("message")
+        if message is None:
+            continue
+        if not isinstance(message, dict) or not isinstance(message.get("author"), dict):
+            return False
+    return True
+
+
+def looks_like_fragment(payload: object) -> bool:
+    """Detect a ChatGPT conversation-mapping *fragment*.
+
+    Individual-record detection (e.g. per-line JSONL sniffing in
+    ``sources/emitter.py``, or a single already-lowered record in
+    ``dispatch._detect_provider_from_record``/fallback lowering) sees only
+    the divergent slice of a conversation a caller chose to hand over one
+    record at a time -- it legitimately lacks document-level identity
+    fields (``current_node``/``create_time``/``conversation_id``/``id``,
+    and even per-node/per-message ``id``) that only exist once a full
+    exported document is assembled. This checks the one structural signal
+    that *is* present per-record: a non-empty ``mapping`` dict whose nodes
+    have a plausible ChatGPT node/message shape (see
+    ``_mapping_node_shape_is_plausible``). See ``looks_like`` for the
+    stricter whole-document check (polylogue-t0ta).
+    """
     if not isinstance(payload, dict):
         return False
-    return isinstance(payload.get("mapping"), dict)
+    mapping = payload.get("mapping")
+    if not isinstance(mapping, dict) or not mapping:
+        return False
+    return _mapping_node_shape_is_plausible(mapping)
+
+
+def looks_like(payload: object) -> bool:
+    """Detect the ChatGPT conversation-export shape (whole document).
+
+    ChatGPT's export format is externally versioned by OpenAI, outside this
+    repo's control, so a bare "has a mapping dict-key" check is the loosest,
+    highest format-drift-risk detector in dispatch: it silently accepts any
+    payload that happens to carry a "mapping" key, including malformed or
+    entirely unrelated shapes. This tightens detection to the export's
+    stable structural fields -- confirmed present across every real fixture
+    and corpus representative in this repo (native/browser-capture/regression
+    fixtures, schema catalog representatives) -- plus Pydantic-validated node
+    shape for every entry in ``mapping``, mirroring the typed-validation
+    pattern already load-bearing for Codex (``codex.looks_like``).
+
+    Use this only where a whole document/list-of-documents is available
+    (``dispatch._detect_provider_from_sequence``'s first-record check, and
+    direct callers validating an assembled export). For a single record
+    that may be an intentionally partial fragment (streamed JSONL lines,
+    already-lowered single records), use ``looks_like_fragment`` instead --
+    it lacks the document-identity fields this function requires.
+    """
+    if not isinstance(payload, dict):
+        return False
+    mapping = payload.get("mapping")
+    if not isinstance(mapping, dict) or not mapping:
+        return False
+    if not isinstance(payload.get("current_node"), str):
+        return False
+    if not isinstance(payload.get("create_time"), (int, float)):
+        return False
+    if not isinstance(payload.get("conversation_id"), str) and not isinstance(payload.get("id"), str):
+        return False
+    return _mapping_nodes_are_valid(mapping)
 
 
 def parse(payload: Mapping[str, object], fallback_id: str) -> ParsedSession:

--- a/tests/infra/source_builders.py
+++ b/tests/infra/source_builders.py
@@ -22,7 +22,7 @@ def make_chatgpt_node(
     message: JsonObject = {
         "id": msg_id,
         "author": {"role": role},
-        "content": {"parts": content_parts},
+        "content": {"content_type": "text", "parts": content_parts},
     }
     node: JsonObject = {
         "id": msg_id,
@@ -68,7 +68,8 @@ class ChatGPTExportBuilder:
         self._title: str | None = None
         self._nodes: JsonObjectList = []
         self._node_counter = 0
-        self._timestamp = 1704067200.0
+        self._create_time = 1704067200.0
+        self._timestamp = self._create_time
 
     def title(self, title: str) -> ChatGPTExportBuilder:
         self._title = title
@@ -115,6 +116,9 @@ class ChatGPTExportBuilder:
     def build(self) -> JsonObject:
         result: JsonObject = {
             "id": self.conv_id,
+            "conversation_id": self.conv_id,
+            "create_time": self._create_time,
+            "current_node": str(self._nodes[-1]["id"]) if self._nodes else "root",
             "mapping": {str(node["id"]): node for node in self._nodes},
         }
         if self._title:
@@ -233,6 +237,9 @@ class InboxBuilder:
         else:
             payload = {
                 "id": conv_id,
+                "conversation_id": conv_id,
+                "create_time": 1704067200.0,
+                "current_node": str(nodes[-1]["id"]) if nodes else "root",
                 "mapping": {str(node["id"]): node for node in nodes},
             }
             if title:

--- a/tests/unit/sources/parsers/test_origin_regression_pack.py
+++ b/tests/unit/sources/parsers/test_origin_regression_pack.py
@@ -166,7 +166,10 @@ def _chatgpt_payload() -> dict[str, Any]:
     """
     return {
         "id": "chatgpt-session-reg-1",
+        "conversation_id": "chatgpt-session-reg-1",
         "title": "ChatGPT regression fixture",
+        "create_time": 1_704_067_200.0,
+        "current_node": "t1",
         "mapping": {
             "u1": {
                 "id": "u1",
@@ -175,7 +178,7 @@ def _chatgpt_payload() -> dict[str, Any]:
                 "message": {
                     "id": "u1",
                     "author": {"role": "user"},
-                    "content": {"parts": ["[Pasted text #1]\nrun checks"]},
+                    "content": {"content_type": "text", "parts": ["[Pasted text #1]\nrun checks"]},
                     "create_time": 1_704_067_200.0,
                 },
             },
@@ -223,7 +226,6 @@ def _chatgpt_payload() -> dict[str, Any]:
                 },
             },
         },
-        "current_node": "t1",
     }
 
 

--- a/tests/unit/sources/test_chatgpt_normalization_survivors.py
+++ b/tests/unit/sources/test_chatgpt_normalization_survivors.py
@@ -209,6 +209,8 @@ def test_bare_legacy_duration_remains_message_local_without_a_synthetic_lifecycl
         "JSONDocument",
         {
             "id": "legacy-duration-only",
+            "conversation_id": "legacy-duration-only",
+            "create_time": 1_700_000_000.0,
             "current_node": "answer-node",
             "mapping": {
                 "answer-node": {
@@ -240,6 +242,8 @@ def test_malformed_native_timing_does_not_promote_a_legacy_duration_to_lifecycle
         "JSONDocument",
         {
             "id": "malformed-native-with-legacy-duration",
+            "conversation_id": "malformed-native-with-legacy-duration",
+            "create_time": 1_700_000_000.0,
             "current_node": "answer-node",
             "mapping": {
                 "answer-node": {
@@ -273,7 +277,15 @@ def test_browser_capture_detector_short_circuits_the_weaker_chatgpt_mapping_shap
     """The browser envelope detector must run before the weak mapping detector."""
 
     payload = _load_fixture(_BROWSER_FIXTURE)
-    payload["mapping"] = {"decoy-chatgpt-node": {}}
+    # A decoy that also satisfies the tightened chatgpt.looks_like structural
+    # check (conversation_id/id, create_time, current_node, plus a
+    # Pydantic-valid mapping node) so this still proves ordering, not just
+    # detector strength.
+    payload["conversation_id"] = "decoy-conversation"
+    payload["id"] = "decoy-conversation"
+    payload["create_time"] = 1_700_000_000.0
+    payload["current_node"] = "decoy-chatgpt-node"
+    payload["mapping"] = {"decoy-chatgpt-node": {"id": "decoy-chatgpt-node", "parent": None, "children": []}}
     assert browser_capture.looks_like(payload)
     assert chatgpt.looks_like(payload)
 

--- a/tests/unit/sources/test_dispatch_ordering.py
+++ b/tests/unit/sources/test_dispatch_ordering.py
@@ -86,7 +86,22 @@ ADVERSARIAL_CATALOG.append(
 ADVERSARIAL_CATALOG.append(
     (
         {
-            "mapping": {"msg-1": {"message": {"content": {"parts": ["hello"]}, "author": {"role": "user"}}}},
+            "id": "adversarial-conv",
+            "conversation_id": "adversarial-conv",
+            "create_time": 1_700_000_000.0,
+            "current_node": "msg-1",
+            "mapping": {
+                "msg-1": {
+                    "id": "msg-1",
+                    "parent": None,
+                    "children": [],
+                    "message": {
+                        "id": "msg-1",
+                        "content": {"content_type": "text", "parts": ["hello"]},
+                        "author": {"role": "user"},
+                    },
+                }
+            },
             "chat_messages": [{"id": "msg-1", "text": "hello", "sender": "human"}],
         },
         Provider.CHATGPT,
@@ -174,7 +189,24 @@ def test_dispatch_ordering(payload: object, expected_provider: Provider, rationa
     ("payload", "expected_provider"),
     [
         (
-            {"mapping": {"msg-1": {"message": {"content": {"parts": ["hi"]}, "author": {"role": "user"}}}}},
+            {
+                "id": "unambiguous-conv",
+                "conversation_id": "unambiguous-conv",
+                "create_time": 1_700_000_000.0,
+                "current_node": "msg-1",
+                "mapping": {
+                    "msg-1": {
+                        "id": "msg-1",
+                        "parent": None,
+                        "children": [],
+                        "message": {
+                            "id": "msg-1",
+                            "content": {"content_type": "text", "parts": ["hi"]},
+                            "author": {"role": "user"},
+                        },
+                    }
+                },
+            },
             Provider.CHATGPT,
         ),
         ({"chat_messages": [{"id": "1", "text": "hi", "sender": "human"}]}, Provider.CLAUDE_AI),

--- a/tests/unit/sources/test_gemini_drive_normalization_laws.py
+++ b/tests/unit/sources/test_gemini_drive_normalization_laws.py
@@ -202,7 +202,11 @@ def _small_ai_studio_session(session_id: str, text: str, *, top_level_chunks: bo
 def test_detector_order_is_tight_and_one_document_streams_keep_specificity() -> None:
     """Detector-order mutation: moving the weak Gemini check upward must fail."""
     valid_chunk = {"role": "user", "text": "safe"}
-    chatgpt_ambiguous = {"mapping": {}, "chunks": [valid_chunk]}
+    # A non-empty mapping is required since polylogue-t0ta tightened ChatGPT
+    # detection to reject a bare/empty ``mapping`` dict-key; this still
+    # proves detector *ordering* (chatgpt.looks_like_fragment before the
+    # weaker gemini chunk check), not detector strength.
+    chatgpt_ambiguous = {"mapping": {"n1": {}}, "chunks": [valid_chunk]}
     cli_ambiguous = {**_gemini_cli_payload(), "chunks": [valid_chunk]}
 
     assert detect_provider({"chunks": []}) is None

--- a/tests/unit/sources/test_import_preflight.py
+++ b/tests/unit/sources/test_import_preflight.py
@@ -12,11 +12,16 @@ from polylogue.sources.import_preflight import ImportPreflightStatus, preflight_
 
 def _chatgpt_payload() -> dict[str, object]:
     return {
+        "id": "chatgpt-preflight-fixture",
+        "conversation_id": "chatgpt-preflight-fixture",
         "title": "Supported ChatGPT fixture",
+        "create_time": 1704067200.0,
+        "current_node": "root",
         "mapping": {
             "root": {
                 "id": "root",
                 "message": {
+                    "id": "root-message",
                     "author": {"role": "user"},
                     "content": {"content_type": "text", "parts": ["hello"]},
                 },

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -3330,6 +3330,7 @@ def test_live_multi_session_divergence_reopens_raw_authority(tmp_path: Path) -> 
         return {
             "id": native_id,
             "title": native_id,
+            "create_time": 1_780_000_000.0,
             "current_node": f"{native_id}-node-{len(texts) - 1}",
             "mapping": mapping,
         }
@@ -3503,6 +3504,7 @@ def test_live_third_raw_reunifies_with_backfill_retired_siblings(tmp_path: Path)
         return {
             "id": native_id,
             "title": native_id,
+            "create_time": 1_780_000_000.0,
             "current_node": f"{native_id}-node-{len(texts) - 1}",
             "mapping": mapping,
         }
@@ -3883,6 +3885,7 @@ def test_live_membership_reprocesses_parser_drift_without_retiring_unrelated_hea
         {
             "id": "parser-drift",
             "title": "current title",
+            "create_time": 1_780_000_000.0,
             "current_node": "node",
             "mapping": {
                 "node": {

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -45,10 +45,40 @@ def _looks_like_code_payload(data: object) -> bool:
 
 
 # MERGED FORMAT + COERCE DETECTION
+_CHATGPT_MINIMAL_VALID: ChatGPTMapping = {
+    "id": "conv-1",
+    "conversation_id": "conv-1",
+    "create_time": 1_700_000_000.0,
+    "current_node": "node1",
+    "mapping": {"node1": {"id": "node1", "parent": None, "children": []}},
+}
 PROVIDER_FORMAT_DETECTION_CASES: list[ProviderDetectionCase] = [
-    # ChatGPT
-    ({"mapping": {}}, True, chatgpt_looks_like, "ChatGPT: valid empty mapping"),
-    ({"mapping": {"node1": {}}}, True, chatgpt_looks_like, "ChatGPT: valid with nodes"),
+    # ChatGPT: a bare "mapping" dict-key is no longer sufficient (polylogue-t0ta)
+    # -- detection also requires the export's stable identity fields
+    # (conversation_id/id, create_time, current_node) and every mapping node
+    # must validate against the typed ChatGPTNode shape.
+    ({**_CHATGPT_MINIMAL_VALID, "mapping": {}}, False, chatgpt_looks_like, "ChatGPT: empty mapping is rejected"),
+    (_CHATGPT_MINIMAL_VALID, True, chatgpt_looks_like, "ChatGPT: valid with nodes"),
+    ({"mapping": {}}, False, chatgpt_looks_like, "ChatGPT: bare mapping key alone is not enough"),
+    ({"mapping": {"node1": {}}}, False, chatgpt_looks_like, "ChatGPT: mapping node missing required id rejected"),
+    (
+        {**_CHATGPT_MINIMAL_VALID, "mapping": {"node1": {"not_a_node": True}}},
+        False,
+        chatgpt_looks_like,
+        "ChatGPT: malformed/format-drifted node shape rejected",
+    ),
+    (
+        {**_CHATGPT_MINIMAL_VALID, "current_node": 123},
+        False,
+        chatgpt_looks_like,
+        "ChatGPT: non-string current_node rejected",
+    ),
+    (
+        {k: v for k, v in _CHATGPT_MINIMAL_VALID.items() if k != "create_time"},
+        False,
+        chatgpt_looks_like,
+        "ChatGPT: missing create_time rejected",
+    ),
     ({}, False, chatgpt_looks_like, "ChatGPT: missing mapping"),
     (None, False, chatgpt_looks_like, "ChatGPT: None input"),
     # Claude AI

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -865,7 +865,13 @@ def test_source_iteration_ignores_stat_failures_for_optional_mtime_contract(
         ),
         (
             "drive",
-            {"mapping": {}, "conversation_id": "chatgpt-ish", "id": "chatgpt-ish"},
+            {
+                "conversation_id": "chatgpt-ish",
+                "id": "chatgpt-ish",
+                "create_time": 1704067200.0,
+                "current_node": "n1",
+                "mapping": {"n1": {"id": "n1", "parent": None, "children": []}},
+            },
             "chatgpt",
             1,
         ),
@@ -2071,8 +2077,20 @@ def test_iter_source_raw_data_streams_grouped_zip_entries_into_blob_store(
             "sessions.json",
             json.dumps(
                 [
-                    {"id": "chatgpt-1", "mapping": {}},
-                    {"id": "chatgpt-2", "mapping": {}},
+                    {
+                        "id": "chatgpt-1",
+                        "conversation_id": "chatgpt-1",
+                        "create_time": 1704067200.0,
+                        "current_node": "n1",
+                        "mapping": {"n1": {"id": "n1", "parent": None, "children": []}},
+                    },
+                    {
+                        "id": "chatgpt-2",
+                        "conversation_id": "chatgpt-2",
+                        "create_time": 1704067200.0,
+                        "current_node": "n1",
+                        "mapping": {"n1": {"id": "n1", "parent": None, "children": []}},
+                    },
                 ]
             ).encode("utf-8"),
             Provider.CHATGPT,
@@ -2130,8 +2148,20 @@ def test_iter_source_raw_data_avoids_whole_blob_provider_detection_for_zip_entri
             "nested/sessions.json",
             json.dumps(
                 [
-                    {"id": "chatgpt-1", "mapping": {}},
-                    {"id": "chatgpt-2", "mapping": {}},
+                    {
+                        "id": "chatgpt-1",
+                        "conversation_id": "chatgpt-1",
+                        "create_time": 1704067200.0,
+                        "current_node": "n1",
+                        "mapping": {"n1": {"id": "n1", "parent": None, "children": []}},
+                    },
+                    {
+                        "id": "chatgpt-2",
+                        "conversation_id": "chatgpt-2",
+                        "create_time": 1704067200.0,
+                        "current_node": "n1",
+                        "mapping": {"n1": {"id": "n1", "parent": None, "children": []}},
+                    },
                 ]
             ).encode("utf-8"),
         )
@@ -2198,8 +2228,20 @@ def test_iter_source_raw_data_reports_split_payload_observations(tmp_path: Path)
             "nested/sessions.json",
             json.dumps(
                 [
-                    {"id": "chatgpt-1", "mapping": {}},
-                    {"id": "chatgpt-2", "mapping": {}},
+                    {
+                        "id": "chatgpt-1",
+                        "conversation_id": "chatgpt-1",
+                        "create_time": 1704067200.0,
+                        "current_node": "n1",
+                        "mapping": {"n1": {"id": "n1", "parent": None, "children": []}},
+                    },
+                    {
+                        "id": "chatgpt-2",
+                        "conversation_id": "chatgpt-2",
+                        "create_time": 1704067200.0,
+                        "current_node": "n1",
+                        "mapping": {"n1": {"id": "n1", "parent": None, "children": []}},
+                    },
                 ]
             ).encode("utf-8"),
         )
@@ -2257,7 +2299,15 @@ def test_iter_source_raw_data_streams_preserved_zip_entries_into_blob_store(
 ) -> None:
     from polylogue.storage.blob_store import get_blob_store
 
-    entry_bytes = json.dumps({"id": "chatgpt-1", "mapping": {}}).encode("utf-8")
+    entry_bytes = json.dumps(
+        {
+            "id": "chatgpt-1",
+            "conversation_id": "chatgpt-1",
+            "create_time": 1704067200.0,
+            "current_node": "n1",
+            "mapping": {"n1": {"id": "n1", "parent": None, "children": []}},
+        }
+    ).encode("utf-8")
     archive_path = tmp_path / "bundle.zip"
     with zipfile.ZipFile(archive_path, "w") as zf:
         zf.writestr("nested/chatgpt-export.json", entry_bytes)
@@ -2279,9 +2329,27 @@ def test_iter_entry_payloads_locks_provider_after_first_detected_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     payloads = [
-        {"id": "chatgpt-1", "mapping": {}},
-        {"id": "chatgpt-2", "mapping": {}},
-        {"id": "chatgpt-3", "mapping": {}},
+        {
+            "id": "chatgpt-1",
+            "conversation_id": "chatgpt-1",
+            "create_time": 1704067200.0,
+            "current_node": "n1",
+            "mapping": {"n1": {"id": "n1", "parent": None, "children": []}},
+        },
+        {
+            "id": "chatgpt-2",
+            "conversation_id": "chatgpt-2",
+            "create_time": 1704067200.0,
+            "current_node": "n1",
+            "mapping": {"n1": {"id": "n1", "parent": None, "children": []}},
+        },
+        {
+            "id": "chatgpt-3",
+            "conversation_id": "chatgpt-3",
+            "create_time": 1704067200.0,
+            "current_node": "n1",
+            "mapping": {"n1": {"id": "n1", "parent": None, "children": []}},
+        },
     ]
     detect_calls: list[JSONDocument] = []
     original_detect_provider = dispatch_module.detect_provider
@@ -2317,27 +2385,35 @@ def test_iter_entry_payloads_preserves_decimal_bearing_chatgpt_records() -> None
     payloads = [
         {
             "id": "chatgpt-1",
+            "conversation_id": "chatgpt-1",
             "title": "Decimal timestamp",
             "create_time": Decimal("1704995846.046526"),
+            "current_node": "root",
             "mapping": {
                 "root": {
+                    "id": "root",
                     "message": {
+                        "id": "root-message",
                         "author": {"role": "user"},
                         "content": {"content_type": "text", "parts": ["hello"]},
-                    }
+                    },
                 }
             },
         },
         {
             "id": "chatgpt-2",
+            "conversation_id": "chatgpt-2",
             "title": "Integral timestamp",
             "create_time": Decimal("1704995847"),
+            "current_node": "root",
             "mapping": {
                 "root": {
+                    "id": "root",
                     "message": {
+                        "id": "root-message",
                         "author": {"role": "assistant"},
                         "content": {"content_type": "text", "parts": ["hi"]},
-                    }
+                    },
                 }
             },
         },


### PR DESCRIPTION
## Summary

Fixes a regression introduced by the (uncommitted, prior-session) chatgpt-export
detection tightening for polylogue-t0ta: `chatgpt.looks_like` was made strict
everywhere, but several call sites only ever see a *fragment* of a ChatGPT
conversation, not a whole document, and the strict check rejected them.

## Problem

polylogue-t0ta correctly identified `chatgpt.looks_like` as the loosest,
highest format-drift-risk detector in `dispatch.py` (a bare
`isinstance(payload.get("mapping"), dict)` check) and tightened it to require
document-identity fields (`current_node`/`create_time`/`conversation_id`-or-`id`)
plus full `ChatGPTNode` Pydantic validation of every mapping node.

That tightening is correct for whole-document detection (the first record of
a bundle/list -- e.g. one conversation from an exported array in
`_detect_provider_from_sequence`), but several other call sites only ever see
one already-lowered record or one line of a streamed JSONL sniff
(`sources/emitter.py`'s `_sniff_jsonl_payloads`, `dispatch._detect_provider_from_record`,
and two fallback lowering branches in `dispatch.py`). A genuine per-record
fragment legitimately lacks document-level identity fields, and can even omit
`id` on the node/message (that duplicates identity the caller already knows
from the mapping key/conversation context). The strict-everywhere check broke
6 tests in `tests/unit/sources/test_source_laws.py`. Re-running the wider
`tests/unit/sources` suite (not just the originally-touched files) surfaced 4
more casualties: `test_gemini_drive_normalization_laws.py`'s detector-ordering
test used a bare empty-mapping fixture, and 3 tests in
`test_live_batch_support.py` used chatgpt document fixtures that predate the
tightening and are missing the document-level `create_time` field.

## Solution

`polylogue/sources/parsers/chatgpt.py` now exposes two detectors:

- `looks_like` (unchanged strict behavior) -- whole-document/list detection:
  requires `current_node`/`create_time`/`conversation_id`-or-`id` plus full
  `ChatGPTNode` Pydantic validation of every mapping node.
- `looks_like_fragment` (new) -- per-record/per-line detection: requires only
  a non-empty `mapping` dict whose nodes have a *plausible* node/message shape
  (each node is a dict; if it carries a `message`, that message must be a
  dict with a dict `author`). No document-identity fields, no mandatory
  `id`. Still meaningfully tighter than the original bare
  `isinstance(mapping, dict)` check (rejects empty mapping, non-dict nodes,
  malformed message/author shapes).

`polylogue/sources/dispatch.py` routes each call site to the tier matching
what it actually sees:
- `_detect_provider_from_record` (single dict -- used by `detect_provider`'s
  record path, and by `emitter.py`'s per-line JSONL sniffing) ->
  `looks_like_fragment`.
- The two single-record fallback lowering branches (`_lower_payload_specs`'s
  drive-like fallthrough, `_lower_fallback_payload`) -> `looks_like_fragment`
  (same reasoning: one already-lowered record, not a document).
- `_detect_provider_from_sequence`'s first-record check (the first element of
  a *list*, i.e. a whole assembled document from a bundle) -> `looks_like`
  (unchanged, stays strict).

Also updated pre-existing test fixtures that predated the tightening
(`test_gemini_drive_normalization_laws.py`, `test_live_batch_support.py`) to
carry a non-empty/complete mapping instead of weakening the new checks.

## Verification

```
devtools test tests/unit/sources/parsers/test_origin_regression_pack.py \
  tests/unit/sources/test_chatgpt_normalization_survivors.py \
  tests/unit/sources/test_dispatch_ordering.py \
  tests/unit/sources/test_import_preflight.py \
  tests/unit/sources/test_parsers_chatgpt.py \
  tests/unit/sources/test_source_laws.py \
  tests/unit/sources/test_gemini_drive_normalization_laws.py \
  tests/unit/sources/test_live_batch_support.py
# 355 passed

devtools test tests/unit/sources
# 6 failed, 1915 passed -- all 6 confirmed pre-existing on origin/master via
# git stash (test_browser_capture.py title-ordering bug,
# test_live_watcher.py / test_live_cursor_persistence.py
# `defer_fts_rebuild` TypeError), unrelated to this change.

uv run mypy --strict polylogue/sources/parsers/chatgpt.py \
  polylogue/sources/dispatch.py polylogue/sources/emitter.py
# Success: no issues found in 3 source files

ruff check + ruff format --check on all touched files
# All checks passed / already formatted

devtools verify --quick
# exit 0 (green after rebasing onto current origin/master)
```

Ref polylogue-t0ta