### PR TITLE
fix(cli): make mark --note update-in-place per session

### DIFF
--- a/polylogue/cli/query_verbs.py
+++ b/polylogue/cli/query_verbs.py
@@ -1693,7 +1693,13 @@ def mark_verb(
             if do_unarchive:
                 await poly.remove_mark(sid, "archive")
             if note_text is not None:
-                digest = hashlib.sha256(f"{sid}\0{note_text}".encode("utf-8", errors="surrogatepass")).hexdigest()
+                # Stable per-session identity, deliberately excluding note_text: the
+                # help text promises "add or update" a single mutable note per
+                # session (mirroring add_mark's one-row-per-target behavior), so a
+                # second `mark --note` call on the same session must update the
+                # existing annotation in place rather than fork a new content-hash
+                # row every time the text changes (polylogue-tilk).
+                digest = hashlib.sha256(sid.encode("utf-8", errors="surrogatepass")).hexdigest()
                 annotation_id = f"note-{digest}"
                 await poly.save_annotation(annotation_id, sid, note_text)
 

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -718,7 +718,20 @@ def upsert_annotation(
     annotation_id: str | None = None,
     now_ms: int | None = None,
 ) -> ArchiveAnnotationEnvelope:
-    """Insert-or-update one annotation assertion with deterministic identity."""
+    """Insert-or-update one annotation assertion with deterministic identity.
+
+    Identity model: a caller-provided ``annotation_id`` is authoritative and
+    is how every current product surface calls this (``save_annotation`` /
+    the ``mark --note`` CLI verb require an explicit id, so the ``body``-hash
+    default below is unreachable from any live caller today). Without an
+    explicit id, the fallback id incorporates ``body`` -- this makes the
+    function idempotent for byte-identical repeat calls but means a content
+    edit computes a *different* id and inserts a new row rather than
+    updating in place, unlike ``upsert_mark``/``upsert_saved_view``. A
+    future caller wanting update-in-place-by-target semantics (as
+    ``mark --note`` does, polylogue-tilk) must supply a target-stable id
+    itself -- do not rely on this default for that.
+    """
     timestamp = now_ms if now_ms is not None else _now_ms()
     resolved_id = annotation_id or _deterministic_id("annotation", target_type, target_id, body)
     upsert_assertion(
@@ -857,7 +870,24 @@ def upsert_blackboard_note(
     context_policy: Mapping[str, object] | AssertionContextPolicy | None = None,
     now_ms: int | None = None,
 ) -> ArchiveBlackboardNoteEnvelope:
-    """Insert-or-update one blackboard note assertion."""
+    """Insert-or-update one blackboard note assertion.
+
+    Identity model: confirmed intentional append-only-log by content-hash
+    default (polylogue-tilk investigation, dogfood-2 round 2). Without an
+    explicit ``note_id``, the id incorporates ``body`` -- byte-identical
+    repeat calls collapse to one row, but any content change appends a new,
+    distinct note rather than updating the previous one. The sole live
+    caller, ``post_blackboard_note`` (``api/archive.py``, backing the MCP
+    ``blackboard_post`` tool), deliberately mints a fresh ``uuid4`` id on
+    every call -- its own docstring states "a fresh note id is allocated,
+    so each call appends a distinct note". That is the intended product
+    semantic for the persistent agent blackboard (an append-only log, not a
+    single mutable note), in contrast to ``upsert_annotation``'s
+    ``mark --note`` caller, which was a genuine bug (fixed to a target-stable
+    id) rather than a deliberate design choice. Do not "fix" this default
+    to be target-stable without re-confirming the blackboard's intended
+    semantics first.
+    """
     timestamp = now_ms if now_ms is not None else _now_ms()
     resolved_id = note_id or _deterministic_id("blackboard-note", target_type or "", target_id or "", body)
     upsert_assertion(

--- a/tests/unit/cli/test_mark_note_identity.py
+++ b/tests/unit/cli/test_mark_note_identity.py
@@ -1,0 +1,94 @@
+"""Regression coverage for `mark --note` update-in-place identity (polylogue-tilk).
+
+Prior behavior minted a fresh random/content-hash id on every `mark --note`
+call (`uuid.uuid4()`, later a `sha256(session_id, note_text)` digest), so two
+notes on the same session -- even byte-identical repeats, and definitely an
+edited note -- produced two distinct rows instead of one row being updated in
+place, despite the command's own help text promising "Add or update a note
+annotation". See `.agent/scratch/dogfood-2/investigations/write-path-correctness.md`
+(finding F-028) for the original empirical evidence.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from polylogue.cli import cli
+from tests.infra.storage_records import SessionBuilder
+
+WorkspacePaths = dict[str, Path]
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    return CliRunner()
+
+
+def _annotation_rows(user_db: Path) -> list[tuple[str, str, str]]:
+    with sqlite3.connect(user_db) as conn:
+        rows = conn.execute(
+            "SELECT assertion_id, target_ref, body_text FROM assertions WHERE kind = 'annotation'"
+        ).fetchall()
+    return [(str(r[0]), str(r[1]), str(r[2])) for r in rows]
+
+
+def test_mark_note_twice_with_same_text_is_a_true_no_op(cli_workspace: WorkspacePaths, cli_runner: CliRunner) -> None:
+    db_path = cli_workspace["db_path"]
+    builder = SessionBuilder(db_path, "conv-note-repeat").provider("claude-code")
+    builder.save()
+    session_id = builder.native_session_id()
+
+    for _ in range(2):
+        result = cli_runner.invoke(
+            cli,
+            ["--plain", "find", f"id:{session_id}", "then", "mark", "--note", "key insight"],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+
+    rows = _annotation_rows(cli_workspace["archive_root"] / "user.db")
+    assert len(rows) == 1
+    assert rows[0][2] == "key insight"
+
+
+def test_mark_note_edit_updates_the_same_row_instead_of_forking(
+    cli_workspace: WorkspacePaths, cli_runner: CliRunner
+) -> None:
+    """The core regression: editing note text must update in place, not insert."""
+    db_path = cli_workspace["db_path"]
+    builder = SessionBuilder(db_path, "conv-note-edit").provider("claude-code")
+    builder.save()
+    session_id = builder.native_session_id()
+
+    first = cli_runner.invoke(
+        cli,
+        ["--plain", "find", f"id:{session_id}", "then", "mark", "--note", "first draft"],
+        catch_exceptions=False,
+    )
+    assert first.exit_code == 0, first.output
+
+    user_db = cli_workspace["archive_root"] / "user.db"
+    rows_after_first = _annotation_rows(user_db)
+    assert len(rows_after_first) == 1
+    assert rows_after_first[0][2] == "first draft"
+    first_assertion_id = rows_after_first[0][0]
+
+    second = cli_runner.invoke(
+        cli,
+        ["--plain", "find", f"id:{session_id}", "then", "mark", "--note", "revised, corrected wording"],
+        catch_exceptions=False,
+    )
+    assert second.exit_code == 0, second.output
+
+    rows_after_second = _annotation_rows(user_db)
+    # Anti-vacuity: a naive content-hash-default fix (or no fix at all) makes
+    # this len(rows_after_second) == 2 -- two distinct annotation rows for one
+    # session's "note" concept -- fail here.
+    assert len(rows_after_second) == 1
+    assert rows_after_second[0][0] == first_assertion_id
+    assert rows_after_second[0][2] == "revised, corrected wording"
+    assert rows_after_second[0][1] == rows_after_first[0][1]

--- a/tests/unit/storage/test_archive_tiers_user_write.py
+++ b/tests/unit/storage/test_archive_tiers_user_write.py
@@ -269,3 +269,35 @@ def test_upsert_recall_pack_without_explicit_id_updates_same_named_pack(tmp_path
 
     refreshed = read_archive_recall_pack_envelope(conn, first.recall_pack_id)
     assert refreshed.payload == {"session_ids": ["session-1", "session-2"]}
+
+
+def test_upsert_blackboard_note_default_id_is_content_hash_append_only_by_design(tmp_path: Path) -> None:
+    """Confirmed-intentional identity model (polylogue-tilk): body IS the identity.
+
+    Unlike ``upsert_recall_pack``/``upsert_saved_view``, ``upsert_blackboard_note``'s
+    content-hash default is a deliberate append-only-log design for the
+    persistent agent blackboard, not a bug -- its real caller
+    (``post_blackboard_note``) always mints a fresh explicit id per post so
+    every call appends a distinct note. This pins the function's own two
+    halves of that contract: byte-identical repeat calls (no explicit id)
+    collapse to one row, while a body change computes a different id and
+    correctly forks a new, independent note rather than overwriting the
+    previous one.
+    """
+    conn = _connect(tmp_path / "user.db")
+
+    first = upsert_blackboard_note(conn, "status update", target_type="session", target_id="session-1", now_ms=1)
+    identical_repeat = upsert_blackboard_note(
+        conn, "status update", target_type="session", target_id="session-1", now_ms=2
+    )
+    assert identical_repeat.note_id == first.note_id
+    notes_after_repeat = list_assertions_for_target(conn, "session:session-1", kind=AssertionKind.NOTE)
+    assert len(notes_after_repeat) == 1
+
+    edited = upsert_blackboard_note(
+        conn, "status update, revised", target_type="session", target_id="session-1", now_ms=3
+    )
+    assert edited.note_id != first.note_id
+    notes_after_edit = list_assertions_for_target(conn, "session:session-1", kind=AssertionKind.NOTE)
+    assert len(notes_after_edit) == 2
+    assert {note.body_text for note in notes_after_edit} == {"status update", "status update, revised"}


### PR DESCRIPTION
## Summary

Fixes the `mark --note` CLI verb so repeated calls on the same session
update the existing note in place instead of forking a new row every
time the note text changes, and documents (without changing) the two
other content-hash-identity `upsert_*` functions in
`storage/sqlite/archive_tiers/user_write.py` whose identity semantics
were flagged as potentially inconsistent by the same investigation.

## Problem

The dogfood-2 write-path investigation
(`.agent/scratch/dogfood-2/investigations/write-path-correctness.md`,
finding F-028, plus `write-path-round2.md`) audited every `upsert_*`
function in `user_write.py` and found identity semantics inconsistent
across superficially identical names: `upsert_mark` /
`upsert_saved_view` / `upsert_workspace` / etc. key on stable
target/name identity (true update-in-place), while `upsert_annotation`,
`upsert_recall_pack`, and `upsert_blackboard_note` default to a
content-hash identity when no id is supplied, making them behave as
append-only logs instead.

Two concrete, empirically-verified bug instances were cited:

- (a) `mark --note` (`polylogue/cli/query_verbs.py`) minted an
  annotation id that embeds the note text itself (originally
  `uuid.uuid4()`, later a `sha256(session_id, note_text)` digest from
  PR #3138) -- so editing a note's text always computes a new id and
  inserts a second row, contradicting the verb's own help text ("Add
  or update a note annotation").
- (b) `upsert_recall_pack` vs `upsert_saved_view` -- already
  independently fixed by PR #3111 (polylogue-2o3d) before this bead
  was picked up; verified no further change needed here.

## Solution

Per-function decision (polylogue-tilk):

- **`mark --note` (`cli/query_verbs.py`) -- fixed.** The annotation id
  is now derived from `session_id` only, not `session_id + note_text`.
  Repeat calls with identical text are a true no-op; edited text
  updates the existing row in place, matching `upsert_mark`'s identity
  model and the verb's own help text.
- **`upsert_annotation` (`user_write.py`) -- documented, not changed.**
  The function is already idempotent for its content-hash default, but
  every current caller (`save_annotation`, `mark --note`) supplies an
  explicit id, so that default path is unreachable dead code today.
  Docstring now states this explicitly so a future caller doesn't
  assume it provides target-stable update-in-place.
- **`upsert_blackboard_note` (`user_write.py`) -- confirmed intentional,
  documented.** Its sole live caller, `post_blackboard_note`
  (`api/archive.py`, backing the MCP `blackboard_post` tool),
  deliberately mints a fresh id on every call -- its own docstring
  already states "a fresh note id is allocated, so each call appends a
  distinct note". This is a deliberate append-only agent-blackboard
  log design, not a bug. Docstring on `upsert_blackboard_note` itself
  now states this so it isn't "fixed" to false idempotency later.
- **`upsert_recall_pack`** -- no change needed; already fixed by PR
  #3111 prior to this bead.

## Verification

```
devtools test tests/unit/storage/test_archive_tiers_user_write.py tests/unit/cli/test_mark_note_identity.py
# 5 passed in 4.11s

mypy --strict polylogue/cli/query_verbs.py polylogue/storage/sqlite/archive_tiers/user_write.py
# Success: no issues found in 2 source files

ruff check / ruff format --check <touched files>
# clean

devtools verify --quick
# exit_code 0 (also ran again automatically on push via pre-push hook, exit 0)
```

`tests/unit/cli/test_verb_cardinality.py` has one pre-existing failure
(`TestDeleteCardinalityLargeNonMocked::test_guard_dry_run_and_deleted_sets_are_identical_and_unlimited`,
`RuntimeServices has no config projection`) reproduced in isolation on
an unrelated delete-cardinality path this change never touches -- not
a regression from this diff.

New regression tests:
- `tests/unit/cli/test_mark_note_identity.py`: two `mark --note`
  invocations with identical text collapse to one row; editing the
  text updates the same row (same `assertion_id`) instead of forking a
  second one.
- `tests/unit/storage/test_archive_tiers_user_write.py`: pins
  `upsert_blackboard_note`'s confirmed-intentional two-halves contract
  -- byte-identical repeat calls (no explicit id) collapse to one row,
  while a body edit correctly forks a new, independent note.

Ref polylogue-tilk

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repeated `mark --note` actions for the same session now update the existing note instead of creating duplicate entries.
  * Editing a note preserves its existing annotation while updating the displayed content.
  * Repeating an identical note is handled as a no-op, preventing unnecessary duplicates.

* **Documentation**
  * Clarified note storage behavior, including when identical notes are combined and when edited notes create separate entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->