### PR TITLE
fix(daemon): unify session-detail message.text into one shared helper

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -64,6 +64,7 @@ from polylogue.storage.sqlite.archive_tiers.write import (
     ArchiveAttachmentRow,
     ArchiveMessageRow,
     ArchiveSessionEnvelope,
+    archive_message_display_text,
 )
 from polylogue.storage.sqlite.connection_profile import open_connection, open_readonly_connection
 from polylogue.storage.sqlite.queries.message_query_reads import MessageTypeName
@@ -1767,7 +1768,7 @@ def _archive_attachment_to_domain(attachment: ArchiveAttachmentRow) -> Attachmen
 
 
 def _archive_message_to_domain(message: ArchiveMessageRow, *, origin: Origin) -> Message:
-    text = "\n\n".join(block.text for block in message.blocks if block.text) or None
+    text = archive_message_display_text(message.blocks) or None
     content_blocks: list[dict[str, object]] = [
         {
             key: value

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -80,6 +80,7 @@ from polylogue.rendering.semantic_cards import (
 )
 from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.write import archive_message_display_text
 from polylogue.surfaces.payloads import (
     AssertionClaimListPayload,
     MutationResultPayload,
@@ -3614,7 +3615,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         semantic_card_suppressed: bool = False,
     ) -> dict[str, object]:
         message_id = str(message.message_id)
-        text = "\n\n".join(str(block.text) for block in message.blocks if block.text)
+        text = archive_message_display_text(message.blocks)
         has_paste = bool(message.has_paste)
         return {
             "id": message_id,

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -187,6 +187,27 @@ class ArchiveSessionEnvelope:
     total_message_count: int | None = None
 
 
+def archive_message_display_text(blocks: Iterable[ArchiveBlockRow]) -> str:
+    """Flatten an archive-tier message's blocks into its display ``text``.
+
+    Single source of truth for the ``message.text`` field the daemon's two
+    session-detail routes each used to compute independently (polylogue-6o9b):
+    the DB-backed route (``api/archive.py:_archive_message_to_domain``,
+    reached via ``Polylogue.get_session()``) and the archive-backed route
+    (``daemon/http.py:_archive_message_payload``) both read the same
+    ``ArchiveMessageRow.blocks`` and must produce byte-identical text for
+    the same message, since ``daemon/web_shell_reader.py``'s client-side
+    rendering heuristic (``renderMessageBlocks``) dispatches off this single
+    flattened field. Joins every non-empty block's text in block order,
+    blank-line separated -- this intentionally includes
+    THINKING/TOOL_USE/TOOL_RESULT/CODE block text, not just prose TEXT
+    blocks, matching both routes' prior (independently duplicated) behavior.
+    Narrowing this to prose-only content is a separate follow-up (see
+    ``investigations/rendering-path-divergence.md``), not this fix's scope.
+    """
+    return "\n\n".join(block.text for block in blocks if block.text)
+
+
 @dataclass(frozen=True, slots=True)
 class ArchiveInsightMaterialization:
     insight_type: str

--- a/tests/unit/daemon/test_session_detail_text_parity.py
+++ b/tests/unit/daemon/test_session_detail_text_parity.py
@@ -1,0 +1,73 @@
+"""Regression test for polylogue-6o9b.
+
+The daemon's two session-detail fast paths must compute an identical
+``message.text`` field for the same message:
+
+- DB-backed: ``daemon/http.py:_do_get_session`` -> ``Polylogue.get_session()``
+  -> ``api/archive.py:_archive_message_to_domain``.
+- Archive-backed: ``daemon/http.py:_do_archive_get_session`` ->
+  ``daemon/http.py:_archive_message_payload``.
+
+Both used to independently reimplement the same "join every block's text"
+formula; a message with mixed block types (TEXT + THINKING + TOOL_USE +
+TOOL_RESULT) is exactly the shape most likely to expose a silent
+re-divergence, since ``daemon/web_shell_reader.py``'s client-side rendering
+heuristic dispatches its fold/thinking/tool treatment off this single
+flattened string per message.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from polylogue.daemon.http import DaemonAPIHandler
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from tests.infra.storage_records import SessionBuilder, db_setup
+
+_MIXED_BLOCKS = [
+    {"type": "text", "text": "Hello prose"},
+    {"type": "thinking", "text": "pondering the fix"},
+    {"type": "tool_use", "tool_name": "shell", "tool_id": "t1"},
+    {"type": "tool_result", "tool_id": "t1", "text": "command output"},
+]
+
+
+async def test_db_backed_and_archive_backed_message_text_agree_for_mixed_blocks(
+    workspace_env: dict[str, Path],
+) -> None:
+    db_path = db_setup(workspace_env)
+    builder = (
+        SessionBuilder(db_path, "mixed-blocks")
+        .provider("codex")
+        .title("Mixed block types")
+        .add_message(text="Hello prose", blocks=list(_MIXED_BLOCKS))
+    )
+
+    # DB-backed route: the exact call ``_do_get_session`` makes.
+    session = await builder.build()
+    assert session is not None
+    session_messages = session.messages.to_list()
+    assert len(session_messages) == 1
+    db_backed_text = session_messages[0].text
+
+    # Archive-backed route: the exact call ``_do_archive_get_session`` makes,
+    # invoked directly on the handler (its body touches no other ``self``
+    # state, so a bare, unconnected instance is sufficient).
+    archive_root = db_path.parent
+    with ArchiveStore(archive_root) as archive:
+        resolved_id = archive.resolve_session_id(builder.native_session_id())
+        envelope = archive.read_session(resolved_id)
+    assert len(envelope.messages) == 1
+
+    handler = object.__new__(DaemonAPIHandler)
+    archive_payload = handler._archive_message_payload(resolved_id, envelope.messages[0])
+    archive_backed_text = archive_payload["text"]
+
+    assert db_backed_text == archive_backed_text
+
+    # Sanity: prove this compared real mixed-block content, not two empty
+    # strings agreeing by accident.
+    assert db_backed_text is not None
+    assert "Hello prose" in db_backed_text
+    assert "pondering the fix" in db_backed_text
+    assert "command output" in db_backed_text


### PR DESCRIPTION
## Summary

Unifies the daemon's two session-detail fast paths so they compute
`message.text` through one shared helper instead of two independently
maintained copies of the same formula.

## Problem

`investigations/rendering-path-divergence.md` (dogfood-2 round-3 rendering
re-inventory) flagged that the DB-backed session-detail route
(`daemon/http.py:_do_get_session` -> `Polylogue.get_session()` ->
`api/archive.py:_archive_message_to_domain`) and the archive-backed route
(`daemon/http.py:_do_archive_get_session` -> `_archive_message_payload`) could
compute different flattened `message.text` for the same message. Since
`daemon/web_shell_reader.py`'s client-side rendering heuristic
(`renderMessageBlocks`) dispatches its fold/thinking/tool treatment off this
single flattened string per message, any drift between the two
implementations is a real, user-visible rendering bug, not a cosmetic one.

Tracing both call sites on current `master` showed they already compute
byte-identical output today (`"\n\n".join(block.text for block in
message.blocks if block.text)`, duplicated verbatim in `api/archive.py:1770`
and the former `daemon/http.py:3617`) — but as two hand-maintained copies with
no shared source, exactly the shape of duplication that lets this class of bug
silently reappear (as the investigation's evidence indicates it once did).

## Solution

- Added `archive_message_display_text()` to
  `polylogue/storage/sqlite/archive_tiers/write.py`, next to the
  `ArchiveBlockRow`/`ArchiveMessageRow` dataclasses both call sites already
  import, as the single canonical implementation.
- Pointed both `_archive_message_to_domain` (`polylogue/api/archive.py`) and
  `_archive_message_payload` (`polylogue/daemon/http.py`) at it.
- Chosen behavior preserves both routes' current output exactly: every
  non-empty block's text, joined in block order with a blank line, across
  all block types (TEXT/THINKING/TOOL_USE/TOOL_RESULT/CODE). This fix targets
  eliminating the duplicate-implementation risk, not narrowing
  `message.text` to prose-only content — narrowing scope (so THINKING/tool
  content isn't silently smushed into the same client-side fold as prose) is
  a larger, separate follow-up already named in the rendering-path-divergence
  investigation's cross-path findings, and out of this bug's scope.

## Verification

- New regression test `tests/unit/daemon/test_session_detail_text_parity.py`:
  seeds one message with mixed TEXT + THINKING + TOOL_USE + TOOL_RESULT
  blocks via the shared test builder, calls the real `Polylogue.get_session()`
  (DB-backed route) and the real `DaemonAPIHandler._archive_message_payload`
  (archive-backed route) against the same archive, and asserts identical
  `text`. Anti-vacuity: temporarily reverted `_archive_message_payload` to its
  old inline formula with a different separator — the test failed with a real
  diff, then passed again after restoring the shared-helper call.
- `devtools test tests/unit/daemon/test_session_detail_text_parity.py
  tests/unit/daemon/test_web_reader.py tests/unit/api/test_facade_contracts.py
  tests/unit/rendering/test_semantic_card_web_cli_parity.py` — 456 passed.
- `mypy` on the 3 touched source files + new test file — no issues.
- `ruff check` / `ruff format --check` — clean.
- `devtools verify --quick` — 18/18 steps, exit 0.

Ref polylogue-6o9b