### PR TITLE
fix(sources): resynthesize append cursor from source.db when ops.db loses it

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -30,6 +30,7 @@ from polylogue.archive.revision_authority import (
     RawRevisionKind,
     append_source_revision,
 )
+from polylogue.archive.revision_replay import RevisionCandidate, plan_revision_replay
 from polylogue.archive.session_revision_membership import MembershipRevision, classify_membership_revisions
 from polylogue.config import Source
 from polylogue.core.degraded import is_degraded
@@ -2403,6 +2404,135 @@ class LiveBatchProcessor:
             excluded=True,
         )
 
+    def _resynthesize_cursor_from_source(self, path: Path) -> CursorRecord | None:
+        """Reconstruct an append-eligible cursor from durable ``source.db`` evidence.
+
+        ``ingest_cursor`` (``CursorStore``) lives in the **disposable** ``ops.db``
+        tier: every reset (index rebuild, schema mismatch, ``polylogue ops
+        reset``) wipes it, forcing the next observation of every still-growing
+        file back onto the full-capture path even though the file itself
+        hasn't changed shape at all (polylogue-aex0, see
+        ``docs/design/prefix-blob-reclamation.md``'s "forward-fix sibling"
+        section). This is a *secondary* lookup, tried only when
+        :meth:`_append_plan`'s primary ``ops.db`` cursor is absent or
+        unusable; it never weakens ``RawRevisionAuthority`` -- the exact same
+        ``plan_revision_replay`` the durable classifier already uses is the
+        sole source of truth for which raw is the accepted head.
+
+        Only a ``revision_kind='full'`` accepted head is resynthesized. An
+        append-kind head's stored raw payload is not guaranteed
+        byte-identical to the live file at that offset (Codex append plans
+        inject a synthetic ``session_meta`` line ahead of the real delta via
+        ``_append_payload_for_provider``), so it cannot stand in for a
+        verified file-byte prefix -- and reusing a *stale* full baseline
+        behind an already-accepted append chain would create a second
+        sibling append candidate at the same offset, making
+        ``plan_revision_replay`` mark the whole chain ambiguous. Declining
+        whenever the head isn't 'full' avoids both hazards. This still
+        covers the dominant real-world case: the very next observation of a
+        file after an ops.db reset takes the full-capture path and writes a
+        fresh byte-proven 'full' revision, which this fallback can
+        immediately use so the *following* observation resumes appending
+        instead of full-recapturing forever.
+
+        Returns ``None`` whenever the durable evidence is ambiguous, absent,
+        or not a 'full' head -- callers fall through to the existing
+        full-capture path exactly as before this fallback existed.
+        """
+        source_db = self._cursor._db_path.with_name("source.db")
+        if not source_db.exists():
+            return None
+        try:
+            conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+        except sqlite3.Error:
+            return None
+        try:
+            key_rows = conn.execute(
+                """
+                SELECT DISTINCT logical_source_key
+                FROM raw_sessions
+                WHERE source_path = ?
+                  AND revision_kind = 'full'
+                  AND revision_authority = 'byte_proven'
+                  AND logical_source_key IS NOT NULL
+                """,
+                (str(path),),
+            ).fetchall()
+            if len(key_rows) != 1:
+                # No durable full head, or more than one distinct logical
+                # identity has ever been captured at this path -- ambiguous.
+                return None
+            logical_source_key = str(key_rows[0][0])
+            rows = conn.execute(
+                """
+                SELECT raw_id, revision_kind, source_revision, acquisition_generation,
+                       revision_authority, blob_size, predecessor_raw_id, baseline_raw_id,
+                       append_start_offset, append_end_offset, predecessor_source_revision,
+                       lower(hex(blob_hash)) AS blob_hash_hex
+                FROM raw_sessions
+                WHERE logical_source_key = ? AND source_revision IS NOT NULL
+                """,
+                (logical_source_key,),
+            ).fetchall()
+        except sqlite3.Error:
+            return None
+        finally:
+            conn.close()
+        if not rows:
+            return None
+        blob_hash_by_raw_id = {str(row[0]): row[11] for row in rows}
+        candidates = [
+            RevisionCandidate(
+                raw_id=str(row[0]),
+                logical_source_key=logical_source_key,
+                kind=RawRevisionKind(str(row[1])),
+                source_revision=str(row[2]),
+                acquisition_generation=int(row[3]),
+                authority=RawRevisionAuthority(str(row[4])),
+                blob_size=int(row[5]),
+                predecessor_source_revision=str(row[10]) if row[10] is not None else None,
+                predecessor_raw_id=str(row[6]) if row[6] is not None else None,
+                baseline_raw_id=str(row[7]) if row[7] is not None else None,
+                append_start_offset=int(row[8]) if row[8] is not None else None,
+                append_end_offset=int(row[9]) if row[9] is not None else None,
+            )
+            for row in rows
+        ]
+        try:
+            replay_plan = plan_revision_replay(candidates)
+        except ValueError:
+            return None
+        if not replay_plan.accepted_chain:
+            return None
+        head_raw_id = replay_plan.accepted_chain[-1]
+        head = next(candidate for candidate in candidates if candidate.raw_id == head_raw_id)
+        if head.kind is not RawRevisionKind.FULL:
+            return None
+        blob_hash_hex = blob_hash_by_raw_id.get(head_raw_id)
+        if blob_hash_hex is None or len(blob_hash_hex) != 64:
+            return None
+        byte_offset = head.blob_size
+        return CursorRecord(
+            source_path=str(path),
+            byte_size=byte_offset,
+            byte_offset=byte_offset,
+            last_complete_newline=byte_offset,
+            record_count=0,
+            updated_at=datetime.now(UTC).isoformat(),
+            parser_fingerprint=self._current_parser_fingerprint(),
+            content_fingerprint=head.source_revision,
+            # The prefix hash IS the 'full' raw's own blob hash (its content is
+            # exactly bytes[0:byte_offset] of the source at capture time); the
+            # tail-hash component is never read by ``_append_plan`` (only the
+            # prefix half of the encoded authority is consulted there), so it
+            # is filled with the same digest rather than re-reading the blob.
+            tail_hash=encode_cursor_hash_authority(blob_hash_hex, blob_hash_hex, ctime_ns=0),
+            source_name=None,
+            st_dev=None,
+            st_ino=None,
+            mtime_ns=None,
+        )
+
     def _append_plan(self, path: Path, *, cursor: CursorRecord | None = None) -> _AppendPlan | _DeferredAppend | None:
         # Append planning is safe only for newline-delimited record streams.
         # Watch-source names describe acquisition routes, not file semantics:
@@ -2424,6 +2554,16 @@ class LiveBatchProcessor:
             # which already handles multi-session grouping correctly.
             return None
         cursor = cursor or self._cursor.get_record(path)
+        if cursor is None:
+            # polylogue-aex0: the disposable ops.db cursor is gone (reset,
+            # schema mismatch, or never written yet) -- try to resynthesize
+            # an equivalent one from source.db's durable revision-chain
+            # evidence before giving up to a full capture. A cursor that
+            # *does* exist but is stale for another reason (parser upgrade,
+            # exclusion, failure bookkeeping) is a deliberate invalidation,
+            # not disposable-tier loss, and must keep forcing a full
+            # re-ingest exactly as before -- never resynthesized over.
+            cursor = self._resynthesize_cursor_from_source(path)
         if (
             cursor is None
             or cursor.parser_fingerprint != self._current_parser_fingerprint()

--- a/tests/unit/sources/test_live_append_cursor_resynthesis.py
+++ b/tests/unit/sources/test_live_append_cursor_resynthesis.py
@@ -1,0 +1,218 @@
+"""polylogue-aex0: append planning must resynthesize a lost ops.db cursor.
+
+``ingest_cursor`` (``CursorStore``) lives in the disposable ``ops.db`` tier --
+every reset (index rebuild, schema mismatch, ``polylogue ops reset``) wipes it,
+forcing the next observation of a still-growing file back onto the
+full-capture path even though the file itself hasn't changed shape. These
+scenarios exercise ``LiveBatchProcessor._append_plan``'s secondary lookup
+against ``source.db``'s durable revision-chain evidence
+(``_resynthesize_cursor_from_source``): unchanged behavior when the ops.db
+cursor is present, successful append recovery when it's gone but a durable
+byte-proven 'full' head exists, and unchanged fallback-to-full-capture when
+neither exists.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+import polylogue.sources.live.watcher as live_watcher
+from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
+from polylogue.core.enums import Provider
+from polylogue.sources.live import WatchSource
+from polylogue.sources.live.batch import LiveBatchProcessor
+from polylogue.sources.live.batch_support import _AppendPlan, encode_cursor_hash_authority
+from polylogue.sources.live.cursor import CursorStore
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+def _session_meta(session_id: str) -> bytes:
+    return f'{{"type":"session_meta","payload":{{"id":"{session_id}"}}}}\n'.encode()
+
+
+def _codex_message(text: str) -> bytes:
+    return (
+        f'{{"type":"response_item","payload":{{"type":"message","role":"user",'
+        f'"content":[{{"type":"input_text","text":"{text}"}}]}}}}\n'
+    ).encode()
+
+
+def _seed_native_session(tmp_path: Path, *, session_id: str) -> None:
+    """Satisfy the Codex append path's identity-lock (``_existing_provider_session_id``)."""
+    with sqlite3.connect(tmp_path / "index.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO sessions (
+                native_id, origin, raw_id, message_count, content_hash, created_at_ms, updated_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (session_id, "codex-session", "unrelated-raw-id", 1, b"a" * 32, 1, 1),
+        )
+        conn.commit()
+
+
+def _processor(tmp_path: Path, cursor: CursorStore) -> LiveBatchProcessor:
+    return LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=tmp_path / "index.db"))),
+        (WatchSource(name="codex", root=tmp_path),),
+        cursor=cursor,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+    )
+
+
+def test_append_plan_resynthesizes_lost_cursor_from_durable_full_head(tmp_path: Path) -> None:
+    """No ops.db cursor, but source.db has a byte-proven 'full' head: append is attempted."""
+    session_id = "resynth-proof"
+    initialize_active_archive_root(tmp_path)
+    source = tmp_path / "rollout-resynth-proof.jsonl"
+    baseline = _session_meta(session_id) + _codex_message("baseline")
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=baseline,
+            source_path=str(source),
+            acquired_at_ms=1,
+            revision=RawRevisionEnvelope(
+                logical_source_key=f"codex:{session_id}",
+                kind=RawRevisionKind.FULL,
+                source_revision="full-0",
+                acquisition_generation=0,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
+            ),
+        )
+    appended = _codex_message("grown-after-reset")
+    source.write_bytes(baseline + appended)
+    _seed_native_session(tmp_path, session_id=session_id)
+
+    cursor = CursorStore(tmp_path / "ops.db")
+    assert cursor.get_record(source) is None  # the ops.db cursor is genuinely gone
+    processor = _processor(tmp_path, cursor)
+
+    plan = processor._append_plan(source)
+
+    assert isinstance(plan, _AppendPlan)
+    assert plan.start_offset == len(baseline)
+    assert plan.cursor_fingerprint == "full-0"
+    assert appended in plan.payload
+
+
+def test_append_plan_uses_ops_db_cursor_without_consulting_source_db(tmp_path: Path) -> None:
+    """An existing ops.db cursor is used as before; the fallback is never invoked."""
+    session_id = "existing-cursor-proof"
+    initialize_active_archive_root(tmp_path)
+    source = tmp_path / "rollout-existing-cursor.jsonl"
+    baseline = _session_meta(session_id) + _codex_message("baseline")
+    source.write_bytes(baseline)
+    baseline_digest = hashlib.sha256(baseline).hexdigest()
+    appended = _codex_message("grown")
+    with source.open("ab") as handle:
+        handle.write(appended)
+    stat = source.stat()
+    _seed_native_session(tmp_path, session_id=session_id)
+
+    cursor = CursorStore(tmp_path / "ops.db")
+    cursor.set(
+        source,
+        len(baseline),
+        byte_offset=len(baseline),
+        last_complete_newline=len(baseline),
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+        content_fingerprint="already-known",
+        tail_hash=encode_cursor_hash_authority(baseline_digest, baseline_digest, ctime_ns=stat.st_ctime_ns),
+        source_name="codex",
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+    )
+    processor = _processor(tmp_path, cursor)
+
+    def _fail_resynthesis(self: LiveBatchProcessor, path: Path) -> None:
+        raise AssertionError("resynthesis must not be consulted when an ops.db cursor is already usable")
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(LiveBatchProcessor, "_resynthesize_cursor_from_source", _fail_resynthesis)
+        plan = processor._append_plan(source)
+
+    assert isinstance(plan, _AppendPlan)
+    assert plan.start_offset == len(baseline)
+    assert appended in plan.payload
+
+
+def test_append_plan_declines_when_neither_cursor_nor_durable_head_exists(tmp_path: Path) -> None:
+    """A genuinely new file falls back to full capture exactly as before."""
+    initialize_active_archive_root(tmp_path)
+    source = tmp_path / "rollout-brand-new.jsonl"
+    source.write_bytes(_session_meta("brand-new") + _codex_message("hello"))
+
+    cursor = CursorStore(tmp_path / "ops.db")
+    processor = _processor(tmp_path, cursor)
+
+    plan = processor._append_plan(source)
+
+    assert plan is None
+
+
+def test_append_plan_declines_resynthesis_for_an_append_kind_head(tmp_path: Path) -> None:
+    """An already-accepted append-kind head must not be treated as resynthesizable.
+
+    Resynthesizing from a stale 'full' baseline behind an already-accepted
+    append chain would create a second sibling append candidate at the same
+    offset and make ``plan_revision_replay`` mark the whole chain ambiguous.
+    """
+    session_id = "append-head-proof"
+    initialize_active_archive_root(tmp_path)
+    source = tmp_path / "rollout-append-head.jsonl"
+    baseline = _session_meta(session_id) + _codex_message("baseline")
+    first_append_delta = _codex_message("first-append")
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=baseline,
+            source_path=str(source),
+            acquired_at_ms=1,
+            revision=RawRevisionEnvelope(
+                logical_source_key=f"codex:{session_id}",
+                kind=RawRevisionKind.FULL,
+                source_revision="full-0",
+                acquisition_generation=0,
+                authority=RawRevisionAuthority.BYTE_PROVEN,
+            ),
+        )
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=_session_meta(session_id) + first_append_delta,
+            source_path=str(source),
+            acquired_at_ms=2,
+            revision=RawRevisionEnvelope(
+                logical_source_key=f"codex:{session_id}",
+                kind=RawRevisionKind.APPEND,
+                source_revision="append-1",
+                acquisition_generation=1,
+                predecessor_source_revision="full-0",
+                predecessor_raw_id=None,
+                baseline_raw_id=None,
+                append_start_offset=len(baseline),
+                append_end_offset=len(baseline) + len(first_append_delta),
+                authority=RawRevisionAuthority.QUARANTINED,
+            ),
+        )
+        # Promote the append into the accepted chain the same way the real
+        # append-ingest path does, via the durable classifier.
+        archive.classify_raw_revision_cohort(f"codex:{session_id}")
+    second_append = _codex_message("second-append")
+    source.write_bytes(baseline + first_append_delta + second_append)
+    _seed_native_session(tmp_path, session_id=session_id)
+
+    cursor = CursorStore(tmp_path / "ops.db")
+    processor = _processor(tmp_path, cursor)
+
+    plan = processor._append_plan(source)
+
+    assert plan is None


### PR DESCRIPTION
## Summary

`_append_plan` (`polylogue/sources/live/batch.py`) now tries a secondary,
source.db-backed cursor lookup when the disposable ops.db cursor is
genuinely absent, instead of immediately falling back to a full re-capture.

## Problem

Only ~2.3% (2,303/101,347) of retained `raw_sessions` rows are
`revision_kind='append'`, even though the large majority of repeated
captures are of growth-only files (Codex rollouts, Claude Code transcripts).
Root-caused in `docs/design/prefix-blob-reclamation.md`'s "forward-fix
sibling" section (polylogue-vzn6's evidence pack): append planning
(`_append_plan`) requires a pre-existing cursor from `CursorStore` in
`ops.db` — the **disposable** tier. Every `ops.db` reset (index rebuilds,
schema mismatches, `polylogue ops reset`) wipes cursor state, forcing the
next observation of every currently-growing file back onto the full-capture
path even though the file itself hasn't changed shape at all.

## Solution

Added `LiveBatchProcessor._resynthesize_cursor_from_source`, consulted only
when the primary `ops.db` cursor lookup returns `None` (never when a cursor
exists but is stale for another reason — see below). It:

1. Queries `source.db` for the path's distinct `logical_source_key` among
   `revision_kind='full', revision_authority='byte_proven'` rows.
2. Builds the full candidate set for that key and runs the existing,
   unmodified `archive.revision_replay.plan_revision_replay` — the exact
   same pure function `classify_raw_revision_cohort` already relies on — to
   find the current accepted head.
3. Only resynthesizes a `CursorRecord` when that head is `revision_kind='full'`.

Verified against the real schema rather than assuming the design sketch's
`predecessor_raw_id`/`baseline_raw_id`/`blob_size` wording applied verbatim:

- A 'full' raw's `blob_hash` column **is** the SHA-256 of bytes
  `[0:blob_size]` of the source at capture time (confirmed via
  `write_raw_payload`/`BlobStore.write_from_bytes`), so the prefix hash
  `_append_plan` needs can be read directly off the column — no blob I/O
  needed to resynthesize.
- An **append-kind** accepted head is deliberately declined, for two
  independent reasons discovered during implementation, not in the design
  doc: (a) its stored raw payload is not guaranteed byte-identical to the
  live file at that offset (Codex append plans inject a synthetic
  `session_meta` line ahead of the real delta via
  `_append_payload_for_provider`), and (b) resynthesizing from a *stale*
  full baseline behind an already-accepted append chain would create a
  second sibling append candidate at the same start offset, making
  `plan_revision_replay` mark the *entire* chain ambiguous — a correctness
  regression, not just a missed optimization. Declining whenever the head
  isn't 'full' avoids both hazards while still covering the dominant
  real-world case: the observation immediately after an `ops.db` reset
  takes the full-capture path and writes a fresh byte-proven 'full'
  revision, which this fallback lets the *next* observation resume
  appending from.

The fallback is scoped to `cursor is None` only (not "cursor exists but
parser fingerprint mismatches" or "content_fingerprint is None") — a
regression surfaced this during development
(`test_failed_parser_upgrade_preserves_accepted_parser_identity`, a stale
cursor from an intentional parser upgrade was being silently bypassed by
resynthesis) and is now a dedicated non-goal documented in the docstring and
enforced by the narrower `if cursor is None:` gate.

Does not weaken `RawRevisionAuthority`: `classify_raw_revision_cohort`
remains the sole acceptance authority for what content is durably accepted.
This only changes which append-path *attempt* is made before falling back
to a full capture.

## Verification

- `python -m mypy --strict polylogue/sources/live/batch.py tests/unit/sources/test_live_append_cursor_resynthesis.py` → `Success: no issues found in 2 source files`
- `ruff check` / `ruff format --check` on both files → all checks passed
- `devtools test tests/unit/sources/test_live_append_cursor_resynthesis.py` → 4 passed:
  - ops.db cursor present → resynthesis never consulted, unchanged behavior
  - ops.db cursor absent + durable byte-proven 'full' head → append now attempted (previously would have declined)
  - neither present → declines exactly as before (full capture)
  - an already-accepted append-kind head → declines (guards the branching hazard above)
- Affected-area sweep: `devtools test tests/unit/sources/test_live_watcher.py tests/unit/sources/test_live_catchup_planning.py tests/unit/sources/test_live_batch_support.py tests/unit/sources/test_live_cursor_locking.py tests/unit/sources/test_live_watcher_locking.py tests/integration/test_append_cohort_memory.py` → 3 failures reproduce byte-for-byte with `git stash` on unmodified `batch.py` (confirmed pre-existing parallel-xdist flake in `test_live_full_ingest_over_ambiguous_membership_fails_closed_with_diagnostic` and two `test_append_cohort_memory.py` memory-counter assertions), unrelated to this change
- `devtools verify --quick` → exit 0 (also ran automatically via the pre-push hook)

Ref polylogue-aex0