### PR TITLE
fix(storage): preserve FTS surface counts on single-session defer

### DIFF
--- a/polylogue/storage/fts/freshness.py
+++ b/polylogue/storage/fts/freshness.py
@@ -272,6 +272,65 @@ async def record_fts_surface_state_async(
     )
 
 
+def record_fts_surface_stale_preserving_counts_sync(
+    conn: sqlite3.Connection,
+    *,
+    surface: str,
+    detail: str,
+) -> None:
+    """Mark ``surface`` STALE without clobbering its last-known row counts.
+
+    Used when a single unit's (e.g. one session's) FTS repair is deferred
+    during a live write: the surface as a whole remains populated -- only
+    that one unit's index entries are pending recomputation -- so writing
+    the ``source_rows=0, indexed_rows=0`` defaults here (polylogue-5eyy) would
+    report a false archive-wide 0% coverage / missing state to every status
+    and readiness consumer (CLI ops status, daemon status API, MCP status
+    tool) even though the archive genuinely has millions of indexed rows.
+
+    Reuses whatever counts are already durably recorded for this surface
+    (falling back to the ordinary zeroed write only when no prior row
+    exists, e.g. a brand new archive) so downstream coverage/state reporting
+    reflects the last known good measurement until the next full invariant
+    snapshot or bounded repair recomputes exact counts. The surface still
+    correctly reports ``state=stale`` -- the pending single-unit repair is a
+    real, if narrow, staleness -- only the counters are preserved rather than
+    falsely zeroed.
+    """
+    ensure_fts_freshness_table_sync(conn)
+    row = conn.execute(
+        """
+        SELECT source_rows, indexed_rows, missing_rows, excess_rows,
+               duplicate_rows, identity_mismatch_rows
+        FROM fts_freshness_state WHERE surface = ?
+        """,
+        (surface,),
+    ).fetchone()
+    if row is None:
+        record_fts_surface_state_sync(conn, surface=surface, state=STALE, detail=detail)
+        return
+    (
+        prior_source_rows,
+        prior_indexed_rows,
+        prior_missing_rows,
+        prior_excess_rows,
+        prior_duplicate_rows,
+        prior_identity_mismatch_rows,
+    ) = row
+    record_fts_surface_state_sync(
+        conn,
+        surface=surface,
+        state=STALE,
+        source_rows=_int_or_zero(prior_source_rows),
+        indexed_rows=_int_or_zero(prior_indexed_rows),
+        missing_rows=_int_or_zero(prior_missing_rows),
+        excess_rows=_int_or_zero(prior_excess_rows),
+        duplicate_rows=_int_or_zero(prior_duplicate_rows),
+        identity_mismatch_rows=_int_or_zero(prior_identity_mismatch_rows),
+        detail=detail,
+    )
+
+
 def record_fts_invariant_snapshot_sync(conn: sqlite3.Connection, snapshot: Any) -> None:
     for surface in snapshot.surfaces:
         record_fts_surface_state_sync(
@@ -530,6 +589,7 @@ __all__ = [
     "message_fts_recorded_state_async",
     "message_fts_recorded_state_sync",
     "record_fts_invariant_snapshot_sync",
+    "record_fts_surface_stale_preserving_counts_sync",
     "record_fts_surface_state_async",
     "record_fts_surface_state_sync",
 ]

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -3296,12 +3296,11 @@ class ArchiveStore:
             if not bulk_build and not defer_fts:
                 repair_message_fts_index_sync(self._conn, [session_id], record_exact_snapshot=False)
             if defer_fts:
-                from polylogue.storage.fts.freshness import STALE, record_fts_surface_state_sync
+                from polylogue.storage.fts.freshness import record_fts_surface_stale_preserving_counts_sync
 
-                record_fts_surface_state_sync(
+                record_fts_surface_stale_preserving_counts_sync(
                     self._conn,
                     surface="messages_fts",
-                    state=STALE,
                     detail="live authoritative replay deferred targeted session FTS repair",
                 )
             assert_session_fts_exact_sync(
@@ -3663,12 +3662,11 @@ class ArchiveStore:
                     if not bulk_build and not defer_fts:
                         repair_message_fts_index_sync(self._conn, [session_id], record_exact_snapshot=False)
                     if defer_fts:
-                        from polylogue.storage.fts.freshness import STALE, record_fts_surface_state_sync
+                        from polylogue.storage.fts.freshness import record_fts_surface_stale_preserving_counts_sync
 
-                        record_fts_surface_state_sync(
+                        record_fts_surface_stale_preserving_counts_sync(
                             self._conn,
                             surface="messages_fts",
-                            state=STALE,
                             detail="live membership replay deferred targeted session FTS repair",
                         )
                     assert_session_fts_exact_sync(

--- a/tests/unit/daemon/test_fts_readiness_fallback.py
+++ b/tests/unit/daemon/test_fts_readiness_fallback.py
@@ -18,7 +18,10 @@ from polylogue.archive.message.roles import Role
 from polylogue.core.enums import BlockType, Provider
 from polylogue.daemon.fts_status import fts_readiness_info
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
-from polylogue.storage.fts.freshness import record_fts_surface_state_sync
+from polylogue.storage.fts.freshness import (
+    record_fts_surface_stale_preserving_counts_sync,
+    record_fts_surface_state_sync,
+)
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
@@ -151,3 +154,63 @@ def test_readiness_trusts_a_healthy_freshness_record_without_recompute(tmp_path:
     assert fts["messages_ready"] is True
     assert fts["coverage_pct"] == 100.0
     assert fts["coverage_exact"] is False
+
+
+def test_single_session_defer_does_not_falsely_zero_archive_wide_coverage(tmp_path: Path) -> None:
+    """polylogue-5eyy: a single deferred session repair must not report 0% archive-wide.
+
+    ``archive.py``'s raw-revision-authoritative write path marks ``messages_fts``
+    STALE (without touching the DB rows themselves) whenever a single session's
+    FTS repair is deferred during a live write. Before the fix,
+    ``record_fts_surface_state_sync`` was called with no ``source_rows``/
+    ``indexed_rows`` -- its defaults are 0 -- which unconditionally clobbered the
+    *entire* surface's durable counts to 0/0 even though the archive-wide FTS
+    index remains fully populated and only one session's repair was deferred.
+    Downstream this made every status/readiness consumer (CLI ops status,
+    daemon status API, MCP status tool) report coverage_pct=0.0 and
+    state=missing for the whole archive.
+    """
+    db = tmp_path / "index.db"
+    _populated_index(db)
+
+    conn = sqlite3.connect(db)
+    try:
+        indexed = int(conn.execute("SELECT COUNT(*) FROM messages_fts_docsize").fetchone()[0])
+        assert indexed > 0
+        # Real, healthy archive-wide coverage recorded (e.g. by a prior
+        # invariant snapshot / bounded repair).
+        record_fts_surface_state_sync(
+            conn,
+            surface="messages_fts",
+            state="ready",
+            source_rows=indexed,
+            indexed_rows=indexed,
+        )
+        conn.commit()
+
+        # Simulate a single session's FTS repair being deferred during a live
+        # authoritative write (archive.py's ``defer_fts`` branch) -- the real
+        # archive-wide FTS rows are untouched, only the freshness ledger is
+        # marked stale to force a later targeted recheck.
+        record_fts_surface_stale_preserving_counts_sync(
+            conn,
+            surface="messages_fts",
+            detail="live authoritative replay deferred targeted session FTS repair",
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    fts = fts_readiness_info(db, exact=False)
+
+    # The pending single-session repair legitimately means the surface isn't
+    # trusted as fully "ready", but the real, still-populated archive-wide
+    # counts must survive -- not be falsely reported as 0/missing.
+    surfaces = fts["surfaces"]
+    assert isinstance(surfaces, dict)
+    messages_fts_surface = surfaces["messages_fts"]
+    assert isinstance(messages_fts_surface, dict)
+    assert messages_fts_surface["freshness_recorded_state"] == "stale"
+    assert fts["message_indexed_count"] == indexed
+    assert fts["message_indexable_count"] == indexed
+    assert fts["coverage_pct"] == 100.0


### PR DESCRIPTION
## Summary

Fixes a real production bug where the daemon's `search`/FTS readiness status falsely reported 0% coverage / missing state archive-wide, even though the archive's FTS index is fully populated (confirmed live: 4,975,956 rows in `messages_fts` against a `fts_freshness_state` row reading `source_rows=0, indexed_rows=0`).

## Problem

`record_fts_surface_state_sync` (`polylogue/storage/fts/freshness.py`) does an unconditional UPSERT of `source_rows`/`indexed_rows`, defaulting to 0 when not passed. Two call sites in `polylogue/storage/sqlite/archive_tiers/archive.py` (the raw-revision-authoritative write path and the membership-replay write path) call it with no counts whenever a *single session's* FTS repair is deferred during a live write (`defer_fts` branch) — a routine, expected event. This clobbers the entire `messages_fts` surface's durable row counts to 0/0, even though only one session's repair is pending and the rest of the archive-wide FTS index remains fully populated. `polylogue/daemon/fts_status.py` reads this row directly into `coverage_pct`/`message_indexed_count`, so every status/readiness consumer (CLI `ops status`, daemon status API, MCP status tool) then falsely reports the whole archive's search as unindexed.

Found while investigating a live daemon status readout during archive-convergence work; verified directly against the production archive (`polylogue-5eyy`).

## Solution

Added `record_fts_surface_stale_preserving_counts_sync` in `freshness.py`: marks the surface `STALE` (the pending single-session repair is real, narrow staleness) while reading and re-writing the surface's *existing* row/coverage counts instead of zeroing them, falling back to the ordinary zeroed write only when no prior row exists (e.g. a brand-new archive). Both `archive.py` call sites now use this instead of `record_fts_surface_state_sync` directly.

## Verification

- `ruff check` / `ruff format --check` on touched files: clean
- `mypy --strict` on touched files: `Success: no issues found in 3 source files`
- `devtools test tests/unit/daemon/test_fts_readiness_fallback.py`: `4 passed`
- Anti-vacuity: temporarily reverted the fix (made the new function delegate straight to the old zeroing call), re-ran the new regression test — failed with `assert 0 == 1` on `message_indexed_count == indexed`, confirming the test catches the exact bug shape. Restored the fix, re-verified green.
- Broader check for regressions: `devtools test tests/unit/storage/test_fts_repair_sql.py tests/unit/storage/test_bulk_fts_prefix_reextract.py tests/unit/storage/test_dangling_fts_derived_surfaces.py tests/unit/daemon/test_fts_identity_convergence.py` — 34 passed, 1 pre-existing unrelated failure (`no such table: main.derived_refresh_guard`), confirmed pre-existing by reproducing it identically on a stash of this change (i.e. present without this diff too).
- `devtools verify --quick` (pre-push hook): exit 0.

Ref polylogue-5eyy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved existing full-text search coverage and row counts when individual repairs are deferred.
  - Prevented archive-wide search readiness from incorrectly showing zero coverage or counts.
  - Continued marking affected search surfaces as stale when targeted repairs are pending.
- **Tests**
  - Added coverage confirming deferred single-session repairs do not falsely reduce archive-wide search coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->