### PR TITLE
fix(daemon): make periodic status refresh resume slow embedding readiness

### DIFF
--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -8,6 +8,8 @@ import os
 import re
 import sqlite3
 import sys
+import threading
+from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -83,10 +85,39 @@ logger = get_logger(__name__)
 # ``live_ingest_attempt_progress``.
 _LIVE_INGEST_ATTEMPT_STALE_AFTER_S = STUCK_AFTER_S
 _LIVE_CURSOR_FAILURE_SAMPLE_LIMIT = 50
+# Deadline for the embedding_readiness component (polylogue-20d.17). A module
+# constant (rather than an inline literal) so tests can patch it down, the
+# same way coordination/envelope.py's _ARCHIVE_EVIDENCE_DEADLINE_S is patched
+# to exercise the timed-out/refreshing/fresh resumability sequence quickly.
+_EMBEDDING_READINESS_DEADLINE_S = 2.0
 
 
 def _active_status_db_path() -> Path:
     return resolve_active_index_db_path(db_anchor=db_path(), index_db=index_db_path())
+
+
+def _daemon_status_fingerprint(active_db: Path) -> str:
+    """Cheap proxy for "has the archive/ops source changed" (polylogue-20d.17 AC #5).
+
+    Mirrors ``polylogue.coordination.envelope._coordination_fingerprint``: a
+    persistent status-component registry (see
+    :func:`periodic_status_component_registry`) must not be able to hide a
+    changed index tier or ops tier behind an unexpired ``ttl_s`` window.
+    Stat-only (no query execution), so checking it stays cheap even when the
+    cached value itself is reused.
+    """
+    parts: list[str] = []
+    for candidate in (
+        active_db,
+        active_db.with_suffix(".db-wal"),
+        active_db.with_name("ops.db"),
+        active_db.with_name("ops.db-wal"),
+    ):
+        try:
+            parts.append(f"{candidate.name}:{candidate.stat().st_mtime_ns}")
+        except OSError:
+            parts.append(f"{candidate.name}:?")
+    return "|".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -2112,6 +2143,206 @@ def _raw_replay_backlog_info(*, include: bool = True) -> dict[str, object]:
         }
 
 
+def _daemon_status_component_specs(
+    *,
+    checked_health: Callable[[], DaemonHealth],
+    include_raw_replay_backlog: bool,
+    include_exact_raw_materialization_readiness: bool,
+    fingerprint: Callable[[], str] | None = None,
+) -> list[StatusComponentSpec]:
+    """Component declarations shared by the ephemeral per-call path and the
+    persistent periodic-refresh registry (polylogue-20d.17).
+
+    Collectors that need the active index db re-resolve it via
+    ``_active_status_db_path()`` on every invocation rather than capturing a
+    path once, so a long-lived persistent registry observes an archive-root
+    change the same way a fresh ephemeral registry would.
+    """
+    return [
+        StatusComponentSpec(
+            name="db_size", scope="archive", collector=_db_size_info, deadline_s=0.5, fingerprint=fingerprint
+        ),
+        StatusComponentSpec(
+            name="blob_size", scope="archive", collector=_blob_size_info, deadline_s=0.5, fingerprint=fingerprint
+        ),
+        StatusComponentSpec(
+            name="archive_storage",
+            scope="archive",
+            collector=_archive_storage_info,
+            deadline_s=1.5,
+            cost_class="moderate",
+            fingerprint=fingerprint,
+        ),
+        StatusComponentSpec(
+            name="fts_readiness",
+            scope="lexical",
+            collector=_fts_readiness_info,
+            deadline_s=1.5,
+            cost_class="moderate",
+            fingerprint=fingerprint,
+        ),
+        StatusComponentSpec(
+            name="insight_freshness",
+            scope="archive",
+            collector=_insight_freshness_info,
+            deadline_s=1.5,
+            cost_class="moderate",
+            fingerprint=fingerprint,
+        ),
+        StatusComponentSpec(
+            name="raw_materialization",
+            scope="archive",
+            collector=lambda: _raw_materialization_readiness_info(
+                classify_gaps=include_exact_raw_materialization_readiness
+            ),
+            deadline_s=3.0 if include_exact_raw_materialization_readiness else 1.5,
+            cost_class="expensive" if include_exact_raw_materialization_readiness else "moderate",
+            fingerprint=fingerprint,
+        ),
+        StatusComponentSpec(
+            name="raw_replay_backlog",
+            scope="archive",
+            collector=lambda: _raw_replay_backlog_info(include=include_raw_replay_backlog),
+            deadline_s=3.0 if include_raw_replay_backlog else 0.3,
+            cost_class="expensive" if include_raw_replay_backlog else "cheap",
+            fingerprint=fingerprint,
+        ),
+        StatusComponentSpec(
+            name="live_cursor",
+            scope="daemon",
+            collector=_live_cursor_summary_info,
+            deadline_s=0.5,
+            fingerprint=fingerprint,
+        ),
+        StatusComponentSpec(
+            name="live_ingest_attempts",
+            scope="daemon",
+            collector=_live_ingest_attempt_summary_info,
+            deadline_s=0.5,
+            fingerprint=fingerprint,
+        ),
+        StatusComponentSpec(
+            name="convergence",
+            scope="daemon",
+            collector=lambda: convergence_debt_summary_info(_active_status_db_path()),
+            deadline_s=0.5,
+            fingerprint=fingerprint,
+        ),
+        StatusComponentSpec(
+            name="cursor_lag",
+            scope="daemon",
+            collector=lambda: cursor_lag_summary_info(_active_status_db_path()),
+            deadline_s=0.5,
+            fingerprint=fingerprint,
+        ),
+        StatusComponentSpec(
+            name="raw_failures",
+            scope="archive",
+            collector=_raw_failure_info,
+            deadline_s=1.0,
+            cost_class="moderate",
+            fingerprint=fingerprint,
+        ),
+        StatusComponentSpec(
+            name="blob_publication_reservations",
+            scope="archive",
+            collector=_blob_publication_reservation_info,
+            deadline_s=1.0,
+            cost_class="moderate",
+            fingerprint=fingerprint,
+        ),
+        StatusComponentSpec(
+            name="embedding_readiness",
+            scope="semantic",
+            collector=lambda: embedding_readiness_info(_active_status_db_path()),
+            deadline_s=_EMBEDDING_READINESS_DEADLINE_S,
+            cost_class="moderate",
+            fingerprint=fingerprint,
+        ),
+        StatusComponentSpec(
+            name="health",
+            scope="daemon",
+            collector=checked_health,
+            deadline_s=1.5,
+            cost_class="moderate",
+            fingerprint=fingerprint,
+        ),
+    ]
+
+
+_PERIODIC_STATUS_REGISTRY_LOCK = threading.Lock()
+_PERIODIC_STATUS_REGISTRY: StatusComponentRegistry | None = None
+
+
+def periodic_status_component_registry() -> StatusComponentRegistry:
+    """Return the process-wide persistent registry backing the periodic status refresh.
+
+    ``_periodic_status_snapshot_refresh`` (``daemon/cli.py``) calls
+    ``refresh_status_snapshot`` every 10s for the life of the daemon process.
+    Before this, each tick built a fresh ephemeral ``StatusComponentRegistry``
+    (see ``build_daemon_status``), so a component whose collector runs longer
+    than its ``deadline_s`` was restarted from scratch on every tick and could
+    never converge — live measurement found ``embedding_readiness_info``
+    alone taking ~5s against the real archive against a declared 2.0s
+    deadline (polylogue-20d.17), so it timed out and was discarded every 10s,
+    forever, while also leaking one orphaned daemon thread per tick (the
+    unfinished attempt cannot be cancelled and keeps running past the
+    deadline on its own thread). This mirrors the resumability gap PR #3131
+    fixed for coordination's ``archive_evidence`` stage: a persistent
+    registry lets a later tick observe ``refreshing`` instead of duplicating
+    the collector, and once an attempt finishes, every subsequent tick reuses
+    the real result until its own ``ttl_s``/fingerprint expires.
+
+    Built once per process (lazily, on first call) with the same collection
+    parameters ``refresh_status_snapshot`` always passes
+    (``include_raw_replay_backlog=False``,
+    ``include_exact_raw_materialization_readiness=False``, fast-tier health
+    only) -- direct one-shot CLI/API status calls are unaffected, since they
+    never pass a ``registry`` into ``build_daemon_status``/
+    ``daemon_status_payload`` and keep their existing fresh-per-call
+    ephemeral-registry contract.
+    """
+    global _PERIODIC_STATUS_REGISTRY
+    with _PERIODIC_STATUS_REGISTRY_LOCK:
+        if _PERIODIC_STATUS_REGISTRY is None:
+            from polylogue.daemon.health import HealthTier
+
+            def _checked_health() -> DaemonHealth:
+                try:
+                    return check_health(tiers={HealthTier.FAST})
+                except Exception as exc:
+                    logger.warning("status: check_health() failed: %s", exc, exc_info=True)
+                    return DaemonHealth(
+                        overall_status=HealthSeverity.ERROR,
+                        checked_at=datetime.now(UTC).isoformat(),
+                        alerts=[
+                            HealthAlert(
+                                check_name="check_health",
+                                tier=HealthTier.FAST,
+                                severity=HealthSeverity.ERROR,
+                                message=f"health check itself failed: {exc}",
+                                checked_at=datetime.now(UTC).isoformat(),
+                            )
+                        ],
+                    )
+
+            specs = _daemon_status_component_specs(
+                checked_health=_checked_health,
+                include_raw_replay_backlog=False,
+                include_exact_raw_materialization_readiness=False,
+                fingerprint=lambda: _daemon_status_fingerprint(_active_status_db_path()),
+            )
+            _PERIODIC_STATUS_REGISTRY = StatusComponentRegistry(specs)
+        return _PERIODIC_STATUS_REGISTRY
+
+
+def reset_periodic_status_component_registry() -> None:
+    """Drop the persistent periodic-refresh registry singleton. Test-only."""
+    global _PERIODIC_STATUS_REGISTRY
+    with _PERIODIC_STATUS_REGISTRY_LOCK:
+        _PERIODIC_STATUS_REGISTRY = None
+
+
 def build_daemon_status(
     *,
     sources: tuple[WatchSource, ...] | None = None,
@@ -2120,8 +2351,27 @@ def build_daemon_status(
     include_expensive_health: bool = False,
     include_raw_replay_backlog: bool = True,
     include_exact_raw_materialization_readiness: bool = True,
+    registry: StatusComponentRegistry | None = None,
 ) -> DaemonStatus:
-    """Build a typed DaemonStatus from durable component state."""
+    """Build a typed DaemonStatus from durable component state.
+
+    ``registry``, when given, is a *persistent* :class:`StatusComponentRegistry`
+    (see :func:`periodic_status_component_registry`) reused across many calls
+    instead of the fresh, ephemeral one built per call below. Live measurement
+    found ``embedding_readiness_info`` alone taking ~5s against the real
+    archive while its declared ``deadline_s`` is 2.0 (polylogue-20d.17): the
+    10s-cadence periodic status-snapshot refresh (``refresh_status_snapshot``)
+    used to build a brand-new ephemeral registry on every tick, so that
+    component timed out and was discarded on every single tick, forever,
+    exactly the resumability gap PR #3131 fixed for coordination's
+    ``archive_evidence`` stage. Passing a persistent registry lets a
+    still-running attempt be observed as ``refreshing`` by a later tick
+    instead of restarted, and the eventual real result is reused (subject to
+    ``ttl_s``/fingerprint invalidation) once it finishes. One-shot callers
+    (direct CLI/API status, all pre-existing parameterized tests) keep the
+    default ``None`` -- a fresh per-call registry, correct for their pure
+    -recompute contract.
+    """
     watch_sources = sources if sources is not None else default_sources()
     effective_browser_capture_spool_path = (
         browser_capture_spool_path
@@ -2176,80 +2426,14 @@ def build_daemon_status(
     # stalled one reports an explicit timed_out/degraded state (with
     # whatever it last collected successfully, if anything) instead of
     # blocking the healthy facts sitting behind it in a call chain.
-    specs = [
-        StatusComponentSpec(name="db_size", scope="archive", collector=_db_size_info, deadline_s=0.5),
-        StatusComponentSpec(name="blob_size", scope="archive", collector=_blob_size_info, deadline_s=0.5),
-        StatusComponentSpec(
-            name="archive_storage",
-            scope="archive",
-            collector=_archive_storage_info,
-            deadline_s=1.5,
-            cost_class="moderate",
-        ),
-        StatusComponentSpec(
-            name="fts_readiness", scope="lexical", collector=_fts_readiness_info, deadline_s=1.5, cost_class="moderate"
-        ),
-        StatusComponentSpec(
-            name="insight_freshness",
-            scope="archive",
-            collector=_insight_freshness_info,
-            deadline_s=1.5,
-            cost_class="moderate",
-        ),
-        StatusComponentSpec(
-            name="raw_materialization",
-            scope="archive",
-            collector=lambda: _raw_materialization_readiness_info(
-                classify_gaps=include_exact_raw_materialization_readiness
-            ),
-            deadline_s=3.0 if include_exact_raw_materialization_readiness else 1.5,
-            cost_class="expensive" if include_exact_raw_materialization_readiness else "moderate",
-        ),
-        StatusComponentSpec(
-            name="raw_replay_backlog",
-            scope="archive",
-            collector=lambda: _raw_replay_backlog_info(include=include_raw_replay_backlog),
-            deadline_s=3.0 if include_raw_replay_backlog else 0.3,
-            cost_class="expensive" if include_raw_replay_backlog else "cheap",
-        ),
-        StatusComponentSpec(name="live_cursor", scope="daemon", collector=_live_cursor_summary_info, deadline_s=0.5),
-        StatusComponentSpec(
-            name="live_ingest_attempts",
-            scope="daemon",
-            collector=_live_ingest_attempt_summary_info,
-            deadline_s=0.5,
-        ),
-        StatusComponentSpec(
-            name="convergence",
-            scope="daemon",
-            collector=lambda: convergence_debt_summary_info(active_db),
-            deadline_s=0.5,
-        ),
-        StatusComponentSpec(
-            name="cursor_lag", scope="daemon", collector=lambda: cursor_lag_summary_info(active_db), deadline_s=0.5
-        ),
-        StatusComponentSpec(
-            name="raw_failures", scope="archive", collector=_raw_failure_info, deadline_s=1.0, cost_class="moderate"
-        ),
-        StatusComponentSpec(
-            name="blob_publication_reservations",
-            scope="archive",
-            collector=_blob_publication_reservation_info,
-            deadline_s=1.0,
-            cost_class="moderate",
-        ),
-        StatusComponentSpec(
-            name="embedding_readiness",
-            scope="semantic",
-            collector=lambda: embedding_readiness_info(active_db),
-            deadline_s=2.0,
-            cost_class="moderate",
-        ),
-        StatusComponentSpec(
-            name="health", scope="daemon", collector=_checked_health, deadline_s=1.5, cost_class="moderate"
-        ),
-    ]
-    snapshots = StatusComponentRegistry(specs).collect()
+    specs = _daemon_status_component_specs(
+        checked_health=_checked_health,
+        include_raw_replay_backlog=include_raw_replay_backlog,
+        include_exact_raw_materialization_readiness=include_exact_raw_materialization_readiness,
+    )
+    snapshots = (registry if registry is not None else StatusComponentRegistry(specs)).collect(
+        names=[spec.name for spec in specs]
+    )
 
     def _v(name: str, default: Any) -> Any:
         value = snapshots[name].value
@@ -2427,8 +2611,14 @@ def daemon_status_payload(
     include_raw_replay_backlog: bool = True,
     include_exact_raw_materialization_readiness: bool = True,
     include_archive_debt: bool = True,
+    registry: StatusComponentRegistry | None = None,
 ) -> JSONDocument:
-    """Return the local daemon component status payload (backward-compat dict)."""
+    """Return the local daemon component status payload (backward-compat dict).
+
+    ``registry``, when given, is threaded through to :func:`build_daemon_status`
+    (see its docstring for what this buys: resumable collection across many
+    calls instead of a fresh, ephemeral registry per call).
+    """
     watch_sources = sources if sources is not None else default_sources()
 
     last_ingestion = None
@@ -2453,6 +2643,7 @@ def daemon_status_payload(
         browser_capture_spool_path=browser_capture_spool_path,
         include_raw_replay_backlog=include_raw_replay_backlog,
         include_exact_raw_materialization_readiness=include_exact_raw_materialization_readiness,
+        registry=registry,
     )
     if include_archive_debt:
         # polylogue-20d.17: this scan is a full archive-debt listing, not a

--- a/polylogue/daemon/status_snapshot.py
+++ b/polylogue/daemon/status_snapshot.py
@@ -430,16 +430,29 @@ def refresh_status_snapshot(*, payload: JSONDocument | None = None, rich: bool =
         try:
             if payload is None:
                 if rich:
-                    from polylogue.daemon.status import daemon_status_payload
+                    from polylogue.daemon.status import daemon_status_payload, periodic_status_component_registry
 
                     # Raw replay selection expands authority cohorts and is a
                     # diagnostic operation, not a bounded health projection.
                     # Running it in the periodic snapshot can strand a
                     # default-executor worker through process shutdown.
+                    #
+                    # ``registry`` is the process-wide persistent
+                    # StatusComponentRegistry (polylogue-20d.17): without it,
+                    # this call built a fresh ephemeral registry every 10s
+                    # tick, so a component slower than its own deadline (e.g.
+                    # embedding_readiness_info, measured ~5s against the real
+                    # archive vs its 2.0s deadline) timed out and was
+                    # discarded on every tick, forever, and leaked one
+                    # orphaned collector thread per tick. The persistent
+                    # registry lets a still-running attempt be observed
+                    # (``refreshing``) instead of restarted, and reuses the
+                    # real result once it finishes.
                     payload = daemon_status_payload(
                         include_raw_replay_backlog=False,
                         include_exact_raw_materialization_readiness=False,
                         include_archive_debt=False,
+                        registry=periodic_status_component_registry(),
                     )
                 else:
                     payload = _minimal_status_payload()
@@ -468,9 +481,12 @@ def reset_status_snapshot() -> None:
     cached payload does not leak into unrelated status-surface tests in the same
     process. Exposed for test teardown; not used in production.
     """
+    from polylogue.daemon.status import reset_periodic_status_component_registry
+
     global _SNAPSHOT, _RUNTIME_COMPONENT_STATE
     with _SNAPSHOT_LOCK:
         _SNAPSHOT = None
+    reset_periodic_status_component_registry()
     with _RUNTIME_COMPONENT_LOCK:
         _RUNTIME_COMPONENT_STATE = RuntimeComponentState()
 

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -27,6 +27,7 @@ from polylogue.daemon.status_snapshot import (
     get_status_snapshot_payload,
     refresh_status_snapshot,
 )
+from polylogue.operations.status_protocol import StatusComponentRegistry
 from polylogue.sources.live.cursor import CursorStore
 from polylogue.storage.blob_publication import ArchiveBlobPublisher
 from polylogue.storage.sqlite.archive_tiers.bootstrap import (
@@ -346,11 +347,15 @@ def test_status_snapshot_refresh_default_builds_rich_payload(monkeypatch: pytest
 
     snapshot = refresh_status_snapshot()
 
-    build.assert_called_once_with(
-        include_raw_replay_backlog=False,
-        include_exact_raw_materialization_readiness=False,
-        include_archive_debt=False,
-    )
+    assert build.call_count == 1
+    call_kwargs = build.call_args.kwargs
+    assert call_kwargs["include_raw_replay_backlog"] is False
+    assert call_kwargs["include_exact_raw_materialization_readiness"] is False
+    assert call_kwargs["include_archive_debt"] is False
+    # polylogue-20d.17: the periodic refresh threads a persistent registry
+    # through so a slower-than-deadline component (e.g. embedding_readiness)
+    # resumes across ticks instead of being restarted from scratch forever.
+    assert isinstance(call_kwargs["registry"], StatusComponentRegistry)
     assert snapshot.payload["checked_at"] == "rich"
     assert snapshot.payload["raw_materialization_readiness"] == {"total": 2}
 
@@ -2320,6 +2325,141 @@ def test_daemon_status_payload_stalled_component_does_not_block_healthy_componen
 
     archive_storage_collection = cast(dict[str, Any], cast(dict[str, Any], readiness["archive_storage"])["collection"])
     assert archive_storage_collection["state"] == "fresh"
+
+
+def test_periodic_status_component_registry_resumes_slow_embedding_readiness_across_ticks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Anti-vacuity for polylogue-20d.17 (resumable detail-query semantics).
+
+    Live measurement against the real archive found ``embedding_readiness_info``
+    taking ~5s while its declared deadline is 2.0s. Before this fix,
+    ``refresh_status_snapshot``'s periodic (10s-cadence) call built a fresh,
+    ephemeral ``StatusComponentRegistry`` on every tick (``build_daemon_status``'s
+    own per-call registry), so a component slower than its deadline timed out
+    and was discarded on *every* tick, forever -- it could never converge on a
+    real value, mirroring the pre-#3131 coordination ``archive_evidence`` bug.
+    This fails on that pre-fix behavior: the collector would be invoked again
+    on tick 2 (a duplicated attempt) instead of the second tick observing
+    ``refreshing`` against the still-running first attempt.
+    """
+    import threading
+    from time import sleep
+
+    from polylogue.daemon import status as status_module
+    from polylogue.daemon.status import (
+        periodic_status_component_registry,
+        reset_periodic_status_component_registry,
+    )
+
+    reset_periodic_status_component_registry()
+    monkeypatch.setattr(status_module, "_EMBEDDING_READINESS_DEADLINE_S", 0.05)
+    db = tmp_path / "index.db"
+    monkeypatch.setattr("polylogue.daemon.status.db_path", lambda: db)
+    monkeypatch.setattr("polylogue.daemon.status.index_db_path", lambda: db)
+
+    calls = {"n": 0}
+    release = threading.Event()
+
+    def slow_embedding_readiness_info(_db: Path) -> dict[str, object]:
+        calls["n"] += 1
+        release.wait(timeout=5.0)
+        return {"embedding_status": "ready"}
+
+    monkeypatch.setattr(status_module, "embedding_readiness_info", slow_embedding_readiness_info)
+
+    try:
+        # Tick 1: the collector starts, blocks past the (patched, 0.05s) deadline.
+        registry = periodic_status_component_registry()
+        first = registry.collect(names=["embedding_readiness"])["embedding_readiness"]
+        assert first.state == "timed_out"
+        assert calls["n"] == 1
+
+        # Tick 2, as a later periodic refresh would trigger: the SAME process
+        # -wide registry must observe the still-running attempt instead of
+        # launching a second one.
+        second_registry = periodic_status_component_registry()
+        assert second_registry is registry
+        second = second_registry.collect(names=["embedding_readiness"])["embedding_readiness"]
+        assert second.state == "refreshing"
+        assert calls["n"] == 1  # still just the one attempt -- not duplicated
+
+        release.set()
+        for _ in range(200):
+            if registry.last_good("embedding_readiness") is not None:
+                break
+            sleep(0.01)
+
+        third = registry.collect(names=["embedding_readiness"])["embedding_readiness"]
+        assert third.state == "fresh"
+        assert calls["n"] == 1  # the one attempt that was allowed to finish
+        assert third.value == {"embedding_status": "ready"}
+    finally:
+        release.set()
+        reset_periodic_status_component_registry()
+
+
+def test_periodic_status_component_registry_fingerprint_forces_refresh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """polylogue-20d.17 AC #5: a changed archive source is not hidden by an
+    unexpired TTL.
+
+    Without a fingerprint, a component's ``ttl_s`` window (10s default) would
+    serve a stale value even after the underlying index db file changed.
+    """
+    from polylogue.daemon.status import (
+        periodic_status_component_registry,
+        reset_periodic_status_component_registry,
+    )
+
+    reset_periodic_status_component_registry()
+    db = tmp_path / "index.db"
+    db.write_bytes(b"v1")
+    monkeypatch.setattr("polylogue.daemon.status.db_path", lambda: db)
+    monkeypatch.setattr("polylogue.daemon.status.index_db_path", lambda: db)
+
+    calls = {"n": 0}
+
+    def fake_db_size_info() -> dict[str, object]:
+        calls["n"] += 1
+        return {"call": calls["n"]}
+
+    monkeypatch.setattr("polylogue.daemon.status._db_size_info", fake_db_size_info)
+
+    try:
+        registry = periodic_status_component_registry()
+        first = registry.collect(names=["db_size"])["db_size"]
+        assert first.value == {"call": 1}
+        assert first.state == "fresh"
+
+        # Immediately re-collecting inside the TTL window with no source
+        # change reuses the cached value -- the fingerprint is stable.
+        cached = registry.collect(names=["db_size"])["db_size"]
+        assert cached.value == {"call": 1}
+        assert cached.state == "fresh"
+        assert calls["n"] == 1
+
+        # A changed index db (mtime bump) must force a refresh even though
+        # ttl_s (10s) has not elapsed.
+        import os
+        import time
+
+        time.sleep(0.01)
+        os.utime(db, None)
+        db.write_bytes(b"v2")
+
+        refreshed = registry.collect(names=["db_size"])["db_size"]
+        for _ in range(200):
+            if refreshed.state == "fresh" and refreshed.value == {"call": 2}:
+                break
+            time.sleep(0.01)
+            refreshed = registry.collect(names=["db_size"])["db_size"]
+        assert refreshed.value == {"call": 2}, (
+            "fingerprint change must force a fresh recollection, not reuse the TTL cache"
+        )
+    finally:
+        reset_periodic_status_component_registry()
 
 
 def test_blob_publication_reservation_info_reports_unresolved_bucket(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Extends polylogue-20d.17's budgeted-component-snapshot protocol (PR #3107/#3116/#3131) with the resumable-detail-query pattern for the daemon's own periodic status refresh, following live measurement that found a real, unfixed instance of the exact resumability gap PR #3131 fixed for coordination's `archive_evidence` stage.

## Problem
Live measurement against the real archive at `/realm/db/polylogue` found `embedding_readiness_info` taking ~5.06s while its declared `deadline_s` in `build_daemon_status`'s component list is 2.0s. The daemon's periodic status-snapshot refresh (`_periodic_status_snapshot_refresh`, every 10s for the process lifetime — `daemon/cli.py`) calls `daemon_status_payload` -> `build_daemon_status`, which built a brand-new **ephemeral** `StatusComponentRegistry` on every tick. A component slower than its own deadline therefore timed out and was discarded on *every single tick, forever* — it could never converge on a real value — and each tick leaked one orphaned collector thread (a timed-out attempt cannot be cancelled and keeps running past the deadline on its own background thread). This is the same resumability gap PR #3131 fixed for coordination's `archive_evidence` stage, now found and fixed on the daemon status side.

None of `build_daemon_status`'s ~14 components had a `fingerprint` either, so even a persistent registry would have hidden a changed archive/ops source behind the 10s `ttl_s` window (polylogue-20d.17 AC #5).

## Solution
- Extracted `build_daemon_status`'s inline `StatusComponentSpec` list into `_daemon_status_component_specs()`, shared by the existing ephemeral per-call path and a new persistent factory.
- `periodic_status_component_registry()` lazily builds ONE process-wide `StatusComponentRegistry` (module singleton) with the same fixed parameters `refresh_status_snapshot` always passes (`include_raw_replay_backlog=False`, `include_exact_raw_materialization_readiness=False`, fast-tier health only), plus a real source fingerprint (`_daemon_status_fingerprint`: index db + ops db + their `-wal` mtimes) so a changed archive/ops source forces a refresh even inside the ttl window.
- `build_daemon_status`/`daemon_status_payload` gained an optional `registry` parameter, threaded through by `refresh_status_snapshot`'s periodic call. Direct one-shot CLI/API status calls keep the default `None` — unchanged fresh-per-call ephemeral registry, correct for their pure-recompute contract (all pre-existing parameterized tests pass unmodified).

**Investigated and found NOT to need this treatment** (false alarm, same methodology as `polylogue-dhjz`): coordination/envelope.py's `beads` and `handoff` stages, and daemon/status.py's `archive_debt`/`assertion_candidate_queue` ephemeral registries.
- Beads probes are already bounded via real subprocess-timeout cancellation (unlike the unbounded blocking-SQL problem `archive_evidence` had, which is *why* it needed a background-thread registry in the first place).
- `handoff` is a cheap filesystem glob + LIMIT-bounded SQLite query.
- `archive_debt`/`assertion_candidate_queue` are only ever reached from one-shot `polylogue check`/`polylogued status` CLI invocations (verified by grepping every call site) — no cross-call state exists for a persistent registry to preserve.

Full detail recorded on the polylogue-20d.17 bead notes.

## Verification
- New anti-vacuity test `test_periodic_status_component_registry_resumes_slow_embedding_readiness_across_ticks`: proves the collector is invoked exactly once across three ticks (`timed_out` -> `refreshing` -> `fresh`) despite exceeding its deadline. Confirmed it fails on the pre-fix ephemeral-registry behavior (reverted the registry-reuse check, reran, saw a duplicated attempt) and fails when `refresh_status_snapshot` stops threading the registry through (reverted that wiring, reran, saw the same failure).
- New test `test_periodic_status_component_registry_fingerprint_forces_refresh` proves a changed index db forces a fresh recollection inside the `ttl_s` window.
- **Live dogfood** (read-only) against the real archive at `/realm/db/polylogue`: `embedding_readiness_info` measured ~5.06s standalone; against the fixed registry, tick 0 times out at the 2.0s deadline, ticks 1-2 (0.2s apart) observe `refreshing` without re-invoking the collector, and once the background attempt finishes (~8s total), a later poll returns `fresh` with the real `embedding_coverage_percent=44.1`. Artifact: `.local/coordination/20d17-embedding-resumability-dogfood.json` (untracked, `.local/` per repo convention).
- `devtools test tests/unit/daemon/test_daemon_status.py` — 63 passed.
- `mypy --strict polylogue/daemon/status.py polylogue/daemon/status_snapshot.py tests/unit/daemon/test_daemon_status.py` — clean.
- `devtools verify --quick` — exit 0 (ran twice: once pre-push, once via the pre-push hook).
- Confirmed `tests/unit/cli/test_status.py::test_archive_facade_route_catalog_covers_public_async_facade` fails identically on baseline `master` (unrelated, pre-existing — not introduced by this change).

Ref polylogue-20d.17