### PR TITLE
fix(extension): cap browser-extension test worker concurrency

### DIFF
--- a/browser-extension/tests/vitest_config.test.js
+++ b/browser-extension/tests/vitest_config.test.js
@@ -1,0 +1,69 @@
+// Regression guard for polylogue-0v5b: caps `npm test` worker concurrency so
+// a full-suite run stays well under an 8G sinnix-background agent scope.
+// 2026-07-13 evidence: an uncapped run let Vitest's default `forks` pool
+// (one child_process per test file, NOT worker_threads) scale toward the
+// host's CPU count; systemd-oomd killed the whole scope mid-iteration.
+//
+// This deliberately does NOT dynamically `import()` vitest.config.js: that
+// module transitively pulls in `vitest/config` -> vite -> esbuild, and
+// esbuild's startup invariant check breaks when run a second time inside
+// this suite's jsdom environment (`TextEncoder().encode("") instanceof
+// Uint8Array` comes back false under jsdom's polyfilled globals). Parsing
+// the source text is also more honest here: it pins the literal config
+// shape a future edit could regress, without needing a real Vitest runtime
+// to evaluate it.
+//
+// This test does not re-run the suite or measure RSS (see the PR/bead for
+// the measured before/after numbers) — it only pins the *shape* of the
+// config so a future edit can't silently drop the cap or raise it back to
+// an unbounded value without a deliberate, reviewed change.
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = join(__dirname, "..", "vitest.config.js");
+const CONFIG_SOURCE = readFileSync(CONFIG_PATH, "utf8");
+
+// A generous ceiling, not the house default (4) — this only guards against
+// the cap being removed or raised to something effectively unbounded
+// (e.g. left to default to host CPU count, which was the original bug).
+const MAX_ALLOWED_WORKERS = 8;
+
+function extractDefaultMaxWorkers(source) {
+  const match = source.match(/const\s+DEFAULT_MAX_WORKERS\s*=\s*(\d+)\s*;/);
+  if (!match) return null;
+  return Number.parseInt(match[1], 10);
+}
+
+describe("vitest.config.js worker concurrency cap", () => {
+  it("declares a numeric, bounded default worker cap", () => {
+    const defaultMaxWorkers = extractDefaultMaxWorkers(CONFIG_SOURCE);
+    expect(defaultMaxWorkers, "DEFAULT_MAX_WORKERS constant must exist").not.toBeNull();
+    expect(defaultMaxWorkers).toBeGreaterThanOrEqual(1);
+    expect(defaultMaxWorkers).toBeLessThanOrEqual(MAX_ALLOWED_WORKERS);
+  });
+
+  it("wires the cap into the active (forks) pool", () => {
+    expect(CONFIG_SOURCE).toMatch(/poolOptions\s*:\s*{[\s\S]*forks\s*:\s*{[\s\S]*maxForks\s*:\s*maxWorkers/);
+  });
+
+  it("wires the cap into the pool-agnostic maxWorkers fallback", () => {
+    expect(CONFIG_SOURCE).toMatch(/test\s*:\s*{[\s\S]*maxWorkers\s*,/);
+  });
+
+  it("keeps the threads pool capped too, in case the default pool changes again", () => {
+    expect(CONFIG_SOURCE).toMatch(/poolOptions\s*:\s*{[\s\S]*threads\s*:\s*{[\s\S]*maxThreads\s*:\s*maxWorkers/);
+  });
+
+  it("supports a bounded env override without unbounding the default", () => {
+    // The override must be validated (falls back to a safe default on
+    // garbage input) rather than passed through raw.
+    expect(CONFIG_SOURCE).toMatch(/POLYLOGUE_EXTENSION_TEST_WORKERS/);
+    expect(CONFIG_SOURCE).toMatch(/Number\.isFinite\(parsed\)/);
+    expect(CONFIG_SOURCE).toMatch(/parsed\s*<\s*1/);
+  });
+});

--- a/browser-extension/vitest.config.js
+++ b/browser-extension/vitest.config.js
@@ -1,9 +1,60 @@
 import { defineConfig } from "vitest/config";
 
+// Worker concurrency cap (polylogue-0v5b): 2026-07-13 evidence showed an
+// uncapped `npm test` spawning a swarm of `forks`-pool child processes
+// (Vitest's default pool since 2.0 is `forks`, i.e. one `child_process`-forked
+// node per test file, NOT worker_threads) inside an 8G sinnix-background
+// agent scope; systemd-oomd killed the whole scope mid-iteration. Each fork
+// carries its own jsdom global + module graph, so per-fork overhead compounds
+// with test-file count and host CPU count (24 on the dev workstation, which
+// is what the default fork count scales toward).
+//
+// DEFAULT_MAX_WORKERS mirrors the Python-side house convention
+// (`devtools/verify.py: DEFAULT_TESTMON_WORKERS = "4"`) rather than
+// hard-coding a single-worker policy — 4 keeps peak RSS well under an 8G
+// scope while still running multiple test files concurrently. Override with
+// POLYLOGUE_EXTENSION_TEST_WORKERS for a one-off wider/narrower run (e.g. CI
+// runners with fewer CPUs, or a deliberately generous local run) without
+// editing this file. Do not remove or raise this cap without new measured
+// evidence — see tests/vitest_config.test.js.
+const DEFAULT_MAX_WORKERS = 4;
+
+function resolveMaxWorkers() {
+  const raw = process.env.POLYLOGUE_EXTENSION_TEST_WORKERS;
+  if (!raw) return DEFAULT_MAX_WORKERS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_MAX_WORKERS;
+  return parsed;
+}
+
+const maxWorkers = resolveMaxWorkers();
+
 export default defineConfig({
   test: {
     environment: "jsdom",
     globals: false,
     include: ["tests/**/*.test.js"],
+    // Applies uniformly to `vitest run` (local/CI) and `vitest` watch mode
+    // (dev loop) — there is no separate CI test command to keep in sync.
+    // Watch mode still runs affected files across up to `maxWorkers`
+    // workers, and a single focused test file only ever needs one worker
+    // regardless of this cap, so interactive parallelism is unaffected.
+    //
+    // `maxWorkers`/`minWorkers` is the pool-agnostic fallback Vitest resolves
+    // for whichever pool is active; `poolOptions.forks.*` additionally pins
+    // the cap for the current default `forks` pool explicitly, so the cap
+    // survives even if the default pool changes again upstream.
+    maxWorkers,
+    minWorkers: 1,
+    poolOptions: {
+      forks: {
+        maxForks: maxWorkers,
+        minForks: 1,
+      },
+      threads: {
+        maxThreads: maxWorkers,
+        minThreads: 1,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
Caps `npm test`'s worker concurrency in `browser-extension/vitest.config.js` so a full-suite run fits comfortably inside an 8G sinnix-background agent scope, applying uniformly across local, agent-scope, and CI (`vitest run` and watch mode share one config; there is no separate CI test command).

## Problem
2026-07-13 live evidence (polylogue-0v5b): the extension-redesign lane's `npm test` spawned enough vitest `forks`-pool child processes (Vitest's default pool since 2.0 — one `child_process` fork per test file, not `worker_threads`) inside an 8G sinnix-background scope that systemd-oomd killed the whole scope mid-iteration. Vitest's default fork count scales toward host CPU count (24 on the dev workstation), and each fork carries its own jsdom global + module graph, so per-fork overhead compounds with test-file count.

## Solution
- `browser-extension/vitest.config.js`: derive a `maxWorkers` cap (default `4`, mirroring the Python-side house convention `devtools/verify.py: DEFAULT_TESTMON_WORKERS`) and wire it into `poolOptions.forks` (the active default pool), `poolOptions.threads` (in case the default pool changes upstream again), and the pool-agnostic `test.maxWorkers`/`minWorkers` fallback. `POLYLOGUE_EXTENSION_TEST_WORKERS` allows a validated one-off override (falls back to the safe default on garbage/missing input) for a deliberately wider or narrower run.
- `browser-extension/tests/vitest_config.test.js`: a new regression guard that parses the config source (deliberately not a runtime `import()` — dynamically importing `vitest.config.js` a second time inside this suite's jsdom environment trips an esbuild startup invariant) and fails if the numeric cap is removed, unbounded, or the env-override validation is deleted.

## Verification
Measured on the 24-core dev workstation. Initial RSS sampling double-counted thread IDs as if they were distinct processes (`pstree -p` lists LWPs, and `/proc/<tid>/status` reports the whole process's RSS); the numbers below sum `VmRSS` once per distinct PID in the descendant tree.

- Uncapped (default fork pool, no cap — verified via `POLYLOGUE_EXTENSION_TEST_WORKERS` override path with the pre-fix threads-only config, which doesn't touch the fork pool): **27 processes, ~2.86GB peak RSS, 9.5s wall**.
- Capped at 4 workers (the shipped default): **10 processes, ~1.1GB peak RSS, 9.6s wall** — no runtime regression (AC#3: well under 2x).
- Env override widened to 8 (`POLYLOGUE_EXTENSION_TEST_WORKERS=8`): 13 processes, ~1.56GB peak RSS, 9.65s wall — confirms the override path scales as expected.
- Focused single-file run (`npx vitest run tests/common.test.js`): 349ms, unaffected by the cap — interactive/watch-mode parallelism is preserved (AC#5).
- `npx vitest run tests/vitest_config.test.js`: 5/5 passing; manually verified it fails when `DEFAULT_MAX_WORKERS` is bumped past the guard ceiling (AC#4).
- `npm run lint` (eslint): clean.
- `devtools verify --quick` (pre-push hook, this repo's Python-side gate covering rendered docs/schema — no Python source touched by this change): all steps green, `exit_code: 0`.

A pre-existing, unrelated flaky test (`tests/build.test.js > full archive emission > executes the packaged service worker fixture without foreground tab activation`, a `vi.waitFor()` timing assertion) fails identically at 4, 8, and 24 workers across every run in this branch — filed as polylogue-07pt rather than fixed here, since it reproduces independent of the worker cap.

## Acceptance criteria (polylogue-0v5b)
1. Satisfied — explicit worker cap honored by `vitest run`/`vitest` watch/CI via one shared config; no separate CI test invocation exists to diverge.
2. Satisfied — representative full suite (16 test files, 355 tests excluding the new guard test) completes without oomd-scale pressure; peak RSS ~1.1GB well under an 8G scope.
3. Satisfied — capped run (9.6s) is not slower than uncapped (9.5s); no tradeoff needed.
4. Satisfied — `tests/vitest_config.test.js` fails if the cap is removed/loosened past 8 workers; manually confirmed.
5. Satisfied — single-file focused run measured at 349ms, unaffected by the cap.

Ref polylogue-0v5b