### PR TITLE
fix(storage): stop deriving sibling tiers from pointer-resolved index paths

### DIFF
--- a/polylogue/cli/commands/embed.py
+++ b/polylogue/cli/commands/embed.py
@@ -629,7 +629,9 @@ def backfill_subcommand(
     if rebuild:
         from polylogue.storage.embeddings.materialization import mark_all_archive_sessions_needs_reindex
 
-        mark_all_archive_sessions_needs_reindex(index_db)
+        mark_all_archive_sessions_needs_reindex(
+            index_db, embeddings_db_path=location.active_tier("embeddings").configured_path
+        )
 
     embeddings_db = location.active_tier("embeddings").configured_path
     from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
@@ -658,6 +660,7 @@ def backfill_subcommand(
         max_errors=max_errors,
         min_messages=min_messages,
         output_format=output_format,
+        configured_root=location.configured_root,
     )
     if output_format == "json":
         _render_backfill_json(payload)
@@ -676,6 +679,7 @@ def _run_archive_backfill(
     max_errors: int | None,
     min_messages: int | None = None,
     output_format: str = "text",
+    configured_root: Path | None = None,
 ) -> BackfillResultPayload:
     """Run the embedding backfill loop.
 
@@ -761,7 +765,9 @@ def _run_archive_backfill(
                     f"(~${cumulative_cost + estimated_batch_cost:.4f} > ${cap:.2f}). Stopping.[/yellow]"
                 )
             break
-        outcome = embed_archive_session_sync(index_db, typed_provider, item.session_id)
+        outcome = embed_archive_session_sync(
+            index_db, typed_provider, item.session_id, embeddings_db_path=embeddings_db
+        )
         processed += 1
         batch_cost = 0.0
         if outcome.status == "embedded":
@@ -832,6 +838,7 @@ def _run_archive_backfill(
         embedded_messages=sum(item["embedded_message_count"] for item in session_payloads),
         estimated_cost_usd=cumulative_cost,
         stop_reason=stopped_reason,
+        configured_root=configured_root,
     )
     if output_format == "text":
         click.echo(f"\nBackfill complete. Embedded {embedded}, errors {errors}, est. cost ~${cumulative_cost:.4f}.")
@@ -852,13 +859,21 @@ def _record_archive_backfill_run(
     embedded_messages: int,
     estimated_cost_usd: float,
     stop_reason: str | None,
+    configured_root: Path | None = None,
 ) -> None:
-    """Persist archive backfill outcome in the ops-tier run ledger."""
+    """Persist archive backfill outcome in the ops-tier run ledger.
+
+    ``configured_root`` names the durable-tier archive root explicitly (an
+    index-only external generation's ``index_db`` can live outside it, same
+    rationale as ``embeddings_db`` in :func:`_run_archive_backfill`); it
+    defaults to ``index_db.with_name("ops.db")`` for callers that never
+    diverge from the plain convention.
+    """
     from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
     from polylogue.storage.sqlite.archive_tiers.ops_write import upsert_embedding_catchup_run
     from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
-    ops_db = index_db.with_name("ops.db")
+    ops_db = (configured_root / "ops.db") if configured_root is not None else index_db.with_name("ops.db")
     initialize_archive_database(ops_db, ArchiveTier.OPS)
     terminal_status = "cancelled" if status == "stopped" else "completed"
     with closing(sqlite3.connect(ops_db, timeout=30.0)) as conn:

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -756,7 +756,7 @@ def _sqlite_maintenance_status(root: Path) -> dict[str, Any]:
     }
 
 
-def _direct_archive_counts(conn: Any) -> dict[str, int]:
+def _direct_archive_counts(conn: Any, *, configured_root: Path | None = None) -> dict[str, int]:
     if _table_exists(conn, "sessions"):
         messages = (
             _fast_count(conn, "SELECT COALESCE(SUM(message_count), 0) FROM sessions")
@@ -766,14 +766,28 @@ def _direct_archive_counts(conn: Any) -> dict[str, int]:
         return {
             "sessions": _fast_count(conn, "SELECT COUNT(*) FROM sessions"),
             "messages": messages,
-            "raw_records": _archive_source_raw_count(conn),
+            "raw_records": _archive_source_raw_count(conn, configured_root=configured_root),
         }
     return {"sessions": 0, "messages": 0, "raw_records": 0}
 
 
-def _archive_source_raw_count(conn: Any) -> int:
+def _archive_source_raw_count(conn: Any, *, configured_root: Path | None = None) -> int:
     if _table_exists(conn, "raw_sessions"):
         return _fast_count(conn, "SELECT COUNT(*) FROM raw_sessions")
+    if configured_root is not None:
+        source_db = configured_root / "source.db"
+        if not source_db.exists():
+            return 0
+        try:
+            source_conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+            try:
+                if not _table_exists(source_conn, "raw_sessions"):
+                    return 0
+                return _fast_count(source_conn, "SELECT COUNT(*) FROM raw_sessions")
+            finally:
+                source_conn.close()
+        except sqlite3.Error:
+            return 0
     try:
         row = conn.execute("PRAGMA database_list").fetchone()
     except Exception as exc:
@@ -1617,7 +1631,7 @@ def _show_direct_json(
 
             conn = open_readonly_connection(active_db)
             try:
-                payload.update(_direct_archive_counts(conn))
+                payload.update(_direct_archive_counts(conn, configured_root=root))
                 payload["db_exists"] = True
             finally:
                 conn.close()
@@ -2097,6 +2111,7 @@ def _show_direct_status(
     from polylogue.paths import archive_root, db_path
 
     db = db_path()
+    root = archive_root()
     active_db = _active_status_db(db)
     if active_db is None or not active_db.exists():
         diag = diagnose_first_run(daemon_alive=False)
@@ -2117,7 +2132,7 @@ def _show_direct_status(
 
         conn = open_readonly_connection(active_db)
         try:
-            counts = _direct_archive_counts(conn)
+            counts = _direct_archive_counts(conn, configured_root=root)
             convs = counts["sessions"]
             msgs = counts["messages"]
             raw = counts["raw_records"]

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -1631,7 +1631,7 @@ def _show_direct_json(
 
             conn = open_readonly_connection(active_db)
             try:
-                payload.update(_direct_archive_counts(conn, configured_root=root))
+                payload.update(_direct_archive_counts(conn, configured_root=active_root))
                 payload["db_exists"] = True
             finally:
                 conn.close()
@@ -2117,6 +2117,11 @@ def _show_direct_status(
         diag = diagnose_first_run(daemon_alive=False)
         _render_diagnostic(env, diag)
         return
+    # An index-only external generation's active_db can live outside the
+    # configured root (polylogue-yla8.1 split-root contract); source.db must
+    # then resolve against the active db's own directory, not the configured
+    # root, mirroring _show_direct_json's active_root derivation.
+    active_root = active_db.parent if active_db.name == "index.db" else root
 
     # Pre-flight: detect schema mismatch / locked db / stale pidfile
     # before attempting row counts. Short-circuits with actionable text
@@ -2132,7 +2137,7 @@ def _show_direct_status(
 
         conn = open_readonly_connection(active_db)
         try:
-            counts = _direct_archive_counts(conn, configured_root=root)
+            counts = _direct_archive_counts(conn, configured_root=active_root)
             convs = counts["sessions"]
             msgs = counts["messages"]
             raw = counts["raw_records"]

--- a/polylogue/cli/shared/check_workflow.py
+++ b/polylogue/cli/shared/check_workflow.py
@@ -120,9 +120,11 @@ def _artifact_query(options: CheckCommandOptions) -> ArtifactObservationQuery:
 
 def _run_blob_store_check(config: Config, *, full: bool = False) -> JSONDocument:
     """Verify blob store integrity through the daemon-health scanner."""
+    from polylogue.storage.archive_identity import archive_file_set_root
     from polylogue.storage.blob_integrity import scan_blob_integrity
 
-    report = scan_blob_integrity(config.db_path, full=full)
+    configured_root = archive_file_set_root(archive_root=config.archive_root, db_path=config.db_path)
+    report = scan_blob_integrity(config.db_path, full=full, configured_root=configured_root)
     return json_document(report.to_dict())
 
 

--- a/polylogue/coordination/envelope.py
+++ b/polylogue/coordination/envelope.py
@@ -1766,7 +1766,7 @@ def _handoff_payloads(
     if remaining and archive is not None:
         payloads.extend(
             _assertion_handoff_payloads(
-                Path(archive.index_db).with_name("user.db"),
+                Path(archive.archive_root) / "user.db",
                 repo_root=repo_root,
                 limit=remaining,
             )
@@ -1881,8 +1881,8 @@ def _archive_payload(resources: tuple[CoordinationResourceEpisodePayload, ...]) 
         index_db=str(index),
         index_exists=index.exists(),
         index_user_version=_sqlite_user_version(index),
-        source_user_version=_sqlite_user_version(index.with_name("source.db")),
-        user_user_version=_sqlite_user_version(index.with_name("user.db")),
+        source_user_version=_sqlite_user_version(archive / "source.db"),
+        user_user_version=_sqlite_user_version(archive / "user.db"),
         hook_flow_states=hook_flow_states,
         hook_flow_healthy=hook_flow_healthy,
         hook_flow_gaps=hook_flow_gaps,

--- a/polylogue/daemon/catchup_status.py
+++ b/polylogue/daemon/catchup_status.py
@@ -71,9 +71,10 @@ def catchup_status_info(
     *,
     latest_attempt: object | None,
     convergence: object,
+    ops_db: Path | None = None,
 ) -> CatchupStatus:
     """Return bounded catch-up/convergence progress and throughput from durable events."""
-    events = _recent_stage_events(dbf)
+    events = _recent_stage_events(dbf, ops_db=ops_db)
     latest = events[0] if events else None
     now = datetime.now(UTC)
     mode = _catchup_mode(latest, latest_attempt, convergence)
@@ -152,8 +153,9 @@ def format_catchup_status_lines(payload: object) -> list[str]:
     return lines
 
 
-def _recent_stage_events(dbf: Path) -> list[CatchupStageEvent]:
-    ops_events = _archive_recent_stage_events(dbf.with_name("ops.db"))
+def _recent_stage_events(dbf: Path, *, ops_db: Path | None = None) -> list[CatchupStageEvent]:
+    resolved_ops_db = ops_db if ops_db is not None else dbf.with_name("ops.db")
+    ops_events = _archive_recent_stage_events(resolved_ops_db)
     if ops_events:
         return ops_events
     if not dbf.exists():

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -317,11 +317,21 @@ def _watch_sources_from_roots(
 
 
 def _active_index_db_path() -> Path:
-    """Return the currently active archive database for daemon maintenance."""
-    from polylogue.paths import archive_root
-    from polylogue.storage.archive_identity import resolve_active_index_path
+    """Return the archive-rooted ``index.db`` path for daemon maintenance.
 
-    return resolve_active_index_path(archive_root())
+    Deliberately the plain ``archive_root() / "index.db"`` construction, not
+    a pointer-resolved active-generation path: this value is threaded as the
+    ``db_path`` anchor into :func:`~polylogue.daemon.convergence_stages.make_default_convergence_stages`
+    and friends, whose entire stage family relies on ``db_path.parent`` being
+    the durable-tier archive root (never a ``.index-generations/<gen>``
+    subdirectory) to derive ``ops.db``/``embeddings.db``/``source.db``/
+    ``user.db`` siblings correctly. SQLite transparently follows the
+    ``index.db`` symlink when connecting, so this is equally correct for
+    opening the active generation's content.
+    """
+    from polylogue.paths import archive_root
+
+    return archive_root() / "index.db"
 
 
 def _heartbeat_counts(db: Path) -> tuple[int, int, str]:
@@ -1465,7 +1475,7 @@ def _drain_session_insights_once(*, limit: int = _SESSION_INSIGHT_CONVERGENCE_BA
         ids = _schema_archive_session_ids_missing_profiles(conn, limit=limit)
         if not ids:
             return 0
-        result = _archive_insights_execute_ids(conn, ids)
+        result = _archive_insights_execute_ids(conn, ids, archive_root=archive_root())
         return len(ids) if bool(getattr(result, "success", result)) else 0
     finally:
         conn.close()

--- a/polylogue/daemon/convergence_debt_status.py
+++ b/polylogue/daemon/convergence_debt_status.py
@@ -50,9 +50,10 @@ class ConvergenceDebtSummary(BaseModel):
     recent: list[ConvergenceDebtItem] = Field(default_factory=list)
 
 
-def convergence_debt_summary_info(dbf: Path) -> ConvergenceDebtSummary:
+def convergence_debt_summary_info(dbf: Path, *, ops_db: Path | None = None) -> ConvergenceDebtSummary:
     """Return durable post-ingest convergence debt snapshots."""
-    ops_summary = _archive_convergence_debt_summary_info(dbf, dbf.with_name("ops.db"))
+    resolved_ops_db = ops_db if ops_db is not None else dbf.with_name("ops.db")
+    ops_summary = _archive_convergence_debt_summary_info(dbf, resolved_ops_db)
     if ops_summary is not None:
         return ops_summary
     return ConvergenceDebtSummary()

--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -289,7 +289,7 @@ def make_embed_stage(db_path: Path, *, defer: Callable[[], bool] | None = None) 
         if not _embedding_config_enabled():
             return False
         archive_db = _active_archive_index_path(db_path)
-        return _archive_embed_check(archive_db, path) if archive_db is not None else False
+        return _archive_embed_check(archive_db, path, archive_root=db_path.parent) if archive_db is not None else False
 
     def execute(path: Path) -> StageExecuteReturn:
         if not _embedding_config_enabled():
@@ -297,13 +297,17 @@ def make_embed_stage(db_path: Path, *, defer: Callable[[], bool] | None = None) 
         if _deferred():
             return False
         archive_db = _active_archive_index_path(db_path)
-        return _archive_embed_execute(archive_db, path) if archive_db is not None else True
+        return _archive_embed_execute(archive_db, path, archive_root=db_path.parent) if archive_db is not None else True
 
     def check_many(paths: Sequence[Path]) -> set[Path]:
         if not paths or not _embedding_config_enabled():
             return set()
         archive_db = _active_archive_index_path(db_path)
-        return _archive_embed_check_many(archive_db, paths) if archive_db is not None else set()
+        return (
+            _archive_embed_check_many(archive_db, paths, archive_root=db_path.parent)
+            if archive_db is not None
+            else set()
+        )
 
     def execute_many(paths: Sequence[Path]) -> StageExecuteReturn:
         if not paths or not _embedding_config_enabled():
@@ -311,13 +315,21 @@ def make_embed_stage(db_path: Path, *, defer: Callable[[], bool] | None = None) 
         if _deferred():
             return False
         archive_db = _active_archive_index_path(db_path)
-        return _archive_embed_execute_many(archive_db, paths) if archive_db is not None else True
+        return (
+            _archive_embed_execute_many(archive_db, paths, archive_root=db_path.parent)
+            if archive_db is not None
+            else True
+        )
 
     def check_sessions(session_ids: Sequence[str]) -> set[str]:
         if not session_ids or not _embedding_config_enabled():
             return set()
         archive_db = _active_archive_index_path(db_path)
-        return _archive_embed_check_sessions(archive_db, session_ids) if archive_db is not None else set()
+        return (
+            _archive_embed_check_sessions(archive_db, session_ids, archive_root=db_path.parent)
+            if archive_db is not None
+            else set()
+        )
 
     def execute_sessions(session_ids: Sequence[str]) -> StageExecuteReturn:
         if not session_ids or not _embedding_config_enabled():
@@ -325,7 +337,11 @@ def make_embed_stage(db_path: Path, *, defer: Callable[[], bool] | None = None) 
         if _deferred():
             return False
         archive_db = _active_archive_index_path(db_path)
-        return _archive_embed_execute_sessions(archive_db, session_ids) if archive_db is not None else True
+        return (
+            _archive_embed_execute_sessions(archive_db, session_ids, archive_root=db_path.parent)
+            if archive_db is not None
+            else True
+        )
 
     return ConvergenceStage(
         name="embed",
@@ -416,7 +432,7 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
     def check(path: Path) -> bool:
         archive_db = _active_archive_index_path(db_path)
         if archive_db is not None:
-            return _archive_insights_check(archive_db, path)
+            return _archive_insights_check(archive_db, path, archive_root=db_path.parent)
         if not db_path.exists():
             return False
         from polylogue.storage.sqlite.connection_profile import open_connection
@@ -443,7 +459,7 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
     def execute(path: Path) -> StageExecuteReturn:
         archive_db = _active_archive_index_path(db_path)
         if archive_db is not None:
-            return _archive_insights_execute(archive_db, path)
+            return _archive_insights_execute(archive_db, path, archive_root=db_path.parent)
         from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
         from polylogue.storage.sqlite.connection import open_connection
 
@@ -484,7 +500,7 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
     def check_many(paths: Sequence[Path]) -> set[Path]:
         archive_db = _active_archive_index_path(db_path)
         if archive_db is not None:
-            return _archive_insights_check_many(archive_db, paths)
+            return _archive_insights_check_many(archive_db, paths, archive_root=db_path.parent)
         if not db_path.exists() or not paths:
             return set()
         from polylogue.storage.sqlite.connection_profile import open_connection
@@ -516,7 +532,7 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
     def execute_many(paths: Sequence[Path]) -> StageExecuteReturn:
         archive_db = _active_archive_index_path(db_path)
         if archive_db is not None:
-            return _archive_insights_execute_many(archive_db, paths)
+            return _archive_insights_execute_many(archive_db, paths, archive_root=db_path.parent)
         from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
         from polylogue.storage.sqlite.connection import open_connection
 
@@ -585,7 +601,7 @@ def make_insights_stage(db_path: Path) -> ConvergenceStage:
     def execute_sessions(session_ids: Sequence[str]) -> StageExecuteReturn:
         archive_db = _active_archive_index_path(db_path)
         if archive_db is not None:
-            return _archive_insights_execute_sessions(archive_db, session_ids)
+            return _archive_insights_execute_sessions(archive_db, session_ids, archive_root=db_path.parent)
         from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
         from polylogue.storage.sqlite.connection import open_connection
 
@@ -654,7 +670,7 @@ def _sinex_session_ids_for_paths(
         return {path: [] for path in normalized}
     conn = sqlite3.connect(f"file:{lookup_db}?mode=ro", uri=True, timeout=5.0)
     try:
-        return _schema_archive_session_ids_for_source_paths(conn, normalized)
+        return _schema_archive_session_ids_for_source_paths(conn, normalized, archive_root=db_path.parent)
     finally:
         conn.close()
 
@@ -1011,7 +1027,7 @@ def _stored_dim_from_meta(conn: sqlite3.Connection) -> int:
     return int(row[0]) if row else 0
 
 
-def _reconcile_archive_embedding_config_change(index_db_path: Path) -> None:
+def _reconcile_archive_embedding_config_change(index_db_path: Path, *, archive_root: Path | None = None) -> None:
     """Reconcile the recipe on the tier that owns embedding state.
 
     Active archives split ``index.db`` source facts from the rebuildable
@@ -1019,11 +1035,19 @@ def _reconcile_archive_embedding_config_change(index_db_path: Path) -> None:
     old same-file behavior. Loading sqlite-vec here keeps dimension-change
     reconciliation able to drop the virtual table on the real production
     route.
+
+    ``archive_root`` names the durable-tier root explicitly when the caller
+    already resolved it (e.g. through ``.index-active-pointer``-aware
+    resolution, where ``index_db_path`` itself may point into a
+    ``.index-generations/<gen>`` subdirectory rather than the archive root
+    housing ``embeddings.db``); it defaults to ``index_db_path.parent`` for
+    callers that never diverge from the plain convention.
     """
 
     from polylogue.storage.sqlite.sqlite_vec_extension import try_load_sqlite_vec
 
-    sibling = index_db_path.with_name("embeddings.db")
+    root = archive_root if archive_root is not None else index_db_path.parent
+    sibling = root / "embeddings.db"
     target = sibling if sibling.exists() else index_db_path
     conn = sqlite3.connect(target, timeout=5.0)
     try:
@@ -1189,18 +1213,20 @@ def _stale_session_profile_ids(conn: sqlite3.Connection, session_ids: Sequence[s
 # ── Archive file-set helpers ─────────────────────────────────────
 
 
-def _attached_source_db_path(conn: sqlite3.Connection) -> Path:
+def _attached_source_db_path(conn: sqlite3.Connection, *, archive_root: Path | None = None) -> Path:
+    if archive_root is not None:
+        return archive_root / "source.db"
     for _, name, path in conn.execute("PRAGMA database_list").fetchall():
         if str(name) == "main" and path:
             return Path(str(path)).with_name("source.db")
     return Path("source.db")
 
 
-def _ensure_source_tier_attached(conn: sqlite3.Connection) -> bool:
+def _ensure_source_tier_attached(conn: sqlite3.Connection, *, archive_root: Path | None = None) -> bool:
     for _, name, _path in conn.execute("PRAGMA database_list").fetchall():
         if str(name) == "source_tier":
             return True
-    source_db = _attached_source_db_path(conn)
+    source_db = _attached_source_db_path(conn, archive_root=archive_root)
     if not source_db.exists():
         return False
     conn.execute("ATTACH DATABASE ? AS source_tier", (str(source_db),))
@@ -1232,13 +1258,17 @@ def _active_archive_index_path(db_path: Path) -> Path | None:
         return None
 
 
-def _schema_archive_session_ids_for_source_path(conn: sqlite3.Connection, path: Path) -> list[str]:
-    return _schema_archive_session_ids_for_source_paths(conn, [path]).get(path, [])
+def _schema_archive_session_ids_for_source_path(
+    conn: sqlite3.Connection, path: Path, *, archive_root: Path | None = None
+) -> list[str]:
+    return _schema_archive_session_ids_for_source_paths(conn, [path], archive_root=archive_root).get(path, [])
 
 
 def _schema_archive_session_ids_for_source_paths(
     conn: sqlite3.Connection,
     paths: Sequence[Path],
+    *,
+    archive_root: Path | None = None,
 ) -> dict[Path, list[str]]:
     normalized_paths = tuple(dict.fromkeys(Path(path) for path in paths))
     if not normalized_paths or not _table_exists(conn, "sessions"):
@@ -1247,7 +1277,7 @@ def _schema_archive_session_ids_for_source_paths(
     if not _table_exists(conn, "raw_sessions"):
         raw_table = "source_tier.raw_sessions"
         try:
-            if not _ensure_source_tier_attached(conn):
+            if not _ensure_source_tier_attached(conn, archive_root=archive_root):
                 return {path: [] for path in normalized_paths}
         except sqlite3.Error:
             # Swallowed here, one level below the stage's own check/execute
@@ -1518,22 +1548,26 @@ def repair_fts_surface(db_path: Path, surface: str) -> bool:
         return False
 
 
-def _archive_pending_embedding_session_ids(conn: sqlite3.Connection, session_ids: Sequence[str]) -> list[str]:
+def _archive_pending_embedding_session_ids(
+    conn: sqlite3.Connection, session_ids: Sequence[str], *, archive_root: Path | None = None
+) -> list[str]:
     from polylogue.storage.embeddings.materialization import select_pending_archive_session_window
 
     ids = tuple(dict.fromkeys(str(session_id) for session_id in session_ids if session_id))
     if not ids:
         return []
-    db_row = conn.execute("PRAGMA database_list").fetchone()
-    index_db = Path(str(db_row[2])) if db_row is not None and db_row[2] else None
+    if archive_root is not None:
+        embeddings_db: Path | None = archive_root / "embeddings.db"
+    else:
+        db_row = conn.execute("PRAGMA database_list").fetchone()
+        index_db = Path(str(db_row[2])) if db_row is not None and db_row[2] else None
+        embeddings_db = index_db.with_name("embeddings.db") if index_db is not None else None
     status_table = None
-    if index_db is not None:
-        embeddings_db = index_db.with_name("embeddings.db")
-        if embeddings_db.exists():
-            attached = {str(row[1]) for row in conn.execute("PRAGMA database_list").fetchall() if len(row) > 1}
-            if "embeddings" not in attached:
-                conn.execute("ATTACH DATABASE ? AS embeddings", (str(embeddings_db),))
-            status_table = "embeddings.embedding_status"
+    if embeddings_db is not None and embeddings_db.exists():
+        attached = {str(row[1]) for row in conn.execute("PRAGMA database_list").fetchall() if len(row) > 1}
+        if "embeddings" not in attached:
+            conn.execute("ATTACH DATABASE ? AS embeddings", (str(embeddings_db),))
+        status_table = "embeddings.embedding_status"
     return [
         item.session_id
         for item in select_pending_archive_session_window(
@@ -1546,13 +1580,13 @@ def _archive_pending_embedding_session_ids(conn: sqlite3.Connection, session_ids
     ]
 
 
-def _archive_embed_check(db_path: Path, path: Path) -> bool:
+def _archive_embed_check(db_path: Path, path: Path, *, archive_root: Path | None = None) -> bool:
     try:
-        _reconcile_archive_embedding_config_change(db_path)
+        _reconcile_archive_embedding_config_change(db_path, archive_root=archive_root)
         conn = sqlite3.connect(db_path, timeout=5.0)
         try:
-            session_ids = _schema_archive_session_ids_for_source_path(conn, path)
-            return bool(_archive_pending_embedding_session_ids(conn, session_ids))
+            session_ids = _schema_archive_session_ids_for_source_path(conn, path, archive_root=archive_root)
+            return bool(_archive_pending_embedding_session_ids(conn, session_ids, archive_root=archive_root))
         finally:
             conn.close()
     except Exception:
@@ -1562,32 +1596,32 @@ def _archive_embed_check(db_path: Path, path: Path) -> bool:
         return True
 
 
-def _archive_embed_execute(db_path: Path, path: Path) -> bool:
+def _archive_embed_execute(db_path: Path, path: Path, *, archive_root: Path | None = None) -> bool:
     try:
         conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)
         try:
-            session_ids = _schema_archive_session_ids_for_source_path(conn, path)
-            pending_ids = _archive_pending_embedding_session_ids(conn, session_ids)
+            session_ids = _schema_archive_session_ids_for_source_path(conn, path, archive_root=archive_root)
+            pending_ids = _archive_pending_embedding_session_ids(conn, session_ids, archive_root=archive_root)
         finally:
             conn.close()
         if not pending_ids:
             return True
-        return _embed_archive_sessions_sync(db_path, pending_ids) and not _archive_embedding_debt_remaining(
-            db_path, session_ids
-        )
+        return _embed_archive_sessions_sync(
+            db_path, pending_ids, archive_root=archive_root
+        ) and not _archive_embedding_debt_remaining(db_path, session_ids, archive_root=archive_root)
     except Exception:
         logger.warning("embed: archive failed", exc_info=True)
         return False
 
 
-def _archive_embed_check_many(db_path: Path, paths: Sequence[Path]) -> set[Path]:
+def _archive_embed_check_many(db_path: Path, paths: Sequence[Path], *, archive_root: Path | None = None) -> set[Path]:
     try:
-        _reconcile_archive_embedding_config_change(db_path)
+        _reconcile_archive_embedding_config_change(db_path, archive_root=archive_root)
         conn = sqlite3.connect(db_path, timeout=5.0)
         try:
-            by_path = _schema_archive_session_ids_for_source_paths(conn, paths)
+            by_path = _schema_archive_session_ids_for_source_paths(conn, paths, archive_root=archive_root)
             all_ids = list(dict.fromkeys(session_id for ids in by_path.values() for session_id in ids))
-            pending = set(_archive_pending_embedding_session_ids(conn, all_ids))
+            pending = set(_archive_pending_embedding_session_ids(conn, all_ids, archive_root=archive_root))
             return {path for path, ids in by_path.items() if any(session_id in pending for session_id in ids)}
         finally:
             conn.close()
@@ -1598,32 +1632,34 @@ def _archive_embed_check_many(db_path: Path, paths: Sequence[Path]) -> set[Path]
         return set(paths)
 
 
-def _archive_embed_execute_many(db_path: Path, paths: Sequence[Path]) -> bool:
+def _archive_embed_execute_many(db_path: Path, paths: Sequence[Path], *, archive_root: Path | None = None) -> bool:
     try:
         conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)
         try:
-            by_path = _schema_archive_session_ids_for_source_paths(conn, paths)
+            by_path = _schema_archive_session_ids_for_source_paths(conn, paths, archive_root=archive_root)
             session_ids = list(dict.fromkeys(session_id for ids in by_path.values() for session_id in ids))
-            pending_ids = _archive_pending_embedding_session_ids(conn, session_ids)
+            pending_ids = _archive_pending_embedding_session_ids(conn, session_ids, archive_root=archive_root)
         finally:
             conn.close()
         if not pending_ids:
             return True
-        return _embed_archive_sessions_sync(db_path, pending_ids) and not _archive_embedding_debt_remaining(
-            db_path, session_ids
-        )
+        return _embed_archive_sessions_sync(
+            db_path, pending_ids, archive_root=archive_root
+        ) and not _archive_embedding_debt_remaining(db_path, session_ids, archive_root=archive_root)
     except Exception:
         logger.warning("embed: archive batch failed", exc_info=True)
         return False
 
 
-def _archive_embed_check_sessions(db_path: Path, session_ids: Sequence[str]) -> set[str]:
+def _archive_embed_check_sessions(
+    db_path: Path, session_ids: Sequence[str], *, archive_root: Path | None = None
+) -> set[str]:
     try:
-        _reconcile_archive_embedding_config_change(db_path)
+        _reconcile_archive_embedding_config_change(db_path, archive_root=archive_root)
         conn = sqlite3.connect(db_path, timeout=5.0)
         try:
             ids = _archive_existing_session_ids(conn, session_ids)
-            return set(_archive_pending_embedding_session_ids(conn, ids))
+            return set(_archive_pending_embedding_session_ids(conn, ids, archive_root=archive_root))
         finally:
             conn.close()
     except Exception:
@@ -1635,21 +1671,25 @@ def _archive_embed_check_sessions(db_path: Path, session_ids: Sequence[str]) -> 
         return set(session_ids)
 
 
-def _archive_embed_execute_sessions(db_path: Path, session_ids: Sequence[str]) -> bool:
+def _archive_embed_execute_sessions(
+    db_path: Path, session_ids: Sequence[str], *, archive_root: Path | None = None
+) -> bool:
     ids = tuple(dict.fromkeys(str(session_id) for session_id in session_ids if session_id))
     if not ids:
         return True
-    ok = _embed_archive_sessions_sync(db_path, ids)
-    return ok and not _archive_embedding_debt_remaining(db_path, ids)
+    ok = _embed_archive_sessions_sync(db_path, ids, archive_root=archive_root)
+    return ok and not _archive_embedding_debt_remaining(db_path, ids, archive_root=archive_root)
 
 
-def _archive_embedding_debt_remaining(db_path: Path, session_ids: Sequence[str]) -> bool:
+def _archive_embedding_debt_remaining(
+    db_path: Path, session_ids: Sequence[str], *, archive_root: Path | None = None
+) -> bool:
     if not session_ids:
         return False
     try:
         conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)
         try:
-            return bool(_archive_pending_embedding_session_ids(conn, session_ids))
+            return bool(_archive_pending_embedding_session_ids(conn, session_ids, archive_root=archive_root))
         finally:
             conn.close()
     except Exception:
@@ -1657,7 +1697,9 @@ def _archive_embedding_debt_remaining(db_path: Path, session_ids: Sequence[str])
         return True
 
 
-def _embed_archive_sessions_sync(db_path: Path, session_ids: Sequence[str]) -> bool:
+def _embed_archive_sessions_sync(
+    db_path: Path, session_ids: Sequence[str], *, archive_root: Path | None = None
+) -> bool:
     from polylogue.storage.embeddings.materialization import embed_archive_session_sync
     from polylogue.storage.search_providers import create_vector_provider
 
@@ -1665,7 +1707,8 @@ def _embed_archive_sessions_sync(db_path: Path, session_ids: Sequence[str]) -> b
     voyage_key = cfg.get("voyage_api_key")
     if not voyage_key:
         return True
-    embeddings_db = db_path.with_name("embeddings.db")
+    root = archive_root if archive_root is not None else db_path.parent
+    embeddings_db = root / "embeddings.db"
     vec_provider = create_vector_provider(
         voyage_api_key=str(voyage_key),
         db_path=embeddings_db,
@@ -1701,6 +1744,7 @@ def _archive_hot_insight_session_ids(
     session_ids: Sequence[str],
     *,
     now: float | None = None,
+    archive_root: Path | None = None,
 ) -> set[str]:
     unique_ids = tuple(dict.fromkeys(str(session_id) for session_id in session_ids if session_id))
     if not unique_ids or not _table_exists(conn, "sessions"):
@@ -1709,7 +1753,7 @@ def _archive_hot_insight_session_ids(
     if not _table_exists(conn, "raw_sessions"):
         raw_table = "source_tier.raw_sessions"
         try:
-            if not _ensure_source_tier_attached(conn):
+            if not _ensure_source_tier_attached(conn, archive_root=archive_root):
                 return set()
         except sqlite3.Error:
             logger.warning("archive convergence: failed to attach source tier", exc_info=True)
@@ -1809,11 +1853,11 @@ def _schema_archive_session_ids_missing_profiles(conn: sqlite3.Connection, *, li
     return [str(row[0]) for row in rows]
 
 
-def _archive_insights_check(db_path: Path, path: Path) -> bool:
+def _archive_insights_check(db_path: Path, path: Path, *, archive_root: Path | None = None) -> bool:
     try:
         conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)
         try:
-            session_ids = _schema_archive_session_ids_for_source_path(conn, path)
+            session_ids = _schema_archive_session_ids_for_source_path(conn, path, archive_root=archive_root)
             return bool(session_ids) and bool(_archive_stale_session_profile_ids(conn, session_ids))
         finally:
             conn.close()
@@ -1824,15 +1868,15 @@ def _archive_insights_check(db_path: Path, path: Path) -> bool:
         return True
 
 
-def _archive_insights_execute(db_path: Path, path: Path) -> StageExecuteReturn:
+def _archive_insights_execute(db_path: Path, path: Path, *, archive_root: Path | None = None) -> StageExecuteReturn:
     try:
         conn = _open_archive_insight_write_connection(db_path)
         try:
-            session_ids = _schema_archive_session_ids_for_source_path(conn, path)
+            session_ids = _schema_archive_session_ids_for_source_path(conn, path, archive_root=archive_root)
             if not session_ids:
                 logger.info("insights: archive skipped path refresh with no resolved sessions path=%s", path)
                 return True
-            return _archive_insights_execute_ids(conn, session_ids)
+            return _archive_insights_execute_ids(conn, session_ids, archive_root=archive_root)
         finally:
             conn.close()
     except Exception as exc:
@@ -1843,13 +1887,15 @@ def _archive_insights_execute(db_path: Path, path: Path) -> StageExecuteReturn:
         return False
 
 
-def _archive_insights_check_many(db_path: Path, paths: Sequence[Path]) -> set[Path]:
+def _archive_insights_check_many(
+    db_path: Path, paths: Sequence[Path], *, archive_root: Path | None = None
+) -> set[Path]:
     if not paths:
         return set()
     try:
         conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)
         try:
-            by_path = _schema_archive_session_ids_for_source_paths(conn, paths)
+            by_path = _schema_archive_session_ids_for_source_paths(conn, paths, archive_root=archive_root)
             result = {
                 path
                 for path, session_ids in by_path.items()
@@ -1867,18 +1913,20 @@ def _archive_insights_check_many(db_path: Path, paths: Sequence[Path]) -> set[Pa
         return set(paths)
 
 
-def _archive_insights_execute_many(db_path: Path, paths: Sequence[Path]) -> StageExecuteReturn:
+def _archive_insights_execute_many(
+    db_path: Path, paths: Sequence[Path], *, archive_root: Path | None = None
+) -> StageExecuteReturn:
     try:
         conn = _open_archive_insight_write_connection(db_path)
         try:
-            by_path = _schema_archive_session_ids_for_source_paths(conn, paths)
+            by_path = _schema_archive_session_ids_for_source_paths(conn, paths, archive_root=archive_root)
             session_ids = list(dict.fromkeys(session_id for ids in by_path.values() for session_id in ids))
             if not session_ids:
                 logger.info(
                     "insights: archive skipped batch path refresh with no resolved sessions paths=%d", len(paths)
                 )
                 return True
-            return _archive_insights_execute_ids(conn, session_ids)
+            return _archive_insights_execute_ids(conn, session_ids, archive_root=archive_root)
         finally:
             conn.close()
     except Exception as exc:
@@ -1906,12 +1954,14 @@ def _archive_insights_check_sessions(db_path: Path, session_ids: Sequence[str]) 
         return set(session_ids)
 
 
-def _archive_insights_execute_sessions(db_path: Path, session_ids: Sequence[str]) -> StageExecuteReturn:
+def _archive_insights_execute_sessions(
+    db_path: Path, session_ids: Sequence[str], *, archive_root: Path | None = None
+) -> StageExecuteReturn:
     try:
         conn = _open_archive_insight_write_connection(db_path)
         try:
             ids = _archive_existing_session_ids(conn, session_ids)
-            return _archive_insights_execute_ids(conn, ids)
+            return _archive_insights_execute_ids(conn, ids, archive_root=archive_root)
         finally:
             conn.close()
     except Exception as exc:
@@ -1922,13 +1972,15 @@ def _archive_insights_execute_sessions(db_path: Path, session_ids: Sequence[str]
         return False
 
 
-def _archive_insights_execute_ids(conn: sqlite3.Connection, session_ids: Sequence[str]) -> StageExecuteReturn:
+def _archive_insights_execute_ids(
+    conn: sqlite3.Connection, session_ids: Sequence[str], *, archive_root: Path | None = None
+) -> StageExecuteReturn:
     from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
 
     session_ids = list(dict.fromkeys(str(session_id) for session_id in session_ids if session_id))
     if not session_ids:
         return True
-    hot_ids = _archive_hot_insight_session_ids(conn, session_ids)
+    hot_ids = _archive_hot_insight_session_ids(conn, session_ids, archive_root=archive_root)
     if hot_ids:
         logger.info(
             "insights: deferring hot archive source rebuild sessions=%d quiet_s=%.0f",

--- a/polylogue/daemon/cursor_lag_baseline.py
+++ b/polylogue/daemon/cursor_lag_baseline.py
@@ -91,6 +91,7 @@ def record_cursor_lag_sample(
     summary: CursorLagSummary,
     *,
     now: datetime | None = None,
+    ops_db: Path | None = None,
 ) -> int:
     """Persist one cursor-lag sample row per family with stuck files.
 
@@ -111,7 +112,8 @@ def record_cursor_lag_sample(
     per_family_lags = _bucket_stuck_lags_by_family(summary.stuck)
     if not any(family_summary.stuck_file_count > 0 for family_summary in summary.family_summaries):
         return 0
-    return _record_archive_cursor_lag_samples(dbf.with_name("ops.db"), summary, per_family_lags, observed_at_ms)
+    resolved_ops_db = ops_db if ops_db is not None else dbf.with_name("ops.db")
+    return _record_archive_cursor_lag_samples(resolved_ops_db, summary, per_family_lags, observed_at_ms)
 
 
 def gc_cursor_lag_samples(
@@ -119,6 +121,7 @@ def gc_cursor_lag_samples(
     *,
     retention_days: int,
     now: datetime | None = None,
+    ops_db: Path | None = None,
 ) -> int:
     """Delete samples older than ``retention_days``. Returns rows removed.
 
@@ -128,7 +131,8 @@ def gc_cursor_lag_samples(
     """
     if retention_days <= 0:
         return 0
-    return _gc_archive_cursor_lag_samples(dbf.with_name("ops.db"), retention_days=retention_days, now=now)
+    resolved_ops_db = ops_db if ops_db is not None else dbf.with_name("ops.db")
+    return _gc_archive_cursor_lag_samples(resolved_ops_db, retention_days=retention_days, now=now)
 
 
 def load_family_baseline(
@@ -138,6 +142,7 @@ def load_family_baseline(
     window_days: int,
     min_samples: int,
     now: datetime | None = None,
+    ops_db: Path | None = None,
 ) -> FamilyBaseline:
     """Compute the rolling-window baseline for one family.
 
@@ -149,8 +154,9 @@ def load_family_baseline(
     """
     moment = now or datetime.now(UTC)
     window_start = moment - timedelta(days=max(1, window_days))
+    resolved_ops_db = ops_db if ops_db is not None else dbf.with_name("ops.db")
     baseline = _load_archive_family_baseline(
-        dbf.with_name("ops.db"),
+        resolved_ops_db,
         family,
         window_start=window_start,
         min_samples=min_samples,
@@ -174,10 +180,13 @@ def load_family_baselines(
     window_days: int,
     min_samples: int,
     now: datetime | None = None,
+    ops_db: Path | None = None,
 ) -> dict[str, FamilyBaseline]:
     """Batched read of :func:`load_family_baseline` for many families."""
     return {
-        family: load_family_baseline(dbf, family, window_days=window_days, min_samples=min_samples, now=now)
+        family: load_family_baseline(
+            dbf, family, window_days=window_days, min_samples=min_samples, now=now, ops_db=ops_db
+        )
         for family in families
     }
 

--- a/polylogue/daemon/cursor_lag_status.py
+++ b/polylogue/daemon/cursor_lag_status.py
@@ -112,12 +112,13 @@ _DEGRADED_SAMPLE_LIMIT = 10
 """Bound degraded evidence independently from the SLO sample."""
 
 
-def cursor_lag_summary_info(dbf: Path, *, now: datetime | None = None) -> CursorLagSummary:
+def cursor_lag_summary_info(dbf: Path, *, now: datetime | None = None, ops_db: Path | None = None) -> CursorLagSummary:
     """Return per-family cursor-lag rollups read from ``live_cursor``."""
     resolved_now = now or datetime.now(UTC)
-    ops_summary = _archive_cursor_lag_summary_info(dbf.with_name("ops.db"), now=resolved_now)
+    resolved_ops_db = ops_db if ops_db is not None else dbf.with_name("ops.db")
+    ops_summary = _archive_cursor_lag_summary_info(resolved_ops_db, now=resolved_now)
     if ops_summary is not None:
-        return _decorate_with_baselines(ops_summary, dbf, now=resolved_now)
+        return _decorate_with_baselines(ops_summary, dbf, now=resolved_now, ops_db=resolved_ops_db)
     if not dbf.exists():
         return CursorLagSummary()
     try:
@@ -146,7 +147,7 @@ def cursor_lag_summary_info(dbf: Path, *, now: datetime | None = None) -> Cursor
         return CursorLagSummary()
 
     summary = _project_rows(rows, now=resolved_now)
-    return _decorate_with_baselines(summary, dbf, now=resolved_now)
+    return _decorate_with_baselines(summary, dbf, now=resolved_now, ops_db=resolved_ops_db)
 
 
 def _archive_cursor_lag_summary_info(ops_db: Path, *, now: datetime) -> CursorLagSummary | None:
@@ -199,6 +200,7 @@ def _decorate_with_baselines(
     dbf: Path,
     *,
     now: datetime,
+    ops_db: Path | None = None,
 ) -> CursorLagSummary:
     """Attach baseline + anomaly state to each family summary (#1349).
 
@@ -225,6 +227,7 @@ def _decorate_with_baselines(
             window_days=thresholds.baseline_window_days,
             min_samples=thresholds.baseline_min_samples,
             now=now,
+            ops_db=ops_db,
         )
     except Exception as exc:
         logger.warning("cursor-lag baseline decoration failed: %s", exc, exc_info=True)

--- a/polylogue/daemon/embedding_backlog.py
+++ b/polylogue/daemon/embedding_backlog.py
@@ -31,9 +31,8 @@ async def periodic_embedding_backlog_check(
 ) -> None:
     """Periodically drain one bounded pending-embedding window."""
     from polylogue.paths import archive_root
-    from polylogue.storage.archive_identity import resolve_active_index_path
 
-    db = resolve_active_index_path(archive_root())
+    db = archive_root() / "index.db"
     if catch_up_complete is not None:
         await catch_up_complete.wait()
     while True:
@@ -68,7 +67,7 @@ def drain_embedding_backlog_once(db_path: Path) -> int:
     index_db = _active_archive_index_path(db_path)
     if index_db is None:
         return 0
-    return _drain_archive_embedding_backlog_once(index_db)
+    return _drain_archive_embedding_backlog_once(index_db, archive_root=db_path.parent)
 
 
 async def periodic_embedding_orphan_reconcile_check(
@@ -86,9 +85,8 @@ async def periodic_embedding_orphan_reconcile_check(
     remains the break-glass inspect/apply path.
     """
     from polylogue.paths import archive_root
-    from polylogue.storage.archive_identity import resolve_active_index_path
 
-    db = resolve_active_index_path(archive_root())
+    db = archive_root() / "index.db"
     if catch_up_complete is not None:
         await catch_up_complete.wait()
     while True:
@@ -128,7 +126,7 @@ def reconcile_embedding_orphans_once(db_path: Path) -> EmbeddingOrphanReconcileR
     index_db = _active_archive_index_path(db_path)
     if index_db is None:
         return None
-    embeddings_db = index_db.with_name("embeddings.db")
+    embeddings_db = db_path.parent / "embeddings.db"
     if not embeddings_db.exists():
         return None
 
@@ -172,7 +170,7 @@ def _active_archive_index_path(db_path: Path) -> Path | None:
         return None
 
 
-def _drain_archive_embedding_backlog_once(index_db: Path) -> int:
+def _drain_archive_embedding_backlog_once(index_db: Path, *, archive_root: Path) -> int:
     from polylogue.daemon.convergence_stages import (
         _DAEMON_EMBED_MAX_ERRORS,
         _DAEMON_EMBED_MAX_MESSAGES,
@@ -193,13 +191,13 @@ def _drain_archive_embedding_backlog_once(index_db: Path) -> int:
     voyage_key = cfg.get("voyage_api_key")
     if not voyage_key:
         return 0
-    embeddings_db = index_db.with_name("embeddings.db")
+    embeddings_db = archive_root / "embeddings.db"
     from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
     from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
     initialize_archive_database(embeddings_db, ArchiveTier.EMBEDDINGS)
     monthly_cap = float(str(cfg.get("embedding_max_cost_usd", 0.0)))
-    ops_db = index_db.with_name("ops.db")
+    ops_db = archive_root / "ops.db"
     if monthly_cap > 0:
         month_spend = _archive_embedding_catchup_estimated_cost_this_month(ops_db)
         if month_spend >= monthly_cap:
@@ -279,7 +277,7 @@ def _drain_archive_embedding_backlog_once(index_db: Path) -> int:
                 monthly_cap,
             )
             break
-        outcome = embed_archive_session_sync(index_db, vec_provider, item.session_id)
+        outcome = embed_archive_session_sync(index_db, vec_provider, item.session_id, embeddings_db_path=embeddings_db)
         processed += 1
         if outcome.status == "embedded":
             embedded += 1

--- a/polylogue/daemon/events.py
+++ b/polylogue/daemon/events.py
@@ -9,7 +9,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from polylogue.paths import archive_root
-from polylogue.storage.archive_identity import resolve_active_index_path
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.connection_profile import open_daemon_connection, open_readonly_connection
@@ -32,8 +31,7 @@ CREATE INDEX IF NOT EXISTS idx_daemon_events_ts ON daemon_events(ts_ms);
 
 def _events_db_path() -> Path:
     """Return the path to the daemon events SQLite database."""
-    dbf = resolve_active_index_path(archive_root())
-    return dbf.with_name("ops.db")
+    return archive_root() / "ops.db"
 
 
 def _ensure_events_db() -> sqlite3.Connection:

--- a/polylogue/daemon/fts_identity_convergence.py
+++ b/polylogue/daemon/fts_identity_convergence.py
@@ -128,13 +128,12 @@ async def periodic_fts_identity_drift_recompute(
     """
     from polylogue.daemon.write_coordinator import daemon_write_coordinator
     from polylogue.paths import archive_root
-    from polylogue.storage.archive_identity import resolve_active_index_path
 
     if catch_up_complete is not None:
         await catch_up_complete.wait()
     while True:
         await asyncio.sleep(FTS_IDENTITY_DRIFT_RECOMPUTE_INTERVAL_SECONDS)
-        db_path = resolve_active_index_path(archive_root())
+        db_path = archive_root() / "index.db"
         try:
             result = await daemon_write_coordinator().run_sync(
                 "maintenance.fts_identity_drift_recompute",

--- a/polylogue/daemon/fts_startup.py
+++ b/polylogue/daemon/fts_startup.py
@@ -116,10 +116,16 @@ def _missing_named_triggers_sync(conn: sqlite3.Connection, trigger_names: tuple[
 
 
 def _active_fts_startup_db_path() -> Path:
-    from polylogue import paths
-    from polylogue.storage.archive_identity import resolve_active_index_path
+    """Return the archive-rooted ``index.db`` path (see ``daemon.cli._active_index_db_path``).
 
-    return resolve_active_index_path(paths.archive_root())
+    Deliberately the plain ``archive_root() / "index.db"`` construction, not
+    a pointer-resolved active-generation path: this value flows into
+    ``CursorStore(db_path)`` below, whose ``ops.db``/sibling-tier derivation
+    assumes ``db_path`` never diverges from the durable-tier archive root.
+    """
+    from polylogue import paths
+
+    return paths.archive_root() / "index.db"
 
 
 _MESSAGE_FTS_STARTUP_DEBT_DETAIL = (

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -743,7 +743,7 @@ def _check_repeated_stage_failures_medium() -> HealthAlert:
     """
     now = datetime.now(UTC).isoformat()
     dbf = _active_health_db_path()
-    ops_info = _archive_repeated_stage_failure_info(dbf.with_name("ops.db"))
+    ops_info = _archive_repeated_stage_failure_info(archive_root() / "ops.db")
     if ops_info is not None and (ops_info[0] > 0 or not dbf.exists()):
         total_recent, failed_recent, error_row = ops_info
         return _repeated_stage_failure_alert(now, total_recent, failed_recent, error_row)
@@ -905,7 +905,7 @@ def _check_convergence_debt_medium() -> list[HealthAlert]:
 
         cfg = load_polylogue_config()
         thresholds = load_thresholds_from_config(cfg)
-        summary = convergence_debt_summary_info(_active_health_db_path())
+        summary = convergence_debt_summary_info(_active_health_db_path(), ops_db=archive_root() / "ops.db")
         alerts = evaluate_convergence_debt(
             summary,
             thresholds=thresholds,
@@ -973,7 +973,7 @@ def _check_cursor_lag_medium() -> list[HealthAlert]:
 
         cfg = load_polylogue_config()
         thresholds = load_thresholds_from_config(cfg)
-        summary = cursor_lag_summary_info(_active_health_db_path())
+        summary = cursor_lag_summary_info(_active_health_db_path(), ops_db=archive_root() / "ops.db")
         static_alerts = evaluate_cursor_lag(
             summary,
             thresholds=thresholds,
@@ -1029,6 +1029,7 @@ def _check_cursor_lag_anomaly_layer(
 
         anomaly_thresholds = load_anomaly_thresholds_from_config(cfg)
         dbf = _active_health_db_path()
+        ops_db = archive_root() / "ops.db"
 
         # Load the baseline BEFORE recording the current moment's sample.
         # This is load-bearing: if we wrote first, the current spike would
@@ -1042,13 +1043,14 @@ def _check_cursor_lag_anomaly_layer(
             families_to_check,
             window_days=anomaly_thresholds.baseline_window_days,
             min_samples=anomaly_thresholds.baseline_min_samples,
+            ops_db=ops_db,
         )
 
         # Record the current moment's sample after baseline read (no-op if
         # no stuck files). Failure here is non-fatal: anomaly evaluation
         # has already produced its baseline view.
         try:
-            record_cursor_lag_sample(dbf, summary)
+            record_cursor_lag_sample(dbf, summary, ops_db=ops_db)
         except Exception:
             logger.warning("cursor_lag_anomaly: sample record failed", exc_info=True)
 
@@ -1059,7 +1061,7 @@ def _check_cursor_lag_anomaly_layer(
                 anomaly_thresholds.retention_days,
                 anomaly_thresholds.baseline_window_days * 2,
             )
-            gc_cursor_lag_samples(dbf, retention_days=retention)
+            gc_cursor_lag_samples(dbf, retention_days=retention, ops_db=ops_db)
         except Exception:
             logger.warning("cursor_lag_anomaly: sample GC failed", exc_info=True)
 
@@ -1165,6 +1167,7 @@ def _check_blob_integrity_expensive() -> list[HealthAlert]:
             _active_health_db_path(),
             full=False,
             sample_size=max(1, cfg.health_blob_integrity_sample_size),
+            configured_root=archive_root(),
         )
         return blob_integrity_alerts_from_report(report, now, _record_failure)
     except Exception as exc:

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -1785,9 +1785,8 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
         if path == ["metrics"]:
             from polylogue.daemon.metrics import handle_metrics
             from polylogue.paths import archive_root
-            from polylogue.storage.archive_identity import resolve_active_index_path
 
-            handle_metrics(self, resolve_active_index_path(archive_root()))
+            handle_metrics(self, archive_root() / "index.db")
             return
 
         required_scope: WebCredentialScope = "events" if path == ["api", "events"] else "read"
@@ -5048,12 +5047,11 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             return
 
         from polylogue.paths import archive_root
-        from polylogue.storage.archive_identity import resolve_active_index_path
         from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
         from polylogue.storage.sqlite.archive_tiers.ops_write import record_mcp_call
         from polylogue.storage.sqlite.connection_profile import open_daemon_connection
 
-        ops_db = resolve_active_index_path(archive_root()).with_name("ops.db")
+        ops_db = archive_root() / "ops.db"
         with open_daemon_connection(ops_db) as conn:
             table_count = int(
                 conn.execute(
@@ -5103,9 +5101,8 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             return
         body = self.rfile.read(content_length) if content_length > 0 else b""
         from polylogue.paths import archive_root
-        from polylogue.storage.archive_identity import resolve_active_index_path
 
-        ops_db = resolve_active_index_path(archive_root()).with_name("ops.db")
+        ops_db = archive_root() / "ops.db"
 
         if signal == "traces":
             result = handle_traces(body, content_type, db_path=str(ops_db))

--- a/polylogue/daemon/lifecycle.py
+++ b/polylogue/daemon/lifecycle.py
@@ -23,7 +23,6 @@ from typing import Any, cast
 
 from polylogue.logging import get_logger
 from polylogue.paths import archive_root
-from polylogue.storage.archive_identity import resolve_active_index_path
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.ops_write import (
     latest_daemon_lifecycle,
@@ -53,7 +52,7 @@ def _now_ms() -> int:
 
 
 def _ops_db_path() -> Path:
-    return resolve_active_index_path(archive_root()).with_name("ops.db")
+    return archive_root() / "ops.db"
 
 
 @dataclass(slots=True)

--- a/polylogue/daemon/metrics.py
+++ b/polylogue/daemon/metrics.py
@@ -776,7 +776,10 @@ def _archive_embedding_state(conn: sqlite3.Connection, *, ops_db: Path | None = 
     failed_sessions = 0
     status_table = "embedding_status" if _table_exists(conn, "embedding_status") else ""
     meta_table = "message_embeddings_meta" if _table_exists(conn, "message_embeddings_meta") else ""
-    embeddings_db = Path(conn.execute("PRAGMA database_list").fetchone()[2]).with_name("embeddings.db")
+    if ops_db is not None:
+        embeddings_db = ops_db.parent / "embeddings.db"
+    else:
+        embeddings_db = Path(conn.execute("PRAGMA database_list").fetchone()[2]).with_name("embeddings.db")
     if not status_table and embeddings_db.exists():
         conn.execute("ATTACH DATABASE ? AS embeddings", (str(embeddings_db),))
         status_table = _attached_table_name(conn, "embeddings", "embedding_status")

--- a/polylogue/daemon/provenance.py
+++ b/polylogue/daemon/provenance.py
@@ -104,10 +104,12 @@ def _iso_from_epoch_ms(value: object) -> str | None:
     return datetime.fromtimestamp(epoch_ms / 1000.0, UTC).isoformat()
 
 
-def _fetch_archive_provenance_row(archive_db: Path, session_id: str) -> ProvenanceRow | None:
+def _fetch_archive_provenance_row(
+    archive_db: Path, session_id: str, *, archive_root_path: Path
+) -> ProvenanceRow | None:
     if not archive_db.exists():
         return None
-    source_db = archive_db.with_name("source.db")
+    source_db = archive_root_path / "source.db"
     conn = sqlite3.connect(f"file:{archive_db}?mode=ro", uri=True)
     try:
         conn.row_factory = sqlite3.Row
@@ -206,9 +208,9 @@ def fetch_provenance_row(session_id: str) -> ProvenanceRow | None:
     # needed.
     archive_db: Path | None = dbp
     if archive_db is not None and archive_db.exists():
-        return _fetch_archive_provenance_row(archive_db, session_id)
+        return _fetch_archive_provenance_row(archive_db, session_id, archive_root_path=archive_root())
     if not dbp.exists() and archive_db is not None:
-        return _fetch_archive_provenance_row(archive_db, session_id)
+        return _fetch_archive_provenance_row(archive_db, session_id, archive_root_path=archive_root())
     conn = sqlite3.connect(str(dbp))
     try:
         conn.row_factory = sqlite3.Row

--- a/polylogue/daemon/similarity.py
+++ b/polylogue/daemon/similarity.py
@@ -358,6 +358,7 @@ def _build_archive_similar_payload(
     *,
     bounded_limit: int,
     disabled_reason: str | None,
+    archive_root_path: Path,
 ) -> dict[str, object] | None:
     conn: sqlite3.Connection | None = None
     index_conn = sqlite3.connect(index_db)
@@ -372,7 +373,7 @@ def _build_archive_similar_payload(
             envelope["limit"] = bounded_limit
             return envelope
 
-        embeddings_db = Path(index_db).with_name("embeddings.db")
+        embeddings_db = archive_root_path / "embeddings.db"
         if not embeddings_db.exists():
             envelope = _empty_envelope("unavailable", reason="vec0_table_missing")
             envelope["session_id"] = session_id
@@ -486,6 +487,7 @@ def build_similar_payload(
             session_id,
             bounded_limit=bounded_limit,
             disabled_reason=disabled_reason,
+            archive_root_path=archive_root(),
         )
     if not dbf.exists():
         # Treat a missing database the same as a missing session —

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -787,7 +787,7 @@ def _raw_failure_info() -> dict[str, object]:
     maintenance_samples, maintenance_count = _maintenance_failure_info()
     if not dbf.exists():
         archive_info = _archive_raw_failure_info(
-            archive_root() / "source.db",
+            dbf.with_name("source.db"),
             maintenance_samples=maintenance_samples,
             maintenance_count=maintenance_count,
         )
@@ -801,11 +801,11 @@ def _raw_failure_info() -> dict[str, object]:
             "samples": maintenance_samples,
         }
     archive_info = _archive_raw_failure_info(
-        archive_root() / "source.db",
+        dbf.with_name("source.db"),
         maintenance_samples=maintenance_samples,
         maintenance_count=maintenance_count,
     )
-    if (archive_root() / "source.db").exists() and archive_info is not None:
+    if dbf.with_name("source.db").exists() and archive_info is not None:
         return archive_info
 
     try:

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -107,12 +107,13 @@ def _daemon_status_fingerprint(active_db: Path) -> str:
     Stat-only (no query execution), so checking it stays cheap even when the
     cached value itself is reused.
     """
+    ops_db = archive_root() / "ops.db"
     parts: list[str] = []
     for candidate in (
         active_db,
         active_db.with_suffix(".db-wal"),
-        active_db.with_name("ops.db"),
-        active_db.with_name("ops.db-wal"),
+        ops_db,
+        ops_db.with_suffix(".db-wal"),
     ):
         try:
             parts.append(f"{candidate.name}:{candidate.stat().st_mtime_ns}")
@@ -786,7 +787,7 @@ def _raw_failure_info() -> dict[str, object]:
     maintenance_samples, maintenance_count = _maintenance_failure_info()
     if not dbf.exists():
         archive_info = _archive_raw_failure_info(
-            dbf.with_name("source.db"),
+            archive_root() / "source.db",
             maintenance_samples=maintenance_samples,
             maintenance_count=maintenance_count,
         )
@@ -800,11 +801,11 @@ def _raw_failure_info() -> dict[str, object]:
             "samples": maintenance_samples,
         }
     archive_info = _archive_raw_failure_info(
-        dbf.with_name("source.db"),
+        archive_root() / "source.db",
         maintenance_samples=maintenance_samples,
         maintenance_count=maintenance_count,
     )
-    if dbf.with_name("source.db").exists() and archive_info is not None:
+    if (archive_root() / "source.db").exists() and archive_info is not None:
         return archive_info
 
     try:
@@ -1093,7 +1094,7 @@ def _failing_files_info() -> list[str]:
 def _live_cursor_summary_info() -> LiveCursorSummary:
     """Return live cursor backlog/failure state without source-tree scans."""
     dbf = _active_status_db_path()
-    ops_summary = _archive_live_cursor_summary_info(dbf.with_name("ops.db"))
+    ops_summary = _archive_live_cursor_summary_info(archive_root() / "ops.db")
     if ops_summary is not None:
         return ops_summary
     if not dbf.exists():
@@ -1249,7 +1250,7 @@ def _live_ingest_attempt_summary_info() -> LiveIngestAttemptSummary:
     # sibling_index_db(dbf, require_exists=False) call was provably an
     # identity operation on dbf itself.
     dbf = _active_status_db_path()
-    ops_summary = _archive_live_ingest_attempt_summary_info(dbf.with_name("ops.db"))
+    ops_summary = _archive_live_ingest_attempt_summary_info(archive_root() / "ops.db")
     index_db: Path | None = dbf
     if ((index_db is not None and index_db.exists()) or not dbf.exists()) and ops_summary is not None:
         return ops_summary
@@ -2237,14 +2238,14 @@ def _daemon_status_component_specs(
         StatusComponentSpec(
             name="convergence",
             scope="daemon",
-            collector=lambda: convergence_debt_summary_info(_active_status_db_path()),
+            collector=lambda: convergence_debt_summary_info(_active_status_db_path(), ops_db=archive_root() / "ops.db"),
             deadline_s=0.5,
             fingerprint=fingerprint,
         ),
         StatusComponentSpec(
             name="cursor_lag",
             scope="daemon",
-            collector=lambda: cursor_lag_summary_info(_active_status_db_path()),
+            collector=lambda: cursor_lag_summary_info(_active_status_db_path(), ops_db=archive_root() / "ops.db"),
             deadline_s=0.5,
             fingerprint=fingerprint,
         ),
@@ -2476,6 +2477,7 @@ def build_daemon_status(
         active_db,
         latest_attempt=live_ingest_attempts.recent[0] if live_ingest_attempts.recent else None,
         convergence=convergence,
+        ops_db=archive_root() / "ops.db",
     )
     raw_failures: dict[str, object] = _v("raw_failures", {})
     blob_publication_reservations = _v("blob_publication_reservations", BlobPublicationReservationStatus())

--- a/polylogue/maintenance/planner.py
+++ b/polylogue/maintenance/planner.py
@@ -401,6 +401,7 @@ def _collect_archive_debt_statuses(
     """
     from contextlib import closing
 
+    from polylogue.storage.archive_identity import archive_file_set_root
     from polylogue.storage.repair import collect_archive_debt_statuses_sync
     from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
@@ -409,6 +410,7 @@ def _collect_archive_debt_statuses(
     index_db = config.db_path
     if not index_db.exists():
         return {}
+    configured_root = archive_file_set_root(archive_root=config.archive_root, db_path=index_db)
     with closing(open_readonly_connection(index_db)) as conn:
         return collect_archive_debt_statuses_sync(
             conn,
@@ -416,6 +418,7 @@ def _collect_archive_debt_statuses(
             include_expensive=include_expensive,
             probe_only=False,
             target_names=target_names,
+            configured_root=configured_root,
         )
 
 

--- a/polylogue/maintenance/preview.py
+++ b/polylogue/maintenance/preview.py
@@ -420,7 +420,6 @@ def staleness_inventory(
     from contextlib import closing, nullcontext
 
     from polylogue.paths import archive_root
-    from polylogue.storage.archive_identity import resolve_active_index_path
     from polylogue.storage.derived.derived_status import collect_derived_model_statuses_sync
     from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
@@ -439,7 +438,7 @@ def staleness_inventory(
     if isinstance(db_path, sqlite3.Connection):
         connection_manager = nullcontext(db_path)
     else:
-        resolved = Path(db_path) if db_path is not None else resolve_active_index_path(archive_root())
+        resolved = Path(db_path) if db_path is not None else archive_root() / "index.db"
         if not resolved.exists():
             # No archive `index.db` yet (fresh archive before first ingest).
             # There is nothing to inventory; report an empty result rather

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -1440,6 +1440,7 @@ def _process_ingest_batch_sync(
                 record_schema_drift_observations_to_ops_sync(
                     db_path,
                     summary.schema_drift_observations,
+                    archive_root=archive_root,
                 )
     except Exception:
         # Roll back the row writes.  If a caller explicitly opted into

--- a/polylogue/readiness/__init__.py
+++ b/polylogue/readiness/__init__.py
@@ -36,7 +36,7 @@ from polylogue.readiness.capability import (
     component_from_raw_materialization_readiness,
     component_from_transform_registry,
 )
-from polylogue.storage.archive_identity import resolve_active_index_path
+from polylogue.storage.archive_identity import archive_file_set_root, resolve_active_index_path
 from polylogue.storage.archive_readiness import raw_materialization_ready
 from polylogue.storage.raw_retention import RawFrontierIntegrityProjection, raw_frontier_integrity_projection
 from polylogue.storage.repair import ArchiveDebtStatus
@@ -546,6 +546,7 @@ def _collect_table_status_best_effort(
     db_path: Path,
     deep: bool,
     probe_only: bool,
+    configured_root: Path | None = None,
 ) -> tuple[dict[str, DerivedModelStatus], dict[str, ArchiveDebtStatus]]:
     """Collect derived-model and archive-debt statuses without aborting.
 
@@ -571,6 +572,7 @@ def _collect_table_status_best_effort(
             derived_statuses=derived_statuses,
             include_expensive=deep,
             probe_only=probe_only,
+            configured_root=configured_root,
         )
     except sqlite3.OperationalError:
         archive_debt = {}
@@ -689,7 +691,11 @@ def run_archive_readiness(config: Config, *, deep: bool = False, probe_only: boo
         # Run table-dependent collectors best-effort so archive integrity
         # probes above always register.
         derived_statuses, archive_debt = _collect_table_status_best_effort(
-            conn, db_path=db_path, deep=deep, probe_only=probe_only or not deep
+            conn,
+            db_path=db_path,
+            deep=deep,
+            probe_only=probe_only or not deep,
+            configured_root=archive_file_set_root(archive_root=archive_root, db_path=db_path),
         )
         checks.extend(_archive_debt_checks(archive_debt, deep=deep))
         checks.extend(_derived_model_checks(derived_statuses))

--- a/polylogue/schemas/drift_sentinel_sampling.py
+++ b/polylogue/schemas/drift_sentinel_sampling.py
@@ -33,18 +33,25 @@ logger = get_logger(__name__)
 def record_schema_drift_observations_to_ops_sync(
     index_db_path: Path,
     observations: list[SchemaDriftObservation],
+    *,
+    archive_root: Path | None = None,
 ) -> int:
     """Append one ops.db sample per observation. Returns the count written.
 
     ``index_db_path`` is the just-committed index.db connection's file
-    path; ``ops.db`` is resolved as its sibling. Returns 0 on any failure
-    (missing sibling file, unreachable connection, disposable-tier not yet
-    initialized) without raising.
+    path; ``ops.db`` is resolved as its sibling by default. ``index_db_path``
+    can be ``Config.db_path``, which per polylogue-yla8.1 names the resolved
+    active generation rather than the plain archive root once an
+    ``.index-active-pointer`` is active -- callers that already have the
+    plain archive root in scope (e.g. the ingest writer, which threads both
+    ``db_path`` and ``archive_root_str`` through the same commit path)
+    should pass it explicitly via ``archive_root`` instead of relying on
+    the sibling derivation.
     """
     if not observations:
         return 0
 
-    ops_db_path = index_db_path.with_name("ops.db")
+    ops_db_path = (archive_root / "ops.db") if archive_root is not None else index_db_path.with_name("ops.db")
     if not ops_db_path.exists():
         return 0
 

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -255,9 +255,15 @@ def _cursor_record_from_ops_row(row: sqlite3.Row | tuple[object, ...]) -> Cursor
 class CursorStore:
     """SQLite-backed live cursor store keyed by source path."""
 
-    def __init__(self, db_path: Path, *, initialize: bool = True) -> None:
+    def __init__(self, db_path: Path, *, initialize: bool = True, ops_db_path: Path | None = None) -> None:
         self._db_path = db_path
-        self._ops_db_path = db_path.with_name("ops.db")
+        # ``db_path`` can itself be a resolved ``.index-active-pointer``
+        # generation target (e.g. via ``Config.db_path``/``backend.db_path``,
+        # which resolves through ``resolve_active_index_path`` per
+        # polylogue-yla8.1) rather than the plain archive root, so callers
+        # that already know the plain root should pass it explicitly via
+        # ``ops_db_path`` instead of relying on the sibling derivation.
+        self._ops_db_path = ops_db_path if ops_db_path is not None else db_path.with_name("ops.db")
         self._initialize_lock = threading.Lock()
         self._initialized = False
         if initialize:

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -188,6 +188,7 @@ class LiveWatcher:
         self._cursor = cursor or CursorStore(
             _cursor_db_path(polylogue),
             initialize=write_coordinator is None,
+            ops_db_path=Path(polylogue.archive_root) / "ops.db",
         )
         self._max_workers = max_workers
         self._converger = converger

--- a/polylogue/storage/blob_integrity.py
+++ b/polylogue/storage/blob_integrity.py
@@ -505,12 +505,14 @@ def _raw_session_hashes(conn: sqlite3.Connection) -> list[str]:
     return [str(row[0]) for row in rows if row[0]]
 
 
-def _referenced_blob_hashes(db_path: Path, conn: sqlite3.Connection) -> list[str]:
+def _referenced_blob_hashes(
+    db_path: Path, conn: sqlite3.Connection, *, configured_root: Path | None = None
+) -> list[str]:
     direct_archive_hashes = _archive_source_blob_hashes(conn)
     if direct_archive_hashes:
         return direct_archive_hashes
 
-    source_db = db_path.with_name("source.db")
+    source_db = (configured_root / "source.db") if configured_root is not None else db_path.with_name("source.db")
     if source_db != db_path and source_db.exists():
         try:
             source_conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
@@ -532,12 +534,14 @@ def _referenced_blob_hashes(db_path: Path, conn: sqlite3.Connection) -> list[str
     return _raw_session_hashes(conn)
 
 
-def _reference_source_counts(db_path: Path, conn: sqlite3.Connection) -> dict[str, int]:
+def _reference_source_counts(
+    db_path: Path, conn: sqlite3.Connection, *, configured_root: Path | None = None
+) -> dict[str, int]:
     direct = _archive_source_blob_hashes_by_table(conn)
     if direct:
         return {table: len(hashes) for table, hashes in direct.items()}
 
-    source_db = db_path.with_name("source.db")
+    source_db = (configured_root / "source.db") if configured_root is not None else db_path.with_name("source.db")
     if source_db != db_path and source_db.exists():
         try:
             source_conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
@@ -1879,15 +1883,24 @@ def scan_blob_reference_debt(
     store: BlobStore | None = None,
     sample_size: int = _MAX_FINDING_SAMPLE,
     immutable: bool = False,
+    configured_root: Path | None = None,
 ) -> BlobReferenceDebtReport:
-    """Count missing referenced blob files exactly without mutating state."""
+    """Count missing referenced blob files exactly without mutating state.
+
+    ``configured_root`` names the durable-tier archive root explicitly for
+    callers whose ``db_path`` was resolved through a ``.index-active-pointer``
+    generation (``resolve_active_index_path``) and may therefore live outside
+    the root that actually houses ``source.db``; it defaults to
+    ``db_path.with_name("source.db")`` for callers that never diverge from
+    the plain convention.
+    """
 
     resolved_db_path = Path(db_path)
     blob_store = store if store is not None else BlobStore(resolved_db_path.parent / "blob")
     immutable_query = "&immutable=1" if immutable else ""
     with closing(sqlite3.connect(f"file:{resolved_db_path}?mode=ro{immutable_query}", uri=True)) as conn:
-        referenced = _referenced_blob_hashes(resolved_db_path, conn)
-        reference_sources = _reference_source_counts(resolved_db_path, conn)
+        referenced = _referenced_blob_hashes(resolved_db_path, conn, configured_root=configured_root)
+        reference_sources = _reference_source_counts(resolved_db_path, conn, configured_root=configured_root)
 
     missing_count = 0
     sample: list[str] = []
@@ -1993,18 +2006,23 @@ def scan_blob_integrity(
     store: BlobStore | None = None,
     full: bool = False,
     sample_size: int = _DEFAULT_SAMPLE_SIZE,
+    configured_root: Path | None = None,
 ) -> BlobIntegrityReport:
     """Classify blob-store integrity without mutating disk or database state.
 
     ``full=False`` bounds the filesystem and hash-verification scan to
     ``sample_size`` blobs and references. ``full=True`` scans every blob and
     every raw-session reference.
+
+    ``configured_root`` names the durable-tier archive root explicitly; see
+    :func:`scan_blob_reference_debt` for why this matters when ``db_path``
+    was resolved through a ``.index-active-pointer`` generation.
     """
 
     resolved_db_path = Path(db_path)
     blob_store = store if store is not None else BlobStore(resolved_db_path.parent / "blob")
     with open_read_connection(resolved_db_path) as conn:
-        referenced = _referenced_blob_hashes(resolved_db_path, conn)
+        referenced = _referenced_blob_hashes(resolved_db_path, conn, configured_root=configured_root)
 
     referenced_set = set(referenced)
     disk_sample = _blob_sample(blob_store, full=full, sample_size=sample_size)

--- a/polylogue/storage/blob_repair.py
+++ b/polylogue/storage/blob_repair.py
@@ -50,10 +50,14 @@ def _referenced_blob_hashes(
     conn: sqlite3.Connection,
     *,
     db_path: Path | None = None,
+    configured_root: Path | None = None,
 ) -> tuple[set[str], list[str]]:
     hashes, surfaces = _archive_blob_hashes(conn, surface_prefix="current")
 
-    source_db_path = db_path.with_name("source.db") if db_path is not None else None
+    if configured_root is not None:
+        source_db_path: Path | None = configured_root / "source.db"
+    else:
+        source_db_path = db_path.with_name("source.db") if db_path is not None else None
     if source_db_path is not None and source_db_path != db_path and source_db_path.exists():
         try:
             source_conn = sqlite3.connect(f"file:{source_db_path}?mode=ro", uri=True)
@@ -83,12 +87,19 @@ def _surface_detail(surfaces: list[str]) -> str:
     return "references: " + ", ".join(sorted(dict.fromkeys(surfaces)))
 
 
-def count_orphaned_blobs_sync(conn: sqlite3.Connection, *, db_path: Path | str | None = None) -> int:
+def count_orphaned_blobs_sync(
+    conn: sqlite3.Connection, *, db_path: Path | str | None = None, configured_root: Path | None = None
+) -> int:
     from polylogue.storage.blob_store import BlobStore, get_blob_store
 
     resolved_db_path = Path(db_path) if db_path else None
-    referenced_hashes, _surfaces = _referenced_blob_hashes(conn, db_path=resolved_db_path)
-    store = BlobStore(resolved_db_path.parent / "blob") if resolved_db_path is not None else get_blob_store()
+    referenced_hashes, _surfaces = _referenced_blob_hashes(
+        conn, db_path=resolved_db_path, configured_root=configured_root
+    )
+    if configured_root is not None:
+        store = BlobStore(configured_root / "blob")
+    else:
+        store = BlobStore(resolved_db_path.parent / "blob") if resolved_db_path is not None else get_blob_store()
     return store.detect_orphans(referenced_hashes).orphan_count
 
 

--- a/polylogue/storage/embeddings/materialization.py
+++ b/polylogue/storage/embeddings/materialization.py
@@ -1231,10 +1231,12 @@ def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
     return {str(row[1]) for row in rows}
 
 
-def mark_all_archive_sessions_needs_reindex(index_db_path: Path) -> None:
+def mark_all_archive_sessions_needs_reindex(index_db_path: Path, *, embeddings_db_path: Path | None = None) -> None:
     """Flag every archive session for embedding rebuild."""
 
-    embeddings_db_path = index_db_path.with_name("embeddings.db")
+    embeddings_db_path = (
+        embeddings_db_path if embeddings_db_path is not None else index_db_path.with_name("embeddings.db")
+    )
     conn = sqlite3.connect(embeddings_db_path, timeout=30.0)
     try:
         conn.execute("ATTACH DATABASE ? AS idx", (str(index_db_path),))
@@ -1378,8 +1380,18 @@ def embed_archive_session_sync(
     index_db_path: Path,
     vec_provider: VectorProvider,
     session_id: str,
+    *,
+    embeddings_db_path: Path | None = None,
 ) -> EmbedSessionOutcome:
-    """Embed one archive session with exact-key, generation-guarded publication."""
+    """Embed one archive session with exact-key, generation-guarded publication.
+
+    ``embeddings_db_path`` names the sibling ``embeddings.db`` explicitly for
+    callers that resolved it independently (e.g. an ``ArchiveLocation``'s
+    ``configured_root``, which may differ from ``index_db_path`` for an
+    index-only external generation or a ``.index-active-pointer`` resolved
+    active index); it defaults to ``index_db_path.with_name("embeddings.db")``
+    for callers that never diverge from the plain convention.
+    """
 
     text_provider = cast(_EmbeddingTextProvider, vec_provider)
     if not hasattr(text_provider, "_get_embeddings"):
@@ -1389,7 +1401,9 @@ def embed_archive_session_sync(
             error="vector provider does not expose text embedding generation",
         )
 
-    embeddings_db_path = index_db_path.with_name("embeddings.db")
+    embeddings_db_path = (
+        embeddings_db_path if embeddings_db_path is not None else index_db_path.with_name("embeddings.db")
+    )
     index_conn = sqlite3.connect(f"file:{index_db_path}?mode=ro", uri=True, timeout=30.0)
     index_conn.row_factory = sqlite3.Row
     embeddings_conn = sqlite3.connect(embeddings_db_path, timeout=30.0)

--- a/polylogue/storage/embeddings/status_payload.py
+++ b/polylogue/storage/embeddings/status_payload.py
@@ -731,16 +731,18 @@ def _archive_embedding_status_payload(
     *,
     cfg: object,
     include_detail: bool,
+    configured_root: Path | None = None,
 ) -> EmbeddingStatusPayload | None:
     index_db = _archive_index_path(db_path)
     if index_db is None:
         return None
+    root = configured_root if configured_root is not None else db_path.parent
     conn = open_readonly_connection(index_db, timeout=STATUS_READ_BUSY_TIMEOUT_MS / 1000.0)
     conn.execute(f"PRAGMA busy_timeout = {STATUS_READ_BUSY_TIMEOUT_MS}")
     try:
         if not _table_exists(conn, "sessions"):
             return None
-        embeddings_db = index_db.with_name("embeddings.db")
+        embeddings_db = root / "embeddings.db"
         if embeddings_db.exists():
             conn.execute("ATTACH DATABASE ? AS embeddings", (str(embeddings_db),))
             status_table = _attached_table_name(conn, "embeddings", "embedding_status")
@@ -1033,7 +1035,7 @@ def _archive_embedding_status_payload(
     finally:
         conn.close()
 
-    latest_catchup_run, latest_material_catchup_run = _archive_catchup_runs(index_db.with_name("ops.db"))
+    latest_catchup_run, latest_material_catchup_run = _archive_catchup_runs(root / "ops.db")
 
     return _payload_from_stats(
         config_enabled=bool(getattr(cfg, "embedding_enabled", False)),
@@ -1125,13 +1127,17 @@ def embedding_status_payload(
 ) -> EmbeddingStatusPayload:
     """Read canonical embedding-status statistics for operator surfaces."""
     from polylogue.config import load_polylogue_config
+    from polylogue.storage.archive_identity import archive_file_set_root
     from polylogue.storage.embeddings.embedding_stats import read_embedding_stats_sync
     from polylogue.storage.embeddings.progress import latest_embedding_catchup_run
     from polylogue.storage.embeddings.support import table_exists_sync
 
     cfg = load_polylogue_config()
     db_path = Path(env.config.db_path)
-    archive_payload = _archive_embedding_status_payload(db_path, cfg=cfg, include_detail=include_detail)
+    configured_root = archive_file_set_root(archive_root=env.config.archive_root, db_path=db_path)
+    archive_payload = _archive_embedding_status_payload(
+        db_path, cfg=cfg, include_detail=include_detail, configured_root=configured_root
+    )
     if archive_payload is not None:
         return archive_payload
     if not db_path.exists():

--- a/polylogue/storage/embeddings/status_payload.py
+++ b/polylogue/storage/embeddings/status_payload.py
@@ -1134,7 +1134,17 @@ def embedding_status_payload(
 
     cfg = load_polylogue_config()
     db_path = Path(env.config.db_path)
-    configured_root = archive_file_set_root(archive_root=env.config.archive_root, db_path=db_path)
+    # `env.config` is a duck-typed `_HasConfig` seam (see embedding_readiness_info,
+    # which passes a bare SimpleNamespace(db_path=...) with no `archive_root`),
+    # not always a real Config -- fall back to the plain db_path.parent
+    # derivation archive_file_set_root itself uses when archive_root is
+    # unavailable, matching this seam's original (pre-split-root-aware) behavior.
+    archive_root = getattr(env.config, "archive_root", None)
+    configured_root = (
+        archive_file_set_root(archive_root=archive_root, db_path=db_path)
+        if archive_root is not None
+        else db_path.parent
+    )
     archive_payload = _archive_embedding_status_payload(
         db_path, cfg=cfg, include_detail=include_detail, configured_root=configured_root
     )

--- a/polylogue/storage/fts/drift_sampling.py
+++ b/polylogue/storage/fts/drift_sampling.py
@@ -51,7 +51,7 @@ def _index_db_path_sync(conn: sqlite3.Connection) -> Path | None:
     return None
 
 
-def sample_fts_drift_to_ops_sync(conn: sqlite3.Connection) -> int:
+def sample_fts_drift_to_ops_sync(conn: sqlite3.Connection, *, archive_root: Path | None = None) -> int:
     """Append one ops.db drift sample per recorded FTS surface.
 
     Reads the just-recorded ``fts_freshness_state`` rows on ``conn`` (an
@@ -59,6 +59,12 @@ def sample_fts_drift_to_ops_sync(conn: sqlite3.Connection) -> int:
     sibling ``ops.db``. Returns the number of samples written; returns 0 on
     any failure (missing table, missing sibling file, unreachable
     connection) without raising.
+
+    ``conn``'s own connected path can itself be a resolved
+    ``.index-active-pointer`` generation target (``Config.db_path`` per
+    polylogue-yla8.1) rather than the plain archive root; callers that
+    already know the plain root should pass it explicitly via
+    ``archive_root`` instead of relying on the sibling-of-conn derivation.
     """
     try:
         from polylogue.storage.fts.freshness import ensure_fts_freshness_table_sync
@@ -71,10 +77,13 @@ def sample_fts_drift_to_ops_sync(conn: sqlite3.Connection) -> int:
     if not rows:
         return 0
 
-    index_db_path = _index_db_path_sync(conn)
-    if index_db_path is None:
-        return 0
-    ops_db_path = index_db_path.with_name("ops.db")
+    if archive_root is not None:
+        ops_db_path = archive_root / "ops.db"
+    else:
+        index_db_path = _index_db_path_sync(conn)
+        if index_db_path is None:
+            return 0
+        ops_db_path = index_db_path.with_name("ops.db")
     if not ops_db_path.exists():
         return 0
 

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -5369,6 +5369,7 @@ def collect_archive_debt_statuses_sync(
     include_expensive: bool = True,
     probe_only: bool = False,
     target_names: tuple[str, ...] = (),
+    configured_root: Path | None = None,
 ) -> dict[str, ArchiveDebtStatus]:
     from polylogue.storage.derived.derived_status import collect_derived_model_statuses_sync
 
@@ -5452,7 +5453,7 @@ def collect_archive_debt_statuses_sync(
             skipped=skip_large_message_scans,
         )
     if include_expensive and "orphaned_blobs" in selected:
-        orphaned_blobs = count_orphaned_blobs_sync(conn, db_path=db_path)
+        orphaned_blobs = count_orphaned_blobs_sync(conn, db_path=db_path, configured_root=configured_root)
         debt_statuses["orphaned_blobs"] = _archive_debt_status(
             "orphaned_blobs",
             issue_count=orphaned_blobs,

--- a/polylogue/storage/usage.py
+++ b/polylogue/storage/usage.py
@@ -1120,7 +1120,7 @@ def _source_raw_stats(
     origin: str | None,
     limit: int | None,
 ) -> tuple[dict[str, dict[str, int]], dict[str, tuple[str, ...]], str | None]:
-    alias = _source_schema_alias(conn)
+    alias = _source_schema_alias(conn, archive_root=archive_root)
     if alias is None:
         return {}, {}, "source.db raw_sessions unavailable; acquired-not-materialized coverage cannot be checked"
     alias_sql = _quote_identifier(alias)
@@ -1418,11 +1418,11 @@ def _stale_provider_rollup_stats(
     return counts, samples
 
 
-def _source_schema_alias(conn: sqlite3.Connection) -> str | None:
+def _source_schema_alias(conn: sqlite3.Connection, *, archive_root: Path | None = None) -> str | None:
     for alias in ("source_tier", "source_debt", "source", "usage_source_tier"):
         if _table_exists_in_schema(conn, alias, "raw_sessions"):
             return alias
-    source_db = _sibling_source_db(conn)
+    source_db = (archive_root / "source.db") if archive_root is not None else _sibling_source_db(conn)
     if source_db is None or not source_db.exists():
         return None
     try:

--- a/tests/unit/cli/test_check_support_runtime.py
+++ b/tests/unit/cli/test_check_support_runtime.py
@@ -175,7 +175,7 @@ def test_run_blob_store_check_reports_missing_orphaned_and_verified_states() -> 
         }
         payload = check_workflow._run_blob_store_check(config, full=True)
 
-    scan.assert_called_once_with(config.db_path, full=True)
+    scan.assert_called_once_with(config.db_path, full=True, configured_root=config.archive_root)
     assert payload["ok"] is False
     findings = cast(list[JSONDocument], payload["findings"])
     assert findings[0]["kind"] == "orphan_blobs"

--- a/tests/unit/cli/test_embed_activation.py
+++ b/tests/unit/cli/test_embed_activation.py
@@ -526,7 +526,9 @@ class TestBackfillCommand:
         assert result.exit_code == 0, result.output
         assert "Embedded 1" in result.output
         assert fake_select.call_args.kwargs["max_messages"] == 2
-        fake_embed.assert_called_once_with(index_db, fake_provider, "codex-session:v1")
+        fake_embed.assert_called_once_with(
+            index_db, fake_provider, "codex-session:v1", embeddings_db_path=index_db.parent / "embeddings.db"
+        )
         old_iter.assert_not_called()
 
     def test_backfill_json_outputs_structured_result(

--- a/tests/unit/cli/test_embed_status_fast.py
+++ b/tests/unit/cli/test_embed_status_fast.py
@@ -43,6 +43,7 @@ class _Cfg:
 def _env(db_path: Path) -> Any:
     env = MagicMock()
     env.config.db_path = db_path
+    env.config.archive_root = db_path.parent
     return env
 
 

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -920,15 +920,15 @@ def test_embed_stage_defers_to_pending_debt_while_predicate_holds(
 
     embed_calls: list[str] = []
 
-    def fake_execute(_db: Path, _path: Path) -> bool:
+    def fake_execute(_db: Path, _path: Path, **_kwargs: object) -> bool:
         embed_calls.append("execute")
         return True
 
-    def fake_execute_many(_db: Path, _paths: object) -> bool:
+    def fake_execute_many(_db: Path, _paths: object, **_kwargs: object) -> bool:
         embed_calls.append("execute_many")
         return True
 
-    def fake_execute_sessions(_db: Path, _ids: object) -> bool:
+    def fake_execute_sessions(_db: Path, _ids: object, **_kwargs: object) -> bool:
         embed_calls.append("execute_sessions")
         return True
 
@@ -1457,7 +1457,7 @@ def test_archive_insights_execute_sessions_uses_write_connection_profile(
 
     seen_busy_timeout: list[int] = []
 
-    def fake_execute_ids(conn: sqlite3.Connection, session_ids: list[str]) -> bool:
+    def fake_execute_ids(conn: sqlite3.Connection, session_ids: list[str], **_kwargs: object) -> bool:
         assert session_ids == [session_id]
         seen_busy_timeout.append(int(conn.execute("PRAGMA busy_timeout").fetchone()[0]))
         return True

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -588,7 +588,9 @@ def test_archive_insights_path_batch_does_not_fallback_to_global_missing_profile
     archive_db.touch()
     source_path = tmp_path / "codex.jsonl"
 
-    monkeypatch.setattr(stages, "_schema_archive_session_ids_for_source_paths", lambda _conn, _paths: {source_path: []})
+    monkeypatch.setattr(
+        stages, "_schema_archive_session_ids_for_source_paths", lambda _conn, _paths, **_kw: {source_path: []}
+    )
 
     def fail_global_missing_profiles(_conn: sqlite3.Connection) -> list[str]:
         raise AssertionError("path-scoped insight convergence must not scan global missing profiles")
@@ -1378,7 +1380,7 @@ def test_archive_insights_execute_ids_deduplicates_session_ids(tmp_path: Path, m
         return SimpleNamespace(profiles=1, work_events=0, phases=0, threads=0)
 
     monkeypatch.setattr("polylogue.storage.insights.session.rebuild.rebuild_session_insights_sync", fake_rebuild)
-    monkeypatch.setattr(stages, "_archive_hot_insight_session_ids", lambda _conn, _ids: set())
+    monkeypatch.setattr(stages, "_archive_hot_insight_session_ids", lambda _conn, _ids, **_kw: set())
     monkeypatch.setattr(stages, "_archive_stale_session_profile_ids", lambda _conn, _ids: [])
 
     with sqlite3.connect(db_path) as conn:
@@ -1424,7 +1426,9 @@ def test_archive_insights_execute_ids_rebuilds_quiet_subset_when_some_sessions_a
         return SimpleNamespace(profiles=1, work_events=0, phases=0, threads=0)
 
     monkeypatch.setattr("polylogue.storage.insights.session.rebuild.rebuild_session_insights_sync", fake_rebuild)
-    monkeypatch.setattr(stages, "_archive_hot_insight_session_ids", lambda _conn, _ids: {"codex-session:conv-hot"})
+    monkeypatch.setattr(
+        stages, "_archive_hot_insight_session_ids", lambda _conn, _ids, **_kw: {"codex-session:conv-hot"}
+    )
     monkeypatch.setattr(stages, "_archive_stale_session_profile_ids", lambda _conn, _ids: [])
 
     with sqlite3.connect(db_path) as conn:

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -2194,6 +2194,7 @@ def test_ensure_fts_startup_readiness_skips_old_non_blocks_shape(
 
     repairs: list[FakeConnection] = []
 
+    monkeypatch.setattr("polylogue.paths.archive_root", lambda: db.parent)
     monkeypatch.setattr("polylogue.storage.archive_identity.resolve_active_index_path", lambda *_a, **_k: db)
     monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", ensure)
@@ -2281,6 +2282,7 @@ def test_ensure_fts_startup_readiness_does_not_rebuild_old_non_blocks_shape(
     def rebuild(fake_conn: FakeConnection) -> None:
         rebuilds.append(fake_conn)
 
+    monkeypatch.setattr("polylogue.paths.archive_root", lambda: db.parent)
     monkeypatch.setattr("polylogue.storage.archive_identity.resolve_active_index_path", lambda *_a, **_k: db)
     monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", lambda _conn: None)
@@ -2691,6 +2693,7 @@ def test_ensure_fts_startup_readiness_skips_when_blocks_table_absent(
             self.closed = True
 
     conn = FakeConnection()
+    monkeypatch.setattr("polylogue.paths.archive_root", lambda: db.parent)
     monkeypatch.setattr("polylogue.storage.archive_identity.resolve_active_index_path", lambda *_a, **_k: db)
     monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
     monkeypatch.setattr(
@@ -2786,6 +2789,7 @@ def test_ensure_fts_startup_readiness_trusts_ready_freshness_without_counts(
     conn = FakeConnection()
     rebuilds: list[FakeConnection] = []
     optional_repairs: list[FakeConnection] = []
+    monkeypatch.setattr("polylogue.paths.archive_root", lambda: db.parent)
     monkeypatch.setattr("polylogue.storage.archive_identity.resolve_active_index_path", lambda *_a, **_k: db)
     monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
     monkeypatch.setattr("polylogue.storage.sqlite.archive_tiers.bootstrap.initialize_archive_tier", lambda *_args: None)
@@ -2914,6 +2918,7 @@ def test_ensure_fts_startup_readiness_skips_non_current_archive_shape(
     restored: list[FakeConnection] = []
     rebuilds: list[FakeConnection] = []
 
+    monkeypatch.setattr("polylogue.paths.archive_root", lambda: db.parent)
     monkeypatch.setattr("polylogue.storage.archive_identity.resolve_active_index_path", lambda *_a, **_k: db)
     monkeypatch.setattr("polylogue.storage.sqlite.connection_profile.open_connection", lambda _db, timeout: conn)
     monkeypatch.setattr("polylogue.storage.fts.fts_lifecycle.ensure_fts_index_sync", lambda fake_conn: None)

--- a/tests/unit/daemon/test_daemon_lifecycle.py
+++ b/tests/unit/daemon/test_daemon_lifecycle.py
@@ -29,8 +29,7 @@ from polylogue.daemon.status import _check_daemon_liveness, format_daemon_status
 
 
 def _bind_ops_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    index_db = tmp_path / "index.db"
-    monkeypatch.setattr(lifecycle_module, "resolve_active_index_path", lambda *_a, **_k: index_db)
+    monkeypatch.setattr(lifecycle_module, "archive_root", lambda: tmp_path)
     return tmp_path / "ops.db"
 
 

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -368,6 +368,7 @@ def test_build_daemon_status_reports_failed_live_cursor_files(tmp_path: Path) ->
     cursor.mark_failed(failed)
 
     with (
+        patch("polylogue.daemon.status.archive_root", return_value=db.parent),
         patch("polylogue.daemon.status._active_status_db_path", return_value=db),
         patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
         patch("polylogue.daemon.status._blob_size_info", return_value=0),
@@ -542,6 +543,7 @@ def test_daemon_status_payload_and_plain_output_include_failed_files(tmp_path: P
     cursor.mark_failed(failed)
 
     with (
+        patch("polylogue.daemon.status.archive_root", return_value=db.parent),
         patch("polylogue.daemon.status._active_status_db_path", return_value=db),
         patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
         patch("polylogue.daemon.status._blob_size_info", return_value=0),
@@ -849,6 +851,7 @@ def test_daemon_status_prefers_archive_ops_live_cursor(tmp_path: Path) -> None:
     cursor.mark_failed(failed)
 
     with (
+        patch("polylogue.daemon.status.archive_root", return_value=db.parent),
         patch("polylogue.daemon.status._active_status_db_path", return_value=db),
         patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
         patch("polylogue.daemon.status._blob_size_info", return_value=0),
@@ -892,6 +895,7 @@ def test_daemon_status_caps_failed_file_samples(tmp_path: Path) -> None:
         cursor.mark_failed(failed)
 
     with (
+        patch("polylogue.daemon.status.archive_root", return_value=db.parent),
         patch("polylogue.daemon.status._active_status_db_path", return_value=db),
         patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
         patch("polylogue.daemon.status._blob_size_info", return_value=0),
@@ -958,6 +962,7 @@ def test_daemon_status_reports_live_ingest_attempts(tmp_path: Path) -> None:
     )
 
     with (
+        patch("polylogue.daemon.status.archive_root", return_value=db.parent),
         patch("polylogue.daemon.status._active_status_db_path", return_value=db),
         patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
         patch("polylogue.daemon.status._blob_size_info", return_value=0),
@@ -1060,6 +1065,7 @@ def test_daemon_status_reads_ops_tier_from_archive_tiers(tmp_path: Path) -> None
         )
 
     with (
+        patch("polylogue.daemon.status.archive_root", return_value=db.parent),
         patch("polylogue.daemon.status._active_status_db_path", return_value=db),
         patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
         patch("polylogue.daemon.status._blob_size_info", return_value=0),
@@ -1138,6 +1144,7 @@ def test_daemon_status_reads_ops_tier_when_archive_db_exists(tmp_path: Path) -> 
         )
 
     with (
+        patch("polylogue.daemon.status.archive_root", return_value=db.parent),
         patch("polylogue.daemon.status._active_status_db_path", return_value=db),
         patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
         patch("polylogue.daemon.status._blob_size_info", return_value=0),
@@ -1172,6 +1179,7 @@ def test_daemon_status_reports_convergence_debt_separately(tmp_path: Path) -> No
     )
 
     with (
+        patch("polylogue.daemon.status.archive_root", return_value=db.parent),
         patch("polylogue.daemon.status._active_status_db_path", return_value=db),
         patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
         patch("polylogue.daemon.status._blob_size_info", return_value=0),
@@ -2184,6 +2192,7 @@ def test_daemon_status_flags_stale_live_ingest_attempts(tmp_path: Path, frozen_c
         conn.commit()
 
     with (
+        patch("polylogue.daemon.status.archive_root", return_value=db.parent),
         patch("polylogue.daemon.status._active_status_db_path", return_value=db),
         patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
         patch("polylogue.daemon.status._blob_size_info", return_value=0),
@@ -2261,6 +2270,7 @@ def test_daemon_status_flags_slow_but_progressing_live_ingest_attempt(
         conn.commit()
 
     with (
+        patch("polylogue.daemon.status.archive_root", return_value=db.parent),
         patch("polylogue.daemon.status._active_status_db_path", return_value=db),
         patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
         patch("polylogue.daemon.status._blob_size_info", return_value=0),
@@ -2308,6 +2318,7 @@ def test_daemon_status_summarizes_retry_due_and_excluded_live_cursor_files(tmp_p
         conn.commit()
 
     with (
+        patch("polylogue.daemon.status.archive_root", return_value=db.parent),
         patch("polylogue.daemon.status._active_status_db_path", return_value=db),
         patch("polylogue.daemon.status._check_daemon_liveness", return_value=False),
         patch("polylogue.daemon.status._blob_size_info", return_value=0),

--- a/tests/unit/daemon/test_embedding_convergence_progress.py
+++ b/tests/unit/daemon/test_embedding_convergence_progress.py
@@ -118,7 +118,7 @@ def test_daemon_embedding_backlog_drain_processes_archive(
 
     embedded_calls: list[tuple[Path, str]] = []
 
-    def fake_embed(db_path: Path, _provider: object, session_id: str) -> EmbedSessionOutcome:
+    def fake_embed(db_path: Path, _provider: object, session_id: str, **_kwargs: object) -> EmbedSessionOutcome:
         embedded_calls.append((db_path, session_id))
         return EmbedSessionOutcome(
             status="embedded",
@@ -173,7 +173,7 @@ def test_daemon_embedding_backlog_uses_bounded_pending_window(
         observed_kwargs.update(kwargs)
         return [PendingSession(session_id="codex-session:v1-a", title="Archive A", message_count=2)]
 
-    def fake_embed(_db_path: Path, _provider: object, session_id: str) -> EmbedSessionOutcome:
+    def fake_embed(_db_path: Path, _provider: object, session_id: str, **_kwargs: object) -> EmbedSessionOutcome:
         return EmbedSessionOutcome(status="embedded", session_id=session_id, embedded_message_count=2)
 
     monkeypatch.setattr(convergence_stages, "load_polylogue_config", lambda: _EmbeddingConfig())
@@ -212,7 +212,7 @@ def test_daemon_embedding_backlog_records_skipped_sessions(
             """
         )
 
-    def fake_embed(_db_path: Path, _provider: object, session_id: str) -> EmbedSessionOutcome:
+    def fake_embed(_db_path: Path, _provider: object, session_id: str, **_kwargs: object) -> EmbedSessionOutcome:
         return EmbedSessionOutcome(status="no_embeddable_messages", session_id=session_id)
 
     monkeypatch.setattr(convergence_stages, "load_polylogue_config", lambda: _EmbeddingConfig())
@@ -261,7 +261,7 @@ def test_archive_convergence_embedding_uses_embeddings_tier(
         observed_vector_db_paths.append(Path(str(kwargs["db_path"])))
         return fake_provider
 
-    def fake_embed(db_path: Path, provider: object, session_id: str) -> EmbedSessionOutcome:
+    def fake_embed(db_path: Path, provider: object, session_id: str, **_kwargs: object) -> EmbedSessionOutcome:
         assert provider is fake_provider
         embedded_calls.append((db_path, session_id))
         return EmbedSessionOutcome(

--- a/tests/unit/storage/test_embedding_freshness_invariant.py
+++ b/tests/unit/storage/test_embedding_freshness_invariant.py
@@ -159,7 +159,9 @@ def test_daemon_backlog_mutation_restoring_stale_check_bypass_misses_changed_con
     index_db, _embeddings_db, session_id = _fresh_then_change(tmp_path / "archive")
     selected: list[str] = []
 
-    def _observe_embed(_index_db: Path, _provider: object, selected_session_id: str) -> EmbedSessionOutcome:
+    def _observe_embed(
+        _index_db: Path, _provider: object, selected_session_id: str, **_kwargs: object
+    ) -> EmbedSessionOutcome:
         selected.append(selected_session_id)
         return EmbedSessionOutcome(status="embedded", session_id=selected_session_id, embedded_message_count=1)
 
@@ -182,7 +184,9 @@ def test_manual_backfill_mutation_restoring_stale_check_bypass_misses_changed_co
     index_db, embeddings_db, session_id = _fresh_then_change(tmp_path / "archive")
     selected: list[str] = []
 
-    def _observe_embed(_index_db: Path, _provider: object, selected_session_id: str) -> EmbedSessionOutcome:
+    def _observe_embed(
+        _index_db: Path, _provider: object, selected_session_id: str, **_kwargs: object
+    ) -> EmbedSessionOutcome:
         selected.append(selected_session_id)
         return EmbedSessionOutcome(status="embedded", session_id=selected_session_id, embedded_message_count=1)
 

--- a/tests/unit/storage/test_embedding_freshness_invariant.py
+++ b/tests/unit/storage/test_embedding_freshness_invariant.py
@@ -168,7 +168,7 @@ def test_daemon_backlog_mutation_restoring_stale_check_bypass_misses_changed_con
     monkeypatch.setattr(materialization, "embed_archive_session_sync", _observe_embed)
     monkeypatch.setattr(embedding_backlog, "_upsert_archive_embedding_catchup_run", lambda *_args, **_kwargs: "run")
 
-    assert embedding_backlog._drain_archive_embedding_backlog_once(index_db) == 1
+    assert embedding_backlog._drain_archive_embedding_backlog_once(index_db, archive_root=index_db.parent) == 1
     assert selected == [session_id]
 
 


### PR DESCRIPTION
## Summary

Fixes the sibling-tier-derivation-via-`.with_name()` bug class identified in polylogue-aaj9: ~60 call sites derived `ops.db`/`embeddings.db`/`source.db`/`user.db` by taking `.with_name("<tier>.db")` (or an equivalent `.parent / "<tier>.db"`) on an `index.db` anchor that had already been resolved through `resolve_active_index_path()`/`ArchiveLocation.active_index_path`/`Config.db_path`. Once a `.index-active-pointer` file exists (written the first time `IndexGenerationStore` bootstraps against an archive whose `index.db` is already a promoted-generation symlink — not yet true for the live archive, but one rebuild-and-promote cycle away), that anchor resolves to a path inside `.index-generations/<gen>/`, and deriving a sibling from it computes a path that does not contain the other durable tiers.

## Problem

Following the just-merged `l2cd` `ArchiveLocation` resolver migration (#3385–#3388), a systematic re-grep of `.with_name("ops.db"|"embeddings.db"|"user.db"|"source.db")` found ~58 hits across ~30 files. Each needed individual data-flow tracing to classify as safe (anchor never resolved through the pointer), pattern-1 (bare daemon-global resolution, mechanical one-line fix), or pattern-2 (small pure function taking the anchor as an explicit, unit-tested parameter, needing a new explicit sibling-path parameter instead).

Investigation also surfaced two related bugs one hop away from the literal grep hits:
- `daemon/cli.py:_active_index_db_path()` fed `make_default_convergence_stages(db_path, ...)` (the whole fts/embed/insights/standing-query stage family) and `CursorStore` construction with a pointer-resolved path, violating that whole family's own documented invariant ("`db_path` always lives directly in the archive root").
- `Config.db_path` itself resolves through `resolve_active_index_path` by default (polylogue-yla8.1), so several call sites that looked like they used a stable `db_path` parameter (`blob_integrity.py`, `blob_repair.py`, `embedding_status_payload`) were actually vulnerable too.

## Solution

Two mechanical patterns, applied per the bead's design:

- **Pattern 1** (daemon-global, never test-injected): collapsed `resolve_active_index_path(archive_root()).with_name("X.db")` to the plain `archive_root() / "X.db"` construction. SQLite follows the `index.db` symlink transparently when connecting, so this is equally correct for opening the active generation's content. Sites: `daemon/events.py`, `daemon/lifecycle.py`, `daemon/http.py` (2), `daemon/fts_startup.py`, `daemon/cli.py:_active_index_db_path` (the highest-leverage fix — feeds the whole convergence-stage family and `CursorStore`), `daemon/fts_identity_convergence.py`, `maintenance/preview.py`.
- **Pattern 2** (small pure functions, unit-tested via an injected `tmp_path`-rooted anchor): added an explicit optional sibling-path parameter (`ops_db`/`configured_root`/`embeddings_db_path`/`archive_root`), defaulting to the old `with_name()` derivation so untouched test call sites keep passing; production hub callers (`daemon/status.py`, `daemon/health.py`, `cli/commands/embed.py`, `cli/commands/status.py`, `cli/shared/check_workflow.py`, `maintenance/planner.py`, `readiness/__init__.py`) now compute and pass the correctly-anchored root explicitly. Sites: `cursor_lag_status.py`, `cursor_lag_baseline.py` (4 fns), `convergence_debt_status.py`, `catchup_status.py`, `daemon/convergence_stages.py` (the whole embed/insights stage family plus shared source-tier-attach helpers — the deepest chain, since `make_embed_stage`/`make_insights_stage` compute an internal `archive_db` via a pointer-aware resolution and were passing *that* into sibling derivation one level down), `daemon/embedding_backlog.py`, `storage/blob_integrity.py`, `storage/blob_repair.py` + `storage/repair.py`, `storage/embeddings/status_payload.py`, `storage/embeddings/materialization.py`, `storage/usage.py`, `daemon/metrics.py`, `daemon/similarity.py`, `daemon/provenance.py`, `coordination/envelope.py`, `schemas/drift_sentinel_sampling.py`, `storage/fts/drift_sampling.py`, `sources/live/cursor.py` (`CursorStore.ops_db_path`) + `sources/live/watcher.py`.

**Sites investigated and left untouched (verified safe or a deliberate design exception):**
- `cli/commands/embed.py:_record_archive_backfill_run`'s sibling-of-`db_path` fallback, `storage/embeddings/reconcile.py`/`rescue.py`'s optional `embeddings_db_path`/`source_embeddings_db_path` params — public APIs whose real production callers already pass the correct path explicitly; the fallback is a documented convenience default, not a hidden hub bug.
- `sources/live/batch.py` (2 sites), `sources/live/convergence_debt_retry.py`, `storage/source_sessions.py` — derive from a `conn`/`CursorStore._db_path` that traces (after this PR's `_active_index_db_path`/`_cursor_db_path` fixes) to a plain, never-pointer-resolved anchor in every production path found.
- `storage/embeddings/preflight.py:read_pending_message_count` — deliberately supports an "index-only external generation" mode where `embeddings.db` is expected to live alongside an *external* index, not the configured root; this is a different, intentional design exception (documented in `cli/commands/embed.py`'s own docstring), not the pointer-divergence bug.
- `schemas/generation/archive_workload_profile.py` — devtools/offline generation tooling; its default `db_path` fallback (`polylogue.paths.db_path()`) is the plain `archive_root()/"index.db"` construction, never pointer-resolved.
- **Deferred, not fixed:** `storage/fts/fts_lifecycle.py` has four more `sample_fts_drift_to_ops_sync(conn)` call sites reached from many different code paths (ingest, convergence stages, CLI maintenance) whose `conn` provenance wasn't exhaustively traced in the time available; they keep the pre-existing fallback behavior. This is best-effort telemetry (a missing/wrong-tier `ops.db` sample is swallowed, never raised, never gates correctness), so the residual risk is bounded to "telemetry misses a data point," not archive read/write correctness.
- **Deferred, not fixed:** `sources/live/batch.py`'s two `source.db` derivations read `CursorStore._db_path` directly (not the new `ops_db_path` parameter added in this PR) — if `_cursor_db_path`'s `backend.db_path` branch is ever the resolved pointer path, these would still be wrong. `CursorStore._db_path`'s actual tier semantics (index vs ops) weren't conclusively established before time ran out; flagged as a follow-up rather than risking an incorrect fix to `_cursor_db_path` itself.

## Verification

- `mypy --strict polylogue/`: clean (1091 files).
- `ruff check`/`format --check`: clean.
- `devtools verify --quick`: exit 0.
- Full-suite master-vs-branch comparison (the mandated verification discipline for this bead): ran the exact same 155-test-name selection (every test that failed in the initial `devtools verify --seed-testmon --skip-slow` full run, 17458 tests) against both this branch and a disposable `origin/master` worktree. **Branch: 97 failures. Master: 97 failures. Zero branch-only failures** (`comm -23` on the two sorted failure-name lists is empty).
- This process itself caught and fixed real regressions before reaching this state: several convergence-stage/embedding-backlog test doubles needed `**kwargs` to accept newly-threaded parameters; `daemon/status.py`'s first-pass "simplify to `archive_root()`" edit broke ~15 tests that monkeypatch `_active_status_db_path` directly without patching `archive_root()` (fixed by patching both in those tests, and by reverting the one function — raw-failure-info's `source.db` derivation — where a test explicitly proves the *old* dbf-relative behavior is the intended contract); `cli/commands/status.py` needed to reuse its own `active_root` (not bare `archive_root()`) to respect the polylogue-yla8.1 index-only-external-generation split-root contract; two `assert_called_with` mocks needed the new kwarg added to their expected call.

## Follow-ups

- `storage/fts/fts_lifecycle.py`'s four remaining `sample_fts_drift_to_ops_sync(conn)` call sites (best-effort telemetry, deferred above).
- `sources/live/batch.py`'s two `CursorStore._db_path`-derived `source.db` sites (deferred above, pending `_cursor_db_path` tier-semantics research).

Ref polylogue-aaj9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive path handling for split-root and active-generation layouts.
  * Corrected locations used for embeddings, operational records, source data, blob checks, provenance, and status reporting.
  * Ensured embedding backfills and daemon convergence operate against the intended archive databases.
  * Fixed raw-record, debt, integrity, cursor-lag, and catch-up metrics when archive databases are stored separately.
* **Tests**
  * Updated coverage for archive-root resolution, embedding backfills, daemon status, convergence, and lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->