### PR TITLE
fix(sources): warn loudly on total ChatGPT bundle shape drift

### DIFF
--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -632,6 +632,93 @@ def _bundle_record_specs(
     ]
 
 
+#: Below this many candidate records, a zero-match bundle is unremarkable --
+#: even a genuine format change might only affect a small shard, and
+#: warning on tiny/edge-case payloads would be noise the next real drift
+#: warning gets lost in.
+_CHATGPT_BUNDLE_DRIFT_MIN_CANDIDATES = 5
+
+
+def _looks_like_chatgpt_mapping_candidate(record: PayloadRecord) -> bool:
+    """True if ``record`` carries a non-empty ``mapping`` dict.
+
+    This is deliberately looser than ``chatgpt.looks_like_fragment`` (which
+    also validates every node's shape): it is the "near miss" test used to
+    decide whether a zero-match bundle is drift-worth-a-warning or routine
+    sibling-file noise. ChatGPT's real metadata siblings
+    (``message_feedback.json``, ``shared_conversations.json``,
+    ``user_settings.json``, ``user.json``) never carry a ``mapping`` key at
+    all, so they never count as candidates here regardless of list length --
+    only records that got as far as having *a* ``mapping`` dict, but whose
+    node shapes then failed validation, count. That is what an export
+    format change to the conversation-tree shape itself would look like,
+    as opposed to a large-but-irrelevant sibling array.
+    """
+    mapping = record.get("mapping")
+    return isinstance(mapping, dict) and bool(mapping)
+
+
+def _chatgpt_bundle_record_specs(
+    payloads: PayloadSequence,
+    fallback_id: str,
+) -> list[LoweredPayloadSpec]:
+    """Lower a ChatGPT bundle-shaped JSON array into per-conversation specs.
+
+    A ChatGPT GDPR/Takeout export ZIP legitimately contains sibling arrays
+    that are shaped like a bundle (a top-level JSON list) but are NOT
+    conversation records -- ``message_feedback.json``,
+    ``shared_conversations.json``, ``user_settings.json``, and (once an
+    export is large enough that OpenAI shards it) the numbered
+    ``conversations-NNN.json`` shard files sit alongside those siblings in
+    the same ZIP, indistinguishable from each other by filename alone
+    (dispatch's detection is shape-based, not filename-based -- see
+    ``sources/dispatch.py`` module docstring). Filtering every candidate
+    record through ``chatgpt.looks_like_fragment`` here, rather than
+    admitting every list item and letting ``chatgpt.parse`` silently emit
+    an empty/near-empty session for a non-conversation item, does two
+    things: it gives non-conversation siblings a distinguishable
+    "did not match the shape" reason instead of an opaque downstream
+    "produced no sessions" parse outcome, and it lets this function detect
+    the one failure mode a per-row parse-error can never distinguish from
+    routine sibling-file noise -- every real conversation record in a
+    shard failing the shape check at once, which is what an upstream
+    export-format change (e.g. OpenAI renaming the ``mapping`` key) would
+    look like. When that happens for a payload large enough to plausibly
+    BE a conversation shard rather than a small sibling array, log a
+    warning so the drop is visible in daemon logs rather than requiring an
+    operator to already suspect drift and query
+    ``raw_sessions.detection_warnings_json`` to find it (polylogue-iwv7).
+    """
+    matched: list[LoweredPayloadSpec] = []
+    candidates = 0
+    for index, item in enumerate(payloads):
+        record = _payload_record(item)
+        if record is None:
+            continue
+        if _looks_like_chatgpt_mapping_candidate(record):
+            candidates += 1
+        if not chatgpt.looks_like_fragment(record):
+            continue
+        matched.append(
+            LoweredPayloadSpec(
+                provider=Provider.CHATGPT,
+                fallback_id=f"{fallback_id}-{index}",
+                mode="bundle_record",
+                payload=record,
+            )
+        )
+    if not matched and candidates >= _CHATGPT_BUNDLE_DRIFT_MIN_CANDIDATES:
+        logger.warning(
+            "ChatGPT bundle payload %r: none of %d candidate records matched the "
+            "conversation-fragment shape (chatgpt.looks_like_fragment); if this array is a "
+            "conversations shard rather than a metadata sibling file, the ChatGPT export "
+            "shape may have changed and conversations are being silently dropped",
+            fallback_id,
+            candidates,
+        )
+    return matched
+
+
 def _lower_bundle_payload(
     provider: Provider,
     shaped_payload: object,
@@ -639,6 +726,8 @@ def _lower_bundle_payload(
 ) -> list[LoweredPayloadSpec]:
     payloads = _payload_sequence(shaped_payload)
     if payloads is not None:
+        if provider is Provider.CHATGPT:
+            return _chatgpt_bundle_record_specs(payloads, fallback_id)
         return _bundle_record_specs(provider, payloads, fallback_id)
     record = _payload_record(shaped_payload)
     return [_single_record_spec(provider, record, fallback_id)] if record is not None else []

--- a/tests/unit/sources/test_dispatch_payloads.py
+++ b/tests/unit/sources/test_dispatch_payloads.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from decimal import Decimal
 from pathlib import Path
 
+import pytest
+
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.config import Source
 from polylogue.core.enums import Provider
@@ -292,3 +294,98 @@ def test_parse_one_source_path_treats_jsonl_text_json_wrappers_as_jsonl(tmp_path
     rows = list(iter_source_sessions_with_raw(Source(name="claude-code", path=source_path), capture_raw=False))
 
     assert [session.provider_session_id for _raw, session in rows] == ["first-session", "second-session"]
+
+
+def _chatgpt_conversation_record(conversation_id: str) -> dict[str, object]:
+    return {
+        "id": conversation_id,
+        "title": "A real conversation",
+        "create_time": 1704995846.046526,
+        "current_node": "root",
+        "mapping": {
+            "root": {
+                "id": "root",
+                "message": {
+                    "author": {"role": "user"},
+                    "content": {"content_type": "text", "parts": ["hello"]},
+                },
+                "children": [],
+            }
+        },
+    }
+
+
+def test_chatgpt_bundle_skips_metadata_sibling_but_keeps_conversation(caplog: pytest.LogCaptureFixture) -> None:
+    """A ChatGPT export ZIP bundles a real conversations shard alongside
+    metadata-only sibling arrays (``message_feedback.json``,
+    ``shared_conversations.json``, ...) in the same top-level-list shape.
+    ``_chatgpt_bundle_record_specs`` (polylogue/sources/dispatch.py) must
+    admit the real conversation and drop the metadata sibling by shape, via
+    ``chatgpt.looks_like_fragment`` -- not by trusting every bundle item to
+    be a session (a regression here -- reverting to the generic
+    ``_bundle_record_specs`` route for CHATGPT -- would let the metadata
+    record through ``chatgpt.parse`` too, producing a second, spuriously
+    empty session and failing the length assertion below).
+    """
+    feedback_sibling = {
+        "content": "{}",
+        "conversation_id": "68dac6b3-cc64-8326-9aff-fa3d358c03e2",
+        "id": "92b8bc4f-7a47-45e6-8c66-df59bf9e6797",
+        "rating": "thumbs_up",
+    }
+    conversation = _chatgpt_conversation_record("real-conversation-1")
+
+    with caplog.at_level("WARNING", logger="polylogue.sources.dispatch"):
+        sessions = parse_payload(Provider.CHATGPT, [feedback_sibling, conversation], "shard-000")
+
+    assert len(sessions) == 1
+    assert sessions[0].provider_session_id == "real-conversation-1"
+    assert not any("ChatGPT bundle payload" in record.message for record in caplog.records)
+
+
+def test_chatgpt_bundle_all_mapping_shape_drift_warns_loudly(caplog: pytest.LogCaptureFixture) -> None:
+    """If every record in a ChatGPT bundle carries a ``mapping`` key (so it
+    is clearly attempting to be a conversation shard, not a metadata
+    sibling file) but none of them pass ``chatgpt.looks_like_fragment``'s
+    node-shape check, that is what an upstream ChatGPT export format
+    change to the conversation-tree shape itself would look like -- e.g.
+    OpenAI changing ``message`` from a dict to something else. This must
+    be surfaced as a loud warning (polylogue-iwv7), not silently dropped
+    the same way a routine non-conversation sibling array is dropped.
+    """
+    drifted_records: list[dict[str, object]] = [
+        {
+            "id": f"drifted-{index}",
+            "mapping": {"root": {"id": "root", "message": "not-a-dict-anymore", "children": []}},
+        }
+        for index in range(6)
+    ]
+
+    with caplog.at_level("WARNING", logger="polylogue.sources.dispatch"):
+        sessions = parse_payload(Provider.CHATGPT, drifted_records, "shard-drifted")
+
+    assert sessions == []
+    assert any(
+        "ChatGPT bundle payload" in record.message and "6 candidate records" in record.message
+        for record in caplog.records
+    )
+
+
+def test_chatgpt_bundle_small_metadata_only_array_does_not_warn(caplog: pytest.LogCaptureFixture) -> None:
+    """A short, legitimate metadata sibling array (no ``mapping`` key at
+    all, e.g. ``shared_conversations.json``) must never trigger the
+    format-drift warning, however many items it has -- only records that
+    got as far as carrying a ``mapping`` dict but then failed shape
+    validation count as "candidates" for the warning. This guards against
+    the warning becoming noise that drowns out a real drift signal.
+    """
+    shared_conversation_siblings = [
+        {"conversation_id": f"conv-{index}", "id": f"share-{index}", "is_anonymous": True, "title": "Shared"}
+        for index in range(25)
+    ]
+
+    with caplog.at_level("WARNING", logger="polylogue.sources.dispatch"):
+        sessions = parse_payload(Provider.CHATGPT, shared_conversation_siblings, "shared-conversations")
+
+    assert sessions == []
+    assert not any("ChatGPT bundle payload" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
Investigated polylogue-iwv7 (ChatGPT export from 2026-04-23 reported as not ingested, six months of history reportedly absent). Root cause turned out to be a stale bead premise, not a live bug — but the investigation surfaced a real gap in silent-failure observability, which this PR fixes.

## Problem
The bead claimed `chatgpt-data-2026-04-23-20-21-52.zip` (OpenAI's export sharded into `conversations-000.json`..`conversations-024.json` once large enough) was unreferenced by any `raw_sessions` row. Read-only investigation against the real export and the live archive (`/realm/db/polylogue`, opened via `mode=ro`) showed:

- `polylogue import <export.zip> --explain` on current master already parses every shard correctly (2421 candidate conversation sessions) — ChatGPT detection is shape-based (`chatgpt.looks_like_fragment`), not filename-based, so numbered shards were never actually a parser blind spot.
- The live archive already contains 2402 real sessions from this export, acquired between 2026-07-02 and 2026-07-14 (source.db `raw_sessions.acquired_at_ms`) — **before** the bead was filed on 2026-07-29. 373 of those sessions fall in the claimed Oct 2025–Apr 2026 gap, all with real message/word counts and titles (e.g. "Declarative NixOS setup", 4 messages, 2416 words).
- The bead's premise was stale, most likely from an earlier check assuming a literal `conversations.json` filename that missed the shard-suffixed paths.

What the investigation did surface as a real, still-open gap: `_lower_bundle_payload`'s ChatGPT branch admitted every item in a bundle-shaped JSON array unconditionally, including legitimate non-conversation siblings (`message_feedback.json`, `shared_conversations.json`, `user_settings.json`), which parse into empty, content-free `ParsedSession`s rather than being recognized by shape. There was no signal distinguishing "this zero-yield array is a routine metadata sibling" from "every real conversation record in this shard failed to match the expected shape" — exactly what a future OpenAI export format change (e.g. renaming `mapping`'s node/message shape) would look like, and exactly the kind of silent-drop the bead worried about.

## Solution
`polylogue/sources/dispatch.py`:
- Added `_chatgpt_bundle_record_specs`, which filters ChatGPT bundle items through `chatgpt.looks_like_fragment` before admission (instead of blindly wrapping every list item via the generic `_bundle_record_specs`).
- Added `_looks_like_chatgpt_mapping_candidate` — a "near miss" check (has a non-empty `mapping` dict) used only to decide whether a zero-match bundle is drift-worth-a-warning or routine metadata-sibling noise. Legitimate siblings never carry a `mapping` key at all, so they never trigger the warning regardless of list length.
- `_lower_bundle_payload` now routes `Provider.CHATGPT` through the new function; `Provider.CLAUDE_AI` (the other `BUNDLE_PROVIDERS` member) is untouched.
- When ≥5 mapping-bearing candidates all fail shape validation, `logger.warning` fires with the candidate count — visible in daemon logs without needing to already suspect drift and query `raw_sessions.detection_warnings_json`.

No schema change; no change to acquisition-tier durable data.

## Verification
- `devtools test tests/unit/sources/test_dispatch_payloads.py` — 13 passed, including 3 new tests:
  - a real conversation record survives alongside a dropped `message_feedback`-shaped sibling, with no warning
  - 6 `mapping`-bearing-but-invalid records trigger the drift warning (`"ChatGPT bundle payload"` + candidate count in the message)
  - a 25-item metadata-only array (no `mapping` key) never warns
- `devtools test tests/unit/sources/test_parsers_chatgpt.py` — 101 passed (no regression in existing ChatGPT parser behavior)
- `devtools verify --quick` — `exit_code: 0` (format/lint/mypy/render-all-check), run twice (once manually, once via the pre-push hook)
- Re-ran `polylogue import <real 2026-04-23 export.zip> --explain` before and after the change, against a scratch `POLYLOGUE_ARCHIVE_ROOT` (the real export was only read, never written to) — byte-identical output, confirming no regression against the real corpus shape

## Acceptance criteria (polylogue-iwv7)
1. **Cause identified by evidence, not assumed** — satisfied. See Problem section above; premise was stale, confirmed via direct archive/export inspection.
2. **The export ingests, sharded exports handled as declared artifact shape in ChatGPT OriginSpec** — satisfied as pre-existing behavior. `_chatgpt_spec()` in `polylogue/sources/origin_specs.py` declares no filename-based artifact rules for ChatGPT; detection was already shape-based and already handles the shard layout. No OriginSpec change was needed or made.
3. **Report sessions and date-range added** — 2402 real conversation sessions from this export are in the live archive (2421 candidates minus attachment/metadata files that correctly produce no session), acquired 2026-07-02 through 2026-07-14, spanning native `create_time` 2022-12-12 through 2026-04-23; 373 of those sessions fall specifically in the previously-claimed Oct 2025–Apr 2026 gap.
4. **A future export layout change fails loudly at acquisition rather than being skipped** — satisfied by this PR's `_chatgpt_bundle_record_specs` warning.

## Residual risk / follow-ups
- No live re-acquisition was run as part of this investigation (would mutate the production archive) — none is needed, since the export is already fully ingested.
- The warning threshold (`_CHATGPT_BUNDLE_DRIFT_MIN_CANDIDATES = 5`) is a `logger.warning`, not an alert/metric; it will show up in daemon logs but isn't wired into `polylogue ops status` aggregation. If stronger guarantees are wanted (e.g. surfaced in daemon status counts), that's separate follow-up work outside this PR's `chatgpt.py`/`dispatch.py` scope.
- `source_path`/entry-name context isn't threaded down to `_lower_bundle_payload` today, so the warning identifies the payload only by `fallback_id` (the zip's stem, shared across all its entries per `decoder_zip.process_zip`) rather than the specific shard filename. Improving that would require touching `decoder_zip.py`/`emitter.py`, which are outside this task's write scope.

Ref polylogue-iwv7