### PR TITLE
fix(storage): refuse a same-source_path raw pair split across two byte-revision keys

### DIFF
--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -899,7 +899,15 @@ def backfill_historical_revision_evidence(
         replayed = 0
         byte_replayed_keys: set[str] = set()
         for logical_key in sorted(logical_keys):
-            plan = archive.classify_raw_revision_cohort(logical_key)
+            # polylogue-eqnv: the offline backfill/rebuild path is the one
+            # where a stale pre-fix parser identity can split one physical
+            # document's re-acquisitions across two logical_source_keys (see
+            # ArchiveStore.classify_raw_revision_cohort's docstring) -- opt
+            # into the source_path cross-key guard here. The live watcher
+            # (sources/live/batch.py) does NOT opt in: a watched path can be
+            # legitimately, atomically replaced with a different session's
+            # content, which must not be quarantined as "divergent evidence".
+            plan = archive.classify_raw_revision_cohort(logical_key, check_source_path_identity_split=True)
             if not plan.accepted_raw_ids:
                 # Complete snapshots that are not a unique byte-prefix chain
                 # still carry semantic evidence. Move only that full-only
@@ -921,7 +929,23 @@ def backfill_historical_revision_evidence(
                         detail=HISTORICAL_NON_PREFIX_GOVERNANCE_DETAIL,
                         retire_full_revision_governance=True,
                     )
-                    membership_candidates.setdefault(logical_key, set()).add(raw_id)
+                    # polylogue-eqnv: bucket by the identity the retirement
+                    # reparse just recomputed (what actually lands in
+                    # raw_session_memberships.logical_source_key inside
+                    # replace_raw_membership_census), NOT the stale outer-
+                    # loop ``logical_key`` this raw was originally censused
+                    # under. Two same-document raws retired here from
+                    # DIFFERENT stale keys (e.g. one carrying a since-fixed
+                    # parser identity bug) re-derive the SAME fresh key on
+                    # reparse; bucketing by the stale key would keep them in
+                    # separate membership cohorts below and let each be
+                    # accepted as an independent membership singleton --
+                    # reproducing the exact fidelity-downgrade defect this
+                    # retirement path exists to prevent, one layer down.
+                    fresh_session = sessions[0]
+                    fresh_key = f"{fresh_session.source_name.value}:{fresh_session.provider_session_id}"
+                    membership_candidates.setdefault(fresh_key, set()).add(raw_id)
+                    membership_keys.add(fresh_key)
                 membership_keys.add(logical_key)
                 continue
             parsed_by_raw_id: dict[str, ParsedSession] = {}

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -2135,8 +2135,76 @@ class ArchiveStore:
         )
         return tuple(str(row[0]) for row in rows)
 
-    def classify_raw_revision_cohort(self, logical_source_key: str) -> RevisionReplayPlan:
-        """Promote only a unique byte-prefix full chain and contiguous appends."""
+    def _raw_revision_source_path_has_divergent_evidence(self, logical_source_key: str) -> bool:
+        """Detect a same-``source_path`` sibling under a DIFFERENT byte-revision key.
+
+        Polylogue-eqnv: two raws of the identical physical document can end
+        up with different ``logical_source_key`` values -- most concretely
+        when one was censused by a parser version with an identity bug since
+        fixed (the source_revision the other raw's key was assigned under
+        never gets revisited, see ``uncensused_historical_revision_raw_ids``'s
+        exact-fingerprint quiescence gate). Neither raw's own key surfaces
+        the other in ``raw_membership_retired_full_revision_siblings``, so
+        both would otherwise be accepted as independent one-member byte
+        chains. ``source_path`` is the correct join key here (as elsewhere
+        in this module, e.g. ``classify_untyped_full_revision_groups``): a
+        real re-acquisition of the same document always keeps the same path.
+        """
+        detail_placeholders = ", ".join("?" for _ in RETIRED_FULL_REVISION_GOVERNANCE_DETAILS)
+        row = (
+            self._ensure_source_conn()
+            .execute(
+                f"""
+                SELECT 1
+                FROM raw_sessions AS this
+                WHERE this.logical_source_key = ? AND this.revision_kind = 'full'
+                  AND (
+                      EXISTS (
+                          SELECT 1 FROM raw_sessions AS other
+                          WHERE other.source_path = this.source_path
+                            AND other.raw_id != this.raw_id
+                            AND other.revision_kind = 'full'
+                            AND (other.logical_source_key IS NULL OR other.logical_source_key != this.logical_source_key)
+                      )
+                      OR EXISTS (
+                          SELECT 1
+                          FROM raw_sessions AS other
+                          JOIN raw_session_memberships AS m ON m.raw_id = other.raw_id
+                          JOIN raw_membership_census AS c ON c.raw_id = other.raw_id
+                          WHERE other.source_path = this.source_path
+                            AND other.raw_id != this.raw_id
+                            AND c.detail IN ({detail_placeholders})
+                      )
+                  )
+                LIMIT 1
+                """,
+                (logical_source_key, *RETIRED_FULL_REVISION_GOVERNANCE_DETAILS),
+            )
+            .fetchone()
+        )
+        return row is not None
+
+    def classify_raw_revision_cohort(
+        self, logical_source_key: str, *, check_source_path_identity_split: bool = False
+    ) -> RevisionReplayPlan:
+        """Promote only a unique byte-prefix full chain and contiguous appends.
+
+        ``check_source_path_identity_split`` (polylogue-eqnv, default
+        ``False`` -- opt in explicitly, see
+        ``_raw_revision_source_path_has_divergent_evidence``) additionally
+        refuses a singleton accept when another 'full' raw shares this raw's
+        ``source_path`` under a DIFFERENT key. That heuristic is sound for a
+        genuine re-acquisition of the same physical document (the offline
+        backfill/rebuild path's use case, where a stale pre-fix parser
+        identity can split one document across two keys) but is NOT sound in
+        general: a watched source path can legitimately be atomically
+        replaced with an entirely different session's content (same path,
+        genuinely different identity, exercised by
+        ``test_full_ingest_does_not_advance_cursor_across_same_size_replacement``
+        et al.) -- the live incremental watcher (``sources/live/batch.py``)
+        must not quarantine that as "divergent evidence", so it leaves this
+        off.
+        """
         if self._blob_publisher is None:
             raise RuntimeError("raw revision classification requires a writable blob publisher")
         source_conn = self._ensure_source_conn()
@@ -2167,6 +2235,34 @@ class ArchiveStore:
         # membership governance instead, where the real prefix-based
         # classifier weighs every known sibling together.
         if full_rows and self.raw_membership_retired_full_revision_siblings(logical_source_key):
+            full_rows = []
+        # polylogue-eqnv: the guard above only catches a retired SIBLING
+        # discoverable under the SAME logical_source_key. A raw whose
+        # identity was assigned by a now-superseded parser (e.g. the
+        # pre-#3179/z1c6 dispatch bug that appended a spurious "-0" to one
+        # of two otherwise-identical Drive re-acquisitions) can carry a
+        # logical_source_key that DIFFERS from a same-document sibling's --
+        # neither raw's own key ever surfaces the other, so each gets
+        # evaluated as a trivial one-member "chain" and unconditionally
+        # accepted as a byte-proven singleton baseline, independent of
+        # which content is actually correct. Two such raws then silently
+        # materialize as two independent sessions (arbitrary last-write-
+        # wins on the shared (origin, native_id) upsert) instead of ever
+        # being compared. Detect this by ``source_path``: a real re-
+        # acquisition of the same physical document always keeps the same
+        # ``source_path``. Refuse the byte-chain path here too whenever
+        # another raw at the same source_path is still an unretired 'full'
+        # row under a different key, OR has already been retired to
+        # membership governance under any key (a prior pass may have
+        # re-derived a DIFFERENT, corrected key during its own retirement
+        # reparse) -- the caller's existing "no accepted chain" fallback
+        # folds this raw into membership governance too, where the real
+        # content-based classifier weighs every known sibling together.
+        if (
+            full_rows
+            and check_source_path_identity_split
+            and self._raw_revision_source_path_has_divergent_evidence(logical_source_key)
+        ):
             full_rows = []
         historical: list[HistoricalRawRevisionStream] = []
         for row in full_rows:

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -514,6 +514,83 @@ def test_divergent_bundle_member_does_not_block_safe_members(tmp_path: Path) -> 
         )
 
 
+def test_stale_pre_fix_identity_split_folds_into_one_ambiguous_cohort(tmp_path: Path) -> None:
+    """polylogue-eqnv: two raws of the SAME physical document, one carrying a
+    ``logical_source_key`` assigned by a since-superseded parser (a stale
+    ``raw_authority_parser_census`` receipt persisted before an identity-bug
+    fix -- the exact shape of the pre-#3179/z1c6 dispatch bug), must not be
+    replayed as two independent byte-proven singletons. The retire-to-
+    membership-governance fallback must bucket both raws under the identity
+    the RETIREMENT reparse actually recomputes, not the stale key either raw
+    was originally censused under, so they land in ONE membership cohort and
+    get jointly arbitrated (here: genuinely divergent content -> ambiguous,
+    neither materializes) instead of each becoming an independent
+    membership-governance "singleton winner" -- which would reproduce the
+    exact fidelity-downgrade bug this retirement path exists to prevent, one
+    layer down.
+    """
+    initialize_active_archive_root(tmp_path)
+    correct_key = "chatgpt:s1"
+    stale_key = "chatgpt:s1-0"
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_correct = archive.write_raw_payload(
+            provider=Provider.CHATGPT,
+            payload=_bundle(_chatgpt_session("s1", "base", "left")),
+            source_path="conversations.json",
+            acquired_at_ms=1,
+        )
+        raw_stale = archive.write_raw_payload(
+            provider=Provider.CHATGPT,
+            payload=_bundle(_chatgpt_session("s1", "base", "right")),
+            source_path="conversations.json",
+            acquired_at_ms=2,
+        )
+
+    # Simulate the durable pre-existing state a since-fixed parser identity
+    # bug leaves behind: both raws already censused and typed 'full', one
+    # under the correct key a fresh reparse yields, the other under a stale,
+    # superseded key -- both stamped with the SAME parser fingerprint, so
+    # the ordinary quiescence gate would never re-derive either.
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        for raw_id, key in ((raw_correct, correct_key), (raw_stale, stale_key)):
+            conn.execute(
+                """
+                UPDATE raw_sessions
+                SET logical_source_key = ?, revision_kind = 'full', source_revision = raw_id,
+                    baseline_raw_id = raw_id, acquisition_generation = 0, revision_authority = 'quarantined'
+                WHERE raw_id = ?
+                """,
+                (key, raw_id),
+            )
+            conn.execute(
+                """
+                INSERT INTO raw_authority_parser_census
+                    (raw_id, parser_fingerprint, status, logical_keys_json, detail, censused_at_ms)
+                VALUES (?, 'revision-membership-v1', 'complete', ?, 'pre-seeded for test', 0)
+                """,
+                (raw_id, json.dumps([key])),
+            )
+        conn.commit()
+
+    result = backfill_historical_revision_evidence(tmp_path, selected_raw_ids=[raw_correct, raw_stale])
+    assert result.replayed_logical_sources == 0
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        memberships = conn.execute(
+            "SELECT raw_id, logical_source_key, decision FROM raw_session_memberships ORDER BY raw_id"
+        ).fetchall()
+    assert {row[0] for row in memberships} == {raw_correct, raw_stale}
+    # Both raws must converge on the SAME (freshly re-derived) identity --
+    # not the stale key either was originally censused under -- and both
+    # must be recorded ambiguous, never silently accepted as a singleton.
+    assert {row[1] for row in memberships} == {correct_key}
+    assert {row[2] for row in memberships} == {"ambiguous"}
+
+    with sqlite3.connect(tmp_path / "index.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone() == (0,)
+
+
 def test_divergent_bundle_member_preserves_last_accepted_session(tmp_path: Path) -> None:
     initialize_active_archive_root(tmp_path)
     with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:

--- a/tests/unit/storage/test_revision_replay.py
+++ b/tests/unit/storage/test_revision_replay.py
@@ -708,6 +708,65 @@ def test_isolated_later_raw_does_not_override_cohort_retired_under_legacy_detail
     assert "cross-route full revision governance" in RETIRED_FULL_REVISION_GOVERNANCE_DETAILS
 
 
+def test_same_source_path_full_siblings_under_different_keys_are_not_independently_accepted(
+    tmp_path: Path,
+) -> None:
+    """polylogue-eqnv: a raw whose byte-revision identity was assigned by a
+    now-superseded parser (e.g. the pre-#3179/z1c6 dispatch bug that
+    appended a spurious ``-0`` to one of two otherwise-identical Drive
+    re-acquisitions of the same document) can carry a
+    ``logical_source_key`` that DIFFERS from a same-``source_path``
+    sibling's. Neither raw's own key ever surfaces the other in
+    ``raw_membership_retired_full_revision_siblings`` (an exact-key-match
+    query), so ``classify_raw_revision_cohort`` evaluates each key as a
+    trivial one-member chain and unconditionally accepts BOTH as
+    independent byte-proven singleton baselines -- silently splitting one
+    physical document into two sessions that then race on the shared
+    ``(origin, native_id)`` upsert (arbitrary last-writer-wins), instead of
+    ever being compared against each other.
+    """
+    initialize_active_archive_root(tmp_path)
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_enriched = archive.write_raw_payload(
+            provider=Provider.GEMINI, payload=b"enriched-bytes", source_path="doc.json", acquired_at_ms=1
+        )
+        archive.bind_raw_revision(
+            raw_enriched,
+            RawRevisionEnvelope(
+                "gemini:doc",
+                RawRevisionKind.FULL,
+                raw_enriched,
+                0,
+                authority=RawRevisionAuthority.QUARANTINED,
+            ),
+        )
+        raw_bare = archive.write_raw_payload(
+            provider=Provider.GEMINI, payload=b"bare-bytes", source_path="doc.json", acquired_at_ms=2
+        )
+        archive.bind_raw_revision(
+            raw_bare,
+            RawRevisionEnvelope(
+                # The stale-parser identity split: same source_path, a
+                # DIFFERENT logical_source_key.
+                "gemini:doc-0",
+                RawRevisionKind.FULL,
+                raw_bare,
+                0,
+                authority=RawRevisionAuthority.QUARANTINED,
+            ),
+        )
+
+        enriched_plan = archive.classify_raw_revision_cohort("gemini:doc", check_source_path_identity_split=True)
+        bare_plan = archive.classify_raw_revision_cohort("gemini:doc-0", check_source_path_identity_split=True)
+
+    # Neither key's lone member may be promoted alone: a same-source_path
+    # sibling under a different key means this identity is genuinely
+    # contested, not a clean singleton chain.
+    assert enriched_plan.accepted_raw_ids == ()
+    assert bare_plan.accepted_raw_ids == ()
+
+
 def test_real_single_append_chain_folds_segmentation_distinct_full_snapshot(tmp_path: Path) -> None:
     initialize_active_archive_root(tmp_path)
 


### PR DESCRIPTION
## Summary

Fixes a proven silent fidelity downgrade: two raws of the same physical
document, censused under different `raw_sessions.logical_source_key`
values, were each independently accepted as a byte-proven singleton
baseline and raced to materialize the same `(origin, native_id)` session
with no comparison ever happening between them.

## Problem

Read-only queries against the live 99 GB archive (`/realm/db/polylogue`)
and the blob store, cross-checked against production parser code, showed
5 aistudio-drive sessions
(`Implementing-066bb070/13ced1c8/37edfeb3/845dd573/d4d7fbab`) with
attachments reporting `unfetched` despite the bytes existing in the blob
store:

- Each affected document has two raws at the SAME `source_path` — a bare
  and an attachment-enriched Drive re-acquisition — but with DIFFERENT
  `raw_sessions.logical_source_key` values (`"...4c69"` vs `"...4c69-0"`).
- `raw_authority_parser_census` proves the `-0` suffix was produced by the
  pre-#3179/z1c6 `dispatch.py` bug (`_lower_drive_like_payload`'s
  `_looks_like_chunked_session_list` branch always appended `-{index}`
  regardless of list length, fixed 2026-07-20 in b473d9256). Reparsing
  both raw blobs with the CURRENT parser gives the identical, correct,
  unsuffixed identity for both — verified directly against the real
  blobs.
- `raw_authority_parser_census`'s quiescence gate only checks the
  `parser_fingerprint` STRING (unchanged across the fix), so the stale,
  buggy identity was never re-derived.
- `ArchiveStore.classify_raw_revision_cohort` classifies a byte-revision
  key in isolation. Neither raw's key ever surfaces the other as a
  sibling (`raw_membership_retired_full_revision_siblings` only matches
  the EXACT key), so each was accepted as a trivial one-member "chain" —
  no `raw_session_memberships` row was ever created for either raw, so
  neither ever reached the ambiguous-decision machinery. Both then raced
  to write the shared `(origin, native_id)` session row; the smaller,
  attachment-unfetched raw happened to write last.

## Solution

- `ArchiveStore.classify_raw_revision_cohort` gains an opt-in
  `check_source_path_identity_split` guard: refuse unconditional
  singleton acceptance when another `'full'` raw shares this raw's
  `source_path` under a DIFFERENT (or already-retired) key, folding both
  into membership governance instead, where the real content-based
  classifier (`classify_membership_revisions`) weighs them jointly.
  **Opt-in only** — the live watcher (`sources/live/batch.py`) does NOT
  set it: a watched path can legitimately be atomically replaced with a
  different session's content, which must not be quarantined as
  "divergent evidence" (proven by
  `test_full_ingest_does_not_advance_cursor_across_same_size_replacement`
  et al., which regressed under an unconditional guard). Only
  `revision_backfill.py`'s offline backfill/rebuild replay loop — the
  path that actually produced this defect — opts in.
- `revision_backfill.py`'s retire-to-membership-governance fallback now
  buckets `membership_candidates`/`membership_keys` by the identity the
  retirement reparse actually recomputes, not the stale outer-loop key
  either raw was originally censused under. Without this, two
  same-document raws retired from different stale keys would land in
  SEPARATE membership cohorts and each be accepted as an independent
  singleton — reproducing the exact defect one layer down (confirmed
  empirically: reverting just this half makes `replayed_logical_sources`
  come back as `1` instead of `0`).

## Non-goals / follow-up

- The live archive's 5 already-downgraded sessions are NOT repaired by
  this PR (code-only fix, per scope; live remediation is a separate,
  explicitly out-of-scope lane).
- `polylogue-9dxn` (filed by a parallel lane) addresses the sibling
  problem — a persisted `ambiguous` verdict has no classifier-version
  column and is treated as terminal forever, so a classifier fix like
  `polylogue-bu1i`'s is inert on existing data. That fix does not, by
  itself, heal this defect: 9dxn's proposed quiescence gate stays
  permissive for any KNOWN fingerprint (to avoid forcing a blanket
  re-census), so a stale-but-`complete` (not `ambiguous`) census receipt
  like the one that caused this bug would stay "already observed"
  forever even after a fingerprint bump. This PR's guard is independent
  of fingerprint versioning and closes the general case regardless of
  how two same-document raws ended up under different keys.
- Filed `polylogue-eqnv` with the full evidence chain and the
  relationship to `polylogue-9dxn`/`polylogue-bu1i`/`polylogue-7ilr`.

## Verification

- `devtools test tests/unit/storage/test_revision_replay.py
  tests/unit/sources/test_revision_backfill.py
  tests/unit/sources/test_live_watcher.py
  tests/unit/sources/test_live_batch_support.py` — 235 passed (one
  unrelated pre-existing timing flake in
  `test_end_to_end_hidden_root_file_creation_triggers_ingest`, confirmed
  to reproduce on `master` without this change, in isolation, and
  disappear on repeated reruns of the same combined selection with this
  change applied — classified as pre-existing/flaky, not caused by this
  PR).
- `devtools verify --quick` — exit 0 (also ran automatically via the
  pre-push hook).
- `mypy polylogue/storage/sqlite/archive_tiers/archive.py
  polylogue/sources/revision_backfill.py` — `Success: no issues found in
  2 source files`.
- Anti-vacuity: reverting `archive.py`'s guard (via `git stash`) makes
  `test_same_source_path_full_siblings_under_different_keys_are_not_independently_accepted`
  fail (`accepted_raw_ids` becomes non-empty instead of `()`). Reverting
  `revision_backfill.py`'s fresh-key bucketing alone makes
  `test_stale_pre_fix_identity_split_folds_into_one_ambiguous_cohort`
  fail (`replayed_logical_sources == 1` instead of `0`). Both confirmed
  by direct revert + rerun, restored afterward.

Ref polylogue-eqnv, polylogue-bu1i, polylogue-7ilr, polylogue-9dxn

Co-Authored-By: Claude <noreply@anthropic.com>