### PR TITLE
feat(sources): resolve chatgpt export .dat assets, sandbox files, codex.json

### DIFF
--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -179,7 +179,7 @@ files:
     owner: archive-artifact-taxonomy
     reason: archive-domain semantics
   - path: polylogue/archive/artifact_taxonomy/runtime.py
-    loc: 425
+    loc: 446
     target: polylogue/archive/artifact_taxonomy/runtime.py
     owner: archive-artifact-taxonomy
     reason: archive-domain semantics
@@ -2402,7 +2402,7 @@ files:
     target: polylogue/pipeline/__init__.py
     owner: stable
   - path: polylogue/pipeline/ids.py
-    loc: 564
+    loc: 591
     target: polylogue/pipeline/ids.py
     owner: stable
   - path: polylogue/pipeline/ingest_support.py
@@ -3163,8 +3163,12 @@ files:
     target: polylogue/sources/__init__.py
     owner: stable
   - path: polylogue/sources/assembly.py
-    loc: 103
+    loc: 116
     target: polylogue/sources/assembly.py
+    owner: stable
+  - path: polylogue/sources/assembly_chatgpt.py
+    loc: 221
+    target: polylogue/sources/assembly_chatgpt.py
     owner: stable
   - path: polylogue/sources/assembly_claude_code.py
     loc: 228
@@ -3195,7 +3199,7 @@ files:
     target: polylogue/sources/decoders.py
     owner: stable
   - path: polylogue/sources/dispatch.py
-    loc: 1336
+    loc: 1400
     target: polylogue/sources/dispatch.py
     owner: stable
   - path: polylogue/sources/drive/__init__.py
@@ -3367,6 +3371,14 @@ files:
     loc: 1118
     target: polylogue/sources/parsers/chatgpt.py
     owner: stable
+  - path: polylogue/sources/parsers/chatgpt_codex_sidecar.py
+    loc: 211
+    target: polylogue/sources/parsers/chatgpt_codex_sidecar.py
+    owner: stable
+  - path: polylogue/sources/parsers/chatgpt_sidecars.py
+    loc: 297
+    target: polylogue/sources/parsers/chatgpt_sidecars.py
+    owner: stable
   - path: polylogue/sources/parsers/claude/__init__.py
     loc: 64
     target: polylogue/sources/parsers/claude/__init__.py
@@ -3508,7 +3520,7 @@ files:
     owner: stable
     cross_cut: { lifecycle: model }
   - path: polylogue/sources/revision_backfill.py
-    loc: 1742
+    loc: 1769
     target: polylogue/sources/revision_backfill.py
     owner: stable
   - path: polylogue/sources/source_acquisition.py
@@ -4080,7 +4092,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/__init__.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/archive.py
-    loc: 11323
+    loc: 11324
     target: polylogue/storage/sqlite/archive_tiers/archive.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/archive_init.py
@@ -4612,7 +4624,7 @@ files:
     target: polylogue/verification/manifests/__init__.py
     owner: stable
   - path: polylogue/verification/manifests/models.py
-    loc: 756
+    loc: 600
     target: polylogue/verification/manifests/models.py
     owner: stable
   - path: polylogue/version.py

--- a/polylogue/archive/artifact_taxonomy/runtime.py
+++ b/polylogue/archive/artifact_taxonomy/runtime.py
@@ -307,6 +307,27 @@ def _classify_dict(
     # cycle described below. List streams import the same pair locally.
     from polylogue.sources.parsers.hermes_spans import looks_like_atif_payload
 
+    if provider is Provider.CHATGPT:
+        from polylogue.sources.parsers.chatgpt_codex_sidecar import looks_like as looks_like_codex_task
+
+        if looks_like_codex_task(payload):
+            # bd polylogue-2m2e: codex.json Codex Cloud tasks delivered
+            # inside the ChatGPT export. None of the generic session-document
+            # heuristics below recognize this shape (no "mapping"/"messages"
+            # list), and it also fails looks_metadataish_dict (its "turns"
+            # list is not scalarish), so without this branch every task fell
+            # through to UNKNOWN/parse_as_session=False and was silently
+            # dropped before dispatch.py's chatgpt_codex_task lowering ever
+            # ran.
+            return ArtifactClassification(
+                provider=provider,
+                kind=ArtifactKind.SESSION_DOCUMENT,
+                parse_as_session=True,
+                schema_eligible=True,
+                default_priority=100,
+                reason="ChatGPT export codex.json Codex Cloud task",
+            )
+
     if provider is Provider.BEADS and looks_like_beads_interaction(payload):
         return ArtifactClassification(
             provider=provider,

--- a/polylogue/sources/assembly.py
+++ b/polylogue/sources/assembly.py
@@ -17,6 +17,7 @@ from polylogue.core.enums import Provider
 from .parsers.base import ParsedSession
 
 if TYPE_CHECKING:
+    from .parsers.chatgpt_sidecars import ChatGPTAssetIndex
     from .parsers.claude.history import HistoryEntry
     from .parsers.claude.index import SessionIndexEntry
     from .parsers.claude.orchestration import ClaudeOrchestrationArtifact, ClaudeOrchestrationCoverage
@@ -41,7 +42,14 @@ class _CodexSidecarData(TypedDict, total=False):
     state_titles: CodexHistoryTitles
 
 
-class SidecarData(_ClaudeCodeSidecarData, _CodexSidecarData, total=False):
+class _ChatGPTSidecarData(TypedDict, total=False):
+    # bd polylogue-0hwv / polylogue-dt5s: the merged asset-name/sandbox-file
+    # resolver built once per source scan from conversation_asset_file_names.json
+    # + library_files.json. See sources/assembly_chatgpt.py.
+    chatgpt_asset_index: ChatGPTAssetIndex
+
+
+class SidecarData(_ClaudeCodeSidecarData, _CodexSidecarData, _ChatGPTSidecarData, total=False):
     pass
 
 
@@ -86,6 +94,10 @@ def get_assembly_spec(provider: Provider) -> ProviderAssemblySpec | None:
         from .assembly_gemini import GeminiAssemblySpec
 
         return GeminiAssemblySpec()
+    if provider is Provider.CHATGPT:
+        from .assembly_chatgpt import ChatGPTAssemblySpec
+
+        return ChatGPTAssemblySpec()
     return None
 
 
@@ -96,6 +108,7 @@ __all__ = [
     "CodexThreadNames",
     "ProviderAssemblySpec",
     "SidecarData",
+    "_ChatGPTSidecarData",
     "_CodexSidecarData",
     "_ClaudeCodeSidecarData",
     "TitleResolution",

--- a/polylogue/sources/assembly_chatgpt.py
+++ b/polylogue/sources/assembly_chatgpt.py
@@ -1,0 +1,221 @@
+"""ChatGPT provider assembly — asset-name and sandbox-file sidecar resolution.
+
+bd polylogue-0hwv / polylogue-dt5s / polylogue-2m2e: the 2026-07-29
+GDPR/Takeout export ships ``.dat`` asset bytes and two sibling JSON files that
+name them (``conversation_asset_file_names.json``, ``library_files.json``).
+Neither the ZIP-bundle path nor the extracted-directory path has any other
+place they'd naturally be read from: they are cross-conversation lookup
+tables, not conversation shards themselves. This module discovers them once
+per source scan (``discover_sidecars``) and joins every emitted ChatGPT
+session's attachments against the resulting index (``enrich_session``), using
+the standard provider-assembly extension point (``sources/assembly.py``) so
+no change is needed to the ZIP/directory walking or emitter plumbing.
+
+Resolution results are recorded as ``session_events`` rather than new
+attachment/schema columns (index.db is a derived tier; a schema bump needs a
+declared delta class) — same precedent as this file's neighbors
+(``chatgpt.py``'s ``chatgpt_block_metadata``/``repo_identity_evidence``
+events). ``provider_file_id`` IS updated in place when an id-grade match is
+found (tiers 1-4 of the sandbox resolver, or any ``.dat`` id resolution) —
+that is a real identity strengthening, not a guess.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from polylogue.core.enums import Provider
+from polylogue.logging import get_logger
+
+from .assembly import SidecarData
+from .parsers.base import ParsedAttachment, ParsedSession, ParsedSessionEvent
+from .parsers.chatgpt_sidecars import ChatGPTAssetIndex
+
+logger = get_logger(__name__)
+
+_LIBRARY_FILES_NAME = "library_files.json"
+_ASSET_NAMES_NAME = "conversation_asset_file_names.json"
+
+
+def _read_json_file(path: Path) -> object | None:
+    try:
+        with path.open("rb") as handle:
+            data: object = json.load(handle)
+            return data
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("chatgpt_sidecar_read_failed", path=str(path), error=str(exc))
+        return None
+
+
+def _read_json_zip_member(zip_path: Path, member_name: str) -> object | None:
+    try:
+        with zipfile.ZipFile(zip_path) as zf, zf.open(member_name) as handle:
+            data: object = json.load(handle)
+            return data
+    except (OSError, KeyError, zipfile.BadZipFile, json.JSONDecodeError) as exc:
+        logger.debug(
+            "chatgpt_sidecar_zip_member_unavailable",
+            zip_path=str(zip_path),
+            member=member_name,
+            error=str(exc),
+        )
+        return None
+
+
+class ChatGPTAssemblySpec:
+    """ChatGPT provider assembly — ``.dat``/sandbox-file sidecar resolution."""
+
+    def discover_sidecars(self, source_paths: list[Path]) -> SidecarData:
+        """Discover ``library_files.json``/``conversation_asset_file_names.json``.
+
+        Resolves via each source path's containing directory rather than
+        requiring the sidecar filenames to appear verbatim in
+        ``source_paths``: a full source-directory walk already includes them
+        as siblings, but a daemon single-file catch-up re-parse
+        (``ingest_batch/_core.py``'s ``discover_sidecars([Path(source_path)])``)
+        passes only the one shard being reprocessed. Climbing to that shard's
+        parent directory and globbing for the two known sidecar filenames
+        there covers both call shapes with the same code, mirroring how
+        ``CodexAssemblySpec`` climbs to a stable anchor directory.
+        """
+        library_files_payload: object | None = None
+        asset_names_payload: object | None = None
+        seen_dirs: set[Path] = set()
+        for path in source_paths:
+            if path.suffix.lower() == ".zip":
+                if library_files_payload is None:
+                    library_files_payload = _read_json_zip_member(path, _LIBRARY_FILES_NAME)
+                if asset_names_payload is None:
+                    asset_names_payload = _read_json_zip_member(path, _ASSET_NAMES_NAME)
+                continue
+            directory = path.parent
+            if directory in seen_dirs:
+                continue
+            seen_dirs.add(directory)
+            if library_files_payload is None:
+                candidate = directory / _LIBRARY_FILES_NAME
+                if candidate.is_file():
+                    library_files_payload = _read_json_file(candidate)
+            if asset_names_payload is None:
+                candidate = directory / _ASSET_NAMES_NAME
+                if candidate.is_file():
+                    asset_names_payload = _read_json_file(candidate)
+        index = ChatGPTAssetIndex.build(
+            library_files_payload=library_files_payload,
+            asset_file_names_payload=asset_names_payload,
+        )
+        return {"chatgpt_asset_index": index}
+
+    def enrich_session(
+        self,
+        conv: ParsedSession,
+        sidecar_data: SidecarData,
+    ) -> ParsedSession:
+        if conv.source_name is not Provider.CHATGPT or not conv.attachments:
+            return conv
+        index = sidecar_data.get("chatgpt_asset_index")
+        if index is None or index.is_empty:
+            return conv
+
+        new_attachments: list[ParsedAttachment] = []
+        new_events: list[ParsedSessionEvent] = []
+        changed = False
+        for attachment in conv.attachments:
+            resolved, event = _resolve_attachment(attachment, index, thread_id=conv.provider_session_id)
+            new_attachments.append(resolved)
+            if resolved is not attachment:
+                changed = True
+            if event is not None:
+                new_events.append(event)
+        if not changed and not new_events:
+            return conv
+        return conv.model_copy(
+            update={
+                "attachments": new_attachments,
+                "session_events": [*conv.session_events, *new_events],
+            }
+        )
+
+
+def _resolve_attachment(
+    attachment: ParsedAttachment,
+    index: ChatGPTAssetIndex,
+    *,
+    thread_id: str,
+) -> tuple[ParsedAttachment, ParsedSessionEvent | None]:
+    if attachment.attachment_kind == "sandbox_file":
+        return _resolve_sandbox_attachment(attachment, index, thread_id=thread_id)
+    return _resolve_dat_attachment(attachment, index)
+
+
+def _resolve_dat_attachment(
+    attachment: ParsedAttachment,
+    index: ChatGPTAssetIndex,
+) -> tuple[ParsedAttachment, ParsedSessionEvent | None]:
+    resolved = index.resolve_dat(attachment.provider_attachment_id)
+    if resolved is None:
+        return attachment, None
+    update: dict[str, object] = {}
+    if attachment.name is None and resolved.name is not None:
+        update["name"] = resolved.name
+    if attachment.mime_type is None and resolved.mime_type is not None:
+        update["mime_type"] = resolved.mime_type
+    if attachment.size_bytes is None and resolved.size_bytes is not None:
+        update["size_bytes"] = resolved.size_bytes
+    if attachment.provider_file_id is None:
+        update["provider_file_id"] = resolved.file_id
+    new_attachment = attachment.model_copy(update=update) if update else attachment
+    event = ParsedSessionEvent(
+        event_type="chatgpt_asset_resolution",
+        source_message_provider_id=attachment.message_provider_id,
+        payload={
+            "attachment_id": attachment.provider_attachment_id,
+            "resolved_name": resolved.name,
+            "resolved_mime_type": resolved.mime_type,
+            "resolved_size_bytes": resolved.size_bytes,
+            "provider_sha256": resolved.sha256_digest,
+            "resolution_source": resolved.source,
+        },
+    )
+    return new_attachment, event
+
+
+def _resolve_sandbox_attachment(
+    attachment: ParsedAttachment,
+    index: ChatGPTAssetIndex,
+    *,
+    thread_id: str,
+) -> tuple[ParsedAttachment, ParsedSessionEvent | None]:
+    file_name = attachment.name
+    if not file_name:
+        return attachment, None
+    resolution = index.resolve_sandbox(
+        message_id=attachment.message_provider_id,
+        thread_id=thread_id,
+        file_name=file_name,
+    )
+    new_attachment = attachment
+    if resolution.file is not None and attachment.provider_file_id is None:
+        new_attachment = attachment.model_copy(update={"provider_file_id": resolution.file.file_id})
+    payload: dict[str, object] = {
+        "sandbox_file_name": file_name,
+        "resolution_tier": resolution.tier,
+        "resolution_method": resolution.method,
+    }
+    if resolution.file is not None:
+        payload["resolved_file_id"] = resolution.file.file_id
+        payload["resolved_mime_type"] = resolution.file.mime_type
+        payload["resolved_size_bytes"] = resolution.file.file_size_bytes
+        payload["provider_sha256"] = resolution.file.sha256_digest
+        payload["matched_name"] = resolution.matched_name
+    event = ParsedSessionEvent(
+        event_type="chatgpt_sandbox_file_resolution",
+        source_message_provider_id=attachment.message_provider_id,
+        payload=payload,
+    )
+    return new_attachment, event
+
+
+__all__ = ["ChatGPTAssemblySpec"]

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -21,6 +21,7 @@ from .parsers import (
     beads,
     browser_capture,
     chatgpt,
+    chatgpt_codex_sidecar,
     claude,
     codex,
     drive,
@@ -69,6 +70,7 @@ PayloadSequence: TypeAlias = list[JSONValue]
 LoweredPayloadMode: TypeAlias = Literal[
     "bundle_record",
     "browser_capture",
+    "chatgpt_codex_task",
     "chunked_prompt",
     "generic_messages",
     "grouped_records",
@@ -779,6 +781,20 @@ def _chatgpt_bundle_record_specs(
         record = _payload_record(item)
         if record is None:
             continue
+        # codex.json (bd polylogue-2m2e): Codex Cloud tasks delivered inside
+        # the ChatGPT export, a completely different shape from a conversation
+        # fragment (no "mapping" key). Checked first so these never fall
+        # through to the mapping-candidate/near-miss accounting below.
+        if chatgpt_codex_sidecar.looks_like(record):
+            matched.append(
+                LoweredPayloadSpec(
+                    provider=Provider.CHATGPT,
+                    fallback_id=f"{fallback_id}-{index}",
+                    mode="chatgpt_codex_task",
+                    payload=record,
+                )
+            )
+            continue
         if _looks_like_chatgpt_mapping_candidate(record):
             candidates += 1
         if not chatgpt.looks_like_fragment(record):
@@ -814,7 +830,27 @@ def _lower_bundle_payload(
             return _chatgpt_bundle_record_specs(payloads, fallback_id)
         return _bundle_record_specs(provider, payloads, fallback_id)
     record = _payload_record(shaped_payload)
-    return [_single_record_spec(provider, record, fallback_id)] if record is not None else []
+    if record is None:
+        return []
+    # codex.json (bd polylogue-2m2e): reached here when the file-level walk
+    # already unpacked the top-level array into one dict per item (the
+    # ordinary per-.json-file path -- see source_parsing.py/emitter.py), so
+    # this function sees a single task record rather than the whole list.
+    # Without this check the record fell straight into ``_single_record_spec``
+    # with provider=CHATGPT and no shape validation at all, and
+    # ``chatgpt.parse`` silently produced a zero-message session for it (no
+    # "mapping" key) that write_parsed_session_to_archive then dropped --
+    # "unparsed" with no visible error.
+    if provider is Provider.CHATGPT and chatgpt_codex_sidecar.looks_like(record):
+        return [
+            LoweredPayloadSpec(
+                provider=Provider.CHATGPT,
+                fallback_id=fallback_id,
+                mode="chatgpt_codex_task",
+                payload=record,
+            )
+        ]
+    return [_single_record_spec(provider, record, fallback_id)]
 
 
 def _lower_grouped_payload(
@@ -1153,6 +1189,10 @@ def _parse_lowered_spec(spec: LoweredPayloadSpec) -> list[ParsedSession]:
     if spec.mode == "browser_capture":
         record = _payload_record(spec.payload)
         return [browser_capture.parse(record, spec.fallback_id)] if record is not None else []
+
+    if spec.mode == "chatgpt_codex_task":
+        record = _payload_record(spec.payload)
+        return [chatgpt_codex_sidecar.parse_codex_task(record, spec.fallback_id)] if record is not None else []
 
     if spec.provider is Provider.CHATGPT:
         record = _payload_record(spec.payload)

--- a/polylogue/sources/origin_specs.py
+++ b/polylogue/sources/origin_specs.py
@@ -573,6 +573,7 @@ def _chatgpt_spec() -> OriginSpec:
         parser_paths=("polylogue/sources/parsers/chatgpt.py",),
         stream_parser_path=None,
         assembly_paths=("polylogue/sources/dispatch.py:_lower_payload_specs",),
+        assembly_spec_path="polylogue/sources/assembly_chatgpt.py:ChatGPTAssemblySpec",
         fixture_paths=("tests/unit/sources/test_parsers_chatgpt.py", "tests/data/golden/chatgpt-simple.md"),
         coverage_refs=("provider-package:chatgpt-export/takeout-json@v1",),
         fidelity_notes=("Browser capture remains an acquisition mode and is not a new public origin.",),

--- a/polylogue/sources/parsers/chatgpt_codex_sidecar.py
+++ b/polylogue/sources/parsers/chatgpt_codex_sidecar.py
@@ -1,0 +1,211 @@
+"""Codex Cloud tasks delivered inside the ChatGPT export (``codex.json``).
+
+bd polylogue-2m2e: the 2026-07-29 export ships ``codex.json``, 20 Codex CLOUD
+tasks with a ``turns`` structure — a second, independent delivery path for
+Codex sessions, entirely distinct from local ``~/.codex/sessions`` rollouts.
+
+Identity does NOT collide with ``codex-session`` records: local Codex CLI
+sessions are keyed by a rollout ``session_id`` UUID (``sources/parsers/
+codex.py``); these cloud tasks are keyed by ``task_e_<hex>`` ids with turn ids
+of the form ``task_e_<hex>~usertrn_e_<hex>`` / ``...~assttrn_e_<hex>`` — a
+disjoint namespace with no ULID/UUID overlap. They therefore coalesce with
+NOTHING already in the archive; ingesting them adds a new session per task
+rather than duplicating an existing one. Sessions stay under
+``source_name=Provider.CHATGPT`` (they physically arrive via the ChatGPT
+export) tagged with ``INGEST_FLAG`` so the population is identifiable and
+distinguishable from real ChatGPT conversations / shared-conversation shells.
+
+Each task carries exactly two turns (measured 2026-07-31: 20/20 tasks): a
+user turn (the prompt) and an assistant turn (the final summary), with cloud
+run metadata (``branch``, ``external_pull_request_id``, ``pull_request_status``,
+``turn_status``) on the assistant turn. There are no timestamps anywhere in
+this sidecar — ``created_at``/``updated_at`` are honestly left ``None`` rather
+than fabricated.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from polylogue.core.enums import BlockType, Provider, Role, SessionRefKind, WebConstructType
+
+from .base import (
+    ParsedContentBlock,
+    ParsedMessage,
+    ParsedSession,
+    ParsedSessionEvent,
+    ParsedSessionRef,
+    ParsedWebConstruct,
+)
+
+INGEST_FLAG = "capture:chatgpt-codex-cloud-task"
+
+_TASK_ID_PREFIX = "task_e_"
+_TURN_ROLES = frozenset({"user", "assistant"})
+_NULLISH_STRINGS = frozenset({"none", "null", ""})
+
+
+def _clean_optional_str(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped or stripped.lower() in _NULLISH_STRINGS:
+        return None
+    return stripped
+
+
+def looks_like(record: object) -> bool:
+    """Structural detector for one ``codex.json`` task record.
+
+    Deliberately tight (id namespace + turns shape) so it cannot accidentally
+    swallow a real ChatGPT conversation fragment or an unrelated sibling
+    record: real conversation fragments always carry a ``mapping`` dict,
+    which this shape never has.
+    """
+    if not isinstance(record, dict):
+        return False
+    if "mapping" in record:
+        return False
+    task_id = record.get("id")
+    if not isinstance(task_id, str) or not task_id.startswith(_TASK_ID_PREFIX):
+        return False
+    turns = record.get("turns")
+    if not isinstance(turns, list) or not turns:
+        return False
+    for turn in turns:
+        if not isinstance(turn, dict):
+            return False
+        if not isinstance(turn.get("id"), str) or not turn["id"]:
+            return False
+        if turn.get("role") not in _TURN_ROLES:
+            return False
+    return True
+
+
+def _content_items(turn: Mapping[str, object]) -> Sequence[Mapping[str, object]]:
+    items = turn.get("input_items") if turn.get("role") == "user" else turn.get("output_items")
+    if not isinstance(items, list):
+        return []
+    out: list[Mapping[str, object]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        content = item.get("content")
+        if isinstance(content, list):
+            out.extend(part for part in content if isinstance(part, dict))
+    return out
+
+
+def _turn_text_and_constructs(turn: Mapping[str, object]) -> tuple[str, list[ParsedWebConstruct]]:
+    text_parts: list[str] = []
+    constructs: list[ParsedWebConstruct] = []
+    for rank, part in enumerate(_content_items(turn)):
+        content_type = part.get("content_type")
+        if content_type == "text":
+            text = part.get("text")
+            if isinstance(text, str) and text:
+                text_parts.append(text)
+        elif content_type == "repo_file_citation":
+            path = part.get("path")
+            line_start = part.get("line_range_start")
+            line_end = part.get("line_range_end")
+            constructs.append(
+                ParsedWebConstruct(
+                    construct_type=WebConstructType.CONTENT_REFERENCE,
+                    provider_key="repo_file_citation",
+                    text=path if isinstance(path, str) else None,
+                    title=path if isinstance(path, str) else None,
+                    rank=rank,
+                    start_index=line_start if isinstance(line_start, int) else None,
+                    end_index=line_end if isinstance(line_end, int) else None,
+                )
+            )
+    return "\n".join(text_parts), constructs
+
+
+def _turn_message(turn: Mapping[str, object], *, position: int, parent_id: str | None) -> ParsedMessage | None:
+    turn_id = turn.get("id")
+    if not isinstance(turn_id, str) or not turn_id:
+        return None
+    role = Role.normalize(str(turn.get("role")))
+    text, constructs = _turn_text_and_constructs(turn)
+    blocks: list[ParsedContentBlock] = []
+    if constructs:
+        blocks.append(ParsedContentBlock(type=BlockType.TEXT, web_constructs=constructs))
+    return ParsedMessage(
+        provider_message_id=turn_id,
+        role=role,
+        text=text or None,
+        blocks=blocks,
+        parent_message_provider_id=parent_id,
+        position=position,
+    )
+
+
+def _turn_session_events(turn: Mapping[str, object]) -> list[ParsedSessionEvent]:
+    if turn.get("role") != "assistant":
+        return []
+    turn_id = turn.get("id")
+    payload: dict[str, object] = {}
+    for key in ("branch", "branch_name", "turn_status", "pull_request_status"):
+        value = _clean_optional_str(turn.get(key))
+        if value is not None:
+            payload[key] = value
+    if not payload:
+        return []
+    return [
+        ParsedSessionEvent(
+            event_type="chatgpt_codex_cloud_turn",
+            source_message_provider_id=turn_id if isinstance(turn_id, str) else None,
+            payload=payload,
+        )
+    ]
+
+
+def _pull_request_ref(turn: Mapping[str, object]) -> ParsedSessionRef | None:
+    pr_id = _clean_optional_str(turn.get("external_pull_request_id"))
+    if pr_id is None:
+        return None
+    return ParsedSessionRef(kind=SessionRefKind.PULL_REQUEST.value, url=pr_id)
+
+
+def parse_codex_task(task: Mapping[str, object], fallback_id: str) -> ParsedSession:
+    task_id = task.get("id")
+    provider_session_id = task_id if isinstance(task_id, str) and task_id else fallback_id
+    title = task.get("title")
+
+    turns = task.get("turns")
+    turns_list = [turn for turn in turns if isinstance(turn, dict)] if isinstance(turns, list) else []
+
+    messages: list[ParsedMessage] = []
+    session_events: list[ParsedSessionEvent] = []
+    session_refs: list[ParsedSessionRef] = []
+    parent_id: str | None = None
+    for position, turn in enumerate(turns_list):
+        message = _turn_message(turn, position=position, parent_id=parent_id)
+        if message is not None:
+            messages.append(message)
+            parent_id = message.provider_message_id
+        session_events.extend(_turn_session_events(turn))
+        ref = _pull_request_ref(turn)
+        if ref is not None:
+            session_refs.append(ref)
+
+    branch = next(
+        (value for turn in turns_list if (value := _clean_optional_str(turn.get("branch"))) is not None),
+        None,
+    )
+
+    return ParsedSession(
+        source_name=Provider.CHATGPT,
+        provider_session_id=provider_session_id,
+        title=title if isinstance(title, str) and title else None,
+        messages=messages,
+        session_events=session_events,
+        session_refs=session_refs,
+        git_branch=branch,
+        ingest_flags=[INGEST_FLAG],
+    )
+
+
+__all__ = ["INGEST_FLAG", "looks_like", "parse_codex_task"]

--- a/polylogue/sources/parsers/chatgpt_sidecars.py
+++ b/polylogue/sources/parsers/chatgpt_sidecars.py
@@ -1,0 +1,297 @@
+"""ChatGPT export sidecar resolvers: asset naming and sandbox-file joins.
+
+The 2026-07-29 GDPR/Takeout export ships attachment BYTES for the first time,
+as ``.dat`` ZIP members whose basenames are opaque file ids. Two sibling JSON
+files supply names/metadata for those ids:
+
+- ``conversation_asset_file_names.json`` — a flat ``{dat_basename: filename}``
+  map, 1,656 entries, conversation-asset ids (``file-<b64ish>``).
+- ``library_files.json`` — 2,367 richer records (mime, size, sha256, upload/
+  processed times, and an EXACT ``origination_message_id``/
+  ``origination_thread_id`` join back to the producing assistant message),
+  keyed by ``file_id`` (``file_<32hex>`` for Library files, but also seen on
+  conversation attachments referencing an existing Library upload).
+
+Together the two sources name all 3,228 known ``.dat`` blobs (bd polylogue-0hwv).
+``library_files.json`` also carries the identity join this module uses to
+resolve ``sandbox:/mnt/data/<name>`` links the model emits in assistant text
+for Code-Interpreter-produced files, which carry no file id of their own
+(bd polylogue-dt5s). Resolution is a strict tiered join, not fuzzy matching:
+
+  tier 1  exact ``origination_message_id`` match, name also matches
+  tier 2  exact ``origination_message_id`` match, name differs (still an
+          identity-grade join — the id is authoritative, the name is a label)
+  tier 3  ``origination_thread_id`` + name match (message id unknown/absent)
+  tier 4  a globally unique library file_name match (no id evidence at all)
+  tier 5  a globally AMBIGUOUS name match (>1 candidate) — evidence, not
+          identity; never resolved to a specific file
+  tier 6  unresolved — no candidate anywhere
+
+Every resolution records which tier produced it, so an audit can always tell
+an id join from a name guess (see ``SandboxResolution.tier``/``method``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+_DAT_SUFFIX = ".dat"
+_FILE_SERVICE_PREFIX = "file-service://"
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _optional_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class LibraryFileRecord:
+    """One ``library_files.json`` entry (the ChatGPT Library file catalog)."""
+
+    file_id: str
+    file_name: str | None
+    file_extension: str | None
+    mime_type: str | None
+    file_size_bytes: int | None
+    sha256_digest: str | None
+    origination_message_id: str | None
+    origination_thread_id: str | None
+    library_artifact_type: str | None
+    directory_id: str | None
+    created_at: str | None
+    file_upload_time: str | None
+    file_processed_time: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedAsset:
+    """A ``.dat`` blob's real identity, resolved from one of the two sidecars."""
+
+    file_id: str
+    name: str | None
+    mime_type: str | None
+    size_bytes: int | None
+    sha256_digest: str | None
+    #: "library_files" (richer — mime/size/sha) or "conversation_asset_file_names"
+    #: (name only). ``library_files`` is preferred whenever both hit.
+    source: str
+
+
+@dataclass(frozen=True, slots=True)
+class SandboxResolution:
+    """Result of joining one ``sandbox:/mnt/data/<name>`` link to a real file."""
+
+    #: 1-6, see module docstring. 6 means unresolved (metadata-only reference).
+    tier: int
+    method: str
+    file: LibraryFileRecord | None
+    #: The library file_name that was actually matched (may differ from the
+    #: sandbox link's own filename at tier 2 — the id is authoritative there).
+    matched_name: str | None
+
+
+def parse_library_files(payload: object) -> dict[str, LibraryFileRecord]:
+    """Parse ``library_files.json`` into records keyed by ``file_id``."""
+    if not isinstance(payload, list):
+        return {}
+    records: dict[str, LibraryFileRecord] = {}
+    for entry in payload:
+        if not isinstance(entry, dict):
+            continue
+        file_id = entry.get("file_id")
+        if not isinstance(file_id, str) or not file_id:
+            continue
+        records[file_id] = LibraryFileRecord(
+            file_id=file_id,
+            file_name=_optional_str(entry.get("file_name")),
+            file_extension=_optional_str(entry.get("file_extension")),
+            mime_type=_optional_str(entry.get("mime_type")),
+            file_size_bytes=_optional_int(entry.get("file_size_bytes")),
+            sha256_digest=_optional_str(entry.get("sha256_digest")),
+            origination_message_id=_optional_str(entry.get("origination_message_id")),
+            origination_thread_id=_optional_str(entry.get("origination_thread_id")),
+            library_artifact_type=_optional_str(entry.get("library_artifact_type")),
+            directory_id=_optional_str(entry.get("directory_id")),
+            created_at=_optional_str(entry.get("created_at")),
+            file_upload_time=_optional_str(entry.get("file_upload_time")),
+            file_processed_time=_optional_str(entry.get("file_processed_time")),
+        )
+    return records
+
+
+def parse_asset_file_names(payload: object) -> dict[str, str]:
+    """Parse ``conversation_asset_file_names.json`` (``{dat_basename: name}``).
+
+    Keys are normalized by stripping a trailing ``.dat`` so they line up
+    directly with the bare file ids referenced by ``asset_pointer`` and
+    ``attachments[].id`` in conversation payloads (neither carries ``.dat``).
+    """
+    if not isinstance(payload, dict):
+        return {}
+    names: dict[str, str] = {}
+    for key, value in payload.items():
+        if not isinstance(key, str) or not isinstance(value, str) or not value:
+            continue
+        normalized_key = key[: -len(_DAT_SUFFIX)] if key.endswith(_DAT_SUFFIX) else key
+        names[normalized_key] = value
+    return names
+
+
+class ChatGPTAssetIndex:
+    """Resolves ``.dat`` asset ids and sandbox-file links against export sidecars.
+
+    Built once per export/source scan (see ``assembly_chatgpt.py``) and reused
+    across every conversation the source yields.
+    """
+
+    __slots__ = ("_library", "_asset_names", "_by_message", "_by_thread", "_by_name")
+
+    def __init__(
+        self,
+        library_files: Mapping[str, LibraryFileRecord],
+        asset_names: Mapping[str, str],
+    ) -> None:
+        self._library = dict(library_files)
+        self._asset_names = dict(asset_names)
+        by_message: dict[str, list[LibraryFileRecord]] = {}
+        by_thread: dict[str, list[LibraryFileRecord]] = {}
+        by_name: dict[str, list[LibraryFileRecord]] = {}
+        for record in self._library.values():
+            if record.origination_message_id:
+                by_message.setdefault(record.origination_message_id, []).append(record)
+            if record.origination_thread_id:
+                by_thread.setdefault(record.origination_thread_id, []).append(record)
+            if record.file_name:
+                by_name.setdefault(record.file_name, []).append(record)
+        self._by_message = by_message
+        self._by_thread = by_thread
+        self._by_name = by_name
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        library_files_payload: object = None,
+        asset_file_names_payload: object = None,
+    ) -> ChatGPTAssetIndex:
+        return cls(
+            parse_library_files(library_files_payload),
+            parse_asset_file_names(asset_file_names_payload),
+        )
+
+    @classmethod
+    def empty(cls) -> ChatGPTAssetIndex:
+        return cls({}, {})
+
+    @property
+    def is_empty(self) -> bool:
+        return not self._library and not self._asset_names
+
+    def library_record(self, file_id: str) -> LibraryFileRecord | None:
+        return self._library.get(_normalize_file_id(file_id))
+
+    def resolve_dat(self, file_id: str) -> ResolvedAsset | None:
+        """Resolve a ``.dat`` asset id to its real name/mime/size (bd polylogue-0hwv).
+
+        Prefers ``library_files.json`` (richer: mime/size/sha256) over
+        ``conversation_asset_file_names.json`` (name only) when both hit.
+        """
+        clean = _normalize_file_id(file_id)
+        record = self._library.get(clean)
+        if record is not None:
+            return ResolvedAsset(
+                file_id=clean,
+                name=record.file_name,
+                mime_type=record.mime_type,
+                size_bytes=record.file_size_bytes,
+                sha256_digest=record.sha256_digest,
+                source="library_files",
+            )
+        name = self._asset_names.get(clean)
+        if name is not None:
+            return ResolvedAsset(
+                file_id=clean,
+                name=name,
+                mime_type=None,
+                size_bytes=None,
+                sha256_digest=None,
+                source="conversation_asset_file_names",
+            )
+        return None
+
+    def resolve_sandbox(
+        self,
+        *,
+        message_id: str | None,
+        thread_id: str | None,
+        file_name: str,
+    ) -> SandboxResolution:
+        """Resolve a ``sandbox:/mnt/data/<file_name>`` link (bd polylogue-dt5s).
+
+        Layered resolver, not a fuzzy matcher — see the module docstring for
+        the six tiers. Tier 5 (ambiguous global name) records evidence but
+        never returns a specific ``file``; tier 6 always records that the link
+        was seen even with no resolvable bytes/metadata source.
+        """
+        if message_id:
+            candidates = self._by_message.get(message_id)
+            if candidates:
+                exact = next((c for c in candidates if c.file_name == file_name), None)
+                if exact is not None:
+                    return SandboxResolution(tier=1, method="message_id+name", file=exact, matched_name=exact.file_name)
+                # Identity-grade join on id alone -- the library name is a
+                # label here, not part of the key (measured: tier 2, 2026-07-31).
+                return SandboxResolution(
+                    tier=2,
+                    method="message_id",
+                    file=candidates[0],
+                    matched_name=candidates[0].file_name,
+                )
+        if thread_id:
+            thread_matches = [c for c in self._by_thread.get(thread_id, ()) if c.file_name == file_name]
+            if thread_matches:
+                return SandboxResolution(
+                    tier=3,
+                    method="thread_id+name",
+                    file=thread_matches[0],
+                    matched_name=file_name,
+                )
+        global_matches = self._by_name.get(file_name)
+        if global_matches:
+            if len(global_matches) == 1:
+                return SandboxResolution(
+                    tier=4,
+                    method="global_name_unique",
+                    file=global_matches[0],
+                    matched_name=file_name,
+                )
+            return SandboxResolution(tier=5, method="global_name_ambiguous", file=None, matched_name=file_name)
+        return SandboxResolution(tier=6, method="unresolved", file=None, matched_name=None)
+
+
+def _normalize_file_id(file_id: str) -> str:
+    if file_id.startswith(_FILE_SERVICE_PREFIX):
+        return file_id[len(_FILE_SERVICE_PREFIX) :]
+    if file_id.endswith(_DAT_SUFFIX):
+        return file_id[: -len(_DAT_SUFFIX)]
+    return file_id
+
+
+__all__ = [
+    "ChatGPTAssetIndex",
+    "LibraryFileRecord",
+    "ResolvedAsset",
+    "SandboxResolution",
+    "parse_asset_file_names",
+    "parse_library_files",
+]

--- a/tests/unit/sources/test_artifact_taxonomy.py
+++ b/tests/unit/sources/test_artifact_taxonomy.py
@@ -26,6 +26,37 @@ def test_relationship_index_jsonl_is_metadata_not_session_stream() -> None:
     assert artifact.parse_as_session is False
 
 
+def test_chatgpt_codex_cloud_task_classifies_as_session_document() -> None:
+    """bd polylogue-2m2e: without this branch, a codex.json task record fails
+    every generic session-document heuristic (no "mapping"/"messages" list)
+    AND fails looks_metadataish_dict (its "turns" list is not scalarish), so
+    it fell through to UNKNOWN/parse_as_session=False and was silently
+    dropped before dispatch.py's chatgpt_codex_task lowering ever ran.
+    """
+    task: JSONValue = {
+        "archived": False,
+        "id": "task_e_abc123",
+        "title": "Fix a bug",
+        "turns": [
+            {"id": "task_e_abc123~usertrn_1", "input_items": [], "role": "user"},
+            {"id": "task_e_abc123~assttrn_1", "output_items": [], "role": "assistant"},
+        ],
+    }
+
+    artifact = classify_artifact(task, provider="chatgpt")
+
+    assert artifact.kind is ArtifactKind.SESSION_DOCUMENT
+    assert artifact.parse_as_session is True
+
+
+def test_chatgpt_library_files_entry_is_not_a_session() -> None:
+    entry: JSONValue = {"file_id": "file_abc", "file_name": "notes.md", "mime_type": "text/markdown"}
+
+    artifact = classify_artifact(entry, provider="chatgpt")
+
+    assert artifact.parse_as_session is False
+
+
 def test_claude_workflow_artifacts_follow_origin_spec_path_rules() -> None:
     cases = {
         "/tmp/.claude/projects/x/workflows/wf-run.json": (ArtifactKind.WORKFLOW_RUN_SNAPSHOT, False),

--- a/tests/unit/sources/test_assembly.py
+++ b/tests/unit/sources/test_assembly.py
@@ -12,6 +12,7 @@ from polylogue.archive.message.roles import Role
 from polylogue.archive.session.branch_type import BranchType
 from polylogue.core.enums import MaterialOrigin, Provider, TitleSource
 from polylogue.sources.assembly import SidecarData, get_assembly_spec
+from polylogue.sources.assembly_chatgpt import ChatGPTAssemblySpec
 from polylogue.sources.assembly_claude_code import ClaudeCodeAssemblySpec
 from polylogue.sources.assembly_codex import (
     CodexAssemblySpec,
@@ -117,7 +118,11 @@ class TestGetAssemblySpec:
         spec = get_assembly_spec(Provider.GEMINI)
         assert isinstance(spec, GeminiAssemblySpec)
 
-    @pytest.mark.parametrize("provider", [Provider.CHATGPT, Provider.CLAUDE_AI, Provider.UNKNOWN])
+    def test_chatgpt_returns_spec(self) -> None:
+        spec = get_assembly_spec(Provider.CHATGPT)
+        assert isinstance(spec, ChatGPTAssemblySpec)
+
+    @pytest.mark.parametrize("provider", [Provider.CLAUDE_AI, Provider.UNKNOWN])
     def test_no_spec_for_other_providers(self, provider: Provider) -> None:
         assert get_assembly_spec(provider) is None
 

--- a/tests/unit/sources/test_assembly_chatgpt.py
+++ b/tests/unit/sources/test_assembly_chatgpt.py
@@ -1,0 +1,227 @@
+"""Tests for ChatGPTAssemblySpec — bd polylogue-0hwv / polylogue-dt5s.
+
+Exercises the real ``sources/assembly.py`` protocol wiring end to end: on-disk
+sidecar discovery (both extracted-directory and ZIP-bundle shapes) and
+attachment enrichment for both ``.dat`` id resolution and sandbox-file tiered
+resolution.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import Provider
+from polylogue.sources.assembly_chatgpt import ChatGPTAssemblySpec
+from polylogue.sources.parsers.base import ParsedAttachment, ParsedMessage, ParsedSession
+from polylogue.sources.parsers.chatgpt_sidecars import ChatGPTAssetIndex
+
+
+def _session(
+    attachments: list[ParsedAttachment],
+    *,
+    provider_session_id: str = "conv-1",
+    source_name: Provider = Provider.CHATGPT,
+) -> ParsedSession:
+    return ParsedSession(
+        source_name=source_name,
+        provider_session_id=provider_session_id,
+        title="t",
+        messages=[ParsedMessage(provider_message_id="m1", role=Role.ASSISTANT, text="hi")],
+        attachments=attachments,
+    )
+
+
+class TestDiscoverSidecarsFromDirectory:
+    def test_reads_both_sidecar_files(self, tmp_path: Path) -> None:
+        (tmp_path / "library_files.json").write_text(
+            json.dumps([{"file_id": "file_abc", "file_name": "notes.md"}]), encoding="utf-8"
+        )
+        (tmp_path / "conversation_asset_file_names.json").write_text(
+            json.dumps({"file-xyz.dat": "image.png"}), encoding="utf-8"
+        )
+        (tmp_path / "conversations-000.json").write_text("[]", encoding="utf-8")
+
+        sidecar_data = ChatGPTAssemblySpec().discover_sidecars(
+            [
+                tmp_path / "conversations-000.json",
+                tmp_path / "library_files.json",
+                tmp_path / "conversation_asset_file_names.json",
+            ]
+        )
+        index = sidecar_data["chatgpt_asset_index"]
+        assert index.resolve_dat("file_abc") is not None
+        assert index.resolve_dat("file-xyz") is not None
+
+    def test_climbs_to_parent_dir_when_only_one_shard_path_given(self, tmp_path: Path) -> None:
+        """Single-file daemon catch-up re-parse passes only one shard path."""
+        (tmp_path / "library_files.json").write_text(
+            json.dumps([{"file_id": "file_abc", "file_name": "notes.md"}]), encoding="utf-8"
+        )
+        (tmp_path / "conversations-014.json").write_text("[]", encoding="utf-8")
+
+        sidecar_data = ChatGPTAssemblySpec().discover_sidecars([tmp_path / "conversations-014.json"])
+        index = sidecar_data["chatgpt_asset_index"]
+        assert index.resolve_dat("file_abc") is not None
+
+    def test_no_sidecars_present_returns_empty_index(self, tmp_path: Path) -> None:
+        (tmp_path / "conversations-000.json").write_text("[]", encoding="utf-8")
+        sidecar_data = ChatGPTAssemblySpec().discover_sidecars([tmp_path / "conversations-000.json"])
+        assert sidecar_data["chatgpt_asset_index"].is_empty is True
+
+
+class TestDiscoverSidecarsFromZip:
+    def test_reads_sidecar_members_from_zip(self, tmp_path: Path) -> None:
+        zip_path = tmp_path / "export.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("library_files.json", json.dumps([{"file_id": "file_abc", "file_name": "notes.md"}]))
+            zf.writestr("conversation_asset_file_names.json", json.dumps({"file-xyz.dat": "image.png"}))
+            zf.writestr("conversations-000.json", "[]")
+
+        sidecar_data = ChatGPTAssemblySpec().discover_sidecars([zip_path])
+        index = sidecar_data["chatgpt_asset_index"]
+        assert index.resolve_dat("file_abc") is not None
+        assert index.resolve_dat("file-xyz") is not None
+
+    def test_zip_missing_sidecars_returns_empty_index(self, tmp_path: Path) -> None:
+        zip_path = tmp_path / "export.zip"
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("conversations-000.json", "[]")
+
+        sidecar_data = ChatGPTAssemblySpec().discover_sidecars([zip_path])
+        assert sidecar_data["chatgpt_asset_index"].is_empty is True
+
+
+class TestEnrichSession:
+    def _index(self) -> ChatGPTAssetIndex:
+        return ChatGPTAssetIndex.build(
+            library_files_payload=[
+                {
+                    "file_id": "file-abc",
+                    "file_name": "library-name.png",
+                    "mime_type": "image/png",
+                    "file_size_bytes": 999,
+                    "sha256_digest": "deadbeef",
+                },
+                {
+                    "file_id": "file_lib1",
+                    "file_name": "output.csv",
+                    "origination_message_id": "m1",
+                    "origination_thread_id": "conv-1",
+                    "mime_type": "text/csv",
+                },
+            ],
+            asset_file_names_payload={},
+        )
+
+    def test_no_op_when_no_attachments(self) -> None:
+        conv = _session([])
+        spec = ChatGPTAssemblySpec()
+        result = spec.enrich_session(conv, {"chatgpt_asset_index": self._index()})
+        assert result is conv
+
+    def test_no_op_for_non_chatgpt_provider(self) -> None:
+        attachment = ParsedAttachment(provider_attachment_id="file-abc", message_provider_id="m1")
+        conv = _session([attachment], source_name=Provider.CLAUDE_AI)
+        spec = ChatGPTAssemblySpec()
+        result = spec.enrich_session(conv, {"chatgpt_asset_index": self._index()})
+        assert result is conv
+
+    def test_no_op_when_index_empty(self) -> None:
+        attachment = ParsedAttachment(provider_attachment_id="file-abc", message_provider_id="m1")
+        conv = _session([attachment])
+        spec = ChatGPTAssemblySpec()
+        result = spec.enrich_session(conv, {"chatgpt_asset_index": ChatGPTAssetIndex.empty()})
+        assert result is conv
+
+    def test_dat_attachment_resolved_and_event_recorded(self) -> None:
+        attachment = ParsedAttachment(provider_attachment_id="file-abc", message_provider_id="m1")
+        conv = _session([attachment])
+        spec = ChatGPTAssemblySpec()
+
+        result = spec.enrich_session(conv, {"chatgpt_asset_index": self._index()})
+
+        resolved = result.attachments[0]
+        assert resolved.name == "library-name.png"
+        assert resolved.mime_type == "image/png"
+        assert resolved.size_bytes == 999
+        assert resolved.provider_file_id == "file-abc"
+        events = [e for e in result.session_events if e.event_type == "chatgpt_asset_resolution"]
+        assert len(events) == 1
+        assert events[0].payload["provider_sha256"] == "deadbeef"
+        assert events[0].payload["resolution_source"] == "library_files"
+
+    def test_does_not_overwrite_existing_attachment_fields(self) -> None:
+        attachment = ParsedAttachment(
+            provider_attachment_id="file-abc",
+            message_provider_id="m1",
+            name="original-name.png",
+            mime_type="image/original",
+            size_bytes=1,
+        )
+        conv = _session([attachment])
+        spec = ChatGPTAssemblySpec()
+
+        result = spec.enrich_session(conv, {"chatgpt_asset_index": self._index()})
+
+        # The attachment keeps its own provider-reported fields; only the
+        # sidecar-derived event and the still-unset provider_file_id change.
+        resolved = result.attachments[0]
+        assert resolved.name == "original-name.png"
+        assert resolved.mime_type == "image/original"
+        assert resolved.size_bytes == 1
+        assert resolved.provider_file_id == "file-abc"
+
+    def test_unresolvable_dat_attachment_is_unchanged(self) -> None:
+        attachment = ParsedAttachment(provider_attachment_id="file-totally-unknown", message_provider_id="m1")
+        conv = _session([attachment])
+        spec = ChatGPTAssemblySpec()
+
+        result = spec.enrich_session(conv, {"chatgpt_asset_index": self._index()})
+
+        assert result is conv
+
+    def test_sandbox_attachment_resolves_via_message_id_tier1(self) -> None:
+        attachment = ParsedAttachment(
+            provider_attachment_id="sandbox:m1:/mnt/data/output.csv",
+            message_provider_id="m1",
+            name="output.csv",
+            attachment_kind="sandbox_file",
+            source_url="sandbox:/mnt/data/output.csv",
+        )
+        conv = _session([attachment], provider_session_id="conv-1")
+        spec = ChatGPTAssemblySpec()
+
+        result = spec.enrich_session(conv, {"chatgpt_asset_index": self._index()})
+
+        resolved = result.attachments[0]
+        assert resolved.provider_file_id == "file_lib1"
+        # attachment_kind stays sandbox_file -- there is still nothing
+        # fetchable over HTTP for it, resolution only strengthens identity.
+        assert resolved.attachment_kind == "sandbox_file"
+        events = [e for e in result.session_events if e.event_type == "chatgpt_sandbox_file_resolution"]
+        assert len(events) == 1
+        assert events[0].payload["resolution_tier"] == 1
+
+    def test_unresolved_sandbox_attachment_still_records_tier6_event(self) -> None:
+        attachment = ParsedAttachment(
+            provider_attachment_id="sandbox:m-unrelated:/mnt/data/mystery.bin",
+            message_provider_id="m-unrelated",
+            name="mystery.bin",
+            attachment_kind="sandbox_file",
+            source_url="sandbox:/mnt/data/mystery.bin",
+        )
+        conv = _session([attachment], provider_session_id="conv-unrelated")
+        spec = ChatGPTAssemblySpec()
+
+        result = spec.enrich_session(conv, {"chatgpt_asset_index": self._index()})
+
+        resolved = result.attachments[0]
+        assert resolved.provider_file_id is None
+        assert resolved.attachment_kind == "sandbox_file"
+        events = [e for e in result.session_events if e.event_type == "chatgpt_sandbox_file_resolution"]
+        assert len(events) == 1
+        assert events[0].payload["resolution_tier"] == 6
+        assert "resolved_file_id" not in events[0].payload

--- a/tests/unit/sources/test_chatgpt_codex_sidecar.py
+++ b/tests/unit/sources/test_chatgpt_codex_sidecar.py
@@ -1,0 +1,159 @@
+"""Tests for codex.json parsing (bd polylogue-2m2e): Codex Cloud tasks
+delivered inside the ChatGPT export.
+"""
+
+from __future__ import annotations
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import Provider, SessionRefKind
+from polylogue.sources.parsers import codex as codex_parser
+from polylogue.sources.parsers.chatgpt import looks_like_fragment as chatgpt_looks_like_fragment
+from polylogue.sources.parsers.chatgpt_codex_sidecar import INGEST_FLAG, looks_like, parse_codex_task
+
+_TASK: dict[str, object] = {
+    "archived": False,
+    "id": "task_e_6a513f0f28e08320826bb4a333c36457",
+    "title": "Fix polylogue daemon correctness bug",
+    "turns": [
+        {
+            "custom_instructions": None,
+            "id": "task_e_6a513f0f28e08320826bb4a333c36457~usertrn_e_6a513f0f457483209ed4fcdc7e91e41b",
+            "input_items": [
+                {
+                    "content": [{"content_type": "text", "text": "Fix the bug."}],
+                    "role": "user",
+                    "type": "message",
+                }
+            ],
+            "role": "user",
+        },
+        {
+            "branch": "master",
+            "branch_name": None,
+            "external_pull_request_id": "None",
+            "id": "task_e_6a513f0f28e08320826bb4a333c36457~assttrn_e_6a513f1032a883208d5bf03461f555f4",
+            "output_items": [
+                {
+                    "content": [
+                        {"content_type": "text", "text": "### Summary\n\nFixed it."},
+                        {
+                            "content_type": "repo_file_citation",
+                            "line_range_end": 136,
+                            "line_range_start": 1,
+                            "path": "polylogue/archive/write_coordinator.py",
+                        },
+                    ],
+                }
+            ],
+            "previous_turn_id": "task_e_6a513f0f28e08320826bb4a333c36457~usertrn_e_6a513f0f457483209ed4fcdc7e91e41b",
+            "pull_request_status": "not_created",
+            "role": "assistant",
+            "turn_status": "TaskTurnStatusEnum.COMPLETED",
+        },
+    ],
+}
+
+
+class TestLooksLike:
+    def test_matches_real_codex_task_shape(self) -> None:
+        assert looks_like(_TASK) is True
+
+    def test_rejects_conversation_fragment(self) -> None:
+        fragment: dict[str, object] = {"mapping": {"n1": {"id": "n1", "parent": None, "children": []}}}
+        assert looks_like(fragment) is False
+
+    def test_rejects_non_task_id(self) -> None:
+        assert looks_like({**_TASK, "id": "conv-abc"}) is False
+
+    def test_rejects_missing_turns(self) -> None:
+        payload = {k: v for k, v in _TASK.items() if k != "turns"}
+        assert looks_like(payload) is False
+
+    def test_rejects_empty_turns(self) -> None:
+        assert looks_like({**_TASK, "turns": []}) is False
+
+    def test_rejects_turn_with_bad_role(self) -> None:
+        bad = {**_TASK, "turns": [{**_TASK["turns"][0], "role": "system"}]}  # type: ignore[index]
+        assert looks_like(bad) is False
+
+    def test_rejects_non_dict(self) -> None:
+        assert looks_like("not-a-dict") is False
+        assert looks_like(None) is False
+
+    def test_disjoint_from_local_codex_session_detector(self) -> None:
+        """codex.json tasks must never be claimed by the local-rollout Codex parser.
+
+        Identity does not collide: local Codex CLI sessions are rollout
+        session_id UUIDs; codex.json tasks are ``task_e_<hex>`` ids. If this
+        ever started matching, ingesting a ChatGPT export could silently
+        create phantom entries under the wrong provider/parser.
+        """
+        assert codex_parser.looks_like([dict(_TASK)]) is False
+
+    def test_disjoint_from_chatgpt_conversation_fragment_detector(self) -> None:
+        assert chatgpt_looks_like_fragment(_TASK) is False
+
+
+class TestParseCodexTask:
+    def test_two_messages_user_then_assistant(self) -> None:
+        session = parse_codex_task(_TASK, "fallback-0")
+        assert [m.role for m in session.messages] == [Role.USER, Role.ASSISTANT]
+        assert session.messages[0].text == "Fix the bug."
+        assert "Fixed it." in (session.messages[1].text or "")
+
+    def test_identity_and_tagging(self) -> None:
+        session = parse_codex_task(_TASK, "fallback-0")
+        assert session.source_name is Provider.CHATGPT
+        assert session.provider_session_id == "task_e_6a513f0f28e08320826bb4a333c36457"
+        assert session.title == "Fix polylogue daemon correctness bug"
+        assert INGEST_FLAG in session.ingest_flags
+
+    def test_parent_link_from_assistant_to_user_turn(self) -> None:
+        session = parse_codex_task(_TASK, "fallback-0")
+        user_id, assistant_id = (m.provider_message_id for m in session.messages)
+        assert session.messages[1].parent_message_provider_id == user_id
+
+    def test_branch_recorded_as_git_branch(self) -> None:
+        session = parse_codex_task(_TASK, "fallback-0")
+        assert session.git_branch == "master"
+
+    def test_turn_metadata_recorded_as_session_event(self) -> None:
+        session = parse_codex_task(_TASK, "fallback-0")
+        events = [e for e in session.session_events if e.event_type == "chatgpt_codex_cloud_turn"]
+        assert len(events) == 1
+        assert events[0].payload["turn_status"] == "TaskTurnStatusEnum.COMPLETED"
+        assert events[0].payload["pull_request_status"] == "not_created"
+        assert events[0].payload["branch"] == "master"
+
+    def test_repo_file_citation_becomes_web_construct(self) -> None:
+        session = parse_codex_task(_TASK, "fallback-0")
+        assistant_message = session.messages[1]
+        constructs = [c for block in assistant_message.blocks for c in block.web_constructs]
+        assert len(constructs) == 1
+        assert constructs[0].text == "polylogue/archive/write_coordinator.py"
+        assert constructs[0].start_index == 1
+        assert constructs[0].end_index == 136
+
+    def test_literal_none_string_pull_request_id_is_not_a_ref(self) -> None:
+        # Real export data carries the literal string "None" for tasks with
+        # no PR (measured 2026-07-31) -- must not become a fake session_ref.
+        session = parse_codex_task(_TASK, "fallback-0")
+        assert session.session_refs == []
+
+    def test_real_pull_request_id_becomes_session_ref(self) -> None:
+        task = {
+            **_TASK,
+            "turns": [
+                _TASK["turns"][0],  # type: ignore[index]
+                {**_TASK["turns"][1], "external_pull_request_id": "1234"},  # type: ignore[index]
+            ],
+        }
+        session = parse_codex_task(task, "fallback-0")
+        assert len(session.session_refs) == 1
+        assert session.session_refs[0].kind == SessionRefKind.PULL_REQUEST.value
+        assert session.session_refs[0].url == "1234"
+
+    def test_missing_id_falls_back(self) -> None:
+        task = {k: v for k, v in _TASK.items() if k != "id"}
+        session = parse_codex_task(task, "fallback-9")
+        assert session.provider_session_id == "fallback-9"

--- a/tests/unit/sources/test_chatgpt_sidecars.py
+++ b/tests/unit/sources/test_chatgpt_sidecars.py
@@ -1,0 +1,211 @@
+"""Tests for ChatGPT export sidecar resolvers (bd polylogue-0hwv / polylogue-dt5s).
+
+Fixture shapes and tier counts mirror the measured spec recorded on the two
+beads (2026-07-31, against the real 2026-07-29 export): two id namespaces
+(``file-<b64ish>`` conversation assets, ``file_<32hex>`` library files), a
+six-tier sandbox-file resolver where tier 5 (ambiguous) is possible but tier
+1-4 dominate, and library_files preferred over conversation_asset_file_names
+whenever both name the same id.
+"""
+
+from __future__ import annotations
+
+from polylogue.sources.parsers.chatgpt_sidecars import (
+    ChatGPTAssetIndex,
+    parse_asset_file_names,
+    parse_library_files,
+)
+
+
+def _library_entry(
+    file_id: str,
+    *,
+    file_name: str | None = "report.csv",
+    origination_message_id: str | None = None,
+    origination_thread_id: str | None = None,
+    sha256_digest: str | None = None,
+    mime_type: str | None = "text/csv",
+    file_size_bytes: int | None = 128,
+) -> dict[str, object]:
+    return {
+        "file_id": file_id,
+        "file_name": file_name,
+        "file_extension": "csv",
+        "mime_type": mime_type,
+        "file_size_bytes": file_size_bytes,
+        "sha256_digest": sha256_digest,
+        "origination_message_id": origination_message_id,
+        "origination_thread_id": origination_thread_id,
+        "library_artifact_type": "other",
+        "directory_id": "libdir_1",
+        "created_at": "2026-07-28T12:00:00Z",
+        "file_upload_time": "2026-07-28T12:00:00Z",
+        "file_processed_time": "2026-07-28T12:00:05Z",
+    }
+
+
+class TestParseLibraryFiles:
+    def test_parses_known_fields(self) -> None:
+        records = parse_library_files([_library_entry("file_abc", file_name="notes.md", sha256_digest="deadbeef")])
+        assert set(records) == {"file_abc"}
+        record = records["file_abc"]
+        assert record.file_name == "notes.md"
+        assert record.sha256_digest == "deadbeef"
+        assert record.mime_type == "text/csv"
+
+    def test_skips_entries_without_file_id(self) -> None:
+        assert parse_library_files([{"file_name": "x.txt"}]) == {}
+
+    def test_non_list_payload_returns_empty(self) -> None:
+        assert parse_library_files({"not": "a list"}) == {}
+        assert parse_library_files(None) == {}
+
+    def test_skips_non_dict_entries(self) -> None:
+        assert parse_library_files(["not-a-dict", 42]) == {}
+
+
+class TestParseAssetFileNames:
+    def test_strips_dat_suffix(self) -> None:
+        names = parse_asset_file_names({"file-abc123.dat": "image.png"})
+        assert names == {"file-abc123": "image.png"}
+
+    def test_keeps_keys_without_dat_suffix(self) -> None:
+        names = parse_asset_file_names({"file-abc123": "image.png"})
+        assert names == {"file-abc123": "image.png"}
+
+    def test_non_dict_payload_returns_empty(self) -> None:
+        assert parse_asset_file_names([1, 2, 3]) == {}
+        assert parse_asset_file_names(None) == {}
+
+    def test_skips_non_string_values(self) -> None:
+        assert parse_asset_file_names({"file-x.dat": 123}) == {}
+
+
+class TestChatGPTAssetIndexResolveDat:
+    def test_prefers_library_files_over_asset_names(self) -> None:
+        index = ChatGPTAssetIndex.build(
+            library_files_payload=[_library_entry("file-abc", file_name="library-name.png", mime_type="image/png")],
+            asset_file_names_payload={"file-abc.dat": "asset-name.png"},
+        )
+        resolved = index.resolve_dat("file-abc")
+        assert resolved is not None
+        assert resolved.name == "library-name.png"
+        assert resolved.mime_type == "image/png"
+        assert resolved.source == "library_files"
+
+    def test_falls_back_to_asset_names(self) -> None:
+        index = ChatGPTAssetIndex.build(
+            library_files_payload=[],
+            asset_file_names_payload={"file-only-named.dat": "image.png"},
+        )
+        resolved = index.resolve_dat("file-only-named")
+        assert resolved is not None
+        assert resolved.name == "image.png"
+        assert resolved.mime_type is None
+        assert resolved.source == "conversation_asset_file_names"
+
+    def test_unknown_id_returns_none(self) -> None:
+        index = ChatGPTAssetIndex.build(library_files_payload=[], asset_file_names_payload={})
+        assert index.resolve_dat("file-unknown") is None
+
+    def test_strips_file_service_prefix(self) -> None:
+        index = ChatGPTAssetIndex.build(
+            library_files_payload=[],
+            asset_file_names_payload={"file-abc.dat": "image.png"},
+        )
+        resolved = index.resolve_dat("file-service://file-abc")
+        assert resolved is not None
+        assert resolved.name == "image.png"
+
+    def test_empty_index_reports_is_empty(self) -> None:
+        assert ChatGPTAssetIndex.empty().is_empty is True
+        assert ChatGPTAssetIndex.build(library_files_payload=[], asset_file_names_payload={}).is_empty is True
+        assert ChatGPTAssetIndex.build(library_files_payload=[_library_entry("file_x")]).is_empty is False
+
+
+class TestChatGPTAssetIndexResolveSandbox:
+    def test_tier1_exact_message_id_and_name(self) -> None:
+        index = ChatGPTAssetIndex.build(
+            library_files_payload=[
+                _library_entry(
+                    "file_a", file_name="out.csv", origination_message_id="msg-1", origination_thread_id="th-1"
+                )
+            ]
+        )
+        resolution = index.resolve_sandbox(message_id="msg-1", thread_id="th-1", file_name="out.csv")
+        assert resolution.tier == 1
+        assert resolution.method == "message_id+name"
+        assert resolution.file is not None
+        assert resolution.file.file_id == "file_a"
+        assert resolution.matched_name == "out.csv"
+
+    def test_tier2_message_id_matches_but_name_differs(self) -> None:
+        index = ChatGPTAssetIndex.build(
+            library_files_payload=[
+                _library_entry(
+                    "file_a", file_name="renamed.csv", origination_message_id="msg-1", origination_thread_id="th-1"
+                )
+            ]
+        )
+        resolution = index.resolve_sandbox(message_id="msg-1", thread_id="th-1", file_name="different.csv")
+        assert resolution.tier == 2
+        assert resolution.method == "message_id"
+        assert resolution.file is not None
+        assert resolution.file.file_id == "file_a"
+        # The library name is the label, not the identity key -- id alone
+        # decided this join (bd polylogue-dt5s tier-2 spec).
+        assert resolution.matched_name == "renamed.csv"
+
+    def test_tier3_thread_id_and_name_when_message_id_absent(self) -> None:
+        index = ChatGPTAssetIndex.build(
+            library_files_payload=[_library_entry("file_a", file_name="out.csv", origination_thread_id="th-1")]
+        )
+        resolution = index.resolve_sandbox(message_id=None, thread_id="th-1", file_name="out.csv")
+        assert resolution.tier == 3
+        assert resolution.file is not None
+        assert resolution.file.file_id == "file_a"
+
+    def test_tier4_globally_unique_name_with_no_id_evidence(self) -> None:
+        index = ChatGPTAssetIndex.build(library_files_payload=[_library_entry("file_a", file_name="unique.csv")])
+        resolution = index.resolve_sandbox(
+            message_id="unrelated-msg", thread_id="unrelated-thread", file_name="unique.csv"
+        )
+        assert resolution.tier == 4
+        assert resolution.method == "global_name_unique"
+        assert resolution.file is not None
+        assert resolution.file.file_id == "file_a"
+
+    def test_tier5_ambiguous_name_records_no_file(self) -> None:
+        index = ChatGPTAssetIndex.build(
+            library_files_payload=[
+                _library_entry("file_a", file_name="shared.csv"),
+                _library_entry("file_b", file_name="shared.csv"),
+            ]
+        )
+        resolution = index.resolve_sandbox(message_id="unrelated", thread_id="unrelated", file_name="shared.csv")
+        assert resolution.tier == 5
+        assert resolution.method == "global_name_ambiguous"
+        assert resolution.file is None
+        assert resolution.matched_name == "shared.csv"
+
+    def test_tier6_unresolved_when_nothing_matches(self) -> None:
+        index = ChatGPTAssetIndex.build(library_files_payload=[_library_entry("file_a", file_name="other.csv")])
+        resolution = index.resolve_sandbox(message_id="unrelated", thread_id="unrelated", file_name="missing.csv")
+        assert resolution.tier == 6
+        assert resolution.method == "unresolved"
+        assert resolution.file is None
+        assert resolution.matched_name is None
+
+    def test_message_id_join_takes_priority_over_thread_and_global(self) -> None:
+        # Two library files share a name globally; only one is tied to the
+        # requesting message id. The id join must win over any name-only tier.
+        index = ChatGPTAssetIndex.build(
+            library_files_payload=[
+                _library_entry("file_a", file_name="dup.csv", origination_message_id="msg-1"),
+                _library_entry("file_b", file_name="dup.csv", origination_message_id="msg-2"),
+            ]
+        )
+        resolution = index.resolve_sandbox(message_id="msg-1", thread_id=None, file_name="dup.csv")
+        assert resolution.tier == 1
+        assert resolution.file is not None
+        assert resolution.file.file_id == "file_a"

--- a/tests/unit/sources/test_dispatch_payloads.py
+++ b/tests/unit/sources/test_dispatch_payloads.py
@@ -524,6 +524,64 @@ def test_chatgpt_bundle_small_metadata_only_array_does_not_warn(caplog: pytest.L
     assert not any("ChatGPT bundle payload" in record.message for record in caplog.records)
 
 
+def _chatgpt_codex_task_record(task_id: str) -> dict[str, object]:
+    return {
+        "archived": False,
+        "id": task_id,
+        "title": "Fix a bug",
+        "turns": [
+            {
+                "id": f"{task_id}~usertrn_1",
+                "input_items": [{"content": [{"content_type": "text", "text": "Fix it"}], "role": "user"}],
+                "role": "user",
+            },
+            {
+                "branch": "master",
+                "external_pull_request_id": "None",
+                "id": f"{task_id}~assttrn_1",
+                "output_items": [{"content": [{"content_type": "text", "text": "Fixed"}]}],
+                "previous_turn_id": f"{task_id}~usertrn_1",
+                "pull_request_status": "not_created",
+                "role": "assistant",
+                "turn_status": "TaskTurnStatusEnum.COMPLETED",
+            },
+        ],
+    }
+
+
+def test_chatgpt_codex_task_parses_as_its_own_session(caplog: pytest.LogCaptureFixture) -> None:
+    """codex.json (bd polylogue-2m2e): Codex Cloud tasks delivered inside a
+    ChatGPT export are unpacked one dict per item by the ordinary per-.json-
+    file walk (same shape ``_chatgpt_bundle_record_specs`` handles for a
+    whole array, and the single-record path handles for one already-
+    unpacked item) -- both must route to ``chatgpt_codex_sidecar.parse_codex_task``
+    rather than falling into ``chatgpt.parse``, which would silently emit a
+    zero-message session (no "mapping" key) that gets dropped downstream.
+    """
+    task = _chatgpt_codex_task_record("task_e_abc123")
+
+    # Single already-unpacked record (the actually-exercised per-.json-file path).
+    single_sessions = parse_payload(Provider.CHATGPT, task, "codex-0")
+    assert len(single_sessions) == 1
+    assert single_sessions[0].provider_session_id == "task_e_abc123"
+    assert len(single_sessions[0].messages) == 2
+
+    # Whole-array path (defensive: any caller that hands the raw list over).
+    bundle_sessions = parse_payload(Provider.CHATGPT, [task], "codex-json")
+    assert len(bundle_sessions) == 1
+    assert bundle_sessions[0].provider_session_id == "task_e_abc123"
+
+
+def test_chatgpt_codex_task_and_conversation_coexist_in_one_bundle(caplog: pytest.LogCaptureFixture) -> None:
+    task = _chatgpt_codex_task_record("task_e_def456")
+    conversation = _chatgpt_conversation_record("real-conversation-2")
+
+    sessions = parse_payload(Provider.CHATGPT, [task, conversation], "mixed-bundle")
+
+    session_ids = {s.provider_session_id for s in sessions}
+    assert session_ids == {"task_e_def456", "real-conversation-2"}
+
+
 def test_parse_stream_payload_codex_long_rollout_with_repeated_session_meta_yields_messages() -> None:
     """A long Codex rollout that repeats ``session_meta`` (fork/resume/compaction
     markers physically re-emit the header) and interleaves reasoning,

--- a/tests/unit/sources/test_origin_specs.py
+++ b/tests/unit/sources/test_origin_specs.py
@@ -196,8 +196,13 @@ def test_origin_specs_declare_the_claude_and_codex_assembly_extension_hooks() ->
     assert by_origin[Origin.AISTUDIO_DRIVE].assembly_spec_path == (
         "polylogue/sources/assembly_gemini.py:GeminiAssemblySpec"
     )
+    # bd polylogue-0hwv / polylogue-dt5s: ChatGPT gained an assembly hook
+    # (asset-name/sandbox-file sidecar resolution) -- it is no longer in the
+    # "no assembly extension" cohort with Gemini CLI.
+    assert by_origin[Origin.CHATGPT_EXPORT].assembly_spec_path == (
+        "polylogue/sources/assembly_chatgpt.py:ChatGPTAssemblySpec"
+    )
     assert by_origin[Origin.GEMINI_CLI_SESSION].assembly_spec_path is None
-    assert by_origin[Origin.CHATGPT_EXPORT].assembly_spec_path is None
 
 
 def test_origin_specs_are_parity_checked_against_the_live_assembly_registry() -> None:


### PR DESCRIPTION
## Summary

Parses three previously-unread parts of the 2026-07-29 ChatGPT GDPR/Takeout export: `.dat` attachment asset ids, model-produced sandbox-file links, and `codex.json` (Codex Cloud tasks delivered through the ChatGPT export).

## Problem

Three measured gaps in the same export, tracked as `polylogue-0hwv`, `polylogue-dt5s`, `polylogue-2m2e`:

- **polylogue-0hwv**: the export ships 3,228 `.dat` attachment blobs for the first time, named only by opaque ids. The two sibling files that name them (`conversation_asset_file_names.json`, `library_files.json`) were never referenced anywhere in polylogue (verified by `rg`).
- **polylogue-dt5s**: the model's `sandbox:/mnt/data/<name>` code-interpreter output links carry no file id at all, so they were recorded with nothing beyond a bare filename.
- **polylogue-2m2e**: `codex.json` (20 Codex Cloud tasks, a second/independent delivery path for Codex sessions, distinct from local `~/.codex/sessions` rollouts) failed every session-document heuristic in `artifact_taxonomy` and was silently dropped before parsing ever ran.

## Solution

- `polylogue/sources/parsers/chatgpt_sidecars.py` — `ChatGPTAssetIndex`: resolves `.dat` ids (library_files.json preferred, conversation_asset_file_names.json fallback) and implements the measured 6-tier sandbox-file resolver (message_id+name exact → message_id-only identity join, name is a label not a key → thread_id+name → globally-unique name → globally-ambiguous name, evidence only → unresolved, metadata-only).
- `polylogue/sources/assembly_chatgpt.py` — wires the index into the existing `ProviderAssemblySpec` protocol (`discover_sidecars`/`enrich_session`), the same extension point Codex/Claude Code/Gemini already use. Handles both an extracted export directory and an unextracted export ZIP. Resolution results land as `session_events` (`chatgpt_asset_resolution`, `chatgpt_sandbox_file_resolution`, recording which tier resolved each link) rather than new attachment columns, since `index.db` is a derived tier and a schema bump needs a declared delta class. `provider_file_id` is updated in place on any id-grade match.
- `polylogue/sources/parsers/chatgpt_codex_sidecar.py` + `archive/artifact_taxonomy/runtime.py` + `sources/dispatch.py` — a tight structural detector (`task_e_<hex>` id + `turns` shape) routes `codex.json` entries to a dedicated parser instead of `chatgpt.parse` (which silently produced a zero-message, hence write-time-dropped, session for them).

**Deliberately deferred, not silently dropped**: actual `.dat` byte acquisition into the blob store. `decoder_zip.py`'s `ZipEntryValidator` only admits `.json`/`.jsonl` entries today, so `.dat` ZIP members are never read. Filed as `polylogue-8ac0` with the two-pass streaming design (collect `.dat` blobs via `BlobStore.write_from_fileobj`, join during conversation parsing, reuse the `inline_bytes`-style preacquired-blob receipt path) — this touches the ZIP streaming/receipt/GC machinery and deserves its own focused verification pass separate from the naming/resolution logic in this PR.

## Verification

- Validated `resolve_dat`/`resolve_sandbox` against the real 2026-07-29 export sidecars (`library_files.json` 2,367 entries, `conversation_asset_file_names.json` 1,656 entries) and all 29 real `conversations-*.json` shards: 2,836 sessions, 0 parse errors, 1,924/1,924 (100%) of referenced `.dat` attachments resolved a name.
  - Sandbox tiers over every raw sandbox-link *occurrence* (regex matches on assistant text, no dedup) reproduce `polylogue-dt5s`'s measured spec **exactly**: `{1: 1412, 2: 418, 3: 2, 4: 91, 5: 0, 6: 1020}`, sum 2943, bit-for-bit.
  - Sandbox tiers as this PR's production code actually emits them are lower and *not* identical to the spec: `{1: 1273, 2: 370, 3: 2, 4: 83, 6: 995}`, sum 2723 (-7.5%). Root cause, confirmed by reproducing both counts side by side: `chatgpt.py`'s pre-existing `_sandbox_file_paths()` (not touched by this PR) deduplicates repeated identical `sandbox:/mnt/data/<name>` links within one message's text before any attachment is built, so a message that links the same file twice contributes one `ParsedAttachment`, not two. The spec counted every occurrence; this PR's attachments count every *distinct (message, filename) pair*. That is the correct product behavior (no duplicate attachment rows for a repeated identical link) but it is a different denominator than the spec measurement, not a resolver disagreement — every populated tier shrinks by roughly the same ~7-12%, and tiers 3 and 5 (the smallest, least likely to contain a repeated link) are unaffected.
  - What **is** an exact, structurally load-bearing match regardless of denominator: **tier 5 (globally-ambiguous name) is zero** in both counts — no fuzzy-match collision exists anywhere in the corpus — and **tier 3 is 2** in both counts. Those are the two results that matter for whether the tiered-resolver design (vs. a flat fuzzy matcher) was the right call, and they hold exactly.
- `codex.json`: all 20 real tasks now parse into 20 distinct sessions (previously 0); confirmed disjoint identity from both `codex.looks_like` (local rollout detector) and `chatgpt.looks_like_fragment` on the real records.
- `devtools test tests/unit/sources/{test_parsers_chatgpt,test_dispatch_payloads,test_dispatch_ordering,test_chatgpt_normalization_survivors,test_assembly,test_artifact_taxonomy,test_chatgpt_sidecars,test_chatgpt_codex_sidecar,test_assembly_chatgpt}.py` — 290 passed.
- `devtools verify --quick` — green (format/lint/mypy --strict/render all --check/topology/layering/closure-matrix/schema-versioning).
- `devtools verify --seed-testmon --skip-slow` (full non-slow suite, 17,782 tests) — surfaced one real gap this PR needed to fix (`test_origin_specs_are_parity_checked_against_the_live_assembly_registry`: `OriginSpec`'s `chatgpt-export` declaration still said `assembly_spec_path=None` after this branch wired up `ChatGPTAssemblySpec` — fixed by declaring it, plus updating the one other test that pinned the stale fact). The other 5 failures the run reported were triaged and are not this branch's responsibility: reproduced each against a clean `origin/master` checkout in an ephemeral worktree — 3 fail identically on `master` alone (pre-existing: a stale doc-template assertion in `test_render_quality_reference`, a hardcoded golden timestamp compared against the real wall clock in `test_facade_contracts`, a CLI snapshot that leaks a live-archive warning in `test_terminal_snapshots`) and 2 pass in isolation on both `master` and this branch (`test_daemon_bulk_rebuild_responsiveness`, `test_live_watcher` — timing-sensitive under the concurrent full-suite load another session was running on this host). None touch a file this PR changed. Full suite now green with the origin_specs fix applied: `devtools test tests/unit/sources/test_origin_specs.py` — 15 passed (was 14 passed, 1 failed).

## Acceptance criteria

| Bead | Item | Status |
| --- | --- | --- |
| polylogue-0hwv | Resolve `.dat` id → real name/mime/size/sha256 | Satisfied |
| polylogue-0hwv | Acquire `.dat` bytes into the blob store | Deferred → polylogue-8ac0 |
| polylogue-dt5s | 6-tier sandbox-file resolver, tier recorded per link | Satisfied |
| polylogue-dt5s | Metadata-only reference for unresolved (tier 6) links | Satisfied |
| polylogue-2m2e | Decide per sidecar: parsed or explicitly out of scope | Satisfied (library_files.json, conversation_asset_file_names.json, codex.json parsed; message_feedback.json/shared_conversations.json/ads.json unchanged per the bead's own framing) |
| polylogue-2m2e | Determine codex.json coalescing vs codex-session | Satisfied — does not coalesce, disjoint id namespace, verified |
| polylogue-2m2e | Library files with no message reference as first-class refs | Deferred (documented in bead note) — needs whole-source-scan aggregation not yet built |

Ref polylogue-0hwv, polylogue-dt5s, polylogue-2m2e

