### PR TITLE
feat(browser): upgrade Grok capture from DOM-only to native REST

### DIFF
--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -76,7 +76,9 @@ Nightly with `xpinstall.signatures.required = false`.
 polylogued browser-capture status
 ```
 
-Then navigate to `chatgpt.com`, `claude.ai`, or a supported Grok/X route.
+Then navigate to `chatgpt.com`, `claude.ai`, or `grok.com`. (Grok on `x.com`/`twitter.com`
+is not supported: it is served through X's own API rather than grok.com's, so it has no
+capture path here.)
 Open the popup and use **Capture page** for the current page or
 **Sync open tabs** for all currently open supported tabs. The extension does
 not continuously watch page mutations or capture while you type.
@@ -228,7 +230,7 @@ pages the badge shows grey and no data is sent.
 
 | Symptom | Check |
 |---------|-------|
-| Badge is grey | Navigate to a supported page (chatgpt.com, claude.ai, or Grok/X) |
+| Badge is grey | Navigate to a supported page (chatgpt.com, claude.ai, or grok.com) |
 | Badge is red | Receiver is not running — start `polylogued browser-capture serve` |
 | Captures not appearing in archive | Run `polylogue check` to verify the daemon is ingesting |
 | Popup says `stale` | The receiver has a newer spool artifact than the indexed archive. Leave the daemon running and inspect the debug log request id if it does not converge. |

--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -75,9 +75,17 @@
     },
     {
       "matches": [
-        "https://grok.com/*",
-        "https://x.com/*",
-        "https://twitter.com/*"
+        "https://grok.com/*"
+      ],
+      "js": [
+        "src/content/grok_bridge.js"
+      ],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
+    {
+      "matches": [
+        "https://grok.com/*"
       ],
       "js": [
         "src/common.js",

--- a/browser-extension/src/backfill/providers.js
+++ b/browser-extension/src/backfill/providers.js
@@ -132,7 +132,7 @@ function claudeText(message) {
   }).filter(Boolean).join("\n");
 }
 
-function envelope({ provider, nativeId, title, createdAt, updatedAt, turns, rawPayload, adapterName, sourceUrl, attribution, captureFidelity = "native_full" }) {
+function envelope({ provider, nativeId, title, createdAt, updatedAt, turns, rawPayload, adapterName, sourceUrl, attribution, captureFidelity = "native_full", sessionKind = "standard" }) {
   return {
     polylogue_capture_kind: "browser_llm_session",
     schema_version: 1,
@@ -151,6 +151,7 @@ function envelope({ provider, nativeId, title, createdAt, updatedAt, turns, rawP
     session: {
       provider,
       provider_session_id: nativeId,
+      session_kind: sessionKind === "temporary" ? "temporary" : "standard",
       title: title || nativeId,
       created_at: createdAt,
       updated_at: updatedAt,
@@ -338,10 +339,114 @@ export class ClaudeBackfillAdapter {
   }
 }
 
+// grok.com's own REST surface (verified live 2026-07-31, see
+// src/content/grok_bridge.js): pageToken-based pagination
+// (`nextPageToken` absent/empty marks the last page -- confirmed against a
+// 20-conversation account with pageSize=200), plus a two-fetch conversation
+// read (metadata + `/responses`) combined into one synthetic Response-like
+// object so this adapter's fetchNative/normalizeCapture contract matches
+// ChatGPT/Claude's single-response shape.
+const GROK_PAGE_SIZE = 60;
+
+export class GrokBackfillAdapter {
+  constructor(fetchImpl = globalThis.fetch, options = {}) {
+    this.fetchImpl = fetchImpl;
+    this.requirePageContext = Boolean(options.requirePageContext);
+    this.provider = "grok";
+  }
+  configure() {}
+  // Every native fetch costs two provider requests (conversation metadata +
+  // responses), same accounting ChatGPT uses for its own two-stage fetch.
+  requestCost() { return 2; }
+  async enumerate(cursor = "0", cutoff = null) {
+    const pageToken = cursor && cursor !== "0" ? cursor : null;
+    const url = new URL("https://grok.com/rest/app-chat/conversations");
+    url.searchParams.set("pageSize", String(GROK_PAGE_SIZE));
+    if (pageToken) url.searchParams.set("pageToken", pageToken);
+    const response = await providerRequest(this.fetchImpl, url.href);
+    if (this.requirePageContext && response.polyloguePageContext !== true) {
+      return { response, classification: "auth_or_challenge", items: [], next_cursor: cursor, done: false, request_count: 1 };
+    }
+    if (!response.ok) return { response, classification: responseClass(response), items: [], next_cursor: cursor, done: false, request_count: 1 };
+    const body = await jsonResponse(response, "grok_inventory");
+    const records = requireArray(body.conversations, "grok_inventory.conversations");
+    const projected = records.map((item, index) => ({
+      native_id: requireString(item.conversationId, `grok_inventory.conversations[${index}].conversationId`),
+      title: typeof item.title === "string" ? item.title : null,
+      updated_at: isoTimestamp(item.modifyTime),
+    }));
+    const items = projected.filter((item) => !cutoff || !item.updated_at || item.updated_at >= cutoff);
+    const crossedCutoff = Boolean(cutoff && projected.some((item) => item.updated_at && item.updated_at < cutoff));
+    const nextPageToken = typeof body.nextPageToken === "string" && body.nextPageToken ? body.nextPageToken : null;
+    const done = !nextPageToken || crossedCutoff;
+    return { response, classification: "success", items, next_cursor: nextPageToken || cursor, done, request_count: 1 };
+  }
+  async fetchNative(nativeId) {
+    const conversationResponse = await providerRequest(this.fetchImpl, `https://grok.com/rest/app-chat/conversations/${encodeURIComponent(nativeId)}`);
+    if (!conversationResponse.ok) return conversationResponse;
+    const responsesResponse = await providerRequest(this.fetchImpl, `https://grok.com/rest/app-chat/conversations/${encodeURIComponent(nativeId)}/responses`);
+    if (!responsesResponse.ok) return responsesResponse;
+    const conversation = await jsonResponse(conversationResponse, "grok_conversation");
+    const responsesBody = await jsonResponse(responsesResponse, "grok_conversation_responses");
+    const responses = requireArray(responsesBody.responses, "grok_conversation_responses.responses");
+    return {
+      ok: true,
+      status: 200,
+      polyloguePageContext: responsesResponse.polyloguePageContext,
+      async json() {
+        return { ...conversation, responses };
+      },
+    };
+  }
+  classifyResponse(response) {
+    if (this.requirePageContext && response.polyloguePageContext !== true) return "auth_or_challenge";
+    return responseClass(response);
+  }
+  async normalizeCapture(response, item, attribution) {
+    const body = await jsonResponse(response, "grok_conversation_combined");
+    const responses = requireArray(body.responses, "grok_conversation_combined.responses");
+    const turns = responses.flatMap((entry, index) => {
+      if (!entry || typeof entry.responseId !== "string") return [];
+      const text = grokConversationText(entry).trim();
+      if (!text) return [];
+      return [{
+        provider_turn_id: requireString(entry.responseId, `grok_conversation_combined.responses[${index}].responseId`),
+        role: normalizedRole(String(entry.sender || "").toLowerCase()),
+        text,
+        timestamp: isoTimestamp(entry.createTime),
+        parent_turn_id: entry.parentResponseId || null,
+        provider_meta: {
+          model: entry.model || null,
+          sender: entry.sender || null,
+          capture_source: "grok_app_chat_api",
+        },
+      }];
+    });
+    return envelope({
+      provider: "grok",
+      nativeId: item.native_id,
+      title: body.title || item.title,
+      createdAt: isoTimestamp(body.createTime),
+      updatedAt: isoTimestamp(body.modifyTime) || item.updated_at,
+      turns,
+      rawPayload: body,
+      adapterName: "grok-backfill-native-v1",
+      sourceUrl: `https://grok.com/c/${item.native_id}`,
+      attribution,
+      sessionKind: body.temporary === true ? "temporary" : "standard",
+    });
+  }
+}
+
+function grokConversationText(response) {
+  return typeof response?.message === "string" ? response.message : "";
+}
+
 export function providerAdapters(fetchImpl = globalThis.fetch, options = {}) {
   return {
     chatgpt: new ChatGptBackfillAdapter(fetchImpl, { requirePageContext: options.requirePageContext }),
     "claude-ai": new ClaudeBackfillAdapter(fetchImpl, options.claudeOrganizationId || null, { requirePageContext: options.requirePageContext }),
+    grok: new GrokBackfillAdapter(fetchImpl, { requirePageContext: options.requirePageContext }),
   };
 }
 import { PROVIDER_REQUEST_TIMEOUT_MS } from "./models.js";

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -434,15 +434,19 @@ function injectionPlanForUrl(url) {
         },
       ];
     }
-    if (
-      parsed.hostname === "grok.com" ||
-      parsed.hostname.endsWith(".grok.com") ||
-      parsed.hostname === "x.com" ||
-      parsed.hostname.endsWith(".x.com") ||
-      parsed.hostname === "twitter.com" ||
-      parsed.hostname.endsWith(".twitter.com")
-    ) {
-      return [{ files: ["src/common.js", "src/content/grok.js"] }];
+    if (parsed.hostname === "grok.com" || parsed.hostname.endsWith(".grok.com")) {
+      // grok.com now has a MAIN-world bridge (native REST capture,
+      // polylogue Grok native-capture upgrade 2026-07-31) mirroring
+      // chatgpt/claude above. x.com/twitter.com were dropped here: Grok's
+      // embedded surface on X is served through X's own API, not
+      // grok.com's /rest/app-chat/* REST surface this bridge calls, and
+      // this upgrade deleted the DOM-only capture path that used to be the
+      // (lossy) fallback for those origins. See manifest.json's matching
+      // content_scripts change and this repo's Grok-on-X follow-up bead.
+      return [
+        { files: ["src/content/grok_bridge.js"], world: "MAIN" },
+        { files: ["src/common.js", "src/content/grok.js"] },
+      ];
     }
   } catch {
     return [];
@@ -2624,6 +2628,11 @@ function conversationIdForUrl(url) {
       return parts[0] === "chat" && parts[1] ? parts[1] : null;
     }
     if (provider === "grok") {
+      // grok.com's own conversation URLs are /c/<uuid> (verified live,
+      // 2026-07-31, same convention as ChatGPT/Claude above). The /chat/
+      // and /grok/ segment guesses below predate that verification.
+      const marker = parts.indexOf("c");
+      if (marker >= 0 && parts[marker + 1]) return parts[marker + 1];
       const pathId = parts.find((part, index) => parts[index - 1] === "chat" || parts[index - 1] === "grok");
       if (pathId) return pathId;
       const queryId = parsed.searchParams.get("conversation") || parsed.searchParams.get("conversationId");

--- a/browser-extension/src/common.js
+++ b/browser-extension/src/common.js
@@ -26,11 +26,18 @@
     }
     if (provider === "claude-ai") return null;
     if (provider === "grok") {
+      // grok.com's own conversation URLs are /c/<uuid> (verified live,
+      // 2026-07-31), matching the same convention ChatGPT/Claude use. The
+      // /chat/ and /grok/ segment guesses below predate that verification
+      // and are kept only as a defensive fallback for URL shapes this has
+      // not been checked against.
+      const marker = parts.indexOf("c");
+      if (marker >= 0 && parts[marker + 1]) return parts[marker + 1];
       const grokPathId = parts.find((part, index) => parts[index - 1] === "chat" || parts[index - 1] === "grok");
       if (grokPathId) return grokPathId;
       const queryId = parsed.searchParams.get("conversation") || parsed.searchParams.get("conversationId");
       if (queryId) return queryId;
-      return `dom:${fnv1a(parsed.origin + parsed.pathname + parsed.search)}`;
+      return null;
     }
     const sessionToken = parts.at(-1) || parsed.pathname || parsed.hostname;
     return `${provider}:${sessionToken}:${fnv1a(parsed.origin + parsed.pathname)}`;

--- a/browser-extension/src/content/grok.js
+++ b/browser-extension/src/content/grok.js
@@ -2,131 +2,531 @@
   if (window.__polylogueGrokCaptureInstalled) return;
   window.__polylogueGrokCaptureInstalled = true;
 
-  const domAdapterName = "grok-dom-v1";
+  // Native-only adapter (polylogue Grok native-capture upgrade, 2026-07-31).
+  //
+  // grok.js used to be the only provider adapter with no MAIN-world bridge:
+  // it scraped whatever turn nodes happened to be mounted in the DOM and
+  // hardcoded `native_attempts: []`. Every other provider's DOM path has
+  // proven lossy by roughly two orders of magnitude once a conversation
+  // scrolls past the virtualized viewport (measured live: one ChatGPT
+  // conversation held 5 DOM nodes against 996 API messages). grok.com's own
+  // `/rest/app-chat/conversations/<id>` + `.../responses` REST surface
+  // (verified live 2026-07-31 via CDP against an authenticated session) is
+  // strictly superior for every field DOM scraping could ever observe, so
+  // there is no DOM fallback here at all -- a native-capture failure fails
+  // loud (diagnostics attached) rather than silently degrading to an
+  // under-observed capture that looks the same as a complete one.
+  const nativeAdapterName = "grok-native-v1";
+  const nativeCaptureMessage = "polylogue.grok.nativeCapture";
+  const nativeFetchRequestMessage = "polylogue.grok.nativeFetchRequest";
+  const nativeFetchResponseMessage = "polylogue.grok.nativeFetchResponse";
+  const nativeFetchTimeoutMs = 8000;
+  const assetFetchRequestMessage = "polylogue.grok.assetFetchRequest";
+  const assetFetchResponseMessage = "polylogue.grok.assetFetchResponse";
+  const assetFetchTimeoutMs = 10000;
+  const assetMaxBytesPerFile = 25 * 1024 * 1024;
+  const assetMaxBytesTotal = 75 * 1024 * 1024;
+  const assetTotalTimeBudgetMs = 10000;
+  const assetConsecutiveFailureLimit = 3;
 
-  function roleFromNode(node, index) {
-    const attrs = [
-      node.getAttribute("data-testid"),
-      node.getAttribute("data-message-author-role"),
-      node.getAttribute("aria-label"),
-      node.className,
-    ]
-      .filter(Boolean)
-      .join(" ");
-    if (/user|you|human/i.test(attrs)) return "user";
-    if (/assistant|grok|ai/i.test(attrs)) return "assistant";
-    return index % 2 === 0 ? "user" : "assistant";
+  const nativeCaptures = [];
+  const nativeFetchResponses = new Map();
+  const assetResponses = new Map();
+  const nativeAttemptDiagnostics = [];
+
+  function rememberNativeAttempt(diagnostic) {
+    nativeAttemptDiagnostics.push({ attempted_at: new Date().toISOString(), ...diagnostic });
+    if (nativeAttemptDiagnostics.length > 8) {
+      nativeAttemptDiagnostics.splice(0, nativeAttemptDiagnostics.length - 8);
+    }
   }
 
-  function attachmentNameFromNode(node) {
-    const label = node.getAttribute("aria-label") || "";
-    const download = node.getAttribute("download") || "";
-    const alt = node.getAttribute("alt") || "";
-    const text = window.polylogueCapture.visibleText(node);
-    const href = node.getAttribute("href") || node.getAttribute("src") || "";
-    const basename = href.split(/[/?#]/).filter(Boolean).at(-1) || "";
-    const candidates = [label, download, alt, text, basename]
-      .map((value) => String(value || "").trim())
-      .filter(Boolean);
-    const filePattern =
-      /(?:^|\s)([^\s@/]+\.(?:zip|tar|tgz|gz|bz2|xz|7z|rar|md|txt|pdf|doc|docx|json|jsonl|csv|tsv|py|js|ts|tsx|jsx|rs|go|java|c|cc|cpp|h|hpp|png|jpe?g|gif|webp|svg|mp3|mp4|wav|webm))(?:\s|$)/i;
-    for (const candidate of candidates) {
-      const match = candidate.match(filePattern);
-      if (match) return match[1].trim();
+  // grok.com conversation URLs are /c/<uuid> (verified live 2026-07-31).
+  function conversationIdFromUrl(url = window.location.href) {
+    const parsed = new URL(url);
+    const parts = parsed.pathname.split("/").filter(Boolean);
+    const marker = parts.indexOf("c");
+    if (marker >= 0 && parts[marker + 1]) return parts[marker + 1];
+    return null;
+  }
+
+  window.addEventListener("message", (event) => {
+    if (event.source !== window || event.origin !== window.location.origin) return;
+    const data = event.data || {};
+    if (data.type === nativeCaptureMessage && data.capture) {
+      nativeCaptures.push(data.capture);
+      if (nativeCaptures.length > 8) nativeCaptures.splice(0, nativeCaptures.length - 8);
+      return;
+    }
+    if (data.type === nativeFetchResponseMessage && data.requestId) {
+      const pending = nativeFetchResponses.get(data.requestId);
+      if (!pending) return;
+      nativeFetchResponses.delete(data.requestId);
+      pending.resolve({ capture: data.capture || null, error: data.error || null });
+      return;
+    }
+    if (data.type === assetFetchResponseMessage && data.requestId) {
+      const pending = assetResponses.get(data.requestId);
+      if (!pending) return;
+      assetResponses.delete(data.requestId);
+      pending.resolve(data.outcome && typeof data.outcome === "object" ? data.outcome : { status: "request_failed", detail: "bridge_response_missing" });
+    }
+  });
+
+  async function requestNativeCaptureFromPage(conversationId) {
+    const requestId = `polylogue-grok-native-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const responsePromise = new Promise((resolve) => {
+      const timeout = window.setTimeout(() => {
+        nativeFetchResponses.delete(requestId);
+        resolve({ capture: null, error: "timeout" });
+      }, nativeFetchTimeoutMs);
+      nativeFetchResponses.set(requestId, {
+        resolve(value) {
+          window.clearTimeout(timeout);
+          resolve(value);
+        },
+      });
+    });
+    window.postMessage({ type: nativeFetchRequestMessage, requestId, conversationId }, window.location.origin);
+    return responsePromise;
+  }
+
+  function parseNativeCapture(capture, expectedConversationId) {
+    if (!capture || !capture.ok || typeof capture.body !== "string") return null;
+    let payload;
+    try {
+      payload = JSON.parse(capture.body);
+    } catch {
+      return null;
+    }
+    if (!payload || typeof payload !== "object" || !Array.isArray(payload.responses)) return null;
+    const payloadConversationId = payload.conversationId;
+    if (expectedConversationId && payloadConversationId && String(payloadConversationId) !== expectedConversationId) {
+      return null;
+    }
+    return payload;
+  }
+
+  function latestNativePayload(expectedConversationId) {
+    for (let index = nativeCaptures.length - 1; index >= 0; index -= 1) {
+      const payload = parseNativeCapture(nativeCaptures[index], expectedConversationId);
+      if (payload) return payload;
     }
     return null;
   }
 
-  function collectAttachments(node, turnIndex) {
-    const selector = [
-      '[role="group"][aria-label]',
-      "a[download]",
-      "a[href][aria-label]",
-      "img[alt]",
-      "img[src]",
-    ].join(",");
+  async function fetchNativePayloadOnDemand(requestedConversationId) {
+    const conversationId = requestedConversationId || conversationIdFromUrl();
+    if (!conversationId || !/^[A-Za-z0-9_-]{1,256}$/.test(conversationId)) {
+      rememberNativeAttempt({ stage: "conversation_id_resolution", accepted: false, reason: "no_conversation_id_in_url" });
+      return null;
+    }
+    const pageResult = await requestNativeCaptureFromPage(conversationId);
+    const payload = parseNativeCapture(pageResult && pageResult.capture, conversationId);
+    rememberNativeAttempt({
+      stage: "page_bridge_fetch",
+      ok: pageResult?.capture?.ok ?? null,
+      status: pageResult?.capture?.status ?? null,
+      response_count: Array.isArray(payload?.responses) ? payload.responses.length : null,
+      accepted: Boolean(payload),
+      error: pageResult?.error || pageResult?.capture?.error || null,
+    });
+    if (payload) return payload;
+    return latestNativePayload(conversationId);
+  }
+
+  function roleFromSender(sender) {
+    const normalized = String(sender || "").toLowerCase();
+    if (normalized === "human") return "user";
+    if (normalized === "assistant") return "assistant";
+    return "unknown";
+  }
+
+  function timestampFromValue(value) {
+    if (typeof value === "string" && value) return value;
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return new Date(value < 10_000_000_000 ? value * 1000 : value).toISOString();
+    }
+    return null;
+  }
+
+  // Structured evidence a Grok response node carries beyond its `message`
+  // prose: reasoning steps, web/X/RAG/connector search evidence, and raw
+  // tool responses. Each recognized shape becomes a typed
+  // BrowserCaptureBlock; anything with content this function does not
+  // recognize is still emitted (never dropped) as a tool_result block
+  // flagged `metadata.unrecognized_shape = true` so a payload shape change
+  // shows up as a visible diagnostic instead of a silently-shrunken capture.
+  function stepBlocks(response) {
+    const steps = Array.isArray(response.steps) ? response.steps : [];
+    return steps.flatMap((step, index) => {
+      const text = Array.isArray(step?.text) ? step.text.filter((line) => typeof line === "string" && line).join("\n") : "";
+      const blocks = [];
+      if (text) {
+        blocks.push({ type: "thinking", text, metadata: { step_index: index, tags: Array.isArray(step?.tags) ? step.tags : [] } });
+      }
+      for (const usage of Array.isArray(step?.toolUsageResults) ? step.toolUsageResults : []) {
+        blocks.push(toolUsageBlock(usage, response.responseId, index));
+      }
+      for (const card of Array.isArray(step?.toolUsageCards) ? step.toolUsageCards : []) {
+        blocks.push(toolUsageBlock(card, response.responseId, index, "tool_usage_card"));
+      }
+      return blocks;
+    });
+  }
+
+  function toolUsageBlock(usage, ownId, stepIndex, sourceLabel = "tool_usage_result") {
+    const toolName =
+      (usage && typeof usage === "object" && (usage.toolName || usage.tool_name || usage.name || usage.type)) || null;
+    if (toolName && typeof toolName === "string") {
+      return {
+        type: "tool_result",
+        tool_id: ownId,
+        tool_name: toolName,
+        text: typeof usage.text === "string" ? usage.text : null,
+        metadata: { step_index: stepIndex, source: sourceLabel, raw: usage },
+      };
+    }
+    return {
+      type: "tool_result",
+      tool_id: ownId,
+      text: JSON.stringify(usage),
+      metadata: { step_index: stepIndex, source: sourceLabel, unrecognized_shape: true },
+    };
+  }
+
+  const RESULT_LIST_FIELDS = [
+    ["webSearchResults", "web_search"],
+    ["citedWebSearchResults", "web_search"],
+    ["xposts", "x_search"],
+    ["citedXposts", "x_search"],
+    ["ragResults", "rag_search"],
+    ["citedRagResults", "rag_search"],
+    ["searchProductResults", "product_search"],
+    ["connectorSearchResults", "connector_search"],
+    ["citedConnectorSearchResults", "connector_search"],
+    ["collectionSearchResults", "collection_search"],
+    ["citedCollectionSearchResults", "collection_search"],
+  ];
+
+  function resultListBlocks(response) {
+    const blocks = [];
+    for (const [field, toolName] of RESULT_LIST_FIELDS) {
+      const value = response[field];
+      if (!Array.isArray(value) || !value.length) continue;
+      blocks.push({
+        type: "tool_result",
+        tool_id: response.responseId,
+        tool_name: toolName,
+        metadata: { field, count: value.length, results: value },
+      });
+    }
+    if (response.query) {
+      blocks.unshift({
+        type: "tool_use",
+        tool_id: response.responseId,
+        tool_name: "web_search",
+        tool_input: { query: response.query, query_type: response.queryType || null },
+      });
+    }
+    return blocks;
+  }
+
+  function toolResponseBlocks(response) {
+    const toolResponses = Array.isArray(response.toolResponses) ? response.toolResponses : [];
+    return toolResponses.map((entry, index) => {
+      const name = entry && typeof entry === "object" && (entry.toolName || entry.tool_name || entry.name);
+      if (typeof name === "string" && name) {
+        return {
+          type: "tool_use",
+          tool_id: `${response.responseId}:tool_response:${index}`,
+          tool_name: name,
+          tool_input: entry.input || entry.tool_input || null,
+          metadata: { source: "toolResponses", index },
+        };
+      }
+      return {
+        type: "tool_result",
+        tool_id: `${response.responseId}:tool_response:${index}`,
+        text: JSON.stringify(entry),
+        metadata: { source: "toolResponses", index, unrecognized_shape: true },
+      };
+    });
+  }
+
+  function nativeTurnBlocks(response) {
+    return [...stepBlocks(response), ...resultListBlocks(response), ...toolResponseBlocks(response)];
+  }
+
+  // Attachments carry no bytes in `/responses` -- only identifying metadata
+  // plus a `fileUri`/`key` resolvable through assets.grok.com (see
+  // grok_bridge.js). fileAttachmentsMetadata and fileAttachmentAssetMetadata
+  // both key by the same id (verified live 2026-07-31); merge them so a
+  // single attachment descriptor carries both the display metadata and the
+  // acquirable content key.
+  function attachmentDescriptorsForResponse(response) {
+    const descriptors = [];
     const seen = new Set();
+    const assetById = new Map(
+      (Array.isArray(response.fileAttachmentAssetMetadata) ? response.fileAttachmentAssetMetadata : [])
+        .filter((asset) => asset && typeof asset.assetId === "string")
+        .map((asset) => [asset.assetId, asset]),
+    );
+    for (const meta of Array.isArray(response.fileAttachmentsMetadata) ? response.fileAttachmentsMetadata : []) {
+      if (!meta || typeof meta.fileMetadataId !== "string" || !meta.fileMetadataId) continue;
+      if (seen.has(meta.fileMetadataId)) continue;
+      seen.add(meta.fileMetadataId);
+      const asset = assetById.get(meta.fileMetadataId) || null;
+      descriptors.push({
+        provider_attachment_id: meta.fileMetadataId,
+        message_provider_id: response.responseId,
+        name: meta.fileName || asset?.name || null,
+        mime_type: meta.fileMimeType || asset?.mimeType || null,
+        size_bytes: typeof asset?.sizeBytes === "number" ? asset.sizeBytes : null,
+        asset_key: meta.fileUri || asset?.key || null,
+        provider_meta: { capture_source: "grok_app_chat_api", file_source: meta.fileSource || asset?.fileSource || null },
+      });
+    }
+    for (const url of Array.isArray(response.generatedImageUrls) ? response.generatedImageUrls : []) {
+      if (typeof url !== "string" || !url) continue;
+      const id = `generated:${window.polylogueCapture.fnv1a(url)}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      descriptors.push({
+        provider_attachment_id: id,
+        message_provider_id: response.responseId,
+        name: null,
+        mime_type: null,
+        size_bytes: null,
+        url: /^https?:\/\//i.test(url) ? url : null,
+        provider_meta: { capture_source: "grok_generated_image" },
+      });
+    }
+    for (const url of Array.isArray(response.imageEditUris) ? response.imageEditUris : []) {
+      if (typeof url !== "string" || !url) continue;
+      const id = `image_edit:${window.polylogueCapture.fnv1a(url)}`;
+      if (seen.has(id)) continue;
+      seen.add(id);
+      descriptors.push({
+        provider_attachment_id: id,
+        message_provider_id: response.responseId,
+        name: null,
+        mime_type: null,
+        size_bytes: null,
+        url: /^https?:\/\//i.test(url) ? url : null,
+        provider_meta: { capture_source: "grok_image_edit" },
+      });
+    }
+    // imageAttachments' element shape has not been observed live with
+    // content (empty in every fixture captured so far). Record it rather
+    // than silently guessing a shape for it.
+    if (Array.isArray(response.imageAttachments) && response.imageAttachments.length) {
+      rememberNativeAttempt({
+        stage: "attachment_shape",
+        accepted: false,
+        reason: "imageAttachments_shape_unverified",
+        sample: response.imageAttachments.slice(0, 2),
+      });
+    }
+    return descriptors;
+  }
+
+  function requestAssetFromPage(request) {
+    const requestId = `polylogue-grok-asset-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const responsePromise = new Promise((resolve) => {
+      const timeout = window.setTimeout(() => {
+        assetResponses.delete(requestId);
+        resolve({ status: "request_failed", detail: "response_timeout" });
+      }, assetFetchTimeoutMs);
+      assetResponses.set(requestId, {
+        resolve(value) {
+          window.clearTimeout(timeout);
+          resolve(value);
+        },
+      });
+    });
+    window.postMessage({ type: assetFetchRequestMessage, requestId, request }, window.location.origin);
+    return responsePromise;
+  }
+
+  async function acquireAssets(descriptors) {
+    const outcome = {
+      attempted: descriptors.length,
+      acquired: 0,
+      failed: [],
+      status_counts: {},
+      skipped_over_budget: 0,
+      skipped_time_budget: 0,
+      skipped_circuit_breaker: 0,
+    };
     const attachments = [];
-    for (const candidate of node.querySelectorAll(selector)) {
-      const name = attachmentNameFromNode(candidate);
-      if (!name) continue;
-      const rawHref = candidate.getAttribute("href") || candidate.getAttribute("src") || null;
-      const url = rawHref && /^https?:\/\//i.test(rawHref) ? rawHref : null;
-      const key = `${name}\n${url || ""}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      attachments.push({
-        provider_attachment_id: `dom:${window.polylogueCapture.fnv1a(`${turnIndex}:${key}`)}`,
-        name,
-        url,
+    let totalBytes = 0;
+    let consecutiveFailures = 0;
+    const startedAt = Date.now();
+    for (const descriptor of descriptors) {
+      const resolvable = descriptor.asset_key || descriptor.url;
+      if (!resolvable) {
+        attachments.push({ ...descriptor, provider_meta: { ...descriptor.provider_meta, byte_acquisition: "no_resolvable_source" } });
+        continue;
+      }
+      if (totalBytes >= assetMaxBytesTotal) {
+        outcome.skipped_over_budget += 1;
+        attachments.push(descriptor);
+        continue;
+      }
+      if (Date.now() - startedAt >= assetTotalTimeBudgetMs) {
+        outcome.skipped_time_budget += 1;
+        attachments.push(descriptor);
+        continue;
+      }
+      if (consecutiveFailures >= assetConsecutiveFailureLimit) {
+        outcome.skipped_circuit_breaker += 1;
+        attachments.push(descriptor);
+        continue;
+      }
+      const request = descriptor.asset_key
+        ? { key: descriptor.asset_key, name: descriptor.name, maxBytes: Math.min(assetMaxBytesPerFile, assetMaxBytesTotal - totalBytes) }
+        : { key: descriptor.url, name: descriptor.name, maxBytes: Math.min(assetMaxBytesPerFile, assetMaxBytesTotal - totalBytes) };
+      const result = await requestAssetFromPage(request);
+      const status = typeof result.status === "string" ? result.status : "request_failed";
+      const contentSha256 = result.asset && result.asset.sha256;
+      const acquiredIsValid =
+        status === "acquired" && result.asset && result.asset.base64 && typeof contentSha256 === "string" && /^[0-9a-f]{64}$/.test(contentSha256);
+      outcome.status_counts[status] = (outcome.status_counts[status] || 0) + 1;
+      if (acquiredIsValid) {
+        totalBytes += result.asset.size_bytes || 0;
+        consecutiveFailures = 0;
+        outcome.acquired += 1;
+        attachments.push({
+          ...descriptor,
+          mime_type: result.asset.mime_type || descriptor.mime_type,
+          size_bytes: result.asset.size_bytes || descriptor.size_bytes,
+          inline_base64: result.asset.base64,
+          provider_meta: { ...descriptor.provider_meta, content_sha256: contentSha256, byte_acquisition: "acquired" },
+        });
+      } else {
+        consecutiveFailures += 1;
+        outcome.failed.push({ provider_attachment_id: descriptor.provider_attachment_id, status, detail: result.detail || null });
+        attachments.push({ ...descriptor, provider_meta: { ...descriptor.provider_meta, byte_acquisition: status, byte_acquisition_detail: result.detail || null } });
+      }
+    }
+    return { attachments, outcome };
+  }
+
+  function collectNativeTurns(payload) {
+    const responses = Array.isArray(payload.responses) ? payload.responses : [];
+    const turns = [];
+    for (const response of responses) {
+      if (!response || typeof response !== "object" || typeof response.responseId !== "string") {
+        rememberNativeAttempt({ stage: "turn_shape", accepted: false, reason: "response_missing_id" });
+        continue;
+      }
+      const text = typeof response.message === "string" ? response.message : "";
+      const blocks = nativeTurnBlocks(response);
+      if (!text && !blocks.length) continue;
+      turns.push({
+        provider_turn_id: response.responseId,
+        role: roleFromSender(response.sender),
+        text: text || null,
+        timestamp: timestampFromValue(response.createTime),
+        parent_turn_id: response.parentResponseId || null,
+        blocks,
         provider_meta: {
-          dom_selector_index: turnIndex,
-          dom_label: candidate.getAttribute("aria-label") || null,
-          dom_text: window.polylogueCapture.visibleText(candidate) || null,
-          capture_source: "grok_dom_attachment",
+          capture_source: "grok_app_chat_api",
+          model: response.model || null,
+          partial: response.partial === true,
+          manual: response.manual === true,
+          shared: response.shared === true,
+          stream_error_count: Array.isArray(response.streamErrors) ? response.streamErrors.length : 0,
+          stream_errors: Array.isArray(response.streamErrors) && response.streamErrors.length ? response.streamErrors : null,
         },
       });
     }
-    return attachments;
-  }
-
-  function collectTurns() {
-    const nodes = [
-      ...document.querySelectorAll(
-        '[data-testid*="conversation"], [data-testid*="message"], [data-message-author-role], article, main [role="article"]',
-      ),
-    ];
-    return nodes
-      .map((node, index) => {
-        const text = window.polylogueCapture.visibleText(node);
-        const attachments = collectAttachments(node, index);
-        return text || attachments.length
-          ? {
-              role: roleFromNode(node, index),
-              text,
-              attachments,
-              provider_meta: {
-                selector_index: index,
-                capture_source: "grok_dom",
-              },
-            }
-          : null;
-      })
-      .filter(Boolean);
-  }
-
-  async function capture(reason = null) {
-    const turns = collectTurns();
-    if (!turns.length) return { ok: false, error: "no_turns" };
-    const envelope = window.polylogueCapture.buildEnvelope({
-      provider: "grok",
-      adapterName: domAdapterName,
-      turns,
-      providerMeta: {
-        capture_source: "grok_dom",
-        capture_fidelity: "dom_degraded",
-        native_attempts: [],
-      },
+    turns.sort((left, right) => {
+      const leftTime = left.timestamp ? Date.parse(left.timestamp) : 0;
+      const rightTime = right.timestamp ? Date.parse(right.timestamp) : 0;
+      return leftTime - rightTime;
     });
-    const captureResult = await window.polylogueCapture.sendCapture(envelope, reason);
-    if (!captureResult?.ok) return {
-      ok: false,
-      envelope,
-      captureResult,
-      error: captureResult?.error || "capture_rejected",
-      timelineRecorded: true,
-    };
-    const archiveState = await window.polylogueCapture.refreshArchiveState(
-      "grok",
-      envelope.session.provider_session_id,
+    return turns;
+  }
+
+  function modelFromNativePayload(payload) {
+    for (const response of Array.isArray(payload.responses) ? payload.responses : []) {
+      if (typeof response?.model === "string" && response.model) return response.model;
+    }
+    return null;
+  }
+
+  async function buildNativeEnvelope(payload, generationDiagnostics) {
+    const turns = collectNativeTurns(payload);
+    if (!turns.length) return null;
+    const descriptors = (Array.isArray(payload.responses) ? payload.responses : []).flatMap((response) =>
+      attachmentDescriptorsForResponse(response),
     );
+    const assetAcquisition = descriptors.length ? await acquireAssets(descriptors) : { attachments: [], outcome: null };
+    const inflightCount = Array.isArray(payload.inflightResponses) ? payload.inflightResponses.length : 0;
+    return window.polylogueCapture.buildEnvelope({
+      provider: "grok",
+      adapterName: nativeAdapterName,
+      turns,
+      providerSessionId: String(payload.conversationId),
+      sessionKind: payload.temporary === true ? "temporary" : null,
+      title: typeof payload.title === "string" && payload.title ? payload.title : null,
+      createdAt: timestampFromValue(payload.createTime),
+      updatedAt: timestampFromValue(payload.modifyTime),
+      model: modelFromNativePayload(payload),
+      providerMeta: {
+        capture_source: "grok_app_chat_api",
+        response_count: turns.length,
+        inflight_response_count: inflightCount,
+        conversation_temporary: payload.temporary === true,
+        session_kind: payload.temporary === true ? "temporary" : null,
+        asset_acquisition: assetAcquisition.outcome,
+        native_attempts: generationDiagnostics.slice(-8),
+      },
+      rawProviderPayload: payload,
+      attachments: assetAcquisition.attachments,
+    });
+  }
+
+  async function capture(reason = null, requestedConversationId = null, deferReceiver = false) {
+    const nativePayload = await fetchNativePayloadOnDemand(requestedConversationId);
+    if (!nativePayload) {
+      return {
+        ok: false,
+        error: "native_capture_unavailable",
+        native_attempts: nativeAttemptDiagnostics.slice(-8),
+      };
+    }
+    const envelope = await buildNativeEnvelope(nativePayload, nativeAttemptDiagnostics);
+    if (!envelope) {
+      return {
+        ok: false,
+        error: "no_turns",
+        native_attempts: nativeAttemptDiagnostics.slice(-8),
+      };
+    }
+    if (deferReceiver) return { ok: true, envelope, deferred: true };
+    const captureResult = await window.polylogueCapture.sendCapture(envelope, reason);
+    if (!captureResult?.ok) {
+      return {
+        ok: false,
+        envelope,
+        captureResult,
+        error: captureResult?.error || "capture_rejected",
+        timelineRecorded: true,
+      };
+    }
+    const archiveState = await window.polylogueCapture.refreshArchiveState("grok", envelope.session.provider_session_id);
     return { ok: true, envelope, captureResult, archiveState };
   }
 
   window.polylogueCapture.capturePage = capture;
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     if (message.type !== "polylogue.capturePage") return false;
-    capture(message.reason || null).then(sendResponse).catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));
+    capture(message.reason || null, message.providerSessionId || null, message.deferReceiver === true)
+      .then(sendResponse)
+      .catch((error) => sendResponse({ ok: false, error: String(error.message || error) }));
     return true;
   });
 })();

--- a/browser-extension/src/content/grok_bridge.js
+++ b/browser-extension/src/content/grok_bridge.js
@@ -1,0 +1,329 @@
+(function () {
+  // MAIN-world companion to src/content/grok.js. Grok is the only provider
+  // that previously had no bridge at all -- grok.js hardcoded
+  // `native_attempts: []` and scraped the DOM, which this extension's other
+  // adapters have shown is lossy by roughly two orders of magnitude once a
+  // conversation scrolls past the virtualized viewport. grok.com exposes a
+  // clean, cookie-authenticated REST surface
+  // (/rest/app-chat/conversations/<id>, .../responses, .../response-node)
+  // that this bridge fetches with the page's own credentials, exactly the
+  // way chatgpt_bridge.js/claude_bridge.js do for their providers.
+  const nativeCaptureMessage = "polylogue.grok.nativeCapture";
+  const nativeFetchRequestMessage = "polylogue.grok.nativeFetchRequest";
+  const nativeFetchResponseMessage = "polylogue.grok.nativeFetchResponse";
+  const assetFetchRequestMessage = "polylogue.grok.assetFetchRequest";
+  const assetFetchResponseMessage = "polylogue.grok.assetFetchResponse";
+  const currentOrigin = window.location.origin;
+  const nativeFetchTimeoutMs = 8000;
+  const assetFetchTimeoutMs = 9000;
+  const assetAbsoluteMaxBytes = 25 * 1024 * 1024;
+
+  window.__polylogueGrokCapturedFetches = Array.isArray(window.__polylogueGrokCapturedFetches)
+    ? window.__polylogueGrokCapturedFetches
+    : [];
+
+  function post(capture) {
+    window.postMessage({ type: nativeCaptureMessage, capture }, currentOrigin);
+  }
+
+  function remember(capture) {
+    window.__polylogueGrokCapturedFetches.push(capture);
+    if (window.__polylogueGrokCapturedFetches.length > 8) {
+      window.__polylogueGrokCapturedFetches.splice(0, window.__polylogueGrokCapturedFetches.length - 8);
+    }
+    post(capture);
+  }
+
+  const existingCaptures = window.__polylogueGrokCapturedFetches.slice(-8);
+  window.__polylogueGrokCapturedFetches = existingCaptures;
+  for (const capture of existingCaptures) post(capture);
+
+  if (window.__polylogueGrokFetchHookInstalled) return;
+  window.__polylogueGrokFetchHookInstalled = true;
+
+  const originalFetch = window.fetch;
+
+  function timeoutError(label, timeoutMs) {
+    const error = new Error(`${label}_timeout_after_${timeoutMs}ms`);
+    error.name = "PolylogueTimeoutError";
+    return error;
+  }
+
+  function conversationUrl(conversationId, suffix = "") {
+    return new URL(
+      `/rest/app-chat/conversations/${encodeURIComponent(String(conversationId))}${suffix}`,
+      currentOrigin,
+    );
+  }
+
+  async function fetchJson(url, label) {
+    const controller = new globalThis.AbortController();
+    const timeoutId = window.setTimeout(
+      () => controller.abort(timeoutError(label, nativeFetchTimeoutMs)),
+      nativeFetchTimeoutMs,
+    );
+    let response;
+    try {
+      response = await originalFetch.call(window, url.href, {
+        credentials: "include",
+        cache: "no-store",
+        signal: controller.signal,
+      });
+    } finally {
+      window.clearTimeout(timeoutId);
+    }
+    const contentType = response.headers.get("content-type") || "";
+    const bodyText = contentType.includes("application/json") ? await response.clone().text() : "";
+    let parsed = null;
+    if (bodyText) {
+      try {
+        parsed = JSON.parse(bodyText);
+      } catch {
+        parsed = null;
+      }
+    }
+    return { ok: response.ok, status: response.status, contentType, bodyText, parsed };
+  }
+
+  // A Grok conversation's content lives across three independent endpoints:
+  // metadata+identity (title/temporary/timestamps), the actual turn content
+  // (`/responses` -- confirmed live 2026-07-31 to carry `message` text,
+  // `steps`, attachments, tool/search evidence; `/response-node` alone is
+  // just an id/parent skeleton with no message content), and any
+  // still-generating tail (`inflightResponses`, best-effort). Bundle all
+  // three into one combined JSON body so grok.js has a single capture
+  // artifact to parse, exactly like the other bridges hand back one
+  // conversation payload.
+  async function fetchConversation(conversationId) {
+    const conversationResult = await fetchJson(conversationUrl(conversationId), "conversation_metadata");
+    if (!conversationResult.ok || !conversationResult.parsed) {
+      return {
+        url: conversationUrl(conversationId).href,
+        status: conversationResult.status,
+        ok: false,
+        contentType: conversationResult.contentType,
+        body: conversationResult.bodyText,
+        capturedAt: new Date().toISOString(),
+        error: "conversation_metadata_fetch_failed",
+      };
+    }
+    const responsesResult = await fetchJson(conversationUrl(conversationId, "/responses"), "conversation_responses");
+    if (!responsesResult.ok || !Array.isArray(responsesResult.parsed?.responses)) {
+      return {
+        url: conversationUrl(conversationId, "/responses").href,
+        status: responsesResult.status,
+        ok: false,
+        contentType: responsesResult.contentType,
+        body: responsesResult.bodyText,
+        capturedAt: new Date().toISOString(),
+        error: "conversation_responses_fetch_failed",
+      };
+    }
+    // response-node is best-effort: it only ever adds inflight-generation
+    // skeleton entries, never turn content, so its failure must not fail
+    // the whole capture.
+    let inflightResponses = [];
+    try {
+      const responseNodeResult = await fetchJson(conversationUrl(conversationId, "/response-node"), "response_node");
+      if (responseNodeResult.ok && Array.isArray(responseNodeResult.parsed?.inflightResponses)) {
+        inflightResponses = responseNodeResult.parsed.inflightResponses;
+      }
+    } catch {
+      inflightResponses = [];
+    }
+    const combined = {
+      ...conversationResult.parsed,
+      responses: responsesResult.parsed.responses,
+      inflightResponses,
+    };
+    return {
+      url: conversationUrl(conversationId).href,
+      status: 200,
+      ok: true,
+      contentType: "application/json",
+      body: JSON.stringify(combined),
+      capturedAt: new Date().toISOString(),
+    };
+  }
+
+  window.addEventListener("message", async (event) => {
+    if (event.source !== window || event.origin !== currentOrigin) return;
+    const data = event.data || {};
+    if (data.type !== nativeFetchRequestMessage || !data.requestId || !data.conversationId) return;
+    try {
+      const capture = await fetchConversation(data.conversationId);
+      if (capture.ok && capture.body) remember(capture);
+      window.postMessage({ type: nativeFetchResponseMessage, requestId: data.requestId, capture }, currentOrigin);
+    } catch (error) {
+      window.postMessage(
+        {
+          type: nativeFetchResponseMessage,
+          requestId: data.requestId,
+          error: String(error && error.message ? error.message : error),
+        },
+        currentOrigin,
+      );
+    }
+  });
+
+  // --- Attachment byte acquisition -----------------------------------
+  //
+  // File/image attachments never carry bytes in `/responses` -- only a
+  // `fileUri`/`key` such as `users/<uid>/<assetId>/content`, served from the
+  // separate `assets.grok.com` host. Verified live 2026-07-31: that host
+  // requires the same grok.com session credentials (403 with
+  // credentials:"omit", 200 with credentials:"include" from a grok.com
+  // page), unlike ChatGPT's signed object-store URLs which must NOT receive
+  // page credentials cross-origin. So, deliberately unlike
+  // chatgpt_bridge.js's asset fetch, this always sends credentials.
+  function assetOutcome(status, { httpStatus = null, detail = null, sizeBytes = null, asset = null } = {}) {
+    const outcome = { status };
+    if (httpStatus !== null) outcome.http_status = httpStatus;
+    if (detail !== null) outcome.detail = detail;
+    if (sizeBytes !== null) outcome.size_bytes = sizeBytes;
+    if (asset !== null) outcome.asset = asset;
+    return outcome;
+  }
+
+  function boundedMaxBytes(request) {
+    const requested = Number(request.maxBytes);
+    if (!Number.isFinite(requested) || requested <= 0) return assetAbsoluteMaxBytes;
+    return Math.min(requested, assetAbsoluteMaxBytes);
+  }
+
+  function declaredContentLength(response) {
+    const raw = response.headers.get("content-length");
+    if (!raw || !/^\d+$/.test(raw)) return null;
+    const parsed = Number(raw);
+    return Number.isSafeInteger(parsed) ? parsed : null;
+  }
+
+  async function readBoundedBody(response, maxBytes) {
+    if (!response.body || typeof response.body.getReader !== "function") {
+      const buffer = await response.arrayBuffer();
+      if (buffer.byteLength > maxBytes) return { tooLarge: true, sizeBytes: buffer.byteLength };
+      return { tooLarge: false, buffer };
+    }
+    const reader = response.body.getReader();
+    const chunks = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        return { tooLarge: true, sizeBytes: total };
+      }
+      chunks.push(value);
+    }
+    const merged = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      merged.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return { tooLarge: false, buffer: merged.buffer };
+  }
+
+  function arrayBufferToBase64(buffer) {
+    const bytes = new Uint8Array(buffer);
+    const chunkSize = 0x8000;
+    let binary = "";
+    for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+      binary += String.fromCharCode.apply(null, bytes.subarray(offset, offset + chunkSize));
+    }
+    return window.btoa(binary);
+  }
+
+  function bytesToHex(buffer) {
+    return [...new Uint8Array(buffer)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+
+  async function sha256Hex(buffer) {
+    if (!globalThis.crypto?.subtle) throw new Error("asset_sha256_unavailable");
+    return bytesToHex(await globalThis.crypto.subtle.digest("SHA-256", buffer));
+  }
+
+  async function fetchAssetBytes(request) {
+    let assetUrl;
+    try {
+      assetUrl = new URL(`/${String(request.key).replace(/^\/+/, "")}`, "https://assets.grok.com");
+    } catch {
+      return assetOutcome("invalid_request", { detail: "asset_key_invalid" });
+    }
+    if (typeof request.key !== "string" || !request.key || assetUrl.protocol !== "https:") {
+      return assetOutcome("invalid_request", { detail: "asset_key_invalid" });
+    }
+    const controller = new globalThis.AbortController();
+    const timeoutId = window.setTimeout(
+      () => controller.abort(timeoutError("asset_bytes_fetch", assetFetchTimeoutMs)),
+      assetFetchTimeoutMs,
+    );
+    let response;
+    try {
+      response = await originalFetch.call(window, assetUrl.href, {
+        credentials: "include",
+        cache: "no-store",
+        signal: controller.signal,
+      });
+    } catch (error) {
+      const timedOut = error?.name === "AbortError" || error?.name === "PolylogueTimeoutError";
+      return assetOutcome("request_failed", { detail: timedOut ? "request_timeout" : "request_failed" });
+    } finally {
+      window.clearTimeout(timeoutId);
+    }
+    if ([401, 403, 404, 410].includes(response.status)) {
+      return assetOutcome("signed_url_expired", { httpStatus: response.status, detail: `asset_http_${response.status}` });
+    }
+    if (!response.ok) {
+      return assetOutcome("request_failed", { httpStatus: response.status, detail: `asset_http_${response.status}` });
+    }
+    const maxBytes = boundedMaxBytes(request);
+    const contentLength = declaredContentLength(response);
+    if (contentLength !== null && contentLength > maxBytes) {
+      return assetOutcome("too_large", { httpStatus: response.status, detail: "content_length_over_limit", sizeBytes: contentLength });
+    }
+    const bodyResult = await readBoundedBody(response, maxBytes);
+    if (bodyResult.tooLarge) {
+      return assetOutcome("too_large", { httpStatus: response.status, detail: "downloaded_bytes_over_limit", sizeBytes: bodyResult.sizeBytes });
+    }
+    const buffer = bodyResult.buffer;
+    let contentSha256;
+    try {
+      contentSha256 = await sha256Hex(buffer);
+    } catch {
+      return assetOutcome("integrity_error", { detail: "sha256_unavailable" });
+    }
+    return assetOutcome("acquired", {
+      httpStatus: response.status,
+      asset: {
+        base64: arrayBufferToBase64(buffer),
+        size_bytes: buffer.byteLength,
+        sha256: contentSha256,
+        mime_type: response.headers.get("content-type") || null,
+        name: request.name || null,
+      },
+    });
+  }
+
+  window.addEventListener("message", async (event) => {
+    if (event.source !== window || event.origin !== currentOrigin) return;
+    const data = event.data || {};
+    if (data.type !== assetFetchRequestMessage || !data.requestId || !data.request) return;
+    try {
+      const outcome = await fetchAssetBytes(data.request);
+      window.postMessage({ type: assetFetchResponseMessage, requestId: data.requestId, outcome }, currentOrigin);
+    } catch (error) {
+      const timedOut = error?.name === "AbortError" || error?.name === "PolylogueTimeoutError";
+      window.postMessage(
+        {
+          type: assetFetchResponseMessage,
+          requestId: data.requestId,
+          outcome: assetOutcome("request_failed", { detail: timedOut ? "request_timeout" : "request_failed" }),
+        },
+        currentOrigin,
+      );
+    }
+  });
+})();

--- a/browser-extension/tests/backfill.test.js
+++ b/browser-extension/tests/backfill.test.js
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BackfillCoordinator } from "../src/backfill/coordinator.js";
 import { backfillAlarmName, serializedContentHash, serializedJson } from "../src/backfill/models.js";
-import { ChatGptBackfillAdapter, ClaudeBackfillAdapter } from "../src/backfill/providers.js";
+import { ChatGptBackfillAdapter, ClaudeBackfillAdapter, GrokBackfillAdapter } from "../src/backfill/providers.js";
 import { IndexedDbBackfillStore, MemoryBackfillStore, progressBuckets } from "../src/backfill/storage.js";
 
 function response(body, { status = 200, retryAfter = null } = {}) {
@@ -1165,5 +1165,88 @@ describe("provider adapter contracts", () => {
     expect(fetchImpl.mock.calls[2][0]).toContain("consistency=strong");
 
     await expect(adapter.normalizeCapture(response({ messages: [] }), inventory.items[0], {})).rejects.toThrow("provider_contract_drift:claude_conversation.chat_messages_must_be_array");
+  });
+
+  // Grok's own /rest/app-chat/conversations REST surface, verified live
+  // 2026-07-31 (see src/content/grok_bridge.js): pageToken-cursored
+  // enumeration, and a two-request native fetch (conversation metadata +
+  // /responses) combined into one payload for normalizeCapture.
+  it("enumerates Grok conversations by pageToken and stops when nextPageToken is absent", async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response({
+        conversations: [
+          { conversationId: "g-1", title: "First", modifyTime: "2026-07-01T00:00:00Z" },
+          { conversationId: "g-2", title: "Second", modifyTime: "2026-06-30T00:00:00Z" },
+        ],
+        nextPageToken: "g-2",
+      }))
+      .mockResolvedValueOnce(response({
+        conversations: [{ conversationId: "g-3", title: "Third", modifyTime: "2026-06-01T00:00:00Z" }],
+      }));
+    const adapter = new GrokBackfillAdapter(fetchImpl);
+
+    const first = await adapter.enumerate("0", null);
+    expect(first).toMatchObject({ classification: "success", done: false, next_cursor: "g-2" });
+    expect(first.items.map((item) => item.native_id)).toEqual(["g-1", "g-2"]);
+    expect(fetchImpl.mock.calls[0][0]).not.toContain("pageToken");
+
+    const second = await adapter.enumerate(first.next_cursor, null);
+    expect(second).toMatchObject({ classification: "success", done: true });
+    expect(second.items.map((item) => item.native_id)).toEqual(["g-3"]);
+    expect(fetchImpl.mock.calls[1][0]).toContain("pageToken=g-2");
+  });
+
+  it("stops Grok pagination once a page crosses the cutoff", async () => {
+    const adapter = new GrokBackfillAdapter(vi.fn(async () => response({
+      conversations: [
+        { conversationId: "new", modifyTime: "2026-07-01T00:00:00Z" },
+        { conversationId: "old", modifyTime: "2020-01-01T00:00:00Z" },
+      ],
+      nextPageToken: "old",
+    })));
+    const inventory = await adapter.enumerate("0", "2026-01-01T00:00:00Z");
+    expect(inventory.items.map((item) => item.native_id)).toEqual(["new"]);
+    expect(inventory.done).toBe(true);
+  });
+
+  it("rejects a non-array Grok inventory loudly", async () => {
+    const adapter = new GrokBackfillAdapter(vi.fn(async () => response({ conversations: "not-an-array" })));
+    await expect(adapter.enumerate()).rejects.toThrow("provider_contract_drift:grok_inventory.conversations_must_be_array");
+  });
+
+  it("combines Grok conversation metadata and /responses into one normalized capture, including temporary sessions", async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response({ conversationId: "g-1", title: "Fixture", temporary: true, createTime: "2026-06-27T12:39:08Z", modifyTime: "2026-06-27T13:46:12Z" }))
+      .mockResolvedValueOnce(response({
+        responses: [
+          { responseId: "r-1", sender: "human", message: "hello", createTime: "2026-06-27T12:39:09Z" },
+          { responseId: "r-2", sender: "ASSISTANT", parentResponseId: "r-1", message: "hi there", createTime: "2026-06-27T12:39:15Z", model: "grok-3" },
+        ],
+      }));
+    const adapter = new GrokBackfillAdapter(fetchImpl);
+    const capture = await adapter.normalizeCapture(await adapter.fetchNative("g-1"), { native_id: "g-1", title: "Fixture" }, { job_id: "j" });
+
+    expect(capture.session.provider).toBe("grok");
+    expect(capture.session.session_kind).toBe("temporary");
+    expect(capture.session.turns).toHaveLength(2);
+    expect(capture.session.turns[0]).toMatchObject({ role: "user", text: "hello" });
+    expect(capture.session.turns[1]).toMatchObject({ role: "assistant", text: "hi there", parent_turn_id: "r-1" });
+    expect(capture.session.turns[1].provider_meta.model).toBe("grok-3");
+    expect(fetchImpl.mock.calls[1][0]).toContain("/responses");
+
+    await expect(
+      adapter.normalizeCapture(response({ responses: "not-an-array" }), { native_id: "g-1" }, {}),
+    ).rejects.toThrow("provider_contract_drift:grok_conversation_combined.responses_must_be_array");
+  });
+
+  it("surfaces a failed Grok /responses fetch as the fetchNative result without a second request", async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(response({ conversationId: "g-1" }))
+      .mockResolvedValueOnce(response({ code: 5 }, { status: 404 }));
+    const adapter = new GrokBackfillAdapter(fetchImpl);
+
+    const result = await adapter.fetchNative("g-1");
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(404);
   });
 });

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -2463,8 +2463,8 @@ describe("background receiver diagnostics", () => {
     expect(stored.polylogueDebugLog[0].ok).toBe(false);
   });
 
-  it("injects Grok DOM capture scripts for open Grok/X tabs", async () => {
-    tabs = [{ id: 77, url: "https://x.com/i/grok", title: "Grok" }];
+  it("injects the Grok native bridge and content script for open grok.com tabs", async () => {
+    tabs = [{ id: 77, url: "https://grok.com/c/1f9de430-6505-4d43-935b-ec0dd1c13222", title: "Grok" }];
 
     await sendRuntimeMessage({ type: "polylogue.captureSupportedTabs", reason: "popup_sync_open_tabs" });
 
@@ -2472,8 +2472,29 @@ describe("background receiver diagnostics", () => {
 
     expect(globalThis.chrome.scripting.executeScript).toHaveBeenCalledWith({
       target: { tabId: 77 },
+      files: ["src/content/grok_bridge.js"],
+      world: "MAIN",
+    });
+    expect(globalThis.chrome.scripting.executeScript).toHaveBeenCalledWith({
+      target: { tabId: 77 },
       files: ["src/common.js", "src/content/grok.js"],
     });
+  });
+
+  // Grok's native REST capture (polylogue Grok native-capture upgrade,
+  // 2026-07-31) is only reachable from grok.com itself -- x.com's embedded
+  // Grok surface is served through X's own API, not grok.com's
+  // /rest/app-chat/* this bridge calls. The DOM-only fallback that used to
+  // give x.com/twitter.com tabs a (lossy) capture path was removed in the
+  // same change, so those tabs now correctly get no injection at all rather
+  // than a script that would silently produce nothing.
+  it("does not inject any Grok capture script for x.com/twitter.com tabs", async () => {
+    tabs = [{ id: 78, url: "https://x.com/i/grok", title: "Grok" }];
+
+    await sendRuntimeMessage({ type: "polylogue.captureSupportedTabs", reason: "popup_sync_open_tabs" });
+
+    expect(globalThis.chrome.scripting.executeScript).not.toHaveBeenCalled();
+    expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/browser-extension/tests/content/grok.test.js
+++ b/browser-extension/tests/content/grok.test.js
@@ -1,66 +1,280 @@
+import { Buffer } from "node:buffer";
+import { createHash, webcrypto } from "node:crypto";
 import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { TextEncoder } from "node:util";
+import { fileURLToPath } from "node:url";
+import { Script } from "node:vm";
 
 import { JSDOM } from "jsdom";
-import { expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-const commonSource = readFileSync("src/common.js", "utf8");
-const grokSource = readFileSync("src/content/grok.js", "utf8");
+const testDirectory = dirname(fileURLToPath(import.meta.url));
+const bridgeSource = readFileSync(resolve(testDirectory, "../../src/content/grok_bridge.js"), "utf8");
+const commonSource = readFileSync(resolve(testDirectory, "../../src/common.js"), "utf8");
+const contentSource = readFileSync(resolve(testDirectory, "../../src/content/grok.js"), "utf8");
+const conversationId = "1f9de430-6505-4d43-935b-ec0dd1c13222";
+const assetBytes = new TextEncoder().encode("polylogue grok attachment fixture\n");
+const expectedSha256 = createHash("sha256").update(assetBytes).digest("hex");
+const openDoms = [];
 
-it("forwards an automatic capture reason through the Grok content handler", async () => {
-  const dom = new JSDOM('<article data-message-author-role="user">Capture this</article>', {
-    runScripts: "outside-only",
-    url: "https://grok.com/chat/conversation-1",
-  });
-  const runtimeListener = vi.fn();
-  const sendMessage = vi.fn(async (message) => {
-    if (message.type === "polylogue.capture") return { ok: true, state: "spooled_only" };
-    if (message.type === "polylogue.archiveState") return { state: "spooled_only" };
-    return null;
-  });
-  dom.window.chrome = {
+function jsonResponse(body, status = 200) {
+  return new globalThis.Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+function byteResponse(bytes, status = 200) {
+  return new globalThis.Response(bytes, { status, headers: { "content-type": "text/markdown" } });
+}
+
+function conversationMetadata(overrides = {}) {
+  return {
+    conversationId,
+    title: "Kane's insatiable seed: breeding legacy",
+    temporary: false,
+    createTime: "2026-06-27T12:39:08.985242Z",
+    modifyTime: "2026-06-27T13:46:12.022Z",
+    ...overrides,
+  };
+}
+
+function humanResponse(overrides = {}) {
+  return {
+    responseId: "r-human-1",
+    sender: "human",
+    message: "Do write much better story",
+    createTime: "2026-06-27T12:39:09.006Z",
+    model: "grok-3",
+    ...overrides,
+  };
+}
+
+function assistantResponse(overrides = {}) {
+  return {
+    responseId: "r-assistant-1",
+    parentResponseId: "r-human-1",
+    sender: "ASSISTANT",
+    message: "The Seed\n\nKane Voss was born restless.",
+    createTime: "2026-06-27T12:39:59.733Z",
+    model: "grok-3",
+    steps: [
+      { text: ["Thinking about your request"], tags: ["header", "thinking_start"] },
+      { text: ["Writing the improved story"], tags: ["header"] },
+    ],
+    ...overrides,
+  };
+}
+
+function makeDom(fetchImpl, url = `https://grok.com/c/${conversationId}`) {
+  const dom = new JSDOM("<!doctype html><title>Grok fixture</title>", { url, runScripts: "outside-only" });
+  openDoms.push(dom);
+  const cryptoAdapter = {
+    subtle: {
+      digest(algorithm, data) {
+        return webcrypto.subtle.digest(algorithm, Buffer.from(new dom.window.Uint8Array(data)));
+      },
+      getRandomValues: (array) => webcrypto.getRandomValues(array),
+    },
+    getRandomValues: (array) => webcrypto.getRandomValues(array),
+  };
+  Object.defineProperty(dom.window, "crypto", { configurable: true, value: cryptoAdapter });
+  Object.defineProperty(dom.window, "fetch", { configurable: true, value: fetchImpl });
+  return dom;
+}
+
+function installFullCapture(fetchImpl, { url } = {}) {
+  const dom = makeDom(fetchImpl, url);
+  const runtimeMessages = [];
+  const runtimeListeners = [];
+  const chrome = {
     runtime: {
+      id: "synthetic-extension-id",
       getManifest: () => ({ version: "0.1.0" }),
-      onMessage: { addListener: runtimeListener },
-      sendMessage,
+      onMessage: { addListener: (listener) => runtimeListeners.push(listener) },
+      async sendMessage(message) {
+        runtimeMessages.push(message);
+        if (message.type === "polylogue.capture") {
+          return { ok: true, provider: "grok", provider_session_id: conversationId, receiver_request_id: "synthetic-request" };
+        }
+        if (message.type === "polylogue.archiveState") return { captured: true, state: "archived" };
+        return { ok: true };
+      },
     },
   };
-
-  dom.window.eval(commonSource);
-  dom.window.eval(grokSource);
-  const listener = runtimeListener.mock.calls[0][0];
-  const response = await new Promise((resolve) => {
-    expect(listener({ type: "polylogue.capturePage", reason: "auto_capture_missing" }, {}, resolve)).toBe(true);
+  Object.defineProperty(dom.window, "chrome", { configurable: true, value: chrome });
+  Object.defineProperty(dom.window, "postMessage", {
+    configurable: true,
+    value(data) {
+      dom.window.queueMicrotask(() => {
+        dom.window.dispatchEvent(new dom.window.MessageEvent("message", { source: dom.window, origin: dom.window.location.origin, data }));
+      });
+    },
   });
+  const context = dom.getInternalVMContext();
+  new Script(bridgeSource).runInContext(context);
+  new Script(commonSource).runInContext(context);
+  new Script(contentSource).runInContext(context);
+  function sendRuntimeMessage(message) {
+    return new Promise((resolve, reject) => {
+      const listener = runtimeListeners.find((candidate) => candidate(message, {}, resolve) === true);
+      if (!listener) reject(new Error(`no runtime listener accepted ${message.type}`));
+    });
+  }
+  return { dom, runtimeMessages, sendRuntimeMessage };
+}
 
-  expect(response).toEqual({ ok: true, envelope: expect.any(Object), captureResult: expect.any(Object), archiveState: expect.any(Object) });
-  expect(sendMessage).toHaveBeenNthCalledWith(1, expect.objectContaining({
-    type: "polylogue.capture",
-    reason: "auto_capture_missing",
-  }));
+function conversationFetchImpl({ conversation = conversationMetadata(), responses = [humanResponse(), assistantResponse()], responsesStatus = 200, asset = null } = {}) {
+  return vi.fn(async (input, options = {}) => {
+    const url = new URL(String(input));
+    if (url.hostname === "grok.com" && url.pathname === `/rest/app-chat/conversations/${conversationId}`) {
+      return jsonResponse(conversation);
+    }
+    if (url.hostname === "grok.com" && url.pathname === `/rest/app-chat/conversations/${conversationId}/responses`) {
+      return responsesStatus === 200 ? jsonResponse({ responses }) : jsonResponse({ code: 5 }, responsesStatus);
+    }
+    if (url.hostname === "grok.com" && url.pathname === `/rest/app-chat/conversations/${conversationId}/response-node`) {
+      return jsonResponse({ responseNodes: [], inflightResponses: [] });
+    }
+    if (url.hostname === "assets.grok.com") {
+      if (!asset) return new globalThis.Response("", { status: 404 });
+      expect(options.credentials).toBe("include");
+      return byteResponse(asset);
+    }
+    throw new Error(`unexpected request: ${url.href}`);
+  });
+}
+
+afterEach(() => {
+  for (const dom of openDoms.splice(0)) dom.window.close();
 });
 
-it("reports a rejected runtime capture without refreshing archive state", async () => {
-  const dom = new JSDOM('<article data-message-author-role="user">Capture this</article>', {
-    runScripts: "outside-only",
-    url: "https://grok.com/chat/conversation-1",
-  });
-  const runtimeListener = vi.fn();
-  const sendMessage = vi.fn(async () => ({ ok: false, error: "capture_rejected" }));
-  dom.window.chrome = {
-    runtime: {
-      getManifest: () => ({ version: "0.1.0" }),
-      onMessage: { addListener: runtimeListener },
-      sendMessage,
-    },
-  };
+describe("Grok native capture end to end", () => {
+  it("captures message text, reasoning steps as thinking blocks, and forwards the capture reason", async () => {
+    const { runtimeMessages, sendRuntimeMessage } = installFullCapture(conversationFetchImpl());
+    const response = await sendRuntimeMessage({ type: "polylogue.capturePage", reason: "auto_capture_missing" });
 
-  dom.window.eval(commonSource);
-  dom.window.eval(grokSource);
-  const listener = runtimeListener.mock.calls[0][0];
-  const response = await new Promise((resolve) => {
-    listener({ type: "polylogue.capturePage", reason: "auto_capture_missing" }, {}, resolve);
+    expect(response.ok).toBe(true);
+    expect(response.envelope.provenance.adapter_name).toBe("grok-native-v1");
+    expect(response.envelope.session.provider_session_id).toBe(conversationId);
+    expect(response.envelope.session.session_kind).toBe("standard");
+    const turns = response.envelope.session.turns;
+    expect(turns).toHaveLength(2);
+    expect(turns[0]).toMatchObject({ role: "user", text: "Do write much better story" });
+    expect(turns[1]).toMatchObject({ role: "assistant" });
+    expect(turns[1].blocks).toContainEqual(
+      expect.objectContaining({ type: "thinking", text: "Thinking about your request" }),
+    );
+    expect(runtimeMessages[0]).toMatchObject({ type: "polylogue.capture" });
+    expect(runtimeMessages[0].reason).toBe("auto_capture_missing");
   });
 
-  expect(response).toMatchObject({ ok: false, timelineRecorded: true, error: "capture_rejected" });
-  expect(sendMessage).toHaveBeenCalledTimes(1);
+  it("marks a temporary conversation's session_kind from the provider's own temporary flag", async () => {
+    const { sendRuntimeMessage } = installFullCapture(
+      conversationFetchImpl({ conversation: conversationMetadata({ temporary: true }) }),
+    );
+    const response = await sendRuntimeMessage({ type: "polylogue.capturePage" });
+
+    expect(response.ok).toBe(true);
+    expect(response.envelope.session.session_kind).toBe("temporary");
+    expect(response.envelope.session.provider_meta.conversation_temporary).toBe(true);
+  });
+
+  it("acquires a file attachment's bytes through assets.grok.com and verifies its sha256", async () => {
+    const withAttachment = humanResponse({
+      fileAttachments: ["asset-1"],
+      fileUris: ["asset-1"],
+      fileAttachmentsMetadata: [{ fileMetadataId: "asset-1", fileMimeType: "text/markdown", fileName: "notes.md", fileUri: "users/u1/asset-1/content", fileSource: "SELF_UPLOAD_FILE_SOURCE" }],
+    });
+    const { sendRuntimeMessage } = installFullCapture(
+      conversationFetchImpl({ responses: [withAttachment, assistantResponse()], asset: assetBytes }),
+    );
+    const response = await sendRuntimeMessage({ type: "polylogue.capturePage" });
+
+    expect(response.ok).toBe(true);
+    const attachment = response.envelope.session.attachments.find((entry) => entry.provider_attachment_id === "asset-1");
+    expect(attachment).toBeTruthy();
+    expect(attachment.name).toBe("notes.md");
+    expect(attachment.provider_meta.content_sha256).toBe(expectedSha256);
+    expect(Buffer.from(attachment.inline_base64, "base64").toString("utf8")).toBe("polylogue grok attachment fixture\n");
+  });
+
+  it("keeps an unrecognized toolResponses entry as a flagged diagnostic block instead of dropping it silently", async () => {
+    const withOddTool = assistantResponse({ toolResponses: [{ weird_shape: true, payload: [1, 2, 3] }] });
+    const { sendRuntimeMessage } = installFullCapture(conversationFetchImpl({ responses: [humanResponse(), withOddTool] }));
+    const response = await sendRuntimeMessage({ type: "polylogue.capturePage" });
+
+    expect(response.ok).toBe(true);
+    const assistantTurn = response.envelope.session.turns.find((turn) => turn.role === "assistant");
+    expect(assistantTurn.blocks).toContainEqual(
+      expect.objectContaining({ type: "tool_result", metadata: expect.objectContaining({ unrecognized_shape: true, source: "toolResponses" }) }),
+    );
+  });
+
+  it("projects web search evidence into tool_use/tool_result blocks", async () => {
+    const searchResponse = humanResponse({
+      responseId: "r-search",
+      query: "latest EU battery regulations",
+      queryType: "web",
+      webSearchResults: [{ url: "https://example.test/a", title: "A" }],
+    });
+    const { sendRuntimeMessage } = installFullCapture(conversationFetchImpl({ responses: [searchResponse, assistantResponse({ parentResponseId: "r-search" })] }));
+    const response = await sendRuntimeMessage({ type: "polylogue.capturePage" });
+
+    const searchTurn = response.envelope.session.turns.find((turn) => turn.provider_turn_id === "r-search");
+    expect(searchTurn.blocks).toContainEqual(
+      expect.objectContaining({ type: "tool_use", tool_name: "web_search", tool_input: { query: "latest EU battery regulations", query_type: "web" } }),
+    );
+    expect(searchTurn.blocks).toContainEqual(
+      expect.objectContaining({ type: "tool_result", tool_name: "web_search", metadata: expect.objectContaining({ field: "webSearchResults", count: 1 }) }),
+    );
+  });
+
+  it("fails loud instead of sending an empty capture when the responses endpoint is unavailable", async () => {
+    const { runtimeMessages, sendRuntimeMessage } = installFullCapture(conversationFetchImpl({ responsesStatus: 404 }));
+    const response = await sendRuntimeMessage({ type: "polylogue.capturePage" });
+
+    expect(response.ok).toBe(false);
+    expect(response.error).toBe("native_capture_unavailable");
+    expect(response.native_attempts.length).toBeGreaterThan(0);
+    expect(runtimeMessages).toHaveLength(0);
+  });
+
+  it("fails loud when no conversation id is present in the URL, without ever sending a capture", async () => {
+    const { runtimeMessages, sendRuntimeMessage } = installFullCapture(conversationFetchImpl(), { url: "https://grok.com/" });
+    const response = await sendRuntimeMessage({ type: "polylogue.capturePage" });
+
+    expect(response.ok).toBe(false);
+    expect(response.error).toBe("native_capture_unavailable");
+    expect(runtimeMessages).toHaveLength(0);
+  });
+
+  it("reports a rejected runtime capture without refreshing archive state", async () => {
+    const dom = makeDom(conversationFetchImpl());
+    const runtimeListeners = [];
+    const chrome = {
+      runtime: {
+        getManifest: () => ({ version: "0.1.0" }),
+        onMessage: { addListener: (listener) => runtimeListeners.push(listener) },
+        sendMessage: vi.fn(async (message) => (message.type === "polylogue.capture" ? { ok: false, error: "capture_rejected" } : { ok: true })),
+      },
+    };
+    Object.defineProperty(dom.window, "chrome", { configurable: true, value: chrome });
+    Object.defineProperty(dom.window, "postMessage", {
+      configurable: true,
+      value(data) {
+        dom.window.queueMicrotask(() => {
+          dom.window.dispatchEvent(new dom.window.MessageEvent("message", { source: dom.window, origin: dom.window.location.origin, data }));
+        });
+      },
+    });
+    const context = dom.getInternalVMContext();
+    new Script(bridgeSource).runInContext(context);
+    new Script(commonSource).runInContext(context);
+    new Script(contentSource).runInContext(context);
+    const listener = runtimeListeners[0];
+    const response = await new Promise((resolve) => {
+      listener({ type: "polylogue.capturePage" }, {}, resolve);
+    });
+
+    expect(response).toMatchObject({ ok: false, timelineRecorded: true, error: "capture_rejected" });
+  });
 });

--- a/browser-extension/tests/content/grok_bridge.test.js
+++ b/browser-extension/tests/content/grok_bridge.test.js
@@ -1,0 +1,190 @@
+import { Buffer } from "node:buffer";
+import { createHash, webcrypto } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { TextEncoder } from "node:util";
+import { fileURLToPath } from "node:url";
+import { Script } from "node:vm";
+
+import { JSDOM } from "jsdom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const testDirectory = dirname(fileURLToPath(import.meta.url));
+const bridgeSource = readFileSync(resolve(testDirectory, "../../src/content/grok_bridge.js"), "utf8");
+const conversationId = "1f9de430-6505-4d43-935b-ec0dd1c13222";
+const assetBytes = new TextEncoder().encode("polylogue grok asset fixture\n");
+const expectedSha256 = createHash("sha256").update(assetBytes).digest("hex");
+const openDoms = [];
+
+function jsonResponse(body, status = 200) {
+  return new globalThis.Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+function byteResponse(bytes, status = 200) {
+  return new globalThis.Response(bytes, { status, headers: { "content-type": "text/plain" } });
+}
+
+function conversationMetadata(overrides = {}) {
+  return { conversationId, title: "Fixture conversation", temporary: false, createTime: "2026-06-27T12:39:08Z", modifyTime: "2026-06-27T13:46:12Z", ...overrides };
+}
+
+function responsesPayload() {
+  return {
+    responses: [
+      { responseId: "r-1", sender: "human", message: "hello", createTime: "2026-06-27T12:39:09Z" },
+      { responseId: "r-2", sender: "ASSISTANT", parentResponseId: "r-1", message: "hi there", createTime: "2026-06-27T12:39:15Z" },
+    ],
+  };
+}
+
+function makeDom(fetchImpl, url = `https://grok.com/c/${conversationId}`) {
+  const dom = new JSDOM("<!doctype html><title>Grok fixture</title>", { url, runScripts: "outside-only" });
+  openDoms.push(dom);
+  const cryptoAdapter = {
+    subtle: {
+      digest(algorithm, data) {
+        return webcrypto.subtle.digest(algorithm, Buffer.from(new dom.window.Uint8Array(data)));
+      },
+    },
+  };
+  Object.defineProperty(dom.window, "crypto", { configurable: true, value: cryptoAdapter });
+  Object.defineProperty(dom.window, "fetch", { configurable: true, value: fetchImpl });
+  return dom;
+}
+
+function installBridge(fetchImpl) {
+  const dom = makeDom(fetchImpl);
+  const pending = new Map();
+  const posted = [];
+  Object.defineProperty(dom.window, "postMessage", {
+    configurable: true,
+    value(data) {
+      posted.push(data);
+      const resolve = pending.get(data?.requestId);
+      if (resolve && (data?.type === "polylogue.grok.nativeFetchResponse" || data?.type === "polylogue.grok.assetFetchResponse")) {
+        pending.delete(data.requestId);
+        resolve(data);
+      }
+    },
+  });
+  new Script(bridgeSource).runInContext(dom.getInternalVMContext());
+
+  function requestNative(overrides = {}) {
+    const requestId = `native-request-${pending.size + 1}-${posted.length}`;
+    const response = new Promise((resolve) => pending.set(requestId, resolve));
+    dom.window.dispatchEvent(new dom.window.MessageEvent("message", {
+      source: dom.window,
+      origin: dom.window.location.origin,
+      data: { type: "polylogue.grok.nativeFetchRequest", requestId, conversationId, ...overrides },
+    }));
+    return response;
+  }
+
+  function requestAsset(overrides = {}) {
+    const requestId = `asset-request-${pending.size + 1}-${posted.length}`;
+    const response = new Promise((resolve) => pending.set(requestId, resolve));
+    dom.window.dispatchEvent(new dom.window.MessageEvent("message", {
+      source: dom.window,
+      origin: dom.window.location.origin,
+      data: { type: "polylogue.grok.assetFetchRequest", requestId, request: { key: "users/u1/asset-1/content", maxBytes: 1024, ...overrides } },
+    }));
+    return response;
+  }
+
+  return { dom, posted, requestNative, requestAsset };
+}
+
+afterEach(() => {
+  for (const dom of openDoms.splice(0)) dom.window.close();
+});
+
+describe("Grok bridge conversation fetch contract", () => {
+  it("combines conversation metadata, responses, and inflight skeleton into one capture", async () => {
+    const fetch = vi.fn(async (input) => {
+      const url = new URL(String(input), "https://grok.com");
+      if (url.pathname === `/rest/app-chat/conversations/${conversationId}`) return jsonResponse(conversationMetadata());
+      if (url.pathname === `/rest/app-chat/conversations/${conversationId}/responses`) return jsonResponse(responsesPayload());
+      if (url.pathname === `/rest/app-chat/conversations/${conversationId}/response-node`) {
+        return jsonResponse({ responseNodes: [], inflightResponses: [{ responseId: "r-3", sender: "ASSISTANT" }] });
+      }
+      throw new Error(`unexpected request: ${url.pathname}`);
+    });
+    const { requestNative } = installBridge(fetch);
+
+    const result = await requestNative();
+    expect(result.capture.ok).toBe(true);
+    const body = JSON.parse(result.capture.body);
+    expect(body.conversationId).toBe(conversationId);
+    expect(body.responses).toHaveLength(2);
+    expect(body.responses[1].message).toBe("hi there");
+    expect(body.inflightResponses).toEqual([{ responseId: "r-3", sender: "ASSISTANT" }]);
+    // Every request must carry the page's own session cookies.
+    for (const call of fetch.mock.calls) {
+      expect(call[1].credentials).toBe("include");
+    }
+  });
+
+  it("fails the whole capture when /responses cannot be fetched, but not when /response-node fails", async () => {
+    const fetch = vi.fn(async (input) => {
+      const url = new URL(String(input), "https://grok.com");
+      if (url.pathname === `/rest/app-chat/conversations/${conversationId}`) return jsonResponse(conversationMetadata());
+      if (url.pathname === `/rest/app-chat/conversations/${conversationId}/responses`) return jsonResponse({ code: 5, message: "Not Found" }, 404);
+      if (url.pathname === `/rest/app-chat/conversations/${conversationId}/response-node`) throw new Error("network down");
+      throw new Error(`unexpected request: ${url.pathname}`);
+    });
+    const { requestNative } = installBridge(fetch);
+
+    const result = await requestNative();
+    expect(result.capture.ok).toBe(false);
+    expect(result.capture.error).toBe("conversation_responses_fetch_failed");
+  });
+
+  it("does not fail the capture when response-node (inflight skeleton) is unavailable", async () => {
+    const fetch = vi.fn(async (input) => {
+      const url = new URL(String(input), "https://grok.com");
+      if (url.pathname === `/rest/app-chat/conversations/${conversationId}`) return jsonResponse(conversationMetadata());
+      if (url.pathname === `/rest/app-chat/conversations/${conversationId}/responses`) return jsonResponse(responsesPayload());
+      if (url.pathname === `/rest/app-chat/conversations/${conversationId}/response-node`) return jsonResponse({ code: 5 }, 500);
+      throw new Error(`unexpected request: ${url.pathname}`);
+    });
+    const { requestNative } = installBridge(fetch);
+
+    const result = await requestNative();
+    expect(result.capture.ok).toBe(true);
+    expect(JSON.parse(result.capture.body).inflightResponses).toEqual([]);
+  });
+});
+
+describe("Grok bridge asset acquisition (assets.grok.com requires the grok.com session)", () => {
+  it("acquires bytes with credentials:include and verifies sha256", async () => {
+    const fetch = vi.fn(async (input, options = {}) => {
+      const url = new URL(String(input));
+      expect(url.hostname).toBe("assets.grok.com");
+      expect(options.credentials).toBe("include");
+      return byteResponse(assetBytes);
+    });
+    const { requestAsset } = installBridge(fetch);
+
+    const result = await requestAsset();
+    expect(result.outcome.status).toBe("acquired");
+    expect(result.outcome.asset.sha256).toBe(expectedSha256);
+    expect(Buffer.from(result.outcome.asset.base64, "base64").toString("utf8")).toBe("polylogue grok asset fixture\n");
+  });
+
+  it("reports too_large without buffering past the requested byte budget", async () => {
+    const fetch = vi.fn(async () => byteResponse(assetBytes));
+    const { requestAsset } = installBridge(fetch);
+
+    const result = await requestAsset({ maxBytes: 4 });
+    expect(result.outcome.status).toBe("too_large");
+  });
+
+  it("classifies a 403 (verified live: assets.grok.com without credentials) as signed_url_expired", async () => {
+    const fetch = vi.fn(async () => new globalThis.Response("", { status: 403 }));
+    const { requestAsset } = installBridge(fetch);
+
+    const result = await requestAsset();
+    expect(result.outcome.status).toBe("signed_url_expired");
+    expect(result.outcome.http_status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary

Grok was the only browser-extension provider adapter with no MAIN-world bridge: `grok.js` scraped the DOM and hardcoded `native_attempts: []`. This adds a native REST adapter (matching the ChatGPT/Claude bridge pattern), a backfill adapter for pageToken-cursored history, wires `session_kind: "temporary"` from Grok's own `temporary` field, and deletes the DOM-only path entirely rather than keeping it as a fallback.

## Problem

DOM capture on other providers has been measured to be lossy by roughly two orders of magnitude once a conversation scrolls past the virtualized viewport (one live ChatGPT conversation held 5 DOM nodes against 996 API messages). grok.com exposes a clean, cookie-authenticated REST surface that makes native capture strictly superior for every field DOM scraping could ever observe there too, so there is no field where the DOM path would still be authoritative. Grok's temporary-chat flag was also unused: Polylogue has `TEMPORARY_CHAT_INGEST_FLAG`/`SessionKind.TEMPORARY`, but zero temporary sessions have ever landed from any provider.

All endpoints below were verified live via `sinnix-chrome-control` against an authenticated grok.com session (2026-07-31), not assumed:

- `GET /rest/app-chat/conversations?pageSize=N[&pageToken=T]` → `{conversations[], nextPageToken?}`; absent `nextPageToken` marks the last page (confirmed against a 20-conversation account with `pageSize=200`); `pageToken` pagination confirmed correct across two pages.
- `GET /rest/app-chat/conversations/<id>` → metadata including `temporary`.
- `GET /rest/app-chat/conversations/<id>/response-node` → **id/parent skeleton only, no message text** (a real gap vs. the original brief, which assumed turn content lived here).
- `GET /rest/app-chat/conversations/<id>/responses` → the actual turn content: `message`, `sender`, `steps` (reasoning), `webSearchResults`/`citedXposts`/etc. (tool evidence), `fileAttachmentsMetadata`/`fileAttachmentAssetMetadata` (attachments).
- `GET https://assets.grok.com/<key>` → attachment bytes; **403 without credentials, 200 with** — unlike ChatGPT's signed object-store URLs, this requires the grok.com session cookie cross-subdomain.

## Solution

- **`src/content/grok_bridge.js`** (new, MAIN world): fetches conversation metadata + `/responses` + best-effort `/response-node`, combines them into one capture body; acquires attachment bytes from `assets.grok.com` with bounded reads + sha256 verification (mirrors `chatgpt_bridge.js`'s asset discipline, but deliberately keeps `credentials: "include"` cross-origin since that host requires it).
- **`src/content/grok.js`** (rewritten, ISOLATED world, DOM path deleted): maps `responses[]` into typed `BrowserCaptureTurn`/`BrowserCaptureBlock` rows — message text, `steps` as `thinking` blocks, web/X/RAG/connector search evidence as `tool_use`/`tool_result`, file/generated-image attachments with bounded byte acquisition. Sets `session_kind: "temporary"` from the conversation's own flag. **Fails loud**: an unrecognized `toolResponses`/`imageAttachments` shape is kept as a block flagged `unrecognized_shape: true` rather than silently dropped, and a native-fetch failure returns `{ok: false, error, native_attempts: [...]}` instead of sending an empty capture (there is no DOM fallback left to degrade into).
- **`src/backfill/providers.js`**: `GrokBackfillAdapter`, registered in `providerAdapters()`. `enumerate()` walks `pageToken` pagination; `fetchNative()` combines the two REST calls into one synthetic `Response`-like object matching ChatGPT/Claude's adapter contract; `normalizeCapture()` threads `session_kind` through an additive `sessionKind` param on the shared `envelope()` helper (default `"standard"`, so ChatGPT/Claude are unaffected).
- **`manifest.json` / `background.js` `injectionPlanForUrl`**: added the `grok_bridge.js` MAIN-world entry; restricted matches to `grok.com` only.
- **`src/common.js`**: fixed a pre-existing bug where `buildEnvelope` silently dropped every turn's `blocks` field (chatgpt.js's native adapter already computed `tool_use`/`tool_result` blocks that never survived envelope construction — this was invisible until Grok's native adapter needed the same path). Also corrected `sessionIdFromUrl`'s grok branch, which guessed a `/chat/`/`/grok/` URL pattern; live verification shows real Grok conversation URLs are `/c/<uuid>` (same convention as ChatGPT/Claude).
- **`background.js` `conversationIdForUrl`**: same `/c/<uuid>` fix, needed for any auto-capture trigger to find a conversation id on a real grok.com URL at all — without it, auto-capture on grok.com silently did nothing regardless of DOM vs. native.

**x.com/twitter.com**: dropped from the manifest match and `injectionPlanForUrl` rather than left with a DOM-less no-op script. I could not verify live whether X's embedded Grok surface has its own distinct API (no authenticated x.com Grok conversation tab was available this session), but it is not grok.com's `/rest/app-chat/*` surface this bridge calls — a same-site fetch from an x.com page cannot reach grok.com's session-cookie-scoped API. Filed **polylogue-54gj** to track: (1) verifying X's actual API and building a dedicated adapter if worth it, or (2) dropping the residual "Grok / X" labeling in `background.js`/`popup.js` that still implies a capture path exists there.

## Verification

- `npx vitest run` — 379 passed, 1 pre-existing failure unrelated to this change (`tests/build.test.js` packaged-service-worker fixture, confirmed failing at HEAD before this branch; per repo notes this is a known gap, not something to chase).
- `npm run lint` — clean.
- `npm run validate` — manifest ok.
- New coverage: `tests/content/grok.test.js` (8 cases, full bridge+content-script integration harness), `tests/content/grok_bridge.test.js` (6 cases), `tests/backfill.test.js` (+5 Grok adapter cases), `tests/background.test.js` (updated the one case that asserted the old x.com DOM-injection behavior, +1 case for the new no-injection-on-x.com behavior).

Ref polylogue-54gj