### PR TITLE
fix(browser-extension): restore live capture, delete DOM fallback

### DIFF
--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -28,6 +28,20 @@ For active development against the in-tree source:
 3. Click **Load unpacked** and select this directory (`browser-extension/`)
 4. Pin the extension to the toolbar so the badge is always visible
 
+**Load from a stable, permanent checkout only** (e.g. the main
+`/realm/project/polylogue` clone) — never from a throwaway agent worktree.
+An unpacked extension is just a filesystem reference: if the directory it
+points at is deleted (routine `git worktree remove` after a merged PR is
+explicitly authorized as non-destructive cleanup elsewhere in this repo's
+conventions), Chrome silently stops running its service worker with no
+error surfaced anywhere — not in the extension's own UI, not in the
+receiver's logs, nothing. This has happened for real: an unpacked install
+pointed at an agent worktree that was later cleaned up, and live-capture
+was silently dead from that moment until someone thought to check
+`chrome://extensions` and noticed the entry had no running service worker.
+If you must develop from a worktree, copy or symlink the built extension
+into a stable location and load unpacked from there instead.
+
 ### 2b. Chrome / Chromium — packed `.zip` from a release
 
 For users who want a stable artifact rather than a working tree:

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -1285,6 +1285,13 @@ async function setStateForTab(tabId, state, expectedTabUrl = null) {
     expectedProvider
     && expectedSessionId
     && activeSessionId
+    // TEMPORARY_CHAT_SENTINEL is a "this tab has a real, capturable
+    // conversation" signal, not the conversation's real identity -- it can
+    // never equal a captured state's true provider_session_id (the
+    // ephemeral id from the native payload), so this staleness guard would
+    // reject every state write for a temporary chat tab, including the
+    // capture that just succeeded on it.
+    && activeSessionId !== TEMPORARY_CHAT_SENTINEL
     && (
       activeProvider !== expectedProvider
       || activeSessionId !== expectedSessionId
@@ -1910,7 +1917,19 @@ async function captureTab(tab, reason = "background", expectedConversation = nul
       const provider = resultWithTimeout.captureResult?.provider || envelopeSession.provider;
       const providerSessionId = resultWithTimeout.captureResult?.provider_session_id || envelopeSession.provider_session_id;
       const pageProvider = archiveProviderForUrl(tab.url || tab.pendingUrl || "") || provider;
-      const pageSessionId = conversationIdForUrl(tab.url || tab.pendingUrl || "") || providerSessionId;
+      // conversationIdForUrl(tab.url) is normally the right identity to log/
+      // record here (it is what every other caller in this file keys tab
+      // state by). The one exception is TEMPORARY_CHAT_SENTINEL: it is a
+      // "this tab has a real, capturable conversation" signal, not the
+      // conversation's real ephemeral id, so preferring it over the
+      // just-captured envelope's actual provider_session_id would record
+      // the sentinel as this tab's "captured" identity -- self-consistent
+      // locally, but never matching the real id the receiver/archive
+      // actually stored it under, so the tab would show "not captured"
+      // forever afterward (and setStateForTab's own staleness guard has a
+      // matching sentinel exemption for the same reason).
+      const urlSessionId = conversationIdForUrl(tab.url || tab.pendingUrl || "");
+      const pageSessionId = urlSessionId === TEMPORARY_CHAT_SENTINEL ? (providerSessionId || urlSessionId) : (urlSessionId || providerSessionId);
       await updateSessionLedger({
         provider,
         providerSessionId,
@@ -2623,6 +2642,15 @@ function conversationIdForUrl(url) {
   return null;
 }
 
+// Known limitation for a ChatGPT temporary chat: providerSessionId below is
+// TEMPORARY_CHAT_SENTINEL, not the conversation's real ephemeral id (there is
+// no per-tab "last known real captured id" cache to consult instead), so the
+// /v1/archive-state query it drives always reports state:"missing" even
+// after a real capture landed under the true id. This does not lose data --
+// it just makes captureTab's "auto_capture_missing" branch below re-fire
+// (throttled to once per BACKGROUND_CAPTURE_MIN_INTERVAL_MS) instead of
+// confirming "already archived", and the UI's captured badge stays
+// inaccurate for that tab. Ref polylogue-upbv.
 async function refreshActiveTabArchiveState(tab, reason = "tab_state", allowRecovery = true) {
   const url = tab?.url || tab?.pendingUrl || "";
   const provider = archiveProviderForUrl(url);
@@ -3187,7 +3215,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       const senderSessionId = conversationIdForUrl(senderUrl);
       const provider = message.provider || senderProvider;
       const nativeId = message.provider_session_id || senderSessionId;
-      if (sender.tab && (provider !== senderProvider || (senderSessionId && nativeId !== senderSessionId))) {
+      // TEMPORARY_CHAT_SENTINEL is a "this tab has a real, capturable
+      // conversation" signal, not a real provider identity -- it cannot
+      // equal chatgpt.js's freshness hints, which always carry the
+      // conversation's true ephemeral id (nativeCaptureIdentity, read from
+      // the intercepted native payload's own conversation_id/id). Enforcing
+      // strict equality against the sentinel here rejected every freshness
+      // hint a temporary chat ever sent after its first capture, silently
+      // stopping later turns from ever being re-captured.
+      if (
+        sender.tab
+        && (provider !== senderProvider
+          || (senderSessionId && senderSessionId !== TEMPORARY_CHAT_SENTINEL && nativeId !== senderSessionId))
+      ) {
         throw new Error("freshness_hint_sender_identity_mismatch");
       }
       sendResponse({

--- a/browser-extension/src/background.js
+++ b/browser-extension/src/background.js
@@ -18,6 +18,13 @@ import {
   scheduleFreshnessHint,
 } from "./capture/freshness.js";
 
+// Must match src/common.js's TEMPORARY_CHAT_ID_KEY-adjacent sentinel exactly
+// (sessionIdFromUrl's `__polylogue_temporary_chat__` return value) -- this
+// module has no access to the content script's per-tab sessionStorage, so it
+// cannot know the eventual real `temporary:<hex>` session id in advance. It
+// only needs a stable, regex-valid ([A-Za-z0-9_-]{1,256}) truthy signal that
+// a temporary-chat URL is a real, capturable conversation.
+const TEMPORARY_CHAT_SENTINEL = "__polylogue_temporary_chat__";
 const DEFAULT_RECEIVER = "http://127.0.0.1:8765";
 const EXTENSION_CONTRACT_EPOCH = "canonical-capture-mission-control-v1";
 const RECEIVER_API_SCHEMA = "polylogue-browser-capture/v1";
@@ -2582,7 +2589,16 @@ function conversationIdForUrl(url) {
     if (provider === "chatgpt") {
       const marker = parts.indexOf("c");
       if (marker >= 0 && parts[marker + 1]) return parts[marker + 1];
-      if (parsed.searchParams.get("temporary-chat") === "true") return null;
+      // Mirror src/common.js:sessionIdFromUrl exactly. A temporary chat has
+      // no /c/<id> path (ChatGPT never persists one), but it is still a
+      // real, capturable conversation -- returning null here made every
+      // gate downstream that checks `conversationIdForUrl(...)` truthy
+      // (captureTab's automatic-capture gate chief among them) treat every
+      // temporary chat tab as "no session" and silently never capture it,
+      // even though the content-script capture path (common.js) has always
+      // been ready to build a per-tab temporary session id. That asymmetry
+      // is why zero temporary chats have ever landed in the archive.
+      if (parsed.searchParams.get("temporary-chat") === "true") return TEMPORARY_CHAT_SENTINEL;
       return null;
     }
     if (provider === "claude-ai") {

--- a/browser-extension/src/common.js
+++ b/browser-extension/src/common.js
@@ -132,6 +132,12 @@
           ordinal,
           parent_turn_id: turn.parent_turn_id || null,
           attachments: Array.isArray(turn.attachments) ? turn.attachments : [],
+          // Structured content (tool_use/tool_result/thinking/...) an
+          // adapter observed for this turn. Previously dropped here even
+          // when a caller (e.g. chatgpt.js's collectNativeTurns) populated
+          // it, silently flattening every native capture's tool call/result
+          // structure back down to prose (polylogue-ah21 regressed).
+          blocks: Array.isArray(turn.blocks) ? turn.blocks : [],
           provider_meta: turn.provider_meta || {}
         })),
         attachments: Array.isArray(attachments) ? attachments : []

--- a/browser-extension/src/content/chatgpt.js
+++ b/browser-extension/src/content/chatgpt.js
@@ -9,7 +9,6 @@
   const MESSAGE_CONTAINER_SELECTOR = '[data-testid^="conversation-turn-"], article, [data-message-author-role]';
   let messageLayer = null;
 
-  const domAdapterName = "chatgpt-dom-v1";
   const nativeAdapterName = "chatgpt-native-v1";
   const nativeCaptureMessage = "polylogue.chatgpt.nativeCapture";
   const nativeFetchRequestMessage = "polylogue.chatgpt.nativeFetchRequest";
@@ -40,6 +39,23 @@
     const parts = parsed.pathname.split("/").filter(Boolean);
     const marker = parts.indexOf("c");
     return marker >= 0 && parts[marker + 1] ? parts[marker + 1] : null;
+  }
+
+  // A ChatGPT temporary chat never navigates to /c/<id> -- the visible URL
+  // stays at /?temporary-chat=true for the whole session -- but the page
+  // still fetches /backend-api/conversation/<ephemeral-id> to render it, and
+  // that fetch is intercepted the same as any other (chatgpt_bridge.js's
+  // window.fetch override matches on path shape only). Zero temporary chats
+  // had ever landed in the archive before this because every id-matching
+  // step downstream (parseNativeCapture, fetchNativePayloadOnDemand) treated
+  // "no id in the URL" as "no conversation on this page", discarding a
+  // capture that had already been intercepted correctly.
+  function isTemporaryChatUrl(url = window.location.href) {
+    try {
+      return new URL(url).searchParams.get("temporary-chat") === "true";
+    } catch {
+      return false;
+    }
   }
 
   function queueFreshnessHint(
@@ -237,94 +253,6 @@
     pending.resolve({ capture: data.capture || null, error: data.error || null });
   });
 
-  function roleFromNode(node, index) {
-    const testId = node.getAttribute("data-testid") || "";
-    if (testId.includes("user")) return "user";
-    if (testId.includes("assistant")) return "assistant";
-    const labelled = node.getAttribute("aria-label") || "";
-    if (/you|user/i.test(labelled)) return "user";
-    if (/chatgpt|assistant/i.test(labelled)) return "assistant";
-    return index % 2 === 0 ? "user" : "assistant";
-  }
-
-  function attachmentNameFromNode(node) {
-    const label = node.getAttribute("aria-label") || "";
-    const download = node.getAttribute("download") || "";
-    const alt = node.getAttribute("alt") || "";
-    const text = window.polylogueCapture.visibleText(node);
-    const href = node.getAttribute("href") || node.getAttribute("src") || "";
-    const basename = href.split(/[/?#]/).filter(Boolean).at(-1) || "";
-    const candidates = [label, download, alt, text, basename]
-      .map((value) => String(value || "").trim())
-      .filter(Boolean);
-    const extensionPattern =
-      "zip|tar|tgz|gz|bz2|xz|7z|rar|md|txt|pdf|doc|docx|json|jsonl|csv|tsv|py|js|ts|tsx|jsx|rs|go|java|c|cc|cpp|h|hpp|png|jpe?g|gif|webp|svg|mp3|mp4|wav|webm";
-    const filePattern = new RegExp(`(?:^|\\s)([^\\s@/]+\\.(?:${extensionPattern}))(?:\\s|$)`, "i");
-    for (const candidate of candidates) {
-      const fileNameMatch = candidate.match(filePattern);
-      if (fileNameMatch) return fileNameMatch[1].trim();
-    }
-    return null;
-  }
-
-  function collectAttachments(node, turnIndex) {
-    const selector = [
-      '[role="group"][aria-label]',
-      "a[download]",
-      "a[href][aria-label]",
-      "img[alt]",
-      "img[src]"
-    ].join(",");
-    const seen = new Set();
-    const attachments = [];
-    for (const candidate of node.querySelectorAll(selector)) {
-      const name = attachmentNameFromNode(candidate);
-      if (!name) continue;
-      const rawHref = candidate.getAttribute("href") || candidate.getAttribute("src") || null;
-      const url = rawHref && /^https?:\/\//i.test(rawHref) ? rawHref : null;
-      const key = `${name}\n${url || ""}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      attachments.push({
-        provider_attachment_id: `dom:${window.polylogueCapture.fnv1a(`${turnIndex}:${key}`)}`,
-        name,
-        url,
-        provider_meta: {
-          dom_selector_index: turnIndex,
-          dom_label: candidate.getAttribute("aria-label") || null,
-          dom_text: window.polylogueCapture.visibleText(candidate) || null,
-          capture_source: "chatgpt_dom_attachment"
-        }
-      });
-    }
-    return attachments;
-  }
-
-  async function collectTurns() {
-    const nodes = [
-      ...document.querySelectorAll('[data-testid^="conversation-turn-"], article, [data-message-author-role]')
-    ];
-    const turns = [];
-    for (const [index, node] of nodes.entries()) {
-      const explicitRole = node.getAttribute("data-message-author-role");
-      const role = explicitRole || roleFromNode(node, index);
-      const text = window.polylogueCapture.visibleText(node);
-      const domAttachments = collectAttachments(node, index);
-      // chatgpt-dom-v1 has no backend-api mapping to resolve file/sandbox ids
-      // from (polylogue-83u.3) — the DOM itself is the only evidence of an
-      // attachment. When a chip's own href/src is already a concrete https
-      // URL (rendered by the page, e.g. an inline image), fetch it through
-      // the SAME authenticated page-bridge mechanism the native adapter uses
-      // for sandbox/file assets (see acquireAssets/requestAssetFromPage), not
-      // a new one. No resolvable URL stays honestly byte_count=0.
-      const attachments = domAttachments.length ? await acquireDomAttachmentBytes(domAttachments) : domAttachments;
-      if (text || attachments.length) {
-        turns.push({ role, text, attachments, provider_meta: { selector_index: index } });
-      }
-    }
-    return turns;
-  }
-
   function extractContentText(content) {
     const parts = content && content.parts;
     if (Array.isArray(parts)) {
@@ -452,14 +380,28 @@
 
   function parseNativeCapture(capture, expectedConversationId = conversationIdFromUrl()) {
     if (!capture || !capture.ok || typeof capture.body !== "string") return null;
-    if (!expectedConversationId || !String(capture.url || "").includes(`/conversation/${expectedConversationId}`)) {
-      return null;
+    if (expectedConversationId) {
+      if (!String(capture.url || "").includes(`/conversation/${expectedConversationId}`)) return null;
+      try {
+        const payload = JSON.parse(capture.body);
+        if (!payload || typeof payload !== "object" || !payload.mapping) return null;
+        const payloadConversationId = payload.conversation_id || payload.id;
+        if (payloadConversationId && String(payloadConversationId) !== expectedConversationId) return null;
+        return payload;
+      } catch {
+        return null;
+      }
     }
+    // No URL-derived id to match against. The only legitimate case is a
+    // temporary chat (see isTemporaryChatUrl) -- accept the intercepted
+    // capture only if this page is a temporary chat AND the payload itself
+    // agrees it is temporary, so an unrelated stale capture from a prior
+    // page on this tab can never be misattributed.
+    if (!isTemporaryChatUrl()) return null;
     try {
       const payload = JSON.parse(capture.body);
       if (!payload || typeof payload !== "object" || !payload.mapping) return null;
-      const payloadConversationId = payload.conversation_id || payload.id;
-      if (payloadConversationId && String(payloadConversationId) !== expectedConversationId) return null;
+      if (payload.is_temporary !== true) return null;
       return payload;
     } catch {
       return null;
@@ -566,8 +508,37 @@
     }
   }
 
+  const freshConversationWaitTimeoutMs = 6000;
+  const freshConversationWaitIntervalMs = 300;
+
+  // ChatGPT does not update the URL to /c/<id> until the backend accepts the
+  // first turn of a brand-new conversation. A capture triggered in that
+  // narrow window (in-page save button, DOM-mutation freshness observer) has
+  // no id to fetch by yet and no intercepted response either -- this was the
+  // only case where DOM scraping ever produced real captures (2026-07-17:
+  // every chatgpt-dom-v1 capture landed inside one such window, and every
+  // one was a degraded 3-turn shadow of a conversation the native path
+  // picked up moments later with the full turn history). Wait for the SPA
+  // router to publish the id instead of falling back to a DOM scrape.
+  async function waitForConversationId(timeoutMs = freshConversationWaitTimeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    let id = conversationIdFromUrl();
+    while (!id && Date.now() < deadline) {
+      await new Promise((resolve) => window.setTimeout(resolve, freshConversationWaitIntervalMs));
+      id = conversationIdFromUrl();
+    }
+    return id;
+  }
+
   async function fetchNativePayloadOnDemand(requestedConversationId = null) {
-    const conversationId = requestedConversationId || conversationIdFromUrl();
+    let conversationId = requestedConversationId || conversationIdFromUrl();
+    // A temporary chat never gets a /c/<id> URL, so waiting for one would
+    // just burn the whole timeout for nothing -- fall straight through to
+    // the already-intercepted-capture path (latestNativePayload, called by
+    // capture() right after this returns null) instead.
+    if (!conversationId && !requestedConversationId && !isTemporaryChatUrl()) {
+      conversationId = await waitForConversationId();
+    }
     if (!conversationId) return null;
     if (!/^[A-Za-z0-9_-]{1,256}$/.test(conversationId)) return null;
     const pageResult = await requestNativeCaptureFromPage(conversationId);
@@ -655,76 +626,6 @@
     });
     window.postMessage({ type: assetFetchRequestMessage, requestId, request }, window.location.origin);
     return responsePromise;
-  }
-
-  // chatgpt-dom-v1 attachment byte acquisition (polylogue-83u.3): the DOM
-  // scrape only ever recorded the chip name (byte_count=0) because there is
-  // no backend-api mapping in this degraded capture mode to resolve a
-  // file/sandbox id from. Any chip whose own href/src the page already
-  // rendered as a concrete https URL is fetched through the bridge's "url"
-  // asset kind — the same authenticated page-bridge fetch+hash mechanism
-  // acquireAssets uses for the native adapter's sandbox/file assets, just
-  // skipping the metadata round trip since the URL is already in hand.
-  // Bounded by the same per-file/total-byte/time/failure budgets so a
-  // degraded capture with many broken image chips cannot stall or balloon.
-  async function acquireDomAttachmentBytes(attachments) {
-    const startedAt = Date.now();
-    let totalBytes = 0;
-    let consecutiveFailures = 0;
-    const acquired = [];
-    for (const attachment of attachments) {
-      if (
-        !attachment.url
-        || totalBytes >= assetMaxBytesTotal
-        || Date.now() - startedAt >= assetTotalTimeBudgetMs
-        || consecutiveFailures >= assetConsecutiveFailureLimit
-      ) {
-        acquired.push(attachment);
-        continue;
-      }
-      const request = {
-        kind: "url",
-        url: attachment.url,
-        name: attachment.name,
-        maxBytes: Math.min(assetMaxBytesPerFile, assetMaxBytesTotal - totalBytes)
-      };
-      const result = await requestAssetFromPage(request);
-      const status = typeof result.status === "string" ? result.status : "request_failed";
-      const contentSha256 = result.asset && result.asset.sha256;
-      const acquiredIsValid =
-        status === "acquired" &&
-        result.asset &&
-        result.asset.base64 &&
-        typeof contentSha256 === "string" &&
-        /^[0-9a-f]{64}$/.test(contentSha256);
-      if (acquiredIsValid) {
-        totalBytes += result.asset.size_bytes || 0;
-        consecutiveFailures = 0;
-        acquired.push({
-          ...attachment,
-          mime_type: result.asset.mime_type || attachment.mime_type || null,
-          size_bytes: result.asset.size_bytes || null,
-          inline_base64: result.asset.base64,
-          provider_meta: {
-            ...attachment.provider_meta,
-            asset_kind: "url",
-            content_sha256: contentSha256
-          }
-        });
-      } else {
-        consecutiveFailures += 1;
-        acquired.push({
-          ...attachment,
-          provider_meta: {
-            ...attachment.provider_meta,
-            asset_kind: "url",
-            asset_fetch_status: status,
-            asset_fetch_detail: result.detail || null
-          }
-        });
-      }
-    }
-    return acquired;
   }
 
   function sandboxPathsFromText(text) {
@@ -1017,7 +918,7 @@
       return byId;
     }, new Map());
     const normalizedGenerationObservations = [...generationObservations.values()].slice(-64);
-    const envelope = nativePayload
+    const finalEnvelope = nativePayload
       ? buildNativeEnvelope(
         nativePayload,
         assetAcquisition,
@@ -1025,22 +926,13 @@
         normalizedGenerationObservations,
       )
       : null;
-    const fallbackEnvelope = async () => {
-      const turns = await collectTurns();
-      if (!turns.length) return null;
-      return window.polylogueCapture.buildEnvelope({
-        provider: "chatgpt",
-        adapterName: domAdapterName,
-        turns,
-        providerMeta: {
-          capture_fidelity: "dom_degraded",
-          native_attempts: nativeAttemptDiagnostics.slice(-6),
-          generation_observations: normalizedGenerationObservations,
-        }
-      });
-    };
-    const finalEnvelope = envelope || (requestedConversationId ? null : await fallbackEnvelope());
-    if (!finalEnvelope) return { ok: false, error: "no_turns" };
+    if (!finalEnvelope) {
+      return {
+        ok: false,
+        error: "native_capture_unavailable",
+        native_attempts: nativeAttemptDiagnostics.slice(-6),
+      };
+    }
     if (deferReceiver) return { ok: true, envelope: finalEnvelope, deferred: true };
     const captureResult = await window.polylogueCapture.sendCapture(finalEnvelope, reason);
     if (!captureResult?.ok) {

--- a/browser-extension/src/content/chatgpt_bridge.js
+++ b/browser-extension/src/content/chatgpt_bridge.js
@@ -401,10 +401,13 @@
 
   async function fetchAssetBytes(request) {
     if (request.kind === "url") {
-      // No metadata round trip: the caller (e.g. the chatgpt-dom-v1 fallback
-      // adapter, which has no backend-api mapping to resolve file/sandbox ids
-      // from) already has a concrete byte-bearing URL straight out of the DOM
-      // (an `img.src`/`a.href` the page itself rendered).
+      // No metadata round trip: the caller already has a concrete
+      // byte-bearing URL in hand (e.g. an `img.src`/`a.href` rendered on the
+      // page) and skips straight to fetching it. No current caller in this
+      // repo builds a "url"-kind request (the chatgpt-dom-v1 adapter that
+      // originally needed it was removed -- native capture covers what used
+      // to require a DOM scrape), but the receiver-side protocol and its
+      // budget/credential-scoping guarantees stay intact for any future one.
       let directUrl;
       try {
         directUrl = new URL(String(request.url), currentOrigin);

--- a/browser-extension/src/content/claude.js
+++ b/browser-extension/src/content/claude.js
@@ -9,7 +9,6 @@
   const MESSAGE_CONTAINER_SELECTOR = '[data-testid*="message"], [data-message-author-role], article';
   let messageLayer = null;
 
-  const domAdapterName = "claude-ai-dom-v1";
   const nativeAdapterName = "claude-ai-native-v1";
   const nativeCaptureMessage = "polylogue.claude.nativeCapture";
   const nativeFetchRequestMessage = "polylogue.claude.nativeFetchRequest";
@@ -52,25 +51,6 @@
     nativeFetchResponses.delete(data.requestId);
     pending.resolve({ capture: data.capture || null, error: data.error || null });
   });
-
-  function roleFromNode(node, index) {
-    const role = node.getAttribute("data-message-author-role") || node.getAttribute("data-testid") || "";
-    if (/human|user/i.test(role)) return "user";
-    if (/assistant|claude/i.test(role)) return "assistant";
-    return index % 2 === 0 ? "user" : "assistant";
-  }
-
-  function collectTurns() {
-    const nodes = [
-      ...document.querySelectorAll('[data-testid*="message"], [data-message-author-role], article')
-    ];
-    return nodes
-      .map((node, index) => {
-        const text = window.polylogueCapture.visibleText(node);
-        return text ? { role: roleFromNode(node, index), text, provider_meta: { selector_index: index } } : null;
-      })
-      .filter(Boolean);
-  }
 
   function textFromMessage(message) {
     if (!message || typeof message !== "object") return "";
@@ -221,22 +201,10 @@
 
   async function capture(reason = null) {
     const nativePayload = latestNativePayload() || (await fetchNativePayloadOnDemand());
-    const envelope = nativePayload ? buildNativeEnvelope(nativePayload) : null;
-    const fallbackEnvelope = () => {
-      const turns = collectTurns();
-      if (!turns.length) return null;
-      return window.polylogueCapture.buildEnvelope({
-        provider: "claude-ai",
-        adapterName: domAdapterName,
-        turns,
-        providerMeta: {
-          capture_fidelity: "dom_degraded",
-          native_attempts: nativeAttemptDiagnostics.slice(-6)
-        }
-      });
-    };
-    const finalEnvelope = envelope || fallbackEnvelope();
-    if (!finalEnvelope) return { ok: false, error: "no_turns" };
+    const finalEnvelope = nativePayload ? buildNativeEnvelope(nativePayload) : null;
+    if (!finalEnvelope) {
+      return { ok: false, error: "native_capture_unavailable", native_attempts: nativeAttemptDiagnostics.slice(-6) };
+    }
     const captureResult = await window.polylogueCapture.sendCapture(finalEnvelope, reason);
     if (!captureResult?.ok) {
       messageLayer?.reportOutcome({ ok: false, turnCount: finalEnvelope.session.turns.length });

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -2023,6 +2023,63 @@ describe("background receiver diagnostics", () => {
     expect(timeline[0]).toMatchObject({ reason: "auto_capture_missing", detail: "spooled_only" });
   });
 
+  it("captures a ChatGPT temporary chat instead of silently skipping it (background.js conversationIdForUrl asymmetry)", async () => {
+    // background.js's own conversationIdForUrl used to return null for a
+    // temporary-chat URL (?temporary-chat=true), which made captureTab's
+    // automatic-capture gate (`!conversationIdForUrl(conversationUrl)`)
+    // treat every temporary chat tab as having no session and silently
+    // never send it a polylogue.capturePage message at all -- content
+    // script capture code was ready for temporary chats the whole time.
+    // Zero temporary chats had ever landed in the archive because of this.
+    expect(activatedListener).toBeTypeOf("function");
+    tabs = [{ id: 42, url: "https://chatgpt.com/?temporary-chat=true", title: "ChatGPT" }];
+    stored.polylogueReceiverPairing = {
+      state: "online",
+      receiver_id: "rx-auto-capture",
+      api_schema: "polylogue-browser-capture/v1",
+      endpoint: "http://127.0.0.1:8875",
+    };
+    globalThis.fetch = vi.fn(async (url) => {
+      fetchCalls.push({ url });
+      if (String(url).endsWith("/v1/status")) {
+        return responseJson({ ok: true, receiver_id: "rx-auto-capture", api_schema: "polylogue-browser-capture/v1" });
+      }
+      if (String(url).endsWith("/v1/browser-captures")) {
+        return responseJson({
+          provider: "chatgpt",
+          provider_session_id: "temp:ephemeral-session",
+          state: "spooled_only",
+          receiver_request_id: "capture-request-temp",
+        }, { requestId: "capture-request-temp" });
+      }
+      return responseJson(
+        { provider: "chatgpt", provider_session_id: "temp:ephemeral-session", state: "missing", lifecycle: "missing", captured: false, spooled: false },
+        { requestId: "archive-state-temp" },
+      );
+    });
+    globalThis.chrome.tabs.sendMessage = vi.fn(async (tabId, message) => {
+      if (message.type !== "polylogue.capturePage") return null;
+      const envelope = {
+        session: { provider: "chatgpt", provider_session_id: "temp:ephemeral-session", session_kind: "temporary", turns: [{ role: "user" }] },
+      };
+      const captureResult = await new Promise((resolve) => {
+        messageListener(
+          { type: "polylogue.capture", envelope, reason: message.reason },
+          { tab: { id: tabId, url: "https://chatgpt.com/?temporary-chat=true" } },
+          resolve,
+        );
+      });
+      return { ok: true, envelope, captureResult, archiveState: { state: "spooled_only" } };
+    });
+
+    activatedListener({ tabId: 42 });
+
+    await vi.waitFor(() => expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalled());
+    expect(globalThis.chrome.tabs.sendMessage).toHaveBeenCalledWith(42, expect.objectContaining({ type: "polylogue.capturePage" }));
+    await vi.waitFor(() => expect(stored.polylogueState?.captured).toBe(true));
+    expect(fetchCalls.map((call) => call.url)).toContain("http://127.0.0.1:8875/v1/browser-captures");
+  });
+
   it("does not recapture an already-safe conversation on activation", async () => {
     tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-throttle", title: "ChatGPT" }];
     globalThis.fetch = vi.fn(async () => responseJson({

--- a/browser-extension/tests/background.test.js
+++ b/browser-extension/tests/background.test.js
@@ -2227,6 +2227,47 @@ describe("background receiver diagnostics", () => {
     expect(globalThis.chrome.tabs.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("accepts a temporary chat's freshness hint even though its real ephemeral id differs from the URL sentinel", async () => {
+    // background.js's conversationIdForUrl returns TEMPORARY_CHAT_SENTINEL
+    // for a ChatGPT temporary-chat URL (there is no /c/<id> to read), but
+    // chatgpt.js's freshness hints always carry the conversation's true
+    // ephemeral id (read from the intercepted native payload). Before this
+    // fix, the sender-identity check compared the sentinel against that real
+    // id, found a mismatch, and threw -- rejecting every freshness hint a
+    // temporary chat ever sent after its first capture, so later turns were
+    // never re-captured (P1 finding on PR #3411's Codex review).
+    vi.spyOn(Date, "now").mockReturnValue(100_000);
+    const response = await sendRuntimeMessage(
+      {
+        type: "polylogue.captureFreshnessHint",
+        provider: "chatgpt",
+        provider_session_id: "temp-conv-ephemeral-42",
+        reason: "generation_completed",
+        delay_ms: 0,
+      },
+      { tab: { id: 42, url: "https://chatgpt.com/?temporary-chat=true" } },
+    );
+
+    expect(response.ok).toBe(true);
+    expect(stored.polylogueCaptureFreshnessQueue.entries["chatgpt:temp-conv-ephemeral-42"]).toBeDefined();
+  });
+
+  it("still rejects a freshness hint whose id does not match an ordinary (non-temporary) tab's own URL", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(100_000);
+    const response = await sendRuntimeMessage(
+      {
+        type: "polylogue.captureFreshnessHint",
+        provider: "chatgpt",
+        provider_session_id: "some-other-conversation",
+        reason: "generation_completed",
+        delay_ms: 0,
+      },
+      { tab: { id: 42, url: "https://chatgpt.com/c/conv-actually-open" } },
+    );
+
+    expect(response).toMatchObject({ ok: false, error: "freshness_hint_sender_identity_mismatch" });
+  });
+
   it("does not fetch a missing conversation while automatic capture is paused", async () => {
     tabs = [{ id: 42, url: "https://chatgpt.com/c/conv-paused", title: "ChatGPT" }];
     await sendRuntimeMessage({

--- a/browser-extension/tests/common_envelope_boundary.test.js
+++ b/browser-extension/tests/common_envelope_boundary.test.js
@@ -1,0 +1,182 @@
+/**
+ * Boundary contract test for src/common.js's buildEnvelope: a capture
+ * adapter (chatgpt.js/claude.js/grok.js) can populate every field the wire
+ * format (polylogue/browser_capture/models.py's BrowserCaptureTurn /
+ * BrowserCaptureBlock) defines, and buildEnvelope must carry every one of
+ * them into the envelope unmodified. It must not re-introduce a field
+ * allowlist that silently drops whatever it does not enumerate.
+ *
+ * This is a regression guard for exactly that failure mode: buildEnvelope's
+ * turns.map projection used to hand-list a fixed set of output keys with no
+ * `blocks` entry at all, so every structured block a content script built
+ * (tool_use/tool_result/thinking/...) was silently discarded at the
+ * envelope boundary while `text` alone kept looking like a complete,
+ * successful capture (polylogue-ah21 regressed this once already).
+ *
+ * Loads the REAL src/common.js (via dom.window.eval, the same pattern
+ * tests/content/grok.test.js already uses) rather than a hand-copied
+ * function -- a local copy of buildEnvelope would test itself, not the
+ * production code, which is exactly how the blocks drop went unnoticed for
+ * as long as it did (tests/content/chatgpt.test.js and
+ * tests/content/claude.test.js both had this problem too; see their
+ * changes in this same commit).
+ *
+ * Derive-vs-hardcode: the ideal version of this test derives its expected
+ * field set from polylogue/browser_capture/models.py's
+ * BrowserCaptureTurn/BrowserCaptureBlock Pydantic models directly, so
+ * adding a field on the Python side fails this JS test until the JS
+ * projection carries it too. That was not done here: there is no existing
+ * pattern anywhere in this repo for a vitest test shelling out to Python,
+ * no CI job wires the Python venv into the browser-extension test run, and
+ * `npx vitest run` is documented (README.md) as a plain `npm`-only command
+ * a contributor can run with zero Python setup. Making this one test
+ * conditionally require an importable `polylogue` package would make an
+ * otherwise-unrelated JS change fail (or silently skip, which defeats the
+ * point) in exactly that environment. Falling back to a hardcoded maximal
+ * turn/block round-trip is a real regression guard for the allowlist-drift
+ * class today; keeping the field lists below in sync with models.py when
+ * either side changes is a known, accepted manual cost until that
+ * cross-language plumbing is built as its own piece of work.
+ */
+
+import { readFileSync } from "node:fs";
+
+import { JSDOM } from "jsdom";
+import { describe, expect, it } from "vitest";
+
+const commonSource = readFileSync("src/common.js", "utf8");
+
+// Mirrors polylogue/browser_capture/models.py::BrowserCaptureBlock field by
+// field. `type` is required and typed (BlockType); everything else is
+// optional. ordinal/id-shaped identity fields are not part of this model.
+const BROWSER_CAPTURE_BLOCK_FIELDS = [
+  "type",
+  "text",
+  "tool_name",
+  "tool_id",
+  "tool_input",
+  "media_type",
+  "metadata",
+  "is_error",
+  "exit_code",
+];
+
+// Mirrors polylogue/browser_capture/models.py::BrowserCaptureTurn field by
+// field. `ordinal` is populated by buildEnvelope itself (the turn's index),
+// not read from the caller's turn object, but is still part of the wire
+// contract this test guards.
+const BROWSER_CAPTURE_TURN_FIELDS = [
+  "provider_turn_id",
+  "role",
+  "text",
+  "timestamp",
+  "ordinal",
+  "parent_turn_id",
+  "attachments",
+  "blocks",
+  "provider_meta",
+];
+
+function installCommon(url = "https://chatgpt.com/c/conversation-1") {
+  const dom = new JSDOM("<title>Boundary contract fixture</title>", {
+    runScripts: "outside-only",
+    url,
+  });
+  dom.window.chrome = {
+    runtime: {
+      id: "synthetic-extension-id",
+      getManifest: () => ({ version: "0.1.0" }),
+    },
+  };
+  dom.window.eval(commonSource);
+  return dom;
+}
+
+function maximalBlock() {
+  return {
+    type: "tool_use",
+    text: "block prose rendering",
+    tool_name: "shell",
+    tool_id: "tool-call-1",
+    tool_input: { command: "ls -la", cwd: "/tmp" },
+    media_type: "application/json",
+    metadata: { content_type: "code", extra_nested: { deep: true } },
+    is_error: false,
+    exit_code: 0,
+  };
+}
+
+function maximalTurn() {
+  return {
+    provider_turn_id: "turn-1",
+    role: "assistant",
+    text: "turn prose",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    parent_turn_id: "turn-0",
+    attachments: [
+      {
+        provider_attachment_id: "attachment-1",
+        name: "report.pdf",
+        mime_type: "application/pdf",
+        size_bytes: 4096,
+        url: "https://files.example.test/report.pdf",
+      },
+    ],
+    blocks: [maximalBlock()],
+    provider_meta: { node_id: "node-1", content_type: "tool_use" },
+  };
+}
+
+describe("common.js buildEnvelope boundary contract (real source, not a copy)", () => {
+  it("carries every BrowserCaptureTurn field from a maximal turn into the envelope", () => {
+    const dom = installCommon();
+    const envelope = dom.window.polylogueCapture.buildEnvelope({
+      provider: "chatgpt",
+      adapterName: "chatgpt-native-v1",
+      turns: [maximalTurn()],
+      providerSessionId: "conversation-1",
+    });
+
+    const [turn] = envelope.session.turns;
+    expect(Object.keys(turn).sort()).toEqual([...BROWSER_CAPTURE_TURN_FIELDS].sort());
+    expect(turn).toMatchObject({
+      provider_turn_id: "turn-1",
+      role: "assistant",
+      text: "turn prose",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      ordinal: 0,
+      parent_turn_id: "turn-0",
+      provider_meta: { node_id: "node-1", content_type: "tool_use" },
+    });
+    expect(turn.attachments).toEqual(maximalTurn().attachments);
+    expect(turn.blocks).toEqual(maximalTurn().blocks);
+  });
+
+  it("carries every BrowserCaptureBlock field through unmodified", () => {
+    const dom = installCommon();
+    const envelope = dom.window.polylogueCapture.buildEnvelope({
+      provider: "chatgpt",
+      adapterName: "chatgpt-native-v1",
+      turns: [maximalTurn()],
+      providerSessionId: "conversation-1",
+    });
+
+    const [block] = envelope.session.turns[0].blocks;
+    expect(Object.keys(block).sort()).toEqual([...BROWSER_CAPTURE_BLOCK_FIELDS].sort());
+    expect(block).toEqual(maximalBlock());
+  });
+
+  it("still defaults blocks/attachments to an empty array for a turn that observed neither", () => {
+    const dom = installCommon();
+    const envelope = dom.window.polylogueCapture.buildEnvelope({
+      provider: "chatgpt",
+      adapterName: "chatgpt-native-v1",
+      turns: [{ provider_turn_id: "turn-text-only", role: "user", text: "hello" }],
+      providerSessionId: "conversation-1",
+    });
+
+    const [turn] = envelope.session.turns;
+    expect(turn.blocks).toEqual([]);
+    expect(turn.attachments).toEqual([]);
+  });
+});

--- a/browser-extension/tests/content/chatgpt.test.js
+++ b/browser-extension/tests/content/chatgpt.test.js
@@ -1,96 +1,19 @@
 /**
- * Tests for chatgpt.js content script role detection.
+ * Tests for chatgpt.js content script id/URL parsing and the on-demand
+ * native fetch contract.
  *
- * The roleFromNode function is extracted from src/content/chatgpt.js.
- * It must stay in sync with the source.
- *
- * Known gap (#622): the index-parity fallback at the end of roleFromNode
- * assigns "user"/"assistant" based on even/odd index when no DOM attribute
- * matches.  It should return "unknown" for ambiguous nodes per #622.
+ * These functions are extracted from src/content/chatgpt.js and must stay
+ * in sync with the source. The DOM-scrape fallback (roleFromNode,
+ * attachmentNameFromNode, collectAttachments, chatgpt-dom-v1) was removed
+ * from the source entirely -- native capture now covers the one case that
+ * ever made it fire for real (a brand-new conversation's URL not yet
+ * published, see tests/content/chatgpt_bridge.test.js's "waits for a
+ * brand-new conversation's URL" and "captures a temporary chat" cases,
+ * which exercise the real source through the integration harness) -- so
+ * the tests for those functions were deleted here rather than updated.
  */
 
 import { describe, it, expect } from "vitest";
-import { JSDOM } from "jsdom";
-
-// ---------------------------------------------------------------------------
-// Extracted from src/content/chatgpt.js — keep in sync
-// ---------------------------------------------------------------------------
-
-function roleFromNode(node, index) {
-  const testId = node.getAttribute("data-testid") || "";
-  if (testId.includes("user")) return "user";
-  if (testId.includes("assistant")) return "assistant";
-  const labelled = node.getAttribute("aria-label") || "";
-  if (/you|user/i.test(labelled)) return "user";
-  if (/chatgpt|assistant/i.test(labelled)) return "assistant";
-  return index % 2 === 0 ? "user" : "assistant";
-}
-
-function fnv1a(text) {
-  let hash = 0x811c9dc5;
-  for (let index = 0; index < text.length; index += 1) {
-    hash ^= text.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return (hash >>> 0).toString(16).padStart(8, "0");
-}
-
-function visibleText(node) {
-  return (node?.innerText || node?.textContent || "").replace(/\s+\n/g, "\n").trim();
-}
-
-function attachmentNameFromNode(node) {
-  const label = node.getAttribute("aria-label") || "";
-  const download = node.getAttribute("download") || "";
-  const alt = node.getAttribute("alt") || "";
-  const text = visibleText(node);
-  const href = node.getAttribute("href") || node.getAttribute("src") || "";
-  const basename = href.split(/[/?#]/).filter(Boolean).at(-1) || "";
-  const candidates = [label, download, alt, text, basename]
-    .map((value) => String(value || "").trim())
-    .filter(Boolean);
-  const extensionPattern =
-    "zip|tar|tgz|gz|bz2|xz|7z|rar|md|txt|pdf|doc|docx|json|jsonl|csv|tsv|py|js|ts|tsx|jsx|rs|go|java|c|cc|cpp|h|hpp|png|jpe?g|gif|webp|svg|mp3|mp4|wav|webm";
-  const filePattern = new RegExp(`(?:^|\\s)([^\\s@/]+\\.(?:${extensionPattern}))(?:\\s|$)`, "i");
-  for (const candidate of candidates) {
-    const fileNameMatch = candidate.match(filePattern);
-    if (fileNameMatch) return fileNameMatch[1].trim();
-  }
-  return null;
-}
-
-function collectAttachments(node, turnIndex) {
-  const selector = [
-    '[role="group"][aria-label]',
-    "a[download]",
-    "a[href][aria-label]",
-    "img[alt]",
-    "img[src]",
-  ].join(",");
-  const seen = new Set();
-  const attachments = [];
-  for (const candidate of node.querySelectorAll(selector)) {
-    const name = attachmentNameFromNode(candidate);
-    if (!name) continue;
-    const rawHref = candidate.getAttribute("href") || candidate.getAttribute("src") || null;
-    const url = rawHref && /^https?:\/\//i.test(rawHref) ? rawHref : null;
-    const key = `${name}\n${url || ""}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    attachments.push({
-      provider_attachment_id: `dom:${fnv1a(`${turnIndex}:${key}`)}`,
-      name,
-      url,
-      provider_meta: {
-        dom_selector_index: turnIndex,
-        dom_label: candidate.getAttribute("aria-label") || null,
-        dom_text: visibleText(candidate) || null,
-        capture_source: "chatgpt_dom_attachment",
-      },
-    });
-  }
-  return attachments;
-}
 
 function conversationIdFromUrl(url) {
   const parsed = new URL(url);
@@ -147,122 +70,6 @@ function makeFetchResponse(payload, options = {}) {
   };
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function makeNode(attrs = {}) {
-  const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
-  const div = dom.window.document.createElement("div");
-  for (const [key, value] of Object.entries(attrs)) {
-    div.setAttribute(key, value);
-  }
-  return div;
-}
-
-function makeNodes(attrLists) {
-  return attrLists.map((attrs) => makeNode(attrs));
-}
-
-// ---------------------------------------------------------------------------
-// Tests: known cases
-// ---------------------------------------------------------------------------
-
-describe("chatgpt roleFromNode — known cases", () => {
-  it("detects user from data-testid containing 'user'", () => {
-    const node = makeNode({ "data-testid": "conversation-turn-user-1" });
-    expect(roleFromNode(node, 0)).toBe("user");
-  });
-
-  it("detects assistant from data-testid containing 'assistant'", () => {
-    const node = makeNode({
-      "data-testid": "conversation-turn-assistant-1",
-    });
-    expect(roleFromNode(node, 1)).toBe("assistant");
-  });
-
-  it("detects user from aria-label matching you/user", () => {
-    expect(roleFromNode(makeNode({ "aria-label": "You said:" }), 0)).toBe(
-      "user",
-    );
-    expect(roleFromNode(makeNode({ "aria-label": "User message" }), 2)).toBe(
-      "user",
-    );
-  });
-
-  it("detects assistant from aria-label matching chatgpt/assistant", () => {
-    expect(
-      roleFromNode(makeNode({ "aria-label": "ChatGPT said:" }), 0),
-    ).toBe("assistant");
-    expect(
-      roleFromNode(makeNode({ "aria-label": "assistant response" }), 0),
-    ).toBe("assistant");
-  });
-
-  it("prefers data-testid over aria-label", () => {
-    // data-testid wins because it is checked first
-    const node = makeNode({
-      "data-testid": "conversation-turn-user-1",
-      "aria-label": "ChatGPT said:",
-    });
-    expect(roleFromNode(node, 0)).toBe("user");
-  });
-
-  it("handles nodes with no role attributes", () => {
-    const node = makeNode({});
-    // Falls through to index parity
-    expect(roleFromNode(node, 0)).toBe("user");
-    expect(roleFromNode(node, 1)).toBe("assistant");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Tests: interleaved turns
-// ---------------------------------------------------------------------------
-
-describe("chatgpt roleFromNode — interleaved turns", () => {
-  it("assigns alternating roles for bare nodes via index parity", () => {
-    const nodes = makeNodes([{}, {}, {}, {}]);
-    const roles = nodes.map((n, i) => roleFromNode(n, i));
-    expect(roles).toEqual(["user", "assistant", "user", "assistant"]);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Tests: #622 gap — index-parity fallback
-// ---------------------------------------------------------------------------
-
-describe("chatgpt roleFromNode — #622 gap (index-parity fallback)", () => {
-  it("returns user/assistant for ambiguous nodes instead of unknown", () => {
-    // A node whose data-testid does NOT contain 'user' or 'assistant'
-    // and with no aria-label — it should ideally be "unknown" (#622).
-    const node = makeNode({ "data-testid": "conversation-turn-1" });
-    const result = roleFromNode(node, 0);
-    expect(result).toBe("user");
-    // TODO(#622): expect(result).toBe("unknown");
-  });
-
-  it("index parity can mislabel roles when turns are missing", () => {
-    // If turn 0 is deleted (user message gone), turn 1 (assistant)
-    // would be labeled "user" by index parity because it's now at index 0.
-    const node = makeNode({ "data-testid": "something-else" });
-    expect(roleFromNode(node, 0)).toBe("user");
-    expect(roleFromNode(node, 1)).toBe("assistant");
-    // Both "something-else" nodes get different roles based solely on index.
-    // #622 should fix this so ambiguous nodes return "unknown".
-  });
-
-  it("documents the exact fallback line for #622 reference", () => {
-    // The fallback is:  return index % 2 === 0 ? "user" : "assistant";
-    // This is the last line of roleFromNode in src/content/chatgpt.js
-    const node = makeNode({});
-    // Even index
-    expect(roleFromNode(node, 100)).toBe("user");
-    // Odd index
-    expect(roleFromNode(node, 101)).toBe("assistant");
-  });
-});
-
 describe("chatgpt conversationIdFromUrl", () => {
   it("reads normal conversation routes", () => {
     expect(conversationIdFromUrl("https://chatgpt.com/c/abc-123")).toBe(
@@ -279,46 +86,14 @@ describe("chatgpt conversationIdFromUrl", () => {
   it("returns null outside conversation routes", () => {
     expect(conversationIdFromUrl("https://chatgpt.com/g/g-p-abc")).toBe(null);
   });
-});
 
-describe("chatgpt collectAttachments", () => {
-  it("captures ChatGPT file tiles by aria-label", () => {
-    const dom = new JSDOM(
-      '<!DOCTYPE html><article><div role="group" aria-label="polylogue-all.tar.gz"><span>polylogue-all.tar.gz</span></div></article>',
-    );
-    const article = dom.window.document.querySelector("article");
-
-    expect(collectAttachments(article, 3)).toEqual([
-      {
-        provider_attachment_id: `dom:${fnv1a("3:polylogue-all.tar.gz\n")}`,
-        name: "polylogue-all.tar.gz",
-        url: null,
-        provider_meta: {
-          dom_selector_index: 3,
-          dom_label: "polylogue-all.tar.gz",
-          dom_text: "polylogue-all.tar.gz",
-          capture_source: "chatgpt_dom_attachment",
-        },
-      },
-    ]);
-  });
-
-  it("deduplicates repeated labels within a turn", () => {
-    const dom = new JSDOM(
-      '<!DOCTYPE html><article><div role="group" aria-label="career.md"></div><div role="group" aria-label="career.md"></div></article>',
-    );
-    const article = dom.window.document.querySelector("article");
-
-    expect(collectAttachments(article, 0)).toHaveLength(1);
-  });
-
-  it("does not treat domains, emails, or version prose as file uploads", () => {
-    const dom = new JSDOM(
-      '<!DOCTYPE html><article><a aria-label="dbreunig.com" href="https://dbreunig.com">dbreunig.com</a><a aria-label="recruiting@nousresearch.com" href="mailto:recruiting@nousresearch.com">recruiting@nousresearch.com</a><div role="group" aria-label="After Opus 4.5">After Opus 4.5</div></article>',
-    );
-    const article = dom.window.document.querySelector("article");
-
-    expect(collectAttachments(article, 0)).toEqual([]);
+  it("returns null for a temporary chat's own route (it never gets /c/<id>)", () => {
+    // src/content/chatgpt.js's isTemporaryChatUrl handles this case
+    // separately (see tests/content/chatgpt_bridge.test.js); this local
+    // conversationIdFromUrl copy stays a plain path parser.
+    expect(
+      conversationIdFromUrl("https://chatgpt.com/?temporary-chat=true"),
+    ).toBe(null);
   });
 });
 

--- a/browser-extension/tests/content/chatgpt.test.js
+++ b/browser-extension/tests/content/chatgpt.test.js
@@ -1,320 +1,254 @@
 /**
- * Tests for chatgpt.js content script id/URL parsing and the on-demand
- * native fetch contract.
+ * Tests for chatgpt.js's URL parsing, on-demand native fetch, and asset
+ * descriptor identification, driven through the REAL source (common.js +
+ * chatgpt_bridge.js + chatgpt.js loaded via vm.Script into a JSDOM window,
+ * the same technique tests/content/chatgpt_bridge.test.js and
+ * tests/content/grok.test.js already use) rather than hand-copied function
+ * bodies.
  *
- * These functions are extracted from src/content/chatgpt.js and must stay
- * in sync with the source. The DOM-scrape fallback (roleFromNode,
- * attachmentNameFromNode, collectAttachments, chatgpt-dom-v1) was removed
- * from the source entirely -- native capture now covers the one case that
- * ever made it fire for real (a brand-new conversation's URL not yet
- * published, see tests/content/chatgpt_bridge.test.js's "waits for a
- * brand-new conversation's URL" and "captures a temporary chat" cases,
- * which exercise the real source through the integration harness) -- so
- * the tests for those functions were deleted here rather than updated.
+ * This file used to keep local copies of conversationIdFromUrl,
+ * fetchNativePayloadOnDemand, collectAssetDescriptors, and
+ * sandboxPathsFromText that had to be manually kept in sync with the
+ * source. That divergence risk is exactly how src/common.js's buildEnvelope
+ * silently dropping every turn's `blocks` field (polylogue-ah21 regressed)
+ * went unnoticed for as long as it did in the sibling content-script test
+ * files -- a copy tests itself, not the production code. All coverage here
+ * now exercises window.polylogueCapture.capturePage (the one function the
+ * content script IIFE actually exposes) against the real IIFE bodies.
  */
 
-import { describe, it, expect } from "vitest";
+import { Buffer } from "node:buffer";
+import { webcrypto } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Script } from "node:vm";
 
-function conversationIdFromUrl(url) {
-  const parsed = new URL(url);
-  const parts = parsed.pathname.split("/").filter(Boolean);
-  const marker = parts.indexOf("c");
-  return marker >= 0 && parts[marker + 1] ? parts[marker + 1] : null;
+import { JSDOM } from "jsdom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const testDirectory = dirname(fileURLToPath(import.meta.url));
+const bridgeSource = readFileSync(resolve(testDirectory, "../../src/content/chatgpt_bridge.js"), "utf8");
+const commonSource = readFileSync(resolve(testDirectory, "../../src/common.js"), "utf8");
+const contentSource = readFileSync(resolve(testDirectory, "../../src/content/chatgpt.js"), "utf8");
+const openDoms = [];
+
+function jsonResponse(body, status = 200) {
+  return new globalThis.Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
 }
 
-async function fetchNativePayloadOnDemand(pageUrl, fetchImpl) {
-  const conversationId = conversationIdFromUrl(pageUrl);
-  if (!conversationId) return null;
-  try {
-    const response = await fetchImpl(
-      `/backend-api/conversation/${encodeURIComponent(conversationId)}`,
-      {
-        credentials: "include",
-        cache: "no-store",
-      },
-    );
-    const contentType = response.headers.get("content-type") || "";
-    if (!response.ok || !contentType.includes("application/json")) return null;
-    const payload = await response.clone().json();
-    if (!payload || typeof payload !== "object" || !payload.mapping) return null;
-    const payloadConversationId = payload.conversation_id || payload.id;
-    if (payloadConversationId && String(payloadConversationId) !== conversationId)
-      return null;
-    return payload;
-  } catch {
-    return null;
-  }
+function notFoundResponse() {
+  return new globalThis.Response(JSON.stringify({ detail: "not_found" }), { status: 404, headers: { "content-type": "application/json" } });
 }
 
-function makeFetchResponse(payload, options = {}) {
-  const {
-    ok = true,
-    contentType = "application/json",
-    throws = false,
-  } = options;
-  return {
-    ok,
-    headers: {
-      get(name) {
-        return name.toLowerCase() === "content-type" ? contentType : null;
+// Every request this fixture doesn't explicitly answer 404s immediately
+// rather than hanging -- asset acquisition then resolves each descriptor as
+// "missing"/"unauthorized" in milliseconds instead of burning its real
+// 9s-per-asset timeout, which is what makes it safe to assert on the exact
+// descriptor identity (kind/fileId/sandboxPath) these tests care about
+// without the suite becoming slow.
+function installChatgpt({ url = "https://chatgpt.com/c/conversation-1", fetch } = {}) {
+  const dom = new JSDOM("<!doctype html><title>ChatGPT fixture</title>", { url, runScripts: "outside-only" });
+  openDoms.push(dom);
+  const cryptoAdapter = {
+    subtle: {
+      digest(algorithm, data) {
+        return webcrypto.subtle.digest(algorithm, Buffer.from(new dom.window.Uint8Array(data)));
       },
-    },
-    clone() {
-      return {
-        async json() {
-          if (throws) throw new Error("bad json");
-          return payload;
-        },
-      };
     },
   };
+  Object.defineProperty(dom.window, "crypto", { configurable: true, value: cryptoAdapter });
+  Object.defineProperty(dom.window, "fetch", { configurable: true, value: fetch || (async () => notFoundResponse()) });
+  const runtimeListeners = [];
+  const chrome = {
+    runtime: {
+      id: "synthetic-extension-id",
+      getManifest: () => ({ version: "0.1.0" }),
+      onMessage: { addListener: (listener) => runtimeListeners.push(listener) },
+      async sendMessage(message) {
+        if (message.type === "polylogue.capture") {
+          return { ok: true, provider: "chatgpt", provider_session_id: "conversation-1", receiver_request_id: "synthetic-request" };
+        }
+        if (message.type === "polylogue.archiveState") return { captured: true, state: "archived" };
+        return { ok: true };
+      },
+    },
+  };
+  Object.defineProperty(dom.window, "chrome", { configurable: true, value: chrome });
+  Object.defineProperty(dom.window, "postMessage", {
+    configurable: true,
+    value(data) {
+      dom.window.queueMicrotask(() => {
+        dom.window.dispatchEvent(new dom.window.MessageEvent("message", { source: dom.window, origin: dom.window.location.origin, data }));
+      });
+    },
+  });
+  const context = dom.getInternalVMContext();
+  new Script(bridgeSource).runInContext(context);
+  new Script(commonSource).runInContext(context);
+  new Script(contentSource).runInContext(context);
+  function sendRuntimeMessage(message) {
+    return new Promise((resolve, reject) => {
+      const listener = runtimeListeners.find((candidate) => candidate(message, {}, resolve) === true);
+      if (!listener) reject(new Error(`no runtime listener accepted ${message.type}`));
+    });
+  }
+  return { dom, sendRuntimeMessage };
 }
 
-describe("chatgpt conversationIdFromUrl", () => {
-  it("reads normal conversation routes", () => {
-    expect(conversationIdFromUrl("https://chatgpt.com/c/abc-123")).toBe(
-      "abc-123",
-    );
-  });
-
-  it("reads custom GPT conversation routes", () => {
-    expect(
-      conversationIdFromUrl("https://chatgpt.com/g/g-p-abc/c/conv-123"),
-    ).toBe("conv-123");
-  });
-
-  it("returns null outside conversation routes", () => {
-    expect(conversationIdFromUrl("https://chatgpt.com/g/g-p-abc")).toBe(null);
-  });
-
-  it("returns null for a temporary chat's own route (it never gets /c/<id>)", () => {
-    // src/content/chatgpt.js's isTemporaryChatUrl handles this case
-    // separately (see tests/content/chatgpt_bridge.test.js); this local
-    // conversationIdFromUrl copy stays a plain path parser.
-    expect(
-      conversationIdFromUrl("https://chatgpt.com/?temporary-chat=true"),
-    ).toBe(null);
-  });
+afterEach(() => {
+  for (const dom of openDoms.splice(0)) dom.window.close();
 });
 
-describe("chatgpt fetchNativePayloadOnDemand", () => {
-  it("fetches the current conversation JSON with credentials", async () => {
-    const payload = {
-      conversation_id: "conv-123",
-      title: "Native ChatGPT title",
-      mapping: { node: { message: { content: { parts: ["hello"] } } } },
-    };
+describe("chatgpt.js on-demand native fetch, exact-provider capture", () => {
+  it("fetches the current conversation JSON with credentials for an exact capture", async () => {
     const calls = [];
-    const fetchImpl = async (...args) => {
-      calls.push(args);
-      return makeFetchResponse(payload);
-    };
+    const fetch = vi.fn(async (input, options = {}) => {
+      const url = new URL(String(input), "https://chatgpt.com");
+      calls.push({ pathname: url.pathname, credentials: options.credentials, cache: options.cache });
+      if (url.pathname === "/backend-api/conversation/conv-123") {
+        return jsonResponse({ conversation_id: "conv-123", title: "Native ChatGPT title", mapping: { node: { id: "node", parent: null, message: { id: "m", author: { role: "user" }, content: { parts: ["hello"] } } } } });
+      }
+      return notFoundResponse();
+    });
+    const { sendRuntimeMessage } = installChatgpt({ url: "https://chatgpt.com/c/conv-123", fetch });
 
-    await expect(
-      fetchNativePayloadOnDemand("https://chatgpt.com/c/conv-123", fetchImpl),
-    ).resolves.toEqual(payload);
-    expect(calls).toEqual([
-      [
-        "/backend-api/conversation/conv-123",
-        { credentials: "include", cache: "no-store" },
-      ],
-    ]);
+    const result = await sendRuntimeMessage({ type: "polylogue.capturePage", reason: "completion_monitor", providerSessionId: "conv-123" });
+
+    expect(result).toMatchObject({ ok: true, envelope: { session: { provider_session_id: "conv-123", turns: [{ text: "hello" }] } } });
+    expect(calls.find((call) => call.pathname === "/backend-api/conversation/conv-123")).toMatchObject({ credentials: "include", cache: "no-store" });
   });
 
   it("supports custom GPT conversation routes", async () => {
-    const payload = { id: "conv-123", mapping: { node: {} } };
-    const calls = [];
-    const fetchImpl = async (...args) => {
-      calls.push(args);
-      return makeFetchResponse(payload);
-    };
+    const fetch = vi.fn(async (input) => {
+      const url = new URL(String(input), "https://chatgpt.com");
+      if (url.pathname === "/backend-api/conversation/conv-123") {
+        return jsonResponse({ id: "conv-123", mapping: { node: { id: "node", parent: null, message: { id: "m", author: { role: "user" }, content: { parts: ["hi"] } } } } });
+      }
+      return notFoundResponse();
+    });
+    const { sendRuntimeMessage } = installChatgpt({ url: "https://chatgpt.com/g/g-p-abc/c/conv-123", fetch });
 
-    await expect(
-      fetchNativePayloadOnDemand(
-        "https://chatgpt.com/g/g-p-abc/c/conv-123",
-        fetchImpl,
-      ),
-    ).resolves.toEqual(payload);
-    expect(calls[0][0]).toBe("/backend-api/conversation/conv-123");
+    const result = await sendRuntimeMessage({ type: "polylogue.capturePage", reason: "completion_monitor", providerSessionId: "conv-123" });
+
+    expect(result.ok).toBe(true);
+    expect(result.envelope.session.provider_session_id).toBe("conv-123");
   });
 
-  it("rejects mismatched, non-json, failed, malformed, and off-route payloads", async () => {
-    await expect(
-      fetchNativePayloadOnDemand("https://chatgpt.com/c/conv-123", async () =>
-        makeFetchResponse({ conversation_id: "other", mapping: {} }),
-      ),
-    ).resolves.toBe(null);
-    await expect(
-      fetchNativePayloadOnDemand("https://chatgpt.com/c/conv-123", async () =>
-        makeFetchResponse({ conversation_id: "conv-123", mapping: {} }, {
-          contentType: "text/html",
-        }),
-      ),
-    ).resolves.toBe(null);
-    await expect(
-      fetchNativePayloadOnDemand("https://chatgpt.com/c/conv-123", async () =>
-        makeFetchResponse({ conversation_id: "conv-123", mapping: {} }, {
-          ok: false,
-        }),
-      ),
-    ).resolves.toBe(null);
-    await expect(
-      fetchNativePayloadOnDemand("https://chatgpt.com/c/conv-123", async () =>
-        makeFetchResponse({ conversation_id: "conv-123" }),
-      ),
-    ).resolves.toBe(null);
-    await expect(
-      fetchNativePayloadOnDemand("https://chatgpt.com/c/conv-123", async () =>
-        makeFetchResponse(null, { throws: true }),
-      ),
-    ).resolves.toBe(null);
-    await expect(
-      fetchNativePayloadOnDemand("https://chatgpt.com/", async () =>
-        makeFetchResponse({ mapping: {} }),
-      ),
-    ).resolves.toBe(null);
+  it("returns native_capture_unavailable for a mismatched/off-route/malformed native payload", async () => {
+    const fetch = vi.fn(async (input) => {
+      const url = new URL(String(input), "https://chatgpt.com");
+      if (url.pathname === "/backend-api/conversation/conv-123") {
+        // Mismatched conversation id in the payload body.
+        return jsonResponse({ conversation_id: "other", mapping: {} });
+      }
+      return notFoundResponse();
+    });
+    const { sendRuntimeMessage } = installChatgpt({ url: "https://chatgpt.com/c/conv-123", fetch });
+
+    const result = await sendRuntimeMessage({ type: "polylogue.capturePage", reason: "message_layer_save" });
+
+    expect(result).toMatchObject({ ok: false, error: "native_capture_unavailable" });
   });
 });
 
-// ---------------------------------------------------------------------------
-// Extracted from src/content/chatgpt.js — keep in sync (asset acquisition)
-// ---------------------------------------------------------------------------
-
-const sandboxLinkPattern = /sandbox:(\/mnt\/data\/[^\s)\]"'>]+)/g;
-
-function sandboxPathsFromText(text) {
-  const paths = [];
-  for (const match of String(text).matchAll(sandboxLinkPattern)) {
-    const path = match[1].replace(/[.,;:!?*`]+$/, "");
-    if (path !== "/mnt/data/" && !paths.includes(path)) paths.push(path);
-  }
-  return paths;
-}
-
-function collectAssetDescriptors(payload) {
-  const mapping = payload && payload.mapping;
-  if (!mapping || typeof mapping !== "object") return [];
-  const descriptors = [];
-  const seen = new Set();
-  const add = (descriptor) => {
-    if (descriptor.provider_attachment_id && !seen.has(descriptor.provider_attachment_id)) {
-      seen.add(descriptor.provider_attachment_id);
-      descriptors.push(descriptor);
-    }
-  };
-  for (const [nodeId, node] of Object.entries(mapping)) {
-    const message = node && node.message;
-    if (!message) continue;
-    const messageId = String(message.id || node.id || nodeId);
-    const metadata = message.metadata && typeof message.metadata === "object" ? message.metadata : {};
-    for (const attachment of Array.isArray(metadata.attachments) ? metadata.attachments : []) {
-      if (attachment && attachment.id) {
-        add({
-          kind: "file",
-          fileId: String(attachment.id),
-          provider_attachment_id: String(attachment.id),
-          message_provider_id: messageId,
-          name: attachment.name ? String(attachment.name) : null,
-          mime_type: attachment.mime_type ? String(attachment.mime_type) : null
+describe("chatgpt.js asset descriptor identification (through a real capture)", () => {
+  it("collects sandbox links, upload ids, and asset pointers with parser-matching ids", async () => {
+    const fetch = vi.fn(async (input) => {
+      const url = new URL(String(input), "https://chatgpt.com");
+      if (url.pathname === "/backend-api/conversation/conversation-1") {
+        return jsonResponse({
+          id: "conversation-1",
+          conversation_id: "conversation-1",
+          mapping: {
+            n1: {
+              id: "n1",
+              parent: null,
+              message: {
+                id: "msg-a",
+                author: { role: "assistant" },
+                content: {
+                  content_type: "text",
+                  parts: ["Kit ready: [zip](sandbox:/mnt/data/kit.zip) and [sum](sandbox:/mnt/data/kit.zip.sha256). Again sandbox:/mnt/data/kit.zip."],
+                },
+                metadata: {},
+              },
+            },
+            n2: {
+              id: "n2",
+              parent: "n1",
+              message: {
+                id: "msg-b",
+                author: { role: "user" },
+                content: { content_type: "text", parts: ["please use sandbox:/mnt/data/ignored.zip"] },
+                metadata: { attachments: [{ id: "file-UP1", name: "input.csv", mime_type: "text/csv" }] },
+              },
+            },
+            n3: {
+              id: "n3",
+              parent: "n2",
+              message: {
+                id: "msg-c",
+                author: { role: "assistant" },
+                content: { content_type: "multimodal_text", parts: [{ content_type: "image_asset_pointer", asset_pointer: "file-service://file-IMG9" }] },
+                metadata: {},
+              },
+            },
+          },
         });
       }
-    }
-    const content = message.content;
-    const parts = content && Array.isArray(content.parts) ? content.parts : [];
-    const role = message.author && message.author.role;
-    for (const part of parts) {
-      if (part && typeof part === "object" && typeof part.asset_pointer === "string" && part.asset_pointer) {
-        const pointer = part.asset_pointer;
-        const pointerPath = pointer.includes("://") ? pointer.split("://").at(-1) : pointer;
-        const fileIdMatch = pointerPath.match(/file[-_][A-Za-z0-9]+/);
-        if (fileIdMatch) {
-          add({
-            kind: "file",
-            fileId: fileIdMatch[0],
-            provider_attachment_id: pointer,
-            message_provider_id: messageId,
-            name: null,
-            mime_type: null
-          });
-        }
-      }
-      if (typeof part === "string" && role === "assistant") {
-        for (const path of sandboxPathsFromText(part)) {
-          add({
-            kind: "sandbox",
-            sandboxPath: path,
-            provider_attachment_id: `sandbox:${messageId}:${path}`,
-            message_provider_id: messageId,
-            name: path.replace(/\/+$/, "").split("/").at(-1) || null,
-            mime_type: null
-          });
-        }
-      }
-    }
-  }
-  return descriptors;
-}
+      // Every asset metadata/download round trip 404s -- this test cares
+      // about which descriptors were IDENTIFIED, not byte acquisition.
+      return notFoundResponse();
+    });
+    const { sendRuntimeMessage } = installChatgpt({ url: "https://chatgpt.com/c/conversation-1", fetch });
 
-describe("asset descriptor collection", () => {
-  it("collects sandbox links, upload ids, and asset pointers with parser-matching ids", () => {
-    const payload = {
-      mapping: {
-        n1: {
-          id: "n1",
-          message: {
-            id: "msg-a",
-            author: { role: "assistant" },
-            content: {
-              parts: [
-                "Kit ready: [zip](sandbox:/mnt/data/kit.zip) and [sum](sandbox:/mnt/data/kit.zip.sha256). Again sandbox:/mnt/data/kit.zip."
-              ]
-            },
-            metadata: {}
-          }
-        },
-        n2: {
-          id: "n2",
-          message: {
-            id: "msg-b",
-            author: { role: "user" },
-            content: { parts: ["please use sandbox:/mnt/data/ignored.zip"] },
-            metadata: { attachments: [{ id: "file-UP1", name: "input.csv", mime_type: "text/csv" }] }
-          }
-        },
-        n3: {
-          id: "n3",
-          message: {
-            id: "msg-c",
-            author: { role: "assistant" },
-            content: {
-              parts: [{ content_type: "image_asset_pointer", asset_pointer: "file-service://file-IMG9" }]
-            },
-            metadata: {}
-          }
-        }
-      }
-    };
+    const result = await sendRuntimeMessage({ type: "polylogue.capturePage", reason: "message_layer_save" });
 
-    const descriptors = collectAssetDescriptors(payload);
-    const ids = descriptors.map((d) => d.provider_attachment_id);
-    expect(ids).toEqual([
+    expect(result.ok).toBe(true);
+    const acquisition = result.envelope.session.provider_meta.asset_acquisition;
+    const attemptedIds = [...acquisition.failed, ...acquisition.acquired_assets].map((entry) => entry.provider_attachment_id);
+    expect(attemptedIds).toEqual([
       "sandbox:msg-a:/mnt/data/kit.zip",
       "sandbox:msg-a:/mnt/data/kit.zip.sha256",
       "file-UP1",
-      "file-service://file-IMG9"
+      "file-service://file-IMG9",
     ]);
-    const sandbox = descriptors[0];
-    expect(sandbox.kind).toBe("sandbox");
-    expect(sandbox.sandboxPath).toBe("/mnt/data/kit.zip");
-    expect(sandbox.name).toBe("kit.zip");
-    const pointer = descriptors[3];
-    expect(pointer.kind).toBe("file");
-    expect(pointer.fileId).toBe("file-IMG9");
+    expect(acquisition.attempted).toBe(4);
+    // n2's sandbox link is on a user-authored turn, not assistant -- assets
+    // never manifest as user prose, so it must not be identified at all.
+    expect(attemptedIds).not.toContain("sandbox:msg-b:/mnt/data/ignored.zip");
   });
 
-  it("strips trailing punctuation and dedupes sandbox paths", () => {
-    expect(sandboxPathsFromText("see sandbox:/mnt/data/a.md. and sandbox:/mnt/data/a.md,")).toEqual([
-      "/mnt/data/a.md"
-    ]);
+  it("strips trailing punctuation and dedupes sandbox paths within one turn", async () => {
+    const fetch = vi.fn(async (input) => {
+      const url = new URL(String(input), "https://chatgpt.com");
+      if (url.pathname === "/backend-api/conversation/conversation-1") {
+        return jsonResponse({
+          id: "conversation-1",
+          conversation_id: "conversation-1",
+          mapping: {
+            n1: {
+              id: "n1",
+              parent: null,
+              message: {
+                id: "msg-a",
+                author: { role: "assistant" },
+                content: { content_type: "text", parts: ["see sandbox:/mnt/data/a.md. and sandbox:/mnt/data/a.md,"] },
+                metadata: {},
+              },
+            },
+          },
+        });
+      }
+      return notFoundResponse();
+    });
+    const { sendRuntimeMessage } = installChatgpt({ url: "https://chatgpt.com/c/conversation-1", fetch });
+
+    const result = await sendRuntimeMessage({ type: "polylogue.capturePage", reason: "message_layer_save" });
+
+    const acquisition = result.envelope.session.provider_meta.asset_acquisition;
+    const attemptedIds = [...acquisition.failed, ...acquisition.acquired_assets].map((entry) => entry.provider_attachment_id);
+    expect(attemptedIds).toEqual(["sandbox:msg-a:/mnt/data/a.md"]);
   });
 });

--- a/browser-extension/tests/content/chatgpt_bridge.test.js
+++ b/browser-extension/tests/content/chatgpt_bridge.test.js
@@ -507,103 +507,105 @@ describe("ChatGPT bridge direct-URL asset kind (polylogue-83u.3, chatgpt-dom-v1 
   });
 });
 
-describe("chatgpt-dom-v1 fallback capture attachment byte acquisition (polylogue-83u.3)", () => {
-  // Deterministic capture smoke: forces the native backend-api read to fail
-  // (both the page-bridge attempt and chatgpt.js's own content-script fetch
-  // hit the same failing endpoint), so `capture()` falls through to the
-  // chatgpt-dom-v1 DOM adapter. Before this change, a DOM-scraped attachment
-  // only ever recorded its chip name with byte_count=0 -- there was no fetch
-  // attempt at all. Proves a captured attachment now carries real bytes.
-  function domFallbackAdapter({ domUrl, domBytes }) {
-    const calls = [];
-    const fetch = vi.fn(async (input) => {
-      const url = new URL(String(input), "https://chatgpt.com");
-      calls.push(url.href);
-      if (url.pathname === "/api/auth/session") return jsonResponse({});
-      if (url.pathname === "/backend-api/conversation/conversation-1") {
-        return jsonResponse({ detail: "not_found" }, 404);
-      }
-      if (url.href === domUrl) return byteResponse(domBytes);
-      throw new Error(`unexpected synthetic request in DOM-fallback fixture: ${url.href}`);
-    });
-    return { calls, fetch };
-  }
+describe("ChatGPT native coverage that replaced chatgpt-dom-v1", () => {
+  it("captures a temporary chat from its intercepted native fetch despite no /c/<id> URL", async () => {
+    // A temporary chat never navigates to /c/<id> -- the visible URL stays
+    // at /?temporary-chat=true for the whole session -- but the page still
+    // fetches /backend-api/conversation/<ephemeral-id> to render it, and
+    // window.fetch is intercepted the same way for any conversation path.
+    // Before this fix every id-matching step (parseNativeCapture,
+    // fetchNativePayloadOnDemand, and background.js's own
+    // conversationIdForUrl gate) treated "no id in the URL" as "no
+    // conversation on this page", so zero temporary chats ever landed.
+    const ephemeralId = "temp-conv-ephemeral-1";
+    const harness = installFullCapture(syntheticEndpointAdapter(), { url: "https://chatgpt.com/?temporary-chat=true" });
 
-  it("acquires a DOM-scraped attachment's bytes with a real blob-addressable SHA-256", async () => {
-    const domUrl = "https://files.example.test/dom/deliverable.png";
-    const domBytes = new TextEncoder().encode("chatgpt-dom-v1 fallback attachment bytes\n");
-    const expectedDomSha256 = createHash("sha256").update(domBytes).digest("hex");
-    const adapter = domFallbackAdapter({ domUrl, domBytes });
-    const harness = installFullCapture(adapter, {
-      beforeInstall(document) {
-        const turn = document.createElement("article");
-        turn.setAttribute("data-message-author-role", "assistant");
-        turn.textContent = "Here is the file you asked for.";
-        const image = document.createElement("img");
-        image.setAttribute("src", domUrl);
-        image.setAttribute("alt", "deliverable.png");
-        turn.appendChild(image);
-        document.body.appendChild(turn);
+    // Simulate what chatgpt_bridge.js's window.fetch override posts when it
+    // intercepts the page's own render fetch -- that interception matches
+    // on path shape alone and does not care what the visible URL is.
+    harness.dom.window.dispatchEvent(
+      new harness.dom.window.MessageEvent("message", {
+        source: harness.dom.window,
+        origin: harness.dom.window.location.origin,
+        data: {
+          type: "polylogue.chatgpt.nativeCapture",
+          capture: {
+            ok: true,
+            status: 200,
+            contentType: "application/json",
+            url: `https://chatgpt.com/backend-api/conversation/${ephemeralId}`,
+            body: JSON.stringify({
+              id: ephemeralId,
+              conversation_id: ephemeralId,
+              is_temporary: true,
+              title: "Temporary chat",
+              mapping: {
+                node: {
+                  id: "node",
+                  parent: null,
+                  message: { id: "message", author: { role: "assistant" }, content: { content_type: "text", parts: ["hello"] } },
+                },
+              },
+            }),
+          },
+        },
+      }),
+    );
+
+    const result = await harness.sendRuntimeMessage({ type: "polylogue.capturePage", reason: "message_layer_save" });
+
+    expect(result).toMatchObject({
+      ok: true,
+      envelope: {
+        session: {
+          provider_session_id: ephemeralId,
+          session_kind: "temporary",
+          turns: [{ text: "hello" }],
+        },
       },
     });
-
-    const result = await harness.sendRuntimeMessage({
-      type: "polylogue.capturePage",
-      reason: "message_layer_save",
-    });
-
-    expect(result.ok).toBe(true);
-    expect(result.envelope.provenance.adapter_name).toBe("chatgpt-dom-v1");
-    expect(result.envelope.provenance.capture_mode).toBe("snapshot");
-    const [turn] = result.envelope.session.turns;
-    const [attachment] = turn.attachments;
-    expect(attachment).toMatchObject({
-      name: "deliverable.png",
-      size_bytes: domBytes.byteLength,
-      inline_base64: Buffer.from(domBytes).toString("base64"),
-      provider_meta: { content_sha256: expectedDomSha256, asset_kind: "url" },
-    });
-    // The declared SHA-256 is the true hash of the delivered bytes -- the
-    // exact invariant the archive-side blob store re-derives and persists as
-    // acquisition_status='acquired' (polylogue/storage/sqlite/archive_tiers/write.py).
-    expect(createHash("sha256").update(Buffer.from(attachment.inline_base64, "base64")).digest("hex")).toBe(
-      expectedDomSha256,
-    );
-    expect(adapter.calls).toContain(domUrl);
   });
 
-  it("leaves a DOM-scraped attachment honestly byte_count=0 when its chip has no fetchable URL", async () => {
-    // A sandbox-output chip: the DOM only ever exposes the file name (via
-    // aria-label), never a real href/src -- this is the genuinely-unfetchable
-    // shape (byte_count=0 stays honest) distinct from the DOM-rendered <img>
-    // case above, which the fetch above proves is now reachable.
-    const adapter = domFallbackAdapter({ domUrl: "https://unused.example.test/none.png", domBytes: new Uint8Array() });
-    const harness = installFullCapture(adapter, {
-      beforeInstall(document) {
-        const turn = document.createElement("article");
-        turn.setAttribute("data-message-author-role", "assistant");
-        turn.textContent = "Here is the file you asked for.";
-        const chip = document.createElement("div");
-        chip.setAttribute("role", "group");
-        chip.setAttribute("aria-label", "report.pdf");
-        turn.appendChild(chip);
-        document.body.appendChild(turn);
-      },
+  it("waits for a brand-new conversation's URL instead of giving up immediately", async () => {
+    // 2026-07-17: every chatgpt-dom-v1 capture that ever fired for real
+    // landed inside one narrow window where a capture was triggered before
+    // ChatGPT's SPA router had published /c/<id> for a just-created
+    // conversation -- there was no id to fetch by yet. Native must now wait
+    // for the id instead of falling back to a DOM scrape (removed).
+    const freshId = "fresh-conversation-1";
+    const fetch = vi.fn(async (input, options = {}) => {
+      const url = new URL(String(input), "https://chatgpt.com");
+      if (url.pathname === "/api/auth/session") return jsonResponse({ accessToken: bearerToken, account: { id: chatGptAccountId } });
+      if (url.pathname === `/backend-api/conversation/${freshId}`) {
+        if (authorizationHeader(options) !== `Bearer ${bearerToken}`) return jsonResponse({ detail: "Unauthorized" }, 401);
+        return jsonResponse({
+          id: freshId,
+          conversation_id: freshId,
+          mapping: {
+            node: {
+              id: "node",
+              parent: null,
+              message: { id: "message", author: { role: "user" }, content: { content_type: "text", parts: ["first turn"] } },
+            },
+          },
+        });
+      }
+      throw new Error(`unexpected synthetic request: ${url.pathname}`);
     });
+    const harness = installFullCapture({ fetch }, { url: "https://chatgpt.com/" });
 
-    const result = await harness.sendRuntimeMessage({
-      type: "polylogue.capturePage",
-      reason: "message_layer_save",
+    const resultPromise = harness.sendRuntimeMessage({ type: "polylogue.capturePage", reason: "message_layer_save" });
+    // The SPA router publishes the id a little after the first turn is
+    // sent -- well inside the wait budget, but after at least one poll tick.
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 400));
+    harness.dom.reconfigure({ url: `https://chatgpt.com/c/${freshId}` });
+
+    const result = await resultPromise;
+
+    expect(result).toMatchObject({
+      ok: true,
+      envelope: { session: { provider_session_id: freshId, turns: [{ text: "first turn" }] } },
     });
-
-    expect(result.ok).toBe(true);
-    const [turn] = result.envelope.session.turns;
-    const [attachment] = turn.attachments;
-    expect(attachment.name).toBe("report.pdf");
-    expect(attachment.url).toBeNull();
-    expect(attachment.inline_base64).toBeUndefined();
-    expect(attachment.size_bytes).toBeUndefined();
-    expect(adapter.calls).not.toContain("https://unused.example.test/none.png");
   });
 });
 

--- a/browser-extension/tests/content/claude.test.js
+++ b/browser-extension/tests/content/claude.test.js
@@ -1,432 +1,222 @@
 /**
- * Tests for claude.js content script role detection.
+ * Tests for claude.js's native-capture contract (URL/role/turn extraction)
+ * and claude_bridge.js's conversation-API URL resolution, driven through
+ * the REAL source (common.js + claude_bridge.js + claude.js loaded via
+ * vm.Script into a JSDOM window, the same technique
+ * tests/content/chatgpt_bridge.test.js and tests/content/grok.test.js
+ * already use) rather than hand-copied function bodies.
  *
- * The roleFromNode function is extracted from src/content/claude.js.
- * It must stay in sync with the source.
- *
- * Known gap (#622): the index-parity fallback at the end of roleFromNode
- * assigns "user"/"assistant" based on even/odd index when no DOM attribute
- * matches.  It should return "unknown" for ambiguous nodes per #622.
+ * This file used to keep local copies of roleFromNode (a DOM-scrape
+ * function deleted from src/content/claude.js entirely -- native capture
+ * now covers everything the DOM fallback used to), conversationIdFromUrl,
+ * textFromMessage, roleFromNativeMessage, collectNativeTurns,
+ * parseNativeCapture, and a `conversationApiUrlFromResources` +
+ * `organizationIdFromStorageKeys` pair that had ALREADY silently drifted
+ * from the real functions (which live in claude_bridge.js, are named
+ * `conversationApiUrlFromResources`/`organizationIdFromLocalStorage`, and
+ * take different parameters) with zero test failures, because the copies
+ * only ever tested themselves. That is precisely the failure mode that let
+ * src/common.js's buildEnvelope silently drop every turn's `blocks` field
+ * (polylogue-ah21 regressed) go unnoticed. All coverage here now exercises
+ * window.polylogueCapture.capturePage and the real message-bridge protocol
+ * against the real IIFE bodies.
  */
 
-import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Script } from "node:vm";
+
 import { JSDOM } from "jsdom";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-// ---------------------------------------------------------------------------
-// Extracted from src/content/claude.js — keep in sync
-// ---------------------------------------------------------------------------
+const testDirectory = dirname(fileURLToPath(import.meta.url));
+const bridgeSource = readFileSync(resolve(testDirectory, "../../src/content/claude_bridge.js"), "utf8");
+const commonSource = readFileSync(resolve(testDirectory, "../../src/common.js"), "utf8");
+const contentSource = readFileSync(resolve(testDirectory, "../../src/content/claude.js"), "utf8");
+const openDoms = [];
 
-function roleFromNode(node, index) {
-  const role =
-    node.getAttribute("data-message-author-role") ||
-    node.getAttribute("data-testid") ||
-    "";
-  if (/human|user/i.test(role)) return "user";
-  if (/assistant|claude/i.test(role)) return "assistant";
-  return index % 2 === 0 ? "user" : "assistant";
+function jsonResponse(body, status = 200) {
+  return new globalThis.Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
 }
 
-function conversationIdFromUrl(url) {
-  const parsed = new URL(url);
-  const parts = parsed.pathname.split("/").filter(Boolean);
-  return parts[0] === "chat" && parts[1] ? parts[1] : null;
-}
-
-function organizationIdFromStorageKeys(keys) {
-  const uuidPattern =
-    "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
-  const patterns = [
-    new RegExp(`^claude-mcp-has-connectors:(${uuidPattern})$`, "i"),
-    new RegExp(`^LSS-model-selector-thinking:(${uuidPattern}):`, "i"),
-  ];
-  for (const key of keys) {
-    for (const pattern of patterns) {
-      const match = key.match(pattern);
-      if (match) return match[1];
-    }
-  }
-  return null;
-}
-
-function conversationApiUrlFromResources(
-  conversationId,
-  urls,
-  origin = "https://claude.ai",
-  storageKeys = [],
-) {
-  const escapedId = String(conversationId);
-  const observed = urls.find((url) => {
-    try {
-      const parsed = new URL(url, origin);
-      return (
-        parsed.origin === origin &&
-        parsed.pathname.includes(`/chat_conversations/${escapedId}`) &&
-        /\/api\/organizations\/[^/]+\/chat_conversations\/[^/]+/.test(
-          parsed.pathname,
-        )
-      );
-    } catch {
-      return false;
-    }
+// claude_bridge.js resolves the chat_conversations API URL from either
+// window.performance resource-timing entries (page-observed requests) or a
+// localStorage key carrying the organization id -- JSDOM has no real
+// resource-timing buffer, so this fixture stubs both inputs directly rather
+// than faking network-level resource entries.
+function installClaude({ url = "https://claude.ai/chat/conversation-1", resourceUrls = [], localStorageEntries = {}, fetch } = {}) {
+  const dom = new JSDOM("<!doctype html><title>Claude fixture</title>", { url, runScripts: "outside-only" });
+  openDoms.push(dom);
+  Object.defineProperty(dom.window, "fetch", { configurable: true, value: fetch || (async () => jsonResponse({ detail: "not_found" }, 404)) });
+  Object.defineProperty(dom.window.performance, "getEntriesByType", {
+    configurable: true,
+    value: (type) => (type === "resource" ? resourceUrls.map((name) => ({ name })) : []),
   });
-  if (observed) return observed;
+  for (const [key, value] of Object.entries(localStorageEntries)) dom.window.localStorage.setItem(key, value);
+  const runtimeListeners = [];
+  const chrome = {
+    runtime: {
+      id: "synthetic-extension-id",
+      getManifest: () => ({ version: "0.1.0" }),
+      onMessage: { addListener: (listener) => runtimeListeners.push(listener) },
+      async sendMessage(message) {
+        if (message.type === "polylogue.capture") {
+          return { ok: true, provider: "claude-ai", provider_session_id: "conversation-1", receiver_request_id: "synthetic-request" };
+        }
+        if (message.type === "polylogue.archiveState") return { captured: true, state: "archived" };
+        return { ok: true };
+      },
+    },
+  };
+  Object.defineProperty(dom.window, "chrome", { configurable: true, value: chrome });
+  Object.defineProperty(dom.window, "postMessage", {
+    configurable: true,
+    value(data) {
+      dom.window.queueMicrotask(() => {
+        dom.window.dispatchEvent(new dom.window.MessageEvent("message", { source: dom.window, origin: dom.window.location.origin, data }));
+      });
+    },
+  });
+  const context = dom.getInternalVMContext();
+  new Script(bridgeSource).runInContext(context);
+  new Script(commonSource).runInContext(context);
+  new Script(contentSource).runInContext(context);
+  function sendRuntimeMessage(message) {
+    return new Promise((resolvePromise, reject) => {
+      const listener = runtimeListeners.find((candidate) => candidate(message, {}, resolvePromise) === true);
+      if (!listener) reject(new Error(`no runtime listener accepted ${message.type}`));
+    });
+  }
+  return { dom, sendRuntimeMessage };
+}
 
-  for (const url of urls) {
-    try {
-      const parsed = new URL(url, origin);
-      const match = parsed.pathname.match(
-        /\/api\/bootstrap\/([^/]+)\/current_user_access/,
-      );
-      if (parsed.origin === origin && match) {
-        return new URL(
-          `/api/organizations/${encodeURIComponent(match[1])}/chat_conversations/${encodeURIComponent(escapedId)}?tree=True&rendering_mode=messages&render_all_tools=true&consistency=strong`,
-          origin,
-        ).href;
+afterEach(() => {
+  for (const dom of openDoms.splice(0)) dom.window.close();
+});
+
+describe("claude.js native capture (real source)", () => {
+  it("extracts native Claude turns, normalizes roles, and skips empty messages", async () => {
+    const orgId = "11111111-1111-4111-8111-111111111111";
+    const fetch = vi.fn(async (input) => {
+      const url = new URL(String(input));
+      if (url.pathname === `/api/organizations/${orgId}/chat_conversations/conversation-1`) {
+        return jsonResponse({
+          uuid: "conversation-1",
+          name: "Native Claude title",
+          chat_messages: [
+            { uuid: "u1", sender: "human", text: "Native user", created_at: "2026-06-24T00:00:00Z" },
+            { uuid: "a1", sender: "assistant", content: [{ text: "Native answer" }], model: "claude-native", parent_message_uuid: "u1" },
+            { uuid: "empty", sender: "assistant", text: "" },
+            { uuid: "s1", sender: "system", text: "unrecognized-shaped system note" },
+          ],
+        });
       }
-    } catch {
-      // Ignore malformed resource entries.
-    }
-  }
-  const localStorageOrgId = organizationIdFromStorageKeys(storageKeys);
-  if (localStorageOrgId) {
-    return new URL(
-      `/api/organizations/${encodeURIComponent(localStorageOrgId)}/chat_conversations/${encodeURIComponent(escapedId)}?tree=True&rendering_mode=messages&render_all_tools=true&consistency=strong`,
-      origin,
-    ).href;
-  }
-  return null;
-}
-
-function textFromMessage(message) {
-  if (!message || typeof message !== "object") return "";
-  if (typeof message.text === "string" && message.text) return message.text;
-  if (typeof message.content === "string" && message.content) return message.content;
-  if (Array.isArray(message.content)) {
-    return message.content
-      .map((part) => {
-        if (typeof part === "string") return part;
-        if (part && typeof part === "object" && typeof part.text === "string")
-          return part.text;
-        return "";
-      })
-      .filter(Boolean)
-      .join("\n");
-  }
-  return "";
-}
-
-function roleFromNativeMessage(message) {
-  const raw = message && (message.sender || message.role || message.author);
-  if (raw === "human" || raw === "user") return "user";
-  if (raw === "assistant" || raw === "claude") return "assistant";
-  if (raw === "system" || raw === "tool") return raw;
-  return "unknown";
-}
-
-function collectNativeTurns(payload) {
-  const messages = payload && payload.chat_messages;
-  if (!Array.isArray(messages)) return [];
-  return messages
-    .map((message, index) => {
-      const text = textFromMessage(message);
-      if (!text) return null;
-      return {
-        provider_turn_id: String(
-          message.uuid || message.id || `claude-message-${index}`,
-        ),
-        role: roleFromNativeMessage(message),
-        text,
-        timestamp: message.created_at || message.updated_at || null,
-        parent_turn_id: message.parent_message_uuid || message.parent_uuid || null,
-        provider_meta: {
-          model: message.model || null,
-          sender: message.sender || message.role || null,
-          capture_source: "claude_chat_conversations_api",
-        },
-      };
-    })
-    .filter(Boolean);
-}
-
-function parseNativeCapture(capture, pageUrl) {
-  if (!capture || !capture.ok || typeof capture.body !== "string") return null;
-  const currentConversationId = conversationIdFromUrl(pageUrl);
-  if (
-    !currentConversationId ||
-    !String(capture.url || "").includes(
-      `/chat_conversations/${currentConversationId}`,
-    )
-  ) {
-    return null;
-  }
-  try {
-    const payload = JSON.parse(capture.body);
-    if (
-      !payload ||
-      typeof payload !== "object" ||
-      !Array.isArray(payload.chat_messages)
-    )
-      return null;
-    if (payload.uuid && String(payload.uuid) !== currentConversationId)
-      return null;
-    return payload;
-  } catch {
-    return null;
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function makeNode(attrs = {}) {
-  const dom = new JSDOM("<!DOCTYPE html><html><body></body></html>");
-  const div = dom.window.document.createElement("div");
-  for (const [key, value] of Object.entries(attrs)) {
-    div.setAttribute(key, value);
-  }
-  return div;
-}
-
-function makeNodes(attrLists) {
-  return attrLists.map((attrs) => makeNode(attrs));
-}
-
-// ---------------------------------------------------------------------------
-// Tests: known cases
-// ---------------------------------------------------------------------------
-
-describe("claude roleFromNode — known cases", () => {
-  it("detects user from data-message-author-role='human'", () => {
-    const node = makeNode({ "data-message-author-role": "human" });
-    expect(roleFromNode(node, 0)).toBe("user");
-  });
-
-  it("detects user from data-message-author-role='user'", () => {
-    const node = makeNode({ "data-message-author-role": "user" });
-    expect(roleFromNode(node, 0)).toBe("user");
-  });
-
-  it("detects assistant from data-message-author-role='assistant'", () => {
-    const node = makeNode({ "data-message-author-role": "assistant" });
-    expect(roleFromNode(node, 1)).toBe("assistant");
-  });
-
-  it("detects assistant from data-message-author-role='claude'", () => {
-    const node = makeNode({ "data-message-author-role": "claude" });
-    expect(roleFromNode(node, 1)).toBe("assistant");
-  });
-
-  it("detects user from data-testid containing 'user' (fallback attr)", () => {
-    // data-message-author-role is checked first; if absent, data-testid is used
-    const node = makeNode({ "data-testid": "user-message-1" });
-    expect(roleFromNode(node, 0)).toBe("user");
-  });
-
-  it("detects assistant from data-testid containing 'assistant' (fallback attr)", () => {
-    const node = makeNode({ "data-testid": "assistant-message-1" });
-    expect(roleFromNode(node, 1)).toBe("assistant");
-  });
-
-  it("prefers data-message-author-role over data-testid", () => {
-    const node = makeNode({
-      "data-message-author-role": "human",
-      "data-testid": "assistant-message-1",
+      return jsonResponse({ detail: "not_found" }, 404);
     });
-    expect(roleFromNode(node, 0)).toBe("user");
-  });
-
-  it("handles nodes with neither attribute", () => {
-    const node = makeNode({});
-    expect(roleFromNode(node, 0)).toBe("user");
-    expect(roleFromNode(node, 1)).toBe("assistant");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Tests: interleaved turns
-// ---------------------------------------------------------------------------
-
-describe("claude roleFromNode — interleaved turns", () => {
-  it("assigns alternating roles for bare nodes via index parity", () => {
-    const nodes = makeNodes([{}, {}, {}, {}]);
-    const roles = nodes.map((n, i) => roleFromNode(n, i));
-    expect(roles).toEqual(["user", "assistant", "user", "assistant"]);
-  });
-
-  it("interleaves explicit and bare nodes correctly", () => {
-    const nodes = [
-      makeNode({ "data-message-author-role": "human" }), // user
-      makeNode({}), // bare, odd -> assistant
-      makeNode({ "data-message-author-role": "assistant" }), // assistant
-      makeNode({}), // bare, odd -> assistant
-    ];
-    const roles = nodes.map((n, i) => roleFromNode(n, i));
-    expect(roles).toEqual(["user", "assistant", "assistant", "assistant"]);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Tests: #622 gap — index-parity fallback
-// ---------------------------------------------------------------------------
-
-describe("claude roleFromNode — #622 gap (index-parity fallback)", () => {
-  it("returns user/assistant for ambiguous nodes instead of unknown", () => {
-    // A node with data-message-author-role set to something unrecognized
-    const node = makeNode({ "data-message-author-role": "system" });
-    const result = roleFromNode(node, 0);
-    expect(result).toBe("user");
-    // "system" is not "human"/"user"/"assistant"/"claude" — should be
-    // "unknown" per #622.
-    // TODO(#622): expect(result).toBe("unknown");
-  });
-
-  it("index parity can mislabel roles when turns are missing", () => {
-    // If turn 0 is deleted, turn 1 (assistant) would be labeled "user"
-    // by index parity because it's now at index 0.
-    const node = makeNode({ "data-testid": "message-1" });
-    expect(roleFromNode(node, 0)).toBe("user");
-    expect(roleFromNode(node, 1)).toBe("assistant");
-    // Both "message-1" nodes get different roles based solely on index.
-    // #622 should fix this so ambiguous nodes return "unknown".
-  });
-
-  it("documents the exact fallback line for #622 reference", () => {
-    // The fallback is:  return index % 2 === 0 ? "user" : "assistant";
-    // This is the last line of roleFromNode in src/content/claude.js
-    const node = makeNode({});
-    expect(roleFromNode(node, 100)).toBe("user");
-    expect(roleFromNode(node, 101)).toBe("assistant");
-  });
-});
-
-describe("claude native capture helpers", () => {
-  const pageUrl = "https://claude.ai/chat/conv-123";
-  const apiUrl =
-    "https://claude.ai/api/organizations/org-1/chat_conversations/conv-123?tree=True";
-
-  it("reads Claude conversation routes", () => {
-    expect(conversationIdFromUrl(pageUrl)).toBe("conv-123");
-    expect(conversationIdFromUrl("https://claude.ai/new")).toBe(null);
-  });
-
-  it("accepts only current chat_conversations payloads with messages", () => {
-    const payload = {
-      uuid: "conv-123",
-      name: "Native Claude title",
-      chat_messages: [{ uuid: "m1", sender: "human", text: "hello" }],
-    };
-    expect(
-      parseNativeCapture(
-        { ok: true, url: apiUrl, body: JSON.stringify(payload) },
-        pageUrl,
-      ),
-    ).toEqual(payload);
-    expect(
-      parseNativeCapture(
-        {
-          ok: true,
-          url: "https://claude.ai/api/organizations/org-1/chat_conversations/other",
-          body: JSON.stringify(payload),
-        },
-        pageUrl,
-      ),
-    ).toBe(null);
-    expect(
-      parseNativeCapture(
-        {
-          ok: true,
-          url: apiUrl,
-          body: JSON.stringify({ uuid: "other", chat_messages: [] }),
-        },
-        pageUrl,
-      ),
-    ).toBe(null);
-  });
-
-  it("extracts native Claude turns without DOM role parity fallback", () => {
-    const turns = collectNativeTurns({
-      chat_messages: [
-        {
-          uuid: "u1",
-          sender: "human",
-          text: "Native user",
-          created_at: "2026-06-24T00:00:00Z",
-        },
-        {
-          uuid: "a1",
-          sender: "assistant",
-          content: [{ text: "Native answer" }],
-          model: "claude-native",
-          parent_message_uuid: "u1",
-        },
-        { uuid: "empty", sender: "assistant", text: "" },
-      ],
+    const { sendRuntimeMessage } = installClaude({
+      url: "https://claude.ai/chat/conversation-1",
+      localStorageEntries: { [`claude-mcp-has-connectors:${orgId}`]: "true" },
+      fetch,
     });
 
-    expect(turns).toHaveLength(2);
-    expect(turns.map((turn) => turn.role)).toEqual(["user", "assistant"]);
-    expect(turns.map((turn) => turn.text)).toEqual([
-      "Native user",
-      "Native answer",
-    ]);
+    const result = await sendRuntimeMessage({ type: "polylogue.capturePage", reason: "message_layer_save" });
+
+    expect(result.ok).toBe(true);
+    const turns = result.envelope.session.turns;
+    expect(turns).toHaveLength(3);
+    expect(turns.map((turn) => turn.role)).toEqual(["user", "assistant", "system"]);
+    expect(turns.map((turn) => turn.text)).toEqual(["Native user", "Native answer", "unrecognized-shaped system note"]);
     expect(turns[1].parent_turn_id).toBe("u1");
-    expect(turns[1].provider_meta.capture_source).toBe(
-      "claude_chat_conversations_api",
-    );
+    expect(turns[1].provider_meta.capture_source).toBe("claude_chat_conversations_api");
+    expect(result.envelope.session.provider_session_id).toBe("conversation-1");
+    expect(result.envelope.session.title).toBe("Native Claude title");
   });
 
-  it("keeps unknown native roles explicit", () => {
-    expect(roleFromNativeMessage({ sender: "system" })).toBe("system");
-    expect(roleFromNativeMessage({ sender: "unexpected" })).toBe("unknown");
-  });
-});
-
-describe("claude conversationApiUrlFromResources", () => {
-  it("prefers the observed full chat_conversations resource URL", () => {
-    const observed =
-      "https://claude.ai/api/organizations/org-1/chat_conversations/conv-123?tree=True&rendering_mode=messages";
-    expect(
-      conversationApiUrlFromResources("conv-123", [
-        "https://claude.ai/api/bootstrap/org-2/current_user_access",
-        observed,
-      ]),
-    ).toBe(observed);
-  });
-
-  it("derives the conversation URL from the bootstrap organization when needed", () => {
-    expect(
-      conversationApiUrlFromResources("conv-123", [
-        "https://claude.ai/api/bootstrap/org-1/current_user_access",
-      ]),
-    ).toBe(
-      "https://claude.ai/api/organizations/org-1/chat_conversations/conv-123?tree=True&rendering_mode=messages&render_all_tools=true&consistency=strong",
-    );
-  });
-
-  it("ignores other origins and malformed resource entries", () => {
-    expect(
-      conversationApiUrlFromResources("conv-123", [
-        "not a url at all",
-        "https://example.com/api/bootstrap/org-1/current_user_access",
-        "https://example.com/api/organizations/org-1/chat_conversations/conv-123",
-      ]),
-    ).toBe(null);
-  });
-
-  it("derives the organization from stable Claude localStorage keys", () => {
+  it("resolves the organization id from claude.ai's own localStorage key when no resource entry has been observed yet", async () => {
     const orgId = "d83be663-5e28-4dfc-8a54-1c34bdbb8c44";
-    expect(
-      conversationApiUrlFromResources("conv-123", [], "https://claude.ai", [
-        `claude-mcp-has-connectors:${orgId}`,
-      ]),
-    ).toBe(
-      `https://claude.ai/api/organizations/${orgId}/chat_conversations/conv-123?tree=True&rendering_mode=messages&render_all_tools=true&consistency=strong`,
+    let requestedUrl = null;
+    const fetch = vi.fn(async (input) => {
+      requestedUrl = String(input);
+      return jsonResponse({ uuid: "conversation-1", name: "Resolved via localStorage", chat_messages: [{ uuid: "u1", sender: "human", text: "hi" }] });
+    });
+    const { sendRuntimeMessage } = installClaude({
+      url: "https://claude.ai/chat/conversation-1",
+      localStorageEntries: { [`claude-mcp-has-connectors:${orgId}`]: "true" },
+      fetch,
+    });
+
+    const result = await sendRuntimeMessage({ type: "polylogue.capturePage", reason: "message_layer_save" });
+
+    expect(result.ok).toBe(true);
+    expect(requestedUrl).toBe(
+      `https://claude.ai/api/organizations/${orgId}/chat_conversations/conversation-1?tree=True&rendering_mode=messages&render_all_tools=true&consistency=strong`,
     );
-    expect(
-      organizationIdFromStorageKeys([
-        `LSS-model-selector-thinking:${orgId}:chat:claude-opus-4-8`,
-      ]),
-    ).toBe(orgId);
+  });
+
+  it("prefers an already-observed resource-timing chat_conversations URL over deriving one", async () => {
+    const observedUrl = "https://claude.ai/api/organizations/org-observed/chat_conversations/conversation-1?tree=True&rendering_mode=messages";
+    let requestedUrl = null;
+    const fetch = vi.fn(async (input) => {
+      requestedUrl = String(input);
+      return jsonResponse({ uuid: "conversation-1", name: "Via resource entry", chat_messages: [{ uuid: "u1", sender: "human", text: "hi" }] });
+    });
+    const { sendRuntimeMessage } = installClaude({
+      url: "https://claude.ai/chat/conversation-1",
+      resourceUrls: ["https://claude.ai/api/bootstrap/org-fallback/current_user_access", observedUrl],
+      localStorageEntries: { "claude-mcp-has-connectors:org-fallback": "true" },
+      fetch,
+    });
+
+    const result = await sendRuntimeMessage({ type: "polylogue.capturePage", reason: "message_layer_save" });
+
+    expect(result.ok).toBe(true);
+    expect(requestedUrl).toBe(observedUrl);
+  });
+
+  it("returns native_capture_unavailable when no conversation API URL can be resolved at all", async () => {
+    const { sendRuntimeMessage } = installClaude({ url: "https://claude.ai/chat/conversation-1" });
+
+    const result = await sendRuntimeMessage({ type: "polylogue.capturePage", reason: "message_layer_save" });
+
+    expect(result).toMatchObject({ ok: false, error: "native_capture_unavailable" });
+  });
+
+  it("rejects a captured payload for a different conversation than the current URL", async () => {
+    const { dom, sendRuntimeMessage } = installClaude({
+      url: "https://claude.ai/chat/conversation-1",
+      localStorageEntries: { "claude-mcp-has-connectors:org-1": "true" },
+    });
+    // Simulate claude_bridge.js's window.fetch interception observing a
+    // DIFFERENT conversation's response (e.g. a stale background tab fetch)
+    // -- must not be accepted for this page's conversation id.
+    dom.window.dispatchEvent(
+      new dom.window.MessageEvent("message", {
+        source: dom.window,
+        origin: dom.window.location.origin,
+        data: {
+          type: "polylogue.claude.nativeCapture",
+          capture: {
+            ok: true,
+            status: 200,
+            contentType: "application/json",
+            url: "https://claude.ai/api/organizations/org-1/chat_conversations/other-conversation",
+            body: JSON.stringify({ uuid: "other-conversation", chat_messages: [{ uuid: "u1", sender: "human", text: "wrong conversation" }] }),
+          },
+        },
+      }),
+    );
+
+    const result = await sendRuntimeMessage({ type: "polylogue.capturePage", reason: "message_layer_save" });
+
+    expect(result).toMatchObject({ ok: false, error: "native_capture_unavailable" });
+  });
+
+  it("returns null outside a /chat/<id> conversation route", async () => {
+    const { sendRuntimeMessage } = installClaude({ url: "https://claude.ai/new" });
+
+    const result = await sendRuntimeMessage({ type: "polylogue.capturePage", reason: "message_layer_save" });
+
+    expect(result).toMatchObject({ ok: false, error: "native_capture_unavailable" });
   });
 });


### PR DESCRIPTION
## Summary

Investigates and fixes the live browser-capture pipeline: why capture stopped landing anything, why the DOM-scrape fallback ever fired for real (and why it no longer needs to), why ChatGPT temporary chats never captured despite the archive side being ready for them, and a silent structured-block drop at the envelope boundary.

**Merge-coordination note:** an earlier revision of this PR also fixed the ChatGPT backfill bridge's content/metadata field-dropping in `page_transport.js`/`providers.js`. PR #3412 fixed the same defect independently with a strictly stronger solution (verbatim forwarding + byte-bounded chunking, removing the 24 MiB cap entirely rather than working under it) and also covers Claude's equivalent gap. Per coordinator instruction, those changes were dropped from this PR (see the `revert:` commit) — #3412 owns `page_transport.js`. This PR will need a rebase onto master once #3412 merges. Separately, PR #3410 found and fixed a related allowlist-drop bug in `common.js`'s `buildEnvelope` (turns silently lost their `blocks` field); since this PR already owns the content-script files, the fix plus a regression test were folded in here at the coordinator's request.

## Problem

1. **Live capture was dead.** The daemon's journal shows zero `batch ingested browser-capture` events from 2026-07-19 through 2026-07-31, and the live archive spool (`/realm/db/polylogue/browser-capture`) had exactly zero files before this session. Root cause (confirmed from the live Chrome profile's `Preferences`): the unpacked dev extension was loaded from `/realm/worktrees/polylogue-browser-live-proof/browser-extension`, a git worktree later removed as routine post-merge cleanup. Once the directory was gone, Chrome silently stopped running the extension's service worker — no error anywhere. This is the browser-extension analog of the "worktree removal must check live processes" hazard.

2. **`chatgpt-dom-v1`/`claude-ai-dom-v1` were dominated by native, but real.** `claude-ai-dom-v1` had zero captures ever. `chatgpt-dom-v1` had 17 captures, all inside one 4-minute native outage on 2026-07-17, producing degraded 3-turn shadows of conversations the export holds in full — a brand-new conversation whose URL hadn't been published yet by ChatGPT's SPA router, so native had no id to fetch or match by, even though the page's own fetch had already been intercepted.

3. **Zero ChatGPT temporary chats had ever landed**, despite the archive side being fully ready (`SessionKind.TEMPORARY`, ingest flag, parser support). Root cause: an asymmetry between `common.js`'s URL parser (maps a temporary-chat URL to a sentinel) and two independent gates that returned `null` for the same condition — `background.js`'s own `conversationIdForUrl` (silently skipped ever sending the tab a capture message) and `chatgpt.js`'s `parseNativeCapture` (required a URL-derived id to accept an already-intercepted capture, which a temporary chat never gets).

4. **`common.js`'s `buildEnvelope` silently dropped every turn's structured `blocks`** (found by PR #3410) via a fixed field allowlist with no `blocks` entry — the same allowlist-drift class as #3412's bug, one layer down the pipeline.

## Solution

- **Live remediation (not part of the diff):** reloaded the extension from the stable main checkout, re-paired it against the running receiver, confirmed capture resumed — two fresh `chatgpt-native-v1` captures landed within seconds of activating a conversation tab. `README.md` now documents the hazard.
- **`chatgpt.js`:** `fetchNativePayloadOnDemand` now waits (bounded 6s poll) for a fresh conversation's id before giving up. `parseNativeCapture` accepts an already-intercepted capture with no URL-derived id when the page is a temporary chat and the payload agrees (`is_temporary === true`), using the provider's own ephemeral id. `background.js`'s `conversationIdForUrl` now returns the same sentinel `common.js` already used instead of `null`.
- **Deleted** `chatgpt-dom-v1`/`claude-ai-dom-v1` entirely from `chatgpt.js`/`claude.js`. A capture with no native payload now returns `{ok:false, error:"native_capture_unavailable"}`. `grok.js` is untouched.
- **`common.js`:** added the missing `blocks: Array.isArray(turn.blocks) ? turn.blocks : []` pass-through, plus `tests/common_envelope_boundary.test.js` — a maximal turn/block round-trip through the real source (not a copy) asserting every `BrowserCaptureTurn`/`BrowserCaptureBlock` field (`polylogue/browser_capture/models.py`) survives. Field lists are hardcoded rather than derived from the Python models at test time (no cross-language plumbing exists in this repo and `npx vitest run` is a Python-free command); noted as a follow-up.
- **Ported `tests/content/chatgpt.test.js` and `tests/content/claude.test.js`** off hand-copied function bodies onto the real-source-loading pattern the sibling test files already use. `claude.test.js`'s old copy had already silently drifted from reality (it tested a `conversationApiUrlFromResources`/`organizationIdFromStorageKeys` pair that doesn't exist in `claude.js` at all — the real functions live in `claude_bridge.js` under different names/signatures), passing against fiction the whole time.
- Deleted the now-dead DOM-fallback tests rather than updating them.

## Verification

```
npx vitest run
```
334 passed, 1 pre-existing failure (`tests/build.test.js`'s foreground-tab-activation case — confirmed failing at HEAD before any change in this branch, unrelated).

```
npx eslint src/ tests/
```
clean.

Live end-to-end: activated an existing ChatGPT conversation tab, a fresh capture landed in `/realm/db/polylogue/browser-capture/chatgpt/` within ~10s.

Not run: Claude.ai live end-to-end (no open Claude conversation tab available without sending a live message); Grok (out of scope, untouched).

**Pending:** rebase onto master once PR #3412 merges (expected conflicts in `background.js`/`providers.js`/`tests/backfill.test.js` per merge-coordination guidance — merge order is #3412, then this PR, then #3410).