### PR TITLE
fix(storage): union messages/blocks across acquisitions, not re-parses

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -510,6 +510,20 @@ def write_parsed_session_to_archive(
                     "INSERT OR REPLACE INTO derived_refresh_guard(guard_name) VALUES (?)",
                     (FTS_BULK_SESSION_WRITE_GUARD,),
                 )
+            # polylogue-geop: capture whichever raw acquisition is CURRENTLY
+            # stored before the upsert below overwrites sessions.raw_id with
+            # this write's own value -- _union_with_existing_rows needs the
+            # PRIOR raw_id to tell "same acquisition re-parsed" (replace)
+            # from "different acquisition" (union) apart. Reading it after
+            # the upsert would always see this write's own raw_id and could
+            # never observe a difference.
+            existing_session_raw_id: str | None = None
+            if not merge_append:
+                existing_raw_id_row = conn.execute(
+                    "SELECT raw_id FROM sessions WHERE session_id = ?", (session_id,)
+                ).fetchone()
+                if existing_raw_id_row is not None:
+                    existing_session_raw_id = existing_raw_id_row[0]
             t0 = time.perf_counter()
             conn.execute(
                 """
@@ -627,6 +641,9 @@ def write_parsed_session_to_archive(
                     session,
                     messages,
                     duplicate_native_ids=duplicate_message_native_ids,
+                    raw_id=raw_id,
+                    existing_raw_id=existing_session_raw_id,
+                    force_replace=force_replace,
                     stage_timings_s=stage_timings_s,
                     stage_timing_prefix=stage_timing_prefix,
                     bulk_build=bulk_build,
@@ -2174,6 +2191,10 @@ def _union_with_existing_rows(
     session_id: str,
     message_rows: list[tuple[object, ...]],
     block_rows: list[tuple[object, ...]],
+    *,
+    raw_id: str | None,
+    existing_raw_id: str | None,
+    force_replace: bool = False,
 ) -> tuple[list[tuple[object, ...]], list[tuple[object, ...]]]:
     """Field-path union coalesce of a fresh full-replace against what is stored.
 
@@ -2187,6 +2208,40 @@ def _union_with_existing_rows(
     them, then returns the merged row tuples for ``_write_messages``/
     ``_write_blocks`` to insert in place of the plain freshly-built rows.
 
+    THIS ONLY APPLIES ACROSS TWO DIFFERENT ACQUISITIONS, never within one.
+    A full-session replace has two structurally different causes that this
+    function must not conflate:
+
+      - Two DIFFERENT acquisitions of the same logical session (a second
+        export download, a later browser capture) are independent partial
+        observations of one underlying reality -- neither is authoritative,
+        so they union. This is the measured chatgpt case above.
+      - A RE-PARSE of the SAME acquisition (unchanged raw bytes, a parser
+        bugfix or corrected message-boundary logic) is not a second
+        observation -- it is a better reading of the same evidence, and
+        must be able to REPLACE a value the old parse got wrong. Unioning
+        here would make every historical mis-parse immortal and defeat the
+        entire point of a `reprocess` re-run.
+
+    ``raw_id`` is the discriminator: it is content-addressed (SHA-256 of the
+    acquired bytes, `polylogue/pipeline/services/acquisition_records.py`),
+    so the SAME raw file re-parsed via `reprocess` (parse-only, no
+    re-acquire) always carries the identical `raw_id` its original ingest
+    did, while a genuinely different acquisition (different export
+    generation, different capture) gets a different one. When both the
+    incoming `raw_id` and the session's currently-stored `sessions.raw_id`
+    are known and equal, this is a same-acquisition re-parse: return the
+    rows unchanged (ordinary replace, exactly as before this change) with no
+    field union and no reinjection. Union only fires when both are known and
+    differ -- proven different acquisitions. When either side is unknown
+    (`None` -- e.g. a caller that writes directly via `ArchiveStore.
+    write_parsed()`, used by demo seeding and unit tests, never threads a
+    raw_id through), there is no positive evidence of a different
+    acquisition, so this also falls back to plain replace rather than
+    guessing; approximating "unknown" as "different" would let a corrected
+    re-parse's retraction be silently defeated by union whenever a caller
+    doesn't happen to supply provenance.
+
     Only messages carrying a stable provider ``native_id`` participate --
     a message with no native id has no cross-acquisition identity to union
     against (its archive identity is a position/variant fallback that is
@@ -2194,6 +2249,19 @@ def _union_with_existing_rows(
     the prior whole-row-replace behavior unchanged, exactly as before this
     change.
     """
+    # ``existing_raw_id`` must be captured by the CALLER before its own
+    # sessions upsert overwrites ``sessions.raw_id`` -- by the time this
+    # function runs, a fresh re-query here would always see this write's own
+    # value and could never detect a difference. See
+    # ``_replace_full_session_messages_and_blocks``'s docstring.
+    if force_replace or raw_id is None or existing_raw_id is None or existing_raw_id == raw_id:
+        # Same acquisition re-parsed, provenance unknown on either side, or
+        # the caller already made its own authoritative precedence call
+        # (force_replace): ordinary replace, no union -- a corrected
+        # re-parse (or a caller-decided supersession) must be able to
+        # retract content the old parse wrongly produced.
+        return message_rows, block_rows
+
     m_spec = archive_tiers_specs.MESSAGES_SPEC
     b_spec = archive_tiers_specs.BLOCKS_SPEC
     m_cols = [col.name for col in m_spec.writable_columns if col.extract_placeholder == "?"]
@@ -2379,6 +2447,9 @@ def _replace_full_session_messages_and_blocks(
     messages: list[ParsedMessage],
     *,
     duplicate_native_ids: frozenset[str],
+    raw_id: str | None = None,
+    existing_raw_id: str | None = None,
+    force_replace: bool = False,
     stage_timings_s: dict[str, float] | None = None,
     stage_timing_prefix: str = "append",
     bulk_build: bool = False,
@@ -2403,6 +2474,22 @@ def _replace_full_session_messages_and_blocks(
     of the precomputed tuples; only the ``executemany`` against SQLite still
     runs on this (writer) thread. ``None`` (the default) reproduces the exact
     prior behavior byte-for-byte.
+
+    ``raw_id`` (polylogue-geop) identifies which raw acquisition this write's
+    ``messages`` were parsed from; ``existing_raw_id`` is whatever
+    ``sessions.raw_id`` held for this session BEFORE this write's caller
+    upserted its own value over it (the caller must capture this ahead of
+    that upsert -- by the time this function runs, the row already reflects
+    the new write). See ``_union_with_existing_rows`` for how the two are
+    compared to discriminate "different acquisition, union" from "same
+    acquisition re-parsed, replace".
+
+    ``force_replace`` also disables the union outright: it is the caller's
+    OWN authoritative precedence decision (e.g. `ingest_precedence.
+    browser_capture_precedence()` deciding a fuller native capture supersedes
+    a weaker DOM-fallback one) that this write must win wholesale, not merge
+    with -- unioning against a session the caller has explicitly ruled
+    inferior would silently partially undo that decision.
     """
 
     def add_timing(name: str, started_at: float) -> None:
@@ -2429,6 +2516,9 @@ def _replace_full_session_messages_and_blocks(
         list(prepared.block_rows)
         if prepared is not None
         else _build_block_rows(session_id, messages, duplicate_native_ids=duplicate_native_ids),
+        raw_id=raw_id,
+        existing_raw_id=existing_raw_id,
+        force_replace=force_replace,
     )
     add_timing("field_path_union", t0)
     t0 = time.perf_counter()

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -2131,6 +2131,248 @@ def _write_web_constructs(
     )
 
 
+def _merge_json_value(new: object, old: object, *, context: str = "") -> object:
+    """Field-path union of two JSON-decoded values (polylogue-geop).
+
+    An acquisition is a PARTIAL OBSERVATION: measured across 44,171 chatgpt
+    messages present in both an April and a July export, 453,956 field
+    observations were April-only, zero were July-only, and the 2,479
+    "conflicts" were the newer export simply carrying fewer keys one level
+    deeper (dropped ``start_idx``/``end_idx``/``matched_text``/... from
+    citation records) -- never a genuine value disagreement. So the rule is:
+    for each path, take whichever side has a non-null value; when both do,
+    prefer the newer (``new``) side but log loudly if they disagree, since
+    that case is not expected to occur for any provider observed so far.
+    """
+    if new is None:
+        return old
+    if old is None:
+        return new
+    if isinstance(new, dict) and isinstance(old, dict):
+        merged: dict[object, object] = {}
+        for key in dict.fromkeys((*old.keys(), *new.keys())):
+            merged[key] = _merge_json_value(new.get(key), old.get(key), context=context)
+        return merged
+    if isinstance(new, list) and isinstance(old, list) and len(new) == len(old):
+        return [_merge_json_value(n, o, context=context) for n, o in zip(new, old, strict=True)]
+    if new != old:
+        logger.warning(
+            "field-path union conflict at %s: newer=%r older=%r -- keeping newer (polylogue-geop)",
+            context,
+            new,
+            old,
+        )
+    return new
+
+
+def _coalesce_scalar(new: object, old: object) -> object:
+    return new if new is not None else old
+
+
+def _union_with_existing_rows(
+    conn: sqlite3.Connection,
+    session_id: str,
+    message_rows: list[tuple[object, ...]],
+    block_rows: list[tuple[object, ...]],
+) -> tuple[list[tuple[object, ...]], list[tuple[object, ...]]]:
+    """Field-path union coalesce of a fresh full-replace against what is stored.
+
+    polylogue-geop: newer provider exports are not supersets of older ones
+    (measured: a 2026-07 chatgpt export dropped the entire tool/system role
+    layer and 20K+ code blocks present in the 2026-04 export of the same
+    conversations). A full-session replace must therefore never let a
+    newer, poorer acquisition delete a field -- or a whole message/block --
+    that an older acquisition already supplied. This runs *before* the
+    session's old ``messages``/``blocks`` rows are deleted so it can read
+    them, then returns the merged row tuples for ``_write_messages``/
+    ``_write_blocks`` to insert in place of the plain freshly-built rows.
+
+    Only messages carrying a stable provider ``native_id`` participate --
+    a message with no native id has no cross-acquisition identity to union
+    against (its archive identity is a position/variant fallback that is
+    not guaranteed stable across independent acquisitions), so those keep
+    the prior whole-row-replace behavior unchanged, exactly as before this
+    change.
+    """
+    m_spec = archive_tiers_specs.MESSAGES_SPEC
+    b_spec = archive_tiers_specs.BLOCKS_SPEC
+    m_cols = [col.name for col in m_spec.writable_columns if col.extract_placeholder == "?"]
+    b_cols = [col.name for col in b_spec.writable_columns if col.extract_placeholder == "?"]
+    m_idx = {name: i for i, name in enumerate(m_cols)}
+    b_idx = {name: i for i, name in enumerate(b_cols)}
+
+    existing_message_rows = conn.execute(
+        f"SELECT {', '.join(m_cols)} FROM messages WHERE session_id = ?", (session_id,)
+    ).fetchall()
+    existing_by_native_id: dict[str, tuple[object, ...]] = {}
+    for erow in existing_message_rows:
+        row_native_id = erow[m_idx["native_id"]]
+        if row_native_id is not None:
+            existing_by_native_id[cast(str, row_native_id)] = tuple(erow)
+
+    if not existing_by_native_id:
+        # Nothing previously stored under a stable identity -- ordinary
+        # first-write path, nothing to union against.
+        return message_rows, block_rows
+
+    existing_block_rows = conn.execute(
+        f"SELECT {', '.join(b_cols)} FROM blocks WHERE session_id = ?", (session_id,)
+    ).fetchall()
+    existing_blocks_by_message: dict[str, dict[int, tuple[object, ...]]] = {}
+    for erow in existing_block_rows:
+        row_message_id = cast(str, erow[b_idx["message_id"]])
+        row_position = cast(int, erow[b_idx["position"]])
+        existing_blocks_by_message.setdefault(row_message_id, {})[row_position] = tuple(erow)
+
+    native_idx = m_idx["native_id"]
+    position_idx = m_idx["position"]
+    variant_idx = m_idx["variant_index"]
+    tool_input_idx = b_idx["tool_input"]
+    block_content_hash_idx = b_idx["content_hash"]
+
+    # A session that is itself the resolved parent of a prefix-sharing child
+    # has a load-bearing message set: the child's stored
+    # `branch_point_message_id` names a specific message this session must
+    # still contain, or composition falls back to "dangling" (by design --
+    # see session_links' docstring and _extract_prefix_tail). Reinjecting a
+    # message this acquisition intentionally dropped (e.g. a corrected
+    # variant cut) would silently resurrect a branch point and fabricate a
+    # prefix the operator's own re-ingest just removed. Whole-message
+    # reinjection is skipped for such parents; field-path union of messages
+    # and blocks BOTH acquisitions still assert is unaffected (it never
+    # changes which messages exist).
+    is_prefix_sharing_parent = (
+        conn.execute(
+            "SELECT 1 FROM session_links WHERE resolved_dst_session_id = ? AND inheritance = 'prefix-sharing' LIMIT 1",
+            (session_id,),
+        ).fetchone()
+        is not None
+    )
+
+    incoming_native_ids = {cast(str, row[native_idx]) for row in message_rows if row[native_idx] is not None}
+    used_positions = {cast(int, row[position_idx]) for row in message_rows}
+    next_position = (max(used_positions) + 1) if used_positions else 0
+
+    merged_message_rows: list[tuple[object, ...]] = []
+    merged_message_ids: dict[str, str] = {}  # native_id -> merged message_id
+    for row in message_rows:
+        row_native_id = row[native_idx]
+        existing_row = existing_by_native_id.get(cast(str, row_native_id)) if row_native_id is not None else None
+        if existing_row is None:
+            merged_message_rows.append(row)
+        else:
+            merged_message_rows.append(
+                tuple(_coalesce_scalar(new_v, old_v) for new_v, old_v in zip(row, existing_row, strict=True))
+            )
+        if row_native_id is not None:
+            merged_message_ids[cast(str, row_native_id)] = archive_message_id(
+                session_id,
+                cast(str, row_native_id),
+                position=cast(int, row[position_idx]),
+                variant_index=cast(int, row[variant_idx] or 0),
+            )
+
+    for existing_native_id, existing_row in existing_by_native_id.items():
+        if existing_native_id in incoming_native_ids:
+            continue
+        if is_prefix_sharing_parent:
+            continue
+        # This message's content was observed by a prior acquisition but is
+        # absent from this one entirely -- reinject it verbatim rather than
+        # letting the full-replace delete it. Reassign position only if the
+        # original collides with an incoming row (native_id already makes
+        # message_id independent of position, so this is always safe).
+        reinject_position = cast(int, existing_row[position_idx])
+        if reinject_position in used_positions:
+            reinject_position = next_position
+            next_position += 1
+            row_list = list(existing_row)
+            row_list[position_idx] = reinject_position
+            existing_row = tuple(row_list)
+        used_positions.add(reinject_position)
+        merged_message_rows.append(existing_row)
+        merged_message_ids[existing_native_id] = archive_message_id(
+            session_id,
+            existing_native_id,
+            position=reinject_position,
+            variant_index=cast(int, existing_row[variant_idx] or 0),
+        )
+        logger.info(
+            "field-path union (polylogue-geop): reinjecting message native_id=%s session_id=%s "
+            "dropped by newer acquisition",
+            existing_native_id,
+            session_id,
+        )
+
+    # Blocks are matched within a still-live message by (message_id, position).
+    incoming_block_positions: dict[str, set[int]] = {}
+    merged_block_rows: list[tuple[object, ...]] = []
+    for row in block_rows:
+        row_message_id = cast(str, row[b_idx["message_id"]])
+        row_position = cast(int, row[b_idx["position"]])
+        incoming_block_positions.setdefault(row_message_id, set()).add(row_position)
+        existing_block = existing_blocks_by_message.get(row_message_id, {}).get(row_position)
+        if existing_block is None or existing_block[b_idx["block_type"]] != row[b_idx["block_type"]]:
+            # No stored block at this slot, or a re-parse reordered/replaced
+            # what occupies it (block identity is content-addressed, not
+            # position -- svfj deliberately excludes position/tool_id from
+            # the evidence hash because both can shift on re-parse). Only
+            # coalesce when the same kind of evidence still occupies the
+            # slot; otherwise this is a fresh block, not a partial
+            # observation of the old one.
+            merged_block_rows.append(row)
+            continue
+        merged_values: list[object] = list(row)
+        conflict_context = f"blocks.tool_input message_id={row_message_id} position={row_position}"
+        for col_name, idx in b_idx.items():
+            if col_name in ("message_id", "session_id", "position", "content_hash"):
+                continue
+            if col_name == "tool_input":
+                new_raw = cast("str | None", row[idx])
+                old_raw = cast("str | None", existing_block[idx])
+                new_json = json.loads(new_raw) if new_raw is not None else None
+                old_json = json.loads(old_raw) if old_raw is not None else None
+                merged_json = _merge_json_value(new_json, old_json, context=conflict_context)
+                merged_values[idx] = _json_dumps(merged_json) if merged_json is not None else None
+            else:
+                merged_values[idx] = _coalesce_scalar(row[idx], existing_block[idx])
+        is_error_value = merged_values[b_idx["tool_result_is_error"]]
+        merged_values[block_content_hash_idx] = _block_content_hash(
+            block_type=cast(str, merged_values[b_idx["block_type"]]),
+            text=cast("str | None", merged_values[b_idx["text"]]),
+            tool_name=cast("str | None", merged_values[b_idx["tool_name"]]),
+            tool_input_json=cast("str | None", merged_values[tool_input_idx]),
+            semantic_type=cast("str | None", merged_values[b_idx["semantic_type"]]),
+            media_type=cast("str | None", merged_values[b_idx["media_type"]]),
+            language=cast("str | None", merged_values[b_idx["language"]]),
+            is_error=None if is_error_value is None else bool(is_error_value),
+            exit_code=cast("int | None", merged_values[b_idx["tool_result_exit_code"]]),
+            outcome_unknown_reason=cast("str | None", merged_values[b_idx["tool_result_outcome_unknown_reason"]]),
+        )
+        merged_block_rows.append(tuple(merged_values))
+
+    live_message_ids = set(merged_message_ids.values())
+    for message_id, existing_blocks in existing_blocks_by_message.items():
+        # Only reinject blocks belonging to a message that survives the merge
+        # (either still incoming, or itself reinjected above) -- a block
+        # whose parent message is genuinely gone has nothing to attach to.
+        if message_id not in live_message_ids and message_id not in incoming_block_positions:
+            continue
+        seen_positions = incoming_block_positions.get(message_id, set())
+        for block_position, existing_block in existing_blocks.items():
+            if block_position in seen_positions:
+                continue
+            merged_block_rows.append(existing_block)
+            logger.info(
+                "field-path union (polylogue-geop): reinjecting block message_id=%s position=%s "
+                "dropped by newer acquisition",
+                message_id,
+                block_position,
+            )
+
+    return merged_message_rows, merged_block_rows
+
+
 def _replace_full_session_messages_and_blocks(
     conn: sqlite3.Connection,
     session: ParsedSession,
@@ -2174,6 +2416,21 @@ def _replace_full_session_messages_and_blocks(
     origin = origin_from_provider(session.source_name)
     session_id = archive_session_id(origin.value, session.provider_session_id)
     _assert_unique_message_coordinates(session_id, messages)
+    t0 = time.perf_counter()
+    # polylogue-geop: compute the field-path union against whatever is
+    # currently stored *before* any delete below removes it. Must run ahead
+    # of the FTS/base-table deletes -- both messages and blocks are read here.
+    unioned_message_rows, unioned_block_rows = _union_with_existing_rows(
+        conn,
+        session_id,
+        list(prepared.message_rows)
+        if prepared is not None
+        else _build_message_rows(session_id, messages, duplicate_native_ids=duplicate_native_ids),
+        list(prepared.block_rows)
+        if prepared is not None
+        else _build_block_rows(session_id, messages, duplicate_native_ids=duplicate_native_ids),
+    )
+    add_timing("field_path_union", t0)
     t0 = time.perf_counter()
     use_scoped_fts_rebuild = not bulk_build and message_fts_triggers_present_sync(conn)
     add_timing("fts_probe", t0)
@@ -2221,7 +2478,7 @@ def _replace_full_session_messages_and_blocks(
             session_id,
             messages,
             duplicate_native_ids=duplicate_native_ids,
-            rows=list(prepared.message_rows) if prepared is not None else None,
+            rows=unioned_message_rows,
         )
         add_timing("messages", t0)
         t0 = time.perf_counter()
@@ -2230,7 +2487,7 @@ def _replace_full_session_messages_and_blocks(
             session_id,
             messages,
             duplicate_native_ids=duplicate_native_ids,
-            rows=list(prepared.block_rows) if prepared is not None else None,
+            rows=unioned_block_rows,
         )
         add_timing("blocks", t0)
         t0 = time.perf_counter()

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -1363,24 +1363,19 @@ def test_provider_usage_model_switch_on_reingest_does_not_double_count(tmp_path:
     )
 
 
-def test_provider_usage_model_vanishing_on_reingest_preserves_message_with_zero_usage_rollup(
-    tmp_path: Path,
-) -> None:
-    """polylogue-geop changed this test's outcome intentionally.
+def test_provider_usage_model_vanishing_on_reingest_leaves_no_stale_rollup(tmp_path: Path) -> None:
+    """A message's model can vanish between full re-ingests (e.g. corrected
+    message-boundary re-parsing). The old model's session_model_usage row
+    must not survive as an orphaned, stale contributor to per-model sums.
 
-    Previously a message whose native id no longer appeared in a full
-    re-ingest was treated as superseded and purged along with its
-    session_model_usage rollup. Since polylogue-geop, a full re-ingest is a
-    field-path UNION against what is already archived (measured: newer
-    provider exports are not supersets of older ones -- a message missing
-    from the newer acquisition is not proof it was corrected away, only
-    that this acquisition didn't observe it), so message m1 is reinjected
-    rather than deleted. Its session_model_usage skeleton row is seeded from
-    the reinjected message's model_name, but session_events (the token_count
-    usage evidence) are NOT unioned -- that tier is out of this change's
-    scope (see polylogue-geop follow-up) -- so the reinjected model
-    legitimately rolls up to zero usage rather than carrying stale, summed
-    tokens forward."""
+    polylogue-geop note: this is a SAME-ACQUISITION re-parse (neither write
+    passes a ``raw_id``, so ``_union_with_existing_rows`` has no positive
+    evidence of a different acquisition and falls back to plain replace) --
+    the corrected re-parse must be able to retract m1's stale attribution.
+    Contrast with ``test_reingest_with_poorer_export_unions_fields_instead_of_deleting_them``,
+    which passes two DIFFERENT ``raw_id``s and asserts the opposite: a
+    genuinely different acquisition must never delete what a prior one
+    supplied."""
     conn = _connect(tmp_path / "index.db")
 
     def _usage_event(model: str, *, input_tokens: int, cached: int, output: int) -> ParsedSessionEvent:
@@ -1433,20 +1428,7 @@ def test_provider_usage_model_vanishing_on_reingest_preserves_message_with_zero_
         (session_id,),
     ).fetchall()
     per_model = {row["model_name"]: (row["input_tokens"], row["output_tokens"]) for row in rows}
-    # gpt-5-codex-mini's message (m1) was reinjected by the field-path union
-    # (polylogue-geop) instead of deleted, so its skeleton rollup row still
-    # exists; it carries zero tokens because session_events weren't unioned.
-    assert per_model == {"gpt-5-codex": (50, 10), "gpt-5-codex-mini": (0, 0)}, (
-        f"reinjected message's model rollup should be a zero-usage skeleton, not stale or absent: {per_model}"
-    )
-
-    surviving_native_ids = {
-        row["native_id"]
-        for row in conn.execute("SELECT native_id FROM messages WHERE session_id = ?", (session_id,)).fetchall()
-    }
-    assert surviving_native_ids == {"m1", "m2"}, (
-        f"field-path union must reinject the message a newer acquisition dropped: {surviving_native_ids}"
-    )
+    assert per_model == {"gpt-5-codex": (50, 10)}, f"stale vanished-model rollup survived: {per_model}"
 
 
 def test_provider_usage_disjoint_lanes_subtracts_cached_and_does_not_re_add_reasoning() -> None:
@@ -4295,6 +4277,16 @@ def test_reingest_with_poorer_export_unions_fields_instead_of_deleting_them(tmp_
     already-archived session must never delete a message, a block, or a
     field within a block's ``tool_input`` that a prior, richer acquisition
     supplied -- it must union, not replace.
+
+    The two writes pass DIFFERENT ``raw_id``s (distinct content-addressed
+    acquisitions -- the April and July export blobs are genuinely different
+    bytes), which is what makes this the union path rather than a
+    same-acquisition replace: see ``_union_with_existing_rows``'s docstring
+    and contrast with
+    ``test_provider_usage_model_vanishing_on_reingest_leaves_no_stale_rollup``,
+    which passes no ``raw_id`` at all (unknown provenance, falls back to
+    replace) and asserts the opposite -- a corrected re-parse retracting a
+    stale attribution.
     """
     conn = _connect(tmp_path / "index.db")
     try:
@@ -4337,7 +4329,7 @@ def test_reingest_with_poorer_export_unions_fields_instead_of_deleting_them(tmp_
                 ),
             ],
         )
-        session_id = write_parsed_session_to_archive(conn, rich)
+        session_id = write_parsed_session_to_archive(conn, rich, raw_id="raw-2026-04-export")
 
         # The July-shaped re-export: message m1's citation record survives but
         # loses several keys one level deeper; message m2-tool is entirely
@@ -4368,7 +4360,7 @@ def test_reingest_with_poorer_export_unions_fields_instead_of_deleting_them(tmp_
                 ),
             ],
         )
-        write_parsed_session_to_archive(conn, poorer)
+        write_parsed_session_to_archive(conn, poorer, raw_id="raw-2026-07-export")
 
         message_rows = conn.execute(
             "SELECT native_id FROM messages WHERE session_id = ? ORDER BY native_id",
@@ -4408,5 +4400,62 @@ def test_reingest_with_poorer_export_unions_fields_instead_of_deleting_them(tmp_
             (session_id,),
         ).fetchone()
         assert tool_block_row["text"] == "tool output"
+    finally:
+        conn.close()
+
+
+def test_reingest_with_same_raw_id_replaces_instead_of_unioning(tmp_path: Path) -> None:
+    """polylogue-geop: the SAME raw acquisition re-parsed must be able to
+    retract a message the previous parse produced -- explicitly exercises
+    the ``existing_raw_id == raw_id`` branch of ``_union_with_existing_rows``
+    (not just the "no raw_id supplied" fallback that
+    ``test_provider_usage_model_vanishing_on_reingest_leaves_no_stale_rollup``
+    covers). A `reprocess` re-run (parse-only, no re-acquire) always carries
+    forward the identical content-addressed ``raw_id`` its original ingest
+    used, so this is the real-world shape of a parser bugfix re-run."""
+    conn = _connect(tmp_path / "index.db")
+    try:
+        first_parse = ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="reparse-same-raw-id",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="m1",
+                    role=Role.ASSISTANT,
+                    blocks=[ParsedContentBlock(type=BlockType.TEXT, text="mis-split first half")],
+                ),
+                ParsedMessage(
+                    provider_message_id="m2",
+                    role=Role.ASSISTANT,
+                    blocks=[ParsedContentBlock(type=BlockType.TEXT, text="mis-split second half")],
+                ),
+            ],
+        )
+        session_id = write_parsed_session_to_archive(conn, first_parse, raw_id="raw-unchanged-file")
+
+        # A parser bugfix re-parses the SAME bytes (same raw_id) and decides
+        # m1/m2 were one message wrongly split in two -- the corrected parse
+        # must be able to retract the wrong boundary, not have it unioned
+        # back in.
+        corrected_parse = ParsedSession(
+            source_name=Provider.CODEX,
+            provider_session_id="reparse-same-raw-id",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="m1-corrected",
+                    role=Role.ASSISTANT,
+                    blocks=[ParsedContentBlock(type=BlockType.TEXT, text="correctly joined message")],
+                ),
+            ],
+        )
+        write_parsed_session_to_archive(conn, corrected_parse, raw_id="raw-unchanged-file")
+
+        native_ids = {
+            row["native_id"]
+            for row in conn.execute("SELECT native_id FROM messages WHERE session_id = ?", (session_id,)).fetchall()
+        }
+        assert native_ids == {"m1-corrected"}, (
+            f"same-raw_id re-parse must replace, not union -- retracted messages resurfaced: {native_ids}"
+        )
     finally:
         conn.close()

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import sqlite3
 from pathlib import Path
 
@@ -1362,10 +1363,24 @@ def test_provider_usage_model_switch_on_reingest_does_not_double_count(tmp_path:
     )
 
 
-def test_provider_usage_model_vanishing_on_reingest_leaves_no_stale_rollup(tmp_path: Path) -> None:
-    """A message's model can vanish between full re-ingests (e.g. corrected
-    message-boundary re-parsing). The old model's session_model_usage row
-    must not survive as an orphaned, stale contributor to per-model sums."""
+def test_provider_usage_model_vanishing_on_reingest_preserves_message_with_zero_usage_rollup(
+    tmp_path: Path,
+) -> None:
+    """polylogue-geop changed this test's outcome intentionally.
+
+    Previously a message whose native id no longer appeared in a full
+    re-ingest was treated as superseded and purged along with its
+    session_model_usage rollup. Since polylogue-geop, a full re-ingest is a
+    field-path UNION against what is already archived (measured: newer
+    provider exports are not supersets of older ones -- a message missing
+    from the newer acquisition is not proof it was corrected away, only
+    that this acquisition didn't observe it), so message m1 is reinjected
+    rather than deleted. Its session_model_usage skeleton row is seeded from
+    the reinjected message's model_name, but session_events (the token_count
+    usage evidence) are NOT unioned -- that tier is out of this change's
+    scope (see polylogue-geop follow-up) -- so the reinjected model
+    legitimately rolls up to zero usage rather than carrying stale, summed
+    tokens forward."""
     conn = _connect(tmp_path / "index.db")
 
     def _usage_event(model: str, *, input_tokens: int, cached: int, output: int) -> ParsedSessionEvent:
@@ -1418,7 +1433,20 @@ def test_provider_usage_model_vanishing_on_reingest_leaves_no_stale_rollup(tmp_p
         (session_id,),
     ).fetchall()
     per_model = {row["model_name"]: (row["input_tokens"], row["output_tokens"]) for row in rows}
-    assert per_model == {"gpt-5-codex": (50, 10)}, f"stale vanished-model rollup survived: {per_model}"
+    # gpt-5-codex-mini's message (m1) was reinjected by the field-path union
+    # (polylogue-geop) instead of deleted, so its skeleton rollup row still
+    # exists; it carries zero tokens because session_events weren't unioned.
+    assert per_model == {"gpt-5-codex": (50, 10), "gpt-5-codex-mini": (0, 0)}, (
+        f"reinjected message's model rollup should be a zero-usage skeleton, not stale or absent: {per_model}"
+    )
+
+    surviving_native_ids = {
+        row["native_id"]
+        for row in conn.execute("SELECT native_id FROM messages WHERE session_id = ?", (session_id,)).fetchall()
+    }
+    assert surviving_native_ids == {"m1", "m2"}, (
+        f"field-path union must reinject the message a newer acquisition dropped: {surviving_native_ids}"
+    )
 
 
 def test_provider_usage_disjoint_lanes_subtracts_cached_and_does_not_re_add_reasoning() -> None:
@@ -4252,3 +4280,133 @@ def test_merge_append_advances_derived_updated_at_ms_from_new_message_evidence(
     # updated_at_ms advances to the newly appended message's timestamp.
     assert second_row["created_at_ms"] == 1_775_001_600_000
     assert second_row["updated_at_ms"] == 1_775_007_000_000  # 2026-04-01T01:30:00Z
+
+
+def test_reingest_with_poorer_export_unions_fields_instead_of_deleting_them(tmp_path: Path) -> None:
+    """polylogue-geop: newer provider exports are not supersets of older ones.
+
+    Measured on chatgpt (2026-07-31): a 2026-07 export of the same
+    conversations as a 2026-04 export dropped the ENTIRE tool/system role
+    layer (24,914 tool messages, 20,384 code blocks) and, within citation
+    records both exports still carried, dropped several keys one level
+    deeper (start_idx/end_idx/matched_text/refs/safe_urls/error/status/
+    style) while keeping identical record counts and byte-identical message
+    text. This pins the fix: re-ingesting a POORER acquisition of an
+    already-archived session must never delete a message, a block, or a
+    field within a block's ``tool_input`` that a prior, richer acquisition
+    supplied -- it must union, not replace.
+    """
+    conn = _connect(tmp_path / "index.db")
+    try:
+        rich = ParsedSession(
+            source_name=Provider.CHATGPT,
+            provider_session_id="union-rich-vs-poor",
+            title="citations",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="m1",
+                    role=Role.ASSISTANT,
+                    text="see citation",
+                    blocks=[
+                        ParsedContentBlock(
+                            type=BlockType.TEXT,
+                            text="see citation",
+                            tool_input={
+                                "content_references": [
+                                    {
+                                        "type": "webpage",
+                                        "start_idx": 10,
+                                        "end_idx": 42,
+                                        "matched_text": "the source",
+                                        "refs": ["r1", "r2"],
+                                        "safe_urls": ["https://example.com"],
+                                        "url": "https://example.com",
+                                    }
+                                ]
+                            },
+                        )
+                    ],
+                ),
+                # A whole message/role the newer export drops entirely (the
+                # measured tool-layer removal).
+                ParsedMessage(
+                    provider_message_id="m2-tool",
+                    role=Role.TOOL,
+                    text="tool output",
+                    blocks=[ParsedContentBlock(type=BlockType.TOOL_RESULT, text="tool output")],
+                ),
+            ],
+        )
+        session_id = write_parsed_session_to_archive(conn, rich)
+
+        # The July-shaped re-export: message m1's citation record survives but
+        # loses several keys one level deeper; message m2-tool is entirely
+        # absent (the dropped tool layer).
+        poorer = ParsedSession(
+            source_name=Provider.CHATGPT,
+            provider_session_id="union-rich-vs-poor",
+            title="citations",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="m1",
+                    role=Role.ASSISTANT,
+                    text="see citation",
+                    blocks=[
+                        ParsedContentBlock(
+                            type=BlockType.TEXT,
+                            text="see citation",
+                            tool_input={
+                                "content_references": [
+                                    {
+                                        "type": "webpage",
+                                        "url": "https://example.com",
+                                    }
+                                ]
+                            },
+                        )
+                    ],
+                ),
+            ],
+        )
+        write_parsed_session_to_archive(conn, poorer)
+
+        message_rows = conn.execute(
+            "SELECT native_id FROM messages WHERE session_id = ? ORDER BY native_id",
+            (session_id,),
+        ).fetchall()
+        native_ids = {row["native_id"] for row in message_rows}
+        assert native_ids == {"m1", "m2-tool"}, (
+            f"the poorer re-export deleted a message the richer acquisition supplied: {native_ids}"
+        )
+
+        block_row = conn.execute(
+            """
+            SELECT b.tool_input FROM blocks b
+            JOIN messages m ON m.message_id = b.message_id
+            WHERE m.session_id = ? AND m.native_id = 'm1' AND b.position = 0
+            """,
+            (session_id,),
+        ).fetchone()
+        merged_tool_input = json.loads(block_row["tool_input"])
+        merged_citation = merged_tool_input["content_references"][0]
+        assert merged_citation == {
+            "type": "webpage",
+            "start_idx": 10,
+            "end_idx": 42,
+            "matched_text": "the source",
+            "refs": ["r1", "r2"],
+            "safe_urls": ["https://example.com"],
+            "url": "https://example.com",
+        }, f"field-path union dropped keys the richer acquisition supplied: {merged_citation}"
+
+        tool_block_row = conn.execute(
+            """
+            SELECT b.text FROM blocks b
+            JOIN messages m ON m.message_id = b.message_id
+            WHERE m.session_id = ? AND m.native_id = 'm2-tool' AND b.position = 0
+            """,
+            (session_id,),
+        ).fetchone()
+        assert tool_block_row["text"] == "tool output"
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Full-session re-ingest previously did `DELETE FROM messages WHERE session_id=?`
followed by a blind re-insert. A field-path union coalesce now runs ahead of
that delete, but only when there is positive evidence this write is a
genuinely different raw acquisition of the same logical session — not a
same-acquisition re-parse.

## Problem

Measured on chatgpt (`polylogue-geop`): a 2026-07 export of the same
conversations as a 2026-04 export dropped the entire tool/system role layer
(24,914 tool messages, 20,384 code blocks) and, within citation records both
exports still carried, dropped keys one level deeper
(`start_idx`/`end_idx`/`matched_text`/`refs`/`safe_urls`/`error`/`status`/`style`)
while keeping identical record counts and byte-identical message text. Field
walk over 44,171 common messages: 291,774 field observations agreed, 2,479
"conflicts" were strict key-subsetting (never a real disagreement), 453,956
were April-only, zero were July-only. `Latest wins` silently deletes data a
prior acquisition already supplied.

A first pass at the fix applied field-path union unconditionally to every
full-session replace. Review caught that this conflates two structurally
different causes of a full replace, confirmed by running the wider suite
(`devtools verify --seed-testmon --skip-slow`), which broke ~19 tests:

- Two **different acquisitions** of the same logical session (a second export
  download, a later browser capture) are independent partial observations —
  they should union.
- A **re-parse of the same acquisition** (unchanged raw bytes, a parser
  bugfix or corrected message-boundary logic) is a better reading of the same
  evidence and must be able to **retract** a value the old parse got wrong —
  unioning here makes every historical mis-parse immortal and defeats the
  point of a `reprocess` re-run. This is exactly what
  `test_provider_usage_model_vanishing_on_reingest_leaves_no_stale_rollup`
  pins, and what the 19 browser-capture/native-vs-DOM-fallback precedence
  tests (`ingest_precedence.browser_capture_precedence()` deciding a fuller
  native capture supersedes a weaker DOM-fallback one, via `force_replace`)
  encode as a caller-decided supersession.

## Solution

`polylogue/storage/sqlite/archive_tiers/write.py`:

- `_union_with_existing_rows` runs before the full replace's delete, reads
  what's currently stored, and merges it against the freshly-built row
  tuples for `messages`/`blocks` — but **only fires when there is positive
  proof of a different acquisition**:
  - `raw_id` is content-addressed (SHA-256 of the acquired bytes,
    `pipeline/services/acquisition_records.py`) and is carried forward
    unchanged by a `reprocess` (parse-only) re-run of the same raw file
    (confirmed via `pipeline/ingest_support.py`'s stage table and the parse
    backlog in `pipeline/services/planning_runtime.py`, which loads the
    existing `RawSessionRecord` rather than recomputing an id).
  - The caller (`write_parsed_session_to_archive`) captures
    `sessions.raw_id` for this session **before** its own upsert overwrites
    it, and threads both the incoming and prior raw_id down.
  - Union fires only when both raw_ids are known and differ. Equal raw_ids,
    unknown provenance on either side (e.g. `ArchiveStore.write_parsed()`'s
    direct path used by demo seeding/most unit tests), or
    `force_replace=True` (an explicit caller precedence decision) all fall
    back to plain replace — unchanged from before this feature.
- Matched messages/blocks coalesce column-wise (new value wins when present,
  else the stored value survives — mirroring the existing
  `sessions.title`-style `COALESCE(excluded.x, table.x)` upsert pattern).
- `blocks.tool_input` (the one non-scalar column) gets a recursive
  field-path JSON union (`_merge_json_value`) — this is what restores dropped
  citation keys; block `content_hash` is recomputed from the merged fields
  since it feeds citation/evidence matching.
- A message/block entirely absent from the new acquisition is reinjected
  verbatim (position reassigned only on collision — safe because `native_id`
  already makes `message_id` position-independent).
- A block only merges when `block_type` matches at that position — a
  re-parse that reorders/replaces what occupies a slot is a different block,
  not a partial observation of the old one (block identity is
  content-addressed, not position — `svfj` already excludes
  `tool_id`/position from the evidence hash for the same reason).
- Whole-message reinjection is skipped for a session that is itself the
  resolved parent of a prefix-sharing lineage child — the child's stored
  `branch_point_message_id` is load-bearing, and resurrecting a message a
  parent's own re-ingest intentionally dropped would fabricate a prefix the
  correction just removed.

## What each test now covers

- `test_provider_usage_model_vanishing_on_reingest_leaves_no_stale_rollup`
  (unchanged from before this PR): neither write passes a `raw_id`, so this
  exercises "unknown provenance → replace" — a same-acquisition correction
  retracting a stale model attribution.
- `test_reingest_with_poorer_export_unions_fields_instead_of_deleting_them`
  (new): passes two **different** `raw_id`s (matching the real April/July
  export scenario) — pins the union path, asserting a dropped tool-role
  message and narrowed citation keys are both restored.
- `test_reingest_with_same_raw_id_replaces_instead_of_unioning` (new):
  explicitly exercises the `existing_raw_id == raw_id` branch (same
  acquisition, corrected message-boundary re-parse) — the retraction must
  survive, not get unioned back.

## Deferred scope

Filed as `polylogue-u8x7`: `web_content_constructs`/`file_edits` are sidecar
tables populated only from the current acquisition's parsed domain objects,
so a reinjected message's citation/edit sidecar rows aren't restored yet;
`session_events`/`session_model_usage` aren't unioned either, so a reinjected
message's model rolls up with zero usage. Both need the same
`raw_id`/`force_replace` discriminator extended per-table.

## Verification

```
devtools test tests/unit/storage/test_archive_tiers_write.py
  76 passed

devtools test tests/unit/storage/test_archive_tiers_write.py tests/unit/storage/test_lineage_normalization.py \
  tests/unit/storage/test_prepared_session_rows.py tests/unit/storage/test_archive_tiers_archive.py \
  tests/unit/storage/test_bulk_fts_prefix_reextract.py tests/unit/storage/test_fts_bloat_invariants.py \
  tests/unit/sources/test_browser_capture.py tests/unit/storage/test_fts_identity_ledger.py \
  tests/unit/storage/test_embedding_rebuild_survival.py tests/unit/pipeline/test_ingest_batch.py \
  tests/unit/sources/test_chatgpt_normalization_survivors.py tests/unit/daemon/test_daemon_bulk_rebuild_responsiveness.py \
  tests/unit/devtools/test_pytest_supervisor.py
  309 passed

ruff format --check / ruff check / mypy --strict polylogue/storage/sqlite/archive_tiers/write.py
  clean

devtools render all --check
  OK, no drift

devtools verify --quick (pre-push hook)
  exit 0
```

One pre-existing failure was investigated and excluded:
`test_archive_tiers_api_raw_artifacts_read_source_tier` (a clock-freeze gap
in `revision_governance.py`'s `_raw_parse_success_state`) reproduces
identically against unmodified `origin/master`, confirmed by temporarily
swapping in the master version of the touched file and re-running the test in
isolation.

Ref polylogue-geop

🤖 Generated with [Claude Code](https://claude.com/claude-code)