### PR TITLE
fix(paths): make archive_root() honour polylogue.toml, not just env

### DIFF
--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -2172,6 +2172,37 @@ def _resolved_runtime_path(value: str | Path | None, *, bootstrap: _BootstrapPat
     return _expand_bootstrap_path(value, home=bootstrap.home, cwd=bootstrap.cwd)
 
 
+def resolve_archive_root(
+    *,
+    environment: Mapping[str, str] | None = None,
+    cwd: Path | None = None,
+    home: Path | None = None,
+) -> Path:
+    """Resolve the archive root using the same layered precedence as the rest
+    of this module: built-in XDG default, site ``polylogue.toml``, user
+    ``polylogue.toml``, then ``POLYLOGUE_ARCHIVE_ROOT`` (low to high).
+
+    Exists so :mod:`polylogue.paths` -- deliberately stdlib-only, with no
+    top-level dependency on this module to avoid an import cycle (this module
+    itself imports :mod:`polylogue.paths` for shared constants) -- can honour
+    ``polylogue.toml``'s ``[archive] root`` instead of silently ignoring it
+    (polylogue-4ma3). ``paths.archive_root()`` only reaches this function via
+    a lazy, function-local import when ``POLYLOGUE_ARCHIVE_ROOT`` is unset, so
+    a process that never touches config-file resolution never pays for it.
+
+    Deliberately not cached: re-reads the environment and any config files on
+    every call, exactly like :func:`load_polylogue_config` and the rest of
+    ``paths._roots``'s XDG accessors, so a test that monkeypatches
+    ``POLYLOGUE_ARCHIVE_ROOT`` (or the XDG/``POLYLOGUE_CONFIG``/
+    ``POLYLOGUE_SITE_CONFIG`` variables that select which config files are
+    read) observes the change on its very next call with no cache to
+    invalidate.
+    """
+    bootstrap = _snapshot_bootstrap(environment=environment, cwd=cwd, home=home)
+    settings = load_polylogue_config(_bootstrap=bootstrap)
+    return _resolved_runtime_path(settings.archive_root, bootstrap=bootstrap, fallback=bootstrap.data_home)
+
+
 def resolve_runtime_config(
     *,
     config_path: Path | None = None,
@@ -2849,4 +2880,5 @@ __all__ = [
     "load_polylogue_config",
     "redact_config_mapping",
     "redact_secret_value",
+    "resolve_archive_root",
 ]

--- a/polylogue/paths/_roots.py
+++ b/polylogue/paths/_roots.py
@@ -131,8 +131,36 @@ def browser_capture_pairing_state_path() -> Path:
 
 
 def archive_root() -> Path:
-    """Archive root (overridable via POLYLOGUE_ARCHIVE_ROOT)."""
-    return _xdg_path("POLYLOGUE_ARCHIVE_ROOT", data_home())
+    """Archive root.
+
+    Precedence (highest first): the ``POLYLOGUE_ARCHIVE_ROOT`` environment
+    variable, then ``[archive] root`` in ``polylogue.toml`` (site then user
+    config layer, same as :func:`polylogue.config.load_polylogue_config`),
+    then the XDG data-home default. Two archive roots must never exist
+    simultaneously and silently -- a process without the env var used to
+    fall straight through to the XDG default even when a config file named a
+    different root, splitting writes (hooks, browser-capture spool, inbox)
+    across two disjoint directories that nothing reconciled (polylogue-4ma3).
+
+    This module is intentionally stdlib-only, and :mod:`polylogue.config`
+    itself imports from here (``GEMINI_DRIVE_FOLDER``), so a top-level
+    import of ``polylogue.config`` would create an import cycle. The env-var
+    fast path below never touches ``polylogue.config`` at all; the config
+    lookup is a *lazy*, function-local import that only runs once the env
+    var is absent, by which point both modules are already fully loaded.
+    Nothing here is cached, so a test that monkeypatches
+    ``POLYLOGUE_ARCHIVE_ROOT`` (or the config-selecting env vars) between
+    calls sees the change immediately -- this must never regress, since many
+    tests rely on a per-test ``POLYLOGUE_ARCHIVE_ROOT`` to isolate scratch
+    archives from each other and from the real one.
+    """
+    raw = os.environ.get("POLYLOGUE_ARCHIVE_ROOT", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+
+    from ..config import resolve_archive_root  # lazy: avoid paths<->config import cycle
+
+    return resolve_archive_root()
 
 
 def render_root() -> Path:

--- a/tests/unit/core/test_paths.py
+++ b/tests/unit/core/test_paths.py
@@ -13,6 +13,108 @@ from polylogue.config import get_config
 from polylogue.paths.sanitize import is_within_root, safe_path_component
 
 
+class TestArchiveRootHonoursConfigFile:
+    """polylogue-4ma3: paths.archive_root() must not resolve from the
+    environment alone -- it has to fall back to ``polylogue.toml``'s
+    ``[archive] root`` before the bare XDG default, matching the precedence
+    :func:`polylogue.config.load_polylogue_config` documents and implements.
+
+    Reverted-mutation witness: replace ``archive_root()`` in
+    ``polylogue/paths/_roots.py`` with the pre-fix
+    ``return _xdg_path("POLYLOGUE_ARCHIVE_ROOT", data_home())`` -- every test
+    below except ``test_env_var_overrides_config_file`` and
+    ``test_default_with_neither_env_nor_config_lands_under_xdg_data_home``
+    then fails because the TOML-configured root is silently ignored.
+
+    Every test here relies on the autouse ``_clear_polylogue_env`` fixture
+    (``tests/conftest.py``) to strip inherited ``POLYLOGUE_*`` vars and repoint
+    ``XDG_CONFIG_HOME``/``XDG_DATA_HOME`` at a fresh ``tmp_path``, so no test
+    can read the real operator's ``~/.config/polylogue/polylogue.toml``.
+    """
+
+    def _write_user_config(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path, root: Path) -> None:
+        config_dir = tmp_path / "xdg-config" / "polylogue"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "polylogue.toml").write_text(f'[archive]\nroot = "{root.as_posix()}"\n', encoding="utf-8")
+
+    def test_config_file_only_resolution_works_with_no_env_var(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from polylogue.paths import archive_root
+
+        monkeypatch.delenv("POLYLOGUE_ARCHIVE_ROOT", raising=False)
+        configured_root = tmp_path / "configured-archive"
+        self._write_user_config(monkeypatch, tmp_path, configured_root)
+
+        assert archive_root() == configured_root
+
+    def test_env_var_overrides_config_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        from polylogue.paths import archive_root
+
+        configured_root = tmp_path / "configured-archive"
+        self._write_user_config(monkeypatch, tmp_path, configured_root)
+        env_root = tmp_path / "env-override-archive"
+        monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(env_root))
+
+        assert archive_root() == env_root
+
+    def test_per_test_env_override_still_isolates(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """A monkeypatched POLYLOGUE_ARCHIVE_ROOT must take effect immediately
+        and un-set again just as fast -- archive_root() must not cache a
+        resolution across calls within one test (or across tests), which
+        would break the many fixtures/tests that isolate scratch archives via
+        a per-test override."""
+        from polylogue.paths import archive_root
+
+        configured_root = tmp_path / "configured-archive"
+        self._write_user_config(monkeypatch, tmp_path, configured_root)
+
+        monkeypatch.delenv("POLYLOGUE_ARCHIVE_ROOT", raising=False)
+        assert archive_root() == configured_root
+
+        scratch_a = tmp_path / "scratch-a"
+        monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(scratch_a))
+        assert archive_root() == scratch_a
+
+        scratch_b = tmp_path / "scratch-b"
+        monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(scratch_b))
+        assert archive_root() == scratch_b
+
+        monkeypatch.delenv("POLYLOGUE_ARCHIVE_ROOT", raising=False)
+        assert archive_root() == configured_root
+
+    def test_default_with_neither_env_nor_config_lands_under_xdg_data_home(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from polylogue.paths import archive_root, data_home
+
+        monkeypatch.delenv("POLYLOGUE_ARCHIVE_ROOT", raising=False)
+        # No polylogue.toml written under XDG_CONFIG_HOME for this test.
+
+        assert archive_root() == data_home()
+        assert archive_root() == Path(tmp_path / "xdg-data" / "polylogue")
+
+    def test_site_config_lower_precedence_than_user_config(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from polylogue.paths import archive_root
+
+        monkeypatch.delenv("POLYLOGUE_ARCHIVE_ROOT", raising=False)
+        site_root = tmp_path / "site-archive"
+        site_path = tmp_path / "site.toml"
+        site_path.write_text(f'[archive]\nroot = "{site_root.as_posix()}"\n', encoding="utf-8")
+        monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", str(site_path))
+
+        # Only the site layer is configured so far.
+        assert archive_root() == site_root
+
+        user_root = tmp_path / "user-archive"
+        self._write_user_config(monkeypatch, tmp_path, user_root)
+
+        # The user layer must win over the site layer once both are present.
+        assert archive_root() == user_root
+
+
 def test_external_active_pointer_changes_only_the_index_tier(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     root = tmp_path / "archive"
     root.mkdir()


### PR DESCRIPTION
## Summary

`polylogue.paths._roots.archive_root()` resolved `POLYLOGUE_ARCHIVE_ROOT` from the environment only and never consulted `polylogue.toml`'s `[archive] root`. This PR gives it a `polylogue.config`-backed fallback so exactly one archive root exists per configuration, matching the precedence `config.py` already documents.

## Problem

`polylogue/config.py` implements a documented 5-layer precedence (defaults, site TOML, user TOML, env, CLI) for every setting, including `archive_root`. But `polylogue/paths/_roots.py` — the module every path helper (`index_db_path`, `hooks_sidecar_dir`, `browser_capture_spool_root`, ...) is built on — had its own, independent, environment-only resolver:

```python
def archive_root() -> Path:
    return _xdg_path("POLYLOGUE_ARCHIVE_ROOT", data_home())
```

Any process without `POLYLOGUE_ARCHIVE_ROOT` in its own environment silently fell back to `XDG_DATA_HOME/polylogue` instead of the operator's configured root (`/realm/db/polylogue` via `~/.config/polylogue/polylogue.toml`), even though the daemon (whose systemd unit does export the env var) used the correct root. Two archive roots existed simultaneously and silently, and nothing reconciled them.

Measured live damage before this fix: 108,094 files (2.2 GB) accumulated in `~/.local/share/polylogue/hooks/pending/` since 2026-07-14 at roughly 195/hour, while the daemon watched and drained `/realm/db/polylogue/hooks/pending/`, which held zero. 67,280 files in `acknowledged/` prove the pipeline works fine when both sides agree on the root. Browser-capture spool and `inbox/` content were split across both roots too, at different times, depending on which process's environment happened to carry the override.

## Solution

- `polylogue/config.py`: new `resolve_archive_root()` — reuses `load_polylogue_config()` (the existing site/user-TOML + env resolver) and `_resolved_runtime_path()` (the existing path-expansion helper), so the archive-root precedence has exactly one implementation, not two that can drift.
- `polylogue/paths/_roots.py`: `archive_root()` now checks `POLYLOGUE_ARCHIVE_ROOT` first (fast path — no import, matches this module's existing stdlib-only design), and only falls back to a **lazy, function-local** `from ..config import resolve_archive_root` when the env var is unset.

**Why lazy import, not top-level:** `polylogue/config.py` already imports `polylogue.paths` at module scope (`GEMINI_DRIVE_FOLDER`). A top-level `from .config import ...` in `_roots.py` would be a real import cycle regardless of which module is imported first. A function-local import only runs once both modules are fully initialized (i.e. once someone actually calls `archive_root()`), so it's safe either way.

**Why no caching:** the fixture suite isolates dozens of scratch archives via a per-test `POLYLOGUE_ARCHIVE_ROOT` monkeypatch, and the module's other XDG accessors (`config_root()`, `data_root()`, ...) already re-read `os.environ` on every call with no cache. `resolve_archive_root()` re-reads the environment and any config files on every call too, so a test (or an operator) that changes `POLYLOGUE_ARCHIVE_ROOT` between calls sees the change immediately.

**Explicitly out of scope:** migrating the ~176K files already misplaced under the XDG root (hooks pending+acknowledged, browser-capture spool, inbox) — that's a separate data-migration lane, tracked in `polylogue-4ma3`'s notes but not this PR.

## Verification

- `devtools test tests/unit/core/test_paths.py` — 25 passed. New `TestArchiveRootHonoursConfigFile` suite covers: config-file-only resolution with no env var, env var overriding the config file, per-test env-override isolation across repeated monkeypatch changes (including toggling back to the config-file value), the bare default with neither env nor config landing under `XDG_DATA_HOME`, and site-vs-user TOML precedence.
- `devtools test tests/unit/core/test_config_resolution_regression.py` — 9 passed (existing fd2s/cxlk/uu8r regression suite, including the pre-existing `test_archive_root_toml_reaches_resolved_runtime_paths` for `resolve_runtime_config`, unaffected).
- `devtools test tests/unit/core/test_config.py tests/unit/cli/test_paths.py tests/unit/browser_capture/test_receiver_token.py tests/unit/sources/test_hook_spool.py` — 143 passed (config diagnostics, CLI path plumbing, browser-capture token scoping, hook spool scoping — all archive-root-adjacent surfaces).
- `devtools verify --quick` — ok (ruff format/check, `mypy --strict`, `render all --check`, topology/layering/manifests/schema/degrade-loudly/hash-boundary/schema-versioning gates).
- Manual check with an isolated fake `HOME`: config-only resolution, env-overrides-config, and the bare-default case all resolved to the expected path; importing `polylogue.config` before `polylogue.paths` (and vice versa) does not raise `ImportError`.
- Not run: `devtools test` on the full `tests/unit` directory (anti-pattern per repo convention — testmon-affected selection only) and integration tests (not implicated — this change has no I/O or provider-parsing surface).

Ref polylogue-4ma3