### PR TITLE
feat(sources): wire opt-in Beads-issue ledger acquisition

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,7 +163,7 @@ configured Voyage key.
 
 | Class | Where it lives | Examples | Reload behavior |
 | --- | --- | --- | --- |
-| Static startup config | TOML/env/CLI | archive root, API host/port/token, browser-capture host/port/spool/origins, source roots | Restart `polylogued` after changing. |
+| Static startup config | TOML/env/CLI | archive root, API host/port/token, browser-capture host/port/spool/origins, source roots, beads roots | Restart `polylogued` after changing. |
 | Deployment policy | TOML/env/Nix/HM/systemd | remote-bind opt-in, auth requirements, systemd memory/IO limits, schema validation mode | Restart the managed service; policy is outside archive content hashes. |
 | Runtime mutable user state | `user.db` | tags, marks, saved views, workspaces, assertions, authored overlays | Mutated through CLI/API; not TOML and not source content. |
 | Provider/cost controls | TOML/env | `embedding.enabled`, `embedding.max_cost_usd`, `VOYAGE_API_KEY` | Embedding loops read the gate/cost controls; no provider call happens unless explicitly enabled and credentials are present. |
@@ -198,6 +198,13 @@ debounce_s = 2.0
 
 [sources]
 roots = ["/home/user/.claude/projects", "/home/user/.codex/sessions"]
+# beads_roots names repository roots (not their .beads/ directories) whose
+# append-only .beads/interactions.jsonl issue-evidence ledger should be
+# watched and ingested as beads-issue sessions. Opt-in and empty by default:
+# unlike every other source above, a Beads ledger is scoped to one git
+# repository, not a single home-relative directory, so there is no safe
+# default to guess.
+# beads_roots = ["/home/user/project/polylogue", "/home/user/project/sinnix"]
 
 [embedding]
 enabled = false
@@ -343,6 +350,7 @@ A few keys not shown in the full example above, with their TOML path:
 | `no_daemon` | `client.no_daemon` | Force direct in-process archive access, bypassing the daemon client even when one is reachable. |
 | `debug_timing` | `ui.debug_timing` | Emit per-stage timing diagnostics in CLI output. |
 | `hermes_root` | `sources.hermes.root` | Runtime root watched for Hermes state, snapshots, NeMo Relay ATIF/ATOF artifacts, and verification evidence. Defaults to `~/.hermes`. |
+| `beads_roots` | `sources.beads_roots` | Repository roots (not their `.beads/` directories) whose append-only `.beads/interactions.jsonl` ledger is watched and ingested as `beads-issue` sessions, one session per issue. Opt-in; empty by default, since a Beads ledger belongs to one git repository rather than a single home-relative directory. |
 | `hook_sidecar_dir` | `sources.hook_sidecar_dir` | Directory for hook-event sidecar files consumed by the Claude Code/Codex hook harness. Defaults to `<archive_root>/hooks`, so a scratch/test `POLYLOGUE_ARCHIVE_ROOT` genuinely isolates its hook spool from the real one; set explicitly only if you need the spool somewhere other than the archive it belongs to. |
 | `hook_provider` | `sources.hook_provider` | Force hook-event harness detection to `claude-code` or `codex` instead of sniffing the payload shape; unset auto-detects. |
 | `backup_verify_tmpdir` | `maintenance.backup_verify_tmpdir` | Scratch directory for backup-restore verification; defaults to the system temp dir when unset. |
@@ -390,6 +398,7 @@ Common runtime overrides:
 | `POLYLOGUE_SITE_CONFIG` | config layer | Explicit site config path; empty disables site config. |
 | `POLYLOGUE_ARCHIVE_ROOT` | `archive_root` | Override the archive root. |
 | `POLYLOGUE_HERMES_ROOT` | `hermes_root` | Override the Hermes runtime root watched by the daemon. |
+| `POLYLOGUE_BEADS_ROOTS` | `beads_roots` | Comma-separated repository roots whose `.beads/interactions.jsonl` ledger the daemon watches. |
 | `POLYLOGUE_DAEMON_URL` | `daemon_url` | CLI/MCP client daemon base URL. |
 | `POLYLOGUE_API_HOST` / `POLYLOGUE_API_PORT` | `api_host` / `api_port` | Daemon HTTP API bind. |
 | `POLYLOGUE_API_AUTH_TOKEN` | `api_auth_token` | API bearer token; redacted in config output. |

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -564,6 +564,24 @@ class PolylogueConfig:
         return ()
 
     @property
+    def beads_roots(self) -> tuple[str, ...]:
+        """Repository roots whose ``.beads/interactions.jsonl`` ledger is watched.
+
+        Opt-in and empty by default: unlike every other source, a Beads
+        ledger is repository-scoped, not home-relative, so there is no safe
+        default set of repositories to guess. Set ``sources.beads_roots`` in
+        ``polylogue.toml`` (or ``POLYLOGUE_BEADS_ROOTS``, comma-separated) to
+        the repository roots (not the ``.beads`` directories themselves)
+        whose issue-interaction history should be archived.
+        """
+        v = self._data.get("beads_roots")
+        if isinstance(v, (list, tuple)):
+            return tuple(str(item) for item in v)
+        if isinstance(v, str) and v.strip():
+            return tuple(s.strip() for s in v.split(",") if s.strip())
+        return ()
+
+    @property
     def hermes_root(self) -> str:
         """Optional layered override for the Hermes runtime root."""
         return str(self._data.get("hermes_root", ""))
@@ -1032,6 +1050,19 @@ _CONFIG_INVENTORY: tuple[ConfigInventoryEntry, ...] = (
         owner_class="path-layout",
         reload_behavior="startup-bound",
         description="Additional source roots watched by the daemon.",
+    ),
+    ConfigInventoryEntry(
+        "beads_roots",
+        toml_path="sources.beads_roots",
+        env_var="POLYLOGUE_BEADS_ROOTS",
+        owner_class="path-layout",
+        reload_behavior="startup-bound",
+        description=(
+            "Repository roots (not .beads/ directories) whose append-only "
+            "interactions.jsonl ledger is watched and ingested as beads-issue "
+            "sessions. Opt-in; empty by default -- Beads ledgers are "
+            "repository-scoped, so there is no safe home-relative default."
+        ),
     ),
     ConfigInventoryEntry(
         "hermes_root",
@@ -1839,6 +1870,7 @@ def _default_config_values(bootstrap: _BootstrapPaths | None = None) -> dict[str
         "browser_capture_allow_remote": False,
         "browser_capture_allow_no_auth": False,
         "source_roots": (),
+        "beads_roots": (),
         "hermes_root": "",
         "drive_credentials_path": str(captured.config_home / "polylogue-credentials.json"),
         "drive_token_path": str(captured.state_home / "token.json"),
@@ -2132,6 +2164,7 @@ class ResolvedSourcePaths:
     inbox: Path
     hooks_pending: Path
     explicit: tuple[Path, ...]
+    beads: tuple[Path, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -2234,6 +2267,9 @@ def resolve_runtime_config(
     explicit_roots = tuple(
         _resolved_runtime_path(value, bootstrap=bootstrap, fallback=bootstrap.cwd) for value in settings.source_roots
     )
+    beads_roots = tuple(
+        _resolved_runtime_path(value, bootstrap=bootstrap, fallback=bootstrap.cwd) for value in settings.beads_roots
+    )
     source_paths = ResolvedSourcePaths(
         claude_code=bootstrap.home / ".claude" / "projects",
         codex=bootstrap.home / ".codex" / "sessions",
@@ -2248,6 +2284,7 @@ def resolve_runtime_config(
         inbox=paths.inbox_root,
         hooks_pending=hook_sidecar / "pending",
         explicit=explicit_roots,
+        beads=beads_roots,
     )
     local_candidates = (
         ("claude-code", source_paths.claude_code),
@@ -2260,6 +2297,11 @@ def resolve_runtime_config(
         ("hooks", source_paths.hooks_pending),
     )
     sources = [Source(name=name, path=path) for name, path in local_candidates if path.exists()]
+    sources.extend(
+        Source(name=f"beads:{repository_root.name}", path=repository_root / ".beads" / "interactions.jsonl")
+        for repository_root in beads_roots
+        if (repository_root / ".beads" / "interactions.jsonl").exists()
+    )
     gemini_cache = drive_cache / "gemini"
     if gemini_cache.exists() or drive_credentials.exists() or drive_token.exists():
         sources.append(Source(name="aistudio", folder=GEMINI_DRIVE_FOLDER, path=gemini_cache))
@@ -2445,10 +2487,13 @@ def _config_diagnostic(
     return payload
 
 
+_MULTI_PATH_CONFIG_KEYS = frozenset({"source_roots", "beads_roots"})
+
+
 def _iter_path_config_values(key: str, value: object) -> list[str]:
     if value in (None, "", ()):
         return []
-    if key == "source_roots":
+    if key in _MULTI_PATH_CONFIG_KEYS:
         if isinstance(value, str):
             return [value]
         if isinstance(value, (tuple, list)):
@@ -2516,6 +2561,21 @@ def _config_path_diagnostics(resolved: PolylogueConfig) -> list[dict[str, object
                         key=entry.key,
                         message=f"Configured source root does not exist: {raw_path}.",
                         next_action="Remove the stale source root or create/mount it before running the daemon.",
+                        cfg=resolved,
+                    )
+                )
+            if entry.key == "beads_roots" and not path.exists():
+                diagnostics.append(
+                    _config_diagnostic(
+                        code="configured_beads_root_missing",
+                        severity="warning",
+                        key=entry.key,
+                        message=f"Configured Beads repository root does not exist: {raw_path}.",
+                        next_action=(
+                            "Remove the stale beads root or point it at an existing repository checkout; "
+                            "the ledger itself (.beads/interactions.jsonl) may not exist yet -- only the "
+                            "repository root must."
+                        ),
                         cfg=resolved,
                     )
                 )

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -294,6 +294,7 @@ def _watch_sources_from_roots(
     *,
     browser_capture_spool_path: Path | None = None,
     hermes_root: Path | None = None,
+    beads_roots: tuple[Path, ...] = (),
 ) -> tuple[WatchSource, ...]:
     """Build watch sources for explicit daemon roots.
 
@@ -302,9 +303,13 @@ def _watch_sources_from_roots(
     including ChatGPT ``.json`` files and zipped takeouts, so an isolated
     daemon pointed at that inbox must keep the same suffix contract as the
     default inbox source.
+
+    ``beads_roots`` only applies to the default (no explicit ``--root``)
+    case, matching how an explicit ``--root`` already replaces every other
+    default source rather than adding to it.
     """
     if not roots:
-        sources = list(default_sources(hermes_root=hermes_root))
+        sources = list(default_sources(hermes_root=hermes_root, beads_roots=beads_roots))
         if browser_capture_spool_path is not None:
             spool = browser_capture_spool_path.expanduser()
             sources = [source for source in sources if source.name != "browser-capture"]
@@ -2779,6 +2784,7 @@ def run_command(
         roots,
         browser_capture_spool_path=spool_path,
         hermes_root=runtime.source_paths.hermes,
+        beads_roots=runtime.source_paths.beads,
     )
     components = []
     if enable_watch:
@@ -2835,7 +2841,12 @@ def run_command(
 def watch_command(roots: tuple[Path, ...], debounce_s: float) -> None:
     from polylogue.config import resolve_runtime_config
 
-    sources = _watch_sources_from_roots(roots, hermes_root=resolve_runtime_config().source_paths.hermes)
+    runtime_source_paths = resolve_runtime_config().source_paths
+    sources = _watch_sources_from_roots(
+        roots,
+        hermes_root=runtime_source_paths.hermes,
+        beads_roots=runtime_source_paths.beads,
+    )
 
     click.echo(
         f"Watching {len(sources)} source(s); debounce={debounce_s}s. Ctrl-C to stop.",

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -1335,12 +1335,24 @@ def _interleave_by_source(candidates: list[CandidateSourceFile]) -> list[Candida
     return ordered
 
 
-def default_sources(*, hermes_root: Path | None = None) -> tuple[WatchSource, ...]:
+def default_sources(*, hermes_root: Path | None = None, beads_roots: tuple[Path, ...] = ()) -> tuple[WatchSource, ...]:
     """Discover the default live-source roots from XDG/home conventions.
 
     Includes the archive inbox so that ``polylogue ingest PATH``
     (which stages to ``archive_root()/inbox``) is observed by the
     daemon-owned watcher.
+
+    ``beads_roots`` are repository roots (not ``.beads`` directories
+    themselves) whose append-only ``.beads/interactions.jsonl`` ledger
+    should be watched. Beads is opt-in and unlike every other source here:
+    a single global runtime directory does not exist for it (each git
+    repository owns its own ledger), so there is no home-relative default
+    -- callers must supply the repository roots explicitly (see
+    ``PolylogueConfig.beads_roots`` / ``sources.beads_roots`` in
+    ``polylogue.toml``). A repository without a ``.beads/interactions.jsonl``
+    ledger yet is still watched (``WatchSource.exists()`` reports it
+    absent) so a ledger created later is picked up without a daemon
+    restart.
     """
     from polylogue.core.enums import Provider
     from polylogue.paths import (
@@ -1353,6 +1365,19 @@ def default_sources(*, hermes_root: Path | None = None) -> tuple[WatchSource, ..
         hermes_sessions_path,
     )
     from polylogue.sources.origin_specs import artifact_suffixes_for_provider
+
+    beads_sources = tuple(
+        WatchSource(
+            name=f"beads:{repository_root.name}",
+            root=repository_root / ".beads",
+            # Scoped to the append-only interaction ledger, never the
+            # mutable current-state ``issues.jsonl``/backup snapshots that
+            # also live under ``.beads/`` -- those are not evidence
+            # timelines and would misrepresent issue history if ingested.
+            suffixes=("interactions.jsonl",),
+        )
+        for repository_root in beads_roots
+    )
 
     return (
         WatchSource(
@@ -1393,6 +1418,7 @@ def default_sources(*, hermes_root: Path | None = None) -> tuple[WatchSource, ..
         # GDPR exports (typically .zip) and raw .json dumps are observed.
         WatchSource(name="inbox", root=archive_root() / "inbox", suffixes=INBOX_SOURCE_SUFFIXES),
         WatchSource(name="hooks", root=pending_hook_spool_dir(), suffixes=(".json",)),
+        *beads_sources,
     )
 
 

--- a/polylogue/sources/origin_specs.py
+++ b/polylogue/sources/origin_specs.py
@@ -793,7 +793,11 @@ def _beads_spec() -> OriginSpec:
         acquisition_modes=("issue-jsonl",),
         parser_paths=("polylogue/sources/parsers/beads.py",),
         fixture_paths=("tests/unit/sources/parsers/test_beads.py",),
-        stream_parser_path="polylogue/sources/parsers/beads.py:parse_beads_stream",
+        # dispatch.py:parse_stream_payload routes Provider.BEADS to the
+        # plain ``beads.parse`` entry point -- there is no dedicated
+        # ``parse_beads_stream`` function; this declaration must name the
+        # function dispatch actually calls.
+        stream_parser_path="polylogue/sources/parsers/beads.py:parse",
         display_description="Beads issue exports (non-chat work artifacts)",
     )
 

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -451,6 +451,12 @@ class TestPolylogueConfigDefaults:
         cfg = load_polylogue_config()
         assert cfg.source_roots == ()
 
+    def test_beads_roots_default(self, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        assert cfg.beads_roots == ()
+
     def test_hermes_root_default(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.config import load_polylogue_config
 
@@ -613,6 +619,46 @@ class TestPolylogueConfigTOML:
         )
         cfg = load_polylogue_config(config_path=toml_path)
         assert cfg.source_roots == ("/tmp/extra", "/tmp/more")
+
+    def test_toml_sets_beads_roots(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
+        from polylogue.config import load_polylogue_config, resolve_runtime_config
+
+        repo_a = tmp_path / "repo-a"
+        repo_b = tmp_path / "repo-b"
+        repo_a.mkdir()
+        repo_b.mkdir()
+        toml_path = tmp_path / "polylogue.toml"
+        toml_path.write_text(
+            f'[sources]\nbeads_roots = ["{repo_a}", "{repo_b}"]\n',
+            encoding="utf-8",
+        )
+        cfg = load_polylogue_config(config_path=toml_path)
+        assert cfg.beads_roots == (str(repo_a), str(repo_b))
+        assert resolve_runtime_config(config_path=toml_path).source_paths.beads == (repo_a, repo_b)
+
+    def test_configured_beads_root_with_ledger_is_a_discovered_source(
+        self, tmp_path: Path, workspace_env: dict[str, Path]
+    ) -> None:
+        """A repo with an on-disk ledger shows up in ``sources`` for status/diagnostics
+        surfaces; a configured root without one yet does not (nothing to report)."""
+        from polylogue.config import resolve_runtime_config
+
+        with_ledger = tmp_path / "with-ledger"
+        (with_ledger / ".beads").mkdir(parents=True)
+        (with_ledger / ".beads" / "interactions.jsonl").write_text("", encoding="utf-8")
+        without_ledger = tmp_path / "without-ledger"
+        without_ledger.mkdir()
+        toml_path = tmp_path / "polylogue.toml"
+        toml_path.write_text(
+            f'[sources]\nbeads_roots = ["{with_ledger}", "{without_ledger}"]\n',
+            encoding="utf-8",
+        )
+
+        runtime = resolve_runtime_config(config_path=toml_path)
+
+        names = {source.name for source in runtime.sources}
+        assert "beads:with-ledger" in names
+        assert "beads:without-ledger" not in names
 
     def test_toml_sets_hermes_root(self, tmp_path: Path, workspace_env: dict[str, Path]) -> None:
         from polylogue.config import load_polylogue_config, resolve_runtime_config

--- a/tests/unit/core/test_config_inventory.py
+++ b/tests/unit/core/test_config_inventory.py
@@ -161,6 +161,41 @@ roots = ["{missing_root}"]
     assert diag["next_action"] == "Remove the stale source root or create/mount it before running the daemon."
 
 
+def test_effective_config_payload_reports_configured_beads_root_debt(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    workspace_env: dict[str, Path],
+) -> None:
+    from polylogue.config import effective_config_payload, load_polylogue_config
+
+    missing_root = tmp_path / "missing-beads-repo"
+    cfg_path = tmp_path / "polylogue.toml"
+    cfg_path.write_text(
+        f"""
+[sources]
+beads_roots = ["{missing_root}"]
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
+
+    payload = effective_config_payload(load_polylogue_config(config_path=cfg_path))
+
+    diagnostics = payload["diagnostics"]
+    assert isinstance(diagnostics, list)
+    matches = [
+        diag for diag in diagnostics if isinstance(diag, dict) and diag.get("code") == "configured_beads_root_missing"
+    ]
+    assert matches
+    diag = matches[0]
+    assert diag["severity"] == "warning"
+    assert diag["key"] == "beads_roots"
+    assert diag["toml_path"] == "sources.beads_roots"
+    assert diag["source_layer"] == "user"
+    assert diag["value"] == [str(missing_root)]
+    assert diag["message"] == f"Configured Beads repository root does not exist: {missing_root}."
+
+
 def test_effective_config_payload_reports_invalid_home_expansion(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -1837,6 +1837,7 @@ def test_polylogued_run_uses_default_sources() -> None:
     assert result.exit_code == 0
     assert default_sources.call_count == 1
     assert default_sources.call_args.kwargs["hermes_root"] == Path.home() / ".hermes"
+    assert default_sources.call_args.kwargs["beads_roots"] == ()
     coroutine = run.call_args.kwargs.get("main") or run.call_args.args[0]
     assert inspect.iscoroutine(coroutine)
     coroutine.close()
@@ -1911,6 +1912,7 @@ def test_polylogued_watch_uses_default_sources() -> None:
     assert result.exit_code == 0
     assert default_sources.call_count == 1
     assert default_sources.call_args.kwargs["hermes_root"] == Path.home() / ".hermes"
+    assert default_sources.call_args.kwargs["beads_roots"] == ()
     coroutine = run.call_args.kwargs.get("main") or run.call_args.args[0]
     assert inspect.iscoroutine(coroutine)
     coroutine.close()

--- a/tests/unit/sources/test_live_watcher_catchup_order.py
+++ b/tests/unit/sources/test_live_watcher_catchup_order.py
@@ -80,6 +80,40 @@ def test_default_sources_uses_resolved_hermes_root(tmp_path: Path) -> None:
     assert hermes.accepts(configured_root / "observability" / "hermes-atof.jsonl")
 
 
+def test_default_sources_omits_beads_by_default() -> None:
+    """Beads has no home-relative default -- unlike every other source here,
+    a ledger belongs to a specific git repository. Omitting ``beads_roots``
+    must not synthesize a watch source out of nowhere."""
+    names = {source.name for source in live_watcher.default_sources()}
+
+    assert not any(name.startswith("beads:") for name in names)
+
+
+def test_default_sources_watches_configured_beads_roots(tmp_path: Path) -> None:
+    repo_a = tmp_path / "repo-a"
+    repo_b = tmp_path / "repo-b"
+    repo_a.mkdir()
+    repo_b.mkdir()
+
+    sources = {
+        source.name: source
+        for source in live_watcher.default_sources(beads_roots=(repo_a, repo_b))
+        if source.name.startswith("beads:")
+    }
+
+    assert set(sources) == {"beads:repo-a", "beads:repo-b"}
+    beads_a = sources["beads:repo-a"]
+    assert beads_a.root == repo_a / ".beads"
+    assert beads_a.accepts(repo_a / ".beads" / "interactions.jsonl")
+    # The mutable current-state ledger and rotated backups must never be
+    # treated as the append-only interaction timeline.
+    assert not beads_a.accepts(repo_a / ".beads" / "issues.jsonl")
+    assert not beads_a.accepts(repo_a / ".beads" / "backup" / "snapshot.darc")
+    # A repository without a ledger yet is still watched so a ledger
+    # created later is picked up without a daemon restart.
+    assert not beads_a.exists()
+
+
 def test_default_sources_watch_codex_state_db(monkeypatch: Any, tmp_path: Path) -> None:
     """polylogue-0jf4: a second, narrower WatchSource covers the five live
     ~/.codex SQLite databases without widening the existing "codex" JSONL


### PR DESCRIPTION
## Summary

`Origin.BEADS_ISSUE` had a real parser (`polylogue/sources/parsers/beads.py`), a real taxonomy detector (`looks_like_beads_interaction`), and real dispatch routing, but had never ingested anything: `select count(*) from sessions where origin='beads-issue'` returned zero against a live archive despite three real `.beads/interactions.jsonl` ledgers existing on disk. This PR wires the missing acquisition route.

## Problem

Investigated the full chain from ledger to archive:

- **Parser**: real, tested (`tests/unit/sources/parsers/test_beads.py`), handles idempotent per-issue timelines with workspace-namespaced identity.
- **Detection**: real, ordered correctly in `dispatch.py:RECORD_DETECTOR_PROVIDER_ORDER` (tightness 40, between antigravity and codex) — no collision risk with earlier/looser detectors.
- **Acquisition**: **missing**. `polylogue/sources/live/watcher.py:default_sources()` — the function the daemon actually calls to build its watch list — enumerates one home-relative directory per provider (`~/.claude/projects`, `~/.codex/sessions`, `~/.gemini/tmp`, `~/.hermes`, ...) and never mentioned Beads. `polylogue/paths/_roots.py` has no `beads_path()` accessor either. Nothing ever handed a `.beads/interactions.jsonl` file to the parser, live or via catch-up scan.
- Also found a stale `OriginSpec.stream_parser_path="polylogue/sources/parsers/beads.py:parse_beads_stream"` — that function was never implemented; `dispatch.py:parse_stream_payload` actually calls the plain `beads.parse`. Fixed alongside since it's the same declaration surface and the same "declared but never actually exercised" defect class.

## Solution

Beads is structurally different from every other source here: a ledger belongs to one git repository, not a single home-relative runtime directory, so there's no safe default to guess (and hardcoding `/realm/project/*` paths in a general-purpose public archive tool would be wrong).

- **`polylogue/sources/live/watcher.py`**: `default_sources(beads_roots=...)` builds one `WatchSource` per configured repository root, `root=<repo>/.beads`, `suffixes=("interactions.jsonl",)` — scoped to the append-only ledger only, never the mutable current-state `issues.jsonl` or rotated `backup/*.darc` snapshots that also live under `.beads/`.
- **`polylogue/config.py`**: new opt-in `sources.beads_roots` config key (mirrors the existing `sources.roots`/`source_roots` pattern exactly): property, default `()`, `ConfigInventoryEntry`, `POLYLOGUE_BEADS_ROOTS` env var, `ResolvedSourcePaths.beads`, path-existence diagnostics for a configured-but-missing repo root, and a per-repo `Source` entry in `ResolvedRuntimeConfig.sources` (for `/api/sources`-style status surfaces) when a ledger already exists on disk.
- **`polylogue/daemon/cli.py`**: `run_command`/`watch_command`/`_watch_sources_from_roots` thread `beads_roots` through. An explicit `--root` still fully replaces the default source set (existing semantics, unchanged) — `beads_roots` only applies to the unqualified default case, same as the existing `hermes_root` pattern.
- **`docs/configuration.md`**: documents `sources.beads_roots` / `POLYLOGUE_BEADS_ROOTS` (required — `devtools verify docs-coverage` fails on an undocumented public config key).

## Design questions (answered explicitly, not silently picked)

**Which repos get ingested?** No repos are hardcoded. There is no existing project-registry concept in Polylogue to hook into (checked `config.py`, `paths/_roots.py` — nothing). `sources.beads_roots` is opt-in, empty by default; an operator lists the repository roots they want archived in their own `polylogue.toml`, exactly like `sources.roots` already works for arbitrary extra JSONL trees.

**Is one-session-per-issue still the right shape?** Checked before enabling, given the hook-event inflation precedent (83,286 → 18,391 sessions from ingesting non-conversation records as standalone sessions):

| Repo | Issues (= projected sessions) |
| --- | --- |
| polylogue | 857 |
| sinnix | 55 |
| sinity-lynchpin | 12 |
| **Total** | **924** |

924 sessions is a modest, proportionate number — nowhere near the inflation-incident scale, and each session genuinely represents one coherent unit of work-evidence (an issue's full interaction timeline), not a fragment of one. The parser's existing design (one session per issue, not per interaction event) holds up.

**Idempotency under repeated ingest of an append-only, growing ledger?** `parse_issue_timeline` derives `provider_session_id` from `issue_id` + a hash of the resolved repository root (`_provider_session_id`/`_repository_root` in `beads.py`), stable across re-parses of the same repo. New interactions appended to the ledger change that issue's session content hash, so the standard content-hash pipeline updates the existing session rather than duplicating it; unchanged issues hash identically and are skipped. Already covered by the existing `test_workspace_namespace_prevents_cross_repository_issue_collisions` parser test; I did not touch `storage/archive_tiers/write.py` (owned by another lane) and didn't need to.

## Verification

```
devtools test tests/unit/core/test_config.py tests/unit/core/test_config_inventory.py \
  tests/unit/sources/test_live_watcher_catchup_order.py tests/unit/daemon/test_daemon_cli.py \
  tests/unit/sources/parsers/test_beads.py tests/unit/sources/test_origin_specs.py
# -> 310 passed in 8.55s
```

```
devtools verify --quick
# -> exit_code 0 (ruff format/check, mypy --strict, render all --check, topology,
#    layering, docs-coverage, schema-versioning policy, schema promotion audit)
```

Pre-push quick verification baseline also ran clean on push.

**Not run**: a live `polylogued run` against a real archive with `beads_roots` configured (needs an operator archive, not a cloud/CI sandbox) — the config resolution, watch-source construction, and detector/parser chain are each independently tested, but the full daemon startup → catch-up scan → write path is the natural next real-world check once this merges.

Ref polylogue-2qx