### PR TITLE
fix(sources): require positive conversation evidence before session classification

### DIFF
--- a/polylogue/archive/artifact_taxonomy/support.py
+++ b/polylogue/archive/artifact_taxonomy/support.py
@@ -13,9 +13,17 @@ _PATH_ONLY_SIDECARS = {
 }
 _SUBAGENT_SUFFIXES = (".jsonl", ".jsonl.txt", ".ndjson")
 _SCALAR_TYPES = (str, int, float, bool, type(None))
+#: Keys specific enough that their bare presence alone is positive evidence of
+#: a provider conversation/tool record. Deliberately does NOT include bare
+#: ``"type"`` (see ``_TYPE_ENVELOPE_MARKERS`` below): a generic ``"type"``
+#: field shows up on all kinds of non-conversational structured data (graph
+#: edges, index rows, run manifests), so "record has *a* type key" is not
+#: discriminating evidence on its own -- treating it as sufficient is exactly
+#: how a third-party analysis artifact like ``conversation_relationships.jsonl``
+#: (rows shaped ``{"conversation", "parent", "child", "type", "timestamp"}``,
+#: no envelope at all) misclassified as a session-record stream (polylogue-9ykn).
 _RECORDISH_KEYS = frozenset(
     {
-        "type",
         "record_type",
         "sessionId",
         "parentUuid",
@@ -25,8 +33,21 @@ _RECORDISH_KEYS = frozenset(
         "tool_input",
     }
 )
+#: A bare ``"type"`` key only counts as positive record evidence when it
+#: co-occurs with at least one of these genuine provider-record envelope
+#: markers (mirrors ``sources/parsers/claude/code_detection.py``'s
+#: ``looks_like_code``, which has the same "type-only is too weak" defect and
+#: the same fix shape).
+_TYPE_ENVELOPE_MARKERS = frozenset({"uuid", "sessionId", "parentUuid", "message", "payload", "cwd", "version"})
 _MESSAGE_KEYS = frozenset({"role", "content", "text", "parts", "author"})
+#: Third-party graph/relationship-index JSONL rows (e.g. a sinex analysis
+#: artifact recording conversation parent/child edges) that happen to sit
+#: under a watched Claude Code directory tree. Both observed field-name
+#: variants are guarded explicitly rather than relying solely on the
+#: ``_TYPE_ENVELOPE_MARKERS`` fix above, so this shape is refused even if a
+#: future provider record legitimately grows one of the envelope markers.
 _RELATIONSHIP_INDEX_KEYS = frozenset({"session", "parent", "child", "type", "timestamp"})
+_RELATIONSHIP_INDEX_KEYS_CONVERSATION = frozenset({"conversation", "parent", "child", "type", "timestamp"})
 _HOOK_EVENT_KEYS = frozenset({"event_type", "session_id", "timestamp", "provider"})
 _BEADS_INTERACTION_KEYS = frozenset({"id", "kind", "created_at", "issue_id", "extra"})
 
@@ -64,11 +85,14 @@ def looks_like_record_stream(payload: list[JSONDocument]) -> bool:
 
 
 def looks_like_record_entry(payload: JSONDocument) -> bool:
-    if _RELATIONSHIP_INDEX_KEYS.issubset(payload) and not any(
-        key in payload for key in ("message", "payload", "sessionId", "parentUuid", "uuid")
-    ):
+    has_envelope_marker = any(key in payload for key in _TYPE_ENVELOPE_MARKERS)
+    if (
+        _RELATIONSHIP_INDEX_KEYS.issubset(payload) or _RELATIONSHIP_INDEX_KEYS_CONVERSATION.issubset(payload)
+    ) and not has_envelope_marker:
         return False
     if any(key in payload for key in _RECORDISH_KEYS):
+        return True
+    if "type" in payload and has_envelope_marker:
         return True
     if "role" in payload and any(key in payload for key in ("content", "text")) and len(payload) <= 16:
         return True

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -778,13 +778,50 @@ def _direct_archive_counts(conn: Any, *, configured_root: Path | None = None) ->
             "sessions": _fast_count(conn, "SELECT COUNT(*) FROM sessions"),
             "messages": messages,
             "raw_records": _archive_source_raw_count(conn, configured_root=configured_root),
+            "unidentified_artifacts": _archive_unidentified_artifact_count(conn, configured_root=configured_root),
         }
-    return {"sessions": 0, "messages": 0, "raw_records": 0}
+    return {"sessions": 0, "messages": 0, "raw_records": 0, "unidentified_artifacts": 0}
 
 
 def _archive_source_raw_count(conn: Any, *, configured_root: Path | None = None) -> int:
-    if _table_exists(conn, "raw_sessions"):
-        return _fast_count(conn, "SELECT COUNT(*) FROM raw_sessions")
+    return _archive_source_table_count(
+        conn, table="raw_sessions", sql="SELECT COUNT(*) FROM raw_sessions", configured_root=configured_root
+    )
+
+
+def _archive_unidentified_artifact_count(conn: Any, *, configured_root: Path | None = None) -> int:
+    """Count ``raw_artifacts`` rows classified ``artifact_kind='unknown'``.
+
+    polylogue-9ykn: a record that cannot be positively identified as a
+    session, sidecar, or other known artifact kind is durably ledgered in
+    ``source.db``'s ``raw_artifacts`` table (``archive.artifact_taxonomy.
+    classify_artifact`` -> ``storage.artifacts.inspection.inspect_raw_artifact``
+    -> ``save_artifact_observation``, run for every acquired record) rather
+    than silently becoming a session or silently vanishing. Surfacing the
+    live count here is what makes a NEW unidentified artifact class (e.g. a
+    third-party sidecar under a watched directory nobody has seen before)
+    show up in routine ``polylogue ops status`` output the week it appears,
+    instead of sitting unnoticed for a year -- see
+    ``polylogue check --check-artifact-coverage --check-cohorts`` for the
+    full per-kind/per-provider breakdown this count summarizes.
+    """
+    return _archive_source_table_count(
+        conn,
+        table="raw_artifacts",
+        sql="SELECT COUNT(*) FROM raw_artifacts WHERE artifact_kind = 'unknown'",
+        configured_root=configured_root,
+    )
+
+
+def _archive_source_table_count(conn: Any, *, table: str, sql: str, configured_root: Path | None = None) -> int:
+    """Shared source.db row-count resolution: active connection, configured
+    root, or (fallback) the active db's sibling directory via PRAGMA
+    database_list. Factored out of ``_archive_source_raw_count`` so a second
+    source.db-tier count (``_archive_unidentified_artifact_count``) does not
+    duplicate the three-branch resolution.
+    """
+    if _table_exists(conn, table):
+        return _fast_count(conn, sql)
     if configured_root is not None:
         source_db = configured_root / "source.db"
         if not source_db.exists():
@@ -792,9 +829,9 @@ def _archive_source_raw_count(conn: Any, *, configured_root: Path | None = None)
         try:
             source_conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
             try:
-                if not _table_exists(source_conn, "raw_sessions"):
+                if not _table_exists(source_conn, table):
                     return 0
-                return _fast_count(source_conn, "SELECT COUNT(*) FROM raw_sessions")
+                return _fast_count(source_conn, sql)
             finally:
                 source_conn.close()
         except sqlite3.Error:
@@ -802,7 +839,7 @@ def _archive_source_raw_count(conn: Any, *, configured_root: Path | None = None)
     try:
         row = conn.execute("PRAGMA database_list").fetchone()
     except Exception as exc:
-        logger.warning("raw-record count unavailable (database_list probe failed: %s); reporting 0", exc)
+        logger.warning("%s count unavailable (database_list probe failed: %s); reporting 0", table, exc)
         return 0
     if row is None or len(row) < 3 or not row[2]:
         return 0
@@ -812,9 +849,9 @@ def _archive_source_raw_count(conn: Any, *, configured_root: Path | None = None)
     try:
         source_conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
         try:
-            if not _table_exists(source_conn, "raw_sessions"):
+            if not _table_exists(source_conn, table):
                 return 0
-            return _fast_count(source_conn, "SELECT COUNT(*) FROM raw_sessions")
+            return _fast_count(source_conn, sql)
         finally:
             source_conn.close()
     except sqlite3.Error:
@@ -1339,6 +1376,7 @@ def _compact_status_payload(status: dict[str, Any], *, source: str) -> dict[str,
         "sessions",
         "messages",
         "raw_records",
+        "unidentified_artifacts",
         "next_action",
         "gil_enabled",
     ):
@@ -2152,6 +2190,7 @@ def _show_direct_status(
             convs = counts["sessions"]
             msgs = counts["messages"]
             raw = counts["raw_records"]
+            unidentified = counts["unidentified_artifacts"]
             fts = _fast_fts_doc_count(conn)
         finally:
             conn.close()
@@ -2221,6 +2260,11 @@ def _show_direct_status(
         env.ui.console.print(f"  Sessions: {convs:,}")
         env.ui.console.print(f"  Messages: {msgs:,}")
         env.ui.console.print(f"  Raw records: {raw:,}")
+        if unidentified:
+            env.ui.console.print(
+                f"  Unidentified artifacts: [yellow]{unidentified:,}[/yellow] "
+                "(never became a session; see `polylogue check --check-artifact-coverage --check-cohorts`)"
+            )
         if fts:
             fts_pct = 100 * fts / msgs if msgs else 100
             fts_color = "green" if fts_pct > 99 else "yellow"

--- a/polylogue/sources/parsers/claude/code_detection.py
+++ b/polylogue/sources/parsers/claude/code_detection.py
@@ -4,18 +4,37 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+#: Type tokens specific enough to Claude Code's own record vocabulary that
+#: their bare presence is sufficient evidence on its own.
 _CODE_ONLY_TYPES = frozenset(
     {
         "file-history-snapshot",
         "queue-operation",
         "custom-title",
-        "user",
-        "assistant",
         "summary",
         "progress",
         "result",
     }
 )
+#: ``"user"``/``"assistant"`` are NOT specific to Claude Code -- they are
+#: generic role/edge-type words that also appear as a bare ``"type"`` value on
+#: unrelated structured data sitting under a watched Claude Code directory
+#: (e.g. a third-party graph-edge index recording
+#: ``{"conversation", "parent", "child", "type", "timestamp"}`` rows, whose
+#: ``type`` happens to be "assistant"/"user" -- polylogue-9ykn). Treating them
+#: as sufficient on their own is exactly how such a file misclassified as a
+#: Claude Code session. Require them to co-occur with a genuine record
+#: envelope marker instead -- every real Claude Code JSONL record carries at
+#: least one of these regardless of its own ``type``.
+_AMBIGUOUS_ROLE_TYPES = frozenset({"user", "assistant"})
+#: Keys strong enough that their bare presence alone is sufficient evidence
+#: (unchanged from the original detector).
+_STRONG_SESSION_KEYS = ("parentUuid", "leafUuid", "sessionId", "session_id")
+#: Weaker companion markers that only count when paired with an ambiguous
+#: role-word ``type`` value (see ``_AMBIGUOUS_ROLE_TYPES``) -- not strong
+#: enough to stand alone (``"uuid"`` in particular is too generic a field name
+#: across unrelated JSON shapes to be positive evidence by itself).
+_AMBIGUOUS_TYPE_ENVELOPE_MARKERS = frozenset({"uuid", "cwd", "version", "message"})
 
 
 def looks_like_code(payload: Sequence[object]) -> bool:
@@ -25,10 +44,14 @@ def looks_like_code(payload: Sequence[object]) -> bool:
     for item in payload:
         if not isinstance(item, dict):
             continue
-        if any(key in item for key in ("parentUuid", "leafUuid", "sessionId", "session_id")):
+        if any(key in item for key in _STRONG_SESSION_KEYS):
             return True
         item_type = item.get("type")
-        if isinstance(item_type, str) and item_type in _CODE_ONLY_TYPES:
+        if not isinstance(item_type, str):
+            continue
+        if item_type in _CODE_ONLY_TYPES:
+            return True
+        if item_type in _AMBIGUOUS_ROLE_TYPES and any(key in item for key in _AMBIGUOUS_TYPE_ENVELOPE_MARKERS):
             return True
     return False
 

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -14,9 +14,10 @@ from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from io import BytesIO
+from itertools import chain, islice
 from pathlib import Path
 from types import TracebackType
-from typing import BinaryIO, Final, Literal
+from typing import BinaryIO, Final, Literal, cast
 
 from polylogue import logging as _polylogue_logging
 from polylogue.archive.ingest_flags import (
@@ -1655,8 +1656,13 @@ class _ParsedSessionSpill:
         return sessions, payload_bytes
 
 
-def _is_declared_non_session_artifact(provider: Provider, source_path: str) -> bool:
-    """Return whether OriginSpec declares this path a non-session "fact" artifact.
+def _is_declared_non_session_artifact(
+    provider: Provider,
+    source_path: str,
+    *,
+    sample: Sequence[object] = (),
+) -> bool:
+    """Return whether this raw revision must not be session-parsed on replay.
 
     polylogue-b508: retained raw revisions include OriginSpec-declared fact
     artifacts (``agent-*.meta.json`` sidecars, ``workflows/*.json`` run
@@ -1672,9 +1678,43 @@ def _is_declared_non_session_artifact(provider: Provider, source_path: str) -> b
     that fix is meant to eliminate on every future rebuild. Same check, same
     rule table, so a declared fact artifact can never become a session
     through either entry point.
+
+    polylogue-9ykn: a path-declared rule is only half of the live path's
+    gate. ``pipeline/services/ingest_worker.py`` also runs every sampled
+    JSONL payload through ``archive.artifact_taxonomy.classify_artifact`` --
+    the richer, CONTENT-based classifier that catches a non-conversational
+    record sitting under a watched Claude Code directory with no matching
+    path rule at all (e.g. a third-party analysis index such as
+    ``conversation_relationships.jsonl`` that happens to satisfy the loose
+    per-record shape check). Without the same content check here, replay
+    (this module) and rebuild (``maintenance/rebuild_index.py`` -> this
+    module) silently resurrect exactly the phantom sessions the live gate
+    now refuses, on every future rebuild -- the two "single chokepoints"
+    disagreeing is the location-as-identity defect recurring at a second
+    layer. ``sample`` -- the first up to 64 decoded records, mirroring the
+    live path's own sample bound (``ingest_worker.py``'s
+    ``_sample_jsonl_payload_with_detail(..., max_samples=64)``) -- is
+    classified only when no path rule already decided the question; an
+    empty ``sample`` (the default) preserves the original path-only
+    behavior exactly, so every existing caller is unaffected until it opts
+    in.
     """
     rule = artifact_rule_for_path(provider, source_path)
-    return rule is not None and rule.parse_policy != "session"
+    if rule is not None:
+        return rule.parse_policy != "session"
+    if not sample:
+        return False
+    from polylogue.archive.artifact_taxonomy import classify_artifact
+    from polylogue.core.json import JSONValue
+
+    # ``sample`` records come from ``_iter_json_stream`` (this module's own
+    # decode path, typed ``JsonValue`` -- ``core/query_identity.py``'s
+    # structurally-equivalent but nominally distinct alias) rather than
+    # ``classify_artifact``'s own ``core.json.JSONValue``; both describe the
+    # same decoded-JSON shape ijson/json.loads ever produce, so the cast is
+    # a type-identity bridge, not a real behavior narrowing.
+    classification = classify_artifact(cast(list[JSONValue], list(sample)), provider=provider, source_path=source_path)
+    return not classification.parse_as_session
 
 
 def _parse_one(
@@ -1685,17 +1725,20 @@ def _parse_one(
     payload_path: Path | None = None,
     archive_root: Path | None = None,
 ) -> list[ParsedSession]:
-    if _is_declared_non_session_artifact(provider, source_path):
-        return []
     source_name = Path(source_path).name
     fallback_id = Path(source_path).stem
     if is_stream_record_provider(source_path, str(provider)):
+        records = list(_iter_json_stream(BytesIO(payload), source_name))
+        if _is_declared_non_session_artifact(provider, source_path, sample=records[:64]):
+            return []
         return parse_stream_payload(
             provider,
-            _iter_json_stream(BytesIO(payload), source_name),
+            records,
             fallback_id,
             source_path=source_path,
         )
+    if _is_declared_non_session_artifact(provider, source_path):
+        return []
     if provider is Provider.HERMES and looks_like_sqlite_bytes(payload):
         with _sqlite_payload_path(payload, payload_path, archive_root) as sqlite_path:
             if hermes_state.looks_like_state_db_path(sqlite_path):
@@ -1747,9 +1790,18 @@ def _parse_stream(provider: Provider, payload: BinaryIO, source_path: str) -> li
         return []
     source_name = Path(source_path).name
     fallback_id = Path(source_path).stem
+    stream = _iter_json_stream(payload, source_name)
+    # Multi-GiB Claude Code JSONL must stay memory-bounded (module docstring:
+    # "a memory-bounded streaming path exists for multi-GiB Claude Code
+    # JSONL"), so only the first 64 records -- the same sample bound the live
+    # ingest gate uses -- are materialized for content classification; the
+    # rest of the stream is chained back on unread.
+    sample = list(islice(stream, 64))
+    if _is_declared_non_session_artifact(provider, source_path, sample=sample):
+        return []
     return parse_stream_payload(
         provider,
-        _iter_json_stream(payload, source_name),
+        chain(sample, stream),
         fallback_id,
         source_path=source_path,
     )

--- a/tests/unit/cli/commands/test_status.py
+++ b/tests/unit/cli/commands/test_status.py
@@ -21,6 +21,7 @@ from polylogue.cli.commands.status import (
     _archive_table_counts,
     _archive_tier_files,
     _archive_tier_status,
+    _archive_unidentified_artifact_count,
     _candidate_daemon_urls,
     _column_exists,
     _default_daemon_url,
@@ -738,6 +739,53 @@ class TestDirectArchiveCounts:
             result = _direct_archive_counts(conn)
             assert result["sessions"] == 2
             assert result["messages"] == 3
+        finally:
+            conn.close()
+
+    def test_counts_unidentified_artifacts_from_source_tier(self, tmp_path: Path) -> None:
+        """Regression for polylogue-9ykn: a record that classify_artifact
+        could not positively identify as a session/sidecar/other known kind
+        is durably ledgered in source.db's raw_artifacts with
+        artifact_kind='unknown'. That count must be visible from the index
+        connection's sibling source.db, the same resolution
+        _archive_source_raw_count already uses for raw_records.
+        """
+        index_path = tmp_path / "index.db"
+        source_path = tmp_path / "source.db"
+        initialize_archive_database(index_path, ArchiveTier.INDEX)
+        initialize_archive_database(source_path, ArchiveTier.SOURCE)
+        source_conn = sqlite3.connect(source_path)
+        try:
+            source_conn.execute(
+                """
+                INSERT INTO raw_sessions (
+                    raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size, acquired_at_ms
+                ) VALUES ('raw1', 'claude-code-session', 'native-1', 'one.jsonl', 0, ?, 32, 1)
+                """,
+                (bytes.fromhex("1" * 64),),
+            )
+            source_conn.execute(
+                """
+                INSERT INTO raw_artifacts (
+                    artifact_id, raw_id, origin, source_path, source_index, artifact_kind,
+                    support_status, classification_reason, parse_as_session, schema_eligible,
+                    first_observed_at_ms, last_observed_at_ms
+                ) VALUES
+                    ('art1', 'raw1', 'claude-code-session', 'one.jsonl', 0, 'unknown',
+                     'unknown', 'unrecognized document payload', 0, 0, 1, 1),
+                    ('art2', 'raw1', 'claude-code-session', 'two.jsonl', 0, 'agent_sidecar_meta',
+                     'recognized_unparsed', 'agent sidecar metadata path', 0, 0, 1, 1)
+                """
+            )
+            source_conn.commit()
+        finally:
+            source_conn.close()
+
+        conn = sqlite3.connect(index_path)
+        try:
+            assert _archive_unidentified_artifact_count(conn, configured_root=tmp_path) == 1
+            result = _direct_archive_counts(conn, configured_root=tmp_path)
+            assert result["unidentified_artifacts"] == 1
         finally:
             conn.close()
 

--- a/tests/unit/sources/test_artifact_taxonomy.py
+++ b/tests/unit/sources/test_artifact_taxonomy.py
@@ -26,6 +26,98 @@ def test_relationship_index_jsonl_is_metadata_not_session_stream() -> None:
     assert artifact.parse_as_session is False
 
 
+def test_relationship_index_jsonl_conversation_field_is_metadata_not_session_stream() -> None:
+    """Regression for polylogue-9ykn (gvgi): the REAL live-archive shape uses
+    a ``"conversation"`` field, not ``"session"`` (the field name the sibling
+    test above happens to use). Both must be refused -- pinning only the
+    ``"session"`` spelling gave false confidence: with the real field name,
+    ``looks_like_record_entry`` fell through to the generic ``"type"``-key
+    match and misclassified this as a session-record stream before this fix
+    (verified against a synthetic fixture matching the measured shape of
+    ``conversation_relationships.jsonl``, the single largest contributor to
+    the archive's empty-message rows: 96,748 of 101,765, ~95%).
+    """
+    records: list[JSONValue] = [
+        {
+            "conversation": f"conv-{index}",
+            "parent": f"parent-{index}",
+            "child": f"child-{index}",
+            "type": "assistant" if index % 2 else "user",
+            "timestamp": "2026-05-01T00:00:00.000Z",
+        }
+        for index in range(4)
+    ]
+
+    artifact = classify_artifact(
+        records,
+        provider="claude-code",
+        source_path="/tmp/project/analysis/index/conversation_relationships.jsonl",
+    )
+
+    assert artifact.kind is ArtifactKind.METADATA_DOCUMENT
+    assert artifact.parse_as_session is False
+
+
+def test_bare_tool_use_id_record_does_not_classify_as_session() -> None:
+    """Regression for polylogue-9ykn: a record whose only distinguishing
+    field is a ``tool_use_id``-shaped value (the real archive has 3 sessions
+    whose native_id is a bare ``toolu_*`` tool-use id, evidence of a
+    tool-result artifact acquired as an independent session rather than
+    joined as a sidecar -- see the sibling investigation polylogue-omsw for
+    the tool-result-specific acquisition-scope fix). A record with no
+    session/message envelope and no recognized record-ish key must fall
+    through to UNKNOWN, not default into a session.
+    """
+    record: JSONValue = {
+        "tool_use_id": "toolu_01AbCdEfGhIjKlMnOpQrStUv",
+        "output": "some tool output text, not a conversation turn",
+    }
+
+    artifact = classify_artifact(
+        record,
+        provider="claude-code",
+        source_path="/tmp/.claude/projects/x/tool-results/toolu_01AbCdEfGhIjKlMnOpQrStUv.json",
+    )
+
+    # Falls through the metadata-shaped fallback (a small scalar-valued dict)
+    # rather than UNKNOWN -- either way the invariant that matters holds: it
+    # never becomes a session.
+    assert artifact.kind in (ArtifactKind.UNKNOWN, ArtifactKind.METADATA_DOCUMENT)
+    assert artifact.parse_as_session is False
+
+
+def test_agent_sidecar_meta_never_classifies_as_session() -> None:
+    """Regression pin for polylogue-b508, re-verified as part of the
+    polylogue-9ykn general classifier: an agent-*.meta.json sidecar must
+    never become a session regardless of its content, only its path."""
+    payload: JSONValue = {"agentId": "agent-deadbeef", "transcriptPath": "agent-deadbeef.jsonl"}
+
+    artifact = classify_artifact(
+        payload,
+        provider="claude-code",
+        source_path="/tmp/.claude/projects/x/subagents/agent-deadbeef.meta.json",
+    )
+
+    assert artifact.kind is ArtifactKind.AGENT_SIDECAR_META
+    assert artifact.parse_as_session is False
+
+
+def test_workflow_run_snapshot_never_classifies_as_session() -> None:
+    """Regression pin: a workflows/wf_*.json run-snapshot record (real shape:
+    top-level runId/taskId/script keys, no session/message envelope) must
+    never become a session regardless of content, only its path."""
+    payload: JSONValue = {"runId": "wf_54d4fb2e-841", "taskId": "wq88yulle", "script": "export const meta = {}"}
+
+    artifact = classify_artifact(
+        payload,
+        provider="claude-code",
+        source_path="/tmp/.claude/projects/x/workflows/wf_54d4fb2e-841.json",
+    )
+
+    assert artifact.kind is ArtifactKind.WORKFLOW_RUN_SNAPSHOT
+    assert artifact.parse_as_session is False
+
+
 def test_chatgpt_codex_cloud_task_classifies_as_session_document() -> None:
     """bd polylogue-2m2e: without this branch, a codex.json task record fails
     every generic session-document heuristic (no "mapping"/"messages" list)

--- a/tests/unit/sources/test_dispatch_ordering.py
+++ b/tests/unit/sources/test_dispatch_ordering.py
@@ -240,3 +240,31 @@ def test_dispatch_ordering(payload: object, expected_provider: Provider, rationa
 def test_unambiguous_payloads_still_work(payload: object, expected_provider: Provider) -> None:
     """Regression: unambiguous payloads must still resolve correctly."""
     assert detect_provider(payload) is expected_provider
+
+
+def test_relationship_index_records_do_not_detect_as_claude_code() -> None:
+    """Regression for polylogue-9ykn (gvgi): a third-party graph-edge index
+    JSONL (real shape: a sinex analysis artifact recording conversation
+    parent/child edges) sitting under a watched Claude Code directory has no
+    session/message envelope at all -- just conversation/parent/child/type/
+    timestamp keys, whose bare ``type`` value happens to be the generic role
+    word "assistant"/"user". Before this fix, ``claude.looks_like_code``
+    treated a bare ``type in {"user", "assistant"}`` match as sufficient
+    Claude Code evidence on its own, misdetecting this shape and (via the
+    dispatch-level auto-detection paths that call ``detect_provider`` when no
+    provider is already known from the watched directory) letting it become a
+    phantom claude-code-session with one empty message per JSONL line -- the
+    single largest contributor to the archive's empty-message rows (96,748 of
+    101,765, ~95%, per the live-archive measurement in polylogue-gvgi).
+    """
+    payload = [
+        {
+            "conversation": f"conv-{index}",
+            "parent": f"parent-{index}",
+            "child": f"child-{index}",
+            "type": "assistant" if index % 2 else "user",
+            "timestamp": "2026-05-01T00:00:00.000Z",
+        }
+        for index in range(8)
+    ]
+    assert detect_provider(payload) is None

--- a/tests/unit/sources/test_revision_backfill.py
+++ b/tests/unit/sources/test_revision_backfill.py
@@ -186,6 +186,86 @@ def test_parse_one_refuses_declared_fact_artifacts(tmp_path: Path, source_path_s
     assert sessions == []
 
 
+def _relationship_index_jsonl_bytes(count: int = 8) -> bytes:
+    """Bytes shaped like the real sinex analysis artifact from polylogue-9ykn
+    (gvgi): a graph-edge index sitting under a watched Claude Code directory,
+    with no session/message envelope at all -- just conversation/parent/
+    child/type/timestamp keys, whose ``type`` happens to be a bare
+    "assistant"/"user" role word.
+    """
+    lines = [
+        json.dumps(
+            {
+                "conversation": f"conv-{index}",
+                "parent": f"parent-{index}",
+                "child": f"child-{index}",
+                "type": "assistant" if index % 2 else "user",
+                "timestamp": "2026-05-01T00:00:00.000Z",
+            }
+        )
+        for index in range(count)
+    ]
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def test_parse_one_refuses_non_conversational_content_with_no_path_rule(tmp_path: Path) -> None:
+    """Regression for polylogue-9ykn: a record with no OriginSpec path rule
+    at all (so ``_is_declared_non_session_artifact``'s path check alone would
+    admit it) must still be refused when its CONTENT carries no positive
+    conversation evidence.
+
+    Before this fix, this replay chokepoint (``polylogue ops reset --index``
+    / ``devtools`` rebuild-index) only consulted ``artifact_rule_for_path`` --
+    a path-pattern allowlist -- so a file with no matching path pattern, like
+    a third-party analysis index sitting under
+    ``~/.claude/projects/<proj>/analysis/index/``, sailed through unchanged
+    on every rebuild even after the live daemon ingest path (which also
+    consults the richer content classifier, ``classify_artifact``) learned to
+    refuse it. The two "single chokepoints" disagreeing is exactly the
+    location-as-identity defect recurring at a second layer.
+    """
+    source_path = tmp_path / ".claude" / "projects" / "proj" / "analysis" / "index" / "conversation_relationships.jsonl"
+    payload = _relationship_index_jsonl_bytes()
+
+    sessions = _parse_one(Provider.CLAUDE_CODE, payload, str(source_path))
+
+    assert sessions == []
+
+
+def test_parse_stream_refuses_non_conversational_content_with_no_path_rule(tmp_path: Path) -> None:
+    """Streaming-path sibling of the test above (large multi-GiB JSONL never
+    materializes fully; the content-classification sample is bounded to the
+    first 64 records instead)."""
+    source_path = tmp_path / ".claude" / "projects" / "proj" / "analysis" / "index" / "conversation_relationships.jsonl"
+    payload = BytesIO(_relationship_index_jsonl_bytes())
+
+    sessions = revision_backfill._parse_stream(Provider.CLAUDE_CODE, payload, str(source_path))
+
+    assert sessions == []
+
+
+def test_parse_one_still_replays_real_claude_code_sessions_with_no_path_rule(tmp_path: Path) -> None:
+    """Guard against the regression-direction failure mode: the content gate
+    added for polylogue-9ykn must not start refusing genuine Claude Code
+    session records that (like most session JSONL files) carry no matching
+    OriginSpec path rule."""
+    source_path = tmp_path / ".claude" / "projects" / "proj" / "analysis" / "index" / "sess-real.jsonl"
+    record = {
+        "uuid": "u1",
+        "parentUuid": None,
+        "sessionId": "sess-real",
+        "type": "user",
+        "message": {"role": "user", "content": "hello"},
+        "timestamp": "2026-05-01T00:00:00.000Z",
+    }
+    payload = (json.dumps(record) + "\n").encode("utf-8")
+
+    sessions = _parse_one(Provider.CLAUDE_CODE, payload, str(source_path))
+
+    assert len(sessions) == 1
+    assert sessions[0].messages
+
+
 def test_historical_backfill_replays_single_session_state_db(tmp_path: Path) -> None:
     """End-to-end proof that the historical-repair entry point (which always
     has a real on-disk blob path, unlike the direct-bytes test above) also


### PR DESCRIPTION
## Summary

The ingest path's default disposition for an unclassified record was "this is a session" — a record only avoided becoming a session if some specific rule refused it. This PR flips two of the weakest link-in-the-chain heuristics from "type-only is sufficient" to requiring genuine conversation-record envelope evidence, and unifies the two places that decide whether to attempt session parsing at all (live ingest vs. rebuild replay), which previously disagreed.

## Problem

Bead `polylogue-9ykn` (P0): measured against the live archive, 5,255 of 23,296 sessions (22.6%) have zero messages. The single largest contributor (`polylogue-gvgi`) is `conversation_relationships.jsonl` — a sinex analysis artifact recording conversation parent/child graph edges, sitting under a watched Claude Code directory — misclassified as a `claude-code-session` with 96,748 empty messages (~95% of the archive's zero-block messages).

Root cause, traced to source:

- `archive/artifact_taxonomy/support.py:looks_like_record_entry()` treated a bare `"type"` key as sufficient positive evidence of a conversation record (`_RECORDISH_KEYS`). A relationship-index row's `type` value happens to be the generic role word `"assistant"`/`"user"`, so it passed.
- `sources/parsers/claude/code_detection.py:looks_like_code()` had the identical defect one layer up: a bare `type in {"user", "assistant"}` match was treated as sufficient Claude Code evidence on its own.
- An **existing regression test** for this exact scenario (`test_relationship_index_jsonl_is_metadata_not_session_stream`) used a guessed field name (`"session"`) that does not match the real corpus's field name (`"conversation"`) — giving false confidence the defect was already handled. Verified live: with the real field name, the pre-fix classifier returned `SESSION_RECORD_STREAM`/`parse_as_session=True`.
- Separately, the two decision points that gate "should this record even be parsed as a session" **disagreed**: `pipeline/services/ingest_worker.py` (live daemon ingest) already runs every sampled JSONL payload through `archive.artifact_taxonomy.classify_artifact` before parsing. `sources/revision_backfill.py` (used by `polylogue ops reset --index` rebuild replay and historical backfill) only consulted the narrower path-pattern-only `artifact_rule_for_path` (OriginSpec). A record with no matching path rule — like `conversation_relationships.jsonl`, which sits in an `analysis/index/` subdirectory no rule pattern matches — sailed through the rebuild path unchanged even after the live path learned to refuse it. Any future `ops reset --index` rebuild would silently resurrect exactly the phantoms the live gate now catches.

## Solution

- `polylogue/archive/artifact_taxonomy/support.py`: `looks_like_record_entry()` no longer treats a bare `"type"` key as sufficient on its own; it must co-occur with a genuine record-envelope marker (`uuid`/`sessionId`/`parentUuid`/`message`/`payload`/`cwd`/`version`). Both observed relationship-index field-name variants (`"session"` and the real corpus's `"conversation"`) are guarded explicitly, as defense in depth alongside the general fix.
- `polylogue/sources/parsers/claude/code_detection.py`: `looks_like_code()`'s ambiguous role-word types (`"user"`/`"assistant"`) now require a companion envelope marker. Claude-Code-specific unambiguous types (`file-history-snapshot`, `queue-operation`, `custom-title`, `summary`, `progress`, `result`) are unchanged — they're specific enough to stand alone.
- `polylogue/sources/revision_backfill.py`: `_is_declared_non_session_artifact()` now also runs `classify_artifact()` against a bounded 64-record content sample (mirroring the live path's own sample bound) when no OriginSpec path rule already decided the question, so `_parse_one`/`_parse_stream` (rebuild replay) enforce the *same* policy as live ingest. The true-streaming path (`_parse_stream`, used for multi-GiB Claude Code JSONL) stays memory-bounded via `itertools.islice`/`chain` — only the sample is materialized, the rest of the stream is chained back on unread.
- `polylogue/cli/commands/status.py`: `polylogue ops status` now surfaces a live **"Unidentified artifacts"** count (`raw_artifacts.artifact_kind='unknown'` in `source.db`) so a novel unrecognized artifact class is noticed the week it appears. This ledger already existed and was already populated for every acquired record (`pipeline/services/acquisition_persistence.py` → `inspect_raw_artifact` → `save_artifact_observation`, run unconditionally on acquisition) — the gap was never "no ledger", it was the classifier feeding it misclassifying some non-conversational content as a session before the ledger ever saw it as unidentified. The full per-kind/per-provider breakdown is already reachable via `polylogue check --check-artifact-coverage --check-cohorts`.

## Chokepoint findings (as requested)

Exactly one literal `INSERT INTO sessions` exists in the whole codebase (`storage/sqlite/archive_tiers/write.py:516`, inside `write_parsed_session_to_archive`) — the row-write chokepoint is real and singular; aggz invariant 2 holds at that layer.

Upstream of that single writer, **three** distinct call sites decide whether to even attempt producing a `ParsedSession` destined for it:

1. `pipeline/services/ingest_worker.py` (live daemon ingest, default `validation_mode=advisory`) — already gated by `classify_artifact`.
2. `sources/revision_backfill.py` (`polylogue ops reset --index` rebuild replay, historical backfill) — previously gated only by the narrower `artifact_rule_for_path`; **unified with (1) by this PR**.
3. `sources/live/append_ingest.py` (`_ingest_append_plans_archive`, live incremental append for an already-watched growing file) — calls `dispatch.parse_payload` directly with **no** `classify_artifact` consultation at all.

(3) was **not** touched by this PR, for lack of time to verify it safely. It is very likely safe-by-construction (append plans should only ever be created for a path `sources/live/batch.py`'s discovery phase already classified as a session stream when first registered for tracking), but this was not empirically proven. Filed `polylogue-xwkh` to verify and, if needed, close that gap.

`unknown-export`/ZIP absorption (`polylogue-hs3y`, raised by a sibling investigation) is a separate, origin-acquisition-level gap — which `Origin` a raw ZIP gets at acquisition time — not fixed here and not in conflict with this PR's artifact-kind-level classification fix.

## Regression-direction guard (per-shape classification, verified)

All four required real shapes now refuse to become a session (regression tests added), while a real Claude Code record with genuine envelope evidence is unaffected:

- `agent-*.meta.json` sidecar — before: refused (pre-existing, `polylogue-b508`); after: refused (pinned).
- `conversation_relationships.jsonl` graph-edge index (`conversation`/`parent`/`child`/`type`/`timestamp`) — before: **admitted as session**; after: refused, classified `METADATA_DOCUMENT`.
- `workflows/wf_*.json` run snapshot — before: refused (pre-existing, path-rule); after: refused (pinned).
- bare `toolu_*` tool-result-shaped record — before: refused (pre-existing, generic-unrecognized fallback); after: refused (pinned) — `polylogue-omsw` owns the tool-result acquisition-scope fix specifically.
- real Claude Code session record (`uuid`/`sessionId`/`message`) — before: admitted; after: **still admitted** (no regression).

No schema change: `raw_artifacts` already carries `artifact_kind`/`classification_reason`/`support_status`; the `ops status` addition is a read-only query against the existing derived surface.

## Deliberately not done here (follow-up beads filed)

- `polylogue-zqph`: repair pass for the ~5,257 existing empty-session rows already in the live archive. This PR only stops *new* phantoms going forward; dataset cleanup needs explicit operator sign-off and careful reclassification logic (`polylogue-ne6k` found a blanket empty-session delete is unsafe — it would delete the 832 sessions the 2026-07-22 hook-inflation postmortem deliberately retained).
- `polylogue-xwkh`: verify/close the `append_ingest.py` gap noted above.
- `polylogue-gvgi`'s own scoped purge of the live `conversation_relationships.jsonl` phantom, and `polylogue-omsw`'s workflow/tool-result acquisition-scope dedup, are not reimplemented here — this PR's `looks_like_record_entry`/`looks_like_code` fixes are a general byproduct that also prevents their shapes from recurring, but those sibling lanes own their own AC and evidence.

No rows were deleted or modified in any tier by this PR.

## Verification

- `devtools verify --quick` (ruff format/check, mypy --strict, render all --check, topology/layering/closure-matrix/manifests/ci-workflows/doc-commands/docs-coverage/test-infra-currency/test-clock-hygiene/pytest-timeout-overrides/degrade-loudly/hash-boundary-census, lab policy schema-versioning, schema promotion audit) — all green, `exit_code: 0` (ran twice: once locally, once via the pre-push hook).
- `devtools test tests/unit/sources/test_revision_backfill.py tests/unit/sources/test_artifact_taxonomy.py tests/unit/sources/test_dispatch_ordering.py tests/unit/cli/commands/test_status.py tests/unit/cli/test_status.py tests/unit/sources/test_parsers_props.py tests/unit/sources/parsers/test_origin_regression_pack.py tests/unit/sources/test_parser_crashlessness.py tests/unit/sources/test_origin_specs.py` — `320 passed`.
- `python3 -m mypy` on every touched source and test file — `Success: no issues found`.
- Not run: the full `devtools test tests/unit` suite (anti-pattern per this repo's Verification discipline — testmon-affected selection is the intended inner loop) and any command touching the live archive (`/realm/db/polylogue`) — read-only `sqlite3 ... ?mode=ro` evidence gathering only, no writes, per the task's hard constraint.

Ref polylogue-9ykn
