### PR TITLE
refactor(storage): dedup 2 of 10 remaining archive.py query_* methods

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -1133,6 +1133,72 @@ def _hydrate_archive_file_query_row(row: sqlite3.Row) -> ArchiveFileQueryRow:
     )
 
 
+# polylogue-aif4: the same drift hazard, for ``ArchiveActionQueryRow``.
+# ``query_actions`` and ``query_session_actions`` both join the actions view
+# (aliased ``a``) to ``sessions``/``messages`` and project the identical
+# sixteen-column action shape -- hand-duplicated byte-for-byte before this.
+# ``query_session_action_occurrences`` is deliberately NOT included: it
+# selects from raw ``blocks`` (aliased ``u``/``r``, no follow-up relation) to
+# stay cheap on very large sessions, so its column *sources* genuinely
+# differ even though the output shape rhymes -- forcing it onto this same
+# fragment would either lose that cost tradeoff or fake follow-up columns
+# that were never computed.
+_ARCHIVE_ACTION_QUERY_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("session_id", "a.session_id"),
+    ("message_id", "a.message_id"),
+    ("origin", "s.origin"),
+    ("title", "s.title"),
+    ("tool_use_block_id", "a.tool_use_block_id"),
+    ("tool_result_block_id", "a.tool_result_block_id"),
+    ("tool_name", "a.tool_name"),
+    ("semantic_type", "a.semantic_type"),
+    ("tool_command", _action_command_expression("a")),
+    ("tool_path", "a.tool_path"),
+    ("occurred_at_ms", "m.occurred_at_ms"),
+    ("output_text", "a.output_text"),
+    ("is_error", "a.is_error"),
+    ("exit_code", "a.exit_code"),
+    ("followup_class", "a.followup_class"),
+    ("followup_message_ref", "a.followup_message_ref"),
+)
+
+_ARCHIVE_ACTION_QUERY_SELECT_SQL = ",\n                ".join(
+    expr if expr.endswith(f".{name}") else f"{expr} AS {name}" for name, expr in _ARCHIVE_ACTION_QUERY_COLUMNS
+)
+
+
+# polylogue-aif4: ``query_unit_counts`` and ``query_unit_multi_counts`` each
+# hand-maintained an identical copy of the unit -> row-alias map and the unit
+# -> FROM-clause map used to dispatch a terminal aggregate query across the
+# seven SQL-backed query units. Both dicts were byte-identical between the
+# two methods (the only per-call variation is the ``action`` entry's derived
+# relation name, now a parameter). One source of truth here means a new
+# query unit is wired into aggregate counts by editing one place, not two
+# that can silently drift apart.
+_QUERY_UNIT_ROW_ALIAS: dict[str, str] = {
+    "message": "m",
+    "action": "a",
+    "block": "b",
+    "file": "f",
+    "assertion": "a",
+    "observed-event": "e",
+    "delegation": "d",
+}
+
+
+def _query_unit_from_sql_by_unit(action_relation_name: str) -> dict[str, str]:
+    """Return the unit -> FROM-clause map shared by both aggregate-count methods."""
+
+    return {
+        "message": "messages m JOIN sessions s ON s.session_id = m.session_id",
+        "action": f"{action_relation_name} a JOIN sessions s ON s.session_id = a.session_id",
+        "block": "blocks b JOIN sessions s ON s.session_id = b.session_id",
+        "assertion": "user_tier.assertions a LEFT JOIN sessions s ON a.target_ref = 'session:' || s.session_id",
+        "observed-event": "observed_events e JOIN sessions s ON s.session_id = e.session_id",
+        "delegation": "delegations d JOIN sessions s ON s.session_id = d.parent_session_id",
+    }
+
+
 def _query_unit_aggregate_order(
     sort: Literal["count", "key"] | None,
     direction: Literal["asc", "desc"],
@@ -6755,15 +6821,7 @@ class ArchiveStore:
         if unit == "assertion":
             self._attach_user_tier_if_present()
 
-        row_alias = {
-            "message": "m",
-            "action": "a",
-            "block": "b",
-            "file": "f",
-            "assertion": "a",
-            "observed-event": "e",
-            "delegation": "d",
-        }.get(unit)
+        row_alias = _QUERY_UNIT_ROW_ALIAS.get(unit)
         if row_alias is None:
             raise ValueError(f"Query unit {unit!r} is not wired to SQL aggregate counts")
         if unit == "file":
@@ -6800,14 +6858,7 @@ class ArchiveStore:
                 predicate=predicate,
                 include_followup=action_needs_followup,
             )
-        from_sql_by_unit = {
-            "message": "messages m JOIN sessions s ON s.session_id = m.session_id",
-            "action": (f"{action_relation_name} a JOIN sessions s ON s.session_id = a.session_id"),
-            "block": "blocks b JOIN sessions s ON s.session_id = b.session_id",
-            "assertion": "user_tier.assertions a LEFT JOIN sessions s ON a.target_ref = 'session:' || s.session_id",
-            "observed-event": "observed_events e JOIN sessions s ON s.session_id = e.session_id",
-            "delegation": "delegations d JOIN sessions s ON s.session_id = d.parent_session_id",
-        }
+        from_sql_by_unit = _query_unit_from_sql_by_unit(action_relation_name)
         from_sql = "observed_events e" if unit == "observed-event" and not needs_session else from_sql_by_unit[unit]
         order_clause = _query_unit_aggregate_order(sort, sort_direction)
         source_where = "0=1"
@@ -6886,15 +6937,7 @@ class ArchiveStore:
         if unit == "assertion":
             self._attach_user_tier_if_present()
 
-        row_alias = {
-            "message": "m",
-            "action": "a",
-            "block": "b",
-            "file": "f",
-            "assertion": "a",
-            "observed-event": "e",
-            "delegation": "d",
-        }.get(unit)
+        row_alias = _QUERY_UNIT_ROW_ALIAS.get(unit)
         if row_alias is None:
             raise ValueError(f"Query unit {unit!r} is not wired to SQL multi-aggregate counts")
 
@@ -6954,14 +6997,7 @@ class ArchiveStore:
                     predicate=predicate,
                     include_followup=action_needs_followup,
                 )
-            from_sql_by_unit = {
-                "message": "messages m JOIN sessions s ON s.session_id = m.session_id",
-                "action": f"{action_relation_name} a JOIN sessions s ON s.session_id = a.session_id",
-                "block": "blocks b JOIN sessions s ON s.session_id = b.session_id",
-                "assertion": "user_tier.assertions a LEFT JOIN sessions s ON a.target_ref = 'session:' || s.session_id",
-                "observed-event": "observed_events e JOIN sessions s ON s.session_id = e.session_id",
-                "delegation": "delegations d JOIN sessions s ON s.session_id = d.parent_session_id",
-            }
+            from_sql_by_unit = _query_unit_from_sql_by_unit(action_relation_name)
             from_sql = "observed_events e" if unit == "observed-event" and not needs_session else from_sql_by_unit[unit]
             if unit == "observed-event":
                 source_where, source_params = observed_event_source_pushdown(predicate)

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -7217,22 +7217,7 @@ class ArchiveStore:
             f"""
             {prefix_sql}
             SELECT
-                a.session_id,
-                a.message_id,
-                s.origin,
-                s.title,
-                a.tool_use_block_id,
-                a.tool_result_block_id,
-                a.tool_name,
-                a.semantic_type,
-                {_action_command_expression("a")} AS tool_command,
-                a.tool_path,
-                m.occurred_at_ms,
-                a.output_text,
-                a.is_error,
-                a.exit_code,
-                a.followup_class,
-                a.followup_message_ref
+                {_ARCHIVE_ACTION_QUERY_SELECT_SQL}
             FROM {action_relation_name} a
             JOIN sessions s ON s.session_id = a.session_id
             JOIN messages m ON m.message_id = a.message_id
@@ -7272,22 +7257,7 @@ class ArchiveStore:
             f"""
             {prefix_sql}
             SELECT
-                a.session_id,
-                a.message_id,
-                s.origin,
-                s.title,
-                a.tool_use_block_id,
-                a.tool_result_block_id,
-                a.tool_name,
-                a.semantic_type,
-                {_action_command_expression("a")} AS tool_command,
-                a.tool_path,
-                m.occurred_at_ms,
-                a.output_text,
-                a.is_error,
-                a.exit_code,
-                a.followup_class,
-                a.followup_message_ref
+                {_ARCHIVE_ACTION_QUERY_SELECT_SQL}
             FROM {action_relation_name} a
             JOIN sessions s ON s.session_id = a.session_id
             JOIN messages m ON m.message_id = a.message_id


### PR DESCRIPTION
## Summary

Finishes polylogue-aif4, PR #3427's follow-up bead scoping the 10
`query_*` methods left untouched after that PR's two exact-duplicate
extractions. Audited all 10 for the genuine drift hazard (hand-duplicated
column lists/dicts that can silently diverge between sibling methods, not
the `TableColumnSpec.select_column_names` shape from the INSERT side,
which #3427 already established doesn't fit these bespoke join
projections) and extracted the two instances that qualified.

## Problem

polylogue-aif4 named 10 remaining `query_*` methods and asked for an
honest audit: which subset shares the bead's stated drift hazard (a
column list or dispatch table hand-copied between sibling methods) versus
which are genuinely one-off projections. Two genuine instances were
found:

1. `query_actions` and `query_session_actions` both project the
   identical sixteen-column action shape (`actions` view joined to
   `sessions`/`messages`) — hydration already went through the shared
   `_archive_action_query_row()`, but the SELECT column list text itself
   was hand-duplicated byte-for-byte in both methods.
2. `query_unit_counts` and `query_unit_multi_counts` each hand-maintained
   an identical copy of the unit -> row-alias map and the unit ->
   FROM-clause map used to dispatch a terminal aggregate query across the
   seven SQL-backed query units — both dicts were byte-identical between
   the two methods.

## Solution

- `polylogue/storage/sqlite/archive_tiers/archive.py`: extracted
  `_ARCHIVE_ACTION_QUERY_COLUMNS` / `_ARCHIVE_ACTION_QUERY_SELECT_SQL`
  (same `(output_name, source_expr)` pattern PR #3427 used for the
  file-query projection) and wired both `query_actions` and
  `query_session_actions` to it. Extracted `_QUERY_UNIT_ROW_ALIAS` and
  `_query_unit_from_sql_by_unit()` and wired both `query_unit_counts` and
  `query_unit_multi_counts` to them.

**Left alone, with reasons (per aif4's honest-audit framing):**

- `query_session_action_occurrences` — selects from raw `blocks`
  (aliased `u`/`r`, no follow-up relation) instead of the `actions` view,
  deliberately staying cheap on very large sessions per its own
  docstring. Output columns rhyme with `query_actions` but the column
  *sources* genuinely differ; forcing it onto the shared fragment would
  either lose that cost tradeoff or fake follow-up columns that were
  never computed.
- `query_delegations`, `query_files`/`query_session_files` (already done
  in #3427), `query_blocks`, `query_assertions` — each a single one-off
  projection with no sibling to collapse.
- `query_runs`, `query_observed_events`, `query_context_snapshots` —
  structurally rhyme (relation-CTE prefix + join sessions + hydrate via a
  typed projector) but each hydrates through a *different* domain
  function (`projected_run_from_row`, `observed_event_from_row`,
  `context_snapshot_from_row`) with different predicate/order-by shapes.
  aif4's own note says any table-driving here should start from
  `run_projection_relations.py`, not `archive.py` — out of scope for this
  bead.

No query-shape redesign, no behavior change: same SQL text is generated,
same columns, same aliases, same order.

## Verification

- `mypy --strict polylogue/storage/sqlite/archive_tiers/` — clean (via
  `devtools verify --quick`, exit 0; steps `03-mypy` and `04-render-all`
  both passed).
- `devtools verify --quick` (pre-push gate) — exit 0, all 19 steps green.
- Behavior-preserving refactor, no test changed:
  `devtools test tests/unit/cli/test_query_verbs_runtime.py
  tests/unit/archive/test_query_multi_aggregate.py
  tests/unit/storage/test_query_unit_time_expression.py` — 71 passed.
  `devtools test tests/unit/storage/test_archive_tiers_archive.py
  tests/unit/cli/test_query_composition_laws.py
  tests/unit/cli/test_query_expression.py
  tests/unit/cli/test_query_support_runtime.py` — 482 passed, 1 skipped.
  `devtools test tests/unit/cli/test_query_exec_laws.py` — 91 passed.
  Total 644 passed, 1 skipped, 0 failed, across the two extracted
  surfaces' full test coverage — no test needed to change.
- Not run: the heavy full `test` suite (per-PR CI skip convention; runs
  post-merge).

Ref polylogue-aif4.

Co-Authored-By: Claude <noreply@anthropic.com>