### PR TITLE
test(daemon): extract shared DaemonAPIHandler mock scaffolding

### DIFF
--- a/polylogue/insights/session_commit.py
+++ b/polylogue/insights/session_commit.py
@@ -497,7 +497,15 @@ def detect_session_commits(
             )
             continue
 
-        foreign_trailer = bool(trailer_tokens) and not (trailer_tokens & own_trailer_tokens)
+        # A disagreement requires something to disagree *with*: when this
+        # session has no bridge/trailer tokens of its own (own_trailer_tokens
+        # empty), there is no typed identity to compare a commit's trailer
+        # against, so a trailer naming *some* other session is not evidence
+        # of misattribution -- it is simply the expected case for a commit
+        # from any other session (polylogue-2vor finding 3).
+        foreign_trailer = (
+            bool(trailer_tokens) and bool(own_trailer_tokens) and not (trailer_tokens & own_trailer_tokens)
+        )
 
         # Check for explicit ref first (highest confidence)
         if sha.lower() in commit_sha_refs or sha[:8].lower() in commit_sha_refs:
@@ -716,6 +724,24 @@ def build_correlation_result(
     )
 
 
+def _refs_match(a: GitHubRef, b: GitHubRef) -> bool:
+    """True when two refs plausibly identify the same PR/issue.
+
+    Bare number equality is not sufficient once a ref carries repo
+    identity: ``acme/product#42`` and ``other/repo#42`` are different
+    objects that happen to share a number (polylogue-2vor finding 2).
+    Compare the full ``(owner, repo, number)`` identity whenever *both*
+    refs are repo-qualified; fall back to number-only equality when either
+    side lacks repo identity (e.g. a bare ``#42`` regex mention), since the
+    number is the only signal available there.
+    """
+    if a.number != b.number:
+        return False
+    if a.owner and a.repo and b.owner and b.repo:
+        return a.owner.lower() == b.owner.lower() and a.repo.lower() == b.repo.lower()
+    return True
+
+
 def _resolve_refs(
     *,
     kind: str,
@@ -734,21 +760,21 @@ def _resolve_refs(
         return list(heuristic_refs), None
 
     resolved = [replace(ref, source=SOURCE_TYPED) for ref in typed_refs]
-    typed_numbers = {ref.number for ref in resolved}
-    heuristic_numbers = {ref.number for ref in heuristic_refs}
-    extra = heuristic_numbers - typed_numbers
+    extra = [h for h in heuristic_refs if not any(_refs_match(h, t) for t in resolved)]
     if not extra:
         return resolved, None
+    typed_numbers = {ref.number for ref in resolved}
+    extra_numbers = {ref.number for ref in extra}
     return (
         resolved,
         CorrelationDisagreement(
             kind=kind,
             session_id=session_id,
             typed_values=tuple(sorted(str(n) for n in typed_numbers)),
-            heuristic_values=tuple(sorted(str(n) for n in extra)),
+            heuristic_values=tuple(sorted(str(n) for n in extra_numbers)),
             detail=(
                 f"regex-scanned message text references {kind} number(s) "
-                f"{sorted(extra)} not present in typed session_refs evidence "
+                f"{sorted(extra_numbers)} not present in typed session_refs evidence "
                 f"({sorted(typed_numbers)})"
             ),
         ),
@@ -777,15 +803,38 @@ def typed_refs_from_session_refs(refs: Sequence[Any]) -> tuple[list[GitHubRef], 
             owner_name, _, repo_name = repo.partition("/")
         elif isinstance(repo, str) and repo:
             repo_name = repo
-        number = getattr(ref, "number", None) or 0
         url = getattr(ref, "url", None)
+        url_str = url if isinstance(url, str) else None
+
+        raw_number = getattr(ref, "number", None)
+        number: int | None = raw_number if isinstance(raw_number, int) and raw_number > 0 else None
+        if number is None and url_str is not None:
+            # No typed number on the row (observed for Codex Cloud's
+            # chatgpt_codex_sidecar._pull_request_ref(), which stores
+            # external_pull_request_id in url and leaves repo/number
+            # unset). Try to recover a real number by parsing a genuine
+            # github.com PR/issue URL out of it.
+            url_pattern = _GITHUB_PR_URL_RE if kind == "pull_request" else _GITHUB_ISSUE_URL_RE
+            match = url_pattern.search(url_str)
+            if match:
+                owner_name = owner_name or match.group(1)
+                repo_name = repo_name or match.group(2)
+                number = int(match.group(3))
+        if number is None:
+            # Still nothing usable (e.g. url holds an opaque non-GitHub
+            # id). Coercing this to number=0 would fabricate a bogus
+            # "PR #0" that -- because typed evidence is authoritative --
+            # would silently outrank a correctly-parsed regex fallback
+            # result (polylogue-2vor finding 1). Skip the row instead.
+            continue
+
         built = GitHubRef(
             owner=owner_name,
             repo=repo_name,
-            number=int(number),
+            number=number,
             kind="pr" if kind == "pull_request" else "issue",
-            url=url if isinstance(url, str) else None,
-            raw_match=url if isinstance(url, str) else "",
+            url=url_str,
+            raw_match=url_str or "",
             source=SOURCE_TYPED,
         )
         if kind == "pull_request":

--- a/tests/infra/daemon_http_harness.py
+++ b/tests/infra/daemon_http_harness.py
@@ -1,0 +1,158 @@
+"""Shared HTTP-transport mocks for ``DaemonAPIHandler`` tests (polylogue-myhg).
+
+CodeRabbit flagged (PR #2559) that the ``_MockServer``/``_MockHeaders``/
+``_make_handler`` trio was hand-duplicated near-identically across three
+daemon test files, and drift already happened once: the ``host=`` parameter
+was added to two of the three copies during a fast-follow, not all three.
+This module is the single place that logic lives now.
+
+**What this mocks, and why that is still a real test:** ``DaemonAPIHandler``
+is a ``socketserver.BaseRequestHandler`` subclass that normally gets
+constructed by ``ThreadingHTTPServer`` from a live TCP connection. Standing
+up a real socket per test is unnecessary I/O for exercising handler logic,
+so these helpers replace exactly the transport it sits on:
+
+- ``MockDaemonServer`` stands in for the listening ``DaemonAPIHTTPServer``
+  (its thread pool / admission semaphore / configured auth token), not for
+  the handler being tested.
+- ``MockHeaders`` stands in for the parsed ``http.client.HTTPMessage`` a
+  real socket read would produce.
+- ``handler.rfile``/``handler.wfile`` are ``BytesIO`` standing in for the
+  socket's read/write ends.
+
+Everything downstream of the transport — ``do_GET``/``do_POST`` dispatch,
+``_check_auth``, cross-origin checks, route handlers, JSON/SSE
+serialization — is the real, unmocked ``DaemonAPIHandler`` implementation
+built via ``DaemonAPIHandler.__new__``. Do not add production-logic
+short-circuits here: the point of this harness is to exercise the real
+handler against a fake network, not to replace the handler.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from email.message import Message
+from io import BytesIO
+from typing import TYPE_CHECKING, cast
+from unittest.mock import MagicMock
+
+from polylogue.daemon.web_auth import WebCredentialRegistry
+
+if TYPE_CHECKING:
+    from polylogue.daemon.http import DaemonAPIHandler, DaemonAPIHTTPServer
+
+
+class MockDaemonServer:
+    """Stand-in for ``DaemonAPIHTTPServer``: the listening socket, thread
+    pool, and admission semaphore the real server owns — not the
+    request-handling logic under test. ``archive_query_executor``/
+    ``archive_query_admission`` are generously sized shared class
+    attributes; no test in this harness exercises their throttling."""
+
+    api_host = "127.0.0.1"
+    archive_query_executor = ThreadPoolExecutor(max_workers=1)
+    archive_query_admission = threading.BoundedSemaphore(64)
+
+    def __init__(self, *, auth_token: str = "", web_credentials: WebCredentialRegistry | None = None) -> None:
+        self.auth_token = auth_token
+        self.web_credentials = web_credentials if web_credentials is not None else WebCredentialRegistry()
+
+
+class MockHeaders:
+    """Stand-in for ``http.client.HTTPMessage`` (the parsed header block a
+    real socket read would produce)."""
+
+    def __init__(self, headers: dict[str, str] | None = None) -> None:
+        self._headers = headers or {}
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return self._headers.get(key, default)
+
+
+def make_daemon_handler(
+    method: str,
+    path: str,
+    *,
+    body: bytes = b"",
+    auth_header: str = "",
+    origin: str = "",
+    host: str = "",
+    cookie: str = "",
+    referer: str = "",
+    fetch_site: str = "",
+    web_client: bool = False,
+    extra_headers: dict[str, str] | None = None,
+    server: object | None = None,
+) -> DaemonAPIHandler:
+    """Build a real ``DaemonAPIHandler`` with only its transport replaced.
+
+    The handler is a genuine ``DaemonAPIHandler`` instance — ``do_GET``/
+    ``do_POST``/``_check_auth``/route dispatch all run the production
+    implementation against it. Callers invoke ``handler.do_GET()`` (etc.)
+    and assert against ``handler.wfile`` or a patched ``_send_json``/
+    ``_send_error`` (see ``capture_json_response``/``capture_responses``).
+
+    ``host`` defaults to unset, matching every pre-existing caller of the
+    predecessor per-file helpers — ``_check_host_admission_logic`` treats
+    an absent Host header as permissive, so omitting it is equivalent to a
+    non-browser client and does not gate auth/origin coverage. Pass ``host``
+    explicitly to test the Host gate itself.
+
+    Pass ``server=`` to control the auth token the request is checked
+    against (default: no token configured, i.e. auth open — the local-dev
+    default). ``extra_headers`` is a low-level escape hatch for header
+    shapes the named kwargs don't cover; named kwargs win on conflict since
+    they are applied first and ``extra_headers`` is merged in last.
+    """
+    from polylogue.daemon.http import DaemonAPIHandler
+
+    handler = DaemonAPIHandler.__new__(DaemonAPIHandler)
+    handler.server = cast("DaemonAPIHTTPServer", server or MockDaemonServer())
+    handler.client_address = ("127.0.0.1", 12345)
+    handler.path = path
+    handler.command = method
+    handler.requestline = f"{method} {path} HTTP/1.1"
+    handler.request_version = "HTTP/1.1"
+    handler.protocol_version = "HTTP/1.1"
+
+    headers: dict[str, str] = {"Content-Length": str(len(body))}
+    if auth_header:
+        headers["Authorization"] = auth_header
+    if origin:
+        headers["Origin"] = origin
+    if host:
+        headers["Host"] = host
+    if cookie:
+        headers["Cookie"] = cookie
+    if referer:
+        headers["Referer"] = referer
+    if fetch_site:
+        headers["Sec-Fetch-Site"] = fetch_site
+    if web_client:
+        headers["X-Polylogue-Web-Client"] = "1"
+    if extra_headers:
+        headers.update(extra_headers)
+
+    handler.headers = cast("Message[str, str]", MockHeaders(headers))
+    handler.rfile = BytesIO(body)
+    handler.wfile = BytesIO()
+    return handler
+
+
+def capture_json_response(handler: DaemonAPIHandler) -> MagicMock:
+    """Patch ``handler._send_json`` so its call args can be asserted
+    instead of parsing raw bytes off ``handler.wfile``."""
+    send_json = MagicMock()
+    handler._send_json = send_json  # type: ignore[method-assign]
+    return send_json
+
+
+def capture_responses(handler: DaemonAPIHandler) -> tuple[MagicMock, MagicMock]:
+    """Patch both ``_send_error`` and ``_send_json`` so a single call site
+    can assert whichever response path a route actually took."""
+    send_error = MagicMock()
+    send_json = MagicMock()
+    handler._send_error = send_error  # type: ignore[method-assign]
+    handler._send_json = send_json  # type: ignore[method-assign]
+    return send_error, send_json

--- a/tests/unit/daemon/test_daemon_events_endpoint.py
+++ b/tests/unit/daemon/test_daemon_events_endpoint.py
@@ -20,9 +20,6 @@ from __future__ import annotations
 import json
 import re
 import sqlite3
-import threading
-from concurrent.futures import ThreadPoolExecutor
-from email.message import Message
 from http import HTTPStatus
 from io import BytesIO
 from pathlib import Path
@@ -33,24 +30,10 @@ import pytest
 
 from polylogue.core.json import JSONDocument
 from polylogue.daemon.web_auth import WebCredentialRegistry
+from tests.infra.daemon_http_harness import MockDaemonServer, capture_json_response, make_daemon_handler
 
 if TYPE_CHECKING:
-    from polylogue.daemon.http import DaemonAPIHandler, DaemonAPIHTTPServer
-
-
-class _MockServer:
-    auth_token = ""
-    api_host = "127.0.0.1"
-    archive_query_executor = ThreadPoolExecutor(max_workers=1)
-    archive_query_admission = threading.BoundedSemaphore(64)  # generous: not under test
-
-
-class _MockHeaders:
-    def __init__(self, headers: dict[str, str] | None = None) -> None:
-        self._headers = headers or {}
-
-    def get(self, key: str, default: str | None = None) -> str | None:
-        return self._headers.get(key, default)
+    from polylogue.daemon.http import DaemonAPIHandler
 
 
 def _make_handler(
@@ -59,30 +42,9 @@ def _make_handler(
     *,
     body: bytes = b"",
     extra_headers: dict[str, str] | None = None,
+    server: object | None = None,
 ) -> DaemonAPIHandler:
-    from polylogue.daemon.http import DaemonAPIHandler
-
-    handler = DaemonAPIHandler.__new__(DaemonAPIHandler)
-    handler.server = cast("DaemonAPIHTTPServer", _MockServer())
-    handler.client_address = ("127.0.0.1", 12345)
-    handler.path = path
-    handler.command = method
-    handler.requestline = f"{method} {path} HTTP/1.1"
-    handler.request_version = "HTTP/1.1"
-    handler.protocol_version = "HTTP/1.1"
-    headers: dict[str, str] = {"Content-Length": str(len(body))}
-    if extra_headers:
-        headers.update(extra_headers)
-    handler.headers = cast("Message", _MockHeaders(headers))
-    handler.rfile = BytesIO(body)
-    handler.wfile = BytesIO()
-    return handler
-
-
-def _capture_json(handler: DaemonAPIHandler) -> MagicMock:
-    send_json = MagicMock()
-    handler._send_json = send_json  # type: ignore[method-assign]
-    return send_json
+    return make_daemon_handler(method, path, body=body, extra_headers=extra_headers, server=server)
 
 
 def _complete_healthy_frontier() -> JSONDocument:
@@ -142,7 +104,7 @@ class TestEventsPollFallback:
 
     def test_poll_with_no_events_returns_empty_envelope(self, empty_events_db: Path) -> None:
         handler = _make_handler("GET", "/api/events?poll=1&since=0")
-        send_json = _capture_json(handler)
+        send_json = capture_json_response(handler)
         handler.do_GET()
 
         send_json.assert_called_once()
@@ -158,7 +120,7 @@ class TestEventsPollFallback:
         emit_daemon_event("ingest", operation_id="op-2", payload={"path": "/tmp/x"})
 
         handler = _make_handler("GET", "/api/events?poll=1&since=0")
-        send_json = _capture_json(handler)
+        send_json = capture_json_response(handler)
         handler.do_GET()
 
         status, payload = send_json.call_args.args
@@ -174,7 +136,7 @@ class TestEventsPollFallback:
         emit_daemon_event("noise", payload={"n": 2})
 
         handler = _make_handler("GET", "/api/events?poll=1&since=0&kinds=ingestion_batch,ingest")
-        send_json = _capture_json(handler)
+        send_json = capture_json_response(handler)
         handler.do_GET()
 
         payload = send_json.call_args.args[1]
@@ -186,12 +148,12 @@ class TestEventsPollFallback:
 
         emit_daemon_event("ingestion_batch", payload={})
         handler = _make_handler("GET", "/api/events?poll=1&since=0")
-        send_json = _capture_json(handler)
+        send_json = capture_json_response(handler)
         handler.do_GET()
         first_id = send_json.call_args.args[1]["events"][0]["id"]
 
         handler = _make_handler("GET", f"/api/events?poll=1&since={first_id}")
-        send_json = _capture_json(handler)
+        send_json = capture_json_response(handler)
         handler.do_GET()
         assert send_json.call_args.args[1] == {"events": [], "last_event_id": first_id}
 
@@ -225,7 +187,7 @@ class TestEventsSSEStream:
 
         # Last-Event-ID set to the first event's id should suppress it.
         handler_first = _make_handler("GET", "/api/events?poll=1&since=0")
-        send_json_first = _capture_json(handler_first)
+        send_json_first = capture_json_response(handler_first)
         handler_first.do_GET()
         first_id = send_json_first.call_args.args[1]["events"][0]["id"]
 
@@ -551,7 +513,7 @@ class TestGranularEventKinds:
             "GET",
             "/api/events?poll=1&since=0&kinds=message.appended,session.updated",
         )
-        send_json = _capture_json(handler)
+        send_json = capture_json_response(handler)
         handler.do_GET()
         kinds = {e["kind"] for e in send_json.call_args.args[1]["events"]}
         assert kinds == {"message.appended", "session.updated"}
@@ -661,7 +623,7 @@ class TestBackpressureCoalescing:
             emit_message_appended(session_id="c", appended_count=1)
 
         handler = _make_handler("GET", "/api/events?poll=1&since=0&coalesce=5")
-        send_json = _capture_json(handler)
+        send_json = capture_json_response(handler)
         handler.do_GET()
         payload = send_json.call_args.args[1]
         assert payload["coalesced"] is True
@@ -682,7 +644,7 @@ class TestBackpressureCoalescing:
             emit_message_appended(session_id="c", appended_count=1)
 
         handler = _make_handler("GET", "/api/events?poll=1&since=0&coalesce=10")
-        send_json = _capture_json(handler)
+        send_json = capture_json_response(handler)
         handler.do_GET()
         payload = send_json.call_args.args[1]
         assert payload.get("coalesced") is None
@@ -712,18 +674,10 @@ class TestAccessTokenQueryRejected:
         empty_events_db: Path,
         credential_param: str,
     ) -> None:
-        handler = _make_handler("GET", f"/api/events?poll=1&since=0&{credential_param}=secret")
-        handler.server = cast(
-            "DaemonAPIHTTPServer",
-            type(
-                "_Srv",
-                (),
-                {
-                    "auth_token": "secret",
-                    "api_host": "127.0.0.1",
-                    "web_credentials": WebCredentialRegistry(),
-                },
-            )(),
+        handler = _make_handler(
+            "GET",
+            f"/api/events?poll=1&since=0&{credential_param}=secret",
+            server=MockDaemonServer(auth_token="secret"),
         )
         send_error = MagicMock()
         handler._send_error = send_error  # type: ignore[method-assign]
@@ -735,14 +689,10 @@ class TestAccessTokenQueryRejected:
         )
 
     def test_access_token_in_query_string_is_rejected_on_non_sse_routes(self, empty_events_db: Path) -> None:
-        handler = _make_handler("GET", "/api/status?access_token=secret")
-        handler.server = cast(
-            "DaemonAPIHTTPServer",
-            type(
-                "_Srv",
-                (),
-                {"auth_token": "secret", "api_host": "127.0.0.1"},
-            )(),
+        handler = _make_handler(
+            "GET",
+            "/api/status?access_token=secret",
+            server=MockDaemonServer(auth_token="secret"),
         )
         send_error = MagicMock()
         handler._send_error = send_error  # type: ignore[method-assign]
@@ -765,14 +715,7 @@ class TestAccessTokenQueryRejected:
                 "Sec-Fetch-Site": "same-origin",
                 "X-Polylogue-Web-Client": "1",
             },
-        )
-        handler.server = cast(
-            "DaemonAPIHTTPServer",
-            type(
-                "_Srv",
-                (),
-                {"auth_token": "secret", "api_host": "127.0.0.1", "web_credentials": registry},
-            )(),
+            server=MockDaemonServer(auth_token="secret", web_credentials=registry),
         )
         status_handler = MagicMock()
         handler._handle_status = status_handler  # type: ignore[method-assign]

--- a/tests/unit/daemon/test_daemon_http_security.py
+++ b/tests/unit/daemon/test_daemon_http_security.py
@@ -19,12 +19,8 @@ same security coverage.
 from __future__ import annotations
 
 import json
-import threading
 import zipfile
-from concurrent.futures import ThreadPoolExecutor
-from email.message import Message
 from http import HTTPStatus
-from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from unittest.mock import MagicMock, patch
@@ -34,7 +30,8 @@ import pytest
 from polylogue.core.loopback import is_loopback_host
 from polylogue.daemon.http import _check_auth_logic
 from polylogue.daemon.route_contracts import ROUTE_CONTRACTS, RouteContract
-from polylogue.daemon.web_auth import WebCredentialRegistry, exact_origin_allowed
+from polylogue.daemon.web_auth import exact_origin_allowed
+from tests.infra.daemon_http_harness import MockDaemonServer, capture_responses, make_daemon_handler
 
 if TYPE_CHECKING:
     from polylogue.daemon.http import DaemonAPIHandler, DaemonAPIHTTPServer
@@ -201,24 +198,6 @@ class TestOriginAllowlist:
 # ---------------------------------------------------------------------------
 
 
-class _MockServer:
-    auth_token = "secret"
-    api_host = "127.0.0.1"
-    archive_query_executor = ThreadPoolExecutor(max_workers=1)
-    archive_query_admission = threading.BoundedSemaphore(64)  # generous: not under test
-
-    def __init__(self) -> None:
-        self.web_credentials = WebCredentialRegistry()
-
-
-class _MockHeaders:
-    def __init__(self, headers: dict[str, str] | None = None) -> None:
-        self._headers = headers or {}
-
-    def get(self, key: str, default: str | None = None) -> str | None:
-        return self._headers.get(key, default)
-
-
 def _make_handler(
     method: str,
     path: str,
@@ -243,44 +222,24 @@ def _make_handler(
     permissive (see its docstring), so omitting it here is equivalent to a
     non-browser client and does not gate any of the auth/origin coverage
     below. Tests of the Host gate itself pass ``host`` explicitly.
+
+    This file's default server has a configured token (``"secret"``) —
+    unlike the shared harness's own open-by-default ``MockDaemonServer`` —
+    because this file's whole point is exercising the auth-required path.
     """
-    from polylogue.daemon.http import DaemonAPIHandler
-
-    handler = DaemonAPIHandler.__new__(DaemonAPIHandler)
-    handler.server = cast("DaemonAPIHTTPServer", server or _MockServer())
-    handler.client_address = ("127.0.0.1", 12345)
-    handler.path = path
-    handler.command = method
-    handler.requestline = f"{method} {path} HTTP/1.1"
-
-    headers: dict[str, str] = {"Content-Length": str(len(body))}
-    if auth_header:
-        headers["Authorization"] = auth_header
-    if origin:
-        headers["Origin"] = origin
-    if host:
-        headers["Host"] = host
-    if cookie:
-        headers["Cookie"] = cookie
-    if referer:
-        headers["Referer"] = referer
-    if fetch_site:
-        headers["Sec-Fetch-Site"] = fetch_site
-    if web_client:
-        headers["X-Polylogue-Web-Client"] = "1"
-    handler.headers = cast("Message[str, str]", _MockHeaders(headers))
-    handler.rfile = BytesIO(body)
-    handler.wfile = BytesIO()
-    return handler
-
-
-def _capture_responses(handler: DaemonAPIHandler) -> tuple[MagicMock, MagicMock]:
-    """Patch the response writers so we can assert what was sent."""
-    send_error = MagicMock()
-    send_json = MagicMock()
-    handler._send_error = send_error  # type: ignore[method-assign]
-    handler._send_json = send_json  # type: ignore[method-assign]
-    return send_error, send_json
+    return make_daemon_handler(
+        method,
+        path,
+        auth_header=auth_header,
+        origin=origin,
+        host=host,
+        cookie=cookie,
+        referer=referer,
+        fetch_site=fetch_site,
+        web_client=web_client,
+        body=body,
+        server=server or MockDaemonServer(auth_token="secret"),
+    )
 
 
 @pytest.mark.parametrize("path", ENDPOINTS_GET)
@@ -289,13 +248,13 @@ class TestGetEndpointAuthGate:
 
     def test_missing_token_returns_401(self, path: str) -> None:
         handler = _make_handler("GET", path)
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_GET()
         send_error.assert_called_once_with(HTTPStatus.UNAUTHORIZED, "unauthorized")
 
     def test_invalid_token_returns_401(self, path: str) -> None:
         handler = _make_handler("GET", path, auth_header="Bearer wrong")
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_GET()
         send_error.assert_called_once_with(HTTPStatus.UNAUTHORIZED, "unauthorized")
 
@@ -311,20 +270,20 @@ class TestPostEndpointAuthAndOriginGate:
 
     def test_missing_token_returns_401(self, path: str) -> None:
         handler = _make_handler("POST", path)
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_POST()
         send_error.assert_called_once_with(HTTPStatus.UNAUTHORIZED, "unauthorized")
 
     def test_invalid_token_returns_401(self, path: str) -> None:
         handler = _make_handler("POST", path, auth_header="Bearer wrong")
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_POST()
         send_error.assert_called_once_with(HTTPStatus.UNAUTHORIZED, "unauthorized")
 
     def test_valid_token_no_origin_passes_gates(self, path: str) -> None:
         """Auth + origin gates admit a curl/hook-style request (no Origin)."""
         handler = _make_handler("POST", path, auth_header="Bearer secret")
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         with (
             patch.object(handler, "_handle_reset"),
             patch.object(handler, "_handle_ingest"),
@@ -348,7 +307,7 @@ class TestPostEndpointAuthAndOriginGate:
             origin="http://127.0.0.1:8766",
             host="127.0.0.1:8766",
         )
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         with (
             patch.object(handler, "_handle_reset"),
             patch.object(handler, "_handle_ingest"),
@@ -377,7 +336,7 @@ class TestPostEndpointAuthAndOriginGate:
             auth_header="Bearer secret",
             origin="https://evil.example.com",
         )
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_POST()
         send_error.assert_called_once_with(HTTPStatus.FORBIDDEN, "cross_origin_denied")
 
@@ -392,13 +351,13 @@ class TestDeleteEndpointAuthAndOriginGate:
 
     def test_missing_token_returns_401(self, path: str) -> None:
         handler = _make_handler("DELETE", path)
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_DELETE()
         send_error.assert_called_once_with(HTTPStatus.UNAUTHORIZED, "unauthorized")
 
     def test_invalid_token_returns_401(self, path: str) -> None:
         handler = _make_handler("DELETE", path, auth_header="Bearer wrong")
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_DELETE()
         send_error.assert_called_once_with(HTTPStatus.UNAUTHORIZED, "unauthorized")
 
@@ -410,14 +369,14 @@ class TestDeleteEndpointAuthAndOriginGate:
             auth_header="Bearer secret",
             origin="https://evil.example.com",
         )
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_DELETE()
         send_error.assert_called_once_with(HTTPStatus.FORBIDDEN, "cross_origin_denied")
 
     def test_valid_token_no_origin_passes_gates(self, path: str) -> None:
         """Auth + origin gates admit a curl/hook-style request (no Origin)."""
         handler = _make_handler("DELETE", path, auth_header="Bearer secret")
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         with patch("polylogue.daemon.user_state_http.dispatch_delete", return_value=True):
             handler.do_DELETE()
         for call in send_error.call_args_list:
@@ -435,7 +394,7 @@ class TestDeleteEndpointAuthAndOriginGate:
             origin="http://localhost:8766",
             host="localhost:8766",
         )
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         with patch("polylogue.daemon.user_state_http.dispatch_delete", return_value=True):
             handler.do_DELETE()
         for call in send_error.call_args_list:
@@ -499,13 +458,13 @@ class TestGetEndpointHostGate:
         independently of auth, closing the archive-read hole even when the
         daemon has no token set (the common local-dev default)."""
         handler = _make_handler("GET", path, host="evil.example.com")
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_GET()
         send_error.assert_called_once_with(HTTPStatus.FORBIDDEN, "host_not_allowed")
 
     def test_loopback_host_reaches_the_auth_gate(self, path: str) -> None:
         handler = _make_handler("GET", path, host="127.0.0.1:8766")
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_GET()
         # No token configured on the mock server -> passes straight through
         # to the route handler layer; the point here is that it is NOT
@@ -530,7 +489,7 @@ class TestBootstrapAndProbeRoutesHostGate:
 
     def test_foreign_host_returns_403(self, path: str) -> None:
         handler = _make_handler("GET", path, host="evil.example.com")
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_GET()
         send_error.assert_called_once_with(HTTPStatus.FORBIDDEN, "host_not_allowed")
 
@@ -557,7 +516,7 @@ class TestBootstrapAndProbeRoutesHostGate:
 class TestPostEndpointHostGate:
     def test_foreign_host_returns_403_even_with_valid_token(self, path: str) -> None:
         handler = _make_handler("POST", path, auth_header="Bearer secret", host="evil.example.com")
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_POST()
         send_error.assert_called_once_with(HTTPStatus.FORBIDDEN, "host_not_allowed")
 
@@ -566,7 +525,7 @@ class TestPostEndpointHostGate:
 class TestDeleteEndpointHostGate:
     def test_foreign_host_returns_403_even_with_valid_token(self, path: str) -> None:
         handler = _make_handler("DELETE", path, auth_header="Bearer secret", host="evil.example.com")
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_DELETE()
         send_error.assert_called_once_with(HTTPStatus.FORBIDDEN, "host_not_allowed")
 
@@ -613,7 +572,7 @@ class TestIngestEndpointInboxBoundary:
             }
         ).encode("utf-8")
         handler = _make_handler("POST", "/api/ingest", auth_header="Bearer secret", body=body)
-        send_error, send_json = _capture_responses(handler)
+        send_error, send_json = capture_responses(handler)
 
         with (
             patch("polylogue.paths.archive_root", return_value=workspace_env["archive_root"]),
@@ -645,7 +604,7 @@ class TestIngestEndpointInboxBoundary:
 
         body = json.dumps({"path": str(staged)}).encode("utf-8")
         handler = _make_handler("POST", "/api/ingest", auth_header="Bearer secret", body=body)
-        send_error, send_json = _capture_responses(handler)
+        send_error, send_json = capture_responses(handler)
 
         with (
             patch("polylogue.paths.archive_root", return_value=workspace_env["archive_root"]),
@@ -689,7 +648,7 @@ class TestIngestEndpointInboxBoundary:
 
         body = json.dumps({"path": str(staged)}).encode("utf-8")
         handler = _make_handler("POST", "/api/ingest", auth_header="Bearer secret", body=body)
-        send_error, send_json = _capture_responses(handler)
+        send_error, send_json = capture_responses(handler)
 
         with (
             patch("polylogue.paths.archive_root", return_value=workspace_env["archive_root"]),
@@ -716,7 +675,7 @@ class TestIngestEndpointInboxBoundary:
 
         body = json.dumps({"path": str(outside)}).encode("utf-8")
         handler = _make_handler("POST", "/api/ingest", auth_header="Bearer secret", body=body)
-        send_error, send_json = _capture_responses(handler)
+        send_error, send_json = capture_responses(handler)
 
         with (
             patch("polylogue.paths.archive_root", return_value=workspace_env["archive_root"]),
@@ -768,7 +727,7 @@ class TestIngestEndpointInboxBoundary:
 
         body = json.dumps({"path": traversal_path}).encode("utf-8")
         handler = _make_handler("POST", "/api/ingest", auth_header="Bearer secret", body=body)
-        send_error, send_json = _capture_responses(handler)
+        send_error, send_json = capture_responses(handler)
 
         with (
             patch("polylogue.paths.archive_root", return_value=workspace_env["archive_root"]),
@@ -817,7 +776,7 @@ class TestIngestEndpointInboxBoundary:
         # Client sends a dotdot path whose basename is "session.jsonl"
         body = json.dumps({"path": "../inbox/session.jsonl"}).encode("utf-8")
         handler = _make_handler("POST", "/api/ingest", auth_header="Bearer secret", body=body)
-        send_error, send_json = _capture_responses(handler)
+        send_error, send_json = capture_responses(handler)
 
         with (
             patch("polylogue.paths.archive_root", return_value=workspace_env["archive_root"]),
@@ -850,7 +809,7 @@ class TestIngestEndpointInboxBoundary:
 
         body = json.dumps({"path": "escape_link.jsonl"}).encode("utf-8")
         handler = _make_handler("POST", "/api/ingest", auth_header="Bearer secret", body=body)
-        send_error, send_json = _capture_responses(handler)
+        send_error, send_json = capture_responses(handler)
 
         with (
             patch("polylogue.paths.archive_root", return_value=workspace_env["archive_root"]),
@@ -1008,7 +967,7 @@ class TestOptionsReturnsMethodNotAllowed:
     @pytest.mark.parametrize("path", ENDPOINTS_GET + ENDPOINTS_POST)
     def test_options_405(self, path: str) -> None:
         handler = _make_handler("OPTIONS", path)
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_OPTIONS()
         send_error.assert_called_once_with(HTTPStatus.METHOD_NOT_ALLOWED, "method_not_allowed")
 
@@ -1393,7 +1352,7 @@ class TestOtlpGating:
             lambda: SimpleNamespace(observability_enabled=True, otlp_max_body_bytes=8 * 1024 * 1024),
         )
         handler = _make_handler("POST", path, host="evil.example.com")
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_POST()
         send_error.assert_called_once_with(HTTPStatus.FORBIDDEN, "host_not_allowed")
 
@@ -1406,7 +1365,7 @@ class TestOtlpGating:
             lambda: SimpleNamespace(observability_enabled=False, otlp_max_body_bytes=8 * 1024 * 1024),
         )
         handler = _make_handler("POST", path, origin="")
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
         handler.do_POST()
         send_error.assert_called_once_with(HTTPStatus.NOT_FOUND, "not_found")
 
@@ -1454,7 +1413,7 @@ class TestOtlpGating:
 
         handler = _make_handler("POST", path)
         handler.server = cast("DaemonAPIHTTPServer", RemoteMockServer())
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
 
         handler.do_POST()
 
@@ -1473,7 +1432,7 @@ class TestOtlpGating:
 
         big_body = b"x" * 4096  # 4 KiB > 1 KiB cap
         handler = _make_handler("POST", path, body=big_body)
-        send_error, _ = _capture_responses(handler)
+        send_error, _ = capture_responses(handler)
 
         handler.do_POST()
 

--- a/tests/unit/daemon/test_provider_usage_endpoint.py
+++ b/tests/unit/daemon/test_provider_usage_endpoint.py
@@ -11,55 +11,19 @@ that it behaves correctly).
 
 from __future__ import annotations
 
-import threading
-from concurrent.futures import ThreadPoolExecutor
-from email.message import Message
 from http import HTTPStatus
-from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
-from unittest.mock import MagicMock
+from typing import TYPE_CHECKING
 
+from tests.infra.daemon_http_harness import capture_json_response, make_daemon_handler
 from tests.infra.storage_records import SessionBuilder, db_setup
 
 if TYPE_CHECKING:
-    from polylogue.daemon.http import DaemonAPIHandler, DaemonAPIHTTPServer
-
-
-class _MockServer:
-    auth_token = ""
-    api_host = "127.0.0.1"
-    archive_query_executor = ThreadPoolExecutor(max_workers=1)
-    archive_query_admission = threading.BoundedSemaphore(64)  # generous: not under test
-
-
-class _MockHeaders:
-    def __init__(self, headers: dict[str, str] | None = None) -> None:
-        self._headers = headers or {}
-
-    def get(self, key: str, default: str | None = None) -> str | None:
-        return self._headers.get(key, default)
+    from polylogue.daemon.http import DaemonAPIHandler
 
 
 def _make_handler(path: str = "/api/provider-usage") -> DaemonAPIHandler:
-    from polylogue.daemon.http import DaemonAPIHandler
-
-    handler = DaemonAPIHandler.__new__(DaemonAPIHandler)
-    handler.server = cast("DaemonAPIHTTPServer", _MockServer())
-    handler.client_address = ("127.0.0.1", 12345)
-    handler.path = path
-    handler.command = "GET"
-    handler.requestline = f"GET {path} HTTP/1.1"
-    handler.headers = cast("Message[str, str]", _MockHeaders({"Content-Length": "0"}))
-    handler.rfile = BytesIO(b"")
-    handler.wfile = BytesIO()
-    return handler
-
-
-def _capture_json(handler: DaemonAPIHandler) -> MagicMock:
-    send_json = MagicMock()
-    handler._send_json = send_json  # type: ignore[method-assign]
-    return send_json
+    return make_daemon_handler("GET", path)
 
 
 def test_returns_200_with_empty_origins_when_archive_has_no_sessions(workspace_env: dict[str, Path]) -> None:
@@ -67,7 +31,7 @@ def test_returns_200_with_empty_origins_when_archive_has_no_sessions(workspace_e
     initialized, session-free archive, the endpoint must return a
     structured 200, not crash with the AttributeError this bead fixed."""
     handler = _make_handler()
-    send_json = _capture_json(handler)
+    send_json = capture_json_response(handler)
 
     handler.do_GET()
 
@@ -84,7 +48,7 @@ def test_returns_200_with_origin_usage_for_seeded_session(workspace_env: dict[st
     ).add_message(role="assistant", text="hi").save()
 
     handler = _make_handler()
-    send_json = _capture_json(handler)
+    send_json = capture_json_response(handler)
 
     handler.do_GET()
 
@@ -103,7 +67,7 @@ def test_default_detail_is_headline_not_full(workspace_env: dict[str, Path]) -> 
     path — headline is fast (SQL-side rollups only) and the MCP tool's
     detail="full" default is deliberately NOT mirrored here."""
     handler = _make_handler()
-    send_json = _capture_json(handler)
+    send_json = capture_json_response(handler)
 
     handler.do_GET()
 
@@ -114,7 +78,7 @@ def test_default_detail_is_headline_not_full(workspace_env: dict[str, Path]) -> 
 
 def test_respects_detail_and_limit_query_params(workspace_env: dict[str, Path]) -> None:
     handler = _make_handler("/api/provider-usage?detail=headline&limit=5")
-    send_json = _capture_json(handler)
+    send_json = capture_json_response(handler)
 
     handler.do_GET()
 

--- a/tests/unit/daemon/test_route_contracts.py
+++ b/tests/unit/daemon/test_route_contracts.py
@@ -16,11 +16,11 @@ from polylogue.daemon.route_contracts import (
     route_contract_for_pattern,
     stable_route_contracts,
 )
+from tests.infra.daemon_http_harness import capture_responses
 from tests.unit.daemon.test_daemon_http_security import (
     ENDPOINTS_DELETE,
     ENDPOINTS_GET,
     ENDPOINTS_POST,
-    _capture_responses,
     _make_handler,
 )
 
@@ -105,7 +105,7 @@ def test_rebuild_index_handler_forwards_resumable_pass_options_through_writer_br
         ).encode(),
         server=bridge,
     )
-    _send_error, send_json = _capture_responses(handler)
+    _send_error, send_json = capture_responses(handler)
 
     handler._handle_rebuild_index()
 
@@ -300,7 +300,7 @@ def test_shell_bootstrap_is_unauthenticated_on_loopback(path: str) -> None:
     """Local shell bootstrap remains frictionless on loopback."""
 
     handler = _make_handler("GET", path)
-    send_error, _ = _capture_responses(handler)
+    send_error, _ = capture_responses(handler)
     handler._serve_web_shell = lambda: None  # type: ignore[method-assign]
     handler._serve_webui_archive_overview = lambda: None  # type: ignore[method-assign]
     handler._serve_paste_browser_page = lambda: None  # type: ignore[method-assign]
@@ -323,7 +323,7 @@ def test_shell_bootstrap_requires_token_on_non_loopback(path: str) -> None:
     handler = _make_handler("GET", path)
     handler.server = RemoteMockServer()  # type: ignore[assignment]
     handler.client_address = ("192.0.2.10", 12345)
-    send_error, _ = _capture_responses(handler)
+    send_error, _ = capture_responses(handler)
 
     handler.do_GET()
 

--- a/tests/unit/daemon/test_web_auth.py
+++ b/tests/unit/daemon/test_web_auth.py
@@ -20,11 +20,8 @@ from polylogue.daemon.web_auth import (
     read_web_credential_cookie,
     same_origin_from_headers,
 )
-from tests.unit.daemon.test_daemon_http_security import (
-    _capture_responses,
-    _make_handler,
-    _MockServer,
-)
+from tests.infra.daemon_http_harness import MockDaemonServer, capture_responses
+from tests.unit.daemon.test_daemon_http_security import _make_handler
 
 
 def _cookie_pair(set_cookie: str) -> tuple[str, str]:
@@ -97,7 +94,7 @@ def test_registry_bounds_rotation_records_and_preserves_recent_lifecycle_state()
 
 
 def test_bootstrap_rotates_http_only_cookie_and_authenticates_read_route() -> None:
-    server = _MockServer()
+    server = MockDaemonServer(auth_token="secret")
     origin = "http://127.0.0.1:8766"
     bootstrap = _make_handler(
         "POST",
@@ -107,7 +104,7 @@ def test_bootstrap_rotates_http_only_cookie_and_authenticates_read_route() -> No
         web_client=True,
         server=server,
     )
-    send_error, _ = _capture_responses(bootstrap)
+    send_error, _ = capture_responses(bootstrap)
     send_cookie_json = MagicMock()
     bootstrap._send_json_with_cookie = send_cookie_json  # type: ignore[method-assign]
     bootstrap.do_POST()
@@ -154,7 +151,7 @@ def test_bootstrap_rotates_http_only_cookie_and_authenticates_read_route() -> No
     ],
 )
 def test_web_credential_cannot_execute_archive_control_routes(path: str, handler_name: str) -> None:
-    server = _MockServer()
+    server = MockDaemonServer(auth_token="secret")
     origin = "http://127.0.0.1:8766"
     issued = server.web_credentials.issue(origin)
     handler = _make_handler(
@@ -169,7 +166,7 @@ def test_web_credential_cannot_execute_archive_control_routes(path: str, handler
     )
     route_handler = MagicMock()
     setattr(handler, handler_name, route_handler)
-    send_error, _ = _capture_responses(handler)
+    send_error, _ = capture_responses(handler)
 
     handler.do_POST()
 
@@ -185,7 +182,7 @@ def test_bootstrap_rejects_wrong_origin_without_minting_cookie() -> None:
         host="127.0.0.1:8766",
         web_client=True,
     )
-    send_error, send_json = _capture_responses(handler)
+    send_error, send_json = capture_responses(handler)
     handler.do_POST()
 
     send_error.assert_called_once()
@@ -204,7 +201,7 @@ def test_bootstrap_host_rejection_uses_typed_wrong_origin_contract() -> None:
         host="evil.example.com",
         web_client=True,
     )
-    send_error, _ = _capture_responses(handler)
+    send_error, _ = capture_responses(handler)
 
     handler.do_POST()
 
@@ -215,7 +212,7 @@ def test_bootstrap_host_rejection_uses_typed_wrong_origin_contract() -> None:
 
 
 def test_non_loopback_bootstrap_rejection_uses_typed_wrong_origin_contract() -> None:
-    server = _MockServer()
+    server = MockDaemonServer(auth_token="secret")
     server.api_host = "archive.internal"
     handler = _make_handler(
         "POST",
@@ -225,7 +222,7 @@ def test_non_loopback_bootstrap_rejection_uses_typed_wrong_origin_contract() -> 
         web_client=True,
         server=server,
     )
-    send_error, _ = _capture_responses(handler)
+    send_error, _ = capture_responses(handler)
 
     handler.do_POST()
 
@@ -238,7 +235,7 @@ def test_non_loopback_bootstrap_rejection_uses_typed_wrong_origin_contract() -> 
 def test_non_ascii_cookie_is_total_across_bootstrap_read_and_revoke() -> None:
     origin = "http://127.0.0.1:8766"
     malformed_cookie = f'{WEB_CREDENTIAL_COOKIE}="\N{LATIN SMALL LETTER E WITH ACUTE}"'
-    server = _MockServer()
+    server = MockDaemonServer(auth_token="secret")
 
     bootstrap = _make_handler(
         "POST",
@@ -249,7 +246,7 @@ def test_non_ascii_cookie_is_total_across_bootstrap_read_and_revoke() -> None:
         web_client=True,
         server=server,
     )
-    bootstrap_error, _ = _capture_responses(bootstrap)
+    bootstrap_error, _ = capture_responses(bootstrap)
     bootstrap_cookie_json = MagicMock()
     bootstrap._send_json_with_cookie = bootstrap_cookie_json  # type: ignore[method-assign]
     bootstrap.do_POST()
@@ -265,7 +262,7 @@ def test_non_ascii_cookie_is_total_across_bootstrap_read_and_revoke() -> None:
         web_client=True,
         server=server,
     )
-    reader_error, _ = _capture_responses(reader)
+    reader_error, _ = capture_responses(reader)
     reader.do_GET()
     assert reader_error.call_args.args[:2] == (HTTPStatus.UNAUTHORIZED, "web_credential_invalid")
 
@@ -279,7 +276,7 @@ def test_non_ascii_cookie_is_total_across_bootstrap_read_and_revoke() -> None:
         web_client=True,
         server=server,
     )
-    revoke_error, _ = _capture_responses(revoke)
+    revoke_error, _ = capture_responses(revoke)
     revoke.do_DELETE()
     assert revoke_error.call_args.args[:2] == (HTTPStatus.UNAUTHORIZED, "web_credential_invalid")
 
@@ -292,7 +289,7 @@ def test_browser_missing_credential_has_explicit_recoverable_state() -> None:
         fetch_site="same-origin",
         web_client=True,
     )
-    send_error, _ = _capture_responses(handler)
+    send_error, _ = capture_responses(handler)
     handler.do_GET()
 
     assert send_error.call_args.args[:2] == (HTTPStatus.UNAUTHORIZED, "web_credential_missing")

--- a/tests/unit/insights/test_session_commit.py
+++ b/tests/unit/insights/test_session_commit.py
@@ -494,6 +494,48 @@ class TestTrailerTakesPriorityOverHeuristics:
         assert edges[0].detection_method == "file_overlap"
         assert edges[0].disagreement_note is None
 
+    def test_foreign_trailer_present_but_no_own_bridge_ids_is_not_a_disagreement(self, tmp_path: Path) -> None:
+        """polylogue-2vor finding 3: when this session has no
+        bridge_session_ids of its own, there is no typed identity to
+        compare a commit's Claude-Session trailer against -- a trailer
+        naming *some other* session is the expected case for any commit
+        that isn't this session's, not evidence of misattribution. Unlike
+        ``test_no_bridge_session_ids_falls_back_to_heuristics_unflagged``
+        above (whose commit carries no trailer at all), this commit DOES
+        carry a foreign trailer, which is exactly the shape that used to
+        false-positive."""
+        _init_git_repo(tmp_path)
+        other_token = "01OtherSessionToken0000000"
+        sha = _commit(
+            tmp_path,
+            "src/main.py",
+            f"fix: ship it\n\nClaude-Session: https://claude.ai/code/session_{other_token}\n",
+        )
+        now = datetime.now(timezone.utc)
+
+        messages = [
+            {
+                "id": "m1",
+                "text": "editing src/main.py",
+                "content_blocks": [{"type": "tool_use", "name": "Edit", "affected_paths": ["src/main.py"]}],
+            }
+        ]
+
+        edges = detect_session_commits(
+            session_id="claude-code-session:own-session",
+            messages=messages,
+            session_created_at=now - timedelta(minutes=5),
+            session_updated_at=now,
+            repo_path=str(tmp_path),
+            bridge_session_ids=None,  # this session asserts no bridge identity of its own
+        )
+
+        assert len(edges) == 1
+        edge = edges[0]
+        assert edge.commit_sha == sha
+        assert edge.detection_method == "file_overlap"
+        assert edge.disagreement_note is None
+
 
 class TestTypedRefsPreferredOverRegex:
     """polylogue-l9su AC2/AC4: typed session_refs-derived GitHubRefs are
@@ -535,6 +577,30 @@ class TestTypedRefsPreferredOverRegex:
         pr_disagreement = next(d for d in result.disagreements if d.kind == "pr_ref")
         assert "42" in pr_disagreement.heuristic_values
 
+    def test_disagreement_recorded_for_same_number_different_repo(self) -> None:
+        """polylogue-2vor finding 2: comparing PR/issue identity by bare
+        number alone means acme/product#42 and other/repo#42 compare
+        equal, silently swallowing a real disagreement across
+        differently-named repos. Typed evidence names Sinity/polylogue#42;
+        the message text names a *different* repo's #42 -- that must still
+        surface as a disagreement even though the numbers match."""
+        messages = [{"id": "m1", "text": "https://github.com/other/repo/pull/42", "content_blocks": []}]
+        typed_pr = GitHubRef(owner="Sinity", repo="polylogue", number=42, kind="pr", url="https://x/pull/42")
+
+        result = build_correlation_result(
+            session_id="s",
+            messages=messages,
+            repo_path="/nonexistent/path",
+            typed_pr_refs=[typed_pr],
+        )
+
+        assert [r.number for r in result.pr_refs] == [42]  # typed still wins
+        pr_disagreements = [d for d in result.disagreements if d.kind == "pr_ref"]
+        assert len(pr_disagreements) == 1, (
+            "other/repo#42 must not be silently treated as corroborating Sinity/polylogue#42"
+        )
+        assert "42" in pr_disagreements[0].heuristic_values
+
 
 class TestTypedRefsFromSessionRefs:
     def test_converts_pull_request_kind(self) -> None:
@@ -563,6 +629,45 @@ class TestTypedRefsFromSessionRefs:
         pr_refs, issue_refs = typed_refs_from_session_refs([_FakeRef()])
         assert pr_refs == []
         assert issue_refs == []
+
+    def test_missing_number_with_non_github_url_is_skipped_not_pr_zero(self) -> None:
+        """polylogue-2vor finding 1: Codex Cloud's
+        chatgpt_codex_sidecar._pull_request_ref() stores
+        external_pull_request_id in ``url`` and leaves ``repo``/``number``
+        unset. Coercing that to number=0 fabricates a bogus "PR #0" that,
+        because typed evidence is authoritative over the regex fallback,
+        would silently suppress a correctly-parsed regex result. The row
+        must be skipped instead of appearing as PR #0."""
+
+        class _FakeRef:
+            kind = "pull_request"
+            repo = None
+            number = None
+            url = "task_e_68abcdef"  # opaque Codex Cloud id, not a github.com URL
+
+        pr_refs, issue_refs = typed_refs_from_session_refs([_FakeRef()])
+        assert pr_refs == []
+        assert issue_refs == []
+        assert all(ref.number != 0 for ref in pr_refs)
+
+    def test_missing_number_is_parsed_from_github_url(self) -> None:
+        """When the row lacks a typed number but ``url`` is a genuine
+        github.com PR/issue URL, recover the number (and owner/repo, if
+        not already set) from the URL rather than skipping it."""
+
+        class _FakeRef:
+            kind = "pull_request"
+            repo = None
+            number = None
+            url = "https://github.com/Sinity/polylogue/pull/3265"
+
+        pr_refs, issue_refs = typed_refs_from_session_refs([_FakeRef()])
+        assert issue_refs == []
+        assert len(pr_refs) == 1
+        assert pr_refs[0].number == 3265
+        assert pr_refs[0].owner == "Sinity"
+        assert pr_refs[0].repo == "polylogue"
+        assert pr_refs[0].source == SOURCE_TYPED
 
 
 class TestBridgeSessionIdsFromEvents:


### PR DESCRIPTION
## Summary

- Extracts the hand-duplicated `_MockServer`/`_MockHeaders`/`_make_handler` trio from three daemon test files into a shared `tests/infra/daemon_http_harness.py` (polylogue-myhg).
- Closes three CodeRabbit findings from PR #3425's review that were triaged and filed as polylogue-2vor rather than blocking that merge (all three are in `polylogue/insights/session_commit.py`, with regression tests).

## Problem

**polylogue-myhg**: CodeRabbit flagged (PR #2559) that `_MockServer`/`_MockHeaders`/`_make_handler` were duplicated near-identically across `test_daemon_http_security.py`, `test_daemon_events_endpoint.py`, and `test_provider_usage_endpoint.py`. Drift already happened once: the `host=` parameter was added to two of the three copies during a fast-follow, not all three. A fresh grep tonight confirmed the duplication was still live.

**polylogue-2vor**: three P2 findings in `session_commit.py` were left unaddressed at PR #3425's merge time:
1. `typed_refs_from_session_refs()` coerced a `session_refs` row with a valid `url`/`repo` but no `ref_number` to "PR #0" (observed for Codex Cloud's `chatgpt_codex_sidecar._pull_request_ref()`, which stores `external_pull_request_id` in `url` and leaves `repo`/`number` unset). Since typed refs are authoritative over the regex fallback, this could suppress a correctly-parsed regex result with a bogus PR #0.
2. Disagreement detection compared PR/issue identity by bare number only, so `acme/product#42` and `other/repo#42` compared equal — a real cross-repo disagreement was never surfaced.
3. Foreign-trailer classification flagged a disagreement whenever a commit carried *any* Claude-Session trailer, even when the current session has no `bridge_session_ids` of its own — i.e. even with no typed identity to compare against.

## Solution

**Mock harness extraction** (`tests/infra/daemon_http_harness.py`):
- `MockDaemonServer`, `MockHeaders`, `make_daemon_handler`, `capture_json_response`, `capture_responses` — these mock only the HTTP transport boundary (the listening socket/`ThreadingHTTPServer` a real `DaemonAPIHandler` normally sits on, and the parsed header block a socket read would produce). `do_GET`/`do_POST` dispatch, `_check_auth`, cross-origin checks, route handlers, and JSON/SSE serialization all still run as the real production `DaemonAPIHandler` built via `__new__` — no boundary that was previously mocked is hollowed out.
- The three named test files now import the shared harness instead of defining their own copies. `test_daemon_http_security.py` keeps a thin file-local `_make_handler` wrapper because that file's whole point is exercising the auth-required path, so its default server needs a configured token (`"secret"`) unlike the harness's own open-by-default `MockDaemonServer`.
- While touching `test_daemon_events_endpoint.py`, three ad-hoc `type()`-built `_Srv` server stand-ins were also converted to `MockDaemonServer` — same duplication pattern CodeRabbit flagged in the original trio.
- Fixed two cross-file importers (`test_web_auth.py`, `test_route_contracts.py`) that imported `_MockServer`/`_capture_responses` *from* `test_daemon_http_security.py` rather than defining their own copies — a case a narrow per-file `devtools test` run doesn't catch but whole-repo `mypy --strict` does.

**session_commit.py fixes** (regression test per finding, see `tests/unit/insights/test_session_commit.py`):
1. `typed_refs_from_session_refs()` now tries to recover a real number by parsing a genuine `github.com` PR/issue URL out of `url` when `number` is absent; if that also fails, the row is skipped rather than defaulting to 0.
2. New `_refs_match()` compares the full `(owner, repo, number)` identity whenever both refs are repo-qualified, falling back to number-only equality when either side lacks repo identity (e.g. a bare `#42` regex mention).
3. `foreign_trailer` now additionally requires `own_trailer_tokens` to be non-empty.

## Verification

- `ruff check` + `mypy` (strict, whole repo: 2397 source files) clean.
- `devtools test tests/unit/daemon/test_daemon_http_security.py tests/unit/daemon/test_daemon_events_endpoint.py tests/unit/daemon/test_provider_usage_endpoint.py tests/unit/daemon/test_web_auth.py tests/unit/daemon/test_route_contracts.py` → 709 passed.
- `devtools test tests/unit/insights/test_session_commit.py` → 46 passed; also ran `tests/unit/cli/test_correlate_view.py tests/unit/storage/test_archive_tiers_write.py` (other consumers of `session_commit.py`) → 80 passed.
- `devtools verify --quick` → clean end to end.

Ref polylogue-myhg
Ref polylogue-2vor