### PR TITLE
fix(sources): stop GDPR export ZIP siblings and gemini-cli stubs misclassifying

### DIFF
--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -241,7 +241,18 @@ def _detect_provider_from_sequence(payloads: PayloadSequence) -> Provider | None
         # one-element sequence on the stream path. Preserve the established
         # Claude-Code-before-Codex sequence ordering while restoring this
         # stronger local-session discriminator ahead of weaker family shapes.
-        if len(payloads) == 1 and local_agent.looks_like_gemini_cli(first_record):
+        # Gemini CLI's ``.jsonl`` chat-log checkpoint format is a genuinely
+        # different multi-line shape: a session-open stub record (no
+        # ``messages`` key -- see ``local_agent.looks_like_gemini_cli``)
+        # followed by one JSON object per turn/event, so it reaches here as
+        # a many-element sequence whose bare ``sessionId`` field otherwise
+        # collides with Claude Code's own ``_STRONG_SESSION_KEYS`` (#3428
+        # sibling gap, polylogue-hs3y). Trust the stub shape at any sequence
+        # length; keep the ``messages``-embedded shape restricted to the
+        # single-document case above, unchanged.
+        if local_agent.looks_like_gemini_cli(first_record) and (
+            len(payloads) == 1 or not isinstance(first_record.get("messages"), list)
+        ):
             return Provider.GEMINI_CLI
         if browser_capture.looks_like(first_record):
             return _detect_provider_from_record(first_record)

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -118,6 +118,7 @@ from polylogue.sources.parsers import codex_state, hermes_state, hermes_verifica
 from polylogue.sources.parsers.base import ParsedSession
 from polylogue.sources.revision_backfill import parse_retained_raw_sessions
 from polylogue.sources.source_acquisition_components import (
+    _DETECTION_PREFIX_SIZE,
     ZipEntryReadContext,
     iter_zip_entry_raw_data,
 )
@@ -2528,7 +2529,23 @@ class LiveBatchProcessor:
         )
         try:
             with zipfile.ZipFile(path) as zf:
-                for info in validator.filter_entries(zf.infolist()):
+                entries = list(validator.filter_entries(zf.infolist()))
+                # A GDPR/Takeout export ZIP dropped into a provider-agnostic
+                # inbox (``fallback_provider is Provider.UNKNOWN``) still has
+                # a real dominant provider -- it just isn't visible from any
+                # *one* member in isolation. Establish it once from whichever
+                # member detects cleanly (typically ``conversations.json``)
+                # and seed every member's detection with it, rather than
+                # each low-signal sibling (``user.json``,
+                # ``message_feedback.json``, ``shared_conversations.json``,
+                # attachment ``file_*.json`` blobs, ...) independently
+                # falling back to ``Provider.UNKNOWN`` -> ``unknown-export``
+                # (polylogue-hs3y). A source that already resolved a
+                # provider (a per-provider watched directory) is left alone.
+                zip_provider_hint = fallback_provider
+                if fallback_provider is Provider.UNKNOWN:
+                    zip_provider_hint = self._sniff_zip_provider(zf, entries) or fallback_provider
+                for info in entries:
                     if info.file_size == 0:
                         continue
                     for raw_data in iter_zip_entry_raw_data(
@@ -2538,7 +2555,7 @@ class LiveBatchProcessor:
                             zip_path=path,
                             entry=info,
                             file_mtime=file_mtime,
-                            provider_hint=fallback_provider,
+                            provider_hint=zip_provider_hint,
                             blob_store=blob_store,
                         ),
                     ):
@@ -2572,6 +2589,42 @@ class LiveBatchProcessor:
             logger.warning("Failed to expand inbox ZIP %s: %s", path, exc)
             return [], 0
         return records, total_bytes
+
+    @staticmethod
+    def _sniff_zip_provider(
+        zf: zipfile.ZipFile,
+        entries: list[zipfile.ZipInfo],
+    ) -> Provider | None:
+        """Detect a ZIP's dominant provider from whichever member detects cleanly.
+
+        Reads only a small prefix (``_DETECTION_PREFIX_SIZE``, matching the
+        equivalent whole-file detection budget in
+        ``source_acquisition_components.read_plain_source_file``) of each
+        JSON/JSONL member in order until one yields a positive, non-unknown
+        ``detect_provider`` result. Returns ``None`` if no member detects
+        (e.g. a genuinely mixed or non-conversation ZIP), leaving the caller
+        to keep the original ``Provider.UNKNOWN`` fallback.
+        """
+        for info in entries:
+            name_lower = info.filename.lower()
+            if not name_lower.endswith((".json", ".jsonl", ".jsonl.txt", ".ndjson")):
+                continue
+            try:
+                with zf.open(info.filename) as handle:
+                    prefix = handle.read(_DETECTION_PREFIX_SIZE)
+            except (zipfile.BadZipFile, OSError):
+                continue
+            if not prefix:
+                continue
+            detected = _detect_provider_from_raw_bytes(
+                prefix,
+                info.filename,
+                Provider.UNKNOWN,
+                truncated_tail_ok=True,
+            )
+            if detected is not Provider.UNKNOWN:
+                return detected
+        return None
 
     def _mark_excluded_cursor(self, path: Path, stat: object, *, source_name: str) -> None:
         st_size = int(getattr(stat, "st_size", 0))

--- a/polylogue/sources/parsers/local_agent.py
+++ b/polylogue/sources/parsers/local_agent.py
@@ -40,12 +40,36 @@ def _block_metadata_evidence_events(messages: list[ParsedMessage]) -> list[Parse
     return events
 
 
+#: Gemini CLI's own "kind" enum for a chat/session checkpoint (present on
+#: both wire shapes below).
+_GEMINI_CLI_KIND_VALUES = frozenset({"chat", "main", "subagent"})
+
+
 def looks_like_gemini_cli(payload: JSONDocument) -> bool:
-    return (
-        isinstance(payload.get("sessionId"), str)
-        and isinstance(payload.get("messages"), list)
-        and ("startTime" in payload or "lastUpdated" in payload or payload.get("kind") in {"chat", "main", "subagent"})
-    )
+    """Detect a Gemini CLI checkpoint document in either of its two shapes.
+
+    The common "one JSON object per session, ``messages`` embedded" shape
+    (``sessionId`` + a ``messages`` list + ``startTime``/``lastUpdated``/
+    ``kind``) is the original detector. Gemini CLI also has a genuinely
+    different on-disk shape for its ``.jsonl`` chat-log checkpoints: a
+    session-*open* stub record (``sessionId`` + ``projectHash`` + ``kind``,
+    written the instant a session starts, before any turn exists) followed
+    by one JSON object per turn/event on subsequent lines -- the stub itself
+    carries no ``messages`` key at all. Without a positive check for that
+    stub shape, its only strong-looking field is a bare ``sessionId``, which
+    also happens to be one of Claude Code's own
+    ``code_detection._STRONG_SESSION_KEYS`` -- so a freshly-opened Gemini CLI
+    session (no turns yet, or read mid-write) silently misclassified as
+    ``claude-code-session`` (polylogue-hs3y, 4 confirmed live archive rows
+    under ``~/.gemini/tmp/*/chats/*.jsonl``). ``projectHash`` is unique to
+    Gemini CLI's own checkpoint envelope, so requiring it alongside the
+    ``kind`` enum keeps this branch as tight as the ``messages``-bearing one.
+    """
+    if not isinstance(payload.get("sessionId"), str):
+        return False
+    if isinstance(payload.get("messages"), list):
+        return "startTime" in payload or "lastUpdated" in payload or payload.get("kind") in _GEMINI_CLI_KIND_VALUES
+    return isinstance(payload.get("projectHash"), str) and payload.get("kind") in _GEMINI_CLI_KIND_VALUES
 
 
 def looks_like_hermes(payload: JSONDocument) -> bool:

--- a/tests/unit/sources/parsers/test_origin_regression_pack.py
+++ b/tests/unit/sources/parsers/test_origin_regression_pack.py
@@ -1048,6 +1048,62 @@ def test_browser_capture_snapshot_dispatches_to_chatgpt_export_origin() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Gemini CLI JSONL checkpoint / Claude Code sessionId collision (polylogue-hs3y)
+# ---------------------------------------------------------------------------
+#
+# Gemini CLI's ``.jsonl`` chat-log checkpoint format opens with a
+# session-metadata *stub* record (no embedded ``messages`` list -- turns
+# arrive as later lines instead), shaped exactly like the live archive rows
+# recovered under ``~/.gemini/tmp/*/chats/*.jsonl``: real field names
+# (``sessionId``, ``projectHash``, ``startTime``, ``lastUpdated``, ``kind``),
+# synthetic values. Before the fix, this stub's bare ``sessionId`` key alone
+# satisfied ``claude.looks_like_code``'s ``_STRONG_SESSION_KEYS`` check,
+# misdetecting a freshly-opened Gemini CLI session as ``claude-code-session``.
+
+
+def _gemini_cli_jsonl_checkpoint_stream() -> list[dict[str, Any]]:
+    """A Gemini CLI ``.jsonl`` checkpoint: session-open stub + per-turn lines."""
+    return [
+        {
+            "sessionId": "gemini-cli-jsonl-reg-1",
+            "projectHash": "project-hash-jsonl-reg",
+            "startTime": "2026-04-26T07:13:41.172Z",
+            "lastUpdated": "2026-04-26T07:13:41.172Z",
+            "kind": "main",
+        },
+        {
+            "id": "turn-1",
+            "timestamp": "2026-04-26T07:13:51.467Z",
+            "type": "user",
+            "content": [{"text": "why is DEEPSEEK_API_KEY empty?"}],
+        },
+        {"$set": {"lastUpdated": "2026-04-26T07:13:51.467Z"}},
+    ]
+
+
+def test_gemini_cli_jsonl_checkpoint_stub_does_not_collide_with_claude_code() -> None:
+    """polylogue-hs3y: a Gemini CLI checkpoint stub must not detect as Claude Code.
+
+    Documents the collision this guards: the stub record alone WOULD satisfy
+    Claude Code's ``_STRONG_SESSION_KEYS`` bare-``sessionId`` rule if the
+    Gemini CLI structural detector didn't run first.
+    """
+    payload = _gemini_cli_jsonl_checkpoint_stream()
+    stub = payload[0]
+
+    assert claude_code_looks_like([stub]), (
+        "fixture no longer demonstrates the sessionId collision this regression guards"
+    )
+    assert looks_like_gemini_cli(stub)
+
+    detected = detect_provider(payload)
+    assert detected is Provider.GEMINI_CLI, (
+        f"expected Gemini CLI checkpoint stub to detect as GEMINI_CLI, got {detected!r}"
+    )
+    assert origin_from_provider(detected) is Origin.GEMINI_CLI_SESSION
+
+
+# ---------------------------------------------------------------------------
 # Antigravity degraded-flag regression (#1764)
 # ---------------------------------------------------------------------------
 # The brain-metadata fragmentation test extends the test in

--- a/tests/unit/sources/test_live_watcher.py
+++ b/tests/unit/sources/test_live_watcher.py
@@ -2011,6 +2011,99 @@ async def test_live_full_ingest_expands_inbox_zip_members(
 
 
 @pytest.mark.asyncio
+async def test_live_full_ingest_sniffs_zip_provider_for_non_session_siblings(
+    workspace_env: dict[str, Path],
+) -> None:
+    """polylogue-hs3y: a GDPR export ZIP's non-conversation siblings inherit the
+    ZIP's dominant provider instead of independently falling back to unknown.
+
+    A ChatGPT GDPR export ZIP legitimately ships several sibling files
+    alongside ``conversations.json`` -- ``message_feedback.json``,
+    ``shared_conversations.json``, ``user.json``, etc. -- none of which are
+    conversation-shaped on their own. When such a ZIP is dropped into a
+    provider-agnostic watched root (source name not itself a provider
+    token, so ``fallback_provider`` resolves to ``Provider.UNKNOWN``), each
+    ZIP member used to be provider-detected independently with a fresh
+    ``Provider.UNKNOWN`` seed: the real ``conversations.json`` detected
+    cleanly as ChatGPT, but its non-conversation siblings landed in
+    ``raw_sessions`` tagged ``origin='unknown-export'`` even though the ZIP
+    as a whole is unambiguously a ChatGPT export (this is what the live
+    archive's 25 ``unknown-export`` raw rows all turned out to be). Confirm
+    every member -- including the non-session sibling -- now carries the
+    ZIP's sniffed ``chatgpt-export`` origin.
+    """
+    root = workspace_env["data_root"] / "inbox"
+    root.mkdir(parents=True)
+    conversation = {
+        "id": "chatgpt-zip-sniff-1",
+        "conversation_id": "chatgpt-zip-sniff-1",
+        "title": "GDPR export sniff fixture",
+        "create_time": 1_704_067_200.0,
+        "current_node": "a1",
+        "mapping": {
+            "u1": {
+                "id": "u1",
+                "parent": None,
+                "children": ["a1"],
+                "message": {
+                    "id": "u1",
+                    "author": {"role": "user"},
+                    "content": {"content_type": "text", "parts": ["hello from the export"]},
+                    "create_time": 1_704_067_200.0,
+                },
+            },
+            "a1": {
+                "id": "a1",
+                "parent": "u1",
+                "children": [],
+                "message": {
+                    "id": "a1",
+                    "author": {"role": "assistant"},
+                    "content": {"content_type": "text", "parts": ["hi there"]},
+                    "create_time": 1_704_067_201.0,
+                },
+            },
+        },
+    }
+    zip_path = root / "chatgpt-data-2026-04-23.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("conversations.json", json.dumps([conversation]))
+        zf.writestr("message_feedback.json", json.dumps([{"conversation_id": "chatgpt-zip-sniff-1", "rating": 1}]))
+
+    db_path = workspace_env["data_root"] / "inbox-zip-sniff-live.db"
+    archive = Polylogue(archive_root=workspace_env["archive_root"], db_path=db_path)
+    cursor = CursorStore(db_path)
+    processor = LiveBatchProcessor(
+        archive,
+        (WatchSource(name="inbox", root=root),),
+        cursor=cursor,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+    )
+
+    try:
+        metrics = await processor.ingest_files([zip_path], emit_event=False)
+
+        assert ("inbox", "chatgpt-export:chatgpt-zip-sniff-1") in metrics.new_sessions
+
+        session = await archive.get_session("chatgpt-export:chatgpt-zip-sniff-1")
+        assert session is not None
+
+        with sqlite3.connect(workspace_env["archive_root"] / "source.db") as conn:
+            rows = conn.execute(
+                "SELECT source_path, origin FROM raw_sessions WHERE source_path LIKE ?",
+                (f"{zip_path}:%",),
+            ).fetchall()
+        origins_by_member = {source_path.rsplit(":", 1)[-1]: origin for source_path, origin in rows}
+        assert origins_by_member.get("conversations.json") == "chatgpt-export"
+        assert origins_by_member.get("message_feedback.json") == "chatgpt-export", (
+            f"non-conversation ZIP sibling should inherit the sniffed ZIP provider, got {origins_by_member!r}"
+        )
+        assert "unknown-export" not in origins_by_member.values()
+    finally:
+        await archive.close()
+
+
+@pytest.mark.asyncio
 async def test_live_full_ingest_detects_provider_when_source_name_is_not_provider(
     workspace_env: dict[str, Path],
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes two verified live-archive origin-classification defects (polylogue-hs3y): GDPR export ZIP sidecar members falling back to `unknown-export`, and Gemini CLI JSONL checkpoint stubs colliding with Claude Code's session detector.

## Problem

Read-only audit of the live archive (`/realm/db/polylogue`):

- 25 `raw_sessions` rows carried `origin='unknown-export'`. All 25 turned out to be non-conversation sidecar files (`user.json`, `message_feedback.json`, `shared_conversations.json`, attachment `file_*.json`, `projects.json`, `memories.json`, ...) sitting *inside* otherwise-correctly-detected ChatGPT/Claude GDPR export ZIPs dropped into the generic inbox. Each ZIP member is provider-detected independently with a fresh `Provider.UNKNOWN` seed, so only the member whose own JSON shape detects cleanly (`conversations.json`) got tagged correctly — every low-signal sibling fell back on its own.
- 4 live sessions under `~/.gemini/tmp/*/chats/*.jsonl` carried `origin='claude-code-session'`. Gemini CLI's `.jsonl` chat-log checkpoint format opens with a session-metadata *stub* record (`sessionId`+`projectHash`+`kind`, **no** `"messages"` key — turns arrive as later lines). That bare `sessionId` key alone satisfied Claude Code's `_STRONG_SESSION_KEYS` rule, and the existing Gemini CLI structural detector only ran for single-document payloads (`len(payloads) == 1`), never for a genuine multi-line JSONL sequence.

## Solution

- `polylogue/sources/live/batch.py`: add `_sniff_zip_provider`, a one-time pre-scan of a ZIP's members (small prefix read, same budget as whole-file detection) that establishes the ZIP's dominant provider once so every low-signal sibling inherits it instead of independently falling back to unknown. Only activates when the top-level fallback provider is itself unknown; a source that already resolved a provider (a per-provider watched directory) is untouched.
- `polylogue/sources/parsers/local_agent.py`: widen `looks_like_gemini_cli` to also recognize the messages-less session-open stub shape (requires `projectHash`, unique to Gemini CLI, alongside the `kind` enum).
- `polylogue/sources/dispatch.py`: trust that stub shape at any sequence length in `_detect_provider_from_sequence`; the messages-embedded shape stays restricted to the single-document (`len==1`) case, unchanged.

Neither fix defaults anything to a session (standing design constraint): the ZIP fix only corrects which provider a non-session sidecar is tagged with — it still routes through the existing `raw_artifacts`/`classify_artifact` non-session path, not a fabricated `unknown-export` dumping ground. The gemini-cli fix only corrects provider detection; full turn-by-turn parsing of the JSONL event-log shape does not exist yet (filed as `polylogue-8u1p`) — these 4 sessions now correctly detect as `Provider.GEMINI_CLI` but do not materialize as `sessions` rows (0 messages, by design, no forced empty session).

Also audited (read-only) origin vs source_path shape across all 9 origins present in the live archive. Only the gemini-cli collision above was a genuine detection defect; a similarly-shaped `claude-code-session`/`drive-cache/gemini/` bucket (12 sessions) was investigated and confirmed correctly classified — the content is genuinely Claude-Code-shaped `{"type":"summary",...}` records, a cache-location naming coincidence, not a bug.

No archive data repair is included — a separate lane owns that per the task brief; this PR only fixes the producing code.

## Verification

- `devtools test tests/unit/sources/test_live_watcher.py tests/unit/sources/parsers/test_origin_regression_pack.py tests/unit/sources/test_dispatch_payloads.py tests/unit/sources/test_dispatch_ordering.py tests/unit/sources/test_parsers_local_agent.py tests/unit/sources/test_origin_specs.py` — 190 passed
- New `test_live_full_ingest_sniffs_zip_provider_for_non_session_siblings` confirmed to fail without the `batch.py` fix (`message_feedback.json` → `unknown-export`), pass with it (anti-vacuity check, reverted the fix and reran)
- New `test_gemini_cli_jsonl_checkpoint_stub_does_not_collide_with_claude_code` documents the pre-fix collision (`claude_code_looks_like([stub])` still returns `True` in isolation) and asserts `detect_provider` now resolves `GEMINI_CLI`
- `devtools verify --quick` — exit 0 (format, lint, mypy --strict, render all --check, topology/layering/schema policy gates), run both pre-commit and again via the pre-push hook

Ref polylogue-hs3y.