### PR TITLE
fix(sources): reconcile sidecar coverage with attachment evidence events

### DIFF
--- a/polylogue/sources/parsers/claude/code_parser.py
+++ b/polylogue/sources/parsers/claude/code_parser.py
@@ -1469,6 +1469,7 @@ def _parse_code_records(
                     attachment_event = _attachment_sidecar_event(item, timestamp)
                     if attachment_event is not None:
                         session_events.append(attachment_event)
+                        persisted_this_record = True
                 event_type = _SIDECAR_EVENT_TYPES.get(record_type)
                 if event_type is not None:
                     evidence_payload = _sidecar_evidence_payload(record_type, item)

--- a/tests/unit/sources/test_claude_code_sidecar_evidence.py
+++ b/tests/unit/sources/test_claude_code_sidecar_evidence.py
@@ -323,7 +323,7 @@ def test_attachment_hook_subtypes_share_one_event_type() -> None:
         ],
         "sess-hook",
     )
-    event_types = [e.event_type for e in parsed.session_events]
+    event_types = [e.event_type for e in parsed.session_events if e.event_type != "claude_parse_coverage"]
     assert event_types == ["claude_hook_event", "claude_hook_event"]
 
 
@@ -342,7 +342,7 @@ def test_attachment_queued_command_reuses_queue_operation_event_type() -> None:
         ],
         "sess-queue",
     )
-    events = [(e.event_type, e.payload) for e in parsed.session_events]
+    events = [(e.event_type, e.payload) for e in parsed.session_events if e.event_type != "claude_parse_coverage"]
     assert events == [
         (
             "claude_queue_operation",
@@ -372,7 +372,7 @@ def test_attachment_transient_subtype_emits_no_event() -> None:
         ],
         "sess-transient",
     )
-    assert parsed.session_events == []
+    assert [e for e in parsed.session_events if e.event_type != "claude_parse_coverage"] == []
 
 
 def test_attachment_unrecognized_subtype_fails_loud() -> None:
@@ -389,7 +389,7 @@ def test_attachment_unrecognized_subtype_fails_loud() -> None:
         ],
         "sess-unknown",
     )
-    events = [(e.event_type, e.payload) for e in parsed.session_events]
+    events = [(e.event_type, e.payload) for e in parsed.session_events if e.event_type != "claude_parse_coverage"]
     assert events == [
         (
             "claude_attachment_unclassified",
@@ -415,7 +415,7 @@ def test_attachment_deferred_tools_delta_drops_body_text_keeps_names() -> None:
         ],
         "sess-delta",
     )
-    events = [(e.event_type, e.payload) for e in parsed.session_events]
+    events = [(e.event_type, e.payload) for e in parsed.session_events if e.event_type != "claude_parse_coverage"]
     assert events == [
         (
             "claude_capability_delta",
@@ -444,7 +444,7 @@ def test_attachment_skill_listing_extracts_names_not_full_text() -> None:
         ],
         "sess-skills",
     )
-    events = [(e.event_type, e.payload) for e in parsed.session_events]
+    events = [(e.event_type, e.payload) for e in parsed.session_events if e.event_type != "claude_parse_coverage"]
     assert events == [
         (
             "claude_capability_snapshot",
@@ -481,7 +481,7 @@ def test_attachment_diagnostics_bounds_to_per_file_counts() -> None:
         ],
         "sess-diag",
     )
-    events = [(e.event_type, e.payload) for e in parsed.session_events]
+    events = [(e.event_type, e.payload) for e in parsed.session_events if e.event_type != "claude_parse_coverage"]
     assert events == [
         (
             "claude_diagnostics",


### PR DESCRIPTION
## Summary

Restores master to green. Two independently-correct PRs — #3419 (per-type sidecar coverage) and #3423 (attachment sidecar split) — produced a broken combination, and the merge that joined them was verified against a narrower test selection than the change warranted.

## Problem

`devtools test -k "sidecar or code_parser"` on master: **7 failed, 138 passed**.

All seven are `test_attachment_*` in `tests/unit/sources/test_claude_code_sidecar_evidence.py`. They assert exact equality on `parsed.session_events`; #3419 unconditionally appends a `claude_parse_coverage` event, so every expected list gained an unexpected member:

```
Left contains one more item: ('claude_parse_coverage',
  {'sidecar_seen': {'attachment': 1}, 'sidecar_persisted': {}, ...})
```

That payload also exposes a real defect rather than only a test-reconciliation problem: `sidecar_persisted` is empty while `sidecar_seen` counts the record. The attachment branch appends a `session_event` but never sets `persisted_this_record`, so per-type coverage understated persistence for every attachment record — the exact metric #3419 exists to report.

## Solution

- `polylogue/sources/parsers/claude/code_parser.py` — the attachment branch sets `persisted_this_record = True` when it emits an event, matching every sibling branch in the same dispatch.
- `tests/unit/sources/test_claude_code_sidecar_evidence.py` — the seven exact-equality assertions exclude `claude_parse_coverage`. It is a parse-level report orthogonal to the attachment evidence each test is about; filtering keeps each test pinned to its own subject rather than loosening the assertion.

## Verification

```
devtools test -k "sidecar or code_parser"
  before:  7 failed, 138 passed
  after:       145 passed
```

`devtools test tests/unit/sources/test_claude_code_sidecar_evidence.py` → 30 passed.

## Note

The conflict resolution that produced this was verified with `devtools test tests/unit/sources/test_assembly_claude_code_history.py` (14 passed) — a file that does not exercise the attachment path. A cross-feature merge deserves the affected-area selection, not the file the conflict happened to sit in.