### PR TITLE
feat(query): add agg metrics and with-unit bracket windows

### DIFF
--- a/docs/openapi/search.yaml
+++ b/docs/openapi/search.yaml
@@ -2661,6 +2661,17 @@ components:
         count:
           title: Count
           type: integer
+        metrics:
+          anyOf:
+          - additionalProperties:
+              anyOf:
+              - type: number
+              - type: integer
+              - type: 'null'
+            type: object
+          - type: 'null'
+          default: null
+          title: Metrics
       required:
       - unit
       - count

--- a/docs/schemas/cli-output/query-unit-aggregate-envelope.schema.json
+++ b/docs/schemas/cli-output/query-unit-aggregate-envelope.schema.json
@@ -32,6 +32,31 @@
           "default": null,
           "title": "Group Key"
         },
+        "metrics": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Metrics"
+        },
         "unit": {
           "enum": [
             "message",

--- a/docs/search.md
+++ b/docs/search.md
@@ -38,6 +38,9 @@ through the same typed AST and query planner:
 compact-query      ::= compact-clause*
 boolean-query      ::= ["sessions" "where"] predicate
 projection-query   ::= (compact-query | boolean-query) "with" projection-list
+projection-list    ::= projection-item ("," projection-item)*
+projection-item    ::= unit ["(" field ("," field)* ")"] ["[" bracket-clause ("," bracket-clause)* "]"]
+bracket-clause     ::= field ":" value | ("first" | "last") ":" integer
 unit-query         ::= ("messages" | "actions" | "blocks" | "files" | "assertions" | "runs" | "observed-events" | "context-snapshots" | "delegations") "where" predicate
 pipeline-query     ::= unit-query ("|" pipeline-stage)+
                      | "sessions" "where" predicate "|" unit-query ("|" pipeline-stage)*
@@ -216,6 +219,48 @@ Unsupported forms raise typed `ExpressionCompileError`s and must not broaden
 into looser full-text search. In particular, reserved unit prefixes such as
 `messages where` are errors when malformed; they are not treated as ordinary
 text terms.
+
+### Bracket predicates/windows on attached units (`with unit[...]`)
+
+The `with <units>` projection clause (session-selecting queries, not
+terminal pipelines) accepts an optional bracket after each unit item,
+narrowing what gets attached to every selected session (polylogue-fnm.2):
+
+```bash
+polylogue --format json 'repo:polylogue with messages[role:user, last:20]'
+polylogue --format json 'repo:polylogue with actions[tool:Bash, first:5]'
+polylogue --format json 'repo:polylogue with messages(message_id,role,text)[role:user, last:10]'
+```
+
+A bracket is a comma-separated list of `field:value` equality predicates
+and/or a single `first:N`/`last:N` window, combinable with the existing
+`unit(field, field)` payload-field selector in either order. Bracket
+predicate fields are a small, explicit vocabulary per unit — the fields
+already present on that unit's attached row payload, not the full
+`<unit> where ...` structural predicate field set:
+
+| Unit | Bracket predicate fields |
+|------|---------------------------|
+| `message` | `role`, `type` |
+| `action` | `tool`, `action`, `type`, `is_error`, `exit_code`, `followup_class` |
+| `file` | `path` |
+| `assertion` | `kind`, `status`, `visibility`, `author_kind` |
+
+An unsupported bracket field or malformed clause raises a typed error naming
+the unit, the field, and the supported set. `first:N`/`last:N` trims each
+session's attached rows to the first/last *N* after predicates are applied,
+by fetch order — `last:N` fetches that unit in descending time order (then
+restores ascending order) precisely so the per-session/per-page row cap
+lands on the session's actual tail instead of silently landing on its head
+whenever a session has more matching rows than the cap.
+
+Bracket predicates/windows apply to the already-fetched, capped attached-row
+set (`attached_units.py`'s existing `_MAX_ROWS_PER_SESSION`/
+`_MAX_ROWS_PER_PAGE` caps) — they are not pushed down to the SQL fetch
+itself. A predicate combined with `last:N` on a session whose *matching*
+rows are sparser than the fetch cap can still under-fetch; this is the same
+bounded-fetch tradeoff every other post-fetch filter on this path already
+has, not a window-specific gap.
 
 ### DSL Fields
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -127,8 +127,8 @@ Featured parser-gated examples:
 | `exhaustive` | `files` | `files where session.repo:example-repo AND path:src/mcp/server.py` | Returns file evidence for one path within one repository. | `unit, session_id, origin, title, path, action_count, first_message_id, first_tool_use_block_id, last_tool_use_block_id, first_seen_ms, last_seen_ms` | `selective` |
 | `exhaustive` | `assertions` | `assertions where kind:decision AND text:"schema migration"` | Returns decision assertions about a named topic. | `unit, assertion_id, target_ref, scope_ref, kind, key, body_text, value, author_ref, author_kind, status, visibility, evidence_refs, staleness, context_policy, created_at_ms, updated_at_ms` | `corpus-scale` |
 | `exhaustive` | `messages` | `sessions where repo:example-repo AND origin:unknown-export \| messages where role:assistant` | Returns assistant messages scoped to repository sessions from one origin. | `unit, message_id, session_id, origin, title, role, message_type, material_origin, occurred_at_ms, position, word_count, text` | `selective` |
-| `aggregate` | `messages` | `messages where text:timeout \| group by role \| count` | Counts timeout-matching messages by role. | `unit, group_by, group_key, count` | `corpus-scale` |
-| `aggregate` | `actions` | `actions where is_error:true \| group by tool \| count` | Counts error-marked actions by tool. | `unit, group_by, group_key, count` | `corpus-scale` |
+| `aggregate` | `messages` | `messages where text:timeout \| group by role \| count` | Counts timeout-matching messages by role. | `unit, group_by, group_key, count, metrics` | `corpus-scale` |
+| `aggregate` | `actions` | `actions where is_error:true \| group by tool \| count` | Counts error-marked actions by tool. | `unit, group_by, group_key, count, metrics` | `corpus-scale` |
 | `bounded-context` | `sessions` | `repo:example-repo with messages(message_id,role,text)` | Builds bounded session orientation with selected message columns. | `session_id, message_id, role, text` | `selective` |
 | `bounded-context` | `sessions` | `sessions where title:"query compiler" with messages(message_id,role), actions(tool_name,semantic_type), files(path)` | Builds bounded mixed evidence for sessions whose title mentions the query compiler. | `session_id, message_id, role, tool_name, semantic_type, path` | `selective` |
 | `recursive-page` | `sessions` | `lineage:id:example-origin:session-child` | Seeds a recursive lineage walk from one session. | `session_id, parent_refs, child_refs, continuation` | `selective` |
@@ -167,8 +167,8 @@ per-group reducer metrics (polylogue-fnm.1). It follows an optional
 and precedes `limit`/`offset`:
 
 ```bash
-polylogue --format json 'messages where session.repo:polylogue | group by role | agg count, avg:word_count, p90:word_count'
-polylogue --format json 'actions where session.repo:polylogue | group by tool | agg count, avg:is_error, sum:is_error'
+polylogue --format json messages where session.repo:polylogue | group by role | agg count, avg:word_count, p90:word_count
+polylogue --format json actions where session.repo:polylogue | group by tool | agg count, avg:is_error, sum:is_error
 ```
 
 Each metric is `count` (field-less) or `FN:FIELD`, where `FN` is `sum`,

--- a/docs/search.md
+++ b/docs/search.md
@@ -65,11 +65,15 @@ sequence-step      ::= action-field-clause ("AND" action-field-clause)*
 action-field-clause ::= "action:" value | "tool:" value | "command:" value
                       | "path:" value | "output:" value | "text:" value
 pipeline-stage     ::= "sort" "by" "time" ["asc" | "desc"]
-                     | "group" "by" field
+                     | "group" "by" field ["," field]*
                      | "count"
+                     | "agg" agg-metric ["," agg-metric]*
                      | "sort" "by" ("count" | "key") ["asc" | "desc"]
                      | "limit" integer
                      | "offset" integer
+
+agg-metric         ::= "count"
+                     | ("sum" | "avg" | "min" | "max" | "p" digit+) ":" field
 ```
 
 <!-- BEGIN GENERATED: query-discovery -->
@@ -146,10 +150,45 @@ session Boolean lowerers against the terminal row's owning session. Semantic
 vector predicates still reject in a session pipeline stage until terminal row
 queries have explicit ranked-result semantics. Terminal pipeline stages
 currently support `sort by time [asc|desc]`,
-`group by FIELD | count`, aggregate `sort by count|key [asc|desc]`, `limit N`,
+`group by FIELD[,FIELD...] | count`, `group by FIELD[,FIELD...] | agg METRIC[,METRIC...]`,
+aggregate `sort by count|key [asc|desc]`, `limit N`,
 and `offset N` for SQL-backed terminal rows (`messages`, `actions`, `blocks`,
 `files`, `assertions`). Query-string limits narrow the surface limit instead of expanding
 caller/API caps, and query-string offsets are added to the caller offset.
+
+### Named aggregate metrics (`| agg ...`)
+
+`| agg ...` extends the `count`-only aggregate rollup with named,
+per-group reducer metrics (polylogue-fnm.1). It follows an optional
+`group by` stage (or reduces the whole matched row set with no `group by`)
+and precedes `limit`/`offset`:
+
+```bash
+polylogue --format json 'messages where session.repo:polylogue | group by role | agg count, avg:word_count, p90:word_count'
+polylogue --format json 'actions where session.repo:polylogue | group by tool | agg count, avg:is_error, sum:is_error'
+```
+
+Each metric is `count` (field-less) or `FN:FIELD`, where `FN` is `sum`,
+`avg`, `min`, `max`, or a nearest-rank percentile `pNN` (`p1`..`p99`), and
+`FIELD` is one of the unit's declared numeric metric fields (`message`:
+`word_count`; `action`: `is_error`, `exit_code`). An unsupported function or
+field raises a typed error naming the unit, the metric, and the supported
+field set. Metric labels are stable output keys: `count` for the count
+metric, otherwise `f"{fn}_{field}"` (e.g. `avg_word_count`).
+
+`avg`/`sum`/`min`/`max`/percentile reducers are **not** pushed down to SQL
+today — the `count`-only aggregate lowerer (`ArchiveStore.query_unit_counts`)
+computes exact grouped counts directly in SQL, but named-metric reduction
+fetches up to 50,000 predicate-matching rows through the unit's existing
+row query and reduces them in Python. The pipeline result payload reports
+this explicitly: `result.exact` is `true` when every matching row was
+fetched (the aggregate is exact), or `false` plus `result.sampled_rows` when
+the match set was larger than the cap (the aggregate is a bounded sample of
+the first 50,000 rows in time order, not the full population). Narrow the
+query with session/time/repo filters before trusting an `agg` result on a
+large archive; a `count`-only `| group by ... | count` stage stays exact at
+any scale because it is fully SQL-pushed.
+
 `runs`, `observed-events`, `context-snapshots`, and `delegations` are SQL-backed terminal rows
 over source-derived archive relations (polylogue-dab): main runs,
 `session_started` events, tool-finished events, and session-start context

--- a/polylogue/archive/filter/filters.py
+++ b/polylogue/archive/filter/filters.py
@@ -25,8 +25,10 @@ from polylogue.archive.query.fields import SqlPushdownParams
 from polylogue.archive.query.plan import SessionQueryPlan
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
+    from polylogue.archive.query.expression import WithUnitWindow
     from polylogue.archive.session.domain_models import Session, SessionSummary
     from polylogue.config import Config
     from polylogue.core.protocols import VectorProvider
@@ -44,6 +46,7 @@ class SessionFilter(SessionFilterBuilderMixin):
         query_plan: SessionQueryPlan | None = None,
         with_units: tuple[str, ...] = (),
         with_unit_fields: dict[str, tuple[str, ...]] | None = None,
+        with_unit_windows: Mapping[str, WithUnitWindow] | None = None,
     ) -> None:
         self._archive_root = archive_root
         self._config = config
@@ -52,6 +55,9 @@ class SessionFilter(SessionFilterBuilderMixin):
         #: because it is a post-selection projection, not a filter/sort/limit.
         self._with_units = with_units
         self._with_unit_fields = with_unit_fields or {}
+        #: Bracket predicate/window per unit (polylogue-fnm.2), carried the
+        #: same way as ``with_unit_fields``.
+        self._with_unit_windows = with_unit_windows or {}
 
     @classmethod
     def from_query_plan(
@@ -62,6 +68,7 @@ class SessionFilter(SessionFilterBuilderMixin):
         config: Config | None = None,
         with_units: tuple[str, ...] = (),
         with_unit_fields: dict[str, tuple[str, ...]] | None = None,
+        with_unit_windows: Mapping[str, WithUnitWindow] | None = None,
     ) -> SessionFilter:
         return cls(
             archive_root=archive_root,
@@ -69,6 +76,7 @@ class SessionFilter(SessionFilterBuilderMixin):
             query_plan=query_plan,
             with_units=with_units,
             with_unit_fields=with_unit_fields,
+            with_unit_windows=with_unit_windows,
         )
 
     @property
@@ -116,6 +124,7 @@ class SessionFilter(SessionFilterBuilderMixin):
             config=self._config,
             with_units=self._with_units,
             with_unit_fields=self._with_unit_fields,
+            with_unit_windows=self._with_unit_windows,
         )
 
     async def list_summaries(self) -> builtins.list[SessionSummary]:
@@ -125,6 +134,7 @@ class SessionFilter(SessionFilterBuilderMixin):
             config=self._config,
             with_units=self._with_units,
             with_unit_fields=self._with_unit_fields,
+            with_unit_windows=self._with_unit_windows,
         )
 
     async def list_all_summaries(self) -> builtins.list[SessionSummary]:
@@ -141,6 +151,7 @@ class SessionFilter(SessionFilterBuilderMixin):
             default_limit=1_000_000,
             with_units=self._with_units,
             with_unit_fields=self._with_unit_fields,
+            with_unit_windows=self._with_unit_windows,
         )
 
     async def list_all(self) -> builtins.list[Session]:
@@ -152,6 +163,7 @@ class SessionFilter(SessionFilterBuilderMixin):
             default_limit=1_000_000,
             with_units=self._with_units,
             with_unit_fields=self._with_unit_fields,
+            with_unit_windows=self._with_unit_windows,
         )
 
     async def first(self) -> Session | None:

--- a/polylogue/archive/query/archive_execution.py
+++ b/polylogue/archive/query/archive_execution.py
@@ -13,6 +13,7 @@ does not push down.
 from __future__ import annotations
 
 import builtins
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, TypedDict, TypeVar
 
 from polylogue.archive.message.messages import MessageCollection
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from polylogue.archive.message.models import Message
+    from polylogue.archive.query.expression import WithUnitWindow
     from polylogue.archive.query.plan import SessionQueryPlan
     from polylogue.archive.query.predicate import QueryPredicate
     from polylogue.config import Config
@@ -404,6 +406,7 @@ def _attach_units_to_domain(
     archive: ArchiveStore,
     with_units: tuple[str, ...],
     with_unit_fields: dict[str, tuple[str, ...]] | None = None,
+    with_unit_windows: Mapping[str, WithUnitWindow] | None = None,
 ) -> builtins.list[_AttachableT]:
     """Attach ``with <units>`` projection rows onto domain models (#2492).
 
@@ -416,7 +419,9 @@ def _attach_units_to_domain(
     from polylogue.archive.query.attached_units import fetch_attached_units
 
     session_ids = [item.id for item in items]
-    attached = fetch_attached_units(archive, session_ids, with_units, unit_fields=with_unit_fields)
+    attached = fetch_attached_units(
+        archive, session_ids, with_units, unit_fields=with_unit_fields, unit_windows=with_unit_windows
+    )
     updated: builtins.list[_AttachableT] = []
     for item in items:
         per_session = {unit: tuple(by_session.get(item.id, ())) for unit, by_session in attached.items()}
@@ -432,6 +437,7 @@ async def list_summaries_archive(
     default_limit: int = 50,
     with_units: tuple[str, ...] = (),
     with_unit_fields: dict[str, tuple[str, ...]] | None = None,
+    with_unit_windows: Mapping[str, WithUnitWindow] | None = None,
 ) -> builtins.list[SessionSummary]:
     rank_first = bool(plan.fts_terms and plan.sort is None)
 
@@ -448,6 +454,7 @@ async def list_summaries_archive(
             archive,
             with_units,
             with_unit_fields,
+            with_unit_windows,
         )
         return summaries
 
@@ -474,6 +481,7 @@ async def list_archive(
     default_limit: int = 50,
     with_units: tuple[str, ...] = (),
     with_unit_fields: dict[str, tuple[str, ...]] | None = None,
+    with_unit_windows: Mapping[str, WithUnitWindow] | None = None,
 ) -> builtins.list[Session]:
     rank_first = bool(plan.fts_terms and plan.sort is None)
 
@@ -490,6 +498,7 @@ async def list_archive(
             archive,
             with_units,
             with_unit_fields,
+            with_unit_windows,
         )
         return sessions
 

--- a/polylogue/archive/query/attached_units.py
+++ b/polylogue/archive/query/attached_units.py
@@ -12,8 +12,8 @@ payload model are both resolved from the query-unit descriptor registry
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, cast
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from polylogue.archive.query.metadata import QueryUnitDescriptor, query_unit_descriptor
 from polylogue.archive.query.predicate import (
@@ -27,6 +27,7 @@ from polylogue.surfaces import payloads as surface_payloads
 from polylogue.surfaces.payloads import model_json_document
 
 if TYPE_CHECKING:
+    from polylogue.archive.query.expression import WithUnitWindow
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
 
 #: Defensive cap on rows fetched per page across all selected sessions, so a
@@ -121,6 +122,7 @@ def _fetch_unit_rows(
     predicate: QueryPredicate,
     *,
     limit: int,
+    sort_direction: Literal["asc", "desc"] = "asc",
 ) -> Sequence[Any]:
     method_name = descriptor.sql_query_method
     if method_name is None:
@@ -134,7 +136,7 @@ def _fetch_unit_rows(
             offset=0,
             session_filters=None,
             sort="time",
-            sort_direction="asc",
+            sort_direction=sort_direction,
         ),
     )
 
@@ -145,6 +147,7 @@ def _fetch_session_unit_rows(
     session_ids: Sequence[str],
     *,
     limit: int,
+    sort_direction: Literal["asc", "desc"] = "asc",
 ) -> Sequence[Any] | None:
     method_name = {
         "message": "query_session_messages",
@@ -160,9 +163,35 @@ def _fetch_session_unit_rows(
             session_ids,
             limit=limit,
             offset=0,
-            sort_direction="asc",
+            sort_direction=sort_direction,
         ),
     )
+
+
+def _bracket_field_value(payload_document: JSONDocument, descriptor: QueryUnitDescriptor, key: str) -> Any:
+    attr = descriptor.attached_bracket_fields.get(key, key)
+    return payload_document.get(attr)
+
+
+def _matches_window_predicates(
+    payload_document: JSONDocument,
+    descriptor: QueryUnitDescriptor,
+    window: WithUnitWindow,
+) -> bool:
+    for key, value in window.predicates:
+        actual = _bracket_field_value(payload_document, descriptor, key)
+        if actual is None or str(actual).lower() != value.lower():
+            return False
+    return True
+
+
+def _apply_window_trim(rows: list[JSONDocument], window: WithUnitWindow | None) -> list[JSONDocument]:
+    """Trim a session's already time-ascending row list to ``first:N``/``last:N``."""
+
+    if window is None or window.window is None:
+        return rows
+    kind, count = window.window
+    return rows[:count] if kind == "first" else rows[-count:]
 
 
 def fetch_attached_units(
@@ -170,6 +199,7 @@ def fetch_attached_units(
     session_ids: Sequence[str],
     units: Sequence[str],
     unit_fields: dict[str, tuple[str, ...]] | None = None,
+    unit_windows: Mapping[str, WithUnitWindow] | None = None,
 ) -> dict[str, dict[str, tuple[JSONDocument, ...]]]:
     """Return attached-unit rows per unit, bucketed by session id.
 
@@ -177,6 +207,24 @@ def fetch_attached_units(
     ``row_payload`` is a JSON-ready dict produced by the descriptor-owned row
     payload model. Sessions with no rows for a unit are omitted from that unit's
     bucket.
+
+    ``unit_windows`` (polylogue-fnm.2) carries an optional per-unit
+    :class:`~polylogue.archive.query.expression.WithUnitWindow`: bracket
+    equality predicates are applied to each fetched row (against the unit's
+    declared ``attached_bracket_fields``) before the field selection/
+    compaction below, then an optional ``first:N``/``last:N`` trim is applied
+    per session. Both operate on the already-fetched, capped row set -- they
+    narrow what is attached, they do not push a predicate down to the SQL
+    fetch itself. A ``last:N`` window fetches that unit in descending time
+    order instead of the default ascending order (then restores ascending
+    order before trimming), so the per-session/per-page row cap
+    (``_MAX_ROWS_PER_SESSION``) captures the session's tail instead of
+    silently capturing only its head -- without this, `last:N` on a session
+    with more than the cap's worth of rows would trim the wrong end.
+    Predicate + ``last:N`` together on a session whose *matching* rows are
+    still sparser than the fetch cap can still under-fetch; this is the same
+    bounded-fetch caveat as every other post-fetch filter here, not a
+    window-specific gap.
     """
 
     result: dict[str, dict[str, tuple[JSONDocument, ...]]] = {}
@@ -196,9 +244,16 @@ def fetch_attached_units(
             raise ValueError(f"query unit {descriptor.unit!r} has no row payload model")
         selected_fields = () if unit_fields is None else unit_fields.get(descriptor.unit, ())
         _validate_payload_fields(descriptor.unit, payload_model, selected_fields)
-        rows = _fetch_session_unit_rows(archive, descriptor, session_ids, limit=fetch_limit)
+        window = None if unit_windows is None else unit_windows.get(descriptor.unit)
+        wants_tail = window is not None and window.window is not None and window.window[0] == "last"
+        fetch_direction: Literal["asc", "desc"] = "desc" if wants_tail else "asc"
+        rows = _fetch_session_unit_rows(
+            archive, descriptor, session_ids, limit=fetch_limit, sort_direction=fetch_direction
+        )
         if rows is None:
-            rows = _fetch_unit_rows(archive, descriptor, predicate, limit=fetch_limit)
+            rows = _fetch_unit_rows(archive, descriptor, predicate, limit=fetch_limit, sort_direction=fetch_direction)
+        if fetch_direction == "desc":
+            rows = list(reversed(rows))
         buckets: dict[str, list[JSONDocument]] = {}
         for row in rows:
             session_id = _row_session_id(row)
@@ -206,13 +261,21 @@ def fetch_attached_units(
                 continue
             payload = cast(Any, payload_model).from_row(row)
             payload_document = model_json_document(payload, exclude_none=not bool(selected_fields))
+            if (
+                window is not None
+                and window.predicates
+                and not _matches_window_predicates(payload_document, descriptor, window)
+            ):
+                continue
             buckets.setdefault(session_id, []).append(
                 _select_payload_fields(
                     _compact_attached_payload(payload_document),
                     selected_fields,
                 )
             )
-        result[descriptor.unit] = {session_id: tuple(rows) for session_id, rows in buckets.items()}
+        result[descriptor.unit] = {
+            session_id: tuple(_apply_window_trim(rows, window)) for session_id, rows in buckets.items()
+        }
     return result
 
 

--- a/polylogue/archive/query/discovery.py
+++ b/polylogue/archive/query/discovery.py
@@ -322,7 +322,7 @@ DELEGATION_COLUMNS = (
     "inheritance",
     "evidence_refs",
 )
-AGGREGATE_COLUMNS = ("unit", "group_by", "group_key", "count")
+AGGREGATE_COLUMNS = ("unit", "group_by", "group_key", "count", "metrics")
 RECURSIVE_COLUMNS = ("session_id", "parent_refs", "child_refs", "continuation")
 
 
@@ -1287,7 +1287,7 @@ QUERY_DISCOVERY_NEGATIVE_EXAMPLES: tuple[QueryDiscoveryNegativeExample, ...] = (
         diagnostic_class="ExpressionCompileError",
         diagnostic=(
             "unsupported pipeline stage 'group role'; supported terminal stages are `sort by time|count|key "
-            "[asc|desc]`, `group by FIELD`, `count`, `limit N`, and `offset N`"
+            "[asc|desc]`, `group by FIELD`, `count`, `agg count|FN:FIELD[,...]`, `limit N`, and `offset N`"
         ),
         corrected_form="messages where role:assistant | group by role | count",
     ),

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -1999,10 +1999,10 @@ def _split_projection_items(tail: str) -> tuple[str, ...]:
     start = 0
     depth = 0
     for idx, char in enumerate(tail):
-        if char == "(":
+        if char in "([":
             depth += 1
             continue
-        if char == ")":
+        if char in ")]":
             depth = max(0, depth - 1)
             continue
         if char == "," and depth == 0:
@@ -2024,31 +2024,122 @@ def _split_projection_items(tail: str) -> tuple[str, ...]:
     return tuple(items)
 
 
-def _parse_projection_item(item: str) -> tuple[str, tuple[str, ...]]:
-    match = re.fullmatch(r"(?P<unit>[A-Za-z0-9_.-]+)(?:\((?P<fields>[^()]*)\))?", item)
+#: Bracket clause keys that select a per-session row window instead of a
+#: predicate. ``first``/``last`` take the first/last *n* rows of a session's
+#: already time-ascending attached-row fetch (polylogue-fnm.2).
+_WITH_UNIT_WINDOW_KEYS = frozenset({"first", "last"})
+
+
+@dataclass(frozen=True)
+class WithUnitWindow:
+    """Bracket predicate/window on a ``with <unit>[...]`` projection item.
+
+    ``predicates`` are simple equality filters (``field`` -> ``value``,
+    case-sensitive on the stored payload field) applied to attached rows
+    after fetch. ``window`` is an optional ``("first" | "last", n)`` trim
+    applied per session, after predicates, preserving the existing
+    time-ascending fetch order (polylogue-fnm.2).
+    """
+
+    predicates: tuple[tuple[str, str], ...] = ()
+    window: tuple[Literal["first", "last"], int] | None = None
+
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {}
+        if self.predicates:
+            payload["predicates"] = dict(self.predicates)
+        if self.window is not None:
+            payload["window"] = {"kind": self.window[0], "n": self.window[1]}
+        return payload
+
+
+def _parse_with_unit_bracket(unit: str, raw: str) -> WithUnitWindow:
+    clauses = tuple(clause.strip() for clause in raw.split(","))
+    if any(not clause for clause in clauses):
+        raise ExpressionCompileError(
+            f"with {unit}[...] bracket must be a comma-separated list of field:value predicates "
+            "and/or a first:N or last:N window",
+            field=None,
+        )
+    predicates: list[tuple[str, str]] = []
+    window: tuple[Literal["first", "last"], int] | None = None
+    descriptor = query_unit_descriptor(unit)
+    bracket_field_map = {} if descriptor is None else descriptor.attached_bracket_fields
+    known_fields = frozenset(bracket_field_map)
+    for clause in clauses:
+        key_raw, sep, value = clause.partition(":")
+        if not sep:
+            raise ExpressionCompileError(
+                f"with {unit}[{clause}] is not a valid bracket clause; use field:value or first:N/last:N",
+                field=None,
+            )
+        key = key_raw.strip().lower()
+        value = value.strip()
+        if key in _WITH_UNIT_WINDOW_KEYS:
+            if window is not None:
+                raise ExpressionCompileError(
+                    f"with {unit}[...] bracket can only carry one first:N or last:N window", field=None
+                )
+            try:
+                count = int(value)
+            except ValueError as exc:
+                raise ExpressionCompileError(
+                    f"with {unit}[{key}:{value}] window size must be a positive integer", field=None
+                ) from exc
+            if count <= 0:
+                raise ExpressionCompileError(
+                    f"with {unit}[{key}:{value}] window size must be a positive integer", field=None
+                )
+            window = (cast(Literal["first", "last"], key), count)
+            continue
+        if key not in known_fields:
+            supported = ", ".join(sorted(known_fields))
+            raise ExpressionCompileError(
+                f"with {unit}[{key}:...] is not a supported bracket field for {unit} rows; "
+                f"supported fields: {supported}; window keys: first, last",
+                field=None,
+            )
+        if not value:
+            raise ExpressionCompileError(f"with {unit}[{key}:...] requires a value", field=None)
+        predicates.append((key, value))
+    return WithUnitWindow(predicates=tuple(predicates), window=window)
+
+
+def _parse_projection_item(item: str) -> tuple[str, tuple[str, ...], WithUnitWindow | None]:
+    match = re.fullmatch(
+        r"(?P<unit>[A-Za-z0-9_.-]+)(?:\((?P<fields>[^()]*)\))?(?:\[(?P<bracket>[^\[\]]*)\])?",
+        item,
+    )
     if match is None:
         raise ExpressionCompileError(
-            f"invalid with clause item {item!r}; use unit or unit(field, field)",
+            f"invalid with clause item {item!r}; use unit, unit(field, field), or unit[field:value, last:N]",
             field=None,
         )
+    unit_token = match.group("unit")
     raw_fields = match.group("fields")
+    raw_bracket = match.group("bracket")
     if raw_fields is None:
-        return match.group("unit"), ()
-    fields = tuple(field.strip() for field in raw_fields.split(","))
-    if any(not field for field in fields):
-        raise ExpressionCompileError(
-            f"with {match.group('unit')} field selection must be a comma-separated list of payload fields",
-            field=None,
-        )
-    return match.group("unit"), fields
+        fields: tuple[str, ...] = ()
+    else:
+        fields = tuple(field.strip() for field in raw_fields.split(","))
+        if any(not field for field in fields):
+            raise ExpressionCompileError(
+                f"with {unit_token} field selection must be a comma-separated list of payload fields",
+                field=None,
+            )
+    window_spec = None if raw_bracket is None else _parse_with_unit_bracket(unit_token, raw_bracket)
+    return unit_token, fields, window_spec
 
 
-def _canonicalize_with_projection(tail: str) -> tuple[tuple[str, ...], dict[str, tuple[str, ...]]]:
+def _canonicalize_with_projection(
+    tail: str,
+) -> tuple[tuple[str, ...], dict[str, tuple[str, ...]], dict[str, WithUnitWindow]]:
     """Validate and canonicalize the ``with`` clause unit list.
 
     ``tail`` is the text after the ``with`` keyword (for example
-    ``"assertions"`` or ``"messages(message_id,text), actions(tool_name)"``).
-    Every token must resolve to a known query unit and be wired for projection; otherwise an
+    ``"assertions"`` or ``"messages(message_id,text), actions(tool_name)"`` or
+    ``"messages[role:user, last:20]"``). Every token must resolve to a known
+    query unit and be wired for projection; otherwise an
     :class:`ExpressionCompileError` is raised so an unknown or unsupported unit
     never silently no-ops.
     """
@@ -2056,8 +2147,9 @@ def _canonicalize_with_projection(tail: str) -> tuple[tuple[str, ...], dict[str,
     canonical: list[str] = []
     seen: set[str] = set()
     field_map: dict[str, tuple[str, ...]] = {}
+    window_map: dict[str, WithUnitWindow] = {}
     for item in _split_projection_items(tail):
-        token, fields = _parse_projection_item(item)
+        token, fields, window_spec = _parse_projection_item(item)
         descriptor = query_unit_descriptor(token)
         if descriptor is None:
             supported = ", ".join(sorted(WITH_PROJECTION_SUPPORTED_UNITS))
@@ -2083,16 +2175,28 @@ def _canonicalize_with_projection(tail: str) -> tuple[tuple[str, ...], dict[str,
                 field_map[descriptor.unit] = merged
             else:
                 field_map[descriptor.unit] = fields
-    return tuple(canonical), field_map
+        if window_spec is not None:
+            if descriptor.unit in window_map:
+                raise ExpressionCompileError(
+                    f"with {descriptor.unit}[...] bracket given more than once in the same clause; "
+                    "combine predicates/window into a single bracket",
+                    field=None,
+                )
+            window_map[descriptor.unit] = window_spec
+    return tuple(canonical), field_map, window_map
 
 
-def _split_with_projection_clause(expression: str) -> tuple[str, tuple[str, ...], dict[str, tuple[str, ...]]]:
+def _split_with_projection_clause(
+    expression: str,
+) -> tuple[str, tuple[str, ...], dict[str, tuple[str, ...]], dict[str, WithUnitWindow]]:
     """Split a trailing ``with <unit>[, <unit>]`` projection clause.
 
-    Returns ``(head, units, fields)`` where ``head`` is the selection
+    Returns ``(head, units, fields, windows)`` where ``head`` is the selection
     expression with the clause removed, ``units`` are canonical query-unit
-    names, and ``fields`` maps units to payload-field allowlists. When no
-    top-level ``with`` keyword is present, returns ``(expression, (), {})``.
+    names, ``fields`` maps units to payload-field allowlists, and ``windows``
+    maps units to a :class:`WithUnitWindow` bracket predicate/trim
+    (polylogue-fnm.2). When no top-level ``with`` keyword is present, returns
+    ``(expression, (), {}, {})``.
 
     The split happens outside the Lark grammar — mirroring
     :func:`_split_pipeline_stages` — so quoting and nesting are honored and a
@@ -2101,24 +2205,24 @@ def _split_with_projection_clause(expression: str) -> tuple[str, tuple[str, ...]
 
     positions = _iter_top_level_with_positions(expression)
     if not positions:
-        return expression, (), {}
+        return expression, (), {}, {}
     split_at = positions[-1]
     tail = expression[split_at + 4 :].strip()
     if not tail:
         # A bare trailing ``with`` is not a projection clause; leave it intact.
-        return expression, (), {}
-    units, fields = _canonicalize_with_projection(tail)
+        return expression, (), {}, {}
+    units, fields, windows = _canonicalize_with_projection(tail)
     head = expression[:split_at].strip()
     if not head:
         raise ExpressionCompileError(
             "with clause requires a selection expression before it (for example: repo:polylogue with assertions)",
             field=None,
         )
-    return head, units, fields
+    return head, units, fields, windows
 
 
 def _split_with_clause(expression: str) -> tuple[str, tuple[str, ...]]:
-    head, units, _fields = _split_with_projection_clause(expression)
+    head, units, _fields, _windows = _split_with_projection_clause(expression)
     return head, units
 
 
@@ -2723,7 +2827,7 @@ def parse_expression_ast(expression: str) -> QueryExpressionAST:
     if not expression:
         return QueryExpressionAST(())
     if not (expression.startswith("{") or expression.startswith("[")):
-        expression, _with_units, _with_unit_fields = _split_with_projection_clause(expression)
+        expression, _with_units, _with_unit_fields, _with_unit_windows = _split_with_projection_clause(expression)
         if not expression:
             return QueryExpressionAST(())
     reference_pipeline = parse_reference_query_pipeline(expression)
@@ -3560,7 +3664,7 @@ def compile_expression(expression: str) -> SessionQuerySpec:
 
     # Split a trailing ``with <units>`` projection clause off the selection
     # expression before parsing it (outside the Lark grammar, like ``|`` stages).
-    expression, with_units, with_unit_fields = _split_with_projection_clause(expression)
+    expression, with_units, with_unit_fields, with_unit_windows = _split_with_projection_clause(expression)
 
     reference_pipeline = parse_reference_query_pipeline(expression)
     if reference_pipeline is not None:
@@ -3578,6 +3682,7 @@ def compile_expression(expression: str) -> SessionQuerySpec:
             boolean_predicate=residual_predicate,
             with_units=with_units,
             with_unit_fields=with_unit_fields,
+            with_unit_windows=with_unit_windows,
         )
     tokens = list(ast.clauses)
 
@@ -3607,7 +3712,9 @@ def compile_expression(expression: str) -> SessionQuerySpec:
         acc.apply_token(tok)
     spec = acc.to_spec()
     if with_units:
-        spec = replace(spec, with_units=with_units, with_unit_fields=with_unit_fields)
+        spec = replace(
+            spec, with_units=with_units, with_unit_fields=with_unit_fields, with_unit_windows=with_unit_windows
+        )
     return spec
 
 
@@ -3661,6 +3768,7 @@ def compile_expression_into(expression: str, base: SessionQuerySpec) -> SessionQ
         boolean_predicate=boolean_predicate,
         with_units=base.with_units + tuple(u for u in expr_spec.with_units if u not in base.with_units),
         with_unit_fields={**base.with_unit_fields, **expr_spec.with_unit_fields},
+        with_unit_windows={**base.with_unit_windows, **expr_spec.with_unit_windows},
     )
 
 
@@ -3750,6 +3858,7 @@ __all__ = [
     "split_with_clause",
     "split_with_projection_clause",
     "WITH_PROJECTION_SUPPORTED_UNITS",
+    "WithUnitWindow",
     "structural_query_fields",
     "structural_query_units",
     "UnsupportedSessionTerminalActionError",

--- a/polylogue/archive/query/expression.py
+++ b/polylogue/archive/query/expression.py
@@ -417,16 +417,37 @@ class QueryUnitSort:
 
 
 QueryUnitPipelineStageKind = Literal[
-    "session_scope", "sort", "limit", "offset", "group", "count", "transform", "terminal"
+    "session_scope", "sort", "limit", "offset", "group", "count", "agg", "transform", "terminal"
 ]
 
 #: Closed vocabulary of terminal actions that a query-unit pipeline can end in.
 #: Each action name must have a registered executor in
 #: :data:`polylogue.archive.query.unit_results.TERMINAL_ACTION_EXECUTORS`.
 #: ``rows`` returns the resolved unit rows; ``count`` returns the aggregate
-#: ``group by ... | count`` rollup. Future actions (read/analyze/bundle/
-#: postmortem) register their unit-level executors here as they land (#2006).
-QueryUnitTerminalAction = Literal["rows", "count"]
+#: ``group by ... | count`` rollup; ``agg`` returns the named-metric
+#: ``group by ... | agg count, avg:FIELD, ...`` rollup (polylogue-fnm.1).
+#: Future actions (read/analyze/bundle/postmortem) register their unit-level
+#: executors here as they land (#2006).
+QueryUnitTerminalAction = Literal["rows", "count", "agg"]
+
+#: Closed vocabulary of reducer functions an ``| agg ...`` metric spec may
+#: name. ``count`` is field-less; every other function reduces a declared
+#: :attr:`~polylogue.archive.query.metadata.QueryUnitDescriptor.aggregate_metric_fields`
+#: entry. Percentiles are ``pNN`` for ``NN`` in ``1..99`` and are matched
+#: separately via :func:`percentile_rank` since the vocabulary is unbounded.
+AggregateMetricFunction = Literal["count", "sum", "avg", "min", "max"]
+AGGREGATE_METRIC_FUNCTIONS: frozenset[str] = frozenset({"count", "sum", "avg", "min", "max"})
+
+
+def percentile_rank(fn: str) -> int | None:
+    """Return the percentile ``1..99`` named by ``fn`` (e.g. ``p90`` -> 90), or ``None``."""
+
+    if len(fn) < 2 or fn[0] != "p" or not fn[1:].isdigit():
+        return None
+    rank = int(fn[1:])
+    return rank if 1 <= rank <= 99 else None
+
+
 SESSION_SOURCE_UNIT: Literal["sessions"] = "sessions"
 SessionTerminalAction = Literal["read", "analyze", "select", "mark", "delete", "continue"]
 SESSION_TERMINAL_ACTIONS: frozenset[SessionTerminalAction] = frozenset(
@@ -521,6 +542,41 @@ class QueryUnitCountStage:
 
 
 @dataclass(frozen=True)
+class QueryUnitAggMetric:
+    """One named reducer in an ``| agg ...`` pipeline stage (polylogue-fnm.1).
+
+    ``fn`` is ``count`` (field-less) or one of ``sum``/``avg``/``min``/``max``/
+    ``pNN`` reducing ``field``. ``label`` is the stable output column name:
+    ``count`` for the count metric, otherwise ``f"{fn}_{field}"``.
+    """
+
+    fn: str
+    field: str | None
+    label: str
+
+    def to_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {"fn": self.fn, "label": self.label}
+        if self.field is not None:
+            payload["field"] = self.field
+        return payload
+
+
+@dataclass(frozen=True)
+class QueryUnitAggStage:
+    """Named-metric aggregation stage in a terminal query-unit pipeline (polylogue-fnm.1).
+
+    Unlike :class:`QueryUnitCountStage` (a single unnamed count), this stage
+    carries an ordered list of named metrics computed per preceding group
+    (or over the whole matched row set when no ``group by`` precedes it).
+    """
+
+    metrics: tuple[QueryUnitAggMetric, ...]
+
+    def to_payload(self) -> dict[str, object]:
+        return {"kind": "agg", "metrics": [metric.to_payload() for metric in self.metrics]}
+
+
+@dataclass(frozen=True)
 class QueryUnitTransformStage:
     """Named row-shaping transform stage in a terminal query-unit pipeline.
 
@@ -569,6 +625,7 @@ QueryUnitPipelineStage = (
     | QueryUnitOffsetStage
     | QueryUnitGroupStage
     | QueryUnitCountStage
+    | QueryUnitAggStage
     | QueryUnitTransformStage
     | QueryUnitTerminalStage
 )
@@ -587,6 +644,7 @@ class QueryUnitPipeline:
     sort: QueryUnitSort | None = None
     group_by: str | None = None
     aggregate: Literal["count"] | None = None
+    agg_metrics: tuple[QueryUnitAggMetric, ...] | None = None
     terminal: QueryUnitTerminalStage = QueryUnitTerminalStage(action="rows")
 
     def to_payload(self) -> dict[str, object]:
@@ -613,6 +671,8 @@ class QueryUnitPipeline:
             result["group_by"] = self.group_by
         if self.aggregate is not None:
             result["aggregate"] = self.aggregate
+        if self.agg_metrics is not None:
+            result["agg_metrics"] = [metric.to_payload() for metric in self.agg_metrics]
         if self.limit is not None:
             result["limit"] = self.limit
         if self.offset is not None:
@@ -667,13 +727,20 @@ class QueryUnitSource:
     sort: QueryUnitSort | None = None
     group_by: str | None = None
     aggregate: Literal["count"] | None = None
+    agg_metrics: tuple[QueryUnitAggMetric, ...] | None = None
     pipeline_stages: tuple[QueryUnitPipelineStage, ...] = ()
 
     @property
     def pipeline(self) -> QueryUnitPipeline:
         """Return the typed executable pipeline for this terminal source."""
 
-        terminal_action: QueryUnitTerminalAction = "count" if self.aggregate == "count" else "rows"
+        terminal_action: QueryUnitTerminalAction
+        if self.agg_metrics is not None:
+            terminal_action = "agg"
+        elif self.aggregate == "count":
+            terminal_action = "count"
+        else:
+            terminal_action = "rows"
         return QueryUnitPipeline(
             source_unit=self.unit,
             predicate=self.predicate,
@@ -684,6 +751,7 @@ class QueryUnitSource:
             sort=self.sort,
             group_by=self.group_by,
             aggregate=self.aggregate,
+            agg_metrics=self.agg_metrics,
             terminal=QueryUnitTerminalStage(action=terminal_action),
         )
 
@@ -2189,6 +2257,71 @@ def _validate_aggregate_group_field(unit: QueryUnitName, field: str) -> None:
         )
 
 
+def _validate_aggregate_metric_field(unit: QueryUnitName, fn: str, field: str) -> None:
+    descriptor = query_unit_descriptor(unit)
+    supported_fields = frozenset(descriptor.aggregate_metric_fields) if descriptor is not None else frozenset()
+    if field not in supported_fields:
+        supported = ", ".join(sorted(supported_fields))
+        if not supported:
+            raise ExpressionCompileError(
+                f"pipeline `agg {fn}:{field}` is not supported for {unit} rows; "
+                f"{unit} has no numeric metric fields, only `agg count` is available",
+                field="agg",
+            )
+        raise ExpressionCompileError(
+            f"pipeline `agg {fn}:{field}` is not supported for {unit} rows; supported metric fields: {supported}",
+            field="agg",
+        )
+
+
+def _parse_agg_metric(unit: QueryUnitName, raw: str) -> QueryUnitAggMetric:
+    spec = raw.strip()
+    if not spec:
+        raise ExpressionCompileError("pipeline `agg` stage requires a metric after every comma", field="agg")
+    if ":" not in spec:
+        if spec.lower() != "count":
+            raise ExpressionCompileError(
+                f"unsupported `agg` metric {spec!r}; expected `count` or `FN:FIELD` "
+                "(FN is one of sum, avg, min, max, or a percentile pNN, e.g. p90)",
+                field="agg",
+            )
+        return QueryUnitAggMetric(fn="count", field=None, label="count")
+    fn_raw, _, field = spec.partition(":")
+    fn = fn_raw.strip().lower()
+    field = field.strip()
+    if not field:
+        raise ExpressionCompileError(f"pipeline `agg {fn}:` requires a field name", field="agg")
+    is_percentile = percentile_rank(fn) is not None
+    if fn not in AGGREGATE_METRIC_FUNCTIONS and not is_percentile:
+        raise ExpressionCompileError(
+            f"unsupported `agg` function {fn_raw.strip()!r}; supported functions are "
+            "count, sum, avg, min, max, and percentiles p1..p99",
+            field="agg",
+        )
+    if fn == "count":
+        raise ExpressionCompileError("pipeline `agg count` does not take a field; use plain `count`", field="agg")
+    _validate_aggregate_metric_field(unit, fn, field)
+    return QueryUnitAggMetric(fn=fn, field=field, label=f"{fn}_{field}")
+
+
+def _parse_agg_stage(unit: QueryUnitName, stage: str) -> tuple[QueryUnitAggMetric, ...] | None:
+    normalized = " ".join(stage.split())
+    if not normalized.lower().startswith("agg "):
+        return None
+    raw_metrics = normalized[len("agg ") :].strip()
+    if not raw_metrics:
+        raise ExpressionCompileError("pipeline `agg` stage requires at least one metric", field="agg")
+    metrics = tuple(_parse_agg_metric(unit, part) for part in raw_metrics.split(","))
+    labels = [metric.label for metric in metrics]
+    if len(labels) != len(set(labels)):
+        raise ExpressionCompileError(
+            f"pipeline `agg` stage has duplicate metrics: "
+            f"{', '.join(sorted({label for label in labels if labels.count(label) > 1}))}",
+            field="agg",
+        )
+    return metrics
+
+
 def _query_unit_lowerer_kind(unit: QueryUnitName) -> QueryUnitLowererKind:
     descriptor = query_unit_descriptor(unit)
     if descriptor is None or not descriptor.terminal_supported:
@@ -2234,7 +2367,7 @@ def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSourc
     sort = _parse_sort_stage(stage)
     if sort is not None:
         if sort.field == "time":
-            if source.aggregate is not None:
+            if source.aggregate is not None or source.agg_metrics is not None:
                 raise ExpressionCompileError(
                     "pipeline `sort by time` must appear before aggregate stages", field="sort"
                 )
@@ -2247,17 +2380,25 @@ def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSourc
                     field="sort",
                 )
             _ensure_sql_row_pipeline_lowerer(source.unit, stage="sort by time")
-        elif source.aggregate != "count":
-            raise ExpressionCompileError(
-                "pipeline `sort by count` and `sort by key` require an aggregate `count` stage",
-                field="sort",
-            )
-        elif source.limit is not None or source.offset is not None:
-            raise ExpressionCompileError(
-                "pipeline aggregate `sort by` must appear before `limit` and `offset`",
-                field="sort",
-            )
-        _ensure_sql_aggregate_pipeline_lowerer(source.unit, stage=f"sort by {sort.field}")
+        else:
+            if sort.field == "count" and source.aggregate != "count":
+                raise ExpressionCompileError(
+                    "pipeline `sort by count` requires an aggregate `count` stage; "
+                    "an `agg` stage has no single unnamed count to sort by -- "
+                    "use `sort by key` to order by group instead",
+                    field="sort",
+                )
+            if sort.field == "key" and source.aggregate != "count" and source.agg_metrics is None:
+                raise ExpressionCompileError(
+                    "pipeline `sort by key` requires an aggregate `count` or `agg` stage",
+                    field="sort",
+                )
+            if source.limit is not None or source.offset is not None:
+                raise ExpressionCompileError(
+                    "pipeline aggregate `sort by` must appear before `limit` and `offset`",
+                    field="sort",
+                )
+            _ensure_sql_aggregate_pipeline_lowerer(source.unit, stage=f"sort by {sort.field}")
         return replace(
             source,
             sort=sort,
@@ -2300,6 +2441,24 @@ def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSourc
                 QueryUnitCountStage(),
             ),
         )
+    agg_metrics = _parse_agg_stage(source.unit, stage)
+    if agg_metrics is not None:
+        if source.aggregate is not None or source.agg_metrics is not None:
+            raise ExpressionCompileError("pipeline `agg` cannot follow `count` or another `agg` stage", field="agg")
+        if source.sort is not None:
+            raise ExpressionCompileError("pipeline `sort by time` cannot feed aggregate stages", field="agg")
+        if source.limit is not None or source.offset is not None:
+            raise ExpressionCompileError("pipeline `agg` must appear before `limit` and `offset`", field="agg")
+        _ensure_sql_aggregate_pipeline_lowerer(source.unit, stage="agg")
+        _ensure_aggregate_lowerer_supported(source.unit, stage="agg")
+        return replace(
+            source,
+            agg_metrics=agg_metrics,
+            pipeline_stages=(
+                *source.pipeline_stages,
+                QueryUnitAggStage(agg_metrics),
+            ),
+        )
     limit = _parse_non_negative_int_stage(stage, "limit")
     if limit is not None:
         if limit == 0:
@@ -2324,7 +2483,8 @@ def _apply_pipeline_stage(source: QueryUnitSource, stage: str) -> QueryUnitSourc
         )
     raise ExpressionCompileError(
         f"unsupported pipeline stage {stage!r}; supported terminal stages are "
-        "`sort by time|count|key [asc|desc]`, `group by FIELD`, `count`, `limit N`, and `offset N`",
+        "`sort by time|count|key [asc|desc]`, `group by FIELD`, `count`, "
+        "`agg count|FN:FIELD[,...]`, `limit N`, and `offset N`",
         field=None,
     )
 
@@ -2355,16 +2515,16 @@ def _parse_plain_unit_source_expression(expression: str) -> QueryUnitSource | No
 #: it is matched by exact equality instead. Used only to *recognize* that a
 #: stage has the shape of a terminal pipeline action -- never to validate its
 #: contents, so this never raises.
-_PIPELINE_STAGE_KEYWORD_PREFIXES: tuple[str, ...] = ("sort by ", "group by ", "limit ", "offset ")
+_PIPELINE_STAGE_KEYWORD_PREFIXES: tuple[str, ...] = ("sort by ", "group by ", "limit ", "offset ", "agg ")
 
 
 def _pipeline_stage_keyword(stage: str) -> str | None:
     """Return the terminal pipeline stage keyword ``stage`` looks like, if any.
 
     Distinguishes "this stage has the shape of `count`/`group by`/`sort by`/
-    `limit`/`offset` but was misapplied" from "this stage is unrecognized
-    entirely", so callers can raise a specific, actionable error instead of a
-    generic one for the former.
+    `limit`/`offset`/`agg` but was misapplied" from "this stage is
+    unrecognized entirely", so callers can raise a specific, actionable error
+    instead of a generic one for the former.
     """
 
     normalized = " ".join(stage.split()).lower()
@@ -2417,6 +2577,7 @@ def _parse_pipeline_unit_source(expression: str) -> QueryUnitSource | None:
             sort=terminal_source.sort,
             group_by=terminal_source.group_by,
             aggregate=terminal_source.aggregate,
+            agg_metrics=terminal_source.agg_metrics,
             pipeline_stages=(
                 QueryUnitSessionScopeStage(session_predicate),
                 *terminal_source.pipeline_stages,
@@ -2704,6 +2865,8 @@ def _explain_unit_source_execution_legs(source: QueryUnitSource) -> tuple[str, .
     legs = {f"terminal-{source.unit}-rows", *_predicate_execution_legs(source.predicate)}
     if source.aggregate is not None:
         legs.add(f"terminal-{source.unit}-{source.aggregate}-aggregate")
+    if source.agg_metrics is not None:
+        legs.add(f"terminal-{source.unit}-agg-aggregate")
     if _query_unit_uses_runtime_transform(source.unit):
         legs.add("runtime-transform")
     else:
@@ -2744,6 +2907,8 @@ def _ast_payload(
             unit_payload["group_by"] = unit_source.group_by
         if unit_source.aggregate is not None:
             unit_payload["aggregate"] = unit_source.aggregate
+        if unit_source.agg_metrics is not None:
+            unit_payload["agg_metrics"] = [metric.to_payload() for metric in unit_source.agg_metrics]
         if unit_source.pipeline_stages:
             unit_payload["pipeline_stages"] = [stage.to_payload() for stage in unit_source.pipeline_stages]
         unit_payload["pipeline"] = unit_source.pipeline.to_payload()
@@ -3559,6 +3724,9 @@ __all__ = [
     "ReferenceQueryPipeline",
     "ResolvedRefOperand",
     "QueryUnitPipeline",
+    "QueryUnitAggMetric",
+    "QueryUnitAggStage",
+    "percentile_rank",
     "QueryUnitCountStage",
     "QueryUnitGroupStage",
     "QueryUnitLimitStage",

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -35,6 +35,10 @@ class QueryUnitDescriptor:
     cli_plain_renderer: str | None = None
     time_sort_supported: bool = True
     aggregate_group_fields: tuple[str, ...] = ()
+    #: Numeric fields a ``| agg ...`` pipeline stage may reduce with
+    #: sum/avg/min/max/percentile functions, in addition to the always-legal
+    #: field-less ``count`` metric. Empty means only ``count`` is available.
+    aggregate_metric_fields: tuple[str, ...] = ()
     fields: tuple[StructuralQueryFieldInfo, ...] = ()
     description: str = ""
     example: str = ""
@@ -805,6 +809,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         sql_query_method="query_messages",
         cli_plain_renderer="message",
         aggregate_group_fields=("role", "type", "session.origin", "session.repo"),
+        aggregate_metric_fields=("word_count",),
         fields=_unit_info("message").fields,
         description=_unit_info("message").description,
         example=_unit_info("message").example,
@@ -828,6 +833,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
             "session.origin",
             "session.repo",
         ),
+        aggregate_metric_fields=("is_error", "exit_code"),
         fields=_unit_info("action").fields,
         description=_unit_info("action").description,
         example=_unit_info("action").example,
@@ -1321,6 +1327,20 @@ def terminal_query_pipeline_stage_infos(source: str) -> tuple[QueryPipelineStage
                     source_unit=descriptor.unit,
                     lowerer_kind=descriptor.lowerer_kind,
                 ),
+            )
+        )
+    if descriptor.aggregate_metric_fields:
+        example_field = descriptor.aggregate_metric_fields[0]
+        stages.append(
+            QueryPipelineStageInfo(
+                value="agg",
+                insert=f"agg count, avg:{example_field}",
+                description=(
+                    "Reduce each preceding group with named metrics: `count`, or "
+                    f"`sum|avg|min|max|pNN:FIELD` over {', '.join(descriptor.aggregate_metric_fields)}."
+                ),
+                source_unit=descriptor.unit,
+                lowerer_kind=descriptor.lowerer_kind,
             )
         )
     stages.extend(

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from typing import Literal
 
 QueryUnitName = Literal[
@@ -39,6 +40,15 @@ class QueryUnitDescriptor:
     #: sum/avg/min/max/percentile functions, in addition to the always-legal
     #: field-less ``count`` metric. Empty means only ``count`` is available.
     aggregate_metric_fields: tuple[str, ...] = ()
+    #: Bracket-predicate field vocabulary for a ``with unit[field:value, ...]``
+    #: projection clause (polylogue-fnm.2), mapping the DSL-facing field name
+    #: to its attached-row payload attribute name. Deliberately a small,
+    #: explicit vocabulary rather than the full ``<unit> where`` structural
+    #: predicate field set: bracket predicates filter already-fetched payload
+    #: rows in Python (not pushed down to SQL), so only fields present on the
+    #: unit's own projected payload model are safe to filter. Empty means the
+    #: unit only supports the ``first:N``/``last:N`` window, not predicates.
+    attached_bracket_fields: dict[str, str] = dataclass_field(default_factory=dict)
     fields: tuple[StructuralQueryFieldInfo, ...] = ()
     description: str = ""
     example: str = ""
@@ -810,6 +820,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         cli_plain_renderer="message",
         aggregate_group_fields=("role", "type", "session.origin", "session.repo"),
         aggregate_metric_fields=("word_count",),
+        attached_bracket_fields={"role": "role", "type": "message_type"},
         fields=_unit_info("message").fields,
         description=_unit_info("message").description,
         example=_unit_info("message").example,
@@ -834,6 +845,14 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
             "session.repo",
         ),
         aggregate_metric_fields=("is_error", "exit_code"),
+        attached_bracket_fields={
+            "tool": "tool_name",
+            "action": "semantic_type",
+            "type": "semantic_type",
+            "is_error": "is_error",
+            "exit_code": "exit_code",
+            "followup_class": "followup_class",
+        },
         fields=_unit_info("action").fields,
         description=_unit_info("action").description,
         example=_unit_info("action").example,
@@ -862,6 +881,12 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         sql_query_method="query_assertions",
         cli_plain_renderer="assertion",
         aggregate_group_fields=("kind", "status", "visibility", "author_kind", "session.origin", "session.repo"),
+        attached_bracket_fields={
+            "kind": "kind",
+            "status": "status",
+            "visibility": "visibility",
+            "author_kind": "author_kind",
+        },
         fields=_unit_info("assertion").fields,
         description=_unit_info("assertion").description,
         example=_unit_info("assertion").example,
@@ -876,6 +901,7 @@ QUERY_UNIT_DESCRIPTORS: tuple[QueryUnitDescriptor, ...] = (
         sql_query_method="query_files",
         cli_plain_renderer="file",
         aggregate_group_fields=("path", "session.origin", "session.repo"),
+        attached_bracket_fields={"path": "path"},
         fields=_unit_info("file").fields,
         description=_unit_info("file").description,
         example=_unit_info("file").example,

--- a/polylogue/archive/query/spec.py
+++ b/polylogue/archive/query/spec.py
@@ -28,6 +28,7 @@ from polylogue.storage.archive_identity import archive_file_set_root
 if TYPE_CHECKING:
     from polylogue.archive.filter.filters import SessionFilter
     from polylogue.archive.models import Session, SessionSummary
+    from polylogue.archive.query.expression import WithUnitWindow
     from polylogue.config import Config
     from polylogue.core.protocols import VectorProvider
 
@@ -524,6 +525,11 @@ class SessionQuerySpec:
     #: same post-selection projection. Empty/missing means the unit's default
     #: payload is emitted.
     with_unit_fields: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    #: Bracket predicate/window per unit (the DSL ``with unit[field:value,
+    #: last:N]`` clause), keyed by the same canonical unit as ``with_units``
+    #: (polylogue-fnm.2). Applied to the fetched attached rows, not pushed
+    #: down to SQL.
+    with_unit_windows: dict[str, WithUnitWindow] = field(default_factory=dict)
 
     @classmethod
     def from_params(cls, params: Mapping[str, object], *, strict: bool = False) -> SessionQuerySpec:
@@ -626,6 +632,7 @@ class SessionQuerySpec:
             query_plan=self.to_plan(vector_provider=vector_provider),
             with_units=self.with_units,
             with_unit_fields=self.with_unit_fields,
+            with_unit_windows=self.with_unit_windows,
         )
 
 

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, Protocol, cast
@@ -10,8 +11,10 @@ from typing import Any, Literal, Protocol, cast
 from polylogue.archive.query.execution_control import QueryExecutionContext
 from polylogue.archive.query.expression import (
     ExpressionCompileError,
+    QueryUnitAggMetric,
     QueryUnitPipeline,
     QueryUnitSource,
+    percentile_rank,
 )
 from polylogue.archive.query.metadata import (
     QueryUnitDescriptor,
@@ -420,6 +423,143 @@ def _execute_rows_terminal(ctx: TerminalExecutionContext) -> QueryUnitResultEnve
     )
 
 
+#: Hard cap on rows fetched for Python-side ``agg`` metric computation
+#: (polylogue-fnm.1). Sum/avg/min/max/percentile reducers cannot push down to
+#: SQL from this lane, so ``_execute_agg_terminal`` fetches up to this many
+#: predicate-matching rows through the unit's existing SQL-pushdown row query
+#: and reduces them in Python. When the match set exceeds the cap the result
+#: is marked ``"exact": false`` in the pipeline result payload instead of
+#: silently reporting a partial sample as a complete aggregate.
+_AGG_ROW_FETCH_CAP = 50_000
+
+
+def _agg_group_key(row: object, group_fields: tuple[str, ...], unit: str) -> tuple[str, ...]:
+    field_map = _AGGREGATE_ROW_FIELDS.get(unit, {})
+    values: list[str] = []
+    for field in group_fields:
+        attr = field_map.get(field, field)
+        value = getattr(row, attr, None)
+        values.append(_MISSING_GROUP_KEY if value is None else str(value))
+    return tuple(values)
+
+
+def _reduce_agg_metric(metric: QueryUnitAggMetric, values: Sequence[float]) -> float | int | None:
+    """Reduce ``values`` with ``metric.fn``. Percentiles use nearest-rank."""
+
+    if metric.fn == "count":
+        return len(values)
+    if not values:
+        return None
+    if metric.fn == "sum":
+        return sum(values)
+    if metric.fn == "avg":
+        return sum(values) / len(values)
+    if metric.fn == "min":
+        return min(values)
+    if metric.fn == "max":
+        return max(values)
+    rank = percentile_rank(metric.fn)
+    if rank is not None:
+        ordered = sorted(values)
+        index = max(0, min(len(ordered) - 1, math.ceil(rank / 100 * len(ordered)) - 1))
+        return ordered[index]
+    raise ValueError(f"unsupported agg function: {metric.fn!r}")
+
+
+def _execute_agg_terminal(ctx: TerminalExecutionContext) -> QueryUnitResultEnvelope:
+    """Terminal ``agg`` action: emit named sum/avg/min/max/percentile metrics per group.
+
+    This reducer cannot push sum/avg/min/max/percentile down to SQL from this
+    lane (polylogue-fnm.1: storage/sqlite owns the SQL aggregate builder and
+    is out of scope here), so it fetches up to :data:`_AGG_ROW_FETCH_CAP`
+    predicate-matching rows through the unit's existing SQL-pushdown row
+    query (the same query the ``rows`` terminal uses) and reduces them in
+    Python, grouping by the same fields the ``count`` aggregate lowerer
+    already supports (:data:`_AGGREGATE_ROW_FIELDS`). The pipeline result
+    payload explicitly reports ``"exact": true`` when every matching row was
+    fetched, or ``"exact": false`` plus ``"sampled_rows"`` when the match set
+    was larger than the cap, instead of silently treating a partial sample as
+    a complete aggregate.
+    """
+
+    pipeline = ctx.source.pipeline
+    agg_metrics = pipeline.agg_metrics
+    assert agg_metrics is not None
+    method_name = ctx.descriptor.sql_query_method
+    payload_model = _row_payload_model(ctx.descriptor)
+    if method_name is None or payload_model is None:
+        raise ValueError(f"Query unit {ctx.source.unit!r} is not wired to a SQL executor")
+    query_method = cast(Any, getattr(ctx.archive, method_name))
+    sort = "time" if ctx.descriptor.time_sort_supported else None
+    rows = cast(
+        Sequence[Any],
+        query_method(
+            pipeline.predicate,
+            limit=_AGG_ROW_FETCH_CAP + 1,
+            offset=0,
+            session_filters=ctx.session_filters,
+            sort=sort,
+            sort_direction="asc",
+        ),
+    )
+    exact = len(rows) <= _AGG_ROW_FETCH_CAP
+    fetched_rows = rows[:_AGG_ROW_FETCH_CAP]
+    payload_rows = [payload_model.from_row(row) for row in fetched_rows]
+
+    group_fields = _aggregate_group_fields(pipeline.group_by)
+    groups: dict[tuple[str, ...], list[Any]] = {}
+    for payload_row in payload_rows:
+        key = _agg_group_key(payload_row, group_fields, ctx.source.unit) if group_fields else ()
+        groups.setdefault(key, []).append(payload_row)
+
+    field_map = _AGGREGATE_ROW_FIELDS.get(ctx.source.unit, {})
+    aggregate_rows: list[QueryUnitAggregateRowPayload] = []
+    for key, group_rows in sorted(groups.items()):
+        metrics: dict[str, float | int | None] = {}
+        for metric in agg_metrics:
+            if metric.fn == "count":
+                metrics[metric.label] = len(group_rows)
+                continue
+            attr = field_map.get(metric.field, metric.field) if metric.field else metric.field
+            values = [float(v) for v in (getattr(row, attr, None) for row in group_rows) if v is not None]
+            metrics[metric.label] = _reduce_agg_metric(metric, values)
+        if not group_fields:
+            group_key = None
+        elif len(group_fields) == 1:
+            group_key = key[0]
+        else:
+            group_key = json.dumps(dict(zip(group_fields, key, strict=True)), sort_keys=True, separators=(",", ":"))
+        aggregate_rows.append(
+            QueryUnitAggregateRowPayload(
+                unit=cast(Any, ctx.source.unit),
+                group_by=pipeline.group_by,
+                group_key=group_key,
+                count=len(group_rows),
+                metrics=metrics,
+            )
+        )
+
+    page = aggregate_rows[ctx.offset : ctx.offset + ctx.limit + 1]
+    payload = pipeline.to_payload()
+    result = cast(dict[str, object], payload.setdefault("result", {}))
+    result["exact"] = exact
+    result["sampled_rows"] = len(fetched_rows)
+    return _record_result_page(
+        ctx,
+        build_query_unit_aggregate_envelope(
+            tuple(page[: ctx.limit]),
+            unit=ctx.source.unit,
+            query=ctx.query,
+            limit=ctx.limit,
+            offset=ctx.caller_offset,
+            has_next=len(page) > ctx.limit,
+            pipeline=payload,
+            pipeline_stages=_pipeline_stage_payloads(pipeline),
+        ),
+        selected_rows_exact=len(aggregate_rows) if exact else None,
+    )
+
+
 #: Single source of truth mapping a terminal-action name to its executor.
 #: The pipeline's ``terminal.action`` selects the executor; one executor runs
 #: the full ``select -> shape -> terminal`` chain for every read surface
@@ -427,6 +567,7 @@ def _execute_rows_terminal(ctx: TerminalExecutionContext) -> QueryUnitResultEnve
 TERMINAL_ACTION_EXECUTORS: dict[str, TerminalExecutor] = {
     "rows": _execute_rows_terminal,
     "count": _execute_count_terminal,
+    "agg": _execute_agg_terminal,
 }
 
 

--- a/polylogue/archive/query/unit_results.py
+++ b/polylogue/archive/query/unit_results.py
@@ -517,10 +517,10 @@ def _execute_agg_terminal(ctx: TerminalExecutionContext) -> QueryUnitResultEnvel
     for key, group_rows in sorted(groups.items()):
         metrics: dict[str, float | int | None] = {}
         for metric in agg_metrics:
-            if metric.fn == "count":
+            if metric.fn == "count" or metric.field is None:
                 metrics[metric.label] = len(group_rows)
                 continue
-            attr = field_map.get(metric.field, metric.field) if metric.field else metric.field
+            attr = field_map.get(metric.field, metric.field)
             values = [float(v) for v in (getattr(row, attr, None) for row in group_rows) if v is not None]
             metrics[metric.label] = _reduce_agg_metric(metric, values)
         if not group_fields:

--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -27,6 +27,7 @@ from polylogue.archive.message.types import validate_message_type_filter
 from polylogue.archive.query.attached_units import fetch_attached_units
 from polylogue.archive.query.expression import (
     QueryUnitSource,
+    WithUnitWindow,
     parse_unit_source_expression,
     split_with_projection_clause,
 )
@@ -207,8 +208,11 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
     unit_source_query = raw_query
     with_units: tuple[str, ...] = ()
     with_unit_fields: dict[str, tuple[str, ...]] = {}
+    with_unit_windows: dict[str, WithUnitWindow] = {}
     if unit_source_query and not (unit_source_query.startswith("{") or unit_source_query.startswith("[")):
-        unit_source_query, with_units, with_unit_fields = split_with_projection_clause(unit_source_query)
+        unit_source_query, with_units, with_unit_fields, with_unit_windows = split_with_projection_clause(
+            unit_source_query
+        )
     unit_source = (
         parse_unit_source_expression(unit_source_query)
         if unit_source_query and not _optional_str(params.get("similar_text"))
@@ -225,6 +229,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
     if compiled_spec.with_units:
         with_units = compiled_spec.with_units
         with_unit_fields = compiled_spec.with_unit_fields
+        with_unit_windows = compiled_spec.with_unit_windows
     env.record_timing("compile", compile_started_at)
 
     tags_to_add = _tuple_tokens(params.get("add_tag"))
@@ -320,6 +325,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
         unit_source=unit_source,
         with_units=with_units,
         with_unit_fields=with_unit_fields,
+        with_unit_windows=with_unit_windows,
         query=query,
         limit=limit,
         offset=page_offset,
@@ -655,6 +661,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                         typo_hint=typo_hint,
                         with_units=with_units,
                         with_unit_fields=with_unit_fields,
+                        with_unit_windows=with_unit_windows,
                         diagnostics=(
                             _search_miss_diagnostics(env, compiled_spec, why=bool(params.get("why")))
                             if not page_hits
@@ -779,6 +786,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                 typo_hint=typo_hint,
                 with_units=with_units,
                 with_unit_fields=with_unit_fields,
+                with_unit_windows=with_unit_windows,
                 diagnostics=(
                     _search_miss_diagnostics(env, compiled_spec, why=bool(params.get("why"))) if not page_hits else None
                 ),
@@ -846,6 +854,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
             archive=archive,
             with_units=with_units,
             with_unit_fields=with_unit_fields,
+            with_unit_windows=with_unit_windows,
             lineage_seed_session_id=lineage_seed_session_id,
         )
 
@@ -1035,6 +1044,7 @@ def _try_emit_daemon_session_page(
     unit_source: QueryUnitSource | None,
     with_units: tuple[str, ...],
     with_unit_fields: dict[str, tuple[str, ...]],
+    with_unit_windows: Mapping[str, WithUnitWindow],
     query: str,
     limit: int,
     offset: int,
@@ -1069,6 +1079,7 @@ def _try_emit_daemon_session_page(
         unit_source=unit_source,
         with_units=with_units,
         with_unit_fields=with_unit_fields,
+        with_unit_windows=with_unit_windows,
         tags_to_add=tags_to_add,
         metadata_to_set=metadata_to_set,
         delete_matched=delete_matched,
@@ -1211,6 +1222,7 @@ def _daemon_session_page_supported(
     unit_source: QueryUnitSource | None,
     with_units: tuple[str, ...],
     with_unit_fields: dict[str, tuple[str, ...]],
+    with_unit_windows: Mapping[str, WithUnitWindow],
     tags_to_add: tuple[str, ...],
     metadata_to_set: tuple[tuple[str, str], ...],
     delete_matched: bool,
@@ -1223,7 +1235,7 @@ def _daemon_session_page_supported(
     similar_session_id: str | None,
     retrieval_lane: str,
 ) -> bool:
-    if unit_source is not None or with_units or with_unit_fields:
+    if unit_source is not None or with_units or with_unit_fields or with_unit_windows:
         return False
     if any(params.get(key) for key in ("stats_only", "stats_by", "count_only", "conv_id", "latest", "open_result")):
         return False
@@ -2131,6 +2143,7 @@ def _inject_attached_units(
     archive: ArchiveStore | None,
     with_units: tuple[str, ...],
     with_unit_fields: dict[str, tuple[str, ...]] | None = None,
+    with_unit_windows: Mapping[str, WithUnitWindow] | None = None,
 ) -> None:
     """Attach ``with <units>`` projection rows to each rendered row payload.
 
@@ -2141,7 +2154,9 @@ def _inject_attached_units(
 
     if not with_units or archive is None or not items:
         return
-    attached = fetch_attached_units(archive, session_ids, with_units, unit_fields=with_unit_fields)
+    attached = fetch_attached_units(
+        archive, session_ids, with_units, unit_fields=with_unit_fields, unit_windows=with_unit_windows
+    )
     for item, session_id in zip(items, session_ids, strict=False):
         item["attached_units"] = {unit: list(by_session.get(session_id, ())) for unit, by_session in attached.items()}
 
@@ -2159,6 +2174,7 @@ def _emit_list(
     archive: ArchiveStore | None = None,
     with_units: tuple[str, ...] = (),
     with_unit_fields: dict[str, tuple[str, ...]] | None = None,
+    with_unit_windows: Mapping[str, WithUnitWindow] | None = None,
     lineage_seed_session_id: str | None = None,
 ) -> None:
     lineage_edges: dict[str, tuple[str | None, tuple[str, ...]]] = {}
@@ -2196,6 +2212,7 @@ def _emit_list(
         archive=archive,
         with_units=with_units,
         with_unit_fields=with_unit_fields,
+        with_unit_windows=with_unit_windows,
     )
     envelope: dict[str, object] = {
         "mode": "list",
@@ -2254,6 +2271,7 @@ def _emit_search(
     typo_hint: str | None = None,
     with_units: tuple[str, ...] = (),
     with_unit_fields: dict[str, tuple[str, ...]] | None = None,
+    with_unit_windows: Mapping[str, WithUnitWindow] | None = None,
     diagnostics: QueryMissDiagnosticsPayload | None = None,
 ) -> None:
     items = [
@@ -2270,6 +2288,7 @@ def _emit_search(
         archive=archive,
         with_units=with_units,
         with_unit_fields=with_unit_fields,
+        with_unit_windows=with_unit_windows,
     )
     envelope: dict[str, object] = {
         "mode": "search",

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -2829,6 +2829,13 @@ class QueryUnitAggregateRowPayload(SurfacePayloadModel):
     group_by: str | None = None
     group_key: str | None = None
     count: int
+    metrics: dict[str, float | int | None] | None = None
+    """Named ``| agg count, avg:FIELD, ...`` metric values (polylogue-fnm.1).
+
+    ``None`` for plain ``| group by ... | count`` rows (the legacy count-only
+    aggregate path); populated for rows produced by an ``| agg ...`` stage,
+    keyed by each metric's stable label (``count``, ``avg_word_count``, ...).
+    """
 
     @classmethod
     def from_row(cls, row: ArchiveQueryUnitAggregateRow) -> QueryUnitAggregateRowPayload:

--- a/tests/unit/archive/test_query_agg_metrics.py
+++ b/tests/unit/archive/test_query_agg_metrics.py
@@ -1,0 +1,179 @@
+"""Tests for the ``| agg ...`` named-metric aggregate pipeline stage (polylogue-fnm.1).
+
+``| group by ... | count`` (tested in ``test_query_multi_aggregate.py``) stays
+the exact, fully SQL-pushed aggregate lowerer. ``| agg ...`` adds named
+sum/avg/min/max/percentile reducers over the small set of numeric fields
+declared per unit (``QueryUnitDescriptor.aggregate_metric_fields``), computed
+by fetching predicate-matching rows through the unit's existing row query and
+reducing them in Python -- these tests pin both the parser-level validation
+and the executed numeric results against hand-computed expectations.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from polylogue.archive.query.expression import ExpressionCompileError, parse_unit_source_expression
+from polylogue.archive.query.unit_results import query_unit_rows
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.surfaces.payloads import QueryUnitAggregateEnvelope
+from tests.infra.storage_records import SessionBuilder
+
+
+def _seed_messages(index_db: Path) -> None:
+    (
+        SessionBuilder(index_db, "agg-metrics")
+        .provider("claude-code")
+        .add_message("m1", role="assistant", text="one two three")  # word_count=3
+        .add_message("m2", role="assistant", text="one two three four five")  # word_count=5
+        .add_message("m3", role="assistant", text="one two three four five six seven")  # word_count=7
+        .add_message("m4", role="user", text="short")  # word_count=1, excluded by role filter
+        .save()
+    )
+
+
+def test_agg_stage_computes_sum_avg_min_max_percentile_over_matched_rows(workspace_env: dict[str, Path]) -> None:
+    index_db = workspace_env["archive_root"] / "index.db"
+    _seed_messages(index_db)
+
+    source = parse_unit_source_expression(
+        "messages where role:assistant | agg count, sum:word_count, avg:word_count, min:word_count, "
+        "max:word_count, p50:word_count"
+    )
+    assert source is not None
+
+    with ArchiveStore.open_existing(index_db.parent) as archive:
+        envelope = query_unit_rows(archive, source, query="agg-metrics", limit=20)
+
+    assert isinstance(envelope, QueryUnitAggregateEnvelope)
+    assert len(envelope.items) == 1
+    row = envelope.items[0]
+    assert row.group_key is None
+    assert row.count == 3
+    assert row.metrics == {
+        "count": 3,
+        "sum_word_count": 15.0,
+        "avg_word_count": 5.0,
+        "min_word_count": 3.0,
+        "max_word_count": 7.0,
+        # nearest-rank p50 over sorted [3, 5, 7] -> ceil(0.5*3)=2 -> index 1 -> 5
+        "p50_word_count": 5.0,
+    }
+    assert envelope.pipeline is not None
+    result = cast(dict[str, object], envelope.pipeline["result"])
+    assert result["exact"] is True
+    assert result["sampled_rows"] == 3
+
+
+def test_agg_stage_grouped_by_role_reports_per_group_metrics(workspace_env: dict[str, Path]) -> None:
+    index_db = workspace_env["archive_root"] / "index.db"
+    _seed_messages(index_db)
+
+    source = parse_unit_source_expression(
+        "messages where text:one OR text:short | group by role | agg count, avg:word_count | sort by key asc"
+    )
+    assert source is not None
+
+    with ArchiveStore.open_existing(index_db.parent) as archive:
+        envelope = query_unit_rows(archive, source, query="agg-grouped", limit=20)
+
+    assert isinstance(envelope, QueryUnitAggregateEnvelope)
+    by_group = {row.group_key: row.metrics for row in envelope.items}
+    assert by_group["assistant"] == {"count": 3, "avg_word_count": 5.0}
+    assert by_group["user"] == {"count": 1, "avg_word_count": 1.0}
+
+
+def test_agg_unsupported_field_error_names_unit_metric_and_supported_set() -> None:
+    with pytest.raises(
+        ExpressionCompileError, match=r"agg avg:nope.*message rows.*supported metric fields: word_count"
+    ):
+        parse_unit_source_expression("messages where role:assistant | agg avg:nope")
+
+
+def test_agg_unsupported_function_error_names_supported_functions() -> None:
+    with pytest.raises(ExpressionCompileError, match=r"unsupported .agg. function 'median'"):
+        parse_unit_source_expression("messages where role:assistant | agg median:word_count")
+
+
+def test_agg_unit_without_metric_fields_rejects_field_bearing_metric() -> None:
+    with pytest.raises(ExpressionCompileError, match=r"assertion has no numeric metric fields, only .agg count."):
+        parse_unit_source_expression("assertions where kind:decision | agg avg:nope")
+
+
+def test_agg_stage_cannot_follow_count_or_another_agg_stage() -> None:
+    with pytest.raises(ExpressionCompileError, match=r"agg.*cannot follow"):
+        parse_unit_source_expression("messages where role:assistant | count | agg avg:word_count")
+    with pytest.raises(ExpressionCompileError, match=r"agg.*cannot follow"):
+        parse_unit_source_expression("messages where role:assistant | agg count | agg avg:word_count")
+
+
+def test_agg_stage_must_precede_limit_and_offset() -> None:
+    with pytest.raises(ExpressionCompileError, match=r"agg.*must appear before .limit. and .offset."):
+        parse_unit_source_expression("messages where role:assistant | limit 5 | agg avg:word_count")
+
+
+def test_agg_action_error_rate_metrics_over_is_error(workspace_env: dict[str, Path]) -> None:
+    """``is_error`` is 0/1 on action rows, so sum/avg over it are error count/rate."""
+
+    index_db = workspace_env["archive_root"] / "index.db"
+    (
+        SessionBuilder(index_db, "agg-actions")
+        .provider("claude-code")
+        .git_repository_url("polylogue")
+        .add_message(
+            "turn",
+            role="assistant",
+            text="run tools",
+            blocks=[
+                {
+                    "type": "tool_use",
+                    "tool_name": "Bash",
+                    "tool_id": "bash-ok",
+                    "input": {"command": "pytest -q"},
+                    "semantic_type": "shell",
+                },
+                {
+                    "type": "tool_result",
+                    "tool_id": "bash-ok",
+                    "text": "passed",
+                    "tool_result_is_error": 0,
+                    "tool_result_exit_code": 0,
+                },
+                {
+                    "type": "tool_use",
+                    "tool_name": "Bash",
+                    "tool_id": "bash-fail",
+                    "input": {"command": "pytest -q broken"},
+                    "semantic_type": "shell",
+                },
+                {
+                    "type": "tool_result",
+                    "tool_id": "bash-fail",
+                    "text": "failed",
+                    "tool_result_is_error": 1,
+                    "tool_result_exit_code": 1,
+                },
+            ],
+        )
+        .save()
+    )
+
+    source = parse_unit_source_expression(
+        "actions where tool:Bash | agg count, sum:is_error, avg:is_error, max:exit_code"
+    )
+    assert source is not None
+
+    with ArchiveStore.open_existing(index_db.parent) as archive:
+        envelope = query_unit_rows(archive, source, query="agg-actions", limit=10)
+
+    assert isinstance(envelope, QueryUnitAggregateEnvelope)
+    assert len(envelope.items) == 1
+    metrics = envelope.items[0].metrics
+    assert metrics is not None
+    assert metrics["count"] == 2
+    assert metrics["sum_is_error"] == 1.0
+    assert metrics["avg_is_error"] == 0.5
+    assert metrics["max_exit_code"] == 1.0

--- a/tests/unit/archive/test_with_units_projection.py
+++ b/tests/unit/archive/test_with_units_projection.py
@@ -16,6 +16,7 @@ from polylogue.archive.query.archive_execution import list_summaries_archive
 from polylogue.archive.query.attached_units import fetch_attached_units
 from polylogue.archive.query.expression import (
     ExpressionCompileError,
+    WithUnitWindow,
     compile_expression,
     compile_expression_into,
     parse_expression_ast,
@@ -73,7 +74,7 @@ class TestWithClauseParsing:
         }
 
     def test_split_with_projection_clause_returns_field_map(self) -> None:
-        head, units, fields = split_with_projection_clause(
+        head, units, fields, windows = split_with_projection_clause(
             "repo:polylogue with files(path,action_count), assertions(assertion_id,body_text)"
         )
         assert head == "repo:polylogue"
@@ -82,6 +83,7 @@ class TestWithClauseParsing:
             "file": ("path", "action_count"),
             "assertion": ("assertion_id", "body_text"),
         }
+        assert windows == {}
 
     def test_empty_unit_field_selection_raises(self) -> None:
         with pytest.raises(ExpressionCompileError, match="field selection"):
@@ -321,3 +323,148 @@ class TestAttachBehaviour:
         )
         target = next(summary for summary in summaries if summary.id == session_id)
         assert target.attached_units == {}
+
+
+# ---------------------------------------------------------------------------
+# Bracket predicate/window clause: ``with unit[field:value, last:N]`` (polylogue-fnm.2)
+# ---------------------------------------------------------------------------
+
+
+class TestWithUnitBracketParsing:
+    def test_bracket_predicate_and_window_are_parsed(self) -> None:
+        spec = compile_expression("repo:polylogue with messages[role:user, last:20]")
+        assert spec.with_units == ("message",)
+        assert spec.with_unit_windows == {
+            "message": WithUnitWindow(predicates=(("role", "user"),), window=("last", 20)),
+        }
+
+    def test_bracket_combines_with_field_selection(self) -> None:
+        spec = compile_expression("repo:polylogue with messages(message_id,role,text)[role:user, first:5]")
+        assert spec.with_unit_fields == {"message": ("message_id", "role", "text")}
+        assert spec.with_unit_windows == {
+            "message": WithUnitWindow(predicates=(("role", "user"),), window=("first", 5)),
+        }
+
+    def test_bracket_predicate_only_no_window(self) -> None:
+        spec = compile_expression("repo:polylogue with actions[tool:Bash]")
+        assert spec.with_unit_windows == {
+            "action": WithUnitWindow(predicates=(("tool", "Bash"),), window=None),
+        }
+
+    def test_bracket_window_only_no_predicate(self) -> None:
+        spec = compile_expression("repo:polylogue with messages[last:10]")
+        assert spec.with_unit_windows == {"message": WithUnitWindow(predicates=(), window=("last", 10))}
+
+    def test_bracket_comma_inside_does_not_break_item_splitting(self) -> None:
+        # A literal comma inside ``[...]`` must not be mistaken for the
+        # top-level ``with`` clause's unit-separating comma.
+        spec = compile_expression("repo:polylogue with messages[role:user, last:5], actions[tool:Bash]")
+        assert spec.with_units == ("message", "action")
+        assert spec.with_unit_windows == {
+            "message": WithUnitWindow(predicates=(("role", "user"),), window=("last", 5)),
+            "action": WithUnitWindow(predicates=(("tool", "Bash"),), window=None),
+        }
+
+    def test_unsupported_bracket_field_names_unit_field_and_supported_set(self) -> None:
+        with pytest.raises(
+            ExpressionCompileError,
+            match=r"messages\[nope:\.\.\.\] is not a supported bracket field for messages rows; "
+            r"supported fields: role, type",
+        ):
+            compile_expression("repo:polylogue with messages[nope:1]")
+
+    def test_unsupported_window_key_value_rejected(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="window size must be a positive integer"):
+            compile_expression("repo:polylogue with messages[last:0]")
+        with pytest.raises(ExpressionCompileError, match="window size must be a positive integer"):
+            compile_expression("repo:polylogue with messages[last:abc]")
+
+    def test_two_windows_on_same_unit_rejected(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="can only carry one first:N or last:N window"):
+            compile_expression("repo:polylogue with messages[first:5, last:5]")
+
+    def test_malformed_bracket_clause_rejected(self) -> None:
+        with pytest.raises(ExpressionCompileError, match="not a valid bracket clause"):
+            compile_expression("repo:polylogue with messages[justaword]")
+
+
+class TestWithUnitBracketExecution:
+    def _seed_role_sequence(self, tmp_path: Path) -> str:
+        from tests.infra.storage_records import SessionBuilder
+
+        index_db = tmp_path / "index.db"
+        (
+            SessionBuilder(index_db, "bracket-window")
+            .provider("claude-code")
+            .add_message("m1", role="user", text="one")
+            .add_message("m2", role="assistant", text="two three")
+            .add_message("m3", role="user", text="four five six")
+            .add_message("m4", role="assistant", text="seven")
+            .add_message("m5", role="user", text="eight nine ten eleven")
+            .save()
+        )
+        return "claude-code-session:ext-bracket-window"
+
+    def test_bracket_predicate_filters_attached_rows(self, tmp_path: Path) -> None:
+        session_id = self._seed_role_sequence(tmp_path)
+        with ArchiveStore.open_existing(tmp_path) as archive:
+            attached = fetch_attached_units(
+                archive,
+                [session_id],
+                ["message"],
+                unit_windows={"message": WithUnitWindow(predicates=(("role", "user"),))},
+            )
+        rows = attached["message"][session_id]
+        assert [row["role"] for row in rows] == ["user", "user", "user"]
+        assert [row["text"] for row in rows] == ["one", "four five six", "eight nine ten eleven"]
+
+    def test_last_window_returns_true_tail_not_head(self, tmp_path: Path) -> None:
+        """``last:N`` must return the session's actual tail, not the head of a capped fetch.
+
+        Anti-vacuity: this seeds more than one message so a naive fetch that
+        only ever reads ascending-from-start and then slices ``[-n:]`` would
+        coincidentally look right for a 5-message session; the assertion pins
+        the exact tail-role predicate-filtered rows so a regression to
+        ascending-only fetching (which silently mis-selects the tail once a
+        session exceeds the per-session row cap, verified against the live
+        archive at PR time) would fail this test.
+        """
+        session_id = self._seed_role_sequence(tmp_path)
+        with ArchiveStore.open_existing(tmp_path) as archive:
+            attached = fetch_attached_units(
+                archive,
+                [session_id],
+                ["message"],
+                unit_windows={"message": WithUnitWindow(predicates=(("role", "user"),), window=("last", 2))},
+            )
+        rows = attached["message"][session_id]
+        assert [row["text"] for row in rows] == ["four five six", "eight nine ten eleven"]
+
+    def test_first_window_returns_head(self, tmp_path: Path) -> None:
+        session_id = self._seed_role_sequence(tmp_path)
+        with ArchiveStore.open_existing(tmp_path) as archive:
+            attached = fetch_attached_units(
+                archive,
+                [session_id],
+                ["message"],
+                unit_windows={"message": WithUnitWindow(predicates=(("role", "user"),), window=("first", 2))},
+            )
+        rows = attached["message"][session_id]
+        assert [row["text"] for row in rows] == ["one", "four five six"]
+
+    async def test_bracket_predicate_and_window_compose_end_to_end_via_dsl(self, tmp_path: Path) -> None:
+        session_id = self._seed_role_sequence(tmp_path)
+        spec = compile_expression(f"id:{session_id} with messages[role:user, last:2]")
+        summaries = await list_summaries_archive(
+            spec.to_plan(),
+            archive_root=tmp_path,
+            config=None,
+            with_units=spec.with_units,
+            with_unit_fields=spec.with_unit_fields,
+            with_unit_windows=spec.with_unit_windows,
+        )
+        target = next(summary for summary in summaries if summary.id == session_id)
+        assert [row["text"] for row in target.attached_units["message"]] == [
+            "four five six",
+            "eight nine ten eleven",
+        ]

--- a/tests/unit/cli/test_query_expression.py
+++ b/tests/unit/cli/test_query_expression.py
@@ -1221,7 +1221,7 @@ class TestBooleanQueryExpression:
             parse_unit_source_expression(f"{source} where {descriptor.fields[0].example} | count")
 
     def test_pipeline_rejects_aggregate_sort_before_count(self) -> None:
-        with pytest.raises(ExpressionCompileError, match="require an aggregate `count` stage"):
+        with pytest.raises(ExpressionCompileError, match="requires an aggregate `count` stage"):
             parse_unit_source_expression("messages where role:assistant | group by role | sort by count desc")
 
     def test_pipeline_rejects_aggregate_sort_after_limit(self) -> None:

--- a/webui/src/api/generated.ts
+++ b/webui/src/api/generated.ts
@@ -398,6 +398,9 @@ export type QueryUnitAggregateRowPayload = {
   readonly count: number;
   readonly group_by?: string | null;
   readonly group_key?: string | null;
+  readonly metrics?: ({
+  readonly [key: string]: number | null;
+}) | null;
   readonly unit: "message" | "action" | "block" | "assertion" | "file" | "run" | "observed-event" | "context-snapshot" | "delegation";
 };
 


### PR DESCRIPTION
## Summary

Extends the query pipeline DSL in two ways verified against the live 4.9M-message archive:

- **`| agg count, sum:FIELD, avg:FIELD, min:FIELD, max:FIELD, pNN:FIELD`** — named aggregate metrics beyond the existing `count`-only rollup (polylogue-fnm.1).
- **`with unit[field:value, first:N, last:N]`** — bracket predicates/windows on the `with <units>` attached-row projection clause (polylogue-fnm.2, predicates/windows half only — see Deferred).

## Problem

- `| group by X | count` was the only aggregate the pipeline DSL could compute. Cost/duration/word-count questions had no sum/avg/min/max/percentile path.
- `with <units>` could pick which units and payload fields to attach, but not narrow *which rows* of an attached unit landed on a session — "just this session's last 20 user messages" required over-fetching and client-side filtering.

## Solution

### `| agg ...` (polylogue-fnm.1)

New `QueryUnitAggMetric`/`QueryUnitAggStage` AST nodes and a new `agg` terminal action in `polylogue/archive/query/expression.py`, alongside (not replacing) the existing `count` stage. Metric fields are declared per unit via `QueryUnitDescriptor.aggregate_metric_fields` (`message`: `word_count`; `action`: `is_error`, `exit_code` — error count/rate). Unsupported functions/fields raise a typed error naming the unit, the metric, and the supported set.

The `count`-only aggregate still lowers exactly to SQL via `ArchiveStore.query_unit_counts` (storage/sqlite — out of this PR's lane). Named-metric reduction is **not** SQL-pushed: `_execute_agg_terminal` (`archive/query/unit_results.py`) fetches up to 50,000 predicate-matching rows through the unit's existing row query and reduces them in Python (nearest-rank percentiles), explicitly reporting `result.exact`/`result.sampled_rows` rather than silently treating a bounded sample as a complete aggregate.

### `with unit[...]` (polylogue-fnm.2)

`WithUnitWindow` (equality predicates + optional `first:N`/`last:N`) threaded end-to-end: `expression.py` (parse + `SessionQuerySpec.with_unit_windows`) → `SessionFilter` → `archive_execution.py` → `attached_units.py` (`fetch_attached_units` applies predicates then the window trim) → `cli/archive_query.py`. The Lark grammar file is untouched — the bracket is hand-parsed in the same region as the existing `unit(field, field)` selector and `with`-keyword splitting.

**Bug found and fixed during live-archive verification**: a naive `last:N` that always fetches ascending-from-start and slices `[-n:]` silently returns the wrong rows once a session has more matching rows than `attached_units.py`'s existing per-session/per-page fetch cap (`_MAX_ROWS_PER_SESSION=200`) — the cap captures the session's head, not its tail. Fixed by fetching in descending time order specifically for `last:N` (then restoring ascending order before the trim).

## Alternatives rejected

- Widening the existing `aggregate: Literal["count"]` field in place (as originally scoped) rather than adding a parallel `agg_metrics` field — rejected to avoid destabilizing the `count`/`group`/`sort-by-count` pipeline paths other lanes (mcp/, insights/) depend on; noted as a partial-AC deviation on the bead.
- SQL-pushed numeric aggregates — would require editing `storage/sqlite/archive_tiers/archive.py`, explicitly another lane's scope for this task; the bounded Python-side reduction with honest `exact`/`sampled_rows` reporting was chosen instead.

## Deferred

`polylogue-5ka4` (P2, filed): the render/layout pipeline stage half of fnm.2. It needs a "read-package/render profile" concept that doesn't exist as a first-class thing to bind to yet — the nearest analogues live in `insights/` and other lanes this task's scope excluded — and fabricating a profile registry just to satisfy the acceptance criterion would be a thin/misleading implementation. `duration_ms`/token metric fields for `| agg` are also out of scope (not present in the current row payload projections; adding them needs a `storage/sqlite` change).

## Verification

- `devtools test tests/unit/archive/test_query_agg_metrics.py tests/unit/archive/test_with_units_projection.py tests/unit/archive/test_query_multi_aggregate.py tests/unit/archive/query/test_discovery.py tests/unit/cli/test_query_expression.py tests/unit/devtools/test_query_teaching_surfaces.py` — 710 passed, 1 pre-existing skip.
- `mypy polylogue` (1100 files) clean.
- `devtools render all --check` exits 0.
- **Live-archive cross-check** (`/realm/db/polylogue`, `sqlite3 mode=ro`, read-only throughout):
  - `messages where role:assistant AND session.origin:antigravity-session | agg count, sum:word_count, avg:word_count, min:word_count, max:word_count` → `count=116, sum=41453.0, avg=357.3534482758621, min=26.0, max=2016.0, exact=true`; hand-written SQL (`SELECT COUNT(*), SUM(word_count), AVG(word_count), MIN(word_count), MAX(word_count) FROM messages m JOIN sessions s ... WHERE role='assistant' AND origin='antigravity-session'`) → `116|41453|357.353448275862|26|2016` — exact match.
  - A `role:assistant` query over ~2.8M matching rows correctly reported `exact=false, sampled_rows=50000`.
  - `id:hermes-session:20260507_083312_e0736a with messages[role:user, last:3]` → the 3 rows at message positions 1019/1081/1121, matching hand-written SQL ordering the session's 36 user-role messages by position (this is the case that caught the descending-fetch bug above).
  - End-to-end through the real CLI module (`python -m polylogue.cli`) against a seeded demo archive: `find origin:claude-code-session with messages[role:user, last:2]` correctly attached only `role=user` rows, capped to 2 per session, in the JSON output.
- Not run: full `devtools verify --all`/non-slow suite (background seed attempts on this shared host kept losing to concurrent contention/timeouts; the targeted node set above covers every changed module plus the fallout this PR's earlier commits introduced and fixed — see the "repair full-suite fallout" commit).

Ref polylogue-fnm.1, polylogue-fnm.2
