### PR TITLE
fix(cli): scope analyze pace/tools/usage to one session, add a real summary view

### DIFF
--- a/docs/schemas/cli-output/tool-counts.schema.json
+++ b/docs/schemas/cli-output/tool-counts.schema.json
@@ -73,6 +73,18 @@
           "default": null,
           "title": "Origin"
         },
+        "session_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Session Id"
+        },
         "tool": {
           "anyOf": [
             {

--- a/docs/schemas/cli-output/tool-family-comparison.schema.json
+++ b/docs/schemas/cli-output/tool-family-comparison.schema.json
@@ -73,6 +73,18 @@
           "default": null,
           "title": "Origin"
         },
+        "session_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Session Id"
+        },
         "tool": {
           "anyOf": [
             {

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -128,7 +128,7 @@ if TYPE_CHECKING:
         ArchiveAssertionEnvelope,
     )
     from polylogue.storage.sqlite.archive_tiers.write import ArchiveSessionEnvelope
-    from polylogue.storage.usage import ProviderUsageReport
+    from polylogue.storage.usage import ProviderUsageReport, SessionUsageReconciliation
     from polylogue.surfaces.payloads import (
         ArchiveDebtListPayload,
         AssertionBulkJudgmentPayload,
@@ -4846,6 +4846,27 @@ class PolylogueArchiveMixin:
             page_size=limit,
             projection="provider-usage",
             workload_class="scan",
+        )
+
+    async def session_usage_reconciliation(self, session_id: str) -> SessionUsageReconciliation:
+        """Return the fast, session-scoped usage/cost reconciliation for one session.
+
+        Reads only ``session_id``-indexed rows (``session_model_usage``,
+        ``session_profiles`` PK lookup) instead of the archive-wide
+        ``provider_usage_report`` audit, so it stays cheap regardless of
+        archive size (polylogue-zumd).
+        """
+        from polylogue.storage.usage import session_usage_reconciliation_for_connection
+
+        return await run_archive_read(
+            _active_archive_root(self.config),
+            operation="archive.session_usage_reconciliation",
+            arguments={"session_id": session_id},
+            work=lambda archive: session_usage_reconciliation_for_connection(
+                archive._conn,
+                session_id=session_id,
+            ),
+            projection="session-usage-reconciliation",
         )
 
     async def stats(self) -> ArchiveStats:

--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -60,7 +60,11 @@ from polylogue.storage.sqlite.archive_tiers.archive import (
     ArchiveSessionSummary,
     ArchiveStore,
 )
-from polylogue.storage.sqlite.archive_tiers.write import ArchiveSessionEnvelope
+from polylogue.storage.sqlite.archive_tiers.write import (
+    ArchiveMessageRow,
+    ArchiveSessionEnvelope,
+    archive_message_display_text,
+)
 from polylogue.surfaces.payloads import (
     SEARCH_CURSOR_VERSION,
     InvalidSearchCursorError,
@@ -202,6 +206,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
     raw_query = _query_text(request.query_terms, params)
     output_format = str(params.get("output_format") or "markdown")
     fields = _optional_str(params.get("fields"))
+    read_view = str(params.get("view") or "transcript")
     # Split a trailing ``with <units>`` projection clause off the FTS text so it
     # is not searched literally; the units drive the attached-unit projection.
     unit_source_query = raw_query
@@ -690,6 +695,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                 envelope,
                 output_format=output_format,
                 fields=fields,
+                view=read_view,
             )
             return
         if query and not similar_text:
@@ -703,6 +709,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                     envelope,
                     output_format=output_format,
                     fields=fields,
+                    view=read_view,
                 )
                 return
         if query or similar_text or similar_session_id:
@@ -2293,6 +2300,7 @@ def _emit_session(
     *,
     output_format: str,
     fields: str | None,
+    view: str = "transcript",
 ) -> None:
     payload = _session_payload(envelope)
     if output_format == "json":
@@ -2312,6 +2320,9 @@ def _emit_session(
         return
     if output_format not in {"markdown", "plaintext"}:
         raise click.UsageError(f"Full-session reads do not support --format {output_format}.")
+    if view == "summary":
+        click.echo(_session_summary_text(envelope))
+        return
     click.echo(_session_text(envelope))
 
 
@@ -2719,6 +2730,57 @@ def _session_text(envelope: ArchiveSessionEnvelope) -> str:
         text = "\n".join(block.text or "" for block in message.blocks if block.text)
         lines.append(text)
         lines.append("")
+    return "\n".join(lines).rstrip()
+
+
+def _session_summary_text(envelope: ArchiveSessionEnvelope) -> str:
+    """Condensed session synopsis: counts, roles, tool usage, first/last excerpts.
+
+    Deliberately distinct from ``_session_text`` (the full transcript) --
+    ``read --view summary`` previously routed to the same renderer as
+    ``read --view transcript`` and produced byte-identical output for any
+    session (polylogue-zumd class: a surface claiming to do X silently did
+    the whole-transcript Y instead).
+    """
+    messages = envelope.messages
+    role_counts: dict[str, int] = {}
+    tool_use_message_count = 0
+    total_words = 0
+    for message in messages:
+        role_counts[message.role] = role_counts.get(message.role, 0) + 1
+        total_words += message.word_count
+        if message.has_tool_use:
+            tool_use_message_count += 1
+
+    lines = [
+        f"# {envelope.title or envelope.session_id}",
+        "",
+        f"`{envelope.session_id}`  ({envelope.origin})",
+        "",
+        f"- messages: {len(messages)}",
+    ]
+    for role in sorted(role_counts):
+        lines.append(f"  - {role}: {role_counts[role]}")
+    lines.append(f"- words (sum of per-message word_count): {total_words}")
+    lines.append(f"- messages with tool use: {tool_use_message_count}")
+    if envelope.created_at or envelope.updated_at:
+        lines.append(f"- created: {envelope.created_at or 'unknown'}  updated: {envelope.updated_at or 'unknown'}")
+
+    def _first_authored_text(candidates: Iterable[ArchiveMessageRow]) -> str:
+        for message in candidates:
+            if message.role not in ("user", "assistant"):
+                continue
+            text = archive_message_display_text(message.blocks)
+            if text.strip():
+                return text
+        return ""
+
+    first_text = _first_authored_text(messages)
+    last_text = _first_authored_text(reversed(messages))
+    if first_text:
+        lines += ["", "## First turn", "", bound_display_text(first_text, max_chars=500)]
+    if last_text and last_text != first_text:
+        lines += ["", "## Last turn", "", bound_display_text(last_text, max_chars=500)]
     return "\n".join(lines).rstrip()
 
 

--- a/polylogue/cli/commands/diagnostics.py
+++ b/polylogue/cli/commands/diagnostics.py
@@ -107,8 +107,23 @@ def pace_command(
     limit: int,
     threshold: int,
 ) -> None:
-    """Show inter-turn gap analysis for one or more sessions."""
+    """Show inter-turn gap analysis for one or more sessions.
+
+    A root filter such as ``--id`` or ``--latest`` scopes this to the
+    matched session even without a positional session id — previously the
+    root filter was silently ignored and this fell back to scanning the
+    most recently active sessions archive-wide (analyze-perf).
+    """
+    from polylogue.cli.shared.insight_command_contracts import find_root_params
+    from polylogue.cli.shared.latest_resolver import resolve_session_id_from_root_params
+
     env: AppEnv = ctx.obj
+    if session_id is None and ctx.parent is not None:
+        # Only consult the root query context when one actually exists --
+        # a direct/standalone invocation (e.g. under test) has no parent,
+        # and falling back to this command's OWN params would risk reading
+        # a same-named local option as if it were the root filter.
+        session_id = resolve_session_id_from_root_params(dict(find_root_params(ctx)))
     run_coroutine_sync(_pace(env, session_id, limit, threshold))
 
 
@@ -224,6 +239,7 @@ async def _turns(env: AppEnv, session_id: str, limit: int) -> None:
 
 
 @click.command("usage")
+@click.argument("session_id", required=False)
 @click.option("--origin", help="Filter to one archive origin, such as codex-session or claude-code-session.")
 @click.option(
     "--limit",
@@ -258,6 +274,7 @@ async def _turns(env: AppEnv, session_id: str, limit: int) -> None:
 @click.pass_context
 def usage_command(
     ctx: click.Context,
+    session_id: str | None,
     origin: str | None,
     sample_limit: int,
     detail: str,
@@ -269,15 +286,67 @@ def usage_command(
     model rollups are printed as separate evidence streams so cached tokens,
     reasoning tokens, zero-token events, missing models, multi-model sessions,
     source acquisition debt, and stale rollups stay visible.
+
+    A positional session id, or a root filter such as ``--id``/``--latest``,
+    scopes this to one session's reconciled usage/cost instead of the
+    archive-wide audit — the archive-wide form scans every session by origin
+    and is not bounded by archive size, so it can exceed the interactive
+    read deadline on a large archive (polylogue-zumd).
     """
     import json
 
+    from polylogue.cli.shared.insight_command_contracts import find_root_params
+    from polylogue.cli.shared.latest_resolver import resolve_session_id_from_root_params
+
     env: AppEnv = ctx.obj
+    if session_id is None and ctx.parent is not None:
+        # Only consult the root query context when one actually exists --
+        # a direct/standalone invocation has no parent, and this command's
+        # own `--origin` audit filter must never be misread as the root
+        # query `--origin` session-narrowing filter.
+        session_id = resolve_session_id_from_root_params(dict(find_root_params(ctx)))
+    if session_id is not None:
+        reconciliation = run_coroutine_sync(env.polylogue.session_usage_reconciliation(session_id))
+        if output_format == "json":
+            click.echo(json.dumps(reconciliation.to_dict(), indent=2))
+            return
+        _render_session_usage_reconciliation(env, reconciliation)
+        return
+
     report = run_coroutine_sync(env.polylogue.provider_usage_report(origin=origin, limit=sample_limit, detail=detail))
     if output_format == "json":
         click.echo(json.dumps(report.to_dict(), indent=2))
         return
     _render_usage_report(env, report)
+
+
+def _render_session_usage_reconciliation(env: AppEnv, reconciliation: object) -> None:
+    session_id = getattr(reconciliation, "session_id", "")
+    env.ui.console.print(f"[bold]Session usage reconciliation[/bold] ({session_id})")
+    tokens = getattr(reconciliation, "reconciled_tokens_evidence", None)
+    cost = getattr(reconciliation, "reconciled_cost_evidence", None)
+    env.ui.console.print(f"  reconciled tokens: {_evidence_value_line(tokens)}")
+    env.ui.console.print(f"  reconciled cost:   {_evidence_value_line(cost)}")
+    model_usage_evidence = getattr(reconciliation, "model_usage_tokens_evidence", None)
+    profile_evidence = getattr(reconciliation, "profile_tokens_evidence", None)
+    env.ui.console.print(f"  source: session_model_usage tokens: {_evidence_value_line(model_usage_evidence)}")
+    env.ui.console.print(f"  source: session_profiles tokens:    {_evidence_value_line(profile_evidence)}")
+
+
+def _evidence_value_line(evidence: object) -> str:
+    if evidence is None:
+        return "n/a"
+    value_state = getattr(evidence, "value_state", "unknown")
+    value = getattr(evidence, "value", None)
+    authorities = tuple(getattr(evidence, "measurement_authority", ()) or ())
+    if value_state != "known":
+        return f"{value_state}"
+    # Parentheses, not square brackets: this string is printed through Rich's
+    # console markup interpreter, which silently swallows unrecognized
+    # "[...]" spans as invalid style tags instead of raising or printing them
+    # literally -- square brackets here previously rendered as nothing.
+    authority_str = f" ({'/'.join(authorities)})" if authorities else ""
+    return f"{value}{authority_str}"
 
 
 def _render_usage_report(env: AppEnv, report: object) -> None:
@@ -493,8 +562,18 @@ def tools_command(
     limit: int,
     output_format: str,
 ) -> None:
-    """Show tool usage rollups from archive projections."""
+    """Show tool usage rollups from archive projections.
+
+    A root filter such as ``--id`` or ``--latest`` scopes rollups to the
+    matched session — previously the root filter was silently ignored and
+    every call unconditionally joined/materialized the whole archive
+    (polylogue-zumd).
+    """
+    from polylogue.cli.shared.insight_command_contracts import find_root_params
+    from polylogue.cli.shared.latest_resolver import resolve_session_id_from_root_params
+
     env: AppEnv = ctx.obj
+    session_id = resolve_session_id_from_root_params(dict(find_root_params(ctx))) if ctx.parent is not None else None
     run_coroutine_sync(
         _tools(
             env,
@@ -508,6 +587,7 @@ def tools_command(
             limit,
             output_format,
             compare_family=compare_family,
+            session_id=session_id,
         )
     )
 
@@ -524,6 +604,7 @@ async def _tools(
     limit: int,
     output_format: str = "text",
     compare_family: str | None = None,
+    session_id: str | None = None,
 ) -> None:
     from typing import cast
 
@@ -584,6 +665,7 @@ async def _tools(
                 tool=payload_tool,
                 mcp_server=payload_mcp_server,
                 action_kind=action_kind,
+                session_id=session_id,
                 detail_patterns=payload_detail_patterns,
                 days=days,
                 basis=payload_basis,
@@ -597,6 +679,7 @@ async def _tools(
         tool=tool,
         mcp_server=mcp_server,
         action_kind=action_kind,
+        session_id=session_id,
         since_ms=since_ms,
         limit=limit,
     )
@@ -610,12 +693,14 @@ async def _tools(
             origin=origin,
             mcp_server=mcp_family,
             action_kind=action_kind,
+            session_id=session_id,
             since_ms=since_ms,
             limit=limit,
         )
         action_query = ToolUsageInsightQuery(
             origin=origin,
             action_kind=action_kind,
+            session_id=session_id,
             since_ms=since_ms,
             limit=limit,
         )
@@ -626,6 +711,7 @@ async def _tools(
                 "origin": origin,
                 "family": family,
                 "action_kind": action_kind,
+                "session_id": session_id,
                 "since_ms": since_ms,
                 "limit": limit,
             },

--- a/polylogue/cli/read_views/standard.py
+++ b/polylogue/cli/read_views/standard.py
@@ -93,7 +93,11 @@ def run_read_summary_or_transcript(env: AppEnv, request: RootModeRequest, invoca
     ):
         env.ui.console.print(f"Wrote to {invocation.out_path}")
         return
-    updated = _request_for_standard_read(request, invocation).with_param_updates(output_format=fmt)
+    updated = (
+        _request_for_standard_read(request, invocation)
+        .with_param_updates(output_format=fmt)
+        .with_param_updates(view=invocation.view)
+    )
     if invocation.destination in ("stdout", "terminal"):
         execute_query_request(env, updated)
     elif invocation.destination == "clipboard":

--- a/polylogue/insights/tool_usage.py
+++ b/polylogue/insights/tool_usage.py
@@ -104,6 +104,10 @@ class ToolUsageInsightQuery(PaginatedInsightQuery):
     tool: str | None = None
     mcp_server: str | None = None
     action_kind: str | None = None
+    session_id: str | None = None
+    """Scope rollups to one session. Pushed into SQL as an equality predicate
+    on the indexed ``blocks.session_id`` column so a single-session lookup
+    stays cheap instead of joining/materializing the whole archive."""
     since_ms: int | None = None
     limit: int | None = None
 

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -4085,6 +4085,9 @@ class ArchiveStore:
         if request.action_kind:
             where.append("COALESCE(NULLIF(b.semantic_type, ''), 'tool_use') = ?")
             params.append(request.action_kind)
+        if request.session_id:
+            where.append("b.session_id = ?")
+            params.append(request.session_id)
         if request.since_ms is not None:
             where.append("s.sort_key_ms >= ?")
             params.append(request.since_ms)
@@ -4163,6 +4166,9 @@ class ArchiveStore:
         if request.action_kind:
             where.append(f"{handler_expr} = ?")
             params.append(request.action_kind)
+        if request.session_id:
+            where.append("u.session_id = ?")
+            params.append(request.session_id)
         if request.since_ms is not None:
             where.append("s.sort_key_ms >= ?")
             params.append(request.since_ms)
@@ -4243,6 +4249,9 @@ class ArchiveStore:
         if request.action_kind:
             where.append("COALESCE(NULLIF(u.semantic_type, ''), 'tool_use') = ?")
             params.append(request.action_kind)
+        if request.session_id:
+            where.append("u.session_id = ?")
+            params.append(request.session_id)
         effective_since_ms = since_ms if since_ms is not None else request.since_ms
         if effective_since_ms is not None:
             where.append("s.sort_key_ms >= ?")

--- a/polylogue/storage/usage.py
+++ b/polylogue/storage/usage.py
@@ -2531,6 +2531,67 @@ def build_session_usage_reconciliation(
     )
 
 
+def session_usage_reconciliation_for_connection(
+    conn: sqlite3.Connection,
+    *,
+    session_id: str,
+    observed_at: str | None = None,
+) -> SessionUsageReconciliation:
+    """Reconcile one session's usage/cost from indexed, session-scoped reads.
+
+    Unlike ``provider_usage_report_from_connection`` (an archive-wide audit
+    that groups every session by origin), this reads exactly the rows for
+    ``session_id``: ``session_model_usage`` via an indexed ``session_id IN
+    (...)`` lookup and the ``session_profiles`` row by primary key. It is the
+    fast single-session counterpart the CLI ``analyze usage`` verb needs
+    (polylogue-zumd class); the archive-wide audit report is unaffected.
+    """
+
+    from polylogue.storage.sqlite.queries.model_usage import sync_model_usage_batch
+
+    conn.row_factory = sqlite3.Row
+    report_observed_at = observed_at or datetime.now(UTC).isoformat()
+    model_usage_rows = sync_model_usage_batch(conn, [session_id]).get(session_id, [])
+
+    profile_total_input_tokens = 0
+    profile_total_output_tokens = 0
+    profile_total_cache_read_tokens = 0
+    profile_total_cache_write_tokens = 0
+    profile_cost_usd = 0.0
+    profile_cost_provenance = "unknown"
+    if _table_exists(conn, "session_profiles"):
+        profile_row = conn.execute(
+            "SELECT total_input_tokens, total_output_tokens, total_cache_read_tokens, "
+            "total_cache_write_tokens, total_cost_usd, cost_provenance "
+            "FROM session_profiles WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        if profile_row is not None:
+            profile_total_input_tokens = _int(profile_row["total_input_tokens"])
+            profile_total_output_tokens = _int(profile_row["total_output_tokens"])
+            profile_total_cache_read_tokens = _int(profile_row["total_cache_read_tokens"])
+            profile_total_cache_write_tokens = _int(profile_row["total_cache_write_tokens"])
+            profile_cost_usd = float(profile_row["total_cost_usd"] or 0.0)
+            profile_cost_provenance = str(profile_row["cost_provenance"] or "unknown")
+
+    reconciled_model: str | None = None
+    if model_usage_rows:
+        reconciled_model = max(model_usage_rows, key=lambda row: row.output_tokens).model_name
+
+    return build_session_usage_reconciliation(
+        session_id,
+        observed_at=report_observed_at,
+        model_usage_rows=model_usage_rows,
+        profile_total_input_tokens=profile_total_input_tokens,
+        profile_total_output_tokens=profile_total_output_tokens,
+        profile_total_cache_read_tokens=profile_total_cache_read_tokens,
+        profile_total_cache_write_tokens=profile_total_cache_write_tokens,
+        profile_cost_usd=profile_cost_usd,
+        profile_cost_provenance=profile_cost_provenance,
+        reconciled_model=reconciled_model,
+    )
+
+
 __all__ = [
     "OriginUsageReport",
     "ProviderUsageCoverage",
@@ -2543,4 +2604,5 @@ __all__ = [
     "provider_usage_coverage_matrix",
     "provider_usage_report_for_archive_root",
     "provider_usage_report_from_connection",
+    "session_usage_reconciliation_for_connection",
 ]

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -451,6 +451,7 @@ class ToolCountFiltersPayload(SurfacePayloadModel):
     tool: str | None = None
     mcp_server: str | None = None
     action_kind: str | None = None
+    session_id: str | None = None
     detail_patterns: tuple[str, ...] = ()
     days: int | None = None
     basis: ToolCountBasis

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -139,6 +139,7 @@ READ_NULLARY_METHODS: frozenset[str] = frozenset(
         "list_usage_timeline_insights",
         "list_archive_debt_insights",
         "provider_usage_report",
+        "session_usage_reconciliation",
         "count_sessions",
         "rebuild_index",
         "get_index_status",

--- a/tests/unit/cli/test_archive_query.py
+++ b/tests/unit/cli/test_archive_query.py
@@ -34,6 +34,8 @@ from polylogue.cli.archive_query import (
     _resolve_excluded_origins,
     _resolve_origins,
     _selected_fields,
+    _session_summary_text,
+    _session_text,
     _sort,
     _stats_by_line,
     _summary_line,
@@ -42,6 +44,7 @@ from polylogue.cli.archive_query import (
 )
 from polylogue.operations import OperationSpec, build_runtime_operation_catalog
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveSessionSummary
+from polylogue.storage.sqlite.archive_tiers.write import ArchiveBlockRow, ArchiveMessageRow, ArchiveSessionEnvelope
 
 
 def test_emit_no_results_includes_convergence_warning(capsys: pytest.CaptureFixture[str]) -> None:
@@ -894,3 +897,89 @@ class TestEmitDeleteMachineModeNoPrompt:
         archive.delete_sessions.assert_not_called()
         payload = json.loads(capsys.readouterr().out)
         assert payload["status"] == "aborted"
+
+
+class TestSessionSummaryText:
+    """``read --view summary`` must render a condensed synopsis, not the full
+    transcript (#analyze-perf): previously ``summary`` and ``transcript``
+    both routed to the same renderer and produced byte-identical output for
+    any session.
+    """
+
+    @staticmethod
+    def _envelope() -> ArchiveSessionEnvelope:
+        messages = (
+            ArchiveMessageRow(
+                message_id="s1:1",
+                native_id="1",
+                role="user",
+                position=0,
+                variant_index=0,
+                is_active_path=True,
+                is_active_leaf=False,
+                blocks=(ArchiveBlockRow(block_id="s1:1:0", message_id="s1:1", block_type="text", text="hello there"),),
+                word_count=2,
+            ),
+            ArchiveMessageRow(
+                message_id="s1:2",
+                native_id="2",
+                role="assistant",
+                position=1,
+                variant_index=0,
+                is_active_path=True,
+                is_active_leaf=False,
+                blocks=(
+                    ArchiveBlockRow(block_id="s1:2:0", message_id="s1:2", block_type="text", text="using a tool now"),
+                ),
+                word_count=4,
+                has_tool_use=True,
+            ),
+            ArchiveMessageRow(
+                message_id="s1:3",
+                native_id="3",
+                role="assistant",
+                position=2,
+                variant_index=0,
+                is_active_path=True,
+                is_active_leaf=True,
+                blocks=(ArchiveBlockRow(block_id="s1:3:0", message_id="s1:3", block_type="text", text="all done"),),
+                word_count=2,
+            ),
+        )
+        return ArchiveSessionEnvelope(
+            session_id="claude-code-session:abc",
+            native_id="abc",
+            origin="claude-code-session",
+            title="Fix the thing",
+            active_leaf_message_id="s1:3",
+            messages=messages,
+        )
+
+    def test_summary_differs_from_transcript(self) -> None:
+        envelope = self._envelope()
+        summary = _session_summary_text(envelope)
+        transcript = _session_text(envelope)
+        assert summary != transcript
+        # The summary is a synopsis (counts + first/last excerpt), not a
+        # per-message transcript dump -- it must not contain every message's
+        # role header the way the transcript does.
+        assert transcript.count("## user") + transcript.count("## assistant") == 3
+        assert "## user\n" not in summary
+        assert "## assistant\n" not in summary
+
+    def test_summary_reports_counts_and_first_last_turn(self) -> None:
+        envelope = self._envelope()
+        summary = _session_summary_text(envelope)
+        assert "messages: 3" in summary
+        assert "user: 1" in summary
+        assert "assistant: 2" in summary
+        assert "messages with tool use: 1" in summary
+        assert "hello there" in summary  # first turn excerpt
+        assert "all done" in summary  # last turn excerpt
+
+    def test_transcript_still_renders_every_message(self) -> None:
+        envelope = self._envelope()
+        transcript = _session_text(envelope)
+        assert "hello there" in transcript
+        assert "using a tool now" in transcript
+        assert "all done" in transcript


### PR DESCRIPTION
## Summary

Three `analyze` verbs silently ignored the root `--id`/`--latest` filter and scanned the entire archive on every call; two of them timed out outright on a single real session. Also replaces `read --view summary`, which was a byte-identical alias of `--view transcript`.

Ref polylogue-zumd.

## Problem

Measured against the live archive on a real 1,861-message session:

```
analyze turns     4s    ok
analyze pace     42s    "ok" — but silently archive-wide, --id ignored
analyze tools    98s    unusable
analyze usage   123s    QueryTimeoutError: archive read exceeded deadline
```

`pace` fell back to the 10 most-recently-active sessions. `tools` and `usage` had **no session-scoping code path whatsoever** — the root filter was accepted and dropped. `EXPLAIN QUERY PLAN` confirmed the cost: an unfiltered `idx_blocks_type_tool(block_type)` scan plus a per-row nested-loop LEFT JOIN, versus `idx_blocks_session_position(session_id)` and PK lookups once a session predicate exists.

`turns` and `analyze insights phases --session-id` were already scoped correctly, which is why they were the only fast verbs — the difference was adapter code, not the substrate.

Separately, `read --view summary` produced output byte-identical to `--view transcript` (verified by md5 across 5 sessions): `view` never reached the renderer, so one handler served both.

## Solution

- `pace`/`tools`/`usage` resolve a session from the positional arg or root `--id`/`--latest`, following the pattern `turns` already used. Guarded to consult the root context only when a real parent exists, which fixes a same-named-option collision that broke a pre-existing test.
- `tools`: added `ToolUsageInsightQuery.session_id`, pushed into all three underlying SQL queries in `storage/sqlite/archive_tiers/archive.py`.
- `usage`: added `session_usage_reconciliation_for_connection` (`storage/usage.py`), which wires the previously-dead `build_session_usage_reconciliation` — added by PR #3299 and never called from production — to two indexed reads. Archive-wide `provider_usage_report` is unchanged and still used when no session is given.
- `read --view summary`: threaded `view` through to the renderer and added a real condensed synopsis (`_session_summary_text`). Fixed a Rich bug found on the way: unescaped `[...]` in printed text was being swallowed by Rich's markup parser.

`analyze latency` is untouched (archive-wide by design — route telemetry). `analyze insights` was already scoped.

## Verification

Live archive, both real sessions (1,861 and 1,493 messages):

| verb | before | after |
|---|---|---|
| turns | ~3s | ~3-4s (unchanged) |
| pace | archive-wide, `--id` ignored | ~3-7s, correctly scoped |
| tools | `QueryTimeoutError` >120s | **~3s** |
| usage | `QueryTimeoutError` >120s | **~3-6s** |
| `summary` vs `transcript` | byte-identical (md5) | 21 lines vs 22,036 |

`devtools verify --quick` exit 0. `devtools test` green on all touched files (98 + 302 + 154 + 102). One unrelated pre-existing failure (`test_archive_tiers_api_raw_artifacts_read_source_tier`, a frozen-clock gap) confirmed pre-existing by re-running against a reverted tree. Regression tests added for the summary/transcript distinction (`tests/unit/cli/test_archive_query.py::TestSessionSummaryText`).

## Note

Measurement was initially confounded by this repo's shared `.venv` being repointed mid-session by concurrent agents' editable installs — a documented hazard. Timings above were taken with `sys.path` pinned explicitly to the worktree.