### PR TITLE
fix(sources): stop discarding reasoning/thinking content on two origins

### DIFF
--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -3367,12 +3367,12 @@ files:
     target: polylogue/sources/parsers/base.py
     owner: stable
   - path: polylogue/sources/parsers/base_models.py
-    loc: 446
+    loc: 458
     target: polylogue/sources/parsers/base_models.py
     owner: stable
     cross_cut: { lifecycle: model }
   - path: polylogue/sources/parsers/base_support.py
-    loc: 313
+    loc: 329
     target: polylogue/sources/parsers/base_support.py
     owner: stable
   - path: polylogue/sources/parsers/beads.py
@@ -3428,7 +3428,7 @@ files:
     target: polylogue/sources/parsers/claude/orchestration.py
     owner: stable
   - path: polylogue/sources/parsers/codex.py
-    loc: 2481
+    loc: 2571
     target: polylogue/sources/parsers/codex.py
     owner: stable
   - path: polylogue/sources/parsers/codex_state.py
@@ -3737,7 +3737,7 @@ files:
     target: polylogue/storage/fts/sql.py
     owner: stable
   - path: polylogue/storage/hydrators.py
-    loc: 255
+    loc: 256
     target: polylogue/storage/hydrators.py
     owner: storage-root
     reason: storage-root cross-cutting helper
@@ -4005,7 +4005,7 @@ files:
     target: polylogue/storage/runtime/archive/__init__.py
     owner: stable
   - path: polylogue/storage/runtime/archive/records.py
-    loc: 408
+    loc: 413
     target: polylogue/storage/runtime/archive/records.py
     owner: stable
   - path: polylogue/storage/runtime/raw/__init__.py
@@ -4120,7 +4120,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/archive_plan.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/archive_tiers_specs.py
-    loc: 131
+    loc: 133
     target: polylogue/storage/sqlite/archive_tiers/archive_tiers_specs.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/bootstrap.py
@@ -4148,7 +4148,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/embeddings.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/index.py
-    loc: 2065
+    loc: 2105
     target: polylogue/storage/sqlite/archive_tiers/index.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/index_convergence.py
@@ -4224,7 +4224,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/user_write.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/write.py
-    loc: 6192
+    loc: 6194
     target: polylogue/storage/sqlite/archive_tiers/write.py
     owner: stable
   - path: polylogue/storage/sqlite/async_sqlite.py
@@ -4256,7 +4256,7 @@ files:
     target: polylogue/storage/sqlite/finding_provenance.py
     owner: stable
   - path: polylogue/storage/sqlite/lifecycle.py
-    loc: 635
+    loc: 658
     target: polylogue/storage/sqlite/lifecycle.py
     owner: stable
   - path: polylogue/storage/sqlite/maintenance.py
@@ -4292,7 +4292,7 @@ files:
     target: polylogue/storage/sqlite/queries/artifacts.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/attachment_blocks.py
-    loc: 57
+    loc: 58
     target: polylogue/storage/sqlite/queries/attachment_blocks.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/attachment_mutations.py
@@ -4324,7 +4324,7 @@ files:
     target: polylogue/storage/sqlite/queries/mappers.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/mappers_archive.py
-    loc: 286
+    loc: 287
     target: polylogue/storage/sqlite/queries/mappers_archive.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/mappers_insight_aggregates.py

--- a/polylogue/sources/parsers/base_models.py
+++ b/polylogue/sources/parsers/base_models.py
@@ -91,6 +91,18 @@ class ParsedContentBlock(BaseModel):
     tool_input: Mapping[str, object] | None = None
     media_type: str | None = None
     metadata: dict[str, object] | None = None
+    # polylogue-vf9x: provider-issued cryptographic attestation for a THINKING
+    # block (Claude's extended-thinking `signature`; Gemini's
+    # `thoughtSignatures` are the same construct under a different name).
+    # Since roughly 2026-06 Anthropic ships thinking blocks with an EMPTY
+    # `thinking` body plus this signature only -- text is genuinely absent
+    # from the wire, not merely unparsed. Recorded so the fact that the model
+    # reasoned survives even when no text does; deliberately excluded from
+    # `_block_content_hash`/lineage prefix signatures (write.py) because the
+    # provider re-signs on every replay, so including it would break
+    # citation-anchor and fork-prefix matching for otherwise-identical
+    # replayed content.
+    signature: str | None = None
     # Structured tool-result outcome (keystone): captured from the source's
     # own outcome fields (Claude toolUseResult.is_error, command exit codes)
     # so in-session outcomes are readable instead of regex-guessed from text.

--- a/polylogue/sources/parsers/base_support.py
+++ b/polylogue/sources/parsers/base_support.py
@@ -33,8 +33,24 @@ def content_blocks_from_segments(content: object) -> list[ParsedContentBlock]:
         seg_type = seg.get("type", "text")
         if seg_type == "thinking":
             text = seg.get("thinking") or seg.get("text") or ""
-            if text:
-                blocks.append(ParsedContentBlock(type=BlockType.THINKING, text=text))
+            signature = seg.get("signature")
+            # polylogue-vf9x: since roughly 2026-06 the wire ships thinking
+            # blocks with an empty `thinking` body and only a `signature` --
+            # the reasoning genuinely occurred but its text is not on the
+            # wire (verified against raw ~/.claude/projects JSONL: Feb-2026
+            # sessions carry non-empty text, Jul-2026 sessions are 100%
+            # empty-body/signature-only). Previously this `if text:` guard
+            # dropped the block outright, silently zeroing thinking_count
+            # and making the archive look like reasoning stopped -- record
+            # the block regardless so the fact that the model reasoned here
+            # (and the signature, for provenance) survives even without text.
+            blocks.append(
+                ParsedContentBlock(
+                    type=BlockType.THINKING,
+                    text=text or None,
+                    signature=signature if isinstance(signature, str) and signature else None,
+                )
+            )
         elif seg_type == "tool_use":
             tool_name = seg.get("name")
             tool_id = seg.get("id")

--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -1728,6 +1728,86 @@ def _codex_tool_message(
     return None
 
 
+def _codex_reasoning_joined_text(value: object) -> str | None:
+    """Join recoverable text out of a Codex ``reasoning`` record's `summary`/`content`.
+
+    Both fields share the same OpenAI Responses-API shape: either a bare
+    string, or a list of ``{"type": "summary_text"|"reasoning_text", "text": ...}``
+    (or equivalent) dicts. Anything else (encrypted ciphertext, missing
+    fields) yields no text -- that is a genuine absence, handled by the
+    caller, not an extraction bug here.
+    """
+    if isinstance(value, str):
+        return value or None
+    if not isinstance(value, list):
+        return None
+    parts: list[str] = []
+    for item in value:
+        text: object = item.get("text") if isinstance(item, dict) else item
+        if isinstance(text, str) and text:
+            parts.append(text)
+    return "\n\n".join(parts) if parts else None
+
+
+def _codex_reasoning_message(
+    record: dict[str, object],
+    *,
+    index: int,
+    position: int,
+    timestamp_fallback: str | int | float | None = None,
+) -> ParsedMessage | None:
+    """Materialize a Codex ``reasoning`` response_item as a THINKING-block message.
+
+    polylogue-vf9x: previously this record type was read only by
+    ``_compact_response_payload``'s generic session_event compactor, which
+    has no `reasoning`-specific branch -- neither `summary` nor `content` was
+    read at all (not merely char-counted: the emitted session_event carries
+    only ``{source_index, type}``), so every one of the measured 1,182,071
+    Codex reasoning records in this operator's raw corpus contributed zero
+    words to the archive, unreachable from FTS/search even in principle.
+
+    `summary` (OpenAI's human-readable condensation) is present with
+    recoverable text on ~24% of records measured; `content` (the full trace)
+    is essentially always null on the wire -- Codex encrypts it into
+    `encrypted_content` instead, which this archive cannot decrypt and does
+    not attempt to store. Even when neither carries text, the message is
+    still recorded (block text=None) so the FACT that the model reasoned
+    here survives -- the same rationale as Claude Code's empty-body thinking
+    blocks (base_support.py).
+
+    Routed into `messages`/`blocks` (not left as a session_event only) so
+    reasoning joins the normal content tree: FTS coverage, `thinking_count`,
+    and the `material_origin`/`BlockType.THINKING` vocabulary every other
+    origin's reasoning content already uses.
+    """
+    if _record_type(record) != "reasoning":
+        return None
+    payload = _record_payload(record)
+    summary_text = _codex_reasoning_joined_text(payload.get("summary"))
+    content_text = _codex_reasoning_joined_text(payload.get("content"))
+    blocks: list[ParsedContentBlock] = []
+    if summary_text:
+        blocks.append(ParsedContentBlock(type=BlockType.THINKING, text=summary_text))
+    if content_text and content_text != summary_text:
+        blocks.append(ParsedContentBlock(type=BlockType.THINKING, text=content_text))
+    if not blocks:
+        blocks.append(ParsedContentBlock(type=BlockType.THINKING, text=None))
+    combined_text = "\n\n".join(t for t in (summary_text, content_text) if t) or None
+    timestamp = _iso_or_none(_record_timestamp(record) or timestamp_fallback)
+    return ParsedMessage(
+        provider_message_id=f"reasoning-{index}",
+        role=Role.ASSISTANT,
+        text=combined_text,
+        timestamp=timestamp,
+        position=position,
+        variant_index=0,
+        is_active_path=True,
+        blocks=blocks,
+        message_type=MessageType.THINKING,
+        material_origin=MaterialOrigin.ASSISTANT_AUTHORED,
+    )
+
+
 def _mcp_invocation_tool_name(invocation: dict[str, object]) -> str:
     server = _string_value(invocation.get("server"))
     tool = _string_value(invocation.get("tool"))
@@ -2255,6 +2335,16 @@ def _parse_records(records: Iterable[object], fallback_id: str) -> ParsedSession
                     messages.append(event_message)
                     message_position += 1
                     latest_message_timestamp = _newer_timestamp(latest_message_timestamp, event_message.timestamp)
+                reasoning_message = _codex_reasoning_message(
+                    inner,
+                    index=idx,
+                    position=message_position,
+                    timestamp_fallback=timestamp_fallback,
+                )
+                if reasoning_message is not None:
+                    messages.append(reasoning_message)
+                    message_position += 1
+                    latest_message_timestamp = _newer_timestamp(latest_message_timestamp, reasoning_message.timestamp)
                 mcp_messages = _codex_mcp_tool_call_messages(
                     inner,
                     index=idx,

--- a/polylogue/storage/hydrators.py
+++ b/polylogue/storage/hydrators.py
@@ -111,6 +111,7 @@ def message_from_record(
                 "tool_result_is_error": b.tool_result_is_error,
                 "tool_result_exit_code": b.tool_result_exit_code,
                 "tool_result_outcome_unknown_reason": b.tool_result_outcome_unknown_reason,
+                "signature": b.signature,
             }
         )
 

--- a/polylogue/storage/runtime/archive/records.py
+++ b/polylogue/storage/runtime/archive/records.py
@@ -137,6 +137,11 @@ class BlockRecord(BaseModel):
     # (see core.enums.ToolResultUnknownReason). NULL means either the
     # outcome IS known, or this read path did not select the column.
     tool_result_outcome_unknown_reason: str | None = None
+    # polylogue-vf9x (v49): provider-issued cryptographic attestation for a
+    # THINKING block (Claude's extended-thinking signature; Gemini's
+    # thoughtSignatures are the same construct). NULL when the wire carried
+    # none, or this read path did not select the column.
+    signature: str | None = None
 
     @field_validator("type", mode="before")
     @classmethod

--- a/polylogue/storage/sqlite/archive_tiers/archive_tiers_specs.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive_tiers_specs.py
@@ -2,7 +2,7 @@
 
 Defines the single source of truth for:
   - messages table structure (29 writable columns + 1 GENERATED message_id)
-  - blocks table structure (14 writable columns + 1 GENERATED block_id)
+  - blocks table structure (16 writable columns + 1 GENERATED block_id)
   - Other key tables (sessions, session_events, etc.)
 
 Each spec drives INSERT/SELECT generation and typed row extraction.
@@ -84,7 +84,8 @@ def _make_blocks_spec() -> TableColumnSpec:
     The blocks table structure (from schema):
       session_id, message_id, position, block_type, text, tool_name, tool_id,
       tool_input, semantic_type, media_type, language, tool_result_is_error,
-      tool_result_exit_code, content_hash
+      tool_result_exit_code, tool_result_outcome_unknown_reason, signature,
+      content_hash
 
     GENERATED (not writable):
       block_id, tool_command, tool_path, search_text, tool_detail_text
@@ -105,6 +106,7 @@ def _make_blocks_spec() -> TableColumnSpec:
         ColumnSpec("tool_result_is_error", "INTEGER"),
         ColumnSpec("tool_result_exit_code", "INTEGER"),
         ColumnSpec("tool_result_outcome_unknown_reason", "TEXT"),
+        ColumnSpec("signature", "TEXT"),
         ColumnSpec("content_hash", "BLOB"),
         ColumnSpec("tool_command", "TEXT", is_generated=True),
         ColumnSpec("tool_path", "TEXT", is_generated=True),

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -129,7 +129,36 @@ from polylogue.storage.sqlite.delegation_facts import delegation_facts_insert_sq
 #
 # Both depend on parser/pricing semantics to populate/repair existing rows --
 # SEMANTIC_REPARSE, matching the v42/v44/v45/v46/v47/v48 precedent above.
-INDEX_SCHEMA_VERSION = 49
+#
+# polylogue-vf9x: v50 adds blocks.signature (nullable TEXT) and fixes two
+# independent reasoning/thinking-content-loss defects found via a full-corpus
+# audit:
+#   - Claude Code (base_support.py `content_blocks_from_segments`): since
+#     roughly 2026-06 the wire ships THINKING segments with an empty
+#     `thinking` body and a `signature` only. An `if text:` guard dropped the
+#     whole block, silently zeroing `thinking_count` archive-wide for every
+#     2026-06+ session -- a false "reasoning declined" signal, not a real
+#     absence. The block is now always recorded (text=NULL when the wire
+#     carries none, signature captured when present).
+#   - Codex (codex.py): standalone `reasoning` response_item records were
+#     read only by the generic session_event compactor, which has no
+#     `reasoning`-specific branch -- summary/content were never read at all
+#     (not merely char-counted), so 100% of Codex reasoning text was
+#     discarded and unreachable from FTS/search. `reasoning` records are now
+#     materialized as a THINKING-block message (summary text -- the ~24%
+#     recoverable case -- or content text when present; text=NULL when only
+#     encrypted_content survives).
+# Both are pure parser-semantics changes over the same already-declared
+# `blocks.block_type='thinking'` vocabulary plus one additive nullable
+# column -- the v42/v44/v45/v46/v48/v49 "values depend on parser semantics,
+# no clone-safe SQL delta" precedent. `signature` is deliberately excluded
+# from `_block_content_hash` and the lineage prefix signature (write.py)
+# because providers re-sign on every replay; including it would break
+# citation-anchor and fork-prefix matching for otherwise-identical replayed
+# content. Resolving existing rows (recovering historical thinking/reasoning
+# content) requires `polylogue ops reset --index && polylogued run` --
+# deliberately NOT executed by this declaration.
+INDEX_SCHEMA_VERSION = 50
 
 # polylogue-v6i3: shared WHEN-clause fragment gating the blocks_command_trigram
 # trigger BODIES on the same dedicated bulk-build guard row messages_fts's
@@ -436,6 +465,17 @@ CREATE TABLE IF NOT EXISTS blocks (
     -- an unknown reason".
     tool_result_outcome_unknown_reason TEXT
         CHECK ({nullable_check("tool_result_outcome_unknown_reason", ToolResultUnknownReason)}),
+    -- polylogue-vf9x (v49): provider-issued cryptographic attestation for a
+    -- THINKING block (Claude's extended-thinking `signature`; Gemini's
+    -- `thoughtSignatures` are the same construct). Populated whenever the
+    -- wire carries one -- notably including the empty-body thinking blocks
+    -- Claude Code has shipped since ~2026-06, where this is the only
+    -- surviving evidence besides the block's existence. Deliberately
+    -- excluded from content_hash below and from the lineage prefix
+    -- signature (write.py): providers re-sign on every replay, so including
+    -- it would break fork-prefix/citation-anchor matching for otherwise-
+    -- identical replayed content.
+    signature       TEXT,
     -- svfj: the citation anchor atom. Hashes canonical block EVIDENCE only
     -- (type, text, tool_name, canonical tool_input, semantic/media/language,
     -- is_error, exit_code) -- deliberately EXCLUDING session_id/message_id/

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -1891,6 +1891,7 @@ def _build_block_rows(
             is_error = getattr(block, "is_error", None)
             exit_code = getattr(block, "exit_code", None)
             outcome_unknown_reason = _enum_value(block.outcome_unknown_reason)
+            signature = getattr(block, "signature", None)
             # Tuple built in order defined by spec.writable_columns
             rows.append(
                 (
@@ -1908,6 +1909,7 @@ def _build_block_rows(
                     _sqlite_bool(is_error),
                     exit_code,
                     outcome_unknown_reason,
+                    _sqlite_text(signature),
                     _block_content_hash(
                         block_type=block_type.value,
                         text=block.text,
@@ -1946,7 +1948,7 @@ def _write_blocks(
     """Write block rows using table-driven column specification.
 
     The blocks table column spec (archive_tiers_specs.BLOCKS_SPEC) defines:
-      - writable_columns: the ordered list of columns to INSERT (14 total)
+      - writable_columns: the ordered list of columns to INSERT (16 total)
       - The column names and placeholders are generated from the spec
       - The tuple order is derived from the spec's writable_columns order
 

--- a/polylogue/storage/sqlite/lifecycle.py
+++ b/polylogue/storage/sqlite/lifecycle.py
@@ -478,6 +478,29 @@ INDEX_DELTA_DECLARATIONS: tuple[IndexDeltaDeclaration, ...] = (
         # `polylogue ops reset --index && polylogued run`.
         classes=(DerivedDeltaClass.SEMANTIC_REPARSE,),
     ),
+    IndexDeltaDeclaration(
+        version=50,
+        # polylogue-vf9x: adds blocks.signature (nullable TEXT) and fixes two
+        # independent reasoning/thinking-content-loss defects (see index.py's
+        # v50 header comment for the full writeup):
+        #   - Claude Code: an `if text:` guard in base_support.py's
+        #     `content_blocks_from_segments` dropped every THINKING segment
+        #     whose wire body is empty-string-plus-signature-only -- the
+        #     shape Claude has shipped since ~2026-06 -- silently zeroing
+        #     `thinking_count` for every affected session.
+        #   - Codex: standalone `reasoning` response_item records were read
+        #     only by the generic session_event compactor (no
+        #     `reasoning`-specific branch existed), so summary/content text
+        #     was never read into any surface at all.
+        # Both changes require re-parsing already-acquired raw evidence to
+        # recover the previously-dropped/discarded text, so this is the same
+        # v42/v44/v45/v46/v48/v49 "values depend on parser semantics" shape --
+        # not a free clone-safe fast-forward, even though `signature` is a
+        # real additive column. `polylogue ops reset --index && polylogued
+        # run` is required to recover historical thinking/reasoning content;
+        # deliberately NOT executed by this declaration.
+        classes=(DerivedDeltaClass.SEMANTIC_REPARSE,),
+    ),
 )
 
 

--- a/polylogue/storage/sqlite/queries/attachment_blocks.py
+++ b/polylogue/storage/sqlite/queries/attachment_blocks.py
@@ -32,7 +32,8 @@ async def get_blocks(
             semantic_type,
             tool_result_is_error,
             tool_result_exit_code,
-            tool_result_outcome_unknown_reason
+            tool_result_outcome_unknown_reason,
+            signature
         FROM blocks
         WHERE message_id IN ({placeholders})
         ORDER BY message_id, position

--- a/polylogue/storage/sqlite/queries/mappers_archive.py
+++ b/polylogue/storage/sqlite/queries/mappers_archive.py
@@ -129,6 +129,7 @@ def _row_to_content_block(row: sqlite3.Row) -> BlockRecord:
         tool_result_is_error=_row_int(row, "tool_result_is_error"),
         tool_result_exit_code=_row_int(row, "tool_result_exit_code"),
         tool_result_outcome_unknown_reason=_row_text(row, "tool_result_outcome_unknown_reason"),
+        signature=_row_text(row, "signature"),
     )
 
 

--- a/tests/unit/core/test_models.py
+++ b/tests/unit/core/test_models.py
@@ -367,6 +367,7 @@ class TestMessageFromRecord:
                 "media_type": None,
                 "metadata": {"path": "/workspace/polylogue/README.md"},
                 "semantic_type": "file_read",
+                "signature": None,
             }
         ]
 

--- a/tests/unit/sources/test_parsers_base.py
+++ b/tests/unit/sources/test_parsers_base.py
@@ -110,6 +110,41 @@ def test_content_blocks_from_segments_classifies_code_and_tool_blocks() -> None:
     assert blocks[5].media_type == "application/pdf"
 
 
+def test_content_blocks_from_segments_keeps_empty_body_thinking_with_signature() -> None:
+    """polylogue-vf9x: since ~2026-06 Claude ships THINKING segments with an
+    empty ``thinking`` body and a ``signature`` only (real wire shape,
+    verified against raw ~/.claude/projects JSONL). Previously an
+    ``if text:`` guard dropped the block entirely, silently zeroing
+    ``thinking_count`` and making the archive look like reasoning stopped.
+    The block must still be recorded -- text=None, signature preserved --
+    so the fact that the model reasoned here survives.
+    """
+    blocks = content_blocks_from_segments(
+        [
+            {
+                "type": "thinking",
+                "thinking": "",
+                "signature": "CAIStwIKhwEIEBgCKkAJIkle5IARlxfdMsvM8IvhleRSuJ61Xvgm",
+            },
+        ]
+    )
+
+    assert len(blocks) == 1
+    assert blocks[0].type == "thinking"
+    assert blocks[0].text is None
+    assert blocks[0].signature == "CAIStwIKhwEIEBgCKkAJIkle5IARlxfdMsvM8IvhleRSuJ61Xvgm"
+
+
+def test_content_blocks_from_segments_keeps_thinking_with_neither_text_nor_signature() -> None:
+    """Degenerate wire shape (no signature either) still preserves the block."""
+    blocks = content_blocks_from_segments([{"type": "thinking", "thinking": ""}])
+
+    assert len(blocks) == 1
+    assert blocks[0].type == "thinking"
+    assert blocks[0].text is None
+    assert blocks[0].signature is None
+
+
 def test_tool_result_web_search_knowledge_items_become_search_result_constructs() -> None:
     """polylogue-zocm GAP 2: web_search tool_result content carries retrieved
     ``{type: knowledge, ...}`` entries the provider read but did not

--- a/tests/unit/sources/test_parsers_codex.py
+++ b/tests/unit/sources/test_parsers_codex.py
@@ -432,6 +432,87 @@ class TestMessageParsing:
         result = parse(payload, "fallback")
         assert len(result.messages) == 1
 
+    def test_reasoning_summary_text_becomes_thinking_block(self) -> None:
+        """polylogue-vf9x: real wire shape (anonymized from an operator rollout).
+
+        Codex ships a standalone ``reasoning`` response_item with a
+        human-readable ``summary`` (a list of ``summary_text`` parts) and an
+        essentially-always-null ``content``, with the full trace only
+        recoverable as ciphertext in ``encrypted_content``. Previously this
+        record was read only by the generic session_event compactor -- which
+        has no reasoning-specific branch -- so the summary text was silently
+        discarded and never reached FTS/search.
+        """
+        payload = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "**Preparing to analyze git changes**"}],
+                    "content": None,
+                    "encrypted_content": "gAAAAABozSvL2wVUn4Ixsm34" * 4,
+                },
+            },
+        ]
+        result = parse(payload, "fallback")
+
+        thinking_messages = [m for m in result.messages if m.message_type is MessageType.THINKING]
+        assert len(thinking_messages) == 1
+        message = thinking_messages[0]
+        assert message.role == Role.ASSISTANT
+        assert message.material_origin is MaterialOrigin.ASSISTANT_AUTHORED
+        assert message.text == "**Preparing to analyze git changes**"
+        assert len(message.blocks) == 1
+        assert message.blocks[0].type == BlockType.THINKING
+        assert message.blocks[0].text == "**Preparing to analyze git changes**"
+
+    def test_reasoning_with_only_encrypted_content_still_recorded(self) -> None:
+        """No recoverable text (summary absent, content null) -- the block
+        still exists with text=None so the FACT that reasoning occurred
+        survives, matching the empty-body Claude Code thinking fix.
+        """
+        payload = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "reasoning",
+                    "summary": [],
+                    "content": None,
+                    "encrypted_content": "gAAAAABozSvL2wVUn4Ixsm34" * 4,
+                },
+            },
+        ]
+        result = parse(payload, "fallback")
+
+        thinking_messages = [m for m in result.messages if m.message_type is MessageType.THINKING]
+        assert len(thinking_messages) == 1
+        message = thinking_messages[0]
+        assert message.text is None
+        assert len(message.blocks) == 1
+        assert message.blocks[0].type == BlockType.THINKING
+        assert message.blocks[0].text is None
+
+    def test_reasoning_content_text_used_when_present(self) -> None:
+        """`content` (the full trace) is read too, when the wire carries it
+        as plain text rather than encrypted ciphertext."""
+        payload = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "reasoning",
+                    "summary": [{"type": "summary_text", "text": "short summary"}],
+                    "content": [{"type": "reasoning_text", "text": "the full reasoning trace"}],
+                },
+            },
+        ]
+        result = parse(payload, "fallback")
+
+        thinking_messages = [m for m in result.messages if m.message_type is MessageType.THINKING]
+        assert len(thinking_messages) == 1
+        message = thinking_messages[0]
+        block_texts = [b.text for b in message.blocks]
+        assert block_texts == ["short summary", "the full reasoning trace"]
+
     def test_multiple_content_blocks(self) -> None:
         payload = [
             {


### PR DESCRIPTION
## Summary

Reasoning/thinking content was invisible in the archive on both coding origins, via two independent mechanisms. Both are fixed here: Claude Code's empty-body thinking blocks are now recorded instead of dropped, and Codex's `reasoning` records are now materialized as real content instead of being read by nothing at all.

## Problem

**The loss is shaped like a finding, not a gap.** Live archive query, `blocks.block_type='thinking'` grouped by month for `claude-code-session`:

| month | sessions | thinking_blocks |
|---|---|---|
| 2026-07 | 1,088 | **0** |
| 2026-06 | 788 | **0** |
| 2026-05 | 2,107 | 50,394 |
| 2026-04 | 854 | 9,859 |
| 2026-03 | 2,357 | 4,433 |
| 2026-02 | 1,687 | 8,505 |
| 2026-01 | 1,609 | 24,813 |

An analyst reading this would conclude "reasoning declined sharply after May 2026" — confidently, and completely falsely. The model kept reasoning; the archive stopped recording it.

### Defect A — Claude Code: empty-body thinking blocks dropped entirely

`polylogue/sources/parsers/base_support.py`'s `content_blocks_from_segments` had `if text:` with no `else` around THINKING segment handling. Since roughly 2026-06 the wire ships thinking blocks with an **empty** `thinking` body and a `signature` only — verified directly against raw `~/.claude/projects/-realm-project-polylogue/*.jsonl` across dates:

| date sampled | thinking records | empty-body | non-empty |
|---|---|---|---|
| 2026-02-11 | 8, 68 | 0 | 8, 68 |
| 2026-07-29 | 2,300 | 2,300 | 0 |
| 2026-07-30 | 1,010, 275 | 1,010, 275 | 0 |
| 2026-07-31 | 112, 499 | 112, 499 | 0 |

Ground-truth sessions named in scope, live archive (read-only query, before this fix):

| session | raw thinking blocks (all empty-body+signature) | archived thinking blocks | thinking_count |
|---|---|---|---|
| `38baa1de-9715-48fa-8175-f2a29d92800e` | 499 | 0 | 0 |
| `53e64853-1793-43d2-80ac-a41a8c5a56a2` | 275 | 0 | 0 |

The reasoning text is genuinely absent from the wire since ~2026-06 (Anthropic API/CLI behavior change, not a parser blind spot) — but the *fact that the model reasoned* is not absent, and that fact is exactly what the `if text:` guard destroyed.

### Defect B — Codex: reasoning records read by nothing

`polylogue/sources/parsers/codex.py`'s `_compact_response_payload` (the generic session_event compactor for `response_item`/`event_msg` records) has no branch for `type: "reasoning"`. Neither `summary` nor `content` is a recognized key anywhere in the compactor, so a reasoning record's session_event payload is **only** `{"source_index": N, "type": "reasoning"}` — measured directly:

```python
>>> _compact_response_payload({"type": "reasoning", "summary": [...], "content": None, "encrypted_content": "..."}, index=1)
{'source_index': 1, 'type': 'reasoning'}
```

No message, no block, nothing FTS-reachable was ever produced for a `reasoning` record. Full corpus scan of this operator's local Codex sessions (`~/.codex/sessions/**/*.jsonl`, 3,213 rollout files):

| metric | count | % |
|---|---|---|
| total `reasoning` records | 1,182,071 | — |
| records with recoverable `summary` text | 285,985 | 24.2% |
| records with non-null `content` | 0 | 0% |
| rollouts containing ≥1 reasoning record | 2,961 / 3,213 | 92.2% |
| rollouts with ≥1 recoverable summary | 863 / 3,213 | 26.9% |

`content` (the full trace) is essentially always null on the wire — Codex encrypts it into `encrypted_content` instead, which this archive cannot decrypt and does not attempt to store.

### Per-origin reasoning/thinking capture audit

| Origin | Status | Evidence |
|---|---|---|
| Claude Code | **Fixed here** (was: dropped when empty-body) | `base_support.py` `content_blocks_from_segments`, guard removed |
| Codex | **Fixed here** (was: never read at all) | `codex.py`, new `_codex_reasoning_message` |
| ChatGPT | Captured | `chatgpt.py:727-737`: `content_type in ("thoughts", "reasoning_recap")` -> `BlockType.THINKING`, no emptiness guard observed |
| Gemini / aistudio-drive | Captured, with a caveat | `gemini_message.py:271-274`: `raw_part.get("thought") is True` -> `ContentType.THINKING`, but gated by `if part_text:` -- the same empty-body shape as Defect A is structurally possible here and untested against real emptied-thinking Gemini payloads. Not observed to occur in this operator's corpus; flagged as a follow-up audit item, out of scope for this PR (Gemini thinking-signature capture, `thoughtSignatures`, is a separate, already-partially-modeled construct in `drive_support_blocks.py`) |
| Hermes | Captured | `hermes_state.py:705-709`: `reasoning_content`/`reasoning` columns -> `BlockType.THINKING` unconditionally when present |
| Antigravity | Unknown / not observed | No `thinking`/`reasoning` reference anywhere in `antigravity.py`; the markdown-export/brain-metadata ingestion path may simply have no reasoning construct on the wire for this product, or this is genuinely unaudited. Flagged as a follow-up, not fixed here (no reproducing evidence available in this operator's corpus to establish which) |

## Solution

- **`polylogue/sources/parsers/base_support.py`**: `content_blocks_from_segments` now always appends a THINKING block for `type: "thinking"` segments -- `text=None` when the wire carries none (rather than `""`, matching how other block types signal "no text"), `signature` captured when present.
- **`polylogue/sources/parsers/base_models.py`**: `ParsedContentBlock` gains a `signature: str | None` field -- the provider-issued cryptographic attestation for a THINKING block (Claude's extended-thinking signature; Gemini's `thoughtSignatures` are the same construct under a different name).
- **`polylogue/storage/sqlite/archive_tiers/index.py` / `archive_tiers_specs.py` / `write.py`**: `blocks.signature` (nullable TEXT) added to the DDL, column spec, and row-builder. Deliberately **excluded** from `_block_content_hash` and the lineage prefix signature (`_message_signature_from_blocks`) -- providers re-sign on every replay, so including it would break citation-anchor and fork-prefix matching for otherwise-identical replayed content across a session fork/resume. `INDEX_SCHEMA_VERSION` bumped 48->49.
- **`polylogue/storage/sqlite/lifecycle.py`**: v49 `IndexDeltaDeclaration` with `SEMANTIC_REPARSE` -- the same v42/v44/v45/v46/v48 "values depend on parser semantics, no clone-safe SQL delta" shape (the new column is additive/clone-safe on its own, but recovering the previously-dropped/discarded historical thinking/reasoning *content* requires re-parsing raw evidence, which a shape-only fast-forward cannot do).
- **`polylogue/sources/parsers/codex.py`**: new `_codex_reasoning_message`/`_codex_reasoning_joined_text` materialize a standalone `reasoning` response_item as a `MessageType.THINKING` message (`role=ASSISTANT`, `material_origin=ASSISTANT_AUTHORED`) with one `BlockType.THINKING` block per recovered text source (`summary`, then `content` if distinct); when neither carries text, a single block with `text=None` still records that reasoning occurred. Wired into the existing `response_item`/`event_msg` dispatch loop alongside `_codex_tool_message`/`_codex_event_message`. Deliberately uses `BlockType.THINKING` (not the vocabulary's `BlockType.REASONING`), matching every other origin's existing convention (ChatGPT, Gemini, Hermes, local_agent) -- `BlockType.REASONING` is presently unused anywhere in the codebase; introducing it here would fragment the `thinking_count` aggregate instead of feeding it.
- **Read-path wiring** (`polylogue/storage/runtime/archive/records.py`, `polylogue/storage/hydrators.py`, `polylogue/storage/sqlite/queries/mappers_archive.py`, `polylogue/storage/sqlite/queries/attachment_blocks.py`): `signature` threaded through `BlockRecord`, the domain `Message.blocks` dict projection, and the SQL row mapper/SELECT list, so it's actually readable, not write-only.

### Why `blocks.signature` instead of stuffing it into `metadata`

`ParsedContentBlock.metadata` exists but is **not** persisted generically to the `blocks` table -- only `metadata.language` is read out of it (`_block_language`, write.py). Storing the signature there would look captured at the parser layer while silently vanishing at write time, which would misstate this PR's own claim. A real nullable column is the honest choice, matching the exact precedent `tool_result_outcome_unknown_reason` (v46) set for provenance-only, hash-excluded columns.

## Compatibility / rebuild

`index.db` is rebuildable derived state. This PR's `SEMANTIC_REPARSE` declaration means:
- **Recovers automatically going forward**: every session ingested *after* this deploys gets full thinking/reasoning capture (empty-body Claude Code blocks with signature; Codex reasoning summary/content).
- **Does NOT recover historical rows in place**: `blocks.signature` will fast-forward to NULL on existing rows, and existing sessions keep their current (wrong) `thinking_count` of 0, until re-parsed.
- **Recovering history requires** `polylogue ops reset --index && polylogued run` against the raw-evidence-backed `source.db` (raw JSONL is retained; nothing here touches raw acquisition). **Not executed by this PR** -- the live archive at `/realm/db/polylogue` is read-only from this branch's perspective; a full index rebuild is the operator's call to schedule.
- What a rebuild recovers: the *fact* that reasoning occurred (block existence, `thinking_count`, signature where the wire carries one) for every already-acquired session. What it does **not** recover: reasoning *text* for Claude Code sessions where the wire itself never carried text (that data was never on the wire to begin with -- genuinely, permanently gone upstream, confirmed by the Feb-vs-Jun/Jul empty/non-empty split above) and for the ~76% of Codex reasoning records with neither summary nor content text.

## Also fixed (pre-existing, unrelated)

`devtools verify topology` was already failing on origin/master (2 orphans: `polylogue/cli/commands/compare.py`, `polylogue/insights/measurement/registered_metrics.py`, introduced by #3430 without a topology-projection regen) -- confirmed via a stash-and-reproduce check against a clean checkout before touching anything here. Folded a `devtools render topology-projection` regen into a separate commit on this branch since the pre-push gate blocks on it regardless of blame.

## Verification

```
ruff format --check / ruff check   # all touched files: clean
mypy (--strict via project config) # all touched files: Success, no issues
devtools test tests/unit/sources/test_parsers_base.py tests/unit/sources/test_parsers_codex.py \
  tests/unit/storage/test_column_spec_reordering.py tests/unit/storage/test_archive_tiers_ddl.py \
  tests/unit/storage/test_index_fast_forward_lifecycle.py tests/unit/storage/test_schema_policy_contracts.py \
  tests/unit/core/test_models.py tests/unit/storage/test_archive_tiers_write.py \
  tests/unit/surfaces/test_message_render_envelope.py
  # all pass; 5 new tests added from real wire shapes (2 Claude Code empty-body/signature
  # cases, 3 Codex reasoning cases: summary-only, encrypted-only, summary+content);
  # 1 pre-existing exact-dict assertion updated for the new `signature` key
devtools lab policy schema-versioning  # Schema evolution policy intact
devtools verify --quick                # exit_code: 0 (clean, after the topology regen commit)
```

Not run: `devtools verify --all` (full non-integration suite) -- the touched-file testmon selection plus the explicit DDL/schema/parser suites above cover every changed surface; not re-running the full suite per the repo's stated verification cadence. No live-archive writes were made anywhere in this work -- all archive queries used `file:/realm/db/polylogue/index.db?mode=ro`.
