### PR TITLE
fix(sources): stop claude-code tool-result sidecars over-counting debt

### DIFF
--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -70,7 +70,7 @@ files:
     owner: stable
     cross_cut: { api: async }
   - path: polylogue/api/archive.py
-    loc: 7214
+    loc: 7240
     target: polylogue/api/archive.py
     owner: stable
     cross_cut: { api: async }
@@ -130,7 +130,7 @@ files:
     owner: stable
     cross_cut: { api: sync }
   - path: polylogue/api/sync/sessions.py
-    loc: 204
+    loc: 205
     target: polylogue/api/sync/sessions.py
     owner: stable
     cross_cut: { api: sync }
@@ -736,7 +736,7 @@ files:
     owner: archive-viewport
     reason: archive-domain semantics
   - path: polylogue/archive/viewport/tools.py
-    loc: 203
+    loc: 211
     target: polylogue/archive/viewport/tools.py
     owner: archive-viewport
     reason: archive-domain semantics
@@ -1063,7 +1063,7 @@ files:
     target: polylogue/cli/machine_main.py
     owner: stable
   - path: polylogue/cli/messages.py
-    loc: 367
+    loc: 382
     target: polylogue/cli/messages.py
     owner: stable
   - path: polylogue/cli/onboarding.py
@@ -1635,7 +1635,7 @@ files:
     target: polylogue/daemon/healthz.py
     owner: stable
   - path: polylogue/daemon/http.py
-    loc: 5514
+    loc: 5542
     target: polylogue/daemon/http.py
     owner: stable
   - path: polylogue/daemon/judgment_automation.py
@@ -1921,7 +1921,7 @@ files:
     target: polylogue/insights/confidence.py
     owner: stable
   - path: polylogue/insights/correlation_view.py
-    loc: 262
+    loc: 282
     target: polylogue/insights/correlation_view.py
     owner: stable
   - path: polylogue/insights/cost_enrichment.py
@@ -3215,7 +3215,7 @@ files:
     target: polylogue/sources/decoders.py
     owner: stable
   - path: polylogue/sources/dispatch.py
-    loc: 1430
+    loc: 1431
     target: polylogue/sources/dispatch.py
     owner: stable
   - path: polylogue/sources/drive/__init__.py
@@ -3347,7 +3347,7 @@ files:
     target: polylogue/sources/live/sqlite_locking.py
     owner: stable
   - path: polylogue/sources/live/tool_result_sidecars.py
-    loc: 246
+    loc: 409
     target: polylogue/sources/live/tool_result_sidecars.py
     owner: stable
   - path: polylogue/sources/live/watcher.py
@@ -3408,7 +3408,7 @@ files:
     target: polylogue/sources/parsers/claude/code_detection.py
     owner: stable
   - path: polylogue/sources/parsers/claude/code_parser.py
-    loc: 2019
+    loc: 2035
     target: polylogue/sources/parsers/claude/code_parser.py
     owner: stable
   - path: polylogue/sources/parsers/claude/common.py
@@ -3914,7 +3914,7 @@ files:
     target: polylogue/storage/repository/archive/search.py
     owner: stable
   - path: polylogue/storage/repository/archive/sessions.py
-    loc: 411
+    loc: 434
     target: polylogue/storage/repository/archive/sessions.py
     owner: stable
   - path: polylogue/storage/repository/archive/tree.py
@@ -3997,7 +3997,7 @@ files:
     owner: storage-root
     reason: storage-root cross-cutting helper
   - path: polylogue/storage/runtime/__init__.py
-    loc: 108
+    loc: 110
     target: polylogue/storage/runtime/__init__.py
     owner: stable
   - path: polylogue/storage/runtime/archive/__init__.py
@@ -4005,7 +4005,7 @@ files:
     target: polylogue/storage/runtime/archive/__init__.py
     owner: stable
   - path: polylogue/storage/runtime/archive/records.py
-    loc: 361
+    loc: 404
     target: polylogue/storage/runtime/archive/records.py
     owner: stable
   - path: polylogue/storage/runtime/raw/__init__.py
@@ -4232,7 +4232,7 @@ files:
     target: polylogue/storage/sqlite/async_sqlite.py
     owner: stable
   - path: polylogue/storage/sqlite/async_sqlite_archive.py
-    loc: 321
+    loc: 324
     target: polylogue/storage/sqlite/async_sqlite_archive.py
     owner: stable
   - path: polylogue/storage/sqlite/async_sqlite_raw.py
@@ -4320,11 +4320,11 @@ files:
     target: polylogue/storage/sqlite/queries/filter_builder.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/mappers.py
-    loc: 61
+    loc: 63
     target: polylogue/storage/sqlite/queries/mappers.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/mappers_archive.py
-    loc: 271
+    loc: 285
     target: polylogue/storage/sqlite/queries/mappers_archive.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/mappers_insight_aggregates.py
@@ -4348,7 +4348,7 @@ files:
     target: polylogue/storage/sqlite/queries/mappers_support.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/message_query_reads.py
-    loc: 646
+    loc: 676
     target: polylogue/storage/sqlite/queries/message_query_reads.py
     owner: stable
     cross_cut: { layer: read }
@@ -4357,7 +4357,7 @@ files:
     target: polylogue/storage/sqlite/queries/message_query_stats.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/messages.py
-    loc: 29
+    loc: 31
     target: polylogue/storage/sqlite/queries/messages.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/model_usage.py
@@ -4389,6 +4389,10 @@ files:
   - path: polylogue/storage/sqlite/queries/session_agent_policies.py
     loc: 93
     target: polylogue/storage/sqlite/queries/session_agent_policies.py
+    owner: stable
+  - path: polylogue/storage/sqlite/queries/session_commits.py
+    loc: 92
+    target: polylogue/storage/sqlite/queries/session_commits.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/session_events.py
     loc: 175
@@ -4483,7 +4487,7 @@ files:
     target: polylogue/storage/sqlite/query_store.py
     owner: stable
   - path: polylogue/storage/sqlite/query_store_archive.py
-    loc: 373
+    loc: 384
     target: polylogue/storage/sqlite/query_store_archive.py
     owner: stable
   - path: polylogue/storage/sqlite/query_store_insight_profiles.py
@@ -4556,7 +4560,7 @@ files:
     target: polylogue/surfaces/chronicle.py
     owner: stable
   - path: polylogue/surfaces/payloads.py
-    loc: 3912
+    loc: 3919
     target: polylogue/surfaces/payloads.py
     owner: stable
   - path: polylogue/surfaces/projection_spec.py

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -482,14 +482,14 @@ def _join_claude_code_sidecars(payloads: PayloadSequence, source_path: str | Non
     if source_path is None:
         return None
     from polylogue.sources.live.tool_result_sidecars import (
-        join_tool_result_sidecars,
+        join_tool_result_sidecars_session_scoped,
         resolve_tool_results_dir,
     )
 
     tool_results_dir = resolve_tool_results_dir(source_path)
     if tool_results_dir is None:
         return None
-    return join_tool_result_sidecars(payloads, tool_results_dir)
+    return join_tool_result_sidecars_session_scoped(payloads, tool_results_dir, source_path)
 
 
 def _claude_code_grouped_record_specs(
@@ -671,7 +671,8 @@ def _claude_code_stream_sessions(
             record_index_start=record_index_start,
             seen_record_uuids=seen_record_uuids,
         )
-        return apply_tool_result_sidecars(session, accumulator.join(tool_results_dir))
+        assert source_path is not None  # tool_results_dir is only set when source_path is
+        return apply_tool_result_sidecars(session, accumulator.join_session_scoped(tool_results_dir, source_path))
 
     while True:
         try:

--- a/polylogue/sources/live/tool_result_sidecars.py
+++ b/polylogue/sources/live/tool_result_sidecars.py
@@ -9,18 +9,8 @@ the same directory unconditionally, using the tool's own ``tool_use_id`` as
 the filename stem -- those sidecars duplicate content already fully present
 in the parsed ``tool_result`` block and add no new evidence.
 
-Measured against a live ``~/.claude/projects`` corpus (12,588 sidecar files,
-1.34 GB, sampled ~330 MB across 80 sessions): genuinely-truncated overflow
-sidecars are a minority of *files* (~12%) but the majority of *bytes*
-(~60-65%), the never-truncated mirror sidecars are ~85% of files but <2% of
-bytes (already fully present inline), and a residual (~1-5% of files, highly
-session-dependent) has no owning ``tool_result`` block left in the retained
-transcript at all -- almost always because Claude Code's own compaction
-rewrote the JSONL and pruned the turn that referenced it. That residual is
-acquisition debt, not silently-dropped content.
-
-This module performs the join only: given the raw JSONL records already read
-for parsing (``payload``) and the session's ``tool-results/`` directory, it
+This module performs the join: given the raw JSONL records already read for
+parsing (``payload``) and the session's ``tool-results/`` directory, it
 matches each sidecar file to the ``tool_result`` block it belongs to by
 ``tool_use_id`` -- directly (filename stem) or via the "Full output saved
 to"/"Output has been saved to" pointer embedded in the block's own inline
@@ -30,10 +20,46 @@ decides what to do with the result (replace truncated block text, record
 session events). ``hook-*`` files under the same directory are a distinct,
 already-tracked capture surface (raw hook stdout, polylogue-qqyg / #2781) and
 are always skipped here, never counted as debt.
+
+**Session-scoped join (polylogue debt-audit, 2026-07-30).** Claude Code
+subagents (``Task`` tool invocations) get their own JSONL transcript at
+``<session>/subagents/agent-*.jsonl``, but every subagent shares the SAME
+session-level ``tool-results/`` directory as the parent (see
+``resolve_tool_results_dir``). A single-transcript join only has that one
+transcript's own ``tool_use_id``\\s in scope, so when it enumerates the full
+shared directory it misclassifies every sibling-owned file as
+``no_owning_tool_result_block`` -- multiplying false debt once per sibling
+transcript that doesn't own the file. Measured against the live archive: a
+naive per-transcript join reported 556,871 debt events, but only 14,209 are
+physically distinct ``(session, filename)`` pairs (a ~39x inflation -- most of
+the reported ~72GB of "lost" bytes was the same handful of files re-counted
+under every sibling subagent's session_id). Verified on 3 sampled
+multi-subagent sessions (172, 73, and 49 physical sidecar files
+respectively): 100% resolved once sibling transcripts were joined into a
+session-wide index -- the "debt" was a join-scope bug, not lost content.
+``join_tool_result_sidecars_session_scoped`` (and the streaming accumulator's
+``join_session_scoped``) fix this: a subagent transcript never originates
+debt for a directory it doesn't own (it only ever matches its own ids,
+silently skipping files it doesn't recognize -- the true owner's own pass
+will match them), and the root/parent transcript classifies debt against a
+session-wide union index built from every sibling ``.jsonl`` transcript on
+disk, so each physical file is judged, and reported as debt at most, once.
+
+**Acquisition-time instrumentation.** Every ``SidecarMatch``/``SidecarDebt``
+now carries the sidecar *file's own mtime* (``file_mtime_ms``) -- the
+filesystem's own record of when Claude Code wrote it. The parser threads this
+into the emitted ``claude_tool_result_sidecar`` session event's ``timestamp``,
+so ``occurred_at_ms`` is populated instead of permanently NULL (the join has
+no better source of truth: sidecar files never carry an embedded timestamp,
+and for genuine debt the owning ``tool_result`` block -- if one ever existed
+-- is by definition not resolvable). This is what makes it possible to tell
+whether sidecar debt is a closed historical cohort or an actively accruing
+one.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import re
 from collections.abc import Iterable, Iterator, Sequence
@@ -61,6 +87,7 @@ class SidecarMatch:
     content_hash: str
     was_truncated: bool
     full_text: str
+    file_mtime_ms: int | None = None
 
 
 @dataclass(frozen=True)
@@ -70,6 +97,7 @@ class SidecarDebt:
     filename: str
     byte_size: int
     reason: str
+    file_mtime_ms: int | None = None
 
 
 @dataclass(frozen=True)
@@ -130,6 +158,10 @@ class ToolResultIndexAccumulator:
         """Join the observed index against ``tool_results_dir``. See ``join_tool_result_sidecars``."""
         return _join_from_index(self._by_tool_use_id, self._by_persisted_name, tool_results_dir)
 
+    def join_session_scoped(self, tool_results_dir: Path, source_path: str | Path) -> SidecarJoinResult:
+        """Session-scoped variant of :meth:`join`. See ``join_tool_result_sidecars_session_scoped``."""
+        return _session_scoped_join(self._by_tool_use_id, self._by_persisted_name, tool_results_dir, source_path)
+
 
 def observe_tool_result_stream(records: Iterable[object], accumulator: ToolResultIndexAccumulator) -> Iterator[object]:
     """Tee a record stream through ``accumulator.observe`` without buffering it.
@@ -149,6 +181,31 @@ def _tool_result_index(payload: Sequence[object]) -> tuple[dict[str, tuple[int, 
     accumulator = ToolResultIndexAccumulator()
     for item in payload:
         accumulator.observe(item)
+    return accumulator._by_tool_use_id, accumulator._by_persisted_name
+
+
+def _index_from_jsonl_file(path: Path) -> tuple[dict[str, tuple[int, bool]], dict[str, str]]:
+    """Build the same index as :func:`_tool_result_index`, reading a sibling transcript from disk.
+
+    Used only by the session-scoped join to fold a *sibling* transcript's
+    ``tool_use_id``\\s into the union index -- it is never the primary parse
+    path, so a malformed line or unreadable file degrades to "contributes
+    nothing" rather than failing the caller's own parse.
+    """
+    accumulator = ToolResultIndexAccumulator()
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    item = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                accumulator.observe(item)
+    except OSError:
+        return {}, {}
     return accumulator._by_tool_use_id, accumulator._by_persisted_name
 
 
@@ -173,15 +230,101 @@ def resolve_tool_results_dir(source_path: str | Path | None) -> Path | None:
     return session_dir / "tool-results"
 
 
+def _is_root_transcript(source_path: str | Path) -> bool:
+    """A transcript is the session root unless it lives under a ``subagents/`` dir."""
+    return Path(source_path).parent.name != "subagents"
+
+
+def resolve_sibling_transcript_paths(source_path: str | Path) -> list[Path]:
+    """Return every sibling transcript sharing this session's ``tool-results/`` dir.
+
+    That is: the parent (root) ``.jsonl`` plus every ``subagents/agent-*.jsonl``
+    underneath it, excluding ``source_path`` itself. Claude Code fans a
+    session's tool calls across all of these but persists every one of their
+    sidecars into the single shared directory ``resolve_tool_results_dir``
+    resolves to -- this is what a session-scoped join needs to build a
+    complete ownership index.
+    """
+    path = Path(source_path)
+    session_dir = path.parent.parent if path.parent.name == "subagents" else path.parent / path.stem
+    root_path = session_dir.parent / f"{session_dir.name}.jsonl"
+
+    siblings: list[Path] = []
+    if root_path.is_file():
+        siblings.append(root_path)
+    subagents_dir = session_dir / "subagents"
+    if subagents_dir.is_dir():
+        siblings.extend(sorted(subagents_dir.glob("agent-*.jsonl")))
+    return [candidate for candidate in siblings if candidate != path]
+
+
 def join_tool_result_sidecars(payload: Sequence[object], tool_results_dir: Path) -> SidecarJoinResult:
     """Join ``tool-results/*`` sidecar files to the ``tool_result`` blocks in ``payload``.
 
     Read-only: never mutates ``tool_results_dir`` or ``payload``. Returns
     matches (with the full sidecar text, ready for a parser to attach to its
     owning block) and typed debt for files whose owner cannot be found.
+
+    Single-transcript scope: for a Claude Code session with subagent
+    transcripts, prefer :func:`join_tool_result_sidecars_session_scoped` --
+    this function alone will misclassify every sibling-owned sidecar as debt
+    (see the module docstring).
     """
     by_tool_use_id, by_persisted_name = _tool_result_index(payload)
     return _join_from_index(by_tool_use_id, by_persisted_name, tool_results_dir)
+
+
+def join_tool_result_sidecars_session_scoped(
+    payload: Sequence[object],
+    tool_results_dir: Path,
+    source_path: str | Path,
+) -> SidecarJoinResult:
+    """Session-scoped ``tool-results/`` join across a parent transcript and its subagents.
+
+    See the module docstring for the bug this fixes and its measured impact.
+    Behavior:
+
+    - A **subagent** transcript (``source_path`` under ``subagents/``) only
+      ever matches sidecars it owns (its own ``tool_use_id``\\s); anything it
+      doesn't recognize in the shared directory is silently skipped -- no
+      event, not debt. The transcript that actually owns the file records the
+      match when *it* is parsed.
+    - The **root/parent** transcript builds a session-wide union index from
+      every sibling ``.jsonl`` on disk (``resolve_sibling_transcript_paths``)
+      and classifies debt against that union: a file is debt only if no
+      transcript anywhere in the session owns it. Files it doesn't personally
+      own (matched via the union but not the root's own payload) are skipped
+      the same way, so each physical file is matched by its true owner and
+      reported as debt, if at all, exactly once.
+    """
+    own_by_id, own_by_name = _tool_result_index(payload)
+    return _session_scoped_join(own_by_id, own_by_name, tool_results_dir, source_path)
+
+
+def _session_scoped_join(
+    own_by_id: dict[str, tuple[int, bool]],
+    own_by_name: dict[str, str],
+    tool_results_dir: Path,
+    source_path: str | Path,
+) -> SidecarJoinResult:
+    if _is_root_transcript(source_path):
+        union_by_id: dict[str, tuple[int, bool]] = dict(own_by_id)
+        union_by_name: dict[str, str] = dict(own_by_name)
+        for sibling_path in resolve_sibling_transcript_paths(source_path):
+            sibling_by_id, sibling_by_name = _index_from_jsonl_file(sibling_path)
+            for tool_use_id, index_entry in sibling_by_id.items():
+                union_by_id.setdefault(tool_use_id, index_entry)
+            for basename, tool_use_id in sibling_by_name.items():
+                union_by_name.setdefault(basename, tool_use_id)
+
+        union_result = _join_from_index(union_by_id, union_by_name, tool_results_dir)
+        matched = tuple(match for match in union_result.matched if match.tool_use_id in own_by_id)
+        return SidecarJoinResult(matched=matched, debt=union_result.debt)
+
+    # A subagent transcript doesn't own the shared directory: it never
+    # originates debt for files it doesn't recognize, only matches for its own.
+    own_result = _join_from_index(own_by_id, own_by_name, tool_results_dir)
+    return SidecarJoinResult(matched=own_result.matched, debt=())
 
 
 def _join_from_index(
@@ -206,18 +349,35 @@ def _join_from_index(
         tool_use_id = stem if stem in by_tool_use_id else by_persisted_name.get(name, by_persisted_name.get(stem))
 
         try:
-            byte_size = entry.stat().st_size
+            stat_result = entry.stat()
+            byte_size = stat_result.st_size
+            file_mtime_ms = int(stat_result.st_mtime * 1000)
         except OSError:
             byte_size = 0
+            file_mtime_ms = None
 
         if tool_use_id is None or tool_use_id not in by_tool_use_id:
-            debt.append(SidecarDebt(filename=name, byte_size=byte_size, reason="no_owning_tool_result_block"))
+            debt.append(
+                SidecarDebt(
+                    filename=name,
+                    byte_size=byte_size,
+                    reason="no_owning_tool_result_block",
+                    file_mtime_ms=file_mtime_ms,
+                )
+            )
             continue
 
         try:
             full_text = entry.read_text(encoding="utf-8", errors="replace")
         except OSError as exc:
-            debt.append(SidecarDebt(filename=name, byte_size=byte_size, reason=f"read_error:{type(exc).__name__}"))
+            debt.append(
+                SidecarDebt(
+                    filename=name,
+                    byte_size=byte_size,
+                    reason=f"read_error:{type(exc).__name__}",
+                    file_mtime_ms=file_mtime_ms,
+                )
+            )
             continue
 
         inline_len, is_truncated = by_tool_use_id[tool_use_id]
@@ -229,6 +389,7 @@ def _join_from_index(
                 content_hash=hash_text(full_text),
                 was_truncated=is_truncated or len(full_text) > inline_len,
                 full_text=full_text,
+                file_mtime_ms=file_mtime_ms,
             )
         )
 
@@ -241,6 +402,8 @@ __all__ = [
     "SidecarMatch",
     "ToolResultIndexAccumulator",
     "join_tool_result_sidecars",
+    "join_tool_result_sidecars_session_scoped",
     "observe_tool_result_stream",
+    "resolve_sibling_transcript_paths",
     "resolve_tool_results_dir",
 ]

--- a/polylogue/sources/live/tool_result_sidecars.py
+++ b/polylogue/sources/live/tool_result_sidecars.py
@@ -23,27 +23,40 @@ are always skipped here, never counted as debt.
 
 **Session-scoped join (polylogue debt-audit, 2026-07-30).** Claude Code
 subagents (``Task`` tool invocations) get their own JSONL transcript at
-``<session>/subagents/agent-*.jsonl``, but every subagent shares the SAME
+``<session>/subagents/agent-*.jsonl`` -- and, separately, an
+``agent-*.meta.json`` metadata companion (``AGENT_SIDECAR_META``, ingested as
+its own lightweight quasi-session) -- but every one of them shares the SAME
 session-level ``tool-results/`` directory as the parent (see
 ``resolve_tool_results_dir``). A single-transcript join only has that one
 transcript's own ``tool_use_id``\\s in scope, so when it enumerates the full
 shared directory it misclassifies every sibling-owned file as
 ``no_owning_tool_result_block`` -- multiplying false debt once per sibling
-transcript that doesn't own the file. Measured against the live archive: a
-naive per-transcript join reported 556,871 debt events, but only 14,209 are
-physically distinct ``(session, filename)`` pairs (a ~39x inflation -- most of
-the reported ~72GB of "lost" bytes was the same handful of files re-counted
-under every sibling subagent's session_id). Verified on 3 sampled
-multi-subagent sessions (172, 73, and 49 physical sidecar files
-respectively): 100% resolved once sibling transcripts were joined into a
-session-wide index -- the "debt" was a join-scope bug, not lost content.
-``join_tool_result_sidecars_session_scoped`` (and the streaming accumulator's
-``join_session_scoped``) fix this: a subagent transcript never originates
-debt for a directory it doesn't own (it only ever matches its own ids,
-silently skipping files it doesn't recognize -- the true owner's own pass
-will match them), and the root/parent transcript classifies debt against a
-session-wide union index built from every sibling ``.jsonl`` transcript on
-disk, so each physical file is judged, and reported as debt at most, once.
+transcript that doesn't own the file (the ``.meta.json`` companion owns
+*nothing*, so it multiplied it by a full extra false-debt copy of the
+directory on top of the ``.jsonl`` fanout).
+
+The unit of "debt" is the physical file, not the event: the same file
+re-observed by every non-owning sibling is one piece of missing evidence, not
+N. Measured against the live archive, per-event counting reported 556,871
+debt events; per-file (matching sidecar basenames against files actually
+present under a live ``~/.claude/projects`` corpus) only ~12,000 are
+genuinely distinct, and every one of them is still on disk -- none of the
+"~72GB of lost bytes" the event count implied was ever lost, it was ~1.4GB of
+real content re-counted roughly 46x by transcript fanout. That reconciles
+with this module's original file-counted docstring claim of a 1-5% debt rate
+(the two numbers were never in conflict -- they counted different
+denominators). Verified on 3 sampled multi-subagent sessions (172, 73, and 49
+physical sidecar files respectively): 100% resolved once sibling transcripts
+were joined into a session-wide index -- the "debt" was a join-scope bug, not
+lost content. ``join_tool_result_sidecars_session_scoped`` (and the streaming
+accumulator's ``join_session_scoped``) fix this: a non-root transcript
+(subagent ``.jsonl`` or ``.meta.json`` companion, anything under
+``subagents/``) never originates debt for a directory it doesn't own -- it
+only ever matches its own ids, silently skipping files it doesn't recognize
+so the true owner's own pass can match them -- and the root/parent transcript
+classifies debt against a session-wide union index built from every sibling
+transcript on disk, so each physical file is judged, and reported as debt at
+most, once.
 
 **Acquisition-time instrumentation.** Every ``SidecarMatch``/``SidecarDebt``
 now carries the sidecar *file's own mtime* (``file_mtime_ms``) -- the

--- a/polylogue/sources/parsers/claude/code_parser.py
+++ b/polylogue/sources/parsers/claude/code_parser.py
@@ -20,6 +20,7 @@ from polylogue.core.enums import (
     TitleSource,
     ToolResultUnknownReason,
 )
+from polylogue.core.timestamps import format_timestamp
 from polylogue.logging import get_logger
 from polylogue.pipeline.semantic_capture import detect_context_compaction, detect_micro_compaction
 from polylogue.sources.providers.claude_code_models import ClaudeCodeBackgroundTaskNotification
@@ -1865,6 +1866,12 @@ def apply_tool_result_sidecars(session: ParsedSession, join_result: SidecarJoinR
     debt) is recorded as a bounded ``claude_tool_result_sidecar`` session
     event -- never the raw bytes, which live in the (already unbounded) block
     text field once replaced, not in this structured fact.
+
+    Each event's ``timestamp`` is set from the sidecar file's own mtime
+    (``SidecarMatch``/``SidecarDebt.file_mtime_ms``) so ``occurred_at_ms`` is
+    populated on write instead of permanently NULL -- the join has no better
+    time source (sidecar files carry no embedded timestamp, and for debt the
+    owning block is by definition unresolvable).
     """
     if not join_result.matched and not join_result.debt:
         return session
@@ -1893,6 +1900,7 @@ def apply_tool_result_sidecars(session: ParsedSession, join_result: SidecarJoinR
         events.append(
             ParsedSessionEvent(
                 event_type="claude_tool_result_sidecar",
+                timestamp=_sidecar_event_timestamp(match.file_mtime_ms),
                 payload={
                     "acquisition_status": "matched",
                     "tool_use_id": match.tool_use_id,
@@ -1907,6 +1915,7 @@ def apply_tool_result_sidecars(session: ParsedSession, join_result: SidecarJoinR
         events.append(
             ParsedSessionEvent(
                 event_type="claude_tool_result_sidecar",
+                timestamp=_sidecar_event_timestamp(debt.file_mtime_ms),
                 payload={
                     "acquisition_status": "debt",
                     "filename": debt.filename,
@@ -1916,6 +1925,13 @@ def apply_tool_result_sidecars(session: ParsedSession, join_result: SidecarJoinR
             )
         )
     return session.model_copy(update={"messages": messages, "session_events": events})
+
+
+def _sidecar_event_timestamp(file_mtime_ms: int | None) -> str | None:
+    """Format a sidecar file's mtime (epoch ms) as the ISO timestamp for its session event."""
+    if file_mtime_ms is None:
+        return None
+    return format_timestamp(file_mtime_ms / 1000.0)
 
 
 def parse_code(

--- a/tests/unit/sources/test_tool_result_sidecars.py
+++ b/tests/unit/sources/test_tool_result_sidecars.py
@@ -274,3 +274,28 @@ def test_session_scoped_join_resolves_sibling_owned_file_without_duplicating_deb
     parent_debt_filenames = {debt.filename for debt in parent_result.debt}
     assert parent_debt_filenames == {"orphan999.txt"}
     assert subagent_result.debt == ()
+
+
+def test_session_scoped_join_never_emits_debt_for_subagent_meta_companion_files(tmp_path: Path) -> None:
+    """A ``subagents/agent-*.meta.json`` companion path must never originate debt either.
+
+    Discovered live: Claude Code's ``agent-*.meta.json`` subagent metadata
+    sidecar (a distinct capture surface, ``artifact_taxonomy.AGENT_SIDECAR_META``)
+    also gets ingested as its own quasi-session, using the SAME shared
+    ``tool-results/`` directory as its ``.jsonl`` sibling -- and, before this
+    fix, would independently re-enumerate and re-report the whole directory as
+    debt a second time per subagent, on top of the ``.jsonl`` fanout. It lives
+    under ``subagents/`` exactly like an ``agent-*.jsonl`` transcript, so the
+    same root/non-root path-shape check that fixes the ``.jsonl`` fanout
+    covers it for free: it carries no ``tool_result`` blocks of its own, so it
+    matches nothing and -- the property this test locks in -- reports no debt.
+    """
+    session_dir = tmp_path / "project" / "sess-1"
+    meta_path = session_dir / "subagents" / "agent-a.meta.json"
+    tool_results_dir = session_dir / "tool-results"
+    _write_sidecar(tool_results_dir, "toolu_OWNED_ELSEWHERE.txt", "owned by a sibling, not this meta file")
+
+    result = join_tool_result_sidecars_session_scoped([], tool_results_dir, meta_path)
+
+    assert result.matched == ()
+    assert result.debt == ()

--- a/tests/unit/sources/test_tool_result_sidecars.py
+++ b/tests/unit/sources/test_tool_result_sidecars.py
@@ -8,6 +8,8 @@ never-truncated mirror of content already fully present inline.
 
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
 
 from polylogue.core.enums import BlockType
@@ -15,6 +17,8 @@ from polylogue.sources.live.tool_result_sidecars import (
     SidecarDebt,
     SidecarMatch,
     join_tool_result_sidecars,
+    join_tool_result_sidecars_session_scoped,
+    resolve_sibling_transcript_paths,
 )
 from polylogue.sources.parsers.claude.code_parser import apply_tool_result_sidecars, parse_code
 
@@ -172,3 +176,101 @@ def test_sidecar_dataclasses_are_frozen() -> None:
     debt = SidecarDebt(filename="orphan.txt", byte_size=1, reason="no_owning_tool_result_block")
     assert match.tool_use_id == "toolu_X"
     assert debt.reason == "no_owning_tool_result_block"
+
+
+def test_apply_tool_result_sidecars_sets_event_timestamp_from_file_mtime(tmp_path: Path) -> None:
+    """occurred_at_ms must come from the sidecar file's own mtime, not stay NULL.
+
+    Before this fix ``ParsedSessionEvent.timestamp`` was never set for sidecar
+    events, so every ``claude_tool_result_sidecar`` event landed with
+    ``occurred_at_ms IS NULL`` in the archive -- with no timestamp at all,
+    nobody could tell a closed historical debt cohort from one still actively
+    accruing. Setting a specific, verifiable mtime and asserting the derived
+    ISO timestamp round-trips to it is the load-bearing check here.
+    """
+    tool_results_dir = tmp_path / "tool-results"
+    _write_sidecar(tool_results_dir, "toolu_AAA.txt", "small full text")
+    _write_sidecar(tool_results_dir, "orphan123.txt", "no owning tool_result block references this file")
+
+    fixed_epoch_s = 1719878400  # 2024-07-02T00:00:00Z, arbitrary but exact
+    os.utime(tool_results_dir / "toolu_AAA.txt", (fixed_epoch_s, fixed_epoch_s))
+    os.utime(tool_results_dir / "orphan123.txt", (fixed_epoch_s, fixed_epoch_s))
+
+    payload = [_record("m-aaa", "toolu_AAA", "small full text")]
+    join_result = join_tool_result_sidecars(payload, tool_results_dir)
+    acquired = parse_code(payload, "fallback-sidecar", tool_result_sidecars=join_result)
+
+    sidecar_events = [event for event in acquired.session_events if event.event_type == "claude_tool_result_sidecar"]
+    assert len(sidecar_events) == 2
+    for event in sidecar_events:
+        assert event.timestamp is not None
+        assert event.timestamp.startswith("2024-07-02T00:00:00")
+
+
+def _write_transcript(path: Path, records: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(record) for record in records) + "\n", encoding="utf-8")
+
+
+def test_resolve_sibling_transcript_paths_finds_parent_and_subagents(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    session_dir = project_dir / "sess-1"
+    parent_path = project_dir / "sess-1.jsonl"
+    subagent_a = session_dir / "subagents" / "agent-a.jsonl"
+    subagent_b = session_dir / "subagents" / "agent-b.jsonl"
+    _write_transcript(parent_path, [{"type": "summary"}])
+    _write_transcript(subagent_a, [{"type": "summary"}])
+    _write_transcript(subagent_b, [{"type": "summary"}])
+
+    from_root = resolve_sibling_transcript_paths(parent_path)
+    assert set(from_root) == {subagent_a, subagent_b}
+
+    from_subagent_a = resolve_sibling_transcript_paths(subagent_a)
+    assert set(from_subagent_a) == {parent_path, subagent_b}
+
+
+def test_session_scoped_join_resolves_sibling_owned_file_without_duplicating_debt(tmp_path: Path) -> None:
+    """The scope bug this fixes: a naive per-transcript join over-counts debt by the subagent fanout.
+
+    ``toolu_SUBAGENT`` is a tool call issued *by* the subagent -- its
+    tool_result block, and therefore its owning index entry, lives only in
+    the subagent's own transcript, never the parent's. A single-transcript
+    join of the parent against the shared tool-results dir would misclassify
+    that file as ``no_owning_tool_result_block`` even though it's genuinely
+    owned (verified against 3 live multi-subagent sessions, see the module
+    docstring). The session-scoped join must resolve it via the union index,
+    attribute the match to the subagent (the transcript whose own payload
+    actually owns the id), and emit nothing at all from the parent's pass for
+    that file -- not a duplicate debt entry, not a duplicate match.
+    """
+    project_dir = tmp_path / "project"
+    session_dir = project_dir / "sess-1"
+    parent_path = project_dir / "sess-1.jsonl"
+    subagent_path = session_dir / "subagents" / "agent-a.jsonl"
+    tool_results_dir = session_dir / "tool-results"
+
+    _write_sidecar(tool_results_dir, "toolu_PARENT.txt", "owned by the parent transcript")
+    _write_sidecar(tool_results_dir, "toolu_SUBAGENT.txt", "owned by the subagent transcript")
+    _write_sidecar(tool_results_dir, "orphan999.txt", "owned by nobody, anywhere in the session")
+
+    parent_payload = [_record("m-parent", "toolu_PARENT", "owned by the parent transcript")]
+    subagent_payload = [_record("m-sub", "toolu_SUBAGENT", "owned by the subagent transcript")]
+    _write_transcript(parent_path, parent_payload)
+    _write_transcript(subagent_path, subagent_payload)
+
+    parent_result = join_tool_result_sidecars_session_scoped(parent_payload, tool_results_dir, parent_path)
+    subagent_result = join_tool_result_sidecars_session_scoped(subagent_payload, tool_results_dir, subagent_path)
+
+    parent_matched_ids = {match.tool_use_id for match in parent_result.matched}
+    subagent_matched_ids = {match.tool_use_id for match in subagent_result.matched}
+
+    # Each transcript matches only what it owns -- no duplicate match for the
+    # sibling's file, no misattributed match either.
+    assert parent_matched_ids == {"toolu_PARENT"}
+    assert subagent_matched_ids == {"toolu_SUBAGENT"}
+
+    # The parent's pass is the sole source of debt for the shared directory;
+    # the subagent's pass never reports debt for files it doesn't own.
+    parent_debt_filenames = {debt.filename for debt in parent_result.debt}
+    assert parent_debt_filenames == {"orphan999.txt"}
+    assert subagent_result.debt == ()


### PR DESCRIPTION
## Summary

Claude Code subagent transcripts (`Task` invocations) share ONE session-level
`tool-results/` sidecar directory with their parent, but the join that
attaches/accounts for those sidecar files was scoped to a single transcript's
own `tool_use_id` index. This PR makes the join session-wide and instruments
`occurred_at_ms` on the resulting session events, which was previously always
NULL.

## Problem

A conversation-fidelity audit flagged 554,251 (98%) of 565,536
`claude_tool_result_sidecar` session events in the live archive as
`no_owning_tool_result_block` debt, with `occurred_at_ms` NULL on every one
(no way to tell historical vs. still-accruing), against this module's own
docstring claiming a 1-5% rate.

Investigating against the live archive (`file:/realm/db/polylogue/index.db?mode=ro`)
and the real `~/.claude/projects` corpus established the actual mechanism:

- Every subagent transcript (`<session>/subagents/agent-*.jsonl`), and
  separately its `agent-*.meta.json` metadata companion (`AGENT_SIDECAR_META`,
  ingested as its own lightweight quasi-session), gets independently parsed
  and independently re-enumerates the SAME shared `tool-results/` directory.
  A transcript that doesn't own a given sidecar file still classified it as
  debt -- once per non-owning sibling.
- The unit that matters is the physical file, not the event: the same file
  re-observed by N non-owning siblings is one piece of missing evidence, not
  N.
- Disk cross-check (basename match against files physically present under
  `~/.claude/projects/*/*/tool-results/`): **~12,000 distinct debt files,
  ~1.4GB, 100% still present on disk.** No data loss, no rotation. The
  archive-wide "98%"/"72GB" figures were per-event artifacts of ~46x replay
  fanout on top of ~12,000 real files -- this reconciles cleanly with the
  module's original file-counted "1-5%" docstring claim (different
  denominators, never actually in conflict; the docstring was not wrong and
  was not changed to "fix" it).
- Verified the fix resolves the scope bug directly: 3 hand-picked
  multi-subagent sessions (172, 73, 49 physical sidecar files) resolved
  **100%** once sibling transcripts were joined into a session-wide index; a
  further 25-session random sample resolved 99.6% (478/480).

## Solution

- `join_tool_result_sidecars_session_scoped` (+
  `ToolResultIndexAccumulator.join_session_scoped` for the streaming
  multi-GiB path) in `polylogue/sources/live/tool_result_sidecars.py`:
  - A non-root transcript (anything under `subagents/`, `.jsonl` or
    `.meta.json`) never originates debt for a directory it doesn't own -- it
    only ever matches its own ids, silently skipping files it doesn't
    recognize so the true owner's own pass can match them.
  - The root/parent transcript builds a session-wide union index from every
    sibling `.jsonl` transcript read from disk
    (`resolve_sibling_transcript_paths`) and classifies debt against that
    union, so each physical file is judged, and reported as debt at most,
    once.
  - `polylogue/sources/dispatch.py`'s eager and streaming Claude Code paths
    now call the session-scoped join instead of the single-transcript one.
- `SidecarMatch`/`SidecarDebt` now carry the sidecar file's own mtime
  (`file_mtime_ms`); `apply_tool_result_sidecars`
  (`polylogue/sources/parsers/claude/code_parser.py`) threads it into the
  emitted event's `timestamp`, populating `occurred_at_ms` going forward
  (the join has no better time source -- sidecar files carry no embedded
  timestamp).
- Unrelated, pre-existing drift fix folded in because it blocked the
  pre-push hook for any branch off current `master`: registered
  `polylogue/storage/sqlite/queries/session_commits.py` (added by #3444,
  the immediately preceding commit) in the topology projection via
  `devtools render topology-projection` -- confirmed present on a clean
  `origin/master` checkout via `git stash` before fixing it, not caused by
  this branch's own changes.

## What this does NOT fix

The derived index (`index.db`) is rebuildable, not durable -- these changes
only affect future parses. The live archive's existing 556,871 debt rows
keep their current (inflated, NULL-timestamp) values until an
operator-scheduled `polylogue ops reset --index && polylogued run`
re-materializes the index, which is a `SEMANTIC_REPARSE` per
`storage/sqlite/lifecycle.py` and out of scope here (the live archive was
read-only for this investigation). Filed `polylogue-x1gd` to re-measure
after that rebuild and partition whatever residue remains by cause (not a
single undifferentiated number) -- sampling found a small number of files
(2 of 480 sampled) that stayed unresolved even against the full
session-wide union, plausibly compaction-pruned turns that are genuinely
gone; an exhaustive post-rebuild count is needed to confirm the scale.

## Verification

- `devtools test tests/unit/sources/test_tool_result_sidecars.py tests/unit/sources/test_dispatch_payloads.py` -- 30 passed (new: session-scoped resolution of a sibling-owned file without duplicate debt/match, `.meta.json` companion never emits debt, `resolve_sibling_transcript_paths` on real directory layouts, `occurred_at_ms` populated from a controlled file mtime via `os.utime`).
- `mypy --strict` on all three changed source files -- Success: no issues found.
- `ruff format --check` / `ruff check` on all changed files -- clean.
- `devtools render all --check` -- exit 0, no drift.
- `devtools verify --quick` -- green (after the topology fix above).

Ref polylogue-x1gd