### PR TITLE
fix(pipeline): stop attachment fetches from losing a freshness tie

### DIFF
--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -384,6 +384,42 @@ def _append_delta_payload(
     ) - len(delta_messages)
 
 
+def _incoming_write_regresses_attachment_coverage(
+    conn: sqlite3.Connection,
+    payload: SessionWritePayload,
+    session_to_write: ParsedSession,
+) -> bool:
+    """Return whether writing ``session_to_write`` would lose acquired attachments.
+
+    polylogue-ixry: two raw acquisitions of the same logical session can
+    carry byte-identical message content -- and therefore an identical
+    content-derived freshness timestamp -- while differing only in which
+    attachments were actually fetched. Drive re-acquisition backfills
+    attachment bytes into a *new* raw_id (`#3073`) without touching any
+    message timestamp, and never establishes revision lineage
+    (`predecessor_raw_id`/`logical_source_key`) the way the governed "live"
+    batch path does for tailed origins, so the two raw rows never form a
+    `raw_revision_heads` cohort either. Without this check, the freshness
+    comparison above ties and falls through to "whichever raw this batch
+    happens to (re)parse last wins" -- observed on the live archive to
+    silently revert a completed attachment fetch back to `unfetched` with no
+    signal (measured: 157/157 duplicate aistudio-drive source_paths landed
+    on the pre-fetch revision). This only ever blocks a regression: an
+    incoming write that ties or improves attachment coverage is unaffected.
+    """
+    incoming_acquired = sum(1 for attachment in session_to_write.attachments if attachment.inline_bytes is not None)
+    existing_acquired_row = conn.execute(
+        """
+        SELECT COUNT(*) FROM attachment_refs r
+        JOIN attachments a ON a.attachment_id = r.attachment_id
+        WHERE r.session_id = ? AND a.acquisition_status = 'acquired'
+        """,
+        (payload.session_id,),
+    ).fetchone()
+    existing_acquired = int(existing_acquired_row[0]) if existing_acquired_row is not None else 0
+    return incoming_acquired < existing_acquired
+
+
 def _write_session(
     conn: sqlite3.Connection,
     payload: SessionWritePayload,
@@ -545,6 +581,19 @@ def _write_session(
         existing_updated_at_ms = existing_row["updated_at_ms"]
         existing_updated_at_int = int(existing_updated_at_ms) if existing_updated_at_ms is not None else None
         if existing_updated_at_int is not None and incoming_freshness_ms < existing_updated_at_int:
+            counts["skipped_sessions"] = 1
+            counts["skipped_messages"] = payload.message_count
+            counts["skipped_attachments"] = payload.attachment_count
+            counts["skipped_session_events"] = len(payload.parsed_session.session_events)
+            return False, counts
+        if (
+            existing_updated_at_int is not None
+            and incoming_freshness_ms == existing_updated_at_int
+            and existing_raw_id
+            and payload.raw_id
+            and existing_raw_id != payload.raw_id
+            and _incoming_write_regresses_attachment_coverage(conn, payload, session_to_write)
+        ):
             counts["skipped_sessions"] = 1
             counts["skipped_messages"] = payload.message_count
             counts["skipped_attachments"] = payload.attachment_count

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -912,6 +912,156 @@ def test_write_session_force_write_replaces_older_freshness(tmp_path: Path) -> N
         assert message["occurred_at_ms"] == 1777636700000
 
 
+def test_write_session_freshness_tie_keeps_acquired_attachment(tmp_path: Path) -> None:
+    """polylogue-ixry: a same-timestamp re-acquisition must not regress attachments.
+
+    Reproduces the aistudio-drive live-fetch race found on the live archive:
+    two raw acquisitions of the same conversation share message content and
+    an identical content-derived `updated_at` (attachment fetch injects bytes
+    into the raw JSON without touching any message timestamp), but only one
+    of the two raw revisions carries the attachment's fetched bytes. Without
+    the tie-break, whichever raw is written second wins outright -- which on
+    the live archive was, 157/157 times, the revision that lost the fetched
+    bytes.
+    """
+    with open_connection(tmp_path / "index.db") as conn:
+        publisher = ArchiveBlobPublisher(tmp_path / "source.db", tmp_path / "blob")
+        fetched = _session_data(
+            "aistudio-drive:tie",
+            content_hash="hash-fetched",
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "aistudio-drive:tie",
+                    role="user",
+                    text="same content",
+                    content_hash="msg-hash-tie",
+                    sort_key=1777636800.0,
+                )
+            ],
+            attachment_tuples=[_attachment_tuple("att-1", inline_bytes=b"real drive bytes")],
+            attachment_ref_tuples=[_attachment_ref_tuple("att-1", "aistudio-drive:tie", "msg-1")],
+            raw_id="raw-fetched",
+            provider=Provider.DRIVE,
+            created_at="2026-07-18T17:46:10Z",
+            updated_at="2026-07-18T17:46:10Z",
+        )
+        changed, counts = _write_session(conn, fetched, blob_publisher=publisher)
+        assert changed is True
+        assert counts["attachments"] == 1
+        conn.commit()
+
+        status_after_fetch = conn.execute(
+            """
+            SELECT a.acquisition_status FROM attachment_refs r
+            JOIN attachments a ON a.attachment_id = r.attachment_id
+            WHERE r.session_id = ?
+            """,
+            ("aistudio-drive:tie",),
+        ).fetchone()
+        assert status_after_fetch["acquisition_status"] == "acquired"
+
+        unfetched_revision = _session_data(
+            "aistudio-drive:tie",
+            content_hash="hash-unfetched",
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "aistudio-drive:tie",
+                    role="user",
+                    text="same content",
+                    content_hash="msg-hash-tie",
+                    sort_key=1777636800.0,
+                )
+            ],
+            attachment_tuples=[_attachment_tuple("att-1", inline_bytes=None)],
+            attachment_ref_tuples=[_attachment_ref_tuple("att-1", "aistudio-drive:tie", "msg-1")],
+            raw_id="raw-prefetch",
+            provider=Provider.DRIVE,
+            created_at="2026-07-18T17:46:10Z",
+            updated_at="2026-07-18T17:46:10Z",
+        )
+        skipped, skipped_counts = _write_session(conn, unfetched_revision)
+        conn.commit()
+
+        assert skipped is False
+        assert skipped_counts["skipped_sessions"] == 1
+        row = conn.execute(
+            "SELECT raw_id FROM sessions WHERE session_id = ?",
+            ("aistudio-drive:tie",),
+        ).fetchone()
+        assert row["raw_id"] == "raw-fetched"
+        status_row = conn.execute(
+            """
+            SELECT a.acquisition_status FROM attachment_refs r
+            JOIN attachments a ON a.attachment_id = r.attachment_id
+            WHERE r.session_id = ?
+            """,
+            ("aistudio-drive:tie",),
+        ).fetchone()
+        assert status_row["acquisition_status"] == "acquired"
+
+
+def test_write_session_freshness_tie_allows_attachment_improvement(tmp_path: Path) -> None:
+    """The tie-break only blocks regressions -- ties/improvements still write."""
+    with open_connection(tmp_path / "index.db") as conn:
+        unfetched = _session_data(
+            "aistudio-drive:improve",
+            content_hash="hash-unfetched",
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "aistudio-drive:improve",
+                    role="user",
+                    text="same content",
+                    content_hash="msg-hash-improve",
+                    sort_key=1777636800.0,
+                )
+            ],
+            attachment_tuples=[_attachment_tuple("att-1", inline_bytes=None)],
+            attachment_ref_tuples=[_attachment_ref_tuple("att-1", "aistudio-drive:improve", "msg-1")],
+            raw_id="raw-prefetch",
+            provider=Provider.DRIVE,
+            created_at="2026-07-18T17:46:10Z",
+            updated_at="2026-07-18T17:46:10Z",
+        )
+        changed, _ = _write_session(conn, unfetched)
+        assert changed is True
+        conn.commit()
+
+        publisher = ArchiveBlobPublisher(tmp_path / "source.db", tmp_path / "blob")
+        fetched = _session_data(
+            "aistudio-drive:improve",
+            content_hash="hash-fetched",
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "aistudio-drive:improve",
+                    role="user",
+                    text="same content",
+                    content_hash="msg-hash-improve",
+                    sort_key=1777636800.0,
+                )
+            ],
+            attachment_tuples=[_attachment_tuple("att-1", inline_bytes=b"real drive bytes")],
+            attachment_ref_tuples=[_attachment_ref_tuple("att-1", "aistudio-drive:improve", "msg-1")],
+            raw_id="raw-fetched",
+            provider=Provider.DRIVE,
+            created_at="2026-07-18T17:46:10Z",
+            updated_at="2026-07-18T17:46:10Z",
+        )
+        changed, counts = _write_session(conn, fetched, blob_publisher=publisher)
+        conn.commit()
+
+        assert changed is True
+        assert counts["attachments"] == 1
+        row = conn.execute(
+            "SELECT raw_id FROM sessions WHERE session_id = ?",
+            ("aistudio-drive:improve",),
+        ).fetchone()
+        assert row["raw_id"] == "raw-fetched"
+
+
 def test_write_session_upserts_ingest_flags_when_content_is_unchanged(tmp_path: Path) -> None:
     """Parser-owned auto-tags still converge when the content hash is unchanged."""
     with open_connection(tmp_path / "index.db") as conn:


### PR DESCRIPTION
## Summary

Investigated the operator's hypothesis that "aistudio/Drive ingestion and its
attachment handling are completely broken." **Partly true, and more precisely
scoped than the hypothesis**: ingestion of conversations works; the attachment
*fetch* mechanism (#3073) also genuinely works; but every successful fetch was
being silently reverted by a raw-revision race in the shared session-write
path, with 100% reproducibility on the live archive. This PR fixes that race.
A sibling lane owns the separate Claude-Code-shaped-drive-cache-file
misrouting bug; this PR does not touch it.

## Problem

Live-archive evidence (read-only queries against `index.db`/`source.db`/
`ops.db`, 2026-07-31; archive index at `user_version=46`, 12 versions behind
`master`'s v50 with v47-v50 all `SEMANTIC_REPARSE`, i.e. current contents
reflect pre-fix parsing until the next reset+reingest):

- `aistudio-drive` origin: 239 sessions, 12063 messages.
- Of 3146 attachments, only 26 (0.8%) are `acquisition_status='acquired'`.
  All 3094 `upload_origin='drive'` attachments (Drive-hosted references,
  the ones #3073 added live fetching for) are `unfetched` -- 0% acquired.
- `schema_drift_samples`: 100% of 302 `aistudio-drive` records ingested
  since 2026-07-01 classify as `unseen_shape` (the gemini schema catalog
  package has no real candidate for the actual wire shape -- real
  `chunkedPrompt` payloads have no top-level `id`/`title`/`createTime`,
  only `chunkedPrompt`/`runSettings`/`systemInstruction`).

Root cause for the attachment non-acquisition, confirmed by direct
inspection, not guessed:

1. The live-fetch mechanism (`polylogue/sources/drive/attachment_fetch.py`,
   landed 2026-07-18) **does work**. 157 of 244 cached
   `~/.local/share/polylogue/drive-cache/gemini/*.json` files carry the
   fetched `_polylogue_drive_live_bytes_b64` payload on disk today.
   Re-parsing one of those files directly with the current parser
   (`polylogue.sources.parsers.drive.parse_chunked_prompt`) produces a real
   4MB `ParsedAttachment.inline_bytes` for
   `1_1M_Reddit_...json` -- proven by running it, not inferred.
2. But each fetch produced a **second, unlinked `raw_sessions` row**
   (different content hash) instead of a revision of the prior one:
   `revision_kind='unknown'`, empty `logical_source_key`,
   `revision_authority='quarantined'` on both rows for every duplicate
   `source_path`. `iter_drive_raw_data` never establishes
   `predecessor_raw_id`/`logical_source_key` linkage for a same-path
   re-read the way the governed "live" batch path
   (`sources/live/batch.py` / `append_ingest.py`) does for tailed origins,
   so `raw_revision_heads` never forms a cohort for it.
3. Because the injected attachment bytes don't change any message
   timestamp, `_write_session`'s content-freshness check
   (`polylogue/pipeline/services/ingest_batch/_core.py`, was line ~547)
   ties exactly between the pre-fetch and post-fetch revisions of the same
   file, and a tie fell through to "whichever raw this batch happens to
   (re)parse last wins" -- with no signal preferring the richer one.
   Measured directly on the live archive: across the 157 duplicate
   `aistudio-drive` source_paths, the **older, pre-fetch revision won
   157/157 times (100%)**. This was independently cross-checked two ways
   ("which raw_id is linked from `sessions.raw_id`" and "which raw_id has
   the later `parsed_at_ms`") -- last-parsed-wins predicts the winner in
   all 157 cases; raw_id lexical order does not (only 72/157). This is why
   a feature that shipped 2026-07-18 shows 0% effect in the live archive
   12 days later: it keeps working and keeps getting silently reverted.

## Solution

`polylogue/pipeline/services/ingest_batch/_core.py`: on an exact freshness
tie between two *different* raw_ids for the same session, compare
acquired-attachment counts (existing acquired attachments already stored in
the archive vs `inline_bytes is not None` on the incoming parsed session)
and skip the incoming write only when it would **regress** attachment
coverage. Ties or genuine improvements still write through unchanged --
this only ever blocks a step backward.

This is a narrow, general safety net at the one place both revisions'
writes actually collide, not a Drive-specific patch (a Drive-only fix would
have needed to duplicate this comparison from outside the write path, or
reach into governance internals this PR deliberately does not touch). The
durable fix -- giving Drive re-acquisition real revision lineage so
`raw_revision_heads` arbitrates it the way tailed origins already get -- is
recorded as follow-up on `polylogue-ixry`, along with the `unseen_shape`
schema-drift finding and a note that the archive-wide 79% unfetched-
attachment rate (chatgpt-export 6145, claude-ai-export 438, grok-export 37
also carry unfetched attachments) was not audited beyond aistudio-drive,
per the operator's ask.

Deliberately out of scope (owned by a sibling lane / other trackers):
the Claude-Code-shaped drive-cache-file misrouting (12 files, 6 colliding
with real local transcripts), `sources/parsers/claude/base_support.py`,
`sources/parsers/codex.py`, `sources/live/tool_result_sidecars.py`,
`maintenance/rebuild_index.py`, `cost/`, `devtools/verify_runs.py`,
`tests/conftest.py`, and the broader OriginSpec work (`polylogue-2qx`).

Drive auth (`sources/drive/auth.py`) was not independently re-exercised
live in this pass; `DriveAuthManager.load_credentials` already raises
`DriveAuthError` loudly on missing/invalid credentials in non-interactive
mode (no silent-degradation code path found), and the 157/244 successful
on-disk fetches from 2026-07-18 are themselves evidence auth worked at
least once. No evidence of a currently broken/silently-degraded auth path
was found.

## Verification

- `devtools test tests/unit/pipeline/test_ingest_batch.py` -- 58 tests, 56
  passed. The 2 failures
  (`test_primary_mode_projects_revision_after_allowed_durable_receipt`,
  `test_primary_mode_keeps_unconfirmed_revision_out_of_index_and_fts`) are
  pre-existing and unrelated: verified by reverting this patch via a
  standalone diff and re-running -- they fail identically
  ("Sinex publication payload rejected before accepted-revision write").
- Anti-vacuity: the two new tests
  (`test_write_session_freshness_tie_keeps_acquired_attachment`,
  `test_write_session_freshness_tie_allows_attachment_improvement`) were
  run against the pre-fix code (same revert) -- the regression test fails
  (`assert True is False`) exactly as expected, and the
  improvement-still-writes test still passes (correctly permissive).
- `devtools test tests/unit/sources/test_parsers_drive.py
  tests/unit/sources/test_drive_attachment_fetch.py` -- 44 passed.
- `devtools verify --quick` -- exit 0 (ran twice: once manually, once via
  the pre-push hook).

## How broken was it, really

Not "completely broken." Detection, parsing, and the attachment-fetch
mechanism itself all function correctly today. The actual defect is a
single silent race in session-write precedence that consistently discarded
every successful attachment fetch before it could be observed -- which,
from the outside, is indistinguishable from "attachments don't work at
all" (0.8% acquired). The schema-drift signal (100% `unseen_shape`) is a
real, separate finding -- the schema catalog is stale relative to the
actual wire format -- but it did not, by itself, block parsing or
attachment extraction; both use structural checks (`looks_like_chunk`),
not the schema catalog. `polylogue-ixry` carries the durable-fix follow-up
and the schema-catalog follow-up so they aren't lost.

Ref polylogue-ixry