### PR TITLE
refactor: collapse three duplicated identical vocabulary definitions

### DIFF
--- a/polylogue/archive/semantic/tokenizer.py
+++ b/polylogue/archive/semantic/tokenizer.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-Provenance = Literal["provider_reported", "tokenizer_estimated", "heuristic_estimated", "unknown"]
+from polylogue.archive.semantic.cost_records import TokenProvenance
+
 Confidence = Literal["reported", "estimated", "unknown"]
 
 TOKENIZER_VERSION = "word-count-1.3-v1"
@@ -28,7 +29,7 @@ class TokenEstimate:
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
     total_tokens: int = 0
-    provenance: Provenance = "unknown"
+    provenance: TokenProvenance = "unknown"
     confidence: Confidence = "unknown"
     tokenizer_version: str = TOKENIZER_VERSION
 
@@ -92,7 +93,6 @@ def token_estimate_from_text(text: str | None, *, tokenizer_version: str = TOKEN
 __all__ = [
     "TOKENIZER_VERSION",
     "Confidence",
-    "Provenance",
     "TokenEstimate",
     "estimate_tokens_from_words",
     "estimate_tokens_from_words_split",

--- a/polylogue/cli/read_views/base.py
+++ b/polylogue/cli/read_views/base.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import click
 
 from polylogue.archive.viewport import READ_VIEW_PROFILE_BY_ID
+from polylogue.cli.read_view_registry import ReadViewSessionPolicy
 from polylogue.cli.shared.types import AppEnv
 
 if TYPE_CHECKING:
@@ -17,7 +18,6 @@ if TYPE_CHECKING:
     from polylogue.surfaces.projection_spec import QueryProjectionSpec
 
 
-ReadViewSessionPolicy = Literal["optional", "required", "query_or_session", "none"]
 ReadViewOptionName = str
 
 
@@ -199,7 +199,6 @@ __all__ = [
     "ReadViewOptionBuilder",
     "ReadViewOptions",
     "ReadViewOptionValues",
-    "ReadViewSessionPolicy",
     "deliver_content",
     "execute_query_request",
 ]

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -23,7 +23,7 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path, PurePath
 from time import monotonic
-from typing import TYPE_CHECKING, Any, Literal, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 from urllib.parse import parse_qs, parse_qsl, unquote, urlparse, urlsplit
 
 from polylogue.archive.query.transaction import archive_read_context
@@ -39,6 +39,7 @@ from polylogue.daemon.events import (
 )
 from polylogue.daemon.route_contracts import RouteContract, route_contract_for_pattern
 from polylogue.daemon.status_snapshot import get_status_snapshot_payload
+from polylogue.daemon.user_state_http import RouteMethod
 from polylogue.daemon.web_auth import (
     WEB_CREDENTIAL_SCOPES,
     WebCredentialBootstrapPayload,
@@ -116,7 +117,6 @@ logger = get_logger(__name__)
 _ARCHIVE_READER_BUSY_TIMEOUT_S = 0.25
 _COORDINATION_CACHE_TTL_S = 2.0
 
-RouteMethod = Literal["GET", "POST", "DELETE"]
 _ArchiveQueryResult = TypeVar("_ArchiveQueryResult")
 
 


### PR DESCRIPTION
## Summary
Deduplicates three closed vocabularies that were defined twice with byte-identical member sets, found by the kind-proliferation audit (census: 383 closed vocabularies / 1,930 members in `polylogue/`; 15 identical-member-set groups).

## Problem
- `ReadViewSessionPolicy` was defined identically in `cli/read_view_registry.py:15` and `cli/read_views/base.py:20`.
- `RouteMethod` was defined identically in `daemon/http.py:119` and `daemon/user_state_http.py:16`.
- `archive/semantic/tokenizer.py`'s `Provenance` duplicated `archive/semantic/cost_records.py`'s `TokenProvenance` member-for-member.

Duplicate definitions of one vocabulary are the seed of the drift pattern already live elsewhere (the two divergent `InvalidationReason` enums in `maintenance/`, the two disjoint `CostBasis` Literals in `archive/semantic/`) — each starts identical and drifts.

## Solution
One canonical definition per vocabulary; the duplicate spelling and its `__all__` re-export are deleted outright (no alias shims). Import directions verified cycle-free (`daemon/http.py` already imports `user_state_http`; `cost_records.py` imports nothing from `tokenizer.py`; `read_view_registry.py` imports nothing from `read_views/`).

## Verification
- `devtools verify --quick` → exit 0 (format, lint, mypy --strict, render all --check)
- `uv run mypy` on the five touched modules → `Success: no issues found`
- `devtools test tests/unit/daemon/test_user_state_http.py tests/unit/insights/test_cost_basis_split.py` → **81 passed**

Part of the conceptual-simplification audit (kind-proliferation lane); the full census report and follow-up beads cover the non-mechanical collapses.