### PR TITLE
fix(storage): restore blocks.signature DDL dropped in the #3451 merge

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -484,6 +484,17 @@ CREATE TABLE IF NOT EXISTS blocks (
     -- an unknown reason".
     tool_result_outcome_unknown_reason TEXT
         CHECK ({nullable_check("tool_result_outcome_unknown_reason", ToolResultUnknownReason)}),
+    -- polylogue-vf9x (v49): provider-issued cryptographic attestation for a
+    -- THINKING block (Claude's extended-thinking `signature`; Gemini's
+    -- `thoughtSignatures` are the same construct). Populated whenever the
+    -- wire carries one -- notably including the empty-body thinking blocks
+    -- Claude Code has shipped since ~2026-06, where this is the only
+    -- surviving evidence besides the block's existence. Deliberately
+    -- excluded from content_hash below and from the lineage prefix
+    -- signature (write.py): providers re-sign on every replay, so including
+    -- it would break fork-prefix/citation-anchor matching for otherwise-
+    -- identical replayed content.
+    signature       TEXT,
     -- svfj: the citation anchor atom. Hashes canonical block EVIDENCE only
     -- (type, text, tool_name, canonical tool_input, semantic/media/language,
     -- is_error, exit_code) -- deliberately EXCLUDING session_id/message_id/


### PR DESCRIPTION
## Summary

Master cannot render. Restores an 11-line column definition that a conflict resolution dropped.

## Problem

```
$ devtools render all --check
sqlite3.OperationalError: table blocks has no column named signature
```

That fails `devtools verify --quick`, which fails **every branch's pre-push hook** — so master being red here blocks all concurrent work, not just this file.

## Cause

Resolving #3451's conflict against master, I took the PR branch's `index.py` wholesale and merged only its **header comments**. That branch predates #3447, so it never carried the `blocks.signature` column added by `polylogue-vf9x` — the provider attestation for empty-body THINKING blocks, which is the only surviving evidence besides block existence for Claude Code sessions since ~2026-06.

The result was the worst possible shape: the v50 header comment *describing* the column survived, so the file read as correct on inspection. The column itself was gone.

## Solution

Restores the column definition and its comment, taken from the correctly-merged working copy. No other difference from master — `git diff` is +11 lines, one file.

## Verification

```
devtools render all --check          clean (was OperationalError)
devtools lab policy schema-versioning "Schema evolution policy intact."
grep 'signature *TEXT' index.py      present in the blocks DDL
```

## Note

Two process lessons worth recording. Mechanically union-merging a schema file is unsafe: the same resolution also collapsed two *different* `IndexDeltaDeclaration(version=50, ...)` blocks — `vf9x` and `u6tl` — into one, which would have silently dropped a declaration. That was caught before landing; this was not.

And `devtools` invoked from a linked worktree resolves `polylogue` through the venv's `.pth` to the **main checkout**, so a schema-version check can compare one tree's constant against another tree's declarations. `PYTHONPATH` does not override it.