### PR TITLE
fix(storage): restore literal_check deleted out from under live call sites

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/common.py
+++ b/polylogue/storage/sqlite/archive_tiers/common.py
@@ -6,12 +6,36 @@ from polylogue.core.enums import (
     PolylogueStrEnum,
     nullable_sql_check_in,
     sql_check_in,
+    sql_string_literal,
 )
 
 
 def check(column: str, enum_type: type[PolylogueStrEnum]) -> str:
     """Return a non-null enum CHECK expression."""
     return sql_check_in(column, enum_type)
+
+
+def literal_check(column: str, *values: str) -> str:
+    """Return a non-null ``column IN (...)`` expression for explicit literals.
+
+    Mirrors :func:`check`, but for closed vocabularies expressed as
+    ``typing.Literal`` aliases rather than ``PolylogueStrEnum`` types. Callers
+    expand the alias with ``typing.get_args`` at the call site so this helper
+    stays free of an ``insights`` import inside the storage substrate.
+
+    PR #3458 deleted this as "zero call sites" (bead polylogue-u6tl); that
+    claim was false at merge time (``archive_tiers/index.py``'s
+    ``delegation_facts`` DDL calls it for ``DelegationMappingState``/
+    ``DelegationResultStatus``, both real ``typing.Literal`` columns) and its
+    deletion broke every import of ``archive_tiers`` — restored here rather
+    than migrating those two call sites to a different mechanism, since
+    ``check()``/``nullable_check()`` only accept ``PolylogueStrEnum``, not a
+    bare ``typing.Literal`` alias.
+    """
+    if not values:
+        raise ValueError("literal_check requires at least one value")
+    rendered = ", ".join(sql_string_literal(value) for value in values)
+    return f"{column} IN ({rendered})"
 
 
 def nullable_check(column: str, enum_type: type[PolylogueStrEnum]) -> str:
@@ -22,7 +46,7 @@ def nullable_check(column: str, enum_type: type[PolylogueStrEnum]) -> str:
 def order_check(later: str, earlier: str, *, nullable: bool = True) -> str:
     """Return a same-row ordering CHECK expression: ``later >= earlier``.
 
-    Mirrors :func:`check` / :func:`json_check` — a relationship
+    Mirrors :func:`literal_check` / :func:`json_check` — a relationship
     between two columns of the *same row* generated from a single call site
     instead of hand-written per table, so every ordering constraint reads
     identically (see ``raw_authority_blockers.resolved_at_ms`` in
@@ -89,6 +113,7 @@ __all__ = [
     "json_array_check",
     "json_check",
     "json_object_check",
+    "literal_check",
     "nullable_check",
     "order_check",
 ]


### PR DESCRIPTION
## Summary

Restores `literal_check` in `polylogue/storage/sqlite/archive_tiers/common.py`, deleted by #3458 as a supposed zero-call-site dead shim. It has real call sites and master's HEAD currently fails to import `archive_tiers/index.py` at all.

## Problem

#3458 (5798b3dd1, "collapse duplicate implementations, dead shims, and split vocabularies") deleted `literal_check` from `common.py` on the strength of a "zero call sites" grep (bead polylogue-u6tl). But #3451 (42bafb0c1, "wire literal_check into DDL, fix a drift CHECK gap") had already landed *earlier the same day* and wired it into `archive_tiers/index.py`'s `delegation_facts` DDL for `DelegationMappingState`/`DelegationResultStatus` CHECK constraints. #3458's grep predated #3451's merge and was never re-run against the merged tree.

Net effect on current `master`: every module that imports `archive_tiers/index.py` (i.e. essentially the whole storage substrate, and by extension most of `tests/`) fails at collection with `ImportError: cannot import name 'literal_check' from 'polylogue.storage.sqlite.archive_tiers.common'`. Discovered while running `devtools test` for unrelated work on polylogue-cgfy — a fresh `devtools test` on any file failed at conftest import.

## Solution

Restore `literal_check` verbatim (matching #3451's usage and `CLAUDE.md`'s still-accurate description of it as real machinery for the ~20 enum-backed columns "and the handful of `literal_check` call sites wired so far"), rather than migrating the two real call sites to `check()`/`nullable_check()` — those only accept `PolylogueStrEnum`, not the `typing.Literal` aliases `DelegationMappingState`/`DelegationResultStatus` actually are. No other part of #3458 touched.

## Verification

- `devtools test tests/unit/sources/test_parsers_claude_code_artifacts.py tests/unit/storage/test_archive_tiers_common.py` — 38 passed (previously failed at collection with `ImportError`)
- `devtools verify --quick` — exit 0 (format, lint, mypy, render all --check, schema-versioning policy) — ran automatically via the pre-push hook