### PR TITLE
fix(storage): restore literal_check deleted out from under live call sites

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/common.py
+++ b/polylogue/storage/sqlite/archive_tiers/common.py
@@ -6,12 +6,36 @@ from polylogue.core.enums import (
     PolylogueStrEnum,
     nullable_sql_check_in,
     sql_check_in,
+    sql_string_literal,
 )
 
 
 def check(column: str, enum_type: type[PolylogueStrEnum]) -> str:
     """Return a non-null enum CHECK expression."""
     return sql_check_in(column, enum_type)
+
+
+def literal_check(column: str, *values: str) -> str:
+    """Return a non-null ``column IN (...)`` expression for explicit literals.
+
+    Mirrors :func:`check`, but for closed vocabularies expressed as
+    ``typing.Literal`` aliases rather than ``PolylogueStrEnum`` types. Callers
+    expand the alias with ``typing.get_args`` at the call site so this helper
+    stays free of an ``insights`` import inside the storage substrate.
+
+    Restored: PR #3458 deleted this as an "uncalled generator", but
+    ``archive_tiers/index.py``'s ``delegation_facts`` DDL calls it twice
+    (``mapping_state``, ``result_status`` CHECK clauses) -- the deletion
+    broke the import chain for the whole ``archive_tiers`` package (and
+    therefore ``ArchiveStore``, the CLI, and every test) on ``master`` as of
+    5798b3dd1. The "zero call sites" audit was simply wrong; both call
+    sites are plain ``literal_check(...)`` calls, not aliased or generated.
+    Re-verify with a real grep before deleting again.
+    """
+    if not values:
+        raise ValueError("literal_check requires at least one value")
+    rendered = ", ".join(sql_string_literal(value) for value in values)
+    return f"{column} IN ({rendered})"
 
 
 def nullable_check(column: str, enum_type: type[PolylogueStrEnum]) -> str:
@@ -89,6 +113,7 @@ __all__ = [
     "json_array_check",
     "json_check",
     "json_object_check",
+    "literal_check",
     "nullable_check",
     "order_check",
 ]


### PR DESCRIPTION
## Summary

Restores `literal_check` in `polylogue/storage/sqlite/archive_tiers/common.py`, deleted by #3458 as an "uncalled generator" while it actually had two live call sites in `archive_tiers/index.py`'s `delegation_facts` DDL, breaking the storage import chain on `master`.

## Problem

Investigating `polylogue-oycw` (verifying the set-based revision-comparison fix landed in #3401/#3405), the very first `devtools status` / any test import failed with:

```
ImportError: cannot import name 'literal_check' from 'polylogue.storage.sqlite.archive_tiers.common'
```

Root cause: #3458 (merged 2026-07-31 16:11, same day) deleted `literal_check`, claiming a zero-call-site audit. That audit was wrong — `archive_tiers/index.py:1642` and `:1657` call `literal_check("mapping_state", *get_args(DelegationMappingState))` and `literal_check("result_status", *get_args(DelegationResultStatus))` in the `delegation_facts` table DDL, built at module import time. Since `archive_tiers/__init__.py` imports `index.py` eagerly, this broke `import polylogue.storage.sqlite.archive_tiers` entirely — and with it `ArchiveStore`, `devtools status`, and any pytest collection that touches storage (i.e. nearly the whole toolchain).

## Solution

Restored `literal_check` verbatim (plus its `sql_string_literal` import from `polylogue.core.enums`), added back to `__all__`, with a docstring noting the deletion's justification was incorrect and to re-verify with a real grep before deleting again.

No behavior change beyond restoring the previously-working import chain — this is a pure revert of one function's deletion.

## Verification

```
python3 -c "import polylogue.storage.sqlite.archive_tiers.index; \
            from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore"
# previously: ImportError. now: succeeds.

devtools status
# previously: crashed with the same ImportError. now: runs.

devtools test tests/unit/storage/test_archive_tiers_common.py tests/unit/archive/test_session_revision_membership.py
# 48 passed in 5.08s

devtools verify --quick
# exit_code: 0 (format, lint, mypy, render all --check, plus this repo's lab/schema/manifest checks)
```

Filed while closing `polylogue-oycw` with full AC verification (already satisfied by #3401/#3405, see that bead's closing notes) — this fix was a blocking prerequisite for running any of that verification, not part of `oycw`'s own scope.

Ref polylogue-oycw