### PR TITLE
docs(daemon): warn against scheduling backup/vacuum against a busy archive

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -627,6 +627,18 @@ these — operators are responsible for scheduling them:
 | Database vacuum | `sqlite3 <db> "VACUUM"` | Monthly | Reclaims space after large deletes or updates. Requires downtime or `VACUUM INTO` to a new file while the daemon runs. |
 | Litestream replication | Litestream | Continuous | Real-time WAL replication to S3-compatible storage. Configure Litestream to watch the database and WAL files; the daemon's periodic WAL checkpoint is compatible with Litestream's replication model. |
 
+**Do not schedule any of these against a busy archive.** `polylogue ops backup`
+checkpoints and copies each tier under a write lock, so it is safe but will
+block on a hot writer; a raw `sqlite3 <db> "VACUUM INTO ..."` outside
+`polylogue ops backup` has no such lock and restarts its read transaction
+whenever the source is written mid-copy, so against a busy WAL file it does
+not merely run slowly — it can livelock, rewriting an ever-growing partial
+copy indefinitely (observed 2026-07-30 on an unrelated host-level `VACUUM
+INTO` cron job: 1.5 TB written in 2 hours against a live `index.db` rebuild
+before the operation was killed by its own timeout). Run any operator-owned
+task in a quiet window and never concurrently with
+`polylogue ops reset --index && polylogued run`.
+
 ### Litestream Integration (Guidance)
 
 Litestream provides continuous SQLite replication by shipping WAL frames


### PR DESCRIPTION
## Summary

Adds one caution paragraph to `docs/daemon.md`'s Operator-Owned Tasks section: don't schedule backup/vacuum/replication against a busy archive, and explain why a raw `sqlite3 VACUUM INTO` is unsafe where `polylogue ops backup` is not. No code changes — investigation confirmed the runaway job that motivated this is not part of this repository (see below).

## Problem

The operator's 2026-07-30 full-archive rebuild (`ops reset --index && polylogued run`, running under `ionice -c3`) took 4h22m, and an hourly-adjacent host-level job wrote **1.5 TB to the same NVMe in a 2-hour window** before it was killed by its own timeout — plausibly worth an hour or more of that rebuild.

Investigation traced this to `polylogue-sqlite-backup.service`/`.timer`, a systemd user unit defined **entirely in the sinnix repo** (`modules/services/polylogue.nix`), not in this repository. It is a standalone `writeShellApplication` that runs `sqlite3 "$db" "VACUUM INTO '$tmp'"` per tier, independent of any `polylogue/` Python code. `VACUUM INTO` takes a single read transaction; against a source being actively written (the index rebuild), SQLite restarts that transaction on every conflicting write instead of failing or blocking — a livelock, not a slow copy. `journalctl` for the incident confirms it: `83.6G read from disk, 1.5T written to disk` over exactly the 2h `TimeoutStartSec` before `start operation timed out. Terminating.` Sinnix's own module comments (added same day) already diagnose this and switch the *sinnix-side* script from `sqlite3 .backup` to `VACUUM INTO` as a partial mitigation — but the operator's position, and mine after reviewing it, is that the service shouldn't exist at all: a scheduled always-on backup that can starve a foreground rebuild is a misconfiguration, not a feature to patch.

**Two separate systems exist and must not be conflated:**

1. **The sinnix systemd timer** (`polylogue-sqlite-backup.service`/`.timer`) — the thing that ran and wrote 1.5 TB. Entirely sinnix-side, does not call any `polylogue/` code. **Not touched by this PR** — see "Pending sinnix change" below.
2. **`polylogue ops backup`** (`polylogue/daemon/backup.py`, `polylogue/storage/backup_attestation.py`, `polylogue/cli/commands/backup.py`) — a manual, on-demand CLI command. `docs/daemon.md` already documents it (and vacuum/replication) as an "Operator-Owned Task... the daemon does not own these — operators are responsible for scheduling them," i.e. it is never auto-run by Polylogue itself. It is also load-bearing: `polylogue/storage/sqlite/migration_runner.py` requires a **verified backup manifest + HMAC attestation** (`backup_attestation.py`, produced only by `polylogue ops backup --verify`) before any durable-tier (`source.db`/`user.db`) migration runs, unless a migration opts out via an explicit `-- migration-safety: additive-no-backup` header. This mechanism copies under a SQLite write lock (`_backup_sqlite`/`_checkpoint_sqlite_for_snapshot`), so it cannot livelock the way raw `VACUUM INTO` did.

Grepped `docs/`, `polylogue/`, and this repo's own Nix modules (`nix/hm-module.nix`, `nix/module.nix`) for any reference to the sinnix unit or its behavior: zero hits. Nothing in this repository implements, schedules, or documents the offending service.

## Solution

No functional/code changes — there is nothing in `polylogue/` that constitutes or schedules the runaway job, and the in-repo backup CLI is a distinct, safe, load-bearing mechanism that must not be weakened. The only change here is a documentation caution derived from the incident, applied to the existing Operator-Owned Tasks table so anyone who does wire up a scheduled backup (via any mechanism) knows the concurrency hazard and that `polylogue ops backup`'s write-lock checkpointing is what makes it safe where a bare `VACUUM INTO` is not.

**Pending sinnix change (different repo — not applied here):** in `/realm/project/sinnix/modules/services/polylogue.nix`, remove:
- the `backupScript` `writeShellApplication` derivation (~lines 162-226)
- `systemd.tmpfiles.rules` entry for `backupRoot` (line 229-230)
- `home-manager.users.${userName}.systemd.user.services.polylogue-sqlite-backup` block (lines 294-320)
- `home-manager.users.${userName}.systemd.user.timers.polylogue-sqlite-backup` block (lines 322-345)
- the `polylogue-sqlite-backup` and `polylogue-sqlite-backup-timer` entries under `sinnix.runtime.surfaces` (lines 363-374)
- the now-dead `backupRoot`/`dbNames`/`dbRoot` `let`-bindings that only fed the removed script

then `nix develop --command switch` from the sinnix repo. If the operator wants ad hoc backups, the removed doc block already covers it: `polylogue ops backup --output-dir ... --verify` (safe, write-locked, produces a migration-usable receipt), or literally `cp`/`sqlite3 <db> ".backup"` while the daemon is quiescent, per the operator's own stated preference.

**Siblings checked (informational only, not touched):** `systemctl list-timers` on the live host shows a cluster of daily maintenance jobs in the same 00:00–06:30 window as this incident, sharing the same NVMe: `borgbackup-root-snapshots.timer` (00:13, 6h cadence → a 06:13 run overlaps a multi-hour rebuild), `machine-telemetry-sqlite-backup.timer` (03:45), `borgbackup-maintenance.timer` (04:58), `borgbackup-job-sinex-blobs.timer` (05:42), plus hourly `borgbackup-job-realm.timer`/`borgbackup-status.timer`. `borgbackup-job-realm` is snapshot-based against a Btrfs subvolume that a 2026-07-06 sinnix comment says deliberately excludes the Polylogue DB subvolume from realm snapshots specifically to avoid WAL churn, so it should not directly hit `/realm/db/polylogue` bytes — but it and the others still consume NVMe IO bandwidth in the same window a rebuild might run. None of these were touched; flagging so a re-run of the rebuild can be scheduled to avoid the cluster if desired.

## Verification

- `devtools render all --check` — no `out of sync` (doc-only change, not a generated surface).
- `devtools verify --quick` — exit 0, ~50-122s (format + lint + mypy + render-all-check + policy/lab checks), run twice (pre-commit local + pre-push hook).
- No `devtools test` run: the change touches only hand-written prose in `docs/daemon.md`, no `polylogue/` source.