### PR TITLE
fix(devtools): correct bead-cluster docstring numbers, add hub-token test

### DIFF
--- a/devtools/bead_cluster.py
+++ b/devtools/bead_cluster.py
@@ -39,11 +39,17 @@ The fix is TF-IDF-flavored edge weighting instead of unweighted adjacency:
      (default 6) -- this caps how far one strong edge can drag in
      unrelated beads through transitive chaining.
 
-Measured on the live backlog (2026-07-30, 615-bead frontier), this produces
-40 multi-bead clusters covering 156 beads and 457 singletons -- coherent
-themes (a claude-ai-export parser-fidelity cluster, a CLI read/render-
-vocabulary cluster, a repair.py shipped-but-dead cluster) instead of one
-blob. The plain any-overlap graph (``_build_overlap_graph`` /
+Measured on the 2026-07-31 backlog at merge time (PR #3462, ``--all-open
+--json``), this produced 33 multi-bead clusters covering 161 beads instead
+of one blob -- coherent themes (a claude-ai-export parser-fidelity cluster,
+a CLI read/render-vocabulary cluster, a repair.py shipped-but-dead cluster).
+An earlier draft of this docstring quoted a different, never-actually-
+measured "40 clusters / 156 beads / 457 singletons" split -- that number was
+aspirational and is corrected here. The backlog moves daily (beads close,
+new ones land), so an exact split is not durable; re-measure with
+``devtools workspace bead-cluster --all-open --json`` and count
+``frontier_clusters`` entries with ``len(beads) > 1`` rather than trusting a
+frozen number. The plain any-overlap graph (``_build_overlap_graph`` /
 ``_connected_components``) is kept as a general-purpose utility (also used
 by ``devtools workspace lane-brief`` and other footprint tooling) but is no
 longer used to shape the FRONTIER-READY cluster output.

--- a/tests/unit/devtools/test_bead_cluster.py
+++ b/tests/unit/devtools/test_bead_cluster.py
@@ -357,6 +357,42 @@ def test_weighted_clusters_refuses_merge_past_max_cluster_size() -> None:
     assert {b["id"] for b in shared_beads} <= covered
 
 
+def test_hub_token_shared_by_many_beads_does_not_merge_them() -> None:
+    # The exact degeneracy this algorithm exists to fix: a hub file
+    # (docs/internals.md-style) referenced by 8 of 10 beads. Unweighted
+    # connected-components would chain all 8 into one mega-cluster via
+    # any-shared-token transitivity. Weighted clustering must not: each
+    # pairwise edge on ONLY the hub token has df=8 among n_docs=10, so
+    # log2(10/8) ~= 0.32 per shared token -- far below --min-similarity's
+    # default of 3.0 -- so no edge involving solely the hub token ever
+    # clears the threshold and none of these beads merge on it.
+    hub_file = "docs/internals.md"
+    hub_beads = [
+        _bead(f"polylogue-hub{i}", labels=["horizon:frontier"], design=f"Update {hub_file} for area {i}.")
+        for i in range(8)
+    ]
+    other_beads = [
+        _bead(f"polylogue-other{i}", labels=["horizon:frontier"], design=f"Touch polylogue/core/mod{i}.py.")
+        for i in range(2)
+    ]
+    beads = hub_beads + other_beads
+    footprints = {b["id"]: bead_cluster._extract_footprint(b) for b in beads}
+
+    df = bead_cluster._document_frequencies(beads, footprints)
+    assert df[hub_file] == 8
+    weight, _shared = bead_cluster._pair_weight(
+        footprints["polylogue-hub0"], footprints["polylogue-hub1"], df, len(beads)
+    )
+    assert weight < bead_cluster.DEFAULT_MIN_SIMILARITY
+
+    clusters = bead_cluster._weighted_clusters(beads, footprints)
+    sizes = sorted(len(c.beads) for c in clusters)
+    # Every bead is its own singleton cluster -- the hub token alone never
+    # produces a qualifying edge, so nothing merges.
+    assert sizes == [1] * len(beads)
+    assert {bid for c in clusters for bid in c.beads} == {b["id"] for b in beads}
+
+
 def test_main_human_output_renders_sections(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     beads = [
         _bead("polylogue-a", priority=1, labels=["horizon:frontier"], design="Touch polylogue/mcp/server.py."),


### PR DESCRIPTION
## Summary
Audits the reported defect that `devtools/bead_cluster.py`'s weighted-clustering fix from PR #3462 was documentation-only. Finds the algorithm itself is already fully implemented and live; the real remaining gap was a false measured-result claim in the docstring. Corrects it and adds a regression test for the specific degeneracy the algorithm exists to prevent.

## Problem
The task brief asserted PR #3462 added ~266 lines that were "all inside the docstring" and that `main()` still routes through unweighted `_build_overlap_graph`/`_connected_components`, with no `--min-similarity`/`--max-cluster-size` flags. That does not match this repo's current `master` (HEAD at time of branching: `d5a1d3fcf`): `devtools/bead_cluster.py` already contains `_document_frequencies`, `_pair_weight` (IDF-flavored `log2(N/df)` per shared token + area bonus), `_UnionFind`, and `_weighted_clusters` (greedy weight-descending merge refusing size-cap violations), and `main()` calls `_weighted_clusters` — not `_connected_components` — to build `frontier_clusters`. Both `--min-similarity` (default 3.0) and `--max-cluster-size` (default 6) exist as documented CLI flags. `git log` shows only one commit ever touched this file since it was recovered (`fc10a33be`, PR #3462, merged 2026-07-31), and it already contains this code — so the described "docstring-only fix" state does not exist in this checkout's history.

What *was* still wrong: the module docstring's stated measured result — "40 multi-bead clusters covering 156 beads and 457 singletons" — was never the actual measured number. PR #3462's own merged verification section reports "33 multi-bead clusters / 161 beads", and a fresh 2026-07-31 measurement (`bd export` then `devtools workspace bead-cluster --all-open --json`) gives 31 multi-bead clusters covering 157 of 257 frontier-ready beads (100 singletons, max cluster size 6 — the cap holds). A second false claim describing a fix is exactly the failure mode #3462 was filed to eliminate, so it needed correcting rather than left in place.

## Solution
- `devtools/bead_cluster.py`: rewrote the docstring's measured-result paragraph to cite the real PR-verified number (33/161), explicitly note the "40/156/457" figure was never measured, and point at `--all-open --json` for reproducible re-measurement instead of re-baking a second snapshot that would just as quickly drift as the backlog changes daily.
- `tests/unit/devtools/test_bead_cluster.py`: added `test_hub_token_shared_by_many_beads_does_not_merge_them` — builds an 8-of-10-bead hub token (`docs/internals.md`-style) and asserts (a) its pairwise weight is below `DEFAULT_MIN_SIMILARITY` and (b) none of the 10 beads merge on it. This is the literal degeneracy #3462 fixed (a small number of hub files appearing in 7-8 beads each), made explicit rather than only implied by the existing regression test's a/b-vs-c/d framing.

## Sibling-tool audit (`devtools/lane_brief.py`, `devtools/merge_conductor.py`)
Read both fully against their docstrings — no doc/code gap found in either:
- `lane_brief.py`: fetches full `bd show` records, extracts footprint paths, and live-verifies each against the working tree (exists / line count / last 3 `git log` entries, loud `PATH NOT FOUND` flag when stale), plus closed-bead prior art via a fresh `bd export`. Matches its docstring's described 3-part behavior exactly.
- `merge_conductor.py`: `classify_file`/`AUTO_RESOLVABLE_CLASSES` genuinely gate `schema-migration` and `hooks-config` to ESCALATE-always (never in the auto-resolvable set); `--execute` only calls `_execute_auto_resolve` for `AUTO-RESOLVABLE` verdicts, and every step there is guarded to abort-and-clean-up on any deviation. The PR body's checkable claim — "`merge-conductor --pr 3461` correctly ESCALATED on `lifecycle.py`" — is corroborated: `gh pr diff 3461 --name-only` confirms `polylogue/storage/sqlite/lifecycle.py` is in that PR's changed-file set, which `classify_file` maps to `schema-migration`, which is never auto-resolvable. No fix needed in either file.

## Verification
- `python -m devtools test tests/unit/devtools/test_bead_cluster.py` → `29 passed`
- `python -m devtools verify --quick` → `exit_code: 0` (18/18 steps, includes render-all-check/layering/topology)
- Anti-vacuity proof: patched `_weighted_clusters` to accept every edge (`min_similarity = -1e9`) with no cap (`max_cluster_size = 10**9`), simulating the pre-fix unweighted/uncapped behavior; reran `-k "hub_token or max_cluster_size"` → both tests **FAIL** (`assert 11 <= 3`; `[10] != [1]*10`), then reverted via `git checkout -- devtools/bead_cluster.py` and reapplied the docstring edit.
- Live measurement (2026-07-31, current backlog): `bd export -o .beads/issues.jsonl` (1448 issues, not committed — contended file per repo convention) then `devtools workspace bead-cluster --all-open --json` → 131 total clusters, 31 multi-bead covering 157 beads, 100 singletons, max cluster size 6.

Ref polylogue-1ebm.