### PR TITLE
feat(devtools): add workspace backlog-calibration duration-model fitter

### DIFF
--- a/devtools/backlog_calibration.py
+++ b/devtools/backlog_calibration.py
@@ -1,0 +1,444 @@
+"""backlog-calibration: measured duration/discovery models over the bead corpus.
+
+Fits the numbers a backlog-execution plan needs from the actual bead history
+(and optionally the merged-PR history) instead of guessing them:
+
+  - closed-bead lead-time percentiles, overall and split by priority, type,
+    epic-child vs standalone, and dependency degree;
+  - a right-censoring-honest survival view (fraction of a >=14d-old cohort
+    closed within 1/3/7/14 days) -- closed-only medians are survivorship-
+    biased and this section is the corrective;
+  - close-reason classification (worked vs already-satisfied / obsolete /
+    duplicate / misframed) with median age-at-closure per class -- the
+    "verify before dispatching" economy;
+  - discovery-vs-drain dynamics: created and closed per day, the
+    created-per-close ratio, and net backlog growth;
+  - optionally, PR open->merge latency by changed-file bucket from a
+    `gh pr list --json` dump.
+
+Calibrated against 2026-07 history for the backlog-execution design
+(/realm/inbox/polylogue-audits-2026-07-31/backlog-execution-design.html);
+registered as a devtools command so the model can be re-fitted as the corpus
+grows instead of going stale like the guesses it replaced.
+
+Usage:
+    # Fresh export (bd export -o <tmpfile> under the hood):
+    devtools workspace backlog-calibration
+
+    # From an existing export / in tests:
+    devtools workspace backlog-calibration --input beads.jsonl
+
+    # Include PR merge-latency calibration:
+    #   gh pr list --state merged --limit 4000 \
+    #     --json number,createdAt,mergedAt,additions,deletions,changedFiles > prs.json
+    devtools workspace backlog-calibration --prs prs.json
+
+    # Machine-readable:
+    devtools workspace backlog-calibration --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from collections import Counter, defaultdict
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from re import IGNORECASE
+from re import compile as re_compile
+from typing import Any
+
+BeadDict = dict[str, Any]
+
+_DAY_SECONDS = 86400.0
+_PERCENTILES = (10, 25, 50, 75, 90, 95)
+_SURVIVAL_WINDOWS_DAYS = (1, 3, 7, 14)
+_COHORT_MIN_AGE_DAYS = 14.0
+
+# Close-reason classes, checked in order; first match wins. "worked" is the
+# fall-through. Regexes over free text are advisory classification, not truth.
+_CLOSE_REASON_CLASSES: tuple[tuple[str, Any], ...] = (
+    ("duplicate", re_compile(r"\bdup(?:e|licate)?\b", IGNORECASE)),
+    (
+        "already-satisfied",
+        re_compile(r"\balready\b|\bsatisfied by\b|\bfixed by\b|\bfixed in\b", IGNORECASE),
+    ),
+    (
+        "obsolete",
+        re_compile(r"\bobsolete\b|\bsuperseded\b|\bno longer\b|\bstale\b|\bmoot\b", IGNORECASE),
+    ),
+    (
+        "misframed",
+        re_compile(r"\bmisframed\b|\binvalid\b|\bnot a bug\b|\bworking as\b", IGNORECASE),
+    ),
+)
+NO_IMPLEMENTATION_CLASSES = frozenset(c for c, _ in _CLOSE_REASON_CLASSES)
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _percentile(sorted_values: list[float], pct: float) -> float:
+    if not sorted_values:
+        raise ValueError("empty distribution")
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = (len(sorted_values) - 1) * pct / 100.0
+    lower = int(rank)
+    if lower >= len(sorted_values) - 1:
+        return sorted_values[-1]
+    frac = rank - lower
+    return sorted_values[lower] + (sorted_values[lower + 1] - sorted_values[lower]) * frac
+
+
+def summarize_days(values: list[float]) -> dict[str, Any]:
+    """Percentile summary of a list of durations expressed in days."""
+    if not values:
+        return {"n": 0}
+    ordered = sorted(values)
+    summary: dict[str, Any] = {"n": len(ordered)}
+    for pct in _PERCENTILES:
+        summary[f"p{pct}_days"] = round(_percentile(ordered, pct), 3)
+    summary["max_days"] = round(ordered[-1], 3)
+    return summary
+
+
+def classify_close_reason(reason: str | None) -> str:
+    """Classify a free-text close reason; 'worked' is the fall-through."""
+    text = reason or ""
+    for name, pattern in _CLOSE_REASON_CLASSES:
+        if pattern.search(text):
+            return name
+    return "worked"
+
+
+def _lead_days(bead: BeadDict) -> float | None:
+    created = _parse_ts(bead.get("created_at"))
+    closed = _parse_ts(bead.get("closed_at"))
+    if created is None or closed is None or bead.get("status") != "closed":
+        return None
+    return (closed - created).total_seconds() / _DAY_SECONDS
+
+
+def _epic_child_ids(beads: list[BeadDict]) -> frozenset[str]:
+    children: set[str] = set()
+    for bead in beads:
+        for dep in bead.get("dependencies") or []:
+            if isinstance(dep, dict) and dep.get("type") == "parent-child":
+                children.add(str(bead.get("id")))
+    return frozenset(children)
+
+
+def _split_summaries(closed: list[tuple[BeadDict, float]], key: Any) -> dict[str, dict[str, Any]]:
+    groups: dict[str, list[float]] = defaultdict(list)
+    for bead, lead in closed:
+        groups[str(key(bead))].append(lead)
+    return {name: summarize_days(values) for name, values in sorted(groups.items())}
+
+
+def _survival(beads: list[BeadDict], as_of: datetime) -> dict[str, Any]:
+    cohort = [
+        bead
+        for bead in beads
+        if (created := _parse_ts(bead.get("created_at"))) is not None
+        and (as_of - created).total_seconds() / _DAY_SECONDS >= _COHORT_MIN_AGE_DAYS
+    ]
+
+    def _fractions(members: list[BeadDict]) -> dict[str, Any]:
+        row: dict[str, Any] = {"n": len(members)}
+        for window in _SURVIVAL_WINDOWS_DAYS:
+            closed_in = sum(1 for bead in members if (lead := _lead_days(bead)) is not None and lead <= window)
+            row[f"closed_within_{window}d_pct"] = round(100.0 * closed_in / len(members), 1) if members else None
+        return row
+
+    by_priority = {
+        f"P{priority}": _fractions([b for b in cohort if b.get("priority") == priority]) for priority in range(5)
+    }
+    return {
+        "cohort_min_age_days": _COHORT_MIN_AGE_DAYS,
+        "overall": _fractions(cohort),
+        "by_priority": by_priority,
+    }
+
+
+def _discovery(beads: list[BeadDict]) -> dict[str, Any]:
+    created_per_day: Counter[str] = Counter()
+    closed_per_day: Counter[str] = Counter()
+    for bead in beads:
+        created = _parse_ts(bead.get("created_at"))
+        closed = _parse_ts(bead.get("closed_at"))
+        if created is not None:
+            created_per_day[created.date().isoformat()] += 1
+        if closed is not None:
+            closed_per_day[closed.date().isoformat()] += 1
+    days = sorted(set(created_per_day) | set(closed_per_day))
+    if not days:
+        return {"days": [], "note": "no dated beads"}
+    # The first day of a corpus is typically a bulk import, not discovery.
+    import_day = days[0]
+    series: list[dict[str, Any]] = [
+        {
+            "day": day,
+            "created": created_per_day.get(day, 0),
+            "closed": closed_per_day.get(day, 0),
+            "net": created_per_day.get(day, 0) - closed_per_day.get(day, 0),
+        }
+        for day in days
+    ]
+    post = [row for row in series if row["day"] != import_day]
+    created_total = sum(int(row["created"]) for row in post)
+    closed_total = sum(int(row["closed"]) for row in post)
+    nets: list[float] = sorted(float(row["net"]) for row in post)
+    return {
+        "import_day_excluded": import_day,
+        "days": series,
+        "post_import_created": created_total,
+        "post_import_closed": closed_total,
+        "created_per_close": (round(created_total / closed_total, 2) if closed_total else None),
+        "median_net_per_day": (round(_percentile(nets, 50), 1) if nets else None),
+        "net_negative_days": sum(1 for net in nets if net < 0),
+        "post_import_day_count": len(post),
+    }
+
+
+def _close_reasons(closed: list[tuple[BeadDict, float]]) -> dict[str, Any]:
+    with_reason = [(bead, lead) for bead, lead in closed if bead.get("close_reason")]
+    classes: dict[str, list[float]] = defaultdict(list)
+    for bead, lead in with_reason:
+        classes[classify_close_reason(bead.get("close_reason"))].append(lead)
+    no_impl = sum(len(v) for name, v in classes.items() if name in NO_IMPLEMENTATION_CLASSES)
+    return {
+        "closed_with_reason": len(with_reason),
+        "no_implementation_pct": (round(100.0 * no_impl / len(with_reason), 1) if with_reason else None),
+        "classes": {name: summarize_days(values) for name, values in sorted(classes.items())},
+    }
+
+
+_PR_FILE_BUCKETS: tuple[tuple[int, int, str], ...] = (
+    (1, 3, "1-2"),
+    (3, 6, "3-5"),
+    (6, 11, "6-10"),
+    (11, 31, "11-30"),
+    (31, 10**9, "31+"),
+)
+
+
+def _pr_latency(prs: list[dict[str, Any]]) -> dict[str, Any]:
+    rows: list[tuple[int, float]] = []
+    for pr in prs:
+        created = _parse_ts(pr.get("createdAt"))
+        merged = _parse_ts(pr.get("mergedAt"))
+        files = pr.get("changedFiles")
+        if created is None or merged is None or not isinstance(files, int):
+            continue
+        rows.append((files, (merged - created).total_seconds() / 3600.0))
+    buckets = {
+        label: summarize_days([hours / 24.0 for files, hours in rows if lo <= files < hi])
+        for lo, hi, label in _PR_FILE_BUCKETS
+    }
+    return {
+        "n": len(rows),
+        "overall_latency_hours": {
+            k: (round(v * 24.0, 3) if isinstance(v, float) else v)
+            for k, v in summarize_days([hours / 24.0 for _, hours in rows]).items()
+        },
+        "by_changed_files_days": buckets,
+        "note": (
+            "open->merge latency measures the merge train, not implementation: "
+            "PRs in this repo open after the work is done"
+        ),
+    }
+
+
+def build_report(
+    beads: list[BeadDict],
+    *,
+    as_of: datetime,
+    prs: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    closed = [(bead, lead) for bead in beads if (lead := _lead_days(bead)) is not None]
+    epic_children = _epic_child_ids(beads)
+    corpus_age_days = None
+    created_times = [t for bead in beads if (t := _parse_ts(bead.get("created_at")))]
+    if created_times:
+        corpus_age_days = round((as_of - min(created_times)).total_seconds() / _DAY_SECONDS, 1)
+    report: dict[str, Any] = {
+        "as_of": as_of.isoformat(),
+        "population": {
+            "total": len(beads),
+            "by_status": dict(Counter(str(b.get("status")) for b in beads)),
+            "corpus_age_days": corpus_age_days,
+            "censoring_note": (
+                "closed-only lead times are right-censored by corpus age and "
+                "survivorship-biased by still-open beads; read the survival "
+                "section for population-honest fractions"
+            ),
+        },
+        "closed_lead_days": {
+            "overall": summarize_days([lead for _, lead in closed]),
+            "by_priority": _split_summaries(closed, lambda b: f"P{b.get('priority')}"),
+            "by_type": _split_summaries(closed, lambda b: b.get("issue_type")),
+            "by_epic_membership": _split_summaries(
+                closed,
+                lambda b: "epic-child" if str(b.get("id")) in epic_children else "standalone",
+            ),
+            "by_dependency_degree": _split_summaries(
+                closed,
+                lambda b: min(int(b.get("dependency_count") or 0), 2),
+            ),
+        },
+        "survival": _survival(beads, as_of),
+        "close_reasons": _close_reasons(closed),
+        "discovery": _discovery(beads),
+    }
+    if prs is not None:
+        report["pr_merge_latency"] = _pr_latency(prs)
+    return report
+
+
+def _load_beads_jsonl(path: Path) -> list[BeadDict]:
+    beads: list[BeadDict] = []
+    for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"{path}:{line_number}: not valid JSON ({exc})") from exc
+        if isinstance(record, dict):
+            beads.append(record)
+    return beads
+
+
+def _export_beads() -> list[BeadDict]:
+    with tempfile.NamedTemporaryFile(suffix=".jsonl", prefix="backlog-calib-") as handle:
+        result = subprocess.run(
+            ["bd", "export", "-o", handle.name],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise SystemExit(f"bd export failed: {result.stderr.strip() or result.stdout.strip()}")
+        return _load_beads_jsonl(Path(handle.name))
+
+
+def _fmt_days(value: Any) -> str:
+    if not isinstance(value, (int, float)):
+        return "-"
+    return f"{value * 24:.1f}h" if value < 1 else f"{value:.1f}d"
+
+
+def _render_summary_line(name: str, summary: dict[str, Any]) -> str:
+    if summary.get("n", 0) == 0:
+        return f"  {name:<16} n=0"
+    return (
+        f"  {name:<16} n={summary['n']:<5} p50={_fmt_days(summary.get('p50_days')):<7} "
+        f"p90={_fmt_days(summary.get('p90_days')):<7} max={_fmt_days(summary.get('max_days'))}"
+    )
+
+
+def _render_human(report: dict[str, Any]) -> str:
+    lines: list[str] = []
+    population = report["population"]
+    lines.append(
+        f"backlog-calibration as of {report['as_of']} -- "
+        f"{population['total']} beads ({population['by_status']}), "
+        f"corpus age {population['corpus_age_days']}d"
+    )
+    lines.append(f"NOTE: {population['censoring_note']}")
+    lead = report["closed_lead_days"]
+    lines.append("\nclosed lead time (days):")
+    lines.append(_render_summary_line("overall", lead["overall"]))
+    for section in ("by_priority", "by_type", "by_epic_membership", "by_dependency_degree"):
+        lines.append(f" {section}:")
+        for name, summary in lead[section].items():
+            lines.append(_render_summary_line(name, summary))
+    survival = report["survival"]
+    lines.append(
+        f"\nsurvival (cohort created >={survival['cohort_min_age_days']:.0f}d ago, "
+        f"n={survival['overall']['n']}): fraction closed within window"
+    )
+    for name, row in [("overall", survival["overall"]), *survival["by_priority"].items()]:
+        if row["n"] == 0:
+            continue
+        windows = "  ".join(f"{window}d={row[f'closed_within_{window}d_pct']}%" for window in _SURVIVAL_WINDOWS_DAYS)
+        lines.append(f"  {name:<8} n={row['n']:<5} {windows}")
+    reasons = report["close_reasons"]
+    lines.append(
+        f"\nclose reasons (n={reasons['closed_with_reason']} with reason; "
+        f"{reasons['no_implementation_pct']}% needed no implementation):"
+    )
+    for name, summary in reasons["classes"].items():
+        lines.append(_render_summary_line(name, summary))
+    discovery = report["discovery"]
+    lines.append(
+        f"\ndiscovery vs drain (excluding import day {discovery.get('import_day_excluded')}): "
+        f"created={discovery.get('post_import_created')} "
+        f"closed={discovery.get('post_import_closed')} "
+        f"created-per-close={discovery.get('created_per_close')} "
+        f"median-net/day={discovery.get('median_net_per_day')} "
+        f"net-negative-days={discovery.get('net_negative_days')}"
+        f"/{discovery.get('post_import_day_count')}"
+    )
+    if "pr_merge_latency" in report:
+        pr = report["pr_merge_latency"]
+        lines.append(f"\nPR open->merge latency (n={pr['n']}): {pr['note']}")
+        for label, summary in pr["by_changed_files_days"].items():
+            lines.append(_render_summary_line(f"{label} files", summary))
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="devtools workspace backlog-calibration",
+        description="Measured duration/discovery models over the bead corpus.",
+    )
+    parser.add_argument(
+        "--input",
+        "-i",
+        metavar="FILE",
+        help="Bead JSONL export (bd export -o FILE); default runs bd export itself",
+    )
+    parser.add_argument(
+        "--prs",
+        metavar="FILE",
+        help=(
+            "Optional gh dump: gh pr list --state merged --limit 4000 "
+            "--json number,createdAt,mergedAt,additions,deletions,changedFiles"
+        ),
+    )
+    parser.add_argument("--json", action="store_true", dest="json_out", help="JSON output")
+    args = parser.parse_args(argv)
+
+    beads = _load_beads_jsonl(Path(args.input)) if args.input else _export_beads()
+    prs: list[dict[str, Any]] | None = None
+    if args.prs:
+        loaded = json.loads(Path(args.prs).read_text())
+        if not isinstance(loaded, list):
+            raise SystemExit(f"{args.prs}: expected a JSON array of PRs")
+        prs = loaded
+
+    report = build_report(beads, as_of=datetime.now(UTC), prs=prs)
+    if args.json_out:
+        print(json.dumps(report, indent=2))
+    else:
+        print(_render_human(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -584,6 +584,29 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "workspace backlog-calibration",
+        "workspace",
+        "Measured lead-time/discovery/staleness distributions over the bead corpus.",
+        "devtools.backlog_calibration",
+        use_when=(
+            "Re-fit the numbers a backlog-execution plan rests on instead of guessing them: "
+            "closed-bead lead-time percentiles split by priority/type/epic-membership/dependency "
+            "degree, a censoring-honest survival view (closed-only medians are survivorship-"
+            "biased), close-reason classification measuring how much of the backlog closes with "
+            "no implementation (already-satisfied/obsolete/duplicate), and created-vs-closed "
+            "discovery dynamics (does the backlog drain?). Optionally calibrates PR open->merge "
+            "latency by size from a gh dump. Answers a different question than "
+            "`workspace beads-state-report` (population shape and graph hygiene, point-in-time) "
+            "and `workspace bead-cluster` (what to batch next): this is duration *models* over "
+            "history, meant to be re-run as the corpus grows so plans stop quoting stale guesses."
+        ),
+        examples=(
+            "devtools workspace backlog-calibration",
+            "devtools workspace backlog-calibration --input beads.jsonl --json",
+            "devtools workspace backlog-calibration --prs prs.json",
+        ),
+    ),
+    CommandSpec(
         "workspace bead-batch-show",
         "workspace",
         "Batch-show beads: id, status, prio, title, desc head, deps, notes tail.",

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -212,6 +212,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools demo real-slice-screen` | Read-only extraction + privacy screening of a candidate real-archive session slice. |
 | `devtools workspace affordance-usage` | Analyze agent affordance/tool usage from archive tool-use rows. |
 | `devtools workspace archive-schema-fast-forward` | Clone-forward the v35 archive tiers without raw replay. |
+| `devtools workspace backlog-calibration` | Measured lead-time/discovery/staleness distributions over the bead corpus. |
 | `devtools workspace basic-usage-demo-check` | Re-run the basic-usage demo suite's commands and assert output shape. |
 | `devtools workspace bead-batch-show` | Batch-show beads: id, status, prio, title, desc head, deps, notes tail. |
 | `devtools workspace bead-cluster` | Footprint/overlap/contention clustering of ready Beads (execution frontier). |

--- a/tests/unit/devtools/test_backlog_calibration.py
+++ b/tests/unit/devtools/test_backlog_calibration.py
@@ -1,0 +1,209 @@
+"""Behavior tests for devtools workspace backlog-calibration.
+
+The tool exists so execution plans quote measured distributions instead of
+guesses; these tests pin the measurement semantics that make those numbers
+trustworthy: percentile math, right-censoring honesty (survival cohort),
+close-reason classification, discovery accounting that excludes the bulk
+import day, and PR latency that reads the merge train rather than guessing
+implementation time.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from devtools.backlog_calibration import (
+    build_report,
+    classify_close_reason,
+    main,
+    summarize_days,
+)
+
+AS_OF = datetime(2026, 7, 31, tzinfo=UTC)
+
+
+def _bead(
+    bead_id: str,
+    *,
+    status: str = "closed",
+    priority: int = 1,
+    issue_type: str = "task",
+    created: str = "2026-07-04T00:00:00Z",
+    closed: str | None = "2026-07-05T00:00:00Z",
+    close_reason: str | None = None,
+    dependencies: list[dict[str, str]] | None = None,
+    dependency_count: int = 0,
+) -> dict[str, object]:
+    record: dict[str, object] = {
+        "id": bead_id,
+        "status": status,
+        "priority": priority,
+        "issue_type": issue_type,
+        "created_at": created,
+        "dependency_count": dependency_count,
+    }
+    if closed is not None:
+        record["closed_at"] = closed
+    if close_reason is not None:
+        record["close_reason"] = close_reason
+    if dependencies is not None:
+        record["dependencies"] = dependencies
+    return record
+
+
+class TestSummarizeDays:
+    def test_percentiles_interpolate_and_report_max(self) -> None:
+        summary = summarize_days([1.0, 2.0, 3.0, 4.0])
+        assert summary["n"] == 4
+        assert summary["p50_days"] == pytest.approx(2.5)
+        assert summary["max_days"] == pytest.approx(4.0)
+
+    def test_empty_population_reports_n_zero_not_a_fit(self) -> None:
+        assert summarize_days([]) == {"n": 0}
+
+
+class TestCloseReasonClassification:
+    @pytest.mark.parametrize(
+        ("reason", "expected"),
+        [
+            ("Duplicate of polylogue-abc", "duplicate"),
+            ("AC already satisfied by #3413", "already-satisfied"),
+            ("Fixed in PR #3397", "already-satisfied"),
+            ("Superseded by the v46 design", "obsolete"),
+            ("Misframed: the gate works as designed", "misframed"),
+            ("Implemented the parser change and merged #3400", "worked"),
+            (None, "worked"),
+        ],
+    )
+    def test_classes(self, reason: str | None, expected: str) -> None:
+        assert classify_close_reason(reason) == expected
+
+
+class TestBuildReport:
+    def test_closed_lead_splits_by_priority_and_epic_membership(self) -> None:
+        beads = [
+            _bead("a", priority=0, closed="2026-07-04T06:00:00Z"),
+            _bead("b", priority=2, closed="2026-07-10T00:00:00Z"),
+            _bead(
+                "c",
+                priority=2,
+                closed="2026-07-08T00:00:00Z",
+                dependencies=[{"type": "parent-child", "depends_on_id": "epic"}],
+            ),
+        ]
+        report = build_report(beads, as_of=AS_OF)
+        lead = report["closed_lead_days"]
+        assert lead["by_priority"]["P0"]["n"] == 1
+        assert lead["by_priority"]["P0"]["p50_days"] == pytest.approx(0.25)
+        assert lead["by_epic_membership"]["epic-child"]["n"] == 1
+        assert lead["by_epic_membership"]["standalone"]["n"] == 2
+
+    def test_survival_counts_open_beads_against_the_cohort(self) -> None:
+        # Two old beads: one closed fast, one still open. Closed-only stats
+        # would report a rosy median; survival must count the open one.
+        beads = [
+            _bead("fast", created="2026-07-01T00:00:00Z", closed="2026-07-01T12:00:00Z"),
+            _bead("open", status="open", created="2026-07-01T00:00:00Z", closed=None),
+            # Too young for the cohort: must be excluded entirely.
+            _bead("young", status="open", created="2026-07-30T00:00:00Z", closed=None),
+        ]
+        report = build_report(beads, as_of=AS_OF)
+        overall = report["survival"]["overall"]
+        assert overall["n"] == 2
+        assert overall["closed_within_1d_pct"] == pytest.approx(50.0)
+        assert overall["closed_within_14d_pct"] == pytest.approx(50.0)
+
+    def test_no_implementation_share_measures_the_verify_first_economy(self) -> None:
+        beads = [
+            _bead("w", close_reason="implemented and merged"),
+            _bead("s", close_reason="already satisfied by #1"),
+            _bead("d", close_reason="duplicate of x"),
+            _bead("n", close_reason=None),  # no reason -> excluded from the denominator
+        ]
+        report = build_report(beads, as_of=AS_OF)
+        reasons = report["close_reasons"]
+        assert reasons["closed_with_reason"] == 3
+        assert reasons["no_implementation_pct"] == pytest.approx(66.7)
+
+    def test_discovery_excludes_the_import_day_and_reports_ratio(self) -> None:
+        beads = [
+            # Import-day bulk: must not count toward the discovery ratio.
+            *[_bead(f"imp{i}", status="open", created="2026-07-03T00:00:00Z", closed=None) for i in range(10)],
+            _bead("d1", status="open", created="2026-07-04T01:00:00Z", closed=None),
+            _bead("d2", status="open", created="2026-07-04T02:00:00Z", closed=None),
+            _bead("d3", created="2026-07-04T03:00:00Z", closed="2026-07-05T00:00:00Z"),
+        ]
+        report = build_report(beads, as_of=AS_OF)
+        discovery = report["discovery"]
+        assert discovery["import_day_excluded"] == "2026-07-03"
+        assert discovery["post_import_created"] == 3
+        assert discovery["post_import_closed"] == 1
+        assert discovery["created_per_close"] == pytest.approx(3.0)
+
+    def test_pr_latency_buckets_by_changed_files(self) -> None:
+        prs = [
+            {
+                "number": 1,
+                "createdAt": "2026-07-30T00:00:00Z",
+                "mergedAt": "2026-07-30T00:06:00Z",
+                "changedFiles": 2,
+            },
+            {
+                "number": 2,
+                "createdAt": "2026-07-30T00:00:00Z",
+                "mergedAt": "2026-07-30T02:00:00Z",
+                "changedFiles": 40,
+            },
+            # Unmerged/malformed rows must be skipped, not crash.
+            {"number": 3, "createdAt": "2026-07-30T00:00:00Z", "mergedAt": None},
+        ]
+        report = build_report([], as_of=AS_OF, prs=prs)
+        latency = report["pr_merge_latency"]
+        assert latency["n"] == 2
+        assert latency["by_changed_files_days"]["1-2"]["n"] == 1
+        assert latency["by_changed_files_days"]["31+"]["n"] == 1
+        # 0.1h and 2.0h -> midpoint 1.05h (1.056 after day-precision rounding)
+        assert latency["overall_latency_hours"]["p50_days"] == pytest.approx(1.05, rel=0.01)
+
+
+class TestCli:
+    def _write_export(self, tmp_path: Path) -> Path:
+        path = tmp_path / "beads.jsonl"
+        rows = [
+            _bead("a", close_reason="already satisfied by #2"),
+            _bead("b", status="open", closed=None),
+        ]
+        path.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+        return path
+
+    def test_json_output_is_parseable_and_complete(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        export = self._write_export(tmp_path)
+        assert main(["--input", str(export), "--json"]) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["population"]["total"] == 2
+        assert set(payload) >= {
+            "population",
+            "closed_lead_days",
+            "survival",
+            "close_reasons",
+            "discovery",
+        }
+
+    def test_human_output_carries_the_censoring_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        export = self._write_export(tmp_path)
+        assert main(["--input", str(export)]) == 0
+        out = capsys.readouterr().out
+        assert "survivorship-biased" in out
+        assert "close reasons" in out
+
+    def test_invalid_jsonl_line_fails_with_location(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.jsonl"
+        path.write_text('{"id": "ok"}\nnot-json\n')
+        with pytest.raises(SystemExit, match="bad.jsonl:2"):
+            main(["--input", str(path), "--json"])


### PR DESCRIPTION
## Summary
Adds `devtools workspace backlog-calibration`: a registered command that fits the duration/discovery models a backlog-execution plan needs — survivorship-corrected lead-time percentiles, close-reason classes (the no-implementation share), and created-vs-closed drain dynamics — from a fresh `bd export`, plus optional PR merge-latency calibration from a `gh pr list --json` dump.

## Problem
The 2026-07-31 backlog-execution design admitted its throughput numbers were guesses ("thresholds are first guesses", "coordinator-halving is a projection"). The calibration pass that replaced them (recorded in `/realm/inbox/polylogue-audits-2026-07-31/backlog-execution-design.html`, §Calibration) found materially different dynamics — closed-only median lead 1.3d but a censoring-honest population median >14d; 48% of closures needing no implementation; 1.83 beads created per bead closed — but one-off analysis scripts rot exactly like the guesses they replaced. The numbers need to be re-fittable in one command as the corpus grows.

## Solution
- `devtools/backlog_calibration.py` — pure-stdlib analysis over a bead JSONL export (`--input`, or `bd export -o <tmpfile>` by default; never touches `.beads/issues.jsonl`): lead percentiles split by priority/type/epic-membership/dependency degree, a >=14d-cohort survival table (the anti-survivorship-bias view), first-match close-reason classification, per-day created/closed with import-day exclusion, and optional `--prs` merge-latency buckets. `--json` for machine output.
- CommandSpec registered under `workspace`, with use_when distinguishing it from `beads-state-report` (population shape, point-in-time) and `bead-cluster` (what to batch next); `docs/devtools.md` regenerated.
- Deliberately reports `n=0`/`None` instead of fitting empty or thin populations, and prints the censoring warning in human output — the honest-measurement semantics are the point of the tool.

## Verification
- `devtools test tests/unit/devtools/test_backlog_calibration.py` → `17 passed` (percentile interpolation, survival counting open beads against the cohort, close-reason classes, import-day exclusion, PR bucket skipping malformed rows, CLI JSON/human/error paths).
- `devtools verify --quick` → all 18 steps ok (format, lint, mypy, render all, topology/layering/manifests/etc).
- Live run against the real corpus (`--input /realm/tmp/calib-beads.jsonl --prs /realm/tmp/calib-prs.json`) reproduces the design doc's measured tables: 48.3% no-implementation closures, created-per-close 1.83, survival P0 82.5%-within-14d.
- Anti-vacuity: the production consumer is the registered CLI path itself (`devtools workspace backlog-calibration`, dispatched via the command catalog); deleting `_survival`'s open-bead counting flips `test_survival_counts_open_beads_against_the_cohort` red.

Not run: full `devtools verify` testmon pass (change is additive; the new test file is its affected set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAAzxpu1wNZLmuAb8Wgyso