### PR TITLE
fix(sources): point the antigravity runtime root at ~/.gemini/antigravity

### DIFF
--- a/polylogue/core/sources.py
+++ b/polylogue/core/sources.py
@@ -125,7 +125,15 @@ _SOURCE_HERMES: Final[Source] = Source(
 )
 _SOURCE_ANTIGRAVITY: Final[Source] = Source(
     family="antigravity-session",
-    runtime_root="~/.antigravity",
+    # 2026-07-31 (polylogue-eo81): the runtime root is ~/.gemini/antigravity,
+    # NOT ~/.antigravity. The latter exists but holds only an `extensions`
+    # directory (4 KB, zero .pb files); the real data -- 345 MB including
+    # conversations/*.pb -- lives under ~/.gemini/. Because the declared root
+    # pointed at the empty path, #3441's conversations/ discovery could never
+    # fire, and the only antigravity rows the archive ever acquired were
+    # *.md.metadata.json sidecars reached by other means: 116 one-message
+    # sessions against 44 real conversations that were never ingested at all.
+    runtime_root="~/.gemini/antigravity",
     originating_lab="google",
 )
 _SOURCE_BEADS: Final[Source] = Source(

--- a/tests/unit/core/test_sources.py
+++ b/tests/unit/core/test_sources.py
@@ -92,7 +92,7 @@ def test_runtime_root_present_for_local_session_sources() -> None:
         Provider.CODEX: "~/.codex/sessions",
         Provider.GEMINI_CLI: "~/.gemini/tmp",
         Provider.HERMES: "~/.hermes",
-        Provider.ANTIGRAVITY: "~/.antigravity",
+        Provider.ANTIGRAVITY: "~/.gemini/antigravity",
     }
     for provider, expected_root in expectations.items():
         assert provider_to_source(provider).runtime_root == expected_root


### PR DESCRIPTION
## Summary

44 real Antigravity conversations have never been acquired. The discovery logic to acquire them landed in #3441 and could never fire, because `Source.runtime_root` points at a directory that does not contain the data.

## Problem

The archive holds **116 `antigravity-session` rows, all of them `*.md.metadata.json` sidecars** materialising as one-message sessions. Meanwhile `~/.gemini/antigravity/conversations/` holds **44 `.pb` files** — the actual conversations — totalling 345 MB, none of it acquired. The origin is inverted: metadata archived, conversations dropped.

PR #3441 fixed the discovery path to ground on `conversations/*.pb` (`sources/source_parsing.py:73`). That fix is correct and has never executed, because:

```
Source.runtime_root = "~/.antigravity"      ← 4 KB, one `extensions` dir, 0 .pb files
actual data          ~/.gemini/antigravity  ← 345 MB, conversations/ with 44 .pb
```

Every acquired sidecar row's `source_path` already points under `~/.gemini/antigravity/brain/…`, so the correct root was observable in the archive's own data the whole time.

## Solution

Corrects `runtime_root`, with the evidence recorded inline at the declaration.

Also updates `tests/unit/core/test_sources.py`, which asserted the literal `"~/.antigravity"`. That test pinned the bug rather than a contract — the enclosing test is `test_runtime_root_present_for_local_session_sources`, whose intent is that local session sources *have* a root, not that antigravity's is any particular string.

## Verification

```
provider_to_source(ANTIGRAVITY).runtime_root  → ~/.gemini/antigravity
  exists: True
  conversations/: True, 44 .pb files
```

`devtools test tests/unit/core/test_sources.py` → 28 passed. `devtools verify --quick` → exit 0.

## Note

This unblocks acquisition but does not perform it — the 44 conversations remain unacquired until an import runs against the corrected root. A rebuild does not recover them; they were never in `source.db`.

Ref polylogue-eo81.