### PR TITLE
refactor(devtools): derive OpenAPI web-credential failure enum from its Literal

### DIFF
--- a/devtools/render_openapi.py
+++ b/devtools/render_openapi.py
@@ -24,7 +24,7 @@ import argparse
 import sys
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, get_args
 
 import yaml
 from pydantic import BaseModel
@@ -42,6 +42,7 @@ from polylogue.daemon.route_contracts import ROUTE_CONTRACTS, RouteContract
 from polylogue.daemon.web_auth import (
     WebCredentialBootstrapPayload,
     WebCredentialFailurePayload,
+    WebCredentialFailureState,
     WebCredentialRevocationPayload,
 )
 from polylogue.surfaces.payloads import (
@@ -79,14 +80,10 @@ _PUBLISHED_MODELS: tuple[type[BaseModel], ...] = (
     QueryExpressionExplanationAst,
 )
 
-_WEB_CREDENTIAL_FAILURE_STATES = [
-    "web_credential_missing",
-    "web_credential_invalid",
-    "web_credential_expired",
-    "web_credential_revoked",
-    "web_credential_wrong_origin",
-    "web_credential_insufficient_scope",
-]
+# Derived from the typed source of truth so the OpenAPI enum cannot drift
+# from the daemon's actual failure vocabulary (same discipline as
+# EXPECTED_TOOL_NAMES / literal_check: derive, don't hand-copy).
+_WEB_CREDENTIAL_FAILURE_STATES = list(get_args(WebCredentialFailureState))
 
 
 def _protected_read_security() -> list[dict[str, list[str]]]:


### PR DESCRIPTION
## Summary
Replace the hand-copied `_WEB_CREDENTIAL_FAILURE_STATES` literal list in `devtools/render_openapi.py` with `list(get_args(WebCredentialFailureState))`, deriving it from the typed source of truth in `polylogue/daemon/web_auth.py`.

## Problem
Found during the 2026-07-31 producer/consumer audit. The list duplicated the six `WebCredentialFailureState` Literal values with no derivation link — structurally identical to the pre-fix `EXPECTED_TOOL_NAMES`/`EXPECTED_PROMPT_NAMES` defect (polylogue-il50): hand-written mirror lists drift silently when the source vocabulary changes; derived lists cannot. It had not yet drifted, which is exactly when the cheap fix applies.

## Solution
One-file change: import the Literal, derive the list, keep the four consuming sites untouched. A comment records why the derivation exists.

## Verification
- `python -c` assert: derived list is byte-identical to the previous literal.
- `devtools render openapi --check` → `sync OK: docs/openapi/search.yaml` (no regeneration needed).
- Pre-commit (format+lint) and pre-push (`devtools verify --quick`) passed.
- Not run: full test suite (no behavior change; generated surface verified unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAAzxpu1wNZLmuAb8Wgyso