### PR TITLE
feat(browser-extension): capture Claude native structured blocks and both attachment channels

### DIFF
--- a/browser-extension/manifest.json
+++ b/browser-extension/manifest.json
@@ -13,6 +13,7 @@
   "host_permissions": [
     "https://chatgpt.com/*",
     "https://claude.ai/*",
+    "https://*.claudeusercontent.com/*",
     "https://grok.com/*",
     "https://x.com/*",
     "https://twitter.com/*",

--- a/browser-extension/scripts/validate-manifest.mjs
+++ b/browser-extension/scripts/validate-manifest.mjs
@@ -30,6 +30,11 @@ const ALLOWED_PERMISSIONS = new Set([
 const ALLOWED_HOST_GLOBS = [
   /^https:\/\/chatgpt\.com\/\*$/,
   /^https:\/\/claude\.ai\/\*$/,
+  // Claude Design serves each project's rendered files from a sandboxed
+  // per-project origin <project-uuid>.claudeusercontent.com (same pattern as
+  // artifacts), so design file content is unreachable from the claude.ai
+  // content script without this. Wildcard is on the subdomain only.
+  /^https:\/\/\*\.claudeusercontent\.com\/\*$/,
   /^https:\/\/grok\.com\/\*$/,
   /^https:\/\/x\.com\/\*$/,
   /^https:\/\/twitter\.com\/\*$/,

--- a/browser-extension/src/content/claude.js
+++ b/browser-extension/src/content/claude.js
@@ -77,19 +77,108 @@
     return "unknown";
   }
 
+  // Claude's chat_conversations API returns the same segment shape as the
+  // GDPR export, so the structure the archive-side parser understands is
+  // already in hand here -- flattening it to prose would discard tool_use /
+  // tool_result / thinking that the export path parses in full.
+  // BlockType names and the is_error contract mirror BrowserCaptureBlock
+  // (polylogue/browser_capture/models.py): outcome fields are read from the
+  // provider's own segment, never inferred from rendered text.
+  function nativeTurnBlocks(message) {
+    const segments = Array.isArray(message && message.content) ? message.content : [];
+    const blocks = [];
+    for (const segment of segments) {
+      if (!segment || typeof segment !== "object") continue;
+      const type = segment.type;
+      if (type === "text" && typeof segment.text === "string" && segment.text) {
+        blocks.push({ type: "text", text: segment.text });
+      } else if (type === "thinking") {
+        const thinking = typeof segment.thinking === "string" ? segment.thinking : segment.text;
+        if (thinking) blocks.push({ type: "thinking", text: thinking, metadata: { content_type: type } });
+      } else if (type === "tool_use") {
+        blocks.push({
+          type: "tool_use",
+          tool_name: segment.name || null,
+          tool_id: segment.id || null,
+          tool_input: segment.input && typeof segment.input === "object" && !Array.isArray(segment.input)
+            ? segment.input
+            : null
+        });
+      } else if (type === "tool_result") {
+        blocks.push({
+          type: "tool_result",
+          tool_id: segment.tool_use_id || null,
+          text: typeof segment.content === "string" ? segment.content : null,
+          // Provider-reported outcome. Absent stays null (unknown), never false.
+          is_error: typeof segment.is_error === "boolean" ? segment.is_error : null,
+          metadata: { tool_name: segment.name || null }
+        });
+      }
+    }
+    return blocks;
+  }
+
+  // Two distinct attachment channels, both present in the conversations API:
+  //   attachments[] carries extracted_content inline (text already extracted
+  //     by the provider) but NO id -- synthesise a stable one.
+  //   files[]       carries a real file_uuid but no bytes; recorded as a
+  //     reference so a later byte acquisition can join on the uuid.
+  function nativeTurnAttachments(message, index) {
+    const out = [];
+    const messageId = String(message.uuid || message.id || `claude-message-${index}`);
+    for (const attachment of Array.isArray(message.attachments) ? message.attachments : []) {
+      if (!attachment || typeof attachment !== "object") continue;
+      const name = attachment.file_name || attachment.name || null;
+      if (!name) continue;
+      const size = Number.parseInt(attachment.file_size, 10);
+      out.push({
+        provider_attachment_id: `claude-attachment:${window.polylogueCapture.fnv1a(`${messageId}:${name}:${attachment.file_size || ""}`)}`,
+        message_provider_id: messageId,
+        name,
+        mime_type: attachment.file_type || null,
+        size_bytes: Number.isFinite(size) ? size : null,
+        extracted_content: typeof attachment.extracted_content === "string" ? attachment.extracted_content : null,
+        provider_meta: { capture_source: "claude_chat_conversations_api", channel: "attachments" }
+      });
+    }
+    for (const file of Array.isArray(message.files) ? message.files : []) {
+      if (!file || typeof file !== "object") continue;
+      const name = file.file_name || file.name || null;
+      const uuid = file.file_uuid || file.uuid || null;
+      if (!name && !uuid) continue;
+      out.push({
+        provider_attachment_id: uuid ? `claude-file:${uuid}` : `claude-file:${window.polylogueCapture.fnv1a(`${messageId}:${name}`)}`,
+        message_provider_id: messageId,
+        name,
+        provider_meta: {
+          capture_source: "claude_chat_conversations_api",
+          channel: "files",
+          file_uuid: uuid || null
+        }
+      });
+    }
+    return out;
+  }
+
   function collectNativeTurns(payload) {
     const messages = payload && payload.chat_messages;
     if (!Array.isArray(messages)) return [];
     return messages
       .map((message, index) => {
         const text = textFromMessage(message);
-        if (!text) return null;
+        const blocks = nativeTurnBlocks(message);
+        const attachments = nativeTurnAttachments(message, index);
+        // A turn with attachments or structured blocks but no prose is still a
+        // real turn -- requiring text would drop image-only and tool-only turns.
+        if (!text && !blocks.length && !attachments.length) return null;
         return {
           provider_turn_id: String(message.uuid || message.id || `claude-message-${index}`),
           role: roleFromNativeMessage(message),
           text,
           timestamp: message.created_at || message.updated_at || null,
           parent_turn_id: message.parent_message_uuid || message.parent_uuid || null,
+          blocks,
+          attachments,
           provider_meta: {
             model: message.model || null,
             sender: message.sender || message.role || null,

--- a/browser-extension/tests/content/claude.test.js
+++ b/browser-extension/tests/content/claude.test.js
@@ -220,3 +220,177 @@ describe("claude.js native capture (real source)", () => {
     expect(result).toMatchObject({ ok: false, error: "native_capture_unavailable" });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Native-payload structure extraction — extracted from src/content/claude.js,
+// keep in sync. Claude's chat_conversations API returns the same segment shape
+// as the GDPR export, so tool_use / tool_result / thinking and both attachment
+// channels are observable at capture time; flattening them to prose loses what
+// the export path parses in full.
+// ---------------------------------------------------------------------------
+
+const fnv1a = (text) => {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < text.length; i += 1) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16);
+};
+
+function nativeTurnBlocks(message) {
+  const segments = Array.isArray(message && message.content) ? message.content : [];
+  const blocks = [];
+  for (const segment of segments) {
+    if (!segment || typeof segment !== "object") continue;
+    const type = segment.type;
+    if (type === "text" && typeof segment.text === "string" && segment.text) {
+      blocks.push({ type: "text", text: segment.text });
+    } else if (type === "thinking") {
+      const thinking = typeof segment.thinking === "string" ? segment.thinking : segment.text;
+      if (thinking) blocks.push({ type: "thinking", text: thinking, metadata: { content_type: type } });
+    } else if (type === "tool_use") {
+      blocks.push({
+        type: "tool_use",
+        tool_name: segment.name || null,
+        tool_id: segment.id || null,
+        tool_input: segment.input && typeof segment.input === "object" && !Array.isArray(segment.input)
+          ? segment.input
+          : null,
+      });
+    } else if (type === "tool_result") {
+      blocks.push({
+        type: "tool_result",
+        tool_id: segment.tool_use_id || null,
+        text: typeof segment.content === "string" ? segment.content : null,
+        is_error: typeof segment.is_error === "boolean" ? segment.is_error : null,
+        metadata: { tool_name: segment.name || null },
+      });
+    }
+  }
+  return blocks;
+}
+
+function nativeTurnAttachments(message, index) {
+  const out = [];
+  const messageId = String(message.uuid || message.id || `claude-message-${index}`);
+  for (const attachment of Array.isArray(message.attachments) ? message.attachments : []) {
+    if (!attachment || typeof attachment !== "object") continue;
+    const name = attachment.file_name || attachment.name || null;
+    if (!name) continue;
+    const size = Number.parseInt(attachment.file_size, 10);
+    out.push({
+      provider_attachment_id: `claude-attachment:${fnv1a(`${messageId}:${name}:${attachment.file_size || ""}`)}`,
+      message_provider_id: messageId,
+      name,
+      mime_type: attachment.file_type || null,
+      size_bytes: Number.isFinite(size) ? size : null,
+      extracted_content: typeof attachment.extracted_content === "string" ? attachment.extracted_content : null,
+      provider_meta: { capture_source: "claude_chat_conversations_api", channel: "attachments" },
+    });
+  }
+  for (const file of Array.isArray(message.files) ? message.files : []) {
+    if (!file || typeof file !== "object") continue;
+    const name = file.file_name || file.name || null;
+    const uuid = file.file_uuid || file.uuid || null;
+    if (!name && !uuid) continue;
+    out.push({
+      provider_attachment_id: uuid ? `claude-file:${uuid}` : `claude-file:${fnv1a(`${messageId}:${name}`)}`,
+      message_provider_id: messageId,
+      name,
+      provider_meta: {
+        capture_source: "claude_chat_conversations_api",
+        channel: "files",
+        file_uuid: uuid || null,
+      },
+    });
+  }
+  return out;
+}
+
+describe("claude native capture — structured blocks", () => {
+  it("preserves tool_use with its id and input rather than flattening to prose", () => {
+    const blocks = nativeTurnBlocks({
+      content: [
+        { type: "text", text: "Let me search." },
+        { type: "tool_use", id: "toolu_01Bzda", name: "web_search", input: { query: "polylogue" } },
+      ],
+    });
+    expect(blocks).toHaveLength(2);
+    expect(blocks[1]).toMatchObject({
+      type: "tool_use",
+      tool_name: "web_search",
+      tool_id: "toolu_01Bzda",
+      tool_input: { query: "polylogue" },
+    });
+  });
+
+  it("carries the provider's own tool_result outcome, and leaves it unknown when absent", () => {
+    const failed = nativeTurnBlocks({
+      content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "boom", is_error: true }],
+    });
+    expect(failed[0]).toMatchObject({ type: "tool_result", tool_id: "toolu_1", is_error: true });
+
+    const unknown = nativeTurnBlocks({
+      content: [{ type: "tool_result", tool_use_id: "toolu_2", content: "ok" }],
+    });
+    // Absent is_error stays null (unknown) — never coerced to false.
+    expect(unknown[0].is_error).toBeNull();
+  });
+
+  it("keeps thinking segments, reading Claude's `thinking` field", () => {
+    const blocks = nativeTurnBlocks({
+      content: [{ type: "thinking", thinking: "considering options" }],
+    });
+    expect(blocks[0]).toMatchObject({ type: "thinking", text: "considering options" });
+  });
+
+  it("ignores segment shapes it does not recognise instead of guessing", () => {
+    expect(nativeTurnBlocks({ content: [{ type: "token_budget", budget: 5 }] })).toEqual([]);
+  });
+});
+
+describe("claude native capture — both attachment channels", () => {
+  it("extracts attachments[] inline content, which carries no provider id", () => {
+    const [attachment] = nativeTurnAttachments(
+      {
+        uuid: "msg-1",
+        attachments: [
+          { file_name: "paste.txt", file_size: "4817", file_type: "txt", extracted_content: "hello" },
+        ],
+      },
+      0,
+    );
+    expect(attachment).toMatchObject({
+      message_provider_id: "msg-1",
+      name: "paste.txt",
+      mime_type: "txt",
+      size_bytes: 4817,
+      extracted_content: "hello",
+    });
+    // Synthesised, stable, and namespaced so it cannot collide with files[].
+    expect(attachment.provider_attachment_id).toMatch(/^claude-attachment:[0-9a-f]+$/);
+  });
+
+  it("extracts files[] by its real uuid so a later byte acquisition can join", () => {
+    const [file] = nativeTurnAttachments(
+      { uuid: "msg-2", files: [{ file_name: "diagram.png", file_uuid: "file-abc123" }] },
+      0,
+    );
+    expect(file.provider_attachment_id).toBe("claude-file:file-abc123");
+    expect(file.provider_meta.file_uuid).toBe("file-abc123");
+  });
+
+  it("keeps the two channels distinct for one message", () => {
+    const out = nativeTurnAttachments(
+      {
+        uuid: "msg-3",
+        attachments: [{ file_name: "a.txt", file_size: "10", extracted_content: "x" }],
+        files: [{ file_name: "b.png", file_uuid: "file-b" }],
+      },
+      0,
+    );
+    expect(out).toHaveLength(2);
+    expect(out.map((a) => a.provider_meta.channel)).toEqual(["attachments", "files"]);
+  });
+});


### PR DESCRIPTION
## Summary
The Claude content script now preserves the chat_conversations API's structured segments (tool_use / tool_result / thinking) as typed BrowserCaptureBlocks instead of flattening turns to prose, extracts both attachment channels, and gains the claudeusercontent.com host permission required to reach Claude Design project files.

## Problem
Claude's chat_conversations API returns the same segment shape as the GDPR export, so the structure the archive-side parser understands is already in hand at capture time — but the content script flattened it to prose, discarding tool_use/tool_result/thinking that the export path parses in full. Attachments were dropped entirely, and Claude Design file content was unreachable: each project's rendered files are served from a sandboxed per-project origin `<uuid>.claudeusercontent.com` that the manifest never granted.

## Solution
- `nativeTurnBlocks()` in `src/content/claude.js` maps API segments to the BlockType names and is_error contract of `BrowserCaptureBlock` (polylogue/browser_capture/models.py). Provider-reported outcomes are read from the provider's own segment; absent stays `null` (unknown), never inferred from rendered text. Unknown segment shapes are ignored, not guessed.
- Both attachment channels handled distinctly: `attachments[]` carries `extracted_content` inline but no id (a stable id is synthesised); `files[]` carries the real uuid, preserved so a later byte acquisition can join.
- `manifest.json` + `scripts/validate-manifest.mjs`: allow `https://*.claudeusercontent.com/*` (subdomain wildcard only), with the rationale documented in the validator.

## Verification
- `npx vitest run tests/content/claude.test.js` — 13 passed.
- Full suite `npx vitest run` — **374 passed, 1 failed**: `build.test.js` service-worker fixture, which fails identically on clean master in an isolated worktree (verified at 0b33b1c5b) — pre-existing, tracked as a P1 bead filed this session.
- `node scripts/validate-manifest.mjs` — manifest ok.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude captures now preserve structured message content, including thinking, tool calls, and tool results.
  * Tool results retain provider-reported error states for more accurate conversation records.
  * Inline attachments and referenced files are captured with stable identifiers and metadata.
  * Messages containing only structured content or attachments are retained, even without visible text.
  * Support added for capturing content hosted on Claude’s content domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->