### PR TITLE
fix(browser-extension): handle array tool_result content and dedupe attachment ids

### DIFF
--- a/browser-extension/src/content/claude.js
+++ b/browser-extension/src/content/claude.js
@@ -84,6 +84,21 @@
   // BlockType names and the is_error contract mirror BrowserCaptureBlock
   // (polylogue/browser_capture/models.py): outcome fields are read from the
   // provider's own segment, never inferred from rendered text.
+  // tool_result.content per Anthropic's API is either a plain string or an
+  // array of content blocks (type: "text" | "image" | ...). Join the text of
+  // "text"-typed blocks, newline-separated; return null only when no text
+  // content is present at all (e.g. an image-only result).
+  function textFromToolResultContent(content) {
+    if (typeof content === "string") return content || null;
+    if (Array.isArray(content)) {
+      const texts = content
+        .filter((part) => part && typeof part === "object" && part.type === "text" && typeof part.text === "string")
+        .map((part) => part.text);
+      return texts.length ? texts.join("\n") : null;
+    }
+    return null;
+  }
+
   function nativeTurnBlocks(message) {
     const segments = Array.isArray(message && message.content) ? message.content : [];
     const blocks = [];
@@ -108,7 +123,12 @@
         blocks.push({
           type: "tool_result",
           tool_id: segment.tool_use_id || null,
-          text: typeof segment.content === "string" ? segment.content : null,
+          // Anthropic's tool_result content can be a plain string OR an array
+          // of content blocks (text/image/...) -- join the text blocks'
+          // `text` fields when it's an array. Never invent text for
+          // non-text blocks (e.g. images); text stays null only when no
+          // text content exists at all.
+          text: textFromToolResultContent(segment.content),
           // Provider-reported outcome. Absent stays null (unknown), never false.
           is_error: typeof segment.is_error === "boolean" ? segment.is_error : null,
           metadata: { tool_name: segment.name || null }
@@ -126,13 +146,17 @@
   function nativeTurnAttachments(message, index) {
     const out = [];
     const messageId = String(message.uuid || message.id || `claude-message-${index}`);
-    for (const attachment of Array.isArray(message.attachments) ? message.attachments : []) {
+    const messageAttachments = Array.isArray(message.attachments) ? message.attachments : [];
+    for (const [attachmentPosition, attachment] of messageAttachments.entries()) {
       if (!attachment || typeof attachment !== "object") continue;
       const name = attachment.file_name || attachment.name || null;
       if (!name) continue;
       const size = Number.parseInt(attachment.file_size, 10);
+      // Include the loop index in the hash input: two attachments with the
+      // same name and size in one message would otherwise collide on the
+      // same synthesised id (name/size alone are not unique within a message).
       out.push({
-        provider_attachment_id: `claude-attachment:${window.polylogueCapture.fnv1a(`${messageId}:${name}:${attachment.file_size || ""}`)}`,
+        provider_attachment_id: `claude-attachment:${window.polylogueCapture.fnv1a(`${messageId}:${attachmentPosition}:${name}:${attachment.file_size || ""}`)}`,
         message_provider_id: messageId,
         name,
         mime_type: attachment.file_type || null,
@@ -314,6 +338,11 @@
   }
 
   window.polylogueCapture.capturePage = capture;
+  // Test-only exposure of the pure structured-block/attachment extractors so
+  // tests exercise the real implementation instead of a hand-copied one that
+  // can silently drift (polylogue-ah21's dropped-`blocks` regression was
+  // caused by exactly that drift). Not used by any runtime capture path.
+  window.polylogueCapture.__claudeNativeInternals = { nativeTurnBlocks, nativeTurnAttachments };
   if (window.polylogueMessageLayer) {
     messageLayer = window.polylogueMessageLayer.mount({
       containerSelector: MESSAGE_CONTAINER_SELECTOR,

--- a/browser-extension/tests/content/claude.test.js
+++ b/browser-extension/tests/content/claude.test.js
@@ -222,94 +222,34 @@ describe("claude.js native capture (real source)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Native-payload structure extraction — extracted from src/content/claude.js,
-// keep in sync. Claude's chat_conversations API returns the same segment shape
-// as the GDPR export, so tool_use / tool_result / thinking and both attachment
-// channels are observable at capture time; flattening them to prose loses what
-// the export path parses in full.
+// Native-payload structure extraction — driven through the REAL
+// nativeTurnBlocks/nativeTurnAttachments implementations in
+// src/content/claude.js (exposed for tests only via
+// window.polylogueCapture.__claudeNativeInternals), not a hand-copied
+// reimplementation. Claude's chat_conversations API returns the same segment
+// shape as the GDPR export, so tool_use / tool_result / thinking and both
+// attachment channels are observable at capture time; flattening them to
+// prose loses what the export path parses in full.
 // ---------------------------------------------------------------------------
 
-const fnv1a = (text) => {
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < text.length; i += 1) {
-    hash ^= text.charCodeAt(i);
-    hash = Math.imul(hash, 0x01000193) >>> 0;
-  }
-  return hash.toString(16);
-};
-
-function nativeTurnBlocks(message) {
-  const segments = Array.isArray(message && message.content) ? message.content : [];
-  const blocks = [];
-  for (const segment of segments) {
-    if (!segment || typeof segment !== "object") continue;
-    const type = segment.type;
-    if (type === "text" && typeof segment.text === "string" && segment.text) {
-      blocks.push({ type: "text", text: segment.text });
-    } else if (type === "thinking") {
-      const thinking = typeof segment.thinking === "string" ? segment.thinking : segment.text;
-      if (thinking) blocks.push({ type: "thinking", text: thinking, metadata: { content_type: type } });
-    } else if (type === "tool_use") {
-      blocks.push({
-        type: "tool_use",
-        tool_name: segment.name || null,
-        tool_id: segment.id || null,
-        tool_input: segment.input && typeof segment.input === "object" && !Array.isArray(segment.input)
-          ? segment.input
-          : null,
-      });
-    } else if (type === "tool_result") {
-      blocks.push({
-        type: "tool_result",
-        tool_id: segment.tool_use_id || null,
-        text: typeof segment.content === "string" ? segment.content : null,
-        is_error: typeof segment.is_error === "boolean" ? segment.is_error : null,
-        metadata: { tool_name: segment.name || null },
-      });
-    }
-  }
-  return blocks;
-}
-
-function nativeTurnAttachments(message, index) {
-  const out = [];
-  const messageId = String(message.uuid || message.id || `claude-message-${index}`);
-  for (const attachment of Array.isArray(message.attachments) ? message.attachments : []) {
-    if (!attachment || typeof attachment !== "object") continue;
-    const name = attachment.file_name || attachment.name || null;
-    if (!name) continue;
-    const size = Number.parseInt(attachment.file_size, 10);
-    out.push({
-      provider_attachment_id: `claude-attachment:${fnv1a(`${messageId}:${name}:${attachment.file_size || ""}`)}`,
-      message_provider_id: messageId,
-      name,
-      mime_type: attachment.file_type || null,
-      size_bytes: Number.isFinite(size) ? size : null,
-      extracted_content: typeof attachment.extracted_content === "string" ? attachment.extracted_content : null,
-      provider_meta: { capture_source: "claude_chat_conversations_api", channel: "attachments" },
-    });
-  }
-  for (const file of Array.isArray(message.files) ? message.files : []) {
-    if (!file || typeof file !== "object") continue;
-    const name = file.file_name || file.name || null;
-    const uuid = file.file_uuid || file.uuid || null;
-    if (!name && !uuid) continue;
-    out.push({
-      provider_attachment_id: uuid ? `claude-file:${uuid}` : `claude-file:${fnv1a(`${messageId}:${name}`)}`,
-      message_provider_id: messageId,
-      name,
-      provider_meta: {
-        capture_source: "claude_chat_conversations_api",
-        channel: "files",
-        file_uuid: uuid || null,
-      },
-    });
-  }
-  return out;
+function installClaudeInternals() {
+  const dom = new JSDOM("<!doctype html><title>Claude internals fixture</title>", {
+    url: "https://claude.ai/chat/conversation-1",
+    runScripts: "outside-only",
+  });
+  openDoms.push(dom);
+  const chrome = { runtime: { id: "synthetic-extension-id", onMessage: { addListener: () => undefined } } };
+  Object.defineProperty(dom.window, "chrome", { configurable: true, value: chrome });
+  const context = dom.getInternalVMContext();
+  new Script(bridgeSource).runInContext(context);
+  new Script(commonSource).runInContext(context);
+  new Script(contentSource).runInContext(context);
+  return dom.window.polylogueCapture.__claudeNativeInternals;
 }
 
 describe("claude native capture — structured blocks", () => {
   it("preserves tool_use with its id and input rather than flattening to prose", () => {
+    const { nativeTurnBlocks } = installClaudeInternals();
     const blocks = nativeTurnBlocks({
       content: [
         { type: "text", text: "Let me search." },
@@ -326,6 +266,7 @@ describe("claude native capture — structured blocks", () => {
   });
 
   it("carries the provider's own tool_result outcome, and leaves it unknown when absent", () => {
+    const { nativeTurnBlocks } = installClaudeInternals();
     const failed = nativeTurnBlocks({
       content: [{ type: "tool_result", tool_use_id: "toolu_1", content: "boom", is_error: true }],
     });
@@ -339,6 +280,7 @@ describe("claude native capture — structured blocks", () => {
   });
 
   it("keeps thinking segments, reading Claude's `thinking` field", () => {
+    const { nativeTurnBlocks } = installClaudeInternals();
     const blocks = nativeTurnBlocks({
       content: [{ type: "thinking", thinking: "considering options" }],
     });
@@ -346,12 +288,46 @@ describe("claude native capture — structured blocks", () => {
   });
 
   it("ignores segment shapes it does not recognise instead of guessing", () => {
+    const { nativeTurnBlocks } = installClaudeInternals();
     expect(nativeTurnBlocks({ content: [{ type: "token_budget", budget: 5 }] })).toEqual([]);
+  });
+
+  it("joins text blocks when tool_result content is an array of content blocks, per Anthropic's API", () => {
+    const { nativeTurnBlocks } = installClaudeInternals();
+    const blocks = nativeTurnBlocks({
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "toolu_3",
+          content: [
+            { type: "text", text: "first line" },
+            { type: "image", source: { type: "base64", data: "..." } },
+            { type: "text", text: "second line" },
+          ],
+        },
+      ],
+    });
+    expect(blocks[0].text).toBe("first line\nsecond line");
+  });
+
+  it("leaves tool_result text null when an array-shaped content has no text blocks (image-only)", () => {
+    const { nativeTurnBlocks } = installClaudeInternals();
+    const blocks = nativeTurnBlocks({
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "toolu_4",
+          content: [{ type: "image", source: { type: "base64", data: "..." } }],
+        },
+      ],
+    });
+    expect(blocks[0].text).toBeNull();
   });
 });
 
 describe("claude native capture — both attachment channels", () => {
   it("extracts attachments[] inline content, which carries no provider id", () => {
+    const { nativeTurnAttachments } = installClaudeInternals();
     const [attachment] = nativeTurnAttachments(
       {
         uuid: "msg-1",
@@ -373,6 +349,7 @@ describe("claude native capture — both attachment channels", () => {
   });
 
   it("extracts files[] by its real uuid so a later byte acquisition can join", () => {
+    const { nativeTurnAttachments } = installClaudeInternals();
     const [file] = nativeTurnAttachments(
       { uuid: "msg-2", files: [{ file_name: "diagram.png", file_uuid: "file-abc123" }] },
       0,
@@ -382,6 +359,7 @@ describe("claude native capture — both attachment channels", () => {
   });
 
   it("keeps the two channels distinct for one message", () => {
+    const { nativeTurnAttachments } = installClaudeInternals();
     const out = nativeTurnAttachments(
       {
         uuid: "msg-3",
@@ -392,5 +370,21 @@ describe("claude native capture — both attachment channels", () => {
     );
     expect(out).toHaveLength(2);
     expect(out.map((a) => a.provider_meta.channel)).toEqual(["attachments", "files"]);
+  });
+
+  it("disambiguates two attachments with identical name and size in one message", () => {
+    const { nativeTurnAttachments } = installClaudeInternals();
+    const out = nativeTurnAttachments(
+      {
+        uuid: "msg-4",
+        attachments: [
+          { file_name: "dup.txt", file_size: "10", extracted_content: "first" },
+          { file_name: "dup.txt", file_size: "10", extracted_content: "second" },
+        ],
+      },
+      0,
+    );
+    expect(out).toHaveLength(2);
+    expect(out[0].provider_attachment_id).not.toBe(out[1].provider_attachment_id);
   });
 });


### PR DESCRIPTION
## Summary
Fixes three CodeRabbit findings from the review of #3481 (Claude native
structured-block capture): tool_result content-array handling, an
attachment-id collision, and a test file that only exercised a hand-copied
reimplementation of the production extractors instead of the real ones.

## Problem
1. `nativeTurnBlocks()`'s `tool_result` branch in `browser-extension/src/content/claude.js`
   set `text: null` whenever `segment.content` was an array of content
   blocks (`type: "text" | "image" | ...`) rather than a plain string.
   That array shape is a real, documented Anthropic API response, not an
   edge case -- it silently dropped tool_result text.
2. `nativeTurnAttachments()`'s `attachments[]` channel synthesised
   `provider_attachment_id` by hashing `messageId:name:file_size` only. Two
   attachments with identical name and size within one message produced
   the same id, so one silently clobbered the other downstream.
3. `browser-extension/tests/content/claude.test.js` kept a hand-copied
   reimplementation of both extractors below the "real source" describe
   block. The tests only ever proved the copy matched itself -- the exact
   drift failure mode the file's own header comment documents as the cause
   of the earlier polylogue-ah21 regression (buildEnvelope silently
   dropping `blocks`).

## Solution
- Added `textFromToolResultContent()` in `claude.js`: joins the `text`
  fields of `type: "text"` blocks (newline-separated) when content is an
  array, keeps existing string handling unchanged, and returns `null` only
  when no text content exists at all -- it never invents text for image
  blocks.
- `nativeTurnAttachments()` now iterates `attachments[]` via `.entries()`
  and folds the loop position into the hash input
  (`messageId:position:name:size`), so identical-name+size attachments in
  one message get distinct ids. `files[]` (keyed by the provider's real
  `file_uuid`) is unaffected.
- Exposed the two pure extractors for tests only via
  `window.polylogueCapture.__claudeNativeInternals` (not used by any
  runtime capture path).
- `claude.test.js`: dropped the local reimplementation. Both `describe`
  blocks now load `claude.js` through the same `vm.Script`/JSDOM technique
  the file's "real source" block already uses and call the real functions
  off `__claudeNativeInternals`. Added cases for array-shaped `tool_result`
  content (multi-block join and image-only null-text) and duplicate-
  attachment id disambiguation.

## Verification
- `npx vitest run tests/content/claude.test.js` -> `Test Files 1 passed
  (1)`, `Tests 16 passed (16)`.
- `npx vitest run` -> `Test Files 1 failed | 18 passed (19)`, `Tests 1
  failed | 377 passed (378)`. The sole failure is
  `tests/build.test.js > build.mjs full archive emission > executes the
  packaged service worker fixture without foreground tab activation`,
  confirmed pre-existing by running the identical full suite against
  `origin/master` in a separate worktree (same failure, same assertion,
  374 passed there). A `background.test.js` timing-sensitive test failed
  once mid-session and passed on every other run (isolated rerun and full
  suite rerun) -- confirmed flaky, not caused by this change.
- `node scripts/validate-manifest.mjs` -> `manifest ok`.

Follow-up to #3481 review findings.

Co-Authored-By: Claude <noreply@anthropic.com>
