### PR TITLE
refactor(context): move preamble git enrichment out of the MCP surface

### DIFF
--- a/polylogue/context/preamble.py
+++ b/polylogue/context/preamble.py
@@ -27,6 +27,42 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+def _git_project_state(cwd: str | None) -> ContextPreambleProjectState | None:
+    """Read branch + recent commits from a local git checkout, best-effort.
+
+    Never raises: a missing/non-git ``cwd`` must not break SessionStart
+    context injection (or CLI context composition run outside a repo).
+    """
+    import subprocess
+
+    try:
+        branch: str | None = None
+        commits: list[str] = []
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=cwd or ".",
+        )
+        if result.returncode == 0:
+            branch = result.stdout.strip()
+        result2 = subprocess.run(
+            ["git", "log", "--oneline", "-5"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=cwd or ".",
+        )
+        if result2.returncode == 0:
+            commits = [line.strip() for line in result2.stdout.strip().split("\n") if line]
+        if branch or commits:
+            return ContextPreambleProjectState(branch=branch, recent_commits=commits)
+    except Exception:
+        pass
+    return None
+
+
 def _candidate_overlap_basis(candidate: object) -> ContextPreambleOverlapBasis | None:
     basis = getattr(candidate, "overlap_basis", None)
     model_dump = getattr(basis, "model_dump", None)
@@ -108,10 +144,13 @@ async def build_context_preamble_payload(
     project: ContextPreambleProjectState | None = None
     git_repo = getattr(conv, "git_repository_url", None) if conv is not None else None
     git_branch = getattr(conv, "git_branch", None) if conv is not None else None
-    if git_repo or git_branch:
+    local_git_state = _git_project_state(cwd)
+    if git_repo or git_branch or local_git_state is not None:
         project = ContextPreambleProjectState(
             repo=str(git_repo) if git_repo else None,
-            branch=str(git_branch) if git_branch else None,
+            branch=(local_git_state.branch if local_git_state and local_git_state.branch else None)
+            or (str(git_branch) if git_branch else None),
+            recent_commits=list(local_git_state.recent_commits) if local_git_state else [],
         )
 
     assertion_guidance: list[ContextPreambleAssertionGuidance] = []

--- a/polylogue/mcp/server_cutover.py
+++ b/polylogue/mcp/server_cutover.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
     from polylogue.maintenance.scope import MaintenanceScopeFilter
     from polylogue.mcp.declarations.adapter import ToolRegistrar
     from polylogue.mcp.server_support import ServerCallbacks
-    from polylogue.surfaces.payloads import ContextPreambleProjectState
 
 
 @dataclass(frozen=True)
@@ -585,44 +584,6 @@ async def _query_insight_projection(
         )
 
 
-def _git_project_state(cwd: str | None) -> ContextPreambleProjectState | None:
-    """Read branch + recent commits from a local git checkout, best-effort.
-
-    Never raises: a missing/non-git ``cwd`` must not break SessionStart
-    context injection.
-    """
-    import subprocess
-
-    from polylogue.surfaces.payloads import ContextPreambleProjectState
-
-    try:
-        branch: str | None = None
-        commits: list[str] = []
-        result = subprocess.run(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            cwd=cwd or ".",
-        )
-        if result.returncode == 0:
-            branch = result.stdout.strip()
-        result2 = subprocess.run(
-            ["git", "log", "--oneline", "-5"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            cwd=cwd or ".",
-        )
-        if result2.returncode == 0:
-            commits = [line.strip() for line in result2.stdout.strip().split("\n") if line]
-        if branch or commits:
-            return ContextPreambleProjectState(branch=branch, recent_commits=commits)
-    except Exception:
-        pass
-    return None
-
-
 async def _resume_preamble(
     hooks: ServerCallbacks,
     *,
@@ -648,12 +609,6 @@ async def _resume_preamble(
     )
     if preamble is None:
         preamble = ContextPreamble(preamble_version="1.0", source_tool_calls={"context": "polylogue-mcp"})
-
-    project = _git_project_state(cwd)
-    if project is not None:
-        payload = preamble.model_dump(mode="json", exclude_none=True)
-        payload["project_state"] = project.model_dump(mode="json", exclude_none=True)
-        preamble = ContextPreamble.model_validate(payload)
     return hooks.json_payload(preamble, exclude_none=True)
 
 

--- a/tests/unit/cli/test_context_view.py
+++ b/tests/unit/cli/test_context_view.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -25,6 +25,11 @@ def _session() -> SimpleNamespace:
     )
 
 
+def _mock_subprocess_failure(**kwargs: object) -> MagicMock:
+    """Simulate a ``cwd`` with no local git checkout (``git`` exits non-zero)."""
+    return MagicMock(returncode=1, stdout="", stderr="")
+
+
 def test_compose_context_preamble_emits_preamble() -> None:
     env = MagicMock()
     env.polylogue.get_session = AsyncMock(return_value=_session())
@@ -35,14 +40,42 @@ def test_compose_context_preamble_emits_preamble() -> None:
         return_value=[SimpleNamespace(session_id="rel-1", title="Related", terminal_state="open")]
     )
 
-    preamble = json.loads(compose_context_preamble(env, session_id="target", related_limit=3))
+    with patch("subprocess.run", side_effect=_mock_subprocess_failure):
+        preamble = json.loads(compose_context_preamble(env, session_id="target", related_limit=3))
 
     assert preamble["preamble_version"] == "1.0"
     assert preamble["session_lineage"]["logical_session_root"] == "root-1"
     assert preamble["session_lineage"]["parent_session_id"] == "parent-1"
     assert preamble["recent_related_sessions"][0]["session_id"] == "rel-1"
+    # No local git checkout at the composing cwd: falls back to the session's
+    # own recorded repo/branch metadata.
     assert preamble["project_state"]["repo"] == "https://github.com/Sinity/polylogue"
     assert preamble["project_state"]["branch"] == "master"
+
+
+def test_compose_context_preamble_git_enrichment_overrides_branch() -> None:
+    """When the composing cwd is inside a live git checkout, its current
+    branch + recent commits enrich the preamble project state (the same
+    enrichment the MCP ``context(intent="resume")`` route applies) —
+    superseding the session's possibly-stale recorded branch."""
+    env = MagicMock()
+    env.polylogue.get_session = AsyncMock(return_value=_session())
+    env.polylogue.get_session_topology = AsyncMock(return_value=None)
+    env.polylogue.find_resume_candidates = AsyncMock(return_value=[])
+
+    def _git_side_effect(args: list[str], **kwargs: object) -> MagicMock:
+        if "rev-parse" in args:
+            return MagicMock(returncode=0, stdout="feature/live-branch\n", stderr="")
+        if "log" in args:
+            return MagicMock(returncode=0, stdout="abc1234 feat: something\n", stderr="")
+        return MagicMock(returncode=1, stdout="", stderr="")
+
+    with patch("subprocess.run", side_effect=_git_side_effect):
+        preamble = json.loads(compose_context_preamble(env, session_id="target", related_limit=3))
+
+    assert preamble["project_state"]["repo"] == "https://github.com/Sinity/polylogue"
+    assert preamble["project_state"]["branch"] == "feature/live-branch"
+    assert preamble["project_state"]["recent_commits"] == ["abc1234 feat: something"]
 
 
 def test_compose_context_preamble_includes_injectable_assertion_claims() -> None:

--- a/tests/unit/context/test_preamble.py
+++ b/tests/unit/context/test_preamble.py
@@ -1,0 +1,137 @@
+"""Unit tests for the shared context-preamble git enrichment.
+
+``build_context_preamble_payload`` (used by both the CLI ``read --view
+context`` route and the MCP ``context(intent="resume")`` route) owns reading
+the composing cwd's current branch + recent commits via ``_git_project_state``
+(polylogue-t46.7) -- this used to be duplicated MCP-surface-only code in
+``mcp/server_cutover.py``. These tests exercise the enrichment against a real
+throwaway git repo rather than mocking ``subprocess.run``, since spinning one
+up is cheap and it proves the actual git command lines parse real output.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from polylogue.context.preamble import _git_project_state, build_context_preamble_payload
+
+
+def _init_git_repo(path: Path, *, branch: str = "main") -> None:
+    subprocess.run(["git", "init", "--initial-branch", branch, str(path)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "config", "user.email", "test@example.com"], check=True, capture_output=True
+    )
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "Test"], check=True, capture_output=True)
+    (path / "README.md").write_text("hello\n")
+    subprocess.run(["git", "-C", str(path), "add", "README.md"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-m", "initial commit"],
+        check=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_DATE": "2026-01-01T00:00:00",
+            "GIT_COMMITTER_DATE": "2026-01-01T00:00:00",
+        },
+    )
+
+
+class TestGitProjectStateRealRepo:
+    """``_git_project_state`` against a real tmp git checkout."""
+
+    def test_reads_branch_and_commits(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path, branch="feature/preamble-move")
+
+        state = _git_project_state(str(tmp_path))
+
+        assert state is not None
+        assert state.branch == "feature/preamble-move"
+        assert len(state.recent_commits) == 1
+        assert "initial commit" in state.recent_commits[0]
+
+    def test_non_git_directory_returns_none(self, tmp_path: Path) -> None:
+        state = _git_project_state(str(tmp_path))
+
+        assert state is None
+
+    def test_missing_directory_never_raises(self) -> None:
+        state = _git_project_state(str(Path("/nonexistent/definitely-not-a-repo-path")))
+
+        assert state is None
+
+
+class TestBuildContextPreambleGitEnrichment:
+    """``build_context_preamble_payload`` merges git enrichment for cwd."""
+
+    @pytest.mark.asyncio
+    async def test_cwd_git_state_populates_project_state(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path, branch="feature/enrich")
+
+        poly = MagicMock()
+        poly.get_session = AsyncMock(return_value=None)
+        poly.get_session_topology = AsyncMock(return_value=None)
+        poly.find_resume_candidates = AsyncMock(return_value=[])
+        poly.list_assertion_claim_payloads = AsyncMock(return_value=[])
+
+        preamble = await build_context_preamble_payload(
+            poly,
+            session_id=None,
+            cwd=str(tmp_path),
+            require_session=False,
+        )
+
+        assert preamble is not None
+        assert preamble.project_state is not None
+        assert preamble.project_state.branch == "feature/enrich"
+        assert len(preamble.project_state.recent_commits) == 1
+
+    @pytest.mark.asyncio
+    async def test_git_branch_supersedes_session_recorded_branch(self, tmp_path: Path) -> None:
+        """A session's recorded git_branch reflects when the session ran; the
+        composing cwd's live branch is the more current signal and wins,
+        matching the prior MCP-only enrichment behavior this move preserves."""
+        _init_git_repo(tmp_path, branch="feature/now")
+
+        session = MagicMock(git_repository_url="https://example.invalid/repo", git_branch="main-stale")
+        poly = MagicMock()
+        poly.get_session = AsyncMock(return_value=session)
+        poly.get_session_topology = AsyncMock(return_value=None)
+        poly.find_resume_candidates = AsyncMock(return_value=[])
+        poly.list_assertion_claim_payloads = AsyncMock(return_value=[])
+
+        preamble = await build_context_preamble_payload(
+            poly,
+            session_id="seed",
+            cwd=str(tmp_path),
+        )
+
+        assert preamble is not None
+        assert preamble.project_state is not None
+        assert preamble.project_state.repo == "https://example.invalid/repo"
+        assert preamble.project_state.branch == "feature/now"
+
+    @pytest.mark.asyncio
+    async def test_no_cwd_git_state_falls_back_to_session_metadata(self) -> None:
+        session = MagicMock(git_repository_url="https://example.invalid/repo", git_branch="recorded-branch")
+        poly = MagicMock()
+        poly.get_session = AsyncMock(return_value=session)
+        poly.get_session_topology = AsyncMock(return_value=None)
+        poly.find_resume_candidates = AsyncMock(return_value=[])
+        poly.list_assertion_claim_payloads = AsyncMock(return_value=[])
+
+        preamble = await build_context_preamble_payload(
+            poly,
+            session_id="seed",
+            cwd=str(Path("/nonexistent/definitely-not-a-repo-path")),
+        )
+
+        assert preamble is not None
+        assert preamble.project_state is not None
+        assert preamble.project_state.repo == "https://example.invalid/repo"
+        assert preamble.project_state.branch == "recorded-branch"
+        assert preamble.project_state.recent_commits == []


### PR DESCRIPTION
## Summary

Moves the git branch/recent-commit enrichment for the context preamble out of `polylogue/mcp/server_cutover.py` (a surface adapter) into `polylogue/context/preamble.py`, where `compose_context_preamble`/`build_context_preamble_payload` already live. Every caller of `build_context_preamble_payload` now gets the same enrichment for the same `cwd`, instead of only the MCP `context(intent="resume")` route.

## Problem

Triage-verified 2026-07-31: `compose_context_preamble` lives in `polylogue/context/preamble.py`, but its git-subprocess enrichment (`git rev-parse`/`git log`) sat in `polylogue/mcp/server_cutover.py:589-635` as a private `_git_project_state` helper plus a post-hoc `project_state` overlay inside `_resume_preamble`. That's surface-layer code owning substrate-ish preamble-composition semantics the preamble module should own, and it meant the CLI `read --view context` route (which also calls `build_context_preamble_payload` via `compose_context_preamble`) never got current git state — only session-recorded `git_repository_url`/`git_branch` metadata, which can be stale.

## Solution

- Moved `_git_project_state` (best-effort `subprocess.run` against `git rev-parse --abbrev-ref HEAD` / `git log --oneline -5`, never raises) into `polylogue/context/preamble.py`.
- Folded it directly into `build_context_preamble_payload`'s project-state construction: a live git checkout's current branch now supersedes a session's possibly-stale recorded `git_branch` (matching the prior MCP-only override behavior — `_resume_preamble` previously replaced `project_state` wholesale when git succeeded); `recent_commits` comes from git only; `repo` still comes from the session's recorded `git_repository_url` (git enrichment never populates repo).
- `polylogue/mcp/server_cutover.py`'s `_resume_preamble` is now a thin caller — it builds the preamble and returns it; no subprocess code of its own, and the `ContextPreambleProjectState` `TYPE_CHECKING` import that only supported the deleted function was removed.
- No new surface→substrate imports; `docs/plans/layering.yaml`'s ratchet is unaffected (code moved *out of* a surface, the desired direction).

## Verification

- `python -m devtools test tests/unit/context/test_preamble.py tests/unit/cli/test_context_view.py tests/unit/mcp/test_context_resume_intent.py` → `33 passed`.
- `python -m devtools verify --quick` → green (ruff format/check, mypy --strict, `render all --check`, layering, topology, closure-matrix, schema/manifests/docs checks).
- Full `devtools verify` (testmon-affected) not run in this worktree — testmon wasn't seeded there; the focused pytest run above plus `--quick` is the evidence for this change. The pre-push hook also ran `--quick` and passed.

**Anti-vacuity**: `tests/unit/context/test_preamble.py::TestBuildContextPreambleGitEnrichment::test_cwd_git_state_populates_project_state` exercises `build_context_preamble_payload` (production code, not a test double) against a real throwaway `git init` repo — deleting the `_git_project_state(cwd)` call (or reverting to not merging its result into `project_state`) fails this test, not only a mocked one. `tests/unit/mcp/test_context_resume_intent.py::TestComposeContextPreambleHappyPath::test_project_state_with_git_output` continues to exercise the MCP route end-to-end (`context(intent="resume")` tool invocation with mocked `subprocess.run`) unmodified, proving the MCP surface still carries the enrichment through the new call path.

Ref polylogue-t46.7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Context information now includes the current local Git branch and up to five recent commits when available.
  - Live local project details take precedence over outdated recorded session information.

- **Bug Fixes**
  - Context generation now gracefully handles non-Git directories, missing paths, and unavailable Git data.
  - Session context continues using recorded project details when local information cannot be found.

- **Tests**
  - Added coverage for Git-based enrichment, fallback behavior, and CLI context display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->