### PR TITLE
fix(sources): require structural evidence for codex CONTINUATION lineage

### DIFF
--- a/polylogue/sources/parsers/codex.py
+++ b/polylogue/sources/parsers/codex.py
@@ -198,6 +198,39 @@ def _newer_timestamp_pair(
     return current
 
 
+def _has_continuation_evidence(
+    *,
+    first_timestamp: _TimestampPair | None,
+    second_timestamp: _TimestampPair | None,
+    first_cwd: str | None,
+    second_cwd: str | None,
+    first_repo_url: str | None,
+    second_repo_url: str | None,
+) -> bool:
+    """Structural test for the legacy (no `forked_from_id`) continuation fallback.
+
+    A resumed Codex session physically replays the parent conversation's own
+    original `session_meta` record as the file's second distinct `session_meta`
+    (verified against real multi-meta rollout files: the replayed header's
+    timestamp always *precedes* the new session's own start time, and reports
+    the same `cwd`/git remote, because the resumed conversation continues in
+    the same working tree). A bare count of session_meta records proves
+    neither fact -- two structurally unrelated session_meta records
+    concatenated into one payload would satisfy the count without satisfying
+    this check, so the count alone is not sufficient evidence of a parent
+    relationship.
+    """
+    if first_timestamp is None or second_timestamp is None:
+        return False
+    if second_timestamp[0] > first_timestamp[0]:
+        # The candidate parent's own header postdates the child's -- not a
+        # replayed prefix.
+        return False
+    cwd_match = bool(first_cwd) and bool(second_cwd) and first_cwd == second_cwd
+    repo_match = bool(first_repo_url) and bool(second_repo_url) and first_repo_url == second_repo_url
+    return cwd_match or repo_match
+
+
 def _validate_record(item: object, *, index: int, context: str = "record") -> CodexRecord | None:
     if not isinstance(item, dict):
         return None
@@ -2079,6 +2112,17 @@ def _parse_records(records: Iterable[object], fallback_id: str) -> ParsedSession
     # prefix in this rollout. See docs/design/session-lineage-model.md.
     forked_from_id: str | None = None
     is_subagent_spawn = False
+    # Structural evidence for the legacy (no forked_from_id) continuation
+    # fallback below: the child's own cwd/git, and the same facts read off
+    # the second distinct session_meta encountered (a resumed session
+    # physically replays the parent's original session_meta as the next
+    # record). Captured independently of `session_git`, which prefers the
+    # *first* meta's git and must not be overwritten by the second's.
+    first_meta_cwd: str | None = None
+    first_meta_repo_url: str | None = None
+    second_meta_timestamp_pair: _TimestampPair | None = None
+    second_meta_cwd: str | None = None
+    second_meta_repo_url: str | None = None
     session_git: dict[str, object] | None = None  # Git context from session metadata
     session_instructions: str | None = None  # System instructions from session metadata
     working_directories: set[str] = set()
@@ -2399,6 +2443,29 @@ def _parse_records(records: Iterable[object], fallback_id: str) -> ParsedSession
                     source_val = session_meta.get("source")
                     if isinstance(source_val, dict) and isinstance(source_val.get("subagent"), dict):
                         is_subagent_spawn = True
+                    cwd_val = session_meta.get("cwd")
+                    if isinstance(cwd_val, str) and cwd_val.strip():
+                        first_meta_cwd = cwd_val.strip()
+                    first_meta_git = _git_context(session_meta)
+                    if first_meta_git is not None:
+                        repo_val = first_meta_git.get("repository_url")
+                        if isinstance(repo_val, str) and repo_val.strip():
+                            first_meta_repo_url = repo_val.strip()
+                elif len(session_metas_seen) == 2:
+                    # The second distinct session_meta is the legacy-fallback
+                    # candidate parent (see the CONTINUATION classification
+                    # below) -- capture its own facts independently of
+                    # `session_git`/`session_timestamp`, which track the
+                    # first (child) meta only.
+                    second_meta_timestamp_pair = parse_timestamp_pair(_record_timestamp(session_meta))
+                    cwd_val = session_meta.get("cwd")
+                    if isinstance(cwd_val, str) and cwd_val.strip():
+                        second_meta_cwd = cwd_val.strip()
+                    second_meta_git = _git_context(session_meta)
+                    if second_meta_git is not None:
+                        repo_val = second_meta_git.get("repository_url")
+                        if isinstance(repo_val, str) and repo_val.strip():
+                            second_meta_repo_url = repo_val.strip()
             git_context = _git_context(session_meta)
             if git_context and not session_git:
                 session_git = git_context
@@ -2504,12 +2571,25 @@ def _parse_records(records: Iterable[object], fallback_id: str) -> ParsedSession
     #     than fabricate FORK from absent evidence. The prefix-sharing
     #     normalization still records the branch point + `inheritance`, so the
     #     shared-prefix fact is preserved.
-    # Fall back to the legacy heuristic (a second embedded session_meta id) when
-    # no explicit marker is present.
+    # Fall back to the legacy heuristic (older exports with no `forked_from_id`
+    # field at all) when no explicit marker is present: a second distinct
+    # session_meta *can* be the replayed parent header of a plain resume, but
+    # only when it carries the structural evidence of that -- see
+    # `_has_continuation_evidence`. A second session_meta id with none of that
+    # evidence is not proof of any relationship (e.g. two structurally
+    # unrelated session_metas concatenated in one payload), so it stays fully
+    # unclassified rather than fabricating CONTINUATION from a bare count.
     if forked_from_id is not None:
         parent_id: str | None = forked_from_id
         branch_type = BranchType.SUBAGENT if is_subagent_spawn else None
-    elif len(session_metas_seen) > 1:
+    elif len(session_metas_seen) > 1 and _has_continuation_evidence(
+        first_timestamp=session_timestamp_pair,
+        second_timestamp=second_meta_timestamp_pair,
+        first_cwd=first_meta_cwd,
+        second_cwd=second_meta_cwd,
+        first_repo_url=first_meta_repo_url,
+        second_repo_url=second_meta_repo_url,
+    ):
         parent_id = session_metas_seen[1]
         branch_type = BranchType.CONTINUATION
     else:

--- a/tests/unit/sources/test_codex_event_stream_contract.py
+++ b/tests/unit/sources/test_codex_event_stream_contract.py
@@ -405,6 +405,54 @@ class TestCrossMessageReferences:
     """Pins the cross-message reference contract carried in the stream."""
 
     def test_second_session_meta_becomes_parent_continuation(self) -> None:
+        # A genuine resume physically replays the parent's own session_meta
+        # as the second distinct meta; the replayed header's timestamp
+        # precedes the new session's, and it shares the same cwd/git remote
+        # (same working tree) -- the structural evidence
+        # `_has_continuation_evidence` requires. Absent that evidence, a
+        # bare second session_meta id is not proof of a parent relationship
+        # (see the negative case below).
+        records: list[object] = [
+            {
+                "type": "session_meta",
+                "payload": {
+                    "id": "child",
+                    "timestamp": "2025-01-15T14:00:00Z",
+                    "cwd": "/repo/polylogue",
+                    "git": {"repository_url": "git@github.com:example/polylogue.git"},
+                },
+            },
+            {
+                "type": "session_meta",
+                "payload": {
+                    "id": "parent",
+                    "timestamp": "2025-01-15T13:00:00Z",
+                    "cwd": "/repo/polylogue",
+                    "git": {"repository_url": "git@github.com:example/polylogue.git"},
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": "u1",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "continued"}],
+                },
+            },
+        ]
+        session = _parse(records, "fallback")
+        assert session.provider_session_id == "child"
+        assert session.parent_session_provider_id == "parent"
+        assert session.branch_type == BranchType.CONTINUATION
+
+    def test_second_session_meta_without_structural_evidence_is_unclassified(self) -> None:
+        # Two session_metas with no forked_from_id marker, no shared cwd/git
+        # remote, and no earlier-timestamp relationship: the bare count of
+        # session_meta records must NOT be enough evidence for CONTINUATION.
+        # Reverting `_has_continuation_evidence`'s call site back to the old
+        # `elif len(session_metas_seen) > 1:` heuristic makes this assertion
+        # fail (it would classify "parent" as the CONTINUATION parent).
         records: list[object] = [
             {"type": "session_meta", "payload": {"id": "child", "timestamp": "2025-01-15T14:00:00Z"}},
             {"type": "session_meta", "payload": {"id": "parent", "timestamp": "2025-01-15T13:00:00Z"}},
@@ -420,8 +468,8 @@ class TestCrossMessageReferences:
         ]
         session = _parse(records, "fallback")
         assert session.provider_session_id == "child"
-        assert session.parent_session_provider_id == "parent"
-        assert session.branch_type == BranchType.CONTINUATION
+        assert session.parent_session_provider_id is None
+        assert session.branch_type is None
 
     def test_turn_context_cwd_changes_collected_into_working_directories(self) -> None:
         records = _load_catalog("interleaved_stream.jsonl")

--- a/tests/unit/sources/test_parsers_codex.py
+++ b/tests/unit/sources/test_parsers_codex.py
@@ -96,10 +96,33 @@ class TestSessionMetadata:
         result = parse(payload, "fallback")
         assert result.provider_session_id == "conv-abc"
 
-    def test_second_session_meta_sets_parent(self) -> None:
+    def test_second_session_meta_with_structural_evidence_sets_continuation(self) -> None:
+        # A genuine resume physically replays the parent conversation's own
+        # session_meta as the second distinct meta in the file. Real Codex
+        # rollout files (verified against multi-meta exports on disk) show
+        # two structural facts about that replayed header: its timestamp
+        # *precedes* the new session's own start time, and it reports the
+        # same cwd/git remote, because the resume continues in the same
+        # working tree.
         payload = [
-            {"type": "session_meta", "payload": {"id": "conv-abc", "timestamp": "2024-01-01"}},
-            {"type": "session_meta", "payload": {"id": "parent-xyz", "timestamp": "2024-01-01"}},
+            {
+                "type": "session_meta",
+                "payload": {
+                    "id": "conv-abc",
+                    "timestamp": "2024-01-01T12:00:20Z",
+                    "cwd": "/realm/project/sinnix",
+                    "git": {"repository_url": "git@github.com:Sinity/sinnix.git"},
+                },
+            },
+            {
+                "type": "session_meta",
+                "payload": {
+                    "id": "parent-xyz",
+                    "timestamp": "2024-01-01T12:00:00Z",
+                    "cwd": "/realm/project/sinnix",
+                    "git": {"repository_url": "git@github.com:Sinity/sinnix.git"},
+                },
+            },
             {
                 "type": "response_item",
                 "payload": {
@@ -113,6 +136,47 @@ class TestSessionMetadata:
         assert result.provider_session_id == "conv-abc"
         assert result.parent_session_provider_id == "parent-xyz"
         assert result.branch_type == BranchType.CONTINUATION
+
+    def test_second_session_meta_without_structural_evidence_stays_unclassified(self) -> None:
+        # Two session_metas with no forked_from_id marker and no structural
+        # relationship (different cwd/repo, and the second one's timestamp
+        # does NOT precede the first's) must not be inferred as a
+        # continuation from the bare count alone. Reverting to the old
+        # count-based heuristic (`elif len(session_metas_seen) > 1:` with no
+        # further check) makes this assertion fail because it would classify
+        # this payload as CONTINUATION with parent "unrelated-session".
+        payload = [
+            {
+                "type": "session_meta",
+                "payload": {
+                    "id": "conv-abc",
+                    "timestamp": "2024-01-01T12:00:00Z",
+                    "cwd": "/realm/project/sinnix",
+                    "git": {"repository_url": "git@github.com:Sinity/sinnix.git"},
+                },
+            },
+            {
+                "type": "session_meta",
+                "payload": {
+                    "id": "unrelated-session",
+                    "timestamp": "2024-06-15T09:00:00Z",
+                    "cwd": "/realm/project/polylogue",
+                    "git": {"repository_url": "git@github.com:Sinity/polylogue.git"},
+                },
+            },
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hello"}],
+                },
+            },
+        ]
+        result = parse(payload, "fallback")
+        assert result.provider_session_id == "conv-abc"
+        assert result.parent_session_provider_id is None
+        assert result.branch_type is None
 
     def test_no_session_meta_uses_fallback(self) -> None:
         payload = [


### PR DESCRIPTION
## Summary

The Codex parser's legacy lineage fallback (used when no `forked_from_id` marker is present) classified a session as `BranchType.CONTINUATION` from a bare count of `session_meta` records — any second embedded `session_meta` was assumed to be the parent, regardless of what it actually was.

## Problem

`polylogue/sources/parsers/codex.py:2512-2514` (pre-fix):

```python
elif len(session_metas_seen) > 1:
    parent_id = session_metas_seen[1]
    branch_type = BranchType.CONTINUATION
```

This is the same proxy-as-truth mechanism already fixed for the adjacent FORK/RESUME (`forked_from_id`) path (comment at the surrounding lines documents that discipline), left unaddressed for the count-based CONTINUATION fallback. A fabricated lineage edge is worse than a missing one — `session_links` composes transcripts from these edges.

I inspected real multi-meta Codex rollout files (`~/.codex/sessions/**/*.jsonl`, files with 2-3 distinct `session_meta` records) to find what a genuine resume's replayed parent header actually looks like structurally. Two facts held consistently: the replayed parent header's timestamp always **precedes** the new session's own start time (by seconds-to-minutes), and it reports the **same `cwd`/git `repository_url`** as the child, because the resume continues in the same working tree. A bare count proves neither.

## Solution

Added `_has_continuation_evidence()` to `polylogue/sources/parsers/codex.py`, requiring:
1. the second `session_meta`'s timestamp does not postdate the first's, and
2. the two metas share a matching `cwd` or a matching git `repository_url`.

The legacy fallback now calls this before assigning `CONTINUATION`. When the evidence is absent, both `parent_id` and `branch_type` stay unclassified (`None`), matching the pattern already applied to `forked_from_id`. Captured the second meta's `cwd`/git/timestamp with new local variables (`second_meta_timestamp_pair`, `second_meta_cwd`, `second_meta_repo_url`) independent of the existing `session_git`/`session_timestamp` bookkeeping, which intentionally tracks only the first (child) meta.

**Anti-vacuity**: the new negative tests (`test_second_session_meta_without_structural_evidence_stays_unclassified` in `tests/unit/sources/test_parsers_codex.py`, `test_second_session_meta_without_structural_evidence_is_unclassified` in `tests/unit/sources/test_codex_event_stream_contract.py`) exercise `polylogue.sources.parsers.codex.parse`/`parse_stream` end to end. Reverting `_has_continuation_evidence`'s call site back to the old `elif len(session_metas_seen) > 1:` heuristic (dropping the evidence check) makes both fail: they'd assert `branch_type is None` / `parent_session_provider_id is None` against a payload the old code would have classified as `CONTINUATION` with an unrelated parent id.

## Verification

- `python -m devtools test tests/unit/sources/test_parsers_codex.py tests/unit/sources/test_codex_event_stream_contract.py tests/unit/sources/test_parsers_codex_catalog.py` → `129 passed`
- `python -m mypy polylogue/sources/parsers/codex.py` → `Success: no issues found in 1 source file`
- `python -m devtools verify --quick` → `exit_code: 0` (ruff format/check, mypy, render-all-check, topology, layering, closure-matrix, schema/manifest/lab policy checks)

## Scope note

Confined to `polylogue/sources/parsers/codex.py` and its two direct test files, per the conflict note in `polylogue-psz6`: the classification-gate work in `sources/dispatch`/`base_support` is a separate lane's territory.

Ref polylogue-psz6