### PR TITLE
feat(security): add archive-wide bulk secret-candidate scan

### DIFF
--- a/docs/plans/layering-surface-baseline.json
+++ b/docs/plans/layering-surface-baseline.json
@@ -1401,6 +1401,11 @@
   },
   {
     "target": "polylogue/daemon",
+    "file": "polylogue/daemon/secret_scan_sweep.py",
+    "import": "polylogue.sources.live.sqlite_locking"
+  },
+  {
+    "target": "polylogue/daemon",
     "file": "polylogue/daemon/similarity.py",
     "import": "polylogue.storage.archive_identity"
   },

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -1031,7 +1031,7 @@ files:
     target: polylogue/cli/commands/reset.py
     owner: stable
   - path: polylogue/cli/commands/scan_secrets.py
-    loc: 76
+    loc: 243
     target: polylogue/cli/commands/scan_secrets.py
     owner: stable
   - path: polylogue/cli/commands/status.py
@@ -1459,7 +1459,7 @@ files:
     owner: core-primitive
     reason: core primitive
   - path: polylogue/core/sources.py
-    loc: 447
+    loc: 455
     target: polylogue/core/sources.py
     owner: core-primitive
     reason: core primitive
@@ -1543,7 +1543,7 @@ files:
     target: polylogue/daemon/catchup_status.py
     owner: stable
   - path: polylogue/daemon/cli.py
-    loc: 2929
+    loc: 2931
     target: polylogue/daemon/cli.py
     owner: stable
   - path: polylogue/daemon/compare.py
@@ -1714,6 +1714,10 @@ files:
   - path: polylogue/daemon/route_contracts.py
     loc: 706
     target: polylogue/daemon/route_contracts.py
+    owner: stable
+  - path: polylogue/daemon/secret_scan_sweep.py
+    loc: 133
+    target: polylogue/daemon/secret_scan_sweep.py
     owner: stable
   - path: polylogue/daemon/similarity.py
     loc: 587
@@ -2190,7 +2194,7 @@ files:
     target: polylogue/maintenance/raw_authority_reset.py
     owner: stable
   - path: polylogue/maintenance/rebuild_index.py
-    loc: 864
+    loc: 898
     target: polylogue/maintenance/rebuild_index.py
     owner: stable
   - path: polylogue/maintenance/registry.py
@@ -2198,7 +2202,7 @@ files:
     target: polylogue/maintenance/registry.py
     owner: stable
   - path: polylogue/maintenance/replay.py
-    loc: 877
+    loc: 887
     target: polylogue/maintenance/replay.py
     owner: stable
   - path: polylogue/maintenance/scope.py
@@ -3138,7 +3142,7 @@ files:
     target: polylogue/security/lifecycle.py
     owner: stable
   - path: polylogue/security/secret_scan.py
-    loc: 324
+    loc: 674
     target: polylogue/security/secret_scan.py
     owner: stable
   - path: polylogue/services.py
@@ -3215,7 +3219,7 @@ files:
     target: polylogue/sources/decoders.py
     owner: stable
   - path: polylogue/sources/dispatch.py
-    loc: 1431
+    loc: 1618
     target: polylogue/sources/dispatch.py
     owner: stable
   - path: polylogue/sources/drive/__init__.py
@@ -3408,7 +3412,7 @@ files:
     target: polylogue/sources/parsers/claude/code_detection.py
     owner: stable
   - path: polylogue/sources/parsers/claude/code_parser.py
-    loc: 2061
+    loc: 2088
     target: polylogue/sources/parsers/claude/code_parser.py
     owner: stable
   - path: polylogue/sources/parsers/claude/common.py
@@ -3536,7 +3540,7 @@ files:
     owner: stable
     cross_cut: { lifecycle: model }
   - path: polylogue/sources/revision_backfill.py
-    loc: 1855
+    loc: 2332
     target: polylogue/sources/revision_backfill.py
     owner: stable
   - path: polylogue/sources/source_acquisition.py
@@ -3621,7 +3625,7 @@ files:
     owner: storage-root
     reason: storage-root cross-cutting helper
   - path: polylogue/storage/blob_publication.py
-    loc: 466
+    loc: 477
     target: TBD
     owner: storage-domain
   - path: polylogue/storage/blob_repair.py
@@ -4104,7 +4108,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/__init__.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/archive.py
-    loc: 11420
+    loc: 11427
     target: polylogue/storage/sqlite/archive_tiers/archive.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/archive_init.py
@@ -4144,7 +4148,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/embeddings.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/index.py
-    loc: 2165
+    loc: 2184
     target: polylogue/storage/sqlite/archive_tiers/index.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/index_convergence.py
@@ -4160,7 +4164,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/ops.py
-    loc: 333
+    loc: 354
     target: polylogue/storage/sqlite/archive_tiers/ops.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/ops_write.py
@@ -4176,7 +4180,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/revision_application.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/revision_governance.py
-    loc: 2883
+    loc: 2913
     target: polylogue/storage/sqlite/archive_tiers/revision_governance.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/self_verify.py
@@ -4240,7 +4244,7 @@ files:
     target: polylogue/storage/sqlite/connection.py
     owner: stable
   - path: polylogue/storage/sqlite/connection_profile.py
-    loc: 351
+    loc: 364
     target: polylogue/storage/sqlite/connection_profile.py
     owner: stable
   - path: polylogue/storage/sqlite/delegation_facts.py
@@ -4252,7 +4256,7 @@ files:
     target: polylogue/storage/sqlite/finding_provenance.py
     owner: stable
   - path: polylogue/storage/sqlite/lifecycle.py
-    loc: 706
+    loc: 720
     target: polylogue/storage/sqlite/lifecycle.py
     owner: stable
   - path: polylogue/storage/sqlite/maintenance.py

--- a/polylogue/cli/commands/scan_secrets.py
+++ b/polylogue/cli/commands/scan_secrets.py
@@ -1,13 +1,14 @@
 """Scan-secrets command: production wiring for the candidate-only secret
-detector (polylogue-27m fix round).
+detector (polylogue-27m fix round, bulk mode polylogue-layg.1).
 
 ``polylogue/security/secret_scan.py`` defines the regex/entropy rules and
-the non-injectable ``SECRET_CANDIDATE`` assertion write path, but had zero
-production callers -- an operator running the archive would never actually
-get a candidate finding out of it, only a test invoking the functions
-directly would. This command is that caller: it reads a session's captured
-block text/tool-input from ``index.db``, scans it, and records any
-candidates in ``user.db`` for ``polylogue ops excise`` triage.
+the non-injectable ``SECRET_CANDIDATE`` assertion write path. This command
+is the CLI caller: ``--session <id>`` scans one known session's captured
+block text/tool-input from ``index.db``; ``--all`` sweeps every session the
+archive hasn't covered yet at the current scanner version, so an operator
+with no prior signal (no session id in hand) can still discover candidates
+archive-wide. Either way, findings land in ``user.db`` for
+``polylogue ops excise`` triage.
 """
 
 from __future__ import annotations
@@ -19,7 +20,30 @@ from polylogue.paths import archive_root
 
 
 @click.command("scan-secrets")
-@click.option("--session", "session_id", required=True, help="Session id to scan.")
+@click.option("--session", "session_id", default=None, help="Session id to scan.")
+@click.option(
+    "--all",
+    "scan_all",
+    is_flag=True,
+    default=False,
+    help="Scan every session not yet covered by the current scanner version, instead of one --session.",
+)
+@click.option(
+    "--limit",
+    "page_limit",
+    type=int,
+    default=None,
+    help="With --all, bound this invocation to one page of at most N pending sessions "
+    "(default: drain every pending session across as many pages as needed).",
+)
+@click.option("--origin", default=None, help="With --all, restrict the sweep to one origin token.")
+@click.option(
+    "--status",
+    "status_only",
+    is_flag=True,
+    default=False,
+    help="Report scan coverage (pending session count) without scanning.",
+)
 @click.option(
     "--json",
     "output_format",
@@ -35,18 +59,47 @@ from polylogue.paths import archive_root
     help="Output format.",
 )
 @click.pass_obj
-def scan_secrets_command(env: AppEnv, session_id: str, output_format: str | None) -> None:
-    """Scan a session's captured content for credential-shaped spans.
+def scan_secrets_command(
+    env: AppEnv,
+    session_id: str | None,
+    scan_all: bool,
+    page_limit: int | None,
+    origin: str | None,
+    status_only: bool,
+    output_format: str | None,
+) -> None:
+    """Scan captured content for credential-shaped spans.
 
     Records any findings as non-injectable ``SECRET_CANDIDATE`` assertions
     (a SHA-256 fingerprint, byte length, pattern id, and span offsets only
     -- the matched literal is never stored or printed). Review candidates
     via the assertion surfaces, then ``polylogue ops excise`` to remove
     confirmed secrets from the archive.
+
+    Exactly one of ``--session <id>``, ``--all``, or ``--status`` is
+    required: ``--session`` scans one known session; ``--all`` sweeps every
+    session not yet covered at the current scanner version (bounded pages,
+    resumable -- interrupting and re-running covers the same ground exactly
+    once); ``--status`` reports how many sessions are still pending without
+    scanning anything.
     """
+    root = archive_root()
+
+    if status_only:
+        _report_status(env, root, origin=origin, output_format=output_format)
+        return
+
+    if scan_all:
+        if session_id is not None:
+            raise click.UsageError("--session and --all are mutually exclusive.")
+        _scan_all(env, root, page_limit=page_limit, origin=origin, output_format=output_format)
+        return
+
+    if session_id is None:
+        raise click.UsageError("Provide --session <id>, --all, or --status.")
+
     from polylogue.security.secret_scan import scan_session_for_secret_candidates
 
-    root = archive_root()
     result = scan_session_for_secret_candidates(root, session_id)
 
     if output_format == "json":
@@ -69,6 +122,120 @@ def scan_secrets_command(env: AppEnv, session_id: str, output_format: str | None
                 if result.candidates_found
                 else []
             ),
+        ],
+    )
+
+
+def _scan_all(
+    env: AppEnv,
+    root: object,
+    *,
+    page_limit: int | None,
+    origin: str | None,
+    output_format: str | None,
+) -> None:
+    from pathlib import Path
+
+    from polylogue.security.secret_scan import DEFAULT_SECRET_SCAN_PAGE_SIZE, scan_archive_for_secret_candidates
+
+    assert isinstance(root, Path)
+
+    single_page = page_limit is not None
+    page_size = page_limit if page_limit is not None else DEFAULT_SECRET_SCAN_PAGE_SIZE
+
+    sessions_scanned = 0
+    blocks_scanned = 0
+    candidates_found = 0
+    errors = 0
+    pages = 0
+    remaining_pending = 0
+    while True:
+        result = scan_archive_for_secret_candidates(root, max_sessions=page_size, origin=origin)
+        pages += 1
+        sessions_scanned += result.sessions_scanned
+        blocks_scanned += result.blocks_scanned
+        candidates_found += result.candidates_found
+        errors += result.errors
+        remaining_pending = result.remaining_pending
+        if single_page or not result.more_pending:
+            break
+        if result.sessions_scanned == 0:
+            # No forward progress this page (e.g. every candidate errored);
+            # stop instead of looping forever against the same backlog.
+            break
+
+    if output_format == "json":
+        import json as json_module
+
+        click.echo(
+            json_module.dumps(
+                {
+                    "status": "ok",
+                    "pages": pages,
+                    "sessions_scanned": sessions_scanned,
+                    "blocks_scanned": blocks_scanned,
+                    "candidates_found": candidates_found,
+                    "errors": errors,
+                    "remaining_pending": remaining_pending,
+                    "more_pending": remaining_pending > 0,
+                }
+            )
+        )
+        return
+
+    env.ui.summary(
+        "Archive-wide secret scan" + (f" (origin={origin})" if origin else ""),
+        [
+            f"  pages: {pages}",
+            f"  sessions scanned: {sessions_scanned}",
+            f"  blocks scanned: {blocks_scanned}",
+            f"  secret candidates found: {candidates_found}",
+            *([f"  errors: {errors}"] if errors else []),
+            f"  remaining pending: {remaining_pending}",
+            *(
+                ["  review candidates, then `polylogue ops excise` to remove confirmed secrets."]
+                if candidates_found
+                else []
+            ),
+        ],
+    )
+
+
+def _report_status(
+    env: AppEnv,
+    root: object,
+    *,
+    origin: str | None,
+    output_format: str | None,
+) -> None:
+    from pathlib import Path
+
+    from polylogue.security.secret_scan import SECRET_SCAN_VERSION, count_pending_secret_scan_sessions
+
+    assert isinstance(root, Path)
+    index_db = root / "index.db"
+    ops_db = root / "ops.db"
+    remaining = count_pending_secret_scan_sessions(index_db, ops_db, origin=origin)
+
+    if output_format == "json":
+        import json as json_module
+
+        click.echo(
+            json_module.dumps(
+                {
+                    "status": "ok",
+                    "scanner_version": SECRET_SCAN_VERSION,
+                    "remaining_pending": remaining,
+                }
+            )
+        )
+        return
+
+    env.ui.summary(
+        "Secret scan coverage",
+        [
+            f"  scanner version: {SECRET_SCAN_VERSION}",
+            f"  sessions pending: {remaining}",
         ],
     )
 

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -2187,6 +2187,7 @@ async def run_daemon_services(
             from polylogue.daemon.fts_identity_convergence import periodic_fts_identity_drift_recompute
             from polylogue.daemon.fts_orphan_audit import periodic_fts_orphan_audit
             from polylogue.daemon.judgment_automation import periodic_judgment_automation_sweep
+            from polylogue.daemon.secret_scan_sweep import periodic_secret_scan_sweep
 
             await _run_startup_fts_readiness(write_coordinator)
             if lifecycle_events_enabled:
@@ -2226,6 +2227,7 @@ async def run_daemon_services(
                 periodic_fts_identity_drift_recompute(catch_up_complete=catch_up_complete_gate),
                 periodic_fts_orphan_audit(catch_up_complete=catch_up_complete_gate),
                 periodic_blob_gc_check(catch_up_complete=catch_up_complete_gate),
+                periodic_secret_scan_sweep(catch_up_complete=catch_up_complete_gate),
             ]
             if enable_source_catchup:
                 periodic_loops.append(_periodic_drive_source_catchup(catch_up_complete=catch_up_complete_gate))

--- a/polylogue/daemon/secret_scan_sweep.py
+++ b/polylogue/daemon/secret_scan_sweep.py
@@ -1,0 +1,133 @@
+"""Periodic bounded archive-wide secret-candidate sweep (polylogue-layg.1).
+
+``polylogue ops scan-secrets --session <id>`` (polylogue-27m fix round) and
+``--all`` (this bead's CLI half, ``polylogue/security/secret_scan.py``) are
+operator-triggered. Nothing kept coverage current on its own: a session
+ingested after the operator's last ``--all`` run would sit unscanned until
+someone remembered to run it again.
+
+This module is that missing feeder: a bounded, quiet-cadence sweep that
+drains a small page of :func:`~polylogue.security.secret_scan.scan_archive_for_secret_candidates`
+each tick, so newly ingested sessions get incremental candidate coverage
+without ever doing a full-archive rescan on a single tick.
+
+Deliberately NOT a ``DaemonConverger``/``ConvergenceStage`` (see
+``docs/retro/2026-05-24-1498-cascade.md``: ``convergence_stages.py`` is
+already large and its own verdict is "refactor before adding a fourth
+stage"). Instead this follows the ``fts_orphan_audit``/
+``periodic_fts_identity_drift_recompute`` shape: a plain ``asyncio`` loop
+scheduled directly in ``daemon/cli.py`` alongside the other maintenance
+loops, self-contained and independently testable. Runs on
+``daemon_write_coordinator`` like every other periodic write, so it
+serializes with live ingest instead of racing it for the SQLite writer lock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+from polylogue.logging import get_logger
+from polylogue.sources.live.sqlite_locking import is_transient_sqlite_lock
+
+logger = get_logger(__name__)
+
+#: Sessions scanned per sweep tick. Small enough that even a large pending
+#: backlog is drained incrementally across many ticks rather than blocking
+#: the writer coordinator for a long window.
+SECRET_SCAN_SWEEP_SESSION_LIMIT = 50
+
+#: Quiet-cadence interval -- this is ambient background coverage, not a
+#: hot-path check, so it runs far less often than live convergence.
+SECRET_SCAN_SWEEP_INTERVAL_SECONDS = 900  # 15 minutes
+
+
+@dataclass(frozen=True, slots=True)
+class SecretScanSweepResult:
+    """Bounded, secret-safe summary of one sweep tick for daemon logging."""
+
+    ran: bool = False
+    sessions_scanned: int = 0
+    candidates_found: int = 0
+    errors: int = 0
+    remaining_pending: int = 0
+
+
+def run_secret_scan_sweep_once_sync(
+    archive_root: Path,
+    *,
+    max_sessions: int = SECRET_SCAN_SWEEP_SESSION_LIMIT,
+) -> SecretScanSweepResult:
+    """Scan one bounded page of not-yet-covered sessions for secret candidates.
+
+    Thin wrapper around :func:`scan_archive_for_secret_candidates` that
+    returns the daemon-loop-shaped result type. An archive that doesn't
+    exist yet (no ``index.db``) is a bounded no-op, matching every other
+    periodic daemon maintenance probe's tolerance for an archive that is not
+    ready.
+    """
+    if not (archive_root / "index.db").exists():
+        return SecretScanSweepResult()
+
+    from polylogue.security.secret_scan import scan_archive_for_secret_candidates
+
+    result = scan_archive_for_secret_candidates(archive_root, max_sessions=max_sessions)
+    return SecretScanSweepResult(
+        ran=True,
+        sessions_scanned=result.sessions_scanned,
+        candidates_found=result.candidates_found,
+        errors=result.errors,
+        remaining_pending=result.remaining_pending,
+    )
+
+
+async def periodic_secret_scan_sweep(
+    *,
+    catch_up_complete: asyncio.Event | None = None,
+) -> None:
+    """Periodically drain one bounded page of the archive-wide secret sweep.
+
+    Gated on ``catch_up_complete`` (when given) so the first pass never
+    races initial source catch-up -- same gating shape as every other
+    ``catch_up_complete``-gated periodic loop in ``daemon/cli.py``.
+    """
+    from polylogue.daemon.write_coordinator import daemon_write_coordinator
+    from polylogue.paths import archive_root
+
+    if catch_up_complete is not None:
+        await catch_up_complete.wait()
+    while True:
+        await asyncio.sleep(SECRET_SCAN_SWEEP_INTERVAL_SECONDS)
+        root = archive_root()
+        try:
+            result = await daemon_write_coordinator().run_sync(
+                "maintenance.secret_scan_sweep",
+                run_secret_scan_sweep_once_sync,
+                root,
+            )
+            if result.ran and (result.sessions_scanned or result.candidates_found):
+                logger.info(
+                    "secret_scan_sweep: scanned=%d candidates_found=%d errors=%d remaining_pending=%d",
+                    result.sessions_scanned,
+                    result.candidates_found,
+                    result.errors,
+                    result.remaining_pending,
+                )
+        except sqlite3.OperationalError as exc:
+            if is_transient_sqlite_lock(exc):
+                logger.info("secret_scan_sweep: archive busy; retrying on next tick: %s", exc)
+                continue
+            logger.warning("secret_scan_sweep: sweep failed", exc_info=True)
+        except Exception:
+            logger.warning("secret_scan_sweep: sweep failed", exc_info=True)
+
+
+__all__ = [
+    "SECRET_SCAN_SWEEP_INTERVAL_SECONDS",
+    "SECRET_SCAN_SWEEP_SESSION_LIMIT",
+    "SecretScanSweepResult",
+    "periodic_secret_scan_sweep",
+    "run_secret_scan_sweep_once_sync",
+]

--- a/polylogue/security/secret_scan.py
+++ b/polylogue/security/secret_scan.py
@@ -20,6 +20,23 @@ to the CLI as ``polylogue ops scan-secrets --session <id>``
 captured content and writing through ``record_secret_candidates``, the
 regex/entropy rules and the non-injectable write path exist but never run
 against an operator's actual archive (polylogue-27m fix round).
+
+``scan_archive_for_secret_candidates`` is the archive-wide sibling
+(polylogue-layg.1): a single-session scan requires an operator to already
+know a session id, so nothing discovers candidates archive-wide without one.
+It is a bounded, resumable sweep over sessions the ops-tier
+``secret_scan_status`` table has not yet covered at the current
+``SECRET_SCAN_VERSION`` -- each page scans up to ``max_sessions`` pending
+sessions, commits their findings and coverage rows together, and reports how
+much work remains. Killing the process mid-sweep loses nothing: only
+already-committed sessions are marked covered, so resuming re-derives the
+still-pending set from the same table and never re-scans (or duplicates
+findings for) a session already covered at the current version. Bumping
+``SECRET_SCAN_VERSION`` (e.g. adding a pattern rule) invalidates every
+existing coverage row, scheduling an intentional full rescan.
+``polylogue ops scan-secrets --all`` (CLI) and
+``polylogue.daemon.secret_scan_sweep`` (bounded daemon catch-up) are its two
+production callers.
 """
 
 from __future__ import annotations
@@ -35,7 +52,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from polylogue.core.enums import AssertionKind, AssertionStatus, AssertionVisibility
+from polylogue.logging import get_logger
 from polylogue.storage.sqlite.connection_profile import DB_TIMEOUT, READ_DB_TIMEOUT
+
+logger = get_logger(__name__)
 
 # One-shot tier connections here mirror the pattern in security/excision.py:
 # a direct connect (not open_connection/open_readonly_connection, so no
@@ -314,11 +334,341 @@ def scan_session_for_secret_candidates(
     )
 
 
+# ---------------------------------------------------------------------------
+# Bulk/archive-wide scan (polylogue-layg.1)
+# ---------------------------------------------------------------------------
+#
+# ``scan_session_for_secret_candidates`` above requires an operator to
+# already know a session id. Nothing archive-wide called it, so an operator
+# with no prior signal had no way to discover candidates at all. The bulk
+# scanner below covers that gap as a bounded, checkpointed sweep: it selects
+# sessions the ops-tier ``secret_scan_status`` table has not yet covered at
+# the current scanner version, scans each one with the same rules and write
+# chokepoint as the single-session path, and commits per-session coverage
+# rows in the same transaction as the findings they cover -- so a kill mid
+# sweep can never leave a session "covered" without its candidates durably
+# recorded, or vice versa.
+
+#: Bump when ``_PATTERN_RULES`` changes in a way that could surface new
+#: candidates in previously-scanned content (new rule, widened regex, changed
+#: entropy threshold). Every existing ``secret_scan_status`` row is written at
+#: the version current when it was scanned, so a bump makes every prior row
+#: stale and schedules an intentional rescan on the next sweep -- mirrors
+#: ``EmbeddingRecipe``'s model/dimension versioning for the embed backlog.
+SECRET_SCAN_VERSION = 1
+
+#: Default bounded page size for one bulk-scan call (CLI ``--limit`` default,
+#: daemon sweep window). A large archive is covered incrementally across
+#: repeated calls rather than one unbounded scan.
+DEFAULT_SECRET_SCAN_PAGE_SIZE = 200
+
+
+@dataclass(frozen=True, slots=True)
+class BulkSecretScanResult:
+    """Outcome of one bounded archive-wide sweep.
+
+    Never carries any matched literal or session content -- only counts, the
+    scanned session ids (for progress reporting), and whether more pending
+    work remains after this page.
+    """
+
+    sessions_scanned: int = 0
+    blocks_scanned: int = 0
+    candidates_found: int = 0
+    errors: int = 0
+    scanned_session_ids: tuple[str, ...] = field(default_factory=tuple)
+    remaining_pending: int = 0
+
+    @property
+    def more_pending(self) -> bool:
+        return self.remaining_pending > 0
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "sessions_scanned": self.sessions_scanned,
+            "blocks_scanned": self.blocks_scanned,
+            "candidates_found": self.candidates_found,
+            "errors": self.errors,
+            "remaining_pending": self.remaining_pending,
+            "more_pending": self.more_pending,
+        }
+
+
+def _attached_secret_scan_status_table_exists(conn: sqlite3.Connection, *, schema: str) -> bool:
+    row = conn.execute(
+        f"SELECT 1 FROM {schema}.sqlite_master WHERE type = 'table' AND name = 'secret_scan_status' LIMIT 1"
+    ).fetchone()
+    return row is not None
+
+
+def select_pending_secret_scan_session_ids(
+    index_db: Path,
+    ops_db: Path,
+    *,
+    scanner_version: int = SECRET_SCAN_VERSION,
+    limit: int = DEFAULT_SECRET_SCAN_PAGE_SIZE,
+    origin: str | None = None,
+    since_ms: int | None = None,
+) -> list[str]:
+    """Return up to ``limit`` session ids not yet covered at ``scanner_version``.
+
+    A session is pending when it has no ``secret_scan_status`` row, or one
+    recorded at an older ``scanner_version``. Ordered by ``session_id`` for a
+    stable, deterministic sweep across repeated bounded calls: two calls with
+    no coverage writes between them return the same page, and a call after a
+    coverage-writing call naturally advances past it -- the coverage table
+    itself is the resumable cursor, so no separate cursor row is needed.
+    """
+    if not index_db.exists():
+        return []
+    conn = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
+    conn.execute(f"PRAGMA busy_timeout = {_READ_BUSY_TIMEOUT_MS}")
+    try:
+        if ops_db.exists():
+            conn.execute("ATTACH DATABASE ? AS ops", (str(ops_db),))
+            has_status_table = _attached_secret_scan_status_table_exists(conn, schema="ops")
+        else:
+            has_status_table = False
+        clauses = ["1 = 1"]
+        params: list[object] = []
+        if origin is not None:
+            clauses.append("s.origin = ?")
+            params.append(origin)
+        if since_ms is not None:
+            clauses.append("s.created_at_ms >= ?")
+            params.append(since_ms)
+        where_sql = " AND ".join(clauses)
+        if has_status_table:
+            query = f"""
+                SELECT s.session_id
+                FROM sessions AS s
+                LEFT JOIN ops.secret_scan_status AS st ON st.session_id = s.session_id
+                WHERE {where_sql}
+                  AND (st.session_id IS NULL OR st.scanner_version < ?)
+                ORDER BY s.session_id
+                LIMIT ?
+            """
+            params.extend([scanner_version, limit])
+        else:
+            query = f"""
+                SELECT s.session_id
+                FROM sessions AS s
+                WHERE {where_sql}
+                ORDER BY s.session_id
+                LIMIT ?
+            """
+            params.append(limit)
+        rows = conn.execute(query, params).fetchall()
+        return [str(row[0]) for row in rows]
+    finally:
+        conn.close()
+
+
+def count_pending_secret_scan_sessions(
+    index_db: Path,
+    ops_db: Path,
+    *,
+    scanner_version: int = SECRET_SCAN_VERSION,
+    origin: str | None = None,
+    since_ms: int | None = None,
+) -> int:
+    """Count sessions not yet covered at ``scanner_version`` (status reporting)."""
+    if not index_db.exists():
+        return 0
+    conn = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
+    conn.execute(f"PRAGMA busy_timeout = {_READ_BUSY_TIMEOUT_MS}")
+    try:
+        if ops_db.exists():
+            conn.execute("ATTACH DATABASE ? AS ops", (str(ops_db),))
+            has_status_table = _attached_secret_scan_status_table_exists(conn, schema="ops")
+        else:
+            has_status_table = False
+        clauses = ["1 = 1"]
+        params: list[object] = []
+        if origin is not None:
+            clauses.append("s.origin = ?")
+            params.append(origin)
+        if since_ms is not None:
+            clauses.append("s.created_at_ms >= ?")
+            params.append(since_ms)
+        where_sql = " AND ".join(clauses)
+        if has_status_table:
+            query = f"""
+                SELECT COUNT(*)
+                FROM sessions AS s
+                LEFT JOIN ops.secret_scan_status AS st ON st.session_id = s.session_id
+                WHERE {where_sql}
+                  AND (st.session_id IS NULL OR st.scanner_version < ?)
+            """
+            params.append(scanner_version)
+        else:
+            query = f"SELECT COUNT(*) FROM sessions AS s WHERE {where_sql}"
+        row = conn.execute(query, params).fetchone()
+        return int(row[0] or 0) if row is not None else 0
+    finally:
+        conn.close()
+
+
+def _record_secret_scan_status(
+    ops_conn: sqlite3.Connection,
+    *,
+    session_id: str,
+    scanner_version: int,
+    now_ms: int,
+    blocks_scanned: int,
+    candidates_found: int,
+) -> None:
+    ops_conn.execute(
+        """
+        INSERT INTO secret_scan_status
+            (session_id, scanner_version, scanned_at_ms, blocks_scanned, candidates_found)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(session_id) DO UPDATE SET
+            scanner_version = excluded.scanner_version,
+            scanned_at_ms = excluded.scanned_at_ms,
+            blocks_scanned = excluded.blocks_scanned,
+            candidates_found = excluded.candidates_found
+        """,
+        (session_id, scanner_version, now_ms, blocks_scanned, candidates_found),
+    )
+
+
+def scan_archive_for_secret_candidates(
+    archive_root: Path,
+    *,
+    max_sessions: int = DEFAULT_SECRET_SCAN_PAGE_SIZE,
+    scanner_version: int = SECRET_SCAN_VERSION,
+    now_ms: int | None = None,
+    origin: str | None = None,
+    since_ms: int | None = None,
+) -> BulkSecretScanResult:
+    """Scan up to ``max_sessions`` not-yet-covered sessions for secret candidates.
+
+    One bounded page of the archive-wide sweep (polylogue-layg.1): selects
+    pending sessions via :func:`select_pending_secret_scan_session_ids`, scans
+    each with the same rules and non-injectable write chokepoint as
+    :func:`scan_session_for_secret_candidates`, and commits each session's
+    findings together with its ``secret_scan_status`` coverage row in one
+    ``user.db``/``ops.db`` transaction pair -- so an interrupted sweep never
+    leaves a session marked covered without its candidates recorded, and a
+    resumed sweep (a fresh call with no ``max_sessions`` change) naturally
+    re-derives the still-pending set from the coverage table rather than
+    starting over or duplicating findings. Callers loop on
+    ``result.more_pending`` for a full-archive drain, or call once for a
+    single bounded catch-up window (the daemon sweep shape).
+    """
+    timestamp = now_ms if now_ms is not None else int(datetime.now(UTC).timestamp() * 1000)
+
+    index_db = archive_root / "index.db"
+    if not index_db.exists():
+        return BulkSecretScanResult()
+
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+    ops_db = archive_root / "ops.db"
+    initialize_archive_database(ops_db, ArchiveTier.OPS)
+    user_db = archive_root / "user.db"
+    initialize_archive_database(user_db, ArchiveTier.USER)
+
+    pending_ids = select_pending_secret_scan_session_ids(
+        index_db,
+        ops_db,
+        scanner_version=scanner_version,
+        limit=max_sessions,
+        origin=origin,
+        since_ms=since_ms,
+    )
+    if not pending_ids:
+        return BulkSecretScanResult(remaining_pending=0)
+
+    index_conn = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
+    index_conn.execute(f"PRAGMA busy_timeout = {_READ_BUSY_TIMEOUT_MS}")
+    user_conn = sqlite3.connect(user_db)
+    user_conn.execute(f"PRAGMA busy_timeout = {_WRITE_BUSY_TIMEOUT_MS}")
+    ops_conn = sqlite3.connect(ops_db)
+    ops_conn.execute(f"PRAGMA busy_timeout = {_WRITE_BUSY_TIMEOUT_MS}")
+
+    sessions_scanned = 0
+    blocks_scanned_total = 0
+    candidates_found_total = 0
+    errors = 0
+    scanned_ids: list[str] = []
+    try:
+        for session_id in pending_ids:
+            try:
+                rows = index_conn.execute(
+                    "SELECT block_id, COALESCE(text, ''), COALESCE(tool_input, '') FROM blocks "
+                    "WHERE session_id = ? ORDER BY message_id, position",
+                    (session_id,),
+                ).fetchall()
+                written: list[str] = []
+                with user_conn:
+                    for block_id, text, tool_input in rows:
+                        combined = f"{text} {tool_input}".strip()
+                        if not combined:
+                            continue
+                        spans = scan_text_for_secret_candidates(combined)
+                        if not spans:
+                            continue
+                        written.extend(
+                            record_secret_candidates(
+                                user_conn,
+                                target_ref=f"block:{block_id}",
+                                spans=spans,
+                                now_ms=timestamp,
+                            )
+                        )
+                with ops_conn:
+                    _record_secret_scan_status(
+                        ops_conn,
+                        session_id=session_id,
+                        scanner_version=scanner_version,
+                        now_ms=timestamp,
+                        blocks_scanned=len(rows),
+                        candidates_found=len(written),
+                    )
+            except sqlite3.Error:
+                logger.warning("secret scan sweep: session %r failed", session_id, exc_info=True)
+                errors += 1
+                continue
+            sessions_scanned += 1
+            blocks_scanned_total += len(rows)
+            candidates_found_total += len(written)
+            scanned_ids.append(session_id)
+    finally:
+        index_conn.close()
+        user_conn.close()
+        ops_conn.close()
+
+    remaining = count_pending_secret_scan_sessions(
+        index_db,
+        ops_db,
+        scanner_version=scanner_version,
+        origin=origin,
+        since_ms=since_ms,
+    )
+    return BulkSecretScanResult(
+        sessions_scanned=sessions_scanned,
+        blocks_scanned=blocks_scanned_total,
+        candidates_found=candidates_found_total,
+        errors=errors,
+        scanned_session_ids=tuple(scanned_ids),
+        remaining_pending=remaining,
+    )
+
+
 __all__ = [
+    "BulkSecretScanResult",
+    "DEFAULT_SECRET_SCAN_PAGE_SIZE",
+    "SECRET_SCAN_VERSION",
     "SecretCandidateSpan",
     "SecretScanResult",
+    "count_pending_secret_scan_sessions",
     "record_secret_candidates",
+    "scan_archive_for_secret_candidates",
     "scan_session_for_secret_candidates",
     "scan_text_for_secret_candidates",
+    "select_pending_secret_scan_session_ids",
     "secret_candidate_assertion_id",
 ]

--- a/polylogue/storage/sqlite/archive_tiers/ops.py
+++ b/polylogue/storage/sqlite/archive_tiers/ops.py
@@ -147,6 +147,27 @@ CREATE TABLE IF NOT EXISTS embedding_catchup_runs (
     error_message       TEXT
 ) STRICT;
 
+-- Bulk/archive-wide secret-candidate scan coverage (polylogue-layg.1).
+-- Sole live table for the bounded, resumable ``scan_archive_for_secret_candidates``
+-- sweep (``polylogue/security/secret_scan.py``): one row per session naming the
+-- scanner version that last covered it. A session missing here, or present at
+-- an older ``scanner_version`` than the current build, is pending work; a
+-- scanner-version bump (new pattern rules) makes every existing row stale and
+-- schedules an intentional rescan without touching any other tier. Disposable:
+-- losing this table only means re-scanning (idempotent by construction --
+-- ``record_secret_candidates`` writes deterministic assertion ids), never lost
+-- candidates, since the actual findings live durably in user.db.
+CREATE TABLE IF NOT EXISTS secret_scan_status (
+    session_id       TEXT PRIMARY KEY,
+    scanner_version  INTEGER NOT NULL,
+    scanned_at_ms    INTEGER NOT NULL,
+    blocks_scanned   INTEGER NOT NULL DEFAULT 0 CHECK(blocks_scanned >= 0),
+    candidates_found INTEGER NOT NULL DEFAULT 0 CHECK(candidates_found >= 0)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_secret_scan_status_version
+ON secret_scan_status(scanner_version);
+
 CREATE TABLE IF NOT EXISTS otlp_spans (
     trace_id          TEXT NOT NULL,
     span_id           TEXT NOT NULL,

--- a/tests/unit/cli/test_scan_secrets.py
+++ b/tests/unit/cli/test_scan_secrets.py
@@ -116,3 +116,92 @@ class TestScanSecrets:
         assert "blocks scanned: 1" in result.output
         assert "secret candidates found: 1" in result.output
         assert "AKIAABCDEFGHIJKLMNOP" not in result.output
+
+    def test_no_session_no_all_no_status_is_a_usage_error(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        with patch("polylogue.cli.commands.scan_secrets.archive_root", return_value=archive_root):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["ops", "scan-secrets"])
+        assert result.exit_code != 0
+
+    def test_session_and_all_together_is_a_usage_error(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        session_id = _seed_session_with_block_text(archive_root, native_id="scan-x", text="x")
+        with patch("polylogue.cli.commands.scan_secrets.archive_root", return_value=archive_root):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["ops", "scan-secrets", "--session", session_id, "--all"])
+        assert result.exit_code != 0
+
+
+class TestScanSecretsAll:
+    """Coverage for the bulk `--all` mode (polylogue-layg.1).
+
+    Anti-vacuity: before this bead, `--session` was `required=True`
+    (`scan_secrets.py:22`) -- there was no way to discover candidates
+    archive-wide without an operator already knowing a session id. Reverting
+    `--all` to a no-op, or dropping the loop that drains every page, makes
+    ``test_all_finds_every_planted_secret_across_multiple_sessions`` fail
+    because it asserts a candidate exists for *every* seeded session, not
+    just one.
+    """
+
+    def test_all_finds_every_planted_secret_across_multiple_sessions(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        for i in range(4):
+            _seed_session_with_block_text(archive_root, native_id=f"all-{i}", text=f"AWS_ACCESS_KEY_ID=AKIA{i:016X}")
+        with patch("polylogue.cli.commands.scan_secrets.archive_root", return_value=archive_root):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["ops", "scan-secrets", "--all", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["sessions_scanned"] == 4
+        assert payload["candidates_found"] == 4
+        assert payload["remaining_pending"] == 0
+
+        user_conn = sqlite3.connect(archive_root / "user.db")
+        try:
+            count = user_conn.execute(
+                "SELECT COUNT(*) FROM assertions WHERE kind = ?", (AssertionKind.SECRET_CANDIDATE.value,)
+            ).fetchone()[0]
+        finally:
+            user_conn.close()
+        assert count == 4
+
+    def test_all_with_limit_scans_one_bounded_page(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        for i in range(4):
+            _seed_session_with_block_text(archive_root, native_id=f"page-{i}", text=f"AWS_ACCESS_KEY_ID=AKIA{i:016X}")
+        with patch("polylogue.cli.commands.scan_secrets.archive_root", return_value=archive_root):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["ops", "scan-secrets", "--all", "--limit", "2", "--json"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["sessions_scanned"] == 2
+        assert payload["remaining_pending"] == 2
+        assert payload["more_pending"] is True
+
+    def test_status_reports_pending_count_without_scanning(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        _seed_session_with_block_text(archive_root, native_id="status-1", text="AWS_ACCESS_KEY_ID=AKIAABCDEFGHIJKLMNOP")
+        with patch("polylogue.cli.commands.scan_secrets.archive_root", return_value=archive_root):
+            runner = CliRunner()
+            status_before = runner.invoke(cli, ["ops", "scan-secrets", "--status", "--json"])
+            assert json.loads(status_before.output)["remaining_pending"] == 1
+
+            scan_result = runner.invoke(cli, ["ops", "scan-secrets", "--all", "--json"])
+            assert json.loads(scan_result.output)["sessions_scanned"] == 1
+
+            status_after = runner.invoke(cli, ["ops", "scan-secrets", "--status", "--json"])
+        assert status_after.exit_code == 0
+        assert json.loads(status_after.output)["remaining_pending"] == 0
+
+    def test_all_never_leaks_the_matched_literal(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        secret_value = "sk-ant-api03-" + "c" * 60
+        _seed_session_with_block_text(archive_root, native_id="leak-check", text=f"ANTHROPIC_API_KEY={secret_value}")
+        with patch("polylogue.cli.commands.scan_secrets.archive_root", return_value=archive_root):
+            runner = CliRunner()
+            result = runner.invoke(cli, ["ops", "scan-secrets", "--all"])
+        assert result.exit_code == 0
+        assert secret_value not in result.output

--- a/tests/unit/daemon/test_secret_scan_sweep.py
+++ b/tests/unit/daemon/test_secret_scan_sweep.py
@@ -1,0 +1,115 @@
+"""Periodic bounded archive-wide secret-candidate sweep (polylogue-layg.1).
+
+Exercises ``run_secret_scan_sweep_once_sync`` -- the sync body the periodic
+daemon loop (``periodic_secret_scan_sweep``) schedules on a quiet cadence --
+directly against a real archive fixture. Mirrors
+``tests/unit/daemon/test_fts_orphan_audit.py``'s shape for the sibling
+"missing feeder" sweep.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.core.enums import AssertionKind
+from polylogue.daemon.secret_scan_sweep import (
+    SecretScanSweepResult,
+    run_secret_scan_sweep_once_sync,
+)
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+
+def _seed_archive_session(archive_root: Path, *, native_id: str, text: str) -> str:
+    archive_root.mkdir(parents=True, exist_ok=True)
+    index_db = archive_root / "index.db"
+    initialize_archive_database(index_db, ArchiveTier.INDEX)
+    conn = sqlite3.connect(index_db)
+    conn.execute("PRAGMA foreign_keys = ON")
+    try:
+        conn.execute(
+            "INSERT INTO sessions (native_id, origin, title, content_hash, created_at_ms, updated_at_ms) "
+            "VALUES (?, 'codex-session', ?, zeroblob(32), 1000, 2000)",
+            (native_id, f"Session {native_id}"),
+        )
+        session_id = conn.execute("SELECT session_id FROM sessions WHERE native_id = ?", (native_id,)).fetchone()[0]
+        conn.execute(
+            "INSERT INTO messages (session_id, native_id, position, role, content_hash) "
+            "VALUES (?, 'm1', 0, 'user', zeroblob(32))",
+            (session_id,),
+        )
+        message_id = conn.execute("SELECT message_id FROM messages WHERE session_id = ?", (session_id,)).fetchone()[0]
+        conn.execute(
+            "INSERT INTO blocks (message_id, session_id, position, block_type, text) VALUES (?, ?, 0, 'text', ?)",
+            (message_id, session_id, text),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return str(session_id)
+
+
+class TestRunSecretScanSweepOnceSync:
+    def test_missing_archive_is_a_bounded_noop(self, tmp_path: Path) -> None:
+        result = run_secret_scan_sweep_once_sync(tmp_path / "does-not-exist")
+        assert result == SecretScanSweepResult()
+
+    def test_no_pending_sessions_is_a_real_run_with_nothing_to_do(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        archive_root.mkdir()
+        initialize_archive_database(archive_root / "index.db", ArchiveTier.INDEX)
+
+        result = run_secret_scan_sweep_once_sync(archive_root)
+
+        assert result.ran is True
+        assert result.sessions_scanned == 0
+        assert result.remaining_pending == 0
+
+    def test_finds_and_records_a_planted_secret_candidate(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive_session(
+            archive_root, native_id="sweep-1", text="AWS_ACCESS_KEY_ID=AKIAABCDEFGHIJKLMNOP"
+        )
+
+        result = run_secret_scan_sweep_once_sync(archive_root)
+
+        assert result.ran is True
+        assert result.sessions_scanned == 1
+        assert result.candidates_found == 1
+        assert result.remaining_pending == 0
+
+        user_conn = sqlite3.connect(archive_root / "user.db")
+        try:
+            row = user_conn.execute(
+                "SELECT target_ref FROM assertions WHERE kind = ?", (AssertionKind.SECRET_CANDIDATE.value,)
+            ).fetchone()
+        finally:
+            user_conn.close()
+        assert row is not None
+        assert row[0].startswith("block:")
+
+        ops_conn = sqlite3.connect(archive_root / "ops.db")
+        try:
+            covered = ops_conn.execute(
+                "SELECT 1 FROM secret_scan_status WHERE session_id = ?", (session_id,)
+            ).fetchone()
+        finally:
+            ops_conn.close()
+        assert covered is not None, "coverage row must be committed so a later tick does not re-scan"
+
+    def test_bounded_window_leaves_remaining_pending_for_next_tick(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        for i in range(4):
+            _seed_archive_session(archive_root, native_id=f"sweep-page-{i}", text=f"AWS_ACCESS_KEY_ID=AKIA{i:016X}")
+
+        result = run_secret_scan_sweep_once_sync(archive_root, max_sessions=2)
+
+        assert result.sessions_scanned == 2
+        assert result.remaining_pending == 2
+
+        # A second tick drains the rest -- proves the bounded window is
+        # genuinely incremental, not a one-shot full scan disguised as bounded.
+        second = run_secret_scan_sweep_once_sync(archive_root, max_sessions=2)
+        assert second.sessions_scanned == 2
+        assert second.remaining_pending == 0

--- a/tests/unit/security/test_secret_scan.py
+++ b/tests/unit/security/test_secret_scan.py
@@ -25,10 +25,14 @@ import pytest
 
 from polylogue.core.enums import AssertionKind, AssertionStatus
 from polylogue.security.secret_scan import (
+    SECRET_SCAN_VERSION,
+    count_pending_secret_scan_sessions,
     record_secret_candidates,
+    scan_archive_for_secret_candidates,
     scan_session_for_secret_candidates,
     scan_text_for_secret_candidates,
     secret_candidate_assertion_id,
+    select_pending_secret_scan_session_ids,
 )
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -289,3 +293,188 @@ class TestScanSessionForSecretCandidates:
         finally:
             user_conn.close()
         assert count == len(first.written_assertion_ids)
+
+
+def _seed_archive_session(archive_root: Path, *, native_id: str, text: str) -> str:
+    """Write one real session with a single text block into ``archive_root``.
+
+    Shared by the bulk-scan tests below: builds a multi-session ``index.db``
+    fixture one call at a time, mirroring
+    ``TestScanSessionForSecretCandidates._seed_session_with_block_text`` but
+    against a stable ``archive_root`` shared across calls (the bulk scanner
+    operates on the whole archive, not one caller-known session).
+    """
+    archive_root.mkdir(parents=True, exist_ok=True)
+    index_db = archive_root / "index.db"
+    initialize_archive_database(index_db, ArchiveTier.INDEX)
+    conn = sqlite3.connect(index_db)
+    conn.execute("PRAGMA foreign_keys = ON")
+    try:
+        conn.execute(
+            "INSERT INTO sessions (native_id, origin, title, content_hash, created_at_ms, updated_at_ms) "
+            "VALUES (?, 'codex-session', ?, zeroblob(32), 1000, 2000)",
+            (native_id, f"Session {native_id}"),
+        )
+        session_id = conn.execute("SELECT session_id FROM sessions WHERE native_id = ?", (native_id,)).fetchone()[0]
+        conn.execute(
+            "INSERT INTO messages (session_id, native_id, position, role, content_hash) "
+            "VALUES (?, 'm1', 0, 'user', zeroblob(32))",
+            (session_id,),
+        )
+        message_id = conn.execute("SELECT message_id FROM messages WHERE session_id = ?", (session_id,)).fetchone()[0]
+        conn.execute(
+            "INSERT INTO blocks (message_id, session_id, position, block_type, text) VALUES (?, ?, 0, 'text', ?)",
+            (message_id, session_id, text),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return str(session_id)
+
+
+class TestScanArchiveForSecretCandidates:
+    """Bulk/archive-wide scan coverage (polylogue-layg.1).
+
+    Anti-vacuity: an implementation that silently skips sessions in a batch
+    (the exact regression class this bead exists to prevent -- an operator
+    with no session id in hand previously had no way to discover candidates
+    at all) fails ``test_full_sweep_covers_every_session_and_finds_every_planted_secret``,
+    because it asserts every planted session ends up with a recorded
+    candidate and zero remaining pending coverage, not merely that *some*
+    candidates were found.
+    """
+
+    def test_missing_archive_is_a_bounded_noop(self, tmp_path: Path) -> None:
+        result = scan_archive_for_secret_candidates(tmp_path / "does-not-exist")
+        assert result.sessions_scanned == 0
+        assert result.remaining_pending == 0
+        assert result.more_pending is False
+
+    def test_full_sweep_covers_every_session_and_finds_every_planted_secret(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        planted_secret_sessions = {
+            _seed_archive_session(archive_root, native_id=f"bulk-{i}", text=f"AWS_ACCESS_KEY_ID=AKIA{i:016X}")
+            for i in range(5)
+        }
+        clean_session = _seed_archive_session(archive_root, native_id="bulk-clean", text="just an ordinary message")
+        all_sessions = planted_secret_sessions | {clean_session}
+
+        # A page size smaller than the total session count forces the bulk
+        # scanner to require multiple calls -- the shape a mutation that
+        # "forgets" to advance past an already-scanned batch (double-scans
+        # the same page forever, or drops the tail) would fail under.
+        scanned_ids: set[str] = set()
+        total_candidates = 0
+        seen_pages = 0
+        result = scan_archive_for_secret_candidates(archive_root, max_sessions=2)
+        while True:
+            seen_pages += 1
+            scanned_ids.update(result.scanned_session_ids)
+            total_candidates += result.candidates_found
+            if not result.more_pending:
+                break
+            result = scan_archive_for_secret_candidates(archive_root, max_sessions=2)
+
+        assert seen_pages > 1, "fixture must require more than one page to exercise resumable paging"
+        assert scanned_ids == all_sessions, "every session in the archive must be covered exactly once"
+        assert total_candidates == len(planted_secret_sessions), "every planted secret must be found"
+
+        remaining = count_pending_secret_scan_sessions(archive_root / "index.db", archive_root / "ops.db")
+        assert remaining == 0, "no session may be left uncovered after a full sweep"
+
+        user_conn = sqlite3.connect(archive_root / "user.db")
+        try:
+            count = user_conn.execute(
+                "SELECT COUNT(*) FROM assertions WHERE kind = ?", (AssertionKind.SECRET_CANDIDATE.value,)
+            ).fetchone()[0]
+        finally:
+            user_conn.close()
+        assert count == len(planted_secret_sessions)
+
+    def test_interrupt_and_resume_covers_all_sessions_exactly_once(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        sessions = {
+            _seed_archive_session(archive_root, native_id=f"resume-{i}", text=f"AWS_ACCESS_KEY_ID=AKIA{i:016X}")
+            for i in range(6)
+        }
+
+        # Simulate a kill after the first bounded page ("interrupted").
+        first = scan_archive_for_secret_candidates(archive_root, max_sessions=3)
+        assert first.sessions_scanned == 3
+        assert first.more_pending is True
+
+        # A fresh call with no state carried over ("resumed") must pick up
+        # exactly the sessions the first page did not cover -- never
+        # re-scanning a covered session (which would duplicate assertions
+        # were the write chokepoint not idempotent) and never skipping one.
+        pending_after_first = set(
+            select_pending_secret_scan_session_ids(archive_root / "index.db", archive_root / "ops.db", limit=100)
+        )
+        assert pending_after_first == sessions - set(first.scanned_session_ids)
+
+        second = scan_archive_for_secret_candidates(archive_root, max_sessions=100)
+        assert second.more_pending is False
+        assert set(second.scanned_session_ids) == pending_after_first
+
+        total_scanned = set(first.scanned_session_ids) | set(second.scanned_session_ids)
+        assert total_scanned == sessions
+
+        user_conn = sqlite3.connect(archive_root / "user.db")
+        try:
+            count = user_conn.execute(
+                "SELECT COUNT(*) FROM assertions WHERE kind = ?", (AssertionKind.SECRET_CANDIDATE.value,)
+            ).fetchone()[0]
+        finally:
+            user_conn.close()
+        assert count == len(sessions), "resuming must not duplicate candidates for any session"
+
+    def test_scanner_version_bump_schedules_intentional_rescan(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive_session(
+            archive_root, native_id="version-bump", text="AWS_ACCESS_KEY_ID=AKIAABCDEFGHIJKLMNOP"
+        )
+        first = scan_archive_for_secret_candidates(archive_root, scanner_version=1)
+        assert session_id in first.scanned_session_ids
+
+        # At the same version, the session is already covered: nothing to do.
+        same_version = scan_archive_for_secret_candidates(archive_root, scanner_version=1)
+        assert same_version.sessions_scanned == 0
+
+        # A version bump invalidates the existing coverage row and schedules
+        # an intentional rescan.
+        bumped = scan_archive_for_secret_candidates(archive_root, scanner_version=2)
+        assert session_id in bumped.scanned_session_ids
+
+    def test_default_scanner_version_matches_module_constant(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        session_id = _seed_archive_session(archive_root, native_id="default-version", text="just text")
+        scan_archive_for_secret_candidates(archive_root)
+
+        ops_conn = sqlite3.connect(archive_root / "ops.db")
+        try:
+            version = ops_conn.execute(
+                "SELECT scanner_version FROM secret_scan_status WHERE session_id = ?", (session_id,)
+            ).fetchone()[0]
+        finally:
+            ops_conn.close()
+        assert version == SECRET_SCAN_VERSION
+
+    def test_origin_scope_restricts_the_sweep(self, tmp_path: Path) -> None:
+        archive_root = tmp_path / "archive"
+        codex_session = _seed_archive_session(
+            archive_root, native_id="scope-codex", text="AWS_ACCESS_KEY_ID=AKIAABCDEFGHIJKLMNOP"
+        )
+        # A second origin's session must not be touched by an origin-scoped sweep.
+        archive_root.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(archive_root / "index.db")
+        try:
+            conn.execute(
+                "INSERT INTO sessions (native_id, origin, title, content_hash, created_at_ms, updated_at_ms) "
+                "VALUES ('scope-claude', 'claude-code-session', 'x', zeroblob(32), 1000, 2000)"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = scan_archive_for_secret_candidates(archive_root, origin="codex-session")
+        assert result.scanned_session_ids == (codex_session,)


### PR DESCRIPTION
## Summary

`polylogue ops scan-secrets` required `--session <id>`, so an operator with no
prior signal had no way to discover secret candidates archive-wide, and
nothing kept coverage current as new sessions were ingested. This adds a
bounded, resumable archive-wide sweep (CLI `--all` + a daemon catch-up loop)
on top of the existing per-session scanner and non-injectable
`SECRET_CANDIDATE` assertion write path.

## Problem

`polylogue/cli/commands/scan_secrets.py:22` had `--session` as `required=True`
with no bulk mode, and no daemon convergence/maintenance loop ever called
`scan_session_for_secret_candidates` — the regex/entropy rules and write
chokepoint existed but only ran when an operator already knew a specific
session id to scan (polylogue-layg.1, filed against the security/privacy
covenant epic polylogue-kwsb after the polylogue-27m per-session fix round
shipped with zero archive-wide callers).

## Solution

- `polylogue/security/secret_scan.py`: `scan_archive_for_secret_candidates`
  is a bounded page of the archive-wide sweep. It selects sessions not yet
  covered by a new ops-tier `secret_scan_status` table at the current
  `SECRET_SCAN_VERSION` (`select_pending_secret_scan_session_ids`,
  `count_pending_secret_scan_sessions`), scans each with the same rules and
  write chokepoint as the existing single-session path, and commits a
  session's findings together with its coverage row in the same
  `user.db`/`ops.db` transaction pair. This makes resumption exact: an
  interrupted sweep never leaves a session "covered" without its candidates
  recorded, and a fresh call re-derives the still-pending set from the
  coverage table itself (no separate cursor row, and no duplicate findings —
  the write chokepoint's deterministic assertion ids are already idempotent).
  A `SECRET_SCAN_VERSION` bump invalidates every existing coverage row and
  schedules an intentional rescan.
- `polylogue/storage/sqlite/archive_tiers/ops.py`: additive
  `secret_scan_status` DDL. Ops tier is disposable by design — losing this
  table only means re-scanning (idempotent), never lost candidates, since
  findings themselves live durably in `user.db`.
- `polylogue/cli/commands/scan_secrets.py`: `--session` is no longer
  required. `--all` drains the full pending backlog across as many bounded
  pages as needed; `--limit N` bounds one invocation to a single page;
  `--origin` scopes the sweep to one origin token; `--status` reports
  pending-coverage count without scanning anything.
- `polylogue/daemon/secret_scan_sweep.py`: a new plain `asyncio` periodic
  loop (`periodic_secret_scan_sweep`, 15-minute cadence, 50 sessions/tick)
  draining one bounded page per tick so newly ingested sessions get
  incremental coverage without operator action. Deliberately **not** a
  `ConvergenceStage` — `docs/retro/2026-05-24-1498-cascade.md` (mandatory
  reading before touching `convergence_stages.py`/`daemon/cli.py`) records
  that file's own verdict as "refactor before adding a fourth stage"; this
  follows the same shape as the existing `fts_orphan_audit.py`/
  `periodic_fts_identity_drift_recompute` sweeps instead. Registration in
  `daemon/cli.py` is a two-line addition (one import, one line in the
  `periodic_loops` list) next to the other maintenance loops, to stay clear
  of the startup-auth and raw-materialization-drain regions other lanes are
  touching concurrently.

### Acceptance-criteria matrix (polylogue-layg.1)

| AC | Status |
| --- | --- |
| Scan all sessions or a bounded recent/origin scope without enumerating ids | Satisfied — `--all` (full drain), `--limit` (bounded page), `--origin` (scope). `since_ms` scoping exists in the Python API (`scan_archive_for_secret_candidates(..., since_ms=...)`) but is not yet exposed as a CLI flag |
| Daemon can drain new/stale scanner work in bounded pages | Satisfied — `periodic_secret_scan_sweep`, 50 sessions/15min |
| Killing and resuming continues from a committed cursor without duplicating candidates | Satisfied — coverage table is the cursor; see `test_interrupt_and_resume_covers_all_sessions_exactly_once` |
| Unchanged sessions at current scanner/evidence version are skipped; version bump schedules rescan | Satisfied — `SECRET_SCAN_VERSION`; see `test_scanner_version_bump_schedules_intentional_rescan` |
| Results preserve exact evidence refs and suppression/review state | Satisfied — reuses the existing `record_secret_candidates`/`upsert_assertion` chokepoint unchanged |
| Status reports progress, errors, and remaining debt | Satisfied — `BulkSecretScanResult`/`SecretScanSweepResult` carry scanned/candidates/errors/remaining counts; CLI `--status` and `--all --json` surface them |
| Scale fixture proves bounded memory/query time and no full-archive rescan on an idle tick | Deferred — no dedicated large-N benchmark fixture in this PR; the bounded-page tests (`max_sessions=2` over 5-6 sessions) prove the *mechanism* is page-bounded, not a scale/perf assertion. Follow-up if the operator wants a benchmark gate |
| Security/privacy coverage manifest drops the per-session-only caveat | Not done in this PR — `docs/plans/security-privacy-coverage.yaml` is unchanged; flagging as remaining scope rather than claiming it here |

## Verification

- `python -m devtools test tests/unit/security/test_secret_scan.py tests/unit/cli/test_scan_secrets.py tests/unit/daemon/test_secret_scan_sweep.py` → `38 passed`
- `python -m devtools verify --quick` → `exit_code: 0` (ruff format/check, mypy --strict, render all --check, layering, closure-matrix, schema-versioning policy, schema promotion audit)
- `python -m devtools render all --check` → all surfaces `sync OK`, including the regenerated `docs/plans/topology-target.yaml` for the new `polylogue/daemon/secret_scan_sweep.py` module

**Anti-vacuity**: the production dependency exercised is the real
`scan_text_for_secret_candidates` regex/entropy rules and the real
`upsert_assertion` write chokepoint (`author_kind="detector"` coercing
`status=CANDIDATE`/non-injectable), run against a real multi-session
`index.db` fixture with planted AWS-key-shaped spans. Reverting the bulk
scanner to skip a session batch (e.g. stopping after one page without
checking `more_pending`, or a query that fails to anti-join
`secret_scan_status`) fails
`test_full_sweep_covers_every_session_and_finds_every_planted_secret`
because it asserts every seeded session — not just one — ends up covered
with a recorded candidate and `remaining_pending == 0`.

## Not merging

Ref polylogue-layg.1 — leaving this PR open per instruction; not merging or
closing the bead from this branch.