### PR TITLE
refactor(status): converge CLI/daemon tier-version probing onto one assembly

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -15,6 +15,7 @@ debugging landmarks. For the conceptual system shape, see
 | SQLite read/write tuning is profile-driven, not backend-local | `storage/sqlite/connection_profile.py` |
 | FTS tokenizer is `unicode61` (no porter stemmer) | `storage/sqlite/archive_tiers/index.py` |
 | Schema bootstrap branching is shared across sync and async backends | `storage/sqlite/schema_bootstrap.py:decide_schema_bootstrap()` |
+| A tier file's existence/size/`PRAGMA user_version` status is computed exactly once, in the substrate, and consumed by every status surface -- reimplementing this probe per-surface previously let a bare CLI status and a daemon-backed status disagree in production (polylogue-703) | `storage/archive_readiness.py:probe_archive_tier()`, consumed by `daemon/status.py:_archive_tier_status()` and `cli/commands/status.py:_archive_one_tier_status()` |
 
 ## Hot Files
 

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -26,7 +26,6 @@ from polylogue.readiness.claim_guard import derive_claim_guard
 from polylogue.storage.archive_identity import archive_file_set_root
 from polylogue.storage.archive_readiness import archive_readiness_status as _archive_readiness_status
 from polylogue.storage.archive_readiness import raw_materialization_ready as _raw_materialization_ready_bool
-from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
 logger = get_logger(__name__)
@@ -635,35 +634,39 @@ def _archive_tier_status(root: Path) -> dict[str, dict[str, Any]]:
 
 
 def _archive_one_tier_status(tier: str, path: Path) -> dict[str, Any]:
-    expected_version = ARCHIVE_VERSION_BY_TIER[_ARCHIVE_TIER_ENUM[tier]]
+    """Coarse per-tier existence/size/version facts come from the shared
+    ``probe_archive_tier`` (polylogue-703 -- ONE status assembly): this used
+    to reimplement its own ``PRAGMA user_version`` probe independently of
+    ``polylogue.daemon.status``, which is how a bare CLI status and a
+    daemon-backed status could disagree in production (2026-07-03). Only
+    ``table_counts`` (row-level detail with no daemon equivalent, used by
+    ``--full``/diagnostics) is still computed locally here, on top of the
+    shared probe's facts.
+    """
+    from polylogue.storage.archive_readiness import probe_archive_tier
+
+    probe = probe_archive_tier(_ARCHIVE_TIER_ENUM[tier], path)
     status: dict[str, Any] = {
-        "path": str(path),
-        "exists": path.exists(),
-        "size_bytes": path.stat().st_size if path.exists() else None,
-        "expected_user_version": expected_version,
-        "user_version": None,
-        "version_status": "missing",
+        "path": probe.path,
+        "exists": probe.exists,
+        "size_bytes": probe.size_bytes if probe.exists else None,
+        "expected_user_version": probe.expected_user_version,
+        "user_version": probe.user_version,
+        "version_status": probe.version_status,
         "table_counts": {},
     }
-    if not path.exists():
+    if not probe.exists:
         return status
 
     try:
         conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
         try:
-            row = conn.execute("PRAGMA user_version").fetchone()
-            user_version = int(row[0] or 0) if row is not None else 0
-            status["user_version"] = user_version
-            status["version_status"] = "ok" if user_version == expected_version else "mismatch"
-            counts, precision = _archive_table_counts(
-                conn, _ARCHIVE_TIER_TABLES[tier], db_size_bytes=path.stat().st_size
-            )
+            counts, precision = _archive_table_counts(conn, _ARCHIVE_TIER_TABLES[tier], db_size_bytes=probe.size_bytes)
             status["table_counts"] = counts
             status["table_count_precision"] = precision
         finally:
             conn.close()
     except sqlite3.Error as exc:
-        status["version_status"] = "error"
         status["error"] = str(exc)
     return status
 

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -69,12 +69,12 @@ from polylogue.sources.live.watcher import default_sources
 from polylogue.storage.archive_identity import resolve_active_index_path
 from polylogue.storage.archive_readiness import (
     active_rebuild_index_attempts,
+    probe_archive_tier,
     raw_materialization_readiness_snapshot,
     raw_materialization_ready,
 )
 from polylogue.storage.raw_retention import raw_frontier_integrity_projection, raw_frontier_integrity_summary
 from polylogue.storage.repair import raw_materialization_replay_backlog
-from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
@@ -643,39 +643,36 @@ def _archive_tier_status(
     name: Literal["source", "index", "embeddings", "user", "ops"],
     path: Path,
 ) -> ArchiveTierStatus:
-    wal_path = Path(f"{path}-wal")
-    tier = ArchiveTier(name)
-    expected_user_version = ARCHIVE_VERSION_BY_TIER[tier]
-    if not path.exists():
-        return ArchiveTierStatus(name=name, path=str(path), expected_user_version=expected_user_version)
-    user_version: int | None = None
+    # Existence/size/``PRAGMA user_version`` facts come from the shared
+    # ``probe_archive_tier`` (polylogue-703 -- ONE status assembly): this
+    # function used to reimplement the same PRAGMA read independently of the
+    # CLI's direct-fallback status, which is how a bare CLI status and a
+    # daemon-backed status could disagree in production (2026-07-03). Only
+    # ``table_count`` (a daemon-status-only fact, not needed by the CLI
+    # fallback) is still computed here.
+    probe = probe_archive_tier(ArchiveTier(name), path)
+    if not probe.exists:
+        return ArchiveTierStatus(name=name, path=probe.path, expected_user_version=probe.expected_user_version)
     table_count = 0
-    version_status: Literal["ok", "missing", "mismatch", "invalid"] = "invalid"
     try:
         conn = open_readonly_connection(path)
         try:
-            user_version = _row_int(conn.execute("PRAGMA user_version").fetchone()[0])
-            version_status = "ok" if user_version == expected_user_version else "mismatch"
             table_count = _row_int(
                 conn.execute("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table'").fetchone()[0]
             )
         finally:
             conn.close()
     except sqlite3.Error as exc:
-        # version_status already defaults to "invalid" above and stays that
-        # way here, so this branch does carry a signal — but the exception
-        # itself was previously discarded. Log it so operators can tell a
-        # read failure from a genuinely corrupt/unversioned tier.
-        logger.warning("archive tier status query failed for %s (%s): %s", path, name, exc, exc_info=True)
+        logger.warning("archive tier table-count query failed for %s (%s): %s", path, name, exc, exc_info=True)
     return ArchiveTierStatus(
         name=name,
-        path=str(path),
+        path=probe.path,
         exists=True,
-        size_bytes=path.stat().st_size,
-        wal_size_bytes=wal_path.stat().st_size if wal_path.exists() else 0,
-        user_version=user_version,
-        expected_user_version=expected_user_version,
-        version_status=version_status,
+        size_bytes=probe.size_bytes,
+        wal_size_bytes=probe.wal_size_bytes,
+        user_version=probe.user_version,
+        expected_user_version=probe.expected_user_version,
+        version_status=probe.version_status,
         table_count=table_count,
     )
 

--- a/polylogue/storage/archive_readiness.py
+++ b/polylogue/storage/archive_readiness.py
@@ -8,19 +8,91 @@ import time
 from collections import Counter
 from collections.abc import Mapping
 from contextlib import closing
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from polylogue.archive.raw_materialization import (
     parsed_non_session_artifact_reason,
     source_path_native_id_candidates,
 )
 from polylogue.archive.revision_authority import BYTE_AUTHORITY_CENSUS_DETAIL
+from polylogue.core.payload_coercion import row_int as _row_int
 from polylogue.logging import get_logger
 from polylogue.storage.insights.session.status import session_insight_status_sync
 from polylogue.storage.raw_authority import raw_authority_detail_query_handle
+from polylogue.storage.sqlite.archive_tiers import ARCHIVE_VERSION_BY_TIER
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.connection_profile import open_readonly_connection
 
 logger = get_logger(__name__)
+
+ArchiveTierVersionStatus = Literal["ok", "missing", "mismatch", "invalid"]
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveTierProbe:
+    """One archive tier file's existence/size/schema-version facts.
+
+    The sole, shared read-only probe of a tier file's ``PRAGMA user_version``
+    against ``ARCHIVE_VERSION_BY_TIER`` (polylogue-703 -- ONE status
+    assembly). ``polylogue.daemon.status`` (daemon HTTP/TUI/web status) and
+    ``polylogue.cli.commands.status`` (CLI direct-fallback status, used when
+    the daemon is unreachable) both build their per-tier status payload from
+    this probe instead of each reimplementing the PRAGMA read independently
+    -- the prior independent implementations were the mechanism behind a
+    real production disagreement between bare-CLI and daemon-backed status
+    (2026-07-03). Do not add a third independent tier-version probe; import
+    this one.
+    """
+
+    tier: ArchiveTier
+    path: str
+    exists: bool
+    size_bytes: int
+    wal_size_bytes: int
+    user_version: int | None
+    expected_user_version: int
+    version_status: ArchiveTierVersionStatus
+
+
+def probe_archive_tier(tier: ArchiveTier, path: Path) -> ArchiveTierProbe:
+    """Read-only probe of one archive tier file's existence/size/version."""
+    expected_user_version = ARCHIVE_VERSION_BY_TIER[tier]
+    if not path.exists():
+        return ArchiveTierProbe(
+            tier=tier,
+            path=str(path),
+            exists=False,
+            size_bytes=0,
+            wal_size_bytes=0,
+            user_version=None,
+            expected_user_version=expected_user_version,
+            version_status="missing",
+        )
+    wal_path = Path(f"{path}-wal")
+    user_version: int | None = None
+    version_status: ArchiveTierVersionStatus = "invalid"
+    try:
+        conn = open_readonly_connection(path)
+        try:
+            user_version = _row_int(conn.execute("PRAGMA user_version").fetchone()[0])
+            version_status = "ok" if user_version == expected_user_version else "mismatch"
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        logger.warning("archive tier version probe failed for %s (%s): %s", path, tier.value, exc, exc_info=True)
+    return ArchiveTierProbe(
+        tier=tier,
+        path=str(path),
+        exists=True,
+        size_bytes=path.stat().st_size,
+        wal_size_bytes=wal_path.stat().st_size if wal_path.exists() else 0,
+        user_version=user_version,
+        expected_user_version=expected_user_version,
+        version_status=version_status,
+    )
+
 
 CLAUDE_WORKFLOW_STAGE_NAME = "claude_workflow"
 """daemon_stage_events ``stage`` value written by the claude_workflow

--- a/tests/unit/cli/commands/test_status.py
+++ b/tests/unit/cli/commands/test_status.py
@@ -665,6 +665,51 @@ class TestArchiveOneTierStatus:
         assert result["table_counts"]["messages"] == 1
 
 
+class TestArchiveOneTierStatusDaemonParity:
+    """polylogue-703 regression guard: CLI and daemon must agree by construction.
+
+    Both surfaces now build their per-tier exists/size/user_version/
+    version_status facts from the single shared
+    ``polylogue.storage.archive_readiness.probe_archive_tier`` (see
+    ``_archive_one_tier_status`` here and
+    ``polylogue.daemon.status._archive_tier_status``). This test would fail
+    if either surface went back to computing those facts independently (e.g.
+    a version-mismatch tier reported "ok" by one surface and "mismatch" by
+    the other) -- the exact bug class behind the 2026-07-03 production
+    disagreement (bare CLI status: FTS 100%/844.6 MB vs daemon-backed web
+    header: degraded/28.5 GB during an unacknowledged rebuild).
+    """
+
+    def test_version_mismatch_agrees_with_daemon(self, tmp_path: Path) -> None:
+        from polylogue.daemon.status import _archive_tier_status as _daemon_archive_tier_status
+
+        db_path = tmp_path / "index.db"
+        conn = sqlite3.connect(db_path)
+        expected_version = ARCHIVE_VERSION_BY_TIER[_ARCHIVE_TIER_ENUM["index"]]
+        conn.execute(f"PRAGMA user_version = {expected_version + 999}")
+        conn.commit()
+        conn.close()
+
+        cli_result = _archive_one_tier_status("index", db_path)
+        daemon_result = _daemon_archive_tier_status("index", db_path)
+
+        assert cli_result["exists"] is daemon_result.exists
+        assert cli_result["user_version"] == daemon_result.user_version
+        assert cli_result["expected_user_version"] == daemon_result.expected_user_version
+        assert cli_result["version_status"] == daemon_result.version_status == "mismatch"
+        assert cli_result["size_bytes"] == daemon_result.size_bytes
+
+    def test_missing_tier_agrees_with_daemon(self, tmp_path: Path) -> None:
+        from polylogue.daemon.status import _archive_tier_status as _daemon_archive_tier_status
+
+        nonexistent = tmp_path / "nonexistent.db"
+        cli_result = _archive_one_tier_status("index", nonexistent)
+        daemon_result = _daemon_archive_tier_status("index", nonexistent)
+
+        assert cli_result["exists"] is daemon_result.exists is False
+        assert cli_result["version_status"] == daemon_result.version_status == "missing"
+
+
 class TestArchiveTierStatus:
     """Tests for _archive_tier_status()."""
 


### PR DESCRIPTION
## Summary

`cli/commands/status.py`'s direct-fallback status (used when the daemon is
unreachable) and `daemon/status.py` each reimplemented their own read-only
`PRAGMA user_version` / tier-existence probe independently. This PR extracts
the shared per-tier fact set into one substrate function that both surfaces
now call, so a tier's `exists`/`size_bytes`/`user_version`/`version_status`
cannot disagree between the CLI and the daemon by construction.

## Problem

Status/health is computed independently in multiple places. Live evidence
cited on polylogue-703 (2026-07-03): a bare CLI `polylogue status` reported
`FTS: 100.0% indexed / DB: 844.6 MB` while the daemon-backed web header
reported degraded insights and 28.5 GB, during a rebuild neither surface
acknowledged. The FTS-percentage half of that specific incident was already
fixed by PR #3429 (polylogue-8zzs). This PR addresses the remaining,
still-live half confirmed by the bead's 2026-07-31 re-verification: `grep -n
'_table_exists|_direct_|StatusComponentSpec|compose_status_snapshot'
polylogue/cli/commands/status.py` showed a `_table_exists`/`_direct_*`
probing family in the CLI, fully disconnected from
`polylogue/daemon/status.py`'s own independent tier-version probe
(`_archive_tier_status`, pre-existing at daemon/status.py:642).

## Solution

- Added `polylogue.storage.archive_readiness.probe_archive_tier(tier, path)`
  -- a substrate module already shared by both surfaces for readiness facts
  -- returning the coarse, read-only per-tier facts: `exists`, `size_bytes`,
  `wal_size_bytes`, `user_version`, `expected_user_version`,
  `version_status`. It uses the canonical `open_readonly_connection` helper
  (daemon already used this; the CLI previously used a bare
  `sqlite3.connect(...?mode=ro...)`).
- `daemon/status.py::_archive_tier_status()` now builds its `ArchiveTierStatus`
  from `probe_archive_tier()`, keeping only its own `table_count` (schema
  object count) computation, which has no CLI equivalent.
- `cli/commands/status.py::_archive_one_tier_status()` now builds its dict
  from the same `probe_archive_tier()`, keeping only its own row-level
  `table_counts` (per-table row counts for `--full`/diagnostics -- genuinely
  additive detail with no daemon equivalent, including the large-tier
  `sqlite_stat1` estimate fallback) computed on top.
- Deleted the CLI's independent `PRAGMA user_version` read and its ad hoc
  `"error"` version-status sentinel (no longer reachable: version/existence
  now comes from the already-resilient shared probe; a `table_counts` read
  failure now surfaces as an `"error"` key without corrupting
  `version_status`, which is more honest than before).
- Documented the invariant in `docs/internals.md`'s Key Invariants table so
  a future patch reaching for a third independent probe gets caught in
  review.
- Non-goals (per explicit lane scope, to avoid colliding with the concurrent
  polylogue-20d.17 lane which owns daemon component-snapshot budgeting):
  `StatusComponentSpec`/`StatusComponentRegistry` budgeted-collection wiring,
  `git_head` daemon status column, ops-diagnostics workload/schema-drift
  status (CLI-only facts with no daemon equivalent to converge onto), and
  `cli/archive_query.py` / `cli/query_verbs.py` rendering internals (owned by
  a separate concurrent lane).

## Before/after (`polylogue/cli/commands/status.py`)

- Before: 2,482 lines
- After: 2,485 lines (net +3; the duplicate PRAGMA-read block was replaced
  by a probe call plus a documentation docstring explaining why -- this
  slice's real win is deleting *drift*, i.e. two independently-maintained
  implementations of the same fact, not raw line count. `daemon/status.py`
  went from 3,211 to 3,208 lines for the same reason.)

## AC matrix (polylogue-703)

| AC | Status |
| --- | --- |
| Declares a before/after measurement | Satisfied -- see above; this is one convergent probe, not the full multi-thousand-line daemon/CLI/workload merge the bead originally scoped (net line delta is small by design: the fix is de-duplicating *logic*, specifically the fact class that caused the cited production disagreement) |
| Acceptable resource envelope | Satisfied for the touched surface -- no new full-table scans introduced; daemon's tier probe now opens one extra short-lived read-only connection (for `table_count`) instead of reusing the version-probe's connection, a negligible cost for a `PRAGMA`-only open |
| Regression guard | Satisfied -- added `TestArchiveOneTierStatusDaemonParity` (`tests/unit/cli/commands/test_status.py`), which calls both surfaces against the same tier file and asserts identical `exists`/`user_version`/`version_status`/`size_bytes`; it fails if either surface reverts to an independent probe |
| Fails loudly on stale/partial state | Preserved -- `probe_archive_tier()` logs (`logger.warning`, `exc_info=True`) on a `sqlite3.Error` and reports `version_status="invalid"` rather than silently defaulting to "ok" |
| Records phase timing where relevant | Not applicable to this slice -- no new multi-phase operation was introduced; timing instrumentation lives in the (untouched) `StatusComponentSpec`/registry machinery this lane intentionally did not touch |
| Verification artifact: CLI/daemon/MCP/Python/web query parity suite + content-hash citation drift fixture | Partially satisfied -- this PR adds a direct CLI/daemon parity test for the specific fact class that caused the cited incident; it does not build the full cross-surface (MCP/Python/web) parity suite or a content-hash citation drift fixture the AC also names. Those remain open scope; the daemon-side `StatusComponentSpec` budgeting, `ArchiveStorageStatus`/`archive_ready` end-to-end convergence across the daemon HTTP API, MCP `status` tool, and ops-diagnostics workload views are real remaining work tracked by `polylogue-703` staying open (this PR is one converging slice, not the epic's full close) |

## Anti-vacuity

Production caller exercised: `polylogue status` with no daemon reachable
(`_show_direct_status` / `_show_direct_json` in `cli/commands/status.py`)
calls `_archive_tier_status()` -> `_archive_one_tier_status()` ->
`probe_archive_tier()` on every invocation; `polylogued` HTTP `/api/status`
calls `build_daemon_status()` -> `_archive_storage_info()` ->
`_archive_tier_status()` -> `probe_archive_tier()` on every invocation. The
mutation that makes `TestArchiveOneTierStatusDaemonParity` fail: reverting
either `_archive_tier_status()` (daemon) or `_archive_one_tier_status()`
(CLI) to read `PRAGMA user_version` directly instead of calling
`probe_archive_tier()` -- e.g. hand-computing `version_status` from a
locally-read `user_version` using an off-by-one comparison -- breaks the
parity assertion without touching the test file itself.

## Verification

- `python -m devtools test tests/unit/cli/commands/test_status.py
  tests/unit/cli/test_status.py tests/unit/daemon/test_daemon_status.py
  tests/unit/storage/test_archive_readiness.py` -- 240 passed, 1 failed
  (`test_archive_facade_route_catalog_covers_public_async_facade`),
  confirmed pre-existing and unrelated: it asserts `_ARCHIVE_FACADE_ROUTES`
  covers every public async-facade method, and fails identically against
  `origin/master` (this PR's diff never touches `_ARCHIVE_FACADE_ROUTES`;
  the gap is newer facade methods -- `list_comparative_judgments`,
  `get_file_edits`, `record_comparative_judgment`,
  `session_usage_reconciliation`, `get_agent_policies` -- landing on master
  without a route-catalog update, unrelated to this bead).
- `python -m devtools verify --quick` -- all 18 steps green (ruff
  format/check, mypy --strict, render all, layering, closure-matrix, schema
  roundtrip, manifests, ci-workflows, doc-commands, docs-coverage,
  test-infra-currency, pytest-timeout-overrides, degrade-loudly,
  hash-boundary-census, schema-versioning policy, schema promotion audit).
- Not run: the full `devtools test` suite (per repo policy, testmon-affected
  selection is the default; the selection above is the affected-area check
  for the substrate module + both consuming surfaces). Whole-directory
  `tests/unit/storage/` was run once during investigation and surfaced 10
  unrelated failures (`test_blob_gc.py`, `test_store_ops.py`,
  `test_bulk_delete_guarded.py`, `test_durable_migrations.py`) that do not
  reference `archive_readiness`/`probe_archive_tier` and reproduce the same
  way against a narrower, non-xdist-contended run of just
  `test_archive_readiness.py` passing cleanly -- classified as pre-existing
  environment/xdist flakiness (clock-guard `time.time()` violations,
  execnet gateway timeouts), not caused by this change.

Ref polylogue-703
