### PR TITLE
fix(daemon): auto-mint and persist the daemon API bearer token

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -80,7 +80,17 @@ local process can then read/post to the receiver).
 |------|---------|-------------|
 | `--api-host` | `127.0.0.1` | API server host |
 | `--api-port` | `8766` | API server port |
-| `--api-auth-token` | auto | API auth token (auto-generated if not provided) |
+| `--api-auth-token` (`daemon.api.auth_token` / `api_auth_token`) | auto | API bearer token; auto-minted/loaded from a 0600 file if not given |
+| `--api-allow-no-auth` (`daemon.api.allow_no_auth` / `api_allow_no_auth`) | off | Explicit opt-out: serve the API with no bearer token at all |
+
+By default the daemon API requires the auto-minted/loaded bearer token on
+every route that isn't explicitly classified unauthenticated (see the route
+class table below) — run `polylogued api token show` to print it. Pass
+`--api-allow-no-auth` (or set `daemon.api.allow_no_auth` /
+`POLYLOGUE_API_ALLOW_NO_AUTH=true`) to opt out and serve without a token (any
+local process can then read/write through the API); this cannot be combined
+with a non-loopback `--api-host` (`--insecure-allow-remote` still requires a
+real token in effect).
 
 ## HTTP API Endpoints
 

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -1035,7 +1035,7 @@ files:
     target: polylogue/cli/commands/scan_secrets.py
     owner: stable
   - path: polylogue/cli/commands/status.py
-    loc: 2482
+    loc: 2485
     target: polylogue/cli/commands/status.py
     owner: stable
   - path: polylogue/cli/commands/status_diagnostics.py
@@ -1309,7 +1309,7 @@ files:
     target: polylogue/cli/verb_names.py
     owner: stable
   - path: polylogue/config.py
-    loc: 2882
+    loc: 2897
     target: polylogue/config.py
     owner: kernel
     reason: kernel root rule
@@ -1330,7 +1330,7 @@ files:
     target: polylogue/context/hermes_lifecycle_reconciliation.py
     owner: stable
   - path: polylogue/context/preamble.py
-    loc: 195
+    loc: 234
     target: polylogue/context/preamble.py
     owner: stable
   - path: polylogue/context/selection.py
@@ -1518,6 +1518,10 @@ files:
     loc: 19
     target: polylogue/daemon/__init__.py
     owner: stable
+  - path: polylogue/daemon/api_auth.py
+    loc: 135
+    target: polylogue/daemon/api_auth.py
+    owner: stable
   - path: polylogue/daemon/backup.py
     loc: 1057
     target: polylogue/daemon/backup.py
@@ -1543,7 +1547,7 @@ files:
     target: polylogue/daemon/catchup_status.py
     owner: stable
   - path: polylogue/daemon/cli.py
-    loc: 2931
+    loc: 2964
     target: polylogue/daemon/cli.py
     owner: stable
   - path: polylogue/daemon/compare.py
@@ -1635,7 +1639,7 @@ files:
     target: polylogue/daemon/healthz.py
     owner: stable
   - path: polylogue/daemon/http.py
-    loc: 5542
+    loc: 5546
     target: polylogue/daemon/http.py
     owner: stable
   - path: polylogue/daemon/judgment_automation.py
@@ -1724,7 +1728,7 @@ files:
     target: polylogue/daemon/similarity.py
     owner: stable
   - path: polylogue/daemon/status.py
-    loc: 3211
+    loc: 3208
     target: polylogue/daemon/status.py
     owner: stable
   - path: polylogue/daemon/status_snapshot.py
@@ -2318,7 +2322,7 @@ files:
     target: polylogue/mcp/server.py
     owner: stable
   - path: polylogue/mcp/server_cutover.py
-    loc: 2370
+    loc: 2325
     target: polylogue/mcp/server_cutover.py
     owner: stable
   - path: polylogue/mcp/server_prompts.py
@@ -2402,11 +2406,11 @@ files:
     target: polylogue/operations/work_effect_reconciliation.py
     owner: stable
   - path: polylogue/paths/__init__.py
-    loc: 74
+    loc: 76
     target: polylogue/paths/__init__.py
     owner: stable
   - path: polylogue/paths/_roots.py
-    loc: 234
+    loc: 246
     target: polylogue/paths/_roots.py
     owner: stable
   - path: polylogue/paths/sanitize.py
@@ -3432,7 +3436,7 @@ files:
     target: polylogue/sources/parsers/claude/orchestration.py
     owner: stable
   - path: polylogue/sources/parsers/codex.py
-    loc: 2571
+    loc: 2651
     target: polylogue/sources/parsers/codex.py
     owner: stable
   - path: polylogue/sources/parsers/codex_state.py
@@ -3540,7 +3544,7 @@ files:
     owner: stable
     cross_cut: { lifecycle: model }
   - path: polylogue/sources/revision_backfill.py
-    loc: 2332
+    loc: 2463
     target: polylogue/sources/revision_backfill.py
     owner: stable
   - path: polylogue/sources/source_acquisition.py
@@ -3581,7 +3585,7 @@ files:
     target: TBD
     owner: storage-domain
   - path: polylogue/storage/archive_readiness.py
-    loc: 1294
+    loc: 1366
     target: TBD
     owner: storage-domain
   - path: polylogue/storage/archive_views.py
@@ -3875,7 +3879,7 @@ files:
     target: polylogue/storage/raw/models.py
     owner: stable
   - path: polylogue/storage/raw_authority.py
-    loc: 2264
+    loc: 2280
     target: TBD
     owner: storage-domain
   - path: polylogue/storage/raw_reconciler.py
@@ -3888,7 +3892,7 @@ files:
     owner: storage-root
     reason: storage-root cross-cutting helper
   - path: polylogue/storage/repair.py
-    loc: 7108
+    loc: 7149
     target: polylogue/storage/repair.py
     owner: storage-root
     reason: storage-root cross-cutting helper

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -398,6 +398,10 @@ class PolylogueConfig:
         return v if isinstance(v, str) and v else None
 
     @property
+    def api_allow_no_auth(self) -> bool:
+        return bool(self._data.get("api_allow_no_auth"))
+
+    @property
     def browser_capture_port(self) -> int:
         return int(str(self._data.get("browser_capture_port", 8765)))
 
@@ -942,7 +946,16 @@ _CONFIG_INVENTORY: tuple[ConfigInventoryEntry, ...] = (
         cli_override="polylogued run --api-auth-token",
         owner_class="network-security",
         reload_behavior="startup-bound",
-        description="Bearer token required when the daemon API is exposed beyond loopback.",
+        description="Bearer token for the daemon API; auto-minted/loaded from a 0600 file if unset.",
+    ),
+    ConfigInventoryEntry(
+        "api_allow_no_auth",
+        toml_path="daemon.api.allow_no_auth",
+        env_var="POLYLOGUE_API_ALLOW_NO_AUTH",
+        cli_override="polylogued run --api-allow-no-auth",
+        owner_class="network-security",
+        reload_behavior="startup-bound",
+        description="Explicit opt-out of the auto-minted API bearer token (API serves unauthenticated).",
     ),
     ConfigInventoryEntry(
         "browser_capture_host",
@@ -1620,6 +1633,7 @@ _BOOL_CONFIG_KEYS = frozenset(
     {
         "browser_capture_allow_remote",
         "browser_capture_allow_no_auth",
+        "api_allow_no_auth",
         "embedding_enabled",
         "force_plain",
         "no_color",
@@ -1768,6 +1782,7 @@ def _default_config_values(bootstrap: _BootstrapPaths | None = None) -> dict[str
         "api_host": "127.0.0.1",
         "api_port": 8766,
         "api_auth_token": None,
+        "api_allow_no_auth": False,
         "browser_capture_port": 8765,
         "browser_capture_allowed_origins": "chrome-extension://*",
         "embedding_enabled": False,

--- a/polylogue/daemon/api_auth.py
+++ b/polylogue/daemon/api_auth.py
@@ -1,0 +1,135 @@
+"""Daemon HTTP API bearer-token lifecycle and CLI (polylogue-rzve).
+
+Mirrors :mod:`polylogue.browser_capture.receiver`'s auto-mint/load/rotate
+pattern for the receiver's pairing token. ``docs/daemon.md`` documents
+``--api-auth-token`` as "auto-generated if not provided" but, before this
+module existed, nothing actually minted one: the daemon simply started the
+API with ``auth_token=None`` (fully open on loopback) whenever the flag was
+omitted. That is the "ambiguous unauthenticated state" the owning bead
+(polylogue-rzve) calls out -- a remotely-reachable, write-capable API must
+not silently default to open. This module closes the gap by giving the API
+the same explicit contract the browser-capture receiver already has: an
+auto-minted, persisted 0600 token by default, with a loud, explicit
+``--api-allow-no-auth`` opt-out for the rare setup that wants the previous
+fully-open posture.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+
+import click
+
+from polylogue.core.json import dumps
+from polylogue.logging import get_logger
+from polylogue.paths import api_auth_token_path
+
+logger = get_logger(__name__)
+
+#: Entropy (bytes, pre-base64) for an auto-minted API bearer token. Matches
+#: RECEIVER_TOKEN_ENTROPY_BYTES in polylogue.browser_capture.receiver.
+API_AUTH_TOKEN_ENTROPY_BYTES = 32
+
+#: Env flag that must equal ``"1"`` before the daemon API will start with no
+#: bearer token at all. Default OFF, mirroring
+#: BROWSER_CAPTURE_ALLOW_NO_AUTH_ENV: without a token any local process (not
+#: just an authenticated client) can read/write through the API, so
+#: auto-minting a token closes that hole by default and this flag is the
+#: explicit, logged escape hatch.
+API_ALLOW_NO_AUTH_ENV = "POLYLOGUE_API_ALLOW_NO_AUTH"
+
+
+def load_or_mint_api_auth_token(path: Path | None = None, *, rotate: bool = False) -> str:
+    """Return the daemon API's persisted bearer token, minting one on first use.
+
+    Written atomically (mkstemp + ``fchmod(0o600)`` before any bytes land,
+    then ``os.replace``) so the token is never briefly world-readable under a
+    permissive umask -- identical idiom to
+    :func:`polylogue.browser_capture.receiver.load_or_mint_receiver_token`.
+    """
+    target = path if path is not None else api_auth_token_path()
+    if not rotate and target.exists():
+        existing = target.read_text(encoding="utf-8").strip()
+        if existing:
+            return existing
+    token = secrets.token_urlsafe(API_AUTH_TOKEN_ENTROPY_BYTES)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(token)
+        os.replace(tmp_path, target)
+    except BaseException:
+        with suppress(FileNotFoundError):
+            tmp_path.unlink()
+        raise
+    return token
+
+
+def resolve_api_auth_token(
+    explicit_token: str | None,
+    *,
+    allow_no_auth: bool = False,
+    token_path: Path | None = None,
+) -> str | None:
+    """Return the bearer token the daemon API should require before serving.
+
+    An explicitly configured token (CLI flag / config layer) always wins.
+    Otherwise the daemon auto-mints/loads a persisted 0600 token so the API
+    is never started ambiguously open. ``allow_no_auth`` is the explicit,
+    loudly-logged opt-out for a deployment that wants the fully-open posture
+    (e.g. a firewalled loopback-only dev box).
+    """
+    if explicit_token:
+        return explicit_token
+    if allow_no_auth:
+        logger.warning(
+            "daemon_api.auth_disabled",
+            reason="allow_no_auth explicitly set",
+            risk="any local process can read/write through the daemon API",
+        )
+        return None
+    return load_or_mint_api_auth_token(token_path)
+
+
+@click.group("api")
+def api_command() -> None:
+    """Manage the daemon HTTP API's auto-minted bearer token."""
+
+
+@api_command.group("token")
+def token_group() -> None:
+    """Manage the daemon API's local bearer token."""
+
+
+@token_group.command("show")
+@click.option("--rotate", is_flag=True, help="Mint a new token, invalidating the previous one.")
+@click.option("--format", "output_format", type=click.Choice(["json"]), default=None, help="Output format.")
+def token_show(rotate: bool, output_format: str | None) -> None:
+    """Print the daemon API's bearer token, minting one if none exists yet.
+
+    Use this value for ``Authorization: Bearer <token>`` when calling the
+    daemon API from a script, or when configuring ``daemon.api.auth_token`` /
+    ``POLYLOGUE_API_AUTH_TOKEN`` for a client (``polylogue ops rebuild-index``
+    and friends already read this from config automatically).
+    """
+    token = load_or_mint_api_auth_token(rotate=rotate)
+    if output_format == "json":
+        click.echo(dumps({"token": token, "rotated": rotate}))
+        return
+    click.echo(token)
+
+
+__all__ = [
+    "API_ALLOW_NO_AUTH_ENV",
+    "API_AUTH_TOKEN_ENTROPY_BYTES",
+    "api_command",
+    "load_or_mint_api_auth_token",
+    "resolve_api_auth_token",
+]

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -27,6 +27,11 @@ from polylogue.browser_capture.server import BrowserCaptureHTTPServer, make_serv
 from polylogue.core.degraded import DegradedReason, set_degraded
 from polylogue.core.json import JSONDocument, dumps, json_document, loads
 from polylogue.core.loopback import bind_hosts_overlap, is_loopback_host
+from polylogue.daemon.api_auth import (
+    API_ALLOW_NO_AUTH_ENV,
+    api_command,
+    resolve_api_auth_token,
+)
 from polylogue.daemon.browser_capture import browser_capture_command
 
 # FTS startup readiness extracted to ``polylogue.daemon.fts_startup`` (#1614).
@@ -1948,6 +1953,7 @@ async def run_daemon_services(
     api_host: str = "127.0.0.1",
     api_port: int = 8766,
     api_auth_token: str | None = None,
+    api_allow_no_auth: bool = False,
 ) -> None:
     """Run configured daemon components until interrupted."""
     from polylogue.daemon import process_start as _process_start
@@ -1976,16 +1982,28 @@ async def run_daemon_services(
             f"Set distinct --api-port/--port values or bind one component to a non-overlapping host."
         )
 
-    # Non-localhost API binding requires explicit opt-in AND an auth token.
+    # The daemon API must never start in an ambiguous unauthenticated state
+    # (polylogue-rzve): an explicit --api-auth-token always wins, otherwise a
+    # persisted 0600 token is auto-minted/loaded (mirroring the
+    # browser-capture receiver's resolve_receiver_auth_token contract), and
+    # --api-allow-no-auth is the loud, explicit opt-out for a deployment that
+    # wants the API fully open.
+    resolved_api_auth_token = (
+        resolve_api_auth_token(api_auth_token, allow_no_auth=api_allow_no_auth) if enable_api else None
+    )
+
+    # Non-localhost API binding requires explicit opt-in AND an auth token --
+    # allow_no_auth cannot be combined with a remote bind.
     if enable_api and not is_loopback_host(api_host):
         if not browser_capture_allow_remote:
             raise click.UsageError(
                 f"--api-host={api_host} is not a loopback address. "
                 f"Add --insecure-allow-remote to accept the risk of exposing the daemon API."
             )
-        if not api_auth_token:
+        if not resolved_api_auth_token:
             raise click.UsageError(
-                f"--api-host={api_host} with --insecure-allow-remote requires --api-auth-token. "
+                f"--api-host={api_host} with --insecure-allow-remote requires --api-auth-token "
+                f"(or an auto-minted token; drop --api-allow-no-auth). "
                 f"Remote binding without authentication is not supported."
             )
     configure_runtime_components(
@@ -2148,7 +2166,7 @@ async def run_daemon_services(
             api_server = DaemonAPIHTTPServer(
                 (api_host, api_port),
                 DaemonAPIHandler,
-                auth_token=api_auth_token,
+                auth_token=resolved_api_auth_token,
                 api_host=api_host,
                 write_bridge=DaemonWriteThreadBridge(write_coordinator, asyncio.get_running_loop()),
             )
@@ -2159,7 +2177,7 @@ async def run_daemon_services(
             uds_server = DaemonAPIUnixHTTPServer(
                 daemon_socket_path(),
                 DaemonAPIHandler,
-                auth_token=api_auth_token,
+                auth_token=resolved_api_auth_token,
                 write_bridge=DaemonWriteThreadBridge(write_coordinator, asyncio.get_running_loop()),
             )
             uds_server_task = asyncio.create_task(asyncio.to_thread(uds_server.serve_forever, 0.5))
@@ -2169,7 +2187,7 @@ async def run_daemon_services(
                     "component_started",
                     archive_root_path=archive_root_path,
                     component="api",
-                    payload={"host": api_host, "port": api_port, "auth_enabled": bool(api_auth_token)},
+                    payload={"host": api_host, "port": api_port, "auth_enabled": resolved_api_auth_token is not None},
                 )
 
         # Ensure FTS structure after HTTP surfaces are bound and before live
@@ -2533,6 +2551,7 @@ def main() -> None:
 
 
 main.add_command(browser_capture_command)
+main.add_command(api_command)
 
 
 _LIVE_DAEMON_STATUS_TIMEOUT_S = 0.3
@@ -2761,7 +2780,17 @@ def health_command(
 @click.option(
     "--api-auth-token",
     default=None,
-    help="Daemon API auth token (generate one if not provided; write to archive root).",
+    help="Daemon API auth token; auto-minted/loaded from a 0600 file if not given.",
+)
+@click.option(
+    "--api-allow-no-auth",
+    is_flag=True,
+    default=False,
+    envvar=API_ALLOW_NO_AUTH_ENV,
+    help=(
+        "Run the daemon API with no bearer token at all. Any local process can then read/write "
+        "through it -- default OFF; an explicit opt-out for the auto-minted-token default."
+    ),
 )
 @click.pass_context
 def run_command(
@@ -2782,6 +2811,7 @@ def run_command(
     api_host: str,
     api_port: int,
     api_auth_token: str | None,
+    api_allow_no_auth: bool,
 ) -> None:
     """Run configured daemon components.
 
@@ -2834,6 +2864,8 @@ def run_command(
             api_port = cfg.daemon_port
     if parameter_is_default("api_auth_token") and cfg.api_auth_token:
         api_auth_token = cfg.api_auth_token
+    if parameter_is_default("api_allow_no_auth"):
+        api_allow_no_auth = cfg.api_allow_no_auth
 
     enable_watch = not no_watch
     enable_source_catchup = not no_source_catchup
@@ -2881,6 +2913,7 @@ def run_command(
                 api_host=api_host,
                 api_port=api_port,
                 api_auth_token=api_auth_token,
+                api_allow_no_auth=api_allow_no_auth,
             )
         )
     except KeyboardInterrupt:

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -1353,10 +1353,14 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
     def _check_auth(self, required_scope: WebCredentialScope = "read", *, allow_web: bool = True) -> bool:
         """Validate a machine bearer or a scoped first-party web credential.
 
-        When no token is configured the API is open (local dev default).
-        When a token IS configured, all clients — including localhost —
-        must present it. Loopback is not a security boundary when a
-        browser on the same host can reach the daemon.
+        When no token is configured the API is open. This server object only
+        ever receives ``auth_token=None`` when the operator explicitly opted
+        out via ``--api-allow-no-auth`` (``polylogue.daemon.api_auth``
+        auto-mints/loads a persisted token by default, mirroring the
+        browser-capture receiver's contract; polylogue-rzve). When a token
+        IS configured, all clients — including localhost — must present it.
+        Loopback is not a security boundary when a browser on the same host
+        can reach the daemon.
 
         Native ``EventSource`` receives the same HttpOnly cookie as fetch, so
         no credential is ever accepted from a query parameter.

--- a/polylogue/paths/__init__.py
+++ b/polylogue/paths/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from polylogue.paths._roots import (
     GEMINI_DRIVE_FOLDER,
     antigravity_path,
+    api_auth_token_path,
     archive_file_set_index_available_for_paths,
     archive_root,
     blob_store_root,
@@ -43,6 +44,7 @@ from polylogue.paths._roots import (
 __all__ = [
     "GEMINI_DRIVE_FOLDER",
     "antigravity_path",
+    "api_auth_token_path",
     "archive_root",
     "blob_store_root",
     "browser_capture_pairing_state_path",

--- a/polylogue/paths/_roots.py
+++ b/polylogue/paths/_roots.py
@@ -117,6 +117,18 @@ def browser_capture_receiver_identity_path() -> Path:
     return archive_root() / "browser-capture-receiver-id"
 
 
+def api_auth_token_path() -> Path:
+    """Path for the auto-minted daemon HTTP API bearer token, scoped under the archive root.
+
+    Mirrors :func:`browser_capture_receiver_token_path` (polylogue-rzve): must
+    track ``archive_root()`` (not ``state_home()``) so two ``polylogued``
+    instances with different ``POLYLOGUE_ARCHIVE_ROOT`` values never share one
+    API token, and so an explicit ``--api-auth-token``/config value always
+    takes precedence over whatever is minted here.
+    """
+    return archive_root() / "api-auth-token"
+
+
 def browser_capture_pairing_state_path() -> Path:
     """Path for the receiver's ephemeral one-time pairing-code state.
 

--- a/tests/unit/daemon/test_api_auth.py
+++ b/tests/unit/daemon/test_api_auth.py
@@ -1,0 +1,134 @@
+"""Auto-minted daemon HTTP API bearer token (polylogue-rzve).
+
+``docs/daemon.md`` documented ``--api-auth-token`` as "auto-generated if not
+provided" while ``run_daemon_services`` merely stored ``auth_token=None`` --
+no minting code existed anywhere. These tests cover the mint/load/rotate/
+resolve primitives in ``polylogue.daemon.api_auth`` (mirroring the
+browser-capture receiver's already-shipped token contract exactly) and the
+CLI ``polylogued api token show`` surface.
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from polylogue.daemon.api_auth import (
+    api_command,
+    load_or_mint_api_auth_token,
+    resolve_api_auth_token,
+)
+from polylogue.paths import api_auth_token_path
+
+
+def test_load_or_mint_api_auth_token_creates_0600_file_and_persists(tmp_path: Path) -> None:
+    token_path = tmp_path / "api-auth-token"
+
+    first = load_or_mint_api_auth_token(token_path)
+    second = load_or_mint_api_auth_token(token_path)
+
+    assert first == second
+    assert token_path.read_text(encoding="utf-8").strip() == first
+    assert stat.S_IMODE(token_path.stat().st_mode) == 0o600
+
+
+def test_load_or_mint_api_auth_token_rotate_changes_the_value(tmp_path: Path) -> None:
+    token_path = tmp_path / "api-auth-token"
+
+    original = load_or_mint_api_auth_token(token_path)
+    rotated = load_or_mint_api_auth_token(token_path, rotate=True)
+    reloaded = load_or_mint_api_auth_token(token_path)
+
+    assert rotated != original
+    assert reloaded == rotated
+
+
+def test_default_token_path_is_scoped_to_archive_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two POLYLOGUE_ARCHIVE_ROOT values must never resolve to the same
+    default token file -- a scratch archive must not silently authenticate
+    against the real daemon's token (mirrors the receiver-token test)."""
+    root_a = tmp_path / "archive-a"
+    root_b = tmp_path / "archive-b"
+
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root_a))
+    path_a = api_auth_token_path()
+    token_a = load_or_mint_api_auth_token()
+
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root_b))
+    path_b = api_auth_token_path()
+    token_b = load_or_mint_api_auth_token()
+
+    assert path_a != path_b
+    assert token_a != token_b
+    assert root_a in path_a.parents
+    assert root_b in path_b.parents
+
+
+def test_resolve_api_auth_token_prefers_explicit_token(tmp_path: Path) -> None:
+    token_path = tmp_path / "api-auth-token"
+
+    resolved = resolve_api_auth_token("explicit-secret", token_path=token_path)
+
+    assert resolved == "explicit-secret"
+    assert not token_path.exists()
+
+
+def test_resolve_api_auth_token_allow_no_auth_returns_none(tmp_path: Path) -> None:
+    token_path = tmp_path / "api-auth-token"
+
+    resolved = resolve_api_auth_token(None, allow_no_auth=True, token_path=token_path)
+
+    assert resolved is None
+    assert not token_path.exists()
+
+
+def test_resolve_api_auth_token_default_mints_and_persists(tmp_path: Path) -> None:
+    """The startup-without-token path: no explicit token, no opt-out ->
+    a real token is minted AND persisted to disk. This is the exact
+    behavior that was documented but never implemented (polylogue-rzve);
+    removing the mint call from ``resolve_api_auth_token`` makes this fail
+    (the file would never be created and ``resolved`` would be ``None``)."""
+    token_path = tmp_path / "api-auth-token"
+
+    resolved = resolve_api_auth_token(None, token_path=token_path)
+
+    assert resolved is not None
+    assert token_path.exists()
+    assert token_path.read_text(encoding="utf-8").strip() == resolved
+    assert stat.S_IMODE(token_path.stat().st_mode) == 0o600
+
+
+def test_resolve_api_auth_token_default_is_stable_across_calls(tmp_path: Path) -> None:
+    """A second daemon start (or client resolving the same config) must
+    load the same persisted token rather than minting a fresh one each
+    time -- otherwise every restart would invalidate every existing
+    client's credential."""
+    token_path = tmp_path / "api-auth-token"
+
+    first = resolve_api_auth_token(None, token_path=token_path)
+    second = resolve_api_auth_token(None, token_path=token_path)
+
+    assert first == second
+
+
+def test_api_token_show_command_mints_and_prints(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "archive"))
+
+    result = CliRunner().invoke(api_command, ["token", "show"])
+
+    assert result.exit_code == 0, (result.output, result.exception)
+    token = result.output.strip()
+    assert token
+    assert api_auth_token_path().read_text(encoding="utf-8").strip() == token
+
+
+def test_api_token_show_command_rotate_changes_value(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "archive"))
+
+    first = CliRunner().invoke(api_command, ["token", "show"]).output.strip()
+    rotated = CliRunner().invoke(api_command, ["token", "show", "--rotate"]).output.strip()
+
+    assert rotated != first

--- a/tests/unit/daemon/test_daemon_cli_remote_bind.py
+++ b/tests/unit/daemon/test_daemon_cli_remote_bind.py
@@ -1,21 +1,26 @@
-"""Remote-bind enforcement for the daemon API (#868-A4, #868-A5).
+"""Remote-bind enforcement for the daemon API (#868-A4, #868-A5, polylogue-rzve).
 
 The daemon must refuse to start an HTTP API on a non-loopback address
 unless the operator explicitly opts in (``--insecure-allow-remote``)
-*and* configures a bearer token (``--api-auth-token``). The logic lives
-at the top of ``run_daemon_services`` and is the gate that prevents
-accidental exposure of the local archive over the network.
+*and* an auth token is in effect (``--api-auth-token`` is an "auto"
+default -- polylogue-rzve made that real: a token is auto-minted/loaded
+unless the operator explicitly opts all the way out with
+``--api-allow-no-auth``). The logic lives at the top of
+``run_daemon_services`` and is the gate that prevents accidental
+exposure of the local archive over the network.
 
-Two refusal conditions, each tested:
+Refusal conditions, each tested:
 
 1. Non-loopback bind without ``--insecure-allow-remote`` → UsageError.
-2. Non-loopback bind with ``--insecure-allow-remote`` but no token →
-   UsageError.
+2. Non-loopback bind with ``--insecure-allow-remote`` *and*
+   ``--api-allow-no-auth`` (the only way to reach "no token in effect"
+   now that a token auto-mints by default) → UsageError.
 
-A passing positive case (loopback bind, no token required) would
-require mocking the entire daemon startup chain, which is out of scope
-for a focused security test. The pure-logic refusal lives at the top
-of the function and fires before any heavyweight setup.
+A passing positive case (loopback bind, no explicit token, token
+auto-mints) would require mocking the entire daemon startup chain,
+which is out of scope for a focused security test. The pure-logic
+refusal lives at the top of the function and fires before any
+heavyweight setup.
 """
 
 from __future__ import annotations
@@ -68,11 +73,61 @@ def test_non_loopback_bind_without_allow_remote_refuses(api_host: str) -> None:
 
 
 @pytest.mark.parametrize("api_host", ["0.0.0.0", "192.168.1.1"])
-def test_non_loopback_bind_with_allow_remote_but_no_token_refuses(
+def test_non_loopback_bind_with_allow_remote_and_allow_no_auth_refuses(
     api_host: str,
 ) -> None:
-    """Even with the explicit risk-acknowledgement flag, a token is required."""
+    """Even with the explicit risk-acknowledgement flag, an explicit
+    ``--api-allow-no-auth`` opt-out cannot be combined with a remote bind --
+    remote exposure without any credential in effect is never supported."""
     with pytest.raises(click.UsageError, match="requires --api-auth-token"):
+        _run(
+            run_daemon_services(
+                sources=(),
+                debounce_s=1.0,
+                enable_watch=False,
+                enable_browser_capture=False,
+                browser_capture_host="127.0.0.1",
+                browser_capture_port=8765,
+                browser_capture_spool_path=None,
+                browser_capture_allow_remote=True,
+                browser_capture_auth_token=None,
+                browser_capture_extra_origins=(),
+                enable_api=True,
+                api_host=api_host,
+                api_port=8766,
+                api_auth_token=None,
+                api_allow_no_auth=True,
+            )
+        )
+
+
+@pytest.mark.parametrize("api_host", ["0.0.0.0", "192.168.1.1"])
+def test_non_loopback_bind_with_allow_remote_and_no_explicit_token_auto_mints(
+    api_host: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A remote bind with no explicit ``--api-auth-token`` and no
+    ``--api-allow-no-auth`` opt-out succeeds -- the gate is satisfied by a
+    real auto-minted token, matching the browser-capture receiver's
+    already-shipped contract (polylogue-rzve). Removing the auto-mint call
+    from ``resolve_api_auth_token`` makes this raise UsageError instead.
+
+    The HTTP/UDS server classes are stubbed out so the test never attempts a
+    real bind to a non-loopback address that may not exist on the test host
+    (``192.168.1.1``) -- only the pure-logic gate at the top of
+    ``run_daemon_services`` is under test here.
+    """
+    from unittest.mock import MagicMock
+
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(tmp_path / "archive"))
+    with (
+        patch("polylogue.daemon.http.DaemonAPIHTTPServer", return_value=MagicMock()),
+        patch("polylogue.daemon.uds.DaemonAPIUnixHTTPServer", return_value=MagicMock()),
+        patch(
+            "polylogue.daemon.cli._run_startup_fts_readiness",
+            side_effect=RuntimeError("post-gate sentinel"),
+        ),
+        pytest.raises(RuntimeError, match="post-gate sentinel"),
+    ):
         _run(
             run_daemon_services(
                 sources=(),
@@ -91,32 +146,9 @@ def test_non_loopback_bind_with_allow_remote_but_no_token_refuses(
                 api_auth_token=None,
             )
         )
+    from polylogue.paths import api_auth_token_path
 
-
-@pytest.mark.parametrize("api_host", ["0.0.0.0", "192.168.1.1"])
-def test_non_loopback_bind_with_allow_remote_and_empty_token_refuses(
-    api_host: str,
-) -> None:
-    """Empty string token is treated as no token (truthy check)."""
-    with pytest.raises(click.UsageError, match="requires --api-auth-token"):
-        _run(
-            run_daemon_services(
-                sources=(),
-                debounce_s=1.0,
-                enable_watch=False,
-                enable_browser_capture=False,
-                browser_capture_host="127.0.0.1",
-                browser_capture_port=8765,
-                browser_capture_spool_path=None,
-                browser_capture_allow_remote=True,
-                browser_capture_auth_token=None,
-                browser_capture_extra_origins=(),
-                enable_api=True,
-                api_host=api_host,
-                api_port=8766,
-                api_auth_token="",
-            )
-        )
+    assert api_auth_token_path().exists()
 
 
 @pytest.mark.parametrize(
@@ -242,11 +274,18 @@ def test_run_command_applies_configured_remote_api_fail_closed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """TOML/env network policy feeds the same remote-bind safety gate as CLI flags."""
+    """TOML/env network policy feeds the same remote-bind safety gate as CLI flags.
+
+    A remote bind alone no longer fails closed by itself -- an auth token
+    now auto-mints by default (polylogue-rzve) -- so this also sets the
+    explicit ``POLYLOGUE_API_ALLOW_NO_AUTH`` opt-out to reach the "no token
+    in effect" state the remote-bind gate refuses.
+    """
     monkeypatch.setenv("POLYLOGUE_SITE_CONFIG", "")
     monkeypatch.setenv("POLYLOGUE_CONFIG", str(tmp_path / "absent.toml"))
     monkeypatch.setenv("POLYLOGUE_API_HOST", "0.0.0.0")
     monkeypatch.setenv("POLYLOGUE_BROWSER_CAPTURE_ALLOW_REMOTE", "true")
+    monkeypatch.setenv("POLYLOGUE_API_ALLOW_NO_AUTH", "true")
 
     result = CliRunner().invoke(main, ["run", "--no-watch", "--no-browser-capture"])
 


### PR DESCRIPTION
## Summary

`docs/daemon.md` documented `--api-auth-token` as "auto-generated if not provided," but no minting code existed anywhere: `run_daemon_services` simply stored `auth_token=None` when the flag was omitted, so the daemon HTTP API started fully open on loopback by default. This implements the documented behavior by mirroring the browser-capture receiver's already-shipped token-lifecycle contract.

## Problem

Discovered while implementing polylogue-gnie (2026-07-08), triage-verified 2026-07-31: `docs/daemon.md:83` claims auto-generation; `polylogue/daemon/cli.py` (pre-fix) only checked `if not api_auth_token` for the remote-bind gate, with no minting path anywhere in the codebase. `DaemonAPIHTTPServer.__init__` just stored whatever `auth_token` it was given — `None` by default. This is exactly the "ambiguous unauthenticated state" polylogue-rzve's design note calls out for a remotely-reachable, write-capable local API.

## Solution

- `polylogue/daemon/api_auth.py` (new): `load_or_mint_api_auth_token` (atomic mkstemp + `fchmod(0o600)` + `os.replace`, matching `polylogue.browser_capture.receiver.load_or_mint_receiver_token` byte-for-byte in idiom), `resolve_api_auth_token` (explicit token wins → auto-mint/load → `allow_no_auth` opt-out returns `None` with a loud warning log), and a `polylogued api token show [--rotate]` CLI surface.
- `polylogue/paths/_roots.py`: `api_auth_token_path()`, scoped under `archive_root()` (not `state_home()`) so two `POLYLOGUE_ARCHIVE_ROOT` archives never share one token — same reasoning as `browser_capture_receiver_token_path()`.
- `polylogue/daemon/cli.py`: `run_daemon_services` now resolves the token via `resolve_api_auth_token` before the remote-bind gate and before constructing `DaemonAPIHTTPServer`/`DaemonAPIUnixHTTPServer`. Added `--api-allow-no-auth` (mirrors `--browser-capture-allow-no-auth`), wired through config layering (`daemon.api.allow_no_auth` / `POLYLOGUE_API_ALLOW_NO_AUTH`). Remote binding (`--insecure-allow-remote`) still requires a real token in effect and cannot be paired with `--api-allow-no-auth`.
- `polylogue/config.py`: `api_allow_no_auth` property + `ConfigInventoryEntry` + bool-key/default registration, identical pattern to `browser_capture_allow_no_auth`.
- `polylogue/daemon/http.py`: corrected the `_check_auth` docstring, which described the pre-fix "open by default" behavior as an intentional "local dev default."
- `docs/daemon.md`: documents `--api-allow-no-auth` and clarifies the auto-mint contract for `--api-auth-token`.

**Deliberate behavior change**: the daemon API is no longer ambiguously open by default on loopback — a real, persisted 0600 token is always in effect unless the operator explicitly opts out with `--api-allow-no-auth`.

**Alternatives rejected**: fixing only the docs (removing the "auto-generated" claim) was the AC's other allowed option, but the bead's design section and priority-correction note ("a sensitive local daemon cannot have documentation claim credential minting while runtime may start with no token") plus the receiver precedent point at implementing the documented behavior as the default expectation.

## Verification

- `devtools test tests/unit/daemon/test_api_auth.py tests/unit/daemon/test_daemon_cli_remote_bind.py` → `23 passed`
- `devtools test tests/unit/cli/test_config_command.py tests/unit/core/test_config_inventory.py tests/unit/cli/test_query_exec_laws.py tests/unit/core/test_config.py tests/unit/devtools/test_render_openapi.py tests/unit/devtools/test_deployment_smoke.py` → `306 passed`
- `devtools verify --quick` → `exit_code: 0` (ruff format/check, `mypy --strict`, `render all --check`, topology/layering/closure-matrix, docs-coverage, hash-boundary-census, schema-versioning policy, schema promotion audit)
- `devtools render topology-projection` (new module `polylogue/daemon/api_auth.py` regenerates `docs/plans/topology-target.yaml`)

**Anti-vacuity**: `test_resolve_api_auth_token_default_mints_and_persists` calls the production `resolve_api_auth_token` → `load_or_mint_api_auth_token` path directly against a real temp file; reverting the auto-mint call to `return None` makes the `resolved is not None` and persisted-file assertions fail. `test_non_loopback_bind_with_allow_remote_and_no_explicit_token_auto_mints` exercises the same path through `run_daemon_services`'s real gate logic and asserts the token file exists on disk afterward — it fails if the mint call is removed or the gate regresses to always requiring an explicit token.

Ref polylogue-rzve