### PR TITLE
fix(tests): repair whale-pass daemon-cli tests broken by #3455

### DIFF
--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -4295,6 +4295,7 @@ def test_periodic_raw_materialization_convergence_skips_whale_pass_mid_burst(
 
 def test_maybe_run_raw_materialization_whale_pass_runs_scoped_pass_and_emits_events(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """A found whale candidate must run through the writer coordinator
     scoped to that one raw id at the resolved whale envelope, and emit
@@ -4306,6 +4307,17 @@ def test_maybe_run_raw_materialization_whale_pass_runs_scoped_pass_and_emits_eve
         "polylogue.daemon.events.emit_daemon_event",
         lambda kind, *, payload: events.append((kind, payload)),
     )
+    # ``archive_root()`` is patched directly (the established seam used
+    # throughout this file) rather than via ``load_polylogue_config``: the
+    # autouse env-clearing fixture removes ``POLYLOGUE_ARCHIVE_ROOT``, so
+    # production's real ``archive_root()`` falls through to
+    # ``resolve_archive_root()``, which calls
+    # ``load_polylogue_config(_bootstrap=...)`` -- a call shape a bare
+    # zero-arg lambda here cannot satisfy without also faking a full
+    # ``ResolvedSettings``-like object. Patching the resolved-path functions
+    # keeps this test focused on the whale-pass call it actually verifies.
+    monkeypatch.setattr("polylogue.paths.archive_root", lambda: tmp_path)
+    monkeypatch.setattr("polylogue.paths.render_root", lambda: tmp_path / "render")
     monkeypatch.setattr(
         "polylogue.config.load_polylogue_config",
         lambda: SimpleNamespace(raw_authority_whale_payload_bytes=None),
@@ -4350,12 +4362,18 @@ def test_maybe_run_raw_materialization_whale_pass_runs_scoped_pass_and_emits_eve
 
 def test_maybe_run_raw_materialization_whale_pass_no_candidate_skips_writer(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """No qualifying component this tick must never touch the writer
     coordinator -- the read-only candidate lookup is the only thing that
     runs."""
     from polylogue.daemon import cli as daemon_cli
 
+    # See the sibling whale-pass test above for why ``archive_root()``/
+    # ``render_root()`` are patched directly instead of relying solely on
+    # ``load_polylogue_config`` to satisfy production's env-fallback path.
+    monkeypatch.setattr("polylogue.paths.archive_root", lambda: tmp_path)
+    monkeypatch.setattr("polylogue.paths.render_root", lambda: tmp_path / "render")
     monkeypatch.setattr(
         "polylogue.config.load_polylogue_config",
         lambda: SimpleNamespace(raw_authority_whale_payload_bytes=None),


### PR DESCRIPTION
## Summary

Repairs `test_maybe_run_raw_materialization_whale_pass_{runs_scoped_pass_and_emits_events,no_candidate_skips_writer}` in `tests/unit/daemon/test_daemon_cli.py`, which fail on `master` both in isolation and file-scope with:

```
TypeError: <lambda>() got an unexpected keyword argument '_bootstrap'
```

raised from `polylogue/config.py:2173` (`resolve_archive_root` -> `load_polylogue_config(_bootstrap=bootstrap)`).

## Problem

`#3455` ("refactor(config): delete two inert config keys and the whale off-switch") touched `polylogue/config.py` and this exact test file in the same commit, and the failing tests are named after that PR's whale-pass feature.

## Which side was wrong, and why

Production is correct; the tests are the stale side. Diagnosis:

- `_maybe_run_raw_materialization_whale_pass` (`polylogue/daemon/cli.py:1265`) calls `archive_root()` (from `polylogue.paths`) first.
- Both tests' autouse `_clear_polylogue_env` fixture (`tests/conftest.py:447`) removes `POLYLOGUE_ARCHIVE_ROOT`, so `archive_root()`'s env fast path is empty and it falls through to `config.resolve_archive_root()`, which calls `load_polylogue_config(_bootstrap=bootstrap)`.
- Both tests monkeypatch `polylogue.config.load_polylogue_config` with a zero-argument lambda (originally added only to satisfy `_resolve_raw_materialization_whale_blob_limit_bytes`'s separate zero-arg `load_polylogue_config().raw_authority_whale_payload_bytes` call) — it was never updated to accept the `_bootstrap` keyword the `archive_root()` fallback path actually needs.
- Widening the lambda's signature to `**kwargs` would still fail: `resolve_archive_root` reads `settings.archive_root` off the return value, and a bare `SimpleNamespace(raw_authority_whale_payload_bytes=None)` has no such attribute.

Fix: patch `polylogue.paths.archive_root` / `polylogue.paths.render_root` directly — the exact seam ~20 other tests in this same file already use to sidestep this identical env-fallback path. This keeps `load_polylogue_config`'s existing zero-arg patch scoped to the one call site it's actually meant for (`_resolve_raw_materialization_whale_blob_limit_bytes`).

This also resolves `polylogue-010x`: patching `load_polylogue_config` alone made these tests pass only when some other test's `POLYLOGUE_ARCHIVE_ROOT` override happened to leak into this test's environment (order-dependent). Patching `archive_root()` directly makes the archive root deterministic regardless of run order.

## Solution

- `tests/unit/daemon/test_daemon_cli.py`: both whale-pass tests now take a `tmp_path` fixture and `monkeypatch.setattr("polylogue.paths.archive_root", ...)` / `render_root` before invoking `_maybe_run_raw_materialization_whale_pass`.
- No production code changed — `archive_root()`'s env-fallback behavior is correct as designed (per its own docstring, polylogue-4ma3).

## Anti-vacuity

The production dependency exercised is the real `archive_root()` -> `resolve_archive_root()` -> `load_polylogue_config(_bootstrap=...)` fallback chain in `polylogue/config.py` and `polylogue/paths/_roots.py`; reverting this diff (restoring the zero-arg lambda) reproduces the original `TypeError` deterministically, both in isolation and file-scope.

## Verification

```
python -m devtools test tests/unit/daemon/test_daemon_cli.py -k whale_pass   # 4 passed (isolation)
python -m devtools test tests/unit/daemon/test_daemon_cli.py                 # 113 passed (full file)
python -m devtools verify --quick                                            # exit 0
```

Ref polylogue-jsxj, polylogue-010x