### PR TITLE
feat(assertions): wire HIGHLIGHT/PROMPT_EVAL writers and claim expiry

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -179,6 +179,8 @@ _CANDIDATE_CAPTURE_KIND_MAP: dict[str, AssertionKind] = {
     "claim": AssertionKind.DECISION,
     "correction": AssertionKind.CORRECTION,
     "lesson": AssertionKind.LESSON,
+    "highlight": AssertionKind.HIGHLIGHT,
+    "prompt_eval": AssertionKind.PROMPT_EVAL,
 }
 
 
@@ -1660,8 +1662,17 @@ def _archive_capture_assertion_candidate(
     author_ref: str = "user:local",
     author_kind: str = "user",
     idempotency_key: str | None = None,
+    ttl_seconds: int | None = None,
 ) -> Any:
-    """Write one terminal-captured assertion through the user-tier gate."""
+    """Write one terminal-captured assertion through the user-tier gate.
+
+    ``ttl_seconds``, when given, stamps ``staleness={"expires_at_ms": ...}``
+    on the written row (polylogue-37t.1): the admission read
+    (:func:`~polylogue.storage.sqlite.archive_tiers.user_write.list_assertion_claims`)
+    excludes expired claims from the preamble compiler and every other
+    ``ASSERTION_CLAIM_KINDS`` consumer once ``expires_at_ms`` elapses, with no
+    new assertion status introduced.
+    """
 
     from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
     from polylogue.storage.sqlite.archive_tiers.user_write import read_assertion_envelope, upsert_assertion
@@ -1673,6 +1684,8 @@ def _archive_capture_assertion_candidate(
     normalized_author_kind = author_kind.strip().lower()
     if not normalized_author_kind:
         raise ValueError("author_kind cannot be empty")
+    if ttl_seconds is not None and ttl_seconds <= 0:
+        raise ValueError("ttl_seconds must be positive")
 
     normalized_idempotency_key = None if idempotency_key is None else idempotency_key.strip()
     if idempotency_key is not None and not normalized_idempotency_key:
@@ -1766,6 +1779,8 @@ def _archive_capture_assertion_candidate(
                     conn.commit()
                     return existing
                 raise ValueError("idempotency_key conflicts with a different assertion candidate capture")
+            capture_now_ms = int(datetime.now(UTC).timestamp() * 1000)
+            staleness = None if ttl_seconds is None else {"expires_at_ms": capture_now_ms + ttl_seconds * 1000}
             envelope = upsert_assertion(
                 conn,
                 assertion_id=assertion_id,
@@ -1783,7 +1798,9 @@ def _archive_capture_assertion_candidate(
                 author_kind=normalized_author_kind,
                 evidence_refs=tuple(dict.fromkeys((*resolved_refs, *normalized_scope_refs))),
                 status=AssertionStatus.CANDIDATE,
+                staleness=staleness,
                 context_policy={"inject": False, "promotion_required": True},
+                now_ms=capture_now_ms,
             )
             conn.commit()
             return envelope
@@ -3048,8 +3065,13 @@ class PolylogueArchiveMixin:
         author_ref: str = "user:local",
         author_kind: str = "user",
         idempotency_key: str | None = None,
+        ttl_seconds: int | None = None,
     ) -> AssertionClaimPayload:
-        """Capture a terminal assertion as a non-injected candidate for review."""
+        """Capture a terminal assertion as a non-injected candidate for review.
+
+        ``ttl_seconds`` stamps an expiry on the written row (polylogue-37t.1);
+        see :func:`_archive_capture_assertion_candidate`.
+        """
 
         from polylogue.surfaces.payloads import AssertionClaimPayload
 
@@ -3063,6 +3085,7 @@ class PolylogueArchiveMixin:
             author_ref=author_ref,
             author_kind=author_kind,
             idempotency_key=idempotency_key,
+            ttl_seconds=ttl_seconds,
         )
         return AssertionClaimPayload.from_envelope(envelope)
 

--- a/polylogue/cli/commands/note.py
+++ b/polylogue/cli/commands/note.py
@@ -16,7 +16,7 @@ from polylogue.surfaces.payloads import AssertionClaimPayload
 
 MAX_NOTE_STDIN_BYTES = 256 * 1024
 
-_KIND_NAMES = ("note", "claim", "correction", "lesson")
+_KIND_NAMES = ("note", "claim", "correction", "lesson", "highlight", "prompt_eval")
 
 
 def _scope_refs(repo: str | None, topic: str | None) -> tuple[str, ...]:
@@ -52,6 +52,14 @@ def _stdin_note() -> str:
     default=None,
     help="Caller-scoped retry key; exact replays return the original lifecycle row.",
 )
+@click.option(
+    "--ttl-seconds",
+    "ttl_seconds",
+    type=click.IntRange(min=1),
+    default=None,
+    help="Expire this candidate this many seconds after capture (staleness.expires_at_ms); "
+    "expired claims are excluded from ASSERTION_CLAIM_KINDS reads (preamble compiler etc.).",
+)
 @click.option("--format", "output_format", type=click.Choice(("text", "json")), default="text", show_default=True)
 def note_command(
     text: str | None,
@@ -61,6 +69,7 @@ def note_command(
     topic: str | None,
     kind_name: str,
     idempotency_key: str | None,
+    ttl_seconds: int | None,
     output_format: str,
 ) -> None:
     """Capture one terminal memory candidate; judgment remains a separate step."""
@@ -79,6 +88,7 @@ def note_command(
                 scope_refs=_scope_refs(repo, topic),
                 cwd=Path.cwd(),
                 idempotency_key=idempotency_key,
+                ttl_seconds=ttl_seconds,
             )
 
     try:

--- a/polylogue/mcp/server_cutover.py
+++ b/polylogue/mcp/server_cutover.py
@@ -1545,6 +1545,8 @@ async def _dispatch_write(hooks: ServerCallbacks, *, operation: str, kwargs: dic
             refs = _field(fields, "refs")
             scope_refs = _field(fields, "scope_refs")
             cwd = _field(fields, "cwd")
+            ttl_seconds_field = _field(fields, "ttl_seconds")
+            ttl_seconds = ttl_seconds_field if isinstance(ttl_seconds_field, int) else None
             candidate_result = await poly.capture_assertion_candidate(
                 body_text=body_text,
                 kind=candidate_capture_kind(kind if isinstance(kind, str) else "note"),
@@ -1553,6 +1555,7 @@ async def _dispatch_write(hooks: ServerCallbacks, *, operation: str, kwargs: dic
                 cwd=Path(cwd) if isinstance(cwd, str) else None,
                 author_ref=author_ref,
                 author_kind="agent",
+                ttl_seconds=ttl_seconds,
             )
             return hooks.json_payload(candidate_result, exclude_none=False)
 

--- a/polylogue/storage/sqlite/archive_tiers/user_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/user_write.py
@@ -1809,6 +1809,12 @@ ASSERTION_CANDIDATE_JUDGMENT_KINDS: tuple[AssertionKind, ...] = (
     AssertionKind.NOTE,
     AssertionKind.CORRECTION,
     AssertionKind.COMPARATIVE_JUDGMENT,
+    # HIGHLIGHT/PROMPT_EVAL (polylogue-37t.1): both are now capturable via
+    # `capture_assertion_candidate` (candidate_capture_kind); without a slot
+    # here every row it writes would be a permanently-unjudgeable orphan --
+    # visible to no queue, reachable by no `judge` call.
+    AssertionKind.HIGHLIGHT,
+    AssertionKind.PROMPT_EVAL,
 )
 
 
@@ -1834,6 +1840,9 @@ def list_assertion_candidate_reviews(
         target_ref=target_ref,
         statuses=statuses,
         limit=limit,
+        # Audit surface: never let an expiry silently erase judged history
+        # (mirrors the deliberate status retention documented above).
+        include_expired=True,
     )
     return [
         ArchiveAssertionCandidateReviewEnvelope(
@@ -2398,6 +2407,13 @@ ASSERTION_CLAIM_KINDS: tuple[AssertionKind, ...] = (
     AssertionKind.PATHOLOGY,
     AssertionKind.FINDING,
     AssertionKind.COMPARATIVE_JUDGMENT,
+    # HIGHLIGHT (polylogue-37t.1): an accepted highlight is exactly the kind
+    # of quoted-evidence guidance the preamble compiler already renders for
+    # LESSON/DECISION rows (see context/preamble.py's
+    # `_assertion_guidance_from_claim`). PROMPT_EVAL is deliberately absent
+    # here -- it is stc-lifecycle experiment-definition data
+    # (insights/judgment/experiments.py), not context guidance prose.
+    AssertionKind.HIGHLIGHT,
 )
 
 
@@ -2415,12 +2431,24 @@ def list_assertion_claims(
     annotation_target_kind: str | None = None,
     limit: int | None = None,
     offset: int = 0,
+    include_expired: bool = False,
+    as_of_ms: int | None = None,
 ) -> list[ArchiveAssertionEnvelope]:
     """List lifecycle claims for successor-context/profile consumers.
 
     This helper intentionally covers authored/transform claims, not every
     overlay assertion row. Marks, annotations, saved views, recall packs, and
     workspaces keep their domain-specific read helpers above.
+
+    Expiry (polylogue-37t.1): a claim carrying ``staleness={"expires_at_ms":
+    N}`` (see :func:`upsert_assertion`) is excluded once ``N`` has elapsed --
+    this is the single admission read every ``ASSERTION_CLAIM_KINDS``
+    consumer goes through (the preamble compiler's
+    ``list_assertion_claim_payloads`` call among them), so no separate
+    expiry-aware status or a parallel filtered read path is needed. Rows with
+    no ``expires_at_ms`` (the default -- most rows never carry one) are
+    unaffected. Pass ``include_expired=True`` for audit/export reads that
+    must still see expired rows.
     """
 
     if not _table_exists(conn, "assertions"):
@@ -2464,6 +2492,14 @@ def list_assertion_claims(
         target_prefix = f"{annotation_target_kind}:"
         where.append("substr(target_ref, 1, length(?)) = ?")
         params.extend((target_prefix, target_prefix))
+    if not include_expired:
+        effective_as_of_ms = as_of_ms if as_of_ms is not None else _now_ms()
+        where.append(
+            "(staleness_json IS NULL"
+            " OR json_extract(staleness_json, '$.expires_at_ms') IS NULL"
+            " OR json_extract(staleness_json, '$.expires_at_ms') > ?)"
+        )
+        params.append(effective_as_of_ms)
 
     sql = f"SELECT {_ASSERTION_COLUMNS} FROM assertions"
     if where:

--- a/tests/unit/cli/test_note.py
+++ b/tests/unit/cli/test_note.py
@@ -87,11 +87,36 @@ def test_terminal_note_kind_options_all_land_as_candidates(cli_workspace: dict[s
         "claim": AssertionKind.DECISION,
         "correction": AssertionKind.CORRECTION,
         "lesson": AssertionKind.LESSON,
+        "highlight": AssertionKind.HIGHLIGHT,
+        "prompt_eval": AssertionKind.PROMPT_EVAL,
     }
     for option, assertion_kind in expected.items():
         payload = _capture(cli_workspace, [f"{option} capture", "--kind", option])
         assert payload["kind"] == assertion_kind.value
         assert payload["status"] == AssertionStatus.CANDIDATE.value
+
+
+def test_terminal_note_highlight_and_prompt_eval_reach_the_judgment_queue(
+    cli_workspace: dict[str, Path],
+) -> None:
+    """Anti-vacuity: HIGHLIGHT/PROMPT_EVAL had a schema slot and a user_audit
+    surface entry but no production writer (polylogue-37t.1). Capturing
+    through the real `note` command must also land the row somewhere a human
+    can actually judge it -- an unreachable CANDIDATE row is as dead as no
+    writer at all.
+    """
+
+    highlight = _capture(cli_workspace, ["a highlight worth keeping", "--kind", "highlight"])
+    prompt_eval = _capture(cli_workspace, ["an eval definition candidate", "--kind", "prompt_eval"])
+
+    async def read() -> list[str]:
+        async with Polylogue(archive_root=cli_workspace["archive_root"]) as poly:
+            reviews = await poly.list_assertion_candidate_reviews()
+            return [review.candidate.assertion_id for review in reviews.items]
+
+    review_ids = asyncio.run(read())
+    assert highlight["assertion_id"] in review_ids
+    assert prompt_eval["assertion_id"] in review_ids
 
 
 def test_terminal_note_reads_bounded_stdin(cli_workspace: dict[str, Path]) -> None:

--- a/tests/unit/storage/test_archive_tiers_assertions.py
+++ b/tests/unit/storage/test_archive_tiers_assertions.py
@@ -732,6 +732,7 @@ def test_list_assertion_claims_filters_lifecycle_assertions(tmp_path: Path) -> N
             AssertionKind.PATHOLOGY,
             AssertionKind.FINDING,
             AssertionKind.COMPARATIVE_JUDGMENT,
+            AssertionKind.HIGHLIGHT,
         }
 
         rows: list[tuple[str, str, AssertionKind, str, str, dict[str, object] | None, int]] = [
@@ -825,6 +826,124 @@ def test_list_assertion_claims_filters_lifecycle_assertions(tmp_path: Path) -> N
         assert list_assertion_claims(conn, kinds=()) == []
         assert list_assertion_claims(conn, statuses=()) == []
         assert [claim.assertion_id for claim in list_assertion_claims(conn, limit=1)] == ["claim-lesson-other"]
+    finally:
+        conn.close()
+
+
+def test_list_assertion_claims_excludes_expired_claims_from_the_admission_read(tmp_path: Path) -> None:
+    """polylogue-37t.1: expiry gates the same admission read the preamble
+    compiler (context/preamble.py -> list_assertion_claim_payloads ->
+    list_assertion_claims) and every other ASSERTION_CLAIM_KINDS consumer
+    goes through -- no new AssertionStatus, no parallel filtered read path.
+    """
+    conn = _connect(tmp_path / "user.db")
+    try:
+        upsert_assertion(
+            conn,
+            assertion_id="claim-expired",
+            target_ref="session:s-1",
+            kind=AssertionKind.LESSON,
+            status="active",
+            context_policy={"inject": True},
+            staleness={"expires_at_ms": 1_700_000_010_000},
+            now_ms=1_700_000_000_000,
+        )
+        upsert_assertion(
+            conn,
+            assertion_id="claim-not-yet-expired",
+            target_ref="session:s-1",
+            kind=AssertionKind.LESSON,
+            status="active",
+            context_policy={"inject": True},
+            staleness={"expires_at_ms": 1_700_000_999_000},
+            now_ms=1_700_000_001_000,
+        )
+        upsert_assertion(
+            conn,
+            assertion_id="claim-no-expiry",
+            target_ref="session:s-1",
+            kind=AssertionKind.LESSON,
+            status="active",
+            context_policy={"inject": True},
+            now_ms=1_700_000_002_000,
+        )
+
+        # as_of_ms after claim-expired's deadline but before the other two's.
+        live = list_assertion_claims(conn, target_ref="session:s-1", as_of_ms=1_700_000_500_000)
+        assert {claim.assertion_id for claim in live} == {"claim-not-yet-expired", "claim-no-expiry"}
+
+        # include_expired=True is the explicit audit/export escape hatch.
+        everything = list_assertion_claims(
+            conn, target_ref="session:s-1", as_of_ms=1_700_000_500_000, include_expired=True
+        )
+        assert {claim.assertion_id for claim in everything} == {
+            "claim-expired",
+            "claim-not-yet-expired",
+            "claim-no-expiry",
+        }
+
+        # An as_of_ms before every deadline keeps all of them live.
+        early = list_assertion_claims(conn, target_ref="session:s-1", as_of_ms=1_700_000_000_500)
+        assert {claim.assertion_id for claim in early} == {
+            "claim-expired",
+            "claim-not-yet-expired",
+            "claim-no-expiry",
+        }
+    finally:
+        conn.close()
+
+
+def test_highlight_candidate_promotion_carries_expiry_into_the_active_claim(tmp_path: Path) -> None:
+    """End-to-end HIGHLIGHT loop (polylogue-37t.1): capture -> judge accept
+    with injection -> the promoted ACTIVE row keeps the candidate's
+    ``staleness`` (``_promote_candidate_assertion`` copies it verbatim) --
+    and once ``expires_at_ms`` elapses, ``list_assertion_claims`` (the exact
+    read ``context/preamble.py`` uses) stops serving it, with HIGHLIGHT now a
+    member of ``ASSERTION_CLAIM_KINDS``.
+    """
+    conn = _connect(tmp_path / "user.db")
+    try:
+        candidate = upsert_assertion(
+            conn,
+            assertion_id="assertion-terminal-note:highlight-1",
+            target_ref="session:s-1",
+            kind=AssertionKind.HIGHLIGHT,
+            body_text="a highlight worth remembering",
+            author_ref="agent:codex:session-1",
+            author_kind="agent",
+            status=AssertionStatus.CANDIDATE,
+            staleness={"expires_at_ms": 1_700_000_100_000},
+            context_policy={"inject": False, "promotion_required": True},
+            now_ms=1_700_000_000_000,
+        )
+        assert candidate.kind is AssertionKind.HIGHLIGHT
+
+        judgment = judge_assertion_candidate(
+            conn,
+            candidate_ref=f"assertion:{candidate.assertion_id}",
+            decision="accept",
+            reason="genuinely worth keeping",
+            actor_ref="user:local",
+            inject=True,
+            now_ms=1_700_000_010_000,
+        )
+        assert judgment.resulting_assertion is not None
+        assert judgment.resulting_assertion.kind is AssertionKind.HIGHLIGHT
+        assert judgment.resulting_assertion.status is AssertionStatus.ACTIVE
+        assert judgment.resulting_assertion.context_policy == {"inject": True}
+        assert judgment.resulting_assertion.staleness == {"expires_at_ms": 1_700_000_100_000}
+
+        assert AssertionKind.HIGHLIGHT in ASSERTION_CLAIM_KINDS
+
+        before_expiry = list_assertion_claims(
+            conn, target_ref="session:s-1", context_inject=True, as_of_ms=1_700_000_050_000
+        )
+        assert [claim.assertion_id for claim in before_expiry] == [judgment.resulting_assertion.assertion_id]
+
+        after_expiry = list_assertion_claims(
+            conn, target_ref="session:s-1", context_inject=True, as_of_ms=1_700_000_200_000
+        )
+        assert after_expiry == []
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary

Wires the two write-only `AssertionKind`s (`HIGHLIGHT`, `PROMPT_EVAL`) to a
real production writer, and adds expiry semantics to the assertion-claims
admission read consumed by the preamble compiler and every other
`ASSERTION_CLAIM_KINDS` consumer.

## Problem

Baseline audit (polylogue-37t.1) found `HIGHLIGHT`/`PROMPT_EVAL` present in
`core/enums.py` and registered in the `user_audit` every-kind-has-a-surface
table (`storage/sqlite/archive_tiers/user_audit.py:14/31`), but with zero
production writer anywhere in the tree -- a shipped-but-dead vocabulary.
Separately, `grep -n 'expires_at\|expiry' user_write.py` was empty: the
`ASSERTION_CLAIM_KINDS` admission read (`list_assertion_claims`, which
`context/preamble.py`'s `build_context_preamble_payload` goes through via
`list_assertion_claim_payloads`) had no notion of expiry, so an expired
claim could never be excluded from the preamble compiler's input.

## Solution

- `polylogue/api/archive.py`: extended `_CANDIDATE_CAPTURE_KIND_MAP` (the
  vocabulary behind `candidate_capture_kind`) with `"highlight"` ->
  `AssertionKind.HIGHLIGHT` and `"prompt_eval"` -> `AssertionKind.PROMPT_EVAL`.
  This map already backs two live production routes -- the CLI `note`
  command and the MCP `write(operation="capture_assertion_candidate")`
  dispatcher -- so no new surface needed to be built, only the kind
  vocabulary those existing surfaces accept.
  `_archive_capture_assertion_candidate` / `Polylogue.capture_assertion_candidate`
  also gained an optional `ttl_seconds` that stamps
  `staleness={"expires_at_ms": ...}` on the written row.
- `polylogue/cli/commands/note.py`: `--kind` choices extended to
  `highlight`/`prompt_eval`; new `--ttl-seconds` option threads through to
  the API.
- `polylogue/mcp/server_cutover.py`: the `capture_assertion_candidate`
  dispatch branch reads an optional `fields["ttl_seconds"]`. No new MCP tool
  or tool contract was needed -- `capture_assertion_candidate` is an
  existing operation on the already-pinned `write` tool
  (`tests/unit/mcp/test_server_surfaces.py`'s `EXPECTED_TOOL_NAMES`).
- `polylogue/storage/sqlite/archive_tiers/user_write.py`:
  - `ASSERTION_CANDIDATE_JUDGMENT_KINDS` gains `HIGHLIGHT`/`PROMPT_EVAL`.
    Without this, every row the new writer produces would land as a
    `CANDIDATE` invisible to `judge`/`list_assertion_candidates` --
    unjudgeable forever, which is nearly as dead as having no writer.
  - `ASSERTION_CLAIM_KINDS` gains `HIGHLIGHT` only. An accepted+injected
    highlight is exactly the kind of quoted-evidence guidance the preamble
    compiler already renders for `LESSON`/`DECISION`. `PROMPT_EVAL` is
    deliberately excluded from this set -- per
    `insights/judgment/experiments.py`'s module docstring it is
    stc-lifecycle experiment-definition data (mechanism J), not context
    guidance prose; it stays judgeable but does not feed the preamble.
  - `list_assertion_claims` gains expiry filtering: a row whose
    `staleness={"expires_at_ms": N}` has elapsed by `as_of_ms` (default:
    real now) is excluded, no new `AssertionStatus` introduced.
    `include_expired=True` is the explicit escape hatch.
  - `list_assertion_candidate_reviews` passes `include_expired=True`
    explicitly, preserving its documented promise to retain full judged
    history (accepted/rejected/deferred/superseded) regardless of staleness.
  - `_promote_candidate_assertion` already carried `staleness` from
    candidate to the promoted `ACTIVE` row verbatim (pre-existing code,
    unchanged) -- so a ttl set at capture time survives judgment.

## AC matrix (polylogue-37t.1)

- **First writers for HIGHLIGHT/PROMPT_EVAL, passing the user_audit surface
  invariant with a registered ObjectRef scope_ref/author_ref** --
  **satisfied**. Both reuse the existing `capture_assertion_candidate`
  chokepoint (already registered ObjectRef kinds: `session:`, `repo:`,
  `insight:`, `agent:`), reachable from `polylogue note --kind highlight`
  and the MCP `write` tool. `user_audit`'s surface table already had both
  entries (pre-existing); no change needed there. Verified by
  `tests/unit/cli/test_note.py::test_terminal_note_kind_options_all_land_as_candidates`
  (one written row per kind, including highlight/prompt_eval) and
  `test_terminal_note_highlight_and_prompt_eval_reach_the_judgment_queue`.
- **Preamble-consumed claims gain expiry (no new status)** -- **satisfied**.
  `list_assertion_claims` extends its default filter with an
  `expires_at_ms`-vs-`as_of_ms` check; verified by
  `tests/unit/storage/test_archive_tiers_assertions.py::test_list_assertion_claims_excludes_expired_claims_from_the_admission_read`
  and the end-to-end
  `test_highlight_candidate_promotion_carries_expiry_into_the_active_claim`
  (capture -> judge accept+inject -> promoted ACTIVE row excluded from
  `list_assertion_claims(context_inject=True)` once expired).
- **Content-hash invariant** -- **satisfied by construction**: all writes go
  through the existing `upsert_assertion` chokepoint in `user.db`; nothing
  in this change touches `index.db`/`sessions.content_hash`. Not
  re-mirrored as a new test (would duplicate
  `tests/unit/insights/test_feedback.py`'s existing coverage of that
  invariant for the same write chokepoint family).
- **Operator judgment ergonomics (bulk accept/reject)** -- **out of scope,
  deferred**. This bead's design field explicitly routes that to a separate
  judgment-queue child bead (unowned as of the bead's notes); this PR only
  ensures HIGHLIGHT/PROMPT_EVAL candidates are visible to the *existing*
  bulk `judge` dispatcher (`items=[...]`) via `ASSERTION_CANDIDATE_JUDGMENT_KINDS`,
  it does not add new bulk-review UX.

## Verification

```
devtools test tests/unit/cli/test_note.py \
  tests/unit/storage/test_archive_tiers_assertions.py \
  tests/unit/storage/test_archive_tiers_user_write.py \
  tests/unit/storage/test_archive_tiers_user_audit.py \
  tests/unit/context/ tests/unit/insights/test_objective_posture.py \
  tests/unit/mcp/ -k "assertion or capture or candidate or judge or highlight or prompt_eval"
# -> 10 + 47 + 29 + 12 passed

devtools verify --quick
# -> exit_code 0 (ruff format/check, mypy --strict, render all --check,
#    layering, closure-matrix, schema/policy lanes)
```

Not run: `devtools verify --all` (full non-integration suite) -- left to CI's
post-merge heavy `test` job per this repo's per-PR test-skip policy; the
targeted selection above covers every file this diff touches plus its direct
consumers (context preamble, objective posture, MCP surfaces).

Ref polylogue-37t.1