### PR TITLE
fix(browser-extension): repair packaged-worker backfill fixture

### DIFF
--- a/browser-extension/tests/build.test.js
+++ b/browser-extension/tests/build.test.js
@@ -115,7 +115,21 @@ describe("build.mjs full archive emission", () => {
     execFileSync("python3", ["-c", "import sys,zipfile; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])", archive, unpacked]);
     let messageListener;
     let alarmListener;
-    let stored = { receiverBaseUrl: "http://127.0.0.1:8765", receiverAuthToken: "token" };
+    // The backfill exact-capture path (requirePairedTrustedReceiver,
+    // fix(extension): require pairing before provider capture #2983) needs a
+    // real receiver pairing, not just a configured base URL + token -- a
+    // manually-configured-but-never-paired receiver is a distinct state from
+    // the one this fixture exercises. Seed it the same way
+    // background.test.js's successful-capture fixtures do.
+    let stored = {
+      receiverBaseUrl: "http://127.0.0.1:8765",
+      receiverAuthToken: "token",
+      polylogueReceiverPairing: {
+        state: "online",
+        receiver_id: "packaged-receiver",
+        api_schema: "polylogue-browser-capture/v1",
+      },
+    };
     let sessionStored = {};
     const pageRequests = [];
     const pageFetchCalls = [];
@@ -142,7 +156,15 @@ describe("build.mjs full archive emission", () => {
         return new Response(JSON.stringify({ id: "fixture-1", mapping: { one: { message: { id: "m1", author: { role: "user" }, content: { parts: ["fixture"] } } } } }), { headers: { "Content-Type": "application/json" } });
       }),
     };
-    const ownedTabs = [];
+    // Passive/automatic backfill work is observe-only: it must find an
+    // already-open, operator-owned provider tab via chrome.tabs.query and
+    // never call chrome.tabs.create itself (fix(extension): avoid automatic
+    // provider transport tabs, #2974; background.test.js's "never creates a
+    // transport tab when passive backfill has no provider page" pins this).
+    // Seed one open ChatGPT tab up front so this fixture models that real
+    // precondition instead of a permanently empty tab list, and make
+    // chrome.tabs.query reflect it dynamically like background.test.js does.
+    const ownedTabs = [{ id: 42, url: "https://chatgpt.com/", active: true, status: "complete" }];
     const tabs = {
       create: vi.fn(async ({ url, active }) => {
         const tab = { id: 77, url, active, status: "complete" };
@@ -152,7 +174,7 @@ describe("build.mjs full archive emission", () => {
       get: vi.fn(async (tabId) => ownedTabs.find((tab) => tab.id === tabId)),
       update: vi.fn(),
       remove: vi.fn(),
-      query: vi.fn(async () => []),
+      query: vi.fn(async () => ownedTabs),
       sendMessage: vi.fn(async (_tabId, message) => {
         if (message.type !== "polylogue.capturePage") return undefined;
         return {
@@ -212,6 +234,12 @@ describe("build.mjs full archive emission", () => {
       let body;
       if (String(url).endsWith("/v1/browser-captures/capabilities")) {
         return { ok: true, status: 200, headers: { get: (name) => name === "X-Request-ID" ? "packaged-capability" : null }, json: async () => ({ durable_ack_fields: ["receiver_request_id", "content_hash"] }) };
+      }
+      if (String(url).endsWith("/v1/status")) {
+        // requirePairedTrustedReceiver's health probe (ensureTrustedReceiver ->
+        // checkReceiverHealth -> GET /v1/status), matching the seeded
+        // polylogueReceiverPairing identity above.
+        return { ok: true, status: 200, headers: { get: () => null }, json: async () => ({ ok: true, receiver_id: "packaged-receiver", api_schema: "polylogue-browser-capture/v1" }) };
       }
       if (String(url).includes("/v1/backfill-checkpoint")) {
         // Best-effort ledger-checkpoint mirror/restore traffic (polylogue-06zm)
@@ -291,14 +319,16 @@ describe("build.mjs full archive emission", () => {
     const recovered = await send({ type: "polylogue.backfill.status" });
     expect(recovered.jobs[0].progress.complete).toBe(1);
     expect(pageRequests.filter((message) => message.operation === "conversation")).toHaveLength(1);
-    expect(tabs.create).toHaveBeenCalledWith({ url: "https://chatgpt.com/", active: false });
+    // The whole run rides the pre-seeded operator tab; passive backfill must
+    // never materialize its own transport tab or foreground-activate it.
+    expect(tabs.create).not.toHaveBeenCalled();
     expect(tabs.update).not.toHaveBeenCalled();
     expect(pageRequests.filter((message) => message.operation !== "identity").map((message) => message.operation))
       .toEqual(["inventory", "inventory", "inventory", "inventory", "conversation"]);
     expect(pageFetchCalls.filter((call) => call.url.pathname === "/api/auth/session").length).toBeGreaterThanOrEqual(5);
     expect(JSON.stringify(pageRequests)).not.toContain(pageToken);
     expect(JSON.stringify(pageRequests)).not.toContain(pageAccount);
-    expect(tabs.sendMessage).toHaveBeenCalledWith(77, expect.objectContaining({
+    expect(tabs.sendMessage).toHaveBeenCalledWith(42, expect.objectContaining({
       type: "polylogue.capturePage",
       reason: "backfill_exact_capture",
       providerSessionId: "fixture-1",


### PR DESCRIPTION
## Summary

`tests/build.test.js`'s packaged-service-worker fixture test was failing
on master because two of its mocks were stale relative to intentional,
already-shipped, already-tested production behavior. This PR fixes only
the fixture — no production code changed.

## Problem

Ref polylogue-uegw. `tests/build.test.js`'s "executes the packaged
service worker fixture without foreground tab activation" test failed:
`vi.waitFor` at line 274 timed out because `polylogue.backfill.start`
never issued a page request.

## Root-cause evidence

Bisected two independent, unrelated fixture defects:

1. **Dead `chrome.tabs.query` mock.** It was `vi.fn(async () => [])`,
   never reflecting the fixture's own `ownedTabs` array, so
   `observedProviderTab()` could never find a provider tab. Passive/
   automatic backfill is intentionally observe-only by design
   (`fix(extension): avoid automatic provider transport tabs`, #2974:
   "Only explicit queued UI actions may create an extension-owned
   inactive transport"), and is heavily pinned by `background.test.js`
   ("never creates a transport tab when passive backfill has no
   provider page", "defers backfill when no supported provider surface
   is open", "shares an existing provider surface across concurrent
   backfill jobs"). The fixture's `tabs.create` assertion (expecting
   the extension to create its own tab) directly contradicted that
   tested contract.

2. **No seeded receiver pairing.** `stored` never set
   `polylogueReceiverPairing`, and the fetch mock had no `/v1/status`
   handler, so `requirePairedTrustedReceiver()` (`fix(extension):
   require pairing before provider capture`, #2983) always threw
   `receiver_unpaired` for the exact-capture path.
   `background.test.js`'s successful-capture fixtures all seed this
   pairing; `build.test.js` never did.

Both gaps were pre-existing, and were already known: PR #2986's own
verification note from 2026-07-17 says "one pre-existing
packaged-worker fixture failure reproduced unchanged" — this test broke
around the same time #2974/#2983 tightened the passive-capture and
pairing contracts, and was never updated.

**Anti-vacuity check (confirms this is a fixture bug, not a production
bug):** I first attempted a production-code fix, threading
`allowCreate`/`requirePairing` options through `providerPageFetch`,
`providerAccountHandle`, and `captureProviderConversation` in
`src/background.js` so backfill could create/use its own tab and skip
pairing. That DID make `build.test.js` pass, but it broke 4
`background.test.js` tests that explicitly pin the opposite behavior
("never creates a transport tab when passive backfill has no provider
page", "defers backfill when no supported provider surface is open",
"shares an existing provider surface across concurrent backfill jobs").
That change was reverted (`git checkout -- src/background.js`); this PR
only touches the test.

## Solution

In `browser-extension/tests/build.test.js`:

- Seed one already-open, operator-owned ChatGPT tab (id 42, matching
  `background.test.js`'s convention) instead of an empty tab list, and
  make `chrome.tabs.query` return it dynamically.
- Seed `polylogueReceiverPairing` in `stored` and add a `/v1/status`
  fetch handler, matching how `background.test.js`'s successful-capture
  fixtures already model a paired receiver.
- Replace the incorrect `tabs.create` assertion with
  `expect(tabs.create).not.toHaveBeenCalled()` — consistent with the
  test's own name ("without foreground tab activation" is about not
  materializing/activating a tab at all, not merely not making it
  foreground) and with the adjacent `tabs.update` assertion.
- Update the `tabs.sendMessage` assertion's tab id from the stale
  fixture-only id 77 to the pre-seeded tab id 42.

No production capture behavior changed. Shipped artifacts were never
affected by the fixture bug itself, but the two gates the fixture was
failing to model (observe-only passive/automatic transport,
pairing-gated exact capture) are real, already-shipped invariants this
fixture now correctly exercises instead of accidentally bypassing.

## Verification

- `npx vitest run tests/build.test.js` — 6/6 passed.
- `npx vitest run` (full extension suite) — 378/378 passed, run twice.
  `tests/background.test.js`'s one known-flaky timing test ("falls back
  to the adapter's full-fidelity normalization...") failed once on a
  full-suite run and passed clean when re-run in isolation — pre-existing
  flake, unrelated to this change, matches the operator's advance note.
- `node scripts/validate-manifest.mjs` — manifest ok.
- pre-push `devtools verify --quick` — passed (18 steps, 68.7s).

Ref polylogue-uegw.