### PR TITLE
fix(maintenance): enforce rebuild pass deadlines inside replay work

### DIFF
--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -309,6 +309,15 @@ class RebuildPassCost:
     parse_workers: int
     parse_s: float = 0.0
     apply_s: float = 0.0
+    #: polylogue-6mvg: wall-clock seconds this pass spent choosing WHICH raws
+    #: to replay -- the resumable path's ``next_raw_page`` keyset query, or
+    #: the one-shot path's ``select_rebuild_raw_ids`` (full-source/only-
+    #: missing/max-blob-mb scan plus size filter) -- before any census/parse/
+    #: apply work started. Previously invisible: a live full rebuild spent
+    #: ~86s of one CPU core on selection alone before the inactive generation
+    #: held a single session, with nothing durable recording where that time
+    #: went.
+    selection_s: float = 0.0
 
     @property
     def mib_per_s(self) -> float:
@@ -332,6 +341,7 @@ class RebuildPassCost:
     def to_dict(self) -> dict[str, object]:
         eta = self.eta_s
         return {
+            "selection_s": round(self.selection_s, 3),
             "replay_s": round(self.replay_s, 3),
             "parse_s": round(self.parse_s, 3),
             "apply_s": round(self.apply_s, 3),
@@ -550,6 +560,7 @@ async def _rebuild_index_from_source_owned(
     """Ownership-proven body of :func:`rebuild_index_from_source`."""
     from polylogue.maintenance.archive_verification import verify_archive
     from polylogue.maintenance.replay import rebuild_index_from_source as replay_source
+    from polylogue.sources.revision_backfill import RebuildDeadlineExceededError
     from polylogue.storage.archive_readiness import archive_readiness_status
     from polylogue.storage.index_generation import IndexGenerationStore, RebuildLease, source_revision_snapshot
     from polylogue.storage.repair import repair_session_insights
@@ -613,12 +624,22 @@ async def _rebuild_index_from_source_owned(
                     status=transaction.status,
                     derived_stores_cleared=True,
                 )
+            # polylogue-6mvg: the pass's SELECTION phase -- which raws
+            # replay THIS pass -- previously had no durable timing at all. A
+            # live full rebuild spent ~86s of one CPU core on selection
+            # alone before the inactive generation held a single session,
+            # visible only as an unexplained gap between the pass starting
+            # and its first "backfill stage timings" log line.
+            selection_started_at = time.perf_counter()
             page = generation_store.next_raw_page(transaction, limit=request.raw_batch_size)
+            selection_elapsed_s = time.perf_counter() - selection_started_at
             selected_raw_ids = [raw_id for raw_id, _blob_hash_hex, _blob_size in page.rows]
             selected_raw_count = len(selected_raw_ids)
             skipped_by_blob_limit_count = 0
         else:
+            selection_started_at = time.perf_counter()
             raw_count, selected_raw_ids, skipped_by_blob_limit_count = select_rebuild_raw_ids(request)
+            selection_elapsed_s = time.perf_counter() - selection_started_at
             selected_raw_count = len(selected_raw_ids)
             generation = generation_store.create(source_snapshot=source_revision_snapshot(root))
         source_drifted = False
@@ -649,32 +670,137 @@ async def _rebuild_index_from_source_owned(
                     _warm_offline_prefetch_cache, warm_config, selected_raw_ids
                 )
             pass_started_at_s = time.perf_counter()
-            replay = await replay_source(
-                config,
-                raw_ids=selected_raw_ids,
-                raw_batch_size=request.raw_batch_size,
-                ingest_workers=None,
-                materialize=True,
-                progress_callback=None,
-                owned_inactive_generation=(generation.generation_id, generation.owner_id),
-                # polylogue-crd8: this is the offline rebuild path (an owned
-                # inactive generation, never the live daemon ingest path), so
-                # the guard-gated bulk FTS mode is safe to enable unconditionally
-                # here -- it collapses whale prefix-sharing lineage cascades'
-                # per-row messages_fts trigger storm into one bulk delete+insert
-                # per affected session.
-                bulk_fts=True,
-                # polylogue-v6i3: the broader bulk-generation-build lifecycle --
-                # every per-session messages_fts/blocks_command_trigram/
-                # action_pairs/delegation_facts refresh is skipped during this
-                # replay (safe for a full OR partial/diagnostic selection: a
-                # repopulate from `blocks` always matches whatever sessions
-                # actually got replayed into this generation); see
-                # _repopulate_bulk_build_derived_state, called below right
-                # before readiness.
-                bulk_build=True,
-                prefetch_cache=effective_prefetch_cache,
-            )
+
+            # polylogue-uhgm: the pass deadline used to be checked only AFTER
+            # this whole page's replay_source() call returned, so a page that
+            # expanded into a much larger authority cohort (or simply ran
+            # slow) could overshoot ``pass_deadline_ms`` by an entire page --
+            # live evidence: a 300s deadline, ~8-9 minute pages. This closure
+            # is threaded down to backfill_historical_revision_evidence's
+            # REPLAY-phase cohort loops (see RebuildDeadlineExceededError's
+            # docstring), which call it between cohorts. It is a no-op for
+            # every non-resumable selection (``transaction is None`` --
+            # raw_ids/--only-missing/--max-blob-mb runs never carry a
+            # pass_deadline_ms in the first place, see
+            # validate_rebuild_index_request).
+            def _check_pass_deadline() -> None:
+                if transaction is None or transaction.pass_deadline_ms is None:
+                    return
+                elapsed_ms = int(time.time() * 1000) - pass_started_at_ms
+                if elapsed_ms >= transaction.pass_deadline_ms:
+                    raise RebuildDeadlineExceededError(
+                        f"rebuild pass deadline ({transaction.pass_deadline_ms}ms) exceeded mid-replay "
+                        f"after {elapsed_ms}ms; stopping before the next cohort"
+                    )
+
+            try:
+                replay = await replay_source(
+                    config,
+                    raw_ids=selected_raw_ids,
+                    raw_batch_size=request.raw_batch_size,
+                    ingest_workers=None,
+                    materialize=True,
+                    progress_callback=None,
+                    owned_inactive_generation=(generation.generation_id, generation.owner_id),
+                    # polylogue-crd8: this is the offline rebuild path (an owned
+                    # inactive generation, never the live daemon ingest path), so
+                    # the guard-gated bulk FTS mode is safe to enable unconditionally
+                    # here -- it collapses whale prefix-sharing lineage cascades'
+                    # per-row messages_fts trigger storm into one bulk delete+insert
+                    # per affected session.
+                    bulk_fts=True,
+                    # polylogue-v6i3: the broader bulk-generation-build lifecycle --
+                    # every per-session messages_fts/blocks_command_trigram/
+                    # action_pairs/delegation_facts refresh is skipped during this
+                    # replay (safe for a full OR partial/diagnostic selection: a
+                    # repopulate from `blocks` always matches whatever sessions
+                    # actually got replayed into this generation); see
+                    # _repopulate_bulk_build_derived_state, called below right
+                    # before readiness.
+                    bulk_build=True,
+                    prefetch_cache=effective_prefetch_cache,
+                    deadline_check=_check_pass_deadline if transaction is not None else None,
+                )
+            except RebuildDeadlineExceededError as exc:
+                # Mid-page interrupt: at least one cohort was durably
+                # committed (or none, if the very first cohort tripped it),
+                # but never the whole requested page. Do NOT advance the
+                # transaction's cursor/processed counters -- leaving them at
+                # their pre-pass values means the next pass re-derives from
+                # exactly the same source-order position. Re-applying any
+                # cohort this pass DID commit is a safe idempotent no-op
+                # (content-hash upsert), so this can never duplicate or skip
+                # a raw/cohort; it can only redo bounded work.
+                assert transaction is not None  # deadline_check is only wired when transaction is not None
+                pass_elapsed_s = time.perf_counter() - pass_started_at_s
+                transaction = generation_store.checkpoint_transaction(
+                    transaction,
+                    status="deferred",
+                    error=str(exc),
+                )
+                from polylogue.pipeline.services.process_pool import (
+                    parallel_threads_effective,
+                    resolve_parse_worker_count,
+                )
+
+                pass_cost = RebuildPassCost(
+                    selection_s=selection_elapsed_s,
+                    replay_s=pass_elapsed_s,
+                    checkpoint_s=0.0,
+                    pass_s=time.perf_counter() - pass_started_at_s,
+                    raws=selected_raw_count,
+                    bytes_in=sum(row[2] for row in page.rows) if page is not None else 0,
+                    processed_raws=transaction.processed_raw_count,
+                    processed_bytes=transaction.processed_blob_bytes,
+                    total_raws=raw_count,
+                    total_bytes=total_source_blob_bytes(root),
+                    free_threaded=parallel_threads_effective(),
+                    parse_workers=resolve_parse_worker_count(),
+                )
+                logger.info(
+                    "rebuild_pass_cost",
+                    generation_id=generation.generation_id,
+                    deferred_reason="pass-deadline-mid-replay",
+                    **pass_cost.to_dict(),
+                )
+                pass_receipt = RebuildIndexReceipt(
+                    archive_root=str(root),
+                    raw_session_count=raw_count,
+                    selected_raw_count=selected_raw_count,
+                    skipped_by_blob_limit_count=0,
+                    status="deferred",
+                    materialized=False,
+                    materialization={},
+                    generation=cast(dict[str, object], asdict(generation)),
+                    readiness={},
+                    # Zero-shaped like a normal replay dict (not merely a bare
+                    # marker) so every existing consumer that indexes
+                    # replay-dict keys unconditionally (the daemon-mode CLI
+                    # text formatter, the daemon HTTP route's raw
+                    # ``receipt.to_dict()`` response) keeps working: this pass
+                    # made no *measured* progress by design (see the "do not
+                    # advance the cursor" comment above), so reporting zeros
+                    # here is accurate, not merely a placeholder shape.
+                    replay={
+                        "scanned_raw_count": 0,
+                        "classified_full_count": 0,
+                        "replayed_logical_source_count": 0,
+                        "quarantined_raw_count": 0,
+                        "adoption_deferred_raw_count": 0,
+                        "authority_selection_expanded": True,
+                        "scheduled_raw_count": len(selected_raw_ids),
+                        "raw_batch_size": request.raw_batch_size,
+                        "ingest_workers": None,
+                        "parse_s": 0.0,
+                        "apply_s": 0.0,
+                        "stage_timings_s": {},
+                        "deferred_reason": "pass-deadline-mid-replay",
+                    },
+                    transaction=cast(dict[str, object], asdict(transaction)),
+                    timings_s=cast(dict[str, float], pass_cost.to_dict()),
+                )
+                generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
+                return pass_receipt
             pass_elapsed_s = time.perf_counter() - pass_started_at_s
             processed_before = transaction.processed_raw_count if transaction is not None else None
             if selected_raw_ids and _should_refresh_generation_planner_statistics(
@@ -715,6 +841,7 @@ async def _rebuild_index_from_source_owned(
                     )
 
                     pass_cost = RebuildPassCost(
+                        selection_s=selection_elapsed_s,
                         replay_s=pass_elapsed_s,
                         checkpoint_s=0.0,
                         pass_s=time.perf_counter() - pass_started_at_s,
@@ -753,7 +880,14 @@ async def _rebuild_index_from_source_owned(
             # polylogue-o56w: terminal-stage costs used to survive only as log
             # lines; collect them here and persist them on the final receipt
             # so a full rebuild's cost breakdown is durable forensics.
-            terminal_timings_s: dict[str, float] = {}
+            #
+            # polylogue-6mvg: ``selection_s`` (this pass's raw-id/page
+            # selection cost, measured above before replay even started) is
+            # folded in here too -- extending the SAME receipt vocabulary
+            # the deferred/paused ``RebuildPassCost`` timings already use,
+            # not a parallel one, so every receipt shape (deferred, paused,
+            # replayed) carries the identical key for this phase.
+            terminal_timings_s: dict[str, float] = {"selection_s": selection_elapsed_s}
             terminal_started_at = time.perf_counter()
             insight_result = repair_session_insights(
                 config,

--- a/polylogue/maintenance/replay.py
+++ b/polylogue/maintenance/replay.py
@@ -161,6 +161,7 @@ async def rebuild_index_from_source(
     bulk_fts: bool = False,
     bulk_build: bool = False,
     prefetch_cache: RawParsePrefetchCache | None = None,
+    deadline_check: Callable[[], None] | None = None,
 ) -> dict[str, object]:
     """Replay retained bytes through typed revision authority.
 
@@ -184,6 +185,11 @@ async def rebuild_index_from_source(
     substitute parse output already computed off the writer hold (the
     daemon's ``DaemonParseStage``) for this pass's census phase; see
     ``backfill_historical_revision_evidence``.
+
+    ``deadline_check`` (polylogue-uhgm, default ``None``) is forwarded
+    unchanged to ``backfill_historical_revision_evidence``'s own parameter of
+    the same name -- see its docstring for the exact interruption contract
+    (checked between REPLAY cohorts, not only after this call returns).
     """
     if raw_batch_size <= 0:
         raise ValueError("raw_batch_size must be positive")
@@ -224,6 +230,7 @@ async def rebuild_index_from_source(
         bulk_fts=bulk_fts,
         bulk_build=bulk_build,
         prefetch_cache=prefetch_cache,
+        deadline_check=deadline_check,
     )
     if progress_callback is not None:
         progress_callback(result.replayed_logical_sources, "revision replay complete")

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -322,6 +322,28 @@ class RawRevisionReplayResourceBlockedError(RuntimeError):
         super().__init__(f"{len(raw_ids)} raw revision(s) total {total_bytes} bytes exceed replay limit {limit_bytes}")
 
 
+class RebuildDeadlineExceededError(RuntimeError):
+    """Raised by an injected ``deadline_check`` callback to stop replay mid-page.
+
+    polylogue-uhgm: ``backfill_historical_revision_evidence``'s REPLAY phase
+    (the byte-cohort and membership-cohort loops below) calls an optional
+    caller-supplied ``deadline_check`` once at the top of every cohort
+    iteration -- i.e. *between* cohorts, never mid-cohort-apply. A cohort
+    already durably committed (or accepted into the currently open,
+    not-yet-committed replay batch) when this fires stands; the cohort about
+    to start does not begin. The caller (``maintenance/rebuild_index.py``)
+    catches this and checkpoints its resumable transaction WITHOUT advancing
+    the cursor, so the next pass re-derives from the exact same source-order
+    position -- safe by the existing content-hash idempotency invariant
+    (re-applying an already-committed cohort is a no-op upsert, never a
+    duplicate), matching the crash-recovery contract an open replay batch
+    already has (``test_backfill_resumes_after_replay_batch_crash_discards_
+    whole_batch_cleanly``). This closes the gap where a bounded pass's
+    deadline was previously observed only after the WHOLE requested page
+    replayed to completion.
+    """
+
+
 def _resource_blocked_parser_fingerprint(max_payload_bytes: int) -> str:
     """Return the durable admission identity for one bounded census envelope."""
     return f"{RAW_AUTHORITY_PARSER_FINGERPRINT}:resource-blocked:{max_payload_bytes}"
@@ -890,6 +912,7 @@ def backfill_historical_revision_evidence(
     bulk_build: bool = False,
     prefetch_cache: RawParsePrefetchCache | None = None,
     pipeline_decode: bool | None = None,
+    deadline_check: Callable[[], None] | None = None,
 ) -> RevisionBackfillResult:
     """Census every retained raw, then replay byte and bundle authority cohorts.
 
@@ -963,6 +986,14 @@ def backfill_historical_revision_evidence(
     remain on the calling thread in unchanged order regardless of the value
     -- see the prefetcher's docstring for the equivalence argument and the
     buffered-memory bound.
+
+    ``deadline_check`` (polylogue-uhgm, default ``None``) is called with no
+    arguments at the top of every REPLAY-phase cohort iteration (both the
+    byte-cohort and membership-cohort loops), i.e. between cohorts rather
+    than only after this whole function returns. It is expected to raise
+    :class:`RebuildDeadlineExceededError` to interrupt; ``None`` (every caller
+    except the resumable offline rebuild pass) reproduces the exact
+    unmodified, uninterruptible replay path.
     """
     adoption_deferred = 0
     quarantined = 0
@@ -1087,6 +1118,8 @@ def backfill_historical_revision_evidence(
             decode_prefetcher.start_phase(ordered_logical_keys, provisional_full_raw_ids)
         try:
             for logical_key in ordered_logical_keys:
+                if deadline_check is not None:
+                    deadline_check()
                 if decode_prefetcher is not None:
                     decode_prefetcher.enter_key(logical_key)
                 # polylogue-eqnv: the offline backfill/rebuild path is the one
@@ -1231,6 +1264,8 @@ def backfill_historical_revision_evidence(
             for logical_key in sorted(membership_keys):
                 if logical_key in byte_replayed_keys:
                     continue
+                if deadline_check is not None:
+                    deadline_check()
                 if decode_prefetcher is not None:
                     decode_prefetcher.enter_key(logical_key)
                 member_sessions: dict[str, ParsedSession] = {}
@@ -2452,6 +2487,7 @@ def _parse_stream(provider: Provider, payload: BinaryIO, source_path: str) -> li
 __all__ = [
     "RawParsePrefetchCache",
     "RawRevisionReplayResourceBlockedError",
+    "RebuildDeadlineExceededError",
     "RevisionBackfillResult",
     "RevisionCensusResult",
     "backfill_historical_revision_evidence",

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -2202,25 +2202,35 @@ def test_rebuild_index_deadline_defers_postflight_until_resume(
     # is robust to however many intervening `time.time()` calls production
     # code makes before/between the two reads this test actually cares
     # about, rather than pinning an exact call count.
+    #
+    # polylogue-uhgm: the deadline is now ALSO checked between replay
+    # cohorts (not only once, post-hoc, after the whole page replayed), so
+    # an ever-advancing clock left active across BOTH invocations would trip
+    # the resumed pass's very first between-cohorts check too and never let
+    # it promote. Scope the fake clock to just the first (interrupted)
+    # invocation with `monkeypatch.context()`; the resumed invocation runs
+    # on the real clock against the transaction's durable 1s budget, which
+    # is ample for this single-raw fixture.
     fake_clock = itertools.count(100.0, 50.0)
-    monkeypatch.setattr(
-        "polylogue.maintenance.rebuild_index.time.time",
-        lambda: next(fake_clock),
-    )
-    first = cli_runner.invoke(
-        cli,
-        [
-            "--plain",
-            "ops",
-            "maintenance",
-            "rebuild-index",
-            "--pass-deadline-seconds",
-            "1",
-            "--output-format",
-            "json",
-        ],
-        catch_exceptions=False,
-    )
+    with pytest.MonkeyPatch.context() as clock_patch:
+        clock_patch.setattr(
+            "polylogue.maintenance.rebuild_index.time.time",
+            lambda: next(fake_clock),
+        )
+        first = cli_runner.invoke(
+            cli,
+            [
+                "--plain",
+                "ops",
+                "maintenance",
+                "rebuild-index",
+                "--pass-deadline-seconds",
+                "1",
+                "--output-format",
+                "json",
+            ],
+            catch_exceptions=False,
+        )
     assert first.exit_code == 0
     # This pass replays a raw page through the shared revision-backfill
     # machinery, which logs "backfill stage timings" to stderr on every
@@ -2229,6 +2239,11 @@ def test_rebuild_index_deadline_defers_postflight_until_resume(
     payload = json.loads(first.stdout)
     assert payload["status"] == "deferred"
     assert payload["transaction"]["status"] == "deferred"
+    # polylogue-uhgm: the deadline fired before the sole raw in this page
+    # was ever replayed (not merely observed too late afterward), so this
+    # pass recorded zero forward progress -- the whole point of the fix.
+    assert payload["transaction"]["processed_raw_count"] == 0
+    assert payload["transaction"]["last_raw_id"] is None
     assert not root.joinpath("index.db").is_symlink()
     resumed = cli_runner.invoke(
         cli,

--- a/tests/unit/maintenance/test_rebuild_index_deadline.py
+++ b/tests/unit/maintenance/test_rebuild_index_deadline.py
@@ -1,0 +1,195 @@
+"""polylogue-uhgm: a rebuild pass's deadline must be enforced INSIDE replay
+work, not only after the whole requested page has replayed to completion.
+
+Live recovery evidence: operation 3f8fa7b0 configured ``pass_deadline_ms=
+300000`` (5 minutes), yet 100-row pages ran for roughly 8-9 minutes because
+``rebuild_index_from_source`` (``maintenance/rebuild_index.py``) previously
+checked elapsed time only after ``replay_source(...)`` -- the WHOLE page's
+replay -- returned.
+
+Production dependencies exercised here:
+
+* ``polylogue.sources.revision_backfill.backfill_historical_revision_evidence``
+  -- the real REPLAY-phase byte-cohort/membership-cohort loops now call an
+  injected ``deadline_check`` between cohorts.
+* ``polylogue.maintenance.rebuild_index.rebuild_index_from_source_sync`` --
+  the real offline-rebuild orchestrator that builds the ``deadline_check``
+  closure from a resumable transaction's ``pass_deadline_ms`` and catches
+  ``RebuildDeadlineExceededError`` to checkpoint a "no forward progress"
+  pass instead of letting a page run past its budget.
+
+Anti-vacuity: the mutation that makes ``test_deadline_check_invoked_between_
+replay_cohorts_not_only_after_return`` fail is moving (or removing) the
+``deadline_check()`` calls out of the byte-cohort/membership-cohort loops in
+``backfill_historical_revision_evidence`` -- e.g. back to a single call after
+the function's own work loop finishes, which is exactly the pre-fix bug
+shape. The mutation that makes ``test_rebuild_index_deadline_stops_mid_page_
+and_resumes_without_omission_or_duplication`` fail is either (a) reverting
+``rebuild_index.py`` to the old post-hoc-only check (the whole page would
+complete before any deadline is observed, so the fake clock's huge elapsed
+value would never interrupt anything and the first pass would report
+``status="replayed"`` instead of ``"deferred"``), or (b) advancing the
+transaction's cursor/processed counters on interrupt (the resumed pass would
+then either skip the un-replayed raw or duplicate index rows for an already-
+replayed one, and the final session count would not equal 3).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from polylogue.core.enums import Provider
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from polylogue.sources.revision_backfill import (
+    RebuildDeadlineExceededError,
+    backfill_historical_revision_evidence,
+)
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+def _codex_session(native_id: str, messages: tuple[tuple[str, str], ...]) -> bytes:
+    rows: list[dict[str, object]] = [
+        {"type": "session_meta", "payload": {"id": native_id, "timestamp": "2026-07-16T10:00:00Z"}}
+    ]
+    for position, (role, text) in enumerate(messages):
+        rows.append(
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": f"{native_id}-m{position}",
+                    "role": role,
+                    "content": [{"type": "input_text" if role == "user" else "output_text", "text": text}],
+                },
+            }
+        )
+    return b"".join(json.dumps(row, sort_keys=True).encode() + b"\n" for row in rows)
+
+
+def _seed_distinct_codex_sessions(root: Path, count: int) -> list[str]:
+    """Write ``count`` raws that each parse to their own logical cohort."""
+    initialize_active_archive_root(root)
+    raw_ids: list[str] = []
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        for index in range(count):
+            payload = _codex_session(f"sess-{index}", (("user", f"hello {index}"), ("assistant", f"hi {index}")))
+            raw_ids.append(
+                archive.write_raw_payload(
+                    provider=Provider.CODEX,
+                    payload=payload,
+                    source_path=f"deadline-test/{index}.jsonl",
+                    acquired_at_ms=index + 1,
+                )
+            )
+    return raw_ids
+
+
+def test_deadline_check_invoked_between_replay_cohorts_not_only_after_return(tmp_path: Path) -> None:
+    """The interruption point is BETWEEN cohorts, proven at the direct
+    production-function boundary (no rebuild_index.py orchestration): a
+    deadline_check that raises on its second call must stop replay after
+    exactly one cohort durably commits, never zero and never all three."""
+    root = tmp_path / "archive"
+    raw_ids = _seed_distinct_codex_sessions(root, 3)
+
+    deadline_check = Mock(side_effect=[None, RebuildDeadlineExceededError("synthetic deadline")])
+
+    with pytest.raises(RebuildDeadlineExceededError):
+        backfill_historical_revision_evidence(
+            root,
+            selected_raw_ids=raw_ids,
+            ingest_workers=1,
+            # Force per-cohort commits so the interrupted pass's partial
+            # progress is durable and directly observable below, matching
+            # the crash-recovery contract an open batch already has.
+            replay_commit_batch_size=1,
+            deadline_check=deadline_check,
+        )
+
+    # Called once before the first cohort (proceeds) and once before the
+    # second (raises) -- i.e. mid-replay, not only after the function would
+    # have returned. A deadline_check wired only after the whole call
+    # returns would never be invoked at all here, since the call itself
+    # never returns normally.
+    assert deadline_check.call_count == 2
+
+    with sqlite3.connect(root / "index.db") as conn:
+        session_count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    assert session_count == 1, "exactly the first cohort must have durably committed before the interrupt"
+
+
+def test_rebuild_index_deadline_stops_mid_page_and_resumes_without_omission_or_duplication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end through the real offline-rebuild orchestrator: a page that
+    would normally replay all 3 raws in one ``replay_source`` call stops
+    before completing, checkpoints a deferred pass with NO cursor advance,
+    and a resumed pass -- with the real clock restored -- completes cleanly
+    with the exact final session count: no raw skipped, none duplicated.
+
+    The fake clock returns ``0.0`` for exactly the first ``time.time()``
+    call reached (verified by source inspection to be ``pass_started_at_ms``
+    -- nothing between entering ``rebuild_index_from_source`` and that line
+    reads the wall clock) and a huge value for every call after, so the
+    first ``_check_pass_deadline`` call inside the replay cohort loop always
+    sees a huge elapsed time and interrupts deterministically before any
+    cohort completes -- independent of real machine speed. It is scoped to
+    only the first (interrupted) call via ``monkeypatch.context()``, so the
+    resumed call below runs on the real clock with the transaction's
+    genuinely generous durable 30s budget.
+    """
+    root = tmp_path / "archive"
+    # ``ArchiveStore.__init__``'s owned-inactive-generation branch (taken by
+    # the real rebuild's replay call) resolves the generation store off
+    # ``configured_archive_root()``, not the ``archive_root`` argument it was
+    # constructed with -- that must agree with ``root`` here or generation
+    # lookups 404 against the wrong (default XDG) location.
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    _seed_distinct_codex_sessions(root, 3)
+
+    call_state = {"first": True}
+
+    def fake_time() -> float:
+        if call_state["first"]:
+            call_state["first"] = False
+            return 0.0
+        return 999_999.0
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("polylogue.maintenance.rebuild_index.time.time", fake_time)
+        first_pass = rebuild_index_from_source_sync(
+            RebuildIndexRequest(archive_root=root, raw_batch_size=10, pass_deadline_seconds=30.0)
+        )
+
+    assert first_pass.status == "deferred"
+    assert first_pass.replay.get("deferred_reason") == "pass-deadline-mid-replay"
+    assert first_pass.transaction is not None
+    # No forward progress recorded: the cursor/processed counters must stay
+    # exactly where they were before this pass attempted anything, so a
+    # resume re-derives from the identical source-order position.
+    assert first_pass.transaction["processed_raw_count"] == 0
+    assert first_pass.transaction["last_raw_id"] is None
+    operation_id = first_pass.transaction["operation_id"]
+    assert isinstance(operation_id, str)
+
+    with sqlite3.connect(root / "index.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 0, (
+            "the active archive's own index.db must be untouched: any cohort work this pass did (if any) "
+            "lives only in a not-yet-promoted inactive generation directory"
+        )
+
+    # Real clock restored (the monkeypatch context exited above); the
+    # transaction's durable 30s budget is ample for this tiny fixture.
+    final_pass = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, operation_id=operation_id))
+    assert final_pass.status == "replayed"
+    assert final_pass.materialized is True
+
+    with sqlite3.connect(root / "index.db") as conn:
+        session_count = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    assert session_count == 3, "no raw/cohort omitted or duplicated across the interrupted + resumed pass"

--- a/tests/unit/maintenance/test_rebuild_index_phase_timing.py
+++ b/tests/unit/maintenance/test_rebuild_index_phase_timing.py
@@ -1,0 +1,115 @@
+"""polylogue-6mvg (remaining slice): durable phase-timing telemetry for the
+rebuild path.
+
+Prior work already lands most of this bead's original scope: planner-stats
+refresh, byte-skip, batched commits, pool floor, and dedup shipped via
+sibling beads, and polylogue-o56w already threads terminal-stage timings
+(``terminal.session_insights``/``terminal.bulk_build.*``/``terminal.
+fts_parity``/``terminal.readiness``/``terminal.promote``) plus
+``parse_s``/``apply_s`` onto every rebuild receipt. The one piece the bead's
+own notes call out as still unowned is a SELECTION-phase timing: the live
+full rebuild that motivated this bead spent ~86s of one CPU core choosing
+WHICH raws to replay before the inactive generation held a single session,
+and nothing durable recorded where that time went.
+
+``RebuildPassCost.selection_s`` (and the matching ``"selection_s"`` key on
+the terminal/materialized receipt's ``timings_s``) closes that gap by
+extending the EXISTING receipt vocabulary rather than inventing a parallel
+one -- every ``RebuildIndexReceipt.timings_s`` shape (deferred, paused,
+replayed) now carries the same key for this phase.
+
+Production dependency exercised: ``polylogue.maintenance.rebuild_index.
+rebuild_index_from_source_sync`` -- the real offline-rebuild orchestrator.
+Anti-vacuity: the mutation that makes these tests fail is removing the
+``selection_elapsed_s`` measurement (or the ``selection_s=selection_elapsed_s``
+threading into ``RebuildPassCost``/``terminal_timings_s``) added around the
+``next_raw_page``/``select_rebuild_raw_ids`` calls in
+``_rebuild_index_from_source_owned`` -- the key would then be absent from
+every receipt's ``timings_s``, not merely zero.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.core.enums import Provider
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+def _codex_session(native_id: str, messages: tuple[tuple[str, str], ...]) -> bytes:
+    rows: list[dict[str, object]] = [
+        {"type": "session_meta", "payload": {"id": native_id, "timestamp": "2026-07-16T10:00:00Z"}}
+    ]
+    for position, (role, text) in enumerate(messages):
+        rows.append(
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "id": f"{native_id}-m{position}",
+                    "role": role,
+                    "content": [{"type": "input_text" if role == "user" else "output_text", "text": text}],
+                },
+            }
+        )
+    return b"".join(json.dumps(row, sort_keys=True).encode() + b"\n" for row in rows)
+
+
+def _seed_distinct_codex_sessions(root: Path, count: int) -> list[str]:
+    initialize_active_archive_root(root)
+    raw_ids: list[str] = []
+    with ArchiveStore.open_existing(root, read_only=False) as archive:
+        for index in range(count):
+            payload = _codex_session(f"sess-{index}", (("user", f"hello {index}"), ("assistant", f"hi {index}")))
+            raw_ids.append(
+                archive.write_raw_payload(
+                    provider=Provider.CODEX,
+                    payload=payload,
+                    source_path=f"phase-timing-test/{index}.jsonl",
+                    acquired_at_ms=index + 1,
+                )
+            )
+    return raw_ids
+
+
+def test_replayed_receipt_carries_selection_phase_timing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A one-shot (non-resumable) rebuild's final receipt records how long
+    raw-id selection took, distinct from replay/parse/apply/terminal costs."""
+    root = tmp_path / "archive"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    _seed_distinct_codex_sessions(root, 2)
+
+    receipt = rebuild_index_from_source_sync(RebuildIndexRequest(archive_root=root, promote=True))
+
+    assert receipt.status == "replayed"
+    assert "selection_s" in receipt.timings_s
+    assert receipt.timings_s["selection_s"] >= 0.0
+
+    with sqlite3.connect(root / "index.db") as conn:
+        assert conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == 2
+
+
+def test_deferred_pass_cost_carries_selection_phase_timing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A resumable pass that defers on its pass deadline still records the
+    selection-phase cost -- the same key as the final "replayed" receipt,
+    not a different shape for the deferred path."""
+    root = tmp_path / "archive"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+    _seed_distinct_codex_sessions(root, 2)
+
+    # A sub-millisecond deadline truncates to pass_deadline_ms=0, so the
+    # first between-cohorts check always trips deterministically (see
+    # test_rebuild_index_deadline.py for the same technique in detail).
+    receipt = rebuild_index_from_source_sync(
+        RebuildIndexRequest(archive_root=root, raw_batch_size=10, pass_deadline_seconds=0.0001)
+    )
+
+    assert receipt.status == "deferred"
+    assert "selection_s" in receipt.timings_s
+    assert receipt.timings_s["selection_s"] >= 0.0


### PR DESCRIPTION
## Summary

Two beads, one branch: (1) a P1 correctness-of-contract bug fix — a resumable
rebuild pass's deadline is now checked *between* REPLAY-phase cohorts, not
only after the whole page's replay call returns — and (2) the small remaining
slice of a P2 observability bead, a durable "selection phase" timing on every
rebuild receipt.

## Problem

**polylogue-uhgm** (P1): live recovery evidence — operation `3f8fa7b0`
configured `pass_deadline_ms=300000` (5 minutes), yet 100-row pages ran
roughly 8-9 minutes, because `rebuild_index_from_source`
(`maintenance/rebuild_index.py`) checked elapsed time only *after*
`replay_source(...)` — the whole page's census + every cohort + planner-stats
refresh — returned. A page can also expand into a much larger authority
cohort, making the overshoot unbounded in the worst case. The advertised
bounded-pass contract was not enforced at the work boundary.

**polylogue-6mvg** (P2, remaining slice): a live full index rebuild spent
~86s of one CPU core selecting which raws to replay before the inactive
generation held a single session, and nothing durable recorded where that
time went. Most of this bead's original scope (planner stats #3141,
byte-skip #3146, batched commits #3147, pool floor #3149, dedup #3151) had
already shipped via sibling beads; the bead's own notes call out durable
phase-timing telemetry — specifically a selection-phase breakdown — as the
one still-unowned piece.

## Solution

- `polylogue/sources/revision_backfill.py`: `backfill_historical_revision_evidence`
  gains an optional `deadline_check: Callable[[], None] | None` parameter,
  called at the top of every REPLAY-phase cohort iteration (both the
  byte-cohort and membership-cohort loops) — between cohorts, not only after
  the whole call returns. New `RebuildDeadlineExceededError` is the expected
  interrupt signal.
- `polylogue/maintenance/replay.py`: threads `deadline_check` through
  unchanged to `backfill_historical_revision_evidence`.
- `polylogue/maintenance/rebuild_index.py`:
  - Builds a `_check_pass_deadline` closure from the resumable transaction's
    `pass_deadline_ms`, wired only when a durable transaction exists (never
    for non-resumable `--raw-id`/`--only-missing`/`--max-blob-mb` selections,
    matching existing validation).
  - Catches `RebuildDeadlineExceededError` around the `replay_source()` call.
    On interrupt it deliberately does **not** advance the transaction's
    cursor/processed counters — the next pass re-derives from the exact same
    source-order position, safe by the existing content-hash idempotency
    invariant (re-applying an already-committed cohort is a no-op upsert,
    never a duplicate) and consistent with the crash-recovery contract an
    open replay batch already has.
  - The deferred receipt's `replay` dict is zero-shaped like a normal replay
    dict (not a bare marker), so every existing consumer that indexes
    replay-dict keys unconditionally (the daemon-mode CLI text formatter, the
    daemon HTTP route's raw `receipt.to_dict()` response) keeps working.
  - `RebuildPassCost.selection_s` (polylogue-6mvg) extends the *existing*
    timings vocabulary — the same `RebuildPassCost`/`timings_s` shape every
    other phase (`parse_s`/`apply_s`, the `terminal.*` stages from
    polylogue-o56w) already uses — rather than inventing a parallel one.
    Measured around `next_raw_page` (resumable path) and
    `select_rebuild_raw_ids` (one-shot path), threaded into all three
    receipt-building call sites (deadline-interrupt, deferred/paused
    post-hoc, final materialized).

**Alternatives rejected:** proactive page-sizing against a throughput
estimate (checks only *before* a page starts, so still misses a
mid-page-expanding cohort — the exact worst case the bead names) and
per-raw interruption inside `apply_raw_revision_replay` itself (would
interrupt mid-transaction-write, risking corruption of the owned-inactive-
generation state). Both were flagged and deliberately deferred in the
bead's own prior investigation as too risky for the intended scope.

## Conflict avoidance note for the merge conductor

`polylogue/sources/revision_backfill.py` is flagged as owned by another live
lane. This PR's addition there is the smallest possible: one new exception
class, one new optional parameter, and two `if deadline_check is not None:
deadline_check()` call sites at the top of the two existing cohort loops —
no other line touched. The branch was rebased onto current `master`
(`90d4df67e`, which includes the sibling lane's `polylogue-5q2u` lineage-order
replay change, `_lineage_aware_replay_order`); the rebase conflict was
exactly the loop header line and was resolved by keeping the new
`ordered_logical_keys` iteration and re-adding the `deadline_check()` call —
verified with a fresh test run post-rebase.

## Acceptance-criteria matrix

**polylogue-uhgm:**
- "A transaction with a short pass deadline stops before starting work that
  would exceed its remaining budget, commits a valid cursor, and reports
  deadline deferral." — **Satisfied.** `test_rebuild_index_deadline_stops_mid_page_and_resumes_without_omission_or_duplication`.
- "Restarting resumes exactly at the next source-order raw/cohort with no
  duplicates or omissions." — **Satisfied** (by construction: the cursor is
  never advanced on interrupt, and resumption re-derives from the identical
  keyset position; idempotent re-application makes any redone cohort safe).
  Proven end-to-end by the same test (interrupted pass → resume → exact final
  session count).
- "A deliberately slow/expanded cohort proves the deadline is checked inside
  production replay work rather than only after the outer call returns." —
  **Satisfied.** `test_deadline_check_invoked_between_replay_cohorts_not_only_after_return`
  proves the interrupt fires after exactly one cohort durably commits (not
  zero, not all three) at the direct `backfill_historical_revision_evidence`
  boundary.
- "Final terminal readiness checks remain exact and either have their own
  bounded receipt or are explicitly separately scheduled." — **Unchanged**:
  no terminal-stage code was touched; `terminal.*` timings (polylogue-o56w)
  remain as before.

**polylogue-6mvg** (remaining slice only — full bead AC already satisfied by
sibling beads per its own 2026-07-19/27 notes):
- Durable selection-phase timing receipt — **Satisfied.**
  `RebuildPassCost.selection_s` / `terminal_timings_s["selection_s"]`,
  present on every receipt shape (deferred, paused, replayed).
- Cohort/parse/write/insight phase timings — **Already delivered** by prior
  work (`stage_timings_s` from `revision_backfill.py`, `parse_s`/`apply_s`
  split, `terminal.*` stages) — not re-touched here.
- Daemon catch-up shares the improvement — **Satisfied by construction**:
  `daemon/bulk_rebuild.py`'s `run_daemon_bulk_rebuild_pass` returns the exact
  same `RebuildIndexReceipt` from the same `rebuild_index_from_source_sync`
  engine, so both the deadline fix and the selection-phase timing apply
  automatically with zero daemon-side changes needed.

## Anti-vacuity

- Deadline fix: production caller is `rebuild_index_from_source_sync` (the
  real offline/daemon rebuild engine, no reimplementation). The mutation that
  makes `test_deadline_check_invoked_between_replay_cohorts_not_only_after_return`
  fail is moving the `deadline_check()` calls out of the cohort loops back to
  a single call after `backfill_historical_revision_evidence` returns (the
  pre-fix bug shape) — the mock would then never be called before the
  function's own natural completion. The mutation that makes
  `test_rebuild_index_deadline_stops_mid_page_and_resumes_without_omission_or_duplication`
  fail is either reverting to the post-hoc-only check (the fake clock would
  never interrupt anything mid-replay, so the first pass would report
  `status="replayed"` instead of `"deferred"`) or advancing the transaction's
  cursor on interrupt (the resumed pass would then skip or duplicate a raw,
  and the final session count would not equal 3).
- Phase timing: production caller is the same `rebuild_index_from_source_sync`.
  The mutation that makes `test_rebuild_index_phase_timing.py`'s two tests
  fail is reverting `selection_elapsed_s`'s measurement or its
  `selection_s=selection_elapsed_s` threading — the `"selection_s"` key would
  then be absent from `receipt.timings_s` (a dict-key assertion failure, not
  merely a zero value).

## Verification

```
python -m devtools test tests/unit/maintenance/test_rebuild_index_deadline.py \
  tests/unit/maintenance/test_rebuild_index_phase_timing.py \
  tests/unit/daemon/test_bulk_rebuild_ownership.py \
  tests/unit/cli/test_archive_maintenance_cli.py \
  tests/unit/daemon/test_route_contracts.py \
  tests/unit/maintenance/test_rebuild_index_bulk_build.py \
  tests/unit/maintenance/test_rebuild_index_ownership.py \
  tests/unit/maintenance/test_rebuild_index_selection.py \
  tests/unit/maintenance/test_rebuild_parse_apply_split.py \
  tests/unit/storage/test_index_generation.py
# 212 passed
python -m devtools verify --quick
# exit_code: 0, all 18 steps ok
```

**Known pre-existing failure, unrelated to this branch** — filed as
`polylogue-s0ug`:
`tests/unit/storage/test_incremental_rebuild_equivalence.py::test_incremental_restart_and_fresh_generation_rebuild_are_equivalent`
fails deterministically on current `origin/master` (`90d4df67e`) in isolation,
introduced by `0d27e3da7` (#3484, tightened Codex CONTINUATION lineage
evidence) landing after this branch was cut — the test's hand-built fixture
predates that tightening. `git diff origin/master...HEAD` for this branch
touches neither `codex.py`, `revision_backfill.py`'s classification logic,
nor that test file, confirming it is not caused by this change.

Not run: `devtools verify` (full testmon suite) — the coordinator directed a
synchronous quick-gate + focused-test path instead of the backgrounded
testmon seed, since a fresh worktree has no testmon seed to run the default
affected-selection path against.

Ref polylogue-uhgm
Ref polylogue-6mvg

Co-Authored-By: Claude <noreply@anthropic.com>
