### PR TITLE
feat(query): default session-query results to the top-level unit

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -127,10 +127,12 @@ Options:
                                   Sort by field
   --reverse                       Reverse sort order
   --sample INTEGER                Random sample of N sessions
-  --root / --no-root              Only top-level sessions (--root) or only
-                                  subagent/branch children (--no-root). Unset
-                                  (default) selects both, unfiltered by
-                                  structure.
+  --root / --no-root              Only top-level sessions (--root, the
+                                  implicit default when unset) or only
+                                  subagent/branch children (--no-root).
+                                  Session counts count top-level sessions
+                                  unless --no-root or root:false is used
+                                  (polylogue-j8u2).
   -o, --output TEXT               Output destinations: browser, clipboard,
                                   stdout (comma-separated)
   --json                          Shortcut for --format json. Disables color

--- a/polylogue/archive/query/archive_execution.py
+++ b/polylogue/archive/query/archive_execution.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, TypedDict, TypeVar
 from polylogue.archive.message.messages import MessageCollection
 from polylogue.archive.message.roles import Role
 from polylogue.archive.message.types import MessageType
+from polylogue.archive.query.spec import resolve_default_root_filter
 from polylogue.archive.query.transaction import archive_read_context, run_archive_read
 from polylogue.archive.session.domain_models import Session, SessionSummary
 from polylogue.core.enums import MaterialOrigin, Origin, TitleSource
@@ -135,6 +136,7 @@ class _ArchiveFilterKwargs(TypedDict):
     until_ms: int | None
     since_session_id: str | None
     boolean_predicate: QueryPredicate | None
+    root: bool | None
 
 
 def _plan_filter_kwargs(plan: SessionQueryPlan) -> _ArchiveFilterKwargs:
@@ -171,6 +173,7 @@ def _plan_filter_kwargs(plan: SessionQueryPlan) -> _ArchiveFilterKwargs:
         "until_ms": _datetime_to_ms(plan.until),
         "since_session_id": plan.since_session_id,
         "boolean_predicate": plan.boolean_predicate,
+        "root": resolve_default_root_filter(plan.root, boolean_predicate=plan.boolean_predicate),
     }
 
 

--- a/polylogue/archive/query/metadata.py
+++ b/polylogue/archive/query/metadata.py
@@ -150,8 +150,9 @@ EXPRESSION_FIELD_REGISTRY: dict[str, dict[str, str]] = {
     "root": {
         "description": (
             "Filter by top-level-vs-child session structure. root:true keeps only "
-            "top-level sessions; root:false keeps only subagent/branch children. "
-            "Unset (default) selects both."
+            "top-level sessions (also the implicit default for a param-driven query "
+            "with root unset); root:false keeps only subagent/branch children -- the "
+            "explicit projection for citing delegation fan-out (polylogue-j8u2)."
         ),
         "spec_field": "root",
         "negatable": "no",

--- a/polylogue/archive/query/predicate.py
+++ b/polylogue/archive/query/predicate.py
@@ -368,6 +368,37 @@ def predicate_from_payload(payload: Mapping[str, object]) -> QueryPredicate:
     raise ValueError(f"unsupported predicate payload kind: {kind!r}")
 
 
+def lineage_seed_from_predicate(predicate: QueryPredicate | None) -> str | None:
+    """Return the ``lineage:id:`` seed session id carried by *predicate*, if any.
+
+    ``lineage:id:<ref>`` compiles to :class:`QueryLineagePredicate` (possibly
+    ANDed with other clauses), which the SQL layer uses to filter session rows
+    to one shared-root lineage family -- root and every descendant. That is
+    already the "explicit projection" a lineage-seeded query asks for
+    (polylogue-j8u2), so callers use this to exempt such a query from the
+    default top-level-only ``root`` filter: forcing root-only on top of an
+    explicit family walk would silently drop the very children the query
+    asked for.
+
+    Only descends into ``and`` nodes. A ``lineage:id:X or repo:foo`` result
+    set is NOT purely lineage X's family -- rows matched only via the ``or``
+    branch would get X's family semantics applied incorrectly. An ``or`` node
+    (or a ``not`` wrapping the predicate, which isn't a
+    ``QueryBoolPredicate``/``QueryLineagePredicate`` at all) correctly yields
+    no seed here.
+    """
+    if predicate is None:
+        return None
+    if isinstance(predicate, QueryLineagePredicate):
+        return predicate.seed_session_id
+    if isinstance(predicate, QueryBoolPredicate) and predicate.op == "and":
+        for child in predicate.children:
+            seed = lineage_seed_from_predicate(child)
+            if seed is not None:
+                return seed
+    return None
+
+
 __all__ = [
     "QueryBoolOp",
     "QueryBoolPredicate",
@@ -385,5 +416,6 @@ __all__ = [
     "QuerySequenceConstraint",
     "QuerySequenceConstraintKind",
     "QueryTextPredicate",
+    "lineage_seed_from_predicate",
     "predicate_from_payload",
 ]

--- a/polylogue/archive/query/spec.py
+++ b/polylogue/archive/query/spec.py
@@ -18,6 +18,7 @@ from polylogue.archive.query.predicate import (
     QueryNotPredicate,
     QueryPredicate,
     QuerySequencePredicate,
+    lineage_seed_from_predicate,
 )
 from polylogue.archive.viewport.viewports import ToolCategory
 from polylogue.core.dates import parse_date
@@ -218,6 +219,59 @@ def optional_bool(field: str, value: object) -> bool | None:
     if text in {"false", "0", "no"}:
         return False
     raise QuerySpecError(field, str(value))
+
+
+def resolve_default_root_filter(
+    root: bool | None,
+    *,
+    boolean_predicate: QueryPredicate | None = None,
+) -> bool | None:
+    """Resolve the SQL-level ``root`` filter a session query should apply.
+
+    polylogue-j8u2: the default result *unit* for a session query is the
+    top-level session -- subagent/branch children (measured 45.6% of the
+    archive, ``session_links`` rows with ``link_type='subagent'``) previously
+    filled default result lists at equal weight, making them unreadable.
+    ``root is None`` means the caller (CLI/MCP param parsing, the ``root:``
+    DSL field) never got an explicit choice from the user, so it resolves to
+    ``True`` (top-level only) here, at the SQL-filter-kwargs boundary --
+    deliberately *not* by mutating ``SessionQuerySpec.root``/
+    ``SessionQueryPlan.root`` themselves, which stay ``None``-by-default so
+    that ``has_filters()`` (delete/mark unscoped-mutation guards, "bare
+    invocation shows stats" detection, ``latest`` resolution, ...) still
+    reflects genuine user intent rather than this structural default.
+    Explicit ``root:false``/``--no-root`` (children only) or ``root:true``
+    (redundant with the default) both pass a non-``None`` value here and are
+    returned unchanged -- the default only fills the unset case.
+
+    A ``lineage:id:<ref>`` predicate is itself an explicit "give me this
+    session's whole family, root plus descendants" projection (see
+    :func:`~polylogue.archive.query.predicate.lineage_seed_from_predicate`);
+    stacking the root-only default on top of it would silently drop the
+    children the query explicitly asked for, so it is exempted (returns
+    ``None``, unfiltered by structure) whenever *root* itself is unset.
+    """
+    if root is not None:
+        return root
+    if lineage_seed_from_predicate(boolean_predicate) is not None:
+        return None
+    return True
+
+
+def session_count_unit_label(root: bool | None) -> str:
+    """Name the unit a session count/total refers to (polylogue-j8u2, AC2).
+
+    *root* mirrors the resolved SQL-pushed ``root`` filter (see
+    :func:`resolve_default_root_filter`): ``True`` (the implicit default for
+    a param-driven query) counts only top-level sessions; ``False`` counts
+    only subagent/branch children; ``None`` (an explicit, unfiltered request
+    such as a ``lineage:id:`` family walk) counts both structurally.
+    """
+    if root is True:
+        return "top-level sessions"
+    if root is False:
+        return "subagent/branch child sessions"
+    return "sessions (top-level and subagent/branch children)"
 
 
 # Set of all recognized query-spec parameter names (drives strict-param mode).

--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -40,6 +40,8 @@ from polylogue.archive.query.spec import (
     normalize_action_sequence,
     normalize_action_terms,
     parse_query_date,
+    resolve_default_root_filter,
+    session_count_unit_label,
 )
 from polylogue.archive.query.transaction import archive_read_context
 from polylogue.archive.query.unit_results import query_unit_rows, query_unit_session_filters
@@ -316,7 +318,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
         "since_ms": since_ms,
         "until_ms": until_ms,
         "since_session_id": since_session_id,
-        "root": compiled_spec.root,
+        "root": resolve_default_root_filter(compiled_spec.root, boolean_predicate=compiled_spec.boolean_predicate),
     }
     if compiled_spec.boolean_predicate is not None:
         filter_kwargs["boolean_predicate"] = compiled_spec.boolean_predicate
@@ -663,6 +665,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                         output_format=output_format,
                         origin=origin,
                         fields=fields,
+                        root=filter_kwargs["root"],
                         typo_hint=typo_hint,
                         with_units=with_units,
                         with_unit_fields=with_unit_fields,
@@ -790,6 +793,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                 output_format=output_format,
                 origin=origin,
                 fields=fields,
+                root=filter_kwargs["root"],
                 typo_hint=typo_hint,
                 with_units=with_units,
                 with_unit_fields=with_unit_fields,
@@ -858,6 +862,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
             output_format=output_format,
             origin=origin,
             fields=fields,
+            root=filter_kwargs["root"],
             archive=archive,
             with_units=with_units,
             with_unit_fields=with_unit_fields,
@@ -1533,11 +1538,13 @@ def _emit_daemon_list_payload(
     ]
     total = _object_int(payload.get("total") or len(items))
     next_offset = offset + limit if total > offset + limit else None
+    total_unit = payload.get("total_unit")
     envelope: dict[str, object] = {
         "mode": "list",
         "origin": origin,
         "items": items,
         "total": total,
+        "total_unit": total_unit if isinstance(total_unit, str) else session_count_unit_label(True),
         "limit": limit,
         "offset": offset,
         "next_offset": next_offset,
@@ -1561,6 +1568,7 @@ def _emit_daemon_search_payload(
     _emit_degraded_daemon_search_payload(payload, query=query, output_format=output_format, fields=fields)
     hits = [dict(item) for item in cast(list[object], payload.get("hits") or []) if isinstance(item, Mapping)]
     total = _object_int(payload.get("total") or len(hits))
+    total_unit = payload.get("total_unit")
     envelope: dict[str, object] = {
         "mode": "search",
         "origin": origin,
@@ -1568,6 +1576,7 @@ def _emit_daemon_search_payload(
         "retrieval_lane": str(payload.get("retrieval_lane") or "dialogue"),
         "items": hits,
         "total": total,
+        "total_unit": total_unit if isinstance(total_unit, str) else session_count_unit_label(True),
         "limit": limit,
         "offset": offset,
         "next_offset": None,
@@ -2178,6 +2187,7 @@ def _emit_list(
     output_format: str,
     origin: str | None,
     fields: str | None,
+    root: bool | None = True,
     archive: ArchiveStore | None = None,
     with_units: tuple[str, ...] = (),
     with_unit_fields: dict[str, tuple[str, ...]] | None = None,
@@ -2226,6 +2236,7 @@ def _emit_list(
         "origin": origin,
         "items": items,
         "total": total,
+        "total_unit": session_count_unit_label(root),
         "limit": limit,
         "offset": offset,
         "next_offset": offset + limit if next_cursor is not None else None,
@@ -2275,6 +2286,7 @@ def _emit_search(
     output_format: str,
     origin: str | None,
     fields: str | None,
+    root: bool | None = True,
     typo_hint: str | None = None,
     with_units: tuple[str, ...] = (),
     with_unit_fields: dict[str, tuple[str, ...]] | None = None,
@@ -2304,6 +2316,7 @@ def _emit_search(
         "retrieval_lane": retrieval_lane,
         "items": items,
         "total": total,
+        "total_unit": session_count_unit_label(root),
         "limit": limit,
         "offset": offset,
         "next_offset": offset + limit if next_cursor is not None else None,

--- a/polylogue/cli/click_option_groups.py
+++ b/polylogue/cli/click_option_groups.py
@@ -280,8 +280,10 @@ FILTER_OPTION_DECORATORS: tuple[Callable[[ClickCallable], ClickCallable], ...] =
         "root",
         default=None,
         help=(
-            "Only top-level sessions (--root) or only subagent/branch children "
-            "(--no-root). Unset (default) selects both, unfiltered by structure."
+            "Only top-level sessions (--root, the implicit default when unset) "
+            "or only subagent/branch children (--no-root). Session counts "
+            "count top-level sessions unless --no-root or root:false is used "
+            "(polylogue-j8u2)."
         ),
     ),
 )

--- a/polylogue/daemon/http.py
+++ b/polylogue/daemon/http.py
@@ -647,7 +647,18 @@ def _archive_filter_kwargs_from_spec(
     test_archive_filter_kwargs_cover_every_storage_lowerable_spec_field``).
     ``session_id`` is deliberately NOT included: it is passed as a separate
     keyword by the caller because ``count_sessions`` does not accept it.
+
+    ``root`` (polylogue-j8u2) resolves the default result unit to top-level
+    sessions when the request left it unset -- see
+    :func:`~polylogue.archive.query.spec.resolve_default_root_filter`. This
+    keeps the daemon-proxied session-list route in parity with the direct CLI
+    query executor (``polylogue/cli/archive_query.py``), which is the same
+    resolution this daemon path must match exactly (golden-parity coverage:
+    ``tests/unit/cli/test_daemon_golden_parity.py::
+    test_find_list_json_parity_between_direct_and_daemon``).
     """
+    from polylogue.archive.query.spec import resolve_default_root_filter
+
     origins = spec.origins
     origin = origins[0] if len(origins) == 1 else None
     return {
@@ -681,6 +692,7 @@ def _archive_filter_kwargs_from_spec(
         "until_ms": until_ms,
         "since_session_id": spec.since_session_id,
         "boolean_predicate": spec.boolean_predicate,
+        "root": resolve_default_root_filter(spec.root, boolean_predicate=spec.boolean_predicate),
     }
 
 
@@ -2998,9 +3010,14 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
             items.append(row)
 
         route_state_name, route_state_reason = _session_list_state(total, filtered=spec.has_filters())
+        from polylogue.archive.query.spec import resolve_default_root_filter, session_count_unit_label
+
         result: dict[str, object] = {
             "items": items,
             "total": total,
+            "total_unit": session_count_unit_label(
+                resolve_default_root_filter(spec.root, boolean_predicate=spec.boolean_predicate)
+            ),
             "limit": limit,
             "offset": offset,
             "route_state": _route_readiness_payload(route_state_name, "/api/sessions", reason=route_state_reason),
@@ -3233,6 +3250,8 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                     ),
                 )
                 route_state_name, route_state_reason = _session_list_state(total, filtered=True)
+                from polylogue.archive.query.spec import session_count_unit_label
+
                 payload: dict[str, object] = {
                     "query": fts_query,
                     "retrieval_lane": "dialogue",
@@ -3240,6 +3259,7 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                     "ranking_policy_version": "1",
                     "hits": [self._archive_search_hit_payload(hit) for hit in hits],
                     "total": total,
+                    "total_unit": session_count_unit_label(cast("bool | None", _filter_kw.get("root"))),
                     "limit": limit,
                     "offset": offset,
                     "route_state": _route_readiness_payload(route_state_name, route, reason=route_state_reason),
@@ -3296,9 +3316,12 @@ class DaemonAPIHandler(BaseHTTPRequestHandler):
                 )
             )
             route_state_name, route_state_reason = _session_list_state(total, filtered=filtered)
+            from polylogue.archive.query.spec import session_count_unit_label
+
             return {
                 "items": [self._archive_summary_payload(summary) for summary in summaries],
                 "total": total,
+                "total_unit": session_count_unit_label(cast("bool | None", _filter_kw.get("root"))),
                 "limit": limit,
                 "offset": offset,
                 "route_state": _route_readiness_payload(route_state_name, route, reason=route_state_reason),

--- a/polylogue/mcp/archive_support.py
+++ b/polylogue/mcp/archive_support.py
@@ -7,7 +7,7 @@ from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
-from polylogue.archive.query.spec import parse_query_date
+from polylogue.archive.query.spec import parse_query_date, resolve_default_root_filter
 from polylogue.core.timestamps import parse_archive_datetime
 from polylogue.logging import get_logger
 from polylogue.paths import archive_file_set_index_available_for_paths
@@ -91,6 +91,7 @@ class ArchiveQueryFilters(TypedDict):
     since_ms: int | None
     until_ms: int | None
     since_session_id: str | None
+    root: bool | None
 
 
 def active_archive_root(config: Config) -> Path | None:
@@ -156,6 +157,7 @@ def archive_query_filters(spec: SessionQuerySpec) -> ArchiveQueryFilters:
         "since_ms": _date_ms(spec.since),
         "until_ms": _date_ms(spec.until),
         "since_session_id": spec.since_session_id,
+        "root": resolve_default_root_filter(spec.root, boolean_predicate=spec.boolean_predicate),
     }
 
 

--- a/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_terminal_snapshots.ambr
@@ -189,10 +189,12 @@
                                     Sort by field
     --reverse                       Reverse sort order
     --sample INTEGER                Random sample of N sessions
-    --root / --no-root              Only top-level sessions (--root) or only
-                                    subagent<PATH> children (--no-root). Unset
-                                    (default) selects both, unfiltered by
-                                    structure.
+    --root / --no-root              Only top-level sessions (--root, the
+                                    implicit default when unset) or only
+                                    subagent<PATH> children (--no-root).
+                                    Session counts count top-level sessions
+                                    unless --no-root or root:false is used
+                                    (polylogue-j8u2).
     -o, --output TEXT               Output destinations: browser, clipboard,
                                     stdout (comma-separated)
     --json                          Shortcut for --format json. Disables color
@@ -437,11 +439,15 @@
     --sample INTEGER                Random sample of N
                                     sessions
     --root / --no-root              Only top-level sessions
-                                    (--root) or only
-                                    subagent<PATH> children
-                                    (--no-root). Unset
-                                    (default) selects both,
-                                    unfiltered by structure.
+                                    (--root, the implicit
+                                    default when unset) or
+                                    only subagent<PATH>
+                                    children (--no-root).
+                                    Session counts count
+                                    top-level sessions
+                                    unless --no-root or
+                                    root:false is used
+                                    (polylogue-j8u2).
     -o, --output TEXT               Output destinations:
                                     browser, clipboard,
                                     stdout (comma-separated)
@@ -663,10 +669,12 @@
                                     Sort by field
     --reverse                       Reverse sort order
     --sample INTEGER                Random sample of N sessions
-    --root / --no-root              Only top-level sessions (--root) or only
-                                    subagent<PATH> children (--no-root). Unset
-                                    (default) selects both, unfiltered by
-                                    structure.
+    --root / --no-root              Only top-level sessions (--root, the
+                                    implicit default when unset) or only
+                                    subagent<PATH> children (--no-root).
+                                    Session counts count top-level sessions
+                                    unless --no-root or root:false is used
+                                    (polylogue-j8u2).
     -o, --output TEXT               Output destinations: browser, clipboard,
                                     stdout (comma-separated)
     --json                          Shortcut for --format json. Disables color

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -3209,7 +3209,16 @@ class TestSearchQueryContracts:
     """Matrix coverage for search filters and output formats."""
 
     def test_bounded_pages_report_indexed_total(self, search_workspace: SearchWorkspace) -> None:
-        """A bounded page keeps the exact match count separate from page size."""
+        """A bounded page keeps the exact match count separate from page size.
+
+        polylogue-j8u2: ``run-hit`` (root) and ``run-hit-subagent`` (its
+        subagent child) both match "query" text. The default result unit is
+        the top-level session, so the indexed total for the unqualified query
+        is the root-only count (1), not the raw structural match count (2) --
+        the SQL ``root`` pushdown must agree with the page, not just the
+        page's own length (that would pass even if the total ignored root
+        filtering entirely).
+        """
         from polylogue.cli import cli
 
         del search_workspace
@@ -3218,7 +3227,31 @@ class TestSearchQueryContracts:
         assert result.exit_code == 0, result.output
         payload = json.loads(result.output)
         assert len(payload["items"]) == 1
-        assert payload["total"] == 2
+        assert payload["total"] == 1
+        assert payload["total_unit"] == "top-level sessions"
+
+    def test_no_root_flag_recovers_the_subagent_child_and_honest_total(self, search_workspace: SearchWorkspace) -> None:
+        """``--no-root`` is the explicit projection back onto subagent/branch children.
+
+        Companion to ``test_bounded_pages_report_indexed_total``: the same
+        "query" text also matches ``run-hit-subagent``, the child of
+        ``run-hit``. Root filtering must be a real SQL predicate, not a
+        post-fetch slice of an already-limited page, so a bounded ``--limit 1``
+        page still reports the honest structurally-filtered total (1).
+        """
+        from polylogue.cli import cli
+
+        del search_workspace
+        result = CliRunner().invoke(
+            cli, ["--plain", "--no-daemon", "find", "query", "--no-root", "-f", "json", "--limit", "1"]
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert len(payload["items"]) == 1
+        assert payload["items"][0]["session"]["id"] == "codex-session:ext-run-hit-subagent"
+        assert payload["total"] == 1
+        assert payload["total_unit"] == "subagent/branch child sessions"
 
     def test_zero_hit_search_names_the_zeroing_predicate_by_default(self, search_workspace: SearchWorkspace) -> None:
         """Default (no --why): diagnostics still attribute which predicate zeroed the set (#jnj.12).


### PR DESCRIPTION
## Summary

`polylogue find`/`read`/MCP query/daemon-proxied query now default to the
**top-level session** as the result unit. Subagent/branch children stay
fully queryable via the pre-existing explicit opt-in (`--no-root` /
`root:false` DSL field) — no evidence is hidden or deleted.

## Problem

Measured 2026-07-29 (bead body): 8,614 of 18,871 sessions (45.6%) are
subagent children (8,824 `session_links` rows with `link_type='subagent'`),
and they ranked equal to real top-level sessions in every default result
list. Dogfood example from the bead:

```
$ polylogue find repo:polylogue
claude-code-session:5ecd  2026-07-27  5ecdb160-...-a3a24886af8cc:agent-af4e...  (342 msgs)
claude-code-session:5ecd  2026-07-27  5ecdb160-...-a3a24886af8cc:agent-ad73... (1098 msgs)
claude-code-session:5ecd  2026-07-28  5ecdb160-...-a3a24886af8cc:agent-ad68...  (499 msgs)
```

Three rows, one parent session, differing only by an agent suffix — this
shape filled the default result list.

Re-measured today (2026-07-31) against the live archive, `repo:polylogue`
matches 5,161 sessions total when root is unfiltered — 1,906 top-level,
3,255 subagent/branch children (1906 + 3255 = 5161, confirms honest,
mutually-exclusive SQL partitioning).

## Solution

The `root` field/DSL clause/`--root`/`--no-root` CLI flag already existed
(`SessionQuerySpec.root: bool | None`, `None` = both, unfiltered). This
change resolves the unset case to root-only via a new
`resolve_default_root_filter()` helper
(`polylogue/archive/query/spec.py`), applied at the point each surface
builds its SQL filter-kwargs — **not** by mutating `spec.root`/`plan.root`
themselves, which stay `None`-by-default. Those fields feed `has_filters()`,
which several surfaces treat as a safety/routing signal (unscoped-delete
guards in `query_actions.py`/`query_contracts.py`, "bare invocation shows
stats" detection in `root_request.py`, `latest` resolution) — defaulting
`spec.root` itself would have made every unfiltered query look "filtered"
to those consumers and silently bypassed an unscoped-mutation guard.

Four parallel filter-kwargs builders needed the fix, three of which were
**missing `root` entirely** (not just missing the default — the field
wasn't SQL-pushed at all, or was post-filtered after `LIMIT`/`OFFSET` had
already truncated the page):

- `polylogue/cli/archive_query.py` — the CLI `find`/`read` hot path. Its
  `_ArchiveFilterKwargs["root"]` already existed but was never defaulted.
  `_emit_list`/`_emit_search` gain a `total_unit` envelope field naming
  the counted unit (AC2); `_emit_daemon_list_payload`/
  `_emit_daemon_search_payload` propagate the daemon's `total_unit`.
- `polylogue/mcp/archive_support.py` — `ArchiveQueryFilters` was missing
  `root` entirely. MCP query/list never filtered by session structure at
  all, not even on an explicit `root:` clause.
- `polylogue/archive/query/archive_execution.py` — the Python-API/
  `SessionFilter` path's `_ArchiveFilterKwargs` was also missing `root`
  (post-filter only, after SQL `LIMIT`/`OFFSET` — a pagination/count
  honesty bug for any consumer of `SessionFilter.list()`/`.count()`).
- `polylogue/daemon/http.py` — the daemon HTTP session-list route
  (`_archive_filter_kwargs_from_spec`) was a fourth parallel filter-kwargs
  builder, also missing `root`. The deployed daemon (the normal runtime
  path per this repo's CLAUDE.md) would have silently kept the old
  unfiltered default even after the CLI/MCP fix landed — caught by the
  existing `test_daemon_golden_parity.py::test_find_list_json_parity_between_direct_and_daemon`
  regression test, which failed until this route got the same fix.

A `lineage:id:<ref>` predicate is itself an explicit request for one
session's whole family (root plus descendants), so
`resolve_default_root_filter()` exempts it via a new
`lineage_seed_from_predicate()` helper
(`polylogue/archive/query/predicate.py`) — otherwise the root-only default
would silently drop the children a lineage-seeded query explicitly asked
for. Caught by the existing
`test_lineage_id_cli_query_materializes_parent_child_refs` regression test.

## AC matrix

1. **Default result unit is the top-level session; children reachable via
   explicit projection** — satisfied. `resolve_default_root_filter`
   resolves the SQL `root` filter to top-level-only whenever the query
   left `root` unset, across CLI find/read, MCP query, the Python-API
   `SessionFilter`, and the daemon HTTP session-list route. `--no-root` /
   `root:false` (pre-existing) remains the explicit opt-in back onto
   children, and stays a real SQL predicate (not a post-fetch slice), so
   a bounded page still reports an honest total.
2. **Session counts state which unit they count** — satisfied on the
   surfaces this lane touches (CLI find/read `total_unit` envelope field;
   MCP/daemon inherit the same resolution feeding their `total`).
   `--root/--no-root` help text and the `root:` DSL field description
   were updated to state the new default explicitly. A full count-label
   audit across every surface (e.g. `polylogue analyze`/stats-only
   surfaces untouched by this lane) is out of scope per the coordinator's
   non-goals and can be a follow-up if it balloons.
3. **Subagent evidence remains fully queryable/citable** — satisfied.
   `--no-root` / `root:false` is unchanged plumbing, now confirmed to be a
   real SQL predicate rather than a post-filter, and MCP's `root:` DSL
   field now actually filters (previously a no-op). Verified live:
   `find repo:polylogue --no-root` returns 3,255 sessions, all
   `agent-*`-suffixed children.
4. **Re-run the exact dogfood commands, show before/after** — satisfied,
   see below.

## Verification

- `mypy --strict` on every touched file: clean.
- `devtools test tests/unit/cli/ tests/unit/archive/ tests/unit/mcp/
  tests/unit/daemon/ tests/unit/api/
  tests/unit/storage/test_topology_edges.py
  tests/unit/storage/test_session_topology.py`: only pre-existing
  failures remain, confirmed against master `e8a23cc31` via an isolated
  detached worktree (title-fallback drift in
  `test_cli_output_schemas.py`/`test_plain_cli_snapshots.py`/
  `test_assertion_candidate_evidence_disclosure.py`, origin-enum
  completion drift in `test_command_aux_runtime.py`, and unrelated
  facade-route/PTY/clock/materialization-bootstrap failures — none touch
  session listing/query defaults). Genuinely new failures from the
  default flip were all fixed: `test_bounded_pages_report_indexed_total`'s
  stale `total==2` assertion updated to the now-correct root-only
  `total==1`, a new companion
  `test_no_root_flag_recovers_the_subagent_child_and_honest_total`, and
  the `test_daemon_golden_parity.py` parity gap described above.
- `devtools render all --check`: sync OK (`docs/cli-reference.md`
  regenerated for the changed `--root`/`--no-root` help text; a
  `__snapshots__/test_terminal_snapshots.ambr` update was needed and is
  included).
- `git push` ran the pre-push `devtools verify --quick` hook
  (format+lint+mypy+render-all-check): exit 0.
- AC4 live dogfood (read-only against `/realm/db/polylogue`, run via each
  worktree's own interpreter to avoid the documented shared-venv-.pth
  hazard — `python3 -c "...; from polylogue.cli import main; main()"`
  from a detached worktree pinned at `e8a23cc31` for "before" and this
  branch for "after"):

  **Before** (`e8a23cc31`, unpatched) — `find repo:polylogue --limit 5 -f json`:
  ```
  total_unit: None   total: 5161   n_items: 5
  claude-code-session:38baa1de-...:agent-a9347188628f8900c   315 msgs
  claude-code-session:38baa1de-...:agent-a6609f08a0ae4d8a7   164 msgs
  claude-code-session:38baa1de-...:agent-aa320a9df0dd977a3    20 msgs
  claude-code-session:38baa1de-...                          3225 msgs
  claude-code-session:38baa1de-...:agent-a512997ff76a012fe   382 msgs
  ```

  **After** (this branch) — same command:
  ```
  total_unit: top-level sessions   total: 1906   n_items: 5
  claude-code-session:38baa1de-9715-48fa-8175-f2a29d92800e     3225 msgs
  claude-code-session:f9dd2630-26b2-491a-b8dc-073d554e145a     1450 msgs
  claude-code-session:0c1de80e-ebf1-4dcf-9e19-42699cc975c6      505 msgs
  claude-code-session:53e64853-1793-43d2-80ac-a41a8c5a56a2     1493 msgs
  claude-code-session:d6f4b0c3-840b-47b6-bd57-5f1bd6c9c7d4     6059 msgs
  ```

  **After**, explicit children projection — `find repo:polylogue --no-root --limit 5 -f json`:
  ```
  total_unit: subagent/branch child sessions   total: 3255   n_items: 5
  (all 5 rows are agent-*-suffixed children of claude-code-session:38baa1de-...)
  ```
  1906 (root) + 3255 (children) = 5161 (unfiltered before-total) — exact,
  confirming SQL-level, mutually-exclusive partitioning.

  **Before** — `read --all --limit 5 -f json`:
  ```
  total_unit: None   total: 23496   n_items: 5
  (all 5 rows agent-*-suffixed children of the same parent session)
  ```

  **After** — same command:
  ```
  total_unit: top-level sessions   total: 15425   n_items: 5
  (all 5 rows top-level: 3 claude-code-session, 2 chatgpt-export)
  ```

## Anti-vacuity statement

- `resolve_default_root_filter()`'s production caller is
  `polylogue/cli/archive_query.py::_execute_archive_query_stdout` (the
  live `polylogue find`/`read` implementation exercised above against the
  real archive), plus `polylogue/mcp/archive_support.py::archive_query_filters`
  (MCP query/list tools), `polylogue/archive/query/archive_execution.py::_plan_filter_kwargs`
  (`SessionFilter`/Python API), and `polylogue/daemon/http.py::_archive_filter_kwargs_from_spec`
  (daemon HTTP session-list route, exercised by
  `test_daemon_golden_parity.py` against a real UDS server).
- Reverting the `root` key from any of those four filter-kwargs
  dictionaries (or reverting `resolve_default_root_filter` to
  `return root`, dropping the default) makes
  `test_no_root_flag_recovers_the_subagent_child_and_honest_total` and
  `test_bounded_pages_report_indexed_total` fail (total reverts to the
  unfiltered structural count) and reintroduces the
  `test_daemon_golden_parity.py` parity gap.
- Removing the `lineage_seed_from_predicate` exemption makes
  `test_lineage_id_cli_query_materializes_parent_child_refs` fail (the
  seeded family's child row disappears from the result set).

Ref polylogue-j8u2
