### PR TITLE
test(maintenance): pin pipeline-decode auto-engagement on both rebuild routes

### DIFF
--- a/tests/unit/maintenance/test_rebuild_parse_apply_split.py
+++ b/tests/unit/maintenance/test_rebuild_parse_apply_split.py
@@ -27,12 +27,14 @@ components are not independently fabricatable from this test's assertions.
 
 from __future__ import annotations
 
+import time
 from pathlib import Path
 
 import pytest
 
 from polylogue.config import Config
 from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from polylogue.sources import revision_backfill
 from polylogue.sources.census_parse_stage import CensusParseStage
 from polylogue.sources.revision_backfill import split_parse_and_apply_seconds
 from tests.infra.revision_backfill_benchmark import build_independent_raw_corpus
@@ -157,3 +159,86 @@ def test_rebuild_index_from_source_sync_warms_prefetch_cache_when_caller_omits_o
     # Every raw the census phase went on to process was offered to the warmer
     # first -- the exact set this pass selected, not a subset/superset.
     assert set(warmed_raw_id_batches[0]) == set(raw_ids)
+
+
+def _give_replay_spill_prefetcher_a_head_start(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Deterministic race pin, mirroring ``test_revision_backfill.py``'s
+    identically-named helper: production makes no ordering promise between
+    the background decode worker and the writer, so a tiny corpus can let
+    the writer finish before the worker buffers anything, making
+    ``spill_prefetch.consumed`` a coin flip. Give the worker a bounded head
+    start before the writer's own replay loop begins."""
+    original_start_phase = revision_backfill._ReplaySpillPrefetcher.start_phase
+
+    def start_phase_with_head_start(
+        self: revision_backfill._ReplaySpillPrefetcher,
+        ordered_keys: object,
+        extra_members: object,
+    ) -> None:
+        original_start_phase(self, ordered_keys, extra_members)  # type: ignore[arg-type]
+        worker = self._thread
+        for _ in range(1000):  # bounded ~10s; normally exits in milliseconds
+            with self._lock:
+                if len(self._buffer) >= 2:
+                    break
+            if worker is None or not worker.is_alive():
+                break
+            time.sleep(0.01)
+
+    monkeypatch.setattr(revision_backfill._ReplaySpillPrefetcher, "start_phase", start_phase_with_head_start)
+
+
+def test_rebuild_index_from_source_sync_auto_engages_pipelined_decode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """polylogue-2cuv: BOTH production rebuild routes -- the offline CLI
+    (``polylogue ops maintenance rebuild-index``) and the daemon bulk-rebuild
+    loop (``daemon/bulk_rebuild.py::run_daemon_bulk_rebuild_pass``) -- drive
+    this exact ``rebuild_index_from_source_sync`` entry point (the daemon via
+    its own write coordinator, unmodified). Both therefore inherit the SAME
+    ``pipeline_decode`` auto-engagement inside ``backfill_historical_revision_
+    evidence`` (Lever A / PR #3478's ``_ReplaySpillPrefetcher``) with zero
+    per-route wiring -- there is no separate knob either route could forget
+    to set.
+
+    Anti-vacuity: this drives the real production entry point with a corpus
+    sized at/above ``_PIPELINE_DECODE_MIN_COHORTS`` (independent raws, so
+    every raw is its own logical cohort) and shrinks the spill's RAM cache
+    tiers to 1 byte so every replay ``for_raw`` misses RAM and must go
+    through the prefetcher-or-inline decode fork. If pipeline_decode were
+    hardcoded ``False`` somewhere between ``rebuild_index_from_source_sync``
+    and ``backfill_historical_revision_evidence`` (e.g. a parameter dropped
+    while threading a future kwarg), ``spill_prefetch.consumed`` would never
+    appear in the stage timings and this assertion would fail -- proving the
+    auto-engagement path is actually reached from the production route, not
+    only from the lower-level unit tests that call
+    ``backfill_historical_revision_evidence`` directly.
+    """
+    monkeypatch.setattr(revision_backfill._ParsedSessionSpill, "_DECODED_CACHE_MIN_TREE_BYTES", 1)
+    monkeypatch.setattr(revision_backfill._ParsedSessionSpill, "_DECODED_CACHE_MAX_TREE_BYTES", 1)
+    monkeypatch.setattr(revision_backfill._ParsedSessionSpill, "_WHALE_CACHE_MAX_TREE_BYTES", 1)
+    _give_replay_spill_prefetcher_a_head_start(monkeypatch)
+
+    root = tmp_path / "archive"
+    cohort_count = revision_backfill._PIPELINE_DECODE_MIN_COHORTS + 4
+    raw_ids = build_independent_raw_corpus(root, raw_count=cohort_count, avg_payload_bytes=20_000)
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(root))
+
+    receipt = rebuild_index_from_source_sync(
+        RebuildIndexRequest(
+            archive_root=root,
+            promote=True,
+            raw_batch_size=500,  # single page: whole corpus fits in one pass
+        )
+    )
+
+    assert receipt.status == "replayed"
+    stage_timings_s = receipt.replay["stage_timings_s"]
+    assert isinstance(stage_timings_s, dict)
+    assert stage_timings_s.get("spill_prefetch.consumed", 0.0) > 0, (
+        "rebuild_index_from_source_sync did not auto-engage the background "
+        "replay-spill prefetcher (Lever A) for a cohort count above "
+        "_PIPELINE_DECODE_MIN_COHORTS -- census+spill_load decode is no "
+        "longer proven to overlap the writer's apply work on this route"
+    )
+    assert receipt.selected_raw_count == len(raw_ids)


### PR DESCRIPTION
## Summary

polylogue-2cuv asked for a bounded-memory producer/consumer pipeline overlapping rebuild parse decode with the writer's apply work, on both the daemon bulk-rebuild route and the offline CLI route. Re-verification against current `master` found this already shipped by PR #3478 (`_ReplaySpillPrefetcher`, "Lever A"), with lineage-order preservation from PR #3485 landed the same day. This PR does not add pipeline plumbing (none is missing) — it adds one regression test proving the pipeline auto-engages from the **production entry point both routes share**, plus an honest before/after measurement in the PR description below.

## Problem

The bead's core measured claim, from a real 4h22m rebuild receipt: `parse_s (census 1202s + spill_load 2830s) + apply_s (8601s) == total (12633s)` **exactly** — zero overlap between decode and the single SQLite writer. `spill_load` (2830s, 22% of the pass) was documented as strictly SERIAL `pickle.loads`/reparse work interleaved with writer apply work. The bead asked for a producer/consumer queue so census+spill hide behind apply, on both `daemon/bulk_rebuild.py` and `maintenance/rebuild_index.py`.

## Solution

**Finding: already done.** Both routes call the identical chain:

- Offline: `maintenance/rebuild_index.py` → `rebuild_index_from_source_sync`
- Daemon: `daemon/bulk_rebuild.py::run_daemon_bulk_rebuild_pass` → `rebuild_index_from_source_sync` (same function, scheduled through the daemon's write coordinator)

Both funnel into `maintenance/replay.py::rebuild_index_from_source` → `sources/revision_backfill.py::backfill_historical_revision_evidence`, which since PR #3478 (`66515459c`/`c6e275bca`, "pipeline replay decode off the writer thread") runs a background `_ReplaySpillPrefetcher` thread that decodes upcoming replay cohorts' parsed sessions while the writer applies the current cohort, auto-engaging via `pipeline_decode=None` whenever `parallel_threads_effective()` (free-threaded build) and the pass has `>= _PIPELINE_DECODE_MIN_COHORTS` (8) cohorts. PR #3485 (`bdffadc2d`, same day) added `_lineage_aware_replay_order`, which both the prefetcher and the writer loop consume from the identical `ordered_logical_keys` sequence — lineage ordering survives pipelining by construction.

Since `pipeline_decode` auto-resolution lives *inside* the shared function, there is no separate per-route knob either the offline or daemon caller could have forgotten to wire — both inherit it for free.

**What this PR adds:** `tests/unit/maintenance/test_rebuild_parse_apply_split.py::test_rebuild_index_from_source_sync_auto_engages_pipelined_decode` — drives the real `rebuild_index_from_source_sync` entry point (not the lower-level `backfill_historical_revision_evidence` the existing unit tests already call directly) with a corpus of `_PIPELINE_DECODE_MIN_COHORTS + 4` independent raws and RAM spill tiers shrunk to force every `for_raw` decode through the prefetcher-or-inline fork, then asserts `stage_timings_s["spill_prefetch.consumed"] > 0`. Anti-vacuity: dropping the `pipeline_decode` parameter anywhere in the `rebuild_index_from_source_sync` → ... → `backfill_historical_revision_evidence` threading chain makes this assertion fail with `0`, not a wrong number.

**What this PR does NOT add:** no new pipeline plumbing. The remaining fully-serial stage is the up-front `census` classification pass — it structurally precedes the replay loop (cohort membership must be resolved before cohorts can be ordered/classified), and `_ReplaySpillPrefetcher` neither touches nor could touch it without a materially larger redesign (overlapping census-page N+1 with replay-page N's apply, across page boundaries). Left as a residual finding, not implemented here — see the honest measurement below for its current relative weight.

## Before/after measurement

Ad hoc synthetic-corpus script (not committed; used `tests/infra/rebuild_cost_model.py`'s `Stratum`/`build_stratum_sample_corpus` machinery against `backfill_historical_revision_evidence` directly, comparing `pipeline_decode=False` — the exact pre-#3478 serial path — against `pipeline_decode=None`/auto, the current production default), 160-raw corpus, ~900KB payloads, 20% chain fraction, 10% ambiguous fraction:

| metric | before (serial) | after (auto pipeline) |
| --- | --- | --- |
| `spill_load` | 3.988s | 0.063s |
| `spill_prefetch.decode_concurrent` (hidden behind apply) | n/a | 2.901s |
| fraction of original `spill_load` now overlapped | — | **72.7%** |

Wall-clock deltas from this run are **not reported as a speedup number**: the host was at load average ~19-22 on 24 cores during measurement (multiple concurrent agent lanes per repo convention), which visibly perturbed unrelated stages (e.g. `census`, which `pipeline_decode` never touches, moved 5.04s → 7.89s between the two runs) — the wall-clock signal was too noisy to trust in isolation. The `spill_load`/`decode_concurrent` stage-timing shift is the reliable signal because it is a structural property of which code path ran, not a wall-clock race against host load.

## Verification

```
python -m devtools test tests/unit/maintenance/test_rebuild_parse_apply_split.py
  -> 5 passed (includes the new test)
python -m devtools test tests/unit/sources/test_revision_backfill.py -k pipelined_decode
  -> 3 passed (pre-existing outcome-parity proofs for pipeline_decode, confirmed still green:
     test_pipelined_decode_matches_serial_archive_state[reparse-fallback-lane],
     test_pipelined_decode_matches_serial_archive_state[sqlite-spill-lane],
     test_pipelined_decode_respects_batched_replay_commits)
python -m devtools test tests/benchmarks/test_rebuild_cost_model.py -k "not full_population"
  -> 4 passed
python -m devtools verify --quick -> exit 0 (ran again on push via pre-push hook, exit 0)
```

Not run: `tests/benchmarks/test_rebuild_cost_model.py::test_full_population_projection` (opt-in, ~40 real rebuild passes, minutes) and the full non-integration suite (`devtools verify --all`) — this PR's surface is a single new test in an already-green file plus a PR-body-only measurement, not new production plumbing.

## AC matrix (against polylogue-2cuv)

| AC | status |
| --- | --- |
| Bounded-memory producer/consumer pipeline overlapping parse decode with apply | **Already satisfied** — `_ReplaySpillPrefetcher` (PR #3478), pre-existing |
| Wired on both daemon bulk-rebuild route and offline route | **Already satisfied** — both share `rebuild_index_from_source_sync`; this PR adds the regression test proving it from that shared entry point |
| Preserve lineage-aware ordering from #3485 | **Already satisfied** — prefetcher consumes the same `ordered_logical_keys` the writer loop does |
| Outcome parity proven by a differential test (accepted_raw_ids/adoption identical) | **Already satisfied** — pre-existing `test_pipelined_decode_matches_serial_archive_state` (byte-identical `RevisionBackfillResult` + full index content manifest, both RAM-miss decode lanes) |
| Honest before/after measurement on the rebuild-cost harness fixture | **Satisfied in this PR body** (see above); wall-clock deltas explicitly caveated as unreliable under current host load rather than reported as a speedup claim |
| Census-stage overlap (the remaining ~9-16% pre-#3478 serial bucket not touched by Lever A) | **Not implemented / out of scope** — would require overlapping census across page boundaries with the prior page's apply, a materially larger redesign than what this bead's "spill_load 2830s SERIAL" evidence targeted |

Ref polylogue-2cuv