### PR TITLE
fix(tests): give codex lineage fixture matching cwd for continuation evidence

### DIFF
--- a/tests/unit/storage/test_incremental_rebuild_equivalence.py
+++ b/tests/unit/storage/test_incremental_rebuild_equivalence.py
@@ -207,10 +207,21 @@ def _codex_session(
     *,
     parent_native_id: str | None = None,
 ) -> bytes:
+    # Real Codex continuation/resume rollouts (sampled from ~/.codex/sessions,
+    # 490/494 multi-session_meta files) replay the parent's original
+    # session_meta as the file's second distinct session_meta, and that
+    # replayed header shares the same cwd (and usually the same git
+    # repository_url) with the child, because a resume continues in the same
+    # working tree. `_has_continuation_evidence`
+    # (polylogue/sources/parsers/codex.py, #3484) requires that structural
+    # match -- a bare second session_meta id is no longer sufficient -- so
+    # this fixture must carry it for the legacy (no forked_from_id)
+    # CONTINUATION fallback to classify.
+    shared_cwd = "/realm/project/lineage-fixture"
     rows: list[dict[str, object]] = [
         {
             "type": "session_meta",
-            "payload": {"id": native_id, "timestamp": "2026-07-16T10:00:00Z"},
+            "payload": {"id": native_id, "timestamp": "2026-07-16T10:00:00Z", "cwd": shared_cwd},
         }
     ]
     if parent_native_id is not None:
@@ -220,6 +231,7 @@ def _codex_session(
                 "payload": {
                     "id": parent_native_id,
                     "timestamp": "2026-07-16T09:00:00Z",
+                    "cwd": shared_cwd,
                 },
             }
         )


### PR DESCRIPTION
## Summary

Fixes the master regression `test_incremental_restart_and_fresh_generation_rebuild_are_equivalent`, which fails deterministically after 0d27e3da7 (#3484, "require structural evidence for codex CONTINUATION lineage"). The fixture, not the parser rule, was wrong — verdict below.

## Problem

0d27e3da7 replaced a bare "second `session_meta` count" heuristic in the Codex parser's legacy (no `forked_from_id`) CONTINUATION fallback with `_has_continuation_evidence()`, requiring (1) the candidate parent's replayed header timestamp does not postdate the child's own start time, and (2) the two `session_meta` records share a matching `cwd` or git `repository_url`.

`tests/unit/storage/test_incremental_rebuild_equivalence.py::_codex_session` builds a synthetic Codex payload with two `session_meta` records that only set `id` and `timestamp` — no `cwd`, no `git`. After 0d27e3da7 this no longer satisfies `_has_continuation_evidence` (timestamp precedence alone is not sufficient; cwd/git must also match), so the parser correctly leaves the fixture's lineage unclassified, and the equivalence test's `session_links` assertion (expecting a `('codex-session:lineage-parent', 'continuation')` edge) fails.

## (a) vs (b) verdict: (a) — the fixture was stale, the rule is correct

I sampled real multi-`session_meta` Codex rollouts from `~/.codex/sessions/**/*.jsonl` (3,213 files total, 494 with ≥2 distinct `session_meta` records) and compared the first two distinct `session_meta` payloads in each:

- **490/494 (99.2%)** share a matching `cwd` between the first and second `session_meta`.
- **0/494** match on git `repository_url` alone without also matching `cwd` (git match is a strict subset of cwd match in this sample).
- **494/494 (100%)** have the second meta's timestamp `<=` the first's (true replay-of-parent-header ordering).
- Only 4/494 files have neither cwd nor git-repo match — inspected manually, these are genuinely unrelated `session_meta` pairs from different repos/directories, i.e. exactly the shape `_has_continuation_evidence` is designed to reject.

This confirms 0d27e3da7's premise: real Codex continuations overwhelmingly carry the structural evidence the tightened rule requires, and the 4 non-matching cases are legitimately *not* continuations. The rule is correct; the pre-existing test fixture simply predates it and never populated `cwd`/`git` on its synthetic `session_meta` records, so it can't produce the evidence a real continuation would.

## Solution

`tests/unit/storage/test_incremental_rebuild_equivalence.py`: `_codex_session` now sets a shared `cwd` (`/realm/project/lineage-fixture`) on both the child's own `session_meta` and the parent's replayed `session_meta`, mirroring what real continuation rollouts structurally carry. Left the existing timestamp ordering (parent timestamp precedes child) untouched — it already matched the requirement.

No changes to `polylogue/sources/parsers/codex.py` or `_has_continuation_evidence` itself — the classification rule from #3484 is unchanged.

## Verification

- `python -m devtools test tests/unit/storage/test_incremental_rebuild_equivalence.py tests/unit/sources/test_parsers_codex.py tests/unit/sources/test_codex_event_stream_contract.py` → `121 passed` (includes the target equivalence test now green, plus #3484's negative case `test_second_session_meta_without_structural_evidence_stays_unclassified` / `..._is_unclassified` still passing unchanged).
- `python -m devtools verify --quick` → `exit_code: 0` (format, lint, mypy, render-all-check, layering, schema/manifest/lab policy checks).

**Anti-vacuity**: the production dependency exercised is `polylogue.sources.parsers.codex._has_continuation_evidence` via `parse()`/`parse_stream()` — reverting the fixture change back to session_metas with no `cwd`/`git` (i.e. restoring the pre-PR state) reproduces the original failure: `_has_continuation_evidence` returns `False`, `session_links` gets no `('codex-session:lineage-parent', 'continuation')` edge, and the equivalence assertion at the affected line fails again.

Ref polylogue-s0ug