### PR TITLE
feat(maintenance): shard from-empty index rebuilds across parallel generations

### DIFF
--- a/docs/plans/hash-boundary-registry.yaml
+++ b/docs/plans/hash-boundary-registry.yaml
@@ -422,6 +422,12 @@ entries:
   occurrence: 0
   classification: identifier
   note: 'stable evidence-ref id for citation; 2026-07-09 hash-boundary census (docs/audits/2026-07-09-hash-boundary-census.md) Table 3.'
+- path: polylogue/maintenance/sharded_rebuild.py
+  function: '<module>.shard_raw_ids'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: identifier
+  note: 'polylogue-pzxm: deterministic bucket assignment for a revision-cohort key (which shard a raw id lands in), never compared for drift -- consumer is list index modulo shard_count.'
 - path: polylogue/material_protocol/v1/encode.py
   function: '<module>._content_digest'
   call: hash_bytes

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -70,7 +70,7 @@ files:
     owner: stable
     cross_cut: { api: async }
   - path: polylogue/api/archive.py
-    loc: 7241
+    loc: 7264
     target: polylogue/api/archive.py
     owner: stable
     cross_cut: { api: async }
@@ -179,7 +179,7 @@ files:
     owner: archive-artifact-taxonomy
     reason: archive-domain semantics
   - path: polylogue/archive/artifact_taxonomy/runtime.py
-    loc: 497
+    loc: 564
     target: polylogue/archive/artifact_taxonomy/runtime.py
     owner: archive-artifact-taxonomy
     reason: archive-domain semantics
@@ -330,7 +330,7 @@ files:
     owner: archive-query
     reason: archive-domain query semantics
   - path: polylogue/archive/query/archive_execution.py
-    loc: 713
+    loc: 716
     target: polylogue/archive/query/archive_execution.py
     owner: archive-query
     reason: archive-domain query semantics
@@ -375,7 +375,7 @@ files:
     owner: archive-query
     reason: archive-domain query semantics
   - path: polylogue/archive/query/metadata.py
-    loc: 1495
+    loc: 1496
     target: polylogue/archive/query/metadata.py
     owner: archive-query
     reason: archive-domain query semantics
@@ -415,7 +415,7 @@ files:
     owner: archive-query
     reason: archive-domain query semantics
   - path: polylogue/archive/query/predicate.py
-    loc: 389
+    loc: 421
     target: polylogue/archive/query/predicate.py
     owner: archive-query
     reason: archive-domain query semantics
@@ -485,7 +485,7 @@ files:
     owner: archive-query
     reason: archive-domain query semantics
   - path: polylogue/archive/query/spec.py
-    loc: 648
+    loc: 702
     target: polylogue/archive/query/spec.py
     owner: archive-query
     reason: archive-domain query semantics
@@ -819,7 +819,7 @@ files:
     target: polylogue/cli/__main__.py
     owner: stable
   - path: polylogue/cli/archive_query.py
-    loc: 2846
+    loc: 2859
     target: polylogue/cli/archive_query.py
     owner: stable
   - path: polylogue/cli/click_app.py
@@ -831,7 +831,7 @@ files:
     target: polylogue/cli/click_command_registration.py
     owner: stable
   - path: polylogue/cli/click_option_groups.py
-    loc: 399
+    loc: 401
     target: polylogue/cli/click_option_groups.py
     owner: stable
   - path: polylogue/cli/command_inventory.py
@@ -983,7 +983,7 @@ files:
     target: polylogue/cli/commands/maintenance/_raw_identity.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_rebuild_index.py
-    loc: 529
+    loc: 548
     target: polylogue/cli/commands/maintenance/_rebuild_index.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_run.py
@@ -1011,7 +1011,7 @@ files:
     target: polylogue/cli/commands/materialize_incident_evidence.py
     owner: stable
   - path: polylogue/cli/commands/note.py
-    loc: 96
+    loc: 106
     target: polylogue/cli/commands/note.py
     owner: stable
   - path: polylogue/cli/commands/ops.py
@@ -1035,7 +1035,7 @@ files:
     target: polylogue/cli/commands/scan_secrets.py
     owner: stable
   - path: polylogue/cli/commands/status.py
-    loc: 2485
+    loc: 2494
     target: polylogue/cli/commands/status.py
     owner: stable
   - path: polylogue/cli/commands/status_diagnostics.py
@@ -1639,7 +1639,7 @@ files:
     target: polylogue/daemon/healthz.py
     owner: stable
   - path: polylogue/daemon/http.py
-    loc: 5546
+    loc: 5569
     target: polylogue/daemon/http.py
     owner: stable
   - path: polylogue/daemon/judgment_automation.py
@@ -2198,7 +2198,7 @@ files:
     target: polylogue/maintenance/raw_authority_reset.py
     owner: stable
   - path: polylogue/maintenance/rebuild_index.py
-    loc: 898
+    loc: 1093
     target: polylogue/maintenance/rebuild_index.py
     owner: stable
   - path: polylogue/maintenance/registry.py
@@ -2206,12 +2206,16 @@ files:
     target: polylogue/maintenance/registry.py
     owner: stable
   - path: polylogue/maintenance/replay.py
-    loc: 887
+    loc: 894
     target: polylogue/maintenance/replay.py
     owner: stable
   - path: polylogue/maintenance/scope.py
     loc: 138
     target: polylogue/maintenance/scope.py
+    owner: stable
+  - path: polylogue/maintenance/sharded_rebuild.py
+    loc: 547
+    target: polylogue/maintenance/sharded_rebuild.py
     owner: stable
   - path: polylogue/maintenance/targets.py
     loc: 302
@@ -2274,7 +2278,7 @@ files:
     target: polylogue/mcp/__init__.py
     owner: stable
   - path: polylogue/mcp/archive_support.py
-    loc: 870
+    loc: 872
     target: polylogue/mcp/archive_support.py
     owner: stable
   - path: polylogue/mcp/call_log.py
@@ -2322,7 +2326,7 @@ files:
     target: polylogue/mcp/server.py
     owner: stable
   - path: polylogue/mcp/server_cutover.py
-    loc: 2325
+    loc: 2328
     target: polylogue/mcp/server_cutover.py
     owner: stable
   - path: polylogue/mcp/server_prompts.py
@@ -2503,7 +2507,7 @@ files:
     target: polylogue/pipeline/services/ingest_batch/_summary.py
     owner: stable
   - path: polylogue/pipeline/services/ingest_worker.py
-    loc: 785
+    loc: 800
     target: polylogue/pipeline/services/ingest_worker.py
     owner: stable
   - path: polylogue/pipeline/services/parsing.py
@@ -3223,7 +3227,7 @@ files:
     target: polylogue/sources/decoders.py
     owner: stable
   - path: polylogue/sources/dispatch.py
-    loc: 1618
+    loc: 1711
     target: polylogue/sources/dispatch.py
     owner: stable
   - path: polylogue/sources/drive/__init__.py
@@ -3295,11 +3299,11 @@ files:
     target: polylogue/sources/live/_lag_sample_ddl.py
     owner: stable
   - path: polylogue/sources/live/append_ingest.py
-    loc: 283
+    loc: 289
     target: polylogue/sources/live/append_ingest.py
     owner: stable
   - path: polylogue/sources/live/batch.py
-    loc: 3134
+    loc: 3146
     target: polylogue/sources/live/batch.py
     owner: stable
   - path: polylogue/sources/live/batch_observability.py
@@ -3544,7 +3548,7 @@ files:
     owner: stable
     cross_cut: { lifecycle: model }
   - path: polylogue/sources/revision_backfill.py
-    loc: 2463
+    loc: 2563
     target: polylogue/sources/revision_backfill.py
     owner: stable
   - path: polylogue/sources/source_acquisition.py
@@ -3796,7 +3800,7 @@ files:
     target: polylogue/storage/insights/session/profiles.py
     owner: stable
   - path: polylogue/storage/insights/session/rebuild.py
-    loc: 1945
+    loc: 2198
     target: polylogue/storage/insights/session/rebuild.py
     owner: stable
   - path: polylogue/storage/insights/session/records.py
@@ -4224,7 +4228,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/user_overlay.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/user_write.py
-    loc: 2608
+    loc: 2644
     target: polylogue/storage/sqlite/archive_tiers/user_write.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/write.py

--- a/polylogue/cli/commands/maintenance/_rebuild_index.py
+++ b/polylogue/cli/commands/maintenance/_rebuild_index.py
@@ -364,6 +364,17 @@ def _rebuild_index_selection_plan(
     show_default="resolved via load_polylogue_config().daemon_url (site/user TOML -> POLYLOGUE_DAEMON_URL -> built-in default)",
     help="Daemon HTTP base URL used with --daemon.",
 )
+@click.option(
+    "--shard-count",
+    type=int,
+    default=1,
+    show_default=True,
+    help=(
+        "polylogue-pzxm: replay this pass's selected raw ids across N owned-inactive "
+        "generations built in parallel, merged before promotion. 1 keeps the unchanged "
+        "single-writer path; unsupported with --daemon."
+    ),
+)
 def rebuild_index_command(
     only_missing: bool,
     raw_ids: tuple[str, ...],
@@ -378,6 +389,7 @@ def rebuild_index_command(
     no_promote: bool,
     use_daemon: bool,
     daemon_url: str,
+    shard_count: int,
 ) -> None:
     """Inspect or execute an authority-safe source-to-index rebuild.
 
@@ -397,6 +409,12 @@ def rebuild_index_command(
         raise click.BadParameter("plan limit must be positive", param_hint="--plan-limit")
     if use_daemon and plan_only:
         raise click.UsageError("--daemon executes a rebuild; --plan is always a local read-only preview")
+    if shard_count <= 0:
+        raise click.BadParameter("shard count must be positive", param_hint="--shard-count")
+    if use_daemon and shard_count > 1:
+        raise click.UsageError("--shard-count is a local-execution option; unsupported with --daemon")
+    if shard_count > 1 and pass_deadline_seconds is not None:
+        raise click.UsageError("--shard-count does not yet honor --pass-deadline-seconds; use one or the other")
     if raw_batch_size <= 0:
         raise click.BadParameter("raw batch size must be positive", param_hint="--raw-batch-size")
     if pass_byte_budget_mb is not None and pass_byte_budget_mb <= 0:
@@ -514,6 +532,7 @@ def rebuild_index_command(
                 raw_batch_size=raw_batch_size,
                 pass_byte_budget_mb=pass_byte_budget_mb,
                 pass_deadline_seconds=pass_deadline_seconds,
+                shard_count=shard_count,
             )
         )
     except (RuntimeError, ValueError) as exc:

--- a/polylogue/maintenance/rebuild_index.py
+++ b/polylogue/maintenance/rebuild_index.py
@@ -257,6 +257,16 @@ class RebuildIndexRequest:
     # to set this explicitly to reuse a cache warmed AHEAD of a writer hold it
     # does not yet hold, which is what the daemon's bulk-rebuild loop does.
     prefetch_cache: RawParsePrefetchCache | None = None
+    # polylogue-pzxm: split this pass's selected raw ids into shard_count
+    # owned-inactive generations built in parallel (free-threaded
+    # interpreter: threads share parsed graphs), merged sequentially into
+    # this pass's real target generation before the existing terminal
+    # stages run. 1 (the default) is the unchanged single-writer path --
+    # every existing caller (CLI, daemon HTTP route, bulk-rebuild loop) is
+    # unaffected until it opts in. See
+    # polylogue.maintenance.sharded_rebuild for the merge/graph-resolution
+    # correctness argument.
+    shard_count: int = 1
 
 
 @dataclass(frozen=True, slots=True)
@@ -421,6 +431,15 @@ def validate_rebuild_index_request(request: RebuildIndexRequest) -> None:
         raise ValueError("pass byte budget must be positive")
     if request.pass_deadline_seconds is not None and request.pass_deadline_seconds <= 0:
         raise ValueError("pass deadline must be positive")
+    if request.shard_count < 1:
+        raise ValueError("shard_count must be positive")
+    if request.shard_count > 1 and request.pass_deadline_seconds is not None:
+        # polylogue-pzxm/polylogue-uhgm interaction: the sharded path has no
+        # deadline_check seam threaded to its K concurrent shard replays (see
+        # the dispatch site's comment in _rebuild_index_from_source_owned) --
+        # reject the combination up front rather than silently ignoring the
+        # deadline.
+        raise ValueError("--shard-count does not yet honor --pass-deadline-seconds; use one or the other")
     if request.operation_id is not None and (
         request.raw_ids or request.only_missing or request.max_blob_mb is not None
     ):
@@ -670,137 +689,179 @@ async def _rebuild_index_from_source_owned(
                     _warm_offline_prefetch_cache, warm_config, selected_raw_ids
                 )
             pass_started_at_s = time.perf_counter()
+            if request.shard_count > 1 and len(selected_raw_ids) >= request.shard_count:
+                # polylogue-pzxm: build request.shard_count owned-inactive
+                # generations in parallel and merge them into `generation`
+                # instead of replaying `selected_raw_ids` through the single
+                # writer directly. Every terminal stage below (planner
+                # statistics, bulk-build repopulate, FTS parity, readiness,
+                # promote) is unchanged: it observes `generation.index_path`
+                # after the merge exactly as it would after a sequential
+                # replay of the same raw ids.
+                #
+                # polylogue-uhgm interaction: the sharded path does NOT yet
+                # honor mid-replay pass deadlines (`_check_pass_deadline`
+                # below is wired only through the non-sharded
+                # `replay_source` call's `deadline_check` param) -- a shard's
+                # own `backfill_historical_revision_evidence` call has no
+                # deadline threaded to it, and there is no natural per-cohort
+                # checkpoint to interrupt across K concurrently-running
+                # shards the way one single-writer replay has. This is
+                # deliberately rejected up front instead of silently
+                # ignored: `validate_rebuild_index_request` refuses
+                # `shard_count > 1` together with `pass_deadline_seconds`,
+                # and this defends the resumed-operation case (a deadline
+                # set on transaction CREATION, before this pass's own
+                # `request.shard_count` was chosen) the request-level
+                # validator cannot see.
+                if transaction is not None and transaction.pass_deadline_ms is not None:
+                    raise ValueError(
+                        f"rebuild operation {transaction.operation_id} carries a pass deadline "
+                        f"({transaction.pass_deadline_ms}ms); shard_count > 1 does not yet honor mid-replay "
+                        "deadlines -- resume with shard_count=1, or start a new undeadlined operation"
+                    )
+                from polylogue.maintenance.sharded_rebuild import replay_selected_raw_ids_sharded
 
-            # polylogue-uhgm: the pass deadline used to be checked only AFTER
-            # this whole page's replay_source() call returned, so a page that
-            # expanded into a much larger authority cohort (or simply ran
-            # slow) could overshoot ``pass_deadline_ms`` by an entire page --
-            # live evidence: a 300s deadline, ~8-9 minute pages. This closure
-            # is threaded down to backfill_historical_revision_evidence's
-            # REPLAY-phase cohort loops (see RebuildDeadlineExceededError's
-            # docstring), which call it between cohorts. It is a no-op for
-            # every non-resumable selection (``transaction is None`` --
-            # raw_ids/--only-missing/--max-blob-mb runs never carry a
-            # pass_deadline_ms in the first place, see
-            # validate_rebuild_index_request).
-            def _check_pass_deadline() -> None:
-                if transaction is None or transaction.pass_deadline_ms is None:
-                    return
-                elapsed_ms = int(time.time() * 1000) - pass_started_at_ms
-                if elapsed_ms >= transaction.pass_deadline_ms:
-                    raise RebuildDeadlineExceededError(
-                        f"rebuild pass deadline ({transaction.pass_deadline_ms}ms) exceeded mid-replay "
-                        f"after {elapsed_ms}ms; stopping before the next cohort"
+                replay = await replay_selected_raw_ids_sharded(
+                    root=root,
+                    generation_store=generation_store,
+                    generation=generation,
+                    selected_raw_ids=selected_raw_ids,
+                    raw_batch_size=request.raw_batch_size,
+                    shard_count=request.shard_count,
+                    prefetch_cache=effective_prefetch_cache,
+                )
+            else:
+                # polylogue-uhgm: the pass deadline used to be checked only AFTER
+                # this whole page's replay_source() call returned, so a page that
+                # expanded into a much larger authority cohort (or simply ran
+                # slow) could overshoot ``pass_deadline_ms`` by an entire page --
+                # live evidence: a 300s deadline, ~8-9 minute pages. This closure
+                # is threaded down to backfill_historical_revision_evidence's
+                # REPLAY-phase cohort loops (see RebuildDeadlineExceededError's
+                # docstring), which call it between cohorts. It is a no-op for
+                # every non-resumable selection (``transaction is None`` --
+                # raw_ids/--only-missing/--max-blob-mb runs never carry a
+                # pass_deadline_ms in the first place, see
+                # validate_rebuild_index_request).
+                def _check_pass_deadline() -> None:
+                    if transaction is None or transaction.pass_deadline_ms is None:
+                        return
+                    elapsed_ms = int(time.time() * 1000) - pass_started_at_ms
+                    if elapsed_ms >= transaction.pass_deadline_ms:
+                        raise RebuildDeadlineExceededError(
+                            f"rebuild pass deadline ({transaction.pass_deadline_ms}ms) exceeded mid-replay "
+                            f"after {elapsed_ms}ms; stopping before the next cohort"
+                        )
+
+                try:
+                    replay = await replay_source(
+                        config,
+                        raw_ids=selected_raw_ids,
+                        raw_batch_size=request.raw_batch_size,
+                        ingest_workers=None,
+                        materialize=True,
+                        progress_callback=None,
+                        owned_inactive_generation=(generation.generation_id, generation.owner_id),
+                        # polylogue-crd8: this is the offline rebuild path (an owned
+                        # inactive generation, never the live daemon ingest path), so
+                        # the guard-gated bulk FTS mode is safe to enable unconditionally
+                        # here -- it collapses whale prefix-sharing lineage cascades'
+                        # per-row messages_fts trigger storm into one bulk delete+insert
+                        # per affected session.
+                        bulk_fts=True,
+                        # polylogue-v6i3: the broader bulk-generation-build lifecycle --
+                        # every per-session messages_fts/blocks_command_trigram/
+                        # action_pairs/delegation_facts refresh is skipped during this
+                        # replay (safe for a full OR partial/diagnostic selection: a
+                        # repopulate from `blocks` always matches whatever sessions
+                        # actually got replayed into this generation); see
+                        # _repopulate_bulk_build_derived_state, called below right
+                        # before readiness.
+                        bulk_build=True,
+                        prefetch_cache=effective_prefetch_cache,
+                        deadline_check=_check_pass_deadline if transaction is not None else None,
+                    )
+                except RebuildDeadlineExceededError as exc:
+                    # Mid-page interrupt: at least one cohort was durably
+                    # committed (or none, if the very first cohort tripped it),
+                    # but never the whole requested page. Do NOT advance the
+                    # transaction's cursor/processed counters -- leaving them at
+                    # their pre-pass values means the next pass re-derives from
+                    # exactly the same source-order position. Re-applying any
+                    # cohort this pass DID commit is a safe idempotent no-op
+                    # (content-hash upsert), so this can never duplicate or skip
+                    # a raw/cohort; it can only redo bounded work.
+                    assert transaction is not None  # deadline_check is only wired when transaction is not None
+                    pass_elapsed_s = time.perf_counter() - pass_started_at_s
+                    transaction = generation_store.checkpoint_transaction(
+                        transaction,
+                        status="deferred",
+                        error=str(exc),
+                    )
+                    from polylogue.pipeline.services.process_pool import (
+                        parallel_threads_effective,
+                        resolve_parse_worker_count,
                     )
 
-            try:
-                replay = await replay_source(
-                    config,
-                    raw_ids=selected_raw_ids,
-                    raw_batch_size=request.raw_batch_size,
-                    ingest_workers=None,
-                    materialize=True,
-                    progress_callback=None,
-                    owned_inactive_generation=(generation.generation_id, generation.owner_id),
-                    # polylogue-crd8: this is the offline rebuild path (an owned
-                    # inactive generation, never the live daemon ingest path), so
-                    # the guard-gated bulk FTS mode is safe to enable unconditionally
-                    # here -- it collapses whale prefix-sharing lineage cascades'
-                    # per-row messages_fts trigger storm into one bulk delete+insert
-                    # per affected session.
-                    bulk_fts=True,
-                    # polylogue-v6i3: the broader bulk-generation-build lifecycle --
-                    # every per-session messages_fts/blocks_command_trigram/
-                    # action_pairs/delegation_facts refresh is skipped during this
-                    # replay (safe for a full OR partial/diagnostic selection: a
-                    # repopulate from `blocks` always matches whatever sessions
-                    # actually got replayed into this generation); see
-                    # _repopulate_bulk_build_derived_state, called below right
-                    # before readiness.
-                    bulk_build=True,
-                    prefetch_cache=effective_prefetch_cache,
-                    deadline_check=_check_pass_deadline if transaction is not None else None,
-                )
-            except RebuildDeadlineExceededError as exc:
-                # Mid-page interrupt: at least one cohort was durably
-                # committed (or none, if the very first cohort tripped it),
-                # but never the whole requested page. Do NOT advance the
-                # transaction's cursor/processed counters -- leaving them at
-                # their pre-pass values means the next pass re-derives from
-                # exactly the same source-order position. Re-applying any
-                # cohort this pass DID commit is a safe idempotent no-op
-                # (content-hash upsert), so this can never duplicate or skip
-                # a raw/cohort; it can only redo bounded work.
-                assert transaction is not None  # deadline_check is only wired when transaction is not None
-                pass_elapsed_s = time.perf_counter() - pass_started_at_s
-                transaction = generation_store.checkpoint_transaction(
-                    transaction,
-                    status="deferred",
-                    error=str(exc),
-                )
-                from polylogue.pipeline.services.process_pool import (
-                    parallel_threads_effective,
-                    resolve_parse_worker_count,
-                )
-
-                pass_cost = RebuildPassCost(
-                    selection_s=selection_elapsed_s,
-                    replay_s=pass_elapsed_s,
-                    checkpoint_s=0.0,
-                    pass_s=time.perf_counter() - pass_started_at_s,
-                    raws=selected_raw_count,
-                    bytes_in=sum(row[2] for row in page.rows) if page is not None else 0,
-                    processed_raws=transaction.processed_raw_count,
-                    processed_bytes=transaction.processed_blob_bytes,
-                    total_raws=raw_count,
-                    total_bytes=total_source_blob_bytes(root),
-                    free_threaded=parallel_threads_effective(),
-                    parse_workers=resolve_parse_worker_count(),
-                )
-                logger.info(
-                    "rebuild_pass_cost",
-                    generation_id=generation.generation_id,
-                    deferred_reason="pass-deadline-mid-replay",
-                    **pass_cost.to_dict(),
-                )
-                pass_receipt = RebuildIndexReceipt(
-                    archive_root=str(root),
-                    raw_session_count=raw_count,
-                    selected_raw_count=selected_raw_count,
-                    skipped_by_blob_limit_count=0,
-                    status="deferred",
-                    materialized=False,
-                    materialization={},
-                    generation=cast(dict[str, object], asdict(generation)),
-                    readiness={},
-                    # Zero-shaped like a normal replay dict (not merely a bare
-                    # marker) so every existing consumer that indexes
-                    # replay-dict keys unconditionally (the daemon-mode CLI
-                    # text formatter, the daemon HTTP route's raw
-                    # ``receipt.to_dict()`` response) keeps working: this pass
-                    # made no *measured* progress by design (see the "do not
-                    # advance the cursor" comment above), so reporting zeros
-                    # here is accurate, not merely a placeholder shape.
-                    replay={
-                        "scanned_raw_count": 0,
-                        "classified_full_count": 0,
-                        "replayed_logical_source_count": 0,
-                        "quarantined_raw_count": 0,
-                        "adoption_deferred_raw_count": 0,
-                        "authority_selection_expanded": True,
-                        "scheduled_raw_count": len(selected_raw_ids),
-                        "raw_batch_size": request.raw_batch_size,
-                        "ingest_workers": None,
-                        "parse_s": 0.0,
-                        "apply_s": 0.0,
-                        "stage_timings_s": {},
-                        "deferred_reason": "pass-deadline-mid-replay",
-                    },
-                    transaction=cast(dict[str, object], asdict(transaction)),
-                    timings_s=cast(dict[str, float], pass_cost.to_dict()),
-                )
-                generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
-                return pass_receipt
+                    pass_cost = RebuildPassCost(
+                        selection_s=selection_elapsed_s,
+                        replay_s=pass_elapsed_s,
+                        checkpoint_s=0.0,
+                        pass_s=time.perf_counter() - pass_started_at_s,
+                        raws=selected_raw_count,
+                        bytes_in=sum(row[2] for row in page.rows) if page is not None else 0,
+                        processed_raws=transaction.processed_raw_count,
+                        processed_bytes=transaction.processed_blob_bytes,
+                        total_raws=raw_count,
+                        total_bytes=total_source_blob_bytes(root),
+                        free_threaded=parallel_threads_effective(),
+                        parse_workers=resolve_parse_worker_count(),
+                    )
+                    logger.info(
+                        "rebuild_pass_cost",
+                        generation_id=generation.generation_id,
+                        deferred_reason="pass-deadline-mid-replay",
+                        **pass_cost.to_dict(),
+                    )
+                    pass_receipt = RebuildIndexReceipt(
+                        archive_root=str(root),
+                        raw_session_count=raw_count,
+                        selected_raw_count=selected_raw_count,
+                        skipped_by_blob_limit_count=0,
+                        status="deferred",
+                        materialized=False,
+                        materialization={},
+                        generation=cast(dict[str, object], asdict(generation)),
+                        readiness={},
+                        # Zero-shaped like a normal replay dict (not merely a bare
+                        # marker) so every existing consumer that indexes
+                        # replay-dict keys unconditionally (the daemon-mode CLI
+                        # text formatter, the daemon HTTP route's raw
+                        # ``receipt.to_dict()`` response) keeps working: this pass
+                        # made no *measured* progress by design (see the "do not
+                        # advance the cursor" comment above), so reporting zeros
+                        # here is accurate, not merely a placeholder shape.
+                        replay={
+                            "scanned_raw_count": 0,
+                            "classified_full_count": 0,
+                            "replayed_logical_source_count": 0,
+                            "quarantined_raw_count": 0,
+                            "adoption_deferred_raw_count": 0,
+                            "authority_selection_expanded": True,
+                            "scheduled_raw_count": len(selected_raw_ids),
+                            "raw_batch_size": request.raw_batch_size,
+                            "ingest_workers": None,
+                            "parse_s": 0.0,
+                            "apply_s": 0.0,
+                            "stage_timings_s": {},
+                            "deferred_reason": "pass-deadline-mid-replay",
+                        },
+                        transaction=cast(dict[str, object], asdict(transaction)),
+                        timings_s=cast(dict[str, float], pass_cost.to_dict()),
+                    )
+                    generation_store.save_pass_receipt(transaction.operation_id, pass_receipt.to_dict())
+                    return pass_receipt
             pass_elapsed_s = time.perf_counter() - pass_started_at_s
             processed_before = transaction.processed_raw_count if transaction is not None else None
             if selected_raw_ids and _should_refresh_generation_planner_statistics(

--- a/polylogue/maintenance/sharded_rebuild.py
+++ b/polylogue/maintenance/sharded_rebuild.py
@@ -1,0 +1,547 @@
+"""Parallel sharded generation build for from-empty index rebuilds.
+
+polylogue-pzxm: the single-writer invariant
+(``connection_profile.BULK_BUILD_WRITE_CONNECTION_PROFILE``'s
+``locking_mode=EXCLUSIVE`` rationale) protects an *owned inactive*
+generation with exactly one writer and zero readers until
+:meth:`~polylogue.storage.index_generation.IndexGenerationStore.promote`
+swaps the active symlink -- it is not load-bearing across *multiple*
+owned-inactive generations built concurrently, each with its own single
+writer. This module exploits that: split a rebuild pass's selected raw ids
+into ``shard_count`` buckets, build each bucket into its own owned inactive
+generation in parallel (:func:`_build_one_shard`), then fold every shard's
+``index.db`` into the pass's real target generation with one sequential
+ATTACH + ``INSERT OR REPLACE ... SELECT`` merge per table
+(:func:`merge_shards_into_target`), and finally re-run cross-session graph
+resolution over the merged generation (:func:`resolve_cross_shard_session_graph`)
+so a parent/child pair split across two shards still composes exactly like a
+single-writer replay would have produced.
+
+Non-goals (see polylogue-pzxm bead + lane brief): this module never touches
+the promote()/lease machinery itself, the online (non-from-empty) single
+writer contract, or ``sources/revision_backfill.py``'s replay-loop
+internals -- it calls the same public
+:func:`polylogue.maintenance.replay.rebuild_index_from_source` entry point
+every non-sharded rebuild pass already uses, once per shard, against a
+distinct owned inactive generation.
+
+Deferred surfaces are unaffected: ``bulk_build=True`` (passed to every shard
+replay, matching the non-sharded rebuild caller) leaves ``messages_fts``,
+``blocks_command_trigram``, ``action_pairs``, and ``delegation_facts`` empty
+throughout -- exactly like a single-writer bulk-build pass -- so those
+surfaces are never merged here; the existing archive-wide
+``_repopulate_bulk_build_derived_state`` terminal stage in
+``maintenance/rebuild_index.py`` repopulates them once, unchanged, from the
+merged ``blocks``/``messages``/``session_links`` content after this module
+returns.
+
+Measured honestly (``tests/benchmarks/test_sharded_rebuild.py``'s K=1/4/8
+sweep, synthetic corpus, see the polylogue-pzxm PR body for the exact
+numbers): at 96-400 synthetic raws sharding was SLOWER than the single-writer
+path, not faster -- K=4 measured 0.63-0.72x and K=8 measured 0.51-0.73x of
+the K=1 baseline. Per-shard generation bootstrap (a full schema DDL replay
+per shard), the merge's ``PRAGMA foreign_key_check``, and the post-merge
+per-session graph-resolution pass are fixed overheads that do not shrink
+with more shards, and this harness's synthetic payloads make the shardable
+apply-phase work too small to amortize them. Whether the real archive's
+apply-phase cost (graph_resolve alone measured ~156s real-run per the bead)
+is large enough to cross over into a net win is NOT yet demonstrated by this
+module -- it is the natural next measurement, not assumed here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
+from polylogue.config import Config
+from polylogue.logging import get_logger
+from polylogue.paths import render_root
+from polylogue.storage.sqlite.connection_profile import BULK_BUILD_WRITE_CONNECTION_PRAGMA_STATEMENTS
+
+if TYPE_CHECKING:
+    from polylogue.sources.revision_backfill import RawParsePrefetchCache
+    from polylogue.storage.index_generation import IndexGeneration, IndexGenerationStore
+
+logger = get_logger(__name__)
+
+#: Every table ``write_parsed_session_to_archive`` writes during a
+#: ``bulk_build=True`` replay pass, in the order they must be merged so
+#: FOREIGN KEY enforcement (deliberately disabled for the duration of the
+#: merge, see :func:`merge_shards_into_target`) never needs to matter --
+#: order is cosmetic here, correctness comes from the post-merge
+#: ``PRAGMA foreign_key_check``. Every one of these tables keys off
+#: content-derived identity (``session_id``/``message_id``/``block_id``
+#: generated columns, or an explicit composite PRIMARY KEY) -- see
+#: ``storage/sqlite/archive_tiers/index.py``'s ``CREATE TABLE`` statements --
+#: never a bare ``INTEGER PRIMARY KEY`` surrogate referenced elsewhere, so an
+#: ``INSERT OR REPLACE ... SELECT`` merge across independently-built shards
+#: is identity-safe: two shards that (via cohort-completeness expansion,
+#: see ``replay.rebuild_index_from_source``'s docstring) both replay the same
+#: raw converge on the same content-derived row, and REPLACE is a no-op.
+#:
+#: ``raw_revision_heads``/``raw_revision_applications`` are included even
+#: though they hold cohort-authority bookkeeping rather than session
+#: content, so a FUTURE incremental rebuild off the promoted generation
+#: still sees every raw this pass applied as applied -- omitting them would
+#: silently break ``--only-missing`` resumability for exactly the raws this
+#: pass sharded.
+MERGE_TABLES: tuple[str, ...] = (
+    "raw_revision_heads",
+    "raw_revision_applications",
+    "sessions",
+    "messages",
+    "blocks",
+    "session_links",
+    "session_events",
+    "session_agent_policies",
+    "attachments",
+    "attachment_refs",
+    "attachment_native_ids",
+    "paste_spans",
+    "file_edits",
+    "session_working_dirs",
+    "session_refs",
+    "repos",
+    "repo_checkouts",
+    "session_repos",
+    "session_commits",
+    "session_model_usage",
+    "session_provider_usage_events",
+    "web_content_constructs",
+    "threads",
+    "thread_sessions",
+    "session_tags",
+)
+
+#: The subset of :data:`MERGE_TABLES` the polylogue-pzxm correctness bar
+#: names explicitly ("byte-identical schema SHA, per-table row counts, and
+#: content SHA over ordered sessions/messages/blocks/session_links/
+#: action_pairs vs a sequential build"). ``action_pairs`` is deliberately
+#: NOT in ``MERGE_TABLES`` (bulk_build leaves it empty per-shard, populated
+#: only by the shared terminal repopulate stage) but IS part of the
+#: equivalence surface, since it is derived from the merged content and
+#: must still match byte-for-byte once that terminal stage runs.
+EQUIVALENCE_TABLES: tuple[str, ...] = ("sessions", "messages", "blocks", "session_links", "action_pairs")
+
+
+def _cohort_keys_for_raw_ids(
+    root: Path, raw_ids: list[str], *, prefetch_cache: RawParsePrefetchCache | None
+) -> dict[str, str]:
+    """Map each raw id to the revision-cohort key it must stay grouped by.
+
+    Two distinct cohort-crossing hazards exist, and only one has a cheap
+    pre-parse fix:
+
+    - Byte-growth revision chains (older/head members of the same logical
+      source) are grouped by ``raw_sessions.logical_source_key``/
+      ``source_path`` (``storage/sqlite/archive_tiers/source.py``) --
+      exactly what ``classify_untyped_full_revision_groups``
+      (revision_backfill.py, read only, not modified by this module) groups
+      candidates by before calling ``revision_replay.plan_revision_replay``.
+      Splitting a chain across two shards makes each shard's own census see
+      a lone candidate and ``plan_revision_replay`` raises (empirically
+      confirmed: "revision replay requires at least one candidate").
+      ``source_path``/``logical_source_key`` are available from ``source.db``
+      BEFORE any parse, since they are set at acquire/prior-classification
+      time.
+
+    - Ambiguous-identity pairs (two raws whose PARSED content both claim the
+      same ``f"{origin}:{provider_session_id}"``) are grouped by that parsed
+      identity, computed fresh every pass inside ``_parse_retained_raws``
+      (``membership_candidates``/``provisional_full_raw_ids`` in
+      revision_backfill.py) -- NOT available from ``source.db`` before a
+      parse on a from-empty rebuild's first pass, where
+      ``logical_source_key`` is still NULL for every raw. Splitting an
+      ambiguous pair across two shards makes each shard materialize its own
+      raw as an unambiguous session instead of correctly arbitrating the
+      conflict (empirically confirmed: sharded row counts exceeded
+      sequential row counts by exactly the split-pair count).
+
+    ``prefetch_cache`` (the SAME ``RawParsePrefetchCache``
+    ``_rebuild_index_from_source_owned`` already warms for every selected
+    raw id before this pass's replay -- see
+    ``rebuild_index.py::_warm_offline_prefetch_cache``) closes the second
+    gap for free: it was already going to parse every selected raw once
+    regardless of sharding, so reading its
+    :meth:`~RawParsePrefetchCache.peek_logical_keys` here costs nothing
+    extra and yields the REAL parsed identity, matching this bead's "threads
+    share parsed graphs" framing -- one shared parse feeds both cohort
+    partitioning and (via the same cache, still populated afterwards) each
+    shard's own replay. A raw id the cache does not cover (cache is ``None``,
+    admission-budget-rejected, or a multi-session bundle raw) falls back to
+    the ``source.db`` key, which is exact for chains but NOT for an
+    ambiguous pair split this way -- a known residual gap, see this
+    function's own docstring above and the polylogue-pzxm PR body.
+    """
+    if not raw_ids:
+        return {}
+    keys: dict[str, str] = dict(prefetch_cache.peek_logical_keys()) if prefetch_cache is not None else {}
+    missing = [raw_id for raw_id in raw_ids if raw_id not in keys]
+    if missing:
+        source_db = root / "source.db"
+        if source_db.exists():
+            placeholders = ",".join("?" for _ in missing)
+            with contextlib.closing(sqlite3.connect(f"file:{source_db}?mode=ro", uri=True, timeout=10.0)) as conn:
+                rows = conn.execute(
+                    f"SELECT raw_id, COALESCE(logical_source_key, source_path) FROM raw_sessions "
+                    f"WHERE raw_id IN ({placeholders})",
+                    missing,
+                ).fetchall()
+            keys.update({str(raw_id): str(cohort_key) for raw_id, cohort_key in rows})
+    return keys
+
+
+def shard_raw_ids(
+    root: Path,
+    raw_ids: list[str],
+    shard_count: int,
+    *,
+    prefetch_cache: RawParsePrefetchCache | None = None,
+) -> list[list[str]]:
+    """Deterministically partition ``raw_ids`` into ``shard_count`` buckets.
+
+    Partitions by revision-cohort key (see :func:`_cohort_keys_for_raw_ids`),
+    not bare ``raw_id`` -- every raw belonging to the same cohort is
+    guaranteed to land in the same bucket, so a bucket's shard-local replay
+    always sees a complete cohort, matching what a sequential replay of the
+    same raw ids would have seen. A raw id with no cohort evidence at all
+    (missing from both the prefetch cache and ``source.db``) falls back to
+    its own raw_id as a singleton cohort key. Hashing (not round-robin/
+    contiguous slicing) so bucket membership does not depend on query row
+    order, and empty buckets are dropped by the caller rather than spun up as
+    a no-op shard build.
+    """
+    if shard_count < 1:
+        raise ValueError("shard_count must be positive")
+    cohort_key_by_raw_id = _cohort_keys_for_raw_ids(root, raw_ids, prefetch_cache=prefetch_cache)
+    bucket_by_cohort_key: dict[str, int] = {}
+    buckets: list[list[str]] = [[] for _ in range(shard_count)]
+    for raw_id in raw_ids:
+        cohort_key = cohort_key_by_raw_id.get(raw_id, raw_id)
+        bucket = bucket_by_cohort_key.get(cohort_key)
+        if bucket is None:
+            digest = hashlib.sha256(cohort_key.encode("utf-8")).digest()
+            bucket = digest[0] % shard_count
+            bucket_by_cohort_key[cohort_key] = bucket
+        buckets[bucket].append(raw_id)
+    return buckets
+
+
+@dataclass(frozen=True, slots=True)
+class ShardBuildStats:
+    """Per-shard evidence folded into the aggregated receipt."""
+
+    generation_id: str
+    raw_count: int
+    replay: dict[str, object]
+    build_s: float
+
+
+async def _build_one_shard(
+    *,
+    generation_store: IndexGenerationStore,
+    source_snapshot: str,
+    raw_ids: list[str],
+    raw_batch_size: int,
+    prefetch_cache: RawParsePrefetchCache | None,
+) -> tuple[IndexGeneration, ShardBuildStats]:
+    """Replay one shard's raw ids into its own owned inactive generation."""
+    from polylogue.maintenance.replay import rebuild_index_from_source as replay_source
+
+    generation = generation_store.create(source_snapshot=source_snapshot)
+    generation_root = Path(generation.index_path).parent
+    config = Config(
+        archive_root=generation_root,
+        render_root=render_root(),
+        sources=[],
+        db_path=Path(generation.index_path),
+    )
+    started_at = time.perf_counter()
+    replay = await replay_source(
+        config,
+        raw_ids=raw_ids,
+        raw_batch_size=raw_batch_size,
+        ingest_workers=None,
+        materialize=True,
+        progress_callback=None,
+        owned_inactive_generation=(generation.generation_id, generation.owner_id),
+        bulk_fts=True,
+        bulk_build=True,
+        prefetch_cache=prefetch_cache,
+    )
+    build_s = time.perf_counter() - started_at
+    return generation, ShardBuildStats(
+        generation_id=generation.generation_id,
+        raw_count=len(raw_ids),
+        replay=replay,
+        build_s=build_s,
+    )
+
+
+def _open_merge_connection(index_path: Path, *, timeout: int) -> sqlite3.Connection:
+    conn = sqlite3.connect(index_path, timeout=timeout)
+    try:
+        for statement in BULK_BUILD_WRITE_CONNECTION_PRAGMA_STATEMENTS:
+            if statement.strip().upper() == "PRAGMA FOREIGN_KEYS = ON":
+                # Merge deliberately runs with FK enforcement OFF: a shard's
+                # own sessions table can reference a parent that only exists
+                # in ANOTHER shard's sessions table, and the ATTACH+INSERT
+                # merge order across shards/tables is not guaranteed to place
+                # parents before children within one INSERT...SELECT (SQLite
+                # checks IMMEDIATE foreign keys per row, not per statement).
+                # `merge_shards_into_target` re-enables enforcement and runs
+                # `PRAGMA foreign_key_check` before returning, so this is a
+                # scoped, verified relaxation, not a weakened invariant.
+                conn.execute("PRAGMA foreign_keys = OFF")
+                continue
+            conn.execute(statement)
+    except BaseException:
+        conn.close()
+        raise
+    return conn
+
+
+def _non_generated_columns(conn: sqlite3.Connection, table: str) -> list[str]:
+    """Column names to move in a merge, excluding GENERATED (STORED/VIRTUAL) columns.
+
+    ``INSERT INTO t SELECT * FROM other.t`` is NOT a reliable way to skip
+    generated columns across an ATTACHed database (unlike a same-connection
+    self-select, it does not consistently apply SQLite's implicit-column-list
+    narrowing -- observed empirically: ``sessions`` has two generated columns
+    (``session_id``, ``sort_key_ms``) and a cross-attach ``SELECT *`` raised
+    ``table sessions has 38 columns but 40 values were supplied``). Building
+    an explicit column list from ``PRAGMA table_xinfo`` (``hidden`` 2=VIRTUAL,
+    3=STORED) is correct regardless of that ATTACH-vs-self-select
+    inconsistency, and self-documents as schema changes add/remove generated
+    columns.
+    """
+    return [str(row[1]) for row in conn.execute(f"PRAGMA table_xinfo({table})").fetchall() if int(row[6]) not in (2, 3)]
+
+
+def merge_shards_into_target(target_index_path: Path, shard_index_paths: list[Path]) -> dict[str, int]:
+    """ATTACH every shard's ``index.db`` and fold its rows into the target.
+
+    Returns per-table total row counts written (across all shards, before
+    REPLACE de-duplication -- i.e. attempted rows, not necessarily the
+    target's final row count, which callers can read directly if needed).
+    Raises ``RuntimeError`` if the merged generation fails
+    ``PRAGMA foreign_key_check`` -- this is the load-bearing correctness
+    check for the FK-relaxed merge above.
+    """
+    from polylogue.storage.fts.sql import FTS_BULK_SESSION_WRITE_GUARD
+
+    row_counts: dict[str, int] = dict.fromkeys(MERGE_TABLES, 0)
+    aliases = [f"shard{i}" for i in range(len(shard_index_paths))]
+    with contextlib.closing(_open_merge_connection(target_index_path, timeout=600)) as conn:
+        conn.execute("PRAGMA busy_timeout = 600000")
+        attached: list[str] = []
+        try:
+            # polylogue-pzxm: messages_fts/blocks_command_trigram's INSERT/
+            # UPDATE/DELETE triggers on `blocks` are unconditional at the SQL
+            # level EXCEPT for this one guard row (`storage/fts/sql.py`'s
+            # `FTS_BULK_SESSION_WRITE_GUARD`, `NOT EXISTS (...)` in every
+            # trigger's WHEN clause) -- a normal per-session bulk_build write
+            # holds it only around that session's own block inserts. This
+            # merge inserts every shard's blocks in one connection with no
+            # such per-row scoping, so without holding the SAME guard for the
+            # whole merge, the target's triggers fire uncontrolled and leave
+            # messages_fts/blocks_command_trigram non-empty and inconsistent
+            # (empirically confirmed: merged messages_fts ended up with MORE
+            # rows than text-bearing blocks). Holding it here reproduces the
+            # exact invariant a sequential bulk_build replay already
+            # maintains (both derived stores stay empty until the shared
+            # terminal `_repopulate_bulk_build_derived_state` stage), so that
+            # stage's `resume_from_empty_message_index=True` precondition
+            # holds for the sharded path too.
+            conn.execute(
+                "INSERT OR IGNORE INTO derived_refresh_guard (guard_name) VALUES (?)", (FTS_BULK_SESSION_WRITE_GUARD,)
+            )
+            for alias, shard_path in zip(aliases, shard_index_paths, strict=True):
+                conn.execute(f"ATTACH DATABASE ? AS {alias}", (str(shard_path),))
+                attached.append(alias)
+            for table in MERGE_TABLES:
+                columns = _non_generated_columns(conn, table)
+                column_list = ", ".join(columns)
+                for alias in aliases:
+                    cursor = conn.execute(
+                        f"INSERT OR REPLACE INTO {table} ({column_list}) SELECT {column_list} FROM {alias}.{table}"
+                    )
+                    row_counts[table] += cursor.rowcount if cursor.rowcount > 0 else 0
+            conn.execute("DELETE FROM derived_refresh_guard WHERE guard_name = ?", (FTS_BULK_SESSION_WRITE_GUARD,))
+            conn.commit()
+            violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+            if violations:
+                raise RuntimeError(
+                    f"sharded rebuild merge produced {len(violations)} foreign-key violations "
+                    f"(first 10: {violations[:10]!r}); merged generation discarded by caller"
+                )
+        finally:
+            for alias in attached:
+                with contextlib.suppress(sqlite3.Error):
+                    conn.execute(f"DETACH DATABASE {alias}")
+        conn.execute("PRAGMA foreign_keys = ON")
+        conn.commit()
+    return row_counts
+
+
+def resolve_cross_shard_session_graph(target_index_path: Path) -> float:
+    """Re-run per-session graph resolution over every merged session.
+
+    Each shard's own replay already resolved links whose OTHER endpoint
+    existed within the same shard (via ``write.py``'s
+    ``_resolve_session_graph``, called per session at write time). A
+    parent/child pair split across two shards never had its counterpart
+    present during either shard's own replay, so ``session_links``/
+    ``parent_session_id``/``root_session_id`` for that pair are still
+    unresolved after :func:`merge_shards_into_target`. Re-running resolution
+    for every session in the merged generation closes that gap; it is safe
+    (not merely convenient) to do so because ``_resolve_session_graph`` is
+    idempotent and fast-paths sessions whose projection is already current
+    (``_root_projection_current`` in write.py), so already-intra-shard-
+    resolved sessions cost only the fast-path check, not a full re-resolve.
+
+    Returns the wall-clock seconds spent, folded into the aggregated
+    receipt's ``apply_s`` by the caller (this is single-writer, serialized
+    work -- it does not shard further).
+    """
+    from polylogue.storage.sqlite.archive_tiers.write import _resolve_session_graph
+
+    started_at = time.perf_counter()
+    with contextlib.closing(_open_merge_connection(target_index_path, timeout=600)) as conn:
+        conn.execute("PRAGMA busy_timeout = 600000")
+        conn.execute("PRAGMA foreign_keys = ON")
+        rows = conn.execute("SELECT session_id, native_id, origin FROM sessions ORDER BY session_id").fetchall()
+        signature_cache: dict[str, list[tuple[str, str]]] = {}
+        for session_id, native_id, origin in rows:
+            _resolve_session_graph(
+                conn,
+                session_id,
+                native_id,
+                origin,
+                cache=signature_cache,
+                add_timing=None,
+                bulk_fts=True,
+                bulk_build=True,
+            )
+        conn.commit()
+    return time.perf_counter() - started_at
+
+
+async def replay_selected_raw_ids_sharded(
+    *,
+    root: Path,
+    generation_store: IndexGenerationStore,
+    generation: IndexGeneration,
+    selected_raw_ids: list[str],
+    raw_batch_size: int,
+    shard_count: int,
+    prefetch_cache: RawParsePrefetchCache | None,
+) -> dict[str, object]:
+    """Replay ``selected_raw_ids`` into ``generation`` via ``shard_count`` parallel shards.
+
+    Drop-in replacement for a single ``replay.rebuild_index_from_source``
+    call targeting the SAME already-created ``generation`` -- callers (see
+    ``maintenance/rebuild_index.py``) keep every terminal stage
+    (planner-statistics refresh, ``_repopulate_bulk_build_derived_state``,
+    FTS parity, readiness, promote) unchanged; this function's only
+    contract is that ``generation.index_path`` ends up holding exactly what
+    a sequential replay of ``selected_raw_ids`` would have written to the
+    tables in :data:`EQUIVALENCE_TABLES`, after its terminal stage runs.
+
+    Shard generations are always discarded (``discard_if_inactive``) before
+    returning, success or failure -- they are scratch, never promotable.
+    """
+    buckets = [
+        bucket for bucket in shard_raw_ids(root, selected_raw_ids, shard_count, prefetch_cache=prefetch_cache) if bucket
+    ]
+    if not buckets:
+        return {
+            "scanned_raw_count": 0,
+            "classified_full_count": 0,
+            "replayed_logical_source_count": 0,
+            "quarantined_raw_count": 0,
+            "adoption_deferred_raw_count": 0,
+            "authority_selection_expanded": True,
+            "scheduled_raw_count": 0,
+            "raw_batch_size": raw_batch_size,
+            "ingest_workers": 0,
+            "parse_s": 0.0,
+            "apply_s": 0.0,
+            "stage_timings_s": {},
+            "shard_count": 0,
+        }
+    logger.info(
+        "sharded_rebuild_build_start",
+        generation_id=generation.generation_id,
+        shard_count=len(buckets),
+        selected_raw_count=len(selected_raw_ids),
+    )
+    build_results = await asyncio.gather(
+        *[
+            _build_one_shard(
+                generation_store=generation_store,
+                source_snapshot=generation.source_snapshot,
+                raw_ids=bucket,
+                raw_batch_size=raw_batch_size,
+                prefetch_cache=prefetch_cache,
+            )
+            for bucket in buckets
+        ]
+    )
+    shard_generations = [pair[0] for pair in build_results]
+    shard_stats = [pair[1] for pair in build_results]
+    try:
+        merge_started_at = time.perf_counter()
+        row_counts = merge_shards_into_target(
+            Path(generation.index_path), [Path(sg.index_path) for sg in shard_generations]
+        )
+        merge_s = time.perf_counter() - merge_started_at
+        graph_resolve_s = resolve_cross_shard_session_graph(Path(generation.index_path))
+    finally:
+        for shard_generation in shard_generations:
+            with contextlib.suppress(Exception):
+                generation_store.discard_if_inactive(shard_generation)
+    logger.info(
+        "sharded_rebuild_merge_complete",
+        generation_id=generation.generation_id,
+        shard_count=len(buckets),
+        merge_s=round(merge_s, 3),
+        graph_resolve_s=round(graph_resolve_s, 3),
+        row_counts=row_counts,
+    )
+    parse_s = max((cast(float, s.replay.get("parse_s", 0.0)) for s in shard_stats), default=0.0)
+    shard_apply_s = max((cast(float, s.replay.get("apply_s", 0.0)) for s in shard_stats), default=0.0)
+    apply_s = shard_apply_s + merge_s + graph_resolve_s
+    stage_timings_s: dict[str, float] = {"shard.merge_s": merge_s, "shard.graph_resolve_s": graph_resolve_s}
+    for stats in shard_stats:
+        stage_timings_s[f"shard.{stats.generation_id}.build_s"] = stats.build_s
+        for key, value in cast(dict[str, float], stats.replay.get("stage_timings_s", {})).items():
+            stage_timings_s[f"shard.{stats.generation_id}.{key}"] = value
+    ingest_workers = int(cast(int, shard_stats[0].replay.get("ingest_workers", 0))) if shard_stats else 0
+    return {
+        "scanned_raw_count": sum(cast(int, s.replay.get("scanned_raw_count", 0)) for s in shard_stats),
+        "classified_full_count": sum(cast(int, s.replay.get("classified_full_count", 0)) for s in shard_stats),
+        "replayed_logical_source_count": sum(
+            cast(int, s.replay.get("replayed_logical_source_count", 0)) for s in shard_stats
+        ),
+        "quarantined_raw_count": sum(cast(int, s.replay.get("quarantined_raw_count", 0)) for s in shard_stats),
+        "adoption_deferred_raw_count": sum(
+            cast(int, s.replay.get("adoption_deferred_raw_count", 0)) for s in shard_stats
+        ),
+        "authority_selection_expanded": True,
+        "scheduled_raw_count": len(selected_raw_ids),
+        "raw_batch_size": raw_batch_size,
+        "ingest_workers": ingest_workers,
+        "parse_s": round(parse_s, 6),
+        "apply_s": round(apply_s, 6),
+        "stage_timings_s": {key: round(value, 6) for key, value in stage_timings_s.items()},
+        "shard_count": len(buckets),
+        "shard_row_counts": row_counts,
+    }

--- a/polylogue/sources/revision_backfill.py
+++ b/polylogue/sources/revision_backfill.py
@@ -269,6 +269,34 @@ class RawParsePrefetchCache:
             self._inflight_bytes -= entry.payload_bytes
             return entry.sessions, entry.payload_bytes, entry.revision_kind
 
+    def peek_logical_keys(self) -> dict[str, str]:
+        """Non-destructive ``raw_id -> "{origin}:{provider_session_id}"`` map.
+
+        polylogue-pzxm: the sharded from-empty rebuild
+        (``maintenance/sharded_rebuild.py``) partitions raw ids by revision-
+        cohort BEFORE any shard consumes this cache with ``pop``, using the
+        exact same logical-key derivation ``_parse_retained_raws`` uses when
+        it writes ``membership_candidates``/``provisional_full_raw_ids``
+        (``f"{session.source_name.value}:{session.provider_session_id}"``),
+        so a byte-growth chain member or an ambiguous-identity pair never
+        gets scheduled onto two different shards, each of which would see
+        only a partial candidate set and reach a wrong (or crashing)
+        classification. Unlike ``pop``, this never removes an entry or
+        touches budget accounting -- reading it does not consume the cache
+        for whichever shard's own replay pops these raw ids afterwards.
+        Sessions with more than one parsed logical unit (bundle raws) are
+        skipped: sharding falls back to that raw id's own ``source_path`` for
+        those, matching pre-classification behavior for any raw this cache
+        does not cover.
+        """
+        with self._lock:
+            keys: dict[str, str] = {}
+            for raw_id, entry in self._entries.items():
+                if len(entry.sessions) == 1:
+                    session = entry.sessions[0]
+                    keys[raw_id] = f"{session.source_name.value}:{session.provider_session_id}"
+            return keys
+
     def content_len(self) -> int:
         """Number of distinct content-cache entries currently resident."""
         with self._lock:

--- a/tests/benchmarks/test_sharded_rebuild.py
+++ b/tests/benchmarks/test_sharded_rebuild.py
@@ -1,0 +1,240 @@
+"""Sharded from-empty index rebuild: equivalence proof + K-sweep benchmark
+(polylogue-pzxm).
+
+Two things live here, both driving the REAL rebuild engine end to end
+(``rebuild_index_from_source_sync``, the same function the offline CLI and
+daemon bulk-rebuild call -- no reimplementation), against the same
+structurally-representative synthetic corpus
+``tests/infra/rebuild_cost_model.py`` builds for the rebuild-cost harness
+(polylogue-623q/o56w):
+
+- :func:`test_sharded_build_matches_sequential_build` -- the bead's
+  correctness bar: byte-identical schema SHA, per-table row counts, and
+  content SHA over ordered ``sessions``/``messages``/``blocks``/
+  ``session_links``/``action_pairs`` between a ``shard_count=1`` (sequential)
+  and a ``shard_count=4`` (sharded) rebuild of the SAME source corpus --
+  the PR #3469 "MANIFESTS IDENTICAL" pattern (see
+  ``tests/unit/sources/test_revision_backfill.py``'s
+  ``_index_content_manifest`` for the prior art this extends with hashing
+  and a wider table set).
+- :func:`test_sharded_build_k_sweep_benchmark` -- an honest K=1/4/8 wall-clock
+  comparison on the harness fixture. This is NOT run against the live
+  archive (forbidden by the lane brief); it is a small, CI-fast synthetic
+  corpus, so the reported ratios are directional evidence for the shardable
+  portion of a rebuild pass, not a promise about the live 41k-raw archive.
+
+Both tests build the corpus ONCE via ``build_stratum_sample_corpus`` (fully
+deterministic, see its docstring) and then physically copy the archive root
+before each rebuild variant, so "same source" is a filesystem fact, not an
+assumption about corpus-generation determinism holding across two calls.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import sqlite3
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+from polylogue.core.enums import Provider
+from polylogue.maintenance.rebuild_index import RebuildIndexRequest, rebuild_index_from_source_sync
+from tests.infra.rebuild_cost_model import Stratum, build_stratum_sample_corpus
+
+#: The bead's named correctness surface, in composite-primary-key order so a
+#: row-for-row comparison is well-defined without depending on SQLite's
+#: physical row order (which ATTACH+INSERT merge does not preserve).
+_EQUIVALENCE_TABLE_ORDER: dict[str, str] = {
+    "sessions": "session_id",
+    "messages": "message_id",
+    "blocks": "block_id",
+    "session_links": "src_session_id, dst_origin, dst_native_id, link_type",
+    "action_pairs": "session_id, tool_use_block_id",
+}
+
+
+#: Every table `polylogue.maintenance.sharded_rebuild.MERGE_TABLES` copies
+#: across shards, checked for row-count parity (cheap, catches a merge
+#: silently dropping or duplicating rows in a table content-hashing doesn't
+#: cover). Mirrors that module's table list; imported by name below rather
+#: than duplicated so a future table addition there is a single edit.
+def _merge_table_names() -> tuple[str, ...]:
+    from polylogue.maintenance.sharded_rebuild import MERGE_TABLES
+
+    return MERGE_TABLES
+
+
+def _schema_sha(index_db: Path) -> str:
+    with sqlite3.connect(f"file:{index_db}?mode=ro", uri=True) as conn:
+        rows = conn.execute(
+            "SELECT type, name, sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY type, name"
+        ).fetchall()
+    digest = hashlib.sha256()
+    for row in rows:
+        for value in row:
+            digest.update(str(value).encode("utf-8"))
+            digest.update(b"\0")
+        digest.update(b"\n")
+    return digest.hexdigest()
+
+
+def _table_row_counts(index_db: Path, tables: tuple[str, ...]) -> dict[str, int]:
+    with sqlite3.connect(f"file:{index_db}?mode=ro", uri=True) as conn:
+        return {table: int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]) for table in tables}
+
+
+def _content_sha(index_db: Path) -> dict[str, str]:
+    """Per-table content SHA over ordered rows -- the PR #3469 currency,
+    extended from ``_index_content_manifest``'s plain-equality dict compare
+    to a hash so the fixture's row payload never has to live in this
+    process's memory at CI runner scale.
+    """
+    digests: dict[str, str] = {}
+    with sqlite3.connect(f"file:{index_db}?mode=ro", uri=True) as conn:
+        for table, order in _EQUIVALENCE_TABLE_ORDER.items():
+            digest = hashlib.sha256()
+            for row in conn.execute(f"SELECT * FROM {table} ORDER BY {order}"):
+                for value in row:
+                    digest.update(repr(value).encode("utf-8"))
+                    digest.update(b"\0")
+                digest.update(b"\n")
+            digests[table] = digest.hexdigest()
+    return digests
+
+
+@contextmanager
+def _archive_root_env(archive_root: Path) -> Iterator[None]:
+    prior = os.environ.get("POLYLOGUE_ARCHIVE_ROOT")
+    os.environ["POLYLOGUE_ARCHIVE_ROOT"] = str(archive_root)
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop("POLYLOGUE_ARCHIVE_ROOT", None)
+        else:
+            os.environ["POLYLOGUE_ARCHIVE_ROOT"] = prior
+
+
+def _build_corpus(tmp_path: Path, *, sample_n: int) -> Path:
+    stratum = Stratum(
+        "claude-code-pzxm",
+        Provider.CLAUDE_CODE,
+        count=sample_n,
+        total_bytes=sample_n * 4000,
+        # Deliberately non-zero: a fork/chain member split across two
+        # shards by the hash partition is exactly the "hard part" the
+        # polylogue-pzxm bead calls out (cohort completeness/authority
+        # arbitration must not depend on which shard a raw landed in).
+        chain_fraction=0.25,
+        ambiguous_fraction=0.25,
+    )
+    source_root = tmp_path / "source-corpus"
+    build_stratum_sample_corpus(source_root, stratum, sample_n=sample_n)
+    return source_root
+
+
+def _rebuild(archive_root: Path, *, shard_count: int, raw_batch_size: int) -> float:
+    with _archive_root_env(archive_root):
+        started_at = time.perf_counter()
+        receipt = rebuild_index_from_source_sync(
+            RebuildIndexRequest(
+                archive_root=archive_root,
+                promote=True,
+                raw_batch_size=raw_batch_size,
+                shard_count=shard_count,
+            )
+        )
+        elapsed_s = time.perf_counter() - started_at
+    assert receipt.status == "replayed", receipt.to_dict()
+    return elapsed_s
+
+
+@pytest.mark.benchmark
+def test_sharded_build_matches_sequential_build(tmp_path: Path) -> None:
+    sample_n = 48
+    source_root = _build_corpus(tmp_path, sample_n=sample_n)
+
+    sequential_root = tmp_path / "sequential"
+    sharded_root = tmp_path / "sharded"
+    shutil.copytree(source_root, sequential_root)
+    shutil.copytree(source_root, sharded_root)
+
+    _rebuild(sequential_root, shard_count=1, raw_batch_size=sample_n)
+    _rebuild(sharded_root, shard_count=4, raw_batch_size=sample_n)
+
+    from polylogue.storage.archive_identity import ArchiveLocation
+
+    sequential_index = ArchiveLocation.resolve(sequential_root).active_index_path
+    sharded_index = ArchiveLocation.resolve(sharded_root).active_index_path
+
+    # 1. Byte-identical schema.
+    schema_sha_sequential = _schema_sha(sequential_index)
+    schema_sha_sharded = _schema_sha(sharded_index)
+    assert schema_sha_sharded == schema_sha_sequential
+
+    # 2. Per-table row counts across every table the shard merge touches.
+    merge_tables = _merge_table_names()
+    counts_sequential = _table_row_counts(sequential_index, merge_tables)
+    counts_sharded = _table_row_counts(sharded_index, merge_tables)
+    assert counts_sharded == counts_sequential
+    # Sanity floor: the corpus actually produced content in the tables that
+    # matter, so an accidentally-empty merge could never pass this trivially.
+    assert counts_sequential["sessions"] > 0
+    assert counts_sequential["messages"] > 0
+    # Not session_links > 0: this corpus's chain_fraction/ambiguous_fraction
+    # produce revision-authority cohorts (byte-growth/ambiguous-identity
+    # conflicts within ONE logical session), not parent/child session forks
+    # -- session_links coverage for the cross-shard graph-resolution "hard
+    # part" lives in tests/unit/maintenance/test_sharded_rebuild.py instead,
+    # via a direct write_parsed_session_to_archive fork scenario.
+
+    # 3. Content SHA over the bead-named equivalence tables (action_pairs
+    #    included: empty per-shard under bulk_build, populated only by the
+    #    shared terminal repopulate stage both paths run unchanged).
+    content_sha_sequential = _content_sha(sequential_index)
+    content_sha_sharded = _content_sha(sharded_index)
+    assert content_sha_sharded == content_sha_sequential
+    for table in _EQUIVALENCE_TABLE_ORDER:
+        assert content_sha_sharded[table] == content_sha_sequential[table], table
+
+
+@pytest.mark.benchmark
+def test_sharded_build_k_sweep_benchmark(tmp_path: Path) -> None:
+    """Honest K=1/4/8 wall-clock comparison on the harness fixture.
+
+    No speedup threshold is asserted: the lane brief's instruction is to
+    report the measured numbers, including a smaller-than-projected win, not
+    to gate on a projection. See this test's printed report for the numbers
+    from the run that produced them.
+    """
+    sample_n = 96
+    source_root = _build_corpus(tmp_path, sample_n=sample_n)
+
+    elapsed_by_k: dict[int, float] = {}
+    for k in (1, 4, 8):
+        root = tmp_path / f"k{k}"
+        shutil.copytree(source_root, root)
+        elapsed_by_k[k] = _rebuild(root, shard_count=k, raw_batch_size=sample_n)
+
+    baseline = elapsed_by_k[1]
+    report_lines = [
+        f"polylogue-pzxm K-sweep ({sample_n} synthetic raws, chain_fraction=0.25, ambiguous_fraction=0.25):",
+    ]
+    for k in (1, 4, 8):
+        speedup = baseline / elapsed_by_k[k] if elapsed_by_k[k] > 0 else float("nan")
+        report_lines.append(f"  K={k}: {elapsed_by_k[k]:.3f}s (speedup vs K=1: {speedup:.2f}x)")
+    report = "\n".join(report_lines)
+    print("\n" + report)
+
+    # Sanity floor only: every configuration must complete and produce a
+    # positive measurement -- this is the harness proving it engaged
+    # sharding at all (K=4/8 shard_count actually took the sharded_rebuild
+    # path -- see rebuild_index.py's dispatch on
+    # `shard_count > 1 and len(selected_raw_ids) >= shard_count`), not a
+    # performance gate.
+    assert all(elapsed > 0 for elapsed in elapsed_by_k.values())

--- a/tests/unit/maintenance/test_sharded_rebuild.py
+++ b/tests/unit/maintenance/test_sharded_rebuild.py
@@ -1,0 +1,209 @@
+"""Sharded from-empty index rebuild (polylogue-pzxm).
+
+Two things are tested at the function level here (fast, no full rebuild
+engine involved):
+
+- :func:`shard_raw_ids` -- deterministic, exhaustive, non-overlapping
+  partitioning.
+- The cross-shard hard part the bead calls out explicitly: a parent/child
+  pair whose two sessions are written into DIFFERENT shard databases never
+  gets to resolve `session_links`/`parent_session_id`/`root_session_id`
+  during either shard's own replay (the counterpart row does not exist in
+  that shard yet). :func:`merge_shards_into_target` +
+  :func:`resolve_cross_shard_session_graph` must produce the exact same
+  resolved state a single-writer replay of both sessions (in either order)
+  would have produced.
+
+The full engine-level equivalence proof (sequential vs. sharded
+``rebuild_index_from_source_sync``, PR #3469 MANIFESTS IDENTICAL pattern) and
+the K=4/8 benchmark live in ``tests/benchmarks/test_sharded_rebuild.py`` --
+both drive the real rebuild engine end to end and are slower.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import BlockType, BranchType, Provider
+from polylogue.maintenance.sharded_rebuild import (
+    merge_shards_into_target,
+    resolve_cross_shard_session_graph,
+    shard_raw_ids,
+)
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    initialize_archive_tier(conn, ArchiveTier.INDEX)
+    return conn
+
+
+def test_shard_raw_ids_is_deterministic_exhaustive_and_disjoint(tmp_path: Path) -> None:
+    raw_ids = [f"raw-{i}" for i in range(200)]
+    # No source.db at tmp_path -- shard_raw_ids falls back to raw_id as its
+    # own cohort key, exercising the no-cohort-evidence path deliberately.
+    first = shard_raw_ids(tmp_path, raw_ids, 8)
+    second = shard_raw_ids(tmp_path, raw_ids, 8)
+    assert first == second  # deterministic: same hash, same bucket every call
+    assert len(first) == 8
+    flattened = [raw_id for bucket in first for raw_id in bucket]
+    assert sorted(flattened) == sorted(raw_ids)  # exhaustive
+    assert len(set(flattened)) == len(raw_ids)  # disjoint (no duplication)
+    # Every bucket gets some share of a 200-item population across 8 buckets
+    # (not a strict balance guarantee, but a degenerate all-in-one-bucket
+    # hash would be a real bug worth catching here).
+    assert all(bucket for bucket in first)
+
+
+def test_shard_raw_ids_rejects_non_positive_shard_count(tmp_path: Path) -> None:
+    import pytest
+
+    with pytest.raises(ValueError, match="shard_count"):
+        shard_raw_ids(tmp_path, ["a"], 0)
+
+
+def _parent_session() -> ParsedSession:
+    return ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id="parent-session",
+        updated_at="2026-01-01T00:00:01+00:00",
+        messages=[
+            ParsedMessage(
+                provider_message_id="p1",
+                role=Role.USER,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="parent")],
+            )
+        ],
+    )
+
+
+def _child_session() -> ParsedSession:
+    return ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id="child-session",
+        parent_session_provider_id="parent-session",
+        branch_type=BranchType.SIDECHAIN,
+        updated_at="2026-01-01T00:00:02+00:00",
+        messages=[
+            ParsedMessage(
+                provider_message_id="c1",
+                role=Role.USER,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="child")],
+            )
+        ],
+    )
+
+
+def test_cross_shard_parent_child_resolves_after_merge(tmp_path: Path) -> None:
+    """The polylogue-pzxm 'hard part': a fork split across two shards.
+
+    Shard A gets only the parent; shard B gets only the child. Neither
+    shard's own replay can resolve the link (the counterpart row does not
+    exist locally), matching
+    ``test_archive_tiers_writer_stores_unresolved_link_when_parent_absent``'s
+    single-writer baseline for a still-missing parent. After merge + one
+    ``resolve_cross_shard_session_graph`` pass, the result must match
+    ``test_archive_tiers_writer_resolves_parent_link_when_parent_already_exists``'s
+    single-writer baseline for an already-present parent.
+    """
+    shard_a = tmp_path / "shard-a" / "index.db"
+    shard_b = tmp_path / "shard-b" / "index.db"
+    shard_a.parent.mkdir(parents=True)
+    shard_b.parent.mkdir(parents=True)
+
+    conn_a = _connect(shard_a)
+    parent_id = write_parsed_session_to_archive(conn_a, _parent_session(), bulk_fts=True, bulk_build=True)
+    conn_a.commit()
+    conn_a.close()
+
+    conn_b = _connect(shard_b)
+    child_id = write_parsed_session_to_archive(conn_b, _child_session(), bulk_fts=True, bulk_build=True)
+    conn_b.commit()
+    child_row_before = conn_b.execute(
+        "SELECT parent_session_id, root_session_id FROM sessions WHERE session_id = ?", (child_id,)
+    ).fetchone()
+    link_row_before = conn_b.execute(
+        "SELECT resolved_dst_session_id FROM session_links WHERE src_session_id = ?", (child_id,)
+    ).fetchone()
+    conn_b.close()
+
+    # Sanity: within its own shard, the child's link is genuinely unresolved
+    # -- this is the gap the merge + resolve pass must close, not a no-op.
+    assert child_row_before["parent_session_id"] is None
+    assert link_row_before["resolved_dst_session_id"] is None
+
+    target = tmp_path / "target" / "index.db"
+    target.parent.mkdir(parents=True)
+    conn_target = _connect(target)
+    conn_target.commit()
+    conn_target.close()
+
+    merge_shards_into_target(target, [shard_a, shard_b])
+    resolve_cross_shard_session_graph(target)
+
+    with sqlite3.connect(target) as conn:
+        conn.row_factory = sqlite3.Row
+        child_row = conn.execute(
+            "SELECT parent_session_id, root_session_id, branch_type FROM sessions WHERE session_id = ?",
+            (child_id,),
+        ).fetchone()
+        link_row = conn.execute(
+            "SELECT resolved_dst_session_id, status FROM session_links WHERE src_session_id = ?",
+            (child_id,),
+        ).fetchone()
+        thread_rows = conn.execute(
+            "SELECT session_id, position FROM thread_sessions WHERE thread_id = ? ORDER BY position",
+            (parent_id,),
+        ).fetchall()
+
+    assert dict(child_row) == {
+        "parent_session_id": parent_id,
+        "root_session_id": parent_id,
+        "branch_type": "sidechain",
+    }
+    assert dict(link_row) == {"resolved_dst_session_id": parent_id, "status": None}
+    assert [dict(row) for row in thread_rows] == [
+        {"session_id": parent_id, "position": 0},
+        {"session_id": child_id, "position": 1},
+    ]
+
+
+def test_merge_shards_into_target_raises_on_foreign_key_violation(tmp_path: Path) -> None:
+    """A shard whose merged content would dangle an FK must fail loudly, not silently promote."""
+    import pytest
+
+    shard_a = tmp_path / "shard-a" / "index.db"
+    shard_a.parent.mkdir(parents=True)
+    conn_a = _connect(shard_a)
+    write_parsed_session_to_archive(conn_a, _child_session(), bulk_fts=True, bulk_build=True)
+    conn_a.commit()
+    # Corrupt the shard by pointing the child's session_links row at a
+    # resolved parent that does not exist in ANY shard -- this must never
+    # happen from a real replay (resolution only ever sets
+    # resolved_dst_session_id to an existing row's id), but proves the
+    # foreign_key_check safety net actually fires rather than being dead
+    # code.
+    conn_a.execute("PRAGMA foreign_keys = OFF")
+    conn_a.execute(
+        "UPDATE sessions SET parent_session_id = 'claude-code-session:missing-parent' WHERE native_id = ?",
+        ("child-session",),
+    )
+    conn_a.commit()
+    conn_a.close()
+
+    target = tmp_path / "target" / "index.db"
+    target.parent.mkdir(parents=True)
+    conn_target = _connect(target)
+    conn_target.commit()
+    conn_target.close()
+
+    with pytest.raises(RuntimeError, match="foreign-key violations"):
+        merge_shards_into_target(target, [shard_a])


### PR DESCRIPTION
## Summary

From-empty index rebuilds (`rebuild_index_from_source_sync`) currently replay every source raw through one SQLite writer end to end. This PR adds an opt-in sharded build path: split a rebuild pass's selected raw ids across N owned-inactive generations, replay each in parallel, merge the results into the real target generation, then let the existing terminal stages (bulk-build repopulate, FTS parity, readiness, promote) run unchanged.

## Problem

`storage/sqlite/connection_profile.py`'s `BULK_BUILD_WRITE_CONNECTION_PROFILE` docstring states the EXCLUSIVE-locking rationale: an owned INACTIVE generation has exactly one writer and zero readers until `promote()` swaps the active symlink. That single-writer contract is per-generation, not archive-wide — nothing prevents building several owned-inactive generations concurrently and merging them before promotion. `polylogue-pzxm` re-verified this premise and scoped Lever B: parallel sharded generation build for the from-empty rebuild route, explicitly deferred from an earlier session as high engineering effort rather than half-attempted.

No baseline profiling number is claimed here beyond what the honest K-sweep benchmark below reports — the lane's own measurement is the evidence.

## Solution

- **`polylogue/maintenance/sharded_rebuild.py`** (new module):
  - `shard_raw_ids` partitions raw ids by **revision-cohort key**, not bare raw id. Two correctness hazards required this instead of naive hashing:
    - Byte-growth revision chains (older/head members of one logical source) are grouped by `raw_sessions.logical_source_key`/`source_path` — the same key `classify_untyped_full_revision_groups` groups by. Splitting a chain across shards crashed `revision_replay.plan_revision_replay` ("revision replay requires at least one candidate") — confirmed empirically before the fix.
    - Ambiguous-identity pairs (two raws whose *parsed* content both claim the same `origin:provider_session_id`) are grouped by that parsed identity, which does not exist in `source.db` before a first-pass parse. Splitting a pair across shards let each shard materialize its own raw as an unambiguous session — confirmed empirically (sharded row counts exceeded sequential by exactly the split-pair count) before the fix.
  - `_build_one_shard` replays one shard's raw ids into its own owned-inactive generation via the **existing** `replay.rebuild_index_from_source` entry point (no reimplementation), `bulk_fts=True, bulk_build=True` — identical to the non-sharded path.
  - `merge_shards_into_target` ATTACHes every shard's `index.db` and does one `INSERT OR REPLACE ... SELECT` per table (explicit non-generated column list via `PRAGMA table_xinfo` — `SELECT *` across an ATTACHed database does NOT reliably skip generated columns, confirmed empirically), with FK enforcement scoped OFF for the merge and verified via `PRAGMA foreign_key_check` before returning.
  - `resolve_cross_shard_session_graph` re-runs `write.py`'s `_resolve_session_graph` over every merged session — closes the case where a parent/child pair split across two shards never saw each other during shard-local replay (idempotent/fast-pathing, so already-resolved sessions cost only a check).
- **`polylogue/sources/revision_backfill.py`**: added `RawParsePrefetchCache.peek_logical_keys()` — a small, read-only accessor (never pops, never touches budget accounting) exposing the parsed `origin:provider_session_id` for every currently-cached entry. This is the "smallest possible hook" the lane brief authorized for exactly this seam: the SAME cache `_warm_offline_prefetch_cache` already builds for every non-sharded pass is reused to derive cohort keys for the ambiguous-pair hazard above, at zero extra parse cost.
- **`polylogue/maintenance/rebuild_index.py`**: `RebuildIndexRequest.shard_count: int = 1` (default keeps every existing caller on the unchanged single-writer path); dispatches to the sharded path only when `shard_count > 1 and len(selected_raw_ids) >= shard_count`.
- **`polylogue/cli/commands/maintenance/_rebuild_index.py`**: `--shard-count` option on `rebuild-index`, local-execution only (rejected with `--daemon`).

Non-goals honored per the lane brief: `promote()`/lease semantics and the online (non-from-empty) single-writer contract are untouched; `storage/repair.py` was not touched (another lane owns it) — only a public function already imported by `replay.py` is called, nothing new added there.

## Verification

```
devtools test tests/unit/maintenance/test_sharded_rebuild.py tests/benchmarks/test_sharded_rebuild.py
# 6 passed in 11.57s
```

- `test_sharded_build_matches_sequential_build` — the PR #3469 "MANIFESTS IDENTICAL" pattern: schema SHA, per-table row counts across every merged table, and content SHA over ordered `sessions`/`messages`/`blocks`/`session_links`/`action_pairs`, `shard_count=1` vs `shard_count=4` on the same synthetic corpus (`tests/infra/rebuild_cost_model.py`'s harness, `chain_fraction=0.25, ambiguous_fraction=0.25` to exercise the cohort hazards above). All match exactly.
- `test_cross_shard_parent_child_resolves_after_merge` — the session-graph "hard part" proven directly: a parent written only to shard A, a child (with `parent_session_provider_id`) written only to shard B; each shard's own replay leaves the link genuinely unresolved (asserted); after `merge_shards_into_target` + `resolve_cross_shard_session_graph` the child's `parent_session_id`/`root_session_id`/`session_links.resolved_dst_session_id`/`thread_sessions` all match the single-writer "parent already exists" baseline exactly.
- `test_merge_shards_into_target_raises_on_foreign_key_violation` — proves the `PRAGMA foreign_key_check` safety net actually fires, not dead code.
- `test_sharded_build_k_sweep_benchmark` — honest K=1/4/8 measurement (`-s` output):
  ```
  polylogue-pzxm K-sweep (96 synthetic raws, chain_fraction=0.25, ambiguous_fraction=0.25):
    K=1: 1.251s (speedup vs K=1: 1.00x)
    K=4: 1.979s (speedup vs K=1: 0.63x)
    K=8: 1.715s (speedup vs K=1: 0.73x)
  ```
  An additional ad hoc run at N=400 raws showed the same direction (K=4: 0.72x, K=8: 0.51x). **Sharding was slower, not faster, at this fixture's scale.** Per-shard generation bootstrap (full schema DDL per shard), the merge's `PRAGMA foreign_key_check`, and the post-merge graph-resolution pass are fixed overheads that don't shrink with more shards, and this harness's small synthetic payloads don't give the shardable apply-phase work enough mass to amortize them. Whether the real archive's apply-phase cost (the bead cites `graph_resolve` alone at ~156s real-run) crosses over into a net win is **not demonstrated by this PR** — see Follow-ups.
- `devtools verify --quick`: exit 0 (format, lint, mypy --strict, render all --check, hash-boundary-census after registering the new `shard_raw_ids` cohort-key hash site as `classification: identifier`, all other quick-gate checks).
- Pre-existing, unrelated failure noted (not caused by this change, confirmed via `git show HEAD:<path>` byte-identical to the working copy): `tests/unit/sources/test_revision_backfill.py::test_parse_one_still_replays_real_claude_code_sessions_with_no_path_rule` fails in isolation on a clean checkout of this branch's parent commit.

## AC matrix (against the polylogue-pzxm bead's stated shape)

| AC | Status |
| --- | --- |
| K shard index databases built in parallel, bulk-build pragma profile | Satisfied — `_build_one_shard` via `IndexGenerationStore.create` (bulk-build profile automatic for an owned-inactive generation) + `asyncio.gather` |
| Sequential merge via ATTACH + INSERT...SELECT, FTS/trigram/action_pairs deferred to existing repopulate | Satisfied — `merge_shards_into_target`; those four surfaces are never merged, left to the unchanged `_repopulate_bulk_build_derived_state` |
| Cross-session work (graph_resolve, session_links resolution) runs post-merge | Satisfied — `resolve_cross_shard_session_graph` |
| Correctness bar: byte-identical schema SHA, row counts, content SHA vs sequential | Satisfied — `test_sharded_build_matches_sequential_build` |
| K=4/8 benchmark, report honestly | Satisfied — reported above; the win is smaller than projected (negative) at this fixture's scale |
| Don't touch promote()/lease semantics or online single-writer contract | Satisfied — untouched |
| Don't touch `revision_backfill.py` replay-loop internals / `storage/repair.py` | `storage/repair.py` untouched. `revision_backfill.py` got one small, explicitly-authorized hook (`peek_logical_keys`, read-only, additive) — the lane brief pre-authorized "the smallest possible hook" for exactly this seam |

## Follow-ups

- Whether sharding nets a real win on archive-scale apply-phase cost (not this synthetic fixture) is unmeasured. A follow-up should profile against a large synthetic corpus with a bigger per-raw apply cost (or, cautiously, an anonymized/structural slice closer to the real archive's shape) to find the actual crossover K and raw-count threshold before recommending `--shard-count` for a real from-empty rebuild.
- Per-shard generation bootstrap cost (full DDL replay per shard) is a candidate optimization if a real win is found to exist at larger scale: a pre-bootstrapped empty-schema template file copied per shard instead of re-executing the DDL could cut fixed overhead.

## Anti-vacuity

Production caller: `polylogue.maintenance.rebuild_index._rebuild_index_from_source_owned` (the same function `rebuild_index_from_source_sync` — used by the offline `rebuild-index` CLI command and the daemon's bulk-rebuild loop — calls for every from-empty rebuild pass) dispatches to `sharded_rebuild.replay_selected_raw_ids_sharded` when `request.shard_count > 1`. The `--shard-count` CLI option on `polylogue ops maintenance rebuild-index` is the real end-user route.

Mutation that fails the equivalence test: removing the `derived_refresh_guard` hold in `merge_shards_into_target` (so `messages_fts`/`blocks_command_trigram` triggers fire uncontrolled during the merge) reproduces the exact failure observed during development — `messages_fts` row count exceeds text-block count, and the terminal readiness check's `search` surface reports `messages_fts_row_mismatch`, which `test_sharded_build_matches_sequential_build`'s underlying `rebuild_index_from_source_sync` call raises on (`RuntimeError: ... not exact-ready; blocked surfaces: search`). Reverting `shard_raw_ids` to partition by bare `raw_id` (instead of revision-cohort key) reproduces the other observed failure: sharded `sessions`/`messages`/`blocks` row counts exceed sequential by exactly the split ambiguous-pair count, failing the row-count-parity assertion.

Ref polylogue-pzxm
