### PR TITLE
feat(devtools): verify-worktree check + lane-brief prior-satisfaction section

### DIFF
--- a/.agent/CONVENTIONS.md
+++ b/.agent/CONVENTIONS.md
@@ -71,8 +71,23 @@ bead's cited facts against master before coding.
 
 ## Execution Tactics
 
-- **Async where the harness allows**: long test runs and imports go to
-  background execution; do light work (reads, bead edits) while they run.
+- **Async is coordinator-only.** An interactive/coordinator session may
+  background long test runs and imports and do light work while they run.
+  Dispatched lane agents (worktree subagents) must run every command
+  synchronously in their own foreground turn — never launch a background job
+  and idle-wait on it across turns (2026-08-01: three lanes each stalled for
+  multiple turns "waiting for the background job", burning wall-clock and
+  coordinator attention until manually interrupted).
+- **Dispatch hygiene (coordinator).** Immediately after spawning a
+  worktree-isolated lane, run
+  `devtools workspace verify-worktree <path> --expect-branch <branch>` before
+  trusting anything the lane reports — a 2026-08-01 dispatch silently ran in
+  the main checkout and left ~1700 uncommitted lines in the live tree. The
+  same check warns when the worktree's frozen `.beads/issues.jsonl` has gone
+  stale relative to the main checkout (any bd invocation or checkout hook in
+  that worktree can then time-machine live bead state — polylogue-2ara);
+  prefer lanes that make no bd writes at all, reporting bead-state changes
+  back to the coordinator instead.
 - **Serial heavy, parallel light.** Serialize anything sharing the pytest
   temp DBs (`/realm/tmp/polylogue-pytest`) or the archive DB; parallel tool
   calls are for reads/searches only.

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -660,6 +660,26 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "workspace verify-worktree",
+        "workspace",
+        "Verify an agent lane's claimed worktree exists, is isolated, and is on the expected branch.",
+        "devtools.verify_worktree",
+        use_when=(
+            "Immediately after spawning a worktree-isolated agent lane (and before trusting its "
+            "reported diff), confirm the claimed working directory is a real LINKED git worktree "
+            "-- not the main checkout (the 2026-08-01 isolation-escape incident left ~1700 "
+            "uncommitted lines in the coordinator's live tree because no such check existed) -- "
+            "and optionally that the expected branch is checked out. Also reports advisory "
+            "hazards: uncommitted changes (worktree auto-cleanup destroys them) and a stale "
+            ".beads/issues.jsonl whose reimport can time-machine live bead state (polylogue-2ara)."
+        ),
+        examples=(
+            "devtools workspace verify-worktree /realm/project/polylogue/.claude/worktrees/agent-abc",
+            "devtools workspace verify-worktree /realm/worktrees/lane-x --expect-branch feature/x/y",
+            "devtools workspace verify-worktree /realm/worktrees/lane-x --json --strict",
+        ),
+    ),
+    CommandSpec(
         "workspace merge-conductor",
         "workspace",
         "Mechanical-conflict triage for the PR merge train (dry-run by default).",

--- a/devtools/lane_brief.py
+++ b/devtools/lane_brief.py
@@ -67,8 +67,15 @@ _ANTI_VACUITY_CONTRACT = (
 _HAZARDS = (
     "commit every logical chunk (worktree auto-clean destroys uncommitted work)",
     "never cd to the main checkout",
+    "run EVERY command synchronously in your own foreground turn -- never launch a "
+    "background job and idle-wait on it across turns (2026-08-01: three lanes stalled for "
+    "multiple turns each waiting on backgrounded devtools test runs)",
     "`bd` reimports .beads/issues.jsonl on every invocation -- run "
     "`bd export -o .beads/issues.jsonl` after every bead write, do not commit that file in this lane",
+    "a worktree's .beads/issues.jsonl is frozen at its branch point: once the worktree ages, "
+    "ANY bd invocation or git-checkout hook inside it can reimport the stale file and revert "
+    "live bead state (polylogue-2ara; 2026-08-01 incident reverted 5+ coordinator writes twice) "
+    "-- prefer no bd writes from lane worktrees at all; report bead-state changes to the coordinator",
     "adding any module under polylogue/ requires "
     "`devtools render topology-projection && devtools render topology-status`",
     "no `git stash` (refs/stash is shared across worktrees)",
@@ -270,11 +277,43 @@ def _find_prior_art(
     return hits
 
 
+def _recent_master_commits(repo_root: Path, paths: list[str], days: int = 7, limit: int = 15) -> list[str]:
+    """Commits on the default-branch tip touching any footprint path in the last N days.
+
+    This is the prior-satisfaction signal the per-path footprint listing buries:
+    on 2026-08-01 a dispatched lane (polylogue-2cuv) burned most of its budget
+    re-investigating a bead whose core ask had already been merged earlier the
+    same session. Aggregating recent-master churn across the whole footprint in
+    one loud list makes "is this already done?" the first question, not a
+    late discovery.
+    """
+    if not paths:
+        return []
+    ref = "origin/master"
+    if (
+        subprocess.run(["git", "rev-parse", "--verify", ref], capture_output=True, text=True, cwd=repo_root).returncode
+        != 0
+    ):
+        ref = "HEAD"
+    result = subprocess.run(
+        ["git", "log", f"--since={days} days ago", "--format=%h %ad %s", "--date=short", ref, "--", *paths],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        return []
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    return lines[:limit]
+
+
 def _render_markdown(
     lane_ids: list[str],
     records: list[BeadRecord],
     footprint: list[FootprintEvidence],
     prior_art: list[PriorArtHit],
+    recent_commits: list[str] | None = None,
+    recent_days: int = 7,
 ) -> str:
     lines: list[str] = []
     lines.append(f"# Lane brief: {', '.join(lane_ids)}")
@@ -339,6 +378,22 @@ def _render_markdown(
         lines.append("No closed beads found mentioning the same file paths.")
     lines.append("")
 
+    lines.append(f"## Recently merged on master (footprint overlap, last {recent_days} days)")
+    lines.append("")
+    if recent_commits:
+        lines.append(
+            f"**PRIOR-SATISFACTION CHECK:** {len(recent_commits)} recent master commit(s) touched "
+            "this lane's footprint. Read them BEFORE implementing -- the bead's core ask may "
+            "already be satisfied by one of these merges. If it is, report that honestly and "
+            "stop; do not re-implement."
+        )
+        lines.append("")
+        for commit in recent_commits:
+            lines.append(f"- {commit}")
+    else:
+        lines.append("No master commits touched the extracted footprint paths in this window.")
+    lines.append("")
+
     lines.append("## Measured baseline")
     lines.append("")
     lines.append("<!-- DISPATCHER MUST FILL -->")
@@ -390,6 +445,13 @@ def main(argv: Sequence[str] | None = None) -> int:
         default="/realm/tmp",
         help="Scratch dir for the bd export used for prior-art scanning (default: /realm/tmp)",
     )
+    parser.add_argument(
+        "--recent-days",
+        type=int,
+        default=7,
+        metavar="N",
+        help="Window for the recently-merged footprint-overlap section (default: 7)",
+    )
     args = parser.parse_args(argv)
 
     repo_root = _repo_root()
@@ -404,8 +466,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     export_records = _load_bd_export(repo_root, tmpdir)
     exclude_ids = {r.id for r in records}
     prior_art = _find_prior_art(export_records, paths, exclude_ids)
+    recent_commits = _recent_master_commits(repo_root, paths, days=args.recent_days)
 
-    brief = _render_markdown(list(args.bead_ids), records, footprint, prior_art)
+    brief = _render_markdown(
+        list(args.bead_ids),
+        records,
+        footprint,
+        prior_art,
+        recent_commits=recent_commits,
+        recent_days=args.recent_days,
+    )
 
     if args.out:
         Path(args.out).write_text(brief)

--- a/devtools/verify_worktree.py
+++ b/devtools/verify_worktree.py
@@ -1,0 +1,254 @@
+"""verify-worktree: confirm an agent lane's claimed worktree is real and isolated.
+
+On 2026-08-01 an `Agent` dispatch with `isolation: "worktree"` silently
+produced NO worktree at all: the lane ran directly in the coordinator's main
+checkout and left ~1700 lines of half-finished schema-regeneration output
+sitting uncommitted in the live tree. The coordinator caught it only by
+noticing a file's mtime was 42 seconds old. Nothing in the dispatch flow
+verified that the isolation actually happened before the lane's diff was
+trusted.
+
+This command is that missing verification: run it against a just-spawned
+lane's claimed working directory BEFORE trusting anything the lane reports.
+
+Hard checks (exit 1 on any failure):
+
+  - the path exists and is inside a git repository;
+  - it is a LINKED worktree (its ``git-dir`` differs from the shared
+    ``git-common-dir``) -- a path that resolves to the main checkout is
+    exactly the isolation-escape failure mode this exists to catch;
+  - its toplevel is not the main checkout's toplevel;
+  - with ``--expect-branch``, the checked-out branch matches.
+
+Advisory checks (reported, exit 0 unless ``--strict``):
+
+  - uncommitted changes count (lanes must commit every chunk -- worktree
+    auto-cleanup destroys uncommitted work);
+  - beads staleness: if the worktree's ``.beads/issues.jsonl`` has an older
+    max ``updated_at`` than the main checkout's, ANY ``bd`` invocation (or
+    git-checkout hook) inside that worktree can reimport the frozen file and
+    time-machine live bead state (polylogue-2ara, live incident 2026-08-01:
+    5+ coordinator writes silently reverted, twice).
+
+Usage:
+    devtools workspace verify-worktree /path/to/worktree
+    devtools workspace verify-worktree /path/to/worktree --expect-branch feature/x/y
+    devtools workspace verify-worktree /path/to/worktree --json --strict
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class CheckResult:
+    name: str
+    ok: bool
+    severity: str  # "hard" | "advisory"
+    detail: str
+
+
+@dataclass
+class WorktreeReport:
+    path: str
+    checks: list[CheckResult] = field(default_factory=list)
+    branch: str | None = None
+    head: str | None = None
+    main_checkout: str | None = None
+
+    def add(self, name: str, ok: bool, severity: str, detail: str) -> None:
+        self.checks.append(CheckResult(name=name, ok=ok, severity=severity, detail=detail))
+
+    def hard_failures(self) -> list[CheckResult]:
+        return [c for c in self.checks if c.severity == "hard" and not c.ok]
+
+    def advisory_failures(self) -> list[CheckResult]:
+        return [c for c in self.checks if c.severity == "advisory" and not c.ok]
+
+
+def _git(path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(path), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def _max_updated_at(jsonl_path: Path) -> str | None:
+    """Max ``updated_at`` across issue rows; None when unreadable/empty.
+
+    ISO-8601 timestamps with a uniform offset compare correctly as strings;
+    rows without the field are skipped. This is a freshness heuristic, not a
+    merge engine -- devtools/bd_reimport_guard.py owns the real per-row logic.
+    """
+    try:
+        raw = jsonl_path.read_text(errors="replace")
+    except OSError:
+        return None
+    latest: str | None = None
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        updated = record.get("updated_at")
+        if isinstance(updated, str) and (latest is None or updated > latest):
+            latest = updated
+    return latest
+
+
+def inspect_worktree(path: Path, expect_branch: str | None = None) -> WorktreeReport:
+    report = WorktreeReport(path=str(path))
+
+    if not path.is_dir():
+        report.add("path_exists", False, "hard", f"{path} is not an existing directory")
+        return report
+    report.add("path_exists", True, "hard", "directory exists")
+
+    rev = _git(path, "rev-parse", "--absolute-git-dir", "--git-common-dir", "--show-toplevel")
+    if rev.returncode != 0:
+        report.add("inside_git_repo", False, "hard", f"not a git repository: {rev.stderr.strip()[:200]}")
+        return report
+    lines = rev.stdout.splitlines()
+    if len(lines) < 3:
+        report.add("inside_git_repo", False, "hard", f"unexpected rev-parse output: {rev.stdout!r}")
+        return report
+    git_dir = Path(lines[0]).resolve()
+    raw_common = Path(lines[1])
+    common_dir = raw_common.resolve() if raw_common.is_absolute() else (path / raw_common).resolve()
+    toplevel = Path(lines[2]).resolve()
+    report.add("inside_git_repo", True, "hard", f"toplevel {toplevel}")
+
+    main_checkout = common_dir.parent
+    report.main_checkout = str(main_checkout)
+
+    if git_dir == common_dir:
+        report.add(
+            "linked_worktree",
+            False,
+            "hard",
+            f"{path} is a MAIN checkout, not a linked worktree -- worktree isolation "
+            "did not happen; do not trust this lane's diff against the live tree",
+        )
+    else:
+        report.add("linked_worktree", True, "hard", f"linked worktree of {main_checkout}")
+
+    if toplevel == main_checkout:
+        report.add(
+            "distinct_toplevel",
+            False,
+            "hard",
+            f"worktree toplevel equals the main checkout toplevel ({main_checkout})",
+        )
+    else:
+        report.add("distinct_toplevel", True, "hard", f"toplevel {toplevel} != main checkout {main_checkout}")
+
+    branch_proc = _git(path, "branch", "--show-current")
+    branch = branch_proc.stdout.strip() if branch_proc.returncode == 0 else None
+    report.branch = branch or None
+    if expect_branch is not None:
+        if branch == expect_branch:
+            report.add("branch_matches", True, "hard", f"on expected branch {expect_branch}")
+        else:
+            report.add(
+                "branch_matches",
+                False,
+                "hard",
+                f"expected branch {expect_branch!r}, found {branch!r}",
+            )
+
+    head_proc = _git(path, "log", "-1", "--format=%h %s")
+    if head_proc.returncode == 0 and head_proc.stdout.strip():
+        report.head = head_proc.stdout.strip()
+
+    status_proc = _git(path, "status", "--porcelain")
+    if status_proc.returncode == 0:
+        dirty = [line for line in status_proc.stdout.splitlines() if line.strip()]
+        report.add(
+            "committed_state",
+            not dirty,
+            "advisory",
+            f"{len(dirty)} uncommitted change(s) -- worktree auto-cleanup destroys uncommitted work"
+            if dirty
+            else "working tree clean",
+        )
+
+    wt_jsonl = toplevel / ".beads" / "issues.jsonl"
+    main_jsonl = main_checkout / ".beads" / "issues.jsonl"
+    if wt_jsonl.is_file() and main_jsonl.is_file() and wt_jsonl != main_jsonl:
+        wt_latest = _max_updated_at(wt_jsonl)
+        main_latest = _max_updated_at(main_jsonl)
+        if wt_latest is not None and main_latest is not None and wt_latest < main_latest:
+            report.add(
+                "beads_freshness",
+                False,
+                "advisory",
+                f"worktree .beads/issues.jsonl is STALE (max updated_at {wt_latest} < main {main_latest}); "
+                "any bd invocation or checkout hook in this worktree can reimport it and revert "
+                "live bead state (polylogue-2ara)",
+            )
+        else:
+            report.add(
+                "beads_freshness",
+                True,
+                "advisory",
+                f"worktree jsonl max updated_at {wt_latest} >= main {main_latest}",
+            )
+
+    return report
+
+
+def _render_text(report: WorktreeReport) -> str:
+    lines = [f"worktree: {report.path}"]
+    if report.branch:
+        lines.append(f"branch: {report.branch}")
+    if report.head:
+        lines.append(f"head: {report.head}")
+    if report.main_checkout:
+        lines.append(f"main checkout: {report.main_checkout}")
+    for check in report.checks:
+        marker = "ok" if check.ok else ("FAIL" if check.severity == "hard" else "WARN")
+        lines.append(f"  [{marker}] {check.name}: {check.detail}")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("path", help="The lane's claimed worktree directory")
+    parser.add_argument("--expect-branch", metavar="BRANCH", help="Fail unless this branch is checked out")
+    parser.add_argument("--json", action="store_true", dest="as_json", help="Emit a JSON report")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Advisory findings (dirty tree, stale beads jsonl) also fail the check",
+    )
+    args = parser.parse_args(argv)
+
+    report = inspect_worktree(Path(args.path), expect_branch=args.expect_branch)
+
+    failed = bool(report.hard_failures()) or (args.strict and bool(report.advisory_failures()))
+    if args.as_json:
+        payload = asdict(report)
+        payload["ok"] = not failed
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_render_text(report))
+        print(f"verdict: {'FAIL' if failed else 'OK'}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -242,6 +242,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools workspace temporal-archive-aggregates` | Build run-projection aggregate artifacts from the active archive. |
 | `devtools workspace temporal-devloop` | Compose git and operating-log events into a temporal evidence window. |
 | `devtools workspace temporal-read-profile` | Measure read --view temporal phase timings on the active archive. |
+| `devtools workspace verify-worktree` | Verify an agent lane's claimed worktree exists, is isolated, and is on the expected branch. |
 | `devtools workspace worktree-gc` | Safe worktree garbage collection — list and remove merged, squash-equivalent, or abandoned git worktrees. |
 
 <!-- END GENERATED: devtools-command-catalog -->

--- a/tests/unit/devtools/test_lane_brief.py
+++ b/tests/unit/devtools/test_lane_brief.py
@@ -120,6 +120,7 @@ def test_render_markdown_includes_all_mandatory_sections() -> None:
         "## Scope",
         "## Footprint (verified)",
         "## Prior art",
+        "## Recently merged on master (footprint overlap, last 7 days)",
         "## Measured baseline",
         "## Non-goals",
         "## Anti-vacuity contract",
@@ -135,6 +136,46 @@ def test_render_markdown_reports_not_found_bead() -> None:
     md = lane_brief._render_markdown(["polylogue-missing"], [record], [], [])
     assert "polylogue-missing -- NOT FOUND" in md
     assert "not found" in md
+
+
+def test_render_markdown_prior_satisfaction_warning_lists_recent_commits() -> None:
+    record = lane_brief.BeadRecord(id="polylogue-a", found=True, priority=1, issue_type="task", title="T")
+    md = lane_brief._render_markdown(
+        ["polylogue-a"],
+        [record],
+        [],
+        [],
+        recent_commits=["abc1234 2026-08-01 feat: already did the thing (#3480)"],
+    )
+    assert "PRIOR-SATISFACTION CHECK" in md
+    assert "abc1234 2026-08-01 feat: already did the thing (#3480)" in md
+
+
+def test_recent_master_commits_finds_footprint_churn(tmp_path: Path) -> None:
+    def _git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-c", "user.name=t", "-c", "user.email=t@example.invalid", "-C", str(tmp_path), *args],
+            check=True,
+            capture_output=True,
+        )
+
+    _git("init", "-b", "master")
+    target = tmp_path / "devtools" / "lane_brief.py"
+    target.parent.mkdir()
+    target.write_text("x = 1\n")
+    _git("add", "devtools/lane_brief.py")
+    _git("commit", "-m", "touch footprint file", "--no-gpg-sign")
+
+    hits = lane_brief._recent_master_commits(tmp_path, ["devtools/lane_brief.py"], days=3650)
+    assert len(hits) == 1
+    assert "touch footprint file" in hits[0]
+    assert lane_brief._recent_master_commits(tmp_path, [], days=3650) == []
+
+
+def test_hazards_forbid_background_waits_and_worktree_bd_writes() -> None:
+    joined = " ".join(lane_brief._HAZARDS)
+    assert "foreground" in joined
+    assert "polylogue-2ara" in joined
 
 
 def test_main_writes_brief_to_out_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/unit/devtools/test_verify_worktree.py
+++ b/tests/unit/devtools/test_verify_worktree.py
@@ -1,0 +1,139 @@
+"""verify-worktree must catch the isolation-escape and stale-beads failure modes.
+
+The production dependency exercised is real git: tests build an actual main
+checkout plus a `git worktree add` linked worktree, then assert the check
+distinguishes them. Mutation that would fail these tests: dropping the
+git-dir vs git-common-dir comparison (main checkout would report ok),
+dropping the branch comparison, or dropping the jsonl updated_at comparison.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from devtools.verify_worktree import _max_updated_at, inspect_worktree, main
+
+_GIT_ENV_ARGS = ["-c", "user.name=test", "-c", "user.email=test@example.invalid"]
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *_GIT_ENV_ARGS, "-C", str(cwd), *args], check=True, capture_output=True, text=True)
+
+
+@pytest.fixture
+def repo_pair(tmp_path: Path) -> tuple[Path, Path]:
+    """A real main checkout and a linked worktree on branch lane-branch."""
+    main_repo = tmp_path / "main"
+    main_repo.mkdir()
+    _git(main_repo, "init", "-b", "master")
+    (main_repo / "file.txt").write_text("hello\n")
+    _git(main_repo, "add", "file.txt")
+    _git(main_repo, "commit", "-m", "initial", "--no-gpg-sign")
+    worktree = tmp_path / "lane"
+    _git(main_repo, "worktree", "add", "-b", "lane-branch", str(worktree))
+    return main_repo, worktree
+
+
+def test_linked_worktree_passes_hard_checks(repo_pair: tuple[Path, Path]) -> None:
+    _, worktree = repo_pair
+    report = inspect_worktree(worktree, expect_branch="lane-branch")
+    assert not report.hard_failures()
+    assert report.branch == "lane-branch"
+
+
+def test_main_checkout_fails_isolation_check(repo_pair: tuple[Path, Path]) -> None:
+    main_repo, _ = repo_pair
+    report = inspect_worktree(main_repo)
+    names = {c.name for c in report.hard_failures()}
+    assert "linked_worktree" in names
+    assert "distinct_toplevel" in names
+
+
+def test_wrong_branch_is_a_hard_failure(repo_pair: tuple[Path, Path]) -> None:
+    _, worktree = repo_pair
+    report = inspect_worktree(worktree, expect_branch="feature/other")
+    assert any(c.name == "branch_matches" for c in report.hard_failures())
+
+
+def test_missing_path_fails(tmp_path: Path) -> None:
+    report = inspect_worktree(tmp_path / "does-not-exist")
+    assert any(c.name == "path_exists" for c in report.hard_failures())
+
+
+def test_non_git_directory_fails(tmp_path: Path) -> None:
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    report = inspect_worktree(plain)
+    assert any(c.name == "inside_git_repo" for c in report.hard_failures())
+
+
+def test_dirty_worktree_is_advisory_not_hard(repo_pair: tuple[Path, Path]) -> None:
+    _, worktree = repo_pair
+    (worktree / "uncommitted.txt").write_text("wip\n")
+    report = inspect_worktree(worktree, expect_branch="lane-branch")
+    assert not report.hard_failures()
+    assert any(c.name == "committed_state" for c in report.advisory_failures())
+
+
+def test_stale_beads_jsonl_is_flagged(repo_pair: tuple[Path, Path]) -> None:
+    main_repo, worktree = repo_pair
+    (main_repo / ".beads").mkdir()
+    (worktree / ".beads").mkdir()
+    (main_repo / ".beads" / "issues.jsonl").write_text(
+        json.dumps({"id": "x-1", "updated_at": "2026-08-01T10:00:00Z"}) + "\n"
+    )
+    (worktree / ".beads" / "issues.jsonl").write_text(
+        json.dumps({"id": "x-1", "updated_at": "2026-07-30T10:00:00Z"}) + "\n"
+    )
+    report = inspect_worktree(worktree)
+    stale = [c for c in report.advisory_failures() if c.name == "beads_freshness"]
+    assert stale and "STALE" in stale[0].detail
+
+
+def test_fresh_beads_jsonl_passes(repo_pair: tuple[Path, Path]) -> None:
+    main_repo, worktree = repo_pair
+    (main_repo / ".beads").mkdir()
+    (worktree / ".beads").mkdir()
+    same = json.dumps({"id": "x-1", "updated_at": "2026-08-01T10:00:00Z"}) + "\n"
+    (main_repo / ".beads" / "issues.jsonl").write_text(same)
+    (worktree / ".beads" / "issues.jsonl").write_text(same)
+    report = inspect_worktree(worktree)
+    assert not [c for c in report.advisory_failures() if c.name == "beads_freshness"]
+
+
+def test_max_updated_at_skips_garbage_lines(tmp_path: Path) -> None:
+    path = tmp_path / "issues.jsonl"
+    path.write_text(
+        "not json\n"
+        + json.dumps({"id": "a", "updated_at": "2026-01-01T00:00:00Z"})
+        + "\n"
+        + json.dumps({"id": "b", "updated_at": "2026-06-01T00:00:00Z"})
+        + "\n"
+        + json.dumps({"id": "c"})
+        + "\n"
+    )
+    assert _max_updated_at(path) == "2026-06-01T00:00:00Z"
+
+
+def test_main_exit_codes_and_json(repo_pair: tuple[Path, Path], capsys: pytest.CaptureFixture[str]) -> None:
+    main_repo, worktree = repo_pair
+    assert main([str(worktree), "--expect-branch", "lane-branch", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["branch"] == "lane-branch"
+
+    assert main([str(main_repo), "--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+
+
+def test_strict_promotes_advisory_to_failure(repo_pair: tuple[Path, Path], capsys: pytest.CaptureFixture[str]) -> None:
+    _, worktree = repo_pair
+    (worktree / "uncommitted.txt").write_text("wip\n")
+    assert main([str(worktree)]) == 0
+    capsys.readouterr()
+    assert main([str(worktree), "--strict"]) == 1


### PR DESCRIPTION
## Summary

Orchestration-machinery hardening from the 2026-08-01 fanout audit: a new `devtools workspace verify-worktree` command that catches the worktree-isolation-escape failure mode before a lane's output is trusted, a `lane-brief` "Recently merged on master (footprint overlap)" section with an explicit PRIOR-SATISFACTION CHECK, standing-hazard updates (no background idle-waits, no lane-side bd writes), and a `.agent/CONVENTIONS.md` fix that scopes background execution to coordinator sessions only.

## Problem

Four verified failure modes from the 2026-08-01 20-lane fanout (each re-verified against source/git, not taken from the incident narrative):

1. An `isolation: "worktree"` dispatch silently ran in the main checkout and left ~1700 uncommitted lines in the coordinator's live tree; no tooling existed to verify a lane's claimed worktree (confirmed via the devtools command catalog).
2. Lane agents' bd calls from stale worktrees reverted 5+ live coordinator bead writes twice (polylogue-2ara, P1 open). Live evidence in this lane: a plain `git switch -c` inside the worktree fired the beads post-checkout JSONL import. Note: `feature/devtools/worktree-import-guard` is NOT this fix — its commit f51f3733d is content-identical to merged PR #3475 (checkout_guard); the branch is superseded and deletable. Remaining polylogue-2ara scope: bd-invocation-time skip-import-if-older.
3. Three lanes stalled for multiple turns idle-waiting on backgrounded `devtools test` runs — and `.agent/CONVENTIONS.md` itself recommended "long test runs ... go to background execution".
4. Lane polylogue-2cuv burned its budget on a bead already satisfied by a same-session merge; the brief's per-path last-3-commits crumbs did not surface this.

Incidents 5/6 (master-red via narrow gates, repaired in #3498/#3500) are assessed in the companion memo as a process-economics tradeoff, deliberately not addressed with new tooling here.

## Solution

- `devtools/verify_worktree.py` (+ catalog entry, regenerated `docs/devtools.md`): hard checks — path exists, inside a git repo, is a LINKED worktree (`--absolute-git-dir` vs `--git-common-dir`), toplevel distinct from the main checkout, `--expect-branch` match; advisory checks — uncommitted changes, stale `.beads/issues.jsonl` (max `updated_at` vs main checkout, string-comparable ISO-8601). `--json`, `--strict`, exit 1 on hard failure.
- `devtools/lane_brief.py`: `_recent_master_commits()` aggregates `git log --since=N days origin/master -- <footprint paths>` into a dedicated section headed by a PRIOR-SATISFACTION CHECK instruction; new `--recent-days`; hazards now forbid background idle-waits and lane-side bd writes (polylogue-2ara).
- `.agent/CONVENTIONS.md`: async execution scoped to coordinator sessions; new coordinator dispatch-hygiene bullet (run verify-worktree after every spawn).

Companion memo (out-of-blast-radius recommendations, incl. sinnix doctrine edits): `.agent/scratch/2026-08-01-orchestration-audit-recommendations.md` (gitignored; copy preserved in the session scratchpad).

## Verification

- `devtools test tests/unit/devtools/test_verify_worktree.py tests/unit/devtools/test_lane_brief.py` — `24 passed in 5.18s`.
- Live smoke: `devtools workspace verify-worktree <this lane's worktree> --expect-branch feature/devtools/orchestration-audit` → `verdict: OK`; `devtools workspace verify-worktree /realm/project/polylogue` → `[FAIL] linked_worktree ... MAIN checkout`, exit 1.
- `devtools verify --quick` — exit 0 (87.3s, all 18 steps green).
- Not run: full suite / `verify --all` (no substrate code touched; testmon-affected + focused tests cover the changed surface).

## Anti-vacuity

The verify-worktree tests build real git repos + `git worktree add` and exercise real `git rev-parse` semantics — dropping the git-dir/common-dir comparison flips `test_main_checkout_fails_isolation_check`; dropping the `updated_at` comparison flips `test_stale_beads_jsonl_is_flagged`. The production caller is the coordinator dispatch flow documented in `.agent/CONVENTIONS.md` (and exercised live in this PR's verification). `test_render_markdown_prior_satisfaction_warning_lists_recent_commits` fails if the new section is dropped from `_render_markdown`.

Ref polylogue-2ara.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7dQJSbhvx7LSu5PW9Ns9S