### PR TITLE
fix(cli): route read --to browser through existing delivery contract

### DIFF
--- a/polylogue/cli/read_views/base.py
+++ b/polylogue/cli/read_views/base.py
@@ -14,6 +14,7 @@ from polylogue.cli.read_view_registry import ReadViewSessionPolicy
 from polylogue.cli.shared.types import AppEnv
 
 if TYPE_CHECKING:
+    from polylogue.archive.session.domain_models import Session
     from polylogue.cli.root_request import RootModeRequest
     from polylogue.surfaces.projection_spec import QueryProjectionSpec
 
@@ -160,8 +161,24 @@ class ReadViewHandler:
         return self.option_builder(values)
 
 
-def deliver_content(env: AppEnv, content: str, *, destination: str, out_path: str | None) -> None:
-    """Deliver captured content to the requested destination."""
+def deliver_content(
+    env: AppEnv,
+    content: str,
+    *,
+    destination: str,
+    out_path: str | None,
+    output_format: str = "markdown",
+    session: Session | None = None,
+) -> None:
+    """Deliver captured content to the requested destination.
+
+    ``destination`` must be one of the values in ``_READ_DESTINATIONS``
+    (``query_verbs.py``): ``terminal``/``stdout``, ``clipboard``, ``file``, or
+    ``browser``. An unrecognized destination raises rather than silently
+    falling back to terminal output -- a prior version of this dispatch let
+    any unhandled destination (including the valid-but-unwired ``browser``)
+    degrade to a plain ``click.echo`` (polylogue-bvnz).
+    """
 
     if destination == "file":
         if not out_path:
@@ -172,8 +189,14 @@ def deliver_content(env: AppEnv, content: str, *, destination: str, out_path: st
         from polylogue.cli.query_output import copy_to_clipboard
 
         copy_to_clipboard(env, content)
-    else:
+    elif destination == "browser":
+        from polylogue.cli.query_output import open_in_browser
+
+        open_in_browser(env, content, output_format, session)
+    elif destination in ("stdout", "terminal"):
         click.echo(content, nl=False)
+    else:
+        raise click.UsageError(f"Unrecognized read destination: {destination!r}.")
 
 
 def execute_query_request(env: AppEnv, request: RootModeRequest) -> None:

--- a/polylogue/cli/read_views/standard.py
+++ b/polylogue/cli/read_views/standard.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
+import click
 import yaml
 
 from polylogue.api.sync.bridge import run_coroutine_sync
@@ -102,14 +103,22 @@ def run_read_summary_or_transcript(env: AppEnv, request: RootModeRequest, invoca
         execute_query_request(env, updated)
     elif invocation.destination == "clipboard":
         execute_query_request(env, updated.with_param_updates(output="clipboard"))
+    elif invocation.destination == "browser":
+        # Route through the same query-output delivery contract that
+        # `find QUERY --to browser` (without `read`) already uses --
+        # `QueryOutputSpec`/`deliver_query_output` (query_output.py) resolve
+        # ``output="browser"`` to the existing browser-opening path
+        # (query_output.open_in_browser). Previously this branch was
+        # missing and fell through to the plain-stdout `else`, so
+        # `read --to browser` silently printed to the terminal
+        # (polylogue-bvnz).
+        execute_query_request(env, updated.with_param_updates(output="browser"))
     elif invocation.destination == "file":
         if not invocation.out_path:
-            import click
-
             raise click.UsageError("--to file requires --out <path>.")
         execute_query_request(env, updated.with_param_updates(output=invocation.out_path))
     else:
-        execute_query_request(env, updated)
+        raise click.UsageError(f"Unrecognized read destination: {invocation.destination!r}.")
 
 
 def run_read_dialogue(env: AppEnv, request: RootModeRequest, invocation: ReadViewInvocation) -> None:
@@ -140,7 +149,14 @@ def run_read_dialogue(env: AppEnv, request: RootModeRequest, invocation: ReadVie
         return
     fmt = invocation.output_format or "markdown"
     content = _format_dialogue_session(session, fmt, projection=projection)
-    deliver_content(env, content, destination=invocation.destination, out_path=invocation.out_path)
+    deliver_content(
+        env,
+        content,
+        destination=invocation.destination,
+        out_path=invocation.out_path,
+        output_format=fmt,
+        session=session,
+    )
 
 
 def _format_dialogue_session(
@@ -452,7 +468,7 @@ def run_read_temporal(env: AppEnv, request: RootModeRequest, invocation: ReadVie
         content = json.dumps({"temporal_window": window.model_dump(mode="json")}, indent=2) + "\n"
     else:
         content = _render_temporal_window_markdown(window)
-    deliver_content(env, content, destination=invocation.destination, out_path=invocation.out_path)
+    deliver_content(env, content, destination=invocation.destination, out_path=invocation.out_path, output_format=fmt)
 
 
 def run_read_browser(env: AppEnv, request: RootModeRequest, invocation: ReadViewInvocation) -> None:

--- a/polylogue/cli/read_views/standard.py
+++ b/polylogue/cli/read_views/standard.py
@@ -149,13 +149,20 @@ def run_read_dialogue(env: AppEnv, request: RootModeRequest, invocation: ReadVie
         return
     fmt = invocation.output_format or "markdown"
     content = _format_dialogue_session(session, fmt, projection=projection)
+    # open_in_browser() re-derives HTML from `session` for non-html formats
+    # rather than using `content` directly, so it must receive the same
+    # windowed session `_format_dialogue_session` rendered from -- passing
+    # the raw, un-windowed `session` here would silently show the full
+    # dialogue in the browser even when a projection/window was requested
+    # (polylogue-bvnz follow-up, CodeRabbit review on #3504).
+    windowed_session = _window_dialogue_session(session, projection)
     deliver_content(
         env,
         content,
         destination=invocation.destination,
         out_path=invocation.out_path,
         output_format=fmt,
-        session=session,
+        session=windowed_session,
     )
 
 

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -21,7 +21,7 @@ from polylogue.config import Config
 from polylogue.context.compiler import ContextImage, ContextSegment, ContextSpec
 from polylogue.core.enums import Origin
 from polylogue.surfaces.payloads import PublicRefResolutionPayload
-from polylogue.surfaces.projection_spec import RenderFormat, projection_from_views
+from polylogue.surfaces.projection_spec import ProjectionSpec, QueryProjectionSpec, RenderFormat, projection_from_views
 from tests.infra.builders import make_conv, make_msg
 
 
@@ -331,6 +331,65 @@ def test_dialogue_read_view_renders_projected_authored_prose(capsys: pytest.Capt
     assert "agent answer" in rendered
     assert "system prompt" not in rendered
     assert "tool output body" not in rendered
+
+
+def test_dialogue_read_view_browser_destination_honors_projection_window() -> None:
+    """``read --view dialogue --to browser`` with a projection window must
+    open the browser on the WINDOWED session, not the full one.
+
+    Regression test (CodeRabbit review on PR #3504, polylogue-bvnz follow-up):
+    ``open_in_browser`` (``query_output.py``) re-derives HTML from the
+    ``session`` kwarg for non-html output formats rather than using the
+    already-rendered ``content`` string, so ``run_read_dialogue`` must pass a
+    session that has already gone through ``_window_dialogue_session`` with
+    the requested projection -- passing the raw, un-windowed session would
+    silently show the full dialogue in the browser even when a body_limit
+    projection was requested. The production caller this test exercises is
+    ``run_read_dialogue`` (``read_views/standard.py``); the mutation that
+    makes this test fail is passing ``session=session`` (the raw session)
+    instead of the windowed one to ``deliver_content``.
+    """
+    session = make_conv(
+        id="session-1",
+        title="Mixed transcript",
+        messages=[
+            make_msg(id="user-1", role="user", text="one", material_origin="human_authored"),
+            make_msg(id="assistant-1", role="assistant", text="two", material_origin="assistant_authored"),
+            make_msg(id="user-2", role="user", text="three", material_origin="human_authored"),
+            make_msg(id="assistant-2", role="assistant", text="four", material_origin="assistant_authored"),
+        ],
+    )
+
+    class _FakePolylogue:
+        async def get_session(self, session_id: str, *, content_projection: object | None = None) -> object | None:
+            assert session_id == "session-1"
+            if content_projection is None:
+                return session
+            return session.with_content_projection(content_projection)  # type: ignore[arg-type]
+
+    env = cast(AppEnv, SimpleNamespace(polylogue=_FakePolylogue(), ui=MagicMock()))
+    projection_spec = QueryProjectionSpec(projection=ProjectionSpec(body_limit=1))
+
+    with patch("polylogue.cli.read_views.standard.deliver_content") as deliver:
+        read_view_handlers.run_read_view(
+            env,
+            RootModeRequest.from_params({}),
+            ReadViewInvocation(
+                view="dialogue",
+                session_id="session-1",
+                output_format="markdown",
+                destination="browser",
+                out_path=None,
+                projection_spec=projection_spec,
+            ),
+        )
+
+    deliver.assert_called_once()
+    delivered_session = deliver.call_args.kwargs["session"]
+    assert delivered_session is not None
+    assert len(delivered_session.messages) == 1, (
+        "browser delivery must receive the windowed session (body_limit=1), not the full 4-message session"
+    )
 
 
 def test_dialogue_json_uses_compact_payload(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/cli/test_query_verbs_runtime.py
+++ b/tests/unit/cli/test_query_verbs_runtime.py
@@ -469,6 +469,47 @@ def _read_verb_kwargs(**overrides: object) -> dict[str, object]:
     return defaults
 
 
+def test_deliver_content_browser_destination_opens_browser() -> None:
+    """base.deliver_content's ``"browser"`` branch must route through the
+    existing query_output.open_in_browser mechanism (polylogue-bvnz), not a
+    second bespoke implementation.
+
+    Anti-vacuity: the production caller is ``deliver_content``
+    (``read_views/base.py``), used by every read view that streams rendered
+    content (dialogue, temporal, context, neighbors, messages, events,
+    file-edits, chronicle). Removing the ``elif destination == "browser":``
+    branch (or reverting it to fall into the generic ``else``) makes this
+    test fail because ``open_in_browser`` would never be called.
+    """
+    from polylogue.cli.read_views.base import deliver_content
+
+    env = cast(AppEnv, SimpleNamespace(ui=MagicMock()))
+    with patch("polylogue.cli.query_output.open_in_browser") as open_browser:
+        deliver_content(
+            env,
+            "rendered content",
+            destination="browser",
+            out_path=None,
+            output_format="markdown",
+            session=None,
+        )
+    open_browser.assert_called_once_with(env, "rendered content", "markdown", None)
+
+
+def test_deliver_content_unrecognized_destination_raises() -> None:
+    """An unrecognized destination must raise, never silently echo to stdout.
+
+    Prior behavior let any destination unhandled by the if/elif chain
+    (including the valid-but-unwired ``"browser"``) fall through to a plain
+    ``click.echo`` -- the exact silent-degradation bug this bead fixes.
+    """
+    from polylogue.cli.read_views.base import deliver_content
+
+    env = cast(AppEnv, SimpleNamespace(ui=MagicMock()))
+    with pytest.raises(click.UsageError, match="Unrecognized read destination"):
+        deliver_content(env, "content", destination="bogus", out_path=None)
+
+
 def _continue_verb_kwargs(**overrides: object) -> dict[str, object]:
     defaults: dict[str, object] = {
         "destination": "terminal",
@@ -501,6 +542,62 @@ def test_read_verb_summary_dispatches_to_execute_query_verb() -> None:
     request = execute.call_args.args[1]
     assert isinstance(request, RootModeRequest)
     assert request.query_params()["origin"] == "chatgpt-export"
+
+
+def test_read_verb_summary_browser_destination_routes_through_query_output_delivery() -> None:
+    """read --to browser must route through the existing browser-delivery
+    contract instead of silently degrading to terminal output.
+
+    Regression test for polylogue-bvnz: the destination dispatch in
+    ``run_read_summary_or_transcript`` (the handler for the default
+    ``summary`` view) previously had no ``"browser"`` branch and fell
+    through to the same ``execute_query_request(env, updated)`` call used
+    for plain stdout -- so ``read --to browser`` printed rows to the
+    terminal with no browser opened and no warning. The production
+    caller this test exercises is ``read_verb`` (``query_verbs.py``)
+    dispatching into ``run_read_summary_or_transcript``
+    (``read_views/standard.py``); the mutation that must make this test
+    fail is removing the ``elif invocation.destination == "browser":``
+    branch there (or dropping the ``output="browser"`` param update),
+    which would revert to the silent-echo fallthrough.
+    """
+    _, child = _context_pair(params={"origin": "chatgpt-export"}, query_terms=("alpha",))
+    wrapped = getattr(query_verbs.read_verb.callback, "__wrapped__", None)
+    assert callable(wrapped)
+
+    with (
+        patch("polylogue.cli.query_verbs._resolve_query_action_session_id", return_value=None),
+        patch("polylogue.cli.read_views.standard.execute_query_request") as execute,
+    ):
+        wrapped(child, **_read_verb_kwargs(view="summary", destination="browser"))
+
+    execute.assert_called_once()
+    request = execute.call_args.args[1]
+    assert isinstance(request, RootModeRequest)
+    # "output" must be set to "browser" so QueryOutputSpec.from_params (in
+    # query_contracts.py) parses a QueryDeliveryTarget(kind="browser") and
+    # deliver_query_output (query_output.py) opens a browser -- the same
+    # contract `find QUERY --to browser` (without `read`) already uses.
+    # Before the fix, "output" was left unset here (defaulting to stdout).
+    assert request.query_params()["output"] == "browser"
+
+
+def test_read_verb_summary_unrecognized_destination_raises() -> None:
+    """An unrecognized destination must raise, never silently echo to stdout."""
+    from polylogue.cli.read_views.base import ReadViewInvocation
+    from polylogue.cli.read_views.standard import run_read_summary_or_transcript
+
+    env = cast(AppEnv, SimpleNamespace(ui=MagicMock(), config=SimpleNamespace(archive_root=None)))
+    request = RootModeRequest.from_params({})
+    invocation = ReadViewInvocation(
+        view="summary",
+        session_id=None,
+        output_format="markdown",
+        destination="bogus",
+        out_path=None,
+    )
+    with pytest.raises(click.UsageError, match="Unrecognized read destination"):
+        run_read_summary_or_transcript(env, request, invocation)
 
 
 def test_read_verb_summary_exact_ref_dispatches_direct_read() -> None:


### PR DESCRIPTION
## Summary

`polylogue find QUERY read --to browser` silently printed rows to the terminal instead of opening a browser. Fixed by routing both affected dispatch sites through the existing browser-delivery mechanism (`query_output.py`'s `destination.kind == "browser"` path) instead of building a second implementation, and by making the previously-silent `else` fallthrough raise on a genuinely unrecognized destination.

## Problem

`_READ_DESTINATIONS` (`polylogue/cli/query_verbs.py:215`) accepts `"browser"` as a valid `--to` value, and browser delivery IS implemented -- but on a path (`query_output.py:291`, `deliver_query_output`'s `destination.kind == "browser"` branch) that two other dispatch sites never adopted:

- `run_read_summary_or_transcript` (`polylogue/cli/read_views/standard.py`) -- the handler for the default `summary`/`transcript` views, which `read_verb` force-routes every `--to browser` invocation through (`query_verbs.py:1282-1296`).
- `deliver_content` (`polylogue/cli/read_views/base.py`) -- used by the dialogue/temporal/context/neighbors/messages/events/file-edits/chronicle read views.

Both had a string-comparison if/elif chain with a silent `else` that fell through to plain stdout echo for any destination the chain didn't explicitly handle -- including the valid-but-unwired `"browser"`.

Reproduced against a demo archive before fixing:

```
$ POLYLOGUE_ARCHIVE_ROOT=/realm/tmp/pl-bvnz-repro polylogue demo seed --root /realm/tmp/pl-bvnz-repro
$ POLYLOGUE_ARCHIVE_ROOT=/realm/tmp/pl-bvnz-repro polylogue find "demo" read --first --to browser
1. codex-session  Map the demo lineage base context. ...
2. gemini-cli-session  demo-gemini-cli · demo/gemini_cli_fixture.py · 2 msgs ...
... (11 rows printed to terminal, no browser opened, no warning, exit 0)
```

## Solution

- `run_read_summary_or_transcript` (standard.py): added an `elif invocation.destination == "browser":` branch that sets `output="browser"` on the query request before delegating to `execute_query_request` -- the same param `QueryOutputSpec.from_params`/`deliver_query_output` (query_output.py) already resolve to `open_in_browser`, i.e. the identical contract `find QUERY --to browser` (without `read`) already uses. No second implementation.
- `deliver_content` (base.py): added an `elif destination == "browser":` branch calling `query_output.open_in_browser` directly. Added optional `output_format: str = "markdown"` and `session: Session | None = None` params (backward compatible for the other 8 existing call sites) so callers holding a `Session` (dialogue) can render richer HTML.
- Both functions' former silent `else` (`click.echo(content, nl=False)` / `execute_query_request(env, updated)`) now `raise click.UsageError(...)` for a genuinely unrecognized destination. `_READ_DESTINATIONS`'s valid set (`terminal`/`stdout`/`browser`/`clipboard`/`file`) is unchanged -- this branch is defensive since Click's `Choice` already constrains the CLI-facing value, but it closes the exact hole that let `"browser"` degrade silently for months.

## Verification

- Reproduced pre-fix (see Problem section) and confirmed post-fix: same invocation now prints `Opened in browser: /realm/tmp/tmpXXXXXX.html`, exit 0.
- Spot-checked `--to stdout`/`clipboard`/`file` against the same demo archive: unchanged behavior.
- `python -m devtools test tests/unit/cli/test_query_verbs_runtime.py` -- 62 passed, including 4 new tests:
  - `test_read_verb_summary_browser_destination_routes_through_query_output_delivery` -- asserts `read_verb` with `destination="browser"` calls `execute_query_request` with `output="browser"` in the request params.
  - `test_read_verb_summary_unrecognized_destination_raises` -- asserts `run_read_summary_or_transcript` raises `click.UsageError` for a bogus destination.
  - `test_deliver_content_browser_destination_opens_browser` -- asserts `deliver_content` calls `query_output.open_in_browser(env, content, output_format, session)` for `destination="browser"`.
  - `test_deliver_content_unrecognized_destination_raises` -- asserts `deliver_content` raises `click.UsageError` for a bogus destination.
- `python -m devtools verify --quick` -- exit 0 (ran twice: once manually, once via the pre-push hook).

## AC matrix (polylogue-bvnz)

| Criterion | Status |
| --- | --- |
| Reproduce the bug against a demo archive before fixing | Satisfied -- see Problem section |
| Fix both dispatch sites (base.py `deliver_content`, standard.py `run_read_summary_or_transcript`) | Satisfied |
| Route through the EXISTING browser-delivery mechanism, not a second implementation | Satisfied -- both branches call into `query_output.open_in_browser`/`deliver_query_output`, no new browser-opening code was written |
| Make the fallthrough `else` raise on unrecognized destination | Satisfied -- both functions now raise `click.UsageError` |
| Do not change `_READ_DESTINATIONS`'s valid set | Satisfied -- `query_verbs.py:215` untouched |

## Anti-vacuity

Production callers exercised: `read_verb` (`query_verbs.py`) dispatching into `run_read_summary_or_transcript` (`read_views/standard.py`), and `deliver_content` (`read_views/base.py`) directly. Removing either function's `elif destination == "browser":` branch (or its `output="browser"` param update in standard.py) makes the corresponding new test fail, since `execute_query_request`/`open_in_browser` would then not be called with the browser-routing arguments -- reverting to the silent-echo fallthrough this PR fixes.

Ref polylogue-bvnz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added browser delivery for standard, dialogue, temporal, and summary reads.
  * Output formatting and session context are now preserved when delivering content.

* **Bug Fixes**
  * Unsupported output destinations now show a clear usage error instead of defaulting to terminal output.

* **Tests**
  * Added coverage for browser delivery and invalid destination handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->