### PR TITLE
refactor(storage): collapse duplicated session-write authority gate to one function

### DIFF
--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -59,6 +59,7 @@ from polylogue.storage.sqlite.archive_tiers.ingest_precedence import (
     browser_capture_precedence,
     record_capture_gap_event,
     record_source_outage_events,
+    revision_authority_refuses_write,
     session_has_parser_ingest_flag,
     should_skip_stale_replace,
     stored_message_count,
@@ -460,62 +461,18 @@ def _write_session(
     merge_append = False
     browser_precedence: BrowserCapturePrecedence = "default"
 
-    has_revision_heads = conn.execute(
-        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'raw_revision_heads'"
-    ).fetchone()
-    if has_revision_heads is not None:
-        governed = conn.execute(
-            "SELECT 1 FROM raw_revision_heads WHERE session_id = ? LIMIT 1",
-            (payload.session_id,),
-        ).fetchone()
-        if governed is not None:
-            counts["skipped_sessions"] = 1
-            counts["skipped_messages"] = payload.message_count
-            counts["skipped_attachments"] = payload.attachment_count
-            counts["skipped_session_events"] = len(payload.parsed_session.session_events)
-            return False, counts
-
-    # polylogue-c737: mirrors ArchiveStore._write_parsed_precedence_result's
-    # ambiguous-membership refusal (#3397/#3398). ``governed`` above only
-    # catches a logical identity with an ACCEPTED revision-authority head
-    # (``raw_revision_heads``, populated only when a cohort has a winner). A
-    # cohort ``classify_membership_revisions`` genuinely refused to
-    # arbitrate never gets an accepted head, so ``governed`` stays ``None``
-    # here even though this raw's own membership is recorded authority
-    # debt -- and this batch write path, the daemon's default for most
-    # non-drive origins, never consulted ``raw_session_memberships`` at all
-    # before this fix. Falling through to the freshness/precedence logic
-    # below then writes the session unconditionally on the raw's next
-    # reparse -- last-writer-wins over the "never silently choose between
-    # branches" invariant.
-    #
-    # Scoped to the membership actually being written (raw_id AND
-    # provider_session_id), not to the raw alone: one retained raw routinely
-    # lowers to many independently-arbitrated sessions (a Claude Code
-    # transcript plus its subagent sidechains, a bundle member set), and
-    # #3398 measured 295 raws carrying a mix of decisions with 489 sessions
-    # whose own membership is NOT ambiguous -- a raw-scoped predicate would
-    # suppress all of those too, trading a fidelity downgrade for outright
-    # absence.
-    if source_conn is not None and payload.raw_id:
-        has_memberships = source_conn.execute(
-            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'raw_session_memberships'"
-        ).fetchone()
-        if has_memberships is not None:
-            ambiguous_membership = source_conn.execute(
-                """
-                SELECT 1 FROM raw_session_memberships
-                WHERE raw_id = ? AND provider_session_id = ? AND decision = 'ambiguous'
-                LIMIT 1
-                """,
-                (payload.raw_id, payload.parsed_session.provider_session_id),
-            ).fetchone()
-            if ambiguous_membership is not None:
-                counts["skipped_sessions"] = 1
-                counts["skipped_messages"] = payload.message_count
-                counts["skipped_attachments"] = payload.attachment_count
-                counts["skipped_session_events"] = len(payload.parsed_session.session_events)
-                return False, counts
+    if revision_authority_refuses_write(
+        conn,
+        source_conn,
+        session_id=payload.session_id,
+        raw_id=payload.raw_id or "",
+        provider_session_id=payload.parsed_session.provider_session_id,
+    ):
+        counts["skipped_sessions"] = 1
+        counts["skipped_messages"] = payload.message_count
+        counts["skipped_attachments"] = payload.attachment_count
+        counts["skipped_session_events"] = len(payload.parsed_session.session_events)
+        return False, counts
 
     if (
         not force_write

--- a/polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
+++ b/polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
@@ -142,6 +142,73 @@ def browser_capture_precedence(
     return "replace" if incoming_owns_browser_merge else "default"
 
 
+def revision_authority_refuses_write(
+    conn: sqlite3.Connection,
+    source_conn: sqlite3.Connection | None,
+    *,
+    session_id: str,
+    raw_id: str,
+    provider_session_id: str,
+) -> bool:
+    """The ONE revision-authority refusal gate for a retained-raw session write.
+
+    Consolidated from two independently hand-maintained copies of the exact
+    same two checks (polylogue-c737: PR #3397 fixed
+    ``ArchiveStore._write_parsed_precedence_result``
+    (``revision_governance.py``), then PR #3398 had to separately re-apply
+    the identical fix to the daemon batch-ingest path's ``_write_session``
+    (``pipeline/services/ingest_batch/_core.py``) -- "the signature of
+    duplicated semantics rather than a missing check". polylogue-aggz
+    Invariant 2 makes this the only implementation; both write paths call it
+    before falling through to their own freshness/browser-capture precedence
+    logic, and neither may reimplement it locally.
+
+    Two independent refusals, checked in order:
+
+    - an ACCEPTED revision-authority head already exists for this
+      ``session_id`` (``raw_revision_heads``) -- some other raw in this
+      cohort already won, so this write is redundant, never authoritative.
+    - this raw's own recorded membership decision for this
+      ``provider_session_id`` is ``'ambiguous'`` -- ``classify_membership_
+      revisions`` genuinely refused to arbitrate a winner for this cohort,
+      and falling through to ordinary freshness comparison would silently
+      pick one anyway by last-writer-wins -- exactly the "never silently
+      choose between branches" invariant this gate exists to enforce.
+
+    ``source_conn`` may be ``None`` only when the caller genuinely has no
+    source.db handle (a synthetic index-only harness); a real batch ingest
+    or governed raw-parsed write always opens one, so the membership-
+    ambiguity leg runs there. ``raw_id`` empty/falsy also skips that leg
+    (there is no raw to look up membership for).
+    """
+    has_revision_heads = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'raw_revision_heads'"
+    ).fetchone()
+    if has_revision_heads is not None:
+        governed = conn.execute(
+            "SELECT 1 FROM raw_revision_heads WHERE session_id = ? LIMIT 1",
+            (session_id,),
+        ).fetchone()
+        if governed is not None:
+            return True
+    if source_conn is None or not raw_id:
+        return False
+    has_memberships = source_conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'raw_session_memberships'"
+    ).fetchone()
+    if has_memberships is None:
+        return False
+    ambiguous_membership = source_conn.execute(
+        """
+        SELECT 1 FROM raw_session_memberships
+        WHERE raw_id = ? AND provider_session_id = ? AND decision = 'ambiguous'
+        LIMIT 1
+        """,
+        (raw_id, provider_session_id),
+    ).fetchone()
+    return ambiguous_membership is not None
+
+
 def stored_message_count(conn: sqlite3.Connection, session_id: str) -> int:
     row = conn.execute(
         "SELECT COUNT(*) FROM messages WHERE session_id = ?",
@@ -285,6 +352,7 @@ __all__ = [
     "browser_capture_precedence",
     "record_capture_gap_event",
     "record_source_outage_events",
+    "revision_authority_refuses_write",
     "session_has_parser_ingest_flag",
     "stored_message_count",
 ]

--- a/polylogue/storage/sqlite/archive_tiers/revision_governance.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_governance.py
@@ -130,6 +130,7 @@ from polylogue.storage.sqlite.archive_tiers.ingest_precedence import (
     browser_capture_precedence,
     record_capture_gap_event,
     record_source_outage_events,
+    revision_authority_refuses_write,
     session_has_parser_ingest_flag,
     should_skip_stale_replace,
     stored_message_count,
@@ -261,59 +262,13 @@ def _write_parsed_precedence_result(
             content_changed=True,
             counts=store._write_counts(session),
         )
-    governed = store._conn.execute(
-        "SELECT 1 FROM raw_revision_heads WHERE session_id = ? LIMIT 1",
-        (session_id,),
-    ).fetchone()
-    if governed is not None:
-        return ArchiveRawParsedWriteResult(
-            raw_id=raw_id,
-            session_id=session_id,
-            content_changed=False,
-            counts=store._skipped_counts(session),
-        )
-    # polylogue-c737: ``governed`` above only catches a logical
-    # identity with an ACCEPTED revision-authority head
-    # (``raw_revision_heads``, populated by
-    # ``apply_raw_membership_classification``/``apply_raw_revision_replay``
-    # only when a cohort has a winner). A cohort that ``classify_
-    # membership_revisions`` refused to arbitrate -- genuinely
-    # ``raw_session_memberships.decision = 'ambiguous'`` -- never gets an
-    # accepted head, so ``governed`` stays ``None`` here even though this
-    # raw's own identity is recorded authority debt. Falling through to
-    # the ordinary browser-capture-precedence/freshness logic below then
-    # writes this raw's session unconditionally on its next parse --
-    # last-writer-wins, exactly the "never silently choose between
-    # branches" invariant this whole subsystem exists to enforce, and
-    # the fidelity-losing side of an aistudio-drive ambiguous pair reaches
-    # the index every time this reparses (measured live: 28 cohorts, 641
-    # attachments reported unfetched despite the bytes existing in the
-    # blob store). Refuse this raw explicitly instead of relying on an
-    # absent head to imply "unclaimed, free to write".
-    #
-    # Scoped to the membership being written, not to the raw. One retained
-    # raw routinely lowers to many sessions -- a Claude Code transcript and
-    # its subagent sidechains, a bundle member set -- and those sessions are
-    # arbitrated independently. Measured on the live archive: 295 raws carry
-    # a mix of decisions, together holding 489 sessions whose own membership
-    # is NOT ambiguous, and one raw carries 106 memberships. A raw-scoped
-    # predicate suppresses every one of those sessions as soon as a single
-    # sibling membership is ambiguous, which trades a fidelity downgrade for
-    # outright absence -- a worse failure, and one that would have landed at
-    # the next full rebuild.
-    ambiguous_membership = (
-        store._ensure_source_conn()
-        .execute(
-            """
-            SELECT 1 FROM raw_session_memberships
-            WHERE raw_id = ? AND provider_session_id = ? AND decision = 'ambiguous'
-            LIMIT 1
-            """,
-            (raw_id, session.provider_session_id),
-        )
-        .fetchone()
-    )
-    if ambiguous_membership is not None:
+    if revision_authority_refuses_write(
+        store._conn,
+        store._ensure_source_conn(),
+        session_id=session_id,
+        raw_id=raw_id,
+        provider_session_id=session.provider_session_id,
+    ):
         return ArchiveRawParsedWriteResult(
             raw_id=raw_id,
             session_id=session_id,


### PR DESCRIPTION
## Summary

Consolidates a duplicated revision-authority refusal check that lived
independently in two production session-write paths into one function,
`revision_authority_refuses_write` (`storage/sqlite/archive_tiers/ingest_precedence.py`).

## Problem

`ArchiveStore._write_parsed_precedence_result` (`archive_tiers/revision_governance.py`,
the real implementation behind `write_parsed_for_retained_raw`/`write_raw_and_parsed`,
used by the one-shot importer and the revision-authority-aware live batch path)
and `_write_session` (`pipeline/services/ingest_batch/_core.py`, the daemon's
default batch-ingest write path for most non-drive origins) each hand-carried
their own copy of two checks: "has this session_id already been claimed by an
accepted `raw_revision_heads` cohort winner" and "is this raw's own
`raw_session_memberships` decision recorded `ambiguous`".

polylogue-c737 is the concrete symptom this duplication produced: the live
archive had 28 `aistudio-drive` cohorts genuinely recorded `ambiguous` (correctly
refused a winner) whose sessions were nonetheless materialized in `index.db`
with 641 attachments stuck `unfetched`. PR #3397 fixed the ambiguous-membership
refusal in `_write_parsed_precedence_result`; PR #3398 then had to independently
re-derive and hand-apply the identical fix to `_write_session` because it was a
separate copy that had never been patched — "the signature of duplicated
semantics rather than a missing check" (polylogue-aggz Invariant 2).

I read both write functions in full (`revision_governance.py` ~2900 lines,
`ingest_batch/_core.py` ~1970 lines) before touching anything, and traced real
callers rather than assuming duplication from file/line coordinates alone. Note:
the coordinator's initial lead (`_write_parsed_precedence_result`/`write_parsed`
duplicated between `revision_governance.py` and `archive.py`) turned out to be a
false positive — `archive.py`'s copies are genuine one-line delegating methods
to the sole implementation in `revision_governance.py`, exactly as that module's
own docstring documents (an already-completed extraction, not a live
duplication). The real duplication was the `_core.py` / `revision_governance.py`
pair named in polylogue-c737's own closure notes as a "known sibling hole."

## Solution

- Added `revision_authority_refuses_write(conn, source_conn, *, session_id,
  raw_id, provider_session_id)` to `ingest_precedence.py` — the module that
  already owns the sibling precedence primitives shared by these same two
  write paths (`should_skip_stale_replace`, `browser_capture_precedence`,
  `session_has_parser_ingest_flag`, `stored_message_count`), so this is a
  continuation of an established consolidation pattern (see that module's own
  `should_skip_stale_replace` docstring, itself a prior 3-copy→1 consolidation
  for polylogue-t83e), not a new one-off shim.
- `_write_parsed_precedence_result` and `_write_session` now call this one
  function instead of carrying their own inline SQL + comment block. The two
  duplicated blocks (~59 lines and ~65 lines including their explanatory
  comments) are **deleted**, not left as bypassable dead alternates, per this
  repo's surgical-renewal rule.
- `session_id`/`raw_id`/`provider_session_id` are required keyword arguments
  with no defaults — a caller cannot invoke the gate without supplying
  identity, and (per the anti-vacuity check below) cannot silently skip
  calling it without a production regression test failing.

## Acceptance criteria (Invariant 2 only — this lane's scope per coordinator reshape)

- "Exactly one code path can write a session, and it cannot be called without
  authority": **partially satisfied**. The specific duplicated-semantics bug
  shape polylogue-c737/#3397/#3398 exhibited (independently hand-maintained
  copies of the revision-authority refusal check) is now structurally
  impossible — there is exactly one implementation of that refusal decision.
  This PR does **not** merge the two write paths themselves into one function;
  `_write_parsed_precedence_result` and `_write_session` remain separate
  entry points serving genuinely different callers (one-shot importer /
  revision-authority-aware live batch vs. the daemon's default batch-ingest
  path), each still carrying its own freshness/browser-capture-precedence
  logic downstream of the shared gate. A full single-function merge of the two
  write paths is a larger, riskier change spanning ~4900 lines across two
  files and many call sites; I judged landing this smaller, verified slice
  safer than forcing that merge in one lane, per this lane's explicit
  "acceptable to land a smaller slice" guidance.
- "At least two existing special-case paths are DELETED, not merely
  bypassed": satisfied for this slice — both inline duplicate-check blocks
  (with their explanatory comments) are deleted from `revision_governance.py`
  and `ingest_batch/_core.py`.

## Anti-vacuity

Production callers exercised: `ArchiveStore.write_parsed_for_retained_raw`
(→ `_write_parsed_precedence_result`) is reached from the one-shot importer
(`pipeline/services/archive_ingest.py`) and the revision-authority-aware live
batch path; `_write_session` is reached from the daemon's default batch-ingest
path (`_write_session_entry` → `_process_ingest_batch_sync`, the daemon's
primary write path for most non-drive origins).

Mutation proof (temporarily replacing each call site's
`if revision_authority_refuses_write(...): ...` with `if False: ...`, one at a
time, then reverting):
- `revision_governance.py` mutation → `tests/unit/storage/test_revision_replay.py::test_precedence_write_refuses_a_raw_recorded_ambiguous` fails (`assert (1,) == (0,)`, i.e. the ambiguous raw's session gets written).
- `ingest_batch/_core.py` mutation → `tests/unit/pipeline/test_ingest_batch.py::test_write_session_refuses_a_raw_recorded_ambiguous_membership` fails (`assert True is False`).
Both pass again once reverted (see Verification below for the clean run).

## Follow-ups (not in scope here)

- A genuine single-function merge of `_write_parsed_precedence_result` and
  `_write_session` into one literal chokepoint (rather than one shared
  authority-gate they both call) remains open, if the full Invariant 2 shape
  is wanted. I have not filed a new bead for this per this lane's bd-write
  restrictions (worktree `.beads/issues.jsonl` reimport hazard) — reporting it
  here for the coordinator to file.
- `ArchiveStore.write_parsed`/`SessionRepository.save_parsed_session` is a
  third code path that writes directly to `sessions` via
  `write_parsed_session_to_archive` with **no** revision-authority
  consultation at all (no raw_id, no governed-head check, no ambiguous-
  membership check). Traced its only production caller
  (`repository_writes.py::save_parsed_session`) and that method itself has no
  real production caller — only a docstring example and test infrastructure
  reference it. Currently dead in the real ingest pipeline, but it is a public
  method reachable from `SessionRepository`/`ArchiveStore`, so it remains a
  structurally-possible fourth way to write a session bypassing authority if
  anything ever calls it for real. Worth a follow-up bead to either delete it
  or route it through the same gate.

## Verification

```
python -m devtools test tests/unit/storage/test_revision_replay.py \
  tests/unit/pipeline/test_ingest_batch.py \
  polylogue/storage/sqlite/archive_tiers/ingest_precedence.py \
  polylogue/storage/sqlite/archive_tiers/revision_governance.py \
  polylogue/pipeline/services/ingest_batch/_core.py \
  tests/unit/storage/test_archive_tiers_archive.py
# 127 passed

python -m devtools verify --quick
# exit_code: 0 (ruff format/check, mypy --strict, render all --check, layering, closure-matrix, schema policies)
```

Ref polylogue-aggz