### PR TITLE
fix(sources): keep strongest title evidence across Claude Code chunks

### DIFF
--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -10,7 +10,7 @@ from itertools import islice
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypeAlias
 
-from polylogue.core.enums import Provider
+from polylogue.core.enums import Provider, TitleSource
 from polylogue.core.json import JSONDocument, JSONValue, is_json_document, is_json_value, normalize_json_decimal
 from polylogue.core.payload_coercion import optional_string
 from polylogue.logging import get_logger
@@ -616,6 +616,42 @@ def _claude_code_grouped_record_specs(
     return specs
 
 
+#  bd polylogue-t5lg: rank a chunk's own resolved title the same way
+# ``_parse_code_records`` ranks candidates within a single pass (custom-title
+# > ai-title > agent-name > first-human-message heuristic > raw id), so that
+# merging streamed chunks of one huge session can never *regress* a stronger
+# title found in one chunk in favor of a weaker one that happened to resolve
+# in an earlier chunk. ``title_source``/``title_confidence`` alone collapse
+# custom-title and ai-title into the same (ORIGIN, 1.0) pair, so a small
+# ref-prefix tie-break preserves the exact within-chunk ordering across
+# chunks too.
+_CLAUDE_CODE_TITLE_REF_PRIORITY: dict[str, int] = {
+    "claude-agent-name:": 0,
+    "claude-ai-title:": 1,
+    "claude-custom-title:": 2,
+}
+
+
+def _claude_code_title_rank(session: ParsedSession) -> tuple[int, float, int]:
+    source_rank = (
+        {
+            TitleSource.UNKNOWN: 0,
+            TitleSource.HEURISTIC: 1,
+            TitleSource.ORIGIN: 2,
+        }.get(session.title_source, 0)
+        if session.title_source is not None
+        else 0
+    )
+    confidence = session.title_confidence or 0.0
+    ref_bonus = 0
+    if session.title_ref:
+        for prefix, bonus in _CLAUDE_CODE_TITLE_REF_PRIORITY.items():
+            if session.title_ref.startswith(prefix):
+                ref_bonus = bonus
+                break
+    return (source_rank, confidence, ref_bonus)
+
+
 def merge_parsed_session_chunks(sessions: Iterable[ParsedSession]) -> list[ParsedSession]:
     """Merge repeated provider-native sessions produced by streaming chunks."""
 
@@ -653,9 +689,24 @@ def merge_parsed_session_chunks(sessions: Iterable[ParsedSession]) -> list[Parse
 
         created_values = [value for value in (existing.created_at, session.created_at) if value]
         updated_values = [value for value in (existing.updated_at, session.updated_at) if value]
+        # bd polylogue-t5lg: pick the chunk with the stronger title EVIDENCE
+        # (title_source/title_confidence, ranked identically to the
+        # single-pass parser's own precedence), not merely "whichever chunk
+        # resolved a non-raw-id title first". The old rule froze the first
+        # chunk's title (even a weak heuristic guess) permanently once it was
+        # non-UUID, silently discarding a stronger ai-title/custom-title
+        # sidecar record that only appeared in a later chunk of the same
+        # huge streamed session -- see the chunk-merge regression this bead
+        # measured on the live archive. All four title fields move together
+        # so title_source/title_ref/title_confidence never point at a
+        # different chunk's evidence than the title text they describe.
+        title_winner = existing if _claude_code_title_rank(existing) >= _claude_code_title_rank(session) else session
         merged[session.provider_session_id] = existing.model_copy(
             update={
-                "title": existing.title if existing.title != existing.provider_session_id else session.title,
+                "title": title_winner.title,
+                "title_source": title_winner.title_source,
+                "title_ref": title_winner.title_ref,
+                "title_confidence": title_winner.title_confidence,
                 "created_at": min(created_values) if created_values else None,
                 "parent_session_provider_id": (
                     existing.parent_session_provider_id or session.parent_session_provider_id

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -43,6 +43,7 @@ from polylogue.sources.decoders import (
 )
 from polylogue.sources.dispatch import (
     detect_provider,
+    merge_parsed_session_chunks,
     parse_drive_payload,
     parse_payload,
     parse_stream_payload,
@@ -1709,6 +1710,79 @@ def test_claude_code_stream_chunk_merge_preserves_git_branch_from_either_chunk()
 
     session_one = next(session for session in sessions if session.provider_session_id == "session-1")
     assert session_one.git_branch == "feature/perf/pipeline-quality-consolidation"
+
+
+def test_merge_parsed_session_chunks_prefers_stronger_title_evidence_over_first_chunk() -> None:
+    """bd polylogue-t5lg: a huge Claude Code session split across streamed
+    chunks must not freeze a weakly-resolved title (the first-human-message
+    heuristic) permanently just because it happened to resolve in an
+    earlier chunk and was already a non-raw-id string. A later chunk's
+    stronger provider-supplied evidence (an ``ai-title`` sidecar record,
+    TitleSource.ORIGIN/confidence 1.0) must win over an earlier chunk's
+    TitleSource.HEURISTIC/confidence 0.5 guess -- and title_source/title_ref/
+    title_confidence must describe the SAME evidence as the winning title
+    text, never a stale mix pulled from a different chunk.
+
+    This reproduces the live-archive regression this bead measured: raw
+    JSONL files large enough to stream in multiple chunks kept a UUID or
+    heuristic title even though the file plainly contains a later ``ai-title``
+    record, because the pre-fix merge rule was "keep whichever chunk
+    resolved a non-UUID title FIRST", not "keep the strongest evidence".
+    """
+    early_chunk = ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id="session-1",
+        title="Fix the flaky retry loop",
+        title_source=TitleSource.HEURISTIC,
+        title_ref="message:u-1",
+        title_confidence=0.5,
+        messages=[],
+    )
+    later_chunk = ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id="session-1",
+        title="Recover what was lost",
+        title_source=TitleSource.ORIGIN,
+        title_ref="claude-ai-title:session-1",
+        title_confidence=1.0,
+        messages=[],
+    )
+
+    merged = merge_parsed_session_chunks([early_chunk, later_chunk])
+
+    assert len(merged) == 1
+    assert merged[0].title == "Recover what was lost"
+    assert merged[0].title_source is TitleSource.ORIGIN
+    assert merged[0].title_ref == "claude-ai-title:session-1"
+    assert merged[0].title_confidence == 1.0
+
+
+def test_merge_parsed_session_chunks_keeps_stronger_earlier_title_over_weaker_later_chunk() -> None:
+    """Inverse direction: a later chunk with no title evidence at all (still
+    a bare provider id) must not clobber an earlier chunk's already-resolved,
+    stronger ``ai-title`` evidence."""
+    early_chunk = ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id="session-1",
+        title="Recover what was lost",
+        title_source=TitleSource.ORIGIN,
+        title_ref="claude-ai-title:session-1",
+        title_confidence=1.0,
+        messages=[],
+    )
+    later_chunk = ParsedSession(
+        source_name=Provider.CLAUDE_CODE,
+        provider_session_id="session-1",
+        title="session-1",
+        messages=[],
+    )
+
+    merged = merge_parsed_session_chunks([early_chunk, later_chunk])
+
+    assert merged[0].title == "Recover what was lost"
+    assert merged[0].title_source is TitleSource.ORIGIN
+    assert merged[0].title_ref == "claude-ai-title:session-1"
+    assert merged[0].title_confidence == 1.0
 
 
 def test_session_emitter_reuses_jsonl_sniff_payloads_for_individual_detection(


### PR DESCRIPTION
## Summary

Fixes a title-merge bug in Claude Code's memory-bounded multi-GiB streaming
ingest path that silently discarded a session's provider-supplied title
(`ai-title`/`custom-title`/`agent-name`) in favor of a weaker guess, whenever
the session was large/long-lived enough to be parsed as multiple streamed
chunks.

## Problem

Ref polylogue-t5lg: "84.6% of Claude Code sessions are titled with a raw
UUID: 10,157 of 12,001." Re-measuring the live archive (read-only,
`/realm/db/polylogue/index.db`) during investigation showed the problem got
**worse**, not better, despite polylogue-pbuh (closed, merged) already adding
a title-resolution ladder to `code_parser.py`'s single-pass parser (ai-title
> custom-title > agent-name > first-human-message heuristic > raw id, with
`title_source`/`title_ref`/`title_confidence` provenance):

```
claude-code-session: 16,552 total / 14,801 UUID-titled (89.4%)
  title_source breakdown: unknown=14,848  heuristic=1,431  origin=273
```

Spot-checking several `ai-title`-bearing raw session files against the live
archive confirmed the single-pass ladder works correctly *when a session is
parsed in one pass* (e.g. `35548562-...` correctly resolved to
`title_source='origin'`, `title='Review lanes performance wave
documentation'`). But `polylogue/sources/dispatch.py:merge_parsed_session_chunks`
— the only caller of Claude Code's streaming path, used for JSONL files large
enough that eager whole-file parsing isn't memory-bounded — merged chunk
titles with:

```python
"title": existing.title if existing.title != existing.provider_session_id else session.title,
```

i.e. "whichever chunk resolves a non-UUID title *first* wins, permanently."
A large session (bead notes cite a 6,059-message / 536,011-word example) that
happens to resolve a weak `TitleSource.HEURISTIC` guess in an early chunk
keeps that guess forever, even when a *later* chunk carries a real
`ai-title` sidecar record (`TitleSource.ORIGIN`, confidence 1.0) — confirmed
directly: `d6f4b0c3-840b-47b6-bd57-5f1bd6c9c7d4.jsonl` contains 490 `ai-title`
records, yet the live archive shows this session `title=native_id`
(`title_source='unknown'`). This is the "551 substantive sessions with zero
human-readable title" defect the bead's own notes call the sharpest instance
of the problem. `title_source`/`title_ref`/`title_confidence` weren't even
part of the merge `update={}` dict, so provenance could point at stale/wrong
evidence relative to whatever `title` string won.

## Solution

- `polylogue/sources/dispatch.py`: added `_claude_code_title_rank`, ranking a
  chunk's title by `title_source`/`title_confidence` using the *same*
  precedence order the single-pass parser already applies (custom-title >
  ai-title > agent-name > heuristic > unknown/raw-id), with a small
  `title_ref`-prefix tie-break (`_CLAUDE_CODE_TITLE_REF_PRIORITY`) so
  ai-title and custom-title — both `(ORIGIN, 1.0)` — keep the exact
  relative order they have within one chunk.
- `merge_parsed_session_chunks` now selects `title`, `title_source`,
  `title_ref`, and `title_confidence` together as one unit (whichever chunk
  ranks higher), instead of merging `title` alone with the old
  first-non-UUID-wins rule.
- Two new regression tests in `tests/unit/sources/test_source_laws.py`
  (`test_merge_parsed_session_chunks_prefers_stronger_title_evidence_over_first_chunk`,
  `test_merge_parsed_session_chunks_keeps_stronger_earlier_title_over_weaker_later_chunk`)
  cover both merge directions.

This does **not** invent a second/parallel resolution mechanism — it fixes
the one place the existing ladder (polylogue-pbuh/ih67-style precedence) was
silently bypassed.

## Verification

```
devtools test tests/unit/sources/test_source_laws.py \
  tests/unit/storage/test_revision_replay.py \
  tests/unit/sources/test_claude_code_sidecar_evidence.py
  -> 194 passed

devtools verify --quick
  -> exit_code: 0 (ruff format/check, mypy --strict, render all --check,
     layering, closure-matrix, schema-versioning/promotion lab checks)
```

Pre-push hook re-ran `devtools verify --quick` on push: exit 0.

## AC matrix (bd polylogue-t5lg)

1. **Title derived from authored content via the existing ladder, not a
   parallel mechanism** — satisfied for the single-pass path by prior work
   (polylogue-pbuh). This PR fixes the one place that mechanism was silently
   discarded: multi-chunk merge for large streamed sessions.
2. **Title provenance recorded (`title_source`/`title_ref`)** —
   `title_source`/`title_ref`/`title_confidence` already existed on
   `sessions` (pbuh); this PR fixes them going stale relative to the merged
   `title` across chunks.
3. **Live re-measure, before/after census** — **NOT attempted in this PR.**
   This is a read-only worktree lane; re-measuring the live archive requires
   an operator-authorized `polylogue ops reprocess`/reset against
   `/realm/db/polylogue`, out of this PR's scope. The "before" numbers cited
   above (16,552 total / 14,801 UUID-titled / 273 `title_source=origin`) were
   measured read-only against the live archive during investigation, not
   mutated by this PR.
4. **Existing rows acquire titles through ordinary reprocess, not a bespoke
   backfill** — unaffected: this fix only changes parse-time merge behavior;
   an ordinary reprocess re-parses affected raws and picks up the corrected
   merge automatically, no separate script needed.

## Anti-vacuity

Reverting `_claude_code_title_rank` and the four-field `title_winner`
selection back to the old
`existing.title if existing.title != existing.provider_session_id else session.title`
(keeping only `title` in the merge `update={}`) makes
`test_merge_parsed_session_chunks_prefers_stronger_title_evidence_over_first_chunk`
fail: it asserts a later `ai-title` chunk's title wins over an earlier
`HEURISTIC` chunk's title, which the old rule cannot produce (it always keeps
whichever chunk resolved a non-UUID title first). Production caller:
`parse_stream_payload` (`dispatch.py`) is the sole entry point for Claude
Code's multi-GiB streaming ingest path
(`pipeline/services/ingest_batch`), invoked for every raw Claude Code session
large enough to require chunked parsing — this is not a test-only code path.

Ref polylogue-t5lg
