### PR TITLE
perf(cli): cut cold-start import tax on drift-marker and query paths

### DIFF
--- a/docs/plans/degrade-loudly-allowlist.yaml
+++ b/docs/plans/degrade-loudly-allowlist.yaml
@@ -322,6 +322,22 @@ entries:
   reason: 'Returns {"checked": False, "reason": str(exc), "surfaces": {}} -- an already-typed signal.
     Extracted from polylogue/cli/commands/status.py (polylogue-ogn1 layering fix); pre-existing
     behavior, unchanged by the move.'
+- path: polylogue/insights/schema_drift.py
+  function: <module>.schema_drift_status
+  exceptions:
+  - Error
+  occurrence: 0
+  reason: 'Returns {"available": False, "reason": str(exc)} -- an already-typed signal.
+    Extracted from polylogue/cli/commands/status.py (import-tax fix); pre-existing
+    behavior, unchanged by the move.'
+- path: polylogue/insights/schema_drift.py
+  function: <module>.schema_drift_status
+  exceptions:
+  - Error
+  occurrence: 1
+  reason: 'Returns {"available": False, "reason": str(exc)} -- an already-typed signal.
+    Extracted from polylogue/cli/commands/status.py (import-tax fix); pre-existing
+    behavior, unchanged by the move.'
 - path: polylogue/storage/artifacts/inspection.py
   function: <module>._hermes_state_db_schema_version
   exceptions:

--- a/docs/plans/layering-surface-baseline.json
+++ b/docs/plans/layering-surface-baseline.json
@@ -487,16 +487,6 @@
   {
     "target": "polylogue/cli",
     "file": "polylogue/cli/commands/status.py",
-    "import": "polylogue.storage.sqlite.archive_tiers"
-  },
-  {
-    "target": "polylogue/cli",
-    "file": "polylogue/cli/commands/status.py",
-    "import": "polylogue.storage.sqlite.archive_tiers.ops_write"
-  },
-  {
-    "target": "polylogue/cli",
-    "file": "polylogue/cli/commands/status.py",
     "import": "polylogue.storage.sqlite.archive_tiers.types"
   },
   {
@@ -1448,11 +1438,6 @@
     "target": "polylogue/daemon",
     "file": "polylogue/daemon/status.py",
     "import": "polylogue.storage.repair"
-  },
-  {
-    "target": "polylogue/daemon",
-    "file": "polylogue/daemon/status.py",
-    "import": "polylogue.storage.sqlite.archive_tiers"
   },
   {
     "target": "polylogue/daemon",

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -1035,7 +1035,7 @@ files:
     target: polylogue/cli/commands/scan_secrets.py
     owner: stable
   - path: polylogue/cli/commands/status.py
-    loc: 2494
+    loc: 2428
     target: polylogue/cli/commands/status.py
     owner: stable
   - path: polylogue/cli/commands/status_diagnostics.py
@@ -2100,6 +2100,10 @@ files:
     loc: 474
     target: polylogue/insights/run_projection.py
     owner: stable
+  - path: polylogue/insights/schema_drift.py
+    loc: 89
+    target: polylogue/insights/schema_drift.py
+    owner: stable
   - path: polylogue/insights/session_analytics.py
     loc: 274
     target: polylogue/insights/session_analytics.py
@@ -2262,7 +2266,7 @@ files:
     target: polylogue/material_protocol/v1/manifest.py
     owner: stable
   - path: polylogue/material_protocol/v1/origin_vocab.py
-    loc: 82
+    loc: 84
     target: polylogue/material_protocol/v1/origin_vocab.py
     owner: stable
   - path: polylogue/material_protocol/v1/records.py
@@ -2718,7 +2722,7 @@ files:
     target: polylogue/scenarios/workload.py
     owner: stable
   - path: polylogue/schemas/__init__.py
-    loc: 9
+    loc: 35
     target: polylogue/schemas/__init__.py
     owner: stable
   - path: polylogue/schemas/audit/__init__.py
@@ -3012,7 +3016,7 @@ files:
     target: polylogue/schemas/registry.py
     owner: stable
   - path: polylogue/schemas/runtime_registry.py
-    loc: 872
+    loc: 1097
     target: polylogue/schemas/runtime_registry.py
     owner: stable
   - path: polylogue/schemas/sampling.py
@@ -4188,7 +4192,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/revision_application.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/revision_governance.py
-    loc: 2913
+    loc: 2922
     target: polylogue/storage/sqlite/archive_tiers/revision_governance.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/self_verify.py

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -528,12 +528,12 @@ def _emit_schema_drift_marker() -> None:
         from datetime import UTC, datetime
         from time import time as _now
 
-        from polylogue.cli.commands.status import _schema_drift_status
+        from polylogue.insights.schema_drift import schema_drift_status
         from polylogue.paths import archive_root
         from polylogue.storage.archive_identity import resolve_active_index_path
 
         active_db = resolve_active_index_path(archive_root())
-        drift = _schema_drift_status(active_db.parent, now_ms=int(_now() * 1000))
+        drift = schema_drift_status(active_db.parent, now_ms=int(_now() * 1000))
         if not drift.get("available"):
             return
         origins = [item for item in (drift.get("origins") or []) if isinstance(item, dict)]

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -14,6 +14,7 @@ from urllib.request import Request, urlopen
 import click
 
 from polylogue.cli.shared.types import AppEnv
+from polylogue.insights.schema_drift import schema_drift_status
 from polylogue.logging import get_logger
 from polylogue.readiness.capability import (
     normalize_raw_frontier_status_payload,
@@ -1006,73 +1007,6 @@ def _ops_workload_status(active_root: Path, *, now_ms: int) -> dict[str, Any]:
     }
 
 
-# polylogue-da1: format-drift sentinel window. Windowed since a date, not
-# lifetime, so an archive with years of clean history does not permanently
-# dilute a recent provider-shape regression signal.
-_SCHEMA_DRIFT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000
-_SCHEMA_DRIFT_RISKY_WARN_RATE = 0.05
-_SCHEMA_DRIFT_RISKY_ERROR_RATE = 0.20
-_SCHEMA_DRIFT_MIN_SAMPLE = 5
-
-
-def _schema_drift_status(active_root: Path, *, now_ms: int, window_ms: int = _SCHEMA_DRIFT_WINDOW_MS) -> dict[str, Any]:
-    """Derive windowed format-drift rates per origin from ops.db (read-only).
-
-    Reads ``schema_drift_samples`` (populated at ingest time -- see
-    ``polylogue.schemas.drift_sentinel``) and returns one entry per origin
-    with a sample in the window. Returns ``available: False`` when the ops
-    tier or table is absent, matching ``_ops_workload_status``'s contract
-    so a synthetic/mid-bootstrap archive degrades quietly.
-    """
-    ops_db = active_root / "ops.db"
-    if not ops_db.exists():
-        return {"available": False, "reason": "missing_ops_tier"}
-    try:
-        conn = sqlite3.connect(f"file:{ops_db}?mode=ro", uri=True)
-    except sqlite3.Error as exc:
-        return {"available": False, "reason": str(exc)}
-    try:
-        if not _table_exists(conn, "schema_drift_samples"):
-            return {"available": False, "reason": "missing_schema_drift_samples"}
-        from polylogue.storage.sqlite.archive_tiers.ops_write import summarize_schema_drift_since
-
-        since_ms = now_ms - window_ms
-        summaries = summarize_schema_drift_since(conn, since_ms=since_ms)
-    except sqlite3.Error as exc:
-        return {"available": False, "reason": str(exc)}
-    finally:
-        conn.close()
-
-    origins = []
-    for summary in summaries:
-        risky_rate = summary.risky_rate
-        if summary.total < _SCHEMA_DRIFT_MIN_SAMPLE:
-            severity = "ok"
-        elif risky_rate >= _SCHEMA_DRIFT_RISKY_ERROR_RATE:
-            severity = "error"
-        elif risky_rate >= _SCHEMA_DRIFT_RISKY_WARN_RATE:
-            severity = "warning"
-        else:
-            severity = "ok"
-        origins.append(
-            {
-                "origin": summary.origin,
-                "total": summary.total,
-                "risky": summary.risky,
-                "benign": summary.benign,
-                "risky_rate": round(risky_rate, 4),
-                "severity": severity,
-                "example_native_ids": list(summary.example_native_ids),
-            }
-        )
-    return {
-        "available": True,
-        "since_ms": since_ms,
-        "window_days": window_ms // (24 * 60 * 60 * 1000),
-        "origins": origins,
-    }
-
-
 def _raw_replay_backlog_status(active_root: Path, *, limit: int = 5) -> dict[str, Any]:
     """Return the weighted raw source-to-index replay backlog for status."""
     try:
@@ -1675,7 +1609,7 @@ def _show_direct_json(
     )
     archive_tiers = _archive_tier_status(active_root)
     ingest_workload = _ops_workload_status(active_root, now_ms=int(time.time() * 1000))
-    schema_drift = _schema_drift_status(active_root, now_ms=int(time.time() * 1000))
+    schema_drift = schema_drift_status(active_root, now_ms=int(time.time() * 1000))
     payload: dict[str, Any] = {
         "ok": _direct_status_ok(component_readiness),
         "daemon_liveness": False,
@@ -2243,7 +2177,7 @@ def _show_direct_status(
         if active_db.name == "index.db":
             active_root = active_db.parent
             _render_ingest_workload(env, workload)
-            _render_schema_drift_status(env, _schema_drift_status(active_root, now_ms=now_ms))
+            _render_schema_drift_status(env, schema_drift_status(active_root, now_ms=now_ms))
             tiers = _archive_tier_status(active_root)
             present = ", ".join(tier for tier, info in tiers.items() if info["exists"])
             missing = ", ".join(tier for tier, info in tiers.items() if not info["exists"])

--- a/polylogue/core/dates.py
+++ b/polylogue/core/dates.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-import dateparser
-
 
 def utc_now() -> datetime:
     """Return the query-time UTC clock through one patchable seam."""
@@ -35,6 +33,8 @@ def parse_date(date_str: str) -> datetime | None:
         >>> parse_date("yesterday")  # doctest: +SKIP
         datetime(2026, 1, 22, ..., tzinfo=timezone.utc)
     """
+    import dateparser  # Deferred: ~0.26s import (timezone tables) off the CLI query path.
+
     settings = {
         "PREFER_DATES_FROM": "past",  # Default to past dates for "last week"
         "RETURN_AS_TIMEZONE_AWARE": True,  # Return UTC-aware for comparison with timestamps

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -681,9 +681,9 @@ def _check_schema_drift_medium() -> HealthAlert:
     """
     now = datetime.now(UTC).isoformat()
     try:
-        from polylogue.cli.commands.status import _schema_drift_status
+        from polylogue.insights.schema_drift import schema_drift_status
 
-        drift = _schema_drift_status(_active_health_db_path().parent, now_ms=int(datetime.now(UTC).timestamp() * 1000))
+        drift = schema_drift_status(_active_health_db_path().parent, now_ms=int(datetime.now(UTC).timestamp() * 1000))
         if not drift.get("available"):
             return HealthAlert(
                 check_name="schema_drift",

--- a/polylogue/insights/schema_drift.py
+++ b/polylogue/insights/schema_drift.py
@@ -1,0 +1,89 @@
+"""Windowed format-drift status derivation (light import path).
+
+This lives outside ``polylogue.cli.commands.status`` deliberately: the root
+CLI callback's drift marker (``click_app._emit_schema_drift_marker``) and the
+daemon health check both need only this derivation, while ``status`` pulls the
+readiness/repair stack (~1s of imports). Keeping this module stdlib-light means
+every ``polylogue`` invocation that never touches the status surface does not
+pay that import tax just to print the drift sentinel.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+# polylogue-da1: format-drift sentinel window. Windowed since a date, not
+# lifetime, so an archive with years of clean history does not permanently
+# dilute a recent provider-shape regression signal.
+SCHEMA_DRIFT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000
+SCHEMA_DRIFT_RISKY_WARN_RATE = 0.05
+SCHEMA_DRIFT_RISKY_ERROR_RATE = 0.20
+SCHEMA_DRIFT_MIN_SAMPLE = 5
+
+
+def _drift_table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type IN ('table') AND name = ? LIMIT 1",
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
+def schema_drift_status(active_root: Path, *, now_ms: int, window_ms: int = SCHEMA_DRIFT_WINDOW_MS) -> dict[str, Any]:
+    """Derive windowed format-drift rates per origin from ops.db (read-only).
+
+    Reads ``schema_drift_samples`` (populated at ingest time -- see
+    ``polylogue.schemas.drift_sentinel``) and returns one entry per origin
+    with a sample in the window. Returns ``available: False`` when the ops
+    tier or table is absent, matching ``_ops_workload_status``'s contract
+    so a synthetic/mid-bootstrap archive degrades quietly.
+    """
+    ops_db = active_root / "ops.db"
+    if not ops_db.exists():
+        return {"available": False, "reason": "missing_ops_tier"}
+    try:
+        conn = sqlite3.connect(f"file:{ops_db}?mode=ro", uri=True)
+    except sqlite3.Error as exc:
+        return {"available": False, "reason": str(exc)}
+    try:
+        if not _drift_table_exists(conn, "schema_drift_samples"):
+            return {"available": False, "reason": "missing_schema_drift_samples"}
+        from polylogue.storage.sqlite.archive_tiers.ops_write import summarize_schema_drift_since
+
+        since_ms = now_ms - window_ms
+        summaries = summarize_schema_drift_since(conn, since_ms=since_ms)
+    except sqlite3.Error as exc:
+        return {"available": False, "reason": str(exc)}
+    finally:
+        conn.close()
+
+    origins = []
+    for summary in summaries:
+        risky_rate = summary.risky_rate
+        if summary.total < SCHEMA_DRIFT_MIN_SAMPLE:
+            severity = "ok"
+        elif risky_rate >= SCHEMA_DRIFT_RISKY_ERROR_RATE:
+            severity = "error"
+        elif risky_rate >= SCHEMA_DRIFT_RISKY_WARN_RATE:
+            severity = "warning"
+        else:
+            severity = "ok"
+        origins.append(
+            {
+                "origin": summary.origin,
+                "total": summary.total,
+                "risky": summary.risky,
+                "benign": summary.benign,
+                "risky_rate": round(risky_rate, 4),
+                "severity": severity,
+                "example_native_ids": list(summary.example_native_ids),
+            }
+        )
+    return {
+        "available": True,
+        "since_ms": since_ms,
+        "window_days": window_ms // (24 * 60 * 60 * 1000),
+        "origins": origins,
+    }

--- a/polylogue/schemas/__init__.py
+++ b/polylogue/schemas/__init__.py
@@ -1,9 +1,35 @@
-"""Runtime-facing schema validation and harmonization API."""
+"""Runtime-facing schema validation and harmonization API.
 
-from polylogue.schemas.validator import SchemaValidator, ValidationResult, validate_provider_export
+The public names are resolved lazily (PEP 562): ``polylogue.schemas.validator``
+transitively imports the whole provider-parser universe
+(``archive.raw_payload.decode`` -> ``sources.dispatch``) plus ``jsonschema``,
+~0.9s of import work. Light in-package modules (``drift_sentinel``) are
+imported from hot CLI paths (the root-callback drift marker, archive-tier DDL
+modules); an eager package ``__init__`` taxed every one of those paths with
+the full validator chain.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from polylogue.schemas.validator import (
+        SchemaValidator,
+        ValidationResult,
+        validate_provider_export,
+    )
 
 __all__ = [
     "SchemaValidator",
     "ValidationResult",
     "validate_provider_export",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        from polylogue.schemas import validator
+
+        return getattr(validator, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/polylogue/storage/sqlite/archive_tiers/revision_governance.py
+++ b/polylogue/storage/sqlite/archive_tiers/revision_governance.py
@@ -96,7 +96,10 @@ from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, BinaryIO, Protocol, cast
+from typing import TYPE_CHECKING, Any, BinaryIO, Protocol, cast
+
+if TYPE_CHECKING:
+    from polylogue.sources.parsers.base import ParsedSession
 
 from polylogue.archive.ingest_flags import DOM_FALLBACK_INGEST_FLAG, NATIVE_BROWSER_CAPTURE_FLAGS
 from polylogue.archive.revision_authority import (
@@ -119,8 +122,6 @@ from polylogue.core.enums import Origin, Provider
 from polylogue.core.sources import origin_from_provider, provider_from_origin
 from polylogue.pipeline.ids import SessionRevisionProjection, session_content_hash, session_revision_projection
 from polylogue.pipeline.ids import session_id as make_session_id
-from polylogue.sources.dispatch import merge_parsed_session_chunks
-from polylogue.sources.parsers.base import ParsedSession
 from polylogue.storage.blob_publication import ArchiveBlobPublisher
 from polylogue.storage.fts.fts_lifecycle import repair_message_fts_index_sync
 from polylogue.storage.fts.session_repair import repair_session_fts_if_needed_sync
@@ -1809,6 +1810,10 @@ def raw_membership_decision_pending(store: RawRevisionGovernanceHost, raw_id: st
 
 def raw_revision_replay_adoptable(store: RawRevisionGovernanceHost, sessions: Sequence[ParsedSession]) -> bool:
     """Return whether replay may adopt an existing ungoverned session."""
+    # Deferred: sources.dispatch imports the full provider-parser universe
+    # (~0.26s); this write-path-only helper must not tax read-path imports.
+    from polylogue.sources.dispatch import merge_parsed_session_chunks
+
     aggregate = merge_parsed_session_chunks(sessions)
     if len(aggregate) != 1:
         return False
@@ -1842,6 +1847,8 @@ def defer_raw_revision_adoption(
         return
     source_conn = store._ensure_source_conn()
     decided_at_ms = int(time.time() * 1000)
+    from polylogue.sources.dispatch import merge_parsed_session_chunks
+
     aggregate = merge_parsed_session_chunks(sessions)
     if len(aggregate) != 1:
         raise RuntimeError("deferred revision cohort did not compose to one session")
@@ -1967,6 +1974,8 @@ def apply_raw_revision_replay(
     """
     if not plan.accepted_raw_ids:
         raise ValueError("cannot apply a revision plan without an accepted chain")
+    from polylogue.sources.dispatch import merge_parsed_session_chunks
+
     candidates = {item.raw_id: item for item in _raw_revision_candidates(store, plan.logical_source_key)}
     aggregate_sessions = merge_parsed_session_chunks(parsed_by_raw_id[raw_id] for raw_id in plan.accepted_raw_ids)
     if len(aggregate_sessions) != 1:

--- a/tests/unit/cli/test_schema_drift_marker.py
+++ b/tests/unit/cli/test_schema_drift_marker.py
@@ -31,7 +31,7 @@ def test_marker_silent_when_sentinel_unavailable(
 ) -> None:
     _patch_active_db(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        "polylogue.cli.commands.status._schema_drift_status",
+        "polylogue.insights.schema_drift.schema_drift_status",
         lambda *a, **kw: {"available": False},
     )
     _emit_schema_drift_marker()
@@ -46,7 +46,7 @@ def test_marker_silent_when_all_origins_ok(
 ) -> None:
     _patch_active_db(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        "polylogue.cli.commands.status._schema_drift_status",
+        "polylogue.insights.schema_drift.schema_drift_status",
         lambda *a, **kw: {
             "available": True,
             "since_ms": 1_700_000_000_000,
@@ -65,7 +65,7 @@ def test_marker_prints_to_stderr_when_worst_origin_is_risky(
 ) -> None:
     _patch_active_db(monkeypatch, tmp_path)
     monkeypatch.setattr(
-        "polylogue.cli.commands.status._schema_drift_status",
+        "polylogue.insights.schema_drift.schema_drift_status",
         lambda *a, **kw: {
             "available": True,
             "since_ms": 1_700_000_000_000,
@@ -96,3 +96,37 @@ def test_marker_never_raises_on_unexpected_error(
     _emit_schema_drift_marker()  # must not raise
     captured = capsys.readouterr()
     assert captured.err == ""
+
+
+@pytest.mark.uses_real_clock("subprocess wall-clock is incidental; asserts module graph only")
+def test_drift_marker_import_path_stays_light() -> None:
+    """The drift marker's import path must not pull heavy subsystems.
+
+    ``_emit_schema_drift_marker`` runs on every ``polylogue`` invocation, so its
+    dependency module (``polylogue.insights.schema_drift``) is a hot cold-start path.
+    Regression contract for the ~1s/invocation taxes measured 2026-08-01:
+    ``polylogue.schemas`` eagerly importing ``validator`` (the whole provider
+    parser universe via ``sources.dispatch``), and ``cli.commands.status``
+    (readiness/repair stack) being imported just for the drift derivation.
+    """
+    import subprocess
+    import sys
+
+    forbidden = (
+        "polylogue.sources.dispatch",
+        "polylogue.schemas.validator",
+        "polylogue.readiness",
+        "polylogue.storage.repair",
+        "polylogue.cli.commands.status",
+    )
+    code = (
+        "import sys\n"
+        "import polylogue.insights.schema_drift\n"
+        "import polylogue.schemas.drift_sentinel\n"
+        "import polylogue.storage.sqlite.archive_tiers.revision_governance\n"
+        f"loaded = [m for m in {forbidden!r} if m in sys.modules]\n"
+        "print(','.join(loaded) if loaded else 'CLEAN')\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, timeout=60)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "CLEAN", f"heavy modules leaked into light import path: {result.stdout.strip()}"

--- a/tests/unit/cli/test_schema_drift_status.py
+++ b/tests/unit/cli/test_schema_drift_status.py
@@ -7,8 +7,9 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
-from polylogue.cli.commands.status import _render_schema_drift_status, _schema_drift_status
+from polylogue.cli.commands.status import _render_schema_drift_status
 from polylogue.cli.shared.types import AppEnv
+from polylogue.insights.schema_drift import schema_drift_status
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.ops_write import record_schema_drift_sample
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -30,7 +31,7 @@ def _make_app_env() -> AppEnv:
 
 
 def test_schema_drift_status_reports_missing_ops_tier(tmp_path: Path) -> None:
-    result = _schema_drift_status(tmp_path, now_ms=10_000)
+    result = schema_drift_status(tmp_path, now_ms=10_000)
     assert result["available"] is False
     assert result["reason"] == "missing_ops_tier"
 
@@ -76,7 +77,7 @@ def test_schema_drift_status_computes_windowed_risky_rate(tmp_path: Path) -> Non
     )
     conn.close()
 
-    result = _schema_drift_status(tmp_path, now_ms=now_ms)
+    result = schema_drift_status(tmp_path, now_ms=now_ms)
     assert result["available"] is True
     origins = result["origins"]
     assert len(origins) == 1

--- a/tests/unit/daemon/test_schema_drift_health_check.py
+++ b/tests/unit/daemon/test_schema_drift_health_check.py
@@ -23,9 +23,9 @@ def test_schema_drift_ok_when_sentinel_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A fresh/synthetic archive with no ops.db data degrades to OK, not an alert."""
-    import polylogue.cli.commands.status as status_module
+    import polylogue.insights.schema_drift as schema_drift_module
 
-    monkeypatch.setattr(status_module, "_schema_drift_status", lambda *a, **kw: {"available": False})
+    monkeypatch.setattr(schema_drift_module, "schema_drift_status", lambda *a, **kw: {"available": False})
     alert = _check_schema_drift_medium()
     assert alert.severity == HealthSeverity.OK
     assert "unavailable" in alert.message
@@ -35,11 +35,11 @@ def test_schema_drift_ok_when_no_risky_origins(
     workspace_env: dict[str, Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import polylogue.cli.commands.status as status_module
+    import polylogue.insights.schema_drift as schema_drift_module
 
     monkeypatch.setattr(
-        status_module,
-        "_schema_drift_status",
+        schema_drift_module,
+        "schema_drift_status",
         lambda *a, **kw: {
             "available": True,
             "origins": [
@@ -56,11 +56,11 @@ def test_schema_drift_warning_when_one_origin_crosses_warn_threshold(
     workspace_env: dict[str, Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import polylogue.cli.commands.status as status_module
+    import polylogue.insights.schema_drift as schema_drift_module
 
     monkeypatch.setattr(
-        status_module,
-        "_schema_drift_status",
+        schema_drift_module,
+        "schema_drift_status",
         lambda *a, **kw: {
             "available": True,
             "origins": [
@@ -86,11 +86,11 @@ def test_schema_drift_error_outranks_warning_across_origins(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When multiple origins carry drift, the ERROR-severity one wins the message."""
-    import polylogue.cli.commands.status as status_module
+    import polylogue.insights.schema_drift as schema_drift_module
 
     monkeypatch.setattr(
-        status_module,
-        "_schema_drift_status",
+        schema_drift_module,
+        "schema_drift_status",
         lambda *a, **kw: {
             "available": True,
             "origins": [
@@ -120,11 +120,11 @@ def test_schema_drift_recovers_after_error(
     workspace_env: dict[str, Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import polylogue.cli.commands.status as status_module
+    import polylogue.insights.schema_drift as schema_drift_module
 
     monkeypatch.setattr(
-        status_module,
-        "_schema_drift_status",
+        schema_drift_module,
+        "schema_drift_status",
         lambda *a, **kw: {
             "available": True,
             "origins": [
@@ -136,8 +136,8 @@ def test_schema_drift_recovers_after_error(
     assert bad.consecutive_failures == 1
 
     monkeypatch.setattr(
-        status_module,
-        "_schema_drift_status",
+        schema_drift_module,
+        "schema_drift_status",
         lambda *a, **kw: {
             "available": True,
             "origins": [


### PR DESCRIPTION
## Summary
Removes three eager-import chains that taxed every cold `polylogue` invocation: the `polylogue.schemas` package init (whole provider-parser universe + jsonschema, ~0.9s), `revision_governance`'s module-level `sources.dispatch` import (write-path helper taxing read paths), and the root-callback drift marker's import of `cli.commands.status` (readiness/repair stack, ~1.2s) for what is a self-contained ops.db read.

## Problem
Measured 2026-08-01 (warm pyc, empty archive, so numbers are pure fixed overhead, `python -X importtime` + cProfile attribution): `polylogue find` 2.87s, `import --help` 1.78s, `config show` 1.78s, vs `--help` 0.55s. Attribution:
- `polylogue.schemas/__init__` eagerly imported `validator` → `archive.raw_payload.decode` → `sources.dispatch` (every provider parser + pydantic models) + `jsonschema`: ~0.9s, paid by anything importing any `archive_tiers` submodule (the package init chains through `ops.py` → `drift_sentinel`, which itself is pure stdlib).
- `storage/sqlite/archive_tiers/revision_governance.py` imported `sources.dispatch` at module top for `merge_parsed_session_chunks`, used only in three raw-replay write paths.
- `click_app._emit_schema_drift_marker` (runs in the root callback for every command, including nested `--help`) imported `cli.commands.status` (~1.2s readiness/repair stack) to call `_schema_drift_status`, whose real dependencies are `sqlite3` + one lazy `ops_write` function.

## Solution
- `polylogue/schemas/__init__.py`: PEP 562 lazy `__getattr__`; public names (`SchemaValidator`, `ValidationResult`, `validate_provider_export`) unchanged.
- `revision_governance.py`: function-local `merge_parsed_session_chunks` imports at the three write-path call sites; `ParsedSession` under `TYPE_CHECKING` (annotation-only).
- `schema_drift_status` extracted (hard move, no shim) from `cli/commands/status.py` to new `polylogue/insights/schema_drift.py` — insights because CLI must route through insights/operations/api per `docs/plans/layering.yaml`; `click_app`, `daemon/health.py`, `status.py`, and the three test files repointed. Three stale layering-baseline entries pruned (ratchet down 308→305). Degrade-loudly allowlist entries moved with the function (same already-typed `{"available": False, "reason": …}` signal, unchanged behavior).
- `core/dates.py`: `dateparser` (~0.26s, timezone tables) deferred to first `parse_date` call.
- New contract test `test_drift_marker_import_path_stays_light` asserts (in a subprocess) that importing `insights.schema_drift` + `schemas.drift_sentinel` + `revision_governance` never loads `sources.dispatch` / `schemas.validator` / `readiness` / `storage.repair` / `cli.commands.status`.

Anti-vacuity: the contract test exercises the real production import graph; re-adding any of the removed eager imports (verified by simulating `import polylogue.cli.commands.status` in the probe: detects `readiness`, `storage.repair`, `cli.commands.status`) fails it. The moved `schema_drift_status` is exercised by the existing drift-status/marker/health tests against real ops.db fixtures.

## Measured results (min of 3, warm pyc, same host)
| command | before | after |
|---|---|---|
| `import --help` | 1.78s | 0.64s |
| `config show` | 1.78s | 0.58s |
| `demo --help` | 2.57s | 2.08s |
| `find <q> --limit 5` | 2.87s | 2.63s |
| `polylogue.api` import | 2.36s | 1.70s |

The residual `find` cost is `polylogue.api`'s diffuse pydantic model construction, imported before the daemon fast-path attempt — deferring that is a structural follow-up (bead filed from this lane).

## Verification
- `devtools verify --quick` — all steps exit 0 (format, lint, mypy, render-check, layering, degrade-loudly, closure-matrix, hash-boundary-census, schema-versioning, promotion audit).
- `devtools test tests/unit/cli/test_schema_drift_marker.py tests/unit/cli/test_schema_drift_status.py tests/unit/daemon/test_schema_drift_health_check.py` — 15 passed (incl. new contract test).
- `devtools test tests/unit/schemas/test_drift_sentinel.py tests/unit/cli/test_click_app.py tests/unit/cli/commands/test_status.py` — 190 passed.
- `devtools test tests/unit/storage/test_revision_replay.py tests/unit/core/test_dates.py` — 34 passed; `test_source_laws.py::test_claude_code_stream_chunk_merge_preserves_git_branch_from_either_chunk` passed.
- Not run: full suite (per-PR CI skips heavy tests; testmon unseeded in this worktree — affected files covered by the focused runs above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7dQJSbhvx7LSu5PW9Ns9S