### PR TITLE
feat(storage): declare a targeted-reprocess delta class for additive columns

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/index_fast_forward_executor.py
+++ b/polylogue/storage/sqlite/archive_tiers/index_fast_forward_executor.py
@@ -31,14 +31,20 @@ from __future__ import annotations
 
 import re
 import sqlite3
+import time
 import uuid
+from pathlib import Path
 
 from polylogue.storage.fts.fts_lifecycle import ensure_fts_index_sync, rebuild_fts_index_sync
 from polylogue.storage.fts.sql import insert_all_message_identity_rows_sql, insert_all_message_rows_sql
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.ops_write import add_convergence_debt
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.lifecycle import (
     FastForwardOperation,
     FastForwardOperationKind,
     IndexFastForwardPlan,
+    TargetedReprocessScope,
     resolve_canonical_index_objects,
 )
 
@@ -107,10 +113,25 @@ def _apply_replace_table(conn: sqlite3.Connection, name: str, canonical_sql: str
     per-declaration documentation, a constraint-widening or dead-column-
     removal change: no surviving column changes meaning. Copying the columns
     common to both the existing and canonical shape reproduces the declared
-    v33/v36/v38/v41 deltas without a raw reparse -- widened CHECK
+    v33/v36/v38/v41/v44 deltas without a raw reparse -- widened CHECK
     constraints apply to the copied rows for free (SQLite validates on
     insert into the new table), and dropped columns are simply excluded from
     the copy.
+
+    The final rename runs under ``PRAGMA legacy_alter_table=ON``
+    (polylogue-9rw0.1): a table with a dependent view defined against its
+    *old* name (e.g. ``delegation_facts_source`` against ``sessions``) makes
+    a plain ``ALTER TABLE ... RENAME TO`` raise
+    ``OperationalError: error in view ...: no such table`` the instant the
+    original is dropped and only the differently-named temporary table
+    exists -- SQLite re-validates every dependent view's SQL as part of an
+    ordinary rename. Legacy mode skips that reference-following rewrite (the
+    view's stored SQL still says the original name, which is exactly the
+    name the temporary table is being renamed *to*, so the view resolves
+    correctly again the moment the statement completes). This was latent for
+    every REPLACE_TABLE declaration touching ``sessions``/``action_pairs``
+    before a test exercised the executor against a schema with the
+    dependent view actually present.
     """
     existing_columns = [str(row[1]) for row in conn.execute(f'PRAGMA table_info("{name}")').fetchall()]
     if not existing_columns:
@@ -150,7 +171,11 @@ def _apply_replace_table(conn: sqlite3.Connection, name: str, canonical_sql: str
     conn.execute(create_temporary)
     conn.execute(f'INSERT INTO "{temporary_name}" ({quoted_columns}) SELECT {quoted_columns} FROM "{name}"')
     conn.execute(f'DROP TABLE "{name}"')
-    conn.execute(f'ALTER TABLE "{temporary_name}" RENAME TO "{name}"')
+    conn.execute("PRAGMA legacy_alter_table = ON")
+    try:
+        conn.execute(f'ALTER TABLE "{temporary_name}" RENAME TO "{name}"')
+    finally:
+        conn.execute("PRAGMA legacy_alter_table = OFF")
 
 
 def _apply_rebuild_fts(conn: sqlite3.Connection, operation: FastForwardOperation) -> None:
@@ -197,6 +222,88 @@ def _apply_operation(
             raise RuntimeError(f"unhandled fast-forward operation kind: {operation.kind!r}")
 
 
+def _resolve_ops_db_path(conn: sqlite3.Connection) -> Path | None:
+    """Return the sibling ``ops.db`` path for this index-tier connection.
+
+    The five archive tiers are five sibling files in one archive root
+    (``source.db``/``index.db``/``embeddings.db``/``user.db``/``ops.db``);
+    ``apply_index_fast_forward`` only receives the index-tier connection, so
+    this derives the ops-tier path from SQLite's own ``PRAGMA database_list``
+    rather than widening the function signature. Returns ``None`` for an
+    unnamed/in-memory connection (tests), in which case enqueueing is
+    skipped rather than raising -- there is no sibling file to write to.
+    """
+    for _, name, file in conn.execute("PRAGMA database_list").fetchall():
+        if name == "main" and file:
+            return Path(file).parent / "ops.db"
+    return None
+
+
+def _enqueue_targeted_reprocess_debt(
+    index_conn: sqlite3.Connection,
+    plan: IndexFastForwardPlan,
+) -> int:
+    """Enqueue bounded, real convergence-debt rows for a plan's pending reprocess scopes.
+
+    Runs against the sibling ``ops.db`` connection (``convergence_debt`` is
+    an ops-tier table, not an index-tier one) so the archive is never left
+    silently claiming its new schema-version columns are populated: every
+    session actually in scope gets one ``convergence_debt`` row the daemon's
+    ordinary retry machinery (``daemon/convergence_debt_status.py``,
+    ``sources/live/convergence_debt_retry.py``) already surfaces and drains
+    the same way it drains every other deferred-until-quiet backlog
+    (CLAUDE.md's ``false_means_pending`` idiom). Returns the total number of
+    debt rows enqueued (0 when the plan has no pending scope, or when
+    ``index_conn`` has no resolvable sibling ops.db, e.g. an in-memory test
+    connection).
+    """
+    scopes = plan.pending_reprocess_scopes
+    if not scopes:
+        return 0
+    ops_db_path = _resolve_ops_db_path(index_conn)
+    if ops_db_path is None:
+        return 0
+    enqueued = 0
+    now_ms = int(time.time() * 1000)
+    ops_conn = sqlite3.connect(ops_db_path)
+    try:
+        initialize_archive_tier(ops_conn, ArchiveTier.OPS)
+        for version, scope in scopes:
+            enqueued += _enqueue_scope(index_conn, ops_conn, version, scope, now_ms)
+        ops_conn.commit()
+    finally:
+        ops_conn.close()
+    return enqueued
+
+
+def _enqueue_scope(
+    index_conn: sqlite3.Connection,
+    ops_conn: sqlite3.Connection,
+    version: int,
+    scope: TargetedReprocessScope,
+    now_ms: int,
+) -> int:
+    where_sql, params = scope.matching_predicate_sql()
+    session_ids = [
+        str(row[0]) for row in index_conn.execute(f"SELECT session_id FROM sessions WHERE {where_sql}", params)
+    ]
+    stage = f"index-v{version}-targeted-reprocess"
+    for session_id in session_ids:
+        add_convergence_debt(
+            ops_conn,
+            stage=stage,
+            target_type="session",
+            target_id=session_id,
+            status="deferred",
+            priority=0,
+            attempts=0,
+            last_error=None,
+            created_at_ms=now_ms,
+            updated_at_ms=now_ms,
+        )
+    return len(session_ids)
+
+
 def apply_index_fast_forward(conn: sqlite3.Connection, plan: IndexFastForwardPlan) -> None:
     """Apply every declaration in ``plan`` to ``conn``, one declaration at a time.
 
@@ -213,6 +320,15 @@ def apply_index_fast_forward(conn: sqlite3.Connection, plan: IndexFastForwardPla
     :func:`polylogue.storage.sqlite.lifecycle.index_fast_forward_plan`, which
     already refuses non-contiguous spans and spans containing a
     ``SEMANTIC_REPARSE`` declaration.
+
+    After every declaration's DDL lands, any declaration classed
+    ``SHAPE_FORWARD_TARGETED_REPROCESS`` (polylogue-9rw0.1) has its declared
+    ``reprocess_scope`` resolved against the just-upgraded ``sessions`` table
+    and enqueued as real ``convergence_debt`` rows in the sibling ``ops.db``
+    -- the DDL alone leaves the new columns/tables schema-correct but
+    populated only where a shared column happened to carry the same value,
+    so the scope must survive as durable, drainable debt rather than being
+    silently dropped once ``user_version`` reaches the target.
     """
     if not plan.eligible_for_sql_fast_forward:
         raise RuntimeError("index fast-forward plan is not eligible for SQL fast-forward")
@@ -242,6 +358,7 @@ def apply_index_fast_forward(conn: sqlite3.Connection, plan: IndexFastForwardPla
             raise
         else:
             conn.commit()
+    _enqueue_targeted_reprocess_debt(conn, plan)
 
 
 __all__ = ["apply_index_fast_forward"]

--- a/polylogue/storage/sqlite/lifecycle.py
+++ b/polylogue/storage/sqlite/lifecycle.py
@@ -24,6 +24,57 @@ class DerivedDeltaClass(StrEnum):
     FTS_REINDEX = "fts-reindex"
     CACHE_REMOVAL = "cache-removal"
     SEMANTIC_REPARSE = "semantic-reparse"
+    # polylogue-9rw0.1: a clone-safe DDL shape (additive nullable columns or
+    # tables) whose new VALUES come from parser/materializer semantics, not
+    # from existing columns. Unlike SEMANTIC_REPARSE, the raw evidence never
+    # needs re-reading in full: a bounded, declared reprocess scope (see
+    # ``TargetedReprocessScope``) names exactly which already-persisted
+    # sessions must be re-materialized to populate the new surface. The v44
+    # witness (sessions.title_ref/title_confidence, 3,201 of 18,871 Codex
+    # sessions) is the measured case this exists to express: previously the
+    # only truthful class was SEMANTIC_REPARSE, which routed every archive
+    # through a full raw replay to backfill two nullable columns on one
+    # origin's sessions.
+    SHAPE_FORWARD_TARGETED_REPROCESS = "shape-forward-targeted-reprocess"
+
+
+@dataclass(frozen=True, slots=True)
+class TargetedReprocessScope:
+    """A bounded reprocess scope over already-persisted sessions, as data.
+
+    Mirrors the ``origin``/``session_ids`` dimensions of
+    ``polylogue.maintenance.scope.MaintenanceScopeFilter`` -- the vocabulary
+    every other maintenance backfill already scopes by -- without importing
+    that module here: ``lifecycle.py`` is deliberately free of any
+    non-stdlib import so the schema-versioning policy lint, the fast-forward
+    executor, and unit tests can all evaluate it from the thinnest possible
+    surface. A caller that already imports ``polylogue.maintenance`` can
+    losslessly round-trip an instance into a ``MaintenanceScopeFilter``.
+
+    At least one dimension must be set -- an empty scope would silently mean
+    "every session", which is exactly the full-corpus cost this delta class
+    exists to avoid.
+    """
+
+    origin: str | None = None
+    session_ids: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.origin is None and not self.session_ids:
+            raise ValueError("TargetedReprocessScope must declare origin and/or session_ids")
+
+    def matching_predicate_sql(self) -> tuple[str, tuple[object, ...]]:
+        """Return a ``sessions``-table WHERE fragment and its bound params."""
+        clauses: list[str] = []
+        params: list[object] = []
+        if self.origin is not None:
+            clauses.append("origin = ?")
+            params.append(self.origin)
+        if self.session_ids:
+            placeholders = ", ".join("?" for _ in self.session_ids)
+            clauses.append(f"session_id IN ({placeholders})")
+            params.extend(self.session_ids)
+        return " AND ".join(clauses), tuple(params)
 
 
 class FastForwardOperationKind(StrEnum):
@@ -52,10 +103,27 @@ class IndexDeltaDeclaration:
     version: int
     classes: tuple[DerivedDeltaClass, ...]
     operations: tuple[FastForwardOperation, ...] = ()
+    # Required exactly when SHAPE_FORWARD_TARGETED_REPROCESS is in ``classes``
+    # (enforced by ``__post_init__``): the exact bounded scope a fast-forward
+    # of this version must enqueue for reprocessing, expressed as data.
+    reprocess_scope: TargetedReprocessScope | None = None
+
+    def __post_init__(self) -> None:
+        declares_class = DerivedDeltaClass.SHAPE_FORWARD_TARGETED_REPROCESS in self.classes
+        has_scope = self.reprocess_scope is not None
+        if declares_class != has_scope:
+            raise ValueError(
+                f"index delta v{self.version}: SHAPE_FORWARD_TARGETED_REPROCESS and reprocess_scope "
+                f"must be declared together (class present={declares_class!r}, scope present={has_scope!r})"
+            )
 
     @property
     def requires_semantic_reparse(self) -> bool:
         return DerivedDeltaClass.SEMANTIC_REPARSE in self.classes
+
+    @property
+    def requires_targeted_reprocess(self) -> bool:
+        return DerivedDeltaClass.SHAPE_FORWARD_TARGETED_REPROCESS in self.classes
 
 
 @dataclass(frozen=True, slots=True)
@@ -77,6 +145,21 @@ class IndexFastForwardPlan:
             and not self.requires_semantic_reparse
             and all(declaration.classes for declaration in self.declarations)
             and all(declaration.operations for declaration in self.declarations)
+        )
+
+    @property
+    def pending_reprocess_scopes(self) -> tuple[tuple[int, TargetedReprocessScope], ...]:
+        """Return the (version, scope) pairs this plan's execution must enqueue.
+
+        Non-empty exactly when the plan crosses a SHAPE_FORWARD_TARGETED_REPROCESS
+        declaration -- the executor consumes this to enqueue real, bounded
+        reprocess debt after the clone-safe DDL lands, instead of silently
+        treating the shape-only copy-forward as complete.
+        """
+        return tuple(
+            (declaration.version, declaration.reprocess_scope)
+            for declaration in self.declarations
+            if declaration.requires_targeted_reprocess and declaration.reprocess_scope is not None
         )
 
     @property
@@ -349,16 +432,30 @@ INDEX_DELTA_DECLARATIONS: tuple[IndexDeltaDeclaration, ...] = (
         # to copy forward -- but their VALUES come from the v44 Codex title
         # resolver (thread name -> authored history -> first HUMAN_AUTHORED
         # message), so a shape-only fast-forward would leave every row NULL
-        # while a cold rebuild populates them. That divergence is exactly what
-        # DerivedDeltaClass cannot currently express: there is no class for
-        # "additive columns, clone-safe shape, values via targeted reprocess".
-        # SEMANTIC_REPARSE is therefore the truthful classification today, and
-        # it keeps the existing full-rebuild behaviour rather than silently
-        # promoting a generation whose new columns disagree with a cold
-        # rebuild. polylogue-9rw0.1 owns extending the vocabulary so this exact
-        # delta class becomes a bounded shape fast-forward plus a Codex-scoped
-        # reprocess instead of a full-corpus replay.
-        classes=(DerivedDeltaClass.SEMANTIC_REPARSE,),
+        # while a cold rebuild populates them.
+        #
+        # polylogue-9rw0.1: re-declared under SHAPE_FORWARD_TARGETED_REPROCESS
+        # instead of SEMANTIC_REPARSE. The DDL still copy-forwards generically
+        # via the shared-columns REPLACE_TABLE path below (existing rows keep
+        # every column they already have; the two new columns start NULL,
+        # same as any additive-column REPLACE_TABLE); what changes is that the
+        # declaration now also states, as data, exactly which already-
+        # persisted sessions need re-materializing to populate them --
+        # origin=codex-session, the full 100% of the affected population
+        # measured in the bead witness -- so the executor enqueues bounded
+        # per-session reprocess debt instead of the archive silently
+        # promoting to v44 with every title_ref left NULL, or an operator
+        # having to reach for a full `polylogue ops reset --index` replay of
+        # all 41,363 raws to backfill two columns on one origin.
+        classes=(DerivedDeltaClass.SHAPE_FORWARD_TARGETED_REPROCESS,),
+        operations=(
+            FastForwardOperation(
+                name="v44-title-ref-shape",
+                kind=FastForwardOperationKind.REPLACE_TABLE,
+                objects=(("table", "sessions"),),
+            ),
+        ),
+        reprocess_scope=TargetedReprocessScope(origin="codex-session"),
     ),
     IndexDeltaDeclaration(
         version=45,
@@ -611,6 +708,7 @@ def index_delta_declaration_report(current_version: int) -> IndexDeltaDeclaratio
         if declaration.version > current_version
         or not declaration.classes
         or (not declaration.requires_semantic_reparse and not declaration.operations)
+        or (declaration.requires_targeted_reprocess and declaration.reprocess_scope is None)
     )
     return {
         "compatibility_floor": INDEX_FAST_FORWARD_COMPATIBILITY_FLOOR,
@@ -712,6 +810,7 @@ __all__ = [
     "IndexDeltaDeclaration",
     "IndexDeltaDeclarationReport",
     "IndexFastForwardPlan",
+    "TargetedReprocessScope",
     "get_latest_sql_fast_forwardable_version",
     "get_semantic_reparse_blocking_version_pair",
     "index_delta_declaration_report",

--- a/tests/unit/storage/test_index_fast_forward_executor.py
+++ b/tests/unit/storage/test_index_fast_forward_executor.py
@@ -396,3 +396,79 @@ def test_replace_table_sanitizes_poisoned_fts_freshness_ready_row(tmp_path: Path
     # An already-honest row is untouched.
     assert rows["threads_fts"][1] == "stale"
     assert rows["threads_fts"][2:] == (15411, 15401, 10)
+
+
+def test_shape_forward_targeted_reprocess_enqueues_bounded_ops_debt(tmp_path: Path) -> None:
+    """polylogue-9rw0.1: a SHAPE_FORWARD_TARGETED_REPROCESS fast-forward enqueues real debt.
+
+    Builds a pre-v44 shaped ``sessions`` table (no ``title_ref``/
+    ``title_confidence`` columns), seeds two codex-session sessions and one
+    other-origin session, then fast-forwards through the production v44
+    declaration. The DDL copy-forward alone would silently leave every new
+    column NULL with no record that anything is owed; this asserts the
+    executor also enqueues one ``convergence_debt`` row per *in-scope*
+    session in the sibling ``ops.db`` -- exactly the origin-scoped population
+    the declaration states as data, not the whole archive.
+
+    ANTI-VACUITY: deleting the ``_enqueue_targeted_reprocess_debt`` call in
+    ``apply_index_fast_forward`` makes the ``ops.db`` file never get created
+    (or, if it already existed, its ``convergence_debt`` table stays empty)
+    -- this test's final assertion on ``debt_rows`` would fail from 2 to 0.
+    """
+    from polylogue.storage.sqlite.archive_tiers.index_fast_forward_executor import apply_index_fast_forward
+    from polylogue.storage.sqlite.lifecycle import index_fast_forward_plan
+
+    index_path = tmp_path / "index.db"
+    conn = sqlite3.connect(index_path)
+    try:
+        initialize_archive_tier(conn, ArchiveTier.INDEX)
+        conn.execute('ALTER TABLE sessions DROP COLUMN "title_ref"')
+        conn.execute('ALTER TABLE sessions DROP COLUMN "title_confidence"')
+        conn.commit()
+
+        _seed_indexable_block(conn, native_suffix="codex-a", text="codex prose one")
+        _seed_indexable_block(conn, native_suffix="codex-b", text="codex prose two")
+        conn.execute(
+            """
+            INSERT INTO sessions (
+                native_id, origin, title, content_hash, created_at_ms, updated_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("native-session-other", "claude-code-session", "unrelated origin", _HASH, 1, 1),
+        )
+        conn.commit()
+        codex_session_ids = {
+            str(row[0])
+            for row in conn.execute("SELECT session_id FROM sessions WHERE origin = 'codex-session'").fetchall()
+        }
+        assert len(codex_session_ids) == 2
+
+        conn.execute("PRAGMA user_version = 43")
+        conn.commit()
+    finally:
+        conn.close()
+
+    conn = sqlite3.connect(index_path)
+    try:
+        plan = index_fast_forward_plan(43, 44)
+        assert plan is not None
+        apply_index_fast_forward(conn, plan)
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 44
+        # Shape landed; values are NOT backfilled by the DDL copy-forward alone.
+        title_refs = {row[0] for row in conn.execute("SELECT title_ref FROM sessions").fetchall()}
+        assert title_refs == {None}
+    finally:
+        conn.close()
+
+    ops_path = tmp_path / "ops.db"
+    assert ops_path.exists()
+    ops_conn = sqlite3.connect(ops_path)
+    try:
+        debt_rows = ops_conn.execute(
+            "SELECT target_id, status FROM convergence_debt WHERE stage = 'index-v44-targeted-reprocess'"
+        ).fetchall()
+    finally:
+        ops_conn.close()
+
+    assert {row[0] for row in debt_rows} == codex_session_ids
+    assert all(row[1] == "deferred" for row in debt_rows)

--- a/tests/unit/storage/test_index_fast_forward_lifecycle.py
+++ b/tests/unit/storage/test_index_fast_forward_lifecycle.py
@@ -171,3 +171,91 @@ def test_schema_policy_rejects_an_index_bump_without_a_delta_declaration(
     payload = json.loads(capsys.readouterr().out)
     assert exit_code == 1
     assert payload["index_delta_declarations"]["missing_versions"] == [INDEX_SCHEMA_VERSION + 1]
+
+
+def test_targeted_reprocess_scope_requires_a_dimension() -> None:
+    """An empty scope would silently mean 'every session' -- refuse it."""
+    with pytest.raises(ValueError, match="origin and/or session_ids"):
+        lifecycle.TargetedReprocessScope()
+
+
+def test_targeted_reprocess_scope_builds_the_declared_predicate() -> None:
+    origin_only = lifecycle.TargetedReprocessScope(origin="codex-session")
+    assert origin_only.matching_predicate_sql() == ("origin = ?", ("codex-session",))
+
+    sessions_only = lifecycle.TargetedReprocessScope(session_ids=("a:1", "a:2"))
+    assert sessions_only.matching_predicate_sql() == ("session_id IN (?, ?)", ("a:1", "a:2"))
+
+    both = lifecycle.TargetedReprocessScope(origin="codex-session", session_ids=("a:1",))
+    assert both.matching_predicate_sql() == ("origin = ? AND session_id IN (?)", ("codex-session", "a:1"))
+
+
+def test_declaration_requires_scope_and_class_together() -> None:
+    """The class/scope pairing is enforced at construction, not just by the report."""
+    with pytest.raises(ValueError, match="must be declared together"):
+        IndexDeltaDeclaration(
+            version=54,
+            classes=(DerivedDeltaClass.SHAPE_FORWARD_TARGETED_REPROCESS,),
+            operations=(
+                FastForwardOperation(
+                    name="synthetic",
+                    kind=FastForwardOperationKind.REPLACE_TABLE,
+                    objects=(("table", "sessions"),),
+                ),
+            ),
+            # reprocess_scope deliberately omitted.
+        )
+    with pytest.raises(ValueError, match="must be declared together"):
+        IndexDeltaDeclaration(
+            version=54,
+            classes=(DerivedDeltaClass.CONSTRAINT_ONLY,),
+            operations=(
+                FastForwardOperation(
+                    name="synthetic",
+                    kind=FastForwardOperationKind.REPLACE_TABLE,
+                    objects=(("table", "sessions"),),
+                ),
+            ),
+            reprocess_scope=lifecycle.TargetedReprocessScope(origin="codex-session"),
+        )
+
+
+def test_plan_aggregates_pending_reprocess_scopes_across_declarations() -> None:
+    """A plan crossing a SHAPE_FORWARD_TARGETED_REPROCESS delta surfaces its scope as data."""
+    declaration = IndexDeltaDeclaration(
+        version=54,
+        classes=(DerivedDeltaClass.SHAPE_FORWARD_TARGETED_REPROCESS,),
+        operations=(
+            FastForwardOperation(
+                name="synthetic",
+                kind=FastForwardOperationKind.REPLACE_TABLE,
+                objects=(("table", "sessions"),),
+            ),
+        ),
+        reprocess_scope=lifecycle.TargetedReprocessScope(origin="codex-session"),
+    )
+    plan = lifecycle.IndexFastForwardPlan(source_version=53, target_version=54, declarations=(declaration,))
+
+    assert plan.eligible_for_sql_fast_forward is True
+    assert plan.requires_semantic_reparse is False
+    assert plan.pending_reprocess_scopes == ((54, lifecycle.TargetedReprocessScope(origin="codex-session")),)
+
+
+def test_v44_is_declared_shape_forward_targeted_reprocess_scoped_to_codex() -> None:
+    """polylogue-9rw0.1 AC#4: v44 is re-declared under the new class.
+
+    ANTI-VACUITY: reverting v44's declared ``classes`` back to
+    ``(SEMANTIC_REPARSE,)`` makes ``eligible_for_sql_fast_forward`` False and
+    this assertion fail -- the whole point of the new class is that v44 now
+    fast-forwards instead of forcing a full rebuild to backfill two nullable
+    columns on one origin's sessions.
+    """
+    v44 = next(d for d in lifecycle.INDEX_DELTA_DECLARATIONS if d.version == 44)
+
+    assert v44.classes == (DerivedDeltaClass.SHAPE_FORWARD_TARGETED_REPROCESS,)
+    assert v44.reprocess_scope == lifecycle.TargetedReprocessScope(origin="codex-session")
+
+    plan = lifecycle.index_fast_forward_plan(43, 44)
+    assert plan is not None
+    assert plan.eligible_for_sql_fast_forward is True
+    assert plan.pending_reprocess_scopes == ((44, lifecycle.TargetedReprocessScope(origin="codex-session")),)


### PR DESCRIPTION
## Summary

Extends `DerivedDeltaClass` (`storage/sqlite/lifecycle.py`) with a new
`SHAPE_FORWARD_TARGETED_REPROCESS` class that expresses "clone-safe DDL
shape, values via a bounded, data-declared targeted reprocess" — a
classification that previously did not exist, forcing every additive
column/table whose values depend on parser semantics to be declared
`SEMANTIC_REPARSE` and route the whole archive through a full raw replay.

## Problem

Measured witness (v44, polylogue-ih67, PR #3378): adds
`sessions.title_ref`/`title_confidence`, two nullable columns on an
18,871-row table, populated for only 3,201 codex-session rows (100% of
that one origin). The only honest classification available today
(`SEMANTIC_REPARSE`) costs a full replay of 41,363 raws against a 36 GB
index generation — measured at multiple hours-to-days — to backfill two
columns on one origin. This is the general case, not a v44 special case:
every future additive column with parser-derived values hits the same
gap (v45/v46/v47/v48/v49/v50 all cite this exact unresolved vocabulary
gap in their own declaration comments).

## Solution

- `storage/sqlite/lifecycle.py`: new `DerivedDeltaClass.SHAPE_FORWARD_TARGETED_REPROCESS`
  and a `TargetedReprocessScope` dataclass (`origin`/`session_ids`) that
  states the reprocess scope as data, not prose. It deliberately mirrors
  `polylogue.maintenance.scope.MaintenanceScopeFilter`'s established
  scope vocabulary without importing that module — `lifecycle.py` stays
  free of any non-stdlib dependency. `IndexDeltaDeclaration.__post_init__`
  enforces the class/scope pairing at construction (both present or
  neither); `IndexFastForwardPlan.pending_reprocess_scopes` aggregates
  every in-scope declaration so callers can see exactly what a plan still
  owes.
- `archive_tiers/index_fast_forward_executor.py`: after a plan's DDL
  lands, `_enqueue_targeted_reprocess_debt` resolves each declared scope
  against the just-upgraded `sessions` table (on the same index-tier
  connection) and enqueues one real `convergence_debt` row per in-scope
  session into the sibling `ops.db` — reusing the existing convergence-
  debt ledger and the daemon's `false_means_pending` idiom instead of
  inventing a new queue. `_resolve_ops_db_path` derives the sibling path
  from `PRAGMA database_list` rather than widening the executor's
  signature; an unnamed/in-memory connection (tests) safely skips
  enqueueing.
- **Fixed a latent, pre-existing bug** in `_apply_replace_table`,
  surfaced only by actually exercising `REPLACE_TABLE` against a live
  schema with a real dependent view: renaming the copy-forward's
  temporary table back to `sessions` raised
  `OperationalError: error in view delegation_facts_source: no such
  table: main.sessions`, because SQLite re-validates every dependent
  view's SQL during an ordinary `ALTER TABLE RENAME`. This was latent
  for the v36/v38/v41 declarations too (nothing had exercised
  `_apply_replace_table` against `sessions`/`action_pairs` with their
  real dependent views present) — wrapped the rename in
  `PRAGMA legacy_alter_table=ON` / `OFF`.
- v44 is re-declared under the new class, scoped to
  `origin=codex-session` (the full affected population per the bead
  witness), so it now fast-forwards instead of forcing a full rebuild.

## Verification

- `devtools test tests/unit/storage/test_index_fast_forward_lifecycle.py tests/unit/storage/test_index_fast_forward_executor.py` — 21 passed
  (7 new): scope validation (`TargetedReprocessScope` requires a
  dimension, predicate-SQL construction), class/scope pairing enforced
  at construction, plan-level `pending_reprocess_scopes` aggregation, v44
  re-declaration + eligibility, and an executor-level test that seeds a
  pre-v44-shaped `sessions` table (columns dropped) with 2 codex-session
  + 1 other-origin session, fast-forwards through the **real** v44
  declaration, and asserts the DDL lands (columns present, NULL) while
  exactly the 2 codex-session ids get `convergence_debt` rows in the
  sibling `ops.db` — the other-origin session does not.
- `devtools test tests/unit/storage/` — 2051 passed, 30 pre-existing
  failures unrelated to this change. Spot-verified two in isolation:
  `test_blob_gc.py::test_run_blob_gc_dry_run_does_not_delete_or_record_generation`
  fails on a `clock_guard` `time.time()` violation in the test file
  itself; `test_raw_authority_ledger.py::test_frontier_classifies_dangling_head_session_as_corrupt`
  fails on a raw-materialization repair-count assertion — neither
  touches `lifecycle.py` or the fast-forward executor.
- `devtools verify --quick` — exit 0 (ruff format/check, mypy --strict,
  render all --check, layering, schema-versioning policy all green;
  the layering check specifically validates the new ops.db write goes
  through the declared `ops_write.add_convergence_debt` entrypoint and
  `bootstrap.initialize_archive_tier`, not an opaque imported-SQL
  `executescript`).

## AC matrix (polylogue-9rw0.1)

1. **SATISFIED** — `SHAPE_FORWARD_TARGETED_REPROCESS` +
   `TargetedReprocessScope` express the scope as data
   (origin/session_ids), not prose.
2. **PARTIALLY SATISFIED** — `index_fast_forward_plan` returns a plan
   whose execution leaves the schema correct and enqueues the exact
   scope as real `convergence_debt` rows. "A generation is not promoted
   while that scope is outstanding" is honored to the extent generation
   promotion exists in this codebase today (it does not yet —
   polylogue-b5l's blue-green transition protocol is still open):
   `PRAGMA user_version` does advance to the target version, matching
   every other declared class's behavior, but the reprocess debt persists
   durably and visibly in `convergence_debt` rather than being silently
   dropped — the same `false_means_pending` idiom every other deferred-
   until-quiet backlog in this codebase already uses. A follow-up under
   polylogue-b5l (or a dedicated bead) should wire an actual
   `ConvergenceStage` that drains this stage name by re-running the
   parse/materialize pipeline for each debt row's session; this PR stops
   at "enqueued and durably visible", not "autonomously drained".
3. **DEFERRED** — byte-equivalence-to-cold-rebuild sampling with honest
   drift surfacing depends on the general source-backed replay
   equivalence mechanism, which is the sole remaining open AC of parent
   epic polylogue-9rw0 itself (no implementation exists yet for *any*
   declared delta class, semantic or not — confirmed by re-reading
   9rw0's own notes). Building that mechanism inside this narrower
   vocabulary-gap lane would preempt the parent epic's still-undesigned
   proof harness rather than extend it. This PR's `reprocess_scope` is
   exactly the input shape that harness will need once it lands.
4. **SATISFIED** — v44 re-declared under the new class, scoped to
   `origin=codex-session`. Live before/after cost measurement against
   the real archive requires an operator-run migration outside this
   sandbox; not executed here.
5. **SATISFIED** — `devtools lab policy schema-versioning` still passes
   (undeclared-versions, invalid-versions, benign-DDL-registry checks
   all report 0).

## Anti-vacuity

- Deleting the `_enqueue_targeted_reprocess_debt` call in
  `apply_index_fast_forward` makes the new executor test's
  `debt_rows` assertion fail from 2 rows to 0 — the production caller
  exercised is `apply_index_fast_forward` itself (called from
  `bootstrap.initialize_archive_database`'s real open-path, the same
  path every CLI/API/daemon entrypoint goes through).
- Reverting v44's `classes` back to `(SEMANTIC_REPARSE,)` makes
  `test_v44_is_declared_shape_forward_targeted_reprocess_scoped_to_codex`
  fail (`eligible_for_sql_fast_forward` becomes `False`).
- Removing the `PRAGMA legacy_alter_table=ON` fix reproduces the
  `OperationalError` in the new executor test immediately (verified by
  temporarily reverting it locally before writing this PR body).

Ref polylogue-9rw0.1