### PR TITLE
fix(cost): strip aistudio-drive models/ prefix, honest zero-token provenance

### DIFF
--- a/polylogue/archive/semantic/cost_compute.py
+++ b/polylogue/archive/semantic/cost_compute.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -14,7 +15,8 @@ from polylogue.archive.semantic.pricing import (
     estimate_session_cost,
 )
 from polylogue.archive.semantic.subscription_pricing import compute_credit_cost, credits_to_usd, get_credit_rate
-from polylogue.archive.semantic.tokenizer import TOKENIZER_VERSION, estimate_tokens_from_words
+from polylogue.archive.semantic.tokenizer import TOKENIZER_VERSION, estimate_tokens_from_words_split
+from polylogue.core.enums import Role
 
 if TYPE_CHECKING:
     from polylogue.archive.models import Session
@@ -105,6 +107,7 @@ def compute_session_cost(
     agg_confidence = "reported"
     has_estimates = False
     has_reported = False
+    has_unknown = False
 
     for _key, breakdown in sorted(per_model.items()):
         norm = breakdown.normalized_model
@@ -156,9 +159,22 @@ def compute_session_cost(
             has_estimates = True
         elif updated.confidence == "reported":
             has_reported = True
+        elif updated.confidence == "unknown":
+            has_unknown = True
 
     if not breakdowns:
         agg_confidence = "unknown"
+    elif has_unknown and (has_reported or has_estimates):
+        # A mixed session -- e.g. one model with genuine provider-reported or
+        # estimated tokens alongside another model whose only evidence is a
+        # zero-token _seed_session_model_usage_rows() skeleton row -- must not
+        # read as a clean "reported"/"estimated" aggregate. Some of the
+        # session's cost is real evidence and some of it is unaccounted for,
+        # which is exactly what "partial" means (polylogue-3b607 P2: without
+        # this branch, has_reported=True from the genuine row silently
+        # overrode the fact that another per-model breakdown was separately
+        # marked unknown).
+        agg_confidence = "partial"
     elif has_estimates:
         agg_confidence = "estimated"
     elif not has_reported:
@@ -242,11 +258,32 @@ def _per_model_from_messages(session: Session) -> dict[str, SessionCostBreakdown
     per-message ``input_tokens``/``output_tokens`` fields are sparse-to-absent
     for Codex, which is why this path historically undercounted Codex sessions
     by ~1000x when it was the only source (polylogue-r7p6).
+
+    Two things this must get right for the estimate-only path (polylogue-3b607,
+    fixing bugs introduced by polylogue-9kjtc):
+
+    - Messages with no per-message declared model (routine for ChatGPT/Claude
+      web *user* turns -- only the assistant turn carries ``model_slug``) fall
+      back to the session's dominant declared model instead of an unpriced
+      "unknown" bucket. This reuses the same Counter/``most_common`` dominant-
+      model pattern ``pricing.py``'s ``_session_level_estimate`` uses, rather
+      than inventing a new heuristic.
+    - Estimated word-count tokens are classified by the message's role: user/
+      human turns are ``input_tokens``, assistant turns are ``output_tokens``.
+      Dumping everything into ``input_tokens`` regardless of role systematically
+      understated cost, since output tokens are typically priced higher.
     """
     per_model: dict[str, SessionCostBreakdown] = {}
 
+    model_counts: Counter[str] = Counter()
     for message in session.messages:
-        model_name = _get_message_model_name(message)
+        declared_model = _get_message_model_name(message)
+        if declared_model:
+            model_counts[declared_model] += 1
+    dominant_model_name = model_counts.most_common(1)[0][0] if model_counts else None
+
+    for message in session.messages:
+        model_name = _get_message_model_name(message) or dominant_model_name
         norm_model = _normalize_model(model_name) if model_name else None
         key = norm_model or "unknown"
 
@@ -262,12 +299,17 @@ def _per_model_from_messages(session: Session) -> dict[str, SessionCostBreakdown
         if tokens is not None and getattr(tokens, "billable_tokens", 0) > 0:
             per_model[key] = _add_provider_reported_tokens(per_model[key], tokens, model_name)
         elif word_count > 0:
-            est = estimate_tokens_from_words(word_count)
+            is_assistant_turn = getattr(message, "role", None) == Role.ASSISTANT
+            est = estimate_tokens_from_words_split(
+                input_words=0 if is_assistant_turn else word_count,
+                output_words=word_count if is_assistant_turn else 0,
+            )
             per_model[key] = SessionCostBreakdown(
                 normalized_model=per_model[key].normalized_model,
                 provider_model_name=per_model[key].provider_model_name,
                 input_tokens=per_model[key].input_tokens + est.input_tokens,
-                total_tokens=per_model[key].total_tokens + est.input_tokens,
+                output_tokens=per_model[key].output_tokens + est.output_tokens,
+                total_tokens=per_model[key].total_tokens + est.total_tokens,
                 confidence="estimated",
                 provenance="heuristic_estimated",
             )

--- a/polylogue/archive/semantic/cost_compute.py
+++ b/polylogue/archive/semantic/cost_compute.py
@@ -87,6 +87,16 @@ def compute_session_cost(
     per_model: dict[str, SessionCostBreakdown] = (
         _per_model_from_model_usage(model_usage) if model_usage else _per_model_from_messages(session)
     )
+    if model_usage and not any(breakdown.total_tokens for breakdown in per_model.values()):
+        # session_model_usage carries model identity but no real usage
+        # counters for every row (e.g. chatgpt-export/claude-ai-export
+        # exports, which don't carry provider token counters -- see
+        # docs/cost-model.md's estimate-only disposition for those origins).
+        # Fall back to the text-length heuristic over messages instead of
+        # reporting a hollow zero-token "reported" breakdown (polylogue-9kjtc).
+        message_based = _per_model_from_messages(session)
+        if message_based:
+            per_model = message_based
 
     breakdowns: list[SessionCostBreakdown] = []
     total_api = 0.0
@@ -94,6 +104,7 @@ def compute_session_cost(
     total_sub = 0.0
     agg_confidence = "reported"
     has_estimates = False
+    has_reported = False
 
     for _key, breakdown in sorted(per_model.items()):
         norm = breakdown.normalized_model
@@ -143,11 +154,25 @@ def compute_session_cost(
         total_sub += sub_equivalent
         if updated.confidence == "estimated":
             has_estimates = True
+        elif updated.confidence == "reported":
+            has_reported = True
 
     if not breakdowns:
         agg_confidence = "unknown"
     elif has_estimates:
         agg_confidence = "estimated"
+    elif not has_reported:
+        # Every breakdown is a model-identity-only fact with no real token
+        # evidence and no text-length estimate to fall back on -- honest
+        # disposition is "unknown", not "reported" (polylogue-9kjtc).
+        agg_confidence = "unknown"
+
+    if agg_confidence == "reported":
+        cost_provenance = "provider_reported"
+    elif agg_confidence == "unknown":
+        cost_provenance = "unknown"
+    else:
+        cost_provenance = "mixed"
 
     return SessionCostSummary(
         total_input_tokens=sum(b.input_tokens for b in breakdowns),
@@ -157,7 +182,7 @@ def compute_session_cost(
         total_api_cost_usd=round(total_api, 6),
         total_credit_cost=round(total_credit, 2),
         total_subscription_equivalent_usd=round(total_sub, 6),
-        cost_provenance="provider_reported" if agg_confidence == "reported" else "mixed",
+        cost_provenance=cost_provenance,
         cost_confidence=agg_confidence,
         tokenizer_version=TOKENIZER_VERSION,
         price_snapshot_version=_PRICE_SNAPSHOT_VERSION,
@@ -168,9 +193,16 @@ def compute_session_cost(
 def _per_model_from_model_usage(model_usage: Sequence[ModelUsageTotals]) -> dict[str, SessionCostBreakdown]:
     """Build the per-model breakdown seed from canonical ``session_model_usage`` rows.
 
-    Every row is provider-reported evidence by construction (the row would not
-    exist without an ingested usage event or message token sum), so this never
-    falls back to the word-count heuristic path the message walk uses.
+    A row's existence proves a model-identity fact (an ingested usage event or
+    message asserted this model was used), but not that the row carries real
+    usage *counts* -- some origins (chatgpt-export, claude-ai-export) write a
+    row with a real ``model_name`` and zero token counters because their
+    exports don't carry provider token counters at all. Only rows whose
+    aggregated tokens are actually nonzero are labelled ``reported``/
+    ``provider_reported``; a model-identity-only row with no real token
+    evidence is labelled ``unknown``/``unknown`` instead, so it can't be
+    mistaken for a provider that genuinely reported and billed zero
+    (polylogue-9kjtc).
     """
     per_model: dict[str, SessionCostBreakdown] = {}
     for row in model_usage:
@@ -196,6 +228,9 @@ def _per_model_from_model_usage(model_usage: Sequence[ModelUsageTotals]) -> dict
             confidence="reported",
             provenance="provider_reported",
         )
+    for key, breakdown in per_model.items():
+        if breakdown.total_tokens == 0:
+            per_model[key] = breakdown.model_copy(update={"confidence": "unknown", "provenance": "unknown"})
     return per_model
 
 

--- a/polylogue/archive/semantic/pricing.py
+++ b/polylogue/archive/semantic/pricing.py
@@ -335,6 +335,11 @@ def _normalize_model(model: str) -> str:
     lowered = lowered.removeprefix("anthropic/")
     lowered = lowered.removeprefix("google/")
     lowered = lowered.removeprefix("gemini/")
+    # aistudio-drive's parser stores the raw Gemini API resource-path model
+    # identifier verbatim (e.g. "models/gemini-2.5-pro") -- strip the
+    # "models/" resource-path segment so it normalizes to the same catalog
+    # key as gemini-cli-session's bare form (polylogue-6j9c).
+    lowered = lowered.removeprefix("models/")
     # Canonicalize trailing date snapshots to the base model so cost rollups
     # don't fragment by release date (e.g. gpt-4o-2024-08-06 -> gpt-4o,
     # claude-opus-4-8-20260101 -> claude-opus-4-8). Done before the exact-match

--- a/tests/unit/core/test_cost_compute.py
+++ b/tests/unit/core/test_cost_compute.py
@@ -1,0 +1,87 @@
+"""Contracts for per-model cost breakdown provenance (polylogue-9kjtc).
+
+``session_model_usage`` rows can carry a real model-identity fact (a
+``model_name``) with zero token counters -- this is the normal shape for
+origins whose exports don't carry provider token counters at all
+(chatgpt-export, claude-ai-export; see docs/cost-model.md's "estimate-only"
+disposition table). Before the fix, every such row was unconditionally
+labelled ``confidence="reported"``/``provenance="provider_reported"``,
+making a hollow zero-token row indistinguishable from a provider that
+genuinely reported and billed a zero cost.
+"""
+
+from __future__ import annotations
+
+from polylogue.archive.semantic.cost_compute import (
+    _per_model_from_model_usage,
+    compute_session_cost,
+)
+from polylogue.archive.semantic.cost_records import ModelUsageTotals
+from tests.infra.builders import make_conv, make_msg
+
+
+def test_zero_token_model_usage_row_is_labelled_unknown_not_reported() -> None:
+    """A model-identity-only row (real model_name, zero tokens) must not be
+    stamped as provider-reported evidence."""
+
+    rows = [ModelUsageTotals(model_name="gpt-4o", input_tokens=0, output_tokens=0)]
+    per_model = _per_model_from_model_usage(rows)
+
+    (breakdown,) = per_model.values()
+    assert breakdown.confidence == "unknown"
+    assert breakdown.provenance == "unknown"
+
+
+def test_nonzero_model_usage_row_stays_provider_reported() -> None:
+    """A row with real token counts is unaffected by the zero-token guard."""
+
+    rows = [ModelUsageTotals(model_name="gpt-4o", input_tokens=100, output_tokens=50)]
+    per_model = _per_model_from_model_usage(rows)
+
+    (breakdown,) = per_model.values()
+    assert breakdown.confidence == "reported"
+    assert breakdown.provenance == "provider_reported"
+
+
+def test_compute_session_cost_falls_back_to_word_count_estimate_for_zero_token_usage() -> None:
+    """polylogue-9kjtc AC2: when session_model_usage carries only zero-token
+    rows (the chatgpt-export/claude-ai-export shape) but the session's
+    messages have real text, compute_session_cost must run the text-length
+    heuristic estimate rather than reporting a hollow $0.0 'reported' cost.
+    """
+
+    session = make_conv(
+        id="chatgpt-zero-token-session",
+        provider="chatgpt",
+        messages=[
+            make_msg(id="m1", role="user", text="a reasonably long user message with several words in it"),
+            make_msg(id="m2", role="assistant", text="a reasonably long assistant reply with several words too"),
+        ],
+    )
+    model_usage = [ModelUsageTotals(model_name="gpt-4o", input_tokens=0, output_tokens=0)]
+
+    summary = compute_session_cost(session, estimate_if_missing=False, model_usage=model_usage)
+
+    assert summary.cost_confidence == "estimated"
+    assert summary.cost_provenance != "provider_reported"
+    assert summary.total_input_tokens > 0
+    assert any(b.confidence == "estimated" for b in summary.per_model)
+
+
+def test_compute_session_cost_is_unknown_when_no_real_evidence_exists() -> None:
+    """When session_model_usage carries only zero-token rows AND the
+    session's messages carry no text/word-count evidence either, the honest
+    disposition is 'unknown', not a default 'reported' with $0.0 cost."""
+
+    session = make_conv(
+        id="no-evidence-session",
+        provider="chatgpt",
+        messages=[],
+    )
+    model_usage = [ModelUsageTotals(model_name="gpt-4o", input_tokens=0, output_tokens=0)]
+
+    summary = compute_session_cost(session, estimate_if_missing=False, model_usage=model_usage)
+
+    assert summary.cost_confidence == "unknown"
+    assert summary.cost_provenance == "unknown"
+    assert summary.total_api_cost_usd == 0.0

--- a/tests/unit/core/test_cost_compute.py
+++ b/tests/unit/core/test_cost_compute.py
@@ -1,4 +1,4 @@
-"""Contracts for per-model cost breakdown provenance (polylogue-9kjtc).
+"""Contracts for per-model cost breakdown provenance (polylogue-9kjtc, polylogue-3b607).
 
 ``session_model_usage`` rows can carry a real model-identity fact (a
 ``model_name``) with zero token counters -- this is the normal shape for
@@ -13,6 +13,7 @@ genuinely reported and billed a zero cost.
 from __future__ import annotations
 
 from polylogue.archive.semantic.cost_compute import (
+    _per_model_from_messages,
     _per_model_from_model_usage,
     compute_session_cost,
 )
@@ -85,3 +86,86 @@ def test_compute_session_cost_is_unknown_when_no_real_evidence_exists() -> None:
     assert summary.cost_confidence == "unknown"
     assert summary.cost_provenance == "unknown"
     assert summary.total_api_cost_usd == 0.0
+
+
+def test_per_model_from_messages_splits_estimated_tokens_by_role_with_dominant_model_fallback() -> None:
+    """polylogue-3b607 P1: a ChatGPT-shaped session where only the assistant
+    turn declares ``model_name`` (the user turn does not, which is the normal
+    ChatGPT/Claude-web export shape) must:
+
+    (1) attribute the model-less *user* turn's estimated tokens to the
+        session's dominant declared model rather than an unpriced "unknown"
+        bucket, and
+    (2) classify each turn's estimated tokens by role -- user text becomes
+        input_tokens, assistant text becomes output_tokens -- instead of
+        dumping everything into input_tokens regardless of role.
+
+    Reverting the dominant-model fallback in ``_per_model_from_messages``
+    (making model-less messages key on "unknown" again) fails assertion (1);
+    reverting the role-based split (using ``estimate_tokens_from_words``
+    unconditionally into ``input_tokens`` again) fails assertion (2), since
+    the assistant reply's tokens would land in input_tokens and
+    output_tokens would stay 0.
+    """
+
+    session = make_conv(
+        id="chatgpt-role-split-session",
+        provider="chatgpt",
+        messages=[
+            make_msg(
+                id="m1",
+                role="user",
+                text="a reasonably long user message with quite a few words in it here",
+            ),
+            make_msg(
+                id="m2",
+                role="assistant",
+                text="a reasonably long assistant reply with even more words in it than that",
+                model_name="gpt-4o",
+            ),
+        ],
+    )
+
+    per_model = _per_model_from_messages(session)
+
+    # No "unknown" bucket -- the model-less user turn inherited the session's
+    # one declared model (gpt-4o) instead of being shunted off unpriced.
+    assert set(per_model.keys()) == {"gpt-4o"}
+    breakdown = per_model["gpt-4o"]
+
+    # Both roles contributed real estimated tokens, split by role rather than
+    # everything landing in input_tokens.
+    assert breakdown.input_tokens > 0, "user turn's estimate should be input_tokens"
+    assert breakdown.output_tokens > 0, "assistant turn's estimate should be output_tokens"
+    assert breakdown.total_tokens == breakdown.input_tokens + breakdown.output_tokens
+    assert breakdown.confidence == "estimated"
+
+
+def test_compute_session_cost_downgrades_to_partial_when_one_model_unknown_alongside_reported() -> None:
+    """polylogue-3b607 P2: a two-model session where one model has genuine
+    nonzero provider-reported usage and the other is only a zero-token
+    ``_seed_session_model_usage_rows`` skeleton row (no telemetry at all) must
+    not read as a clean aggregate 'reported' -- has_reported=True from the
+    genuine row previously masked the fact that another per-model breakdown
+    was separately labelled unknown. The honest aggregate disposition is
+    'partial'.
+
+    Reverting the P2 fix (removing the ``has_unknown`` branch in
+    ``compute_session_cost``'s aggregate loop) makes this fail: the aggregate
+    would fall through to the initial ``agg_confidence = "reported"`` default
+    since ``has_estimates`` is False and ``has_reported`` is True.
+    """
+
+    model_usage = [
+        ModelUsageTotals(model_name="gpt-4o", input_tokens=1000, output_tokens=500),
+        ModelUsageTotals(model_name="claude-3-5-sonnet", input_tokens=0, output_tokens=0),
+    ]
+    session = make_conv(id="mixed-reported-unknown-session", provider="chatgpt", messages=[])
+
+    summary = compute_session_cost(session, estimate_if_missing=False, model_usage=model_usage)
+
+    assert summary.cost_confidence == "partial"
+    assert summary.cost_provenance != "provider_reported"
+    confidences = {b.confidence for b in summary.per_model}
+    assert "reported" in confidences
+    assert "unknown" in confidences

--- a/tests/unit/core/test_pricing.py
+++ b/tests/unit/core/test_pricing.py
@@ -242,6 +242,29 @@ def test_model_normalization_accepts_provider_prefixes_and_version_suffixes() ->
     assert estimate_cost(1000, 500, "openai/gpt-4o-2024-08-06") == pytest.approx(0.0075)
 
 
+def test_aistudio_drive_resource_path_model_prices_like_bare_form() -> None:
+    """polylogue-6j9c: aistudio-drive's parser stores the raw Gemini API
+    resource-path model identifier verbatim (e.g. ``models/gemini-2.5-pro``,
+    see ``tests/unit/sources/test_gemini_drive_normalization_laws.py``), while
+    gemini-cli-session uses the bare form for the same catalog model. Before
+    the fix, ``_normalize_model`` never stripped ``models/`` and the
+    resource-path form failed both the exact-match and prefix-fallback catalog
+    lookups, so ``estimate_cost`` silently returned $0.0 for real,
+    substantial aistudio-drive token usage (105.7M tokens measured on the live
+    archive) despite the catalog carrying a real rate for the underlying
+    model.
+    """
+    from polylogue.archive.semantic.pricing import PRICING
+
+    assert _normalize_model("models/gemini-2.5-pro") == _normalize_model("gemini-2.5-pro")
+    assert _normalize_model("models/gemini-2.5-pro") in PRICING
+
+    bare_cost = estimate_cost(1_000_000, 1_000_000, "gemini-2.5-pro")
+    resource_path_cost = estimate_cost(1_000_000, 1_000_000, "models/gemini-2.5-pro")
+    assert resource_path_cost == pytest.approx(bare_cost)
+    assert resource_path_cost > 0.0
+
+
 def test_current_opus_flagships_are_priced_not_zero() -> None:
     """Opus 4.7/4.8 must be priced (regression: they fell through to $0).
 


### PR DESCRIPTION
## Summary

Two related cost-accounting bugs from a fresh forensics pass (2026-08-01,
read-only census against `index.db`):

1. **polylogue-6j9c** (P1): aistudio-drive prices at $0.00 for 105.7M real
   tokens because `pricing.py`'s `_normalize_model()` never stripped the
   `models/` resource-path prefix aistudio-drive's own parser writes verbatim.
2. **polylogue-9kjtc** (P2): `cost_compute.py` unconditionally labelled every
   `session_model_usage` row `confidence=reported`/`provenance=provider_reported`
   regardless of whether it carried real nonzero tokens, mislabeling 2,264
   chatgpt-export (+55 claude-ai-export) zero-token stub rows as if the
   provider itself reported and billed $0.

## Problem

**#1 (polylogue-6j9c):** aistudio-drive's parser (`sources/parsers/drive.py`)
stores the Gemini API resource-path model identifier verbatim, e.g.
`models/gemini-2.5-pro` (confirmed against
`tests/unit/sources/test_gemini_drive_normalization_laws.py` and
`tests/unit/core/test_schema_generation.py`). `_normalize_model()` stripped
`openai/`/`anthropic/`/`google/`/`gemini/` but never `models/`, so this form
failed both the exact-match catalog lookup and the prefix-fallback lookup.
Measured on the live archive: 239 `session_model_usage` rows / 17 distinct
model names / 105,687,388 tokens across `aistudio-drive`, all pricing to
`cost_provenance=provider_reported`, `total_cost_usd=0.0` for all 183
`session_profiles` rows in that bucket — despite the catalog carrying real
per-token rates for the underlying models (e.g.
`PRICING['gemini-2.5-pro'] = 1.25/10.0` USD/M input/output).
Cross-check: `gemini-cli-session` uses the bare model name for the same
model family and prices correctly on comparable volumes (e.g.
`gemini-3.1-pro-preview`, 6.3M tokens → $23.68).

**#2 (polylogue-9kjtc):** `_per_model_from_model_usage()`'s docstring claimed
"every row is provider-reported evidence by construction," which is true of
the row's *existence* but not of whether it carries real usage *counts*.
chatgpt-export and claude-ai-export exports don't carry provider token
counters at all (`docs/cost-model.md` declares both "estimate-only"), yet
their `session_model_usage` rows still carry a real `model_name` with zero
tokens, and got the same `reported`/`provider_reported` stamp as genuine
provider telemetry. Live-archive confirmation: chatgpt-export has 2,264
`session_profiles` rows with `cost_provenance=provider_reported` and
`total_cost_usd=0.0` for every single one (sum=0.0, avg=0.0); claude-ai-export
had 55 more via a related `compute_session_cost` aggregation gap — that
origin has zero `session_model_usage` rows, so its per-model breakdowns
already carried the record default `confidence=unknown`, but the aggregation
loop's `agg_confidence` started at `"reported"` and only ever downgraded to
`"estimated"`, never to `"unknown"`.

## Solution

- `pricing.py::_normalize_model()`: strip a leading `models/` segment
  alongside the existing vendor prefixes, before catalog lookup.
- `cost_compute.py::_per_model_from_model_usage()`: after aggregating a
  model's rows, downgrade any breakdown whose total tokens are zero to
  `confidence=unknown`/`provenance=unknown` — a model-identity-only fact is
  no longer conflated with real provider-reported usage.
- `cost_compute.py::compute_session_cost()`: when every model_usage-derived
  breakdown is zero-token, fall back to the existing text-length heuristic
  (`_per_model_from_messages`/`estimate_tokens_from_words`) over the
  session's messages — this is the "estimate-only" path `docs/cost-model.md`
  already declares for these origins, previously unreachable because
  model_usage rows short-circuited the fallback entirely.
- `compute_session_cost()`'s aggregation now tracks `has_reported` alongside
  `has_estimates`, so a session with only `unknown`-confidence breakdowns and
  no fallback evidence gets `cost_confidence=unknown`/`cost_provenance=unknown`
  instead of the previous default of `"reported"`.

## Verification

```
devtools test tests/unit/core/test_pricing.py
  → 21 passed (new: test_aistudio_drive_resource_path_model_prices_like_bare_form)

devtools test tests/unit/core/test_cost_compute.py
  → 4 passed (new file)

devtools test tests/unit/storage/test_session_profile_model_usage_consistency.py \
  tests/unit/insights/test_cost_basis_split.py tests/unit/storage/test_cost_queries.py \
  tests/unit/cost/test_contract_suite.py tests/unit/daemon/test_cost_panel_endpoint.py \
  tests/unit/daemon/test_provider_usage_endpoint.py tests/unit/storage/test_provider_usage_report.py \
  tests/unit/storage/test_session_usage_reconciliation.py
  → 77 passed, no regressions

devtools verify --quick
  → all 18 steps exit 0 (ran twice: once manually, once via the pre-push hook)
```

**Anti-vacuity:** every new test calls a real production entry point —
`_normalize_model()`/`estimate_cost()` (called by every session/message cost
estimate) and `compute_session_cost()`/`_per_model_from_model_usage()` (the
exact functions `session_profile.py`/`rebuild.py` invoke to build every
`session_profiles` cost row). Reverting the `models/` `removeprefix()` line,
the zero-token confidence downgrade, or the `has_reported` aggregation fix
each makes its corresponding new test fail.

## AC matrix

**polylogue-6j9c:**
- [x] `_normalize_model()` strips a leading `models/` segment before catalog lookup.
- [x] Regression test: `models/gemini-2.5-pro` normalizes to the same catalog key as the bare form and prices identically to `gemini-cli-session`'s equivalent model.
- [ ] Deferred (out of lane scope, ops concern): live archive's aistudio-drive `session_profiles` still needs a reprice pass over *existing* rows — this PR is a code + test fix for new/re-materialized profiles, not a live-archive backfill. Classification: index-only reprice (no parser semantics changed, so not `SEMANTIC_REPARSE`) — a follow-up rebuild/reprice pass can run `polylogue ops reset --index && polylogued run` or a narrower session_profiles rebuild.

**polylogue-9kjtc:**
- [x] `_per_model_from_model_usage()` distinguishes zero-token rows from real nonzero provider-reported usage, routing the former to `unknown`/`unknown`.
- [x] For `chatgpt-export`/`claude-ai-export`, the text-length heuristic estimate path now runs and materializes `cost_confidence=estimated` when session_model_usage carries only zero-token rows but message text exists (traced: model_usage rows were short-circuiting the `_per_model_from_messages` fallback entirely — fixed).
- [ ] Deferred (out of lane scope, ops concern): existing `session_profiles` rows currently mislabeled `$0.0`/`provider_reported` are not repriced/reclassified by this PR — same reprice-pass follow-up as above covers both beads' residual.

## Residuals

Both beads' third AC item (reprice/reclassify *existing* live-archive rows)
is explicitly out of scope per lane instructions — this PR ships the code
fix + test coverage only. A follow-up ops pass (index rebuild or a narrower
session_profiles-only rebuild) is needed to correct already-materialized
`session_profiles` rows on the live archive.

Ref polylogue-6j9c
Ref polylogue-9kjtc