### PR TITLE
fix(cli): guard the polylogue console script against wrong-checkout imports

### DIFF
--- a/devtools/checkout_guard.py
+++ b/devtools/checkout_guard.py
@@ -37,6 +37,17 @@ Wired into:
   ``python -m pytest`` invocation that bypasses ``devtools`` entirely still
   refuses, because ``tests/conftest.py`` is always collected for any pytest
   run rooted at this repo.
+- ``polylogue/cli/click_app.py:main()`` — the installed ``polylogue``/``plg``
+  console scripts. This one differs from the others: those callers compute
+  "the invoking checkout" from their *own* ``__file__`` (trustworthy, because
+  ``devtools/__main__.py`` and ``tests/conftest.py`` are only ever reached via
+  a real filesystem path on ``sys.path``, never via the shared venv's
+  editable ``.pth``). ``polylogue/cli/click_app.py`` cannot do that: if the
+  hazard has already occurred, *this file itself* resolved from the wrong
+  checkout, so its own ``__file__`` is exactly as compromised as
+  ``polylogue.__file__`` and proves nothing. The trustworthy anchor there is
+  the process's current working directory instead — see
+  :func:`find_git_worktree_root`.
 
 What this does **not** close: an ad hoc one-off script
 (``python3 /realm/tmp/scratch.py``) that never imports ``devtools`` or
@@ -67,6 +78,31 @@ def resolved_polylogue_path() -> Path:
     import polylogue
 
     return Path(polylogue.__file__).resolve()
+
+
+def find_git_worktree_root(start: Path) -> Path | None:
+    """Walk upward from ``start`` looking for a ``.git`` entry.
+
+    Pure filesystem ``stat``/``exists`` calls — no subprocess — so this is
+    cheap enough to run unconditionally on every CLI invocation (a handful of
+    directory levels at most, not a ``git rev-parse`` fork+exec). Matches both
+    a plain repo's ``.git`` directory and a linked worktree's ``.git`` *file*
+    (which points at the shared ``.git/worktrees/<name>`` gitdir elsewhere).
+
+    Returns the first directory containing a ``.git`` entry, or ``None`` if
+    none is found before reaching the filesystem root — e.g. a real installed
+    ``polylogue`` invocation with no dev checkout in its cwd ancestry at all,
+    which this guard deliberately leaves alone.
+    """
+    current = start.resolve()
+    for candidate in (current, *current.parents):
+        try:
+            found = (candidate / ".git").exists()
+        except OSError:
+            found = False
+        if found:
+            return candidate
+    return None
 
 
 def assert_polylogue_matches_checkout(repo_root: Path, *, context: str) -> Path:

--- a/devtools/checkout_guard.py
+++ b/devtools/checkout_guard.py
@@ -62,6 +62,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import tomllib
+
 
 class CheckoutImportMismatchError(RuntimeError):
     """``import polylogue`` resolved to a package outside the invoking checkout."""
@@ -80,8 +82,38 @@ def resolved_polylogue_path() -> Path:
     return Path(polylogue.__file__).resolve()
 
 
+def _is_polylogue_checkout_root(candidate: Path) -> bool:
+    """Return whether ``candidate`` is plausibly the root of a Polylogue checkout.
+
+    Cheap, filesystem-only markers (no subprocess): either a
+    ``pyproject.toml`` whose ``[project].name`` is literally ``"polylogue"``,
+    or (fallback, for the rare case a checkout's ``pyproject.toml`` is
+    missing/unparseable but the source tree is intact) the package's own
+    entry-point file, ``polylogue/cli/click_app.py``, existing under
+    ``candidate``. Either marker is present in every Polylogue checkout and
+    worktree, and absent from an unrelated repository.
+    """
+    pyproject = candidate / "pyproject.toml"
+    try:
+        raw = pyproject.read_bytes()
+    except OSError:
+        raw = None
+    if raw is not None:
+        try:
+            data = tomllib.loads(raw.decode("utf-8"))
+        except (tomllib.TOMLDecodeError, UnicodeDecodeError):
+            data = {}
+        project_name = data.get("project", {}).get("name")
+        if project_name == "polylogue":
+            return True
+    try:
+        return (candidate / "polylogue" / "cli" / "click_app.py").is_file()
+    except OSError:
+        return False
+
+
 def find_git_worktree_root(start: Path) -> Path | None:
-    """Walk upward from ``start`` looking for a ``.git`` entry.
+    """Walk upward from ``start`` looking for the enclosing Polylogue checkout.
 
     Pure filesystem ``stat``/``exists`` calls — no subprocess — so this is
     cheap enough to run unconditionally on every CLI invocation (a handful of
@@ -89,19 +121,37 @@ def find_git_worktree_root(start: Path) -> Path | None:
     a plain repo's ``.git`` directory and a linked worktree's ``.git`` *file*
     (which points at the shared ``.git/worktrees/<name>`` gitdir elsewhere).
 
-    Returns the first directory containing a ``.git`` entry, or ``None`` if
-    none is found before reaching the filesystem root — e.g. a real installed
-    ``polylogue`` invocation with no dev checkout in its cwd ancestry at all,
-    which this guard deliberately leaves alone.
+    Returns the first ``.git``-containing ancestor directory, but **only**
+    when that directory also looks like a Polylogue checkout
+    (:func:`_is_polylogue_checkout_root`). Two ``None`` cases, deliberately
+    not distinguished by the caller:
+
+    - No ``.git`` entry anywhere in the ancestry — e.g. a real installed
+      ``polylogue`` invocation with no dev checkout in its cwd ancestry at
+      all.
+    - A ``.git`` entry *is* found, but it belongs to some other, unrelated
+      repository (``cd ~/some-other-project && polylogue --version`` — an
+      ordinary, common invocation). The walk stops at that repo's root
+      rather than climbing past it into parent directories: a git
+      repository boundary is exactly the boundary of "the checkout the
+      process is running from", so a non-Polylogue repo there means cwd is
+      not inside any Polylogue checkout, full stop — climbing further up
+      could otherwise find an unrelated Polylogue checkout that merely
+      happens to be an ancestor directory and misfire the guard against it.
+
+    Both cases must no-op identically (2026-08-01 regression, polylogue-373yt):
+    the guard exists to catch a linked *Polylogue* worktree resolving a
+    *different* Polylogue checkout's package, not to flag every invocation
+    whose cwd happens to have some ``.git`` ancestor.
     """
     current = start.resolve()
     for candidate in (current, *current.parents):
         try:
-            found = (candidate / ".git").exists()
+            has_git = (candidate / ".git").exists()
         except OSError:
-            found = False
-        if found:
-            return candidate
+            has_git = False
+        if has_git:
+            return candidate if _is_polylogue_checkout_root(candidate) else None
     return None
 
 

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -10,12 +10,18 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 from time import perf_counter
 from typing import TYPE_CHECKING
 
 import click
 from click.shell_completion import CompletionItem
 
+from devtools.checkout_guard import (
+    CheckoutImportMismatchError,
+    assert_polylogue_matches_checkout,
+    find_git_worktree_root,
+)
 from polylogue.cli.click_command_registration import _LazyCommand, _LazyGroup, register_root_commands
 from polylogue.cli.click_option_groups import apply_query_mode_options
 from polylogue.cli.command_inventory import ROOT_COMMAND_ROLE_SECTIONS
@@ -631,6 +637,41 @@ for _verb in sorted(VERB_NAMES):
     cli.add_command(_command)
 
 
+def _guard_checkout_or_exit() -> None:
+    """Refuse to run when ``import polylogue`` resolved outside this checkout.
+
+    Mirrors ``devtools/checkout_guard.py``'s protection of the
+    ``devtools``/``pytest`` entry points (see that module's docstring for the
+    full 2026-07-30/31 hazard writeup): a linked git worktree without its own
+    ``.venv`` silently reuses the main checkout's shared editable install, so
+    ``import polylogue`` can resolve to a *different* checkout than the one
+    the CLI was actually invoked from — no ImportError, just wrong code
+    answering every command while looking genuine.
+
+    Unlike ``devtools/__main__.py``, this module's own ``__file__`` cannot
+    anchor "the invoking checkout": if the hazard already occurred, this file
+    itself is the wrong checkout's copy. The trustworthy anchor is the
+    process's current working directory instead — an agent hits this hazard
+    by ``cd``ing into a worktree and running ``polylogue ...`` there, so a
+    ``.git`` found by walking up from cwd names the checkout actually
+    intended.
+
+    No-ops (does not raise) when cwd has no git ancestry at all (a real
+    installed-tool invocation, not a dev checkout) or when
+    ``POLYLOGUE_ALLOW_WORKTREE_ESCAPE=1`` is set.
+    """
+    if os.environ.get("POLYLOGUE_ALLOW_WORKTREE_ESCAPE") == "1":
+        return
+    repo_root = find_git_worktree_root(Path.cwd())
+    if repo_root is None:
+        return
+    try:
+        assert_polylogue_matches_checkout(repo_root, context="polylogue")
+    except CheckoutImportMismatchError as exc:
+        sys.stderr.write(f"{exc}\n")
+        raise SystemExit(125) from None
+
+
 def main() -> None:
     """CLI entrypoint with machine-error handling.
 
@@ -640,6 +681,7 @@ def main() -> None:
     """
     import sys
 
+    _guard_checkout_or_exit()
     run_machine_entry(cli, sys.argv[1:])
 
 

--- a/tests/unit/cli/test_click_app_main.py
+++ b/tests/unit/cli/test_click_app_main.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 from unittest.mock import patch
 
 import click
 import pytest
 
+import polylogue.cli.click_app as click_app
+from devtools.checkout_guard import CheckoutImportMismatchError
 from polylogue.cli.click_app import main
 from polylogue.core.json import JSONDocument
 from tests.infra.json_contracts import parse_json_object
@@ -123,3 +126,72 @@ def test_main_without_json_converts_click_usage_to_systemexit(
     captured = capsys.readouterr()
     assert "No such option" in captured.err and "--bad-flag" in captured.err
     assert "Hint:" in captured.err
+
+
+def test_main_refuses_on_checkout_mismatch(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """The bare ``polylogue``/``plg`` console script refuses before dispatching (polylogue-6mgg).
+
+    Regression for the gap where ``devtools``/pytest were guarded against the
+    shared-venv worktree-import hazard but the installed CLI entry point was
+    not: an agent `cd`ing into a linked worktree and running `polylogue ...`
+    got silently routed to the main checkout's code with no warning.
+    """
+
+    def _boom(repo_root: Path, *, context: str) -> Path:
+        raise CheckoutImportMismatchError(f"{context}: mismatch against {repo_root}")
+
+    monkeypatch.setattr(click_app, "find_git_worktree_root", lambda start: Path("/some/worktree"))
+    monkeypatch.setattr(click_app, "assert_polylogue_matches_checkout", _boom)
+    monkeypatch.delenv("POLYLOGUE_ALLOW_WORKTREE_ESCAPE", raising=False)
+    monkeypatch.setattr(sys, "argv", ["polylogue", "status", "--json"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+
+    assert excinfo.value.code == 125
+    captured = capsys.readouterr()
+    assert "mismatch against" in captured.err
+    # And critically: it must not have produced the command's normal output --
+    # the whole point is refusing *before* doing any real work.
+    assert captured.out == ""
+
+
+def test_main_skips_guard_when_cwd_has_no_git_ancestry(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No git ancestor from cwd (e.g. a real installed-tool invocation) -- guard no-ops."""
+
+    def _boom(repo_root: Path, *, context: str) -> Path:
+        raise AssertionError("assert_polylogue_matches_checkout must not run without a git root")
+
+    monkeypatch.setattr(click_app, "find_git_worktree_root", lambda start: None)
+    monkeypatch.setattr(click_app, "assert_polylogue_matches_checkout", _boom)
+    monkeypatch.delenv("POLYLOGUE_ALLOW_WORKTREE_ESCAPE", raising=False)
+    monkeypatch.setattr(sys, "argv", ["polylogue", "ops", "doctor", "--format", "json"])
+
+    with patch.object(click_app, "cli", side_effect=click.ClickException("boom")):
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+    # Reaches the normal machine-error path (not the 125 guard exit).
+    assert excinfo.value.code == 1
+
+
+def test_main_bypasses_guard_with_escape_env_var(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``POLYLOGUE_ALLOW_WORKTREE_ESCAPE=1`` skips the check entirely, even on a real mismatch."""
+
+    def _boom(repo_root: Path, *, context: str) -> Path:
+        raise AssertionError("assert_polylogue_matches_checkout must not run when escape is set")
+
+    monkeypatch.setattr(click_app, "find_git_worktree_root", lambda start: Path("/some/worktree"))
+    monkeypatch.setattr(click_app, "assert_polylogue_matches_checkout", _boom)
+    monkeypatch.setenv("POLYLOGUE_ALLOW_WORKTREE_ESCAPE", "1")
+    monkeypatch.setattr(sys, "argv", ["polylogue", "ops", "doctor", "--format", "json"])
+
+    with patch.object(click_app, "cli", side_effect=click.ClickException("boom")):
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+    assert excinfo.value.code == 1

--- a/tests/unit/devtools/test_checkout_guard.py
+++ b/tests/unit/devtools/test_checkout_guard.py
@@ -20,6 +20,7 @@ import polylogue
 from devtools.checkout_guard import (
     CheckoutImportMismatchError,
     assert_polylogue_matches_checkout,
+    find_git_worktree_root,
     resolved_polylogue_path,
 )
 
@@ -60,6 +61,50 @@ def test_assert_matches_checkout_rejects_a_sibling_directory(tmp_path: Path) -> 
     sibling = package_root.parent / f"{package_root.name}-decoy"
     with pytest.raises(CheckoutImportMismatchError):
         assert_polylogue_matches_checkout(sibling, context="sibling probe")
+
+
+def test_find_git_worktree_root_finds_the_real_polylogue_checkout() -> None:
+    """The happy path: cwd inside this actual checkout resolves to its root."""
+    repo_root = Path(polylogue.__file__).resolve().parents[1]
+    assert find_git_worktree_root(repo_root) == repo_root
+
+
+def test_find_git_worktree_root_no_ops_for_an_unrelated_git_repo(tmp_path: Path) -> None:
+    """Regression (polylogue-373yt): an ordinary, unrelated git repo must not be
+
+    mistaken for "the invoking Polylogue checkout". Before this fix,
+    ``find_git_worktree_root`` returned the first ``.git``-containing
+    ancestor unconditionally, so `cd ~/some-other-project && polylogue
+    --version` found that repo's root, and the mismatch guard fired against
+    it (exit 125) for every single command -- a normally pip-installed
+    ``polylogue`` invoked from any unrelated git repository was completely
+    unusable.
+
+    Mutation this guards against: dropping the
+    ``_is_polylogue_checkout_root`` gate from ``find_git_worktree_root`` (i.e.
+    reverting to "return the first ``.git`` ancestor, full stop") makes this
+    test fail because it would return ``unrelated_repo`` instead of ``None``.
+    """
+    unrelated_repo = tmp_path / "some-other-project"
+    unrelated_repo.mkdir()
+    (unrelated_repo / ".git").mkdir()
+    # Deliberately no pyproject.toml and no polylogue/ package tree here --
+    # this is what makes it "unrelated" rather than a Polylogue checkout.
+
+    nested_cwd = unrelated_repo / "src" / "pkg"
+    nested_cwd.mkdir(parents=True)
+
+    assert find_git_worktree_root(nested_cwd) is None
+
+
+def test_find_git_worktree_root_no_ops_with_no_git_ancestry_at_all(tmp_path: Path) -> None:
+    """A plain directory tree with no ``.git`` anywhere -- e.g. a real installed
+
+    ``polylogue`` invocation with no dev checkout in cwd's ancestry at all.
+    """
+    plain_dir = tmp_path / "no-git-here"
+    plain_dir.mkdir()
+    assert find_git_worktree_root(plain_dir) is None
 
 
 def test_click_dispatch_main_refuses_on_checkout_mismatch(


### PR DESCRIPTION
## Summary

Wires `devtools/checkout_guard.py`'s worktree-import protection into the installed `polylogue`/`plg` console scripts, which were the one entry point a cold agent (or an MCP/daemon launcher shelling out to `polylogue`) is most likely to invoke directly, and the one entry point the guard didn't cover.

## Problem

`devtools/checkout_guard.py`'s `assert_polylogue_matches_checkout` closes the shared-venv worktree-import hazard (2026-07-30/31: a linked git worktree without its own `.venv` reuses the main checkout's editable install, so `import polylogue` silently resolves to a *different* checkout's code) for `devtools/__main__.py`, `devtools verify`/`devtools test`, and `tests/conftest.py`. It was never wired into `polylogue/cli/click_app.py`.

Confirmed live: an audit lane running `polylogue --version` from inside a `.claude/worktrees/<id>` linked worktree reported the *main checkout's* dirty commit, while `git rev-parse HEAD` in that same worktree showed a different commit — every `polylogue find/status/demo/...` command in that session had silently exercised the wrong checkout's code and schema expectations, with nothing in the CLI's own output flagging the mismatch.

## Solution

- `devtools/checkout_guard.py`: new `find_git_worktree_root(start)` — a pure filesystem `.git`-entry walk up from `start`, no subprocess, cheap enough for every invocation. Documented in the module docstring alongside the existing wiring list, explaining why this entry point needs a different anchor than the others.
- `polylogue/cli/click_app.py`: new `_guard_checkout_or_exit()`, called first thing in `main()`. Unlike the existing call sites (whose own `__file__` is a trustworthy anchor because they're only ever reached via a real path on `sys.path`), `click_app.py`'s own `__file__` *is* the resolved `polylogue` package — if the hazard already occurred, this file is already the wrong checkout's copy, so it can't self-certify. The trustworthy anchor is the process's cwd instead: `find_git_worktree_root(Path.cwd())` names the checkout the operator actually intended (they `cd`'d into the worktree and ran `polylogue ...` there). No-ops when cwd has no git ancestry (a real installed-tool invocation) or `POLYLOGUE_ALLOW_WORKTREE_ESCAPE=1` is set — reusing the existing bypass convention from the worktree-escape pre-commit hook.
- `tests/unit/cli/test_click_app_main.py`: three regression tests — guard fires on mismatch (exit 125, no stdout produced), no-ops with no git ancestry, bypassed by `POLYLOGUE_ALLOW_WORKTREE_ESCAPE=1`.

Cold-start cost: `python -X importtime -m polylogue --help` shows `devtools.checkout_guard` at 508us cumulative against a ~580ms total `--help` invocation — negligible, relevant because #3507 (merged the same day) specifically cut CLI cold-start import tax and I rebased onto it before finishing this change.

## Verification

- `devtools test tests/unit/cli/test_click_app_main.py tests/unit/devtools/test_checkout_guard.py` — 15 passed (8 + 7, including the 3 new tests).
- `devtools verify --quick` — exit 0 (format, lint, mypy, render-check, layering, degrade-loudly, closure-matrix, hash-boundary-census, schema-versioning, promotion audit); also ran again automatically via the pre-push hook after rebasing onto origin/master.
- `devtools verify` (testmon default) refused: pytest-testmon is unseeded in this worktree (fresh checkout that never ran `--seed-testmon`). Not run given the seeding cost for a two-file change; the focused runs above cover every line touched.
- Manual repro check: ran the (unpatched, main-checkout) installed console script from this worktree's cwd and confirmed it still silently resolves to the main checkout's code — matches the bug report exactly, and is exactly the case this PR's `click_app.py:main()` now catches once the fix is on the running checkout.

## AC matrix

- "Wire assert_polylogue_matches_checkout (or equivalent) into polylogue CLI's entry point" — satisfied (`click_app.py:main()` → `_guard_checkout_or_exit()`).
- "Match the existing guard's error/exit-code contract" — satisfied: same `CheckoutImportMismatchError` type, same stderr message shape, same exit code 125.
- "Gate so it only fires when a `.git` worktree is detected and `POLYLOGUE_ALLOW_WORKTREE_ESCAPE` is unset" — satisfied.
- "Regression test proving the guard fires (mock/simulate)" — satisfied, following `tests/unit/devtools/test_checkout_guard.py`'s own monkeypatch pattern.
- "Verify no meaningful cold-start regression" — satisfied, measured negligible (~0.5ms of ~580ms).

## Anti-vacuity

Production entry point exercised: `polylogue.cli.click_app.main()`, the function bound to the `polylogue`/`plg` console-script entry points in `pyproject.toml`. Mutation that breaks the test: removing the `_guard_checkout_or_exit()` call from `main()` (or removing the `assert_polylogue_matches_checkout` call from inside that helper) makes `test_main_refuses_on_checkout_mismatch` fail — `SystemExit(125)` would never be raised and the (mocked) mismatch would go undetected, silently falling through to normal command dispatch.

Ref polylogue-6mgg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a safety check to ensure the `polylogue` command runs from the same Git checkout where it was installed.
  * Commands now stop with a clear error and exit status 125 when a checkout mismatch is detected.
  * The check is skipped outside Git repositories and can be explicitly bypassed with `POLYLOGUE_ALLOW_WORKTREE_ESCAPE=1`.

* **Bug Fixes**
  * Prevents commands from unintentionally running against a different working tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->