### PR TITLE
fix(cli): route field-syntax zero-result queries through miss diagnostics

### DIFF
--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -334,6 +334,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
         with_unit_fields=with_unit_fields,
         with_unit_windows=with_unit_windows,
         query=query,
+        raw_query=raw_query,
         limit=limit,
         offset=page_offset,
         output_format=output_format,
@@ -843,6 +844,19 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                 print_url=bool(params.get("print_url")),
             )
             return
+        _emit_list_miss_if_field_syntax(
+            env,
+            items=page_summaries,
+            raw_query=raw_query,
+            compiled_spec=compiled_spec,
+            why=bool(params.get("why")),
+            output_format=output_format,
+            origin=origin,
+            limit=limit,
+            offset=page_offset,
+            root=filter_kwargs["root"],
+            typo_hint=typo_hint,
+        )
         _emit_list(
             page_summaries,
             total=(
@@ -1058,6 +1072,7 @@ def _try_emit_daemon_session_page(
     with_unit_fields: dict[str, tuple[str, ...]],
     with_unit_windows: Mapping[str, WithUnitWindow],
     query: str,
+    raw_query: str,
     limit: int,
     offset: int,
     output_format: str,
@@ -1127,6 +1142,20 @@ def _try_emit_daemon_session_page(
         )
         return True
     if isinstance(payload.get("items"), list):
+        daemon_items = cast(list[object], payload.get("items"))
+        _emit_list_miss_if_field_syntax(
+            env,
+            items=daemon_items,
+            raw_query=raw_query,
+            compiled_spec=compiled_spec,
+            why=bool(params.get("why")),
+            output_format=output_format,
+            origin=origin,
+            limit=limit,
+            offset=offset,
+            root=True,
+            typo_hint=typo_hint,
+        )
         _emit_daemon_list_payload(
             payload,
             limit=limit,
@@ -2271,6 +2300,65 @@ def _search_miss_diagnostics(
         logger.exception("_search_miss_diagnostics: diagnose_query_miss failed")
         return None
     return QueryMissDiagnosticsPayload.from_diagnostics(raw_diagnostics)
+
+
+def _list_no_results_envelope(
+    *,
+    origin: str | None,
+    limit: int,
+    offset: int,
+    root: bool | None,
+) -> dict[str, object]:
+    return {
+        "mode": "list",
+        "origin": origin,
+        "items": [],
+        "total": 0,
+        "total_unit": session_count_unit_label(root),
+        "limit": limit,
+        "offset": offset,
+        "next_offset": None,
+        "next_cursor": None,
+    }
+
+
+def _emit_list_miss_if_field_syntax(
+    env: AppEnv,
+    *,
+    items: Sequence[object],
+    raw_query: str,
+    compiled_spec: SessionQuerySpec,
+    why: bool,
+    output_format: str,
+    origin: str | None,
+    limit: int,
+    offset: int,
+    root: bool | None,
+    typo_hint: str | None,
+) -> None:
+    """Route a zero-row list-mode page through the shared miss diagnostics.
+
+    List/browse mode is deliberately silent-success (exit 0, no message) when
+    the request carried no query expression at all -- "show me everything,
+    there is nothing" per the ``mode: list`` contract just above. But a
+    field-syntax-only query expression (e.g. ``repo:polylogue``, ``since:7d``
+    with no bare text term) compiles down to an empty ``query`` string and
+    used to fall through to this same silent-success rendering: zero bytes of
+    stdout, exit 0, no diagnostics, even with ``--why`` -- indistinguishable
+    from the query being silently misrouted (polylogue-hlww). ``raw_query``
+    being non-empty here means the user typed *some* query expression (it
+    just had no free-text residue after field-syntax compilation), so treat
+    that case as a miss like a lexical search: the shared
+    ``Why this may have missed:`` block, exit 2.
+    """
+    if items or not raw_query.strip():
+        return
+    _emit_no_results(
+        _list_no_results_envelope(origin=origin, limit=limit, offset=offset, root=root),
+        output_format=output_format,
+        typo_hint=typo_hint,
+        diagnostics=_search_miss_diagnostics(env, compiled_spec, why=why),
+    )
 
 
 def _emit_search(

--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -844,9 +844,21 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                 print_url=bool(params.get("print_url")),
             )
             return
+        list_total = (
+            None
+            if sample_count is not None
+            else _count_root_matches(
+                archive,
+                query="",
+                similar_text=None,
+                session_id=None,
+                filter_kwargs=filter_kwargs,
+            )
+        )
         _emit_list_miss_if_field_syntax(
             env,
             items=page_summaries,
+            total=list_total,
             raw_query=raw_query,
             compiled_spec=compiled_spec,
             why=bool(params.get("why")),
@@ -859,17 +871,7 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
         )
         _emit_list(
             page_summaries,
-            total=(
-                None
-                if sample_count is not None
-                else _count_root_matches(
-                    archive,
-                    query="",
-                    similar_text=None,
-                    session_id=None,
-                    filter_kwargs=filter_kwargs,
-                )
-            ),
+            total=list_total,
             limit=limit,
             offset=page_offset,
             next_cursor=next_cursor,
@@ -1146,6 +1148,7 @@ def _try_emit_daemon_session_page(
         _emit_list_miss_if_field_syntax(
             env,
             items=daemon_items,
+            total=_object_int(payload.get("total")) if payload.get("total") is not None else None,
             raw_query=raw_query,
             compiled_spec=compiled_spec,
             why=bool(params.get("why")),
@@ -2326,6 +2329,7 @@ def _emit_list_miss_if_field_syntax(
     env: AppEnv,
     *,
     items: Sequence[object],
+    total: int | None,
     raw_query: str,
     compiled_spec: SessionQuerySpec,
     why: bool,
@@ -2350,8 +2354,16 @@ def _emit_list_miss_if_field_syntax(
     just had no free-text residue after field-syntax compilation), so treat
     that case as a miss like a lexical search: the shared
     ``Why this may have missed:`` block, exit 2.
+
+    ``items`` alone cannot distinguish a genuine zero-match query from an
+    exhausted page (a nonzero ``--offset`` past the last row of a query that
+    DID match): both render an empty page. ``total`` is the unpaginated match
+    count when known (``None`` for lanes without a cheap count primitive,
+    e.g. vector/hybrid retrieval) -- a page with no items but a positive
+    total is valid empty pagination, not a miss, and must not fabricate
+    ``total: 0`` or exit 2.
     """
-    if items or not raw_query.strip():
+    if items or (total is not None and total > 0) or not raw_query.strip():
         return
     _emit_no_results(
         _list_no_results_envelope(origin=origin, limit=limit, offset=offset, root=root),

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -3357,6 +3357,41 @@ class TestSearchQueryContracts:
             assert "No sessions matched" in result.output
             assert "Why this may have missed:" in result.output
 
+    def test_field_syntax_query_past_the_last_page_is_exhausted_not_a_miss(
+        self, search_workspace: SearchWorkspace
+    ) -> None:
+        """An offset beyond a REAL match count is valid empty pagination, not a miss.
+
+        ``repo:polylogue`` matches (at least) one session (``run-hit``).
+        Requesting an offset past the last row asks for the page past the
+        last match: the page itself is empty, but the query genuinely
+        matched, so this must render the normal empty-page envelope (exit 0,
+        real nonzero total, no fabricated ``total: 0``) rather than routing
+        through the same miss diagnostics an actual zero-match query gets.
+        """
+        from polylogue.cli import cli
+
+        del search_workspace
+        matched = CliRunner().invoke(
+            cli,
+            ["--plain", "--no-daemon", "find", "repo:polylogue", "-f", "json"],
+        )
+        assert matched.exit_code == 0, matched.output
+        real_total = json.loads(matched.output)["total"]
+        assert real_total > 0, "fixture must have at least one repo:polylogue match for this test to be meaningful"
+
+        result = CliRunner().invoke(
+            cli,
+            ["--plain", "--no-daemon", "find", "repo:polylogue", "--offset", str(real_total), "-f", "json"],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["mode"] == "list"
+        assert payload["items"] == []
+        assert payload["total"] == real_total
+        assert "diagnostics" not in payload
+
     def test_debug_timing_keeps_query_output_on_stdout(
         self, search_workspace: SearchWorkspace, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/cli/test_query_exec_laws.py
+++ b/tests/unit/cli/test_query_exec_laws.py
@@ -3292,6 +3292,71 @@ class TestSearchQueryContracts:
         assert "predicate_zeroed_set" in codes
         assert "fts_structured_disagreement" in codes
 
+    def test_zero_hit_field_syntax_query_gets_the_same_miss_diagnostics(
+        self, search_workspace: SearchWorkspace
+    ) -> None:
+        """A field-syntax-only query (no bare text term) that misses gets diagnostics too.
+
+        polylogue-hlww: ``repo:doesnotexist`` compiles to zero free-text
+        ``query_terms`` (``_query_text`` returns ``""``), which used to route
+        through the plain browse/list ``_emit_list`` -> ``_emit_rows`` path
+        with no ``_emit_no_results`` call at all -- zero bytes of stdout,
+        exit 0, no ``diagnostics`` key even with ``--why``, indistinguishable
+        from the query being silently dropped. This exercises the production
+        ``execute_archive_query`` -> ``_execute_archive_query_stdout`` list
+        branch: removing the ``_emit_list_miss_if_field_syntax`` call (or its
+        ``raw_query.strip()`` guard) restores the old silent zero-byte
+        output and this assertion on ``payload["diagnostics"]`` fails with a
+        ``KeyError``/``JSONDecodeError`` instead.
+        """
+        from polylogue.cli import cli
+
+        del search_workspace
+        result = CliRunner().invoke(
+            cli,
+            ["--plain", "--no-daemon", "find", "repo:doesnotexist-nonexistent-repo", "-f", "json"],
+        )
+
+        assert result.exit_code == 2, result.output
+        assert result.output.strip(), "field-syntax miss must not render zero bytes"
+        payload = json.loads(result.output)
+        assert payload["mode"] == "list"
+        assert payload["items"] == []
+        codes = [reason["code"] for reason in payload["diagnostics"]["reasons"]]
+        assert codes, "field-syntax miss must carry the same shared miss-diagnosis reasons as a search miss"
+
+    def test_zero_hit_field_syntax_and_bare_text_share_exit_code_and_plain_message(
+        self, search_workspace: SearchWorkspace
+    ) -> None:
+        """Bare-text and field-syntax zero-hit queries must be indistinguishable in shape.
+
+        Before the fix, ``find "nonexistent term"`` (bare text, ``mode:
+        search``) exited 2 with a ``No sessions matched.`` /
+        ``Why this may have missed:`` block in plain mode, while
+        ``find "repo:x"`` (field-syntax-only, ``mode: list``) exited 0 with
+        literally no stdout -- a cold caller piping either through a shell
+        script could not tell "ran fine, zero matches" from "silently
+        misrouted" for the field-syntax shape. Pin both zero-hit shapes to
+        the same exit code and the same non-empty plain-mode message so that
+        regression is a single, direct assertion rather than two separate
+        exit-code contracts that could silently drift apart again.
+        """
+        from polylogue.cli import cli
+
+        del search_workspace
+        runner = CliRunner()
+        bare_text = runner.invoke(cli, ["--plain", "--no-daemon", "find", "zzz-nonexistent-term-zzz"])
+        field_syntax = runner.invoke(cli, ["--plain", "--no-daemon", "find", "repo:doesnotexist-nonexistent-repo"])
+
+        assert bare_text.exit_code == 2, bare_text.output
+        assert field_syntax.exit_code == 2, field_syntax.output
+        assert bare_text.exit_code == field_syntax.exit_code
+
+        for result in (bare_text, field_syntax):
+            assert result.output.strip(), result.output
+            assert "No sessions matched" in result.output
+            assert "Why this may have missed:" in result.output
+
     def test_debug_timing_keeps_query_output_on_stdout(
         self, search_workspace: SearchWorkspace, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

A field-syntax-only `find` query (e.g. `find "repo:polylogue"`, no bare
text term) that matched zero sessions rendered **zero bytes of stdout and
exited 0** — even with `--why`. The same zero-match outcome for a bare-text
query (`find "yesterday"`) correctly printed `No sessions matched.` plus a
`Why this may have missed:` breakdown and exited 2. This PR routes the
field-syntax miss through the same diagnostics path and aligns the exit
code.

## Problem

Reproduced live against a `polylogue demo seed` archive (worktree source,
not the live archive):

```
$ polylogue find "zzz-nonexistent-term"
No sessions matched.
Why this may have missed:
  - The archive is reachable, but no materialized session matched this selection.
$ echo $?
2

$ polylogue find "repo:doesnotexist"
(zero bytes of output)
$ echo $?
0

$ polylogue find "repo:doesnotexist" --why
(still zero bytes of output)
```

`--json` always returned the correct empty envelope for both shapes
(`{"items": [], "total": 0, ...}`), so the data path is fine — only
plain-mode rendering silently produced nothing for field-syntax misses. A
cold caller piping `find 'repo:x'` without `--json` cannot distinguish "ran
fine, zero matches" from "the query was silently dropped/misrouted", and
the exit code (2 vs 0) differed between the two zero-result shapes with no
documented reason.

Root cause: `_query_text(compiled_spec.query_terms, ...)` returns `""` for
a query that is 100% field-syntax predicates (no free-text residue), so
`_execute_archive_query_stdout`'s `if query or similar_text or
similar_session_id: ... else: _emit_list(...)` dispatch fell into the
browse/list branch instead of the search branch. Browse/list mode
intentionally renders zero rows as silent success (exit 0) — "show me
everything, there is nothing" — which is correct for a truly unfiltered
`find` with no query expression at all, but wrong for an explicit
field-syntax query that just happens to compile to an empty free-text
term: that's a miss like a lexical search miss, not a browse.

## Solution

- `polylogue/cli/archive_query.py`: added `_emit_list_miss_if_field_syntax`
  (plus its `_list_no_results_envelope` helper), called from both list-mode
  render sites:
  - the direct `ArchiveStore` path in `_execute_archive_query_stdout`
    (before the existing `_emit_list(...)` call), and
  - the daemon-proxied `/api/sessions` list path in
    `_try_emit_daemon_session_page` (which had the identical gap — it
    calls `_emit_daemon_list_payload` -> `_emit_rows` directly with no
    miss check).
- The new helper fires only when the caller's raw query expression was
  non-empty (`raw_query.strip()`) **and** the page is empty — i.e. the user
  typed some query expression that had no free-text residue after
  field-syntax compilation. It routes through the existing
  `_emit_no_results` / `_search_miss_diagnostics` (`diagnose_query_miss`)
  machinery, the same shared "Why this may have missed:" diagnosis already
  used by bare-text search misses.
- True unfiltered browsing — `find` with no query expression at all, or
  narrowing only via root `--origin`/`--since`/etc. CLI options — is
  **unchanged** and still exits 0 silently, per the existing documented
  "browse/list mode" contract (comment left in place in
  `_execute_archive_query_stdout`).
- This aligns exit codes across both zero-result shapes: field-syntax
  misses now exit 2 with the shared diagnostics block, matching bare-text
  misses, instead of exit 0 with no output.

## Verification

- `python -m devtools test tests/unit/cli/test_query_exec_laws.py tests/unit/cli/test_archive_query.py tests/unit/cli/test_exit_code_contracts.py tests/unit/cli/test_daemon_golden_parity.py` → 224 passed
- `python -m devtools verify --quick` → exit 0 (ruff format/check, mypy --strict, render all --check, layering, schema/policy lints), run again on push via the pre-push hook
- **Anti-vacuity**: temporarily replaced the `raw_query.strip()` guard in
  `_emit_list_miss_if_field_syntax` with an unconditional early return and
  reran the two new regression tests — both failed with the exact pre-fix
  symptom (`exit_code == 0` instead of `2`, empty/no-diagnostics payload).
  Restored the fix and reran green.
- Manual repro against a `polylogue demo seed` archive (see Problem above):
  `find "repo:doesnotexist"` now prints `No sessions matched.` + the miss
  breakdown and exits 2; `find "zzz-nonexistent-term"` (bare text) is
  unchanged; a matching field-syntax query (`find "since:2020-01-01"`)
  still renders rows normally, exit 0.

## AC matrix (Ref polylogue-hlww)

| AC | Status |
| --- | --- |
| Field-syntax zero-result queries get the same helpful message as bare-text zero-result queries | Satisfied |
| Exit-code inconsistency (2 vs 0) between the two zero-result paths investigated and resolved to one consistent convention | Satisfied — both now exit 2 |
| Regression tests covering both zero-result shapes, asserting non-empty output + consistent exit code | Satisfied — `test_zero_hit_field_syntax_query_gets_the_same_miss_diagnostics`, `test_zero_hit_field_syntax_and_bare_text_share_exit_code_and_plain_message` |
| Daemon-proxied list path (`_try_emit_daemon_session_page`) parity | Satisfied — same helper wired into both render sites |
| True unfiltered browse-all zero-result behavior (exit 0, silent) | Deliberately unchanged — out of scope per brief, verified no regression |

Ref polylogue-hlww

🤖 Generated with [Claude Code](https://claude.com/claude-code)