### PR TITLE
fix: sweep orphaned attachment rows when their last ref is dropped

### DIFF
--- a/polylogue/cli/commands/maintenance/_blob_integrity.py
+++ b/polylogue/cli/commands/maintenance/_blob_integrity.py
@@ -152,15 +152,21 @@ def attachment_acquisition_debt_command(sample_limit: int, output_format: str) -
         return
 
     click.echo("Attachment acquisition debt")
-    click.echo(f"Total attachments: {report.total_attachments:,}")
-    click.echo(f"Acquired:          {report.acquired_count:,}")
-    click.echo(f"Unavailable:       {report.unavailable_count:,}")
-    click.echo(f"Unfetched:         {report.unfetched_count:,} (honest floor, not missing blobs)")
-    click.echo(f"Acquired missing:  {report.acquired_missing_blob_count:,} (genuine debt)")
-    click.echo(f"Status:            {'ok' if report.ok else 'debt-present'}")
+    click.echo(f"Total attachments:   {report.total_attachments:,}")
+    click.echo(f"Acquired:            {report.acquired_count:,}")
+    click.echo(f"  reachable:         {report.acquired_reachable_count:,} (queryable via a session/message)")
+    click.echo(f"  unreachable:       {report.acquired_unreachable_count:,} (no attachment_refs row -- unqueryable)")
+    click.echo(f"Unavailable:         {report.unavailable_count:,}")
+    click.echo(f"Unfetched:           {report.unfetched_count:,} (honest floor, not missing blobs)")
+    click.echo(f"Acquired missing:    {report.acquired_missing_blob_count:,} (genuine debt)")
+    click.echo(f"Status:              {'ok' if report.ok else 'debt-present'}")
     if report.acquired_missing_blob_sample:
         click.echo("Sample attachment ids with a missing blob file:")
         for attachment_id in report.acquired_missing_blob_sample:
+            click.echo(f"  {attachment_id}")
+    if report.acquired_unreachable_sample:
+        click.echo("Sample attachment ids acquired but unreachable (no attachment_refs row):")
+        for attachment_id in report.acquired_unreachable_sample:
             click.echo(f"  {attachment_id}")
 
 

--- a/polylogue/storage/blob_integrity.py
+++ b/polylogue/storage/blob_integrity.py
@@ -1930,6 +1930,14 @@ class AttachmentAcquisitionDebtReport:
     never fetched, not a broken reference -- and must never be conflated
     with missing referenced blobs. Only an ``acquired`` row whose blob file
     is absent from the store is genuine attachment acquisition debt.
+
+    ``acquisition_status='acquired'`` alone overstates real coverage
+    (polylogue-w06b): it says bytes were fetched, not that anything can
+    read them back. ``acquired_unreachable_count``/``acquired_reachable_count``
+    split the ``acquired`` bucket by whether the attachment also has at
+    least one ``attachment_refs`` row -- without one it cannot be returned
+    by any session/message read path (``get_attachments``, MCP get/read,
+    CLI ``read --view``).
     """
 
     total_attachments: int
@@ -1938,16 +1946,32 @@ class AttachmentAcquisitionDebtReport:
     acquired_missing_blob_sample: tuple[str, ...]
     unavailable_count: int
     unfetched_count: int
+    # polylogue-w06b: `acquisition_status='acquired'` alone overstates real
+    # coverage -- an attachment row with zero `attachment_refs` rows cannot
+    # be surfaced through any session/message read path (`get_attachments`,
+    # MCP get/read, CLI read --view all INNER JOIN attachment_refs). Track
+    # the reachable subset separately so this report can't be read as "N
+    # attachments are queryable" when it means "N attachments have bytes on
+    # disk somewhere, most of which nothing can ever reach".
+    acquired_unreachable_count: int
+    acquired_unreachable_sample: tuple[str, ...]
 
     @property
     def ok(self) -> bool:
         return self.acquired_missing_blob_count == 0
+
+    @property
+    def acquired_reachable_count(self) -> int:
+        return self.acquired_count - self.acquired_unreachable_count
 
     def to_dict(self) -> dict[str, object]:
         return {
             "ok": self.ok,
             "total_attachments": self.total_attachments,
             "acquired_count": self.acquired_count,
+            "acquired_reachable_count": self.acquired_reachable_count,
+            "acquired_unreachable_count": self.acquired_unreachable_count,
+            "acquired_unreachable_sample": list(self.acquired_unreachable_sample),
             "acquired_missing_blob_count": self.acquired_missing_blob_count,
             "acquired_missing_blob_sample": list(self.acquired_missing_blob_sample),
             "unavailable_count": self.unavailable_count,
@@ -1976,6 +2000,21 @@ def scan_attachment_acquisition_debt(
         acquired_rows = conn.execute(
             "SELECT attachment_id, blob_hash FROM attachments WHERE acquisition_status = 'acquired'"
         ).fetchall()
+        # polylogue-w06b: an `acquired` attachment with no `attachment_refs`
+        # row is unreachable from every session/message read path -- track it
+        # as its own dimension, distinct from "bytes missing from the blob
+        # store" (acquired_missing_blob_count, below).
+        unreachable_rows = conn.execute(
+            """
+            SELECT a.attachment_id AS attachment_id
+            FROM attachments a
+            WHERE a.acquisition_status = 'acquired'
+              AND NOT EXISTS (
+                  SELECT 1 FROM attachment_refs r WHERE r.attachment_id = a.attachment_id
+              )
+            ORDER BY a.attachment_id
+            """
+        ).fetchall()
 
     missing_sample: list[str] = []
     missing_count = 0
@@ -1990,6 +2029,8 @@ def scan_attachment_acquisition_debt(
         if len(missing_sample) < sample_size:
             missing_sample.append(str(row["attachment_id"]))
 
+    unreachable_sample = tuple(str(row["attachment_id"]) for row in unreachable_rows[:sample_size])
+
     return AttachmentAcquisitionDebtReport(
         total_attachments=sum(status_counts.values()),
         acquired_count=status_counts.get("acquired", 0),
@@ -1997,6 +2038,8 @@ def scan_attachment_acquisition_debt(
         acquired_missing_blob_sample=tuple(missing_sample),
         unavailable_count=status_counts.get("unavailable", 0),
         unfetched_count=status_counts.get("unfetched", 0),
+        acquired_unreachable_count=len(unreachable_rows),
+        acquired_unreachable_sample=unreachable_sample,
     )
 
 

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -2927,6 +2927,23 @@ def _write_attachments(
         """,
         tuple(sorted(affected_attachment_ids)),
     )
+    # polylogue-w06b: a full-replace re-ingest (or a re-ingest whose attachment
+    # can no longer be matched to a message via `by_native_message_id`, e.g.
+    # the owning message became a duplicate-native-id exclusion or dropped
+    # out of this ingest's message set) drops a previously-written
+    # attachment_refs row for `refresh_attachment_ids` without this
+    # function ever writing a replacement ref. The ref_count UPDATE above
+    # correctly reflects that as 0, but nothing previously swept the now
+    # ref-less `attachments` row -- it survived, unreachable from any
+    # session/message read path (get_attachments/get_attachments_batch both
+    # INNER JOIN attachment_refs), while still reporting
+    # acquisition_status='acquired' and real fetched bytes. Sweep it here,
+    # mirroring the identical cleanup `prune_attachments` and
+    # `delete_session_sql` already perform after their own ref deletions.
+    conn.execute(
+        f"DELETE FROM attachments WHERE ref_count <= 0 AND attachment_id IN ({placeholders})",
+        tuple(sorted(affected_attachment_ids)),
+    )
 
 
 def _session_attachment_ids(conn: sqlite3.Connection, session_id: str) -> set[str]:

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -953,6 +953,8 @@ def test_attachment_acquisition_debt_cli_reports_clean_empty_archive(
     assert payload["ok"] is True
     assert payload["total_attachments"] == 0
     assert payload["acquired_missing_blob_count"] == 0
+    assert payload["acquired_reachable_count"] == 0
+    assert payload["acquired_unreachable_count"] == 0
 
 
 def test_attachment_acquisition_debt_cli_plain_output_distinguishes_unfetched_from_debt(
@@ -967,9 +969,9 @@ def test_attachment_acquisition_debt_cli_plain_output_distinguishes_unfetched_fr
 
     assert result.exit_code == 0
     assert "Attachment acquisition debt" in result.output
-    assert "Unfetched:         0 (honest floor, not missing blobs)" in result.output
-    assert "Acquired missing:  0 (genuine debt)" in result.output
-    assert "Status:            ok" in result.output
+    assert "Unfetched:           0 (honest floor, not missing blobs)" in result.output
+    assert "Acquired missing:    0 (genuine debt)" in result.output
+    assert "Status:              ok" in result.output
 
 
 def test_blob_reference_recovery_plan_cli_writes_raw_backed_manifest(

--- a/tests/unit/storage/test_archive_tiers_write.py
+++ b/tests/unit/storage/test_archive_tiers_write.py
@@ -2462,7 +2462,16 @@ def test_full_replace_without_attachments_does_not_refresh_all_attachment_counts
     assert replace_changes < 80
 
 
-def test_full_replace_refreshes_removed_attachment_ref_counts(tmp_path: Path) -> None:
+def test_full_replace_sweeps_removed_attachment_that_loses_its_last_ref(tmp_path: Path) -> None:
+    """polylogue-w06b: a full replace that drops an attachment's owning
+    message must not leave a ref-less ``attachments`` row behind. Before the
+    fix, ``_write_attachments`` recomputed ``ref_count = 0`` for the removed
+    attachment but never deleted the row, so it survived permanently
+    unreachable from any session/message read path (1,858 such orphans,
+    including 1,783 with real acquired bytes, were found live in
+    production). The row must now be gone entirely, not merely
+    zero-ref-counted.
+    """
     conn = _connect(tmp_path / "index.db")
     att1 = ParsedAttachment(
         provider_attachment_id="att-1",
@@ -2498,7 +2507,7 @@ def test_full_replace_refreshes_removed_attachment_ref_counts(tmp_path: Path) ->
     att2_id = archive_tier_write._attachment_id(session_id, att2)
     write_parsed_session_to_archive(conn, replacement)
 
-    assert conn.execute("SELECT ref_count FROM attachments WHERE attachment_id = ?", (att2_id,)).fetchone()[0] == 0
+    assert conn.execute("SELECT 1 FROM attachments WHERE attachment_id = ?", (att2_id,)).fetchone() is None
     assert conn.execute("SELECT COUNT(*) FROM attachment_refs WHERE attachment_id = ?", (att2_id,)).fetchone()[0] == 0
 
 

--- a/tests/unit/storage/test_attachment_acquisition.py
+++ b/tests/unit/storage/test_attachment_acquisition.py
@@ -185,3 +185,123 @@ def test_low_level_writer_rejects_inline_bytes_without_preacquisition(tmp_path: 
 
     with pytest.raises(ValueError, match="preacquired_attachment_blobs"):
         write_parsed_session_to_archive(conn, session)
+
+
+@pytest.mark.asyncio
+async def test_orphaned_attachment_ref_is_swept_not_left_unreachable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """polylogue-w06b: a full-replace re-ingest whose attachment can no
+    longer be matched to a message (its owning message dropped out of this
+    ingest's message set) must not leave a ref-less ``attachments`` row
+    behind. Before the fix, ``_write_attachments`` recomputed
+    ``ref_count = 0`` for the stale attachment via the UPDATE it already
+    runs, but never deleted the row -- unlike the identical
+    ``prune_attachments``/``delete_session_sql`` cleanups -- so the
+    attachment (real acquired bytes and all) became permanently unreachable
+    from the production read path ``get_attachments``, which INNER JOINs
+    ``attachment_refs`` and therefore can never surface a ref-less
+    ``attachments`` row for any session. Reverting the
+    ``DELETE FROM attachments WHERE ref_count <= 0 ...`` statement added to
+    ``_write_attachments`` makes this test fail: the orphaned row survives
+    in the table (visible via a direct ``SELECT``) even though
+    ``get_attachments`` still (correctly) can't reach it.
+    """
+    import aiosqlite
+
+    from polylogue.storage.sqlite.queries.attachment_records import get_attachments
+
+    store = BlobStore(tmp_path / "blob")
+    monkeypatch.setattr("polylogue.storage.blob_store.get_blob_store", lambda: store)
+
+    attachment = ParsedAttachment(
+        provider_attachment_id="att-orphan",
+        message_provider_id="m0",
+        name="orphan.txt",
+        mime_type="text/plain",
+        inline_bytes=b"will be orphaned",
+    )
+    attachment_id = _attachment_id_for_test(attachment)
+
+    db_path = tmp_path / "index.db"
+    conn = _connect(db_path)
+
+    # First ingest: attachment lands on message m0 and is reachable.
+    first_session = _session_with_attachment(attachment)
+    write_parsed_session_to_archive(
+        conn, first_session, preacquired_attachment_blobs=_preacquired(store, first_session)
+    )
+
+    row = conn.execute(
+        "SELECT acquisition_status, ref_count FROM attachments WHERE attachment_id = ?",
+        (attachment_id,),
+    ).fetchone()
+    assert row is not None
+    assert row["acquisition_status"] == "acquired"
+    assert row["ref_count"] == 1
+
+    # Second ingest of the SAME session (full replace, no merge_append): the
+    # provider's message set no longer includes m0 (e.g. it was renumbered,
+    # or excluded as a duplicate native id on this pass), so the attachment
+    # -- which still names message_provider_id="m0" -- can no longer be
+    # resolved to any message this time and _write_attachments skips
+    # re-writing its ref. The attachment_refs row for it was already dropped
+    # by the full replace's message CASCADE.
+    second_session = ParsedSession(
+        source_name=first_session.source_name,
+        provider_session_id=first_session.provider_session_id,
+        title=first_session.title,
+        messages=[
+            ParsedMessage(
+                provider_message_id="m1",
+                role=Role.USER,
+                text="a different message, m0 is gone",
+                position=0,
+                variant_index=0,
+                blocks=[ParsedContentBlock(type=BlockType.TEXT, text="a different message, m0 is gone")],
+            )
+        ],
+        attachments=[attachment],
+    )
+    write_parsed_session_to_archive(conn, second_session, force_replace=True)
+
+    surviving_row = conn.execute(
+        "SELECT 1 FROM attachments WHERE attachment_id = ?",
+        (attachment_id,),
+    ).fetchone()
+    assert surviving_row is None, (
+        "orphaned attachment row (acquired, real bytes) must be garbage-collected "
+        "once its last ref is dropped, not left permanently unreachable"
+    )
+
+    async with aiosqlite.connect(db_path) as aconn:
+        aconn.row_factory = aiosqlite.Row
+        records = await get_attachments(aconn, "aistudio-drive:s1")
+    assert all(record.attachment_id != attachment_id for record in records), (
+        "get_attachments (the production session-attachment read path) must never surface the orphaned attachment"
+    )
+
+
+def _attachment_id_for_test(attachment: ParsedAttachment) -> str:
+    """Mirror ``write.py:_attachment_id`` (identity hash, session-independent)
+    without importing the private helper across module boundaries.
+    """
+    import hashlib as _hashlib
+
+    def _hash_bytes(*parts: str) -> bytes:
+        digest = _hashlib.sha256()
+        for part in parts:
+            digest.update(part.encode("utf-8", errors="surrogatepass"))
+            digest.update(b"\0")
+        return digest.digest()
+
+    return _hash_bytes(
+        "attachment",
+        attachment.provider_attachment_id,
+        attachment.provider_file_id or "",
+        attachment.provider_drive_id or "",
+        attachment.path or "",
+        attachment.name or "",
+        attachment.mime_type or "",
+        str(attachment.size_bytes or 0),
+    ).hex()

--- a/tests/unit/storage/test_blob_integrity.py
+++ b/tests/unit/storage/test_blob_integrity.py
@@ -285,6 +285,8 @@ def test_scan_attachment_acquisition_debt_never_counts_unfetched_as_missing(
     assert report.unfetched_count == 1
     assert report.acquired_count == 0
     assert report.acquired_missing_blob_count == 0
+    assert report.acquired_unreachable_count == 0
+    assert report.acquired_reachable_count == 0
     assert report.ok is True
 
 
@@ -328,7 +330,57 @@ def test_scan_attachment_acquisition_debt_flags_acquired_row_with_missing_blob_f
     assert report.acquired_missing_blob_count == 1
     assert report.acquired_missing_blob_sample == (expected_attachment_id,)
     assert report.unfetched_count == 0
+    # Missing blob bytes is a distinct dimension from reachability: this
+    # attachment still has its attachment_refs row, it's just missing bytes.
+    assert report.acquired_unreachable_count == 0
+    assert report.acquired_reachable_count == 1
     assert report.ok is False
+
+
+def test_scan_attachment_acquisition_debt_flags_acquired_row_with_no_attachment_ref(tmp_path: Path) -> None:
+    """polylogue-w06b: an acquired attachment row with zero attachment_refs
+    rows is unreachable from every session/message read path even though its
+    bytes are genuinely on disk -- ``acquisition_status='acquired'`` alone
+    overstates real coverage. The writer path no longer produces such rows
+    (see test_archive_tiers_write.py's
+    test_full_replace_sweeps_removed_attachment_that_loses_its_last_ref), but
+    the scanner must still classify one correctly if it's ever found (e.g. in
+    an archive ingested before that fix landed).
+    """
+
+    index_db = tmp_path / "index.db"
+    store = BlobStore(tmp_path / "blob")
+    payload = b"orphaned but genuinely fetched bytes"
+    blob_hash, blob_size = store.write_from_bytes(payload)
+
+    conn = sqlite3.connect(index_db)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    initialize_archive_tier(conn, ArchiveTier.INDEX)
+    conn.execute(
+        """
+        INSERT INTO attachments (
+            attachment_id, display_name, media_type, byte_count, blob_hash, acquisition_status, ref_count
+        ) VALUES (?, ?, ?, ?, ?, 'acquired', 0)
+        """,
+        ("orphan-att-1", "orphan.txt", "text/plain", blob_size, bytes.fromhex(blob_hash)),
+    )
+    conn.commit()
+    conn.close()
+
+    report = scan_attachment_acquisition_debt(index_db, store=store, sample_size=5)
+
+    assert report.total_attachments == 1
+    assert report.acquired_count == 1
+    assert report.acquired_missing_blob_count == 0  # bytes ARE on disk
+    assert report.acquired_unreachable_count == 1
+    assert report.acquired_unreachable_sample == ("orphan-att-1",)
+    assert report.acquired_reachable_count == 0
+    # `ok` only tracks missing blob bytes (a distinct dimension) -- bytes ARE
+    # present on disk here, so `ok` stays True even though the row is
+    # unreachable. Reachability debt is its own signal
+    # (acquired_unreachable_count), deliberately not folded into `ok`.
+    assert report.ok is True
 
 
 def test_classify_blob_reference_debt_groups_recovery_evidence(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes an index.db-tier write-path gap where `_write_attachments` could leave a ref-less `attachments` row behind forever, unreachable from every session/message read path, and adds a reachability split to the existing attachment-acquisition-debt report so that gap can't hide behind `acquisition_status='acquired'` again.

## Problem

Read-only forensics on the live archive (polylogue-w06b, 2026-08-01) found 1,858 `attachments` rows in `index.db` with **zero** `attachment_refs` rows:

```
sqlite3 'file:/realm/db/polylogue/index.db?mode=ro' "
  select acquisition_status, count(*), sum(byte_count) from attachments a
  where not exists (select 1 from attachment_refs r where r.attachment_id = a.attachment_id)
  group by 1;"
-- acquired|1783|439974530
-- unfetched|75|756334471
```

1,783 of those were `acquisition_status='acquired'` (440MB of real, successfully-fetched blob content) but permanently unreachable from every session-scoped read path — `get_attachments`/`get_attachments_batch` (`storage/sqlite/queries/attachment_records.py`) both `INNER JOIN attachment_refs`, so a ref-less row can never be returned to any surface (MCP, CLI `read --view`, transcript view). Of the archive's 1,933 attachments marked `acquired`, only 150 (7.8%) were actually queryable.

**Root cause classification: (a)** — a straightforward missing cleanup step at write time, not a case needing reconstruction/backfill logic. `_write_attachments` (`polylogue/storage/sqlite/archive_tiers/write.py`) already recomputes `ref_count` for attachments whose ref was dropped on a full-replace re-ingest (the owning message disappeared this pass — dropped, renumbered, or excluded as a duplicate native id), via:

```sql
UPDATE attachments SET ref_count = (SELECT COUNT(*) FROM attachment_refs WHERE ...) WHERE attachment_id IN (...)
```

But unlike the **identical** cleanup already performed by `prune_attachments` (`queries/attachment_mutations.py`) and `delete_session_sql` (`queries/sessions_writes.py`) — both of which follow their own ref-count refresh with `DELETE FROM attachments WHERE ref_count <= 0` — `_write_attachments` never had that DELETE. The row survives indefinitely, still reporting `acquisition_status='acquired'`.

## Solution

- `_write_attachments` now runs the same `DELETE FROM attachments WHERE ref_count <= 0 AND attachment_id IN (...)` sweep the other two writers already perform, scoped to the same `affected_attachment_ids` set the ref_count UPDATE just touched.
- `AttachmentAcquisitionDebtReport` (`polylogue/storage/blob_integrity.py`, backing the `attachment-acquisition-debt` CLI command) gains `acquired_reachable_count` / `acquired_unreachable_count` (+ a sample of unreachable ids), computed via a `NOT EXISTS (SELECT 1 FROM attachment_refs ...)` check against `attachments.acquisition_status='acquired'`. This reconciles the "attachment coverage" framing used by polylogue-7r6u/pfdf (AC3 of polylogue-w06b): `acquired_count` alone overstated real coverage, since it never distinguished "bytes fetched" from "bytes anyone can actually read back".
- CLI plain-text output (`ops maintenance attachment-acquisition-debt`) now breaks out reachable/unreachable under the `Acquired:` line and lists a sample of unreachable ids when present.

## Non-goals

- **Backfilling the 1,783 existing orphaned rows in the live archive.** Their owning message was already dropped by the ingest pass that orphaned them; reconstructing the true link (if even possible) requires re-parsing the original source exports, not a mechanical fix from current index.db state alone. This PR does not write to `/realm/db/polylogue` in any way. A follow-up bead should track the backfill/GC decision for the existing rows (delete them outright vs. attempt re-parse-based relinking) — flagging this for the coordinator to file, since this lane's worktree must not write `.beads/`.
- Did not change `attachment_refs`' schema (e.g. adding an `ON DELETE CASCADE` from `attachments` back to some caller) — the gap was in application-level write discipline, not the schema.

## Verification

- `devtools test tests/unit/storage/test_attachment_acquisition.py tests/unit/storage/test_blob_integrity.py tests/unit/storage/test_archive_tiers_write.py tests/unit/storage/test_attachment_first_class_ids.py` → **111 passed**.
- **Anti-vacuity**: reverted the new `DELETE FROM attachments WHERE ref_count <= 0 ...` statement and reran `test_orphaned_attachment_ref_is_swept_not_left_unreachable` — it fails (`assert <sqlite3.Row object at ...> is None`), reproducing the exact live-archive bug shape before restoring the fix. Production caller exercised: `get_attachments` (`storage/sqlite/queries/attachment_records.py`), the read path every session/message attachment surface goes through.
- `devtools test tests/unit/cli/test_archive_maintenance_cli.py -k attachment_acquisition` → **2 passed**.
- `devtools verify --quick` → **exit 0** (format, lint, mypy --strict, render all --check — regenerated docs stayed in sync, no drift).
- Two unrelated pre-existing failures were observed in `tests/unit/cli/test_archive_maintenance_cli.py` (`test_rebuild_index_full_source_resumes_one_candidate_until_terminal_promotion`, `test_rebuild_index_byte_budget_defers_then_reaches_terminal_ready_candidate`) and in `tests/unit/storage/test_repair.py` (11 raw-materialization tests) — confirmed to fail identically with this branch's changes reverted, so classified as pre-existing/unrelated, not caused by this PR.

## AC matrix (polylogue-w06b)

- [x] Determine why rows exist without a ref — done: full-replace ref-count-refresh-without-delete gap in `_write_attachments`, evidenced above.
- [x] Decide fix for going-forward writes — done: GC (delete) at write time, matching the two sibling writers' existing pattern. Backfilling the *existing* 1,783 orphans is explicitly deferred (non-goal above, follow-up bead needed).
- [x] Reconcile the 'attachment coverage' framing (polylogue-7r6u/pfdf) — done via `acquired_reachable_count`/`acquired_unreachable_count` on `AttachmentAcquisitionDebtReport` + CLI output.

Ref polylogue-w06b