### PR TITLE
fix(demo): self-heal stale demo schema and fix tour budget attribution

### DIFF
--- a/polylogue/cli/commands/demo.py
+++ b/polylogue/cli/commands/demo.py
@@ -64,6 +64,11 @@ def seed_command(
     if output_format == "json":
         click.echo(json.dumps(payload, sort_keys=True))
         return
+    healed_note = (
+        f"  Self-healed: {', '.join(result.healed_tiers)} (stale schema moved aside and rebuilt)\n"
+        if result.healed_tiers
+        else ""
+    )
     env.ui.console.print(
         "[bold green]Demo archive ready[/bold green]\n"
         f"  Archive root: {result.archive_root}\n"
@@ -71,6 +76,7 @@ def seed_command(
         f"  Sessions:     {result.session_count}\n"
         f"  Messages:     {result.message_count}\n"
         f"  Overlays:     {'yes' if result.overlays_seeded else 'no'}\n"
+        f"{healed_note}"
         "  Verify:       polylogue demo verify"
     )
 

--- a/polylogue/demo/models.py
+++ b/polylogue/demo/models.py
@@ -20,6 +20,7 @@ class DemoSeedResult:
     overlays_seeded: bool
     assertion_count: int
     construct_coverage: tuple[DemoConstructCoverage, ...] = ()
+    healed_tiers: tuple[str, ...] = ()
 
     def to_payload(self) -> dict[str, object]:
         """Serialize the seed result for CLI JSON output and tests."""
@@ -33,6 +34,7 @@ class DemoSeedResult:
             "overlays_seeded": self.overlays_seeded,
             "assertion_count": self.assertion_count,
             "construct_coverage": [row.to_payload() for row in self.construct_coverage],
+            "healed_tiers": list(self.healed_tiers),
         }
 
 

--- a/polylogue/demo/seed.py
+++ b/polylogue/demo/seed.py
@@ -39,7 +39,7 @@ from polylogue.storage.embeddings.identity import (
 )
 from polylogue.storage.embeddings.materialization import archive_embeddable_message_where, message_prose_sql
 from polylogue.storage.insights.session.rebuild import rebuild_session_insights_sync
-from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.embedding_write import ArchiveEmbeddingWrite, upsert_message_embeddings
 from polylogue.storage.sqlite.archive_tiers.embeddings import EMBEDDING_DIMENSION
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
@@ -85,6 +85,66 @@ def materialize_demo_source(root: Path, *, force: bool = False) -> Path:
     _write_demo_antigravity_sources(source_root)
     _write_demo_hermes_sources(source_root)
     return source_root
+
+
+def _archive_root_is_demo_owned(root: Path) -> bool:
+    """Return whether *root* already holds a prior demo seed's fixture source.
+
+    ``DEMO_SOURCE_DIRNAME`` is written exclusively by :func:`materialize_demo_source`
+    and by nothing else in the codebase -- in particular the live daemon
+    (``polylogued run``) never creates it. Its presence *before* this call is
+    therefore strong, retroactive-compatible evidence that ``root``'s tier
+    databases hold only synthetic demo content this same command is about to
+    regenerate, never real archive data. This is the gate that makes
+    :func:`_self_heal_stale_demo_archive_tiers` safe to call unconditionally
+    for demo seeding while never touching a live/foreign archive that
+    happens to be at the resolved root (e.g. an operator forgot ``--root``
+    and ``archive_root()`` fell through to the configured production root).
+    """
+
+    return (root / DEMO_SOURCE_DIRNAME).exists()
+
+
+def _self_heal_stale_demo_archive_tiers(archive_root: Path) -> tuple[str, ...]:
+    """Move aside and rebuild any demo archive tier whose schema predates the current code.
+
+    Only ever called after :func:`_archive_root_is_demo_owned` has confirmed
+    ``archive_root`` is a disposable demo archive this exact command
+    regenerates every run (never the live/production archive). ``index.db``
+    and friends are declared *rebuildable* tiers (see ``CLAUDE.md``'s "Schema
+    regimes"), and a demo archive's content is entirely synthetic fixture
+    data with no durability requirement at all, so a stale on-disk schema
+    version here is safe to move aside and rebuild automatically -- unlike
+    the live archive, where the same version drift requires an explicit,
+    consented durable-tier migration or ``polylogue ops reset --index``.
+
+    Without this, a demo archive seeded by an older Polylogue version (or by
+    a fresher-schema worktree feeding an older-schema one, and vice versa)
+    fails hard with an unhelpful, unnamed-path error on every subsequent
+    ``demo seed`` against the same root (polylogue-3ycw) even though nothing
+    of value would be lost by rebuilding it.
+
+    Returns the tier filenames that were actually moved aside and rebuilt.
+    """
+
+    healed: list[str] = []
+    stale_suffix = f".stale-{int(time.time())}"
+    for spec in ARCHIVE_TIER_SPECS.values():
+        db_path = archive_root / spec.filename
+        if not db_path.exists():
+            continue
+        try:
+            initialize_archive_database(db_path, spec.tier)
+        except RuntimeError as exc:
+            if "schema version" not in str(exc):
+                raise
+            for sidecar_suffix in ("", "-wal", "-shm"):
+                sidecar = db_path.with_name(db_path.name + sidecar_suffix)
+                if sidecar.exists():
+                    sidecar.rename(sidecar.with_name(sidecar.name + stale_suffix))
+            initialize_archive_database(db_path, spec.tier)
+            healed.append(spec.filename)
+    return tuple(healed)
 
 
 def _write_jsonl(path: Path, records: tuple[dict[str, object], ...]) -> None:
@@ -1291,6 +1351,10 @@ async def seed_demo_archive(
 ) -> DemoSeedResult:
     """Materialize, ingest, and optionally overlay the deterministic demo archive."""
 
+    healed_tiers: tuple[str, ...] = ()
+    if _archive_root_is_demo_owned(archive_root):
+        healed_tiers = _self_heal_stale_demo_archive_tiers(archive_root)
+
     source_root = materialize_demo_source(archive_root, force=force)
     with _pushd(source_root):
         # Force sequential (single-worker) parsing for the fixed, dozen-file
@@ -1325,6 +1389,7 @@ async def seed_demo_archive(
         overlays_seeded=overlay is not None,
         assertion_count=len(overlay.assertion_ids) if overlay else 0,
         construct_coverage=construct_coverage,
+        healed_tiers=healed_tiers,
     )
 
 

--- a/polylogue/demo/tour.py
+++ b/polylogue/demo/tour.py
@@ -80,6 +80,15 @@ def run_demo_tour(
 
     steps: list[DemoTourStep] = []
     first_result_s = 0.0
+    # Deliberately re-based *after* seeding/verification: those are one-time
+    # cold-start archive-construction costs (fixture materialization, ingest,
+    # embedding synthesis), not query latency. The budget below exists to
+    # catch a slow *query*, so its clock must start where the narrated query
+    # steps start, not at the top of the whole tour (polylogue-3ycw --
+    # a cold environment measured 70.9s against the 30s budget here even
+    # though every individual narrated step took 4.6-5.3s; the gap was
+    # entirely pre-query setup time being charged to the query budget).
+    query_phase_start = time.perf_counter()
     env = _tour_env(resolved_archive)
     origin_count = len({session_id.split(":", 1)[0] for session_id in seed.session_ids})
     command_specs = (
@@ -129,7 +138,7 @@ def run_demo_tour(
         steps.append(step)
         transcript_parts.append(rendered)
         if index == 1:
-            first_result_s = time.perf_counter() - start
+            first_result_s = time.perf_counter() - query_phase_start
 
     total_duration_s = time.perf_counter() - start
     problems = _tour_problems(

--- a/polylogue/storage/sqlite/archive_tiers/bootstrap.py
+++ b/polylogue/storage/sqlite/archive_tiers/bootstrap.py
@@ -215,9 +215,14 @@ def initialize_archive_database(
                 if plan is not None:
                     apply_index_fast_forward(conn, plan)
                     return
+            rebuild_command = (
+                "polylogue ops reset --index && polylogued run"
+                if tier is ArchiveTier.INDEX
+                else f"mv {path} {path}.stale"
+            )
             raise RuntimeError(
-                f"{path.name} schema version {current_version} is not the current {tier.value} tier version "
-                f"{expected_version}; move it aside and rebuild the archive root"
+                f"{path} schema version {current_version} is not the current {tier.value} tier version "
+                f"{expected_version}; move it aside and rebuild the archive root, e.g.: {rebuild_command}"
             )
         initialize_archive_tier(conn, tier)
     finally:

--- a/tests/unit/demo/test_demo_seed_verify.py
+++ b/tests/unit/demo/test_demo_seed_verify.py
@@ -378,3 +378,75 @@ async def test_seed_demo_archive_forces_sequential_parse_workers(
 
     assert captured.get("parse_workers") == 1
     assert result.session_count == len(DEMO_SESSION_IDS)
+
+
+@pytest.mark.asyncio
+async def test_seed_demo_archive_self_heals_a_stale_schema_on_a_demo_owned_root(tmp_path: Path) -> None:
+    """Re-seeding a demo archive whose index.db predates the current schema self-heals.
+
+    Reproduces polylogue-3ycw: ``demo seed`` documented as the safe,
+    private-data-free onboarding path failed outright with
+    ``RuntimeError: index.db schema version N is not the current index tier
+    version M; move it aside and rebuild the archive root`` and no
+    self-heal, even though a demo archive's tiers hold only synthetic
+    fixture content this exact command regenerates every run.
+
+    ANTI-VACUITY: the production caller exercised is
+    ``polylogue.demo.seed.seed_demo_archive`` (imported directly, no
+    test-local reimplementation). Deleting the
+    ``_self_heal_stale_demo_archive_tiers`` call from ``seed_demo_archive``
+    (or deleting that helper's move-aside-and-reinitialize body) makes this
+    exact test fail with the original unhandled ``RuntimeError`` instead of
+    seeding successfully a second time.
+    """
+
+    archive_root = tmp_path / "archive"
+    await seed_demo_archive(archive_root, force=True)
+
+    # Roll index.db's schema version back, as if this demo archive had been
+    # seeded by an older Polylogue release whose index tier version was lower
+    # than the current code's.
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        conn.execute("PRAGMA user_version = 1")
+        conn.commit()
+
+    seed = await seed_demo_archive(archive_root, force=False)
+
+    assert seed.healed_tiers == ("index.db",)
+    assert seed.session_count == len(DEMO_SESSION_IDS)
+    assert seed.construct_coverage
+    assert all(row.ok for row in seed.construct_coverage)
+
+    verify = verify_demo_archive(archive_root)
+    assert verify.ok is True
+
+    stale_backups = list(archive_root.glob("index.db.stale-*"))
+    assert len(stale_backups) == 1
+
+
+@pytest.mark.asyncio
+async def test_seed_demo_archive_never_self_heals_a_non_demo_owned_root(tmp_path: Path) -> None:
+    """A stale-schema root lacking the demo fixture source directory is never auto-rebuilt.
+
+    Guards the safety half of the polylogue-3ycw fix: self-heal must never
+    fire for a root that was not itself created by an earlier ``demo seed``
+    call (for example, an operator forgot ``--root`` and
+    ``archive_root()`` fell through to the configured production archive).
+    Without the ``_archive_root_is_demo_owned`` gate this scenario would
+    silently move aside and rebuild real archive tiers on a schema
+    mismatch instead of refusing loudly.
+    """
+
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+    with sqlite3.connect(archive_root / "index.db") as conn:
+        conn.execute("PRAGMA user_version = 1")
+        conn.commit()
+
+    with pytest.raises(RuntimeError, match="move it aside and rebuild the archive root"):
+        await seed_demo_archive(archive_root, force=False)
+
+    # Nothing was moved aside: the non-demo-owned root's tiers are untouched.
+    assert not list(archive_root.glob("index.db.stale-*"))

--- a/tests/unit/demo/test_demo_tour_timing.py
+++ b/tests/unit/demo/test_demo_tour_timing.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+import polylogue.demo.tour as tour_module
+from polylogue.demo.seed import seed_demo_archive as real_seed_demo_archive
+from polylogue.demo.tour import run_demo_tour
+
+_INJECTED_SETUP_DELAY_S = 6.0
+_TEST_FIRST_RESULT_BUDGET_S = 6.0
+
+
+@pytest.mark.slow
+def test_first_result_budget_excludes_one_time_archive_setup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``first_result_s`` must measure query latency, not cold-start seeding.
+
+    Reproduces polylogue-3ycw: a cold environment measured
+    ``first_result_s = 70.9s`` against the 30s budget even though each of
+    the four narrated CLI steps individually took only 4.6-5.3s -- the
+    overrun was one-time fixture seed/verify setup time being charged
+    against a budget meant to catch a slow *query*.
+
+    This test injects a real, artificial delay around the actual
+    ``seed_demo_archive`` call and shrinks the first-result budget to a
+    value that comfortably covers one real narrated step's own cold-start
+    subprocess overhead (observed ~2.5s in this environment) but not that
+    overhead plus the injected delay. That isolates the exact bug: whether
+    the injected setup delay leaks into the budgeted timer.
+
+    ANTI-VACUITY: the production entry point exercised is
+    ``polylogue.demo.tour.run_demo_tour``. Reverting the fix (rebasing
+    ``first_result_s`` back to the tour's overall ``start`` instead of the
+    post-setup ``query_phase_start``) makes this test fail: the injected
+    6s setup delay would then be included in ``first_result_s``, pushing it
+    past the 6s budget and past the assertion below, and the tour's own
+    ``problems`` list would report a budget overrun.
+    """
+
+    async def slow_seed_demo_archive(*args: object, **kwargs: object):  # type: ignore[no-untyped-def]
+        time.sleep(_INJECTED_SETUP_DELAY_S)
+        return await real_seed_demo_archive(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(tour_module, "seed_demo_archive", slow_seed_demo_archive)
+    monkeypatch.setattr(tour_module, "FIRST_RESULT_BUDGET_S", _TEST_FIRST_RESULT_BUDGET_S)
+
+    result = run_demo_tour(output_dir=tmp_path / "tour", force=True)
+
+    # The injected delay must show up in the full tour duration...
+    assert result.total_duration_s >= _INJECTED_SETUP_DELAY_S
+    # ...but must NOT be charged against the first-result query budget.
+    assert result.first_result_s < _INJECTED_SETUP_DELAY_S
+    assert not any("first result exceeded" in problem for problem in result.problems)
+    assert result.ok, result.problems


### PR DESCRIPTION
## Summary

Fixes two failures in the documented, private-data-free onboarding path that CLAUDE.md and TESTING.md point a cold agent at instead of the live archive: `polylogue demo seed` failed hard on a stale-schema demo archive with no self-heal, and `polylogue demo tour` overran its own 30s "first result" latency budget due to a timer-attribution bug.

## Problem

Two related failures reported in polylogue-3ycw:

1. `polylogue demo seed` against a demo archive left over from an older schema version raised:
   `RuntimeError: index.db schema version 46 is not the current index tier version 53; move it aside and rebuild the archive root`
   with no path named and no self-heal, even though a demo archive is entirely synthetic, disposable fixture data that this same command regenerates on every run.

2. `polylogue demo tour` failed its own latency budget: `First result: 70.934s` against a 30s budget, `Full tour: 86.336s` against a 420s budget (which passed). The tour's own `report.md` showed each of the 4 narrated CLI steps individually took only 4.6-5.3s — the 70.9s "first result" number was dominated by one-time archive seed+verify setup happening *before* the first narrated step, not by query latency.

I reproduced both against a fresh scratch archive (`POLYLOGUE_ARCHIVE_ROOT=/realm/tmp/... polylogue demo seed`) — a genuinely fresh root seeds cleanly, confirming issue 1 is not a fundamental demo-seed bug but a missing self-heal for a *pre-existing* stale-schema demo archive at the resolved root. Reading `polylogue/demo/tour.py` confirmed issue 2 directly: `first_result_s = time.perf_counter() - start`, where `start` is set before the seed/verify calls, not before the narrated command loop.

## Solution

- `polylogue/demo/seed.py`: added `_archive_root_is_demo_owned()`, which treats the presence of the demo fixture source directory (`demo-fixture-world-source`, written only by `materialize_demo_source`, never by the live daemon) as strong, retroactive-compatible evidence that a root's tier databases hold only synthetic demo content. `_self_heal_stale_demo_archive_tiers()` then moves aside (`<file>.stale-<timestamp>`) and rebuilds any tier whose on-disk schema version predates the current code's — but **only** when that ownership check passes. A stale-schema *foreign* root (e.g. an operator forgot `--root` and the default `archive_root()` resolved to the configured production archive) is never auto-rebuilt; it still raises loudly, protecting the live/durable archive from any auto-mutation.
- `polylogue/storage/sqlite/archive_tiers/bootstrap.py`: the (still-raised, for non-demo-owned roots) `RuntimeError` now names the full path and an explicit rebuild command (`polylogue ops reset --index && polylogued run` for `index.db`, `mv <path> <path>.stale` otherwise) instead of just the bare filename with no remediation.
- `polylogue/demo/tour.py`: rebased `first_result_s`'s clock (`query_phase_start`) to start *after* the one-time seed+verify setup completes, so the budget measures actual query latency instead of cold-start archive construction. `total_duration_s` is unchanged (it already comfortably includes setup and wasn't flagged as wrong).
- `polylogue/demo/models.py`, `polylogue/cli/commands/demo.py`: surface `healed_tiers` on `DemoSeedResult` and in the CLI `seed` command's plain-text output.

## Verification

Reproduced fresh (scratch `POLYLOGUE_ARCHIVE_ROOT`, no live archive touched):

```
$ POLYLOGUE_ARCHIVE_ROOT=/realm/tmp/demo-seed-clean/archive polylogue demo seed
Demo archive ready
  ...
$ # rolled index.db's PRAGMA user_version back to 46 on that same demo-owned archive
$ POLYLOGUE_ARCHIVE_ROOT=/realm/tmp/demo-seed-clean/archive polylogue demo seed
Demo archive ready
  ...
  Self-healed: index.db (stale schema moved aside and rebuilt)
  Verify:       polylogue demo verify
$ polylogue demo tour --out-dir /realm/tmp/demo-tour-clean
Polylogue demo tour: passed
  First result: 2.680s
  Full tour:    19.651s
```

- `devtools test tests/unit/demo/ tests/unit/cli/test_demo_command.py tests/unit/storage/test_index_fast_forward_executor.py` — 59 passed.
- New tests:
  - `test_seed_demo_archive_self_heals_a_stale_schema_on_a_demo_owned_root` — rolls an already-seeded demo archive's `index.db` back to an old `PRAGMA user_version` and asserts a second `seed_demo_archive()` call self-heals (`healed_tiers == ("index.db",)`) instead of raising.
  - `test_seed_demo_archive_never_self_heals_a_non_demo_owned_root` — a stale-schema root *without* the demo fixture source directory still raises the original `RuntimeError`; nothing is moved aside. This is the control proving self-heal never touches a foreign/live archive.
  - `test_first_result_budget_excludes_one_time_archive_setup` (new file `tests/unit/demo/test_demo_tour_timing.py`) — injects a real 6s delay around the actual `seed_demo_archive` call and shrinks the budget to 6s; asserts the injected delay does not leak into `first_result_s`.
- **Anti-vacuity confirmed by hand**: temporarily reverting the `tour.py` timer rebase (`first_result_s = time.perf_counter() - start`) made the new tour test fail exactly as expected — `first_result_s=9.5s` against the shrunk 6s budget, with `problems=('first result exceeded 6s budget: 9.505s',)`. Restored the fix before committing.
- `devtools verify --quick`: exit 0 (ruff format/check, mypy --strict, render all --check, layering/closure-matrix/schema-versioning lanes, pre-push hook run automatically on `git push`).

## Acceptance criteria (from polylogue-3ycw)

- (a) "demo seed should detect+auto-rebuild a stale schema version rather than erroring with a manual, underspecified remediation instruction" — **satisfied**, scoped to demo-owned roots only (see Solution above for why an unconditional auto-rebuild would be unsafe).
- (b) "demo tour's budget should exclude one-time fixture/archive setup from the 'first result' timer" — **satisfied**.
- The `demo verify` "0/expected" cascade reported in the bead was a downstream symptom of (a) (verifying a never-actually-seeded archive); no separate fix needed once (a) lands.

Ref polylogue-3ycw