### PR TITLE
perf(cli): stop the daemon fast path importing polylogue.api/ArchiveStore

### DIFF
--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -120,7 +120,7 @@ files:
     owner: stable
     cross_cut: { api: sync }
   - path: polylogue/api/sync/bridge.py
-    loc: 59
+    loc: 15
     target: polylogue/api/sync/bridge.py
     owner: stable
     cross_cut: { api: sync }
@@ -819,7 +819,7 @@ files:
     target: polylogue/cli/__main__.py
     owner: stable
   - path: polylogue/cli/archive_query.py
-    loc: 2859
+    loc: 2902
     target: polylogue/cli/archive_query.py
     owner: stable
   - path: polylogue/cli/click_app.py
@@ -1035,7 +1035,7 @@ files:
     target: polylogue/cli/commands/scan_secrets.py
     owner: stable
   - path: polylogue/cli/commands/status.py
-    loc: 2428
+    loc: 2494
     target: polylogue/cli/commands/status.py
     owner: stable
   - path: polylogue/cli/commands/status_diagnostics.py
@@ -1075,7 +1075,7 @@ files:
     target: polylogue/cli/parser_diagnostics.py
     owner: stable
   - path: polylogue/cli/query.py
-    loc: 115
+    loc: 123
     target: polylogue/cli/query.py
     owner: stable
   - path: polylogue/cli/query_actions.py
@@ -1289,7 +1289,7 @@ files:
     target: polylogue/cli/shared/schema_rendering_results.py
     owner: stable
   - path: polylogue/cli/shared/types.py
-    loc: 134
+    loc: 150
     target: polylogue/cli/shared/types.py
     owner: stable
   - path: polylogue/cli/shell_completion_values.py
@@ -1361,6 +1361,11 @@ files:
   - path: polylogue/core/assertions.py
     loc: 160
     target: polylogue/core/assertions.py
+    owner: core-primitive
+    reason: core primitive
+  - path: polylogue/core/async_bridge.py
+    loc: 73
+    target: polylogue/core/async_bridge.py
     owner: core-primitive
     reason: core primitive
   - path: polylogue/core/common.py
@@ -2100,10 +2105,6 @@ files:
     loc: 474
     target: polylogue/insights/run_projection.py
     owner: stable
-  - path: polylogue/insights/schema_drift.py
-    loc: 89
-    target: polylogue/insights/schema_drift.py
-    owner: stable
   - path: polylogue/insights/session_analytics.py
     loc: 274
     target: polylogue/insights/session_analytics.py
@@ -2490,7 +2491,7 @@ files:
     target: polylogue/pipeline/services/ingest_batch/__init__.py
     owner: stable
   - path: polylogue/pipeline/services/ingest_batch/_core.py
-    loc: 1973
+    loc: 1930
     target: polylogue/pipeline/services/ingest_batch/_core.py
     owner: stable
   - path: polylogue/pipeline/services/ingest_batch/_memory.py
@@ -2722,7 +2723,7 @@ files:
     target: polylogue/scenarios/workload.py
     owner: stable
   - path: polylogue/schemas/__init__.py
-    loc: 35
+    loc: 9
     target: polylogue/schemas/__init__.py
     owner: stable
   - path: polylogue/schemas/audit/__init__.py
@@ -3231,7 +3232,7 @@ files:
     target: polylogue/sources/decoders.py
     owner: stable
   - path: polylogue/sources/dispatch.py
-    loc: 1711
+    loc: 1762
     target: polylogue/sources/dispatch.py
     owner: stable
   - path: polylogue/sources/drive/__init__.py
@@ -4172,7 +4173,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/index_fast_forward_executor.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
-    loc: 290
+    loc: 358
     target: polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/ops.py
@@ -4192,7 +4193,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/revision_application.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/revision_governance.py
-    loc: 2922
+    loc: 2868
     target: polylogue/storage/sqlite/archive_tiers/revision_governance.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/self_verify.py

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -556,7 +556,7 @@ files:
     owner: archive-semantic
     reason: archive-domain semantics
   - path: polylogue/archive/semantic/cost_compute.py
-    loc: 298
+    loc: 375
     target: polylogue/archive/semantic/cost_compute.py
     owner: archive-semantic
     reason: archive-domain semantics
@@ -576,7 +576,7 @@ files:
     owner: archive-semantic
     reason: archive-domain semantics
   - path: polylogue/archive/semantic/pricing.py
-    loc: 995
+    loc: 1000
     target: polylogue/archive/semantic/pricing.py
     owner: archive-semantic
     reason: archive-domain semantics
@@ -823,7 +823,7 @@ files:
     target: polylogue/cli/archive_query.py
     owner: stable
   - path: polylogue/cli/click_app.py
-    loc: 652
+    loc: 694
     target: polylogue/cli/click_app.py
     owner: stable
   - path: polylogue/cli/click_command_registration.py
@@ -951,7 +951,7 @@ files:
     target: polylogue/cli/commands/maintenance/_blob_gc.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_blob_integrity.py
-    loc: 430
+    loc: 436
     target: polylogue/cli/commands/maintenance/_blob_integrity.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_blob_publications.py
@@ -1035,7 +1035,7 @@ files:
     target: polylogue/cli/commands/scan_secrets.py
     owner: stable
   - path: polylogue/cli/commands/status.py
-    loc: 2494
+    loc: 2428
     target: polylogue/cli/commands/status.py
     owner: stable
   - path: polylogue/cli/commands/status_diagnostics.py
@@ -2105,6 +2105,10 @@ files:
     loc: 474
     target: polylogue/insights/run_projection.py
     owner: stable
+  - path: polylogue/insights/schema_drift.py
+    loc: 89
+    target: polylogue/insights/schema_drift.py
+    owner: stable
   - path: polylogue/insights/session_analytics.py
     loc: 274
     target: polylogue/insights/session_analytics.py
@@ -2723,7 +2727,7 @@ files:
     target: polylogue/scenarios/workload.py
     owner: stable
   - path: polylogue/schemas/__init__.py
-    loc: 9
+    loc: 35
     target: polylogue/schemas/__init__.py
     owner: stable
   - path: polylogue/schemas/audit/__init__.py
@@ -3633,7 +3637,7 @@ files:
     owner: storage-root
     reason: storage-root cross-cutting helper
   - path: polylogue/storage/blob_integrity.py
-    loc: 2108
+    loc: 2151
     target: polylogue/storage/blob_integrity.py
     owner: storage-root
     reason: storage-root cross-cutting helper
@@ -4169,7 +4173,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/index_convergence.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/index_fast_forward_executor.py
-    loc: 247
+    loc: 364
     target: polylogue/storage/sqlite/archive_tiers/index_fast_forward_executor.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
@@ -4193,7 +4197,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/revision_application.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/revision_governance.py
-    loc: 2868
+    loc: 2877
     target: polylogue/storage/sqlite/archive_tiers/revision_governance.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/self_verify.py
@@ -4237,7 +4241,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/user_write.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/write.py
-    loc: 6295
+    loc: 6312
     target: polylogue/storage/sqlite/archive_tiers/write.py
     owner: stable
   - path: polylogue/storage/sqlite/async_sqlite.py
@@ -4269,7 +4273,7 @@ files:
     target: polylogue/storage/sqlite/finding_provenance.py
     owner: stable
   - path: polylogue/storage/sqlite/lifecycle.py
-    loc: 720
+    loc: 819
     target: polylogue/storage/sqlite/lifecycle.py
     owner: stable
   - path: polylogue/storage/sqlite/maintenance.py

--- a/polylogue/api/sync/bridge.py
+++ b/polylogue/api/sync/bridge.py
@@ -1,59 +1,15 @@
+"""Synchronous bridge re-export.
+
+The real implementation lives in ``polylogue.core.async_bridge`` (dependency-
+free: only ``asyncio``/``threading``) so that CLI hot paths which only need to
+drive a coroutine -- and never touch the ``Polylogue`` facade -- can import it
+without pulling in the whole ``polylogue.api`` package. This module keeps the
+historical import path working for existing callers (Lynchpin, MCP, other API
+consumers) that already depend on the ``Polylogue`` facade being available.
+"""
+
 from __future__ import annotations
 
-import asyncio
-import threading
-from collections.abc import Awaitable, Coroutine
-from typing import TypeVar
-
-T = TypeVar("T")
-
-
-async def _await(awaitable: Awaitable[T]) -> T:
-    return await awaitable
-
-
-def run_coroutine_sync(coro: Awaitable[T]) -> T:
-    """Run a coroutine from sync code, even when already inside an event loop.
-
-    When no event loop is running, drive it directly with ``asyncio.run``.
-    When a loop is already running (sync CLI surfaces invoked from inside an
-    async caller — e.g. a CliRunner test, or one async API calling a sync
-    wrapper), the coroutine is executed on a dedicated short-lived thread with
-    its own fresh event loop.
-
-    A per-call thread is deliberate. An earlier implementation kept a persistent
-    shared worker loop for performance, but a shared mutable loop is fragile
-    under test isolation that patches ``threading.Thread.run`` per test: the
-    global could be left pointing at a loop whose thread had stopped driving it,
-    so ``run_coroutine_threadsafe`` scheduled work that never ran and
-    ``future.result()`` blocked forever (observed hanging the full test suite).
-    A fresh thread + ``asyncio.run`` per call has no shared state, so it cannot
-    be poisoned by prior calls or test ordering; the cost (one thread spawn per
-    sync-bridge call, ~once per CLI invocation) is negligible.
-    """
-    wrapper: Coroutine[object, object, T] = _await(coro)
-
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(wrapper)
-
-    result: list[T] = []
-    error: list[BaseException] = []
-
-    def _runner() -> None:
-        try:
-            result.append(asyncio.run(wrapper))
-        except BaseException as exc:
-            error.append(exc)
-
-    thread = threading.Thread(target=_runner, name="polylogue-sync-bridge", daemon=True)
-    thread.start()
-    thread.join()
-
-    if error:
-        raise error[0]
-    return result[0]
-
+from polylogue.core.async_bridge import run_coroutine_sync
 
 __all__ = ["run_coroutine_sync"]

--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -69,6 +69,7 @@ from polylogue.storage.archive_identity import archive_file_set_root
 # constructs/calls one of these imports it locally at first use.
 if TYPE_CHECKING:
     from polylogue.archive.stats import ArchiveStats
+    from polylogue.core.protocols import VectorProvider
     from polylogue.storage.sqlite.archive_tiers.archive import (
         ArchiveSessionSearchHit,
         ArchiveSessionSummary,
@@ -84,6 +85,27 @@ if TYPE_CHECKING:
         SearchCursor,
     )
 
+
+def __getattr__(name: str) -> object:
+    """PEP 562 lazy module attribute for ``ArchiveStore``.
+
+    ``ArchiveStore`` is otherwise only referenced as a (never-evaluated,
+    ``from __future__ import annotations``) type annotation in this module,
+    so its heavy import chain stays deferred on the daemon fast path
+    (polylogue-g3jk). But several tests patch
+    ``polylogue.cli.archive_query.ArchiveStore.open_existing`` by dotted
+    string path — a function-local import binds a name that shadows this
+    module's own attribute and is invisible to that patch target, so the
+    class must remain resolvable as a real module attribute on demand
+    without being imported eagerly at module load time.
+    """
+    if name == "ArchiveStore":
+        from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+        return ArchiveStore
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 logger = get_logger(__name__)
 
 _PageRow = TypeVar("_PageRow", "ArchiveSessionSummary", "ArchiveSessionSearchHit")
@@ -93,6 +115,21 @@ _QueryUnitTextLine = Callable[[dict[str, object]], str]
 _DAEMON_FAST_PATH_TIMEOUT_S = 0.75
 _NATIVE_REF_RE = re.compile(r"(?=.*\d)[A-Za-z0-9][A-Za-z0-9_.:-]{11,}")
 _TIMING_ENV: ContextVar[AppEnv | None] = ContextVar("archive_query_timing_env", default=None)
+
+
+def create_vector_provider(config: Config, *, db_path: Path) -> VectorProvider | None:
+    """Lazy module-level indirection so tests can patch this name.
+
+    A function-local ``from ... import create_vector_provider`` would bind a
+    local variable that shadows this module attribute, so
+    ``unittest.mock.patch("polylogue.cli.archive_query.create_vector_provider")``
+    would never reach the real call sites below. Keeping the deferred import
+    inside a persistent module-level function preserves both the patch seam
+    and the daemon-fast-path import-cost deferral (polylogue-g3jk).
+    """
+    from polylogue.storage.search_providers import create_vector_provider as _create_vector_provider
+
+    return _create_vector_provider(config, db_path=db_path)
 
 
 def _object_int(value: object) -> int:
@@ -928,7 +965,7 @@ def _query_hits(
     session_id: str | None,
     filter_kwargs: _ArchiveFilterKwargs,
 ) -> tuple[list[ArchiveSessionSearchHit], str]:
-    from polylogue.storage.search_providers import create_vector_provider, reciprocal_rank_fusion
+    from polylogue.storage.search_providers import reciprocal_rank_fusion
 
     # polylogue-yla8.1 split-root contract: config.db_path always names a
     # concrete index.db (explicit override or resolved active generation).

--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -15,7 +15,7 @@ from contextvars import ContextVar
 from dataclasses import replace
 from pathlib import Path
 from time import perf_counter
-from typing import Any, NoReturn, TypeVar, cast
+from typing import TYPE_CHECKING, Any, NoReturn, TypeVar, cast
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode
 from urllib.request import Request, urlopen
@@ -24,7 +24,6 @@ import click
 from typing_extensions import NotRequired, TypedDict
 
 from polylogue.archive.message.types import validate_message_type_filter
-from polylogue.archive.query.attached_units import fetch_attached_units
 from polylogue.archive.query.expression import (
     QueryUnitSource,
     WithUnitWindow,
@@ -44,11 +43,8 @@ from polylogue.archive.query.spec import (
     session_count_unit_label,
 )
 from polylogue.archive.query.transaction import archive_read_context
-from polylogue.archive.query.unit_results import query_unit_rows, query_unit_session_filters
-from polylogue.archive.stats import ArchiveStats
 from polylogue.cli.query_contracts import QueryOutputSpec
 from polylogue.cli.query_feedback import maybe_subcommand_typo_hint
-from polylogue.cli.query_output import deliver_query_output
 from polylogue.cli.query_output_contracts import QueryOutputDocument
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.helpers import load_effective_config
@@ -57,38 +53,40 @@ from polylogue.cli.shared.types import AppEnv
 from polylogue.config import Config
 from polylogue.logging import get_logger
 from polylogue.storage.archive_identity import archive_file_set_root
-from polylogue.storage.search_providers import create_vector_provider, reciprocal_rank_fusion
-from polylogue.storage.sqlite.archive_tiers.archive import (
-    ArchiveSessionSearchHit,
-    ArchiveSessionSummary,
-    ArchiveStore,
-)
-from polylogue.storage.sqlite.archive_tiers.write import (
-    ArchiveMessageRow,
-    ArchiveSessionEnvelope,
-    archive_message_display_text,
-)
-from polylogue.surfaces.payloads import (
-    SEARCH_CURSOR_VERSION,
-    InvalidSearchCursorError,
-    MutationOperation,
-    MutationResultPayload,
-    QueryMissDiagnosticsPayload,
-    SearchCursor,
-    SessionListRowPayload,
-    SessionSearchHitPayload,
-    SessionSearchMatchPayload,
-    SessionSummaryPayload,
-    TargetRefPayload,
-    decode_search_cursor,
-    model_json_document,
-    reader_anchor,
-    reader_message_actions,
-)
+
+# The names below are used only as type annotations across this module (never
+# constructed/called at the module's own top level) except at the specific
+# call sites noted, which import them locally. Each backing module is heavy
+# (ArchiveStore's chain alone costs ~2.2s of import time: schemas/validator ->
+# sources/dispatch -> the whole provider-parser universe, plus surfaces.payloads'
+# pydantic models). Importing them unconditionally here meant every CLI query
+# invocation paid that cost even when the daemon fast path
+# (``_try_emit_daemon_session_page``) served the request over UDS and never
+# touched ArchiveStore, search_providers, or the local emit/mutation renderers
+# at all (polylogue-g3jk). `from __future__ import annotations` (top of file)
+# means annotation-only uses below never evaluate these names at runtime, so
+# TYPE_CHECKING-gating them here is safe; each function that actually
+# constructs/calls one of these imports it locally at first use.
+if TYPE_CHECKING:
+    from polylogue.archive.stats import ArchiveStats
+    from polylogue.storage.sqlite.archive_tiers.archive import (
+        ArchiveSessionSearchHit,
+        ArchiveSessionSummary,
+        ArchiveStore,
+    )
+    from polylogue.storage.sqlite.archive_tiers.write import (
+        ArchiveMessageRow,
+        ArchiveSessionEnvelope,
+    )
+    from polylogue.surfaces.payloads import (
+        MutationOperation,
+        QueryMissDiagnosticsPayload,
+        SearchCursor,
+    )
 
 logger = get_logger(__name__)
 
-_PageRow = TypeVar("_PageRow", ArchiveSessionSummary, ArchiveSessionSearchHit)
+_PageRow = TypeVar("_PageRow", "ArchiveSessionSummary", "ArchiveSessionSearchHit")
 
 _UNSUPPORTED_PARAM_MESSAGES: dict[str, str] = {}
 _QueryUnitTextLine = Callable[[dict[str, object]], str]
@@ -176,6 +174,8 @@ def execute_archive_query(env: AppEnv, request: RootModeRequest) -> None:
         if output.destination_labels() == ("stdout",) or request.params.get("stream"):
             _execute_archive_query_stdout(env, request)
             return
+        from polylogue.cli.query_output import deliver_query_output
+
         rendered = io.StringIO()
         with redirect_stdout(rendered):
             _execute_archive_query_stdout(env, request)
@@ -496,6 +496,8 @@ def _execute_archive_query_stdout(env: AppEnv, request: RootModeRequest) -> None
                 )
                 return
             if query and not session_ids:
+                from polylogue.archive.stats import ArchiveStats
+
                 _emit_stats(
                     ArchiveStats(total_sessions=0, total_messages=0),
                     output_format=output_format,
@@ -926,6 +928,8 @@ def _query_hits(
     session_id: str | None,
     filter_kwargs: _ArchiveFilterKwargs,
 ) -> tuple[list[ArchiveSessionSearchHit], str]:
+    from polylogue.storage.search_providers import create_vector_provider, reciprocal_rank_fusion
+
     # polylogue-yla8.1 split-root contract: config.db_path always names a
     # concrete index.db (explicit override or resolved active generation).
     archive_root = archive_file_set_root(archive_root=config.archive_root, db_path=config.db_path)
@@ -1629,6 +1633,8 @@ def _emit_degraded_daemon_search_payload(
 def _decode_cursor(token: str | None) -> SearchCursor | None:
     if token is None:
         return None
+    from polylogue.surfaces.payloads import InvalidSearchCursorError, decode_search_cursor
+
     try:
         cursor = decode_search_cursor(token)
     except InvalidSearchCursorError as exc:
@@ -1651,6 +1657,8 @@ def _paginate_rows(
 
 def _build_cursor(row: ArchiveSessionSummary | ArchiveSessionSearchHit, *, rank: int, retrieval_lane: str) -> str:
     import base64
+
+    from polylogue.surfaces.payloads import SEARCH_CURSOR_VERSION, SearchCursor
 
     cursor = SearchCursor(
         v=SEARCH_CURSOR_VERSION,
@@ -1690,6 +1698,8 @@ def _emit_stream(
     output_format: str,
     message_limit: int | None,
 ) -> None:
+    from polylogue.storage.sqlite.archive_tiers.write import ArchiveSessionEnvelope
+
     messages = envelope.messages[:message_limit] if message_limit is not None else envelope.messages
     payload = _session_payload(
         ArchiveSessionEnvelope(
@@ -1908,6 +1918,8 @@ def _emit_missing_archive_empty_read(
         )
         return True
     if params.get("stats_only"):
+        from polylogue.archive.stats import ArchiveStats
+
         _emit_stats(
             ArchiveStats(total_sessions=0, total_messages=0),
             output_format=output_format,
@@ -2020,6 +2032,8 @@ def _emit_stats_by(
 
 
 def _emit_mutation(changed: int, *, operation: MutationOperation) -> None:
+    from polylogue.surfaces.payloads import MutationResultPayload
+
     click.echo(
         MutationResultPayload(status="ok", operation=operation, affected_count=changed).to_json(exclude_none=True)
     )
@@ -2032,6 +2046,8 @@ def _emit_user_mutations(
     tags_to_add: tuple[str, ...],
     metadata_to_set: tuple[tuple[str, str], ...],
 ) -> None:
+    from polylogue.surfaces.payloads import MutationResultPayload
+
     changes: dict[str, int] = {}
     if metadata_to_set:
         changes["metadata"] = archive.set_user_metadata(session_ids, metadata_to_set)
@@ -2070,6 +2086,7 @@ def _emit_delete(
     """
     from polylogue.operations.mutation_actuators import SessionDeleteActuator, SessionDeleteArgs
     from polylogue.operations.mutation_transaction import OperationExecutor
+    from polylogue.surfaces.payloads import MutationResultPayload
 
     dry_run = bool(params.get("dry_run"))
     force = bool(params.get("force"))
@@ -2170,6 +2187,8 @@ def _inject_attached_units(
 
     if not with_units or archive is None or not items:
         return
+    from polylogue.archive.query.attached_units import fetch_attached_units
+
     attached = fetch_attached_units(
         archive, session_ids, with_units, unit_fields=with_unit_fields, unit_windows=with_unit_windows
     )
@@ -2264,6 +2283,7 @@ def _search_miss_diagnostics(
     diagnosis must never turn a legitimate zero-hit result into an error.
     """
     from polylogue.api.sync.bridge import run_coroutine_sync
+    from polylogue.surfaces.payloads import QueryMissDiagnosticsPayload
 
     try:
         raw_diagnostics = run_coroutine_sync(env.polylogue.diagnose_query_miss(spec, full=why))
@@ -2500,6 +2520,8 @@ def _emit_unit_source_rows(
     output_format: str,
     fields: str | None,
 ) -> None:
+    from polylogue.archive.query.unit_results import query_unit_rows
+
     envelope_model = query_unit_rows(
         archive,
         source,
@@ -2527,6 +2549,8 @@ def _unit_source_display_name(source: QueryUnitSource) -> str:
 
 
 def _unit_source_session_filters(filter_kwargs: _ArchiveFilterKwargs) -> dict[str, object]:
+    from polylogue.archive.query.unit_results import query_unit_session_filters
+
     filters = dict(filter_kwargs)
     filters.pop("since_session_id", None)
     return query_unit_session_filters(**filters)
@@ -2658,6 +2682,13 @@ def _summary_payload(
     child_refs: tuple[str, ...] | None = None,
     continuation: str | None = None,
 ) -> dict[str, object]:
+    from polylogue.surfaces.payloads import (
+        SessionListRowPayload,
+        TargetRefPayload,
+        model_json_document,
+        reader_anchor,
+    )
+
     return cast(
         "dict[str, object]",
         model_json_document(
@@ -2689,6 +2720,16 @@ def _hit_payload(
     summary: ArchiveSessionSummary,
     retrieval_lane: str,
 ) -> dict[str, object]:
+    from polylogue.surfaces.payloads import (
+        SessionSearchHitPayload,
+        SessionSearchMatchPayload,
+        SessionSummaryPayload,
+        TargetRefPayload,
+        model_json_document,
+        reader_anchor,
+        reader_message_actions,
+    )
+
     return cast(
         "dict[str, object]",
         model_json_document(
@@ -2799,6 +2840,8 @@ def _session_summary_text(envelope: ArchiveSessionEnvelope) -> str:
         lines.append(f"- created: {envelope.created_at or 'unknown'}  updated: {envelope.updated_at or 'unknown'}")
 
     def _first_authored_text(candidates: Iterable[ArchiveMessageRow]) -> str:
+        from polylogue.storage.sqlite.archive_tiers.write import archive_message_display_text
+
         for message in candidates:
             if message.role not in ("user", "assistant"):
                 continue

--- a/polylogue/cli/query.py
+++ b/polylogue/cli/query.py
@@ -8,10 +8,10 @@ from typing import TYPE_CHECKING
 
 import click
 
-from polylogue.api.sync.bridge import run_coroutine_sync
 from polylogue.cli.query_contracts import QueryExecutionPlan
 from polylogue.cli.root_request import RootModeRequest
 from polylogue.cli.shared.types import AppEnv
+from polylogue.core.async_bridge import run_coroutine_sync
 from polylogue.logging import get_logger
 
 logger = get_logger(__name__)
@@ -93,7 +93,15 @@ def _explain_query_request(request: RootModeRequest) -> None:
 
 
 def execute_query_request(env: AppEnv, request: RootModeRequest) -> None:
-    """Execute a typed root-mode request (path)."""
+    """Execute a typed root-mode request (path).
+
+    Uses ``polylogue.core.async_bridge`` (not ``polylogue.api.sync.bridge``)
+    deliberately: the latter is a submodule of ``polylogue.api``, so importing
+    it forces Python to execute ``polylogue/api/__init__.py`` first -- the
+    whole ``Polylogue`` facade, ~1.7-2.8s of import time -- even for a
+    daemon-served ``find`` that never touches the local
+    ``ArchiveStore``/``Polylogue`` facade at all (polylogue-g3jk).
+    """
     run_coroutine_sync(async_execute_query_request(env, request))
 
 

--- a/polylogue/cli/shared/types.py
+++ b/polylogue/cli/shared/types.py
@@ -110,10 +110,26 @@ class AppEnv:
 
     @property
     def runtime(self) -> ResolvedRuntimeConfig:
+        # Short-circuit through the already-resolved runtime when services
+        # have not been built yet, rather than forcing ``self.services``
+        # (below). ``self.services`` (``_lazy_services`` ->
+        # ``polylogue.services``) imports the full ``SessionRepository`` /
+        # ``SQLiteBackend`` stack at module scope -- expensive (part of the
+        # cost this module's docstring already calls out), and entirely
+        # unneeded just to hand back the ``ResolvedRuntimeConfig`` the
+        # composition root already resolved. Callers that only need
+        # config/runtime (e.g. the CLI daemon fast path, polylogue-g3jk)
+        # never pay for backend/repository construction; callers that
+        # actually need ``.backend``/``.repository`` still build the full
+        # services object via those properties below.
+        if self._services is None and self._runtime is not None:
+            return self._runtime
         return self.services.get_runtime()
 
     @property
     def config(self) -> Config:
+        if self._services is None and self._runtime is not None:
+            return self._runtime.as_config()
         return self.services.get_config()
 
     @property

--- a/polylogue/core/async_bridge.py
+++ b/polylogue/core/async_bridge.py
@@ -1,0 +1,73 @@
+"""Synchronous-to-async coroutine bridge, deliberately dependency-free.
+
+Historically this lived at ``polylogue.api.sync.bridge``. Importing anything
+from a submodule of ``polylogue.api`` forces Python to execute
+``polylogue/api/__init__.py`` first -- the whole ``Polylogue`` async facade
+(pydantic viewport/surface models, storage repository mixins, ~1.7-2.8s of
+import time) -- even though this helper itself only needs ``asyncio`` and
+``threading``. CLI hot paths that only want to drive a coroutine (notably the
+daemon-fast-path query dispatch, polylogue-g3jk) import this module directly
+so they never pull in ``polylogue.api`` at all when the daemon serves the
+request. ``polylogue.api.sync.bridge`` re-exports ``run_coroutine_sync`` from
+here for existing callers that already pay the ``polylogue.api`` cost.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Awaitable, Coroutine
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+async def _await(awaitable: Awaitable[T]) -> T:
+    return await awaitable
+
+
+def run_coroutine_sync(coro: Awaitable[T]) -> T:
+    """Run a coroutine from sync code, even when already inside an event loop.
+
+    When no event loop is running, drive it directly with ``asyncio.run``.
+    When a loop is already running (sync CLI surfaces invoked from inside an
+    async caller — e.g. a CliRunner test, or one async API calling a sync
+    wrapper), the coroutine is executed on a dedicated short-lived thread with
+    its own fresh event loop.
+
+    A per-call thread is deliberate. An earlier implementation kept a persistent
+    shared worker loop for performance, but a shared mutable loop is fragile
+    under test isolation that patches ``threading.Thread.run`` per test: the
+    global could be left pointing at a loop whose thread had stopped driving it,
+    so ``run_coroutine_threadsafe`` scheduled work that never ran and
+    ``future.result()`` blocked forever (observed hanging the full test suite).
+    A fresh thread + ``asyncio.run`` per call has no shared state, so it cannot
+    be poisoned by prior calls or test ordering; the cost (one thread spawn per
+    sync-bridge call, ~once per CLI invocation) is negligible.
+    """
+    wrapper: Coroutine[object, object, T] = _await(coro)
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(wrapper)
+
+    result: list[T] = []
+    error: list[BaseException] = []
+
+    def _runner() -> None:
+        try:
+            result.append(asyncio.run(wrapper))
+        except BaseException as exc:
+            error.append(exc)
+
+    thread = threading.Thread(target=_runner, name="polylogue-sync-bridge", daemon=True)
+    thread.start()
+    thread.join()
+
+    if error:
+        raise error[0]
+    return result[0]
+
+
+__all__ = ["run_coroutine_sync"]

--- a/tests/unit/cli/test_app_env_config_fastpath.py
+++ b/tests/unit/cli/test_app_env_config_fastpath.py
@@ -1,0 +1,72 @@
+"""``AppEnv.config``/``.runtime`` must not force ``.services`` when a
+``ResolvedRuntimeConfig`` is already available (polylogue-g3jk).
+
+``AppEnv.services`` (``_lazy_services`` -> ``polylogue.services`` ->
+``storage.repository``/``storage.sqlite``) is expensive to import and
+constructs backend/repository machinery this property never needs: a
+``RuntimeServices.get_config()`` call just returns the same
+``runtime.as_config()`` projection ``AppEnv.config`` can compute directly.
+``polylogue/cli/click_app.py`` always constructs ``AppEnv(runtime=runtime,
+...)`` (no explicit ``services=``), so this is the real production shape the
+daemon fast path hits on every query invocation, not a synthetic corner case.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from polylogue.cli.shared.types import AppEnv
+from polylogue.config import Config, resolve_runtime_config
+
+
+def test_config_returns_runtime_projection_without_building_services(workspace_env: dict[str, Path]) -> None:
+    runtime = resolve_runtime_config()
+    env = AppEnv(runtime=runtime, plain=True)
+
+    config = env.config
+
+    assert isinstance(config, Config)
+    assert config.archive_root == runtime.as_config().archive_root
+    assert config.db_path == runtime.as_config().db_path
+    # The fast path must not have built (or cached) a RuntimeServices object.
+    assert env._services is None
+
+
+def test_runtime_property_returns_the_same_object_without_building_services(
+    workspace_env: dict[str, Path],
+) -> None:
+    runtime = resolve_runtime_config()
+    env = AppEnv(runtime=runtime, plain=True)
+
+    assert env.runtime is runtime
+    assert env._services is None
+
+
+def test_config_still_works_when_services_is_explicitly_supplied(workspace_env: dict[str, Path]) -> None:
+    """Backward compatibility: explicit ``services=`` (tests/library callers) still wins."""
+    from polylogue.services import RuntimeServices
+
+    explicit_root = workspace_env["archive_root"].parent / "explicit"
+    explicit_root.mkdir()
+    explicit_config = Config(archive_root=explicit_root, render_root=explicit_root, sources=[])
+    services = RuntimeServices(config=explicit_config)
+
+    # Also pass a *different* runtime to prove `.config` prefers the already-
+    # constructed `services` object once one exists, exactly as before this
+    # change (the fast path only applies when `services` was never built).
+    runtime = resolve_runtime_config()
+    env = AppEnv(runtime=runtime, services=services, plain=True)
+
+    assert env.config is explicit_config
+    assert env.config.archive_root == explicit_root
+
+
+def test_config_raises_when_neither_runtime_nor_services_supplied() -> None:
+    """No silent success: an AppEnv with nothing resolvable still errors clearly."""
+    from polylogue.config import ConfigError
+
+    env = AppEnv(plain=True)
+    with pytest.raises(ConfigError):
+        _ = env.config

--- a/tests/unit/cli/test_daemon_fastpath_import_cost.py
+++ b/tests/unit/cli/test_daemon_fastpath_import_cost.py
@@ -1,0 +1,125 @@
+"""The daemon fast path must not eagerly import the heavy local-execution stack.
+
+polylogue-g3jk: a daemon-served ``find`` paid the full ``polylogue.api`` import
+cost (~1.7-2.8s of pydantic/provider-parser import time) even though the daemon
+served the request over UDS and the CLI never touched ``ArchiveStore``, the
+``Polylogue`` facade, or any local-execution renderer. Fixed by:
+
+- ``polylogue/cli/query.py`` importing ``polylogue.core.async_bridge`` (a
+  dependency-free coroutine driver) instead of ``polylogue.api.sync.bridge``,
+  which is a submodule of the heavy ``polylogue.api`` package.
+- ``polylogue/cli/archive_query.py`` deferring its local-execution-only
+  imports (``ArchiveStore``, ``polylogue.surfaces.payloads``,
+  ``polylogue.storage.search_providers``, ``polylogue.archive.stats``, the
+  attached-units/unit-results helpers) to the specific functions that call
+  them, instead of the module's own top level.
+- ``polylogue/cli/shared/types.py``'s ``AppEnv.config``/``.runtime``
+  properties returning the already-resolved ``ResolvedRuntimeConfig``
+  directly instead of forcing ``AppEnv.services`` (which imports the full
+  ``polylogue.services`` -> ``storage.repository`` -> ``storage.sqlite``
+  stack merely to hand back a ``Config`` projection that was already
+  computed).
+
+This is a subprocess-based behavioral contract (following the pattern
+``tests/unit/cli/test_schema_drift_status.py::test_drift_marker_import_path_stays_light``
+established for #3507): it actually drives ``execute_query_request`` through a
+mocked daemon-success response and inspects ``sys.modules`` in a fresh
+interpreter, rather than grepping import statements. Reverting any of the
+three fixes above makes this fail: e.g. restoring
+``from polylogue.api.sync.bridge import run_coroutine_sync`` at the top of
+``query.py`` makes ``polylogue.api`` appear in ``sys.modules`` even though the
+daemon served the request.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_FORBIDDEN_ON_DAEMON_HIT = (
+    "polylogue.api",
+    "polylogue.services",
+    "polylogue.storage.repository",
+    "polylogue.storage.sqlite.archive_tiers.archive",
+    "polylogue.storage.sqlite.archive_tiers.write",
+    "polylogue.surfaces.payloads",
+)
+
+_PROBE = r"""
+import sys
+
+import polylogue.cli.archive_query as aq
+
+_PAYLOAD = {
+    "items": [
+        {
+            "id": "demo:1",
+            "origin": "claude-code-session",
+            "title": "demo session",
+            "created_at": None,
+            "updated_at": None,
+            "message_count": 1,
+        }
+    ],
+    "total": 1,
+    "_daemon_elapsed_ms": 1,
+}
+
+
+def _fake_fetch(config, params, disabled=False):
+    return dict(_PAYLOAD)
+
+
+aq._fetch_daemon_sessions_payload = _fake_fetch
+
+import io
+from contextlib import redirect_stdout
+
+from polylogue.cli.query import execute_query_request
+from polylogue.cli.root_request import RootModeRequest
+from polylogue.cli.shared.types import AppEnv
+from polylogue.config import resolve_runtime_config
+
+runtime = resolve_runtime_config()
+env = AppEnv(runtime=runtime, plain=True)
+request = RootModeRequest(params={"output_format": "json", "limit": 5}, query_terms=("demo",))
+
+buf = io.StringIO()
+with redirect_stdout(buf):
+    execute_query_request(env, request)
+
+rendered = buf.getvalue()
+assert '"demo:1"' in rendered, f"daemon-mock payload did not reach output: {rendered!r}"
+
+forbidden = __FORBIDDEN__
+loaded = [m for m in forbidden if m in sys.modules]
+print(",".join(loaded) if loaded else "CLEAN")
+"""
+
+
+@pytest.mark.uses_real_clock(
+    "subprocess wall-clock is incidental; this test asserts the module import graph, not timing"
+)
+def test_daemon_served_query_does_not_import_heavy_local_execution_stack(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A daemon-served ``find`` must never import ``polylogue.api``/ArchiveStore/payloads."""
+    archive_root = tmp_path / "archive"
+    archive_root.mkdir()
+    monkeypatch.delenv("POLYLOGUE_ARCHIVE_ROOT", raising=False)
+    env = dict(**{"POLYLOGUE_ARCHIVE_ROOT": str(archive_root), "POLYLOGUE_FORCE_PLAIN": "1"})
+    code = _PROBE.replace("__FORBIDDEN__", repr(_FORBIDDEN_ON_DAEMON_HIT))
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={**__import__("os").environ, **env},
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "CLEAN", (
+        f"heavy modules leaked into the daemon fast path: {result.stdout.strip()}\nstderr: {result.stderr}"
+    )


### PR DESCRIPTION
## Summary

A daemon-served `find` (or any query command the daemon can serve) paid the
full cold-start import cost of `polylogue.api`, `ArchiveStore`,
`surfaces.payloads`, and `search_providers` even though the daemon served the
request over UDS and none of those modules were ever touched. This PR defers
all of them to the local-execution fallback path, and fixes a related
`AppEnv.config`/`.runtime` inefficiency that forced the same cost via a
different route.

## Problem

Evidence (bead polylogue-g3jk, filed from PR #3507's perf audit — #3507 was
still open/unmerged at the time of this work, so this branch targets current
`master` directly and does not depend on it):

- Cold `polylogue find <q>` paid ~2s beyond `--help`'s baseline even when a
  daemon served the request over UDS in ~50ms — the daemon fast path
  (`_try_emit_daemon_session_page` in `cli/archive_query.py`) saved query
  *execution* but not *import tax*.
- Three compounding eager-import sources, found by tracing the actual call
  graph (not guessing):
  1. `cli/query.py` imported `polylogue.api.sync.bridge.run_coroutine_sync` at
     module scope. Importing any submodule of `polylogue.api` forces Python to
     execute `polylogue/api/__init__.py` first (the whole `Polylogue` facade —
     pydantic viewport/surface models, storage repository mixins), even though
     the sync bridge itself only needs `asyncio`/`threading`.
  2. `cli/archive_query.py` imported `ArchiveStore`, `surfaces.payloads`,
     `search_providers`, `archive.stats`, and the attached-units/unit-results
     helpers at module top — all exclusively used by the local-execution
     fallback, but paid on every *import* of the module regardless of whether
     the daemon fast path ever reaches that fallback.
  3. `AppEnv.config`/`.runtime` routed through `AppEnv.services`
     (`_lazy_services` → `polylogue.services` → `storage.repository` →
     `storage.sqlite`), which imports the full repository/backend stack merely
     to hand back a `Config` projection `RuntimeServices.__post_init__` had
     already computed from `runtime.as_config()`. `load_effective_config(env)`
     is the *first* thing `_execute_archive_query_stdout` calls, before the
     daemon-try — this was actually the single largest remaining cost after
     fixing (1) and (2), found by tracing `sys.modules` deltas through a mocked
     daemon-success call.

## Solution

- New `polylogue/core/async_bridge.py` holds the real `run_coroutine_sync`
  implementation (dependency-free: only `asyncio`/`threading`).
  `polylogue/api/sync/bridge.py` now re-exports it for existing callers that
  already depend on the `Polylogue` facade (Lynchpin, MCP, etc. are
  unaffected); `cli/query.py` imports the light module directly.
- `archive_query.py`'s local-execution-only imports move under
  `TYPE_CHECKING` (safe because they're annotation-only under `from
  __future__ import annotations`) plus function-local imports at each real
  call site: mutation emitters (`_emit_mutation`/`_emit_user_mutations`/
  `_emit_delete`), vector search (`_query_hits`), unit-source rows
  (`_emit_unit_source_rows`/`_unit_source_session_filters`), attached units
  (`_inject_attached_units`), cursor encode/decode (`_decode_cursor`/
  `_build_cursor`), session-detail rendering (`_emit_stream`,
  `_session_summary_text`), and list/search row payloads
  (`_summary_payload`/`_hit_payload`).
- `AppEnv.config`/`.runtime` (`cli/shared/types.py`) return
  `self._runtime`/`self._runtime.as_config()` directly when `.services` was
  never built, instead of forcing it. `click_app.py` already constructs
  `AppEnv(runtime=runtime, ...)` with no explicit `services=`, so this is the
  real production shape every CLI invocation hits, not a synthetic corner
  case — verified by grepping every `AppEnv(` construction site.

**Non-goals / residual cost**: `archive.query.expression`/`archive.query.spec`
(the query DSL compiler) still cost real import time (`dateparser`,
`polylogue.archive.viewport.models` pydantic classes, `polylogue.storage.search_providers`)
— these are used identically by both the daemon and local-execution paths to
compile the query before either path runs, so deferring them wouldn't be
daemon-fast-path-specific and is out of scope here. This is the "diffuse
pydantic model construction, no single lazy-import fix left" the bead already
flagged for the query-compilation layer specifically (as opposed to the
local-execution layer this PR addresses).

## Verification

**Measurement method note**: this workstation runs a live production
`polylogued` daemon against a real personal archive (`systemd --user
polylogued.service`). Two attempts at live-CLI/live-daemon E2E timing during
this work both leaked real archive content into command output because (a)
the daemon UDS socket path (`$XDG_RUNTIME_DIR/polylogue/daemon.sock`) is
machine-wide, not archive-root-scoped, so a second daemon on a custom archive
root never actually gets used — the CLI always finds the live daemon's
socket; and (b) even explicit `--no-daemon` local execution through the real
`polylogue` binary did not honor `POLYLOGUE_ARCHIVE_ROOT` and hit the live
archive. Both are pre-existing, separate bugs (matching/extending the
already-tracked polylogue-z9gh / polylogue-tas4 "two surfaces disagree about
FTS readiness" finding — worth a dedicated follow-up, since (b) is worse than
previously documented: it reproduces even without a daemon involved). No
writes occurred (`find` is read-only) and the live daemon/archive were
unaffected (verified via `systemctl --user status polylogued.service`
before/after — same PID, same start time throughout). All further
measurement in this PR uses an in-process harness
(`execute_query_request` driven directly against a `tmp_path` archive with a
monkeypatched `_fetch_daemon_sessions_payload`) plus the existing
`tests/unit/cli/test_daemon_golden_parity.py` real-UDS-daemon-in-a-thread
pattern — never the live daemon or a shell subprocess against ambient env
vars.

**Before/after** (in-process harness, `git apply -R`/`git apply` roundtrip on
this exact diff to get a clean A/B on identical hardware):

| | before | after |
|---|---|---|
| total wall time | 2.88s | 1.31s |
| `polylogue.api` imported | True | **False** |
| `archive_tiers.archive` imported | True | **False** |
| `archive_tiers.write` imported | True | **False** |
| `surfaces.payloads` imported | True | **False** |
| `search_providers` imported | True | True (unavoidable, see Non-goals) |

**Commands run:**
- `python -m mypy polylogue tests` → `Success: no issues found in 2263 source files`
- `python -m ruff check polylogue tests` / `ruff format --check` → clean
- `python -m devtools test tests/unit/cli/test_daemon_fastpath_import_cost.py tests/unit/cli/test_app_env_config_fastpath.py tests/unit/cli/test_archive_query.py tests/unit/api/test_sync_bridge.py` → `111 passed`
- `python -m devtools test tests/unit/cli/test_daemon_golden_parity.py` (real UDS daemon in a background thread, byte-identical direct-vs-daemon-proxied output contract) → `3 passed`
- `python -m devtools render topology-projection` (required: new `polylogue/core/async_bridge.py` module) → committed `docs/plans/topology-target.yaml`
- `python -m devtools verify --quick` → `exit_code: 0` (ran twice, once locally and once via the pre-push hook)

**Anti-vacuity**: reverted this exact diff (`git apply -R`) and reran both new
tests — all three assertions fail as expected:
- `test_daemon_served_query_does_not_import_heavy_local_execution_stack` →
  `heavy modules leaked into the daemon fast path: polylogue.api,polylogue.services,polylogue.storage.repository,polylogue.storage.sqlite.archive_tiers.archive,polylogue.storage.sqlite.archive_tiers.write,polylogue.surfaces.payloads`
- `test_config_returns_runtime_projection_without_building_services` /
  `test_runtime_property_returns_the_same_object_without_building_services` →
  `AssertionError: assert RuntimeServices(...) is None` (i.e. `.services` got
  built when it shouldn't have)

The production caller exercised is the real dispatch chain: `click_app.py`'s
`_handle_query_mode` → `cli/query.py:execute_query_request` →
`cli/archive_query.py:execute_archive_query` →
`_try_emit_daemon_session_page`, with `AppEnv` constructed exactly as
`click_app.py` constructs it (`runtime=`, no explicit `services=`).

## AC matrix

| Acceptance criterion | Status |
|---|---|
| Investigate exact import chain for `polylogue.api` eager import | Satisfied — traced to `cli/query.py`'s module-level `polylogue.api.sync.bridge` import |
| Defer `polylogue.api` import until after the daemon fast-path decision | Satisfied — `core/async_bridge.py` split, `query.py` no longer touches `polylogue.api` |
| Restructure query-mode dispatch (light preflight module vs. full local executor) | Partially satisfied via a different mechanism — rather than physically splitting `archive_query.py` into two modules, its local-execution-only imports were converted to `TYPE_CHECKING` + function-local imports at their call sites. Same runtime effect (heavy modules never load unless the miss path executes) without the larger risk of a structural file split mid-function (the fast-path check is threaded through a 700-line function that also does shared query-spec compilation). |
| Target ~0.7-0.9s daemon-served cold `find` | Not fully met — measured 1.31s in the in-process harness. The residual cost is `archive.query.expression`/`archive.query.spec` (dateparser, viewport pydantic models), used identically by both daemon and local paths for query-DSL compilation, out of scope for a daemon-fast-path-specific fix. Filing a follow-up for that layer (see below). |
| Real before/after timing | Satisfied, via the safe in-process harness described above (live-CLI/live-daemon timing was unsafe on this host — see Verification) |
| Import-graph contract test, anti-vacuity proof | Satisfied — `test_daemon_fastpath_import_cost.py` + `test_app_env_config_fastpath.py`, both verified to fail when the fix is reverted |

## Follow-ups (not filed as beads from this lane — bd is read-only here; reporting to the coordinator)

- The `--no-daemon` / real-archive-root env-var-precedence bug reproduced
  during this work (real archive content served even with an explicit
  `--no-daemon` flag and a different `POLYLOGUE_ARCHIVE_ROOT`) deserves a
  dedicated investigation — it's more severe than the previously tracked
  polylogue-z9gh/polylogue-tas4 daemon-only finding.
- `archive.query.expression`/`archive.query.spec`'s own import cost
  (dateparser, viewport pydantic models) is a separate, larger effort (would
  need `polylogue.core.dates`/`archive.viewport.viewports` to defer
  `dateparser`/pydantic construction) if the ~0.7-0.9s target is still wanted.

Ref polylogue-g3jk
