### PR TITLE
docs: repair stale MCP/daemon/schema-version documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,7 +219,7 @@ The repository should stay aligned with the workflow above:
 
 - protect `master` against direct pushes
 - require pull requests for normal changes
-- require the `CI`, `Nix`, and `Pull Request Policy` checks before merge
+- require the `CI`, `Nix`, and `PR State Guard` checks before merge
 - keep squash merge enabled and leave merge-commit and rebase-merge disabled
 - enable automatic deletion of head branches after merge
 - allow Update branch for stale PRs

--- a/README.md
+++ b/README.md
@@ -185,14 +185,16 @@ polylogue find 'actions where tool:shell AND command:pytest' then read
 
 ### MCP
 
-`polylogue-mcp` exposes the archive over stdio. It is read-only by default.
-Write access requires an explicitly configured role and remains subject to
-authorization and confirmation rules.
+`polylogue-mcp` exposes the archive over stdio. It is read-only by default and
+takes no CLI flags. Write, judge, and maintenance capability are each an
+independent `polylogue.toml` `[mcp]` opt-in (or `POLYLOGUE_MCP_*_ENABLED` env
+var) resolved at server startup, and remain subject to authorization and
+confirmation rules.
 
 ```json
 {
   "mcpServers": {
-    "polylogue": { "command": "polylogue-mcp", "args": ["--role", "read"] }
+    "polylogue": { "command": "polylogue-mcp" }
   }
 }
 ```

--- a/docs/daemon-threat-model.md
+++ b/docs/daemon-threat-model.md
@@ -38,7 +38,7 @@ redaction, `/api/sources` paths, and `OPTIONS` handling, see
 ## Threats
 
 ### Local process reading the API
-- **Risk**: Any process on the machine can `curl http://127.0.0.1:8765/api/...`
+- **Risk**: Any process on the machine can `curl http://127.0.0.1:8766/api/...`
 - **Mitigation**: Loopback binding limits exposure to the local machine. This is the same trust model as `localhost` databases, dev servers, and CLI tools.
 - **Residual**: Processes running as the same user can read the SQLite archive directly anyway.
 

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -426,8 +426,9 @@ Envelope shape:
 }
 ```
 
-The backend uses a bounded 5-second per-attempt timeout and a single retry on
-transient failure (network error or HTTP 5xx). 4xx responses are treated as
+The backend uses a bounded 5-second per-attempt timeout and up to two retries
+(three attempts total, exponential backoff starting at 0.5s) on transient
+failure (network error or HTTP 5xx). 4xx responses are treated as
 permanent client errors and are not retried. Persistent failure surfaces
 through the existing periodic-loop catch boundary in
 `polylogue/daemon/cli.py`; it does not crash the daemon. Dedup and
@@ -517,12 +518,14 @@ These run automatically inside the daemon process:
 | FTS startup check | Once at startup | Rebuilds the FTS index if messages exist but aren't indexed (covers gaps from pre-daemon data) |
 | Judgment automation | Configurable (default 1 hour), off by default | Judges auto-judgeable assertion candidates per policy and escalates the residue; see [Judgment Automation](#judgment-automation) below. |
 
-Health check tier and interval are configurable via `polylogue.toml`:
+Health check tier and interval are configurable via `polylogue.toml` (the
+`[health]` table's `check_interval_s`/`check_tiers` keys back the
+`health_check_interval_s`/`health_check_tiers` config attributes):
 
 ```toml
 [health]
-health_check_interval_s = 300
-health_check_tiers = "fast"
+check_interval_s = 300
+check_tiers = "fast"
 ```
 
 ### Judgment Automation

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -16,7 +16,8 @@ ambiguous.
 Public read surfaces are keyed by **`origin`** (the `Origin` enum in
 `polylogue/core/enums.py`): `claude-code-session`, `claude-ai-export`,
 `chatgpt-export`, `codex-session`, `gemini-cli-session`, `aistudio-drive`,
-`hermes-session`, `antigravity-session`, `unknown-export`. The provider-wire
+`hermes-session`, `antigravity-session`, `beads-issue`, `grok-export`,
+`unknown-export`. The provider-wire
 `Provider` enum (`chatgpt`, `claude-code`, …) is retained only at the
 parsing/schema boundary and is not the public filter token. Filter and query
 surfaces use `origin`.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -17,7 +17,7 @@ Public read surfaces are keyed by **`origin`** (the `Origin` enum in
 `polylogue/core/enums.py`): `claude-code-session`, `claude-ai-export`,
 `chatgpt-export`, `codex-session`, `gemini-cli-session`, `aistudio-drive`,
 `hermes-session`, `antigravity-session`, `beads-issue`, `grok-export`,
-`unknown-export`. The provider-wire
+`claude-design-session`, `unknown-export`. The provider-wire
 `Provider` enum (`chatgpt`, `claude-code`, …) is retained only at the
 parsing/schema boundary and is not the public filter token. Filter and query
 surfaces use `origin`.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -317,16 +317,45 @@ Polylogue has two schema-evolution regimes, keyed by tier durability.
   it requires either preserving the JSON column or promoting the eight
   provenance keys (`hermes_state.py`) to typed columns, a follow-up decision
   left to polylogue-c3ip.
-- Index schema version 45 (folded into the same version as the
-  `delegation_facts` identity-join rewrite below) resolves the polylogue-c3ip
-  follow-up: `session_provider_usage_events.payload_json` is dropped and its
+- Index schema version 46 (polylogue-2qx.4) lands an "unread-wire" batch of
+  parser-sourced columns/tables in one bump rather than one per origin:
+  `messages.stop_reason` (608,608 live Claude assistant messages carry this
+  on the wire, versus three derived-outcome columns that guess the same fact
+  85-99% `unknown`); `blocks.tool_result_outcome_unknown_reason`
+  (distinguishes "provider emitted nothing" / "parser distrusts it" /
+  "parser doesn't read this origin's field" instead of one flat `NULL`);
+  `sessions.display_name` (subagent slug display name) and
+  `sessions.run_settings_json` (per-session provider run config, e.g.
+  AI Studio/Drive temperature/topP/topK, kept as JSON rather than coupling
+  the schema to one provider); `session_links.parent_tool_use_block_id` (the
+  real join-key column replacing `delegation_facts`' cardinality-gated
+  ordinal dispatch<->child pairing, 842,819 live records); the new
+  `file_edits` table (structured diff evidence from Claude Code Edit/Write
+  tool calls: 105,123 structured diffs, 92,313 pre-edit captures, previously
+  100% discarded); and the new `session_refs` table (tracker-agnostic PR/
+  issue references, 20,702 occurrences). Every value depends on parser
+  semantics to populate honestly, so this is `SEMANTIC_REPARSE` like v42/
+  v44/v45 — existing index tiers must be rebuilt from source evidence
+  (`polylogue ops reset --index && polylogued run`).
+- Index schema version 45 resolves two independent changes folded into one
+  bump: `session_provider_usage_events.payload_json` is dropped and its
   eight billing-provenance keys (`estimated_cost_usd`, `actual_cost_usd`,
   `cost_status`, `cost_source`, `pricing_version`, `billing_provider`,
   `billing_base_url`, `billing_mode`) become nullable typed columns on the
-  same table. `_reextract_provider_usage_tail_db`
+  same table (the polylogue-c3ip follow-up). `_reextract_provider_usage_tail_db`
   (`storage/sqlite/archive_tiers/write.py`) reads the typed columns directly
   instead of `json_extract(payload_json, ...)`. Only 104 of 4,030,168 live
-  rows carried any of these keys, all Hermes-sourced.
+  rows carried any of these keys, all Hermes-sourced. The same bump also
+  carries `delegation_facts_source`'s identity-join rewrite (polylogue-1vpm.7):
+  pairing a Task dispatch to its resolved child session stops using
+  cardinality-gated ordinal position (rank N dispatch <-> rank N child) and
+  instead joins on identity — a trivial 1:1 cohort, or, non-trivially,
+  provider-asserted content equality between the dispatch's own instruction
+  text and the child's first turn. `ambiguous` is retired from the
+  `mapping_state` vocabulary. `delegation_facts` is a materialized table, not
+  a view, so a plain `REPLACE_TABLE` fast-forward cannot re-derive values from
+  the new join logic; existing index tiers must be rebuilt from source
+  evidence.
 - Index schema version 41 stops materializing `tool_input`/`output_text` text
   copies on `action_pairs` (polylogue-2i2w). `action_pairs` keeps only
   join/rank/outcome columns for a paired `tool_use`/`tool_result` block

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -21,10 +21,10 @@ over the `CREATE TABLE` statement.
 
 | Tier file | Tier | Version constant |
 |-----------|------|------------------|
-| `source.py` | `source.db` | `SOURCE_SCHEMA_VERSION = 10` |
-| `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 35` |
+| `source.py` | `source.db` | `SOURCE_SCHEMA_VERSION = 15` |
+| `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 53` |
 | `embeddings.py` | `embeddings.db` | `EMBEDDINGS_SCHEMA_VERSION = 4` |
-| `user.py` | `user.db` | `USER_SCHEMA_VERSION = 6` |
+| `user.py` | `user.db` | `USER_SCHEMA_VERSION = 10` |
 | `ops.py` | `ops.db` | `OPS_SCHEMA_VERSION = 1` |
 
 There is no single global "schema version" number. Each tier is versioned and
@@ -226,14 +226,18 @@ pair a use block with a same-id result block from another session.
 
 ## Full-text search
 
-`index.db` carries three FTS5 virtual tables, all using the `unicode61`
-tokenizer (no porter stemmer in this SQLite build):
+`index.db` carries four FTS5 virtual tables. `messages_fts`,
+`session_work_events_fts`, and `threads_fts` use the `unicode61` tokenizer (no
+porter stemmer in this SQLite build); `blocks_command_trigram` uses the
+`trigram` tokenizer to accelerate substring/`LIKE`-style lookups over tool
+command/detail text:
 
 | Virtual table | Indexes |
 |---------------|---------|
 | `messages_fts` | Block `search_text` (text + tool name + command/path), contentless (`content=''`, `contentless_delete=1`) |
 | `session_work_events_fts` | Work-event search text |
 | `threads_fts` | Thread search text |
+| `blocks_command_trigram` | `tool_use` block `tool_detail_text`, external-content (`content='blocks'`), `tokenize='trigram'` |
 
 `messages_fts` is kept in sync with `blocks` by the `messages_fts_ai/ad/au`
 triggers. During bulk ingest these triggers are suspended for performance and


### PR DESCRIPTION
## Summary
Fixes several docs pages that had drifted from current code: stale MCP `--role` flag references, a wrong daemon port number, renamed health-check config keys, stale schema tier version numbers, a missing v46 schema-history entry, and two missing Origin enum values.

## Problem
Found while triaging a stale agent worktree (`worktree-agent-a70cd2eddac373919`, originally branched for unrelated schema-promotion work) that had these doc corrections sitting uncommitted:
- README/CONTRIBUTING/docs/internals.md described `polylogue-mcp --role read`; `polylogue/mcp/cli.py` has taken no CLI flag or role ladder since polylogue-800m.
- docs/daemon-threat-model.md's API port example said 8765 (that's the browser-capture port); the API server default is 8766.
- docs/daemon.md's health-check TOML example used the pre-rename `health_check_interval_s`/`health_check_tiers` keys instead of the current `health.check_interval_s`/`health.check_tiers` TOML path.
- docs/schema.md's tier version table was stuck at `SOURCE=10`/`INDEX=35`/`USER=6`; current values are 15/53/10, and the `blocks_command_trigram` FTS5 table was undocumented.
- docs/data-model.md's Origin list was missing `beads-issue` and `grok-export`.
- docs/internals.md's schema-version history jumped from v41 to v45, silently skipping v46 (the unread-wire batch).

## Solution
Corrected each item against current source (`polylogue/mcp/cli.py`, `polylogue/config.py`'s `ConfigInventoryEntry` table, the `*_SCHEMA_VERSION` constants, `polylogue/core/enums.py`). v47-53 of the schema-version history remain undocumented — not claimed as covered, left as pre-existing debt.

## Verification
- `devtools verify --quick` → 19 steps, exit 0. (docs-coverage initially failed because renaming the TOML key text to `check_tiers` dropped the only doc mention of the `health_check_tiers` config attribute; fixed by naming the backing attribute inline instead of reverting the corrected TOML syntax.)

Co-Authored-By: Claude <noreply@anthropic.com>