### PR TITLE
fix(sources): stop keying synthetic attachment ids on list position

### DIFF
--- a/polylogue/sources/parsers/base_support.py
+++ b/polylogue/sources/parsers/base_support.py
@@ -204,17 +204,34 @@ def _make_attachment_id(seed: str) -> str:
     return f"att-{hash_text(seed)[:12]}"
 
 
-def attachment_from_meta(meta: object, message_id: str | None, index: int) -> ParsedAttachment | None:
+def attachment_from_meta(meta: object, message_id: str | None) -> ParsedAttachment | None:
     if not isinstance(meta, dict):
         return None
     attachment_id = (
         meta.get("id") or meta.get("file_id") or meta.get("fileId") or meta.get("uuid") or meta.get("file_uuid")
     )
     name = meta.get("name") or meta.get("filename") or meta.get("file_name")
+    mime_type = meta.get("mimeType") or meta.get("mime_type") or meta.get("content_type") or meta.get("file_type")
     if not attachment_id:
         if not name:
             return None
-        seed = f"{message_id or 'msg'}:{name}:{index}"
+        # polylogue-hith: identity must be a property of the attachment
+        # itself, not of its position in whichever bucket ("attachments" vs
+        # "files") or order the export happened to walk them in. `index` used
+        # to be part of this seed, so re-ordering an export's attachment list
+        # -- observed happening between vintages of the SAME conversation --
+        # minted a different id for the same physical attachment even though
+        # nothing about it changed. `mime_type` is included instead: it is
+        # read directly from the export's own metadata (never lazily
+        # acquired the way `size`/inline bytes can be), so it adds real
+        # disambiguation without reintroducing acquisition-state instability.
+        # Two un-identified attachments sharing both name and mime_type on
+        # the same message are genuinely indistinguishable from the metadata
+        # available here; collapsing them to one identity is the honest
+        # outcome of that, not a regression -- see polylogue-hith for the
+        # full trade-off discussion (a real-id-havingness axis is a separate,
+        # unfixed failure mode filed as a follow-up there).
+        seed = f"{message_id or 'msg'}:{name}:{mime_type or ''}"
         attachment_id = _make_attachment_id(seed)
     size_raw = meta.get("size") or meta.get("size_bytes") or meta.get("sizeBytes") or meta.get("file_size")
     size_bytes = None
@@ -223,7 +240,6 @@ def attachment_from_meta(meta: object, message_id: str | None, index: int) -> Pa
             size_bytes = int(size_raw)
         except ValueError:
             size_bytes = None
-    mime_type = meta.get("mimeType") or meta.get("mime_type") or meta.get("content_type") or meta.get("file_type")
     inline_bytes = None
     extracted_content = meta.get("extracted_content")
     if isinstance(extracted_content, str):

--- a/polylogue/sources/parsers/claude/ai_parser.py
+++ b/polylogue/sources/parsers/claude/ai_parser.py
@@ -119,7 +119,7 @@ def _resolve_claude_ai_title(
 _DESIGN_KNOWN_BLOCK_TYPES = frozenset({"text", "thinking", "tool_call", "error", "user_interjection"})
 
 
-def _design_attachment_from_meta(meta: object, message_id: str, index: int) -> ParsedAttachment | None:
+def _design_attachment_from_meta(meta: object, message_id: str) -> ParsedAttachment | None:
     """Adapt a Design attachment record onto the shared attachment builder.
 
     Design attachments carry inline text under ``content`` (not the shared
@@ -135,7 +135,7 @@ def _design_attachment_from_meta(meta: object, message_id: str, index: int) -> P
     content = shimmed.get("content")
     if isinstance(content, str) and "extracted_content" not in shimmed:
         shimmed["extracted_content"] = content
-    attachment = attachment_from_meta(shimmed, message_id, index)
+    attachment = attachment_from_meta(shimmed, message_id)
     if attachment is None:
         return None
     attachment_type = meta.get("type")
@@ -344,8 +344,8 @@ def _design_user_message(
 
     attachments: list[ParsedAttachment] = []
     raw_attachments = content_payload.get("attachments")
-    for index, meta in enumerate(raw_attachments if isinstance(raw_attachments, list) else [], start=1):
-        attachment = _design_attachment_from_meta(meta, message_uuid, index)
+    for meta in raw_attachments if isinstance(raw_attachments, list) else []:
+        attachment = _design_attachment_from_meta(meta, message_uuid)
         if attachment is not None:
             attachments.append(attachment)
 
@@ -543,8 +543,8 @@ def _merge_session_attachments(
         value = payload.get(key)
         if isinstance(value, list):
             top_level.extend(value)
-    for index, meta in enumerate(top_level, start=1):
-        attachment = attachment_from_meta(meta, None, index)
+    for meta in top_level:
+        attachment = attachment_from_meta(meta, None)
         if attachment is not None:
             attachments.append(attachment)
 

--- a/polylogue/sources/parsers/claude/common.py
+++ b/polylogue/sources/parsers/claude/common.py
@@ -603,8 +603,8 @@ def _message_attachments(item: Mapping[str, object], message_id: str) -> list[Pa
         if isinstance(value, list):
             raw_attachments.extend(value)
     attachments: list[ParsedAttachment] = []
-    for index, meta in enumerate(raw_attachments, start=1):
-        attachment = attachment_from_meta(meta, message_id, index)
+    for meta in raw_attachments:
+        attachment = attachment_from_meta(meta, message_id)
         if attachment is not None:
             attachments.append(attachment)
     return attachments

--- a/tests/unit/sources/test_parsers_base.py
+++ b/tests/unit/sources/test_parsers_base.py
@@ -598,7 +598,7 @@ class TestAttachmentFromMeta:
     def test_attachment_from_meta_basic(self) -> None:
         """Creates ParsedAttachment from minimal metadata."""
         meta = {"id": "att123", "name": "file.txt"}
-        result = attachment_from_meta(meta, "msg1", 0)
+        result = attachment_from_meta(meta, "msg1")
 
         assert result is not None
         assert isinstance(result, ParsedAttachment)
@@ -614,7 +614,7 @@ class TestAttachmentFromMeta:
             "mimeType": "application/pdf",
             "size": 1024,
         }
-        result = attachment_from_meta(meta, "msg2", 1)
+        result = attachment_from_meta(meta, "msg2")
 
         assert result is not None
         assert result.provider_attachment_id == "att456"
@@ -626,7 +626,7 @@ class TestAttachmentFromMeta:
     def test_attachment_from_meta_missing_id(self) -> None:
         """Generates fallback ID when id is missing but name exists."""
         meta = {"name": "image.png"}
-        result = attachment_from_meta(meta, "msg3", 2)
+        result = attachment_from_meta(meta, "msg3")
 
         assert result is not None
         assert result.provider_attachment_id.startswith("att-")
@@ -634,69 +634,69 @@ class TestAttachmentFromMeta:
 
     def test_attachment_from_meta_empty_dict(self) -> None:
         """Returns None for empty metadata dict."""
-        result = attachment_from_meta({}, "msg4", 0)
+        result = attachment_from_meta({}, "msg4")
         assert result is None
 
     def test_attachment_from_meta_not_dict(self) -> None:
         """Returns None when meta is not a dict."""
-        result = attachment_from_meta("not_a_dict", "msg5", 0)
+        result = attachment_from_meta("not_a_dict", "msg5")
         assert result is None
 
-        result = attachment_from_meta(None, "msg6", 0)
+        result = attachment_from_meta(None, "msg6")
         assert result is None
 
     def test_attachment_from_meta_alternative_id_fields(self) -> None:
         """Recognizes alternative ID field names."""
         meta1 = {"file_id": "file123", "name": "doc.txt"}
-        result1 = _require_attachment(attachment_from_meta(meta1, "msg", 0))
+        result1 = _require_attachment(attachment_from_meta(meta1, "msg"))
         assert result1.provider_attachment_id == "file123"
 
         meta2 = {"fileId": "file456", "name": "doc.txt"}
-        result2 = _require_attachment(attachment_from_meta(meta2, "msg", 0))
+        result2 = _require_attachment(attachment_from_meta(meta2, "msg"))
         assert result2.provider_attachment_id == "file456"
 
         meta3 = {"uuid": "uuid789", "name": "doc.txt"}
-        result3 = _require_attachment(attachment_from_meta(meta3, "msg", 0))
+        result3 = _require_attachment(attachment_from_meta(meta3, "msg"))
         assert result3.provider_attachment_id == "uuid789"
 
     def test_attachment_from_meta_alternative_name_fields(self) -> None:
         """Recognizes alternative name field names."""
         meta = {"id": "att", "filename": "report.docx"}
-        result = _require_attachment(attachment_from_meta(meta, "msg", 0))
+        result = _require_attachment(attachment_from_meta(meta, "msg"))
         assert result.name == "report.docx"
 
     def test_attachment_from_meta_size_conversion(self) -> None:
         """Converts size from string to int."""
         meta1 = {"id": "att", "name": "file", "size": "2048"}
-        result1 = _require_attachment(attachment_from_meta(meta1, "msg", 0))
+        result1 = _require_attachment(attachment_from_meta(meta1, "msg"))
         assert result1.size_bytes == 2048
 
         meta2 = {"id": "att", "name": "file", "size_bytes": 4096}
-        result2 = _require_attachment(attachment_from_meta(meta2, "msg", 0))
+        result2 = _require_attachment(attachment_from_meta(meta2, "msg"))
         assert result2.size_bytes == 4096
 
         meta3 = {"id": "att", "name": "file", "sizeBytes": "8192"}
-        result3 = _require_attachment(attachment_from_meta(meta3, "msg", 0))
+        result3 = _require_attachment(attachment_from_meta(meta3, "msg"))
         assert result3.size_bytes == 8192
 
     def test_attachment_from_meta_invalid_size(self) -> None:
         """Handles invalid size gracefully."""
         meta = {"id": "att", "name": "file", "size": "invalid"}
-        result = _require_attachment(attachment_from_meta(meta, "msg", 0))
+        result = _require_attachment(attachment_from_meta(meta, "msg"))
         assert result.size_bytes is None
 
     def test_attachment_from_meta_mime_type_variations(self) -> None:
         """Recognizes different mime_type field names."""
         meta1 = {"id": "att", "name": "file", "mimeType": "text/plain"}
-        result1 = _require_attachment(attachment_from_meta(meta1, "msg", 0))
+        result1 = _require_attachment(attachment_from_meta(meta1, "msg"))
         assert result1.mime_type == "text/plain"
 
         meta2 = {"id": "att", "name": "file", "mime_type": "image/jpeg"}
-        result2 = _require_attachment(attachment_from_meta(meta2, "msg", 0))
+        result2 = _require_attachment(attachment_from_meta(meta2, "msg"))
         assert result2.mime_type == "image/jpeg"
 
         meta3 = {"id": "att", "name": "file", "content_type": "application/json"}
-        result3 = _require_attachment(attachment_from_meta(meta3, "msg", 0))
+        result3 = _require_attachment(attachment_from_meta(meta3, "msg"))
         assert result3.mime_type == "application/json"
 
     def test_parsed_attachment_sanitizes_edge_case_name_and_path(self) -> None:

--- a/tests/unit/sources/test_parsers_claude_ai_catalog.py
+++ b/tests/unit/sources/test_parsers_claude_ai_catalog.py
@@ -230,6 +230,47 @@ def test_claude_rich_segments_and_attachment_fields_are_preserved() -> None:
     assert session.attachments[1].inline_bytes is None
 
 
+def test_claude_ai_synthetic_attachment_id_is_stable_across_list_reordering() -> None:
+    """polylogue-hith: two export vintages of the SAME conversation can walk
+    a message's ``attachments``/``files`` arrays in a different order (the
+    16/40 sampled cohorts where message content/order matched exactly but
+    attachment identities were disjoint). Neither attachment here carries a
+    real provider id, so both fall back to synthesis; the synthesized id
+    must depend only on the attachment's own fields (anchoring message,
+    name, mime type), never on where it sits in the merged list.
+    """
+
+    def _payload(*, reordered: bool) -> dict[str, Any]:
+        first = {"name": "alpha.txt", "file_type": "text/plain"}
+        second = {"name": "beta.txt", "file_type": "text/plain"}
+        attachments = [second, first] if reordered else [first, second]
+        return {
+            "uuid": "claude-order",
+            "name": "Order sensitivity",
+            "chat_messages": [
+                {
+                    "uuid": "m1",
+                    "sender": "assistant",
+                    "text": "reply",
+                    "created_at": "2026-06-01T00:00:01Z",
+                    "attachments": attachments,
+                }
+            ],
+        }
+
+    forward = parse_ai(_payload(reordered=False), "fallback")
+    reversed_order = parse_ai(_payload(reordered=True), "fallback")
+
+    forward_ids = {att.name: att.provider_attachment_id for att in forward.attachments}
+    reversed_ids = {att.name: att.provider_attachment_id for att in reversed_order.attachments}
+
+    assert forward_ids.keys() == {"alpha.txt", "beta.txt"}
+    # Same attachment, same identity, regardless of list order.
+    assert forward_ids == reversed_ids
+    # Distinct attachments (different names) still mint distinct identities.
+    assert forward_ids["alpha.txt"] != forward_ids["beta.txt"]
+
+
 def test_claude_ai_tool_use_segment_captures_web_tool_evidence() -> None:
     """Per-block timing, MCP integration identity, and approval-gate fields
     on a ``tool_use``/``tool_result`` segment were read nowhere before --

--- a/tests/unit/sources/test_parsers_props.py
+++ b/tests/unit/sources/test_parsers_props.py
@@ -380,7 +380,7 @@ def test_timestamp_normalization_handles_milliseconds(epoch_ms: int) -> None:
     )
 )
 def test_attachment_extraction_preserves_metadata(attachment_meta: AttachmentMeta) -> None:
-    result = attachment_from_meta(attachment_meta, "msg-1", 1)
+    result = attachment_from_meta(attachment_meta, "msg-1")
 
     assert result is not None
     assert result.provider_attachment_id == attachment_meta["id"]

--- a/tests/unit/storage/test_attachment_first_class_ids.py
+++ b/tests/unit/storage/test_attachment_first_class_ids.py
@@ -174,7 +174,6 @@ def test_parser_parity_claude_code_codex_attachment_has_typed_upload_origin() ->
             "mime_type": "text/plain",
         },
         message_id="msg-1",
-        index=0,
     )
     assert attachment is not None
     assert attachment.provider_attachment_id == "att-1"


### PR DESCRIPTION
## Summary
Fixes claude-ai-export synthetic attachment identity: the id used to depend on the attachment's position in the merged attachments+files list, so re-ordering an export's own arrays between vintages of the SAME conversation minted a different id for the same physical attachment.

## Problem
polylogue-hith found 16 of 40 sampled claude-ai-export ambiguous cohorts with byte-identical message content/order but a disjoint set of `(provider_attachment_id, message_provider_id)` pairs for attachments anchored to the same message. `attachment_from_meta`'s synthetic-id fallback seeded on `f"{message_id}:{name}:{index}"`, where `index` is the attachment's position in the merged iteration — not a property of the attachment itself.

## Solution
Drop the positional `index` from the seed; use `mime_type` (read directly from export metadata, never lazily acquired) as the one extra structural disambiguator available. Two un-identified attachments sharing both name and mime_type on the same message are genuinely indistinguishable from the metadata on hand — collapsing them to one identity is the honest outcome, not a regression, since export list order carries no real signal either.

`index` is removed from `attachment_from_meta`'s signature and all four call sites (`base_support.py`, `ai_parser.py` ×3 — including the design-attachment wrapper `_design_attachment_from_meta` — and `claude/common.py`'s `_message_attachments`).

This is the identity-minting half of the defect; a real-id-presence axis (some export vintages carry a real id/file_id, others fall back to synthesis for the same attachment) is a separate, unfixed failure mode tracked on polylogue-d8al.

Note: this branch's original commit predated a "claude-design" parser addition (polylogue-tbun) that introduced a fourth `attachment_from_meta` call site not present at the original branch point. Rebased manually onto current master rather than mechanically, updating that new call site too.

## Verification
- `devtools test` on the touched parser/base_support/attachment test files → 179 passed, 4 skipped.
- `devtools verify --quick` → 19 steps, exit 0.

Ref polylogue-hith

Co-Authored-By: Claude <noreply@anthropic.com>