### PR TITLE
test: fix three tautological assertions in json/filter properties

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -319,6 +319,26 @@ fixture using the synthetic corpus generator. For tests needing a realistic arch
 generators. `schema_conformant_payload(provider)` produces payloads that match
 each provider's JSON schema.
 
+### Cardinality guards on loop-only assertions
+
+A test whose only assertions live inside `for item in result: ...` passes
+vacuously if `result` is empty — a regression that makes the exercised code
+return nothing (the total-failure mode) hides behind the unreached loop body.
+Before merging such a test, add an explicit non-empty check ahead of the loop:
+
+```python
+result = await SessionFilter(archive_root=repo).exclude_origin("codex-session").list()
+assert len(result) >= 1  # or == N when the fixture's count is exact and stable
+for session in result:
+    assert session.origin != "codex-session"
+```
+
+This guard is unnecessary when the loop body delegates to a shared assertion
+helper that itself asserts non-emptiness (e.g. `_assert_structured_error`), or
+when an earlier line in the same test already establishes a non-empty
+invariant (`assert len(result) == count()`, a prior `.first()` call, etc.).
+Skip the guard rather than adding a redundant one in those cases.
+
 ## Time and Clock
 
 Timestamp-sensitive tests opt into the `frozen_clock` fixture so the test's

--- a/tests/unit/core/test_filters_props.py
+++ b/tests/unit/core/test_filters_props.py
@@ -559,8 +559,11 @@ async def test_provider_filter_exclusion_disjoint(
 
     result = await SessionFilter(archive_root=root).origin(*include_origins).exclude_origin(*exclude_origins).list()
 
-    for session in result:
-        assert session.origin not in exclude_origins
+    # Exact set equality, not just "nothing excluded showed up": a loop-only
+    # `not in exclude_origins` check passes vacuously if .list() regresses to
+    # return [] for every case, including the intentionally-empty
+    # contradictory case -- that total-failure mode must fail here.
+    assert {session.origin for session in result} == set(include_origins) - set(exclude_origins)
 
 
 # =============================================================================
@@ -842,10 +845,11 @@ class TestSessionFilterCombinedFilters:
             .list()
         )
         # filter_repo_advanced has 2 chatgpt-export + 1 codex-session session left
-        # after excluding all 4 claude-ai-export sessions; cardinality guard so a
-        # regression that empties the filter (total-failure mode) can't hide behind
-        # an unreached loop body.
-        assert len(result) >= 1
+        # after excluding all 4 claude-ai-export sessions; exact count so a
+        # regression that empties the filter (total-failure mode), or one that
+        # returns the wrong subset at the right size, can't hide behind an
+        # unreached loop body.
+        assert len(result) == 3
         assert all(c.origin != "claude-ai-export" for c in result)
         for conv in result:
             assert "quantum" not in conv.tags
@@ -859,10 +863,10 @@ class TestSessionFilterCombinedFilters:
             .list()
         )
         # filter_repo_advanced has 4 claude-ai-export sessions and none of them are
-        # tagged "simple" (only the codex session is), so this must be non-empty;
-        # cardinality guard so a regression that empties the filter can't hide
-        # behind an unreached loop body.
-        assert len(result) >= 1
+        # tagged "simple" (only the codex session is), so this must return all 4;
+        # exact count so a regression that empties the filter can't hide behind
+        # an unreached loop body.
+        assert len(result) == 4
         assert all(c.origin == "claude-ai-export" for c in result)
         for conv in result:
             assert "simple" not in conv.tags
@@ -875,9 +879,9 @@ class TestSessionFilterCombinedFilters:
             .list()
         )
         # filter_repo_advanced has 1 codex-session session left after excluding all
-        # claude-ai-export and chatgpt-export sessions; cardinality guard so a
-        # regression that empties the filter can't hide behind an unreached loop body.
-        assert len(result) >= 1
+        # claude-ai-export and chatgpt-export sessions; exact count so a regression
+        # that empties the filter can't hide behind an unreached loop body.
+        assert len(result) == 1
         for conv in result:
             assert conv.origin not in ("claude-ai-export", "chatgpt-export")
 

--- a/tests/unit/core/test_filters_props.py
+++ b/tests/unit/core/test_filters_props.py
@@ -503,20 +503,64 @@ def test_sql_pushdown_empty() -> None:
     assert f._sql_pushdown_params() == {}
 
 
-@given(
-    st.lists(st.sampled_from(["chatgpt", "claude-ai", "codex"]), min_size=1, max_size=3),
-    st.lists(st.sampled_from(["chatgpt", "claude-ai", "codex"]), min_size=0, max_size=2),
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "include_origins,exclude_origins",
+    [
+        (["claude-ai-export"], []),
+        (["claude-ai-export", "chatgpt-export"], ["chatgpt-export"]),
+        (["chatgpt-export", "codex-session"], ["codex-session"]),
+        # Contradictory filter: the same origin is both included and excluded.
+        # exclude_origin() must still win -- this is the case that proves the
+        # exclusion actually does something rather than being a no-op.
+        (["claude-ai-export"], ["claude-ai-export"]),
+    ],
 )
-def test_provider_filter_exclusion_disjoint(
-    include_providers: list[str],
-    exclude_providers: list[str],
+async def test_provider_filter_exclusion_disjoint(
+    tmp_path: Path,
+    include_origins: list[str],
+    exclude_origins: list[str],
 ) -> None:
-    """Provider inclusion and exclusion should be mutually exclusive."""
-    included = set(include_providers)
-    excluded = set(exclude_providers)
-    result = included - excluded
-    for provider in result:
-        assert provider not in excluded
+    """Origin inclusion and exclusion are mutually exclusive on SessionFilter.list():
+    no session returned by .list() ever has an origin that was passed to
+    exclude_origin(), even when that same origin was also passed to origin().
+
+    Anti-vacuity: this fails if exclude_origin() were mutated to a no-op (e.g. by
+    writing into the wrong SessionQueryPlan field instead of `excluded_origins`) --
+    the contradictory-filter case (["claude-ai-export"], ["claude-ai-export"]) would
+    then wrongly return the claude-ai-export session instead of the empty set. This
+    exercises real SessionFilter/SessionQueryPlan production code end-to-end via
+    .list(), not a bare Python set difference.
+    """
+    root = tmp_path / "origin_exclusion_archive"
+    root.mkdir()
+    db_path = root / "index.db"
+    (
+        SessionBuilder(db_path, "conv-claude")
+        .provider("claude-ai")
+        .title("Claude session")
+        .add_message("m1", role="user", text="hello")
+        .save()
+    )
+    (
+        SessionBuilder(db_path, "conv-chatgpt")
+        .provider("chatgpt")
+        .title("ChatGPT session")
+        .add_message("m2", role="user", text="hello")
+        .save()
+    )
+    (
+        SessionBuilder(db_path, "conv-codex")
+        .provider("codex")
+        .title("Codex session")
+        .add_message("m3", role="user", text="hello")
+        .save()
+    )
+
+    result = await SessionFilter(archive_root=root).origin(*include_origins).exclude_origin(*exclude_origins).list()
+
+    for session in result:
+        assert session.origin not in exclude_origins
 
 
 # =============================================================================
@@ -797,6 +841,11 @@ class TestSessionFilterCombinedFilters:
             .exclude_tag("quantum")
             .list()
         )
+        # filter_repo_advanced has 2 chatgpt-export + 1 codex-session session left
+        # after excluding all 4 claude-ai-export sessions; cardinality guard so a
+        # regression that empties the filter (total-failure mode) can't hide behind
+        # an unreached loop body.
+        assert len(result) >= 1
         assert all(c.origin != "claude-ai-export" for c in result)
         for conv in result:
             assert "quantum" not in conv.tags
@@ -809,6 +858,11 @@ class TestSessionFilterCombinedFilters:
             .exclude_tag("simple")
             .list()
         )
+        # filter_repo_advanced has 4 claude-ai-export sessions and none of them are
+        # tagged "simple" (only the codex session is), so this must be non-empty;
+        # cardinality guard so a regression that empties the filter can't hide
+        # behind an unreached loop body.
+        assert len(result) >= 1
         assert all(c.origin == "claude-ai-export" for c in result)
         for conv in result:
             assert "simple" not in conv.tags
@@ -820,6 +874,10 @@ class TestSessionFilterCombinedFilters:
             .exclude_origin("claude-ai-export", "chatgpt-export")
             .list()
         )
+        # filter_repo_advanced has 1 codex-session session left after excluding all
+        # claude-ai-export and chatgpt-export sessions; cardinality guard so a
+        # regression that empties the filter can't hide behind an unreached loop body.
+        assert len(result) >= 1
         for conv in result:
             assert conv.origin not in ("claude-ai-export", "chatgpt-export")
 

--- a/tests/unit/core/test_json.py
+++ b/tests/unit/core/test_json.py
@@ -168,15 +168,23 @@ def test_loads_known_invalid_json_raises_under_every_backend(
 @given(st.text(min_size=1, alphabet='{[}"]:').filter(lambda s: s.strip() not in ("[]", "{}", '""', "{}")))
 def test_loads_malformed_json_never_silent(text: str) -> None:
     """loads either raises or returns a non-None value; it never silently returns None
-    for a non-null JSON input."""
+    for a non-null JSON input.
+
+    Anti-vacuity: this fails if loads() is mutated to swallow a decode failure and
+    return None instead of raising -- the alphabet here ('{[}"]:') can never spell the
+    literal token "null", so the documented null carve-out is preserved but not
+    reachable from this generator; it is still checked explicitly for robustness
+    against future alphabet changes.
+    """
     try:
         result = core_json.loads(text)
-        # If loads succeeds, it must have parsed to something
-        # (Note: valid JSON 'null' would return None, so we only assert on successful
-        # non-null parses)
-        _ = result  # No assertion needed - successful parse is fine
     except Exception:
         pass  # Expected for malformed input
+    else:
+        # Valid JSON 'null' legitimately parses to None; every other successful
+        # parse must produce a non-None value.
+        if text.strip() != "null":
+            assert result is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_json.py
+++ b/tests/unit/core/test_json.py
@@ -178,7 +178,7 @@ def test_loads_malformed_json_never_silent(text: str) -> None:
     """
     try:
         result = core_json.loads(text)
-    except Exception:
+    except core_json.JSONDecodeError:
         pass  # Expected for malformed input
     else:
         # Valid JSON 'null' legitimately parses to None; every other successful


### PR DESCRIPTION
## Summary

Fixes the three concrete false-green findings in polylogue-3a61: two tests with tautological or no assertions, and three tests whose only assertions sat inside a possibly-empty loop.

## Problem

polylogue-3a61 is a false-green test audit. It found:

1. `tests/unit/core/test_json.py::test_loads_malformed_json_never_silent` has a docstring claiming `loads()` "never silently returns None for a non-null JSON input", but the test body has no assertion at all.
2. `tests/unit/core/test_filters_props.py::test_provider_filter_exclusion_disjoint` has a docstring about `SessionFilter` inclusion/exclusion behavior, but the body only computes `included - excluded` over two plain Python `set`s from Hypothesis inputs, never touching `SessionFilter` or any production code.
3. `test_exclude_provider_and_exclude_tag`, `test_provider_with_exclude_tag`, and `test_multiple_exclude_providers` call the real `SessionFilter(...).exclude_origin(...).list()`, but every assertion sits inside `for conv in result:` with no cardinality guard, so a regression that made the filter return `[]` would keep all three green.

## Solution

- `test_json.py`: added `assert result is not None` on the success path, preserving the file's documented carve-out for literal JSON `"null"` (unreachable from this test's `'{[}"]:'` alphabet, but checked explicitly for robustness against future alphabet changes).
- `test_filters_props.py::test_provider_filter_exclusion_disjoint`: rewrote as a parametrized async test that builds a small real archive and asserts on `SessionFilter(...).origin(...).exclude_origin(...).list()`, including a contradictory-filter case (same origin both included and excluded) so the test actually proves `exclude_origin()` restricts results rather than being a no-op.
- The three `TestSessionFilterCombinedFilters` tests: added `assert len(result) >= 1` before each loop, documenting the expected non-empty composition given `filter_repo_advanced`'s fixed session/tag/origin layout.
- Added a short "Cardinality guards on loop-only assertions" convention to `TESTING.md`, scoped narrowly to this pattern (not a rewrite of the file's broader test-pattern section).

Out of scope (per the bead's own AC): the audit's broader AST sweep found 238 loop-only-assertion candidates suite-wide; manual sampling in the bead already showed most are legitimate shared-assertion-helper delegation, and this PR does not audit or fix that wider set.

## Verification

Mutation-proved each fix independently (mutation applied, target test fails; reverted, target test passes):

- `polylogue/core/json.py`: changed the stdlib fallback's `raise exc from None` to `return None` on decode failure → `test_loads_malformed_json_never_silent` failed with `assert None is not None`; reverted → passes.
- `polylogue/archive/filter/builder.py`: made `exclude_origin()` a no-op (`return self`) → 3 of 4 parametrized `test_provider_filter_exclusion_disjoint` cases failed (the contradictory-filter case surfaced the excluded origin in the result); reverted → passes.
- `polylogue/archive/filter/filters.py`: made `SessionFilter.list()` always `return []` → all three `TestSessionFilterCombinedFilters` tests failed at the new `len(result) >= 1` guard; reverted → passes.

Commands run:

```
devtools test tests/unit/core/test_json.py tests/unit/core/test_filters_props.py
# 187 passed, 1 pre-existing unrelated failure:
# TestSessionFilterBranching::test_parent_filters_by_parent_id
# (confirmed failing identically on unmodified master via git stash)

devtools verify --quick
# exit 0 — ruff format/lint, mypy, render-all-check, layering, closure-matrix,
# doc-commands, docs-coverage, schema-versioning/promotion all green
```

Ref polylogue-3a61


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded filter coverage with end-to-end archive scenarios, including provider inclusion and exclusion combinations.
  * Added safeguards ensuring combined-filter tests cannot pass with empty results.
  * Strengthened malformed JSON tests to detect silently swallowed parsing failures.
* **Documentation**
  * Added guidance for preventing vacuous test passes when assertions run inside loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->