### PR TITLE
fix(cli): print archive-root provenance on every ops maintenance command

### DIFF
--- a/polylogue/cli/commands/maintenance/__init__.py
+++ b/polylogue/cli/commands/maintenance/__init__.py
@@ -145,8 +145,23 @@ _COMMANDS: tuple[tuple[str, str, str, str], ...] = (
 
 
 @click.group("maintenance")
-def maintenance_group() -> None:
-    """Preview and run maintenance backfill operations."""
+@click.pass_context
+def maintenance_group(ctx: click.Context) -> None:
+    """Preview and run maintenance backfill operations.
+
+    Prints the resolved archive root and its provenance (env override /
+    config file / default) before dispatching to any subcommand -- see
+    ``_shared.print_archive_root_provenance`` (polylogue-l1qg). This runs
+    for every real subcommand invocation, including ``--help`` on a
+    subcommand, but not for ``maintenance``/``maintenance --help`` on their
+    own (no subcommand resolves, so there is nothing to warn about yet).
+    """
+    from polylogue.cli.commands.maintenance._shared import print_archive_root_provenance
+    from polylogue.cli.shared.types import AppEnv
+
+    env = ctx.obj
+    if isinstance(env, AppEnv):
+        print_archive_root_provenance(env)
 
 
 for _cli_name, _submodule, _attr, _short_help in _COMMANDS:

--- a/polylogue/cli/commands/maintenance/_shared.py
+++ b/polylogue/cli/commands/maintenance/_shared.py
@@ -9,8 +9,53 @@ from typing import Any
 
 import click
 
+from polylogue.cli.shared.types import AppEnv
 from polylogue.core.enums import Origin
 from polylogue.maintenance.scope import MaintenanceScopeFilter
+
+#: Human-readable description of where each config layer's value came from,
+#: keyed by the layer names `PolylogueConfig.layer_of` returns
+#: (`default`/`site`/`user`/`env`/`cli`).
+_LAYER_DESCRIPTIONS: dict[str, str] = {
+    "env": "POLYLOGUE_ARCHIVE_ROOT environment variable",
+    "cli": "CLI flag",
+    "default": "built-in default (no config file or environment override)",
+}
+
+
+def archive_root_provenance_line(env: AppEnv) -> str:
+    """Return a one-line "archive root + provenance" description.
+
+    Every ``ops maintenance`` command resolves its archive root through the
+    same 5-layer precedence as the rest of the CLI (see
+    ``polylogue/config.py``'s module docstring), but a break-glass operator
+    running in an unfamiliar shell has no way to tell whether that root came
+    from ``polylogue.toml`` or from a stray ``POLYLOGUE_ARCHIVE_ROOT`` left
+    over from a devshell/demo session (polylogue-l1qg: an operator drew
+    "archive looks clean" conclusions from a scratch archive this way). This
+    is printed unconditionally at the top of every maintenance invocation --
+    not gated behind ``--verbose`` -- because the whole point is that the
+    operator should not have to know to ask for it.
+    """
+    settings = env.runtime.settings
+    layer = settings.layer_of("archive_root")
+    archive_root = env.config.archive_root
+    if layer in ("site", "user"):
+        config_path = settings.layer_paths.get(layer)
+        source = f"{layer} config file ({config_path})" if config_path else f"{layer} config file"
+    else:
+        source = _LAYER_DESCRIPTIONS.get(layer, layer)
+    return f"Archive root: {archive_root} [source: {source}]"
+
+
+def print_archive_root_provenance(env: AppEnv) -> None:
+    """Print :func:`archive_root_provenance_line` to stderr.
+
+    Stderr (not stdout) so the banner never corrupts a subcommand's
+    ``--output-format json`` payload piped downstream, while still landing
+    in the operator's terminal by default.
+    """
+    click.echo(archive_root_provenance_line(env), err=True)
 
 
 def _build_scope_filter(

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -67,7 +67,7 @@ def test_raw_authority_census_cli_resolves_receipt_handle(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["query_handle"] == receipt.query_handle
     assert payload["census"]["census_id"] == receipt.census_id
 
@@ -115,7 +115,7 @@ def test_raw_authority_cli_bounds_oversized_plan_and_resolves_detail(
     )
     assert census_result.exit_code == 0
     assert len(census_result.output) < 8_000
-    census_payload = json.loads(census_result.output)
+    census_payload = json.loads(census_result.stdout)
     item = census_payload["plans"][0]
     assert item["plan"]["input_raw_count"] == 2_000
     assert "raw-01999" not in census_result.output
@@ -136,7 +136,7 @@ def test_raw_authority_cli_bounds_oversized_plan_and_resolves_detail(
         catch_exceptions=False,
     )
     assert detail_result.exit_code == 0
-    detail_payload = json.loads(detail_result.output)
+    detail_payload = json.loads(detail_result.stdout)
     assert len(detail_payload["chunk"]) <= 256
     assert detail_payload["next_query_handle"] is not None
 
@@ -309,7 +309,7 @@ def test_raw_authority_blockers_cli_lists_unresolved_and_classifies_kind(
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     by_id = {row["blocker_id"]: row for row in payload["blockers"]}
     assert by_id["blocker-stale"]["kind"] == "stale_plan"
     assert by_id["blocker-frontier"]["kind"] == "frontier_judgment"
@@ -340,7 +340,7 @@ def test_raw_authority_blockers_cli_lists_unresolved_and_classifies_kind(
         ["--plain", "ops", "maintenance", "raw-authority-blockers", "--output-format", "json"],
         catch_exceptions=False,
     )
-    after_payload = json.loads(after.output)
+    after_payload = json.loads(after.stdout)
     remaining = {row["blocker_id"] for row in after_payload["blockers"]}
     assert remaining == {"blocker-frontier", "blocker-obligation"}
     assert after_payload["total_count"] == 2
@@ -376,7 +376,7 @@ def test_raw_authority_blockers_cli_paginates_past_the_limit(
         ],
         catch_exceptions=False,
     )
-    first_payload = json.loads(first.output)
+    first_payload = json.loads(first.stdout)
     assert first_payload["returned_count"] == 2
     assert first_payload["total_count"] == 3
     assert first_payload["truncated"] is True
@@ -399,7 +399,7 @@ def test_raw_authority_blockers_cli_paginates_past_the_limit(
         ],
         catch_exceptions=False,
     )
-    second_payload = json.loads(second.output)
+    second_payload = json.loads(second.stdout)
     assert second_payload["returned_count"] == 1
     assert second_payload["truncated"] is False
 
@@ -566,7 +566,7 @@ def test_archive_plan_cli_reports_tier_targets(cli_workspace: dict[str, Path], c
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["ready"] is True
     assert {tier["tier"]: tier["action"] for tier in payload["tiers"]} == {
         "source": "create",
@@ -606,7 +606,7 @@ def test_archive_plan_cli_surfaces_existing_target_blocker(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["ready"] is False
     source_plan = next(tier for tier in payload["tiers"] if tier["tier"] == "source")
     assert source_plan["action"] == "blocked"
@@ -624,7 +624,7 @@ def test_backup_plan_cli_reports_backup_profiles_and_tier_boundaries(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["ok"] is True
     assert payload["mode"] == "backup_plan"
     assert payload["mutates"] is False
@@ -666,7 +666,7 @@ def test_backup_plan_cli_surfaces_missing_tiers_and_wal_checkpoint_warning(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     tiers = {tier["tier"]: tier for tier in payload["tiers"]}
     assert tiers["index"]["present"] is False
     assert tiers["user"]["wal_present"] is True
@@ -703,7 +703,7 @@ def test_assertion_export_cli_emits_all_assertions_as_jsonl(
     )
 
     assert result.exit_code == 0
-    rows = [json.loads(line) for line in result.output.splitlines()]
+    rows = [json.loads(line) for line in result.stdout.splitlines()]
     assert [row["assertion_id"] for row in rows] == ["export-mark", "export-deleted-note"]
     assert rows[0]["kind"] == "mark"
     assert rows[0]["value"] == {"label": "important"}
@@ -738,7 +738,7 @@ def test_assertion_export_cli_filters_and_writes_json_file(
     )
 
     assert result.exit_code == 0
-    assert result.output == f"Exported 1 assertions to {out_path}\n"
+    assert result.stdout == f"Exported 1 assertions to {out_path}\n"
     payload = json.loads(out_path.read_text(encoding="utf-8"))
     assert payload["mode"] == "assertion_export"
     assert payload["count"] == 1
@@ -759,7 +759,7 @@ def test_blob_gc_cli_dry_run_reports_without_deleting(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["ok"] is True
     assert payload["mode"] == "blob_gc"
     assert payload["mutates"] is False
@@ -806,7 +806,7 @@ def test_blob_gc_cli_yes_deletes_and_records_generation(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["mutates"] is True
     assert payload["dry_run"] is False
     assert payload["would_delete_count"] == 0
@@ -842,7 +842,7 @@ def test_blob_publications_cli_requires_confirmation_to_abandon(
         catch_exceptions=False,
     )
     assert inspected.exit_code == 0
-    payload = json.loads(inspected.output)
+    payload = json.loads(inspected.stdout)
     assert payload["mutates"] is False
     assert payload["receipts"][0]["publication_id"] == receipt_id
 
@@ -869,7 +869,7 @@ def test_blob_publications_cli_requires_confirmation_to_abandon(
         catch_exceptions=False,
     )
     assert abandoned.exit_code == 0
-    payload = json.loads(abandoned.output)
+    payload = json.loads(abandoned.stdout)
     assert payload["abandonment"]["abandoned"] == 1
     assert payload["receipts"] == []
 
@@ -899,7 +899,7 @@ def test_blob_reference_debt_cli_classifies_missing_refs(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["mode"] == "blob_reference_debt"
     assert payload["mutates"] is False
     assert payload["ok"] is False
@@ -947,7 +947,7 @@ def test_attachment_acquisition_debt_cli_reports_clean_empty_archive(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["mode"] == "attachment_acquisition_debt"
     assert payload["mutates"] is False
     assert payload["ok"] is True
@@ -998,7 +998,7 @@ def test_blob_reference_recovery_plan_cli_writes_raw_backed_manifest(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["mode"] == "blob_reference_recovery_plan"
     assert payload["mutates"] is False
     assert payload["writes_manifest"] is True
@@ -1047,7 +1047,7 @@ def test_blob_reference_replace_from_source_cli_applies_with_manifest(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["mode"] == "blob_reference_replace_from_source"
     assert payload["mutates"] is True
     assert payload["writes_manifest"] is True
@@ -1080,7 +1080,7 @@ def test_blob_reference_prune_orphans_cli_dry_run_keeps_refs(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["mode"] == "blob_reference_prune_orphans"
     assert payload["mutates"] is False
     assert payload["dry_run"] is True
@@ -1116,7 +1116,7 @@ def test_blob_reference_prune_orphans_cli_apply_quarantines_deleted_refs(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["mutates"] is True
     assert payload["dry_run"] is False
     assert payload["missing_orphan_refs"] == 1
@@ -1250,7 +1250,7 @@ def test_embedding_orphan_reconcile_cli_dry_run_keeps_rows(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["mode"] == "embedding_orphan_reconcile"
     assert payload["mutates"] is False
     assert payload["dry_run"] is True
@@ -1324,7 +1324,7 @@ def test_archive_init_cli_is_dry_run_without_yes(cli_workspace: dict[str, Path],
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["executed"] is False
     assert payload["ready"] is True
     assert not (cli_workspace["archive_root"] / "index.db").exists()
@@ -1360,7 +1360,7 @@ def test_archive_init_cli_executes_confirmed_initialization(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["executed"] is True
     assert payload["tiers"] == [
         {
@@ -1399,7 +1399,7 @@ def test_backup_verify_then_migrate_tier_cli_applies_user_migration_with_receipt
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["ok"] is True
     assert payload["tier"] == "user"
     assert payload["from_version"] == 3
@@ -1454,7 +1454,7 @@ def test_migrate_tier_cli_rejects_unverified_backup_before_user_version_changes(
     )
 
     assert result.exit_code == 1
-    assert "successful backup verification receipt" in json.loads(result.output)["error"]
+    assert "successful backup verification receipt" in json.loads(result.stdout)["error"]
     with sqlite3.connect(user_db) as conn:
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 3
 
@@ -1489,7 +1489,7 @@ def test_migrate_tier_cli_rejects_one_byte_tampered_backup_before_user_version_c
     )
 
     assert result.exit_code == 1
-    assert "tier artifact hash mismatch" in json.loads(result.output)["error"]
+    assert "tier artifact hash mismatch" in json.loads(result.stdout)["error"]
     with sqlite3.connect(user_db) as conn:
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 3
 
@@ -1520,7 +1520,7 @@ def test_migrate_tier_cli_refuses_manifest_missing_target_tier(
     )
 
     assert result.exit_code == 1
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["ok"] is False
     assert "does not include user.db" in payload["error"]
     with sqlite3.connect(user_db) as conn:
@@ -1565,7 +1565,7 @@ def test_raw_authority_frontier_cli_replaces_incident_specific_commands(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["accepted_head_count"] == 0
     assert payload["plan_count"] == 0
     assert payload["executable_plan_count"] == 0
@@ -1673,7 +1673,7 @@ def test_archive_read_cli_lists_archive_sessions(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["mode"] == "list"
     assert payload["sessions"] == [
         {
@@ -1745,7 +1745,7 @@ def test_archive_read_cli_searches_archive_blocks(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["mode"] == "search"
     assert payload["hits"][0]["block_id"] == "codex-session:native-1:m1:0"
     assert payload["hits"][0]["snippet"] == "[needle]"
@@ -2340,7 +2340,7 @@ def test_rebuild_index_explicit_raw_ids_remain_inspectable_in_plan_mode(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["raw_session_count"] == 10
     assert payload["selected_raw_count"] == 2
     assert payload["raw_id_count"] == 3
@@ -2396,7 +2396,7 @@ def test_rebuild_index_filters_selected_rows_by_blob_size(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["selected_raw_count"] == 1
     assert payload["totals"]["blob_bytes"] == 1 * 1024 * 1024
     assert payload["skipped_by_blob_limit_count"] == 1
@@ -2462,7 +2462,7 @@ def test_rebuild_index_plan_reports_weighted_top_rows(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["status"] == "ok"
     assert payload["raw_session_count"] == 3
     assert payload["selected_raw_count"] == 3

--- a/tests/unit/cli/test_embeddings_rescue_cli.py
+++ b/tests/unit/cli/test_embeddings_rescue_cli.py
@@ -78,7 +78,7 @@ def test_embeddings_rescue_cli_plan_mode_is_read_only_on_empty_archive(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["mode"] == "plan"
     assert payload["mutates"] is False
     assert payload["eligible_sessions"] == 0
@@ -111,7 +111,7 @@ def test_embeddings_rescue_cli_apply_mode_no_op_on_empty_archive(
     )
 
     assert result.exit_code == 0
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["mode"] == "execute"
     assert payload["mutates"] is True
     assert payload["rescued_sessions"] == 0

--- a/tests/unit/cli/test_maintenance_archive_root_provenance.py
+++ b/tests/unit/cli/test_maintenance_archive_root_provenance.py
@@ -1,0 +1,82 @@
+"""polylogue-l1qg: ops/maintenance commands must surface archive-root provenance.
+
+Reproduces the bead's live scenario: ``POLYLOGUE_ARCHIVE_ROOT`` inherited from
+a shell environment silently outranks ``polylogue.toml``'s ``[archive] root``
+with no indication to the operator that the resolved root came from an env
+override rather than the config file they believe is authoritative. These
+tests exercise the real CLI entry point (``polylogue ops maintenance ...``
+via :func:`polylogue.cli.click_app.cli`), not a bare internal helper, so a
+regression that stops the banner from actually reaching command output would
+fail here even if the underlying provenance-lookup function still worked.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from polylogue.cli.click_app import cli
+
+
+def test_maintenance_status_prints_env_archive_root_provenance(
+    cli_workspace: dict[str, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`ops maintenance status` names POLYLOGUE_ARCHIVE_ROOT as the source.
+
+    ``cli_workspace`` points ``POLYLOGUE_ARCHIVE_ROOT`` at a real, valid
+    archive. A user ``polylogue.toml`` is layered in pointing at a
+    *different* (bogus) archive root -- env must still win per the
+    documented 5-layer precedence, and the printed banner must say so
+    rather than silently naming the config file or nothing at all.
+    """
+    env_archive_root = cli_workspace["archive_root"]
+    config_only_root = tmp_path / "config-file-archive-should-not-be-used"
+    user_toml = tmp_path / "user.toml"
+    user_toml.write_text(f'[archive]\nroot = "{config_only_root.as_posix()}"\n', encoding="utf-8")
+    monkeypatch.setenv("POLYLOGUE_CONFIG", str(user_toml))
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ops", "maintenance", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert f"Archive root: {env_archive_root}" in result.output
+    assert "POLYLOGUE_ARCHIVE_ROOT environment variable" in result.output
+    # The config-file-only root must never be presented as the resolved one.
+    assert str(config_only_root) not in result.output
+
+
+def test_maintenance_status_prints_user_config_archive_root_provenance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    empty_archive_template: Path,
+) -> None:
+    """Without an env override, the banner names the user config file, not "env"."""
+    monkeypatch.delenv("POLYLOGUE_ARCHIVE_ROOT", raising=False)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "unused-data-home"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state"))
+    monkeypatch.setenv("POLYLOGUE_FORCE_PLAIN", "1")
+    monkeypatch.setenv("POLYLOGUE_SCHEMA_VALIDATION", "off")
+
+    archive_root = tmp_path / "toml-configured-archive"
+    archive_root.mkdir(parents=True, exist_ok=True)
+    import subprocess
+
+    subprocess.run(
+        ["cp", "-a", "--reflink=auto", f"{empty_archive_template}/.", str(archive_root)],
+        check=True,
+    )
+    user_toml = tmp_path / "user.toml"
+    user_toml.write_text(f'[archive]\nroot = "{archive_root.as_posix()}"\n', encoding="utf-8")
+    monkeypatch.setenv("POLYLOGUE_CONFIG", str(user_toml))
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["ops", "maintenance", "status"])
+
+    assert result.exit_code == 0, result.output
+    assert f"Archive root: {archive_root}" in result.output
+    assert f"user config file ({user_toml})" in result.output
+    assert "POLYLOGUE_ARCHIVE_ROOT environment variable" not in result.output

--- a/tests/unit/cli/test_maintenance_verify_archive_cli.py
+++ b/tests/unit/cli/test_maintenance_verify_archive_cli.py
@@ -32,7 +32,7 @@ def test_verify_archive_cli_json_reports_every_registered_check(
     )
 
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["blocking"] is False
     names = {check["name"] for check in payload["checks"]}
     assert names == {
@@ -64,7 +64,7 @@ def test_verify_archive_cli_exits_nonzero_on_schema_drift(
     )
 
     assert result.exit_code == 1
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert payload["blocking"] is True
     tier_check = next(check for check in payload["checks"] if check["name"] == "tier-schema")
     assert tier_check["status"] == "error"
@@ -91,7 +91,7 @@ def test_verify_archive_cli_restricts_to_selected_checks(
     )
 
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     names = {check["name"] for check in payload["checks"]}
     assert names == {"tier-schema", "counts-summary"}
 
@@ -121,7 +121,7 @@ def test_verify_archive_cli_strict_fails_on_warning(
         ["--plain", "ops", "maintenance", "verify-archive", "--check", "planner-stats", "--output-format", "json"],
     )
     assert default_result.exit_code == 0, default_result.output
-    payload = json.loads(default_result.output)
+    payload = json.loads(default_result.stdout)
     assert payload["checks"][0]["status"] == "warning"
 
     strict_result = cli_runner.invoke(


### PR DESCRIPTION
## Summary
`polylogue ops maintenance ...` commands now print the resolved archive root and its provenance (env override / config file / built-in default) before dispatching, so an operator running break-glass maintenance in an unfamiliar shell can immediately see if `POLYLOGUE_ARCHIVE_ROOT` silently redirected the command away from the archive they expect.

## Problem

Reproduced live 2026-07-31 (polylogue-l1qg): with `POLYLOGUE_ARCHIVE_ROOT` inherited from a stray shell environment (a devshell, a leftover export), `polylogue ops maintenance raw-authority-frontier` silently resolved against a scratch archive and reported `census:1 accepted=0 plans=0` — looking totally clean — while the real live archive had census 932 with 17,384 plans. Nothing in the output indicated the root came from an env override rather than `polylogue.toml`.

## Solution

`polylogue/config.py` already tracks per-key layer provenance (`PolylogueConfig.layer_of`/`layer_paths`, the 5-layer precedence: default/site/user/env/cli) but nothing surfaced it on the ops/maintenance CLI surface.

- `polylogue/cli/commands/maintenance/_shared.py`: new `archive_root_provenance_line`/`print_archive_root_provenance` helpers that describe the resolved archive root and name the layer it came from (env var / config file path / built-in default).
- `polylogue/cli/commands/maintenance/__init__.py`: `maintenance_group()` now prints this banner via `ctx.pass_context` before dispatching to any subcommand — unconditionally, not gated behind `--verbose`, on **stderr** so it never corrupts a subcommand's `--output-format json` payload for pipe consumers. Confirmed empirically that Click's group-callback dispatch runs even for a subcommand's own `--help`, but not for `maintenance`/`maintenance --help` alone (no subcommand resolves, nothing to report yet).

**Scope decision on the "refuse env-derived apply" idea in the bead**: implemented banner-only, not a hard refusal gate. The ~25 subcommands under `ops maintenance` don't share one uniform mutation-confirmation flag — `--yes` on `blob-gc`/`raw-authority-frontier`/`raw-authority-blocker-resolve`, `--dry-run` on `run` (mutates by default), a differently-shaped multi-flag confirmation on `rebuild-index`. A blanket "refuse without an extra ack flag" gate risks false-refusing read-only commands or missing a command whose apply path uses a differently-named flag unless each is individually audited first. Filed polylogue-dlmc1 to do that audit as its own scoped follow-up rather than rush a partial gate here.

## Verification

Printing to stderr surfaced a real, unrelated latent issue: ~40 existing CLI tests parsed `result.output` as JSON (Click 8.2+ `CliRunner` mixes stdout+stderr into `.output`; `.stdout` is the stdout-only stream, already used elsewhere in the suite). Any stderr diagnostic — not just this banner — would have broken those. Fixed the call sites to use `.stdout` (`tests/unit/cli/test_archive_maintenance_cli.py`, `test_maintenance_verify_archive_cli.py`, `test_embeddings_rescue_cli.py`) instead of loosening the banner.

```
devtools test tests/unit/cli/test_maintenance_archive_root_provenance.py \
  tests/unit/cli/test_maintenance_registration.py \
  tests/unit/cli/test_archive_maintenance_cli.py \
  tests/unit/cli/test_maintenance_verify_archive_cli.py \
  tests/unit/cli/test_embeddings_rescue_cli.py \
  tests/unit/cli/test_stdout_stderr_split.py \
  tests/unit/cli/test_deterministic_output.py \
  tests/unit/cli/test_json_output.py \
  tests/unit/cli/test_status_diagnostics.py \
  tests/unit/maintenance/test_preview.py \
  tests/unit/maintenance/test_scope_filter.py \
  tests/unit/maintenance/test_envelope_contracts.py \
  tests/unit/maintenance/test_scope_filter_envelope_contract.py
```
All pass except 4 confirmed pre-existing/unrelated failures (reproduced identically via `git stash`): two `rebuild-index` byte-budget count assertions in `test_archive_maintenance_cli.py`, and two snapshot date-drift failures in `test_help_snapshots.py`/`test_terminal_snapshots.py`.

`devtools verify --quick` → exit 0, all 18 gates green.

New test `tests/unit/cli/test_maintenance_archive_root_provenance.py` exercises the real CLI entry point (`polylogue.cli.click_app.cli` via `CliRunner`, not a bare helper call): one case sets `POLYLOGUE_ARCHIVE_ROOT` env + a conflicting user `polylogue.toml` and asserts the banner names the env var as the source (and never the config-file path); the other case removes the env override and asserts the banner names the user config file path instead.

Ref polylogue-l1qg