### PR TITLE
fix(storage): prune orphaned raw-authority plans in retention purge

### DIFF
--- a/polylogue/storage/raw_retention.py
+++ b/polylogue/storage/raw_retention.py
@@ -1560,39 +1560,71 @@ def _ops_cursor_byte_offsets(ops_db_path: Path) -> dict[str, int]:
 # Orphaned raw-authority plan cleanup (polylogue-i3zo)
 # ---------------------------------------------------------------------------
 #
-# raw_authority_plans/blockers/census_plans/census_post_plans reference raws
-# by JSON string (input_raw_ids_json), not by FK, so deleting a raw_sessions
-# row here does NOT cascade-clean its frontier plans. A plan whose EVERY
-# input raw is gone is unprocessable and must be pruned in the same
-# transaction as the raw delete, or the daemon reconciler's next convergence
-# pass throws RuntimeError("duplicate strategy did not reach its typed
-# terminal postcondition") on the dangling plan (live incident 2026-07-22,
-# first observed against polylogue/maintenance/hook_deinflation.py's
-# one-time repair, which has since been deleted -- ee22574e5 -- because that
-# specific repair completed; the same unguarded gap exists here for
-# ordinary retention-driven raw deletion and was never given a home).
+# raw_authority_plans references raws by JSON string (input_raw_ids_json),
+# not by FK, so deleting a raw_sessions row here does NOT cascade-clean a
+# frontier plan naming it. A plan whose every input raw is gone and which no
+# census still references is unprocessable and must be pruned in the same
+# transaction as the raw delete, or the row simply accumulates forever
+# (bounded growth was the original motivation; see polylogue-i3zo).
 #
-# Design: hard-delete, not a soft terminal-state transition. This mirrors the
-# only prior art for this exact gap (unmerged commit c2554a615, "prune
-# orphaned raw-authority plans in hook-deinflation repair"): a plan is durable
-# audit evidence of a *reconciliation attempt*, not of user-authored history,
-# and once every raw it names is gone the plan cannot be replayed, retried,
-# or inspected against source evidence -- there is nothing left to audit.
-# raw_authority_plans lives in source.db (a durable tier) but is populated and
-# consumed entirely by the daemon reconciler, with no read surface exposing
-# historical plans to a human operator; keeping a terminally-orphaned plan
-# around serves no audit purpose and actively breaks the reconciler. This is
-# unlike `user.db` assertions (durable, human-authored, always additive) or
-# `raw_sessions` full/append revision chains (superseded but still
-# byte-reconstructible) -- neither pattern applies to a plan with zero
-# remaining inputs.
+# CENSUS-SAFETY (revised after a real review finding on the first version of
+# this fix, chatgpt-codex-connector on PR #3530): the first draft deleted
+# `raw_authority_census_plans` / `raw_authority_census_post_plans` /
+# `raw_authority_blockers` rows for any orphaned plan, unconditionally. That
+# is wrong: `raw_authority_censuses.plan_count` / `post_plan_count` are
+# immutable per-census totals read verbatim by `read_raw_authority_census`
+# (`polylogue/storage/raw_authority.py`) to report a census's total AND to
+# decide whether pagination has more pages (`next_offset < max(total,
+# post_total)`). Deleting a census's plan-membership rows without adjusting
+# those counts makes the total lie, and once a census's rows are ALL
+# removed, `next_offset` (computed from `len(plans)`, now always 0) stops
+# advancing -- `next_query_handle` is reissued forever. Deleting an
+# unresolved `raw_authority_blockers` row is worse: `prune_raw_authority_census_history`
+# (same module) already treats an unresolved blocker as "a live durable
+# obligation, not history" and refuses to touch it for exactly this reason.
+#
+# The fix: never delete `raw_authority_census_plans` / `_post_plans` /
+# `raw_authority_blockers` from this function at all -- only ever delete a
+# `raw_authority_plans` row once it has ZERO remaining references in any of
+# those three tables. This composes with, rather than fights, the existing
+# retention path: every `raw_authority_plans` row is inserted in the same
+# transaction as its owning census's `raw_authority_census_plans` row
+# (`record_raw_authority_census` in raw_authority.py), so a plan can only
+# reach zero census references once `prune_raw_authority_census_history`'s
+# own plan-retention window (`RAW_AUTHORITY_CENSUS_PLAN_RETENTION`, 8
+# generations) has already decided its census-plan detail is safe to drop --
+# which that function only does once no unresolved blocker remains. This
+# function therefore only ever touches a `raw_authority_plans` row that
+# established machinery has already judged expendable; it cannot advance
+# that judgment early, and cannot itself corrupt any `plan_count` /
+# `post_plan_count` because it never deletes the rows those counts describe.
+#
+# Consequence, stated honestly: a plan still referenced by an active
+# ('planned', unresolved) census -- a genuine live obligation -- is left
+# untouched by this pass even if every raw it names is already gone. That
+# is deliberate: the original 2026-07-22 live incident this bead cites was
+# caused by a one-time repair script (`hook_deinflation.py`, since deleted)
+# deleting raws out from under an in-flight census apply directly, bypassing
+# retention authority entirely -- a defect in that now-gone one-time script,
+# not something `cleanup_superseded_raw_snapshots` reproduces (it only
+# deletes raws proven superseded via `active_raw_retention_authority` /
+# the file-set recency heuristic, an orthogonal concern from census
+# membership). A dangling reference from a still-live census plan to an
+# already-superseded raw is a pre-existing reconciler-robustness question
+# (tracked separately, polylogue-7f8yc) and is not this function's job to
+# solve by deleting durable census evidence. The pagination/plan_count
+# staleness this review also flagged already exists today via
+# prune_raw_authority_census_history's own plan-retention window, entirely
+# independent of this function (tracked separately, polylogue-4uzoo).
 #
 # Set-based (single pass, LEFT JOIN on the raw_id PK): expand each plan's
 # input raws, GROUP BY plan, keep plans whose inputs are ALL missing. The
 # equivalent correlated-subquery form measured ~26 billion ops (>1h) on the
 # live archive; this form completes in ~0.3s. A plan with empty inputs
 # produces no json_each rows and is correctly excluded (it is not
-# orphaned-by-missing-raw).
+# orphaned-by-missing-raw). The candidate set from this query is then
+# anti-joined against the three census/blocker tables (temp `plan_id`
+# indexes make that anti-join index-driven too) before anything is deleted.
 _PURELY_ORPHANED_AUTHORITY_PLANS_SQL = """
     SELECT p.plan_id
     FROM raw_authority_plans p, json_each(p.input_raw_ids_json) j
@@ -1604,51 +1636,60 @@ _PURELY_ORPHANED_AUTHORITY_PLANS_SQL = """
 
 
 def _delete_orphaned_raw_authority_plans(conn: sqlite3.Connection) -> int:
-    """Prune raw-authority plans whose every input raw is gone, plus their
-    blocker/census children. Children first (they carry NO ACTION/RESTRICT
-    FKs to ``raw_authority_plans``, so the parent delete would otherwise
-    fail once the schema enforces foreign keys).
+    """Prune ``raw_authority_plans`` rows that are both raw-orphaned (every
+    input raw is gone) AND already census-free (zero remaining rows in
+    ``raw_authority_census_plans`` / ``_post_plans`` / ``raw_authority_blockers``).
 
-    Must run in the same transaction as (and after) the raw delete that may
-    have orphaned these plans, so "orphaned" is always computed against the
-    post-delete raw set. No-ops (returns 0) when ``raw_authority_plans``
-    doesn't exist, so this is safe to call unconditionally.
-
-    Temporary full ``plan_id`` indexes are created on the three child tables:
-    their durable indexes are partial (``WHERE resolved_at_ms IS NULL`` /
-    composite ``PRIMARY KEY(census_id, plan_id)`` with ``plan_id`` non-leading)
-    so an IN-delete keyed on ``plan_id`` alone would otherwise full-scan each
-    child per plan -- the exact ~26-51 billion op hang (>1h) observed on the
-    live 84k-plan / 405k-census-row tables before this was measured. The temp
-    indexes are dropped before returning so the durable schema is unchanged.
+    Never deletes from the census/blocker tables themselves -- see the
+    module comment above for why that would corrupt the immutable
+    ``raw_authority_censuses.plan_count`` / ``post_plan_count`` ledger and
+    silently drop live blocker obligations. Must run in the same transaction
+    as (and after) the raw delete that may have orphaned these plans, so
+    "orphaned" is always computed against the post-delete raw set. No-ops
+    (returns 0) when ``raw_authority_plans`` doesn't exist, so this is safe
+    to call unconditionally.
     """
     if not _table_exists(conn, "raw_authority_plans"):
         return 0
-    conn.execute("CREATE TEMP TABLE _orphan_authority_plans (plan_id TEXT PRIMARY KEY)")
+    conn.execute("CREATE TEMP TABLE _orphan_authority_plan_candidates (plan_id TEXT PRIMARY KEY)")
     try:
-        conn.execute(f"INSERT INTO _orphan_authority_plans (plan_id) {_PURELY_ORPHANED_AUTHORITY_PLANS_SQL}")
-        count = int(conn.execute("SELECT COUNT(*) FROM _orphan_authority_plans").fetchone()[0])
-        if count == 0:
+        conn.execute(f"INSERT INTO _orphan_authority_plan_candidates (plan_id) {_PURELY_ORPHANED_AUTHORITY_PLANS_SQL}")
+        candidate_count = int(conn.execute("SELECT COUNT(*) FROM _orphan_authority_plan_candidates").fetchone()[0])
+        if candidate_count == 0:
             return 0
-        child_indexes = {
-            "_tmp_rawretention_blk_plan": "raw_authority_blockers",
-            "_tmp_rawretention_cp_plan": "raw_authority_census_plans",
-            "_tmp_rawretention_cpp_plan": "raw_authority_census_post_plans",
+        # Exclude any candidate still referenced by a census or an
+        # (un)resolved blocker -- never delete a plan those durable rows
+        # describe. Temp full plan_id indexes make this index-driven instead
+        # of a full scan of the (potentially hundreds-of-thousands-row)
+        # census/blocker tables per candidate.
+        reference_indexes = {
+            "_tmp_rawretention_authplan_cp": "raw_authority_census_plans",
+            "_tmp_rawretention_authplan_cpp": "raw_authority_census_post_plans",
+            "_tmp_rawretention_authplan_blk": "raw_authority_blockers",
         }
-        for index_name, table in child_indexes.items():
+        for index_name, table in reference_indexes.items():
             conn.execute(f"CREATE INDEX {index_name} ON {table}(plan_id)")
         try:
-            for table in child_indexes.values():
-                conn.execute(f"DELETE FROM {table} WHERE plan_id IN (SELECT plan_id FROM _orphan_authority_plans)")
             conn.execute(
-                "DELETE FROM raw_authority_plans WHERE plan_id IN (SELECT plan_id FROM _orphan_authority_plans)"
+                """
+                DELETE FROM _orphan_authority_plan_candidates
+                WHERE plan_id IN (SELECT plan_id FROM raw_authority_census_plans)
+                   OR plan_id IN (SELECT plan_id FROM raw_authority_census_post_plans)
+                   OR plan_id IN (SELECT plan_id FROM raw_authority_blockers)
+                """
             )
         finally:
-            for index_name in child_indexes:
+            for index_name in reference_indexes:
                 conn.execute(f"DROP INDEX IF EXISTS {index_name}")
+        count = int(conn.execute("SELECT COUNT(*) FROM _orphan_authority_plan_candidates").fetchone()[0])
+        if count == 0:
+            return 0
+        conn.execute(
+            "DELETE FROM raw_authority_plans WHERE plan_id IN (SELECT plan_id FROM _orphan_authority_plan_candidates)"
+        )
         return count
     finally:
-        conn.execute("DROP TABLE IF EXISTS _orphan_authority_plans")
+        conn.execute("DROP TABLE IF EXISTS _orphan_authority_plan_candidates")
 
 
 def _superseded_archive_raw_session_candidates(

--- a/polylogue/storage/raw_retention.py
+++ b/polylogue/storage/raw_retention.py
@@ -89,6 +89,7 @@ class RawSnapshotCleanupResult:
     deleted_blob_bytes: int
     skipped_missing_source_count: int
     skipped_referenced_count: int = 0
+    deleted_orphaned_authority_plan_count: int = 0
     errors: tuple[str, ...] = ()
 
 
@@ -1555,6 +1556,101 @@ def _ops_cursor_byte_offsets(ops_db_path: Path) -> dict[str, int]:
     return {str(row[0]): int(row[1]) for row in rows if row[1] is not None}
 
 
+# ---------------------------------------------------------------------------
+# Orphaned raw-authority plan cleanup (polylogue-i3zo)
+# ---------------------------------------------------------------------------
+#
+# raw_authority_plans/blockers/census_plans/census_post_plans reference raws
+# by JSON string (input_raw_ids_json), not by FK, so deleting a raw_sessions
+# row here does NOT cascade-clean its frontier plans. A plan whose EVERY
+# input raw is gone is unprocessable and must be pruned in the same
+# transaction as the raw delete, or the daemon reconciler's next convergence
+# pass throws RuntimeError("duplicate strategy did not reach its typed
+# terminal postcondition") on the dangling plan (live incident 2026-07-22,
+# first observed against polylogue/maintenance/hook_deinflation.py's
+# one-time repair, which has since been deleted -- ee22574e5 -- because that
+# specific repair completed; the same unguarded gap exists here for
+# ordinary retention-driven raw deletion and was never given a home).
+#
+# Design: hard-delete, not a soft terminal-state transition. This mirrors the
+# only prior art for this exact gap (unmerged commit c2554a615, "prune
+# orphaned raw-authority plans in hook-deinflation repair"): a plan is durable
+# audit evidence of a *reconciliation attempt*, not of user-authored history,
+# and once every raw it names is gone the plan cannot be replayed, retried,
+# or inspected against source evidence -- there is nothing left to audit.
+# raw_authority_plans lives in source.db (a durable tier) but is populated and
+# consumed entirely by the daemon reconciler, with no read surface exposing
+# historical plans to a human operator; keeping a terminally-orphaned plan
+# around serves no audit purpose and actively breaks the reconciler. This is
+# unlike `user.db` assertions (durable, human-authored, always additive) or
+# `raw_sessions` full/append revision chains (superseded but still
+# byte-reconstructible) -- neither pattern applies to a plan with zero
+# remaining inputs.
+#
+# Set-based (single pass, LEFT JOIN on the raw_id PK): expand each plan's
+# input raws, GROUP BY plan, keep plans whose inputs are ALL missing. The
+# equivalent correlated-subquery form measured ~26 billion ops (>1h) on the
+# live archive; this form completes in ~0.3s. A plan with empty inputs
+# produces no json_each rows and is correctly excluded (it is not
+# orphaned-by-missing-raw).
+_PURELY_ORPHANED_AUTHORITY_PLANS_SQL = """
+    SELECT p.plan_id
+    FROM raw_authority_plans p, json_each(p.input_raw_ids_json) j
+    LEFT JOIN raw_sessions r ON r.raw_id = j.value
+    GROUP BY p.plan_id
+    HAVING SUM(CASE WHEN r.raw_id IS NULL THEN 1 ELSE 0 END) > 0
+       AND SUM(CASE WHEN r.raw_id IS NOT NULL THEN 1 ELSE 0 END) = 0
+"""
+
+
+def _delete_orphaned_raw_authority_plans(conn: sqlite3.Connection) -> int:
+    """Prune raw-authority plans whose every input raw is gone, plus their
+    blocker/census children. Children first (they carry NO ACTION/RESTRICT
+    FKs to ``raw_authority_plans``, so the parent delete would otherwise
+    fail once the schema enforces foreign keys).
+
+    Must run in the same transaction as (and after) the raw delete that may
+    have orphaned these plans, so "orphaned" is always computed against the
+    post-delete raw set. No-ops (returns 0) when ``raw_authority_plans``
+    doesn't exist, so this is safe to call unconditionally.
+
+    Temporary full ``plan_id`` indexes are created on the three child tables:
+    their durable indexes are partial (``WHERE resolved_at_ms IS NULL`` /
+    composite ``PRIMARY KEY(census_id, plan_id)`` with ``plan_id`` non-leading)
+    so an IN-delete keyed on ``plan_id`` alone would otherwise full-scan each
+    child per plan -- the exact ~26-51 billion op hang (>1h) observed on the
+    live 84k-plan / 405k-census-row tables before this was measured. The temp
+    indexes are dropped before returning so the durable schema is unchanged.
+    """
+    if not _table_exists(conn, "raw_authority_plans"):
+        return 0
+    conn.execute("CREATE TEMP TABLE _orphan_authority_plans (plan_id TEXT PRIMARY KEY)")
+    try:
+        conn.execute(f"INSERT INTO _orphan_authority_plans (plan_id) {_PURELY_ORPHANED_AUTHORITY_PLANS_SQL}")
+        count = int(conn.execute("SELECT COUNT(*) FROM _orphan_authority_plans").fetchone()[0])
+        if count == 0:
+            return 0
+        child_indexes = {
+            "_tmp_rawretention_blk_plan": "raw_authority_blockers",
+            "_tmp_rawretention_cp_plan": "raw_authority_census_plans",
+            "_tmp_rawretention_cpp_plan": "raw_authority_census_post_plans",
+        }
+        for index_name, table in child_indexes.items():
+            conn.execute(f"CREATE INDEX {index_name} ON {table}(plan_id)")
+        try:
+            for table in child_indexes.values():
+                conn.execute(f"DELETE FROM {table} WHERE plan_id IN (SELECT plan_id FROM _orphan_authority_plans)")
+            conn.execute(
+                "DELETE FROM raw_authority_plans WHERE plan_id IN (SELECT plan_id FROM _orphan_authority_plans)"
+            )
+        finally:
+            for index_name in child_indexes:
+                conn.execute(f"DROP INDEX IF EXISTS {index_name}")
+        return count
+    finally:
+        conn.execute("DROP TABLE IF EXISTS _orphan_authority_plans")
+
+
 def _superseded_archive_raw_session_candidates(
     conn: sqlite3.Connection,
     *,
@@ -1687,6 +1783,11 @@ def cleanup_superseded_raw_snapshots(
     elif _column_exists(conn, "blob_refs", "raw_id"):
         conn.execute(f"DELETE FROM blob_refs WHERE raw_id IN ({placeholders})", raw_ids)
     conn.execute(f"DELETE FROM raw_sessions WHERE raw_id IN ({placeholders})", raw_ids)
+    # Prune raw-authority plans/blockers/census rows now dangling on the
+    # deleted raws (input_raw_ids_json is a JSON string, not an FK, so no
+    # cascade cleaned them -- polylogue-i3zo). Same transaction, after the raw
+    # delete, so orphaned-ness is computed against the post-delete raw set.
+    deleted_orphaned_authority_plan_count = _delete_orphaned_raw_authority_plans(conn)
     conn.commit()
 
     store = blob_store if blob_store is not None else get_blob_store()
@@ -1729,6 +1830,7 @@ def cleanup_superseded_raw_snapshots(
         deleted_blob_bytes=deleted_blob_bytes,
         skipped_missing_source_count=0,
         skipped_referenced_count=skipped_referenced_count,
+        deleted_orphaned_authority_plan_count=deleted_orphaned_authority_plan_count,
         errors=tuple(errors),
     )
 
@@ -1772,6 +1874,9 @@ def compact_paths_superseded_raw_snapshots(
             deleted_blob_bytes=totals.deleted_blob_bytes + result.deleted_blob_bytes,
             skipped_missing_source_count=totals.skipped_missing_source_count + result.skipped_missing_source_count,
             skipped_referenced_count=totals.skipped_referenced_count + result.skipped_referenced_count,
+            deleted_orphaned_authority_plan_count=(
+                totals.deleted_orphaned_authority_plan_count + result.deleted_orphaned_authority_plan_count
+            ),
             errors=tuple(errors),
         )
     return totals

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -5769,6 +5769,11 @@ def repair_superseded_raw_snapshots(config: Config, dry_run: bool = False) -> Re
         if result.skipped_referenced_count
         else ""
     )
+    orphaned_plan_detail = (
+        f"; pruned {result.deleted_orphaned_authority_plan_count:,} orphaned raw-authority plan(s)"
+        if result.deleted_orphaned_authority_plan_count
+        else ""
+    )
     return _repair_result(
         "superseded_raw_snapshots",
         repaired_count=result.deleted_raw_count,
@@ -5776,7 +5781,8 @@ def repair_superseded_raw_snapshots(config: Config, dry_run: bool = False) -> Re
         detail=(
             f"Deleted {result.deleted_raw_count:,} raw rows and {result.deleted_blob_count:,} blob files "
             f"({result.deleted_blob_bytes:,} bytes)"
-            f"{skipped_detail}" + (f"; errors: {'; '.join(result.errors[:3])}" if result.errors else "")
+            f"{skipped_detail}{orphaned_plan_detail}"
+            + (f"; errors: {'; '.join(result.errors[:3])}" if result.errors else "")
         ),
     )
 

--- a/tests/unit/storage/test_raw_retention.py
+++ b/tests/unit/storage/test_raw_retention.py
@@ -930,6 +930,105 @@ def test_superseded_raw_cleanup_keeps_blob_with_remaining_protected_reference(tm
     )
 
 
+def test_superseded_raw_cleanup_prunes_orphaned_raw_authority_plans(tmp_path: Path) -> None:
+    """polylogue-i3zo: retention's raw delete must not orphan raw_authority_plans.
+
+    ``raw_authority_plans.input_raw_ids_json`` references raws by JSON string,
+    not FK, so deleting a raw here does not cascade-clean a plan naming it.
+    Before the fix, a plan whose every input raw is gone survives the purge and
+    the daemon reconciler's next pass throws RuntimeError("duplicate strategy
+    did not reach its typed terminal postcondition") on the dangling plan
+    (live incident 2026-07-22, ``polylogue/storage/raw_reconciler.py``). This
+    reproduces the exact shape against the real production entry point,
+    :func:`cleanup_superseded_raw_snapshots`: a plan whose only input raw is
+    superseded-and-deleted must be pruned along with it, in the same
+    transaction, while a plan whose input raw survives must be untouched.
+    """
+    db_path = tmp_path / "source.db"
+    source = tmp_path / "rollout.jsonl"
+    source.write_text('{"type":"message"}\n', encoding="utf-8")
+    blob_store = BlobStore(tmp_path / "blob")
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    _ensure_archive_source_schema(conn)
+    conn.execute(
+        """CREATE TABLE raw_authority_plans (
+            plan_id TEXT PRIMARY KEY,
+            input_raw_ids_json TEXT NOT NULL
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE raw_authority_blockers (
+            blocker_id TEXT PRIMARY KEY,
+            plan_id TEXT NOT NULL
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE raw_authority_census_plans (
+            plan_id TEXT NOT NULL
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE raw_authority_census_post_plans (
+            plan_id TEXT NOT NULL
+        )"""
+    )
+
+    full_old, full_old_size = _write_blob(blob_store, b"full-old")
+    full_new, full_new_size = _write_blob(blob_store, b"full-new")
+    _insert_archive_raw_session(
+        conn,
+        raw_id=full_old,
+        source_path=source,
+        source_index=0,
+        blob_hash=full_old,
+        blob_size=full_old_size,
+        acquired_at_ms=1_000,
+    )
+    _insert_archive_raw_session(
+        conn,
+        raw_id=full_new,
+        source_path=source,
+        source_index=0,
+        blob_hash=full_new,
+        blob_size=full_new_size,
+        acquired_at_ms=2_000,
+    )
+
+    # plan-orphan names only the raw about to be deleted (full_old); it must
+    # be pruned. plan-kept names the raw that survives; it must be untouched.
+    conn.execute(
+        "INSERT INTO raw_authority_plans (plan_id, input_raw_ids_json) VALUES ('plan-orphan', ?)",
+        (f'["{full_old}"]',),
+    )
+    conn.execute(
+        "INSERT INTO raw_authority_plans (plan_id, input_raw_ids_json) VALUES ('plan-kept', ?)",
+        (f'["{full_new}"]',),
+    )
+    conn.execute("INSERT INTO raw_authority_blockers (blocker_id, plan_id) VALUES ('blk-orphan', 'plan-orphan')")
+    conn.execute("INSERT INTO raw_authority_census_plans (plan_id) VALUES ('plan-orphan')")
+    conn.execute("INSERT INTO raw_authority_census_post_plans (plan_id) VALUES ('plan-kept')")
+    conn.commit()
+
+    candidates = superseded_raw_snapshot_candidates(conn, limit=100)
+    assert {candidate.raw_id for candidate in candidates} == {full_old}
+
+    result = cleanup_superseded_raw_snapshots(conn, dry_run=False, blob_store=blob_store)
+    assert result.deleted_raw_count == 1
+    assert result.deleted_orphaned_authority_plan_count == 1
+
+    remaining_plans = {str(row[0]) for row in conn.execute("SELECT plan_id FROM raw_authority_plans").fetchall()}
+    assert remaining_plans == {"plan-kept"}
+    assert conn.execute("SELECT COUNT(*) FROM raw_authority_blockers").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM raw_authority_census_plans").fetchone()[0] == 0
+    remaining_post_plans = {
+        str(row[0]) for row in conn.execute("SELECT plan_id FROM raw_authority_census_post_plans").fetchall()
+    }
+    assert remaining_post_plans == {"plan-kept"}
+
+
 def test_archive_cleanup_compacts_append_snapshot_without_session_events(tmp_path: Path) -> None:
     # Archive file-set cleanup simply compacts the superseded append snapshot.
     db_path = tmp_path / "source.db"

--- a/tests/unit/storage/test_raw_retention.py
+++ b/tests/unit/storage/test_raw_retention.py
@@ -931,18 +931,33 @@ def test_superseded_raw_cleanup_keeps_blob_with_remaining_protected_reference(tm
 
 
 def test_superseded_raw_cleanup_prunes_orphaned_raw_authority_plans(tmp_path: Path) -> None:
-    """polylogue-i3zo: retention's raw delete must not orphan raw_authority_plans.
+    """polylogue-i3zo: retention's raw delete must not leak raw_authority_plans,
+    but must never corrupt the immutable census ledger doing so.
 
     ``raw_authority_plans.input_raw_ids_json`` references raws by JSON string,
-    not FK, so deleting a raw here does not cascade-clean a plan naming it.
-    Before the fix, a plan whose every input raw is gone survives the purge and
-    the daemon reconciler's next pass throws RuntimeError("duplicate strategy
-    did not reach its typed terminal postcondition") on the dangling plan
-    (live incident 2026-07-22, ``polylogue/storage/raw_reconciler.py``). This
-    reproduces the exact shape against the real production entry point,
-    :func:`cleanup_superseded_raw_snapshots`: a plan whose only input raw is
-    superseded-and-deleted must be pruned along with it, in the same
-    transaction, while a plan whose input raw survives must be untouched.
+    not FK, so deleting a raw here does not cascade-clean a plan naming it. A
+    plan whose every input raw is gone AND which no census still references is
+    safe to prune outright. But a plan a census still references must be left
+    fully alone: ``raw_authority_censuses.plan_count`` / ``post_plan_count``
+    are immutable per-census totals ``read_raw_authority_census`` uses
+    verbatim for its reported total AND to decide whether pagination has more
+    pages (chatgpt-codex-connector's review on the first version of this fix,
+    PR #3530, flagged that an earlier draft deleted census-membership rows
+    without adjusting those counts, making the total lie and, once a census's
+    rows were all removed, making ``next_query_handle`` reissue forever since
+    the offset advanced by zero). This test proves both halves against the
+    real production entry point, :func:`cleanup_superseded_raw_snapshots`:
+
+    * a plan with zero census references and all-missing inputs is pruned;
+    * a plan a census still references is left untouched even though its
+      only input raw is also superseded-and-deleted, and the census's own
+      ``plan_count`` / actual surviving ``raw_authority_census_plans`` row
+      count for it stay mutually consistent before and after the purge (the
+      ledger-consistency proof the review asked for);
+    * the same holds for a plan referenced only by an unresolved blocker
+      (the durable-obligation case ``prune_raw_authority_census_history``
+      already protects, defended here too even though structurally a
+      blocker should never exist without a paired census_plans row).
     """
     db_path = tmp_path / "source.db"
     source = tmp_path / "rollout.jsonl"
@@ -960,73 +975,112 @@ def test_superseded_raw_cleanup_prunes_orphaned_raw_authority_plans(tmp_path: Pa
         )"""
     )
     conn.execute(
-        """CREATE TABLE raw_authority_blockers (
-            blocker_id TEXT PRIMARY KEY,
-            plan_id TEXT NOT NULL
+        """CREATE TABLE raw_authority_censuses (
+            census_id TEXT PRIMARY KEY,
+            plan_count INTEGER NOT NULL
         )"""
     )
     conn.execute(
         """CREATE TABLE raw_authority_census_plans (
+            census_id TEXT NOT NULL,
             plan_id TEXT NOT NULL
         )"""
     )
     conn.execute(
         """CREATE TABLE raw_authority_census_post_plans (
+            census_id TEXT NOT NULL,
             plan_id TEXT NOT NULL
         )"""
     )
-
-    full_old, full_old_size = _write_blob(blob_store, b"full-old")
-    full_new, full_new_size = _write_blob(blob_store, b"full-new")
-    _insert_archive_raw_session(
-        conn,
-        raw_id=full_old,
-        source_path=source,
-        source_index=0,
-        blob_hash=full_old,
-        blob_size=full_old_size,
-        acquired_at_ms=1_000,
-    )
-    _insert_archive_raw_session(
-        conn,
-        raw_id=full_new,
-        source_path=source,
-        source_index=0,
-        blob_hash=full_new,
-        blob_size=full_new_size,
-        acquired_at_ms=2_000,
-    )
-
-    # plan-orphan names only the raw about to be deleted (full_old); it must
-    # be pruned. plan-kept names the raw that survives; it must be untouched.
     conn.execute(
-        "INSERT INTO raw_authority_plans (plan_id, input_raw_ids_json) VALUES ('plan-orphan', ?)",
-        (f'["{full_old}"]',),
+        """CREATE TABLE raw_authority_blockers (
+            blocker_id TEXT PRIMARY KEY,
+            plan_id TEXT NOT NULL,
+            census_id TEXT NOT NULL,
+            resolved_at_ms INTEGER
+        )"""
+    )
+
+    # Three superseded (about-to-be-deleted) raws, plus one that survives.
+    old_free, old_free_size = _write_blob(blob_store, b"old-free")
+    old_census, old_census_size = _write_blob(blob_store, b"old-census")
+    old_blocker, old_blocker_size = _write_blob(blob_store, b"old-blocker")
+    full_new, full_new_size = _write_blob(blob_store, b"full-new")
+    for raw_id, blob_hash, size, ts in (
+        (old_free, old_free, old_free_size, 1_000),
+        (old_census, old_census, old_census_size, 1_100),
+        (old_blocker, old_blocker, old_blocker_size, 1_200),
+        (full_new, full_new, full_new_size, 2_000),
+    ):
+        _insert_archive_raw_session(
+            conn,
+            raw_id=raw_id,
+            source_path=source,
+            source_index=0,
+            blob_hash=blob_hash,
+            blob_size=size,
+            acquired_at_ms=ts,
+        )
+
+    # plan-free-orphan: all inputs gone, zero census/blocker references -> pruned.
+    # plan-census-orphan: all inputs gone, but still a live census_plans member -> untouched.
+    # plan-blocker-orphan: all inputs gone, no census_plans row but an unresolved
+    #   blocker still names it -> untouched (defensive; structurally shouldn't
+    #   happen, but the guard must hold regardless).
+    # plan-kept: its input raw survives -> untouched (not even an orphan candidate).
+    conn.execute(
+        "INSERT INTO raw_authority_plans (plan_id, input_raw_ids_json) VALUES ('plan-free-orphan', ?)",
+        (f'["{old_free}"]',),
+    )
+    conn.execute(
+        "INSERT INTO raw_authority_plans (plan_id, input_raw_ids_json) VALUES ('plan-census-orphan', ?)",
+        (f'["{old_census}"]',),
+    )
+    conn.execute(
+        "INSERT INTO raw_authority_plans (plan_id, input_raw_ids_json) VALUES ('plan-blocker-orphan', ?)",
+        (f'["{old_blocker}"]',),
     )
     conn.execute(
         "INSERT INTO raw_authority_plans (plan_id, input_raw_ids_json) VALUES ('plan-kept', ?)",
         (f'["{full_new}"]',),
     )
-    conn.execute("INSERT INTO raw_authority_blockers (blocker_id, plan_id) VALUES ('blk-orphan', 'plan-orphan')")
-    conn.execute("INSERT INTO raw_authority_census_plans (plan_id) VALUES ('plan-orphan')")
-    conn.execute("INSERT INTO raw_authority_census_post_plans (plan_id) VALUES ('plan-kept')")
+    conn.execute("INSERT INTO raw_authority_censuses (census_id, plan_count) VALUES ('census-a', 1)")
+    conn.execute(
+        "INSERT INTO raw_authority_census_plans (census_id, plan_id) VALUES ('census-a', 'plan-census-orphan')"
+    )
+    conn.execute(
+        "INSERT INTO raw_authority_blockers (blocker_id, plan_id, census_id, resolved_at_ms) "
+        "VALUES ('blk-1', 'plan-blocker-orphan', 'census-a', NULL)"
+    )
     conn.commit()
 
+    def _census_ledger_consistent() -> bool:
+        header_count = int(
+            conn.execute("SELECT plan_count FROM raw_authority_censuses WHERE census_id = 'census-a'").fetchone()[0]
+        )
+        actual_count = int(
+            conn.execute("SELECT COUNT(*) FROM raw_authority_census_plans WHERE census_id = 'census-a'").fetchone()[0]
+        )
+        return header_count == actual_count
+
+    assert _census_ledger_consistent()  # 1 header count == 1 actual row, before the purge
+
     candidates = superseded_raw_snapshot_candidates(conn, limit=100)
-    assert {candidate.raw_id for candidate in candidates} == {full_old}
+    assert {candidate.raw_id for candidate in candidates} == {old_free, old_census, old_blocker}
 
     result = cleanup_superseded_raw_snapshots(conn, dry_run=False, blob_store=blob_store)
-    assert result.deleted_raw_count == 1
-    assert result.deleted_orphaned_authority_plan_count == 1
+    assert result.deleted_raw_count == 3
+    assert result.deleted_orphaned_authority_plan_count == 1  # only plan-free-orphan
 
     remaining_plans = {str(row[0]) for row in conn.execute("SELECT plan_id FROM raw_authority_plans").fetchall()}
-    assert remaining_plans == {"plan-kept"}
-    assert conn.execute("SELECT COUNT(*) FROM raw_authority_blockers").fetchone()[0] == 0
-    assert conn.execute("SELECT COUNT(*) FROM raw_authority_census_plans").fetchone()[0] == 0
-    remaining_post_plans = {
-        str(row[0]) for row in conn.execute("SELECT plan_id FROM raw_authority_census_post_plans").fetchall()
-    }
-    assert remaining_post_plans == {"plan-kept"}
+    assert remaining_plans == {"plan-census-orphan", "plan-blocker-orphan", "plan-kept"}
+
+    # Ledger consistency (the review's explicit ask): plan_count still matches
+    # the actual surviving raw_authority_census_plans rows for census-a --
+    # nothing this purge did touched census/blocker rows, so pagination over
+    # census-a would still terminate correctly and report a truthful total.
+    assert _census_ledger_consistent()
+    assert conn.execute("SELECT COUNT(*) FROM raw_authority_blockers WHERE resolved_at_ms IS NULL").fetchone()[0] == 1
 
 
 def test_archive_cleanup_compacts_append_snapshot_without_session_events(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Retention-driven raw deletion in `cleanup_superseded_raw_snapshots` (polylogue/storage/raw_retention.py) now prunes `raw_authority_plans` rows that become both raw-orphaned (every input raw gone) AND already census-free (zero remaining rows in `raw_authority_census_plans` / `_post_plans` / `raw_authority_blockers`), in the same transaction as the raw delete.

## Problem
`raw_authority_plans.input_raw_ids_json` references raws by JSON string, not by FK, so nothing cascades when `raw_sessions` rows are deleted. Ref polylogue-i3zo.

**Revision history on this PR**: the first version deleted `raw_authority_census_plans`/`_post_plans`/`raw_authority_blockers` rows for any orphaned plan unconditionally. A real automated review finding (chatgpt-codex-connector, comment [3696483963](https://github.com/Sinity/polylogue/pull/3530#issuecomment-3696483963)) caught that this corrupts the immutable census ledger: `raw_authority_censuses.plan_count`/`post_plan_count` are read verbatim by `read_raw_authority_census` (`polylogue/storage/raw_authority.py`) as both the reported total and the pagination-termination signal (`next_offset < max(total, post_total)`). Deleting a census's plan-membership rows without adjusting those counts makes the total lie, and once a census's rows are all removed, `next_offset` (driven by `len(plans)`, now always 0) stops advancing -- `next_query_handle` is reissued forever. Deleting an unresolved `raw_authority_blockers` row is worse: `prune_raw_authority_census_history` (same module) already treats an unresolved blocker as "a live durable obligation, not history" and refuses to touch it for exactly this reason -- the first draft silently violated that established invariant.

## Solution (revised)
- `_delete_orphaned_raw_authority_plans` no longer deletes from `raw_authority_census_plans`/`_post_plans`/`raw_authority_blockers` at all. It only hard-deletes a `raw_authority_plans` row once it *also* has zero remaining references in all three of those tables.
- This composes with, rather than fights, the existing `prune_raw_authority_census_history` retention path: every `raw_authority_plans` row is inserted in the same transaction as its owning census's `raw_authority_census_plans` row (`record_raw_authority_census`), so a plan can only reach zero census references once that function's own plan-retention window (8 generations, `RAW_AUTHORITY_CENSUS_PLAN_RETENTION`) has already judged its census-plan detail safe to drop -- which it only does once no unresolved blocker remains. This function therefore never advances that judgment early and cannot itself corrupt `plan_count`/`post_plan_count`, because it never deletes the rows those counts describe.
- `RawSnapshotCleanupResult.deleted_orphaned_authority_plan_count` (additive, default 0) reports the count; `repair.py`'s `repair_superseded_raw_snapshots` detail surfaces it when non-zero.

**Design decision, restated**: hard-delete a `raw_authority_plans` row, but *only* once established machinery (the census plan-retention window) has already judged its last remaining references safe to drop. This is stricter than the original hard-delete-on-orphan design and deliberately narrower than the bead's literal "prune every orphaned plan" framing, because the census ledger's immutability invariant takes priority.

**Consequence, stated honestly**: a plan still referenced by an active (`'planned'`, unresolved) census is left untouched by this function even if every raw it names is already gone -- a genuine live obligation is never silently dropped. This differs from the 2026-07-22 live incident cited in the bead, which was caused by a since-deleted one-time repair script (`hook_deinflation.py`) deleting raws out from under an in-flight census apply directly, bypassing retention authority entirely; `cleanup_superseded_raw_snapshots` only ever deletes raws proven superseded via `active_raw_retention_authority`/the file-set recency heuristic, an orthogonal concern from census membership, so it's not expected to reproduce that failure mode. Two follow-ups filed for what this PR deliberately leaves open:
- polylogue-7f8yc: teach the reconciler a typed outcome for "this census plan's raw evidence is already gone" instead of falling through to a generic `RuntimeError`.
- polylogue-4uzoo: the pre-existing (not introduced by this PR) `plan_count`/pagination staleness that `prune_raw_authority_census_history` itself already has once its own plan-retention window elapses and a census header outlives its plan detail. This PR's design was specifically checked to never trigger that bug any earlier than it already fires today, since it never touches `census_plans`/`post_plans` at all.

## Verification
- `devtools test tests/unit/storage/test_raw_retention.py` -- 64 passed. `test_superseded_raw_cleanup_prunes_orphaned_raw_authority_plans` now seeds four plans: one with zero census references (pruned), one still referenced by a live `census_plans` row (untouched -- asserts `raw_authority_censuses.plan_count` still matches the actual surviving `raw_authority_census_plans` row count for that census, before and after the purge: the ledger-consistency proof the review asked for), one referenced only by an unresolved blocker (untouched, defensive), and one whose raw survives (untouched, not even an orphan candidate).
- `devtools test tests/unit/storage/test_repair.py -k superseded` -- 3 passed.
- `devtools verify --quick` -- exit 0 (also ran via the pre-push hook).

Ref polylogue-i3zo.