### PR TITLE
feat(devtools): gate parser/classifier decision-boundary drift

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -1255,6 +1255,25 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         examples=("devtools lab policy schema-versioning", "devtools lab policy schema-versioning --json"),
     ),
     CommandSpec(
+        "lab policy classifier-fingerprints",
+        "verification lab",
+        "Verify parser/classifier decision-boundary changes are declared as reparse-requiring or acknowledged.",
+        "devtools.verify_classifier_fingerprints",
+        use_when=(
+            "Catch the gap `lab policy schema-versioning` cannot see (polylogue-gucv): a parser/classifier "
+            "under polylogue/sources/ or polylogue/archive/artifact_taxonomy/ (looks_like*/classify_artifact* "
+            "functions) changes what it accepts for identical input bytes without any INDEX_SCHEMA_VERSION "
+            "bump at all, so already-indexed rows go silently stale with no signal a reparse was needed "
+            "(PR #3428 shipped exactly this, green, against the version-keyed gate)."
+        ),
+        examples=(
+            "devtools lab policy classifier-fingerprints",
+            "devtools lab policy classifier-fingerprints --json",
+            "devtools lab policy classifier-fingerprints --ack polylogue/sources/parsers/foo.py:looks_like_x "
+            "--reason 'only tightens a shape that never validly matched' --ref polylogue-abcd",
+        ),
+    ),
+    CommandSpec(
         "lab policy backlog-hygiene",
         "verification lab",
         "Verify Beads backlog structure invariants (.beads/issues.jsonl).",

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -1779,6 +1779,13 @@ def build_verify_steps(
                 # failure surfaces as an unqueryable live archive rather than
                 # as a test failure.
                 ("lab policy schema-versioning", _devtools_cmd("lab policy schema-versioning")),
+                # Static, archive-independent, sub-second: catches the gap the
+                # schema-versioning gate above cannot see -- a parser/classifier
+                # changing what it accepts for identical input bytes with no
+                # version bump at all (polylogue-gucv; PR #3428 is the
+                # concrete case that shipped green against the version-keyed
+                # gate above).
+                ("lab policy classifier-fingerprints", _devtools_cmd("lab policy classifier-fingerprints")),
                 # Publication gate. Committed provider schema packages are
                 # public artifacts; this blocks local provenance
                 # (bundle_scopes/representative_paths) and scans for secrets.

--- a/devtools/verify_classifier_fingerprints.py
+++ b/devtools/verify_classifier_fingerprints.py
@@ -1,0 +1,437 @@
+"""Verify classifier/parser decision-boundary drift is declared.
+
+Background
+----------
+
+``devtools lab policy schema-versioning`` (``verify_schema_upgrade_lane.py``)
+enforces the durable-vs-derived schema-evolution policy boundary, but it is
+keyed entirely to ``INDEX_SCHEMA_VERSION``: a version integer. It has no
+visibility into ``polylogue/sources/**`` or
+``polylogue/archive/artifact_taxonomy/**``, where the actual acceptance
+decision for "is this raw payload a session?" is made.
+
+A parser/classifier can change what it accepts for *identical input bytes*
+without touching the index schema version at all. PR #3428 (``ab8a92c1a``,
+"require positive conversation evidence before session classification")
+is the concrete case this lint exists to catch retroactively: it tightened
+``looks_like_record_entry`` and ``looks_like_code`` so that a payload the
+classifier used to admit is now refused (or vice versa), while
+``INDEX_SCHEMA_VERSION`` stayed unchanged and ``lifecycle.py`` gained no new
+declaration. ``devtools lab policy schema-versioning`` ran green on that PR --
+correctly, per its own narrow contract, and uselessly for this defect. Rows
+already indexed under the old classification stayed silently stale with no
+signal that a reparse was ever needed (see ``polylogue-gucv``, ``-9ykn``,
+``-zqph``).
+
+What this lint checks
+----------------------
+
+1. Discover every module-level function under ``polylogue/sources/`` or
+   ``polylogue/archive/artifact_taxonomy/`` whose name matches
+   ``looks_like*`` or ``classify_artifact*`` -- the naming convention this
+   codebase already uses for a payload-shape/acceptance decision (grepped
+   directly; see the functions this module's own tests pin).
+
+2. Fingerprint each one: a SHA-256 hash of its AST (leading docstring
+   excluded, line/column attributes excluded by construction), so
+   reformatting, comment edits, and docstring rewrites do not trip the gate,
+   but any change to the function's actual logic does.
+
+3. Compare against the committed manifest
+   (``docs/plans/classifier-fingerprints.json``). A function whose current
+   fingerprint does not match its manifest entry is *undeclared drift*: the
+   classification boundary moved and nothing says whether that was safe.
+   Undeclared drift fails the gate. It resolves one of two ways, both
+   recorded as manifest metadata:
+
+   * ``semantic_reparse_version`` -- the change ships alongside an
+     ``INDEX_SCHEMA_VERSION`` bump whose ``lifecycle.py`` declaration
+     includes ``DerivedDeltaClass.SEMANTIC_REPARSE`` for that version. The
+     manifest entry names the version; this lint cross-checks it is really
+     declared that way.
+   * ``acknowledged_safe`` -- an explicit, reviewed statement (a reason plus
+     a bead/issue reference) that the change is safe without a reparse, e.g.
+     because it only *tightens* acceptance for a shape that was never validly
+     admitted in the first place. This is the escape hatch the parent bead's
+     acceptance criteria call for when a reparse is judged unnecessary --
+     it must still be an explicit, attributable decision, not silence.
+
+4. A function that disappears from source without its manifest entry being
+   removed (an orphaned entry), or a newly added classifier function with no
+   manifest entry at all, both fail -- the manifest must track exactly the
+   live set of classification-relevant functions.
+
+Scope and false-positive discipline
+------------------------------------
+
+Only functions matching the ``looks_like*`` / ``classify_artifact*`` naming
+convention under the two classification directories are in scope. An
+unrelated refactor elsewhere in ``polylogue/sources/`` (a parser's message
+mapping, cost accounting, attachment handling, ...) never touches a function
+this lint fingerprints, so it never fires. Renaming, reformatting, or
+re-documenting a classifier function without changing its AST shape also
+does not fire (docstrings are stripped before hashing; ``ast.dump`` already
+omits source positions). The known residual false-positive source is a
+behaviour-preserving *local* refactor inside a classifier function itself
+(e.g. renaming a local variable) -- accepted deliberately, because these
+functions are small, rarely touched, and the cost of one extra
+``--ack``/``--semantic-reparse`` run is far lower than another silent
+phantom-classification incident.
+
+Wired into ``devtools verify`` directly (like the schema-versioning lane) --
+static, archive-independent, sub-second.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TypedDict
+
+from devtools import repo_root as _get_root
+from polylogue.storage.sqlite.lifecycle import INDEX_DELTA_DECLARATIONS, DerivedDeltaClass
+
+ROOT = _get_root()
+CLASSIFICATION_ROOTS: tuple[Path, ...] = (
+    ROOT / "polylogue" / "sources",
+    ROOT / "polylogue" / "archive" / "artifact_taxonomy",
+)
+MANIFEST_PATH = ROOT / "docs" / "plans" / "classifier-fingerprints.json"
+
+_NAME_PATTERN = re.compile(r"^(looks_like\w*|classify_artifact\w*)$")
+_REF_PATTERN = re.compile(r"^(polylogue-[a-z0-9][a-z0-9.]*|#\d+)$")
+_MIN_REASON_LEN = 20
+
+
+@dataclass(frozen=True, slots=True)
+class ClassifierFunction:
+    qualname: str
+    path: Path
+    lineno: int
+    fingerprint: str
+
+
+def _fingerprint_function(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    """Hash the AST of a function, excluding its leading docstring."""
+    body = list(node.body)
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body = body[1:]
+    replacement_cls = ast.FunctionDef if isinstance(node, ast.FunctionDef) else ast.AsyncFunctionDef
+    replacement = replacement_cls(
+        name="_",
+        args=node.args,
+        body=body or [ast.Pass()],
+        decorator_list=[],
+        returns=None,
+    )
+    dump = ast.dump(replacement, annotate_fields=True, include_attributes=False)
+    return hashlib.sha256(dump.encode("utf-8")).hexdigest()
+
+
+def collect_classifier_functions(roots: tuple[Path, ...] = CLASSIFICATION_ROOTS) -> dict[str, ClassifierFunction]:
+    """Return every in-scope classification function, keyed by qualname."""
+    found: dict[str, ClassifierFunction] = {}
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except SyntaxError:
+                continue
+            for node in tree.body:
+                if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and _NAME_PATTERN.match(node.name):
+                    rel = path.relative_to(ROOT).as_posix()
+                    qualname = f"{rel}:{node.name}"
+                    found[qualname] = ClassifierFunction(
+                        qualname=qualname,
+                        path=path,
+                        lineno=node.lineno,
+                        fingerprint=_fingerprint_function(node),
+                    )
+    return found
+
+
+CoveredByKind = Literal["semantic_reparse_version", "acknowledged_safe"]
+
+
+@dataclass(frozen=True, slots=True)
+class CoveredBy:
+    kind: CoveredByKind
+    reason: str
+    ref: str
+    version: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestEntry:
+    fingerprint: str
+    covered_by: CoveredBy
+
+
+class ManifestJSON(TypedDict):
+    functions: dict[str, dict[str, object]]
+
+
+def _covered_by_from_dict(data: dict[str, object]) -> CoveredBy:
+    kind_raw = data["kind"]
+    if kind_raw not in ("semantic_reparse_version", "acknowledged_safe"):
+        raise ValueError(f"unknown covered_by kind in manifest: {kind_raw!r}")
+    kind: CoveredByKind = kind_raw
+    version_raw = data.get("version")
+    return CoveredBy(
+        kind=kind,
+        reason=str(data["reason"]),
+        ref=str(data["ref"]),
+        version=int(version_raw) if isinstance(version_raw, int) else None,
+    )
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> dict[str, ManifestEntry]:
+    if not path.exists():
+        return {}
+    raw: ManifestJSON = json.loads(path.read_text(encoding="utf-8"))
+    entries: dict[str, ManifestEntry] = {}
+    for qualname, data in raw.get("functions", {}).items():
+        covered_by_raw = data["covered_by"]
+        assert isinstance(covered_by_raw, dict)
+        entries[qualname] = ManifestEntry(
+            fingerprint=str(data["fingerprint"]),
+            covered_by=_covered_by_from_dict(covered_by_raw),
+        )
+    return entries
+
+
+def save_manifest(entries: dict[str, ManifestEntry], path: Path = MANIFEST_PATH) -> None:
+    payload: ManifestJSON = {
+        "functions": {
+            qualname: {
+                "fingerprint": entry.fingerprint,
+                "covered_by": {
+                    "kind": entry.covered_by.kind,
+                    "reason": entry.covered_by.reason,
+                    "ref": entry.covered_by.ref,
+                    **({"version": entry.covered_by.version} if entry.covered_by.version is not None else {}),
+                },
+            }
+            for qualname, entry in sorted(entries.items())
+        }
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+@dataclass(frozen=True, slots=True)
+class DriftReport:
+    missing: tuple[str, ...]
+    orphaned: tuple[str, ...]
+    drifted: tuple[str, ...]
+    invalid_covered_by: tuple[tuple[str, str], ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.missing and not self.orphaned and not self.drifted and not self.invalid_covered_by
+
+
+def _valid_semantic_reparse_version(version: int) -> bool:
+    for declaration in INDEX_DELTA_DECLARATIONS:
+        if declaration.version == version:
+            return DerivedDeltaClass.SEMANTIC_REPARSE in declaration.classes
+    return False
+
+
+def _validate_covered_by(covered_by: CoveredBy) -> str | None:
+    if len(covered_by.reason.strip()) < _MIN_REASON_LEN:
+        return f"reason too short (must explain why no reparse is required, >= {_MIN_REASON_LEN} chars)"
+    if not _REF_PATTERN.match(covered_by.ref):
+        return "ref must be a bead id (polylogue-xxxx) or issue number (#N)"
+    if covered_by.kind == "semantic_reparse_version":
+        if covered_by.version is None:
+            return "semantic_reparse_version covered_by requires a version"
+        if not _valid_semantic_reparse_version(covered_by.version):
+            return (
+                f"version {covered_by.version} has no SEMANTIC_REPARSE declaration in "
+                "polylogue/storage/sqlite/lifecycle.py INDEX_DELTA_DECLARATIONS"
+            )
+    elif covered_by.kind == "acknowledged_safe":
+        pass
+    else:
+        return f"unknown covered_by kind: {covered_by.kind!r}"
+    return None
+
+
+def compute_drift_report(
+    current: dict[str, ClassifierFunction] | None = None,
+    manifest: dict[str, ManifestEntry] | None = None,
+) -> DriftReport:
+    if current is None:
+        current = collect_classifier_functions()
+    if manifest is None:
+        manifest = load_manifest()
+
+    missing = tuple(sorted(qualname for qualname in current if qualname not in manifest))
+    orphaned = tuple(sorted(qualname for qualname in manifest if qualname not in current))
+    drifted = tuple(
+        sorted(
+            qualname
+            for qualname in current
+            if qualname in manifest and manifest[qualname].fingerprint != current[qualname].fingerprint
+        )
+    )
+    invalid_covered_by: list[tuple[str, str]] = []
+    for qualname, entry in sorted(manifest.items()):
+        if qualname in orphaned or qualname in drifted:
+            # An orphaned/drifted entry's covered_by is stale by construction;
+            # report the structural problem once, not a redundant validation.
+            continue
+        problem = _validate_covered_by(entry.covered_by)
+        if problem is not None:
+            invalid_covered_by.append((qualname, problem))
+
+    return DriftReport(
+        missing=missing,
+        orphaned=orphaned,
+        drifted=drifted,
+        invalid_covered_by=tuple(invalid_covered_by),
+    )
+
+
+def _format_report(report: DriftReport) -> str:
+    lines = [
+        f"classification functions missing a manifest entry: {len(report.missing)}",
+        f"stale manifest entries (function no longer exists): {len(report.orphaned)}",
+        f"classification functions with undeclared fingerprint drift: {len(report.drifted)}",
+        f"manifest entries with an invalid covered_by declaration: {len(report.invalid_covered_by)}",
+    ]
+    if report.missing:
+        lines.append("")
+        lines.append("New classification functions with no manifest entry:")
+        for qualname in report.missing:
+            lines.append(f"  {qualname}")
+        lines.append(
+            "  Fix: devtools lab policy classifier-fingerprints --ack <qualname> --reason '...' --ref <bead-or-issue>"
+        )
+    if report.orphaned:
+        lines.append("")
+        lines.append("Manifest entries whose function no longer exists (remove them):")
+        for qualname in report.orphaned:
+            lines.append(f"  {qualname}")
+        lines.append(f"  Fix: edit {MANIFEST_PATH.relative_to(ROOT)} and delete the stale entry.")
+    if report.drifted:
+        lines.append("")
+        lines.append(
+            "Classification functions whose logic changed without a declared reparse "
+            "or acknowledgment (a parser/classifier decision boundary moved for identical "
+            "input bytes -- see devtools/verify_classifier_fingerprints.py's module docstring):"
+        )
+        for qualname in report.drifted:
+            lines.append(f"  {qualname}")
+        lines.append(
+            "  Fix: either bump INDEX_SCHEMA_VERSION with a declared SEMANTIC_REPARSE delta "
+            "and run `devtools lab policy classifier-fingerprints --ack <qualname> "
+            "--semantic-reparse <N> --reason '...' --ref <bead-or-issue>`, or record an explicit "
+            "safety acknowledgment with `devtools lab policy classifier-fingerprints --ack <qualname> "
+            "--reason '...' --ref <bead-or-issue>`."
+        )
+    if report.invalid_covered_by:
+        lines.append("")
+        lines.append("Manifest entries with an invalid covered_by declaration:")
+        for qualname, problem in report.invalid_covered_by:
+            lines.append(f"  {qualname}: {problem}")
+    if report.ok:
+        lines.append("")
+        lines.append("Classifier fingerprint policy intact.")
+    return "\n".join(lines)
+
+
+def _cmd_ack(qualname: str, *, reason: str, ref: str, semantic_reparse_version: int | None) -> int:
+    current = collect_classifier_functions()
+    if qualname not in current:
+        print(f"error: {qualname!r} is not a currently discovered classification function", file=sys.stderr)
+        return 2
+    manifest = load_manifest()
+    covered_by = CoveredBy(
+        kind="semantic_reparse_version" if semantic_reparse_version is not None else "acknowledged_safe",
+        reason=reason,
+        ref=ref,
+        version=semantic_reparse_version,
+    )
+    problem = _validate_covered_by(covered_by)
+    if problem is not None:
+        print(f"error: {problem}", file=sys.stderr)
+        return 2
+    manifest[qualname] = ManifestEntry(fingerprint=current[qualname].fingerprint, covered_by=covered_by)
+    save_manifest(manifest)
+    print(f"recorded {qualname} ({covered_by.kind})")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    parser.add_argument(
+        "--ack",
+        metavar="QUALNAME",
+        help="record an acknowledged_safe (or, with --semantic-reparse, semantic_reparse_version) "
+        "manifest entry for a classification function at its current fingerprint",
+    )
+    parser.add_argument("--reason", help="justification text for --ack (required with --ack)")
+    parser.add_argument("--ref", help="bead id (polylogue-xxxx) or issue number (#N) for --ack (required with --ack)")
+    parser.add_argument(
+        "--semantic-reparse",
+        dest="semantic_reparse_version",
+        type=int,
+        metavar="VERSION",
+        help="with --ack: record semantic_reparse_version covered_by instead of acknowledged_safe",
+    )
+    args = parser.parse_args(argv)
+
+    if args.ack:
+        if not args.reason or not args.ref:
+            parser.error("--ack requires --reason and --ref")
+        return _cmd_ack(
+            args.ack,
+            reason=args.reason,
+            ref=args.ref,
+            semantic_reparse_version=args.semantic_reparse_version,
+        )
+
+    report = compute_drift_report()
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "missing": list(report.missing),
+                    "orphaned": list(report.orphaned),
+                    "drifted": list(report.drifted),
+                    "invalid_covered_by": [
+                        {"qualname": qualname, "problem": problem} for qualname, problem in report.invalid_covered_by
+                    ],
+                    "ok": report.ok,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(_format_report(report))
+
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/devtools/verify_classifier_fingerprints.py
+++ b/devtools/verify_classifier_fingerprints.py
@@ -132,7 +132,7 @@ def _fingerprint_function(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
         name="_",
         args=node.args,
         body=body or [ast.Pass()],
-        decorator_list=[],
+        decorator_list=node.decorator_list,
         returns=None,
     )
     dump = ast.dump(replacement, annotate_fields=True, include_attributes=False)
@@ -148,7 +148,7 @@ def collect_classifier_functions(roots: tuple[Path, ...] = CLASSIFICATION_ROOTS)
         for path in sorted(root.rglob("*.py")):
             try:
                 tree = ast.parse(path.read_text(encoding="utf-8"))
-            except SyntaxError:
+            except (SyntaxError, UnicodeDecodeError):
                 continue
             for node in tree.body:
                 if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and _NAME_PATTERN.match(node.name):

--- a/devtools/verify_schema_upgrade_lane.py
+++ b/devtools/verify_schema_upgrade_lane.py
@@ -41,6 +41,17 @@ with in-place upgrades; it does not try to infer arbitrary SQL patches.
 Wired into ``devtools verify --lab`` rather than the fast default path
 because the policy boundary is a lab/architectural concern, not a
 per-edit gate.
+
+**Out of scope (polylogue-gucv):** this lint is keyed entirely to
+``INDEX_SCHEMA_VERSION``. It has no visibility into whether a parser or
+classifier under ``polylogue/sources/`` or
+``polylogue/archive/artifact_taxonomy/`` changed what it accepts for
+identical input bytes -- that reparse-requiring drift can land with no
+version bump at all, so this lint runs green while already-indexed rows go
+silently stale (PR #3428 is the confirmed case). See
+``devtools/verify_classifier_fingerprints.py`` (``devtools lab policy
+classifier-fingerprints``), which fingerprints those functions directly. A
+green run of *this* lint is not evidence that no reparse is needed.
 """
 
 from __future__ import annotations

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -141,6 +141,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools lab policy backlog-hygiene` | Verify Beads backlog structure invariants (.beads/issues.jsonl). |
 | `devtools lab policy bead-graph` | Bead-graph invariant lint over live `bd` state (cycles, wave labels/inversions, missing AC). |
 | `devtools lab policy campaign-archive-boundaries` | Verify devtools synthetic benchmark/scale campaigns route through ArchiveLocation. |
+| `devtools lab policy classifier-fingerprints` | Verify parser/classifier decision-boundary changes are declared as reparse-requiring or acknowledged. |
 | `devtools lab policy demo-packet-registry` | Verify every registered 212 demo has a conforming Demo Finding Packet. |
 | `devtools lab policy demo-tour-freshness` | Verify a freshly-run demo tour matches the committed docs/examples/demo-tour/ evidence artifacts. |
 | `devtools lab policy docs-drift` | Verify checkable factual claims in the Reference-docs table against current source. |

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -174,7 +174,19 @@ Polylogue has two schema-evolution regimes, keyed by tier durability.
   batched before a live rebuild so the active archive is not reset repeatedly.
 - `devtools lab policy schema-versioning` enforces the boundary: durable SQL
   migrations are allowed only under the numbered migration resource roots, while
-  derived-tier upgrade helpers remain forbidden.
+  derived-tier upgrade helpers remain forbidden. **This check is keyed to
+  `INDEX_SCHEMA_VERSION` and cannot see parser/classifier drift** -- a
+  `looks_like*`/`classify_artifact*` function under `polylogue/sources/` or
+  `polylogue/archive/artifact_taxonomy/` can change what it accepts for
+  identical input bytes with no version bump at all, running this lint green
+  while already-indexed rows silently go stale (polylogue-gucv; PR #3428 is
+  the confirmed case). `devtools lab policy classifier-fingerprints`
+  (`devtools/verify_classifier_fingerprints.py`) closes that gap: it AST-
+  fingerprints every in-scope classifier function against a committed
+  manifest (`docs/plans/classifier-fingerprints.json`) and fails on
+  undeclared drift, requiring either a `SEMANTIC_REPARSE`-declared version
+  bump or an explicit `acknowledged_safe` justification recorded in the
+  manifest.
 
 - User schema version 7 adds durable content-addressed `queries`, mutable
   `query_names`, promoted `result_sets`/`result_set_members`, and planner

--- a/docs/plans/classifier-fingerprints.json
+++ b/docs/plans/classifier-fingerprints.json
@@ -1,0 +1,292 @@
+{
+  "functions": {
+    "polylogue/archive/artifact_taxonomy/runtime.py:classify_artifact": {
+      "fingerprint": "e2c3110262b968d54943e91403e7c2fde02d9f893e6738f3900ebcee77f625c1",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/archive/artifact_taxonomy/runtime.py:classify_artifact_path": {
+      "fingerprint": "10f54d1827fdca585985cf3180e54c27098de26121530076e51a26cef7b2de24",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/archive/artifact_taxonomy/support.py:looks_like_beads_interaction": {
+      "fingerprint": "ca8524db458408ef6a18bcc4a4f91d811e436fa9d2fdd7f6a109d9c602343c35",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/archive/artifact_taxonomy/support.py:looks_like_hook_event": {
+      "fingerprint": "9f5c4061bae7c70195d55fcd8d02a461009f62a11cd082ed6eb8e47bc3ca34f8",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/archive/artifact_taxonomy/support.py:looks_like_hook_event_stream": {
+      "fingerprint": "03fdb9a9d03cda22fc81907e765ecd2bff30a8d3c0e07270c139e062cd4a056a",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/archive/artifact_taxonomy/support.py:looks_like_message_entry": {
+      "fingerprint": "797d7d85a75d45baf5cbda223f081ede31e9c086c52525ff37d594c52f204075",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/archive/artifact_taxonomy/support.py:looks_like_record_entry": {
+      "fingerprint": "99a3dbdeb5b420b5e9059d965f6e8749860d7d9b637fdb0bf9efcbb369f69784",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "PR #3428 (ab8a92c1a) tightened this without an INDEX_SCHEMA_VERSION bump; retroactively acknowledged. Existing misclassified rows tracked by the repair pass.",
+        "ref": "polylogue-zqph"
+      }
+    },
+    "polylogue/archive/artifact_taxonomy/support.py:looks_like_record_stream": {
+      "fingerprint": "f717bdffdfd50a5aefa11d0f9a5c147bfa5e71a1bd57973c6dd2b25141db6ed1",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/archive/artifact_taxonomy/support.py:looks_like_session_document": {
+      "fingerprint": "3c0e09f04a43fbae1b84a8b08a0659fe723714548c31a0b89cb1612757664844",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/antigravity.py:looks_like_brain_metadata": {
+      "fingerprint": "5e80c04e8f9e78920d1bbbd16d1698a330e6e3ccdc2373ae4b9f17fefa144e3a",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/antigravity.py:looks_like_markdown_export": {
+      "fingerprint": "90525b09e2883d8b3093a20ae5f0ae12bc4040d3ab6f763fa794fceb44e8f920",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/beads.py:looks_like": {
+      "fingerprint": "9608a73247813b989ac6e857c374eea112d8f0f342da376a23530cd5ba293079",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/browser_capture.py:looks_like": {
+      "fingerprint": "7b6ca34dac7d1d9a9ca4ddade693396d217a07288e5d1c442f7e56a7cbae9aeb",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/chatgpt.py:looks_like": {
+      "fingerprint": "01785fab9f2de11eda09cf4ed017bacc8f427987962e5f79b72b8c783b9e48fc",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/chatgpt.py:looks_like_fragment": {
+      "fingerprint": "382354bf93637c22bfcec6fc80b9f09b7f040687b97cdd7b1b5ab0c5aefefdb1",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/chatgpt_codex_sidecar.py:looks_like": {
+      "fingerprint": "273bc13adae90435566dc75ef802a83beae650e03894a2146e44e897394dc8d9",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/claude/__init__.py:looks_like_ai": {
+      "fingerprint": "4f2c5a0787adfe9647e40238d43efbe035ae87645fb7b2de2201d4bd460d5499",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/claude/ai_parser.py:looks_like_ai": {
+      "fingerprint": "e5886ec01e23439d5a02ce5515e80de2695c483cd0fe2f0e843c52d504debaa9",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/claude/ai_parser.py:looks_like_claude_design": {
+      "fingerprint": "bd03581f209d7ade36485652ccb863d1652adf05abc8b14332cebcd25ce8779e",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/claude/ai_parser.py:looks_like_claude_memories": {
+      "fingerprint": "a6c6a33039f82b0329eb88c54a7614be7881068812e4e030f1b55bcb610ced5f",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/claude/code_detection.py:looks_like_code": {
+      "fingerprint": "ed3bdb0d2d5414198aba472a62e0ae466307eefb84a728103ad3d7c96324b734",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "PR #3428 (ab8a92c1a) tightened this without an INDEX_SCHEMA_VERSION bump; retroactively acknowledged. Existing misclassified rows tracked by the repair pass.",
+        "ref": "polylogue-zqph"
+      }
+    },
+    "polylogue/sources/parsers/codex.py:looks_like": {
+      "fingerprint": "d552a69c42b30ac6eca88642668d53d1005cf884b6547f7c7839c0b740d09852",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/codex_state.py:looks_like_state_db_payload": {
+      "fingerprint": "9b053731eba94db843149fc65f7ceb1766db882d1a122784489b5b115a39eb93",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/drive.py:looks_like": {
+      "fingerprint": "181729c514fdd5b45ede6223c4093caf7c90d3d2dd84673838f33b8e141dbe76",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/drive.py:looks_like_chunk": {
+      "fingerprint": "3ba252b8c1f859e351ee54eb6651e8d96d1f8b757df9fd260aed7aad37f4ed49",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/grok.py:looks_like_conversation": {
+      "fingerprint": "330f18d22cf6faf5d56bc7b5e051f70036720d9f2b803693b01ed0b00b7afbe3",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/grok.py:looks_like_export": {
+      "fingerprint": "de586e71c6bebdb4f703e33a7754c32c3600098ec100e6ffbfdea83ab2d8eb07",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/hermes_spans.py:looks_like_atif_payload": {
+      "fingerprint": "c8297259d89eec1adec78f5f229ad252d0accefc81d53e04ba916f77c06bb0cb",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/hermes_spans.py:looks_like_atof_payload": {
+      "fingerprint": "41b75f1be8f76d56f5d46104c371ea55ce1867744c97d65ee64a95c77e155649",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/hermes_state.py:looks_like_state_db_path": {
+      "fingerprint": "afbeb93cabf5d6f6e41e2bac0c9d19919e46c01b720fa190b94ae4659a1e5d0f",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/hermes_state.py:looks_like_state_db_payload": {
+      "fingerprint": "0d4ab96a369419e5487fe1a80b6df03eec779527121dd8ed6d0c3084409a869b",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/hermes_verification.py:looks_like_verification_evidence_db_path": {
+      "fingerprint": "afbeb93cabf5d6f6e41e2bac0c9d19919e46c01b720fa190b94ae4659a1e5d0f",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/hermes_verification.py:looks_like_verification_evidence_db_payload": {
+      "fingerprint": "a639334d5ba5ca66247f53ea40944271b5893139ae794a25cfed4b5272e540a3",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/local_agent.py:looks_like_gemini_cli": {
+      "fingerprint": "7fc8e19b0ba0058d8fb1b8606ad4560e810ecf0b4c7356b191b9152e507bff9c",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/parsers/local_agent.py:looks_like_hermes": {
+      "fingerprint": "1bc55fdde8189754f9b69c8ddd4f77735e514625e7b1c8486f18fa932246c9ea",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    },
+    "polylogue/sources/sqlite_snapshot.py:looks_like_sqlite_bytes": {
+      "fingerprint": "7227970ea3a74e682e66b15727a477325ab759563a407e633e3c38957748b487",
+      "covered_by": {
+        "kind": "acknowledged_safe",
+        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
+        "ref": "polylogue-gucv"
+      }
+    }
+  }
+}

--- a/tests/unit/devtools/test_verify_classifier_fingerprints.py
+++ b/tests/unit/devtools/test_verify_classifier_fingerprints.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import ast
+import json
+import subprocess
+
+import pytest
+
+from devtools import verify_classifier_fingerprints as vcf
+
+_CLAUDE_CODE_QUALNAME = "polylogue/sources/parsers/claude/code_detection.py:looks_like_code"
+_RECORD_ENTRY_QUALNAME = "polylogue/archive/artifact_taxonomy/support.py:looks_like_record_entry"
+
+
+def test_live_repo_classifier_fingerprint_manifest_is_current(capsys: pytest.CaptureFixture[str]) -> None:
+    """The committed manifest matches the live repo state: no missing/orphaned/drifted entries."""
+    assert vcf.main(["--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["missing"] == []
+    assert payload["orphaned"] == []
+    assert payload["drifted"] == []
+    assert payload["invalid_covered_by"] == []
+
+
+def test_manifest_covers_the_pr_3428_functions() -> None:
+    """Anti-vacuity: the two functions PR #3428 actually changed are tracked."""
+    manifest = vcf.load_manifest()
+    assert _CLAUDE_CODE_QUALNAME in manifest
+    assert _RECORD_ENTRY_QUALNAME in manifest
+
+
+def test_collect_classifier_functions_only_matches_looks_like_and_classify_artifact_names() -> None:
+    functions = vcf.collect_classifier_functions()
+    assert functions, "expected at least one classification function to be discovered"
+    for qualname in functions:
+        _, _, name = qualname.rpartition(":")
+        assert name.startswith("looks_like") or name.startswith("classify_artifact")
+
+
+def test_fingerprint_ignores_docstring_and_formatting_changes() -> None:
+    src_a = '''
+def looks_like_x(payload):
+    """Original docstring."""
+    return "a" in payload
+'''
+    src_b = '''
+def looks_like_x(payload):
+    """A totally different docstring, reworded for clarity."""
+    return (
+        "a"
+        in
+        payload
+    )
+'''
+    fn_a = ast.parse(src_a).body[0]
+    fn_b = ast.parse(src_b).body[0]
+    assert isinstance(fn_a, ast.FunctionDef)
+    assert isinstance(fn_b, ast.FunctionDef)
+    assert vcf._fingerprint_function(fn_a) == vcf._fingerprint_function(fn_b)
+
+
+def test_fingerprint_changes_when_logic_changes() -> None:
+    src_a = "def looks_like_x(payload):\n    return 'a' in payload\n"
+    src_b = "def looks_like_x(payload):\n    return 'a' in payload or 'b' in payload\n"
+    fn_a = ast.parse(src_a).body[0]
+    fn_b = ast.parse(src_b).body[0]
+    assert isinstance(fn_a, ast.FunctionDef)
+    assert isinstance(fn_b, ast.FunctionDef)
+    assert vcf._fingerprint_function(fn_a) != vcf._fingerprint_function(fn_b)
+
+
+def test_undeclared_drift_fails_and_declared_drift_passes() -> None:
+    current = {
+        "mod.py:looks_like_x": vcf.ClassifierFunction(
+            qualname="mod.py:looks_like_x", path=vcf.ROOT / "mod.py", lineno=1, fingerprint="new-hash"
+        )
+    }
+    undeclared_manifest: dict[str, vcf.ManifestEntry] = {
+        "mod.py:looks_like_x": vcf.ManifestEntry(
+            fingerprint="old-hash",
+            covered_by=vcf.CoveredBy(kind="acknowledged_safe", reason="prior unrelated acknowledgment", ref="#1"),
+        )
+    }
+    report = vcf.compute_drift_report(current=current, manifest=undeclared_manifest)
+    assert report.ok is False
+    assert "mod.py:looks_like_x" in report.drifted
+
+    declared_manifest: dict[str, vcf.ManifestEntry] = {
+        "mod.py:looks_like_x": vcf.ManifestEntry(
+            fingerprint="new-hash",
+            covered_by=vcf.CoveredBy(kind="acknowledged_safe", reason="prior unrelated acknowledgment", ref="#1"),
+        )
+    }
+    ok_report = vcf.compute_drift_report(current=current, manifest=declared_manifest)
+    assert ok_report.ok is True
+
+
+def test_missing_and_orphaned_entries_fail() -> None:
+    current = {
+        "mod.py:looks_like_new": vcf.ClassifierFunction(
+            qualname="mod.py:looks_like_new", path=vcf.ROOT / "mod.py", lineno=1, fingerprint="hash-1"
+        )
+    }
+    manifest = {
+        "mod.py:looks_like_gone": vcf.ManifestEntry(
+            fingerprint="hash-2",
+            covered_by=vcf.CoveredBy(kind="acknowledged_safe", reason="an old, now-removed classifier", ref="#2"),
+        )
+    }
+    report = vcf.compute_drift_report(current=current, manifest=manifest)
+    assert report.missing == ("mod.py:looks_like_new",)
+    assert report.orphaned == ("mod.py:looks_like_gone",)
+    assert report.ok is False
+
+
+def test_semantic_reparse_covered_by_must_reference_a_real_declared_version() -> None:
+    current = {
+        "mod.py:looks_like_x": vcf.ClassifierFunction(
+            qualname="mod.py:looks_like_x", path=vcf.ROOT / "mod.py", lineno=1, fingerprint="hash-1"
+        )
+    }
+    manifest = {
+        "mod.py:looks_like_x": vcf.ManifestEntry(
+            fingerprint="hash-1",
+            covered_by=vcf.CoveredBy(
+                kind="semantic_reparse_version",
+                reason="declared alongside a version bump that does not exist",
+                ref="polylogue-zzzz",
+                version=999_999,
+            ),
+        )
+    }
+    report = vcf.compute_drift_report(current=current, manifest=manifest)
+    assert report.ok is False
+    assert any(qualname == "mod.py:looks_like_x" for qualname, _ in report.invalid_covered_by)
+
+
+def test_covered_by_reason_and_ref_shape_are_validated() -> None:
+    too_short_reason = vcf.CoveredBy(kind="acknowledged_safe", reason="short", ref="polylogue-abcd")
+    assert vcf._validate_covered_by(too_short_reason) is not None
+
+    bad_ref = vcf.CoveredBy(
+        kind="acknowledged_safe", reason="a long enough explanation of safety", ref="not-a-real-ref"
+    )
+    assert vcf._validate_covered_by(bad_ref) is not None
+
+    good = vcf.CoveredBy(kind="acknowledged_safe", reason="a long enough explanation of safety", ref="polylogue-abcd")
+    assert vcf._validate_covered_by(good) is None
+
+
+def test_gate_would_have_caught_pr_3428_classifier_drift_regression() -> None:
+    """Historical regression check (polylogue-gucv verification requirement).
+
+    Reconstructs the manifest state as if this gate had existed the day
+    before PR #3428 (ab8a92c1a) landed -- pinning ``looks_like_code``'s
+    pre-PR fingerprint -- and asserts the gate flags undeclared drift
+    against the current (post-PR) source, proving this lint would have
+    failed that PR green today.
+    """
+    old_source = subprocess.run(
+        ["git", "show", "ab8a92c1a~1:polylogue/sources/parsers/claude/code_detection.py"],
+        cwd=vcf.ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    old_tree = ast.parse(old_source)
+    old_fn = next(
+        node for node in old_tree.body if isinstance(node, ast.FunctionDef) and node.name == "looks_like_code"
+    )
+    old_fingerprint = vcf._fingerprint_function(old_fn)
+
+    current = vcf.collect_classifier_functions()
+    assert _CLAUDE_CODE_QUALNAME in current
+    assert current[_CLAUDE_CODE_QUALNAME].fingerprint != old_fingerprint, (
+        "PR #3428 is expected to have changed looks_like_code's classification logic"
+    )
+
+    manifest = dict(vcf.load_manifest())
+    manifest[_CLAUDE_CODE_QUALNAME] = vcf.ManifestEntry(
+        fingerprint=old_fingerprint,
+        covered_by=manifest[_CLAUDE_CODE_QUALNAME].covered_by,
+    )
+
+    report = vcf.compute_drift_report(current=current, manifest=manifest)
+    assert _CLAUDE_CODE_QUALNAME in report.drifted
+    assert report.ok is False

--- a/tests/unit/devtools/test_verify_classifier_fingerprints.py
+++ b/tests/unit/devtools/test_verify_classifier_fingerprints.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import json
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -68,6 +69,23 @@ def test_fingerprint_changes_when_logic_changes() -> None:
     assert isinstance(fn_a, ast.FunctionDef)
     assert isinstance(fn_b, ast.FunctionDef)
     assert vcf._fingerprint_function(fn_a) != vcf._fingerprint_function(fn_b)
+
+
+def test_fingerprint_changes_when_a_decorator_is_added() -> None:
+    src_a = "def looks_like_x(payload):\n    return 'a' in payload\n"
+    src_b = "@functools.lru_cache\ndef looks_like_x(payload):\n    return 'a' in payload\n"
+    fn_a = ast.parse(src_a).body[0]
+    fn_b = ast.parse(src_b).body[0]
+    assert isinstance(fn_a, ast.FunctionDef)
+    assert isinstance(fn_b, ast.FunctionDef)
+    assert vcf._fingerprint_function(fn_a) != vcf._fingerprint_function(fn_b)
+
+
+def test_collect_classifier_functions_skips_undecodable_file(tmp_path: Path) -> None:
+    bad_file = tmp_path / "broken.py"
+    bad_file.write_bytes(b"def looks_like_x(payload):\n    return b'\xff\xfe' in payload\n")
+    found = vcf.collect_classifier_functions(roots=(tmp_path,))
+    assert not found
 
 
 def test_undeclared_drift_fails_and_declared_drift_passes() -> None:


### PR DESCRIPTION
## Summary

Adds `devtools lab policy classifier-fingerprints`, a new static verification gate that detects when a parser/classifier's acceptance decision changes for identical input bytes without a declared reparse. This closes the gap named in polylogue-gucv: the existing schema-versioning lint is keyed entirely to a version integer and cannot see this class of change.

## Problem

`devtools lab policy schema-versioning` (`devtools/verify_schema_upgrade_lane.py`) enforces the durable-vs-derived schema evolution policy boundary, but every one of its four checks reads from `INDEX_SCHEMA_VERSION` or `lifecycle.py`'s version-keyed declarations. It has zero visibility into `polylogue/sources/**` or `polylogue/archive/artifact_taxonomy/**`, where the actual "is this raw payload a session?" decision is made.

PR #3428 (`ab8a92c1a`, "require positive conversation evidence before session classification") is the confirmed case: it tightened `looks_like_record_entry` and `looks_like_code` so that a payload the classifier used to admit is now refused, for identical bytes. `INDEX_SCHEMA_VERSION` stayed unchanged, `lifecycle.py` gained no new declaration, and `devtools lab policy schema-versioning` ran green — correctly per its own contract, uselessly for this defect. Already-indexed rows under the old classification went silently stale with no signal a reparse was ever needed. CLAUDE.md's own claim ("a bump without a declaration is a policy violation") only holds for the version-bump case; a same-version classifier change bypasses it entirely.

Related, not duplicated: polylogue-9rw0 owns the fast-forward/equivalence-proof mechanism (its own notes already concede "parser-content drift is NOT covered"); polylogue-zqph owns the data-side repair of the ~5,257 existing phantom rows. This PR is the missing gate only.

## Solution

`devtools/verify_classifier_fingerprints.py`:

1. Discovers every module-level function under the two classification directories whose name matches `looks_like*` or `classify_artifact*` (36 functions currently — the exact naming convention this codebase already uses for payload-shape/acceptance decisions).
2. Fingerprints each one as a SHA-256 hash of its AST with the leading docstring stripped, so reformatting, comment edits, and docstring rewrites never trip the gate, but a change to the function's actual logic always does.
3. Compares against a committed manifest (`docs/plans/classifier-fingerprints.json`). A fingerprint mismatch is *undeclared drift* and fails the gate unless the manifest entry names one of:
   - `semantic_reparse_version` — an `INDEX_SCHEMA_VERSION` bump whose `lifecycle.py` declaration actually carries `SEMANTIC_REPARSE` for that version (cross-checked against `INDEX_DELTA_DECLARATIONS`, not just asserted).
   - `acknowledged_safe` — an explicit reason (≥20 chars) plus a bead/issue ref (`polylogue-xxxx` or `#N`), for cases judged safe without a reparse (e.g. only tightening a shape that never validly matched).
4. A brand-new classifier function with no manifest entry, or a manifest entry whose function no longer exists, both fail — the manifest must track exactly the live set.

A `--ack <qualname> --reason ... --ref ... [--semantic-reparse N]` maintenance mode upserts a manifest entry at the function's current fingerprint after validating the covered_by shape.

Wired into `devtools verify`'s default (non-`--commit`) path immediately next to `lab policy schema-versioning` — static, archive-independent, sub-second (0.61s measured).

The initial manifest bootstraps all 36 discovered functions as `acknowledged_safe`. The two functions PR #3428 actually changed (`looks_like_record_entry`, `looks_like_code`) are acknowledged with a reason naming that PR and a ref to polylogue-zqph, which owns the existing-row repair — this PR does not touch live data or trigger a reindex.

Both `devtools/verify_schema_upgrade_lane.py`'s module docstring and `docs/internals.md`'s Schema Versioning Model section now state the scope gap explicitly, per the bead's AC: a green `lab policy schema-versioning` run is no longer readable as "no reparse needed" without checking the classifier-fingerprint gate too.

## Verification

- `devtools test tests/unit/devtools/test_verify_classifier_fingerprints.py` — 10 passed, including a historical regression test that reconstructs the pre-PR-#3428 manifest state (`git show ab8a92c1a~1:polylogue/sources/parsers/claude/code_detection.py`, fingerprinted the same way) and asserts the new gate flags `looks_like_code` as undeclared drift — proving this gate would have caught PR #3428 before it landed.
- `mypy` on the new module and test file: `Success: no issues found in 2 source files`.
- `ruff format --check` / `ruff check` on all changed files: clean.
- `devtools render all --check`: no `out of sync` lines.
- `devtools verify closure-matrix`: `closure-matrix: clean (33 domains)`.
- `devtools verify --quick`: full local static gate, `exit_code: 0`, including the new `lab policy classifier-fingerprints` step (0.61s). Re-ran automatically and passed again via the pre-push hook.

Not run: the heavy `devtools test tests/unit` full suite (per-PR CI convention skips it; this change touches only `devtools/` + one new test file, no `polylogue/` runtime module, so the topology projection did not need regeneration).

Ref polylogue-gucv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a classifier-fingerprint policy check to the verification lab.
  - Detects missing, orphaned, invalid, or changed classifier fingerprints.
  - Supports JSON reporting and recording acknowledged fingerprints.

- **Documentation**
  - Documented classifier-fingerprint verification, acknowledgment requirements, and schema-check limitations.
  - Added the new command to the developer tools catalog.

- **Tests**
  - Added comprehensive coverage for fingerprint discovery, drift detection, manifest validation, and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->