### PR TITLE
feat(storage): dedup Claude Code sidecar text via the blob store

### DIFF
--- a/docs/plans/hash-boundary-registry.yaml
+++ b/docs/plans/hash-boundary-registry.yaml
@@ -584,6 +584,12 @@ entries:
   occurrence: 0
   classification: content-hash
   note: 'per-event content payload feeding event_contents, an explicit per-event-type ALLOWLIST of content-bearing fields rather than a denylist of fields discovered volatile after the fact (polylogue-aggz, polylogue-nuec).'
+- path: polylogue/pipeline/services/ingest_batch/_core.py
+  function: '<module>._preacquire_sidecar_blobs'
+  call: hashlib.sha256
+  occurrence: 0
+  classification: content-hash
+  note: 'precomputed hash checked against ArchiveBlobPublisher.exists() to decide new-vs-deduplicated before publishing acquired Claude Code tool-result sidecar text as a blob (polylogue-rujy AC4); the actual write still re-hashes via write_from_bytes, this is a real drift/dedup decision, not identifier-only.'
 - path: polylogue/scenarios/workload.py
   function: '<module>._identity'
   call: hashlib.sha256

--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -11,10 +11,12 @@ Architecture:
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import os
 import pickle
 import sqlite3
 import time
+import unicodedata
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from concurrent.futures import FIRST_COMPLETED, Future, wait
 from contextlib import AsyncExitStack, closing
@@ -25,7 +27,7 @@ from typing import TYPE_CHECKING, Protocol, cast
 
 from polylogue.archive.ingest_flags import DOM_FALLBACK_INGEST_FLAG, NATIVE_BROWSER_CAPTURE_FLAGS
 from polylogue.archive.write_gateway import ArchiveWriteGateway, WriteOperation
-from polylogue.core.enums import Provider
+from polylogue.core.enums import BlockType, Provider
 from polylogue.core.memory import release_process_memory
 from polylogue.core.metrics import (
     read_current_rss_mb,
@@ -422,6 +424,92 @@ def _incoming_write_regresses_attachment_coverage(
     return incoming_acquired < existing_acquired
 
 
+def _preacquire_sidecar_blobs(
+    session_to_write: ParsedSession,
+    blob_publisher: ArchiveBlobPublisher,
+    publication_receipts: list[tuple[str, bytes]],
+) -> tuple[ParsedSession, dict[str, int]]:
+    """Content-address + dedup Claude Code tool-result sidecar text (polylogue-rujy AC4).
+
+    ``apply_tool_result_sidecars`` (parser-side, side-effect-free) already
+    replaced a matched, truncated ``tool_result`` block's inline preview with
+    the sidecar file's full text and recorded a bounded
+    ``claude_tool_result_sidecar`` session event per file. That leaves the
+    acquired bytes living only as an ordinary SQLite TEXT column: two
+    sessions with byte-identical tool output (a repeated build log, the same
+    lint run) each store their own full copy, and there is no record of how
+    many genuinely new bytes an ingest run added to the archive versus how
+    many were already present under the same hash.
+
+    This mirrors the existing attachment-blob path (``_acquire_attachment_blob``
+    / the ``preacquired_attachment_blobs`` loop above): it publishes the exact
+    bytes the matched block now carries through the archive's content-addressed
+    blob store, records the resulting ``blob_hash`` back onto the event so a
+    reader can locate the durable copy, and returns per-run byte counts
+    (new vs. deduplicated) for the ingest batch's own accounting. It never
+    touches ``blocks.text`` -- that already carries the full text for FTS --
+    this only adds a deduplicated, content-addressed second home for it.
+
+    A no-op (returns ``session_to_write`` unchanged) unless the session
+    actually carries a matched+replaced sidecar event, so non-Claude-Code
+    sessions never pay this cost.
+    """
+    matched_tool_use_ids = {
+        tool_use_id
+        for event in session_to_write.session_events
+        if event.event_type == "claude_tool_result_sidecar"
+        and event.payload.get("acquisition_status") == "matched"
+        and event.payload.get("content_replaced")
+        and isinstance(tool_use_id := event.payload.get("tool_use_id"), str)
+    }
+    if not matched_tool_use_ids:
+        return session_to_write, {}
+
+    text_by_tool_use_id: dict[str, str] = {
+        block.tool_id: block.text
+        for message in session_to_write.messages
+        for block in message.blocks
+        if block.type is BlockType.TOOL_RESULT
+        and block.tool_id is not None
+        and block.tool_id in matched_tool_use_ids
+        and block.text is not None
+    }
+    if not text_by_tool_use_id:
+        return session_to_write, {}
+
+    blob_hash_by_tool_use_id: dict[str, str] = {}
+    bytes_new = 0
+    bytes_dedup = 0
+    for tool_use_id, text in text_by_tool_use_id.items():
+        encoded = unicodedata.normalize("NFC", text).encode("utf-8")
+        precomputed_hash = hashlib.sha256(encoded).hexdigest()
+        already_present = blob_publisher.exists(precomputed_hash)
+        hash_hex, size = blob_publisher.write_from_bytes(encoded)
+        blob_hash_by_tool_use_id[tool_use_id] = hash_hex
+        if already_present:
+            bytes_dedup += size
+        else:
+            bytes_new += size
+        receipt_id = blob_publisher.receipt_id(hash_hex)
+        if receipt_id is not None:
+            publication_receipts.append((receipt_id, bytes.fromhex(hash_hex)))
+
+    updated_events = [
+        event.model_copy(update={"payload": {**event.payload, "blob_hash": blob_hash_by_tool_use_id[tool_use_id]}})
+        if event.event_type == "claude_tool_result_sidecar"
+        and isinstance(tool_use_id := event.payload.get("tool_use_id"), str)
+        and tool_use_id in blob_hash_by_tool_use_id
+        else event
+        for event in session_to_write.session_events
+    ]
+    counts = {
+        "sidecar_blob_bytes_new": bytes_new,
+        "sidecar_blob_bytes_dedup": bytes_dedup,
+        "sidecar_blobs_written": len(blob_hash_by_tool_use_id),
+    }
+    return session_to_write.model_copy(update={"session_events": updated_events}), counts
+
+
 def _write_session(
     conn: sqlite3.Connection,
     payload: SessionWritePayload,
@@ -447,6 +535,9 @@ def _write_session(
         "skipped_attachments": 0,
         "skipped_session_events": 0,
         "raw_links": 0,
+        "sidecar_blob_bytes_new": 0,
+        "sidecar_blob_bytes_dedup": 0,
+        "sidecar_blobs_written": 0,
     }
 
     existing_row = conn.execute(
@@ -608,6 +699,10 @@ def _write_session(
             preacquired_attachment_blobs[id(attachment)] = (blob_hash, size, "acquired")
             if receipt_id is not None:
                 publication_receipts.append((receipt_id, blob_hash))
+        session_to_write, sidecar_blob_counts = _preacquire_sidecar_blobs(
+            session_to_write, blob_publisher, publication_receipts
+        )
+        counts.update(sidecar_blob_counts)
         blob_publisher.flush()
 
     write_parsed_session_to_archive(
@@ -1643,6 +1738,12 @@ async def process_ingest_batch(
             wait_s=round(batch_summary.result_wait_s, 2),
             setup_s=round(batch_summary.setup_elapsed_s, 2),
             tear_s=round(batch_summary.teardown_elapsed_s, 2),
+            # polylogue-rujy AC4: content-addressed tool-result sidecar blob
+            # writes this batch actually added vs. deduplicated (0 unless the
+            # batch touched Claude Code sessions with acquired sidecars).
+            sidecar_blob_new_mb=round(batch_summary.counts["sidecar_blob_bytes_new"] / (1024 * 1024), 2),
+            sidecar_blob_dedup_mb=round(batch_summary.counts["sidecar_blob_bytes_dedup"] / (1024 * 1024), 2),
+            sidecar_blobs_written=batch_summary.counts["sidecar_blobs_written"],
         )
 
     succeeded_raw_ids = successful_raw_ids(batch_summary)

--- a/polylogue/pipeline/services/ingest_batch/_models.py
+++ b/polylogue/pipeline/services/ingest_batch/_models.py
@@ -79,6 +79,14 @@ class _IngestBatchSummary:
             "skipped_messages": 0,
             "skipped_attachments": 0,
             "skipped_session_events": 0,
+            # polylogue-rujy AC4: bytes this batch pushed through the
+            # content-addressed blob store for Claude Code tool-result
+            # sidecar text (see _preacquire_sidecar_blobs). "new" is bytes
+            # whose hash didn't already exist in the store; "dedup" is bytes
+            # whose hash was already present (the write was a free no-op).
+            "sidecar_blob_bytes_new": 0,
+            "sidecar_blob_bytes_dedup": 0,
+            "sidecar_blobs_written": 0,
         }
     )
     changed_counts: dict[str, int] = field(

--- a/tests/unit/pipeline/test_ingest_batch.py
+++ b/tests/unit/pipeline/test_ingest_batch.py
@@ -1062,6 +1062,192 @@ def test_write_session_freshness_tie_allows_attachment_improvement(tmp_path: Pat
         assert row["raw_id"] == "raw-fetched"
 
 
+def _sidecar_matched_event(tool_use_id: str) -> ParsedSessionEvent:
+    return ParsedSessionEvent(
+        event_type="claude_tool_result_sidecar",
+        payload={
+            "acquisition_status": "matched",
+            "tool_use_id": tool_use_id,
+            "filename": f"{tool_use_id}.txt",
+            "byte_size": 999,
+            "content_hash": "irrelevant-precomputed-hash",
+            "content_replaced": True,
+        },
+    )
+
+
+def test_write_session_publishes_sidecar_blob_content_addressed(tmp_path: Path) -> None:
+    """polylogue-rujy AC4: acquired sidecar text is published to the blob store, content-addressed.
+
+    A matched+content_replaced ``claude_tool_result_sidecar`` event alongside
+    a ``tool_result`` block sharing its ``tool_use_id`` is exactly what
+    ``apply_tool_result_sidecars`` (sources/parsers/claude/code_parser.py)
+    produces once a large sidecar file's full text has replaced a truncated
+    block preview. This asserts the write path (not a test-only
+    reimplementation) actually pushes those bytes through
+    ``ArchiveBlobPublisher`` -- the same publisher attachments use -- and
+    records the resulting hash back onto the event.
+    """
+    full_text = "full sidecar output " * 200
+    with open_connection(tmp_path / "index.db") as conn:
+        publisher = ArchiveBlobPublisher(tmp_path / "source.db", tmp_path / "blob")
+        session = _session_data(
+            "claude-code-session:sidecar-1",
+            content_hash="sidecar-hash-1",
+            provider=Provider.CLAUDE_CODE,
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "claude-code-session:sidecar-1",
+                    role="assistant",
+                    text="ran a command",
+                    content_hash="msg-hash-sidecar-1",
+                    sort_key=1777636900.0,
+                )
+            ],
+            block_tuples=[
+                (
+                    "msg-1",
+                    ParsedContentBlock(type=BlockType.TOOL_RESULT, tool_id="toolu_1", text=full_text),
+                )
+            ],
+            action_tuples=[_sidecar_matched_event("toolu_1")],
+        )
+        changed, counts = _write_session(conn, session, blob_publisher=publisher)
+        conn.commit()
+
+        assert changed is True
+        assert counts["sidecar_blobs_written"] == 1
+        assert counts["sidecar_blob_bytes_new"] == len(full_text.encode("utf-8"))
+        assert counts["sidecar_blob_bytes_dedup"] == 0
+
+        expected_hash = sha256(full_text.encode("utf-8")).hexdigest()
+        blob_path = tmp_path / "blob" / expected_hash[:2] / expected_hash[2:]
+        assert blob_path.is_file(), "sidecar bytes must land in the content-addressed blob store"
+        assert blob_path.read_text() == full_text
+
+        event_row = conn.execute(
+            "SELECT payload_json FROM session_events WHERE session_id = ? AND event_type = 'claude_tool_result_sidecar'",
+            ("claude-code-session:sidecar-1",),
+        ).fetchone()
+        assert f'"blob_hash":"{expected_hash}"' in event_row["payload_json"]
+
+        block_row = conn.execute(
+            "SELECT text FROM blocks WHERE session_id = ? AND block_type = 'tool_result'",
+            ("claude-code-session:sidecar-1",),
+        ).fetchone()
+        assert block_row["text"] == full_text, "blob publication must not disturb the FTS-indexed block text (AC2)"
+
+
+def test_write_session_dedups_identical_sidecar_blob_across_sessions(tmp_path: Path) -> None:
+    """Two sessions with byte-identical acquired sidecar text share one blob (AC4 dedup).
+
+    Mutation that would make this fail: removing the ``blob_publisher.exists``
+    pre-check (or always reporting ``bytes_new``) collapses the
+    new-vs-deduplicated distinction the bead asks be reported -- this test
+    fails if the second write is counted as new bytes instead of a dedup hit.
+    """
+    full_text = "identical build log content\n" * 300
+    with open_connection(tmp_path / "index.db") as conn:
+        publisher = ArchiveBlobPublisher(tmp_path / "source.db", tmp_path / "blob")
+        first = _session_data(
+            "claude-code-session:sidecar-dedup-a",
+            content_hash="sidecar-dedup-hash-a",
+            provider=Provider.CLAUDE_CODE,
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "claude-code-session:sidecar-dedup-a",
+                    role="assistant",
+                    text="ran a command",
+                    content_hash="msg-hash-dedup-a",
+                    sort_key=1777637000.0,
+                )
+            ],
+            block_tuples=[
+                (
+                    "msg-1",
+                    ParsedContentBlock(type=BlockType.TOOL_RESULT, tool_id="toolu_a", text=full_text),
+                )
+            ],
+            action_tuples=[_sidecar_matched_event("toolu_a")],
+        )
+        changed_a, counts_a = _write_session(conn, first, blob_publisher=publisher)
+        conn.commit()
+        assert changed_a is True
+        assert counts_a["sidecar_blob_bytes_new"] == len(full_text.encode("utf-8"))
+        assert counts_a["sidecar_blob_bytes_dedup"] == 0
+
+        second = _session_data(
+            "claude-code-session:sidecar-dedup-b",
+            content_hash="sidecar-dedup-hash-b",
+            provider=Provider.CLAUDE_CODE,
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "claude-code-session:sidecar-dedup-b",
+                    role="assistant",
+                    text="ran the same command elsewhere",
+                    content_hash="msg-hash-dedup-b",
+                    sort_key=1777637100.0,
+                )
+            ],
+            block_tuples=[
+                (
+                    "msg-1",
+                    ParsedContentBlock(type=BlockType.TOOL_RESULT, tool_id="toolu_b", text=full_text),
+                )
+            ],
+            action_tuples=[_sidecar_matched_event("toolu_b")],
+        )
+        changed_b, counts_b = _write_session(conn, second, blob_publisher=publisher)
+        conn.commit()
+
+        assert changed_b is True
+        assert counts_b["sidecar_blob_bytes_new"] == 0
+        assert counts_b["sidecar_blob_bytes_dedup"] == len(full_text.encode("utf-8"))
+
+
+def test_write_session_skips_sidecar_blob_for_debt_events(tmp_path: Path) -> None:
+    """Debt (unmatched) sidecar events never trigger a blob write -- there is no owning block/bytes."""
+    with open_connection(tmp_path / "index.db") as conn:
+        publisher = ArchiveBlobPublisher(tmp_path / "source.db", tmp_path / "blob")
+        debt_event = ParsedSessionEvent(
+            event_type="claude_tool_result_sidecar",
+            payload={
+                "acquisition_status": "debt",
+                "filename": "orphan.txt",
+                "byte_size": 42,
+                "reason": "no_owning_tool_result_block",
+            },
+        )
+        session = _session_data(
+            "claude-code-session:sidecar-debt",
+            content_hash="sidecar-debt-hash",
+            provider=Provider.CLAUDE_CODE,
+            message_tuples=[
+                _message_tuple(
+                    "msg-1",
+                    "claude-code-session:sidecar-debt",
+                    role="assistant",
+                    text="ran a command",
+                    content_hash="msg-hash-debt",
+                    sort_key=1777637200.0,
+                )
+            ],
+            action_tuples=[debt_event],
+        )
+        changed, counts = _write_session(conn, session, blob_publisher=publisher)
+        conn.commit()
+
+        assert changed is True
+        assert counts["sidecar_blobs_written"] == 0
+        assert counts["sidecar_blob_bytes_new"] == 0
+        assert not any(p.is_file() for p in (tmp_path / "blob").glob("**/*")), (
+            "no blob file should be written when there is no matched sidecar block"
+        )
+
+
 def test_write_session_upserts_ingest_flags_when_content_is_unchanged(tmp_path: Path) -> None:
     """Parser-owned auto-tags still converge when the content hash is unchanged."""
     with open_connection(tmp_path / "index.db") as conn:


### PR DESCRIPTION
## Summary

Closes the remaining gap (AC4) on polylogue-rujy's Claude Code tool-results sidecar acquisition: acquired sidecar text now also gets published through the archive's content-addressed blob store, deduplicated across sessions, with new-vs-deduplicated byte counts reported per ingest batch.

## Problem

polylogue-rujy's prior PRs (c0fcecb0d, 9bbe4e6bb, 0013364b8, and others) landed the join between Claude Code `tool-results/<tool_id>.<ext>` sidecar files and their owning `tool_result` blocks: AC1 (attach by tool_id, session count unchanged), AC2 (FTS-searchable, since the block text is replaced in place), AC3 (typed acquisition debt for unmatched files), and AC5 (wall-clock impact measured, default-on) are all satisfied on master.

AC4 was left explicitly PARTIAL in the bead's own notes: `content_hash` is computed for each matched sidecar, but there is no blob-store write. Two sessions that happen to share byte-identical tool output (a repeated build log, the same CI run's lint output) each stored their own full copy in `blocks.text`, and there was no accounting of how many bytes an ingest run actually added to the archive versus how many were already present under the same content hash.

## Solution

- `polylogue/pipeline/services/ingest_batch/_core.py`: new `_preacquire_sidecar_blobs`, called from `_write_session` right alongside the existing attachment-blob acquisition loop (same `ArchiveBlobPublisher`, same `flush()`/publication-receipt lifecycle). For every `claude_tool_result_sidecar` session event marked `matched` + `content_replaced`, it looks up the owning `tool_result` block (already carrying the full sidecar text from the existing parser-side join), NFC-normalizes + encodes it the same way `core.hashing.hash_text` does, checks `blob_publisher.exists(hash)` to classify new-vs-dedup *before* writing, publishes the bytes, and records the resulting `blob_hash` back onto the session event's JSON payload. It never touches `blocks.text` — FTS indexing (AC2) is unaffected.
- `polylogue/pipeline/services/ingest_batch/_models.py`: three new `_IngestBatchSummary.counts` keys (`sidecar_blob_bytes_new`, `sidecar_blob_bytes_dedup`, `sidecar_blobs_written`), summed automatically via the existing generic counts-merge loop, and surfaced in the `ingest_batch` log line.
- `docs/plans/hash-boundary-registry.yaml`: registers the new `hashlib.sha256` call site (`content-hash` classification — the hash gates a real dedup decision, not just identifier derivation), required by `devtools verify hash-boundary-census`.

Non-goals / unchanged: the parser-side join (`sources/live/tool_result_sidecars.py`, `sources/parsers/claude/code_parser.py:apply_tool_result_sidecars`) is untouched — this PR only adds a write-time enrichment step downstream of it.

## Verification

- `devtools test tests/unit/pipeline/test_ingest_batch.py` → 64 passed, including 3 new tests: publish-and-content-address (asserts the blob file exists on disk at its hash path with byte-identical content, and the event's `payload_json` carries `blob_hash`), cross-session dedup (two sessions with identical tool output: first write reports `sidecar_blob_bytes_new`, second reports `sidecar_blob_bytes_dedup` for the same byte count), and debt events never trigger a blob write (no owning block, no bytes to publish). Anti-vacuity: nulling the `blob_publisher.exists()` pre-check, or unconditionally reporting `bytes_new`, makes the dedup-count assertions fail — this exercises the real `_write_session` production path, not a test-only reimplementation.
- `devtools test tests/unit/sources/test_tool_result_sidecars.py tests/unit/sources/test_parsers_claude_code_artifacts.py tests/unit/pipeline/test_blob_publication_crash_matrix.py tests/unit/pipeline/test_acquisition_blob_gc_age_gate.py` → 118 passed (adjacent sidecar-join and blob-publication surfaces unaffected).
- `mypy --strict` on both changed pipeline modules: clean.
- `devtools verify --quick`: exit 0 (ruff format/check, mypy, `render all --check`, topology, layering, hash-boundary-census, schema-versioning, schema-promotion-audit all pass).
- Not run: `devtools verify --all` (full non-integration suite) or a live-corpus ingest measurement of the added blob-write wall-clock cost — the per-file work is one extra `sha256` + a store-exists check + a (deduped, no-op-on-repeat) file write, on the same code path already measured as ~1% of ingest budget for AC5.

## AC disposition (polylogue-rujy)

1. Attach by tool_id, session count unchanged — SATISFIED (prior PR, unaffected by this change).
2. FTS-searchable — SATISFIED (prior PR); this PR verifies it's still true (`block_row["text"] == full_text` assertion) since publishing to the blob store must not regress the in-place block replacement.
3. Typed acquisition debt for unmatched files — SATISFIED (prior PR); this PR adds a regression test that debt events specifically never acquire a blob.
4. Content-addressed, deduplicated blob storage with bytes-added report — SATISFIED by this PR.
5. Ingest wall-clock impact measured, default-on — SATISFIED (prior PR, polylogue-wjgf follow-up).

Ref polylogue-rujy