### PR TITLE
fix(daemon): bound raw-materialization writer holds by wall-clock time

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -105,6 +105,26 @@ _RAW_MATERIALIZATION_BACKLOG_BURST_PAUSE_SECONDS = 1
 # does not meaningfully extend the writer hold.
 _RAW_MATERIALIZATION_PARSE_STAGE_WARM_LIMIT = 64
 _RAW_MATERIALIZATION_DAEMON_BLOB_LIMIT_BYTES = 64 * 1024 * 1024
+# polylogue-de2a: declared, enforced ceiling on how long ONE ordinary trickle
+# pass may hold the process-wide writer coordinator. Live evidence showed
+# ``_RAW_MATERIALIZATION_CONVERGENCE_BATCH_LIMIT`` alone did not bound hold
+# time -- a 16-64 component cap still produced measured holds of 187-210s,
+# because per-component cost (parse, replay, then a full FTS/action-pairs/
+# delegation-facts rebuild) dominates, not component count. Other maintenance
+# actors (FTS merge, session insights, convergence debt retry) want a 60s
+# cadence; a 20s ceiling here means the write coordinator's existing
+# maintenance-priority admission (PR #3289) bounds worst-case queued-actor
+# wait to roughly "this pass's remaining budget + at most one more
+# already-queued, equally-bounded ingest hold" instead of an unbounded
+# multi-minute wait. ``repair_raw_materialization`` checks this budget only
+# between components, at a point it already commits and requeries candidates
+# -- a real transaction-boundary checkpoint, not a mid-write yield -- and
+# always completes at least one component regardless of the budget, so a
+# single slower-than-budget component still makes forward progress. Not
+# applied to the whale pass (`_run_raw_materialization_whale_pass_once`),
+# whose entire purpose is converging one oversized, resource-blocked
+# component in a single pass once the ordinary conveyor is quiescent.
+_RAW_MATERIALIZATION_MAX_PASS_SECONDS = 20.0
 # polylogue-t93b: escalation-tier envelope for the whale pass. A component
 # permanently resource-blocked at the ordinary fast-path limit above
 # converges through a dedicated, single-component pass at this wider
@@ -1177,6 +1197,7 @@ def _drain_raw_materialization_once(
             raw_artifact_limit=limit,
             max_payload_bytes=_RAW_MATERIALIZATION_DAEMON_BLOB_LIMIT_BYTES,
             prefetch_cache=prefetch_cache,
+            max_pass_seconds=_RAW_MATERIALIZATION_MAX_PASS_SECONDS,
         )
     finally:
         _close_raw_materialization_fts(config.archive_root / "index.db")

--- a/polylogue/product/raw_authority.py
+++ b/polylogue/product/raw_authority.py
@@ -91,6 +91,7 @@ def repair_materialization(
     max_payload_bytes: int,
     prefetch_cache: RawParsePrefetchCache | None = None,
     raw_artifact_id: str | None = None,
+    max_pass_seconds: float | None = None,
 ) -> Any:
     """Run one bounded raw source->index convergence pass.
 
@@ -104,6 +105,14 @@ def repair_materialization(
     daemon's escalation-tier whale pass uses this to converge one
     resource-blocked component at a time under a widened ``max_payload_bytes``
     envelope instead of re-scanning the whole archive-wide backlog.
+
+    ``max_pass_seconds`` (polylogue-de2a, default ``None`` = unbounded) bounds
+    this call's own wall-clock duration so a caller running it under a
+    process-wide writer lock (the daemon's trickle conveyor) has a declared,
+    enforced ceiling on how long it can hold that lock in one call,
+    independent of ``raw_artifact_limit`` -- see
+    ``polylogue.storage.repair.repair_raw_materialization`` for why a fixed
+    component count alone did not bound hold time in practice.
     """
     from polylogue.storage.repair import repair_raw_materialization
 
@@ -114,6 +123,7 @@ def repair_materialization(
         max_payload_bytes=max_payload_bytes,
         prefetch_cache=prefetch_cache,
         raw_artifact_id=raw_artifact_id,
+        max_pass_seconds=max_pass_seconds,
     )
 
 

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -6120,6 +6120,7 @@ def repair_raw_materialization(
     commit_batch_size: int | None = None,
     progress_callback: ProgressCallback | None = None,
     prefetch_cache: RawParsePrefetchCache | None = None,
+    max_pass_seconds: float | None = None,
 ) -> RepairResult:
     """Converge retained raws through typed per-session revision authority.
 
@@ -6152,14 +6153,39 @@ def repair_raw_materialization(
     ``backfill_historical_revision_evidence`` call further down: that call's
     own parse cost (``_ParsedSessionSpill.for_raw`` over already-typed
     cohorts) is a different, smaller-scope code path left for a later phase.
+
+    ``max_pass_seconds`` (polylogue-de2a, default ``None`` = unbounded, byte-
+    for-byte unchanged for existing callers) bounds this call's own wall-clock
+    duration -- and therefore the writer-coordinator hold a caller runs it
+    under -- independently of ``raw_artifact_limit``. Live evidence showed a
+    16-64 component limit alone did not bound hold time: per-component cost
+    (parse, replay, then a full FTS/action-pairs/delegation-facts rebuild) is
+    itself long enough that a modest component count still produced 188s+
+    holds. Both the CENSUS loop and the REPLAY loop check elapsed time only
+    *between* components, at the same point they already commit and requery
+    candidates -- a genuine transaction-boundary checkpoint, not a mid-write
+    yield (a mid-hold SQLite transaction cannot safely release the write lock
+    without releasing the real DB-level lock). Each loop always completes at
+    least one component before checking the budget, so a single
+    slower-than-budget component still makes forward progress instead of
+    stalling. Any component left unattempted this call remains a candidate
+    for the caller's next call, identically to how ``raw_artifact_limit``
+    already truncates the selected set.
     """
     if max_payload_bytes < 1:
         raise ValueError("max_payload_bytes must be positive")
+    if max_pass_seconds is not None and max_pass_seconds <= 0:
+        raise ValueError("max_pass_seconds must be positive when provided")
     if ingest_workers is None:
         from polylogue.pipeline.services.process_pool import resolve_parse_worker_count
 
         ingest_workers = resolve_parse_worker_count()
     commit_batch_size = _resolve_raw_authority_commit_batch_size(commit_batch_size)
+    pass_started_monotonic = time.monotonic()
+
+    def _pass_deadline_exceeded() -> bool:
+        return max_pass_seconds is not None and (time.monotonic() - pass_started_monotonic) >= max_pass_seconds
+
     archive_root = _raw_materialization_archive_root(config)
     recovered_censuses = recover_interrupted_raw_authority_censuses(archive_root)
     for recovered_census_id, recovered_scope in recovered_censuses:
@@ -6225,6 +6251,14 @@ def repair_raw_materialization(
             if not uncensused_raw_ids.intersection(component):
                 continue
             if census_components_attempted >= census_component_limit:
+                break
+            if census_components_attempted > 0 and _pass_deadline_exceeded():
+                logger.info(
+                    "raw materialization: census phase yielding at time-budget checkpoint "
+                    "(max_pass_seconds=%.1f) after %d component(s)",
+                    max_pass_seconds,
+                    census_components_attempted,
+                )
                 break
             census_components_attempted += 1
             seed = _raw_materialization_component_seed(candidates, component)
@@ -6700,10 +6734,44 @@ def repair_raw_materialization(
             planner_conn.commit()
 
     executable_raw_ids = raw_ids
-    metrics["raw_materialization_executed_count"] = float(len(executable_raw_ids))
+    metrics["raw_materialization_selected_for_execution_count"] = float(len(executable_raw_ids))
     replay_parts: list[RevisionBackfillResult] = []
     execution_outcomes: list[RawReplayPlanOutcome] = []
-    for plan, raw_id in zip(executable_plans, executable_raw_ids, strict=True):
+    components_attempted = 0
+    time_budget_exceeded = False
+    plan_raw_pairs = list(zip(executable_plans, executable_raw_ids, strict=True))
+    for index, (plan, raw_id) in enumerate(plan_raw_pairs):
+        if components_attempted > 0 and _pass_deadline_exceeded():
+            time_budget_exceeded = True
+            deferred = plan_raw_pairs[index:]
+            logger.info(
+                "raw materialization: replay phase yielding at time-budget checkpoint "
+                "(max_pass_seconds=%.1f) after %d/%d selected component(s); "
+                "%d component(s) carried forward to the next pass",
+                max_pass_seconds,
+                components_attempted,
+                len(plan_raw_pairs),
+                len(deferred),
+            )
+            # ``finalize_raw_authority_census`` below is fail-closed on every
+            # SELECTED plan having a recorded outcome -- unlike
+            # ``raw_artifact_limit`` truncation (which keeps a plan out of
+            # ``selected_plan_ids`` in the first place), the plans skipped
+            # here were already recorded as selected by the
+            # ``record_raw_authority_census`` call above this loop, so each
+            # one needs an explicit RETRYABLE outcome, not a silent gap.
+            for deferred_plan, _deferred_raw_id in deferred:
+                outcome = RawReplayPlanOutcome(
+                    deferred_plan.plan_id,
+                    deferred_plan.input_raw_ids,
+                    RawReplayPlanStatus.RETRYABLE,
+                    f"raw materialization time budget ({max_pass_seconds:.1f}s) exceeded before this component's turn",
+                    "retry this unchanged plan on the next bounded pass",
+                )
+                record_raw_replay_outcome(archive_root, census_receipt.census_id, outcome)
+                execution_outcomes.append(outcome)
+            break
+        components_attempted += 1
         component = plan.input_raw_ids
         try:
             part = backfill_historical_revision_evidence(
@@ -6841,6 +6909,9 @@ def repair_raw_materialization(
     )
     metrics.update(
         {
+            "raw_materialization_executed_count": float(components_attempted),
+            "raw_materialization_pass_seconds": time.monotonic() - pass_started_monotonic,
+            "raw_materialization_time_budget_exceeded": 1.0 if time_budget_exceeded else 0.0,
             "raw_materialization_scanned_raw_count": float(replay.scanned),
             "raw_materialization_classified_full_count": float(replay.classified_full),
             "raw_materialization_replayed_logical_source_count": float(replay.replayed_logical_sources),

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -548,6 +548,7 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
         max_payload_bytes: int,
         prefetch_cache: object = None,
         raw_artifact_id: str | None = None,
+        max_pass_seconds: float | None = None,
     ) -> FakeResult:
         order.append("materialize")
         calls["archive_root"] = config.archive_root
@@ -557,6 +558,7 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
         calls["max_payload_bytes"] = max_payload_bytes
         calls["prefetch_cache"] = prefetch_cache
         calls["raw_artifact_id"] = raw_artifact_id
+        calls["max_pass_seconds"] = max_pass_seconds
         return FakeResult()
 
     def fake_recover(config: Config) -> tuple[str, ...]:
@@ -587,6 +589,10 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
     assert counts.repaired_sessions == 7
     assert counts.executed_plans == 3
     assert order == ["restore", "recover-frontier", "materialize", "frontier"]
+    # polylogue-de2a: the ordinary trickle pass must always request a
+    # declared, enforced per-call wall-clock ceiling on the writer hold --
+    # a component-count limit alone did not bound observed hold time.
+    assert calls["max_pass_seconds"] == daemon_cli._RAW_MATERIALIZATION_MAX_PASS_SECONDS
 
     order.clear()
     daemon_cli._drain_raw_materialization_once(limit=11, recover=False)
@@ -606,6 +612,7 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
         "recover_archive_root": tmp_path / "archive",
         "frontier_archive_root": tmp_path / "archive",
         "frontier_limit": 8,
+        "max_pass_seconds": daemon_cli._RAW_MATERIALIZATION_MAX_PASS_SECONDS,
     }
 
 

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import time
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
@@ -2145,6 +2146,69 @@ def test_raw_materialization_processes_independent_components_across_bounded_pas
         repaired_per_pass.append(result.repaired_count)
     assert repaired_per_pass == [5, 5, 5, 5, 5]
     assert repair_mod.repair_raw_materialization(config, raw_artifact_limit=5).success is True
+
+
+def test_raw_materialization_max_pass_seconds_bounds_one_pass_and_preserves_progress(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """polylogue-de2a: a per-pass wall-clock budget must stop a single call
+    from replaying every selected component, even when ``raw_artifact_limit``
+    alone would admit them all in one call -- live evidence showed the
+    component count limit did not bound hold time (188s+ holds at a 16-64
+    component cap). The budget must be checked only *between* components (so
+    at least one always completes, guaranteeing forward progress) and must
+    leave the rest as ordinary candidates for the next call, not lost or
+    corrupted work.
+    """
+    from polylogue.core.enums import Provider
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    initialize_active_archive_root(tmp_path)
+    raw_count = 3
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        raw_ids = [
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=(
+                    f'{{"type":"session_meta","payload":{{"id":"budget-{index}",'
+                    '"timestamp":"2026-07-11T00:00:00Z"}}}}\n'
+                    '{"type":"response_item","payload":{"type":"message","id":"one","role":"user","content":'
+                    f'[{{"type":"input_text","text":"budget {index}"}}]}}}}\n'
+                ).encode(),
+                source_path=f"budget-{index}.jsonl",
+                acquired_at_ms=index,
+            )
+            for index in range(raw_count)
+        ]
+    assert raw_ids
+
+    config = _config(tmp_path)
+    _complete_bounded_raw_census(config, limit=raw_count)
+
+    # A monotonic clock that always advances well past any small budget after
+    # its very first read -- deterministic regardless of exactly how many
+    # ``time.monotonic()`` calls happen elsewhere in the pass, since the
+    # first call establishes the pass start and every later call already
+    # clears a 1-second budget.
+    elapsed = iter(float(step) * 100.0 for step in range(1000))
+    monkeypatch.setattr(time, "monotonic", lambda: next(elapsed))
+
+    bounded = repair_mod.repair_raw_materialization(
+        config,
+        raw_artifact_limit=raw_count,
+        max_pass_seconds=1.0,
+    )
+    assert bounded.repaired_count == 1
+    assert bounded.metrics["raw_materialization_executed_count"] == 1.0
+    assert bounded.metrics["raw_materialization_time_budget_exceeded"] == 1.0
+    assert bounded.metrics["raw_materialization_remaining_candidate_count"] == float(raw_count - 1)
+    assert bounded.success is False
+
+    monkeypatch.undo()
+    remainder = repair_mod.repair_raw_materialization(config, raw_artifact_limit=raw_count)
+    assert remainder.repaired_count == raw_count - 1
+    assert remainder.success is True
 
 
 def test_raw_materialization_durable_ledger_survives_ops_reset_for_fairness(


### PR DESCRIPTION
## Summary

Adds a declared, enforced wall-clock budget to the daemon's raw-materialization trickle pass so it can no longer hold the process-wide writer coordinator for minutes at a time, starving other periodic maintenance actors (FTS merge, session insights, convergence-debt retry).

## Problem

Ref polylogue-de2a. Live-observed 2026-07-27: the daemon's watcher `catch-up.chunk` actor held the sole-writer lock for 860 seconds parsing/writing a single session append; every other periodic daemon actor was queued behind it for that entire window. Several mitigations already shipped against this bead (PR #3288 interval tuning, PR #3289 maintenance-actor priority admission, PR #3358 removing an O(n²) redundant-reapply cost driver), but the bead's own 2026-07-29 convergence audit recorded the remaining gap directly: raw materialization still holds the sole writer for ~188s per pass (four consecutive passes measured: 188.7, 188.9, 187.1, 189.8s) with observed maintenance-actor wait up to 616.3s and queue depth 10 — even though the pass's own component-count limit (`raw_artifact_limit`, 16-64) was already small. The count limit did not bound hold time because per-component cost (parse, replay, then a full FTS/action-pairs/delegation-facts rebuild per component) dominates, not component count.

## Solution

- `repair_raw_materialization` (`polylogue/storage/repair.py`) gains an optional `max_pass_seconds` parameter (`None` default, byte-for-byte unchanged for existing callers).
- Both the CENSUS loop and the REPLAY loop check elapsed time only *between* components — the same point they already commit and requery candidates, a genuine transaction-boundary checkpoint, not an unsafe mid-write yield (a mid-hold SQLite transaction cannot safely release the async gate without releasing the real DB-level write lock, per this bead's own prior analysis). Each loop always completes at least one component before checking the budget, so a single slower-than-budget component still makes forward progress instead of stalling.
- Components the replay loop skips due to the budget get an explicit `RETRYABLE` outcome recorded before the loop breaks: `finalize_raw_authority_census` is fail-closed on every *selected* plan having a recorded outcome (discovered via a first failing test iteration), so silently leaving them unattempted is not safe the way `raw_artifact_limit` truncation (which happens before selection) already is.
- `polylogue/product/raw_authority.py`'s `repair_materialization` wrapper threads the new parameter through.
- `polylogue/daemon/cli.py`'s ordinary drain pass (`_drain_raw_materialization_once`) now always passes a declared `_RAW_MATERIALIZATION_MAX_PASS_SECONDS = 20.0`. The escalation-tier whale pass (`_run_raw_materialization_whale_pass_once`), whose entire purpose is converging one oversized, resource-blocked component in a single pass once the ordinary conveyor is quiescent, is deliberately left unbounded.
- New metrics `raw_materialization_pass_seconds` and `raw_materialization_time_budget_exceeded` are forwarded through the existing `_emit_raw_materialization_pass` daemon-event path alongside the writer-hold/wait metrics `write_coordinator.py` already exports, so the bound's effect is observable per pass without grepping the journal.

## Acceptance criteria (bead has 4)

1. **Hold/wait measured and exported** — already satisfied before this PR by `polylogue/daemon/write_coordinator.py`; unchanged here.
2. **No maintenance actor waits longer than a declared, enforced bound** — materially tightened, not fully closed: combined with the already-shipped maintenance-priority admission (PR #3289, which lets a queued maintenance actor cut ahead of queued ingest actors), worst-case queued-actor wait is now bounded by roughly "current pass's remaining time budget + at most one more already-queued, equally-bounded ingest hold" instead of an unbounded multi-minute wait. This is the dominant offender this bead measured; the same technique is not yet applied to every other actor that can hold the writer.
3. **Long-running convergence work yields at declared checkpoints** — satisfied for the raw-materialization pass specifically: the census and replay loops now check a stated time budget between components instead of holding for the whole selected batch.
4. **Live re-measurement under a comparable backlog** — not done in this PR (requires a deployed daemon against a live-scale backlog); left as explicit follow-up.

## Verification

```
devtools test tests/unit/storage/test_repair.py tests/unit/daemon/test_daemon_cli.py tests/unit/daemon/test_raw_materialization_parse_stage_equivalence.py
```
→ 169 passed, 11 pre-existing failures unchanged from baseline (confirmed by stashing this branch's changes and re-running against origin/master tip: the identical 11 tests fail identically, all an unrelated "no messages, no positive conversational evidence" parser-refusal drift in shared test fixtures — out of scope for this bead).

New regression test `test_raw_materialization_max_pass_seconds_bounds_one_pass_and_preserves_progress` reproduces the shape of the live incident with a synthetic 3-component backlog and a deterministic fake monotonic clock: with `max_pass_seconds=1.0` a single `repair_raw_materialization` call replays exactly 1 of 3 selected components and leaves the other 2 as ordinary candidates (`remaining_candidate_count == 2`, `success is False`), and a follow-up call without a budget finishes the remaining 2 — proving no work is lost or corrupted by the early stop. Verified this test is load-bearing by reverting the production changes only (`git stash` on the three touched non-test files) and confirming it fails with `TypeError: unexpected keyword argument 'max_pass_seconds'`.

```
devtools verify --quick
```
→ passes (ruff format/check, mypy --strict, render all --check, layering, schema-versioning, all other quick gates).

`devtools verify` (testmon) was not run — the checkout's testmon cache is unseeded in this worktree; the two `devtools test` invocations above cover every file this PR touches plus their existing test suites.

## Follow-ups

- AC2's declared bound currently applies only to the raw-materialization pass, the dominant offender this bead measured. If another actor is later found to produce comparably long holds, the same time-budget-between-checkpoints technique should be applied there too.
- AC4 (live re-measurement) needs a deployed daemon under a comparable backlog; not attempted here.