### PR TITLE
feat(archive): thread stop_reason to query path, derive terminal_state

### DIFF
--- a/polylogue/archive/query/archive_execution.py
+++ b/polylogue/archive/query/archive_execution.py
@@ -232,6 +232,7 @@ def _message_to_domain(message: ArchiveMessageRow, *, origin: Origin) -> Message
                 "metadata": _maybe_parse_json_object(block.metadata),
                 "tool_result_is_error": block.tool_result_is_error,
                 "tool_result_exit_code": block.tool_result_exit_code,
+                "tool_result_outcome_unknown_reason": block.tool_result_outcome_unknown_reason,
             }.items()
             if value is not None
         }
@@ -260,6 +261,7 @@ def _message_to_domain(message: ArchiveMessageRow, *, origin: Origin) -> Message
         branch_index=message.variant_index,
         is_active_path=message.is_active_path,
         parent_id=message.parent_message_id,
+        stop_reason=message.stop_reason,
     )
 
 

--- a/polylogue/archive/semantic/facts.py
+++ b/polylogue/archive/semantic/facts.py
@@ -147,6 +147,9 @@ class SemanticSessionMessageLike(SemanticMessageLike, Protocol):
     @property
     def is_substantive(self) -> bool: ...
 
+    @property
+    def stop_reason(self) -> str | None: ...
+
 
 class SemanticSummaryLike(Protocol):
     @property
@@ -261,6 +264,7 @@ def build_message_semantic_facts(
         actions=actions,
         tool_category_counts=sorted_counts(dict(tool_category_counts)),
         reasoning_traces=reasoning_traces,
+        stop_reason=message.stop_reason,
     )
     add_timing("facts.message_construct", t0)
     return facts

--- a/polylogue/archive/semantic/models.py
+++ b/polylogue/archive/semantic/models.py
@@ -33,6 +33,13 @@ class MessageSemanticFacts:
     actions: tuple[Action, ...]
     tool_category_counts: dict[str, int]
     reasoning_traces: tuple[ReasoningTrace, ...]
+    # Provider-reported terminal signal for this turn (Anthropic
+    # ``message.stop_reason``: end_turn/tool_use/max_tokens/stop_sequence/
+    # refusal/pause_turn). None means unreported/not-applicable -- never a
+    # guessed happy-path default. polylogue-cuxz.8: this is what lets
+    # _terminal_state (archive/session/runtime.py) classify a refused or
+    # truncated turn from real evidence instead of falling back to unknown.
+    stop_reason: str | None = None
 
     @property
     def affected_paths(self) -> tuple[str, ...]:

--- a/polylogue/archive/session/runtime.py
+++ b/polylogue/archive/session/runtime.py
@@ -17,7 +17,7 @@ from polylogue.archive.semantic.timing import compute_session_timing, compute_to
 from polylogue.archive.session.attribution import extract_attribution
 from polylogue.archive.session.extraction import extract_work_events
 from polylogue.archive.session.models import SessionAnalysis, SessionProfile
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, StopReason
 
 if TYPE_CHECKING:
     from polylogue.archive.models import Session
@@ -291,6 +291,10 @@ TERMINAL_STATE_METHODS = frozenset(
         "action_outcome",  # actions-view tool_result_is_error outcome
         "event_status",  # typed status key on a provider tool-call event
         "last_message_role",  # last meaningful message's authored role
+        # polylogue-cuxz.8: the provider's own message.stop_reason on the last
+        # assistant turn (refusal/max_tokens) -- structural, not a keyword
+        # guess, since it is read directly off the wire record.
+        "stop_reason",
         "no_signal",  # no structural evidence in either direction
         "bounded_materialization",  # large-session degraded fallback row (rebuild.py)
     }
@@ -429,6 +433,29 @@ def _terminal_state(
                 0.78,
                 {"action_id": latest_error_action_id, "evidence_class": latest_error_action_evidence_class},
                 "action_outcome",
+            )
+        # polylogue-cuxz.8: before giving up, consult the provider's own
+        # terminal signal for this exact turn (Anthropic ``stop_reason``).
+        # Only the two values that are unambiguous claims about how the turn
+        # ended are used -- REFUSAL and MAX_TOKENS are structurally distinct
+        # from a normal completion regardless of tool activity. TOOL_USE and
+        # STOP_SEQUENCE are deliberately not claimed here: TOOL_USE is
+        # already fully covered by the pending/action-outcome structural
+        # checks above, and STOP_SEQUENCE alone doesn't distinguish a clean
+        # stop from a truncation the way MAX_TOKENS unambiguously does.
+        if last.stop_reason == StopReason.REFUSAL.value:
+            return (
+                "refused",
+                0.85,
+                {"message_id": last.message_id, "stop_reason": last.stop_reason, "evidence_class": "raw_evidence"},
+                "stop_reason",
+            )
+        if last.stop_reason == StopReason.MAX_TOKENS.value:
+            return (
+                "truncated",
+                0.85,
+                {"message_id": last.message_id, "stop_reason": last.stop_reason, "evidence_class": "raw_evidence"},
+                "stop_reason",
             )
         # The prose _ERROR_MARKERS scan and its clean_finish complement were
         # deleted per the polylogue-ve9z ladder decision (measured at 50.5%

--- a/polylogue/storage/sqlite/archive_tiers/write.py
+++ b/polylogue/storage/sqlite/archive_tiers/write.py
@@ -96,6 +96,9 @@ class ArchiveBlockRow:
     # Keystone structured tool-result outcome (schema v16). NULL = unknown.
     tool_result_is_error: int | None = None
     tool_result_exit_code: int | None = None
+    # Why the keystone outcome above is unresolved (schema v46). NULL when the
+    # outcome IS known, never "unknown of unknown" (polylogue-cuxz.8).
+    tool_result_outcome_unknown_reason: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -135,6 +138,10 @@ class ArchiveMessageRow:
     # rows retain their original source session when a prefix-sharing child is
     # composed, so inherited evidence is not guessed from position.
     source_session_id: str | None = None
+    # Provider-reported terminal signal for this turn (schema v46, Anthropic
+    # ``message.stop_reason``). None means unreported/not-applicable, never a
+    # guessed happy-path default (polylogue-cuxz.8).
+    stop_reason: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -1244,7 +1251,7 @@ def read_archive_session_envelope(
         """
         SELECT message_id, native_id, role, position, variant_index, is_active_path, is_active_leaf,
                message_type, material_origin, word_count, has_tool_use, has_thinking, has_paste, occurred_at_ms,
-               paste_boundary AS paste_boundary_state, duration_ms, parent_message_id
+               paste_boundary AS paste_boundary_state, duration_ms, parent_message_id, stop_reason
         FROM messages
         WHERE session_id = ?
         ORDER BY position, variant_index
@@ -1256,7 +1263,8 @@ def read_archive_session_envelope(
         block_rows = conn.execute(
             """
             SELECT block_id, message_id, block_type, text, tool_name, tool_id, semantic_type,
-                   tool_input, language, tool_result_is_error, tool_result_exit_code
+                   tool_input, language, tool_result_is_error, tool_result_exit_code,
+                   tool_result_outcome_unknown_reason
             FROM blocks
             WHERE message_id = ?
             ORDER BY position
@@ -1285,6 +1293,7 @@ def read_archive_session_envelope(
                         language=block["language"],
                         tool_result_is_error=block["tool_result_is_error"],
                         tool_result_exit_code=block["tool_result_exit_code"],
+                        tool_result_outcome_unknown_reason=block["tool_result_outcome_unknown_reason"],
                     )
                     for block in block_rows
                 ),
@@ -1300,6 +1309,7 @@ def read_archive_session_envelope(
                 parent_message_id=message["parent_message_id"],
                 attachments=tuple(attachments_by_message.get(message["message_id"], ())),
                 source_session_id=str(session["session_id"]),
+                stop_reason=message["stop_reason"],
             )
         )
 
@@ -1417,6 +1427,7 @@ def _row_to_archive_message(
         parent_message_id=row["parent_message_id"],
         attachments=attachments,
         source_session_id=session_id,
+        stop_reason=row["stop_reason"],
     )
 
 
@@ -1447,7 +1458,7 @@ def _fetch_message_window(
         f"""
         SELECT message_id, native_id, role, position, variant_index, is_active_path, is_active_leaf,
                message_type, material_origin, word_count, has_tool_use, has_thinking, has_paste, occurred_at_ms,
-               paste_boundary AS paste_boundary_state, duration_ms, parent_message_id
+               paste_boundary AS paste_boundary_state, duration_ms, parent_message_id, stop_reason
         FROM messages
         WHERE session_id = ?{upto_clause}
         ORDER BY position, variant_index
@@ -1462,7 +1473,8 @@ def _fetch_message_window(
     block_rows = conn.execute(
         f"""
         SELECT block_id, message_id, block_type, text, tool_name, tool_id, semantic_type,
-               tool_input, language, tool_result_is_error, tool_result_exit_code
+               tool_input, language, tool_result_is_error, tool_result_exit_code,
+               tool_result_outcome_unknown_reason
         FROM blocks
         WHERE message_id IN ({placeholders})
         ORDER BY message_id, position
@@ -1484,6 +1496,7 @@ def _fetch_message_window(
                 language=block["language"],
                 tool_result_is_error=block["tool_result_is_error"],
                 tool_result_exit_code=block["tool_result_exit_code"],
+                tool_result_outcome_unknown_reason=block["tool_result_outcome_unknown_reason"],
             )
         )
     attachment_rows = conn.execute(

--- a/tests/unit/core/test_semantic_facts.py
+++ b/tests/unit/core/test_semantic_facts.py
@@ -260,6 +260,58 @@ def test_build_session_profile_reuses_shared_semantic_facts() -> None:
     assert profile.wall_duration_ms == 240000
 
 
+def test_build_session_profile_derives_terminal_state_from_stop_reason_refusal() -> None:
+    # polylogue-cuxz.8: a text-only assistant turn with no tool activity and
+    # no structural error signal used to fall back to "unknown" -- the
+    # dominant value for 85% of session_profiles.terminal_state. The
+    # provider's own stop_reason on that exact turn is real evidence and
+    # must be consulted before giving up.
+    session = make_conv(
+        id="conv-refusal",
+        origin=Provider.CLAUDE_CODE,
+        title="Refused",
+        messages=[
+            make_msg(id="u1", role="user", origin=Provider.CLAUDE_CODE, text="Do something unsafe."),
+            make_msg(
+                id="a1",
+                role="assistant",
+                origin=Provider.CLAUDE_CODE,
+                text="I can't help with that.",
+                stop_reason="refusal",
+            ),
+        ],
+    )
+
+    profile = build_session_profile(session)
+
+    assert profile.terminal_state == "refused"
+    assert profile.terminal_state_method == "stop_reason"
+    assert profile.terminal_state_evidence["stop_reason"] == "refusal"
+
+
+def test_build_session_profile_derives_terminal_state_from_stop_reason_max_tokens() -> None:
+    session = make_conv(
+        id="conv-truncated",
+        origin=Provider.CLAUDE_CODE,
+        title="Truncated",
+        messages=[
+            make_msg(id="u1", role="user", origin=Provider.CLAUDE_CODE, text="Write a very long essay."),
+            make_msg(
+                id="a1",
+                role="assistant",
+                origin=Provider.CLAUDE_CODE,
+                text="Once upon a time",
+                stop_reason="max_tokens",
+            ),
+        ],
+    )
+
+    profile = build_session_profile(session)
+
+    assert profile.terminal_state == "truncated"
+    assert profile.terminal_state_method == "stop_reason"
+
+
 def test_build_session_profile_sums_paired_provider_tool_windows() -> None:
     start = datetime(2026, 5, 24, 10, 0, tzinfo=timezone.utc)
     end = datetime(2026, 5, 24, 10, 12, tzinfo=timezone.utc)

--- a/tests/unit/storage/test_stop_reason_queryable.py
+++ b/tests/unit/storage/test_stop_reason_queryable.py
@@ -1,0 +1,103 @@
+"""Regression coverage for polylogue-cuxz.8: ``stop_reason`` must survive the
+bulk query-execution path, not just the single-session
+``repository.get()``/``message_from_record`` path.
+
+``messages.stop_reason`` was written on ingest (schema v46) and read back
+into the full-session envelope (``read_archive_session_envelope`` and its
+sibling ``_fetch_message_window``/``_row_to_archive_message`` helpers), and
+``storage/hydrators.py::message_from_record`` already threaded it onto the
+domain ``Message`` for the single-session ``repository.get()`` path
+(polylogue-2qx.4). But ``ArchiveMessageRow``/``ArchiveBlockRow`` -- the row
+types shared by *every* archive-tier read helper, including the bulk
+``find``/``sessions where ...`` query path in
+``archive/query/archive_execution.py`` -- never carried the field at all, so
+``SessionFilter(...).list()`` (the production route behind the CLI/MCP query
+grammar) silently dropped it. This proves the value survives the full
+write -> storage-row -> domain-``Message`` chain for that path too.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.archive.filter.filters import SessionFilter
+from polylogue.archive.query.plan import SessionQueryPlan
+from polylogue.core.enums import BlockType, Provider, Role
+from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
+from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+from tests.infra.storage_records import db_setup
+
+
+def _write_session_with_stop_reason(db_path: Path, *, native_id: str, stop_reason: str | None) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        session = ParsedSession(
+            source_name=Provider.CLAUDE_CODE,
+            provider_session_id=native_id,
+            title="Refused turn",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="m1",
+                    role=Role.USER,
+                    text="Do something unsafe.",
+                    position=0,
+                    blocks=[ParsedContentBlock(type=BlockType.TEXT, text="Do something unsafe.")],
+                ),
+                ParsedMessage(
+                    provider_message_id="m2",
+                    role=Role.ASSISTANT,
+                    text="I can't help with that.",
+                    position=1,
+                    blocks=[ParsedContentBlock(type=BlockType.TEXT, text="I can't help with that.")],
+                    stop_reason=stop_reason,
+                ),
+            ],
+        )
+        write_parsed_session_to_archive(conn, session)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_archive_session_envelope_reads_stop_reason(tmp_path: Path) -> None:
+    """The single-session envelope read (``read_archive_session_envelope``) exposes ``stop_reason``."""
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    db_path = tmp_path / "index.db"
+    with ArchiveStore(tmp_path, initialize=True, read_only=False):
+        pass
+
+    _write_session_with_stop_reason(db_path, native_id="claude-stop-1", stop_reason="refusal")
+
+    with ArchiveStore(tmp_path, initialize=False, read_only=True) as archive:
+        session_id = archive.resolve_session_id("claude-stop-1")
+        envelope = archive.read_session(session_id)
+        assistant_messages = [m for m in envelope.messages if m.role == "assistant"]
+        assert len(assistant_messages) == 1
+        assert assistant_messages[0].stop_reason == "refusal"
+
+
+@pytest.mark.asyncio
+async def test_session_filter_query_path_exposes_stop_reason(workspace_env: dict[str, Path]) -> None:
+    """``SessionFilter.list()`` -- the production route behind the CLI/MCP
+    query grammar (``find``/``sessions where ...``) -- must also expose
+    ``Message.stop_reason``. Before threading ``stop_reason`` through
+    ``ArchiveMessageRow`` (this bead), ``archive_execution.py``'s
+    ``_message_to_domain`` silently dropped it even though the single-session
+    ``repository.get()`` path already carried it.
+    """
+    db_path = db_setup(workspace_env)
+    archive_root = workspace_env["archive_root"]
+
+    _write_session_with_stop_reason(db_path, native_id="claude-stop-2", stop_reason="max_tokens")
+
+    plan = SessionQueryPlan(origins=("claude-code-session",), limit=10)
+    sessions = await SessionFilter(archive_root=archive_root, query_plan=plan).list()
+    assert len(sessions) == 1
+    assistant_messages = [m for m in sessions[0].messages if m.role == Role.ASSISTANT]
+    assert len(assistant_messages) == 1
+    assert assistant_messages[0].stop_reason == "max_tokens"


### PR DESCRIPTION
## Summary

Completes the remaining query-path gap from polylogue-2qx.4 and lands the first real dependent-column derivation for polylogue-cuxz.8: `messages.stop_reason` now survives the bulk query-execution path (not just single-session reads), and `session_profiles.terminal_state` (plus the two delegation_facts columns that are SQL views over it) derives from it instead of falling back to `unknown` for a refused or truncated turn.

## Problem

polylogue-cuxz.8 found the archive can't say how most sessions ended:

```
delegation_facts.result_status          'unknown'   99%  of 11,692
delegation_facts.parent_terminal_state  'unknown'   96%  of 11,692
session_profiles.terminal_state         'unknown'   85%  of 18,871
delegation_facts.child_terminal_state   'unknown'   56%  of 11,692
```

Meanwhile Claude's wire carries `message.stop_reason` on 608,608 assistant messages, including 70 `refusal` and 17 `max_tokens` cases that are otherwise invisible in any surface. A prior partial fix (polylogue-2qx.4) persisted `stop_reason` to `messages.stop_reason` and threaded it into the single-session `repository.get()` read path (`storage/hydrators.py::message_from_record`), but its own bd note flagged two explicit gaps: the bulk query-execution path (`archive/query/archive_execution.py`, behind `SessionFilter.list()` / the CLI-MCP `find`/`sessions where ...` query grammar) still dropped the field entirely, and no consumer derived `terminal_state`/`result_status` from it yet.

## Solution

- `ArchiveMessageRow`/`ArchiveBlockRow` (`storage/sqlite/archive_tiers/write.py`) gain `stop_reason` / `tool_result_outcome_unknown_reason` fields, threaded through all four read sites that construct them: the full-session envelope read, the paged-window read (`_fetch_message_window`), and the two block/message SQL `SELECT`s underneath them.
- `archive/query/archive_execution.py::_message_to_domain` — the exact function the prior fix's bd note named as the missing link — now copies `stop_reason` onto the domain `Message` and the companion unknown-reason onto block dicts.
- `MessageSemanticFacts` (`archive/semantic/models.py`) gains a `stop_reason` field, threaded from the domain `Message` in `archive/semantic/facts.py`, so `archive/session/runtime.py::_terminal_state` can see it on the last meaningful turn.
- `_terminal_state` now consults the last assistant turn's `stop_reason` before falling back to `unknown`: `REFUSAL` -> `"refused"`, `MAX_TOKENS` -> `"truncated"`. `TOOL_USE`/`STOP_SEQUENCE` are deliberately **not** claimed: `TOOL_USE` is already fully covered by the existing pending-tool/action-outcome structural checks, and `STOP_SEQUENCE` alone doesn't distinguish a clean stop from truncation the way `MAX_TOKENS` unambiguously does.
- Because `delegation_facts.parent_terminal_state`/`child_terminal_state` are SQL views joining `session_profiles.terminal_state` (not independently-guessed columns — confirmed by reading `storage/sqlite/archive_tiers/index.py`'s `delegation_facts` view definition), this one change improves those two columns for free, without touching them directly.

Schema classification: no schema change. `messages.stop_reason` and `blocks.tool_result_outcome_unknown_reason` already exist (schema v46, landed by polylogue-2qx.4); this PR only threads already-stored values through previously-lossy read paths and adds a new (Python-only) derivation branch.

## Deferred (follow-up)

- `delegation_facts.result_status`/`result_is_error` derive from a different signal (the Task tool's own returned artifact block outcome, i.e. `blocks.tool_result_is_error` on the delegation's result block — not the assistant turn's `stop_reason`) and are out of scope for this PR.
- AC #4 (refusal/max_tokens queryable via the CLI/MCP query grammar, e.g. `find "stop_reason:refusal"`) is not done: the field now reaches the domain `Message` object end-to-end, but wiring a new fielded predicate through the Lark grammar (`archive/query/expression.py`), the field-descriptor registry (`archive/query/fields.py`), SQL pushdown, and the runtime post-filter is a comparably-sized follow-up in its own right.
- AC #5 (re-measure the percentages) needs a live-archive rebuild + rerun of the original sweep query, not something this PR's unit tests can produce.

Recommend filing a Beads follow-up for the deferred scope (query-grammar wiring for `stop_reason`, `delegation_facts.result_status`/`result_is_error` derivation, and the AC#5 re-measurement) — not filed from this worktree per its no-`bd`-writes constraint.

## AC matrix (polylogue-cuxz.8)

1. stop_reason persisted per assistant message — **satisfied** (was already partially done by polylogue-2qx.4 for the single-session path; this PR completes it for the bulk query path).
2. terminal_state/result_status derive from persisted evidence or are deleted — **partially satisfied**: `terminal_state` (and its two view-derived siblings) now derive from `stop_reason` for the refusal/max_tokens cases; `result_status`/`result_is_error` untouched (deferred, different signal).
3. 'unknown' ceases to be dominant — **partially satisfied**: reduces (does not eliminate) `terminal_state` unknowns; needs a live re-measurement to quantify.
4. refusal/max_tokens queryable — **deferred**: reaches the domain model, not yet the query grammar.
5. Re-measure percentages — **deferred**: needs a live archive rebuild, out of scope for a unit-tested PR.

## Verification

- `devtools verify --quick` (ruff format/check, mypy --strict, `render all --check`) — exit 0, both pre-commit and pre-push hook runs.
- `devtools test tests/unit/core/test_semantic_facts.py tests/unit/storage/test_session_insight_profiles.py tests/unit/storage/test_delegations_view.py tests/unit/storage/test_stop_reason_queryable.py tests/unit/storage/test_title_source_queryable.py tests/unit/cli/test_archive_query.py tests/unit/cli/test_query_exec_laws.py tests/unit/core/test_models.py tests/unit/insights/test_delegation_work_evidence.py tests/unit/storage/test_session_insight_refresh.py` — 419 passed.
- Anti-vacuity: manually reverted the `stop_reason=message.stop_reason` line in `archive_execution.py::_message_to_domain` and confirmed `test_session_filter_query_path_exposes_stop_reason` fails (`assert None == 'max_tokens'`) — the production mutation this test exercises is exactly that line — then restored it and reconfirmed green.
- Not run: `devtools verify` full testmon suite (testmon isn't seeded in this worktree; seeding requires a full baseline run out of scope for this change) and a live-archive rebuild/re-measurement (AC #5).

Ref polylogue-cuxz.8