### PR TITLE
fix(storage): classify raw artifacts before deleting empty sessions

### DIFF
--- a/docs/plans/degrade-loudly-allowlist.yaml
+++ b/docs/plans/degrade-loudly-allowlist.yaml
@@ -432,30 +432,42 @@ entries:
   occurrence: 0
   reason: Narrow probe; False ("index not present/versioned") is the fail-safe direction.
 - path: polylogue/storage/repair.py
-  function: <module>._run_sql_repair
+  function: <module>.repair_empty_sessions
   exceptions:
   - Exception
   occurrence: 0
   reason: 'Returns _repair_result(..., success=False, detail=f"Repair failed: {exc}") -- an already-typed
-    signal, the established pattern for every repair_* function in this file.'
+    signal, the established pattern for every repair_* function in this file (formerly the
+    shared _run_sql_repair helper, inlined here on polylogue-ne6k since the empty-session
+    predicate is no longer pure SQL).'
+- path: polylogue/storage/repair.py
+  function: <module>._raw_artifact_positively_fails_classification
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'Classification failure is not itself an error worth surfacing here: absence of
+    positive evidence (including a raw artifact that fails to decode/classify) always means
+    "retain", the same fail-safe direction as every other predicate in this function. The
+    caller (repair_empty_sessions) already surfaces any real repair-level failure through its
+    own typed _repair_result.'
 - path: polylogue/storage/repair.py
   function: <module>.repair_orphaned_attachments
   exceptions:
   - Exception
   occurrence: 0
-  reason: 'See _run_sql_repair: same _repair_result(success=False, detail=f"...: {exc}") pattern.'
+  reason: 'See repair_empty_sessions: same _repair_result(success=False, detail=f"...: {exc}") pattern.'
 - path: polylogue/storage/repair.py
   function: <module>.repair_orphaned_messages
   exceptions:
   - Exception
   occurrence: 0
-  reason: 'See _run_sql_repair: same _repair_result(success=False, detail=f"...: {exc}") pattern.'
+  reason: 'See repair_empty_sessions: same _repair_result(success=False, detail=f"...: {exc}") pattern.'
 - path: polylogue/storage/repair.py
   function: <module>.repair_session_insights
   exceptions:
   - Exception
   occurrence: 0
-  reason: 'See _run_sql_repair: same _repair_result(success=False, detail=f"...: {exc}") pattern.'
+  reason: 'See repair_empty_sessions: same _repair_result(success=False, detail=f"...: {exc}") pattern.'
 - path: polylogue/storage/sqlite/archive_tiers/archive.py
   function: <module>._ensure_read_runtime_indexes
   exceptions:

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -5206,28 +5206,27 @@ def has_orphaned_messages_sync(conn: sqlite3.Connection) -> bool:
 
 
 def count_empty_sessions_sync(conn: sqlite3.Connection) -> int:
-    """Count session rows that are debris: no messages AND no acquired bytes.
+    """Count session rows that are debris: no messages AND a raw artifact the
+    current classifier positively refuses to admit as a session.
 
-    This deliberately does NOT count every message-less session. A session can
-    be legitimately empty, and the 2026-07-22 hook-inflation postmortem
-    explicitly chose to retain the genuinely-empty sessions that survived
-    de-inflation. Counting those here would report healthy rows as debt and
-    invite an operator to "repair" them away.
-
-    Measured on the live archive 2026-07-29: 874 message-less sessions, all
-    874 carrying a non-empty ``raw_id``. Under the old blanket predicate this
-    reported 874 rows of phantom debt; under the provenance-aware one it
-    reports 0, which is the truth.
+    This deliberately does NOT count every message-less session, and it does
+    NOT use ``raw_id IS NULL`` as the discriminator either (both were tried
+    and refuted -- see polylogue-ne6k). A session can be legitimately empty
+    (the 2026-07-22 hook-inflation postmortem explicitly chose to retain ~832
+    such sessions after de-inflation), and measured on the live archive
+    2026-07-29/31, every one of the 5,257 message-less sessions carries a
+    non-empty ``raw_id`` -- so "no acquired bytes" cannot separate the 4,945+
+    genuine phantoms (``<agent>.meta`` sidecars, misclassified non-transcript
+    artifacts) from the rest. The only discriminator that has evidence behind
+    it is WHAT THE ACQUIRED ARTIFACT IS: re-running each candidate's raw bytes
+    through the same ``classify_artifact``/``inspect_raw_artifact`` pipeline
+    live ingest uses, and counting only the ones it still refuses.
 
     Kept in lockstep with ``repair_empty_sessions``: the counter and the
     deleter must agree, or the report says one thing and the repair does
-    another.
+    another (both call ``_empty_session_debris_session_ids``).
     """
-    return int(
-        conn.execute(
-            f"SELECT COUNT(*) FROM sessions s WHERE {_EMPTY_SESSION_DEBRIS_PREDICATE.format(alias='s')}"
-        ).fetchone()[0]
-    )
+    return len(_empty_session_debris_session_ids(conn))
 
 
 def count_orphaned_attachments_sync(conn: sqlite3.Connection) -> int:
@@ -5520,52 +5519,6 @@ def preview_counts_from_archive_debt(
 
 
 # ---------------------------------------------------------------------------
-# Generic SQL repair helper
-# ---------------------------------------------------------------------------
-
-
-def _run_sql_repair(
-    target_name: str,
-    *,
-    count_sql: str,
-    action_sql: str | None,
-    dry_run: bool,
-    conn: sqlite3.Connection,
-) -> RepairResult:
-    try:
-        count = conn.execute(count_sql).fetchone()[0]
-        if dry_run:
-            return _repair_result(
-                target_name,
-                repaired_count=count,
-                success=True,
-                detail=f"Would: {count} rows affected" if count else "Would: No issues found",
-            )
-        if action_sql:
-            result = conn.execute(action_sql)
-            conn.commit()
-            return _repair_result(
-                target_name,
-                repaired_count=result.rowcount,
-                success=True,
-                detail=f"Repaired {result.rowcount} rows" if result.rowcount else "No repairs needed",
-            )
-        return _repair_result(
-            target_name,
-            repaired_count=0,
-            success=True,
-            detail="No action SQL provided",
-        )
-    except Exception as exc:
-        return _repair_result(
-            target_name,
-            repaired_count=0,
-            success=False,
-            detail=f"Repair failed: {exc}",
-        )
-
-
-# ---------------------------------------------------------------------------
 # Cleanup repairs (orphans, empty sessions, attachments)
 # ---------------------------------------------------------------------------
 
@@ -5631,36 +5584,143 @@ def preview_orphaned_messages(*, count: int) -> RepairResult:
     )
 
 
-#: A session is debris only when it has no messages AND no acquired bytes
-#: behind it. "No messages" alone is not evidence of corruption: a session can
-#: be legitimately empty (a browser-capture stub, a conversation opened and
-#: never used), and the 2026-07-22 hook-inflation postmortem explicitly chose
-#: to RETAIN the genuinely-empty sessions that survived de-inflation.
-#:
-#: Measured on the live archive 2026-07-29: 874 sessions have zero messages,
-#: and ALL 874 carry a non-empty ``raw_id`` -- every one has real acquired
-#: bytes. Zero lack provenance. So the old blanket predicate
-#: (``NOT EXISTS (messages)``) would have deleted 874 legitimately-acquired
-#: sessions and zero pieces of debris: a pure data-loss operation with no
-#: upside, one explicit ``--cleanup`` away from the live archive.
-#:
-#: ``raw_id`` is the provenance signal because it names the retained source
-#: bytes; a session carrying one can always be re-materialized by replay,
-#: which is precisely what makes it not debris.
-_EMPTY_SESSION_DEBRIS_PREDICATE = (
-    "NOT EXISTS (SELECT 1 FROM messages m WHERE m.session_id = {alias}.session_id) "
-    "AND ({alias}.raw_id IS NULL OR {alias}.raw_id = '')"
-)
+def _sibling_source_db_path(conn: sqlite3.Connection) -> Path | None:
+    """Return the ``source.db`` sibling of the index-tier file backing *conn*.
+
+    Both tiers always live side by side under the same archive root
+    (``storage/archive_identity.py``). Reading ``PRAGMA database_list``
+    instead of threading a path parameter keeps this usable both from
+    ``repair_empty_sessions`` (which opens its own index connection) and from
+    ``count_empty_sessions_sync`` (called with a caller-supplied, possibly
+    read-only, connection in ``maintenance/preview.py``).
+    """
+    for _seq, name, file in conn.execute("PRAGMA database_list"):
+        if name == "main" and file:
+            return Path(file).parent / "source.db"
+    return None
+
+
+def _empty_session_message_less_candidates(conn: sqlite3.Connection) -> list[tuple[str, str | None]]:
+    """Return ``(session_id, raw_id)`` for every session with zero messages."""
+    return [
+        (row["session_id"], row["raw_id"])
+        for row in conn.execute(
+            """
+            SELECT s.session_id AS session_id, s.raw_id AS raw_id
+            FROM sessions s
+            WHERE NOT EXISTS (SELECT 1 FROM messages m WHERE m.session_id = s.session_id)
+            """
+        ).fetchall()
+    ]
+
+
+def _raw_artifact_positively_fails_classification(conn: sqlite3.Connection, raw_id: str | None) -> bool:
+    """Return ``True`` only when *raw_id* resolves to source bytes that the
+    CURRENT ``classify_artifact``/``inspect_raw_artifact`` pipeline positively
+    refuses to admit as a session (``parse_as_session is False``).
+
+    Absence of positive evidence always means "retain": a missing/empty
+    ``raw_id``, a ``raw_sessions`` row that no longer exists (e.g. GC'd), or
+    an inspection failure all return ``False`` here rather than being treated
+    as debris by default. This is deliberately conservative in the opposite
+    direction from both predicates tried and refuted on polylogue-ne6k
+    (blanket "no messages", and "``raw_id IS NULL``"): a row can only be
+    deleted by *positive* evidence that the artifact behind it is not a
+    session, mirroring the ``looks_like_code`` fix in
+    ``sources/parsers/claude/code_detection.py`` (polylogue-9ykn/gvgi) that
+    requires a genuine record-envelope marker rather than a weak location- or
+    absence-based guess.
+    """
+    if not raw_id:
+        return False
+    row = conn.execute("SELECT * FROM source.raw_sessions WHERE raw_id = ?", (raw_id,)).fetchone()
+    if row is None:
+        return False
+
+    from polylogue.storage.artifacts.inspection import inspect_raw_artifact
+    from polylogue.storage.sqlite.queries.mappers import _row_to_raw_session
+
+    try:
+        record = _row_to_raw_session(row)
+        observation = inspect_raw_artifact(record)
+    except Exception:
+        # Cannot classify -> no positive evidence -> retain.
+        return False
+    return not observation.parse_as_session
+
+
+def _empty_session_debris_session_ids(conn: sqlite3.Connection) -> list[str]:
+    """Return ``session_id``s for message-less sessions whose raw artifact
+    positively fails the current record-shape classifier.
+
+    Shared by ``count_empty_sessions_sync`` and ``repair_empty_sessions`` so
+    the reported debt and the deleted rows can never diverge (polylogue-ne6k).
+    """
+    candidates = _empty_session_message_less_candidates(conn)
+    if not candidates:
+        return []
+    source_db = _sibling_source_db_path(conn)
+    if source_db is None or not source_db.exists():
+        # No source tier reachable -> no way to obtain positive evidence for
+        # any candidate -> retain all of them.
+        return []
+    conn.execute("ATTACH DATABASE ? AS source", (str(source_db),))
+    try:
+        return [
+            session_id
+            for session_id, raw_id in candidates
+            if _raw_artifact_positively_fails_classification(conn, raw_id)
+        ]
+    finally:
+        conn.execute("DETACH DATABASE source")
 
 
 def repair_empty_sessions(config: Config, dry_run: bool = False) -> RepairResult:
-    with _open_archive_index_connection() as conn:
-        return _run_sql_repair(
+    """Delete message-less sessions whose raw artifact positively fails the
+    current record-shape classifier.
+
+    See ``_raw_artifact_positively_fails_classification`` and
+    ``count_empty_sessions_sync`` for why "no messages" alone, and
+    "``raw_id IS NULL``", are both insufficient predicates -- both were tried
+    and refuted on polylogue-ne6k. A session with no messages is retained
+    unless its raw artifact, re-run through the live classification pipeline,
+    is itself refused as a session.
+    """
+    del config
+    try:
+        with _open_archive_index_connection() as conn:
+            session_ids = _empty_session_debris_session_ids(conn)
+            if dry_run:
+                return _repair_result(
+                    "empty_sessions",
+                    repaired_count=len(session_ids),
+                    success=True,
+                    detail=(f"Would: {len(session_ids)} rows affected" if session_ids else "Would: No issues found"),
+                )
+            if not session_ids:
+                return _repair_result(
+                    "empty_sessions",
+                    repaired_count=0,
+                    success=True,
+                    detail="No repairs needed",
+                )
+            conn.executemany(
+                "DELETE FROM sessions WHERE session_id = ?",
+                [(session_id,) for session_id in session_ids],
+            )
+            conn.commit()
+            return _repair_result(
+                "empty_sessions",
+                repaired_count=len(session_ids),
+                success=True,
+                detail=f"Repaired {len(session_ids)} rows",
+            )
+    except Exception as exc:
+        return _repair_result(
             "empty_sessions",
-            count_sql=(f"SELECT COUNT(*) FROM sessions c WHERE {_EMPTY_SESSION_DEBRIS_PREDICATE.format(alias='c')}"),
-            action_sql=(f"DELETE FROM sessions WHERE {_EMPTY_SESSION_DEBRIS_PREDICATE.format(alias='sessions')}"),
-            dry_run=dry_run,
-            conn=conn,
+            repaired_count=0,
+            success=False,
+            detail=f"Repair failed: {exc}",
         )
 
 

--- a/tests/integration/test_health.py
+++ b/tests/integration/test_health.py
@@ -31,15 +31,68 @@ def _position(native_id: str) -> int:
     return int.from_bytes(hashlib.sha256(native_id.encode()).digest()[:4], "big")
 
 
-def _insert_session(conn: sqlite3.Connection, session_id: str, source_name: str = "test", title: str = "Test") -> None:
+def _insert_session(
+    conn: sqlite3.Connection,
+    session_id: str,
+    source_name: str = "test",
+    title: str = "Test",
+    raw_id: str | None = None,
+) -> None:
     """Helper to insert a session with all required fields."""
     content_hash = hashlib.sha256(f"{source_name}:{session_id}".encode()).digest()
     conn.execute(
         """
-        INSERT INTO sessions (native_id, origin, title, content_hash)
-        VALUES (?, ?, ?, ?)
+        INSERT INTO sessions (native_id, origin, raw_id, title, content_hash)
+        VALUES (?, ?, ?, ?, ?)
         """,
-        (session_id, TEST_ORIGIN, title, content_hash),
+        (session_id, TEST_ORIGIN, raw_id, title, content_hash),
+    )
+
+
+def _write_raw_artifact(archive_root: Path, *, native_id: str, source_path: str, content: bytes) -> str:
+    """Write blob bytes plus a matching ``raw_sessions`` row; return the raw_id.
+
+    ``repair_empty_sessions`` (polylogue-ne6k) re-classifies each message-less
+    session's raw artifact through the live ``classify_artifact`` pipeline, so
+    a session that should be treated as debris (or retained) in these tests
+    needs a *real* raw artifact behind it, not just a bare ``raw_id`` string.
+    """
+    from polylogue.storage.blob_store import BlobStore
+
+    store = BlobStore(archive_root / "blob")
+    raw_id, blob_size = store.write_from_bytes(content)
+    with sqlite3.connect(archive_root / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size, acquired_at_ms
+            ) VALUES (?, ?, ?, ?, 0, ?, ?, 1)
+            """,
+            (raw_id, TEST_ORIGIN, native_id, source_path, bytes.fromhex(raw_id), blob_size),
+        )
+        conn.commit()
+    return raw_id
+
+
+def _write_debris_raw(archive_root: Path, native_id: str) -> str:
+    """An ``agent-*.meta.json`` sidecar: the genuinely-phantom artifact class
+    (4,945 of the 5,257 empty sessions on the live archive, polylogue-ne6k)."""
+    return _write_raw_artifact(
+        archive_root,
+        native_id=native_id,
+        source_path=f"agent-{native_id}.meta.json",
+        content=f'{{"agentType":"general-purpose","agentId":"{native_id}"}}'.encode(),
+    )
+
+
+def _write_legit_raw(archive_root: Path, native_id: str) -> str:
+    """A genuine record the current classifier still admits as a session --
+    the shape the 2026-07-22 hook-inflation postmortem retained ~832 of."""
+    return _write_raw_artifact(
+        archive_root,
+        native_id=native_id,
+        source_path=f"{native_id}.jsonl",
+        content=f'{{"type":"summary","sessionId":"{native_id}"}}\n'.encode(),
     )
 
 
@@ -215,7 +268,14 @@ class TestRepairOrphanedMessages:
 
 
 class TestRepairEmptySessions:
-    """Tests for repair_empty_sessions function."""
+    """Tests for repair_empty_sessions function.
+
+    polylogue-ne6k: a message-less session is deleted only when its raw
+    artifact positively fails the live ``classify_artifact`` pipeline (an
+    ``agent-*.meta.json`` sidecar phantom, here). A session with no messages
+    but a raw artifact the classifier still admits as a session (a genuinely
+    empty conversation), or with no raw provenance at all, must be retained.
+    """
 
     def test_clean_state_no_empty_sessions(self, cli_workspace: CliWorkspace) -> None:
         """repair_empty_sessions should return 0 when no empty convos exist."""
@@ -239,16 +299,19 @@ class TestRepairEmptySessions:
         assert result.success is True
 
     def test_empty_sessions_found_and_deleted(self, cli_workspace: CliWorkspace) -> None:
-        """repair_empty_sessions should find and delete empty sessions."""
+        """repair_empty_sessions deletes sessions whose raw artifact positively
+        fails classification (the agent-*.meta.json phantom shape)."""
         from polylogue.config import get_config
         from polylogue.storage.repair import repair_empty_sessions
         from polylogue.storage.sqlite.connection import connection_context
 
         config = get_config()
+        archive_root = cli_workspace["archive_root"]
+        raw_1 = _write_debris_raw(archive_root, "empty-1")
+        raw_2 = _write_debris_raw(archive_root, "empty-2")
         with connection_context(None) as conn:
-            # Create empty sessions (no messages)
-            _insert_session(conn, "empty-1")
-            _insert_session(conn, "empty-2")
+            _insert_session(conn, "empty-1", raw_id=raw_1)
+            _insert_session(conn, "empty-2", raw_id=raw_2)
             conn.commit()
 
         # Act
@@ -264,6 +327,53 @@ class TestRepairEmptySessions:
             remaining = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
             assert remaining == 0
 
+    def test_empty_sessions_retains_legitimately_empty_session(self, cli_workspace: CliWorkspace) -> None:
+        """A message-less session whose raw artifact the classifier still
+        admits as a session must survive -- this is the exact shape the
+        2026-07-22 hook-inflation postmortem retained ~832 of, and the exact
+        shape the old blanket predicate would have deleted (polylogue-ne6k)."""
+        from polylogue.config import get_config
+        from polylogue.storage.repair import repair_empty_sessions
+        from polylogue.storage.sqlite.connection import connection_context
+
+        config = get_config()
+        archive_root = cli_workspace["archive_root"]
+        legit_raw = _write_legit_raw(archive_root, "legit-empty")
+        debris_raw = _write_debris_raw(archive_root, "phantom")
+        with connection_context(None) as conn:
+            _insert_session(conn, "legit-empty", raw_id=legit_raw)
+            _insert_session(conn, "phantom", raw_id=debris_raw)
+            conn.commit()
+
+        result = repair_empty_sessions(config, dry_run=False)
+
+        assert result.repaired_count == 1
+
+        with connection_context(None) as conn:
+            remaining = {row[0] for row in conn.execute("SELECT native_id FROM sessions").fetchall()}
+            assert remaining == {"legit-empty"}
+
+    def test_empty_sessions_retains_no_provenance_session(self, cli_workspace: CliWorkspace) -> None:
+        """A message-less session with no raw_id at all has no positive
+        evidence either way and must be retained, not treated as debris by
+        default (the refuted 'raw_id IS NULL = debris' direction, polylogue-ne6k)."""
+        from polylogue.config import get_config
+        from polylogue.storage.repair import repair_empty_sessions
+        from polylogue.storage.sqlite.connection import connection_context
+
+        config = get_config()
+        with connection_context(None) as conn:
+            _insert_session(conn, "no-provenance", raw_id=None)
+            conn.commit()
+
+        result = repair_empty_sessions(config, dry_run=False)
+
+        assert result.repaired_count == 0
+
+        with connection_context(None) as conn:
+            remaining = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+            assert remaining == 1
+
     def test_empty_sessions_dry_run_counts_but_doesnt_delete(self, cli_workspace: CliWorkspace) -> None:
         """repair_empty_sessions with dry_run=True should count but not delete."""
         from polylogue.config import get_config
@@ -271,8 +381,10 @@ class TestRepairEmptySessions:
         from polylogue.storage.sqlite.connection import connection_context
 
         config = get_config()
+        archive_root = cli_workspace["archive_root"]
+        raw_1 = _write_debris_raw(archive_root, "empty-1")
         with connection_context(None) as conn:
-            _insert_session(conn, "empty-1")
+            _insert_session(conn, "empty-1", raw_id=raw_1)
             conn.commit()
 
         # Act
@@ -294,8 +406,10 @@ class TestRepairEmptySessions:
         from polylogue.storage.sqlite.connection import connection_context
 
         config = get_config()
+        archive_root = cli_workspace["archive_root"]
+        raw_1 = _write_debris_raw(archive_root, "empty-1")
         with connection_context(None) as conn:
-            _insert_session(conn, "empty-1")
+            _insert_session(conn, "empty-1", raw_id=raw_1)
             conn.commit()
 
         # First repair

--- a/tests/unit/pipeline/test_differential_paths.py
+++ b/tests/unit/pipeline/test_differential_paths.py
@@ -175,6 +175,14 @@ class TestHealthRepairConvergence:
         assert count >= 1, "Should detect at least 1 orphaned message"
 
     def test_empty_session_count_agrees(self: object, workspace_env: dict[str, Path]) -> None:
+        """``count_empty_sessions_sync`` only counts a message-less session as
+        debris when its raw artifact positively fails the live
+        ``classify_artifact`` pipeline (polylogue-ne6k) -- so this seeds a
+        real ``agent-*.meta.json`` sidecar raw artifact (the genuinely-phantom
+        shape) behind the empty session, not a bare session row."""
+        import sqlite3
+
+        from polylogue.storage.blob_store import BlobStore
         from polylogue.storage.repair import count_empty_sessions_sync
         from tests.infra.archive_scenarios import open_index_db
         from tests.infra.storage_records import SessionBuilder, db_setup
@@ -182,17 +190,34 @@ class TestHealthRepairConvergence:
         db_path = db_setup(workspace_env)
         # Seed one real session so the archive schema is bootstrapped.
         SessionBuilder(db_path, "seed").provider("chatgpt").title("Seed").add_message(role="user", text="hi").save()
+
+        archive_root = workspace_env["archive_root"]
+        blob_store = BlobStore(archive_root / "blob")
+        raw_id, blob_size = blob_store.write_from_bytes(b'{"agentType":"general-purpose"}')
+        with sqlite3.connect(archive_root / "source.db") as source_conn:
+            source_conn.execute(
+                """
+                INSERT INTO raw_sessions (
+                    raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size, acquired_at_ms
+                ) VALUES (?, 'chatgpt-export', 'ext-empty', 'agent-empty.meta.json', 0, ?, ?, 1)
+                """,
+                (raw_id, bytes.fromhex(raw_id), blob_size),
+            )
+            source_conn.commit()
+
         with open_index_db(db_path) as conn:
             # A archive session row with no messages is the "empty session"
             # shape; ``content_hash`` is a 32-byte BLOB by CHECK constraint.
             conn.execute(
-                "INSERT INTO sessions (native_id, origin, title, content_hash) "
-                "VALUES ('ext-empty', 'chatgpt-export', 'Empty', X'0011223344556677889900112233445566778899001122334455667788990011')"
+                "INSERT INTO sessions (native_id, origin, raw_id, title, content_hash) "
+                "VALUES ('ext-empty', 'chatgpt-export', ?, 'Empty', "
+                "X'0011223344556677889900112233445566778899001122334455667788990011')",
+                (raw_id,),
             )
             conn.commit()
             count = count_empty_sessions_sync(conn)
 
-        assert count >= 1, "Should detect empty session"
+        assert count >= 1, "Should detect empty session whose raw artifact fails classification"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/storage/test_empty_session_repair_provenance.py
+++ b/tests/unit/storage/test_empty_session_repair_provenance.py
@@ -1,86 +1,182 @@
-"""Empty-session repair must delete debris, not legitimately-empty sessions.
+"""Empty-session repair must delete positively-classified debris, never a
+session that is merely message-less.
 
-`repair_empty_sessions` used a blanket `NOT EXISTS (messages)` predicate, which
-cannot distinguish corruption debris from a session that is legitimately empty.
-That distinction is load-bearing here: the 2026-07-22 hook-inflation postmortem
-explicitly chose to RETAIN the genuinely-empty sessions that survived
+History (polylogue-ne6k): the original ``repair_empty_sessions`` predicate was
+a blanket ``NOT EXISTS (messages)`` join, which cannot distinguish corruption
+debris from a session that is legitimately empty -- the 2026-07-22
+hook-inflation postmortem explicitly chose to RETAIN ~832 such sessions after
 de-inflation.
 
-Measured on the live archive 2026-07-29: 874 message-less sessions, and all 874
-carry a non-empty `raw_id` -- every one has real acquired bytes behind it, zero
-lack provenance. So the old predicate would have deleted 874 legitimately
-acquired sessions and zero pieces of debris. It was one explicit `--cleanup`
-away from running against the live archive.
+A first fix attempt tried ``raw_id IS NULL`` as the discriminator ("no
+acquired bytes behind it = illegitimate"). That was tried and REFUTED: measured
+on the live archive, all 5,257 message-less sessions carry a non-empty
+``raw_id`` -- 4,945 of them are ``<agent>.meta`` sidecar phantoms that were
+genuinely acquired (the sidecar file really was read), so "acquisition
+happened" cannot separate phantoms from legitimate stubs.
 
-`raw_id` is the right signal because it names the retained source bytes: a
-session carrying one can always be re-materialized by replay, which is exactly
-what makes it not debris.
+The real discriminator is WHAT THE ACQUIRED ARTIFACT IS, not whether bytes
+were acquired: re-run each candidate's raw bytes through the same
+``classify_artifact``/``inspect_raw_artifact`` pipeline live ingest uses, and
+only delete the ones that pipeline still refuses to admit as a session. This
+mirrors the ``looks_like_code`` fix in
+``sources/parsers/claude/code_detection.py`` (polylogue-9ykn/gvgi): a genuine
+positive marker is required, never a location- or absence-based guess.
 """
 
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Iterator
+from pathlib import Path
 
+import pytest
+
+from polylogue.storage.blob_store import BlobStore, reset_blob_store
 from polylogue.storage.repair import count_empty_sessions_sync
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+_ORIGIN = "claude-code-session"
 
 
-def _seed(conn: sqlite3.Connection) -> None:
-    conn.executescript(
-        """
-        CREATE TABLE sessions (
-            session_id TEXT PRIMARY KEY,
-            origin     TEXT NOT NULL,
-            raw_id     TEXT
-        );
-        CREATE TABLE messages (
-            message_id TEXT PRIMARY KEY,
-            session_id TEXT NOT NULL
-        );
-        """
-    )
-    conn.executemany(
-        "INSERT INTO sessions (session_id, origin, raw_id) VALUES (?, ?, ?)",
-        [
-            # Legitimately empty: acquired bytes exist, replay can rebuild it.
-            ("claude-code-session:acquired-empty", "claude-code-session", "rawhash-aaa"),
-            # Debris: no messages and no provenance at all.
-            ("claude-code-session:debris", "claude-code-session", None),
-            ("claude-code-session:debris-blank", "claude-code-session", ""),
-            # Healthy: has messages.
-            ("claude-code-session:healthy", "claude-code-session", "rawhash-bbb"),
-        ],
-    )
+@pytest.fixture
+def archive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """A real split source.db/index.db pair plus a blob store, all under tmp_path."""
+    initialize_archive_database(tmp_path / "source.db", ArchiveTier.SOURCE)
+    initialize_archive_database(tmp_path / "index.db", ArchiveTier.INDEX)
+    blob_root = tmp_path / "blob"
+    monkeypatch.setattr("polylogue.paths.blob_store_root", lambda: blob_root)
+    monkeypatch.setattr("polylogue.storage.blob_store.blob_store_root", lambda: blob_root, raising=False)
+    reset_blob_store()
+    yield tmp_path
+    reset_blob_store()
+
+
+def _insert_raw_session(
+    conn: sqlite3.Connection,
+    *,
+    raw_id: str,
+    native_id: str,
+    source_path: str,
+    blob_size: int,
+) -> None:
     conn.execute(
-        "INSERT INTO messages (message_id, session_id) VALUES (?, ?)",
-        ("m1", "claude-code-session:healthy"),
+        """
+        INSERT INTO raw_sessions (
+            raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size, acquired_at_ms
+        ) VALUES (?, ?, ?, ?, 0, ?, ?, 1)
+        """,
+        (raw_id, _ORIGIN, native_id, source_path, bytes.fromhex(raw_id), blob_size),
     )
+
+
+def _insert_session(conn: sqlite3.Connection, *, native_id: str, raw_id: str | None) -> str:
+    conn.execute(
+        "INSERT INTO sessions (native_id, origin, raw_id, title, content_hash) VALUES (?, ?, ?, ?, ?)",
+        (native_id, _ORIGIN, raw_id, "Test", bytes(32)),
+    )
+    row = conn.execute(
+        "SELECT session_id FROM sessions WHERE native_id = ? AND origin = ?",
+        (native_id, _ORIGIN),
+    ).fetchone()
+    return str(row[0])
+
+
+def _insert_message(conn: sqlite3.Connection, *, session_id: str, native_id: str) -> None:
+    conn.execute(
+        "INSERT INTO messages (session_id, native_id, position, role, word_count, content_hash) "
+        "VALUES (?, ?, 0, 'user', 1, ?)",
+        (session_id, native_id, bytes(32)),
+    )
+
+
+def _seed(archive: Path) -> sqlite3.Connection:
+    """Seed one of every candidate shape and return an open index.db connection.
+
+    - ``legit-empty``: raw bytes the current classifier still admits as a
+      session (a genuine Claude Code record with a ``sessionId`` marker) --
+      the shape the hook-inflation postmortem retained ~832 of.
+    - ``phantom``: raw bytes an ``agent-*.meta.json`` sidecar path -- the
+      4,945-row phantom class that is genuinely debris.
+    - ``no-provenance``: no ``raw_id`` at all -- no evidence either way, so it
+      must be retained, not treated as debris by default.
+    - ``healthy``: has a message, excluded regardless of provenance.
+    """
+    store = BlobStore(archive / "blob")
+    legit_raw_id, legit_size = store.write_from_bytes(b'{"type":"summary","sessionId":"legit-empty-1"}\n')
+    phantom_raw_id, phantom_size = store.write_from_bytes(b'{"agentType":"general-purpose"}')
+
+    with sqlite3.connect(archive / "source.db") as source_conn:
+        _insert_raw_session(
+            source_conn,
+            raw_id=legit_raw_id,
+            native_id="legit-empty",
+            source_path="conversation.jsonl",
+            blob_size=legit_size,
+        )
+        _insert_raw_session(
+            source_conn,
+            raw_id=phantom_raw_id,
+            native_id="phantom",
+            source_path="agent-1234.meta.json",
+            blob_size=phantom_size,
+        )
+        source_conn.commit()
+
+    conn = sqlite3.connect(archive / "index.db")
+    conn.row_factory = sqlite3.Row
+    _insert_session(conn, native_id="legit-empty", raw_id=legit_raw_id)
+    _insert_session(conn, native_id="phantom", raw_id=phantom_raw_id)
+    _insert_session(conn, native_id="no-provenance", raw_id=None)
+    healthy_session_id = _insert_session(conn, native_id="healthy", raw_id=None)
+    _insert_message(conn, session_id=healthy_session_id, native_id="m1")
     conn.commit()
+    return conn
 
 
-def test_only_sessions_without_provenance_count_as_debris() -> None:
-    """The exact live shape: an acquired-but-empty session is NOT debt."""
-    conn = sqlite3.connect(":memory:")
-    conn.row_factory = sqlite3.Row
-    _seed(conn)
-
-    # Two debris rows (NULL and empty-string raw_id); the acquired-empty and
-    # the healthy session are both excluded.
-    assert count_empty_sessions_sync(conn) == 2
+def test_only_the_positively_refused_artifact_counts_as_debris(archive: Path) -> None:
+    conn = _seed(archive)
+    try:
+        assert count_empty_sessions_sync(conn) == 1
+    finally:
+        conn.close()
 
 
-def test_blanket_predicate_would_have_reported_the_retained_session() -> None:
-    """Pin the defect itself, so a revert is caught rather than silently re-shipped."""
-    conn = sqlite3.connect(":memory:")
-    conn.row_factory = sqlite3.Row
-    _seed(conn)
+def test_blanket_predicate_would_have_swept_up_legitimate_sessions(archive: Path) -> None:
+    """Pin the defect itself: a revert to the old blanket predicate must fail this."""
+    conn = _seed(archive)
+    try:
+        blanket = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM sessions s "
+                "WHERE NOT EXISTS (SELECT 1 FROM messages m WHERE m.session_id = s.session_id)"
+            ).fetchone()[0]
+        )
+        # The blanket predicate sweeps in the legitimately-empty session and
+        # the no-provenance session too -- three total, not one.
+        assert blanket == 3
+        assert count_empty_sessions_sync(conn) == 1, (
+            "classifier-aware count must exclude the legitimate and no-provenance sessions"
+        )
+    finally:
+        conn.close()
 
-    blanket = int(
-        conn.execute(
-            "SELECT COUNT(*) FROM sessions s "
-            "WHERE NOT EXISTS (SELECT 1 FROM messages m WHERE m.session_id = s.session_id)"
-        ).fetchone()[0]
-    )
 
-    # The old predicate sweeps in the acquired-but-empty session too.
-    assert blanket == 3
-    assert count_empty_sessions_sync(conn) == 2, "provenance-aware count must exclude the acquired session"
+def test_raw_id_is_null_predicate_would_have_missed_the_phantom(archive: Path) -> None:
+    """Pin the other refuted defect (polylogue-ne6k correction): the phantom
+    row carries a non-empty raw_id, so 'debris = raw_id IS NULL' reports zero
+    debris here too, exactly like the live-archive measurement that refuted
+    it."""
+    conn = _seed(archive)
+    try:
+        raw_id_null_predicate = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM sessions s "
+                "WHERE NOT EXISTS (SELECT 1 FROM messages m WHERE m.session_id = s.session_id) "
+                "AND (s.raw_id IS NULL OR s.raw_id = '')"
+            ).fetchone()[0]
+        )
+        assert raw_id_null_predicate == 1  # only "no-provenance" -- the wrong row
+        assert count_empty_sessions_sync(conn) == 1  # only "phantom" -- the right row
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

\`repair_empty_sessions\` / \`count_empty_sessions_sync\` now delete a message-less session only when its raw artifact positively fails the same \`classify_artifact\`/\`inspect_raw_artifact\` classification pipeline live ingest uses. Absence of positive evidence (missing raw_id, a vanished \`raw_sessions\` row, or an inspection failure) always means retain.

## Problem

The bead's own notes (polylogue-ne6k) record two refuted predicates in sequence:

1. An original blanket \`NOT EXISTS (messages)\` predicate would delete every message-less session, including the ~832 sessions the 2026-07-22 hook-inflation postmortem explicitly retained after de-inflation.
2. A first fix attempt tried \`raw_id IS NULL\` as the debris signal. Measured on the live archive, all 5,257 message-less sessions carry a non-empty \`raw_id\`, including the 4,945 \`agent-*.meta.json\` phantom sidecars that are genuine debris — so that predicate reported zero debt while leaving every phantom in place.

The bead's conclusion: the discriminator is WHAT THE ACQUIRED ARTIFACT IS, not whether bytes were acquired, mirroring the \`looks_like_code\` fix in \`sources/parsers/claude/code_detection.py\` (polylogue-9ykn/gvgi) that requires a genuine positive record-envelope marker rather than a location- or absence-based guess.

## Solution

\`polylogue/storage/repair.py\`:

- \`count_empty_sessions_sync\` and \`repair_empty_sessions\` now share \`_empty_session_debris_session_ids\`, which:
  - finds every message-less session (\`session_id\`, \`raw_id\`),
  - attaches the sibling \`source.db\` read-only (via \`PRAGMA database_list\` on the caller's own connection, so it works both for \`repair_empty_sessions\`'s own index connection and for the caller-supplied connection in \`maintenance/preview.py\`),
  - re-derives each candidate's \`raw_sessions\` row and runs it through \`inspect_raw_artifact\` (the same code path \`materialize_artifact_observations\`/live ingest uses),
  - deletes only the ones \`parse_as_session\` refuses.
- Removed the now-dead \`_EMPTY_SESSION_DEBRIS_PREDICATE\` and the \`_run_sql_repair\` helper (repair_empty_sessions no longer expresses its predicate as pure SQL).
- Updated \`docs/plans/degrade-loudly-allowlist.yaml\`: renamed the stale \`_run_sql_repair\` entry to \`repair_empty_sessions\` (same inlined pattern) and added an entry for \`_raw_artifact_positively_fails_classification\`'s except (classification failure is not itself an error worth surfacing — it's just another "no positive evidence, retain" path).

Deliberately out of scope: the separate reindex effort that re-parses everything from raw using the fixed classifiers (prevents most of these phantoms from being recreated going forward). This PR only fixes the repair tool's own predicate and cleans up already-indexed phantom rows on demand; it does not trigger or perform any reindex.

## Verification

- \`devtools test tests/unit/storage/test_repair.py tests/unit/storage/test_empty_session_repair_provenance.py tests/integration/test_health.py tests/unit/pipeline/test_differential_paths.py tests/unit/maintenance/test_preview.py\` — 61 passed (excluding 11 pre-existing \`raw_materialization\`-suite failures unrelated to this change, confirmed present on \`master\` via \`git stash\` before applying this diff).
- \`tests/unit/storage/test_empty_session_repair_provenance.py\` rewritten against a real \`source.db\`/\`index.db\`/blob-store archive (not an in-memory stub); pins both refuted predicates as regressions (a mutation reverting to either the blanket "no messages" predicate or the \`raw_id IS NULL\` predicate fails these tests) alongside the correct classifier-based count.
- \`tests/integration/test_health.py::TestRepairEmptySessions\` gains real raw-artifact fixtures (an \`agent-*.meta.json\` phantom vs. a genuine \`sessionId\` record) and two new tests asserting a legitimately-empty session and a no-provenance session both survive \`repair_empty_sessions\`.
- \`mypy --strict polylogue/storage/repair.py\` clean.
- \`ruff check\` / \`ruff format --check\` clean.
- \`devtools render all --check\` clean.
- \`devtools verify --quick\` clean (18/18 steps, including \`verify degrade-loudly\`).

Ref polylogue-ne6k