### PR TITLE
feat(sources): add per-file acquisition logging and tighten claude-ai detection

### DIFF
--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -927,7 +927,7 @@ files:
     target: polylogue/cli/commands/judge.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/__init__.py
-    loc: 164
+    loc: 179
     target: polylogue/cli/commands/maintenance/__init__.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_archive_plan.py
@@ -991,7 +991,7 @@ files:
     target: polylogue/cli/commands/maintenance/_run.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_shared.py
-    loc: 98
+    loc: 143
     target: polylogue/cli/commands/maintenance/_shared.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_status.py
@@ -1733,7 +1733,7 @@ files:
     target: polylogue/daemon/similarity.py
     owner: stable
   - path: polylogue/daemon/socket_path.py
-    loc: 53
+    loc: 73
     target: polylogue/daemon/socket_path.py
     owner: stable
   - path: polylogue/daemon/status.py
@@ -3240,7 +3240,7 @@ files:
     target: polylogue/sources/decoders.py
     owner: stable
   - path: polylogue/sources/dispatch.py
-    loc: 1762
+    loc: 1828
     target: polylogue/sources/dispatch.py
     owner: stable
   - path: polylogue/sources/drive/__init__.py
@@ -3311,12 +3311,16 @@ files:
     loc: 29
     target: polylogue/sources/live/_lag_sample_ddl.py
     owner: stable
+  - path: polylogue/sources/live/acquisition_log.py
+    loc: 248
+    target: polylogue/sources/live/acquisition_log.py
+    owner: stable
   - path: polylogue/sources/live/append_ingest.py
     loc: 289
     target: polylogue/sources/live/append_ingest.py
     owner: stable
   - path: polylogue/sources/live/batch.py
-    loc: 3146
+    loc: 3166
     target: polylogue/sources/live/batch.py
     owner: stable
   - path: polylogue/sources/live/batch_observability.py
@@ -3376,7 +3380,7 @@ files:
     target: polylogue/sources/live/tool_result_sidecars.py
     owner: stable
   - path: polylogue/sources/live/watcher.py
-    loc: 1470
+    loc: 1499
     target: polylogue/sources/live/watcher.py
     owner: stable
   - path: polylogue/sources/origin_specs.py
@@ -3388,7 +3392,7 @@ files:
     target: polylogue/sources/parsers/antigravity.py
     owner: stable
   - path: polylogue/sources/parsers/base.py
-    loc: 40
+    loc: 42
     target: polylogue/sources/parsers/base.py
     owner: stable
   - path: polylogue/sources/parsers/base_models.py
@@ -3397,7 +3401,7 @@ files:
     owner: stable
     cross_cut: { lifecycle: model }
   - path: polylogue/sources/parsers/base_support.py
-    loc: 345
+    loc: 370
     target: polylogue/sources/parsers/base_support.py
     owner: stable
   - path: polylogue/sources/parsers/beads.py
@@ -3425,7 +3429,7 @@ files:
     target: polylogue/sources/parsers/claude/__init__.py
     owner: stable
   - path: polylogue/sources/parsers/claude/ai_parser.py
-    loc: 672
+    loc: 710
     target: polylogue/sources/parsers/claude/ai_parser.py
     owner: stable
   - path: polylogue/sources/parsers/claude/code_detection.py
@@ -3433,7 +3437,7 @@ files:
     target: polylogue/sources/parsers/claude/code_detection.py
     owner: stable
   - path: polylogue/sources/parsers/claude/code_parser.py
-    loc: 2088
+    loc: 2108
     target: polylogue/sources/parsers/claude/code_parser.py
     owner: stable
   - path: polylogue/sources/parsers/claude/common.py
@@ -3569,7 +3573,7 @@ files:
     target: polylogue/sources/source_acquisition.py
     owner: stable
   - path: polylogue/sources/source_acquisition_components.py
-    loc: 499
+    loc: 533
     target: polylogue/sources/source_acquisition_components.py
     owner: stable
   - path: polylogue/sources/source_parsing.py
@@ -3694,7 +3698,7 @@ files:
     target: polylogue/storage/embeddings/identity.py
     owner: stable
   - path: polylogue/storage/embeddings/materialization.py
-    loc: 1817
+    loc: 1825
     target: polylogue/storage/embeddings/materialization.py
     owner: stable
   - path: polylogue/storage/embeddings/models.py
@@ -3904,12 +3908,12 @@ files:
     target: TBD
     owner: storage-domain
   - path: polylogue/storage/raw_retention.py
-    loc: 1808
+    loc: 1954
     target: polylogue/storage/raw_retention.py
     owner: storage-root
     reason: storage-root cross-cutting helper
   - path: polylogue/storage/repair.py
-    loc: 7149
+    loc: 7155
     target: polylogue/storage/repair.py
     owner: storage-root
     reason: storage-root cross-cutting helper
@@ -4181,7 +4185,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/index_fast_forward_executor.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
-    loc: 358
+    loc: 390
     target: polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/ops.py

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -181,65 +181,83 @@ def _looks_like_gemini_mapping(record: PayloadRecord) -> bool:
     return drive.looks_like(record)
 
 
-def _detect_provider_from_record(record: PayloadRecord) -> Provider | None:
+def _detect_provider_from_record_evidence(record: PayloadRecord) -> tuple[Provider | None, str]:
+    """Detect a provider from a single record, tagging the deciding evidence.
+
+    Sole implementation of the record-level detector order; ``_detect_provider_from_record``
+    below is a thin wrapper that discards the evidence label, so this is the
+    single source of truth -- there is no separate "logging" copy of the
+    decision tree that can silently drift from the real one (observability
+    gap fix, mission item 1).
+    """
     if browser_capture.looks_like(record):
         session = record.get("session")
         provider = session.get("provider") if isinstance(session, dict) else None
-        return Provider.from_string(provider if isinstance(provider, str) else None)
+        return Provider.from_string(provider if isinstance(provider, str) else None), "browser_capture.looks_like"
     # Local-agent JSON session documents share enough generic message keys with
     # Claude Code that they must be recognized before broader validators.
     if local_agent.looks_like_gemini_cli(record):
-        return Provider.GEMINI_CLI
+        return Provider.GEMINI_CLI, "local_agent.looks_like_gemini_cli"
     if hermes_state.looks_like_state_db_payload(record):
-        return Provider.HERMES
+        return Provider.HERMES, "hermes_state.looks_like_state_db_payload"
     if hermes_verification.looks_like_verification_evidence_db_payload(record):
-        return Provider.HERMES
+        return Provider.HERMES, "hermes_verification.looks_like_verification_evidence_db_payload"
     if hermes_spans.looks_like_atif_payload(record):
-        return Provider.HERMES
+        return Provider.HERMES, "hermes_spans.looks_like_atif_payload"
     if hermes_spans.looks_like_atof_payload(record):
-        return Provider.HERMES
+        return Provider.HERMES, "hermes_spans.looks_like_atof_payload"
     if local_agent.looks_like_hermes(record):
-        return Provider.HERMES
+        return Provider.HERMES, "local_agent.looks_like_hermes"
     if antigravity.looks_like_markdown_export(record):
-        return Provider.ANTIGRAVITY
+        return Provider.ANTIGRAVITY, "antigravity.looks_like_markdown_export"
     if antigravity.looks_like_brain_metadata(record, None):
-        return Provider.ANTIGRAVITY
+        return Provider.ANTIGRAVITY, "antigravity.looks_like_brain_metadata"
     if beads.looks_like(record):
-        return Provider.BEADS
+        return Provider.BEADS, "beads.looks_like"
     # Specific type-level checks first (Codex uses Pydantic validation;
     # Claude Code uses a dict-key/type shape check, not Pydantic, despite
     # ClaudeCodeRecord existing as a separate typed parse-time model), then
     # weaker dict-key checks (ChatGPT, Claude AI, Gemini).
     if codex.looks_like([dict(record)]):
-        return Provider.CODEX
+        return Provider.CODEX, "codex.looks_like (pydantic record validation)"
     if claude.looks_like_code([dict(record)]):
-        return Provider.CLAUDE_CODE
+        return Provider.CLAUDE_CODE, "claude.looks_like_code (envelope marker, #3428)"
     # A single record here may be an intentionally partial ChatGPT fragment
     # (e.g. one line of a streamed JSONL sniff), not a whole assembled
     # export document, so this uses the fragment-level check rather than
     # ``chatgpt.looks_like``'s document-identity requirements (polylogue-t0ta).
     if chatgpt.looks_like_fragment(record):
-        return Provider.CHATGPT
+        return Provider.CHATGPT, "chatgpt.looks_like_fragment (mapping node shape)"
     # Claude Design (bd polylogue-tbun) checked before the general claude.ai
     # detector: its shape (messages + project, no chat_messages, camelCase
     # contentBlocks) is a distinct, tighter product signature -- not a
     # claude.ai variant.
     if claude.looks_like_claude_design(record):
-        return Provider.CLAUDE_DESIGN
+        return Provider.CLAUDE_DESIGN, "claude.looks_like_claude_design"
     if claude.looks_like_claude_memories(record):
-        return Provider.CLAUDE_AI
+        return Provider.CLAUDE_AI, "claude.looks_like_claude_memories"
     if claude.looks_like_ai(record):
-        return Provider.CLAUDE_AI
+        return Provider.CLAUDE_AI, "claude.looks_like_ai (non-empty plausible chat_messages)"
     if grok.looks_like_export(record):
-        return Provider.GROK
+        return Provider.GROK, "grok.looks_like_export"
     if _looks_like_gemini_mapping(record):
-        return Provider.GEMINI
-    return None
+        return Provider.GEMINI, "drive.looks_like (chunkedPrompt/chunks)"
+    return None, "no detector matched (single record)"
 
 
-def _detect_provider_from_sequence(payloads: PayloadSequence) -> Provider | None:
+def _detect_provider_from_record(record: PayloadRecord) -> Provider | None:
+    return _detect_provider_from_record_evidence(record)[0]
+
+
+def _detect_provider_from_sequence_evidence(payloads: PayloadSequence) -> tuple[Provider | None, str]:
+    """Detect a provider from a payload sequence, tagging the deciding evidence.
+
+    Sole implementation of the sequence-level detector order; see
+    ``_detect_provider_from_record_evidence`` for the equivalent single-record
+    rationale.
+    """
     if not payloads:
-        return None
+        return None, "empty sequence"
 
     first_record = _payload_record(payloads[0])
     if first_record is not None:
@@ -259,56 +277,84 @@ def _detect_provider_from_sequence(payloads: PayloadSequence) -> Provider | None
         if local_agent.looks_like_gemini_cli(first_record) and (
             len(payloads) == 1 or not isinstance(first_record.get("messages"), list)
         ):
-            return Provider.GEMINI_CLI
+            return Provider.GEMINI_CLI, "local_agent.looks_like_gemini_cli (stub record)"
         if browser_capture.looks_like(first_record):
-            return _detect_provider_from_record(first_record)
+            provider, evidence = _detect_provider_from_record_evidence(first_record)
+            return provider, f"sequence[0] browser_capture.looks_like -> {evidence}"
         if hermes_spans.looks_like_atof_payload(first_record):
-            return Provider.HERMES
+            return Provider.HERMES, "hermes_spans.looks_like_atof_payload (sequence[0])"
         if beads.looks_like(first_record):
-            return Provider.BEADS
+            return Provider.BEADS, "beads.looks_like (sequence[0])"
         # The first record of a *sequence* is a whole assembled document
         # (e.g. one conversation from a ChatGPT bundle array), not a
         # partial per-line fragment, so this uses the strict document-level
         # check rather than ``looks_like_fragment`` (polylogue-t0ta).
         if chatgpt.looks_like(first_record):
-            return Provider.CHATGPT
+            return Provider.CHATGPT, "chatgpt.looks_like (sequence[0] whole-document)"
         if isinstance(first_record.get("chat_messages"), list):
-            return Provider.CLAUDE_AI
+            return Provider.CLAUDE_AI, "sequence[0] chat_messages dict-key present"
         # Claude AI account memory export (memories.json, bd polylogue-zng9)
         # arrives as a bare top-level JSON array of one-per-account records.
         if claude.looks_like_claude_memories(first_record):
-            return Provider.CLAUDE_AI
+            return Provider.CLAUDE_AI, "claude.looks_like_claude_memories (sequence[0])"
         if claude.looks_like_claude_design(first_record):
-            return Provider.CLAUDE_DESIGN
+            return Provider.CLAUDE_DESIGN, "claude.looks_like_claude_design (sequence[0])"
         if grok.looks_like_export(first_record):
-            return Provider.GROK
+            return Provider.GROK, "grok.looks_like_export (sequence[0])"
         if _looks_like_gemini_mapping(first_record):
-            return Provider.GEMINI
+            return Provider.GEMINI, "drive.looks_like (sequence[0])"
 
     if claude.looks_like_code(payloads):
-        return Provider.CLAUDE_CODE
+        return Provider.CLAUDE_CODE, "claude.looks_like_code (record stream envelope markers)"
     if codex.looks_like(payloads):
-        return Provider.CODEX
-    return None
+        return Provider.CODEX, "codex.looks_like (pydantic record stream validation)"
+    return None, "no detector matched (sequence)"
+
+
+def _detect_provider_from_sequence(payloads: PayloadSequence) -> Provider | None:
+    return _detect_provider_from_sequence_evidence(payloads)[0]
+
+
+def detect_provider_evidence(payload: object, path: object | None = None) -> tuple[Provider | None, str]:
+    """Infer provider from payload shape, plus the evidence that decided it.
+
+    ``detect_provider`` is a thin wrapper over this function that discards the
+    evidence label for existing call sites; use this variant wherever the
+    deciding rule needs to be surfaced (acquisition logging, ``import
+    explain``-style diagnostics).
+    """
+    del path
+
+    if record := _payload_record(payload):
+        return _detect_provider_from_record_evidence(record)
+    payloads = _payload_sequence(payload)
+    if payloads is not None:
+        return _detect_provider_from_sequence_evidence(payloads)
+    return None, "payload is not a JSON document or sequence"
 
 
 def detect_provider(payload: object, path: object | None = None) -> Provider | None:
     """Infer provider from payload shape. Path is accepted for surface compatibility."""
-    del path
-
-    if record := _payload_record(payload):
-        return _detect_provider_from_record(record)
-    payloads = _payload_sequence(payload)
-    return _detect_provider_from_sequence(payloads) if payloads is not None else None
+    return detect_provider_evidence(payload, path)[0]
 
 
-def _detect_provider_from_raw_bytes(
+def detect_provider_from_raw_bytes_evidence(
     raw_bytes: bytes,
     stream_name: str,
     fallback_provider: Provider,
     *,
     truncated_tail_ok: bool = False,
-) -> Provider:
+) -> tuple[Provider, str]:
+    """Detect a provider from a raw byte prefix, plus the evidence that decided it.
+
+    Sole implementation of the raw-bytes detection path; ``_detect_provider_from_raw_bytes``
+    is a thin wrapper that discards the evidence label. Used directly by the
+    production per-file acquisition log
+    (``source_acquisition_components.read_plain_source_file``) and by the
+    unclaimed-file sweep's real shape check (``sources.live.acquisition_log.
+    default_file_claim_check``) so both surfaces report the same rule a real
+    ingest would have used, not an approximation.
+    """
     jsonl_like = _is_jsonl_stream_name(stream_name)
     text = None if jsonl_like else _decode_json_bytes(raw_bytes)
     if text is not None:
@@ -317,13 +363,13 @@ def _detect_provider_from_raw_bytes(
         except json.JSONDecodeError:
             payload = None
         else:
-            detected = detect_provider(payload)
+            detected, evidence = detect_provider_evidence(payload)
             if detected is not None:
-                return detected
+                return detected, evidence
 
     stream_bytes = _trim_jsonl_detection_prefix(raw_bytes, stream_name) if truncated_tail_ok else raw_bytes
     if not stream_bytes:
-        return fallback_provider
+        return fallback_provider, "empty byte stream after trimming; used fallback_provider"
     try:
         stream = _iter_json_stream(BytesIO(stream_bytes), stream_name)
         payloads = list(islice(stream, 32)) if jsonl_like else list(stream)
@@ -341,9 +387,27 @@ def _detect_provider_from_raw_bytes(
             error_type=type(exc).__name__,
             error=str(exc),
         )
-        return fallback_provider
+        return fallback_provider, f"stream decode error ({type(exc).__name__}: {exc}); used fallback_provider"
 
-    return detect_provider(payloads) or fallback_provider
+    detected, evidence = detect_provider_evidence(payloads)
+    if detected is None:
+        return fallback_provider, f"{evidence}; used fallback_provider"
+    return detected, evidence
+
+
+def _detect_provider_from_raw_bytes(
+    raw_bytes: bytes,
+    stream_name: str,
+    fallback_provider: Provider,
+    *,
+    truncated_tail_ok: bool = False,
+) -> Provider:
+    return detect_provider_from_raw_bytes_evidence(
+        raw_bytes,
+        stream_name,
+        fallback_provider,
+        truncated_tail_ok=truncated_tail_ok,
+    )[0]
 
 
 def _is_jsonl_stream_name(stream_name: str) -> bool:
@@ -1754,6 +1818,8 @@ __all__ = [
     "LoweredPayloadSpec",
     "_detect_provider_from_raw_bytes",
     "detect_provider",
+    "detect_provider_evidence",
+    "detect_provider_from_raw_bytes_evidence",
     "is_jsonl_source_path",
     "is_stream_record_provider",
     "parse_drive_payload",

--- a/polylogue/sources/live/acquisition_log.py
+++ b/polylogue/sources/live/acquisition_log.py
@@ -1,0 +1,248 @@
+"""Structured per-file acquisition decision logging + unclaimed-file sweep.
+
+Before this module, the acquisition path had no per-file trail: nothing
+recorded what a watched file was classified as, what evidence decided that
+classification, or how long detection took -- and a file under a watched root
+that no detector claimed left no record it was ever seen. This module gives
+both halves a place to live, using the repo's existing structured-logging
+convention (``polylogue.logging.get_logger`` / structlog keyword events), not
+a bespoke framework or a new persisted table.
+
+Two log events:
+
+- ``file_acquisition_decision`` -- one per file the acquisition path (daemon
+  watcher / ``ingest_batch`` pipeline) reads: path, size, mtime, the detected
+  origin (or the literal string ``"UNRECOGNIZED"``), the specific detector
+  evidence that decided it, and per-stage elapsed time.
+- ``file_acquisition_unclaimed`` -- one per file a watch-root sweep finds that
+  no detector/acquisition claimed, with the specific reason.
+
+Both are wired into real production call sites (see
+``polylogue/sources/source_acquisition_components.py:read_plain_source_file``
+and ``polylogue/sources/live/watcher.py:LiveWatcher._scan_catch_up_candidates``),
+not only exercised from tests.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from polylogue.logging import get_logger
+
+logger = get_logger(__name__)
+
+#: The operator deliberately keeps a ``.git`` directory under some watched
+#: roots (e.g. ``~/.claude/projects``) for their own versioning safety. It
+#: must never be walked into, stat'd, read, or reported as an unclaimed file
+#: -- exclusion happens at the directory-walk level below, not as a post-hoc
+#: filter over an already-collected file list.
+GIT_DIR_NAME = ".git"
+
+UNRECOGNIZED_ORIGIN = "UNRECOGNIZED"
+
+
+class AcquisitionStageTimings:
+    """Accumulates named elapsed-time-in-milliseconds spans for one file."""
+
+    def __init__(self) -> None:
+        self._stages: dict[str, float] = {}
+
+    @contextmanager
+    def stage(self, name: str) -> Iterator[None]:
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            self._stages[name] = self._stages.get(name, 0.0) + elapsed_ms
+
+    def record(self, name: str, elapsed_ms: float) -> None:
+        self._stages[name] = self._stages.get(name, 0.0) + elapsed_ms
+
+    def as_dict(self) -> dict[str, float]:
+        return {name: round(elapsed_ms, 3) for name, elapsed_ms in self._stages.items()}
+
+
+def log_file_acquisition_decision(
+    *,
+    path: Path | str,
+    size: int | None,
+    mtime: float | None,
+    origin: str | None,
+    evidence: str,
+    stage_timings: AcquisitionStageTimings | dict[str, float] | None = None,
+    source_name: str | None = None,
+) -> None:
+    """Emit one structured ``file_acquisition_decision`` record.
+
+    ``origin`` should be the resolved ``Origin``/``Provider`` token, or
+    ``None``/``"UNKNOWN"`` when nothing claimed the file -- normalized here to
+    the literal string :data:`UNRECOGNIZED_ORIGIN` so a log consumer can grep
+    for refusals without special-casing every falsy spelling a caller might
+    pass. ``evidence`` names the specific rule that decided the outcome (e.g.
+    ``"claude.looks_like_code (envelope marker)"`` or
+    ``"no detector matched (record)"``), never just the bare outcome.
+    """
+    normalized_origin = origin if origin and origin.upper() != "UNKNOWN" else UNRECOGNIZED_ORIGIN
+    timings = (
+        stage_timings.as_dict() if isinstance(stage_timings, AcquisitionStageTimings) else dict(stage_timings or {})
+    )
+    logger.info(
+        "file_acquisition_decision",
+        path=str(path),
+        size=size,
+        mtime=mtime,
+        source_name=source_name,
+        origin=normalized_origin,
+        evidence=evidence,
+        stage_timings_ms=timings,
+    )
+
+
+def log_unclaimed_file(
+    *,
+    path: Path | str,
+    size: int | None,
+    mtime: float | None,
+    reason: str,
+    source_name: str | None = None,
+) -> None:
+    """Emit one structured ``file_acquisition_unclaimed`` record.
+
+    Used by :func:`sweep_unclaimed_files` and by the watcher's catch-up scan
+    for a file under a watched root that no detector/acquisition claimed.
+    ``reason`` should be specific (``"no detector matched"``,
+    ``"matched an origin but failed validation"``, ``"suffix not in watched
+    set for source <name>"``), not just "unclaimed".
+    """
+    logger.warning(
+        "file_acquisition_unclaimed",
+        path=str(path),
+        size=size,
+        mtime=mtime,
+        source_name=source_name,
+        reason=reason,
+    )
+
+
+def iter_files_excluding_git(
+    root: Path,
+    *,
+    ignored_dir_names: frozenset[str] = frozenset({GIT_DIR_NAME}),
+) -> Iterator[Path]:
+    """Walk ``root`` yielding every regular file, never descending into ``.git``.
+
+    Exclusion happens via ``os.walk``'s ``dirnames`` pruning (mutating the
+    list in place before the walk descends), not as a filter applied to an
+    already-collected listing -- a ``.git`` directory anywhere under ``root``
+    (not only at its top level) is never opened, stat'd, or read.
+    """
+    if not root.exists():
+        return
+    if root.is_file():
+        yield root
+        return
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames[:] = [name for name in dirnames if name not in ignored_dir_names]
+        for filename in filenames:
+            yield Path(dirpath) / filename
+
+
+@dataclass(frozen=True, slots=True)
+class UnclaimedSweepResult:
+    """Outcome of one :func:`sweep_unclaimed_files` call."""
+
+    scanned: int
+    unclaimed: tuple[Path, ...]
+
+
+ClaimCheck = Callable[[Path], tuple[bool, str]]
+
+
+def sweep_unclaimed_files(
+    root: Path,
+    *,
+    source_name: str,
+    is_claimed: ClaimCheck,
+    ignored_dir_names: frozenset[str] = frozenset({GIT_DIR_NAME}),
+) -> UnclaimedSweepResult:
+    """Enumerate every file under ``root`` (excluding ``.git``), logging unclaimed ones.
+
+    ``is_claimed(path) -> (claimed, reason)`` lets a caller supply whatever
+    acquisition-claim evidence it has -- a real shape-detection check
+    (:func:`default_file_claim_check`), a set of paths already ingested this
+    run, or a source's suffix filter -- without this sweep needing to know
+    about the ingest pipeline's internals. ``reason`` is logged verbatim for
+    every unclaimed file via :func:`log_unclaimed_file`.
+    """
+    scanned = 0
+    unclaimed: list[Path] = []
+    for path in iter_files_excluding_git(root, ignored_dir_names=ignored_dir_names):
+        scanned += 1
+        claimed, reason = is_claimed(path)
+        if claimed:
+            continue
+        unclaimed.append(path)
+        try:
+            stat_result = path.stat()
+            size: int | None = stat_result.st_size
+            mtime: float | None = stat_result.st_mtime
+        except OSError:
+            size, mtime = None, None
+        log_unclaimed_file(path=path, size=size, mtime=mtime, reason=reason, source_name=source_name)
+    return UnclaimedSweepResult(scanned=scanned, unclaimed=tuple(unclaimed))
+
+
+#: Bounded prefix read for the sweep's own best-effort shape check -- mirrors
+#: ``source_acquisition_components._DETECTION_PREFIX_SIZE``'s order of
+#: magnitude without importing it (this module must stay import-light: it is
+#: reused from both the daemon watcher and any diagnostic CLI/test caller).
+_SWEEP_DETECTION_PREFIX_SIZE = 65536
+
+
+def default_file_claim_check(path: Path) -> tuple[bool, str]:
+    """Real shape-detection claim check for :func:`sweep_unclaimed_files`.
+
+    Reads a bounded prefix and runs it through the same detector stack
+    production acquisition uses (``sources.dispatch``), so "unclaimed" here
+    means the same thing it means during real ingest: no detector recognized
+    the file's shape, not merely "not on some caller-tracked allowlist".
+    """
+    from polylogue.core.enums import Provider
+    from polylogue.sources.dispatch import detect_provider_from_raw_bytes_evidence
+
+    try:
+        with path.open("rb") as handle:
+            prefix = handle.read(_SWEEP_DETECTION_PREFIX_SIZE)
+    except OSError as exc:
+        return False, f"unreadable: {type(exc).__name__}: {exc}"
+    if not prefix.strip():
+        return False, "empty file"
+    detected, evidence = detect_provider_from_raw_bytes_evidence(
+        prefix,
+        path.name,
+        Provider.UNKNOWN,
+        truncated_tail_ok=True,
+    )
+    if detected is Provider.UNKNOWN:
+        return False, f"no detector matched ({evidence})"
+    return True, evidence
+
+
+__all__ = [
+    "GIT_DIR_NAME",
+    "UNRECOGNIZED_ORIGIN",
+    "AcquisitionStageTimings",
+    "ClaimCheck",
+    "UnclaimedSweepResult",
+    "default_file_claim_check",
+    "iter_files_excluding_git",
+    "log_file_acquisition_decision",
+    "log_unclaimed_file",
+    "sweep_unclaimed_files",
+]

--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -2903,6 +2903,26 @@ class LiveBatchProcessor:
                 {"type": "session_meta", "payload": {"id": identity}},
                 separators=(",", ":"),
             ).encode()
+            # Declared, evidenced transform (mission item: fix or log the
+            # Codex synthetic-header injection, previously silent). A Codex
+            # append-mode delta is the file's tail bytes only -- the real
+            # `session_meta` header that carries native-session identity was
+            # already consumed by an earlier full/append observation and is
+            # not part of this delta. Without re-synthesizing it here, the
+            # delta payload would parse with no identity at all and either
+            # fall back to a path-derived id (breaking continuity with the
+            # session this file's earlier bytes already established) or be
+            # rejected outright. `identity` is recovered from durable
+            # evidence (`_existing_provider_session_id`: the archived
+            # session's own native id, or this file's own previously-read
+            # `session_meta` line) before hashing, never guessed.
+            logger.info(
+                "codex_append_synthetic_session_meta_injected",
+                path=str(path),
+                identity=identity,
+                reason="append-mode delta lacks its own session_meta header; "
+                "identity recovered from archived session / prior session_meta line",
+            )
             return session_meta + b"\n" + payload
         if provider is Provider.CLAUDE_CODE and not self._claude_code_tail_matches_existing_identity(path, payload):
             return None

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -29,6 +29,7 @@ from polylogue.core.enums import Origin
 from polylogue.core.sources import provider_from_origin
 from polylogue.logging import get_logger
 from polylogue.sources.hooks import drain_hook_event_spool, hook_spool_root, pending_hook_spool_dir
+from polylogue.sources.live.acquisition_log import log_unclaimed_file
 from polylogue.sources.live.batch import LiveBatchEventEmitter, LiveBatchProcessor, fingerprint_file
 from polylogue.sources.live.batch_support import (
     _archive_blob_exists,
@@ -117,6 +118,22 @@ def _log_ingest_metrics(prefix: str, metrics: LiveBatchMetrics) -> None:
         getattr(metrics, "wal_bytes_after_checkpoint_max", 0) / 1e6,
         getattr(metrics, "wal_busy_pages_total", 0),
     )
+
+
+def _log_unclaimed_catch_up_candidate(path: Path, *, source_name: str, reason: str) -> None:
+    """Log one file the catch-up scan reached but no source suffix accepted.
+
+    Best-effort ``stat`` for size/mtime -- a file that vanished between the
+    ``os.walk`` listing and this call is still worth a log record (it WAS
+    seen and unclaimed), just without size/mtime detail.
+    """
+    try:
+        stat_result = path.stat()
+        size: int | None = stat_result.st_size
+        mtime: float | None = stat_result.st_mtime
+    except OSError:
+        size, mtime = None, None
+    log_unclaimed_file(path=path, size=size, mtime=mtime, reason=reason, source_name=source_name)
 
 
 @dataclass(frozen=True, slots=True)
@@ -477,6 +494,18 @@ class LiveWatcher:
                 for filename in filenames:
                     path = Path(directory) / filename
                     if not source.accepts(path):
+                        # Unclaimed-file sweep (mission item 2): a file this
+                        # source's own root walk reached but whose suffix no
+                        # detector is configured to accept at all. Logged here
+                        # -- the real catch-up scan, run at daemon startup and
+                        # on every periodic sweep -- rather than only from a
+                        # standalone diagnostic, so the record exists whether
+                        # or not an operator remembers to run one.
+                        _log_unclaimed_catch_up_candidate(
+                            path,
+                            source_name=source.name,
+                            reason=f"suffix not in watched set {source.suffixes} for source {source.name!r}",
+                        )
                         continue
                     try:
                         stat = path.stat()

--- a/polylogue/sources/parsers/claude/ai_parser.py
+++ b/polylogue/sources/parsers/claude/ai_parser.py
@@ -46,8 +46,46 @@ CLAUDE_ACCOUNT_MEMORY_INGEST_FLAG = "capture:claude-account-memory"
 logger = get_logger(__name__)
 
 
+#: Role-shaped keys ``normalize_chat_messages``/``_raw_role`` themselves read
+#: (``common.py:_raw_role``): ``sender``/``role`` directly, or ``author.role``.
+_CLAUDE_AI_MESSAGE_ROLE_KEYS = ("sender", "role", "author")
+#: Content-shaped keys a genuine chat turn carries one of.
+_CLAUDE_AI_MESSAGE_CONTENT_KEYS = ("text", "content")
+
+
+def _chat_message_node_shape_is_plausible(item: object) -> bool:
+    """Positive structural evidence for one claude.ai ``chat_messages`` entry.
+
+    Mirrors the Claude Code envelope-marker fix (#3428,
+    ``code_detection.py:looks_like_code``): a bare ``chat_messages`` key is
+    not sufficient evidence on its own that a payload is a claude.ai export --
+    require at least one entry shaped like a real chat turn (a role/sender
+    field alongside a text/content field), matching what
+    ``normalize_chat_messages``/``_raw_role`` themselves read.
+    """
+    if not isinstance(item, Mapping):
+        return False
+    has_role = any(key in item for key in _CLAUDE_AI_MESSAGE_ROLE_KEYS)
+    has_content = any(key in item for key in _CLAUDE_AI_MESSAGE_CONTENT_KEYS)
+    return has_role and has_content
+
+
 def looks_like_ai(payload: object) -> bool:
-    return isinstance(payload, dict) and isinstance(payload.get("chat_messages"), list)
+    """Detect the claude.ai conversation-export shape.
+
+    Tightened (fail-closed acquisition sweep, sibling fix to #3428): a bare
+    ``chat_messages: []`` -- or a list whose entries don't resemble a real
+    chat turn -- used to be accepted on the strength of the key's mere
+    presence, the same "guess and proceed" shape #3428 closed for Claude
+    Code's bare ``type`` check. This now requires at least one entry with
+    positive structural evidence (see ``_chat_message_node_shape_is_plausible``).
+    """
+    if not isinstance(payload, dict):
+        return False
+    chat_messages = payload.get("chat_messages")
+    if not isinstance(chat_messages, list) or not chat_messages:
+        return False
+    return any(_chat_message_node_shape_is_plausible(item) for item in chat_messages)
 
 
 def looks_like_claude_design(payload: object) -> bool:

--- a/polylogue/sources/source_acquisition_components.py
+++ b/polylogue/sources/source_acquisition_components.py
@@ -22,7 +22,7 @@ from polylogue.storage.cursor_state import CursorStatePayload
 
 from . import decoders as _decoders
 from .decoders import _zip_entry_provider_hint
-from .dispatch import GROUP_PROVIDERS, _detect_provider_from_raw_bytes, detect_provider
+from .dispatch import GROUP_PROVIDERS, detect_provider, detect_provider_from_raw_bytes_evidence
 from .parsers.base import RawSessionData
 from .sqlite_snapshot import is_sqlite_path, original_sqlite_source_path, snapshot_sqlite_to_blob
 
@@ -302,7 +302,24 @@ def make_split_entry_raw_data(
 
 
 def read_plain_source_file(context: SourceReadContext) -> RawSessionData:
-    """Stream one non-ZIP source file into the blob store."""
+    """Stream one non-ZIP source file into the blob store.
+
+    This is the real per-file production acquisition entry point for the
+    daemon watcher / ``ingest_batch`` pipeline (every non-ZIP file a
+    ``WatchSource`` accepts passes through here). It emits one structured
+    ``file_acquisition_decision`` log record (see
+    ``polylogue.sources.live.acquisition_log``) per file, carrying the
+    detected origin (or ``UNRECOGNIZED``), the specific detector evidence
+    that decided it, and elapsed detect-stage time -- the per-file
+    observability trail that was previously missing entirely.
+    """
+    # Deferred import: ``polylogue.sources.live`` (package ``__init__``) pulls
+    # in ``batch.py``, which imports this module at module level -- a
+    # module-level import here would be circular (same hazard documented on
+    # ``dispatch._join_claude_code_sidecars``).
+    from .live.acquisition_log import AcquisitionStageTimings, log_file_acquisition_decision
+
+    stage_timings = AcquisitionStageTimings()
     sqlite_path = is_sqlite_path(context.path)
     original_source_path = original_sqlite_source_path(context.path) if sqlite_path else None
     if (context.provider_hint is Provider.HERMES or original_source_path is not None) and sqlite_path:
@@ -311,10 +328,12 @@ def read_plain_source_file(context: SourceReadContext) -> RawSessionData:
             source_name=context.source.name,
             source_path=str(context.path),
         )
-        snapshot = snapshot_sqlite_to_blob(context.path, context.blob_store, heartbeat=heartbeat)
-        blob_hash, blob_size = snapshot.blob_hash, snapshot.blob_size
-        publication_id = snapshot.blob_publication_receipt_id
-        detected_provider = Provider.HERMES
+        with stage_timings.stage("detect"):
+            snapshot = snapshot_sqlite_to_blob(context.path, context.blob_store, heartbeat=heartbeat)
+            blob_hash, blob_size = snapshot.blob_hash, snapshot.blob_size
+            publication_id = snapshot.blob_publication_receipt_id
+            detected_provider = Provider.HERMES
+            detection_evidence = "sqlite_snapshot.snapshot_sqlite_to_blob (Hermes sqlite state/sidecar)"
     else:
         blob_hash, blob_size = stream_path_to_blob(
             context.blob_store,
@@ -323,14 +342,16 @@ def read_plain_source_file(context: SourceReadContext) -> RawSessionData:
             source_name=context.source.name,
         )
         prefix = context.blob_store.read_prefix(blob_hash, _DETECTION_PREFIX_SIZE)
-        detected_provider = _detect_provider_from_raw_bytes(
-            prefix,
-            context.path.name,
-            context.provider_hint,
-            truncated_tail_ok=blob_size > len(prefix),
-        )
-        if detected_provider is Provider.UNKNOWN and context.source.name == "browser-capture":
-            detected_provider = _stream_browser_capture_provider(context.blob_store, blob_hash)
+        with stage_timings.stage("detect"):
+            detected_provider, detection_evidence = detect_provider_from_raw_bytes_evidence(
+                prefix,
+                context.path.name,
+                context.provider_hint,
+                truncated_tail_ok=blob_size > len(prefix),
+            )
+            if detected_provider is Provider.UNKNOWN and context.source.name == "browser-capture":
+                detected_provider = _stream_browser_capture_provider(context.blob_store, blob_hash)
+                detection_evidence = "browser_capture provider recovered from spool metadata"
         from polylogue.storage.blob_publication import publication_receipt_id
 
         publication_id = publication_receipt_id(context.blob_store, blob_hash)
@@ -341,6 +362,19 @@ def read_plain_source_file(context: SourceReadContext) -> RawSessionData:
         provider_hint=detected_provider,
         blob_size=blob_size,
         blob_publication_receipt_id=publication_id,
+    )
+    try:
+        file_mtime_epoch: float | None = context.path.stat().st_mtime
+    except OSError:
+        file_mtime_epoch = None
+    log_file_acquisition_decision(
+        path=context.path,
+        size=blob_size,
+        mtime=file_mtime_epoch,
+        source_name=context.source.name,
+        origin=str(detected_provider) if detected_provider is not Provider.UNKNOWN else None,
+        evidence=detection_evidence,
+        stage_timings=stage_timings,
     )
     return raw_data_record(
         source_path=str(original_source_path or context.path),

--- a/tests/unit/sources/test_acquisition_log.py
+++ b/tests/unit/sources/test_acquisition_log.py
@@ -1,0 +1,196 @@
+"""Tests for the per-file acquisition decision log + unclaimed-file sweep.
+
+Covers the observability gap this module closes: a real structured log trail
+per file the acquisition path considers (``file_acquisition_decision``), and
+an explicit sweep that logs files under a watched root that no detector
+claimed (``file_acquisition_unclaimed``) while never descending into a
+``.git`` directory anywhere under that root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from polylogue.sources.live import acquisition_log
+from polylogue.sources.live.acquisition_log import (
+    AcquisitionStageTimings,
+    UnclaimedSweepResult,
+    default_file_claim_check,
+    iter_files_excluding_git,
+    log_file_acquisition_decision,
+    log_unclaimed_file,
+    sweep_unclaimed_files,
+)
+
+
+def test_iter_files_excluding_git_never_descends_into_git_directory(tmp_path: Path) -> None:
+    """A ``.git`` directory anywhere under root -- not only at the top -- is pruned
+    before ``os.walk`` descends into it, so a file inside it is never yielded."""
+    root = tmp_path / "claude-projects"
+    root.mkdir()
+    (root / "session-a.jsonl").write_text('{"sessionId": "a"}\n')
+
+    nested = root / "some-project"
+    nested.mkdir()
+    (nested / "session-b.jsonl").write_text('{"sessionId": "b"}\n')
+
+    git_dir = root / ".git"
+    (git_dir / "objects").mkdir(parents=True)
+    (git_dir / "config").write_text("[core]\n")
+    (git_dir / "objects" / "deadbeef").write_text("not a session")
+
+    # A .git directory nested deeper than the top level must also be pruned.
+    nested_git = nested / ".git"
+    nested_git.mkdir()
+    (nested_git / "HEAD").write_text("ref: refs/heads/master\n")
+
+    found = {str(p.relative_to(root)) for p in iter_files_excluding_git(root)}
+
+    assert found == {"session-a.jsonl", str(Path("some-project") / "session-b.jsonl")}
+    assert not any(".git" in part for path in found for part in Path(path).parts)
+
+
+def test_iter_files_excluding_git_missing_root_yields_nothing(tmp_path: Path) -> None:
+    assert list(iter_files_excluding_git(tmp_path / "does-not-exist")) == []
+
+
+def test_iter_files_excluding_git_single_file_root(tmp_path: Path) -> None:
+    single = tmp_path / "solo.jsonl"
+    single.write_text("{}")
+    assert list(iter_files_excluding_git(single)) == [single]
+
+
+def test_sweep_unclaimed_files_logs_unrecognized_file_and_skips_git(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "watched-root"
+    root.mkdir()
+    unclaimed_file = root / "mystery.dat"
+    unclaimed_file.write_bytes(b"not a claude session, not anything recognized\x00\x01")
+    claimed_file = root / "known.jsonl"
+    claimed_file.write_text('{"sessionId": "abc", "uuid": "1"}\n')
+
+    git_dir = root / ".git"
+    git_dir.mkdir()
+    (git_dir / "config").write_text("[core]\n")
+
+    logged: list[dict[str, object]] = []
+    mock_logger = MagicMock()
+    mock_logger.warning.side_effect = lambda event, **kw: logged.append({"event": event, **kw})
+    monkeypatch.setattr(acquisition_log, "logger", mock_logger)
+
+    def is_claimed(path: Path) -> tuple[bool, str]:
+        if path.name == "known.jsonl":
+            return True, "matched"
+        return False, "no detector matched (test stub)"
+
+    result = sweep_unclaimed_files(root, source_name="claude-code", is_claimed=is_claimed)
+
+    assert isinstance(result, UnclaimedSweepResult)
+    assert result.scanned == 2  # .git/config must never be counted
+    assert result.unclaimed == (unclaimed_file,)
+    assert len(logged) == 1
+    assert logged[0]["event"] == "file_acquisition_unclaimed"
+    assert logged[0]["path"] == str(unclaimed_file)
+    assert logged[0]["reason"] == "no detector matched (test stub)"
+    assert logged[0]["source_name"] == "claude-code"
+    assert logged[0]["size"] == unclaimed_file.stat().st_size
+
+
+def test_default_file_claim_check_refuses_unrecognized_shape(tmp_path: Path) -> None:
+    unrecognized = tmp_path / "unrecognized.json"
+    unrecognized.write_text('{"totally": "unrelated", "shape": true}')
+
+    claimed, reason = default_file_claim_check(unrecognized)
+
+    assert claimed is False
+    assert "no detector matched" in reason
+
+
+def test_default_file_claim_check_accepts_recognized_shape(tmp_path: Path) -> None:
+    claude_code_file = tmp_path / "session.jsonl"
+    claude_code_file.write_text('{"sessionId": "abc-123", "uuid": "u1", "type": "user", "cwd": "/tmp"}\n')
+
+    claimed, reason = default_file_claim_check(claude_code_file)
+
+    assert claimed is True
+    assert reason
+
+
+def test_default_file_claim_check_reports_empty_file(tmp_path: Path) -> None:
+    empty = tmp_path / "empty.json"
+    empty.write_text("")
+
+    claimed, reason = default_file_claim_check(empty)
+
+    assert claimed is False
+    assert reason == "empty file"
+
+
+def test_log_file_acquisition_decision_emits_evidence_and_timings(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    mock_logger = MagicMock()
+    mock_logger.info.side_effect = lambda event, **kw: captured.update({"event": event, **kw})
+    monkeypatch.setattr(acquisition_log, "logger", mock_logger)
+
+    timings = AcquisitionStageTimings()
+    with timings.stage("detect"):
+        pass
+
+    log_file_acquisition_decision(
+        path="/watched/root/a.jsonl",
+        size=123,
+        mtime=1700000000.0,
+        origin="claude-code-session",
+        evidence="claude.looks_like_code (envelope marker, #3428)",
+        stage_timings=timings,
+        source_name="claude-code",
+    )
+
+    assert captured["event"] == "file_acquisition_decision"
+    assert captured["path"] == "/watched/root/a.jsonl"
+    assert captured["origin"] == "claude-code-session"
+    assert captured["evidence"] == "claude.looks_like_code (envelope marker, #3428)"
+    stage_timings_ms = captured["stage_timings_ms"]
+    assert isinstance(stage_timings_ms, dict)
+    assert "detect" in stage_timings_ms
+    assert captured["source_name"] == "claude-code"
+
+
+def test_log_file_acquisition_decision_normalizes_unrecognized_origin(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    mock_logger = MagicMock()
+    mock_logger.info.side_effect = lambda event, **kw: captured.update({"event": event, **kw})
+    monkeypatch.setattr(acquisition_log, "logger", mock_logger)
+
+    for origin in (None, "UNKNOWN", "unknown"):
+        log_file_acquisition_decision(
+            path="/watched/root/b.dat",
+            size=1,
+            mtime=None,
+            origin=origin,
+            evidence="no detector matched (record)",
+        )
+        assert captured["origin"] == "UNRECOGNIZED"
+
+
+def test_log_unclaimed_file_emits_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+    mock_logger = MagicMock()
+    mock_logger.warning.side_effect = lambda event, **kw: captured.update({"event": event, **kw})
+    monkeypatch.setattr(acquisition_log, "logger", mock_logger)
+
+    log_unclaimed_file(
+        path="/watched/root/c.dat",
+        size=99,
+        mtime=None,
+        reason="suffix not in watched set",
+        source_name="inbox",
+    )
+
+    assert captured["event"] == "file_acquisition_unclaimed"
+    assert captured["reason"] == "suffix not in watched set"
+    assert captured["source_name"] == "inbox"

--- a/tests/unit/sources/test_dispatch_evidence.py
+++ b/tests/unit/sources/test_dispatch_evidence.py
@@ -1,0 +1,90 @@
+"""Tests for the evidence-tagged detection variants used by acquisition logging.
+
+``detect_provider_evidence``/``detect_provider_from_raw_bytes_evidence`` are the
+single source of truth for detection (``detect_provider``/
+``_detect_provider_from_raw_bytes`` are thin wrappers that discard the evidence
+label) -- these tests both exercise the evidence label content and guard
+against the wrapper functions drifting from the evidence-returning
+implementation.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from polylogue.core.enums import Provider
+from polylogue.sources.dispatch import (
+    detect_provider,
+    detect_provider_evidence,
+    detect_provider_from_raw_bytes_evidence,
+)
+
+_CLAUDE_CODE_RECORD = {"sessionId": "s1", "uuid": "u1", "type": "user", "cwd": "/tmp"}
+_CHATGPT_LIKE_RECORD = {
+    "mapping": {
+        "node-1": {
+            "id": "node-1",
+            "message": {"id": "m1", "author": {"role": "user"}, "content": {"content_type": "text", "parts": ["hi"]}},
+            "parent": None,
+            "children": [],
+        }
+    },
+    "current_node": "node-1",
+    "create_time": 1700000000.0,
+    "conversation_id": "conv-1",
+}
+_CLAUDE_AI_RECORD = {"chat_messages": [{"sender": "human", "text": "hi"}]}
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_provider"),
+    [
+        ([_CLAUDE_CODE_RECORD], Provider.CLAUDE_CODE),
+        (_CHATGPT_LIKE_RECORD, Provider.CHATGPT),
+        (_CLAUDE_AI_RECORD, Provider.CLAUDE_AI),
+        ({"unrelated": "shape"}, None),
+        ([], None),
+    ],
+)
+def test_detect_provider_evidence_matches_detect_provider(payload: object, expected_provider: Provider | None) -> None:
+    """No drift: the wrapper's result must equal the evidence function's own result."""
+    provider, evidence = detect_provider_evidence(payload)
+    assert provider is expected_provider
+    assert detect_provider(payload) is provider
+    assert evidence
+
+
+def test_detect_provider_evidence_names_the_deciding_rule_for_claude_code() -> None:
+    _, evidence = detect_provider_evidence([_CLAUDE_CODE_RECORD])
+    assert "claude.looks_like_code" in evidence
+
+
+def test_detect_provider_evidence_reports_no_match_reason() -> None:
+    provider, evidence = detect_provider_evidence({"unrelated": "shape"})
+    assert provider is None
+    assert "no detector matched" in evidence
+
+
+def test_detect_provider_from_raw_bytes_evidence_matches_document_detection() -> None:
+    raw_bytes = json.dumps(_CHATGPT_LIKE_RECORD).encode()
+
+    provider, evidence = detect_provider_from_raw_bytes_evidence(raw_bytes, "export.json", Provider.UNKNOWN)
+
+    assert provider is Provider.CHATGPT
+    assert "chatgpt" in evidence.lower()
+
+
+def test_detect_provider_from_raw_bytes_evidence_falls_back_with_reason_on_garbage() -> None:
+    raw_bytes = b"not json at all \x00\x01\x02"
+
+    provider, evidence = detect_provider_from_raw_bytes_evidence(
+        raw_bytes,
+        "mystery.dat",
+        Provider.UNKNOWN,
+        truncated_tail_ok=True,
+    )
+
+    assert provider is Provider.UNKNOWN
+    assert "fallback_provider" in evidence

--- a/tests/unit/sources/test_parsers_chatgpt.py
+++ b/tests/unit/sources/test_parsers_chatgpt.py
@@ -85,7 +85,24 @@ PROVIDER_FORMAT_DETECTION_CASES: list[ProviderDetectionCase] = [
     ({}, False, chatgpt_looks_like, "ChatGPT: missing mapping"),
     (None, False, chatgpt_looks_like, "ChatGPT: None input"),
     # Claude AI
-    ({"chat_messages": []}, True, looks_like_ai, "Claude AI: chat_messages"),
+    (
+        {"chat_messages": []},
+        False,
+        looks_like_ai,
+        "Claude AI: empty chat_messages refused (no positive turn evidence, tightened sibling of #3428)",
+    ),
+    (
+        {"chat_messages": [{"foo": "bar"}]},
+        False,
+        looks_like_ai,
+        "Claude AI: chat_messages entries without role+content shape refused",
+    ),
+    (
+        {"chat_messages": [{"sender": "human", "text": "hi"}]},
+        True,
+        looks_like_ai,
+        "Claude AI: chat_messages entry with role+content shape accepted",
+    ),
     ({}, False, looks_like_ai, "Claude AI: missing chat_messages"),
     (None, False, looks_like_ai, "Claude AI: None"),
     # Claude Code


### PR DESCRIPTION
## Summary

Adds a structured per-file acquisition decision log and an unclaimed-file sweep to the daemon/ingest acquisition path, and tightens the loosest remaining "guess and proceed" detector (`claude.looks_like_ai`) to require positive structural evidence. This is the observability + fail-closed acquisition lane ahead of a planned index reindex.

## Problem

The acquisition path had no per-file trail: nothing recorded what a watched file was classified as, what evidence decided that classification, or how long detection took. A file under a watched root that no detector claimed left no record it was ever seen at all.

Separately, `docs/architecture.md` names ChatGPT/Claude-web/Gemini's loose dict-key checks as the highest-risk remaining "guess and proceed" detectors, in the same shape PR #3428 closed for Claude Code's `looks_like_code` (a bare ambiguous `type` value used to be sufficient evidence on its own; it now requires a genuine record-envelope marker). Auditing the three: ChatGPT's `looks_like`/`looks_like_fragment` were already tightened to Pydantic-validated node shapes in an earlier change (the architecture doc's framing is partially stale there). `claude.looks_like_ai` was not: `isinstance(payload, dict) and isinstance(payload.get("chat_messages"), list)` accepted any dict carrying a bare `chat_messages` key -- even an empty list -- as a claude.ai export.

A third finding surfaced independently this session: `sources/live/batch.py`'s `_append_payload_for_provider` unconditionally prepends a synthetic `session_meta` line ahead of every Codex append-mode capture before hashing, with no logged rationale (see `bd show polylogue-u19l --json`).

## Solution

- `polylogue/sources/dispatch.py`: `detect_provider_evidence` and `detect_provider_from_raw_bytes_evidence` are now the sole implementations of record/sequence/raw-bytes detection, each tagging the specific detector rule that decided the outcome. `detect_provider`/`_detect_provider_from_raw_bytes` become thin wrappers that discard the evidence label -- there is no separate "logging" copy of the decision tree that can silently drift from the real one.
- `polylogue/sources/live/acquisition_log.py` (new): `log_file_acquisition_decision` / `log_unclaimed_file` structured log events (existing `polylogue.logging` structlog convention, no new framework), an `AcquisitionStageTimings` helper for per-stage elapsed time, a `.git`-excluding directory walk (`iter_files_excluding_git`, pruned at the `os.walk` level so a `.git` directory anywhere under a watched root -- not only at its top -- is never opened, stat'd, or read), and `sweep_unclaimed_files` + `default_file_claim_check` for a real shape-detection-backed unclaimed-file sweep (not a path-membership check).
- `polylogue/sources/source_acquisition_components.py:read_plain_source_file` -- the real per-file production acquisition entry point (every non-ZIP file a `WatchSource` accepts passes through here) -- now times the detect stage and emits one `file_acquisition_decision` log record per file: path, size, mtime, origin (or `UNRECOGNIZED`), and the deciding evidence string.
- `polylogue/sources/live/watcher.py:_scan_catch_up_candidates` -- the real catch-up scan, run at daemon startup and on every periodic sweep -- now logs `file_acquisition_unclaimed` for a file whose suffix no configured source accepts, instead of silently skipping it.
- `polylogue/sources/live/batch.py:_append_payload_for_provider` -- the synthetic Codex `session_meta` header injection is now a declared, evidenced decision (`codex_append_synthetic_session_meta_injected` log event naming the recovered identity and why the transform is necessary) instead of a silent one.
- `polylogue/sources/parsers/claude/ai_parser.py:looks_like_ai` -- tightened to require at least one `chat_messages` entry with positive structural evidence (a role/sender field alongside a text/content field, matching what `normalize_chat_messages` itself reads), sibling fix to #3428.

**Deferred / not fixed here:** Gemini/Drive's `looks_like` still accepts an empty `chunkedPrompt.chunks` envelope as sufficient evidence. Lower risk than claude-ai's bare-key check (the `chunkedPrompt` key combination is distinctive and rare), but a residual guess-branch. Recommend a follow-up bead for it; the coordinator should file one (`polylogue-drive-chunkedprompt-empty-envelope` or similar, cannot `bd create` from this worktree).

**Non-goals honored:** no changes to `sources/dispatch.py`'s tightness-order architecture itself; no live reindex or production-data mutation; no new logging framework (reused `polylogue.logging.get_logger`); no new persisted table (log-only, no schema change).

## Verification

- `devtools test tests/unit/sources/test_acquisition_log.py tests/unit/sources/test_dispatch_evidence.py tests/unit/sources/test_parsers_chatgpt.py tests/unit/sources/test_dispatch_ordering.py tests/unit/sources/test_parsers_claude_ai_catalog.py tests/unit/sources/test_parsers_claude_design.py` -- 181 passed.
- `devtools test tests/unit/sources/test_live_watcher.py tests/unit/sources/test_live_batch_support.py tests/unit/sources/test_live_batch_observability.py tests/unit/sources/test_acquisition_encoding.py` -- 4 pre-existing failures (durable-excise / multi-session-append / route-observability / durable-attempt tests) reproduce identically on unmodified master (verified via `git stash`); unrelated to this change.
- `devtools verify --quick` -- ruff format/check, mypy --strict, `render all --check` (including `devtools render topology-projection` for the new module), layering, schema-versioning policy: all green.
- `devtools verify layering` -- no new violations against the baseline.

## Acceptance criteria (per the observability/fail-closed mission)

1. Per-file structured decision trail with evidence + timing: satisfied via `test_dispatch_evidence.py` (evidence-tagged detection) and `test_acquisition_log.py::test_log_file_acquisition_decision_emits_evidence_and_timings`, wired into `read_plain_source_file` (real production path, named above).
2. Unclaimed-file sweep + `.git` exclusion at the walk level: satisfied via `test_acquisition_log.py::test_iter_files_excluding_git_never_descends_into_git_directory` and `test_sweep_unclaimed_files_logs_unrecognized_file_and_skips_git`; wired into `watcher.py:_scan_catch_up_candidates` (real daemon catch-up scan).
3. At least one loose detector now refuses-and-logs instead of guessing: `claude.looks_like_ai`, regression-tested in `test_parsers_chatgpt.py` (the previous `{"chat_messages": []}` → `True` case now asserts `False`).
4. Detectors tightened vs. deferred stated above; production caller named per new log path above.