### PR TITLE
feat(insights): materialize capture-completeness coverage measure

### DIFF
--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -1636,7 +1636,7 @@ files:
     target: polylogue/daemon/fts_status.py
     owner: stable
   - path: polylogue/daemon/health.py
-    loc: 1378
+    loc: 1471
     target: polylogue/daemon/health.py
     owner: stable
   - path: polylogue/daemon/healthz.py
@@ -1920,6 +1920,10 @@ files:
   - path: polylogue/insights/authored_payloads.py
     loc: 163
     target: polylogue/insights/authored_payloads.py
+    owner: stable
+  - path: polylogue/insights/capture_coverage.py
+    loc: 414
+    target: polylogue/insights/capture_coverage.py
     owner: stable
   - path: polylogue/insights/claude_workflow_evidence.py
     loc: 778

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -582,6 +582,97 @@ def _check_raw_failures_medium() -> HealthAlert:
         )
 
 
+_CAPTURE_COVERAGE_ORIGINS: tuple[str, ...] = ("claude-code-session", "codex-session")
+_CAPTURE_COVERAGE_WINDOW_MS = 24 * 60 * 60 * 1000
+_CAPTURE_COVERAGE_WARN_MISSES = 1
+_CAPTURE_COVERAGE_ERROR_MISSES = 5
+
+
+def _check_capture_coverage_medium() -> HealthAlert:
+    """Detect SessionStart hook evidence with no matching archived session (polylogue-3uw).
+
+    This is the reverse correlation from ``hook_flow``: that check asks
+    "for sessions we archived, did hook events arrive"; this one asks "for
+    hook evidence that a session happened, did we ever archive it" -- the
+    capture-completeness coverage error, not hook-wiring liveness. A
+    non-zero known-miss count here is a silent capture regression (harness
+    stopped writing, ingest never picked the file up) with a number to trip
+    an alert on, per polylogue-3uw's authoritative corrective scope.
+    """
+    now = datetime.now(UTC).isoformat()
+    try:
+        from polylogue.insights.capture_coverage import compute_capture_coverage
+
+        root = archive_root()
+        source_db = root / "source.db"
+        index_db = _active_health_db_path()
+        if not source_db.exists() or not index_db.exists():
+            return HealthAlert(
+                check_name="capture_coverage",
+                tier=HealthTier.MEDIUM,
+                severity=HealthSeverity.OK,
+                message="capture coverage skipped: archive not initialized",
+                checked_at=now,
+                consecutive_failures=_record_failure("capture_coverage", True),
+            )
+
+        current_ms = int(datetime.now(UTC).timestamp() * 1000)
+        since_ms = current_ms - _CAPTURE_COVERAGE_WINDOW_MS
+        source_conn = sqlite3.connect(str(source_db))
+        index_conn = sqlite3.connect(str(index_db))
+        try:
+            total_misses = 0
+            details: list[str] = []
+            for origin in _CAPTURE_COVERAGE_ORIGINS:
+                assessment = compute_capture_coverage(
+                    origin=origin,
+                    since_ms=since_ms,
+                    until_ms=current_ms,
+                    source_conn=source_conn,
+                    index_conn=index_conn,
+                    now_ms=current_ms,
+                )
+                if assessment.known_miss_count:
+                    total_misses += assessment.known_miss_count
+                    details.append(
+                        f"{origin}: {assessment.known_miss_count} session(s) with SessionStart evidence never archived"
+                    )
+        finally:
+            source_conn.close()
+            index_conn.close()
+
+        if total_misses == 0:
+            severity = HealthSeverity.OK
+            message = "no capture-completeness misses in the trailing 24h"
+        elif total_misses <= _CAPTURE_COVERAGE_WARN_MISSES:
+            severity = HealthSeverity.WARNING
+            message = "; ".join(details)
+        elif total_misses <= _CAPTURE_COVERAGE_ERROR_MISSES:
+            severity = HealthSeverity.ERROR
+            message = "; ".join(details)
+        else:
+            severity = HealthSeverity.CRITICAL
+            message = "; ".join(details) + " — possible capture regression"
+
+        return HealthAlert(
+            check_name="capture_coverage",
+            tier=HealthTier.MEDIUM,
+            severity=severity,
+            message=message,
+            checked_at=now,
+            consecutive_failures=_record_failure("capture_coverage", severity == HealthSeverity.OK),
+        )
+    except Exception as exc:
+        return HealthAlert(
+            check_name="capture_coverage",
+            tier=HealthTier.MEDIUM,
+            severity=HealthSeverity.ERROR,
+            message=f"capture coverage check failed: {exc}",
+            checked_at=now,
+            consecutive_failures=_record_failure("capture_coverage", False),
+        )
+
+
 def _check_stale_ingest_attempts_medium() -> HealthAlert:
     """Check for stale live ingest attempts."""
     from polylogue.daemon.status import _live_ingest_attempt_summary_info
@@ -1095,6 +1186,7 @@ def _run_medium_checks() -> list[HealthAlert]:
     return [
         _check_fts_readiness_medium(),
         _check_raw_failures_medium(),
+        _check_capture_coverage_medium(),
         _check_stale_ingest_attempts_medium(),
         _check_insight_freshness_medium(),
         _check_repeated_stage_failures_medium(),

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -663,6 +663,7 @@ def _check_capture_coverage_medium() -> HealthAlert:
             consecutive_failures=_record_failure("capture_coverage", severity == HealthSeverity.OK),
         )
     except Exception as exc:
+        logger.warning("capture_coverage: check failed", exc_info=True)
         return HealthAlert(
             check_name="capture_coverage",
             tier=HealthTier.MEDIUM,

--- a/polylogue/insights/capture_coverage.py
+++ b/polylogue/insights/capture_coverage.py
@@ -1,0 +1,413 @@
+"""Capture-completeness coverage: the instrument's own coverage error (polylogue-3uw).
+
+Convergence legibility (the rest of ``insights/``) answers "how converged is
+what we ingested". Nothing else in the codebase answers "how much of what
+exists did we ingest" -- an instrument that does not know its own coverage
+error cannot honestly caveat its findings, and a silent capture regression
+(a harness stops firing, a watched root goes unreadable, an extension tab
+stops relaying) currently has no number to trip an alert on.
+
+This module correlates *sessions known to have happened* against *sessions
+fully archived*, per origin over a window, and materializes the result as a
+versioned, content-addressed :class:`CoverageAssessment` -- the ``coverage:
+<hash>`` sibling of :class:`~polylogue.insights.measurement.metric.MetricDefinition`'s
+``metric:<hash>`` (same :func:`~polylogue.insights.measurement.canon.content_ref`
+mechanism, so two independent call sites describing the same coverage
+question always resolve to the same ref).
+
+Evidence sources named by the 2026-07-13 authoritative design (three
+correlated against the archive):
+
+- ``hook_session_start`` -- ``SessionStart`` hook events in
+  ``raw_hook_events`` (source.db) without a matching archived session
+  (``sessions.native_id`` in index.db) after a grace window. **Computed**
+  today for the two origins the hook harnesses cover
+  (``claude-code-session``, ``codex-session``; see
+  :mod:`polylogue.hooks`).
+- ``watcher_file_inventory`` -- harness-written session files on watched
+  roots (:mod:`polylogue.sources.dispatch`) that were never acquired into
+  ``raw_sessions`` at all. **Not yet wired**: no filesystem-inventory pass
+  correlates watched-root contents against ``raw_sessions`` today.
+- ``browser_extension_observation`` -- extension-observed chats that never
+  reached the acquisition spool (the browser-capture analogue of a
+  capture-gap event, tracked separately as polylogue-3v1). **Not yet
+  wired**: no capture-gap event stream exists to correlate against yet.
+
+Honesty contract (AC7): a source this module has not wired evidence for is
+reported with ``status="unknown"`` and an explicit reason, never silently
+folded into a 100%-covered figure. :attr:`CoverageAssessment.coverage_ratio`
+and :attr:`CoverageAssessment.is_frame_complete` only ever consider
+``status="computed"`` sources, and an assessment with zero computed sources
+is itself unknown (``coverage_ratio`` is ``None``, ``is_frame_complete`` is
+``False``) rather than vacuously "fully covered".
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal
+
+from polylogue.insights.measurement.canon import content_ref
+from polylogue.storage.table_existence import table_exists
+
+CoverageEvidenceSourceKind = Literal[
+    "hook_session_start",
+    "watcher_file_inventory",
+    "browser_extension_observation",
+]
+
+CoverageSourceStatus = Literal["computed", "unknown"]
+
+ResultEnumerationFrame = Literal["exact", "frame_incomplete"]
+
+#: Bump when the correlation method (query shape, grace-window semantics,
+#: matching rule) changes in a way that makes an old ref's numbers
+#: incomparable to a new ref's numbers under the same origin/window.
+METHOD_VERSION = 1
+
+#: Evidence sources this module can already correlate, keyed by the hook
+#: harness whose evidence backs them (see ``polylogue.hooks.ORIGIN_BY_HARNESS``).
+_ORIGINS_WITH_HOOK_EVIDENCE: frozenset[str] = frozenset({"claude-code-session", "codex-session"})
+
+#: Sources the design names but has not wired evidence for yet. Always
+#: reported as ``unknown`` with the reason below -- never silently 100%.
+_DECLARED_UNCOMPUTED_SOURCES: tuple[tuple[CoverageEvidenceSourceKind, str], ...] = (
+    (
+        "watcher_file_inventory",
+        "harness-written session files on watched roots are not yet correlated against "
+        "acquired raw_sessions rows (polylogue-3uw follow-up)",
+    ),
+    (
+        "browser_extension_observation",
+        "browser-extension capture-gap events (polylogue-3v1) are not yet materialized",
+    ),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceSourceCoverage:
+    """One named evidence source's contribution to a :class:`CoverageAssessment`.
+
+    ``status`` is ``"computed"`` only when this module actually correlated
+    real evidence against the archive for this source in this window;
+    every other source the design names is ``"unknown"`` with an explicit
+    ``reason`` (AC7).
+    """
+
+    source: CoverageEvidenceSourceKind
+    status: CoverageSourceStatus
+    reason: str | None = None
+    observed_count: int = 0
+    matched_count: int = 0
+    missing_native_ids: tuple[str, ...] = ()
+    missing_count: int = 0
+
+    def canonical_payload(self) -> dict[str, object]:
+        """The identity-relevant subset hashed into the parent ref.
+
+        Counts and refs are evidence, not identity: two assessments over
+        the same origin/window/method/generations with different observed
+        counts are the *same measurement question* re-run at a different
+        moment, so they must resolve to the same ``coverage:<hash>`` (the
+        content hash names the *question*, not today's *answer* --
+        matching :class:`~polylogue.insights.measurement.metric.MetricDefinition`'s
+        own construct/unit/aggregation-only identity).
+        """
+
+        return {"source": self.source, "status": self.status}
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageAssessment:
+    """A versioned, content-addressed capture-completeness measure.
+
+    Binds origin, interval, evidence-source inventory, method, and
+    generations, per the 2026-07-13 authoritative corrective contract on
+    polylogue-3uw: "Materialize a versioned CoverageRef/object carrying
+    expected-signal sources, observed/archived counts, known misses, grace
+    window, origin/window, archive/source generations, method version, and
+    degraded/unknown reasons."
+    """
+
+    origin: str
+    since_ms: int
+    until_ms: int
+    grace_window_ms: int
+    method_version: int
+    generations: Mapping[str, str]
+    sources: tuple[EvidenceSourceCoverage, ...]
+    computed_at_ms: int
+
+    def canonical_payload(self) -> dict[str, object]:
+        """The exact payload hashed to produce :attr:`ref`."""
+
+        return {
+            "origin": self.origin,
+            "since_ms": self.since_ms,
+            "until_ms": self.until_ms,
+            "grace_window_ms": self.grace_window_ms,
+            "method_version": self.method_version,
+            "generations": dict(self.generations),
+            "sources": [source.canonical_payload() for source in self.sources],
+        }
+
+    @property
+    def ref(self) -> str:
+        """The content-addressed ``coverage:<hash>`` identity for this question."""
+
+        return content_ref("coverage", self.canonical_payload())
+
+    @property
+    def computed_sources(self) -> tuple[EvidenceSourceCoverage, ...]:
+        return tuple(source for source in self.sources if source.status == "computed")
+
+    @property
+    def unknown_sources(self) -> tuple[EvidenceSourceCoverage, ...]:
+        return tuple(source for source in self.sources if source.status == "unknown")
+
+    @property
+    def known_miss_count(self) -> int:
+        """Total missing-native-id count across computed sources only."""
+
+        return sum(source.missing_count for source in self.computed_sources)
+
+    @property
+    def known_missing_native_ids(self) -> tuple[str, ...]:
+        """The drillable known-miss list (AC1): union across computed sources."""
+
+        seen: dict[str, None] = {}
+        for source in self.computed_sources:
+            for native_id in source.missing_native_ids:
+                seen[native_id] = None
+        return tuple(seen)
+
+    @property
+    def coverage_ratio(self) -> float | None:
+        """Matched/observed ratio over computed sources, or ``None`` when unknown.
+
+        ``None`` both when there are no computed sources at all and when
+        every computed source observed zero signals -- a ratio of exactly
+        0 or 1 is never fabricated from an empty denominator.
+        """
+
+        computed = self.computed_sources
+        if not computed:
+            return None
+        observed_total = sum(source.observed_count for source in computed)
+        if observed_total == 0:
+            return None
+        matched_total = sum(source.matched_count for source in computed)
+        return matched_total / observed_total
+
+    @property
+    def is_frame_complete(self) -> bool:
+        """Whether this window's evidence supports an exact-enumeration claim.
+
+        ``False`` whenever any computed source has a known miss, or when
+        zero sources were computed at all -- an assessment that cannot
+        vouch for anything is unknown, not complete (AC6/AC7).
+        """
+
+        computed = self.computed_sources
+        if not computed:
+            return False
+        return self.known_miss_count == 0
+
+
+def compute_capture_coverage(
+    *,
+    origin: str,
+    since_ms: int,
+    until_ms: int,
+    source_conn: sqlite3.Connection,
+    index_conn: sqlite3.Connection,
+    grace_window_ms: int = 15 * 60 * 1000,
+    missing_ref_limit: int = 50,
+    generations: Mapping[str, str] | None = None,
+    now_ms: int | None = None,
+) -> CoverageAssessment:
+    """Correlate ``SessionStart`` hook evidence for ``origin`` against archived sessions.
+
+    ``source_conn``/``index_conn`` are already-open connections to
+    source.db/index.db (this function performs read-only queries and never
+    manages connection lifecycle -- the production reference path resolves
+    and opens them; devtools/health/tests pass fixtures directly).
+
+    The hook-evidence window's upper bound is clamped to
+    ``now_ms - grace_window_ms`` so a session that started moments ago and
+    has not finished ingest yet is never counted as a miss.
+    """
+
+    current_ms = now_ms if now_ms is not None else int(datetime.now(UTC).timestamp() * 1000)
+    effective_until_ms = min(until_ms, current_ms - grace_window_ms)
+
+    sources: list[EvidenceSourceCoverage] = [
+        _compute_hook_session_start_coverage(
+            origin=origin,
+            since_ms=since_ms,
+            until_ms=effective_until_ms,
+            source_conn=source_conn,
+            index_conn=index_conn,
+            missing_ref_limit=missing_ref_limit,
+        )
+    ]
+    for source_kind, reason in _DECLARED_UNCOMPUTED_SOURCES:
+        sources.append(EvidenceSourceCoverage(source=source_kind, status="unknown", reason=reason))
+
+    return CoverageAssessment(
+        origin=origin,
+        since_ms=since_ms,
+        until_ms=until_ms,
+        grace_window_ms=grace_window_ms,
+        method_version=METHOD_VERSION,
+        generations=dict(generations or {}),
+        sources=tuple(sources),
+        computed_at_ms=current_ms,
+    )
+
+
+def _compute_hook_session_start_coverage(
+    *,
+    origin: str,
+    since_ms: int,
+    until_ms: int,
+    source_conn: sqlite3.Connection,
+    index_conn: sqlite3.Connection,
+    missing_ref_limit: int,
+) -> EvidenceSourceCoverage:
+    if origin not in _ORIGINS_WITH_HOOK_EVIDENCE:
+        return EvidenceSourceCoverage(
+            source="hook_session_start",
+            status="unknown",
+            reason=f"no hook harness reports SessionStart evidence for origin {origin!r}",
+        )
+    if not table_exists(source_conn, "raw_hook_events"):
+        return EvidenceSourceCoverage(
+            source="hook_session_start",
+            status="unknown",
+            reason="raw_hook_events table is not present in source.db",
+        )
+    if until_ms <= since_ms:
+        return EvidenceSourceCoverage(
+            source="hook_session_start",
+            status="unknown",
+            reason="requested window is entirely inside the grace window; no session has had time to finish ingest yet",
+        )
+
+    expected_ids = {
+        str(row[0])
+        for row in source_conn.execute(
+            """
+            SELECT DISTINCT session_native_id
+            FROM raw_hook_events
+            WHERE origin = ? AND event_type = 'SessionStart'
+              AND session_native_id IS NOT NULL
+              AND observed_at_ms >= ? AND observed_at_ms < ?
+            """,
+            (origin, since_ms, until_ms),
+        ).fetchall()
+    }
+    archived_ids: set[str] = set()
+    if expected_ids and table_exists(index_conn, "sessions"):
+        archived_ids = {
+            str(row[0])
+            for row in index_conn.execute(
+                "SELECT native_id FROM sessions WHERE origin = ?",
+                (origin,),
+            ).fetchall()
+        }
+    missing = tuple(sorted(expected_ids - archived_ids))
+    return EvidenceSourceCoverage(
+        source="hook_session_start",
+        status="computed",
+        observed_count=len(expected_ids),
+        matched_count=len(expected_ids & archived_ids),
+        missing_native_ids=missing[:missing_ref_limit],
+        missing_count=len(missing),
+    )
+
+
+def coverage_citation(assessment: CoverageAssessment) -> dict[str, object]:
+    """A small, embeddable citation a sample-frame/result-frame stanza can quote (AC3/AC5).
+
+    Deliberately does not repeat the full known-miss list -- callers that
+    need to drill down read ``assessment.known_missing_native_ids``
+    directly; a citation stanza only needs the ref plus the headline
+    numbers to let a reader decide whether to look further.
+    """
+
+    return {
+        "coverage_ref": assessment.ref,
+        "origin": assessment.origin,
+        "since_ms": assessment.since_ms,
+        "until_ms": assessment.until_ms,
+        "coverage_ratio": assessment.coverage_ratio,
+        "known_miss_count": assessment.known_miss_count,
+        "frame_complete": assessment.is_frame_complete,
+        "unknown_sources": [source.source for source in assessment.unknown_sources],
+    }
+
+
+def apply_coverage_to_enumeration(
+    claimed_enumeration: ResultEnumerationFrame,
+    assessment: CoverageAssessment,
+) -> ResultEnumerationFrame:
+    """Downgrade an ``"exact"`` enumeration claim when coverage evidence disagrees (AC6).
+
+    A result surface that would otherwise render an ``"exact"`` count or
+    enumeration over ``assessment``'s origin/window must route its claimed
+    frame through this before rendering: a known miss (or an assessment
+    with zero computed sources) forces ``"frame_incomplete"`` instead of
+    silently keeping ``"exact"``.
+    """
+
+    if claimed_enumeration == "exact" and not assessment.is_frame_complete:
+        return "frame_incomplete"
+    return claimed_enumeration
+
+
+def render_capture_coverage_report(assessments: Sequence[CoverageAssessment]) -> str:
+    """Render a per-origin, drillable text report (AC1)."""
+
+    if not assessments:
+        return "Capture-completeness coverage: no origins assessed\n"
+
+    lines = ["Capture-completeness coverage", ""]
+    for assessment in assessments:
+        window = f"[{assessment.since_ms}, {assessment.until_ms})"
+        lines.append(f"## {assessment.origin} {window}")
+        lines.append(f"ref: {assessment.ref}")
+        ratio = assessment.coverage_ratio
+        ratio_text = f"{ratio:.1%}" if ratio is not None else "unknown"
+        lines.append(f"coverage: {ratio_text} (known misses: {assessment.known_miss_count})")
+        for source in assessment.sources:
+            if source.status == "computed":
+                lines.append(
+                    f"  - {source.source}: {source.matched_count}/{source.observed_count} matched, "
+                    f"{source.missing_count} missing"
+                )
+                if source.missing_native_ids:
+                    shown = ", ".join(source.missing_native_ids)
+                    suffix = " (+more)" if source.missing_count > len(source.missing_native_ids) else ""
+                    lines.append(f"    missing refs: {shown}{suffix}")
+            else:
+                lines.append(f"  - {source.source}: unknown ({source.reason})")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+__all__ = [
+    "CoverageAssessment",
+    "CoverageEvidenceSourceKind",
+    "CoverageSourceStatus",
+    "EvidenceSourceCoverage",
+    "METHOD_VERSION",
+    "ResultEnumerationFrame",
+    "apply_coverage_to_enumeration",
+    "compute_capture_coverage",
+    "coverage_citation",
+    "render_capture_coverage_report",
+]

--- a/tests/unit/daemon/test_capture_coverage_alert.py
+++ b/tests/unit/daemon/test_capture_coverage_alert.py
@@ -1,0 +1,89 @@
+"""Capture-completeness health alert tests (polylogue-3uw AC2).
+
+Proves a seeded missed-session scenario (SessionStart hook evidence with no
+matching archived session) trips the daemon health alert via the production
+:func:`~polylogue.daemon.health._check_capture_coverage_medium` check, not a
+parallel alerting path.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.daemon.health import HealthSeverity, _check_capture_coverage_medium
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from tests.infra.frozen_clock import DEFAULT_FROZEN_EPOCH
+
+GRACE_MS = 15 * 60 * 1000
+NOW_MS = int(DEFAULT_FROZEN_EPOCH * 1000)
+
+pytestmark = pytest.mark.frozen_clock_modules("polylogue.daemon.health")
+
+
+@pytest.fixture
+def coverage_archive(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, frozen_clock: object) -> Path:
+    archive = tmp_path / "archive"
+    initialize_archive_database(archive / "source.db", ArchiveTier.SOURCE)
+    initialize_archive_database(archive / "index.db", ArchiveTier.INDEX)
+    monkeypatch.setattr("polylogue.daemon.health.archive_root", lambda: archive)
+    monkeypatch.setattr("polylogue.daemon.health._active_health_db_path", lambda: archive / "index.db")
+    return archive
+
+
+def _insert_hook_event(archive: Path, native_id: str, *, observed_at_ms: int) -> None:
+    payload = {"event_type": "SessionStart", "session_id": native_id}
+    with sqlite3.connect(archive / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, native_id, session_native_id,
+                source_path, event_type, payload_json, observed_at_ms
+            ) VALUES (?, 'claude-code-session', ?, ?, ?, 'SessionStart', ?, ?)
+            """,
+            (
+                f"hook-{native_id}",
+                native_id,
+                native_id,
+                f"/hooks/{native_id}.jsonl",
+                json.dumps(payload),
+                observed_at_ms,
+            ),
+        )
+
+
+def test_seeded_missed_session_trips_capture_coverage_alert(coverage_archive: Path) -> None:
+    _insert_hook_event(coverage_archive, "session-lost", observed_at_ms=NOW_MS - GRACE_MS - 1_000)
+
+    alert = _check_capture_coverage_medium()
+
+    assert alert.check_name == "capture_coverage"
+    assert alert.severity != HealthSeverity.OK
+    assert "1 session(s)" in alert.message
+
+
+def test_no_hook_evidence_is_ok(coverage_archive: Path) -> None:
+    alert = _check_capture_coverage_medium()
+
+    assert alert.check_name == "capture_coverage"
+    assert alert.severity == HealthSeverity.OK
+
+
+def test_matched_session_does_not_trip_alert(coverage_archive: Path) -> None:
+    _insert_hook_event(coverage_archive, "session-ok", observed_at_ms=NOW_MS - GRACE_MS - 1_000)
+    with sqlite3.connect(coverage_archive / "index.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO sessions (native_id, origin, content_hash, updated_at_ms)
+            VALUES ('session-ok', 'claude-code-session', ?, ?)
+            """,
+            (bytes.fromhex("11" * 32), NOW_MS),
+        )
+
+    alert = _check_capture_coverage_medium()
+
+    assert alert.severity == HealthSeverity.OK

--- a/tests/unit/insights/test_capture_coverage.py
+++ b/tests/unit/insights/test_capture_coverage.py
@@ -1,0 +1,329 @@
+"""Capture-completeness coverage materialization tests (polylogue-3uw).
+
+Proves the production reference path: real ``raw_hook_events``/``sessions``
+tables in a bootstrap-initialized source.db/index.db, correlated by
+:func:`compute_capture_coverage`, not a test-only mock of the computation.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.insights.capture_coverage import (
+    apply_coverage_to_enumeration,
+    compute_capture_coverage,
+    coverage_citation,
+    render_capture_coverage_report,
+)
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+NOW_MS = 2_000_000_000_000
+GRACE_MS = 15 * 60 * 1000
+
+
+@pytest.fixture
+def archive(tmp_path: Path) -> Path:
+    root = tmp_path / "archive"
+    initialize_archive_database(root / "source.db", ArchiveTier.SOURCE)
+    initialize_archive_database(root / "index.db", ArchiveTier.INDEX)
+    return root
+
+
+def _insert_hook_event(
+    archive: Path,
+    native_id: str,
+    *,
+    origin: str = "claude-code-session",
+    event: str = "SessionStart",
+    observed_at_ms: int = NOW_MS - GRACE_MS - 1,
+) -> None:
+    payload = {"event_type": event, "session_id": native_id}
+    with sqlite3.connect(archive / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, native_id, session_native_id,
+                source_path, event_type, payload_json, observed_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                f"hook-{native_id}-{event}",
+                origin,
+                native_id,
+                native_id,
+                f"/hooks/{native_id}.jsonl",
+                event,
+                json.dumps(payload),
+                observed_at_ms,
+            ),
+        )
+
+
+def _insert_session(archive: Path, native_id: str, *, origin: str = "claude-code-session") -> None:
+    with sqlite3.connect(archive / "index.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO sessions (native_id, origin, content_hash, updated_at_ms)
+            VALUES (?, ?, ?, ?)
+            """,
+            (native_id, origin, bytes.fromhex("11" * 32), NOW_MS),
+        )
+
+
+def _open(archive: Path) -> tuple[sqlite3.Connection, sqlite3.Connection]:
+    return sqlite3.connect(archive / "source.db"), sqlite3.connect(archive / "index.db")
+
+
+def test_matched_session_reports_full_coverage_no_misses(archive: Path) -> None:
+    _insert_hook_event(archive, "session-ok")
+    _insert_session(archive, "session-ok")
+    source_conn, index_conn = _open(archive)
+
+    assessment = compute_capture_coverage(
+        origin="claude-code-session",
+        since_ms=0,
+        until_ms=NOW_MS,
+        source_conn=source_conn,
+        index_conn=index_conn,
+        now_ms=NOW_MS,
+    )
+
+    hook_source = next(s for s in assessment.sources if s.source == "hook_session_start")
+    assert hook_source.status == "computed"
+    assert hook_source.observed_count == 1
+    assert hook_source.matched_count == 1
+    assert hook_source.missing_count == 0
+    assert assessment.known_miss_count == 0
+    assert assessment.coverage_ratio == 1.0
+    assert assessment.is_frame_complete is True
+
+
+def test_missing_session_is_a_drillable_known_miss(archive: Path) -> None:
+    _insert_hook_event(archive, "session-lost")
+    # Deliberately no matching session row -- a seeded missed-session scenario.
+    source_conn, index_conn = _open(archive)
+
+    assessment = compute_capture_coverage(
+        origin="claude-code-session",
+        since_ms=0,
+        until_ms=NOW_MS,
+        source_conn=source_conn,
+        index_conn=index_conn,
+        now_ms=NOW_MS,
+    )
+
+    assert assessment.known_miss_count == 1
+    assert assessment.known_missing_native_ids == ("session-lost",)
+    assert assessment.coverage_ratio == 0.0
+    assert assessment.is_frame_complete is False
+
+
+def test_recent_hook_event_inside_grace_window_is_not_yet_a_miss(archive: Path) -> None:
+    _insert_hook_event(archive, "session-fresh", observed_at_ms=NOW_MS - 60_000)
+    source_conn, index_conn = _open(archive)
+
+    # A window entirely inside the grace period (the last minute, with a
+    # 15-minute grace window) cannot yet distinguish "in-flight ingest"
+    # from "missed" -- the source must report unknown, not a false miss.
+    assessment = compute_capture_coverage(
+        origin="claude-code-session",
+        since_ms=NOW_MS - 60_000,
+        until_ms=NOW_MS,
+        source_conn=source_conn,
+        index_conn=index_conn,
+        grace_window_ms=GRACE_MS,
+        now_ms=NOW_MS,
+    )
+
+    hook_source = next(s for s in assessment.sources if s.source == "hook_session_start")
+    assert hook_source.status == "unknown"
+
+
+def test_unwired_origin_reports_hook_source_as_unknown_not_zero(archive: Path) -> None:
+    source_conn, index_conn = _open(archive)
+
+    assessment = compute_capture_coverage(
+        origin="chatgpt-export",
+        since_ms=0,
+        until_ms=NOW_MS,
+        source_conn=source_conn,
+        index_conn=index_conn,
+        now_ms=NOW_MS,
+    )
+
+    hook_source = next(s for s in assessment.sources if s.source == "hook_session_start")
+    assert hook_source.status == "unknown"
+    assert hook_source.reason is not None
+
+
+def test_declared_uncomputed_sources_are_always_unknown_with_a_reason(archive: Path) -> None:
+    _insert_hook_event(archive, "session-ok")
+    _insert_session(archive, "session-ok")
+    source_conn, index_conn = _open(archive)
+
+    assessment = compute_capture_coverage(
+        origin="claude-code-session",
+        since_ms=0,
+        until_ms=NOW_MS,
+        source_conn=source_conn,
+        index_conn=index_conn,
+        now_ms=NOW_MS,
+    )
+
+    unknown_kinds = {source.source for source in assessment.unknown_sources}
+    assert "watcher_file_inventory" in unknown_kinds
+    assert "browser_extension_observation" in unknown_kinds
+    for source in assessment.unknown_sources:
+        assert source.reason
+
+
+def test_zero_computed_sources_makes_coverage_ratio_and_frame_unknown(archive: Path) -> None:
+    source_conn, index_conn = _open(archive)
+
+    assessment = compute_capture_coverage(
+        origin="chatgpt-export",
+        since_ms=0,
+        until_ms=NOW_MS,
+        source_conn=source_conn,
+        index_conn=index_conn,
+        now_ms=NOW_MS,
+    )
+
+    assert assessment.computed_sources == ()
+    assert assessment.coverage_ratio is None
+    assert assessment.is_frame_complete is False
+
+
+def test_ref_is_stable_across_independently_constructed_equal_assessments(archive: Path) -> None:
+    _insert_hook_event(archive, "session-a")
+    _insert_session(archive, "session-a")
+    source_conn_1, index_conn_1 = _open(archive)
+    source_conn_2, index_conn_2 = _open(archive)
+
+    first = compute_capture_coverage(
+        origin="claude-code-session",
+        since_ms=0,
+        until_ms=NOW_MS,
+        source_conn=source_conn_1,
+        index_conn=index_conn_1,
+        now_ms=NOW_MS,
+        generations={"index": "gen-1"},
+    )
+    second = compute_capture_coverage(
+        origin="claude-code-session",
+        since_ms=0,
+        until_ms=NOW_MS,
+        source_conn=source_conn_2,
+        index_conn=index_conn_2,
+        now_ms=NOW_MS,
+        generations={"index": "gen-1"},
+    )
+
+    assert first.ref == second.ref
+
+
+def test_ref_changes_when_evidence_source_status_flips(archive: Path) -> None:
+    _insert_hook_event(archive, "session-a")
+    source_conn_1, index_conn_1 = _open(archive)
+    without_session = compute_capture_coverage(
+        origin="claude-code-session",
+        since_ms=0,
+        until_ms=NOW_MS,
+        source_conn=source_conn_1,
+        index_conn=index_conn_1,
+        now_ms=NOW_MS,
+    )
+
+    _insert_session(archive, "session-a")
+    source_conn_2, index_conn_2 = _open(archive)
+    with_session = compute_capture_coverage(
+        origin="claude-code-session",
+        since_ms=0,
+        until_ms=NOW_MS,
+        source_conn=source_conn_2,
+        index_conn=index_conn_2,
+        now_ms=NOW_MS,
+    )
+
+    # Same identity question (both "computed" for hook_session_start): the
+    # ref must be stable even though the miss count differs, since the ref
+    # names the measurement question, not today's answer.
+    assert without_session.ref == with_session.ref
+    assert without_session.known_miss_count == 1
+    assert with_session.known_miss_count == 0
+
+
+def test_coverage_citation_carries_ref_and_headline_numbers(archive: Path) -> None:
+    _insert_hook_event(archive, "session-lost")
+    source_conn, index_conn = _open(archive)
+
+    assessment = compute_capture_coverage(
+        origin="claude-code-session",
+        since_ms=0,
+        until_ms=NOW_MS,
+        source_conn=source_conn,
+        index_conn=index_conn,
+        now_ms=NOW_MS,
+    )
+    citation = coverage_citation(assessment)
+
+    assert citation["coverage_ref"] == assessment.ref
+    assert citation["known_miss_count"] == 1
+    assert citation["frame_complete"] is False
+
+
+def test_seeded_missing_signal_flips_exact_enumeration_to_frame_incomplete(archive: Path) -> None:
+    _insert_hook_event(archive, "session-lost")
+    source_conn, index_conn = _open(archive)
+
+    assessment = compute_capture_coverage(
+        origin="claude-code-session",
+        since_ms=0,
+        until_ms=NOW_MS,
+        source_conn=source_conn,
+        index_conn=index_conn,
+        now_ms=NOW_MS,
+    )
+
+    assert apply_coverage_to_enumeration("exact", assessment) == "frame_incomplete"
+
+
+def test_exact_enumeration_survives_full_coverage(archive: Path) -> None:
+    _insert_hook_event(archive, "session-ok")
+    _insert_session(archive, "session-ok")
+    source_conn, index_conn = _open(archive)
+
+    assessment = compute_capture_coverage(
+        origin="claude-code-session",
+        since_ms=0,
+        until_ms=NOW_MS,
+        source_conn=source_conn,
+        index_conn=index_conn,
+        now_ms=NOW_MS,
+    )
+
+    assert apply_coverage_to_enumeration("exact", assessment) == "exact"
+
+
+def test_render_report_is_drillable_per_origin(archive: Path) -> None:
+    _insert_hook_event(archive, "session-lost")
+    source_conn, index_conn = _open(archive)
+
+    assessment = compute_capture_coverage(
+        origin="claude-code-session",
+        since_ms=0,
+        until_ms=NOW_MS,
+        source_conn=source_conn,
+        index_conn=index_conn,
+        now_ms=NOW_MS,
+    )
+    report = render_capture_coverage_report([assessment])
+
+    assert "claude-code-session" in report
+    assert assessment.ref in report
+    assert "session-lost" in report


### PR DESCRIPTION
## Summary

Adds a capture-completeness coverage measure: for each origin/window, correlate `SessionStart` hook evidence (`raw_hook_events`, source.db) against archived sessions (`sessions`, index.db) to answer "how much of what exists did we ingest," not just "how converged is what we ingested." Materializes the result as a versioned, content-addressed `CoverageAssessment`, wires a health alert for seeded misses, and adds the primitives a result surface needs to cite the number and downgrade an exact-enumeration claim when coverage is incomplete.

## Problem

Convergence legibility (the rest of `polylogue/insights/`) answers how converged the archive is against what it already has. Nothing answered how much of what actually happened got captured at all. A silent capture regression (a hook stops firing, a watched harness goes unwired) had no number to trip an alert on, and no result surface could honestly caveat "this count assumes full capture" because there was no coverage number to check.

## Solution

- New `polylogue/insights/capture_coverage.py`:
  - `CoverageAssessment` / `EvidenceSourceCoverage`: a content-addressed `coverage:<hash>` ref (same `content_ref` mechanism `MetricDefinition`'s `metric:<hash>` already uses) binding origin, interval, evidence-source inventory, method version, generations, and known misses.
  - `compute_capture_coverage()` correlates `SessionStart` hook evidence against archived `sessions.native_id` for `claude-code-session`/`codex-session` (the two origins the hook harnesses cover today), clamped by a grace window so in-flight ingest is never counted as a miss.
  - Two evidence sources the design names but has not wired yet (`watcher_file_inventory`, `browser_extension_observation`) are always reported `status="unknown"` with an explicit reason -- never silently folded into a false 100%. An assessment with zero computed sources is itself unknown (`coverage_ratio is None`, `is_frame_complete is False`).
  - `apply_coverage_to_enumeration()`: downgrades an `"exact"` enumeration claim to `"frame_incomplete"` when coverage disagrees.
  - `coverage_citation()` / `render_capture_coverage_report()`: an embeddable citation payload and a per-origin drillable text report.
- `polylogue/daemon/health.py`: new `_check_capture_coverage_medium` medium-tier health check running the same computation over the trailing 24h and alerting on known misses (wired into `_run_medium_checks`); its broad except now logs (fixed a `devtools verify degrade-loudly` finding on the new code).

Two unrelated fixes needed to get past the repo-wide `devtools verify --quick` pre-push gate, discovered while verifying this branch:
- `docs/plans/classifier-fingerprints.json`: retroactively acknowledged a pre-existing, unrelated fingerprint drift in `polylogue/sources/parsers/claude/ai_parser.py:looks_like_ai` from PR #3537 (d921ef00f), which tightened that detector without recording it in the manifest. Filed and referenced #3540 for the open question of whether already-indexed rows need a reparse.

## Acceptance criteria disposition (polylogue-3uw)

Per the bead's own scope note ("if full scope is too large for one PR, land the coverage computation + AC1/AC4/AC7 as the primary deliverable, and treat AC2/AC3 as a clearly-scoped follow-up"):

1. **Coverage renders per origin, known-miss list drillable to refs** -- satisfied: `render_capture_coverage_report()` renders per origin, `CoverageAssessment.known_missing_native_ids` names the exact missing session native ids. Not yet wired to a CLI/MCP surface (no `devtools`/`polylogue` command exposes it yet) -- follow-up.
2. **Seeded missed-session scenario trips the health alert** -- satisfied: `_check_capture_coverage_medium` wired into `_run_medium_checks`; `tests/unit/daemon/test_capture_coverage_alert.py` proves a seeded miss trips `HealthSeverity != OK`.
3. **Sample-frame stanzas can cite the coverage number** -- partially satisfied: `coverage_citation()` produces the citable payload, but no existing report/finding stanza has been updated to call it yet -- follow-up.
4. **Coverage artifact is resolvable and binds origin, interval, evidence-source inventory, method, generations** -- satisfied: `CoverageAssessment.ref`/`canonical_payload()`.
5. **A result frame can cite it** -- satisfied at the primitive level (`coverage_citation()`); no concrete result-envelope surface wired yet -- follow-up (same gap as AC3).
6. **Seeded missing signal makes an otherwise enumeration-exact result render frame-incomplete** -- satisfied at the mechanism level: `apply_coverage_to_enumeration("exact", assessment)` flips to `"frame_incomplete"` given a seeded miss, proven by `test_seeded_missing_signal_flips_exact_enumeration_to_frame_incomplete`. Not yet wired into an actual query-result envelope type -- follow-up.
7. **Unknown signal-source coverage remains unknown, not 100%** -- satisfied: unwired origins and the two undeclared evidence sources always report `status="unknown"`; zero computed sources yields `coverage_ratio is None`.
8. **Focused materialization and result-envelope tests prove the production reference path** -- satisfied for materialization (bootstrap-initialized source.db/index.db, real `raw_hook_events`/`sessions` tables, no mocked computation); no result-envelope integration test exists yet since no envelope wiring was added (follow-up, tied to AC3/AC5).

**Honest summary**: AC1/AC2/AC4/AC6/AC7/AC8 (the core measurement, its content-addressed identity, its health-alert wiring, and the frame-incompleteness mechanism) are delivered and tested against the production path. AC3/AC5, and the CLI/MCP surface half of AC1, are the scoped follow-up the bead itself anticipates -- wiring the citation primitive into an actual report/finding/result-envelope surface, which needs its own design decision about which surface goes first.

## Verification

- `devtools test tests/unit/insights/test_capture_coverage.py tests/unit/daemon/test_capture_coverage_alert.py` => `15 passed`.
- `mypy --strict` on both changed modules: clean.
- `devtools verify --quick` => `exit_code: 0` (19/19 steps green, including `verify degrade-loudly` and `lab policy classifier-fingerprints`).
- `devtools render all --check`: clean (topology projection regenerated for the new module).
- Not run: `devtools verify --all` / full non-slow suite (a `--seed-testmon --skip-slow` baseline run was kicked off separately in this worktree to establish testmon state, since it had never been seeded here; that is baseline bookkeeping, not evidence specific to this diff).

Ref polylogue-3uw