### PR TITLE
feat(storage): add depth-annotated delegation ancestry/subtree queries

### DIFF
--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -38,7 +38,9 @@ from polylogue.core.refs import (
     EvidenceRef,
     ObjectRef,
     normalize_object_ref_text,
+    parse_delegation_ancestry_object_id,
     parse_delegation_edge_object_id,
+    parse_delegation_subtree_object_id,
     parse_public_ref,
 )
 from polylogue.core.timestamps import parse_archive_datetime
@@ -4238,6 +4240,13 @@ class PolylogueArchiveMixin:
             model_json_document,
         )
 
+        ancestry_session_id = parse_delegation_ancestry_object_id(object_ref.object_id)
+        if ancestry_session_id is not None:
+            return self._resolve_delegation_ancestry_object_ref(archive, ref, normalized_ref, ancestry_session_id)
+        subtree_session_id = parse_delegation_subtree_object_id(object_ref.object_id)
+        if subtree_session_id is not None:
+            return self._resolve_delegation_subtree_object_ref(archive, ref, normalized_ref, subtree_session_id)
+
         edge_identity = parse_delegation_edge_object_id(object_ref.object_id)
         if edge_identity is not None:
             parent_session_id, child_session_id = edge_identity
@@ -4281,6 +4290,76 @@ class PolylogueArchiveMixin:
             actions=(
                 _resolution_action("read parent session", f"polylogue find id:{attempt.parent_session_id} then read"),
             ),
+        )
+
+    def _resolve_delegation_ancestry_object_ref(
+        self,
+        archive: Any,
+        ref: str,
+        normalized_ref: str,
+        session_id: str,
+    ) -> PublicRefResolutionPayload:
+        """Resolve a ``delegation:ancestry:<session_id>`` ref: the full
+        root-to-node dispatch chain for ``session_id`` (polylogue-qsb4),
+        depth-annotated, in one recursive-CTE call
+        (``ArchiveStore.get_delegation_ancestry``)."""
+
+        from polylogue.surfaces.payloads import (
+            DelegationAncestryPayload,
+            PublicRefResolutionPayload,
+            model_json_document,
+        )
+
+        rows = archive.get_delegation_ancestry(session_id)
+        payload = DelegationAncestryPayload.from_rows(session_id, rows)
+        object_refs = tuple(f"session:{node.session_id}" for node in payload.nodes)
+        return PublicRefResolutionPayload(
+            ref=ref,
+            normalized_ref=normalized_ref,
+            kind="delegation",
+            resolved=True,
+            payload_kind="delegation-ancestry",
+            payload=model_json_document(payload),
+            title=f"delegation ancestry for {session_id} ({payload.max_depth} level(s) up)",
+            summary=f"{len(payload.nodes)} node(s), root-to-node",
+            object_refs=object_refs,
+            evidence_refs=(),
+            actions=(_resolution_action("read queried session", f"polylogue find id:{session_id} then read"),),
+        )
+
+    def _resolve_delegation_subtree_object_ref(
+        self,
+        archive: Any,
+        ref: str,
+        normalized_ref: str,
+        session_id: str,
+    ) -> PublicRefResolutionPayload:
+        """Resolve a ``delegation:subtree:<session_id>`` ref: the full
+        dispatch subtree rooted at ``session_id`` (polylogue-qsb4),
+        depth-annotated, in one recursive-CTE call
+        (``ArchiveStore.get_delegation_subtree``)."""
+
+        from polylogue.surfaces.payloads import (
+            DelegationSubtreePayload,
+            PublicRefResolutionPayload,
+            model_json_document,
+        )
+
+        rows = archive.get_delegation_subtree(session_id)
+        payload = DelegationSubtreePayload.from_rows(session_id, rows)
+        object_refs = tuple(f"session:{node.session_id}" for node in payload.nodes)
+        return PublicRefResolutionPayload(
+            ref=ref,
+            normalized_ref=normalized_ref,
+            kind="delegation",
+            resolved=True,
+            payload_kind="delegation-subtree",
+            payload=model_json_document(payload),
+            title=f"delegation subtree rooted at {session_id} ({payload.node_count} node(s))",
+            summary=f"{payload.max_depth} level(s) deep",
+            object_refs=object_refs,
+            evidence_refs=(),
+            actions=(_resolution_action("read root session", f"polylogue find id:{session_id} then read"),),
         )
 
     def _resolve_runtime_object_ref(

--- a/polylogue/core/refs.py
+++ b/polylogue/core/refs.py
@@ -452,6 +452,53 @@ def parse_delegation_edge_object_id(object_id: str) -> tuple[str, str] | None:
     return parent_session_id, child_session_id
 
 
+# polylogue-qsb4: arbitrary-depth ancestry/subtree identities. These share
+# the "delegation" object-ref kind rather than adding new kinds -- both are
+# still delegation-relation identities, just resolved through a recursive
+# traversal instead of one edge lookup. Session ids never begin with
+# "ancestry:"/"subtree:" (origin tokens are provider names such as
+# "claude-code-session"), so these prefixes cannot collide with a plain
+# ``instruction_tool_use_block_id`` or the ``edge:`` shape above.
+_DELEGATION_ANCESTRY_PREFIX: Final[str] = "ancestry:"
+_DELEGATION_SUBTREE_PREFIX: Final[str] = "subtree:"
+
+
+def delegation_ancestry_object_id(session_id: str) -> str:
+    """Return the deterministic delegation-ancestry object id for ``session_id``."""
+
+    if not session_id:
+        raise ValueError("delegation ancestry identity requires a non-empty session id")
+    return f"{_DELEGATION_ANCESTRY_PREFIX}{session_id}"
+
+
+def parse_delegation_ancestry_object_id(object_id: str) -> str | None:
+    """Return the queried ``session_id`` when ``object_id`` is an ancestry
+    identity, else ``None``."""
+
+    if not object_id.startswith(_DELEGATION_ANCESTRY_PREFIX):
+        return None
+    session_id = object_id[len(_DELEGATION_ANCESTRY_PREFIX) :]
+    return session_id or None
+
+
+def delegation_subtree_object_id(session_id: str) -> str:
+    """Return the deterministic delegation-subtree object id for ``session_id``."""
+
+    if not session_id:
+        raise ValueError("delegation subtree identity requires a non-empty session id")
+    return f"{_DELEGATION_SUBTREE_PREFIX}{session_id}"
+
+
+def parse_delegation_subtree_object_id(object_id: str) -> str | None:
+    """Return the queried ``session_id`` when ``object_id`` is a subtree
+    identity, else ``None``."""
+
+    if not object_id.startswith(_DELEGATION_SUBTREE_PREFIX):
+        return None
+    session_id = object_id[len(_DELEGATION_SUBTREE_PREFIX) :]
+    return session_id or None
+
+
 __all__ = [
     "ActorKind",
     "ActorRef",
@@ -462,9 +509,13 @@ __all__ = [
     "ObjectRefKind",
     "PublicRef",
     "WorkerProfileRef",
+    "delegation_ancestry_object_id",
     "delegation_edge_object_id",
+    "delegation_subtree_object_id",
     "normalize_object_ref_text",
     "normalize_public_ref_text",
+    "parse_delegation_ancestry_object_id",
     "parse_delegation_edge_object_id",
+    "parse_delegation_subtree_object_id",
     "parse_public_ref",
 ]

--- a/polylogue/storage/sqlite/archive_tiers/archive.py
+++ b/polylogue/storage/sqlite/archive_tiers/archive.py
@@ -606,6 +606,149 @@ def _archive_delegation_query_row(row: sqlite3.Row) -> ArchiveDelegationQueryRow
     )
 
 
+@dataclass(frozen=True, slots=True)
+class ArchiveDelegationAncestryRow:
+    """One node in a depth-annotated delegation ancestry chain (polylogue-qsb4),
+    root-to-node ordered. ``depth`` is 0 at the queried session itself and
+    increases toward the root. ``child_session_id`` is the next node down the
+    chain (the one dispatched by this node, one step closer to the queried
+    session) -- ``None`` at depth 0, which has no outgoing edge in this
+    traversal. ``mapping_state``/``instruction_tool_use_block_id``/
+    ``link_confidence``/``link_method`` describe that edge (this node ->
+    ``child_session_id``)."""
+
+    session_id: str
+    depth: int
+    child_session_id: str | None
+    mapping_state: DelegationMappingState | None
+    instruction_tool_use_block_id: str | None
+    link_confidence: float | None
+    link_method: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ArchiveDelegationSubtreeRow:
+    """One node in a depth-annotated delegation subtree (polylogue-qsb4),
+    the queried session plus all its transitive dispatch descendants.
+    ``depth`` is 0 at the queried session itself (the subtree root) and
+    increases toward descendants. ``parent_session_id`` is this node's own
+    dispatcher -- ``None`` at depth 0, which is out of scope for this
+    traversal. ``mapping_state``/``instruction_tool_use_block_id``/
+    ``link_confidence``/``link_method`` describe the edge
+    (``parent_session_id`` -> this node)."""
+
+    session_id: str
+    depth: int
+    parent_session_id: str | None
+    mapping_state: DelegationMappingState | None
+    instruction_tool_use_block_id: str | None
+    link_confidence: float | None
+    link_method: str | None
+
+
+def _archive_delegation_ancestry_row(row: sqlite3.Row) -> ArchiveDelegationAncestryRow:
+    return ArchiveDelegationAncestryRow(
+        session_id=str(row["session_id"]),
+        depth=int(row["depth"]),
+        child_session_id=str(row["child_session_id"]) if row["child_session_id"] is not None else None,
+        mapping_state=(
+            cast(DelegationMappingState, str(row["mapping_state"])) if row["mapping_state"] is not None else None
+        ),
+        instruction_tool_use_block_id=(
+            str(row["instruction_tool_use_block_id"]) if row["instruction_tool_use_block_id"] is not None else None
+        ),
+        link_confidence=float(row["link_confidence"]) if row["link_confidence"] is not None else None,
+        link_method=str(row["link_method"]) if row["link_method"] is not None else None,
+    )
+
+
+def _archive_delegation_subtree_row(row: sqlite3.Row) -> ArchiveDelegationSubtreeRow:
+    return ArchiveDelegationSubtreeRow(
+        session_id=str(row["session_id"]),
+        depth=int(row["depth"]),
+        parent_session_id=str(row["parent_session_id"]) if row["parent_session_id"] is not None else None,
+        mapping_state=(
+            cast(DelegationMappingState, str(row["mapping_state"])) if row["mapping_state"] is not None else None
+        ),
+        instruction_tool_use_block_id=(
+            str(row["instruction_tool_use_block_id"]) if row["instruction_tool_use_block_id"] is not None else None
+        ),
+        link_confidence=float(row["link_confidence"]) if row["link_confidence"] is not None else None,
+        link_method=str(row["link_method"]) if row["link_method"] is not None else None,
+    )
+
+
+# polylogue-qsb4: both traversals recurse natively over the `delegations`
+# view (backed by `delegation_facts`, the richer typed source of truth --
+# see the module docstring on insights/delegation_work_evidence.py for why
+# this is a projection *source*, not a table to be replaced by the generic
+# work_evidence graph). One SQLite recursive CTE each -- no N+1, no
+# client-side stitching.
+#
+# Quarantined edges (session_links' TopologyEdgeStatus cycle-break
+# precedent, reused verbatim: delegation_facts_source's `mapping_state =
+# 'quarantined'` rows already mark exactly this) are excluded from
+# traversal by construction (`mapping_state != 'quarantined'`), not
+# reinterpreted into a second vocabulary. A defensive visited-path guard
+# (the `path`/`instr()` machinery below) is still carried on every step
+# despite that exclusion: quarantine is asserted by the topology resolver
+# over `session_links` alone, while `delegations` unions edges resolved by
+# an independent mechanism (`content_pairs`' provider-asserted content-
+# identity match, `delegation_facts_source` in index.py) that the topology
+# resolver's cycle detector never inspects. Two content-identity-matched
+# edges could in principle compose into a cycle the quarantine pass never
+# saw; the guard makes that structurally unreachable rather than assumed
+# absent.
+_DELEGATION_ANCESTRY_SQL = """
+WITH RECURSIVE ancestry(session_id, depth, child_session_id, mapping_state,
+                         instruction_tool_use_block_id, link_confidence, link_method, path) AS (
+    SELECT ?, 0, NULL, NULL, NULL, NULL, NULL, '/' || ? || '/'
+    UNION ALL
+    SELECT
+        d.parent_session_id,
+        a.depth + 1,
+        a.session_id,
+        d.mapping_state,
+        d.instruction_tool_use_block_id,
+        d.link_confidence,
+        d.link_method,
+        a.path || d.parent_session_id || '/'
+    FROM delegations d
+    JOIN ancestry a ON d.child_session_id = a.session_id
+    WHERE d.mapping_state != 'quarantined'
+      AND instr(a.path, '/' || d.parent_session_id || '/') = 0
+)
+SELECT session_id, depth, child_session_id, mapping_state, instruction_tool_use_block_id, link_confidence, link_method
+FROM ancestry
+ORDER BY depth DESC
+"""
+
+_DELEGATION_SUBTREE_SQL = """
+WITH RECURSIVE subtree(session_id, depth, parent_session_id, mapping_state,
+                        instruction_tool_use_block_id, link_confidence, link_method, path) AS (
+    SELECT ?, 0, NULL, NULL, NULL, NULL, NULL, '/' || ? || '/'
+    UNION ALL
+    SELECT
+        d.child_session_id,
+        s.depth + 1,
+        s.session_id,
+        d.mapping_state,
+        d.instruction_tool_use_block_id,
+        d.link_confidence,
+        d.link_method,
+        s.path || d.child_session_id || '/'
+    FROM delegations d
+    JOIN subtree s ON d.parent_session_id = s.session_id
+    WHERE d.mapping_state != 'quarantined'
+      AND d.child_session_id IS NOT NULL
+      AND instr(s.path, '/' || d.child_session_id || '/') = 0
+)
+SELECT session_id, depth, parent_session_id, mapping_state, instruction_tool_use_block_id, link_confidence, link_method
+FROM subtree
+ORDER BY depth, session_id
+"""
+
+
 def _delegation_instruction(payload: str | None) -> str | None:
     if payload is None:
         return None
@@ -7637,6 +7780,28 @@ class ArchiveStore:
             [*params, *session_params, normalized_limit, normalized_offset],
         ).fetchall()
         return [_archive_delegation_query_row(row) for row in rows]
+
+    def get_delegation_ancestry(self, session_id: str) -> list[ArchiveDelegationAncestryRow]:
+        """Return the full root-to-node ancestry chain for ``session_id`` in
+        one recursive-CTE call, depth-annotated (polylogue-qsb4). The queried
+        session is always the last row (``depth=0``); its dispatchers follow
+        at increasing depth, ordered root-first. Quarantined (cycle-break)
+        edges are never traversed. Returns a single-row list (just the
+        origin) when ``session_id`` was never dispatched by anything."""
+
+        rows = self._conn.execute(_DELEGATION_ANCESTRY_SQL, (session_id, session_id)).fetchall()
+        return [_archive_delegation_ancestry_row(row) for row in rows]
+
+    def get_delegation_subtree(self, session_id: str) -> list[ArchiveDelegationSubtreeRow]:
+        """Return the full subtree (``session_id`` plus all transitive
+        dispatch descendants) in one recursive-CTE call, depth-annotated
+        (polylogue-qsb4). The queried session is always the first row
+        (``depth=0``), ordered breadth-first thereafter. Quarantined
+        (cycle-break) edges are never traversed. Returns a single-row list
+        (just the root) when ``session_id`` never dispatched anything."""
+
+        rows = self._conn.execute(_DELEGATION_SUBTREE_SQL, (session_id, session_id)).fetchall()
+        return [_archive_delegation_subtree_row(row) for row in rows]
 
     def query_files(
         self,

--- a/polylogue/surfaces/payloads.py
+++ b/polylogue/surfaces/payloads.py
@@ -84,8 +84,10 @@ if TYPE_CHECKING:
         ArchiveAssertionQueryRow,
         ArchiveBlockQueryRow,
         ArchiveContextSnapshotQueryRow,
+        ArchiveDelegationAncestryRow,
         ArchiveDelegationCard,
         ArchiveDelegationQueryRow,
+        ArchiveDelegationSubtreeRow,
         ArchiveFileQueryRow,
         ArchiveMessageQueryRow,
         ArchiveObservedEventQueryRow,
@@ -2593,6 +2595,103 @@ DELEGATION_STATE_CAVEATS: dict[str, str] = {
 }
 
 
+class DelegationAncestryNodePayload(SurfacePayloadModel):
+    """One node in a depth-annotated delegation ancestry chain (polylogue-qsb4).
+
+    ``depth`` is 0 at the queried session and increases toward the root.
+    ``child_session_id``/``mapping_state``/``instruction_tool_use_block_id``/
+    ``link_confidence``/``link_method`` describe the edge from this node to
+    its own child in the chain (``None`` at depth 0, which has no such edge
+    in this traversal). Quarantined (cycle-break) edges are never traversed.
+    """
+
+    session_id: str
+    depth: int
+    child_session_id: str | None = None
+    mapping_state: DelegationMappingState | None = None
+    instruction_tool_use_block_id: str | None = None
+    link_confidence: float | None = None
+    link_method: str | None = None
+
+    @classmethod
+    def from_row(cls, row: ArchiveDelegationAncestryRow) -> DelegationAncestryNodePayload:
+        return cls(
+            session_id=row.session_id,
+            depth=row.depth,
+            child_session_id=row.child_session_id,
+            mapping_state=row.mapping_state,
+            instruction_tool_use_block_id=row.instruction_tool_use_block_id,
+            link_confidence=row.link_confidence,
+            link_method=row.link_method,
+        )
+
+
+class DelegationSubtreeNodePayload(SurfacePayloadModel):
+    """One node in a depth-annotated delegation subtree (polylogue-qsb4).
+
+    ``depth`` is 0 at the queried session (the subtree root) and increases
+    toward descendants. ``parent_session_id``/``mapping_state``/
+    ``instruction_tool_use_block_id``/``link_confidence``/``link_method``
+    describe the edge from this node's own dispatcher to this node (``None``
+    at depth 0, which is out of scope for this traversal). Quarantined
+    (cycle-break) edges are never traversed.
+    """
+
+    session_id: str
+    depth: int
+    parent_session_id: str | None = None
+    mapping_state: DelegationMappingState | None = None
+    instruction_tool_use_block_id: str | None = None
+    link_confidence: float | None = None
+    link_method: str | None = None
+
+    @classmethod
+    def from_row(cls, row: ArchiveDelegationSubtreeRow) -> DelegationSubtreeNodePayload:
+        return cls(
+            session_id=row.session_id,
+            depth=row.depth,
+            parent_session_id=row.parent_session_id,
+            mapping_state=row.mapping_state,
+            instruction_tool_use_block_id=row.instruction_tool_use_block_id,
+            link_confidence=row.link_confidence,
+            link_method=row.link_method,
+        )
+
+
+class DelegationAncestryPayload(SurfacePayloadModel):
+    """Root-to-node delegation ancestry chain for one session (polylogue-qsb4)."""
+
+    unit: Literal["delegation-ancestry"] = "delegation-ancestry"
+    session_id: str
+    max_depth: int
+    nodes: tuple[DelegationAncestryNodePayload, ...]
+
+    @classmethod
+    def from_rows(cls, session_id: str, rows: Sequence[ArchiveDelegationAncestryRow]) -> DelegationAncestryPayload:
+        nodes = tuple(DelegationAncestryNodePayload.from_row(row) for row in rows)
+        return cls(session_id=session_id, max_depth=max((node.depth for node in nodes), default=0), nodes=nodes)
+
+
+class DelegationSubtreePayload(SurfacePayloadModel):
+    """Full dispatch subtree rooted at one session (polylogue-qsb4)."""
+
+    unit: Literal["delegation-subtree"] = "delegation-subtree"
+    session_id: str
+    max_depth: int
+    node_count: int
+    nodes: tuple[DelegationSubtreeNodePayload, ...]
+
+    @classmethod
+    def from_rows(cls, session_id: str, rows: Sequence[ArchiveDelegationSubtreeRow]) -> DelegationSubtreePayload:
+        nodes = tuple(DelegationSubtreeNodePayload.from_row(row) for row in rows)
+        return cls(
+            session_id=session_id,
+            max_depth=max((node.depth for node in nodes), default=0),
+            node_count=len(nodes),
+            nodes=nodes,
+        )
+
+
 class SessionReadViewEnvelope(SurfacePayloadModel):
     """Stable daemon envelope for one executed session read-view."""
 
@@ -3863,10 +3962,14 @@ __all__ = [
     "MetadataMutationResult",
     "DeleteSessionOutcome",
     "DeleteSessionResult",
+    "DelegationAncestryNodePayload",
+    "DelegationAncestryPayload",
     "DelegationAttemptPayload",
     "DelegationCardPayload",
     "DelegationContextRowPayload",
     "DelegationQueryRowPayload",
+    "DelegationSubtreeNodePayload",
+    "DelegationSubtreePayload",
     "MutationResultPayload",
     "QueryErrorPayload",
     "QueryUnitAggregateEnvelope",

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -44,7 +44,11 @@ from polylogue.archive.message.roles import Role
 from polylogue.core.enums import AssertionKind, AssertionStatus, BlockType, BranchType, MaterialOrigin, Origin, Provider
 from polylogue.core.errors import DatabaseError, PolylogueError
 from polylogue.core.json import JSONDocument
-from polylogue.core.refs import delegation_edge_object_id
+from polylogue.core.refs import (
+    delegation_ancestry_object_id,
+    delegation_edge_object_id,
+    delegation_subtree_object_id,
+)
 from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession
 from polylogue.storage.runtime.store_constants import SESSION_INSIGHT_MATERIALIZER_VERSION
 from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
@@ -3378,6 +3382,90 @@ async def test_resolve_ref_returns_missing_payload_for_unknown_delegation_identi
         )
         assert edge_missing.resolved is False
         assert edge_missing.payload_kind == "missing"
+    finally:
+        await archive.close()
+
+
+async def test_resolve_ref_returns_delegation_ancestry_and_subtree_payloads(tmp_path: Path) -> None:
+    """polylogue-qsb4: the `get` MCP tool (backed by `resolve_ref`) exposes
+    arbitrary-depth delegation traversal through the same `delegation`
+    ObjectRef kind, distinguished by the `ancestry:`/`subtree:` object-id
+    prefixes (mirroring the existing `edge:` shape) -- root-to-node and
+    node-to-descendants, depth-annotated, in one call each."""
+    archive = _archive(tmp_path)
+    try:
+        with ArchiveStore(archive.config.archive_root) as archive_db:
+            root_id = archive_db.write_parsed(
+                _delegation_parent_session(provider_session_id="delegation-tree-root-v1", with_dispatch=True)
+            )
+            mid_id = archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CLAUDE_CODE,
+                    provider_session_id="delegation-tree-mid-v1",
+                    title="Delegation tree mid fixture",
+                    messages=[
+                        ParsedMessage(provider_message_id="mid-0", role=Role.USER, text="please look into this"),
+                        ParsedMessage(
+                            provider_message_id="mid-dispatch",
+                            role=Role.ASSISTANT,
+                            model_name="claude-opus-4-8",
+                            blocks=[
+                                ParsedContentBlock(
+                                    type=BlockType.TOOL_USE,
+                                    tool_name="Task",
+                                    tool_id="task-mid-1",
+                                    tool_input={"prompt": "audit the sub-thing", "subagent_type": "general-purpose"},
+                                )
+                            ],
+                        ),
+                    ],
+                    parent_session_provider_id="delegation-tree-root-v1",
+                    branch_type=BranchType.SUBAGENT,
+                )
+            )
+            leaf_id = archive_db.write_parsed(
+                ParsedSession(
+                    source_name=Provider.CLAUDE_CODE,
+                    provider_session_id="delegation-tree-leaf-v1",
+                    title="Delegation tree leaf fixture",
+                    messages=[ParsedMessage(provider_message_id="leaf-0", role=Role.ASSISTANT, text="on it")],
+                    parent_session_provider_id="delegation-tree-mid-v1",
+                    branch_type=BranchType.SUBAGENT,
+                )
+            )
+
+        ancestry_ref = f"delegation:{delegation_ancestry_object_id(leaf_id)}"
+        ancestry_payload = await archive.resolve_ref(ancestry_ref)
+        assert ancestry_payload.resolved is True
+        assert ancestry_payload.kind == "delegation"
+        assert ancestry_payload.payload_kind == "delegation-ancestry"
+        assert ancestry_payload.payload is not None
+        ancestry_nodes = ancestry_payload.payload["nodes"]
+        assert [node["session_id"] for node in ancestry_nodes] == [root_id, mid_id, leaf_id]
+        assert [node["depth"] for node in ancestry_nodes] == [2, 1, 0]
+        assert ancestry_nodes[0]["child_session_id"] == mid_id
+        assert ancestry_nodes[0]["mapping_state"] == "resolved"
+        assert ancestry_nodes[-1]["child_session_id"] is None
+        assert ancestry_payload.object_refs == (
+            f"session:{root_id}",
+            f"session:{mid_id}",
+            f"session:{leaf_id}",
+        )
+
+        subtree_ref = f"delegation:{delegation_subtree_object_id(root_id)}"
+        subtree_payload = await archive.resolve_ref(subtree_ref)
+        assert subtree_payload.resolved is True
+        assert subtree_payload.payload_kind == "delegation-subtree"
+        assert subtree_payload.payload is not None
+        subtree_nodes = {node["session_id"]: node for node in subtree_payload.payload["nodes"]}
+        assert set(subtree_nodes) == {root_id, mid_id, leaf_id}
+        assert subtree_nodes[root_id]["depth"] == 0
+        assert subtree_nodes[root_id]["parent_session_id"] is None
+        assert subtree_nodes[mid_id]["depth"] == 1
+        assert subtree_nodes[mid_id]["parent_session_id"] == root_id
+        assert subtree_nodes[leaf_id]["depth"] == 2
+        assert subtree_nodes[leaf_id]["parent_session_id"] == mid_id
+        assert subtree_payload.payload["node_count"] == 3
     finally:
         await archive.close()
 

--- a/tests/unit/storage/test_delegations_view.py
+++ b/tests/unit/storage/test_delegations_view.py
@@ -871,4 +871,186 @@ def test_delegation_instruction_filter_matches_preview_extraction(tmp_path: Path
             if item.model_dump(mode="json").get("instruction_tool_use_block_id") == f"{parent_id}:empty:0"
         )
         assert empty_payload["instruction_preview"] is None
-        assert empty_payload["instruction_sha256"] is None
+
+
+# ---------------------------------------------------------------------------
+# polylogue-qsb4: arbitrary-depth ancestry/subtree recursive queries.
+# ---------------------------------------------------------------------------
+
+
+def _dispatch_chain_level(
+    conn: sqlite3.Connection,
+    *,
+    dispatcher_id: str,
+    dispatcher_native_id: str,
+    child_native_id: str,
+    tool_id: str,
+) -> str:
+    """Create one trivial-cohort delegation edge: ``dispatcher_id`` has
+    exactly one dispatch action and exactly one resolved child, so the view
+    pairs them as ``mapping_state='resolved'`` without needing content-
+    identity disambiguation (the trivial-cohort case, see
+    ``delegation_facts_source`` in index.py). Returns the new child's
+    session id."""
+
+    child_id = _insert_session(conn, native_id=child_native_id)
+    message_id = _insert_message(conn, session_id=dispatcher_id, native_id=f"dispatch-{tool_id}", position=0)
+    _insert_dispatch_action(
+        conn,
+        message_id=message_id,
+        session_id=dispatcher_id,
+        position=0,
+        tool_id=tool_id,
+        tool_input="{}",
+        result_text="done",
+    )
+    _insert_session_link(
+        conn,
+        child_session_id=child_id,
+        dst_origin="claude-code-session",
+        dst_native_id=dispatcher_native_id,
+        parent_session_id=dispatcher_id,
+    )
+    return child_id
+
+
+def test_delegation_ancestry_returns_root_to_node_chain_depth_annotated(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    root_id = _insert_session(conn, native_id="root")
+    mid_id = _dispatch_chain_level(
+        conn, dispatcher_id=root_id, dispatcher_native_id="root", child_native_id="mid", tool_id="task-root-mid"
+    )
+    leaf_id = _dispatch_chain_level(
+        conn, dispatcher_id=mid_id, dispatcher_native_id="mid", child_native_id="leaf", tool_id="task-mid-leaf"
+    )
+    conn.commit()
+    conn.close()
+
+    initialize_archive_database(tmp_path / "user.db", ArchiveTier.USER)
+    with ArchiveStore.open_existing(tmp_path) as archive:
+        ancestry = archive.get_delegation_ancestry(leaf_id)
+
+    # Root-first (depth descending), leaf itself last at depth 0 -- no N+1,
+    # one recursive-CTE call produced the whole chain.
+    assert [node.session_id for node in ancestry] == [root_id, mid_id, leaf_id]
+    assert [node.depth for node in ancestry] == [2, 1, 0]
+    assert ancestry[0].child_session_id == mid_id
+    assert ancestry[0].mapping_state == "resolved"
+    assert ancestry[1].child_session_id == leaf_id
+    assert ancestry[1].mapping_state == "resolved"
+    assert ancestry[2].child_session_id is None
+    assert ancestry[2].mapping_state is None
+
+    # A session nobody ever dispatched returns just itself.
+    with ArchiveStore.open_existing(tmp_path) as archive:
+        root_ancestry = archive.get_delegation_ancestry(root_id)
+    assert [node.session_id for node in root_ancestry] == [root_id]
+    assert root_ancestry[0].depth == 0
+
+
+def test_delegation_subtree_returns_all_descendants_depth_annotated(tmp_path: Path) -> None:
+    conn = _connect(tmp_path / "index.db")
+    root_id = _insert_session(conn, native_id="root")
+    child_a = _dispatch_chain_level(
+        conn, dispatcher_id=root_id, dispatcher_native_id="root", child_native_id="child-a", tool_id="task-a"
+    )
+    grandchild = _dispatch_chain_level(
+        conn, dispatcher_id=child_a, dispatcher_native_id="child-a", child_native_id="grandchild", tool_id="task-b"
+    )
+    conn.commit()
+    conn.close()
+
+    initialize_archive_database(tmp_path / "user.db", ArchiveTier.USER)
+    with ArchiveStore.open_existing(tmp_path) as archive:
+        subtree = archive.get_delegation_subtree(root_id)
+
+    by_session = {node.session_id: node for node in subtree}
+    assert set(by_session) == {root_id, child_a, grandchild}
+    assert by_session[root_id].depth == 0
+    assert by_session[root_id].parent_session_id is None
+    assert by_session[child_a].depth == 1
+    assert by_session[child_a].parent_session_id == root_id
+    assert by_session[child_a].mapping_state == "resolved"
+    assert by_session[grandchild].depth == 2
+    assert by_session[grandchild].parent_session_id == child_a
+
+    # A leaf that dispatched nothing returns just itself.
+    with ArchiveStore.open_existing(tmp_path) as archive:
+        leaf_subtree = archive.get_delegation_subtree(grandchild)
+    assert [node.session_id for node in leaf_subtree] == [grandchild]
+
+
+def test_delegation_subtree_excludes_quarantined_edges(tmp_path: Path) -> None:
+    """Quarantined edges (session_links' TopologyEdgeStatus cycle-break
+    precedent) are structural cycle-breaks and must never be traversed --
+    the recursive CTE reuses that vocabulary rather than re-deriving it."""
+
+    conn = _connect(tmp_path / "index.db")
+    parent_id = _insert_session(conn, native_id="quarantine-parent")
+    child_id = _insert_session(conn, native_id="quarantine-child")
+    _insert_session_link(
+        conn,
+        child_session_id=child_id,
+        dst_origin="claude-code-session",
+        dst_native_id="quarantine-parent",
+        parent_session_id=parent_id,
+        status="quarantined",
+    )
+    conn.commit()
+    conn.close()
+
+    initialize_archive_database(tmp_path / "user.db", ArchiveTier.USER)
+    with ArchiveStore.open_existing(tmp_path) as archive:
+        subtree = archive.get_delegation_subtree(parent_id)
+        ancestry = archive.get_delegation_ancestry(child_id)
+
+    # Only the queried node itself -- the quarantined edge is never followed.
+    assert [node.session_id for node in subtree] == [parent_id]
+    assert [node.session_id for node in ancestry] == [child_id]
+
+
+def test_delegation_subtree_visited_path_guard_stops_a_two_node_cycle(tmp_path: Path) -> None:
+    """Two independent trivial-cohort (non-quarantined, `mapping_state=
+    'resolved'`) edges can compose into a cycle that session_links' own
+    quarantine pass never inspects (quarantine is asserted per-edge over
+    session_links alone, not over the composed `delegations` chain). The
+    recursive CTE's own defensive visited-path guard must still terminate
+    -- this is the exact scenario polylogue-qsb4 AC3 requires an explicit
+    answer for."""
+
+    conn = _connect(tmp_path / "index.db")
+    a_id = _insert_session(conn, native_id="cycle-a")
+    b_id = _insert_session(conn, native_id="cycle-b")
+
+    message_a = _insert_message(conn, session_id=a_id, native_id="dispatch-a-b", position=0)
+    _insert_dispatch_action(
+        conn, message_id=message_a, session_id=a_id, position=0, tool_id="task-a-b", tool_input="{}"
+    )
+    _insert_session_link(
+        conn, child_session_id=b_id, dst_origin="claude-code-session", dst_native_id="cycle-a", parent_session_id=a_id
+    )
+
+    message_b = _insert_message(conn, session_id=b_id, native_id="dispatch-b-a", position=0)
+    _insert_dispatch_action(
+        conn, message_id=message_b, session_id=b_id, position=0, tool_id="task-b-a", tool_input="{}"
+    )
+    _insert_session_link(
+        conn, child_session_id=a_id, dst_origin="claude-code-session", dst_native_id="cycle-b", parent_session_id=b_id
+    )
+    conn.commit()
+    conn.close()
+
+    initialize_archive_database(tmp_path / "user.db", ArchiveTier.USER)
+    with ArchiveStore.open_existing(tmp_path) as archive:
+        # Both edges are genuinely `resolved` (neither quarantined) -- proof
+        # the cycle survives topology's own quarantine pass and only the
+        # recursive query's own guard stops it.
+        subtree_from_a = archive.get_delegation_subtree(a_id)
+        ancestry_from_a = archive.get_delegation_ancestry(a_id)
+
+    # The guard must terminate (no RecursionError/timeout) and must not
+    # revisit a session already on the current path.
+    assert [node.session_id for node in subtree_from_a] == [a_id, b_id]
+    assert [node.depth for node in subtree_from_a] == [0, 1]
+    assert [node.session_id for node in ancestry_from_a] == [b_id, a_id]
+    assert [node.depth for node in ancestry_from_a] == [1, 0]


### PR DESCRIPTION
## Summary
Adds one-call, depth-annotated delegation ancestry (root-to-node) and subtree (node-to-descendants) queries over `delegation_facts`, exposed through the existing `get`/`read` MCP surface via new `delegation:ancestry:<id>`/`delegation:subtree:<id>` ObjectRef prefixes.

## Problem
Delegation in this archive is a tree (subagents dispatch their own subagents), and `delegation_facts` already models arbitrary depth implicitly (each row is one parent→child edge). What's missing is a query surface returning a whole ancestry chain or subtree in one call, depth-annotated, without N+1 queries or client-side reassembly.

## Solution
- **Design decision (argued from evidence, not assumed)**: `work_evidence_nodes/edges` (index v46+) supports arbitrary-depth traversal by construction but is measured "structurally hollow" (constant authority/confidence, 100% NULL time/actor, zero rows sourced from Claude Code delegation — only Workflow orchestration runs populate it). A pure on-demand adapter already exists (`polylogue/insights/delegation_work_evidence.py`, polylogue-1vpm.6.1) projecting `delegation_facts` into that vocabulary, with no production caller — establishing that `delegation_facts` is the richer typed source of truth and the generic graph is a consumer-side adapter, not a persistence target. Built natively over `delegation_facts` (via the `delegations` view) rather than growing a second persisted graph.
- `ArchiveStore.get_delegation_ancestry(session_id)` / `get_delegation_subtree(session_id)` (`storage/sqlite/archive_tiers/archive.py`) — `WITH RECURSIVE` CTEs over `delegations`, depth-annotated, no N+1.
- Cycle/orphan handling reuses the existing `mapping_state != 'quarantined'` exclusion (no second vocabulary invented); a defensive visited-path guard is kept and proven necessary by a constructed two-node-cycle test (from genuinely `resolved`, non-quarantined edges the topology quarantine pass never inspects).
- New `delegation:ancestry:`/`delegation:subtree:` ObjectRef prefixes (`core/refs.py`) route through the existing `get`/`read` MCP tools via `resolve_ref` (`api/archive.py`) — no new MCP tool/dispatcher entry needed.
- `docs/plans/classifier-fingerprints.json`/`lifecycle.py`/`archive_tiers/index.py`: also declares INDEX_SCHEMA_VERSION v54 (SEMANTIC_REPARSE) for PR #3537's `looks_like_ai` tightening, which the classifier-fingerprint gate (PR #3532, merged after this branch was cut) correctly flagged as undeclared drift blocking push.

## Non-goals
Rewriting `delegation_facts`' identity-matching mechanism (owned by polylogue-1vpm.7, already fixed). Building the HTML/report rendering (this surface's shape is designed to feed the html-report skill's delegation-tree pattern directly, without restitching, but the renderer itself is out of scope). Live corpus depth/fan-out re-measurement (deferred pending the coordinator's separately-managed reindex).

## Verification
`devtools test tests/unit/storage/test_delegations_view.py tests/unit/api/test_facade_contracts.py tests/unit/core/test_refs.py tests/unit/insights/test_delegation_work_evidence.py` — 390 passed, 1 pre-existing failure (`test_archive_tiers_api_raw_artifacts_read_source_tier`, stale hardcoded timestamp) confirmed identical on unmodified master. `devtools verify --quick` exit 0 (ruff format/check, mypy --strict, render-all-check, classifier-fingerprints, schema-versioning).

Ref polylogue-qsb4

Co-Authored-By: Claude <noreply@anthropic.com>