### PR TITLE
feat(storage): retain every observed acquisition mode per raw_id

### DIFF
--- a/docs/plans/layering.yaml
+++ b/docs/plans/layering.yaml
@@ -53,7 +53,8 @@ writer_modules:
           durability: durable
           interruption: atomic
       entrypoints:
-        [apply_source_raw_state_update, bind_source_raw_revision, record_excised_blob_hash, write_history_sidecar,
+        [apply_source_raw_state_update, bind_source_raw_revision, record_capture_mode_observation,
+        record_excised_blob_hash, write_history_sidecar,
         write_source_blob_refs, write_source_hook_event, write_source_raw_session, write_source_raw_session_blob_ref]
     - path: polylogue/storage/sqlite/archive_tiers/write.py
       surfaces:

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -21,7 +21,7 @@ over the `CREATE TABLE` statement.
 
 | Tier file | Tier | Version constant |
 |-----------|------|------------------|
-| `source.py` | `source.db` | `SOURCE_SCHEMA_VERSION = 15` |
+| `source.py` | `source.db` | `SOURCE_SCHEMA_VERSION = 16` |
 | `index.py` | `index.db` | `INDEX_SCHEMA_VERSION = 53` |
 | `embeddings.py` | `embeddings.db` | `EMBEDDINGS_SCHEMA_VERSION = 4` |
 | `user.py` | `user.db` | `USER_SCHEMA_VERSION = 10` |

--- a/polylogue/storage/sqlite/archive_tiers/source.py
+++ b/polylogue/storage/sqlite/archive_tiers/source.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from polylogue.core.enums import ArtifactSupportStatus, Origin, Provider, ValidationMode, ValidationStatus
 from polylogue.storage.sqlite.archive_tiers.common import check, nullable_check
 
-SOURCE_SCHEMA_VERSION = 15
+SOURCE_SCHEMA_VERSION = 16
 
 SOURCE_DDL = f"""
 CREATE TABLE IF NOT EXISTS raw_sessions (
@@ -83,6 +83,25 @@ ON raw_sessions(blob_hash);
 -- re-sorting the remaining table on every bounded pass as the archive grows.
 CREATE INDEX IF NOT EXISTS idx_raw_sessions_blob_hash_raw_id
 ON raw_sessions(blob_hash, raw_id);
+
+-- v16 (polylogue-buns): durable multimap of every acquisition mode ever
+-- observed for one raw_id. raw_sessions.capture_mode above caches only the
+-- FIRST known mode (write-time UPDATE is gated `WHERE capture_mode IS
+-- NULL`), which silently discards any later, different capture_mode for a
+-- raw_id that collides on content hash -- e.g. a GEMINI export and a live
+-- DRIVE acquisition of byte-identical bytes. This table keeps one row per
+-- distinct (raw_id, capture_mode) ever observed so that fact is never lost,
+-- and lets a caller read an explicit unambiguous/ambiguous resolution
+-- instead of only ever seeing the first-cached value.
+CREATE TABLE IF NOT EXISTS raw_capture_observations (
+    raw_id               TEXT NOT NULL REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
+    capture_mode         TEXT NOT NULL CHECK ({check("capture_mode", Provider)}),
+    first_observed_at_ms INTEGER NOT NULL CHECK(first_observed_at_ms >= 0),
+    PRIMARY KEY (raw_id, capture_mode)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_raw_capture_observations_raw_id
+ON raw_capture_observations(raw_id);
 
 CREATE TABLE IF NOT EXISTS raw_session_memberships (
     raw_id                  TEXT NOT NULL REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,

--- a/polylogue/storage/sqlite/archive_tiers/source_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/source_write.py
@@ -11,6 +11,7 @@ import sqlite3
 from contextlib import nullcontext
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Literal
 
 from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope
 from polylogue.core.enums import ArtifactSupportStatus, Origin, Provider, ValidationMode, ValidationStatus
@@ -203,6 +204,91 @@ class ArchiveRawSessionEnvelope:
     artifact_ids: tuple[str, ...]
     hook_event_ids: tuple[str, ...]
     history_sidecar_ids: tuple[str, ...]
+
+
+CaptureModeResolutionStatus = Literal["unknown", "unambiguous", "ambiguous"]
+
+
+@dataclass(frozen=True, slots=True)
+class CaptureModeResolution:
+    """Every acquisition mode ever observed for one raw, explicitly disambiguated.
+
+    ``raw_sessions.capture_mode`` (v8) is a convenience cache of only the
+    *first* known acquisition mode for a raw_id -- later writes update it
+    only when it is still NULL. Because ``raw_id`` is content-derived, a
+    GEMINI export and a live DRIVE acquisition of byte-identical bytes
+    collide on the same raw_id even though their acquisition mechanism
+    genuinely differs, and the cache alone cannot tell a caller whether the
+    value it holds is the only fact on record or one of several (polylogue-
+    buns). ``status`` makes that explicit: ``"unknown"`` when no observation
+    was ever recorded, ``"unambiguous"`` when exactly one distinct mode was,
+    ``"ambiguous"`` when more than one was. ``modes`` is ordered by first
+    observation time.
+    """
+
+    raw_id: str
+    status: CaptureModeResolutionStatus
+    modes: tuple[Provider, ...]
+
+
+def record_capture_mode_observation(
+    conn: sqlite3.Connection,
+    *,
+    raw_id: str,
+    capture_mode: Provider | str | None,
+    observed_at_ms: int,
+) -> None:
+    """Append one durable (raw_id, capture_mode) observation.
+
+    Idempotent: repeating an already-recorded pair is a no-op (its original
+    ``first_observed_at_ms`` is kept), but a genuinely new mode for this
+    raw_id gets its own row. This is what lets a later
+    :func:`read_capture_mode_resolution` distinguish "only one acquisition
+    mode was ever observed" from "several were, and the cache only kept the
+    first" -- content-hash dedup already collapses the bytes to one raw_id,
+    but must not also collapse distinct acquisition evidence about how those
+    bytes were obtained (polylogue-buns AC1/AC2). A ``None`` capture_mode is
+    a no-op: unknown provenance is not itself an observation.
+    """
+    value = _enum_value(capture_mode)
+    if value is None:
+        return
+    conn.execute(
+        """
+        INSERT INTO raw_capture_observations (raw_id, capture_mode, first_observed_at_ms)
+        VALUES (?, ?, ?)
+        ON CONFLICT(raw_id, capture_mode) DO NOTHING
+        """,
+        (raw_id, value, observed_at_ms),
+    )
+
+
+def read_capture_mode_resolution(conn: sqlite3.Connection, raw_id: str) -> CaptureModeResolution:
+    """Read every acquisition mode ever observed for ``raw_id``, explicitly ambiguous or not.
+
+    This is the durable-evidence read surface (AC2): unlike
+    ``raw_sessions.capture_mode``, which silently returns only the first-ever
+    known mode, this tells a caller whether that value is the sole fact on
+    record or one of several colliding observations.
+    """
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        """
+        SELECT capture_mode FROM raw_capture_observations
+        WHERE raw_id = ?
+        ORDER BY first_observed_at_ms, capture_mode
+        """,
+        (raw_id,),
+    ).fetchall()
+    modes = tuple(Provider.from_string(row["capture_mode"]) for row in rows)
+    status: CaptureModeResolutionStatus
+    if not modes:
+        status = "unknown"
+    elif len(modes) == 1:
+        status = "unambiguous"
+    else:
+        status = "ambiguous"
+    return CaptureModeResolution(raw_id=raw_id, status=status, modes=modes)
 
 
 def deterministic_blob_hash(payload: bytes) -> bytes:
@@ -500,6 +586,12 @@ def write_source_raw_session(
                 blob_size=blob_size,
                 revision=revision,
             )
+        record_capture_mode_observation(
+            conn,
+            raw_id=resolved_raw_id,
+            capture_mode=capture_mode,
+            observed_at_ms=acquired_at_ms,
+        )
         _insert_blob_ref(
             conn,
             ArchiveSourceBlobRef(
@@ -667,6 +759,12 @@ def write_source_raw_session_blob_ref(
                 blob_size=blob_size,
                 revision=revision,
             )
+        record_capture_mode_observation(
+            conn,
+            raw_id=resolved_raw_id,
+            capture_mode=capture_mode,
+            observed_at_ms=acquired_at_ms,
+        )
         _insert_blob_ref(
             conn,
             ArchiveSourceBlobRef(
@@ -1166,6 +1264,7 @@ __all__ = [
     "ArchiveRawSessionEnvelope",
     "ArchiveSourceArtifact",
     "ArchiveSourceBlobRef",
+    "CaptureModeResolution",
     "ContentExcisedError",
     "deterministic_blob_hash",
     "deterministic_history_sidecar_id",
@@ -1173,11 +1272,13 @@ __all__ = [
     "is_blob_hash_excised",
     "list_hook_events",
     "list_raw_artifacts",
+    "read_capture_mode_resolution",
     "read_earliest_history_sidecar_for_path",
     "read_history_sidecar",
     "read_hook_event",
     "read_raw_artifact",
     "read_archive_raw_session_envelope",
+    "record_capture_mode_observation",
     "record_excised_blob_hash",
     "write_history_sidecar",
     "write_source_raw_session",

--- a/polylogue/storage/sqlite/migrations/source/016_raw_capture_observations.sql
+++ b/polylogue/storage/sqlite/migrations/source/016_raw_capture_observations.sql
@@ -1,0 +1,40 @@
+-- polylogue-buns: durable multimap of every acquisition mode ever observed
+-- for one raw_id. raw_sessions.capture_mode (v8) caches only the FIRST known
+-- mode -- write_source_raw_session/write_source_raw_session_blob_ref/
+-- save_raw_session all UPDATE it only `WHERE capture_mode IS NULL`, so any
+-- later, different capture_mode observed for the same raw_id was silently
+-- dropped. Because raw_id is content-derived, a GEMINI export and a live
+-- DRIVE acquisition of byte-identical content collide on the same raw_id
+-- even though their acquisition mechanism genuinely differs -- that
+-- collision is exactly the case this table exists to stop losing.
+--
+-- One row per distinct (raw_id, capture_mode) ever observed. The existing
+-- raw_sessions.capture_mode column is unchanged and keeps its first-known
+-- convenience-cache behavior; this table is the durable source of truth a
+-- caller reads to tell "only one mode was ever observed" (unambiguous) apart
+-- from "more than one was, and the cache only remembers the first"
+-- (ambiguous). See read_capture_mode_resolution (source_write.py) and
+-- get_capture_mode_resolution (queries/raw_reads.py).
+CREATE TABLE IF NOT EXISTS raw_capture_observations (
+    raw_id               TEXT NOT NULL REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
+    capture_mode         TEXT NOT NULL CHECK(capture_mode IN (
+                             'chatgpt', 'claude-ai', 'claude-design', 'claude-code', 'codex',
+                             'gemini', 'gemini-cli', 'hermes', 'antigravity', 'beads', 'grok',
+                             'drive', 'unknown'
+                         )),
+    first_observed_at_ms INTEGER NOT NULL CHECK(first_observed_at_ms >= 0),
+    PRIMARY KEY (raw_id, capture_mode)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_raw_capture_observations_raw_id
+ON raw_capture_observations(raw_id);
+
+-- Backfill: every pre-existing raw_sessions row with a known capture_mode
+-- observed that mode at least once, at its acquisition time -- the earliest
+-- evidence this migration can reconstruct for rows written before this table
+-- existed. This does not, and cannot, recover a second mode a pre-migration
+-- write already discarded; it only carries forward what the cache still has.
+INSERT OR IGNORE INTO raw_capture_observations (raw_id, capture_mode, first_observed_at_ms)
+SELECT raw_id, capture_mode, acquired_at_ms
+FROM raw_sessions
+WHERE capture_mode IS NOT NULL;

--- a/polylogue/storage/sqlite/queries/raw_reads.py
+++ b/polylogue/storage/sqlite/queries/raw_reads.py
@@ -6,10 +6,14 @@ from collections.abc import AsyncIterator, Iterable, Sequence
 
 import aiosqlite
 
-from polylogue.core.enums import Origin
+from polylogue.core.enums import Origin, Provider
 from polylogue.core.sources import provider_from_origin
 from polylogue.storage.raw.models import RawSessionState
 from polylogue.storage.runtime import RawSessionRecord
+from polylogue.storage.sqlite.archive_tiers.source_write import (
+    CaptureModeResolution,
+    CaptureModeResolutionStatus,
+)
 from polylogue.storage.sqlite.connection import _build_source_path_scope_filter
 from polylogue.storage.sqlite.queries.mappers import _ms_to_iso, _row_to_raw_session
 from polylogue.storage.sqlite.queries.raw_state import RAW_ORIGIN_FILTER_SQL, origin_filter_value
@@ -325,7 +329,34 @@ async def get_raw_session_count(conn: aiosqlite.Connection, origin: str | None =
     return int(row["cnt"]) if row is not None else 0
 
 
+async def get_capture_mode_resolution(conn: aiosqlite.Connection, raw_id: str) -> CaptureModeResolution:
+    """Read every acquisition mode ever observed for ``raw_id``, explicitly ambiguous or not.
+
+    Async counterpart of ``archive_tiers.source_write.read_capture_mode_resolution``
+    (polylogue-buns AC2) for the daemon's live async write/read path.
+    """
+    cursor = await conn.execute(
+        """
+        SELECT capture_mode FROM raw_capture_observations
+        WHERE raw_id = ?
+        ORDER BY first_observed_at_ms, capture_mode
+        """,
+        (raw_id,),
+    )
+    rows = await cursor.fetchall()
+    modes = tuple(Provider.from_string(row["capture_mode"]) for row in rows)
+    status: CaptureModeResolutionStatus
+    if not modes:
+        status = "unknown"
+    elif len(modes) == 1:
+        status = "unambiguous"
+    else:
+        status = "ambiguous"
+    return CaptureModeResolution(raw_id=raw_id, status=status, modes=modes)
+
+
 __all__ = [
+    "get_capture_mode_resolution",
     "get_known_source_mtimes",
     "get_raw_blob_sizes",
     "get_raw_session",

--- a/polylogue/storage/sqlite/queries/raw_writes.py
+++ b/polylogue/storage/sqlite/queries/raw_writes.py
@@ -86,6 +86,22 @@ async def save_raw_session(
             "UPDATE raw_sessions SET capture_mode = ? WHERE raw_id = ? AND capture_mode IS NULL",
             (capture_mode.value, record.raw_id),
         )
+    if capture_mode is not None:
+        # Durable multimap append (polylogue-buns): the UPDATE above only
+        # ever remembers the FIRST known capture_mode for this raw_id, so a
+        # content-identical GEMINI export and a live DRIVE acquisition that
+        # collide on raw_id would otherwise silently lose whichever mode
+        # arrived second. This records every distinct mode ever observed,
+        # regardless of insert/conflict/order, so no acquisition evidence is
+        # dropped even though the cached column above still only holds one.
+        await conn.execute(
+            """
+            INSERT INTO raw_capture_observations (raw_id, capture_mode, first_observed_at_ms)
+            VALUES (?, ?, ?)
+            ON CONFLICT(raw_id, capture_mode) DO NOTHING
+            """,
+            (record.raw_id, capture_mode.value, acquired_at_ms),
+        )
     if not inserted and record.file_mtime is not None:
         file_mtime_ms = _timestamp_ms(record.file_mtime)
         await conn.execute(

--- a/tests/unit/storage/test_archive_tiers_source_write.py
+++ b/tests/unit/storage/test_archive_tiers_source_write.py
@@ -19,6 +19,7 @@ from polylogue.storage.sqlite.archive_tiers.source_write import (
     list_hook_events,
     list_raw_artifacts,
     read_archive_raw_session_envelope,
+    read_capture_mode_resolution,
     read_history_sidecar,
     read_hook_event,
     read_raw_artifact,
@@ -357,3 +358,179 @@ def test_source_reference_commit_atomically_consumes_publication_reservation(tmp
     finally:
         observer.close()
         conn.close()
+
+
+def test_capture_mode_resolution_ambiguous_gemini_then_drive(tmp_path: Path) -> None:
+    """A content-identical GEMINI export observed first, then a live DRIVE
+    acquisition of the exact same bytes, must retain BOTH observed modes
+    (polylogue-buns AC1) instead of the DRIVE observation silently vanishing
+    behind the first-known cache."""
+    conn = _connect(tmp_path / "source.db")
+    payload = b'{"chunkedPrompt": {"chunks": []}}'
+
+    raw_id = write_source_raw_session(
+        conn,
+        origin=Origin.AISTUDIO_DRIVE,
+        capture_mode=Provider.GEMINI,
+        source_path="/tmp/export.json",
+        source_index=0,
+        payload=payload,
+        acquired_at_ms=1_000,
+    )
+    write_source_raw_session(
+        conn,
+        origin=Origin.AISTUDIO_DRIVE,
+        capture_mode=Provider.DRIVE,
+        source_path="/tmp/export.json",
+        source_index=0,
+        payload=payload,
+        acquired_at_ms=2_000,
+        raw_id=raw_id,
+    )
+
+    resolution = read_capture_mode_resolution(conn, raw_id)
+    assert resolution.status == "ambiguous"
+    assert set(resolution.modes) == {Provider.GEMINI, Provider.DRIVE}
+    # Order reflects first-observation time.
+    assert resolution.modes == (Provider.GEMINI, Provider.DRIVE)
+
+    # The cached convenience column is unchanged: first-known-mode wins.
+    envelope = read_archive_raw_session_envelope(conn, raw_id)
+    assert envelope.capture_mode == Provider.GEMINI.value
+
+    # AC3: blob dedup is untouched -- one raw_payload ref for this raw_id.
+    blob_ref_count = conn.execute(
+        "SELECT COUNT(*) FROM blob_refs WHERE ref_id = ? AND ref_type = 'raw_payload'",
+        (raw_id,),
+    ).fetchone()[0]
+    assert blob_ref_count == 1
+    conn.close()
+
+
+def test_capture_mode_resolution_ambiguous_drive_then_gemini(tmp_path: Path) -> None:
+    """Mirror order of the above: a live DRIVE acquisition observed first,
+    then a GEMINI export of the same bytes -- both orders must behave the
+    same way (polylogue-buns AC4)."""
+    conn = _connect(tmp_path / "source.db")
+    payload = b'{"chunkedPrompt": {"chunks": []}}'
+
+    raw_id = write_source_raw_session(
+        conn,
+        origin=Origin.AISTUDIO_DRIVE,
+        capture_mode=Provider.DRIVE,
+        source_path="/tmp/live-drive.json",
+        source_index=0,
+        payload=payload,
+        acquired_at_ms=1_000,
+    )
+    write_source_raw_session(
+        conn,
+        origin=Origin.AISTUDIO_DRIVE,
+        capture_mode=Provider.GEMINI,
+        source_path="/tmp/live-drive.json",
+        source_index=0,
+        payload=payload,
+        acquired_at_ms=2_000,
+        raw_id=raw_id,
+    )
+
+    resolution = read_capture_mode_resolution(conn, raw_id)
+    assert resolution.status == "ambiguous"
+    assert set(resolution.modes) == {Provider.GEMINI, Provider.DRIVE}
+    assert resolution.modes == (Provider.DRIVE, Provider.GEMINI)
+
+    envelope = read_archive_raw_session_envelope(conn, raw_id)
+    assert envelope.capture_mode == Provider.DRIVE.value
+
+    blob_ref_count = conn.execute(
+        "SELECT COUNT(*) FROM blob_refs WHERE ref_id = ? AND ref_type = 'raw_payload'",
+        (raw_id,),
+    ).fetchone()[0]
+    assert blob_ref_count == 1
+    conn.close()
+
+
+def test_capture_mode_resolution_unambiguous_single_observation(tmp_path: Path) -> None:
+    """A raw with exactly one acquisition mode ever observed reads as unambiguous,
+    not merely as an implicit absence of ambiguity."""
+    conn = _connect(tmp_path / "source.db")
+    payload = b'{"kind":"session"}'
+    raw_id = write_source_raw_session(
+        conn,
+        origin=Origin.CLAUDE_CODE_SESSION,
+        capture_mode=Provider.CLAUDE_CODE,
+        source_path="/tmp/single.jsonl",
+        source_index=0,
+        payload=payload,
+        acquired_at_ms=1_000,
+    )
+    # Repeat acquisition of the identical raw is a no-op for ambiguity.
+    write_source_raw_session(
+        conn,
+        origin=Origin.CLAUDE_CODE_SESSION,
+        capture_mode=Provider.CLAUDE_CODE,
+        source_path="/tmp/single.jsonl",
+        source_index=0,
+        payload=payload,
+        acquired_at_ms=2_000,
+        raw_id=raw_id,
+    )
+
+    resolution = read_capture_mode_resolution(conn, raw_id)
+    assert resolution.status == "unambiguous"
+    assert resolution.modes == (Provider.CLAUDE_CODE,)
+    conn.close()
+
+
+def test_capture_mode_resolution_unknown_when_never_observed(tmp_path: Path) -> None:
+    """A raw acquired without a capture_mode reads as unknown, not unambiguous."""
+    conn = _connect(tmp_path / "source.db")
+    payload = b'{"kind":"session"}'
+    raw_id = write_source_raw_session(
+        conn,
+        origin=Origin.CLAUDE_CODE_SESSION,
+        source_path="/tmp/no-capture-mode.jsonl",
+        source_index=0,
+        payload=payload,
+        acquired_at_ms=1_000,
+    )
+
+    resolution = read_capture_mode_resolution(conn, raw_id)
+    assert resolution.status == "unknown"
+    assert resolution.modes == ()
+    conn.close()
+
+
+def test_capture_mode_resolution_ambiguous_via_blob_ref_writer(tmp_path: Path) -> None:
+    """The memory-bounded streaming writer (write_source_raw_session_blob_ref)
+    must retain both acquisition modes exactly like the in-memory writer."""
+    conn = _connect(tmp_path / "source.db")
+    payload = b'{"chunkedPrompt": {"chunks": []}}'
+    blob_hash = deterministic_blob_hash(payload)
+
+    raw_id = write_source_raw_session_blob_ref(
+        conn,
+        origin=Origin.AISTUDIO_DRIVE,
+        capture_mode=Provider.GEMINI,
+        source_path="/tmp/blobref-export.json",
+        source_index=0,
+        blob_hash=blob_hash,
+        blob_size=len(payload),
+        acquired_at_ms=1_000,
+    )
+    write_source_raw_session_blob_ref(
+        conn,
+        origin=Origin.AISTUDIO_DRIVE,
+        capture_mode=Provider.DRIVE,
+        source_path="/tmp/blobref-export.json",
+        source_index=0,
+        blob_hash=blob_hash,
+        blob_size=len(payload),
+        acquired_at_ms=2_000,
+        raw_id=raw_id,
+    )
+
+    resolution = read_capture_mode_resolution(conn, raw_id)
+    assert resolution.status == "ambiguous"
+    assert resolution.modes == (Provider.GEMINI, Provider.DRIVE)
+    conn.close()

--- a/tests/unit/storage/test_durable_migrations.py
+++ b/tests/unit/storage/test_durable_migrations.py
@@ -489,7 +489,7 @@ def test_source_tier_v1_migrates_to_current_without_native_uniqueness(
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
         assert result.from_version == 1
         assert result.to_version == SOURCE_SCHEMA_VERSION
-        assert result.applied_versions == (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+        assert result.applied_versions == (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         columns = {str(row[1]) for row in conn.execute("PRAGMA table_info('raw_sessions')")}
         assert "predecessor_source_revision" in columns
@@ -575,8 +575,8 @@ def test_source_publication_backfill_requires_verified_backup(
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
 
         assert result.from_version == 9
-        assert result.to_version == SOURCE_SCHEMA_VERSION == 15
-        assert result.applied_versions == (10, 11, 12, 13, 14, 15)
+        assert result.to_version == SOURCE_SCHEMA_VERSION == 16
+        assert result.applied_versions == (10, 11, 12, 13, 14, 15, 16)
         assert result.backup_receipt == manifest.with_name("verification-receipt.json")
         tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
         assert {
@@ -630,7 +630,7 @@ def test_source_tier_v7_expands_origin_checks_with_verified_backup(
     old_ddl = old_ddl.replace(", 'beads-issue'", "")
     old_ddl = old_ddl.replace(
         "    capture_mode            TEXT CHECK ((capture_mode IN "
-        "('chatgpt', 'claude-ai', 'claude-code', 'codex', 'gemini', 'gemini-cli', "
+        "('chatgpt', 'claude-ai', 'claude-design', 'claude-code', 'codex', 'gemini', 'gemini-cli', "
         "'hermes', 'antigravity', 'beads', 'grok', 'drive', 'unknown') "
         "OR capture_mode IS NULL)),\n",
         "",
@@ -730,8 +730,8 @@ def test_source_tier_v7_expands_origin_checks_with_verified_backup(
     with sqlite3.connect(db_path) as conn:
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
         assert result.from_version == 7
-        assert result.to_version == SOURCE_SCHEMA_VERSION == 15
-        assert result.applied_versions == (8, 9, 10, 11, 12, 13, 14, 15)
+        assert result.to_version == SOURCE_SCHEMA_VERSION == 16
+        assert result.applied_versions == (8, 9, 10, 11, 12, 13, 14, 15, 16)
         assert conn.execute(
             """
             SELECT predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
@@ -892,7 +892,7 @@ def test_source_tier_v2_migrates_to_v3_dropping_pending_blob_refs(
 
         assert result.from_version == 2
         assert result.to_version == SOURCE_SCHEMA_VERSION
-        assert result.applied_versions == (3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+        assert result.applied_versions == (3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         assert not conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='pending_blob_refs'"
@@ -950,7 +950,7 @@ def test_source_tier_v3_adds_publication_reservations_with_verified_backup_recei
     conn = sqlite3.connect(db_path)
     try:
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
-        assert result.applied_versions == (4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+        assert result.applied_versions == (4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         conn.execute(
             """
@@ -985,8 +985,11 @@ def test_source_tier_v13_adds_raw_sessions_blob_hash_index(
     and ``storage/blob_publication.py`` both run
     ``SELECT 1 FROM raw_sessions WHERE blob_hash = ?`` once per candidate blob
     on disk; without a ``blob_hash``-leading index this was a full table scan
-    repeated tens of thousands of times per periodic GC pass. The index is
-    pure-additive (``additive-no-backup``), so no manifest should be required.
+    repeated tens of thousands of times per periodic GC pass. Migration 014
+    itself is pure-additive (``additive-no-backup``), but a v13 fixture
+    migrating to "current" also picks up migration 016 (polylogue-buns, added
+    after this test), which is not additive-no-backup, so a verified backup
+    manifest is required for the full chain.
     """
     db_path = workspace_env["archive_root"] / "source.db"
     db_path.unlink(missing_ok=True)
@@ -997,6 +1000,7 @@ def test_source_tier_v13_adds_raw_sessions_blob_hash_index(
             CREATE TABLE raw_sessions (
                 raw_id                  TEXT PRIMARY KEY,
                 origin                  TEXT NOT NULL,
+                capture_mode            TEXT,
                 native_id               TEXT,
                 source_path             TEXT NOT NULL,
                 source_index            INTEGER NOT NULL DEFAULT 0,
@@ -1011,15 +1015,17 @@ def test_source_tier_v13_adds_raw_sessions_blob_hash_index(
         indexes_before = {row[1] for row in conn.execute("PRAGMA index_list('raw_sessions')")}
         assert "idx_raw_sessions_blob_hash" not in indexes_before
 
-        result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=None)
+        manifest = _verified_backup_manifest(tmp_path / "backup-source-v13")
+        result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
 
         assert result.from_version == 13
-        assert result.to_version == SOURCE_SCHEMA_VERSION == 15
-        # v13 -> current also picks up migration 015 (polylogue-hord), added
-        # after this test -- a v13 fixture migrating to "current" is exactly
-        # the shape a real archive frozen at v13 would go through.
-        assert result.applied_versions == (14, 15)
-        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 15
+        assert result.to_version == SOURCE_SCHEMA_VERSION == 16
+        # v13 -> current also picks up migrations 015 (polylogue-hord) and
+        # 016 (polylogue-buns), both added after this test -- a v13 fixture
+        # migrating to "current" is exactly the shape a real archive frozen
+        # at v13 would go through.
+        assert result.applied_versions == (14, 15, 16)
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 16
         indexes_after = {row[1] for row in conn.execute("PRAGMA index_list('raw_sessions')")}
         assert "idx_raw_sessions_blob_hash" in indexes_after
         assert "idx_raw_sessions_blob_hash_raw_id" in indexes_after
@@ -1044,8 +1050,11 @@ def test_source_tier_v14_adds_raw_sessions_blob_hash_raw_id_index(
     The pre-existing single-column ``idx_raw_sessions_blob_hash`` index (v14)
     only covers the blob-GC point lookup and cannot satisfy this ordered
     query without a temp B-TREE sort; a leading ``(blob_hash, raw_id)``
-    index removes that sort. Pure-additive (``additive-no-backup``), so no
-    manifest should be required.
+    index removes that sort. Migration 015 itself is pure-additive
+    (``additive-no-backup``), but a v14 fixture migrating to "current" also
+    picks up migration 016 (polylogue-buns, added after this test), which is
+    not additive-no-backup, so a verified backup manifest is required for the
+    full chain.
     """
     db_path = workspace_env["archive_root"] / "source.db"
     db_path.unlink(missing_ok=True)
@@ -1056,6 +1065,7 @@ def test_source_tier_v14_adds_raw_sessions_blob_hash_raw_id_index(
             CREATE TABLE raw_sessions (
                 raw_id                  TEXT PRIMARY KEY,
                 origin                  TEXT NOT NULL,
+                capture_mode            TEXT,
                 native_id               TEXT,
                 source_path             TEXT NOT NULL,
                 source_index            INTEGER NOT NULL DEFAULT 0,
@@ -1071,12 +1081,13 @@ def test_source_tier_v14_adds_raw_sessions_blob_hash_raw_id_index(
         indexes_before = {row[1] for row in conn.execute("PRAGMA index_list('raw_sessions')")}
         assert "idx_raw_sessions_blob_hash_raw_id" not in indexes_before
 
-        result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=None)
+        manifest = _verified_backup_manifest(tmp_path / "backup-source-v14")
+        result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
 
         assert result.from_version == 14
-        assert result.to_version == SOURCE_SCHEMA_VERSION == 15
-        assert result.applied_versions == (15,)
-        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 15
+        assert result.to_version == SOURCE_SCHEMA_VERSION == 16
+        assert result.applied_versions == (15, 16)
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 16
         indexes_after = {row[1] for row in conn.execute("PRAGMA index_list('raw_sessions')")}
         assert "idx_raw_sessions_blob_hash_raw_id" in indexes_after
         plan = conn.execute(

--- a/tests/unit/storage/test_raw.py
+++ b/tests/unit/storage/test_raw.py
@@ -24,6 +24,7 @@ from polylogue.storage.runtime import RawSessionRecord
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
+from polylogue.storage.sqlite.queries.raw_reads import get_capture_mode_resolution
 from polylogue.storage.sqlite.queries.raw_reads import get_raw_session as get_query_raw_session
 from polylogue.storage.sqlite.queries.raw_writes import save_raw_session as save_query_raw_session
 from tests.infra.storage_records import make_raw_session, make_session, save_session_to_archive
@@ -178,7 +179,14 @@ class TestRawSessionStorage:
         assert recovered_drive.payload_provider is Provider.DRIVE
 
     async def test_reacquisition_keeps_first_known_capture_mode(self, backend: SQLiteBackend) -> None:
-        """Later canonical fallback cannot erase durable live-Drive provenance."""
+        """Later canonical fallback cannot erase durable live-Drive provenance.
+
+        The cached column keeps first-known-mode behavior, but the durable
+        observation multimap must retain BOTH modes rather than silently
+        dropping the second (polylogue-buns AC1): this is the exact raw_id
+        collision the bead describes, expressed as a same-raw_id reacquisition
+        with a different capture_mode.
+        """
         drive = make_raw_session(
             raw_id="reacquired-aistudio",
             source_name="gemini",
@@ -195,6 +203,36 @@ class TestRawSessionStorage:
         assert recovered is not None
         assert recovered.capture_mode is Provider.DRIVE
         assert recovered.payload_provider is Provider.DRIVE
+
+        async with backend._get_connection() as conn:
+            resolution = await get_capture_mode_resolution(conn, drive.raw_id)
+        assert resolution.status == "ambiguous"
+        assert resolution.modes == (Provider.DRIVE, Provider.GEMINI)
+
+    async def test_reacquisition_ambiguous_gemini_then_drive(self, backend: SQLiteBackend) -> None:
+        """Mirror order of the test above: GEMINI observed first, DRIVE second."""
+        gemini = make_raw_session(
+            raw_id="reacquired-aistudio-reverse",
+            source_name="gemini",
+            source_path="/tmp/export.json",
+            blob_size=2,
+            acquired_at="2026-02-02T12:00:00+00:00",
+        ).model_copy(update={"capture_mode": Provider.GEMINI})
+        live_retry = gemini.model_copy(
+            update={"capture_mode": Provider.DRIVE, "acquired_at": "2026-02-02T12:00:01+00:00"}
+        )
+
+        assert await backend.save_raw_session(gemini) is True
+        assert await backend.save_raw_session(live_retry) is False
+
+        recovered = await backend.get_raw_session(gemini.raw_id)
+        assert recovered is not None
+        assert recovered.capture_mode is Provider.GEMINI
+
+        async with backend._get_connection() as conn:
+            resolution = await get_capture_mode_resolution(conn, gemini.raw_id)
+        assert resolution.status == "ambiguous"
+        assert resolution.modes == (Provider.GEMINI, Provider.DRIVE)
 
     async def test_rehydrated_unknown_capture_mode_remains_unknown(self, backend: SQLiteBackend) -> None:
         """A legacy NULL must not become the canonical GEMINI projection on save."""


### PR DESCRIPTION
## Summary
`raw_sessions.capture_mode` cached only the first-observed acquisition mode per `raw_id`. A content-identical GEMINI export and a live DRIVE acquisition colliding on the same content-derived `raw_id` silently lost whichever mode arrived second.

## Problem
Raw sessions are keyed by content-derived `raw_id`. The nullable `raw_sessions.capture_mode` column preserves only one known mode (`UPDATE ... WHERE capture_mode IS NULL`) and backfills legacy NULL, but cannot truthfully represent both acquisition modes on one raw row.

## Solution
- New additive durable migration `storage/sqlite/migrations/source/016_raw_capture_observations.sql` (SOURCE_SCHEMA_VERSION 15→16): `raw_capture_observations`, a multimap table with one row per distinct `(raw_id, capture_mode)` ever observed, plus a backfill from existing `capture_mode` values.
- `CaptureModeResolution` dataclass + `record_capture_mode_observation`/`read_capture_mode_resolution` (`archive_tiers/source_write.py`), wired into both sync write entrypoints (`write_source_raw_session`, `write_source_raw_session_blob_ref`) and the async daemon path (`queries/raw_writes.py`/`raw_reads.py`).
- Blob deduplication is untouched — verified by test assertion.
- AC2 (explicit ambiguous/unambiguous read surface) is satisfied for the new read functions; broader plumbing into `RawSessionRecord`/API/MCP surfaces is scoped out as an explicit follow-up, not required to land this.

## Verification
`devtools test tests/unit/storage/test_archive_tiers_source_write.py tests/unit/storage/test_raw.py tests/unit/storage/test_durable_migrations.py` — 83 passed. `devtools verify --quick` exit 0. Both acquisition orders (Gemini-first-then-Drive, Drive-first-then-Gemini) tested across all three write entrypoints.

Ref polylogue-buns

Co-Authored-By: Claude <noreply@anthropic.com>