### PR TITLE
fix(storage): repair stale drift-sample CHECK and per-row batch swallow

### DIFF
--- a/polylogue/schemas/drift_sentinel_sampling.py
+++ b/polylogue/schemas/drift_sentinel_sampling.py
@@ -64,28 +64,59 @@ def record_schema_drift_observations_to_ops_sync(
     try:
         ops_conn = open_connection(ops_db_path, timeout=5.0)
         initialize_archive_tier(ops_conn, ArchiveTier.OPS)
-        observed_at_ms = int(time.time() * 1000)
-        written = 0
-        for observation in observations:
-            record_schema_drift_sample(
-                ops_conn,
-                origin=observation.origin,
-                element_kind=observation.element_kind,
-                classification=observation.classification,
-                unseen_key_signature=observation.unseen_key_signature,
-                native_id_example=observation.native_id_example,
-                raw_id=observation.raw_id,
-                observed_at_ms=observed_at_ms,
-            )
-            written += 1
-        return written
     except sqlite3.Error:
-        logger.debug("schema drift sampling: ops.db write failed", exc_info=True)
-        return 0
-    finally:
+        logger.debug("schema drift sampling: ops.db open/init failed", exc_info=True)
         if ops_conn is not None:
             with contextlib.suppress(sqlite3.Error):
                 ops_conn.close()
+        return 0
+
+    observed_at_ms = int(time.time() * 1000)
+    written = 0
+    try:
+        for observation in observations:
+            try:
+                record_schema_drift_sample(
+                    ops_conn,
+                    origin=observation.origin,
+                    element_kind=observation.element_kind,
+                    classification=observation.classification,
+                    unseen_key_signature=observation.unseen_key_signature,
+                    native_id_example=observation.native_id_example,
+                    raw_id=observation.raw_id,
+                    observed_at_ms=observed_at_ms,
+                )
+            except sqlite3.IntegrityError:
+                # polylogue-sd9s: a CHECK/constraint rejection on ONE
+                # observation (e.g. a stale live ops.db CHECK predating a new
+                # DriftClassification member) must not discard the rest of
+                # this batch -- each call is already its own commit
+                # (record_schema_drift_sample's `with conn:`), so prior rows
+                # in this loop are safely persisted; only the offending
+                # observation is lost. Logged above debug because a CHECK
+                # violation here means the schema and the writer have
+                # drifted apart, which is itself the class of defect this
+                # sentinel exists to surface -- swallowing it silently would
+                # hide the sentinel's own malfunction.
+                logger.warning(
+                    "schema drift sampling: rejected one observation (origin=%s, classification=%s) "
+                    "by ops.db CHECK constraint -- schema_drift_samples DDL may be stale",
+                    observation.origin,
+                    observation.classification,
+                    exc_info=True,
+                )
+                continue
+            written += 1
+        return written
+    except sqlite3.Error:
+        # A non-constraint sqlite error (locked db, disk full, ...) is a
+        # genuine best-effort-tier failure, not a per-row data problem --
+        # stop attempting further writes for this batch as before.
+        logger.debug("schema drift sampling: ops.db write failed", exc_info=True)
+        return written
+    finally:
+        with contextlib.suppress(sqlite3.Error):
+            ops_conn.close()
 
 
 __all__ = ["record_schema_drift_observations_to_ops_sync"]

--- a/polylogue/storage/sqlite/archive_tiers/bootstrap.py
+++ b/polylogue/storage/sqlite/archive_tiers/bootstrap.py
@@ -91,6 +91,7 @@ def initialize_archive_tier(conn: sqlite3.Connection, tier: ArchiveTier) -> None
         _ensure_ops_cursor_lag_sample_columns(conn)
         _ensure_ops_ingest_attempt_outcome_columns(conn)
         ensure_embedding_catchup_run_outcome_columns(conn)
+        _ensure_schema_drift_samples_check(conn)
     if tier is ArchiveTier.INDEX:
         from polylogue.storage.sqlite.archive_tiers.pricing_seed import seed_price_catalog
 
@@ -104,6 +105,34 @@ def initialize_archive_tier(conn: sqlite3.Connection, tier: ArchiveTier) -> None
         _ensure_user_annotation_schemas(conn)
     conn.execute(f"PRAGMA user_version = {spec.version}")
     conn.commit()
+
+
+def _ensure_schema_drift_samples_check(conn: sqlite3.Connection) -> None:
+    """Repair a ``schema_drift_samples`` table bootstrapped with a stale CHECK.
+
+    ``CREATE TABLE IF NOT EXISTS`` (the ``OPS_DDL`` reapply path every
+    ``initialize_archive_tier(..., ArchiveTier.OPS)`` call goes through) never
+    rewrites an *existing* table's constraints. An ops.db bootstrapped before
+    the ``literal_check(DriftClassification)`` fix (#3451 / polylogue-u6tl)
+    keeps a live CHECK naming only 3 of ``DriftClassification``'s 4 values --
+    ``known_field_unread`` rows raise ``sqlite3.IntegrityError`` on every
+    insert attempt against that archive forever, not just until the code
+    ships. Detect the stale CHECK via ``sqlite_master.sql`` and drop+recreate:
+    ``schema_drift_samples`` is disposable bounded telemetry (polylogue-da1),
+    so losing its rows on repair is an accepted, documented cost -- there is
+    no migration/version-bump ceremony for this tier.
+    """
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'schema_drift_samples'"
+    ).fetchone()
+    if row is None or row[0] is None:
+        return
+    if "known_field_unread" in row[0]:
+        return
+    from polylogue.storage.sqlite.archive_tiers.ops import SCHEMA_DRIFT_SAMPLES_DDL
+
+    conn.execute("DROP TABLE IF EXISTS schema_drift_samples")
+    conn.executescript(SCHEMA_DRIFT_SAMPLES_DDL)
 
 
 def _ensure_user_annotation_schemas(conn: sqlite3.Connection) -> None:

--- a/polylogue/storage/sqlite/archive_tiers/ops.py
+++ b/polylogue/storage/sqlite/archive_tiers/ops.py
@@ -10,6 +10,30 @@ from polylogue.storage.sqlite.archive_tiers.common import check, literal_check, 
 
 OPS_SCHEMA_VERSION = 1
 
+# Split out of OPS_DDL (polylogue-sd9s) so the ops-bootstrap convergence step
+# that repairs a stale live CHECK (``_ensure_schema_drift_samples_check`` in
+# bootstrap.py) can re-execute exactly this fragment after a DROP TABLE,
+# rather than maintaining a second, hand-copied definition that could itself
+# drift from the canonical fresh-create DDL.
+SCHEMA_DRIFT_SAMPLES_DDL = f"""
+CREATE TABLE IF NOT EXISTS schema_drift_samples (
+    sample_id             TEXT PRIMARY KEY,
+    origin                TEXT NOT NULL CHECK ({check("origin", Origin)}),
+    element_kind          TEXT NOT NULL,
+    classification        TEXT NOT NULL CHECK ({literal_check("classification", *get_args(DriftClassification))}),
+    unseen_key_signature  TEXT NOT NULL DEFAULT '',
+    native_id_example     TEXT NOT NULL,
+    raw_id                TEXT NOT NULL,
+    observed_at_ms        INTEGER NOT NULL
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_schema_drift_samples_origin_time
+ON schema_drift_samples(origin, observed_at_ms DESC);
+
+CREATE INDEX IF NOT EXISTS idx_schema_drift_samples_time
+ON schema_drift_samples(observed_at_ms DESC);
+"""
+
 OPS_DDL = f"""
 CREATE TABLE IF NOT EXISTS ingest_cursor (
     source_path          TEXT PRIMARY KEY,
@@ -354,22 +378,14 @@ ON fts_drift_samples(surface, sampled_at_ms DESC);
 -- label. Generating the CHECK from DriftClassification via literal_check
 -- closes the gap; ops.db is disposable so this needs no migration/version
 -- bump, just the corrected DDL for the next bootstrap/bootstrap-repair.
-CREATE TABLE IF NOT EXISTS schema_drift_samples (
-    sample_id             TEXT PRIMARY KEY,
-    origin                TEXT NOT NULL CHECK ({check("origin", Origin)}),
-    element_kind          TEXT NOT NULL,
-    classification        TEXT NOT NULL CHECK ({literal_check("classification", *get_args(DriftClassification))}),
-    unseen_key_signature  TEXT NOT NULL DEFAULT '',
-    native_id_example     TEXT NOT NULL,
-    raw_id                TEXT NOT NULL,
-    observed_at_ms        INTEGER NOT NULL
-) STRICT;
+--
+-- polylogue-sd9s: ``CREATE TABLE IF NOT EXISTS`` never rewrites an
+-- *existing* table's CHECK, so any ops.db bootstrapped before the fix above
+-- (#3451) keeps rejecting ``known_field_unread`` forever on reopen. See
+-- ``_ensure_schema_drift_samples_check`` (bootstrap.py) for the drop+recreate
+-- convergence step that detects and repairs a stale live CHECK; it reuses
+-- this exact DDL fragment (``SCHEMA_DRIFT_SAMPLES_DDL``) so the two can never
+-- drift apart from each other.
+{SCHEMA_DRIFT_SAMPLES_DDL}"""
 
-CREATE INDEX IF NOT EXISTS idx_schema_drift_samples_origin_time
-ON schema_drift_samples(origin, observed_at_ms DESC);
-
-CREATE INDEX IF NOT EXISTS idx_schema_drift_samples_time
-ON schema_drift_samples(observed_at_ms DESC);
-"""
-
-__all__ = ["OPS_DDL", "OPS_SCHEMA_VERSION"]
+__all__ = ["OPS_DDL", "OPS_SCHEMA_VERSION", "SCHEMA_DRIFT_SAMPLES_DDL"]

--- a/tests/unit/schemas/test_drift_sentinel_sampling.py
+++ b/tests/unit/schemas/test_drift_sentinel_sampling.py
@@ -80,3 +80,94 @@ def test_returns_zero_for_empty_observation_list(tmp_path: Path) -> None:
     index_db = tmp_path / "index.db"
     written = record_schema_drift_observations_to_ops_sync(index_db, [])
     assert written == 0
+
+
+def test_known_field_unread_observation_is_written(tmp_path: Path) -> None:
+    """Regression test for polylogue-sd9s: known_field_unread is a real,
+    legitimately risky DriftClassification member (RISKY_CLASSIFICATIONS)
+    and must persist, not be silently dropped by the ops-tier CHECK.
+    """
+    index_db = tmp_path / "index.db"
+    index_db.touch()
+    ops_db = tmp_path / "ops.db"
+    conn = sqlite3.connect(str(ops_db))
+    try:
+        initialize_archive_tier(conn, ArchiveTier.OPS)
+    finally:
+        conn.close()
+
+    observations = [
+        SchemaDriftObservation(
+            origin="claude-code-session",
+            element_kind="session_record",
+            classification="known_field_unread",
+            unseen_key_signature="",
+            native_id_example="raw-1",
+            raw_id="raw-1",
+        ),
+    ]
+    written = record_schema_drift_observations_to_ops_sync(index_db, observations)
+    assert written == 1
+
+    conn = sqlite3.connect(str(ops_db))
+    try:
+        samples = list_schema_drift_samples(conn, limit=100)
+    finally:
+        conn.close()
+    assert [s.classification for s in samples] == ["known_field_unread"]
+
+
+def test_one_rejected_observation_does_not_swallow_the_rest_of_the_batch(tmp_path: Path) -> None:
+    """polylogue-sd9s: before this fix, the per-batch write loop caught
+    sqlite3.Error around the WHOLE for-loop and returned 0 the instant any
+    single observation's INSERT violated a CHECK constraint (e.g. an
+    unrecognized ``origin`` token) -- discarding every other observation in
+    the same call, not just the bad one. Each ``record_schema_drift_sample``
+    call is already its own commit, so the valid rows before/after the bad
+    one must both persist and both count toward the returned total.
+    """
+    index_db = tmp_path / "index.db"
+    index_db.touch()
+    ops_db = tmp_path / "ops.db"
+    conn = sqlite3.connect(str(ops_db))
+    try:
+        initialize_archive_tier(conn, ArchiveTier.OPS)
+    finally:
+        conn.close()
+
+    observations = [
+        SchemaDriftObservation(
+            origin="claude-code-session",
+            element_kind="session_record",
+            classification="new_field",
+            unseen_key_signature="",
+            native_id_example="raw-good-1",
+            raw_id="raw-good-1",
+        ),
+        SchemaDriftObservation(
+            origin="not-a-real-origin",
+            element_kind="session_record",
+            classification="new_field",
+            unseen_key_signature="",
+            native_id_example="raw-bad",
+            raw_id="raw-bad",
+        ),
+        SchemaDriftObservation(
+            origin="codex-session",
+            element_kind="session_record",
+            classification="field_changed",
+            unseen_key_signature="",
+            native_id_example="raw-good-2",
+            raw_id="raw-good-2",
+        ),
+    ]
+    written = record_schema_drift_observations_to_ops_sync(index_db, observations)
+    assert written == 2
+
+    conn = sqlite3.connect(str(ops_db))
+    try:
+        samples = list_schema_drift_samples(conn, limit=100)
+    finally:
+        conn.close()
+    raw_ids = {sample.raw_id for sample in samples}
+    assert raw_ids == {"raw-good-1", "raw-good-2"}

--- a/tests/unit/storage/test_schema_drift_samples.py
+++ b/tests/unit/storage/test_schema_drift_samples.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
 from polylogue.storage.sqlite.archive_tiers.ops_write import (
     SCHEMA_DRIFT_SAMPLE_RETENTION_MS,
@@ -189,5 +191,124 @@ class TestSchemaDriftSamples:
                 pass
             else:
                 raise AssertionError("expected a CHECK constraint violation for an unrecognized origin token")
+        finally:
+            conn.close()
+
+    def test_drift_sample_writer_accepts_known_field_unread(self, tmp_path: Path) -> None:
+        """Regression test for polylogue-sd9s / #3451.
+
+        ``known_field_unread`` is one of ``DriftClassification``'s 4 members
+        and legitimately risky (``RISKY_CLASSIFICATIONS``) -- the CHECK must
+        accept it on a freshly bootstrapped ops.db.
+        """
+        conn = _ops_conn(tmp_path)
+        try:
+            record_schema_drift_sample(
+                conn,
+                origin="claude-code-session",
+                element_kind="session_record",
+                classification="known_field_unread",
+                unseen_key_signature="",
+                native_id_example="raw-1",
+                raw_id="raw-1",
+                observed_at_ms=1,
+            )
+            samples = list_schema_drift_samples(conn, limit=100)
+            assert [s.classification for s in samples] == ["known_field_unread"]
+        finally:
+            conn.close()
+
+
+class TestSchemaDriftSamplesStaleCheckConvergence:
+    """polylogue-sd9s: an ops.db bootstrapped before the literal_check fix
+    (#3451 / polylogue-u6tl) keeps a live CHECK naming only 3 of
+    DriftClassification's 4 values forever, because ``CREATE TABLE IF NOT
+    EXISTS`` never rewrites an existing table's constraints. Confirm the
+    bootstrap-time convergence step detects and repairs that stale CHECK.
+    """
+
+    _STALE_TABLE_DDL = """
+        CREATE TABLE schema_drift_samples (
+            sample_id             TEXT PRIMARY KEY,
+            origin                TEXT NOT NULL,
+            element_kind          TEXT NOT NULL,
+            classification        TEXT NOT NULL CHECK(classification IN ('unseen_shape', 'new_field', 'field_changed')),
+            unseen_key_signature  TEXT NOT NULL DEFAULT '',
+            native_id_example     TEXT NOT NULL,
+            raw_id                TEXT NOT NULL,
+            observed_at_ms        INTEGER NOT NULL
+        ) STRICT;
+    """
+
+    def test_pre_fix_stale_check_rejects_known_field_unread(self, tmp_path: Path) -> None:
+        """Reproduces the bug: the old 3-value CHECK raises IntegrityError."""
+        conn = sqlite3.connect(str(tmp_path / "ops.db"))
+        try:
+            conn.executescript(self._STALE_TABLE_DDL)
+            conn.execute(
+                "INSERT INTO schema_drift_samples "
+                "(sample_id, origin, element_kind, classification, native_id_example, raw_id, observed_at_ms) "
+                "VALUES ('s1', 'claude-code-session', 'session_record', 'unseen_shape', 'raw-1', 'raw-1', 1)"
+            )
+            with pytest.raises(sqlite3.IntegrityError):
+                conn.execute(
+                    "INSERT INTO schema_drift_samples "
+                    "(sample_id, origin, element_kind, classification, native_id_example, raw_id, observed_at_ms) "
+                    "VALUES ('s2', 'claude-code-session', 'session_record', 'known_field_unread', 'raw-2', 'raw-2', 2)"
+                )
+        finally:
+            conn.close()
+
+    def test_bootstrap_repairs_stale_check_on_reopen(self, tmp_path: Path) -> None:
+        ops_db = tmp_path / "ops.db"
+        conn = sqlite3.connect(str(ops_db))
+        try:
+            conn.executescript(self._STALE_TABLE_DDL)
+            conn.commit()
+        finally:
+            conn.close()
+
+        conn = sqlite3.connect(str(ops_db))
+        try:
+            initialize_archive_tier(conn, ArchiveTier.OPS)
+            live_sql = conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'schema_drift_samples'"
+            ).fetchone()[0]
+            assert "known_field_unread" in live_sql
+
+            # A known_field_unread insert now succeeds against the repaired CHECK.
+            record_schema_drift_sample(
+                conn,
+                origin="claude-code-session",
+                element_kind="session_record",
+                classification="known_field_unread",
+                unseen_key_signature="",
+                native_id_example="raw-3",
+                raw_id="raw-3",
+                observed_at_ms=3,
+            )
+            samples = list_schema_drift_samples(conn, limit=100)
+            assert [s.classification for s in samples] == ["known_field_unread"]
+        finally:
+            conn.close()
+
+    def test_bootstrap_is_a_noop_on_an_already_current_check(self, tmp_path: Path) -> None:
+        """Reopening an already-repaired/fresh ops.db must not drop live rows."""
+        conn = _ops_conn(tmp_path)
+        try:
+            record_schema_drift_sample(
+                conn,
+                origin="claude-code-session",
+                element_kind="session_record",
+                classification="new_field",
+                unseen_key_signature="",
+                native_id_example="raw-1",
+                raw_id="raw-1",
+                observed_at_ms=1,
+            )
+            # Reopen/re-initialize, as every daemon-restart same-version open does.
+            initialize_archive_tier(conn, ArchiveTier.OPS)
+            samples = list_schema_drift_samples(conn, limit=100)
+            assert [s.raw_id for s in samples] == ["raw-1"]
         finally:
             conn.close()


### PR DESCRIPTION
## Summary

Repairs the last two live consequences of polylogue-sd9s: an already-bootstrapped ops.db keeping a stale 3-value `schema_drift_samples.classification` CHECK forever, and a batch-write loop that silently discarded every other observation in a batch when one row hit a CHECK violation.

## Problem

`DriftClassification` (`polylogue/schemas/drift_sentinel.py:48`) has 4 members: `unseen_shape`, `new_field`, `field_changed`, `known_field_unread`. PR #3451 (merged 2026-07-31, same day this bead was filed) already fixed the ops-tier DDL's hand-written 3-value CHECK by generating it from `DriftClassification` via `literal_check` — but that fix only changes the DDL text used by a *fresh* `CREATE TABLE`. `CREATE TABLE IF NOT EXISTS` never rewrites an existing table's constraints, so an ops.db bootstrapped before #3451 keeps rejecting `known_field_unread` forever on every reopen. Confirmed live: `/realm/db/polylogue/ops.db`'s `schema_drift_samples` table still carries the old 3-value CHECK.

Separately, `record_schema_drift_observations_to_ops_sync` (`polylogue/schemas/drift_sentinel_sampling.py`) wrapped its whole per-observation write loop in one `try/except sqlite3.Error: return 0`. Each `record_schema_drift_sample` call is already its own commit (`with conn:`), so earlier rows in a batch were safely persisted on disk — but the moment any single observation's INSERT violated a CHECK (a stale-CHECK `known_field_unread` row, or any other constraint violation, e.g. an unrecognized `origin` token), the function returned early with `written=0`, meaning: (a) the caller's return-count lied about what actually got written, and (b) every observation *after* the bad one in that same batch call was silently skipped, never attempted.

## Solution

- `polylogue/storage/sqlite/archive_tiers/ops.py`: extracted `SCHEMA_DRIFT_SAMPLES_DDL` as its own constant (embedded into `OPS_DDL`) so it can be reused for repair without a second, hand-copied definition.
- `polylogue/storage/sqlite/archive_tiers/bootstrap.py`: added `_ensure_schema_drift_samples_check`, called from `initialize_archive_tier`'s `ArchiveTier.OPS` branch. It inspects `sqlite_master.sql` for the live `schema_drift_samples` table; if the CHECK predates `known_field_unread`, it drops and recreates the table from `SCHEMA_DRIFT_SAMPLES_DDL`. `ops.db` is a disposable tier (per CLAUDE.md), so losing the bounded telemetry rows on repair needs no migration ceremony.
- `polylogue/schemas/drift_sentinel_sampling.py`: moved the connection open/init into its own try/except (unchanged best-effort contract for a missing/unreachable ops.db), then catch `sqlite3.IntegrityError` per observation inside the loop — log at `warning` (not `debug`, since a CHECK violation here means the schema and the writer have drifted apart, the exact defect class this sentinel exists to surface) and continue to the next observation. A non-constraint `sqlite3.Error` (locked db, disk full) still stops the batch, as before.

## Verification

- `devtools test tests/unit/schemas/test_drift_sentinel_sampling.py tests/unit/storage/test_schema_drift_samples.py` — 15 passed, including: a reproduction of the pre-#3451-style stale-CHECK `IntegrityError`, a bootstrap-convergence repair test (stale table → `initialize_archive_tier` → CHECK now includes `known_field_unread`, insert succeeds), a `known_field_unread` persistence regression test, and a batch-continuation test. Anti-vacuity: temporarily reverting only the `drift_sentinel_sampling.py` change reproduces the pre-fix bug on the new test (`written == 0` instead of `2`).
- `devtools test tests/unit/storage/test_archive_tiers_ops_write.py tests/unit/cli/test_schema_drift_status.py tests/unit/daemon/test_fts_identity_convergence.py` — 24 passed.
- `devtools verify --quick` — exit 0 (format, lint, mypy --strict, render-all-check, layering, schema-versioning policy). Also ran automatically and passed via the pre-push hook.

Ref polylogue-sd9s