### PR TITLE
fix(daemon): fail open, not closed, when source tier attach errors

### DIFF
--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -1333,15 +1333,23 @@ def _schema_archive_session_ids_for_source_paths(
     raw_table = "raw_sessions"
     if not _table_exists(conn, "raw_sessions"):
         raw_table = "source_tier.raw_sessions"
-        try:
-            if not _ensure_source_tier_attached(conn, archive_root=archive_root):
-                return {path: [] for path in normalized_paths}
-        except sqlite3.Error:
-            # Swallowed here, one level below the stage's own check/execute
-            # logging (the 1xc.11 fix), so the outer probe never sees this
-            # failure and can't log it either.
-            logger.warning("archive convergence: failed to attach source tier", exc_info=True)
+        if not _ensure_source_tier_attached(conn, archive_root=archive_root):
             return {path: [] for path in normalized_paths}
+        # Deliberately let sqlite3.Error from the attach above propagate
+        # instead of swallowing it into an empty result here (polylogue-co8b):
+        # every caller of this helper (_archive_embed_check[_many],
+        # _archive_insights_check[_many], _sinex_session_ids_for_paths) wraps
+        # its own call in a broad try/except that fails OPEN -- "treating as
+        # needs-work" -- matching every other freshness probe in this file.
+        # Swallowing the error here instead made the outer probe see a clean
+        # `{path: []}` result and conclude there was nothing to do, silently
+        # disabling embed/insights convergence for the affected source paths
+        # with no convergence_debt row and no counter, only a log line. The
+        # existing false_means_pending -> convergence_debt retry path already
+        # bounds the resulting "fires every tick" concern: a genuinely
+        # persistent attach failure surfaces as repeated execute() failures,
+        # which convergence_debt retries with its own backoff rather than
+        # busy-looping here.
     result: dict[Path, list[str]] = {path: [] for path in normalized_paths}
     paths_by_text = {str(path): path for path in normalized_paths}
     placeholders = ", ".join("?" for _ in normalized_paths)

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -179,6 +179,54 @@ def test_archive_probe_exceptions_log_and_fail_toward_work(
     assert all(value is True for value in warning_exc_info)
 
 
+def test_source_tier_attach_failure_fails_open_not_closed(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """polylogue-co8b regression: a broken ``source.db`` must surface as
+    needs-work, not as a silent "nothing to do".
+
+    ``index.db`` (the derived tier) never carries ``raw_sessions`` itself, so
+    every embed/insights probe must attach ``source.db`` through
+    ``_schema_archive_session_ids_for_source_paths`` to resolve a source path
+    to its session ids. Before the fix, a ``sqlite3.Error`` from that attach
+    (e.g. a corrupt/unreadable ``source.db``) was swallowed *inside* that
+    helper and turned into a clean ``{path: []}`` result -- the outer probes
+    (``_archive_insights_check`` etc.) never saw an exception, computed "no
+    sessions for this path", and reported no work needed. Real pending
+    embedding/insights work for that path was silently dropped with no
+    ``convergence_debt`` row and no retry, forever, until the daemon
+    restarted onto a healthy ``source.db``.
+
+    This drives the real production convergence stage (``make_insights_stage``
+    from ``daemon/convergence_stages.py``), not a mock of the attach helper,
+    so it fails if a future change reintroduces the swallow anywhere in the
+    real call path.
+    """
+    archive_db = tmp_path / "index.db"
+    source_path = tmp_path / "codex.jsonl"
+    _seed_minimal_archive(archive_db, source_path)
+
+    # Corrupt source.db in place: the file still exists (passing the
+    # `.exists()` gate in `_ensure_source_tier_attached`) but ATTACH DATABASE
+    # against it raises `sqlite3.DatabaseError` ("file is not a database").
+    source_db = archive_db.with_name("source.db")
+    source_db.write_bytes(b"not a real sqlite database file, deliberately corrupted for polylogue-co8b")
+
+    with pytest.raises(sqlite3.Error):
+        with sqlite3.connect(archive_db) as conn:
+            stages._schema_archive_session_ids_for_source_paths(conn, [source_path], archive_root=tmp_path)
+
+    stage = make_insights_stage(archive_db)
+    with caplog.at_level("WARNING"):
+        assert stage.check(source_path) is True
+        assert stage.check_many is not None
+        assert stage.check_many([source_path]) == {source_path}
+
+    assert "convergence freshness probe" in caplog.text
+    assert "treating as needs-work" in caplog.text
+
+
 def _main_db_path(conn: sqlite3.Connection) -> Path:
     row = conn.execute("PRAGMA database_list").fetchone()
     return Path(str(row[2]))


### PR DESCRIPTION
## Summary

Fixes a fail-closed bug in daemon convergence: a broken/unreadable `source.db` silently disabled embedding and insights convergence for affected source paths instead of surfacing as needs-work, with no `convergence_debt` row, no counter, only an unwatched `logger.warning`.

## Problem

`_schema_archive_session_ids_for_source_paths` in `polylogue/daemon/convergence_stages.py` caught `sqlite3.Error` from `_ensure_source_tier_attached` internally and returned `{path: []}` for every requested path. Every sibling freshness probe in this file deliberately fails OPEN on its own exceptions (logs "treating as needs-work", returns `True`/`set(paths)`/`set(session_ids)`), but this one inner swallow returned a clean empty result instead of raising. That meant the outer probes (`_archive_embed_check`, `_archive_insights_check`, and their `_many` / `_sinex_session_ids_for_paths` variants) never saw a failure at all and concluded there was simply no work for that path.

## Solution

Removed the inner `try/except sqlite3.Error` around the attach call so the exception propagates to the caller's existing try/except, which already fails open exactly like every other probe in this file. This is a one-line-of-logic change (deleting a swallow), not a new mechanism: embed and insights stages both already run with `false_means_pending=True`, so a persistent attach failure now surfaces as a real `execute()` failure that the existing `convergence_debt` retry/backoff path picks up, rather than a silent no-op that never retries. No changes to locking, coordination, or the daemon's convergence driver (`daemon/convergence.py`) — only this one probe's error-handling polarity, per the file's documented #1498 incident history (`docs/retro/2026-05-24-1498-cascade.md`).

## Verification

- `devtools test tests/unit/daemon/test_convergence_stages.py` — 46 passed, including a new regression test `test_source_tier_attach_failure_fails_open_not_closed` that seeds a realistic `index.db` + `source.db` pair (via `_seed_minimal_archive`), corrupts `source.db` in place so `ATTACH DATABASE` raises `sqlite3.DatabaseError` ("file is not a database"), and drives the real `make_insights_stage(...)` convergence stage (not a mock of the attach helper) to confirm `stage.check(path)` / `stage.check_many([path])` now return needs-work with a "treating as needs-work" log line.
- Anti-vacuity: temporarily reverted the production fix (`git stash`) with the new test in place — the test fails against the pre-fix code with `Failed: DID NOT RAISE Error`, confirming it reproduces the original bug and is not a vacuous pass.
- `devtools verify --quick` (format + lint + mypy --strict + render-all --check) — exit 0, twice (once locally, once via the pre-push hook).

Ref polylogue-co8b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of corrupted source databases during insights convergence.
  * Failed database attachments now remain eligible for retry instead of being silently ignored.
  * Missing source databases continue to be handled gracefully.

* **Tests**
  * Added regression coverage for corrupted database attachments in both single-path and batch processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->