### PR TITLE
fix(daemon): wire auto-minted API token through every CLI/MCP client

### DIFF
--- a/docs/daemon-threat-model.md
+++ b/docs/daemon-threat-model.md
@@ -9,13 +9,37 @@ The daemon binds to `127.0.0.1` by default. Non-loopback bind requires
 `--insecure-allow-remote` *and* `--api-auth-token`; the daemon refuses
 to start otherwise (`daemon/cli.py:309-319`).
 
-Authentication: optional bearer token (`--api-auth-token`). When set,
-machine clients present the bearer; the first-party shell uses a separate,
-short-lived, scoped HttpOnly cookie minted only for the exact daemon origin.
-That cookie is limited to reads, events, and user-overlay writes; reset, ingest,
-and maintenance control routes accept only the machine bearer when configured.
-When unset, the API is open on loopback; the loopback bind is the access
-boundary in that mode.
+Authentication: a bearer token is required by default (`--api-auth-token`,
+or `daemon.api.auth_token` / `POLYLOGUE_API_AUTH_TOKEN`). If none is
+explicitly configured, the daemon auto-mints one on first start and persists
+it to a `0600` file under the config root (`polylogue.paths.api_auth_token_path`,
+polylogue-rzve); every first-party CLI/MCP client that talks to the daemon
+resolves the same explicit-or-auto-minted token
+(`polylogue.daemon.api_auth.resolve_api_auth_token`) so this is transparent
+for the common single-user case. Machine clients present the bearer; the
+first-party shell uses a separate, short-lived, scoped HttpOnly cookie minted
+only for the exact daemon origin. That cookie is limited to reads, events,
+and user-overlay writes; reset, ingest, and maintenance control routes accept
+only the machine bearer when configured. The fully-open posture (no token at
+all) now requires an explicit, loudly-logged opt-out
+(`--api-allow-no-auth` / `POLYLOGUE_API_ALLOW_NO_AUTH=1`); it is no longer
+the unconfigured default.
+
+**Cross-uid boundary (polylogue-n6pz, closed):** loopback TCP has no
+peer-uid check, so before auto-minting existed, "the API is open on
+loopback" meant any local uid -- not just the archive's owner -- could read
+full session content over `127.0.0.1:8766` even though the archive's SQLite
+files themselves are `0700` and deny every other uid. The auto-minted,
+`0600`, owner-verified token (`polylogue.daemon.api_auth._is_trusted_token_file`
+checks uid + permission bits before trusting an existing token file, refusing
+to follow a symlink or trust a file it does not exclusively own) restores
+that boundary: a different uid can still reach the loopback port, but cannot
+present a valid bearer, so it is rejected before any route runs. Residual
+risk is unchanged from before: any process running as the *same* uid as the
+daemon can always read the token file (and the archive's SQLite files
+directly), which this design does not attempt to prevent -- same-uid
+co-tenancy is out of scope, same as for any other localhost dev server or
+database that trusts its own uid.
 
 Cross-origin POSTs (CSRF) are refused by exact `Origin`-to-`Host` authority
 matching. Another loopback port is not trusted. First-party credentials are
@@ -38,9 +62,9 @@ redaction, `/api/sources` paths, and `OPTIONS` handling, see
 ## Threats
 
 ### Local process reading the API
-- **Risk**: Any process on the machine can `curl http://127.0.0.1:8766/api/...`
-- **Mitigation**: Loopback binding limits exposure to the local machine. This is the same trust model as `localhost` databases, dev servers, and CLI tools.
-- **Residual**: Processes running as the same user can read the SQLite archive directly anyway.
+- **Risk**: Any process on the machine can `curl http://127.0.0.1:8766/api/...`.
+- **Mitigation**: Loopback binding limits exposure to the local machine, and the auto-minted, `0600`, owner-verified bearer token (see Authentication above) means a process running as a *different* uid gets a `401` with no valid credential available to it -- it cannot read the token file the daemon itself trusts. This is stronger than "the same trust model as `localhost` databases": most dev-server defaults do not restore the OS's own cross-uid file-permission boundary the way this token does.
+- **Residual**: Processes running as the *same* user can always obtain the token (it is a plain file they have read access to) and read the SQLite archive directly anyway. Same-uid co-tenancy is not a boundary this design defends.
 
 ### Extension posting forged captures
 - **Risk**: A malicious browser extension or page could POST to the receiver

--- a/polylogue/browser_capture/receiver.py
+++ b/polylogue/browser_capture/receiver.py
@@ -9,6 +9,7 @@ import os
 import re
 import secrets
 import sqlite3
+import stat
 import tempfile
 import threading
 from collections.abc import Iterator
@@ -94,6 +95,26 @@ RECEIVER_TOKEN_ENTROPY_BYTES = 32
 BROWSER_CAPTURE_ALLOW_NO_AUTH_ENV = "POLYLOGUE_BROWSER_CAPTURE_ALLOW_NO_AUTH"
 
 
+def _is_trusted_token_file(target: Path) -> bool:
+    """Refuse to trust a token file this process does not exclusively own.
+
+    Mirrors :func:`polylogue.daemon.api_auth._is_trusted_token_file` --
+    reading an existing token file's bytes without first checking who put
+    them there repeats the exact filesystem-boundary assumption polylogue-n6pz
+    found reachable elsewhere. A symlink is never followed; a regular file
+    must be owned by our own uid with no group/other permission bits.
+    """
+    try:
+        info = target.lstat()
+    except OSError:
+        return False
+    if stat.S_ISLNK(info.st_mode):
+        return False
+    if info.st_uid != os.getuid():
+        return False
+    return stat.S_IMODE(info.st_mode) & 0o077 == 0
+
+
 def load_or_mint_receiver_token(path: Path | None = None, *, rotate: bool = False) -> str:
     """Return the receiver's persisted bearer token, minting one on first use.
 
@@ -102,13 +123,23 @@ def load_or_mint_receiver_token(path: Path | None = None, *, rotate: bool = Fals
     0600 file rather than :mod:`polylogue.sources.token_store`'s
     keyring-backed store. Written atomically (mkstemp + fchmod(0o600) before
     any bytes land, then ``os.replace``) so the token is never briefly
-    world-readable under a permissive umask.
+    world-readable under a permissive umask. An existing file is trusted only
+    if :func:`_is_trusted_token_file` passes; otherwise it is treated as
+    absent and a fresh token is minted in its place.
     """
     target = path if path is not None else browser_capture_receiver_token_path()
     if not rotate and target.exists():
-        existing = target.read_text(encoding="utf-8").strip()
-        if existing:
-            return existing
+        if _is_trusted_token_file(target):
+            existing = target.read_text(encoding="utf-8").strip()
+            if existing:
+                return existing
+        else:
+            logger.warning(
+                "browser_capture.receiver_token_file_untrusted",
+                path=str(target),
+                action="reminting",
+                reason="existing token file is not an owner-only regular file we exclusively own",
+            )
     token = secrets.token_urlsafe(RECEIVER_TOKEN_ENTROPY_BYTES)
     target.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp")

--- a/polylogue/cli/archive_query.py
+++ b/polylogue/cli/archive_query.py
@@ -1416,12 +1416,19 @@ def _fetch_daemon_payload(
     if _daemon_disabled(flag=disabled):
         return None
     from polylogue.cli.daemon_client import DaemonClient
+    from polylogue.daemon.api_auth import resolve_api_auth_token
     from polylogue.daemon.socket_path import daemon_socket_path
     from polylogue.storage.sqlite.archive_tiers.index import INDEX_SCHEMA_VERSION
     from polylogue.version import POLYLOGUE_VERSION
 
     socket_path = daemon_socket_path(config.archive_root)
-    client = DaemonClient(socket_path, auth_token=getattr(config, "api_auth_token", None))
+    client = DaemonClient(
+        socket_path,
+        auth_token=resolve_api_auth_token(
+            getattr(config, "api_auth_token", None),
+            allow_no_auth=getattr(config, "api_allow_no_auth", False),
+        ),
+    )
     if (
         client.probe(
             archive_root=str(config.archive_root),

--- a/polylogue/cli/click_app.py
+++ b/polylogue/cli/click_app.py
@@ -277,13 +277,17 @@ def _bare_tty_daemon_rows(config: Config) -> list[SelectSessionRow] | None:
 
     from polylogue.cli.daemon_client import DaemonClient
     from polylogue.cli.select import SelectSessionRow
+    from polylogue.daemon.api_auth import resolve_api_auth_token
     from polylogue.daemon.socket_path import daemon_socket_path
     from polylogue.storage.sqlite.archive_tiers.index import INDEX_SCHEMA_VERSION
     from polylogue.version import POLYLOGUE_VERSION
 
     client = DaemonClient(
         daemon_socket_path(config.archive_root),
-        auth_token=getattr(config, "api_auth_token", None),
+        auth_token=resolve_api_auth_token(
+            getattr(config, "api_auth_token", None),
+            allow_no_auth=getattr(config, "api_allow_no_auth", False),
+        ),
     )
     if (
         client.probe(

--- a/polylogue/cli/commands/facets.py
+++ b/polylogue/cli/commands/facets.py
@@ -101,6 +101,7 @@ def _fetch_daemon_facets(
         return None
     from polylogue.cli.daemon_client import DaemonClient
     from polylogue.cli.shared.helpers import load_effective_config
+    from polylogue.daemon.api_auth import resolve_api_auth_token
     from polylogue.daemon.socket_path import daemon_socket_path
     from polylogue.storage.sqlite.archive_tiers.index import INDEX_SCHEMA_VERSION
     from polylogue.surfaces.payloads import FacetsResponse
@@ -109,7 +110,10 @@ def _fetch_daemon_facets(
     config = load_effective_config(env)
     client = DaemonClient(
         daemon_socket_path(config.archive_root),
-        auth_token=getattr(config, "api_auth_token", None),
+        auth_token=resolve_api_auth_token(
+            getattr(config, "api_auth_token", None),
+            allow_no_auth=getattr(config, "api_allow_no_auth", False),
+        ),
     )
     if (
         client.probe(

--- a/polylogue/cli/commands/maintenance/_rebuild_index.py
+++ b/polylogue/cli/commands/maintenance/_rebuild_index.py
@@ -49,6 +49,7 @@ def _run_daemon_rebuild(
 ) -> dict[str, object]:
     """Execute one rebuild pass through the daemon-owned writer."""
     from polylogue.config import load_polylogue_config
+    from polylogue.daemon.api_auth import resolve_api_auth_token
 
     body = json.dumps(
         {
@@ -63,7 +64,8 @@ def _run_daemon_rebuild(
         }
     ).encode("utf-8")
     headers = {"Content-Type": "application/json"}
-    if auth_token := load_polylogue_config().api_auth_token:
+    cfg = load_polylogue_config()
+    if auth_token := resolve_api_auth_token(cfg.api_auth_token, allow_no_auth=cfg.api_allow_no_auth):
         headers["Authorization"] = f"Bearer {auth_token}"
     request = Request(
         f"{daemon_url.rstrip('/')}/api/maintenance/rebuild-index",

--- a/polylogue/daemon/api_auth.py
+++ b/polylogue/daemon/api_auth.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 import secrets
+import stat
 import tempfile
 from contextlib import suppress
 from pathlib import Path
@@ -43,6 +44,30 @@ API_AUTH_TOKEN_ENTROPY_BYTES = 32
 API_ALLOW_NO_AUTH_ENV = "POLYLOGUE_API_ALLOW_NO_AUTH"
 
 
+def _is_trusted_token_file(target: Path) -> bool:
+    """Refuse to trust a token file this process does not exclusively own.
+
+    polylogue-n6pz: the cross-uid audit finding this closes was exactly the
+    mistake of assuming a filesystem boundary holds without checking it. Do
+    not repeat that assumption for the token file itself -- an unmint'd file
+    at ``target`` (planted before this process ever ran, restored from a
+    backup with looser bits, or living under a misconfigured/shared config
+    root) could hand out an attacker-known token while the operator believes
+    the API is private. A symlink is refused outright (never follow it into
+    another owner's file); a regular file must be owned by our own uid and
+    carry no group/other permission bits.
+    """
+    try:
+        info = target.lstat()
+    except OSError:
+        return False
+    if stat.S_ISLNK(info.st_mode):
+        return False
+    if info.st_uid != os.getuid():
+        return False
+    return stat.S_IMODE(info.st_mode) & 0o077 == 0
+
+
 def load_or_mint_api_auth_token(path: Path | None = None, *, rotate: bool = False) -> str:
     """Return the daemon API's persisted bearer token, minting one on first use.
 
@@ -50,12 +75,24 @@ def load_or_mint_api_auth_token(path: Path | None = None, *, rotate: bool = Fals
     then ``os.replace``) so the token is never briefly world-readable under a
     permissive umask -- identical idiom to
     :func:`polylogue.browser_capture.receiver.load_or_mint_receiver_token`.
+    An existing file is trusted only if :func:`_is_trusted_token_file` passes;
+    otherwise it is treated as absent and a fresh token is minted in its
+    place (logging so the operator can investigate why a stray/loose file was
+    sitting at the token path).
     """
     target = path if path is not None else api_auth_token_path()
     if not rotate and target.exists():
-        existing = target.read_text(encoding="utf-8").strip()
-        if existing:
-            return existing
+        if _is_trusted_token_file(target):
+            existing = target.read_text(encoding="utf-8").strip()
+            if existing:
+                return existing
+        else:
+            logger.warning(
+                "daemon_api.token_file_untrusted",
+                path=str(target),
+                action="reminting",
+                reason="existing token file is not an owner-only regular file we exclusively own",
+            )
     token = secrets.token_urlsafe(API_AUTH_TOKEN_ENTROPY_BYTES)
     target.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_name = tempfile.mkstemp(dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp")

--- a/polylogue/mcp/call_log.py
+++ b/polylogue/mcp/call_log.py
@@ -125,10 +125,12 @@ def _read_spooled_delivery(path: Path, config: PolylogueConfig) -> _Delivery:
     )
     if not isinstance(event.success, bool):
         raise ValueError("invalid MCP call outbox success flag")
+    from polylogue.daemon.api_auth import resolve_api_auth_token
+
     return _Delivery(
         event=event,
         daemon_url=config.daemon_url,
-        auth_token=config.api_auth_token,
+        auth_token=resolve_api_auth_token(config.api_auth_token, allow_no_auth=config.api_allow_no_auth),
     )
 
 

--- a/tests/unit/browser_capture/test_receiver_token.py
+++ b/tests/unit/browser_capture/test_receiver_token.py
@@ -88,6 +88,33 @@ def test_load_or_mint_receiver_token_rotate_changes_the_value(tmp_path: Path) ->
     assert reloaded == rotated
 
 
+def test_load_or_mint_rejects_a_token_file_with_group_readable_permissions(tmp_path: Path) -> None:
+    """polylogue-n6pz: mirrors the daemon API token's ownership check -- an
+    existing receiver token file with looser-than-0600 permissions must not
+    be trusted as-is; it is treated as absent and re-minted."""
+    token_path = tmp_path / "receiver-token"
+    token_path.write_text("attacker-known-token", encoding="utf-8")
+    token_path.chmod(0o644)
+
+    resolved = load_or_mint_receiver_token(token_path)
+
+    assert resolved != "attacker-known-token"
+    assert stat.S_IMODE(token_path.stat().st_mode) == 0o600
+
+
+def test_load_or_mint_rejects_a_symlinked_token_file(tmp_path: Path) -> None:
+    real_token = tmp_path / "real-token"
+    real_token.write_text("some-real-token", encoding="utf-8")
+    real_token.chmod(0o600)
+    token_path = tmp_path / "receiver-token"
+    token_path.symlink_to(real_token)
+
+    resolved = load_or_mint_receiver_token(token_path)
+
+    assert resolved != "some-real-token"
+    assert not token_path.is_symlink()
+
+
 def test_default_token_and_spool_paths_are_scoped_to_archive_root(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/cli/test_daemon_golden_parity.py
+++ b/tests/unit/cli/test_daemon_golden_parity.py
@@ -147,6 +147,60 @@ def test_find_list_json_parity_between_direct_and_daemon(
     assert direct_payload["items"], "fixture query must actually match rows, or parity is vacuous"
 
 
+def test_find_daemon_proxied_path_authenticates_with_auto_minted_token(
+    golden_parity_workspace: dict[str, Path],
+    _uds_runtime_dir: Path,
+) -> None:
+    """polylogue-n6pz: the daemon auto-mints and requires a bearer token by
+    default (polylogue-rzve) when no ``daemon.api.auth_token`` is explicitly
+    configured. The CLI fast path must resolve that same auto-minted token
+    (``polylogue.daemon.api_auth.resolve_api_auth_token``) rather than only
+    reading the unset config value -- otherwise every unauthenticated probe
+    gets a 401, ``DaemonClient.probe`` returns ``None``, and the CLI silently
+    falls back to the direct path even though a real daemon is reachable.
+    This test starts the real UDS server with the archive's actual
+    auto-minted token (not an empty one) and asserts the daemon-proxied path
+    is still reached."""
+    from polylogue.daemon.api_auth import load_or_mint_api_auth_token
+
+    archive_root = golden_parity_workspace["archive_root"]
+    args = ["--repo", "polylogue"]
+
+    # Mint the token the same way the daemon itself would on first start,
+    # scoped to this archive root (env already set by golden_parity_workspace).
+    minted_token = load_or_mint_api_auth_token()
+    assert minted_token
+
+    from polylogue.daemon.http import DaemonAPIHandler
+    from polylogue.daemon.uds import DaemonAPIUnixHTTPServer, daemon_socket_path
+
+    socket_path = daemon_socket_path(archive_root, runtime_dir=str(_uds_runtime_dir))
+    server = DaemonAPIUnixHTTPServer(socket_path, DaemonAPIHandler)
+    server.auth_token = minted_token
+    thread = threading.Thread(target=server.serve_forever, name="golden-parity-uds-auth", daemon=True)
+    thread.start()
+    try:
+        from polylogue.cli.daemon_client import DaemonClient
+
+        client = DaemonClient(socket_path, timeout_s=1.0, auth_token=minted_token)
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            if client.request_json("GET", "/api/health") is not None:
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail("daemon UDS server did not become ready")
+
+        daemon_payload = _run_find_json(args)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    assert daemon_payload["source"] == "daemon"
+    assert daemon_payload["items"], "fixture query must actually match rows, or parity is vacuous"
+
+
 def test_facets_json_parity_between_direct_and_daemon(
     golden_parity_workspace: dict[str, Path],
     _uds_runtime_dir: Path,

--- a/tests/unit/daemon/test_api_auth.py
+++ b/tests/unit/daemon/test_api_auth.py
@@ -67,6 +67,53 @@ def test_default_token_path_is_scoped_to_archive_root(tmp_path: Path, monkeypatc
     assert root_b in path_b.parents
 
 
+def test_load_or_mint_rejects_a_token_file_with_group_readable_permissions(tmp_path: Path) -> None:
+    """polylogue-n6pz: an existing token file must be owner-only before it is
+    trusted. A file with looser bits (e.g. inherited from a permissive
+    umask, restored from a backup, or planted by another process before this
+    one ever ran) must not be silently read and handed out as the daemon's
+    bearer token -- it is treated as absent and a fresh, correctly-permissioned
+    token is minted in its place."""
+    token_path = tmp_path / "api-auth-token"
+    token_path.write_text("attacker-known-token", encoding="utf-8")
+    token_path.chmod(0o644)
+
+    resolved = load_or_mint_api_auth_token(token_path)
+
+    assert resolved != "attacker-known-token"
+    assert stat.S_IMODE(token_path.stat().st_mode) == 0o600
+    assert token_path.read_text(encoding="utf-8").strip() == resolved
+
+
+def test_load_or_mint_rejects_a_symlinked_token_file(tmp_path: Path) -> None:
+    """A symlink at the token path must never be followed for trust purposes,
+    even if it happens to point at a 0600 file owned by us -- planting a
+    symlink is itself evidence the path is not exclusively ours."""
+    real_token = tmp_path / "real-token"
+    real_token.write_text("some-real-token", encoding="utf-8")
+    real_token.chmod(0o600)
+    token_path = tmp_path / "api-auth-token"
+    token_path.symlink_to(real_token)
+
+    resolved = load_or_mint_api_auth_token(token_path)
+
+    assert resolved != "some-real-token"
+    assert not token_path.is_symlink()
+    assert stat.S_IMODE(token_path.stat().st_mode) == 0o600
+
+
+def test_load_or_mint_trusts_an_owner_only_existing_file(tmp_path: Path) -> None:
+    """The positive case: an existing 0600 file we own is trusted as-is
+    (no re-mint), matching the pre-existing persistence contract."""
+    token_path = tmp_path / "api-auth-token"
+    token_path.write_text("legit-token", encoding="utf-8")
+    token_path.chmod(0o600)
+
+    resolved = load_or_mint_api_auth_token(token_path)
+
+    assert resolved == "legit-token"
+
+
 def test_resolve_api_auth_token_prefers_explicit_token(tmp_path: Path) -> None:
     token_path = tmp_path / "api-auth-token"
 


### PR DESCRIPTION
## Summary

Follows up on PR #3488 (polylogue-rzve), which made the daemon auto-mint and enforce a bearer token by default instead of serving fully open on loopback. This PR closes the gap that PR left: no client actually read that auto-minted token, so the daemon's own default posture silently broke its own fast paths, and hardens the token file's trust boundary against the same class of mistake the underlying audit (polylogue-n6pz) flagged.

## Problem

`polylogue.config.Config.api_auth_token` only returns an explicitly configured value (`daemon.api.auth_token` / `POLYLOGUE_API_AUTH_TOKEN`). Every daemon client in this repo read that raw config value directly: the CLI's `find`/`facets` daemon fast paths, `maintenance rebuild-index`, and the MCP call-log outbox delivery path. None of them fell back to the daemon's own auto-minted, persisted token (`polylogue.daemon.api_auth.load_or_mint_api_auth_token`).

Net effect in the common unconfigured case (no explicit `daemon.api.auth_token` set, which is the whole point of auto-minting): the daemon requires a real token, every client sends none, every request gets 401. `DaemonClient.probe()` returns `None` on non-200, and the CLI's fast path treats that identically to "daemon unreachable" — it silently falls back to direct SQLite reads. So the auto-mint change from #3488, while closing the cross-uid audit finding server-side, quietly defeated the daemon fast path for every normal single-user setup.

Separately, `load_or_mint_api_auth_token` (and its documented mirror, the browser-capture receiver's `load_or_mint_receiver_token`) trusted an existing token file's bytes without checking who wrote them — no uid or permission-bit check before reading. The n6pz audit's whole point was "don't assume a filesystem boundary holds without verifying it"; the token file itself hadn't received that scrutiny.

## Solution

- **Client wiring** (`polylogue/cli/click_app.py`, `polylogue/cli/commands/facets.py`, `polylogue/cli/archive_query.py`, `polylogue/cli/commands/maintenance/_rebuild_index.py`, `polylogue/mcp/call_log.py`): every daemon-HTTP/UDS client call site now resolves its token via `resolve_api_auth_token(config.api_auth_token, allow_no_auth=config.api_allow_no_auth)` instead of reading the raw config field. This is the same resolver the daemon itself uses to decide its enforced token, so a client with no explicit config transparently picks up the identical auto-minted/persisted value — zero-friction for the common same-uid case, as required.
- **Token-file trust hardening** (`polylogue/daemon/api_auth.py`, `polylogue/browser_capture/receiver.py`): new `_is_trusted_token_file` helper refuses to trust an existing token file that is a symlink, or not owned by the current uid, or has any group/other permission bit set. An untrusted file is treated as absent (logged, then re-minted) rather than read. Applied to both the daemon API token loader and its mirrored browser-capture-receiver counterpart for consistency.
- **Threat-model doc** (`docs/daemon-threat-model.md`): the "when unset, the API is open on loopback" paragraph was stale since #3488 shipped auto-minting. Rewritten to describe the current default (token required unless explicitly opted out), the cross-uid protection it restores, and the residual same-uid risk (unchanged and out of scope, same as any other localhost dev tool).

## Callers audited

- CLI daemon fast paths (`find`, `facets`, `maintenance rebuild-index`) and the MCP call-log outbox: **fixed** in this PR.
- Browser extension: only talks to the separate browser-capture receiver on port 8765 (its own independent, already-required `auth_token`), never the daemon API on 8766 — **no change needed**.
- `archive_query._fetch_daemon_sessions_payload_with_deadline` / `_fetch_daemon_sessions_payload_once` / `_daemon_matches_archive_root`: a second fast-path cluster that already accepts an explicit `auth_token` parameter, but is currently only exercised directly by tests (`tests/unit/cli/test_query_exec_laws.py`), not reachable from any production call site today. No fix needed now; noting it explicitly so whoever wires it into a real caller inherits the same resolver pattern rather than reading raw config.

## Verification

```
devtools test tests/unit/daemon/test_api_auth.py tests/unit/browser_capture/test_receiver_token.py
# 22 passed -- includes 4 new tests for the ownership/permission/symlink token-file check

devtools test tests/unit/cli/test_daemon_golden_parity.py
# 4 passed -- new test_find_daemon_proxied_path_authenticates_with_auto_minted_token starts a
# real UDS daemon server requiring the archive's actual auto-minted token (not an empty one) and
# proves the CLI's daemon-proxied path is still reached (source == "daemon"), which fails without
# the client-side resolver fix (probe would 401 and silently fall back to direct reads)

devtools test tests/unit/cli/test_click_app.py tests/unit/mcp/test_mcp_call_log.py tests/unit/cli/test_daemon_client.py
# 107 passed

devtools test tests/unit/cli/test_archive_maintenance_cli.py
# 2 failures reproduce identically on a clean stash of this branch (git stash + rerun) -- pre-existing, unrelated

devtools verify --quick
# exit 0: ruff format/check, mypy --strict, render all --check, layering, closure-matrix, schema/doc policy checks all green
```

Ref polylogue-n6pz