### PR TITLE
fix(daemon): bound Drive catch-up writer holds by wall-clock time

### DIFF
--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -125,6 +125,26 @@ _RAW_MATERIALIZATION_DAEMON_BLOB_LIMIT_BYTES = 64 * 1024 * 1024
 # whose entire purpose is converging one oversized, resource-blocked
 # component in a single pass once the ordinary conveyor is quiescent.
 _RAW_MATERIALIZATION_MAX_PASS_SECONDS = 20.0
+# polylogue-qlae: the same bounded-hold technique applied to the daemon's
+# other unbounded writer-holding actor. Journal aggregation (2026-07-29 to
+# 2026-07-31) measured `maintenance.drive_catchup` hold_max=18,623s -- a
+# single `coordinator.run("maintenance.drive_catchup", ...)` call wraps the
+# whole Drive acquire+parse pass with no internal checkpoint, so a large
+# first-run or post-outage backlog holds the writer for its entire duration
+# regardless of `_DRIVE_SOURCE_CATCHUP_INTERVAL_SECONDS`. `ParsingService
+# .ingest_sources`'s parse stage (`parse_from_raw`) already batches raw ids
+# by `raw_batch_size`/blob-byte limit -- a genuine transaction-boundary
+# checkpoint identical in shape to raw-materialization's per-component
+# checkpoint -- so the same `max_pass_seconds` parameter, threaded through
+# `ingest_sources` -> `parse_from_raw`, bounds this actor's hold the same
+# way. Raw ids left unattempted this call remain ordinary parse backlog,
+# recomputed by `collect_parse_backlog`/`collect_validation_backlog` on the
+# next `_periodic_drive_source_catchup` tick. This does NOT bound the
+# acquire stage (network/filesystem walk across configured Drive sources,
+# which runs before the parse stage and is not chunked at a granularity this
+# checkpoint can safely cover) -- see the drive_catchup follow-up note where
+# this constant is used.
+_DRIVE_CATCHUP_MAX_PASS_SECONDS = 20.0
 # polylogue-t93b: escalation-tier envelope for the whale pass. A component
 # permanently resource-blocked at the ordinary fast-path limit above
 # converges through a dedicated, single-component pass at this wider
@@ -564,10 +584,17 @@ async def _run_drive_source_catchup_once() -> int:
             sources=sources,
             stage="all",
             parse_records=True,
+            max_pass_seconds=_DRIVE_CATCHUP_MAX_PASS_SECONDS,
         )
         session_ids = sorted(result.parse_result.processed_ids)
         if session_ids:
             await refresh_session_insights_bulk(backend, session_ids)
+        if result.parse_result.time_budget_exceeded:
+            logger.info(
+                "daemon: Drive catch-up pass yielded at time-budget checkpoint "
+                "(max_pass_seconds=%.1f); remaining backlog retried next tick",
+                _DRIVE_CATCHUP_MAX_PASS_SECONDS,
+            )
         logger.info(
             "daemon: Drive source catch-up complete — sources=%d raw=%d sessions=%d changed=%d errors=%d",
             len(sources),

--- a/polylogue/pipeline/services/parsing.py
+++ b/polylogue/pipeline/services/parsing.py
@@ -80,6 +80,7 @@ class ParsingService:
         parse_records: bool = True,
         skip_acquire: bool = False,
         force_write: bool = False,
+        max_pass_seconds: float | None = None,
     ) -> IngestResult:
         return await ingest_sources(
             self,
@@ -90,6 +91,7 @@ class ParsingService:
             parse_records=parse_records,
             skip_acquire=skip_acquire,
             force_write=force_write,
+            max_pass_seconds=max_pass_seconds,
         )
 
     @property
@@ -116,6 +118,7 @@ class ParsingService:
         progress_callback: ProgressCallback | None = None,
         force_write: bool = False,
         repair_message_fts: bool = True,
+        max_pass_seconds: float | None = None,
     ) -> ParseResult:
         return await parse_from_raw(
             self,
@@ -124,6 +127,7 @@ class ParsingService:
             progress_callback=progress_callback,
             force_write=force_write,
             repair_message_fts=repair_message_fts,
+            max_pass_seconds=max_pass_seconds,
         )
 
 

--- a/polylogue/pipeline/services/parsing_models.py
+++ b/polylogue/pipeline/services/parsing_models.py
@@ -128,6 +128,13 @@ class ParseResult:
         # otherwise. Used by `devtools bench ingest-throughput` to attribute
         # ingest time per stage.
         self.stage_timings_s: dict[str, float] = {}
+        # Set when a caller-supplied ``max_pass_seconds`` budget (polylogue-qlae,
+        # mirroring polylogue-de2a's raw-materialization bound) cut this call
+        # short between raw-id batches. Remaining raw_ids were never attempted
+        # this call and stay in the backlog for the caller's next pass --
+        # identical in shape to how ``raw_artifact_limit`` already truncates
+        # raw-materialization's selected set.
+        self.time_budget_exceeded: bool = False
 
     @property
     def changed_session_ids(self) -> tuple[str, ...]:

--- a/polylogue/pipeline/services/parsing_workflow.py
+++ b/polylogue/pipeline/services/parsing_workflow.py
@@ -170,6 +170,7 @@ async def ingest_sources(
     parse_records: bool = True,
     skip_acquire: bool = False,
     force_write: bool = False,
+    max_pass_seconds: float | None = None,
 ) -> IngestResult:
     """Canonical ingestion orchestration.
 
@@ -177,6 +178,13 @@ async def ingest_sources(
     1. Acquire: walk sources, hash files to blob store
     2. Ingest: unified decode + validate + parse + transform + write
        (validation is inline in subprocess workers, not a separate stage)
+
+    ``max_pass_seconds`` (polylogue-qlae, default ``None`` = unbounded)
+    threads through to the parse stage's ``parse_from_raw`` call -- see its
+    docstring. It does not bound the acquire stage (network/filesystem walk
+    for the configured sources), which is not chunked at a granularity this
+    orchestration can safely checkpoint between; see polylogue-qlae follow-up
+    notes for that residual scope.
     """
     from polylogue.pipeline.services.acquisition import AcquireResult, AcquisitionService
     from polylogue.pipeline.services.planning import PlanningService
@@ -263,6 +271,7 @@ async def ingest_sources(
                 raw_ids=parse_raw_ids,
                 progress_callback=progress_callback,
                 force_write=force_write,
+                max_pass_seconds=max_pass_seconds,
             )
         ingest_state.record_parse_completed()
         parse_raw_ids = ingest_state.parse_raw_ids
@@ -320,19 +329,38 @@ async def parse_from_raw(
     progress_callback: ProgressCallback | None = None,
     force_write: bool = False,
     repair_message_fts: bool = True,
+    max_pass_seconds: float | None = None,
 ) -> ParseResult:
     """Parse raw_sessions from DB into sessions.
 
     Uses the unified ingest batch processor (decode + validate + parse +
     transform + write in one pass). Derived session-insight materialization
     happens in an explicit downstream pipeline stage.
+
+    ``max_pass_seconds`` (polylogue-qlae, default ``None`` = unbounded,
+    byte-for-byte unchanged for existing callers) bounds this call's own
+    wall-clock duration -- and therefore the writer-coordinator hold a caller
+    (e.g. the daemon's Drive catch-up actor) runs it under. Mirrors
+    ``repair_raw_materialization``'s ``max_pass_seconds`` (polylogue-de2a):
+    elapsed time is checked only *between* raw-id batches, the same point
+    this loop already commits and would naturally recompute a backlog on the
+    next call -- not a mid-write yield (a mid-batch transaction cannot safely
+    release the write lock without releasing the real DB-level lock). Each
+    branch always completes at least one batch before checking the budget,
+    so a single slower-than-budget batch still makes forward progress
+    instead of stalling. Raw ids left unattempted this call remain ordinary
+    backlog candidates for the caller's next call.
     """
     from polylogue.pipeline.services.ingest_batch import process_ingest_batch
 
     result = ParseResult()
     backend = service._require_backend()
     t_start = time.perf_counter()
+    pass_started_monotonic = time.monotonic()
     batches_processed = 0
+
+    def _pass_deadline_exceeded() -> bool:
+        return max_pass_seconds is not None and (time.monotonic() - pass_started_monotonic) >= max_pass_seconds
 
     if raw_ids is not None:
         raw_headers = await service.repository.get_raw_blob_sizes(raw_ids)
@@ -346,6 +374,17 @@ async def parse_from_raw(
             max_records=service.raw_batch_size,
             max_blob_bytes=service.raw_batch_blob_limit_bytes,
         ):
+            if batches_processed > 0 and _pass_deadline_exceeded():
+                result.time_budget_exceeded = True
+                logger.info(
+                    "parse_from_raw: yielding at time-budget checkpoint "
+                    "(max_pass_seconds=%.1f) after %d batch(es), %d/%d raw processed",
+                    max_pass_seconds,
+                    batches_processed,
+                    processed_so_far,
+                    total,
+                )
+                break
             next_batch = batches_processed + 1
             batch_blob_bytes = _emit_ingest_batch_start(
                 batch=next_batch,
@@ -398,6 +437,17 @@ async def parse_from_raw(
             max_records=service.raw_batch_size,
             max_blob_bytes=service.raw_batch_blob_limit_bytes,
         ):
+            if batches_processed > 0 and _pass_deadline_exceeded():
+                result.time_budget_exceeded = True
+                logger.info(
+                    "parse_from_raw: yielding at time-budget checkpoint "
+                    "(max_pass_seconds=%.1f) after %d batch(es), %d/%d raw processed",
+                    max_pass_seconds,
+                    batches_processed,
+                    processed_so_far,
+                    total,
+                )
+                break
             next_batch = batches_processed + 1
             batch_blob_bytes = _emit_ingest_batch_start(
                 batch=next_batch,

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -1999,13 +1999,21 @@ def test_drive_source_catchup_ingests_configured_drive_source(tmp_path: Path) ->
         def __init__(self, *, repository: object, archive_root: Path, config: Config) -> None:
             events.append(("parser", repository, archive_root, config))
 
-        async def ingest_sources(self, *, sources: list[Source], stage: str, parse_records: bool) -> SimpleNamespace:
-            events.append(("ingest", sources, stage, parse_records))
+        async def ingest_sources(
+            self,
+            *,
+            sources: list[Source],
+            stage: str,
+            parse_records: bool,
+            max_pass_seconds: float | None = None,
+        ) -> SimpleNamespace:
+            events.append(("ingest", sources, stage, parse_records, max_pass_seconds))
             return SimpleNamespace(
                 acquire_result=SimpleNamespace(raw_ids=["raw-1"], errors=0),
                 parse_result=SimpleNamespace(
                     processed_ids={"session-b", "session-a"},
                     counts={"sessions": 2},
+                    time_budget_exceeded=False,
                 ),
             )
 
@@ -2022,7 +2030,7 @@ def test_drive_source_catchup_ingests_configured_drive_source(tmp_path: Path) ->
 
     assert changed == 2
     build_services.assert_called_once_with(config=config, db_path=config.db_path)
-    assert ("ingest", [drive_source], "all", True) in events
+    assert ("ingest", [drive_source], "all", True, daemon_cli._DRIVE_CATCHUP_MAX_PASS_SECONDS) in events
     assert ("refresh", ["session-a", "session-b"]) in events
     assert events[-1] == "close"
 

--- a/tests/unit/pipeline/test_parsing_service.py
+++ b/tests/unit/pipeline/test_parsing_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import time
 from collections.abc import AsyncGenerator, Awaitable, Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -171,7 +172,9 @@ class TestParsingServiceParseSources:
         # In the unified ingest flow, validation backlog is collected as part of parse candidates
         mock_collect_validate.assert_awaited_once()
         mock_collect_parse.assert_awaited_once()
-        mock_parse.assert_awaited_once_with(raw_ids=["raw-1", "raw-2"], progress_callback=None, force_write=False)
+        mock_parse.assert_awaited_once_with(
+            raw_ids=["raw-1", "raw-2"], progress_callback=None, force_write=False, max_pass_seconds=None
+        )
         assert result.counts["sessions"] == 2
         assert result.counts["messages"] == 5
         assert result.processed_ids == {"conv-1", "conv-2"}
@@ -267,6 +270,7 @@ class TestParsingServiceParseSources:
             raw_ids=["raw-1", "raw-2", "raw-3", "raw-4"],
             progress_callback=None,
             force_write=False,
+            max_pass_seconds=None,
         )
 
     async def test_ingest_skips_parse_when_nothing_acquired(self) -> None:
@@ -337,7 +341,9 @@ class TestParsingServiceParseSources:
             drive_config=mock_config.drive_config,
         )
         # In unified ingest, validation is inline — callback passed to parse_from_raw
-        mock_parse.assert_awaited_once_with(raw_ids=["raw-1"], progress_callback=callback, force_write=False)
+        mock_parse.assert_awaited_once_with(
+            raw_ids=["raw-1"], progress_callback=callback, force_write=False, max_pass_seconds=None
+        )
 
     async def test_backend_not_initialized_raises(self) -> None:
         mock_repository = MagicMock()
@@ -549,6 +555,69 @@ class TestParsingServiceStreaming:
             await service.parse_from_raw(provider="chatgpt")
 
         assert events == ["headers-open", "headers-closed", "batch-write"]
+
+    async def test_parse_from_raw_max_pass_seconds_bounds_one_call_and_preserves_progress(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """polylogue-qlae: mirrors polylogue-de2a's raw-materialization budget
+        (``test_raw_materialization_max_pass_seconds_bounds_one_pass_and_preserves_progress``)
+        applied to the daemon's other unbounded writer-holding actor
+        (``maintenance.drive_catchup``, measured hold_max=18,623s). A per-call
+        wall-clock budget must stop ``parse_from_raw`` from draining the whole
+        raw-id backlog in one call even though ``raw_batch_size`` alone would
+        admit every batch. The budget is checked only *between* batches (each
+        batch is a real write/transaction boundary), so at least one batch
+        always completes -- forward progress is guaranteed -- and raw ids left
+        unattempted stay ordinary backlog for the caller's next call, exactly
+        like ``collect_parse_backlog`` recomputing the remainder on the next
+        daemon tick.
+        """
+        backend = MagicMock()
+        repository = MagicMock()
+        repository.backend = backend
+        repository.get_raw_blob_sizes = AsyncMock(
+            side_effect=[
+                [("raw-1", 1), ("raw-2", 1), ("raw-3", 1)],
+                [("raw-2", 1), ("raw-3", 1)],
+            ]
+        )
+        config = Config(archive_root=tmp_path / "archive", render_root=tmp_path / "render", sources=[])
+        service = ParsingService(
+            repository=repository,
+            archive_root=config.archive_root,
+            config=config,
+            raw_batch_size=1,
+        )
+
+        # A monotonic clock that always advances well past any small budget
+        # after its very first read -- deterministic regardless of exactly
+        # how many ``time.monotonic()`` calls happen elsewhere in the pass,
+        # since the first call establishes the pass start and every later
+        # call already clears a 1-second budget.
+        elapsed = iter(float(step) * 100.0 for step in range(1000))
+        monkeypatch.setattr(time, "monotonic", lambda: next(elapsed))
+
+        with patch(
+            "polylogue.pipeline.services.ingest_batch.process_ingest_batch",
+            new=AsyncMock(side_effect=[None, None, None]),
+        ) as mock_process:
+            bounded = await service.parse_from_raw(
+                raw_ids=["raw-1", "raw-2", "raw-3"],
+                max_pass_seconds=1.0,
+            )
+
+        assert mock_process.await_count == 1
+        assert bounded.time_budget_exceeded is True
+
+        monkeypatch.undo()
+        with patch(
+            "polylogue.pipeline.services.ingest_batch.process_ingest_batch",
+            new=AsyncMock(side_effect=[None, None]),
+        ) as mock_process_remainder:
+            remainder = await service.parse_from_raw(raw_ids=["raw-2", "raw-3"])
+
+        assert mock_process_remainder.await_count == 2
+        assert remainder.time_budget_exceeded is False
 
 
 # =====================================================================


### PR DESCRIPTION
## Summary

Applies the same bounded-pass technique polylogue-de2a shipped for the daemon's `raw_materialization` actor (PR #3534, `max_pass_seconds`, merged same day this bead's measurement window predates) to a second, still-unbounded writer-holding actor: `maintenance.drive_catchup`.

## Problem

polylogue-qlae's journal aggregation (2026-07-29 to 2026-07-31) measured:

- `maintenance.raw_materialization` hold_max=21,433.6s -- the actor de2a's PR #3534 bounded via `max_pass_seconds=20.0`. That PR merged 2026-08-02, the same day as this measurement window's upper bound; this bead's specific number predates re-verification against the fix and should not be treated as still-live without a fresh live re-measurement (explicitly called out as AC4/follow-up in #3534's own PR body).
- `maintenance.drive_catchup` hold_max=18,623s -- a **different** actor, not touched by de2a, confirmed still unbounded by reading `_periodic_drive_source_catchup` / `_run_drive_source_catchup_once` (`polylogue/daemon/cli.py`): the entire Drive acquire+parse pass runs inside one `coordinator.run("maintenance.drive_catchup", ...)` call with no internal checkpoint.
- During these holds, every other maintenance actor starved for hours (heartbeat waited up to 17,042s, `wal_checkpoint` 17,642s, `fts_merge` 17,882s, `watcher.catch_up.prefilter` 20,298s).

`DaemonWriteCoordinator`'s priority classes (`write_coordinator.py:44-56`) bound queue *order*, not the *duration* of an already-admitted hold -- this is the same structural gap de2a's own analysis already established.

## Solution

- `parse_from_raw` and `ingest_sources` (`polylogue/pipeline/services/parsing_workflow.py`) gain an optional `max_pass_seconds: float | None = None` parameter, byte-for-byte unchanged for existing callers. `ParsingService.parse_from_raw` / `.ingest_sources` (`polylogue/pipeline/services/parsing.py`) thread it through.
- `parse_from_raw` already batches raw ids by `raw_batch_size` / blob-byte budget (`_iter_raw_id_batches`) -- a genuine write/transaction boundary, structurally identical to raw-materialization's per-component checkpoint. Elapsed time is checked only *between* batches, and each branch always completes at least one batch before the budget is enforced, so a single slower-than-budget batch still makes forward progress instead of stalling.
- `ParseResult` gains `time_budget_exceeded: bool` so callers can observe an early stop.
- `polylogue/daemon/cli.py`'s `_run_drive_source_catchup_once` passes a declared `_DRIVE_CATCHUP_MAX_PASS_SECONDS = 20.0` (matching de2a's constant) and logs when a pass yields early. Raw ids left unattempted this call stay ordinary parse backlog, recomputed by `collect_parse_backlog`/`collect_validation_backlog` on the next `_periodic_drive_source_catchup` tick -- no work is lost or corrupted.

**Deliberately not bounded here:** the acquire stage (network/filesystem walk across configured Drive sources), which runs before the parse stage and isn't chunked at a granularity this checkpoint can safely cover. Left as residual scope.

## On the general per-actor time-budget mechanism (qlae task item 3)

Not attempted in this PR. Both de2a and this PR apply the same manual, per-actor opt-in pattern at a call site the actor's own author understands (its natural transaction boundaries). A general enforcement mechanism inside `DaemonWriteCoordinator` itself would have to either preempt a hold mid-flight (unsafe -- a mid-hold SQLite transaction cannot safely release the async gate without releasing the real DB-level write lock, per de2a's own prior analysis) or externally cancel a non-cooperating actor's task (behavior-changing for any actor not written to expect cancellation mid-write). I recommend a follow-up bead scoped to *auditing every current writer actor* for whether it already has an equivalent natural checkpoint it could opt into, rather than building a generic coordinator-level mechanism speculatively ahead of a third, not-yet-identified offender.

## Verification

```
devtools test tests/unit/pipeline/test_parsing_service.py tests/unit/daemon/test_daemon_cli.py
```
-> 140 passed. Includes new regression test `test_parse_from_raw_max_pass_seconds_bounds_one_call_and_preserves_progress`, mirroring de2a's own raw-materialization regression test shape: with `max_pass_seconds=1.0` and `raw_batch_size=1` against 3 raw ids, exactly 1 batch is processed and `time_budget_exceeded` is `True`; a follow-up call without a budget processes the declared remainder (2 batches), proving no work is lost. Verified load-bearing by reverting the production changes only and confirming the new test fails on a `TypeError: unexpected keyword argument 'max_pass_seconds'`.

Also updated 3 pre-existing tests that asserted the exact kwargs of a mocked `parse_from_raw`/`ingest_sources` call (now includes `max_pass_seconds=None`/the new fake parameter) and one daemon test's fake `ingest_sources` signature.

```
devtools test tests/unit/pipeline/test_hermes_raw_identity.py tests/unit/pipeline/test_stage_independence.py tests/unit/storage/test_repair.py
```
-> 67 passed, 11 pre-existing failures unchanged (same "no messages, no positive conversational evidence" parser-refusal drift already documented as out of scope in de2a's PR #3534; `repair.py` is untouched by this PR).

```
devtools verify --quick
```
-> passes (ruff format/check, mypy --strict, render all --check, layering, schema-versioning, all other quick gates). Ran again as part of the pre-push hook after the branch rename, also green.

`devtools verify` (testmon) was not run -- this worktree's testmon cache is unseeded; the `devtools test` invocations above cover every file this PR touches plus their existing test suites.

## Follow-ups

- AC2 (archive-wide worst-case wait bound) and a live re-measurement under a comparable backlog remain open, same as de2a's own follow-up notes -- both require a deployed daemon under live-scale load.
- Recommend a new bead: audit every remaining `DaemonWriteCoordinator` actor for an unbounded hold, rather than a generic coordinator-level time-budget mechanism (see reasoning above).

Ref polylogue-qlae

Co-Authored-By: Claude <noreply@anthropic.com>