### PR TITLE
fix(daemon): stop coverage metrics from fabricating 100% at zero rows

### DIFF
--- a/polylogue/daemon/fts_status.py
+++ b/polylogue/daemon/fts_status.py
@@ -349,11 +349,15 @@ def _archive_readiness_payload(conn: sqlite3.Connection, *, exact: bool) -> dict
         "invariant_ready": invariant_ready,
         "message_indexed_count": block_indexed_rows,
         "message_indexable_count": block_source_rows,
-        "coverage_pct": (
-            round((block_indexed_rows / block_source_rows) * 100, 1)
-            if block_source_rows > 0
-            else (100.0 if invariant_ready else 0.0)
-        ),
+        # source_rows == 0 means there is nothing to index -- a genuine,
+        # vacuously-true "fully covered" state. invariant_ready alone is
+        # NOT evidence of coverage: it only proves triggers/tables exist,
+        # so reporting 100.0 whenever it happens to be true (regardless of
+        # source_rows) fabricates a measured percentage for an unmeasured
+        # branch (polylogue-oitx). Report None ("not applicable / unknown")
+        # instead; consumers already render that explicitly (polylogue-roax,
+        # cli/commands/status.py's null-coverage handling).
+        "coverage_pct": (round((block_indexed_rows / block_source_rows) * 100, 1) if block_source_rows > 0 else None),
         "coverage_exact": effective_exact,
         "surfaces": {"messages_fts": blocks},
     }
@@ -384,7 +388,9 @@ def _archive_readiness_info(index_db: Path, *, exact: bool) -> dict[str, object]
 def _exact_readiness_payload(snapshot: FtsInvariantSnapshot) -> dict[str, object]:
     surfaces = {surface.name: _surface_payload(surface) for surface in snapshot.surfaces}
     messages = snapshot.messages
-    coverage_pct = round((messages.indexed_rows / messages.source_rows) * 100, 1) if messages.source_rows > 0 else 100.0
+    # source_rows == 0 is a zero-denominator case -- report unmeasured
+    # (None) rather than a fabricated 100.0 (polylogue-oitx).
+    coverage_pct = round((messages.indexed_rows / messages.source_rows) * 100, 1) if messages.source_rows > 0 else None
     return {
         "messages_ready": messages.ready,
         "session_work_events_ready": snapshot.session_work_events.ready,
@@ -514,10 +520,12 @@ def fts_readiness_info(dbf: Path, *, exact: bool = False) -> dict[str, object]:
         "invariant_ready": invariant_ready,
         "message_indexed_count": message_indexed_rows,
         "message_indexable_count": message_source_rows,
+        # message_source_rows == 0 is a zero-denominator case -- report
+        # unmeasured (None) rather than deriving a fabricated 100.0/0.0 from
+        # invariant_ready, which only proves tables/triggers exist and is
+        # not evidence of coverage (polylogue-oitx).
         "coverage_pct": (
-            round((message_indexed_rows / message_source_rows) * 100, 1)
-            if message_source_rows > 0
-            else (100.0 if invariant_ready else 0.0)
+            round((message_indexed_rows / message_source_rows) * 100, 1) if message_source_rows > 0 else None
         ),
         "coverage_exact": False,
         "surfaces": surfaces,

--- a/polylogue/daemon/metrics.py
+++ b/polylogue/daemon/metrics.py
@@ -136,7 +136,9 @@ class EmbeddingMetricState(TypedDict):
     pending_sessions: int
     failed_sessions: int
     embedded_messages: int
-    coverage_percent: float
+    # None when no sessions are eligible for embedding -- a genuine
+    # measurement gap, not a measured percentage (polylogue-oitx).
+    coverage_percent: float | None
     status: str
     retrieval_ready: int
     latest_status: str | None
@@ -808,9 +810,21 @@ def _archive_embedding_state(conn: sqlite3.Connection, *, ops_db: Path | None = 
 
     embedded_messages = _embedding_message_count(conn, status_table=status_table, meta_table=meta_table)
     eligible_sessions = embedded_sessions + pending_sessions
-    coverage_percent = (
-        embedded_sessions / eligible_sessions * 100 if eligible_sessions > 0 else (100.0 if total_sessions > 0 else 0.0)
-    )
+    coverage_percent: float | None
+    if eligible_sessions > 0:
+        coverage_percent = embedded_sessions / eligible_sessions * 100
+    elif total_sessions > 0:
+        # Sessions exist, but none are eligible for embedding (e.g. the
+        # embedding schema branch was never queried) -- this is a genuine
+        # measurement gap, not "fully embedded". Report unmeasured (None,
+        # emitted as NaN on the Prometheus gauge) rather than a fabricated
+        # 100.0 that an alerting pipeline would read as healthy
+        # (polylogue-oitx).
+        coverage_percent = None
+    else:
+        # No sessions at all: there is nothing to embed, and ``status``
+        # below reports "empty" for this case.
+        coverage_percent = 0.0
     if total_sessions <= 0 and pending_sessions <= 0 and embedded_messages <= 0:
         status = "empty"
     elif pending_sessions <= 0:
@@ -897,12 +911,16 @@ def _emit_embedding_metrics(lines: list[str], state: EmbeddingMetricState) -> No
         metric_type="gauge",
         samples=[({"state": "embedded"}, int(state["embedded_messages"]))],
     )
+    coverage_percent = state["coverage_percent"]
     _emit_metric(
         lines,
         name="polylogue_embedding_coverage_percent",
-        help_text="Percent of sessions with current embeddings.",
+        help_text=(
+            "Percent of sessions with current embeddings. NaN when no sessions "
+            "are eligible for embedding (a measurement gap, not 0% or 100%)."
+        ),
         metric_type="gauge",
-        samples=[(None, float(state["coverage_percent"]))],
+        samples=[(None, float("nan") if coverage_percent is None else float(coverage_percent))],
     )
     current_status = str(state["status"])
     _emit_metric(

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -2104,7 +2104,12 @@ def test_fts_readiness_rejects_zero_count_ready_freshness_when_source_has_rows(t
 
     assert readiness["messages_ready"] is False
     assert readiness["invariant_ready"] is False
-    assert readiness["coverage_pct"] == 0.0
+    # source_rows==0 here is a zero-denominator (unmeasured) reading, not a
+    # genuine "0% indexed" measurement -- the freshness record's counts are
+    # untrusted precisely because the source actually has rows (see
+    # freshness_state below), so coverage_pct must report unmeasured (None)
+    # rather than fabricate 0.0 or 100.0 (polylogue-oitx).
+    assert readiness["coverage_pct"] is None
     surfaces = readiness["surfaces"]
     assert isinstance(surfaces, dict)
     messages = surfaces["messages_fts"]

--- a/tests/unit/daemon/test_fts_readiness_fallback.py
+++ b/tests/unit/daemon/test_fts_readiness_fallback.py
@@ -214,3 +214,32 @@ def test_single_session_defer_does_not_falsely_zero_archive_wide_coverage(tmp_pa
     assert fts["message_indexed_count"] == indexed
     assert fts["message_indexable_count"] == indexed
     assert fts["coverage_pct"] == 100.0
+
+
+def test_genuinely_empty_archive_reports_coverage_as_unmeasured_not_exact(tmp_path: Path) -> None:
+    """polylogue-oitx: a freshly initialized, genuinely empty archive has a
+    zero-denominator coverage_pct (0 indexable rows). ``invariant_ready``
+    only proves triggers/tables exist -- it is not evidence of measured
+    coverage, so this must report ``None`` (unmeasured), never a fabricated
+    ``100.0``/``0.0`` derived from ``invariant_ready`` alone.
+    """
+    db = tmp_path / "index.db"
+    initialize_archive_database(db, ArchiveTier.INDEX)
+
+    fts = fts_readiness_info(db, exact=False)
+
+    assert fts["message_indexable_count"] == 0
+    assert fts["message_indexed_count"] == 0
+    assert fts["coverage_pct"] is None
+
+
+def test_genuinely_empty_archive_reports_coverage_as_unmeasured_exact(tmp_path: Path) -> None:
+    """Same as above, through the exact (invariant-snapshot) path."""
+    db = tmp_path / "index.db"
+    initialize_archive_database(db, ArchiveTier.INDEX)
+
+    fts = fts_readiness_info(db, exact=True)
+
+    assert fts["message_indexable_count"] == 0
+    assert fts["message_indexed_count"] == 0
+    assert fts["coverage_pct"] is None

--- a/tests/unit/daemon/test_metrics_endpoint.py
+++ b/tests/unit/daemon/test_metrics_endpoint.py
@@ -960,6 +960,58 @@ class TestFormatMetricsReadsArchiveState:
         assert 'polylogue_embedding_status_state{status="none"} 1' in body
         assert "polylogue_embedding_retrieval_ready 0" in body
 
+    def test_embedding_coverage_percent_is_nan_when_no_sessions_are_eligible(self, tmp_path: Path) -> None:
+        """polylogue-oitx: sessions exist but none are eligible for embedding
+        (no ``embedding_status``/``message_embeddings_meta`` table and no
+        ``messages`` table to derive pending state from) -- a genuine
+        measurement gap, e.g. the embedding schema branch was never queried.
+        Before the fix this fabricated ``100.0`` (read as "fully embedded"
+        by a dashboard/alert) instead of the real "not yet measurable" state.
+        """
+        db = tmp_path / "archive.db"
+        with sqlite3.connect(db) as conn:
+            conn.executescript("""
+                CREATE TABLE sessions (
+                    session_id TEXT PRIMARY KEY,
+                    origin TEXT NOT NULL DEFAULT 'codex-session',
+                    message_count INTEGER NOT NULL DEFAULT 0
+                );
+                INSERT INTO sessions VALUES ('s1', 'codex-session', 1);
+            """)
+
+        body = format_metrics(db)
+
+        assert 'polylogue_embedding_sessions{state="total"} 1' in body
+        assert 'polylogue_embedding_sessions{state="pending"} 0' in body
+        assert "polylogue_embedding_coverage_percent NaN" in body
+
+    def test_embedding_coverage_percent_reports_real_full_coverage(self, tmp_path: Path) -> None:
+        """A genuinely fully-embedded archive must still report a real 100.0,
+        not be swept into the unmeasured/NaN case by the zero-denominator fix.
+        """
+        db = tmp_path / "archive.db"
+        with sqlite3.connect(db) as conn:
+            conn.executescript("""
+                CREATE TABLE sessions (
+                    session_id TEXT PRIMARY KEY,
+                    origin TEXT NOT NULL DEFAULT 'codex-session',
+                    message_count INTEGER NOT NULL DEFAULT 0
+                );
+                CREATE TABLE embedding_status (
+                    session_id TEXT PRIMARY KEY,
+                    needs_reindex INTEGER NOT NULL,
+                    error_message TEXT
+                );
+                INSERT INTO sessions VALUES ('s1', 'codex-session', 1);
+                INSERT INTO embedding_status VALUES ('s1', 0, NULL);
+            """)
+
+        body = format_metrics(db)
+
+        assert 'polylogue_embedding_sessions{state="total"} 1' in body
+        assert 'polylogue_embedding_sessions{state="embedded"} 1' in body
+        assert "polylogue_embedding_coverage_percent 100.0" in body
+
 
 # ---------------------------------------------------------------------------
 # HTTP handler integration — mirrors test_health_contract.py harness


### PR DESCRIPTION
## Summary

`daemon/fts_status.py` and `daemon/metrics.py` derived coverage percentages as `100.0` whenever the measured denominator (`source_rows` / `eligible_sessions`) was zero, gated only by `invariant_ready` (structural readiness, not coverage evidence) or `total_sessions > 0`. A dashboard or alert consumer reading `100%` cannot distinguish "fully covered, verified" from "nothing was ever measured".

## Problem

Re-audit at HEAD after #3429 (eb5796f49) found these sibling instances of the same "vacuous-true reported as a measured 100%" pattern surviving:

1. `daemon/fts_status.py`, `_archive_readiness_payload`: `coverage_pct` was `100.0 if invariant_ready else 0.0` when `source_rows == 0`. `invariant_ready` only proves triggers/tables exist; it is not coverage evidence.
2. `daemon/fts_status.py`, `_exact_readiness_payload`: unconditionally `100.0` whenever `messages.source_rows == 0`, without even the `invariant_ready` gate.
3. `daemon/fts_status.py`, `fts_readiness_info`'s cheap-path return: same `invariant_ready`-gated `100.0/0.0` fallback as (1).
4. `daemon/metrics.py`, `_archive_embedding_state`: the `polylogue_embedding_coverage_percent` Prometheus gauge reported `100.0` when `eligible_sessions == 0` but `total_sessions > 0` (e.g. the embedding schema branch was never queried) -- an alerting pipeline would read this as "fully embedded" during a genuine measurement gap.

## Solution

- All four sites now report the coverage value as unmeasured (`None`) on a zero-denominator, instead of deriving a fabricated `100.0`/`0.0` from readiness/session-existence flags that aren't coverage evidence.
- `cli/commands/status.py` already renders `fts_readiness.coverage_pct is None` as "coverage unknown" (polylogue-roax's fix); this PR is the missing producer-side half -- the CLI's null-handling was already in place but nothing upstream ever emitted `None`.
- `daemon/status.py`'s `FTSReadiness` model already typed `coverage_pct: float | None`, so the None now flows straight through with no further plumbing changes.
- `daemon/metrics.py`: `EmbeddingMetricState.coverage_percent` is now `float | None`. `_emit_embedding_metrics` emits the Prometheus gauge as `NaN` for `None`, using `_format_value`'s existing (previously unused) NaN-formatting support -- the standard Prometheus convention for "not yet measurable", which comparison-based alert rules treat as non-matching rather than a false "healthy" reading.
- Genuine full-coverage cases (non-zero denominator, 100% measured) are untouched and still report a real `100.0` -- covered by new tests alongside the zero-denominator cases.

### Already fixed / no action needed

- `storage/fts/fts_lifecycle.py`'s `message_fts_readiness_sync(verify_total_rows=False)` still returns literal `indexed_rows=0, total_rows=0` placeholders, but PR #3461 (7d30cc497, merged 2026-07-31 after the audit that filed this issue) already changed `convergence_stages.py`'s `_mark_message_fts_ready_after_targeted_repair` to use the exact `fts_invariant_snapshot_sync` instead of this cheap boolean. The only remaining call site (`daemon/cli.py:1556`, `_raw_materialization_fts_needs_repair`) only reads `exists`/`ready` from the result, never the placeholder counts, so nothing durable persists the fabricated zeros anymore.

### Deferred (follow-up recommended)

- `daemon/status_snapshot.py`'s `_minimal_status_payload` hardcodes `raw_parse_failures`/`raw_validation_failures`/`raw_quarantined`/`raw_maintenance_failures`/`raw_detection_warnings` to `0` during the minimal/refreshing snapshot window, without the `require_fresh_snapshot` gate that `raw_frontier_integrity` gets via `normalize_raw_frontier_status_payload`/`status_snapshot_has_fresh_provenance`. Fixing this properly means widening these fields to `int | None` across `DaemonStatus` (`daemon/status.py`), the CLI renderer, and JSON schema render targets (`render openapi`/`cli-output-schemas`) -- `status_snapshot.py` is explicitly documented as a testmon fan-out "hub" whose changes get full-suite-equivalent test selection regardless of edit size (see its module docstring), so this is a larger, separately-scoped change. The bead marks this `SHOULD-RECORD` rather than `MUST-FAIL-LOUD`; recommend a follow-up bead extending the existing `raw_frontier_integrity` freshness-gate pattern to these five counters.

## Verification

```
devtools test tests/unit/daemon/test_fts_readiness_fallback.py tests/unit/daemon/test_metrics_endpoint.py tests/unit/daemon/test_daemon_status.py
# 100 passed
devtools verify --quick
# exit_code: 0 (ruff format, ruff check, mypy, render all --check, layering, closure-matrix, schema/lab policy checks)
```

Ref polylogue-oitx
