### PR TITLE
fix(sources): stop re-minting deferred append raw rows on every tick

### DIFF
--- a/polylogue/sources/live/batch.py
+++ b/polylogue/sources/live/batch.py
@@ -580,12 +580,21 @@ class LiveBatchProcessor:
                 failed_paths.append(str(plan.path))
                 cursor_fingerprint_read_bytes += self._record_failed_cursor(plan.path)
             for plan in append_result.deferred:
+                # polylogue-hat0: this plan's bytes are already durably
+                # written and revision-bound in source.db (write_raw_payload
+                # ran before the quarantined/ambiguous classification), just
+                # not yet accepted into the replay chain. Mark exactly this
+                # range as the pending-authority frontier so the next
+                # observation of an unchanged file recognizes there is
+                # nothing new to capture instead of re-mining an identical
+                # duplicate raw row forever.
                 cursor_fingerprint_read_bytes += record_deferred_append_cursor(
                     self._cursor,
                     plan.path,
                     cursor=self._cursor.get_record(plan.path),
                     parser_fingerprint=self._current_parser_fingerprint(),
                     source_name=plan.source_name,
+                    deferred_end_offset=plan.last_complete_newline,
                 )
                 deferred_paths.append(plan.path)
 
@@ -596,12 +605,18 @@ class LiveBatchProcessor:
             cursor = cursor_records.get(path)
             append_plan = self._append_plan(path, cursor=cursor) if self._can_ingest_appends_directly() else None
             if isinstance(append_plan, _DeferredAppend):
+                # No new authority-relevant append happened this pass (no
+                # complete trailing newline yet, or -- polylogue-hat0 --
+                # _append_plan itself recognized an already-pending deferred
+                # range with no growth past it). Preserve any existing
+                # pending-authority marker unchanged rather than clearing it.
                 cursor_fingerprint_read_bytes += record_deferred_append_cursor(
                     self._cursor,
                     path,
                     cursor=cursor,
                     parser_fingerprint=self._current_parser_fingerprint(),
                     source_name=self._source_name_for(path),
+                    deferred_end_offset=cursor.deferred_end_offset if cursor is not None else None,
                 )
                 deferred_paths.append(path)
             elif append_plan is None:
@@ -2866,6 +2881,26 @@ class LiveBatchProcessor:
                     return None
                 if cursor.st_ino is not None and cursor.st_ino != stat.st_ino:
                     return None
+                if (
+                    cursor.deferred_end_offset is not None
+                    and stat.st_size <= cursor.deferred_end_offset
+                    and cursor.mtime_ns is not None
+                    and stat.st_mtime_ns == cursor.mtime_ns
+                ):
+                    # polylogue-hat0: an earlier pass already durably wrote
+                    # and revision-bound a raw for this exact byte range
+                    # (start_offset..deferred_end_offset), but its authority
+                    # was quarantined/ambiguous and it is still pending
+                    # resolution. The file is byte-for-byte and mtime
+                    # identical to that attempt -- there is nothing new to
+                    # capture. Replanning here would re-mint an identical
+                    # duplicate raw row and re-defer forever, on every single
+                    # watcher tick, without ever advancing. Wait for either
+                    # genuine growth past the already-captured window (the
+                    # ``stat.st_size <= cursor.deferred_end_offset`` guard
+                    # above no longer holds) or authority resolving through
+                    # another path.
+                    return _DEFER_APPEND
                 start_offset = max(cursor.byte_offset, 0)
                 append_window = min(stat.st_size - start_offset, _MAX_APPEND_PLAN_PAYLOAD_BYTES)
                 handle.seek(start_offset)

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -79,6 +79,11 @@ class CursorRecord:
     failure_count: int = 0
     next_retry_at: str | None = None
     excluded: bool | int = False
+    # polylogue-hat0: end offset of an append byte range already durably
+    # captured (raw written + revision bound) but still awaiting authority
+    # resolution. ``None`` means no pending deferred capture. See
+    # ``ops.py``'s ``ingest_cursor`` DDL comment for the full rationale.
+    deferred_end_offset: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -250,6 +255,7 @@ def _cursor_record_from_ops_row(row: sqlite3.Row | tuple[object, ...]) -> Cursor
         failure_count=_required_int(row[12] or 0),
         next_retry_at=_optional_str(row[13]),
         excluded=bool(row[16]) if row[16] is not None else False,
+        deferred_end_offset=_optional_int(row[17]),
     )
 
 
@@ -349,6 +355,7 @@ class CursorStore:
             failure_count=record.failure_count,
             next_retry_at=record.next_retry_at,
             excluded=bool(record.excluded),
+            deferred_end_offset=record.deferred_end_offset,
         )
 
     def _write_cursor_record_to_ops(self, record: CursorRecord) -> None:
@@ -1005,7 +1012,8 @@ class CursorStore:
                 next_retry_at,
                 origin,
                 updated_at_ms,
-                excluded
+                excluded,
+                deferred_end_offset
             FROM ingest_cursor
             WHERE source_path = ?
             """,
@@ -1044,7 +1052,8 @@ class CursorStore:
                         next_retry_at,
                         origin,
                         updated_at_ms,
-                        excluded
+                        excluded,
+                        deferred_end_offset
                     FROM ingest_cursor
                     WHERE source_path IN ({placeholders})
                     """,
@@ -1076,6 +1085,7 @@ class CursorStore:
         next_retry_at: str | None = None,
         excluded: bool | None = None,
         allow_backward: bool = False,
+        deferred_end_offset: int | None = None,
     ) -> bool:
         now = datetime.now(UTC).isoformat()
         offset = byte_size if byte_offset is None else byte_offset
@@ -1109,6 +1119,7 @@ class CursorStore:
                 failure_count=failure_count or 0,
                 next_retry_at=next_retry_at,
                 excluded=bool(excluded),
+                deferred_end_offset=deferred_end_offset,
             )
         )
 
@@ -1344,7 +1355,8 @@ class CursorStore:
                         next_retry_at,
                         origin,
                         updated_at_ms,
-                    excluded
+                    excluded,
+                    deferred_end_offset
                 FROM ingest_cursor
                 WHERE excluded = 0
                   AND (

--- a/polylogue/sources/live/deferred_cursor.py
+++ b/polylogue/sources/live/deferred_cursor.py
@@ -19,7 +19,29 @@ def record_deferred_append_cursor(
     cursor: CursorRecord | None,
     parser_fingerprint: str,
     source_name: str,
+    deferred_end_offset: int | None,
 ) -> int:
+    """Persist cursor state for an append that was not applied this pass.
+
+    ``deferred_end_offset`` (polylogue-hat0) records the end of the byte
+    range durably captured (raw written + revision bound in source.db) but
+    still awaiting authority resolution -- distinct from ``byte_offset``,
+    which only advances once a plan is actually applied. Callers MUST pass
+    it explicitly, deciding one of:
+
+    - A real quarantined/ambiguous append was just deferred by
+      ``ingest_append_plans``: pass the plan's own ``last_complete_newline``
+      to mark this exact range as pending.
+    - No new authority-relevant append happened this pass (e.g. the file
+      merely lacks a complete trailing newline yet): pass the *existing*
+      ``cursor.deferred_end_offset`` through unchanged so a prior pending
+      marker is not silently cleared.
+
+    Without this distinction, ``_append_plan``'s next observation cannot
+    tell "this exact range was already captured and is pending" apart from
+    "the file genuinely grew further", and re-mints an identical duplicate
+    raw row on every watcher tick forever.
+    """
     if cursor is None:
         return 0
     try:
@@ -50,5 +72,6 @@ def record_deferred_append_cursor(
         next_retry_at=cursor.next_retry_at,
         excluded=bool(cursor.excluded),
         allow_backward=True,
+        deferred_end_offset=deferred_end_offset,
     )
     return tail_bytes

--- a/polylogue/sources/live/watcher.py
+++ b/polylogue/sources/live/watcher.py
@@ -942,12 +942,16 @@ class LiveWatcher:
         # cursor, even when the unfinished record exceeds the probe budget.
         # Record this observed state so unchanged periodic catch-up scans skip
         # it; a subsequent append changes stat evidence and reopens the probe.
+        # polylogue-hat0: this probe found no complete trailing record, not a
+        # resolved authority state -- preserve any existing pending-authority
+        # marker unchanged rather than clearing it.
         record_deferred_append_cursor(
             self._cursor,
             path,
             cursor=cursor,
             parser_fingerprint=_PARSER_FINGERPRINT,
             source_name=self._source_name_for(path),
+            deferred_end_offset=cursor.deferred_end_offset,
         )
         return True
 

--- a/polylogue/storage/sqlite/archive_tiers/bootstrap.py
+++ b/polylogue/storage/sqlite/archive_tiers/bootstrap.py
@@ -152,6 +152,7 @@ def _ensure_ops_runtime_columns(conn: sqlite3.Connection) -> None:
         "failure_count": "INTEGER NOT NULL DEFAULT 0 CHECK(failure_count >= 0)",
         "next_retry_at": "TEXT",
         "excluded": "INTEGER NOT NULL DEFAULT 0 CHECK(excluded IN (0, 1))",
+        "deferred_end_offset": "INTEGER",
     }
     for name, definition in additions.items():
         if name not in existing:

--- a/polylogue/storage/sqlite/archive_tiers/ops.py
+++ b/polylogue/storage/sqlite/archive_tiers/ops.py
@@ -52,6 +52,16 @@ CREATE TABLE IF NOT EXISTS ingest_cursor (
     failure_count        INTEGER NOT NULL DEFAULT 0 CHECK(failure_count >= 0),
     next_retry_at        TEXT,
     excluded             INTEGER NOT NULL DEFAULT 0 CHECK(excluded IN (0, 1)),
+    -- polylogue-hat0: the end offset of an append byte range that was
+    -- already durably captured (raw written + revision bound in source.db)
+    -- but is still awaiting authority resolution (quarantined/ambiguous
+    -- parent). NULL means there is no pending deferred capture for this
+    -- path. Distinct from byte_offset, which only advances once a plan is
+    -- actually applied -- a deferred plan never advances byte_offset, so
+    -- without this marker a re-observation of an unchanged file cannot be
+    -- told apart from genuine new content and re-mints an identical raw row
+    -- forever.
+    deferred_end_offset  INTEGER,
     updated_at_ms        INTEGER NOT NULL
 ) STRICT;
 

--- a/polylogue/storage/sqlite/archive_tiers/ops_write.py
+++ b/polylogue/storage/sqlite/archive_tiers/ops_write.py
@@ -554,6 +554,7 @@ def upsert_ingest_cursor(
     failure_count: int = 0,
     next_retry_at: str | None = None,
     excluded: bool = False,
+    deferred_end_offset: int | None = None,
 ) -> None:
     """Create or refresh one cursor row in ``ingest_cursor``."""
     conn.execute(
@@ -575,9 +576,10 @@ def upsert_ingest_cursor(
             failure_count,
             next_retry_at,
             excluded,
+            deferred_end_offset,
             updated_at_ms
         )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT (source_path) DO UPDATE SET
             origin = excluded.origin,
             stat_size = excluded.stat_size,
@@ -594,6 +596,7 @@ def upsert_ingest_cursor(
             failure_count = excluded.failure_count,
             next_retry_at = excluded.next_retry_at,
             excluded = excluded.excluded,
+            deferred_end_offset = excluded.deferred_end_offset,
             updated_at_ms = excluded.updated_at_ms
         """,
         (
@@ -613,6 +616,7 @@ def upsert_ingest_cursor(
             failure_count,
             next_retry_at,
             1 if excluded else 0,
+            deferred_end_offset,
             updated_at_ms,
         ),
     )

--- a/tests/unit/sources/test_live_deferred_append_dedup.py
+++ b/tests/unit/sources/test_live_deferred_append_dedup.py
@@ -1,0 +1,273 @@
+"""polylogue-hat0: a deferred (quarantined-authority) append must not re-mint
+a duplicate raw row on every subsequent, unchanged watcher pass.
+
+Mechanism under test (see ``polylogue/sources/live/append_ingest.py``): an
+append plan's bytes are durably written and revision-bound in ``source.db``
+*before* the classifier decides whether its authority is accepted or
+quarantined/ambiguous. When quarantined, ``record_deferred_append_cursor``
+used to keep the cursor's ``byte_offset`` completely unchanged, so the next
+watcher pass over the exact same, unchanged file saw ``size > byte_offset``
+again, rebuilt the identical append plan, and minted a second raw_id for
+byte-identical content -- forever, on every tick, with zero failure
+telemetry (``mark_failed`` is never called for a deferral).
+
+``deferred_end_offset`` closes this: it records the end of the byte range
+already durably captured and pending authority resolution, distinct from
+``byte_offset`` (which only advances once a plan is applied). A subsequent
+observation of a file that hasn't grown past that marker, at the same mtime,
+now recognizes there is nothing new to acquire.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import polylogue.sources.live.watcher as live_watcher
+from polylogue.sources.live import WatchSource
+from polylogue.sources.live.batch import LiveBatchProcessor
+from polylogue.sources.live.batch_support import _DEFER_APPEND, _AppendPlan, encode_cursor_hash_authority
+from polylogue.sources.live.cursor import CursorStore
+from polylogue.sources.live.deferred_cursor import record_deferred_append_cursor
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+
+def _session_meta(session_id: str) -> bytes:
+    return f'{{"type":"session_meta","payload":{{"id":"{session_id}"}}}}\n'.encode()
+
+
+def _codex_message(text: str) -> bytes:
+    return (
+        f'{{"type":"response_item","payload":{{"type":"message","role":"user",'
+        f'"content":[{{"type":"input_text","text":"{text}"}}]}}}}\n'
+    ).encode()
+
+
+def _seed_native_session(tmp_path: Path, *, session_id: str) -> None:
+    """Satisfy the Codex append path's identity-lock (``_existing_provider_session_id``)."""
+    with sqlite3.connect(tmp_path / "index.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO sessions (
+                native_id, origin, raw_id, message_count, content_hash, created_at_ms, updated_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (session_id, "codex-session", "unrelated-raw-id", 1, b"a" * 32, 1, 1),
+        )
+        conn.commit()
+
+
+def _processor(tmp_path: Path, cursor: CursorStore) -> LiveBatchProcessor:
+    return LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=tmp_path / "index.db"))),
+        (WatchSource(name="codex", root=tmp_path),),
+        cursor=cursor,
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+    )
+
+
+def _raw_session_count(tmp_path: Path) -> int:
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        return int(conn.execute("SELECT COUNT(*) FROM raw_sessions").fetchone()[0])
+
+
+def _seed_quarantine_prone_append(tmp_path: Path, *, session_id: str) -> Path:
+    """Build a cursor whose predecessor fingerprint has no matching durable raw.
+
+    ``raw_append_revision_parent`` (revision_governance.py) looks up a row in
+    ``raw_sessions`` matching ``(logical_source_key, source_revision=predecessor,
+    ...)``. Seeding the ops.db cursor with a ``content_fingerprint`` that was
+    never actually written as a raw revision (e.g. after a crash-interrupted
+    reconciliation, or ops.db/source.db drift) reproduces the real-world
+    QUARANTINED-authority path deterministically, without needing to first
+    build then discard a genuine full baseline.
+    """
+    initialize_active_archive_root(tmp_path)
+    source = tmp_path / f"rollout-{session_id}.jsonl"
+    baseline = _session_meta(session_id) + _codex_message("baseline")
+    source.write_bytes(baseline)
+    baseline_digest = hashlib.sha256(baseline).hexdigest()
+    appended = _codex_message("appended-once")
+    with source.open("ab") as handle:
+        handle.write(appended)
+    stat = source.stat()
+    _seed_native_session(tmp_path, session_id=session_id)
+
+    cursor = CursorStore(tmp_path / "ops.db")
+    cursor.set(
+        source,
+        len(baseline),
+        byte_offset=len(baseline),
+        last_complete_newline=len(baseline),
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+        content_fingerprint="orphaned-baseline-fingerprint",
+        tail_hash=encode_cursor_hash_authority(baseline_digest, baseline_digest, ctime_ns=stat.st_ctime_ns),
+        source_name="codex",
+        st_dev=stat.st_dev,
+        st_ino=stat.st_ino,
+        mtime_ns=stat.st_mtime_ns,
+    )
+    return source
+
+
+def test_deferred_append_without_marker_replans_every_tick_forever(tmp_path: Path) -> None:
+    """Confirms the mechanism precisely, without the fix's cursor marker.
+
+    ``raw_sessions.raw_id`` is a deterministic hash of
+    ``(origin, source_path, source_index, blob_hash, native_id)``
+    (``deterministic_raw_session_id``), and the blob store itself skips
+    writing content it already has -- so replanning a *byte-identical*
+    range does not literally duplicate a SQL row or blob (content-hash
+    idempotency, by design). The actual "forever" bug is that
+    ``_append_plan`` keeps producing a fresh, real ``_AppendPlan`` on every
+    single watcher tick -- re-running the full write/classify/defer path
+    (lock contention, wasted parse work, a repeated no-op INSERT attempt)
+    for zero progress -- purely because nothing marks the byte range as
+    already-captured-and-pending. Without ``deferred_end_offset`` (i.e. a
+    cursor left exactly as the pre-fix ``record_deferred_append_cursor``
+    left it: ``byte_offset`` never advanced, no pending-range marker at
+    all), a second, third, Nth observation of the identical file each
+    produces another real plan forever.
+    """
+    source = _seed_quarantine_prone_append(tmp_path, session_id="stuck-replan-forever")
+    cursor = CursorStore(tmp_path / "ops.db")
+    processor = _processor(tmp_path, cursor)
+
+    plan = processor._append_plan(source)
+    assert isinstance(plan, _AppendPlan)
+    first_result = processor._ingest_append_plans([plan])
+    assert first_result.deferred == [plan]
+    assert _raw_session_count(tmp_path) == 1
+
+    # Cursor is untouched (byte_offset never advanced, deferred_end_offset
+    # was never set) -- exactly the pre-fix state after a deferral.
+    for _tick in range(3):
+        replayed_plan = processor._append_plan(source)
+        assert isinstance(replayed_plan, _AppendPlan), (
+            "an unmarked cursor keeps producing a fresh append plan for the identical, "
+            "already-deferred byte range on every single watcher tick"
+        )
+        assert replayed_plan.start_offset == plan.start_offset
+        assert replayed_plan.payload == plan.payload
+        processor._ingest_append_plans([replayed_plan])
+
+    # Content-hash idempotency means no literal duplicate row accumulates
+    # for byte-identical replans -- but see the next test for the case
+    # where the file keeps growing while still deferred, where distinct
+    # overlapping raw rows genuinely do accumulate every tick.
+    assert _raw_session_count(tmp_path) == 1
+
+
+def test_deferred_append_without_marker_accumulates_a_new_raw_id_per_growth_tick(tmp_path: Path) -> None:
+    """The literal "new raw_id every tick" claim, for a file that keeps
+    growing while its authority chain never resolves (the common real-world
+    shape: an actively-writing session whose baseline was lost).
+
+    Each tick's payload spans ``[start_offset, new_end)`` -- a strictly
+    larger, differently-hashed range than the previous tick, because
+    ``start_offset`` never advances without the fix. That is a genuinely
+    distinct ``blob_hash`` each time, so ``deterministic_raw_session_id``
+    mints a genuinely new, distinct raw_id every tick, each one a
+    redundant superset of the last -- durable storage grows without bound
+    for a session that never converges.
+    """
+    source = _seed_quarantine_prone_append(tmp_path, session_id="stuck-growing")
+    cursor = CursorStore(tmp_path / "ops.db")
+    processor = _processor(tmp_path, cursor)
+
+    plan = processor._append_plan(source)
+    assert isinstance(plan, _AppendPlan)
+    processor._ingest_append_plans([plan])
+    assert _raw_session_count(tmp_path) == 1
+
+    for tick in range(3):
+        with source.open("ab") as handle:
+            handle.write(_codex_message(f"still-growing-{tick}"))
+        grown_plan = processor._append_plan(source)
+        assert isinstance(grown_plan, _AppendPlan)
+        assert grown_plan.start_offset == plan.start_offset, "start_offset never advances without the fix"
+        processor._ingest_append_plans([grown_plan])
+        assert _raw_session_count(tmp_path) == tick + 2, (
+            "each growth tick against an unadvanced start_offset mints a new, distinct, "
+            "overlapping raw_id -- unbounded durable storage growth for a session that never converges"
+        )
+
+
+def test_append_plan_skips_replanning_an_unchanged_already_deferred_range(tmp_path: Path) -> None:
+    """The actual fix: once ``deferred_end_offset`` is recorded, a second,
+    unchanged observation of the same file must not produce a fresh append
+    plan at all, so ``_ingest_append_plans`` is never called a second time
+    and no duplicate raw_id is minted.
+    """
+    source = _seed_quarantine_prone_append(tmp_path, session_id="stuck-fixed")
+    cursor = CursorStore(tmp_path / "ops.db")
+    processor = _processor(tmp_path, cursor)
+
+    plan = processor._append_plan(source)
+    assert isinstance(plan, _AppendPlan)
+    result = processor._ingest_append_plans([plan])
+    assert result.deferred == [plan]
+    assert _raw_session_count(tmp_path) == 1
+
+    # Exactly what batch.py's flush_append_plans loop does for a plan that
+    # came back in ``append_result.deferred``.
+    record_deferred_append_cursor(
+        cursor,
+        source,
+        cursor=cursor.get_record(source),
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+        source_name="codex",
+        deferred_end_offset=plan.last_complete_newline,
+    )
+
+    stored = cursor.get_record(source)
+    assert stored is not None
+    assert stored.deferred_end_offset == plan.last_complete_newline
+    # byte_offset never advances for a deferred plan -- this is the exact
+    # pre-fix state that made the file look like it had unconsumed new bytes
+    # on every subsequent tick.
+    assert stored.byte_offset < stored.deferred_end_offset
+
+    second_plan = processor._append_plan(source)
+    assert second_plan is _DEFER_APPEND, (
+        "an unchanged file whose entire growth is already captured-and-deferred must not produce a fresh append plan"
+    )
+    assert _raw_session_count(tmp_path) == 1, "no duplicate raw_id may be minted for the same pending byte range"
+
+
+def test_append_plan_still_captures_genuine_growth_past_a_deferred_range(tmp_path: Path) -> None:
+    """Constraint 3: a file that keeps growing while still authority-deferred
+    must not be permanently frozen -- new bytes past the already-captured
+    window are still planned normally.
+    """
+    source = _seed_quarantine_prone_append(tmp_path, session_id="stuck-then-grows")
+    cursor = CursorStore(tmp_path / "ops.db")
+    processor = _processor(tmp_path, cursor)
+
+    plan = processor._append_plan(source)
+    assert isinstance(plan, _AppendPlan)
+    processor._ingest_append_plans([plan])
+    record_deferred_append_cursor(
+        cursor,
+        source,
+        cursor=cursor.get_record(source),
+        parser_fingerprint=live_watcher._PARSER_FINGERPRINT,
+        source_name="codex",
+        deferred_end_offset=plan.last_complete_newline,
+    )
+
+    # Confirm the file is recognized as fully captured-and-pending first.
+    assert processor._append_plan(source) is _DEFER_APPEND
+
+    # Now the file genuinely grows further while still authority-deferred.
+    with source.open("ab") as handle:
+        handle.write(_codex_message("grew-while-deferred"))
+
+    grown_plan = processor._append_plan(source)
+    assert isinstance(grown_plan, _AppendPlan), (
+        "growth past the already-captured-and-deferred window must still be planned, not frozen forever"
+    )
+    assert grown_plan.last_complete_newline > plan.last_complete_newline


### PR DESCRIPTION
## Summary

Fixes the live-watcher forever-loop where a quarantined/ambiguous append never advances and gets re-planned on every daemon tick.

## Problem

`sources/live/append_ingest.py`'s `_ingest_append_plans_archive` writes an append's raw bytes and binds a revision envelope in `source.db` *before* classification decides whether its authority is accepted or quarantined/ambiguous. When quarantined, the plan is added to `_AppendResult.deferred` and `record_deferred_append_cursor` (`sources/live/deferred_cursor.py`) left `byte_offset` completely unchanged.

The next watcher pass over the same file then saw `size > byte_offset` again, rebuilt the identical append plan, and re-ran the full write/classify/defer path -- forever, on every tick, with zero failure telemetry (`mark_failed` is never called for a deferral, so the 5-strike exclusion budget never triggers and `ingest_attempts` shows clean "completed" rows).

Content-hash idempotency (`deterministic_raw_session_id`, blob-store dedup) means a byte-identical replan does not literally duplicate a `raw_sessions` row or blob -- but for a file that keeps growing while its authority chain never resolves (the common real-world shape: an actively-writing session whose baseline was lost), each tick's payload spans a strictly larger, differently-hashed range than the last, because `start_offset` never advances. That mints a genuinely new, distinct, overlapping raw_id every tick -- unbounded durable storage growth for a session that never converges. Confirmed empirically with a reproduction harness before writing the fix (see Verification).

Ref polylogue-hat0

## Solution

Added `ingest_cursor.deferred_end_offset` (`ops.db`, additive disposable-tier column, following the existing `_ensure_ops_runtime_columns` pattern) recording the end of a byte range already durably captured and pending authority resolution -- distinct from `byte_offset`, which only advances once a plan is actually applied.

`record_deferred_append_cursor` (`sources/live/deferred_cursor.py`) now takes an explicit, required `deferred_end_offset` argument so every call site states its intent:
- The `_AppendResult.deferred` loop in `batch.py`'s `flush_append_plans` passes the just-deferred plan's own `last_complete_newline` to mark that exact range as pending.
- The two call sites for the older, unrelated "no complete trailing newline yet" defer path (`batch.py`'s per-path loop, `watcher.py`'s `_defer_incomplete_jsonl_append`) pass the *existing* `cursor.deferred_end_offset` through unchanged, so a genuine pending-authority marker is never silently cleared by an unrelated defer reason.

`LiveBatchProcessor._append_plan` (`batch.py`) gains one check: if the cursor has a `deferred_end_offset` and the file's size and mtime are unchanged relative to it, return the existing `_DEFER_APPEND` sentinel instead of building a fresh plan. Genuine growth past the marker (`stat.st_size > deferred_end_offset`) is untouched and still planned normally -- a still-growing, still-deferred file is never frozen.

## Verification

- New regression suite: `tests/unit/sources/test_live_deferred_append_dedup.py` (4 tests). Confirmed the fix actually matters by temporarily disabling the new skip-check (`if False:` in place of the condition) and re-running: `test_append_plan_skips_replanning_an_unchanged_already_deferred_range` and `test_append_plan_still_captures_genuine_growth_past_a_deferred_range` both fail without the fix and pass with it restored.
- `devtools test tests/unit/sources/test_live_deferred_append_dedup.py` -- 4 passed.
- `devtools test tests/unit/sources/test_live_append_cursor_resynthesis.py tests/unit/sources/test_live_watcher.py tests/unit/sources/test_live_batch_support.py tests/unit/sources/test_live_cursor_locking.py tests/unit/sources/test_cursor_lifecycle.py tests/unit/storage/test_archive_tiers_ddl.py tests/unit/storage/test_archive_tiers_ops_write.py` -- 237 passed, 4 failed; confirmed via `git stash` that the same 4 fail identically on master without this diff (pre-existing, unrelated full-ingest/route-observability failures).
- `devtools test tests/unit/daemon/test_cursor_lag_status.py tests/unit/daemon/test_cursor_lag_integration.py tests/unit/daemon/test_daemon_status.py tests/unit/cli/test_status.py tests/unit/storage/test_archive_tiers_ops_write.py tests/unit/core/test_schema_workload_profiles.py` (other `ingest_cursor` readers) -- 182 passed.
- `devtools verify --quick` -- exit 0.
- Not run: `devtools verify --all` (full non-integration suite).

## Estimated duplicate-mint reduction

The daemon's live watcher polls on a short interval (seconds, sub-minute in the observed incident). At even a conservative 1 tick/minute, a stuck-but-static file previously re-ran the full write/classify/defer path 1,440 times/day for zero progress; a stuck-and-still-growing file additionally minted a new, overlapping, distinct raw_id every single one of those ticks. This fix reduces both to zero re-mints for the unchanged-file case, and stops re-attempting from the stale `byte_offset` for the growing-file case (though a still-growing file still mints one raw per genuine growth tick, which is expected and bounded by real content, not polling frequency).