### PR TITLE
feat(storage): relink orphaned attachments recoverable from raw re-parse

### DIFF
--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -3658,6 +3658,10 @@ files:
     loc: 58
     target: polylogue/storage/artifacts/views.py
     owner: stable
+  - path: polylogue/storage/attachment_relink.py
+    loc: 374
+    target: TBD
+    owner: storage-domain
   - path: polylogue/storage/backup_attestation.py
     loc: 181
     target: polylogue/storage/backup_attestation.py
@@ -3941,7 +3945,7 @@ files:
     owner: storage-root
     reason: storage-root cross-cutting helper
   - path: polylogue/storage/repair.py
-    loc: 7286
+    loc: 7326
     target: polylogue/storage/repair.py
     owner: storage-root
     reason: storage-root cross-cutting helper

--- a/polylogue/storage/attachment_relink.py
+++ b/polylogue/storage/attachment_relink.py
@@ -1,0 +1,377 @@
+"""Relink orphaned ``attachments`` rows by re-parsing raw source data.
+
+polylogue-w06b: ``_write_attachments`` (``storage/sqlite/archive_tiers/write.py``)
+was fixed (#3514) so a full-replace re-ingest that drops an attachment's owning
+message now sweeps the ref-less ``attachments`` row at write time instead of
+leaving it permanently unreachable. That fix is going-forward only: it cannot
+help the 1,858 rows the live archive already had orphaned before it landed
+(1,783 ``acquired``, 75 ``unfetched`` -- see the bead's forensics).
+
+``attachments`` carries no ``session_id``/``message_id`` column -- the only
+link back to a session is ``attachment_refs``, and ``attachment_id`` itself is
+a pure content-identity hash of the attachment's own metadata (see
+``write.py:_attachment_id``), independent of which session/message produced
+it. So the *only* durable evidence that can reconstruct "which message owned
+this orphan" is the original raw bytes still held in ``source.db``'s
+``raw_sessions`` -- exactly the rebuildable-tier philosophy already documented
+for ``index.db`` (see ``docs/architecture.md`` schema-regimes section): if the
+raw is still there, re-parsing it can regenerate the same attachment_id and
+message_id the write path would have produced, and confirm the owning message
+is still present in the current index.
+
+This module never guesses. A given orphan is only reported ``eligible`` for
+relink when a raw session's re-parsed content reproduces the *exact* same
+``attachment_id`` (same provider ids/path/name/mime/size -- see
+``_attachment_id``) AND the resolved ``message_id`` is a real row in the
+current ``messages`` table. Every other outcome -- no raw reproduces the
+identity at all, or a raw reproduces it but the owning message no longer
+exists in the current index -- is reported as ``ineligible`` with an exact
+reason, mirroring the read-only plan/execute split used by
+``raw_retention.plan_stale_supersession_reissue`` /
+``reissue_stale_supersession_receipts``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from polylogue.logging import get_logger
+from polylogue.pipeline.services.ingest_worker import IngestRecordResult, SessionWritePayload, ingest_record
+from polylogue.storage.runtime.raw.records import RawSessionRecord
+from polylogue.storage.sqlite.archive_tiers.write import (
+    _attachment_caption,
+    _attachment_id,
+    _attachment_position,
+    _attachment_source_url,
+    _message_id,
+)
+from polylogue.storage.sqlite.queries.mappers_archive import _row_to_raw_session
+
+logger = get_logger(__name__)
+
+# Raw parsing is real work (decode + provider dispatch + normalize); bound how
+# many raw_sessions rows one plan pass inspects unless the caller overrides it.
+DEFAULT_RAW_ROW_LIMIT = 5_000
+
+_NO_RAW_MATCH_REASON = "no raw session in source.db reproduces this attachment's identity"
+_MESSAGE_MISSING_REASON = (
+    "matched raw content but the owning message is no longer present in the current index "
+    "(session likely re-ingested without it since)"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RelinkableAttachment:
+    """One orphaned attachment a re-parsed raw proves is still recoverable."""
+
+    attachment_id: str
+    session_id: str
+    message_id: str
+    position: int
+    upload_origin: str | None
+    source_url: str | None
+    caption: str | None
+    raw_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class UnrecoverableAttachment:
+    attachment_id: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class OrphanedAttachmentRelinkPlan:
+    """Read-only projection: what a relink pass would do against source.db.
+
+    ``eligible`` is the *complete* (never sampled) set a relink must write a
+    fresh ``attachment_refs`` row for -- callers writing refs must use every
+    item here, not just ``unrecoverable_samples``. ``raw_rows_scanned`` records
+    how much of ``raw_sessions`` was actually inspected (bounded by
+    ``raw_row_limit``), so a caller can tell an exhaustive plan apart from a
+    partial one that stopped early.
+    """
+
+    orphan_count: int
+    eligible: tuple[RelinkableAttachment, ...]
+    unrecoverable_reason_counts: Mapping[str, int]
+    unrecoverable_samples: tuple[UnrecoverableAttachment, ...]
+    raw_rows_scanned: int
+    raw_rows_total: int
+
+
+RawSessionParser = Callable[[RawSessionRecord], IngestRecordResult]
+
+
+def _default_raw_session_parser(archive_root: Path, blob_root: Path | None) -> RawSessionParser:
+    archive_root_str = str(archive_root)
+    blob_root_str = str(blob_root) if blob_root is not None else None
+
+    def _parse(raw_record: RawSessionRecord) -> IngestRecordResult:
+        return ingest_record(raw_record, archive_root_str, "advisory", blob_root_str=blob_root_str)
+
+    return _parse
+
+
+def _read_orphaned_attachment_ids(index_conn: sqlite3.Connection) -> list[str]:
+    rows = index_conn.execute(
+        """
+        SELECT attachment_id FROM attachments a
+        WHERE NOT EXISTS (SELECT 1 FROM attachment_refs r WHERE r.attachment_id = a.attachment_id)
+        """
+    ).fetchall()
+    return [str(row[0]) for row in rows]
+
+
+def _message_exists(index_conn: sqlite3.Connection, message_id: str) -> bool:
+    return index_conn.execute("SELECT 1 FROM messages WHERE message_id = ?", (message_id,)).fetchone() is not None
+
+
+def _iter_raw_session_rows(source_conn: sqlite3.Connection, *, raw_row_limit: int | None) -> list[sqlite3.Row]:
+    original_row_factory = source_conn.row_factory
+    source_conn.row_factory = sqlite3.Row
+    try:
+        query = "SELECT * FROM raw_sessions ORDER BY acquired_at_ms DESC"
+        if raw_row_limit is not None:
+            query += f" LIMIT {int(raw_row_limit)}"
+        return source_conn.execute(query).fetchall()
+    finally:
+        source_conn.row_factory = original_row_factory
+
+
+def plan_orphaned_attachment_relink(
+    index_conn: sqlite3.Connection,
+    source_conn: sqlite3.Connection,
+    *,
+    archive_root: Path,
+    blob_root: Path | None = None,
+    sample_limit: int = 20,
+    raw_row_limit: int | None = DEFAULT_RAW_ROW_LIMIT,
+    raw_session_parser: RawSessionParser | None = None,
+) -> OrphanedAttachmentRelinkPlan:
+    """Read-only: find orphaned attachments a raw re-parse can prove recoverable.
+
+    For each ``raw_sessions`` row (newest first, bounded by ``raw_row_limit``),
+    re-parses it via ``ingest_record`` (the same decode+validate+parse+
+    transform entry point the live ingest worker uses -- see module docstring)
+    and checks every attachment it reproduces against the still-pending orphan
+    set. A match is only accepted ``eligible`` when the resolved message_id is
+    a real row in the CURRENT ``messages`` table; a content match whose message
+    is gone is recorded ``ineligible`` (unless a later raw also reproduces the
+    same attachment_id with a message that does still exist -- attachment_id
+    is session-independent, so the same physical attachment can legitimately
+    appear in more than one raw session).
+
+    Never mutates ``index_conn``/``source_conn``. ``raw_session_parser`` is an
+    injection point for tests; production callers should leave it ``None`` to
+    use the real ``ingest_record`` parser.
+    """
+    orphan_ids = _read_orphaned_attachment_ids(index_conn)
+    orphan_count = len(orphan_ids)
+    if orphan_count == 0:
+        return OrphanedAttachmentRelinkPlan(
+            orphan_count=0,
+            eligible=(),
+            unrecoverable_reason_counts={},
+            unrecoverable_samples=(),
+            raw_rows_scanned=0,
+            raw_rows_total=0,
+        )
+
+    pending: set[str] = set(orphan_ids)
+    recovered: dict[str, RelinkableAttachment] = {}
+    ineligible_reasons: dict[str, str] = {}
+
+    parser = raw_session_parser or _default_raw_session_parser(archive_root, blob_root)
+
+    total_rows_row = source_conn.execute("SELECT COUNT(*) FROM raw_sessions").fetchone()
+    raw_rows_total = int(total_rows_row[0]) if total_rows_row is not None else 0
+
+    rows = _iter_raw_session_rows(source_conn, raw_row_limit=raw_row_limit)
+    scanned = 0
+    for row in rows:
+        if not pending:
+            break
+        scanned += 1
+        try:
+            raw_record = _row_to_raw_session(row)
+        except Exception as exc:  # pragma: no cover - defensive, malformed row shape
+            logger.warning("attachment relink: could not build RawSessionRecord for raw_id=%s: %s", row["raw_id"], exc)
+            continue
+        try:
+            result = parser(raw_record)
+        except Exception as exc:
+            logger.warning("attachment relink: reparse failed for raw_id=%s: %s", raw_record.raw_id, exc)
+            continue
+        if result.error is not None:
+            continue
+        for payload in result.sessions:
+            _match_session_payload(payload, pending, recovered, ineligible_reasons, index_conn, raw_record.raw_id)
+
+    reason_counts: dict[str, int] = {}
+    samples: list[UnrecoverableAttachment] = []
+    for attachment_id in orphan_ids:
+        if attachment_id in recovered:
+            continue
+        reason = ineligible_reasons.get(attachment_id, _NO_RAW_MATCH_REASON)
+        reason_counts[reason] = reason_counts.get(reason, 0) + 1
+        if len(samples) < sample_limit:
+            samples.append(UnrecoverableAttachment(attachment_id=attachment_id, reason=reason))
+
+    return OrphanedAttachmentRelinkPlan(
+        orphan_count=orphan_count,
+        eligible=tuple(recovered[attachment_id] for attachment_id in orphan_ids if attachment_id in recovered),
+        unrecoverable_reason_counts=reason_counts,
+        unrecoverable_samples=tuple(samples),
+        raw_rows_scanned=scanned,
+        raw_rows_total=raw_rows_total,
+    )
+
+
+def _match_session_payload(
+    payload: SessionWritePayload,
+    pending: set[str],
+    recovered: dict[str, RelinkableAttachment],
+    ineligible_reasons: dict[str, str],
+    index_conn: sqlite3.Connection,
+    raw_id: str,
+) -> None:
+    if not pending:
+        return
+    session_id = payload.session_id
+    messages = payload.parsed_session.messages
+    by_native_message_id = {
+        message.provider_message_id: _message_id(session_id, message, fallback_position)
+        for fallback_position, message in enumerate(messages)
+        if message.provider_message_id
+    }
+    # Attachments are session-level (``ParsedSession.attachments``), each
+    # linked to its owning message via ``message_provider_id`` -- mirroring
+    # exactly how ``_write_attachments`` consumes them (write.py:3288-3318).
+    for attachment in payload.parsed_session.attachments:
+        attachment_id = _attachment_id(session_id, attachment)
+        if attachment_id not in pending:
+            continue
+        message_id = (
+            by_native_message_id.get(attachment.message_provider_id) if attachment.message_provider_id else None
+        )
+        if message_id is None:
+            ineligible_reasons.setdefault(attachment_id, _NO_RAW_MATCH_REASON)
+            continue
+        if not _message_exists(index_conn, message_id):
+            ineligible_reasons.setdefault(attachment_id, _MESSAGE_MISSING_REASON)
+            continue
+        recovered[attachment_id] = RelinkableAttachment(
+            attachment_id=attachment_id,
+            session_id=session_id,
+            message_id=message_id,
+            position=_attachment_position(attachment),
+            upload_origin=attachment.upload_origin,
+            source_url=_attachment_source_url(attachment),
+            caption=_attachment_caption(attachment),
+            raw_id=raw_id,
+        )
+        pending.discard(attachment_id)
+
+
+@dataclass(frozen=True, slots=True)
+class OrphanedAttachmentRelinkResult:
+    orphan_count: int
+    eligible_count: int
+    relinked_count: int
+    unrecoverable_reason_counts: Mapping[str, int]
+    unrecoverable_samples: tuple[UnrecoverableAttachment, ...]
+    errors: tuple[str, ...] = ()
+
+
+def relink_orphaned_attachments(
+    index_conn: sqlite3.Connection,
+    source_conn: sqlite3.Connection,
+    *,
+    archive_root: Path,
+    blob_root: Path | None = None,
+    dry_run: bool = True,
+    sample_limit: int = 20,
+    raw_row_limit: int | None = DEFAULT_RAW_ROW_LIMIT,
+    raw_session_parser: RawSessionParser | None = None,
+) -> OrphanedAttachmentRelinkResult:
+    """Relink orphaned attachments proven recoverable by :func:`plan_orphaned_attachment_relink`.
+
+    ``dry_run=True`` (the default) performs no writes; it only runs the plan
+    and reports what would happen. When ``dry_run=False``, writes ONE
+    ``attachment_refs`` row per eligible orphan (mirroring the exact INSERT
+    ``_write_attachments`` uses) and refreshes that attachment's ``ref_count``
+    -- it never touches an attachment this plan did not mark eligible, and it
+    is safe to call repeatedly (``INSERT OR REPLACE`` + a ref_count recompute,
+    both idempotent). ``index_conn`` must be a writable index-tier connection
+    when ``dry_run=False``; this function does not commit -- the caller owns
+    transaction/commit scope.
+    """
+    plan = plan_orphaned_attachment_relink(
+        index_conn,
+        source_conn,
+        archive_root=archive_root,
+        blob_root=blob_root,
+        sample_limit=sample_limit,
+        raw_row_limit=raw_row_limit,
+        raw_session_parser=raw_session_parser,
+    )
+    relinked = 0
+    errors: list[str] = []
+    if not dry_run:
+        for item in plan.eligible:
+            try:
+                index_conn.execute(
+                    """
+                    INSERT OR REPLACE INTO attachment_refs (
+                        attachment_id, session_id, message_id, position, upload_origin, source_url, caption
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        item.attachment_id,
+                        item.session_id,
+                        item.message_id,
+                        item.position,
+                        item.upload_origin,
+                        item.source_url,
+                        item.caption,
+                    ),
+                )
+                index_conn.execute(
+                    """
+                    UPDATE attachments
+                    SET ref_count = (
+                        SELECT COUNT(*) FROM attachment_refs WHERE attachment_refs.attachment_id = attachments.attachment_id
+                    )
+                    WHERE attachment_id = ?
+                    """,
+                    (item.attachment_id,),
+                )
+                relinked += 1
+            except sqlite3.Error as exc:
+                logger.warning(
+                    "attachment relink: failed to write ref for attachment_id=%s: %s", item.attachment_id, exc
+                )
+                errors.append(f"{item.attachment_id}: {exc}")
+
+    return OrphanedAttachmentRelinkResult(
+        orphan_count=plan.orphan_count,
+        eligible_count=len(plan.eligible),
+        relinked_count=relinked,
+        unrecoverable_reason_counts=plan.unrecoverable_reason_counts,
+        unrecoverable_samples=plan.unrecoverable_samples,
+        errors=tuple(errors),
+    )
+
+
+__all__ = [
+    "OrphanedAttachmentRelinkPlan",
+    "OrphanedAttachmentRelinkResult",
+    "RelinkableAttachment",
+    "UnrecoverableAttachment",
+    "plan_orphaned_attachment_relink",
+    "relink_orphaned_attachments",
+]

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -5956,11 +5956,48 @@ def preview_stale_supersession_receipts(*, count: int) -> RepairResult:
     )
 
 
+def _relink_orphaned_attachments_best_effort(config: Config, index_conn: sqlite3.Connection) -> int:
+    """polylogue-w06b: try to recover ref-less ``attachments`` rows by
+    re-parsing ``source.db`` raw sessions before the destructive cleanup
+    below deletes them irrecoverably.
+
+    ``attachments`` carries no session/message linkage of its own -- once a
+    ref-less row is deleted, whatever real evidence could have relinked it
+    (the raw bytes still sitting in ``source.db``) is not consulted again by
+    anything downstream. Attempting a relink first is the only way this
+    repair can avoid silently discarding recoverable, already-acquired
+    attachment bytes (1,783 of the 1,858 orphans this bead's forensics found
+    were `acquired`, 440MB of real content) forever.
+
+    Never raises and never blocks the cleanup below: a missing source tier
+    (e.g. a fixture/demo archive with no ``source.db``) or any re-parse
+    failure just means 0 relinked, not a repair failure -- the destructive
+    cleanup still runs on whatever remains ref-less afterward.
+    """
+    from polylogue.storage.attachment_relink import relink_orphaned_attachments
+
+    archive_root = _raw_materialization_archive_root(config)
+    source_db_path = archive_root / "source.db"
+    if not source_db_path.is_file():
+        return 0
+    try:
+        with closing(sqlite3.connect(f"file:{source_db_path}?mode=ro", uri=True)) as source_conn:
+            result = relink_orphaned_attachments(index_conn, source_conn, archive_root=archive_root, dry_run=False)
+        return result.relinked_count
+    except Exception as exc:
+        logger.warning(
+            "orphaned-attachment relink attempt failed, proceeding to delete-only cleanup: %s", exc, exc_info=True
+        )
+        return 0
+
+
 def repair_orphaned_attachments(config: Config, dry_run: bool = False) -> RepairResult:
     try:
         with _open_archive_index_connection() as conn:
             if dry_run:
                 return preview_orphaned_attachments(count=count_orphaned_attachments_sync(conn))
+
+            relinked_count = _relink_orphaned_attachments_best_effort(config, conn)
 
             ref_result = conn.execute(
                 "DELETE FROM attachment_refs WHERE message_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM messages m WHERE m.message_id = attachment_refs.message_id)"
@@ -5981,9 +6018,12 @@ def repair_orphaned_attachments(config: Config, dry_run: bool = False) -> Repair
             total = refs_deleted + conv_refs_deleted + atts_deleted
             return _repair_result(
                 "orphaned_attachments",
-                repaired_count=total,
+                repaired_count=total + relinked_count,
                 success=True,
-                detail=f"Cleaned {refs_deleted} orphaned refs, {conv_refs_deleted} conv refs, {atts_deleted} attachments",
+                detail=(
+                    f"Relinked {relinked_count} recoverable attachment(s) via raw re-parse; "
+                    f"cleaned {refs_deleted} orphaned refs, {conv_refs_deleted} conv refs, {atts_deleted} attachments"
+                ),
             )
     except Exception as exc:
         return _repair_result(

--- a/tests/unit/storage/test_attachment_relink.py
+++ b/tests/unit/storage/test_attachment_relink.py
@@ -1,0 +1,303 @@
+"""polylogue-w06b: relinking orphaned ``attachments`` rows via raw re-parse.
+
+Exercises the real production entry points end to end -- ``ingest_record``
+(the live ingest worker's per-raw parse entry point) parses genuine raw bytes
+out of a real ``source.db``/blob store, and ``relink_orphaned_attachments``
+writes the recovered ``attachment_refs`` row back into a real ``index.db`` --
+no mocking of the parse or matching logic under test.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.core.enums import Provider
+from polylogue.pipeline.services.ingest_worker import ingest_record
+from polylogue.storage.attachment_relink import (
+    plan_orphaned_attachment_relink,
+    relink_orphaned_attachments,
+)
+from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.runtime.raw.records import RawSessionRecord
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_tier
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.archive_tiers.write import write_parsed_session_to_archive
+
+_CLAUDE_AI_PAYLOAD = {
+    "uuid": "relink-session-1",
+    "name": "Relink test session",
+    "chat_messages": [
+        {
+            "uuid": "m0",
+            "sender": "human",
+            "text": "here is a file",
+            "attachments": [
+                {
+                    "file_name": "notes.md",
+                    "file_type": "text/markdown",
+                    "file_size": 11,
+                    "extracted_content": "hello notes",
+                }
+            ],
+        }
+    ],
+}
+
+
+def _index_conn(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    initialize_archive_tier(conn, ArchiveTier.INDEX)
+    return conn
+
+
+def _source_conn(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    initialize_archive_tier(conn, ArchiveTier.SOURCE)
+    return conn
+
+
+def _write_raw_row(
+    source_conn: sqlite3.Connection, blob_store: BlobStore, payload: object, *, raw_id: str, source_path: str
+) -> RawSessionRecord:
+    content = json.dumps(payload).encode("utf-8")
+    blob_hash, blob_size = blob_store.write_from_bytes(content)
+    source_conn.execute(
+        """
+        INSERT INTO raw_sessions (raw_id, origin, source_path, source_index, blob_hash, blob_size, acquired_at_ms)
+        VALUES (?, 'claude-ai-export', ?, 0, ?, ?, 0)
+        """,
+        (raw_id, source_path, bytes.fromhex(blob_hash), blob_size),
+    )
+    source_conn.commit()
+    return RawSessionRecord(
+        raw_id=raw_id,
+        source_name=Provider.CLAUDE_AI.value,
+        payload_provider=Provider.CLAUDE_AI,
+        source_path=source_path,
+        source_index=0,
+        blob_size=blob_size,
+        blob_hash=blob_hash,
+        acquired_at="2026-01-01T00:00:00+00:00",
+    )
+
+
+def _preacquired_blobs(store: BlobStore, session: object) -> dict[int, tuple[bytes | None, int, str]]:
+    acquired: dict[int, tuple[bytes | None, int, str]] = {}
+    for attachment in session.attachments:  # type: ignore[attr-defined]
+        if attachment.inline_bytes is None:
+            continue
+        blob_hash, size = store.write_from_bytes(attachment.inline_bytes)
+        acquired[id(attachment)] = (bytes.fromhex(blob_hash), size, "acquired")
+    return acquired
+
+
+def test_orphaned_attachment_is_relinked_from_raw_reparse(tmp_path: Path) -> None:
+    """The exact live-archive symptom (ref_count 0, real acquired bytes,
+    unreachable from any session) is repaired when the owning raw session
+    and its owning message are still present.
+    """
+    blob_store = BlobStore(tmp_path / "blob")
+    index_conn = _index_conn(tmp_path / "index.db")
+    source_conn = _source_conn(tmp_path / "source.db")
+
+    raw_record = _write_raw_row(
+        source_conn, blob_store, _CLAUDE_AI_PAYLOAD, raw_id="raw-1", source_path="conversations.json"
+    )
+
+    result = ingest_record(raw_record, str(tmp_path), "advisory", blob_root_str=str(blob_store.root))
+    assert result.error is None, result.error
+    assert len(result.sessions) == 1
+    write_payload = result.sessions[0]
+
+    # Establish the "before the bug" good state: attachment written with a
+    # live ref, exactly as first ingest would have produced.
+    write_parsed_session_to_archive(
+        index_conn,
+        write_payload.parsed_session,
+        raw_id=raw_record.raw_id,
+        preacquired_attachment_blobs=_preacquired_blobs(blob_store, write_payload.parsed_session),
+    )
+    row = index_conn.execute(
+        "SELECT attachment_id, ref_count, acquisition_status FROM attachments WHERE display_name = 'notes.md'"
+    ).fetchone()
+    assert row is not None
+    attachment_id = str(row["attachment_id"])
+    assert row["ref_count"] == 1
+    assert row["acquisition_status"] == "acquired"
+
+    # Simulate the historical polylogue-w06b orphan bug: the ref got dropped
+    # (e.g. by a pre-#3514 full-replace pass) but the attachments row itself
+    # survived with ref_count now stale-0 -- the exact shape the bead's
+    # forensics found live (acquisition_status='acquired', ref_count 0).
+    index_conn.execute("DELETE FROM attachment_refs WHERE attachment_id = ?", (attachment_id,))
+    index_conn.execute("UPDATE attachments SET ref_count = 0 WHERE attachment_id = ?", (attachment_id,))
+    index_conn.commit()
+
+    orphan_check = index_conn.execute(
+        "SELECT 1 FROM attachments a WHERE a.attachment_id = ? "
+        "AND NOT EXISTS (SELECT 1 FROM attachment_refs r WHERE r.attachment_id = a.attachment_id)",
+        (attachment_id,),
+    ).fetchone()
+    assert orphan_check is not None, "test setup failed to reproduce an orphaned attachment row"
+
+    plan = plan_orphaned_attachment_relink(index_conn, source_conn, archive_root=tmp_path, blob_root=blob_store.root)
+    assert plan.orphan_count == 1
+    assert len(plan.eligible) == 1
+    assert plan.eligible[0].attachment_id == attachment_id
+    assert plan.eligible[0].session_id == write_payload.session_id
+    assert plan.unrecoverable_reason_counts == {}
+
+    exec_result = relink_orphaned_attachments(
+        index_conn, source_conn, archive_root=tmp_path, blob_root=blob_store.root, dry_run=False
+    )
+    index_conn.commit()
+    assert exec_result.relinked_count == 1
+    assert exec_result.errors == ()
+
+    relinked_row = index_conn.execute(
+        "SELECT ref_count FROM attachments WHERE attachment_id = ?", (attachment_id,)
+    ).fetchone()
+    assert relinked_row is not None
+    assert relinked_row["ref_count"] == 1
+
+    ref_row = index_conn.execute(
+        "SELECT session_id, message_id FROM attachment_refs WHERE attachment_id = ?", (attachment_id,)
+    ).fetchone()
+    assert ref_row is not None
+    assert ref_row["session_id"] == write_payload.session_id
+
+
+@pytest.mark.asyncio
+async def test_orphaned_attachment_is_reachable_via_production_read_path_after_relink(tmp_path: Path) -> None:
+    """Anti-vacuity: after relink, the production ``get_attachments`` read
+    path -- the one every session/message attachment surface (MCP, CLI
+    ``read --view``, transcript view) goes through -- can see it. Reverting
+    the ``INSERT OR REPLACE INTO attachment_refs`` write in
+    ``relink_orphaned_attachments`` makes this assertion fail: the row would
+    still be present in ``attachments`` (visible via a direct SELECT) but
+    ``get_attachments`` INNER JOINs ``attachment_refs``, so a still-ref-less
+    row can never be returned.
+    """
+    import aiosqlite
+
+    from polylogue.storage.sqlite.queries.attachment_records import get_attachments
+
+    blob_store = BlobStore(tmp_path / "blob")
+    index_db_path = tmp_path / "index.db"
+    index_conn = _index_conn(index_db_path)
+    source_conn = _source_conn(tmp_path / "source.db")
+
+    raw_record = _write_raw_row(
+        source_conn, blob_store, _CLAUDE_AI_PAYLOAD, raw_id="raw-1", source_path="conversations.json"
+    )
+    result = ingest_record(raw_record, str(tmp_path), "advisory", blob_root_str=str(blob_store.root))
+    assert result.error is None, result.error
+    write_payload = result.sessions[0]
+
+    write_parsed_session_to_archive(
+        index_conn,
+        write_payload.parsed_session,
+        raw_id=raw_record.raw_id,
+        preacquired_attachment_blobs=_preacquired_blobs(blob_store, write_payload.parsed_session),
+    )
+    attachment_id = str(
+        index_conn.execute("SELECT attachment_id FROM attachments WHERE display_name = 'notes.md'").fetchone()[0]
+    )
+    index_conn.execute("DELETE FROM attachment_refs WHERE attachment_id = ?", (attachment_id,))
+    index_conn.execute("UPDATE attachments SET ref_count = 0 WHERE attachment_id = ?", (attachment_id,))
+    index_conn.commit()
+
+    async with aiosqlite.connect(index_db_path) as aconn:
+        aconn.row_factory = aiosqlite.Row
+        before = await get_attachments(aconn, write_payload.session_id)
+    assert all(record.attachment_id != attachment_id for record in before)
+
+    exec_result = relink_orphaned_attachments(
+        index_conn, source_conn, archive_root=tmp_path, blob_root=blob_store.root, dry_run=False
+    )
+    index_conn.commit()
+    assert exec_result.relinked_count == 1
+
+    async with aiosqlite.connect(index_db_path) as aconn:
+        aconn.row_factory = aiosqlite.Row
+        after = await get_attachments(aconn, write_payload.session_id)
+    assert any(record.attachment_id == attachment_id for record in after)
+
+
+def test_orphan_with_no_matching_raw_is_reported_unrecoverable_not_guessed(tmp_path: Path) -> None:
+    """An orphan whose identity no raw session in source.db reproduces must
+    be reported unrecoverable, never silently linked to an unrelated
+    message.
+    """
+    blob_store = BlobStore(tmp_path / "blob")
+    index_conn = _index_conn(tmp_path / "index.db")
+    source_conn = _source_conn(tmp_path / "source.db")
+
+    # A raw session exists in source.db, but it shares no attachment
+    # identity with the orphan row below.
+    _write_raw_row(source_conn, blob_store, _CLAUDE_AI_PAYLOAD, raw_id="raw-1", source_path="conversations.json")
+
+    index_conn.execute(
+        "INSERT INTO attachments (attachment_id, display_name, media_type, byte_count, acquisition_status, ref_count) "
+        "VALUES ('ghost-attachment-id', 'ghost.bin', 'application/octet-stream', 42, 'acquired', 0)"
+    )
+    index_conn.commit()
+
+    plan = plan_orphaned_attachment_relink(index_conn, source_conn, archive_root=tmp_path, blob_root=blob_store.root)
+    assert plan.orphan_count == 1
+    assert plan.eligible == ()
+    assert sum(plan.unrecoverable_reason_counts.values()) == 1
+    assert plan.unrecoverable_samples[0].attachment_id == "ghost-attachment-id"
+    assert "no raw session" in plan.unrecoverable_samples[0].reason
+
+    exec_result = relink_orphaned_attachments(
+        index_conn, source_conn, archive_root=tmp_path, blob_root=blob_store.root, dry_run=False
+    )
+    index_conn.commit()
+    assert exec_result.relinked_count == 0
+
+    surviving = index_conn.execute(
+        "SELECT ref_count FROM attachments WHERE attachment_id = 'ghost-attachment-id'"
+    ).fetchone()
+    assert surviving is not None
+    assert surviving["ref_count"] == 0
+
+
+def test_plan_is_dry_run_by_default_makes_no_writes(tmp_path: Path) -> None:
+    blob_store = BlobStore(tmp_path / "blob")
+    index_conn = _index_conn(tmp_path / "index.db")
+    source_conn = _source_conn(tmp_path / "source.db")
+
+    raw_record = _write_raw_row(
+        source_conn, blob_store, _CLAUDE_AI_PAYLOAD, raw_id="raw-1", source_path="conversations.json"
+    )
+    result = ingest_record(raw_record, str(tmp_path), "advisory", blob_root_str=str(blob_store.root))
+    write_payload = result.sessions[0]
+    write_parsed_session_to_archive(
+        index_conn,
+        write_payload.parsed_session,
+        raw_id=raw_record.raw_id,
+        preacquired_attachment_blobs=_preacquired_blobs(blob_store, write_payload.parsed_session),
+    )
+    attachment_id = str(
+        index_conn.execute("SELECT attachment_id FROM attachments WHERE display_name = 'notes.md'").fetchone()[0]
+    )
+    index_conn.execute("DELETE FROM attachment_refs WHERE attachment_id = ?", (attachment_id,))
+    index_conn.execute("UPDATE attachments SET ref_count = 0 WHERE attachment_id = ?", (attachment_id,))
+    index_conn.commit()
+
+    exec_result = relink_orphaned_attachments(index_conn, source_conn, archive_root=tmp_path, blob_root=blob_store.root)
+    assert exec_result.eligible_count == 1
+    assert exec_result.relinked_count == 0  # dry_run=True default: plans, never writes
+
+    still_orphaned = index_conn.execute(
+        "SELECT 1 FROM attachment_refs WHERE attachment_id = ?", (attachment_id,)
+    ).fetchone()
+    assert still_orphaned is None


### PR DESCRIPTION
## Summary

Adds a targeted repair for the 1,858 `attachments` rows polylogue-w06b's forensics found with zero `attachment_refs` rows, and closes a data-loss hazard in the existing production repair path that would otherwise delete them unrecoverably.

## Problem

PR #3514 fixed the write-path gap that produced new orphans going forward (`_write_attachments` now sweeps a ref-less row at write time), but explicitly deferred the 1,858 orphans already in the live archive: `attachments` carries no `session_id`/`message_id` column, and `attachment_id` is a content-identity hash of the attachment's own metadata, independent of which session produced it. The only durable evidence that can reconstruct "which message owned this orphan" is the original raw bytes still held in `source.db`'s `raw_sessions`.

Separately, the existing production repair (`repair_orphaned_attachments`, `polylogue/storage/repair.py`) makes this worse: its `dry_run=False` branch unconditionally `DELETE`s every ref-less `attachments` row, including the 1,783 `acquired` ones (440MB of real fetched bytes), without ever attempting to recover them first. Run as-is against the live archive, this repair would permanently destroy exactly the rows this bead asks to recover.

## Solution

- `polylogue/storage/attachment_relink.py`: `plan_orphaned_attachment_relink` (read-only) re-parses `source.db` `raw_sessions` rows via `ingest_record` -- the same decode/parse/materialize entry point the live ingest worker uses -- and checks every attachment it reproduces against the pending orphan set. A match is only accepted `eligible` when the recomputed `attachment_id` equals the orphan's AND the resolved `message_id` is a real row in the current `messages` table; every other outcome (no raw reproduces the identity, or a raw reproduces it but the owning message is gone) is reported `ineligible` with an exact reason -- it never guesses. `relink_orphaned_attachments` (`dry_run=True` default) writes the recovered `attachment_refs` rows, mirroring the exact `INSERT` `_write_attachments` uses. Follows the plan/execute split already used by `raw_retention.plan_stale_supersession_reissue`.
- `polylogue/storage/repair.py`: `repair_orphaned_attachments` now calls a best-effort relink pass before its destructive `DELETE`, so the existing production maintenance sweep can no longer silently discard a recoverable orphan. Never blocks the cleanup: a missing `source.db` or any re-parse failure just means 0 relinked, not a repair failure.

## Non-goals

- Does not run against `/realm/db/polylogue` (production archive) -- this worktree only tests against fixtures. Whether any of the live 1,858 orphans are actually recoverable this way depends on whether their raw sessions are still retained in `source.db`; that census is a follow-up operator action, not something provable from a fixture-only worktree.
- Does not change `repair_orphaned_attachments`'s preview/dry-run path to attempt relink (a full raw re-parse scan is heavier than a routine count-only preview should do); only the actual execute path attempts it.

## Verification

- `devtools test tests/unit/storage/test_attachment_relink.py` -> 4 passed, including a real end-to-end test (genuine raw JSON bytes in a real `source.db` + blob store, parsed via the actual `ingest_record` entry point, no mocking) that reproduces the exact live-archive orphan symptom (`ref_count` 0, `acquisition_status='acquired'`) and verifies both the plan classification and that the production read path (`get_attachments`) can see the attachment after relink. A separate test proves an orphan with no matching raw is reported unrecoverable, not guessed.
- `devtools test tests/unit/storage/test_attachment_relink.py tests/unit/storage/test_repair.py tests/unit/storage/test_attachment_acquisition.py tests/unit/storage/test_archive_tiers_write.py tests/integration/test_health.py -k "not raw_materialization"` -> 128 passed.
- 11 pre-existing `raw_materialization` test failures in `test_repair.py` observed and confirmed unrelated: same 11 tests, same failure shape, documented as pre-existing in PR #3514's own verification section (unrelated subsystem: raw-authority census/replay, not attachments).
- `devtools verify --quick` -> exit 0 (format, lint, mypy --strict, render all --check, topology projection regenerated for the new module). Also ran again by the pre-push hook -> exit 0.
- Anti-vacuity: reverting the `INSERT OR REPLACE INTO attachment_refs` write in `relink_orphaned_attachments` makes `test_orphaned_attachment_is_reachable_via_production_read_path_after_relink` fail, since `get_attachments` INNER JOINs `attachment_refs`. Production callers exercised: `get_attachments` (`storage/sqlite/queries/attachment_records.py`, the read path every attachment surface goes through) and `repair_orphaned_attachments` (the production maintenance entry point, `storage/repair.py`).

Ref polylogue-w06b