### PR TITLE
fix(daemon): make health verdict consult alerts and stop going blind

### DIFF
--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -334,6 +334,10 @@ Enabled by default on `127.0.0.1:8765`. Disable with `--no-browser-capture`.
 
 **Fast** (sub-1s):
 - `daemon_liveness` — pidfile check
+- `heartbeat_staleness` — warns once the heartbeat misses a scheduled beat
+  (`DAEMON_HEARTBEAT_STALE_WARN_SECONDS`, 1.5x `DAEMON_HEARTBEAT_INTERVAL_SECONDS`),
+  errors once it crosses the "vanished" floor
+  (`DAEMON_HEARTBEAT_STALE_AFTER_SECONDS`, 2x the interval)
 - `disk_space` — free disk space (warns at 500 MB, critical at 100 MB)
 - `wal_size` — WAL file size (warns at 50 MB, errors at 200 MB)
 - `source_availability` — watch roots exist and are readable

--- a/docs/plans/degrade-loudly-allowlist.yaml
+++ b/docs/plans/degrade-loudly-allowlist.yaml
@@ -148,6 +148,12 @@ entries:
   occurrence: 0
   reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
 - path: polylogue/daemon/health.py
+  function: <module>._check_heartbeat_staleness_fast
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
   function: <module>._check_hook_flow_fast
   exceptions:
   - Exception

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -2130,7 +2130,17 @@ async def run_daemon_services(
     # guard. It writes only the disposable ops tier and proves that the
     # surviving API/health process is still alive while archive work is
     # intentionally withheld.
-    maintenance_tasks: list[asyncio.Task[None]] = [asyncio.create_task(_periodic_lifecycle_heartbeat())]
+    # Fast-tier health checks are read-only (schema_version, disk/WAL space,
+    # hook flow, source availability, heartbeat staleness) and stay
+    # meaningful precisely when the watcher is schema-blocked -- that is
+    # exactly when an operator most needs "archive tier layout is not ready"
+    # to keep surfacing rather than going silent (polylogue-7eo7 #4: the
+    # daemon used to be blind for the entire blocked duration because this
+    # loop only started inside the `if not watcher_blocked:` branch below).
+    maintenance_tasks: list[asyncio.Task[None]] = [
+        asyncio.create_task(_periodic_lifecycle_heartbeat()),
+        asyncio.create_task(_periodic_health_check()),
+    ]
     if watcher_blocked:
         maintenance_tasks.append(asyncio.create_task(_periodic_schema_preflight_recheck()))
 
@@ -2259,7 +2269,6 @@ async def run_daemon_services(
                 _periodic_heartbeat(),
                 periodic_embedding_backlog_check(catch_up_complete=catch_up_complete_gate),
                 periodic_embedding_orphan_reconcile_check(catch_up_complete=catch_up_complete_gate),
-                _periodic_health_check(),
                 _periodic_db_optimize(),
                 _periodic_status_snapshot_refresh(),
                 periodic_judgment_automation_sweep(catch_up_complete=catch_up_complete_gate),

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -150,6 +150,55 @@ def _check_daemon_liveness_fast() -> HealthAlert:
         )
 
 
+def _check_heartbeat_staleness_fast() -> HealthAlert:
+    """Detect a heartbeat that has silently missed one or more scheduled beats.
+
+    ``daemon_liveness`` only distinguishes "fresh" from "vanished" at
+    ``DAEMON_HEARTBEAT_STALE_AFTER_SECONDS`` (2x the configured interval), so
+    a heartbeat sitting between 1.5x and 2x the interval used to read as
+    flat "running" with no signal at all (polylogue-7eo7 #2: observed
+    1369.8s against a 900s interval -- comfortably past one missed beat, but
+    short of the "vanished" floor). This check narrows that gap with a
+    WARNING tier at ``DAEMON_HEARTBEAT_STALE_WARN_SECONDS``.
+    """
+    from polylogue.daemon.lifecycle import lifecycle_status
+
+    now = datetime.now(UTC).isoformat()
+    try:
+        lifecycle = lifecycle_status()
+        state = lifecycle.get("state")
+        age = lifecycle.get("heartbeat_age_s")
+        if state == "vanished":
+            severity = HealthSeverity.ERROR
+            message = f"heartbeat stale for {age}s -- daemon process considered vanished"
+        elif state == "stale":
+            severity = HealthSeverity.WARNING
+            message = f"heartbeat {age}s old -- missed at least one scheduled beat"
+        else:
+            # "fresh"/"stopped"/"absent"/"unknown": nothing to add here --
+            # daemon_liveness already covers the not-running cases.
+            severity = HealthSeverity.OK
+            message = f"heartbeat {state}" if state else "heartbeat state unavailable"
+        is_ok = severity == HealthSeverity.OK
+        return HealthAlert(
+            check_name="heartbeat_staleness",
+            tier=HealthTier.FAST,
+            severity=severity,
+            message=message,
+            checked_at=now,
+            consecutive_failures=_record_failure("heartbeat_staleness", is_ok),
+        )
+    except Exception as exc:
+        return HealthAlert(
+            check_name="heartbeat_staleness",
+            tier=HealthTier.FAST,
+            severity=HealthSeverity.ERROR,
+            message=f"heartbeat staleness check failed: {exc}",
+            checked_at=now,
+            consecutive_failures=_record_failure("heartbeat_staleness", False),
+        )
+
+
 def _check_disk_space_fast() -> HealthAlert:
     """Check free disk space on the archive volume."""
     now = datetime.now(UTC).isoformat()
@@ -426,6 +475,7 @@ def _check_hook_flow_fast() -> HealthAlert:
 def _run_fast_checks() -> list[HealthAlert]:
     return [
         _check_daemon_liveness_fast(),
+        _check_heartbeat_staleness_fast(),
         _check_schema_version_fast(),
         _check_disk_space_fast(),
         _check_wal_size_fast(),
@@ -1463,6 +1513,7 @@ __all__ = [
     "HealthAlert",
     "HealthSeverity",
     "HealthTier",
+    "_check_heartbeat_staleness_fast",
     "_check_hook_flow_fast",
     "_check_schema_version_fast",
     "check_health",

--- a/polylogue/daemon/lifecycle.py
+++ b/polylogue/daemon/lifecycle.py
@@ -37,7 +37,15 @@ from polylogue.storage.sqlite.connection_profile import open_daemon_connection, 
 logger = get_logger(__name__)
 
 DAEMON_HEARTBEAT_INTERVAL_SECONDS = 15 * 60
+# "vanished" (no stop/atexit marker, heartbeat clearly dead) at 2x the
+# interval -- unchanged, pre-existing floor.
 DAEMON_HEARTBEAT_STALE_AFTER_SECONDS = DAEMON_HEARTBEAT_INTERVAL_SECONDS * 2
+# "stale" (missed at least one scheduled beat, worth a warning) at 1.5x the
+# interval (polylogue-7eo7 #2): a heartbeat sitting between 1x and 2x the
+# interval used to report as flat "running" with no signal whatsoever --
+# the observed case was 1369.8s against a 900s interval, comfortably past
+# one missed beat but short of the 1800s "vanished" floor.
+DAEMON_HEARTBEAT_STALE_WARN_SECONDS = int(DAEMON_HEARTBEAT_INTERVAL_SECONDS * 1.5)
 _SIGNAL_WRITE_TIMEOUT_SECONDS = 0.5
 
 _last_heartbeat_monotonic: float | None = None
@@ -208,15 +216,19 @@ def lifecycle_status(*, now_ms: int | None = None) -> dict[str, object]:
     age_s = max(0.0, (current_ms - row.last_heartbeat_at_ms) / 1000)
     if row.stopped_at_ms is not None:
         state = "stopped"
-    elif age_s <= DAEMON_HEARTBEAT_STALE_AFTER_SECONDS:
-        state = "fresh"
-    else:
+    elif age_s > DAEMON_HEARTBEAT_STALE_AFTER_SECONDS:
         # No stop/atexit marker plus a stale heartbeat is the durable trace
         # of a hard kill or vanished process.
         state = "vanished"
+    elif age_s > DAEMON_HEARTBEAT_STALE_WARN_SECONDS:
+        # Missed at least one scheduled beat but short of the "vanished"
+        # floor -- still running, worth a staleness signal (polylogue-7eo7 #2).
+        state = "stale"
+    else:
+        state = "fresh"
     return {
         "state": state,
-        "running": state == "fresh",
+        "running": state in ("fresh", "stale"),
         "heartbeat_age_s": round(age_s, 3),
         "run_id": row.run_id,
         "started_at_ms": row.started_at_ms,
@@ -276,6 +288,7 @@ def _atexit_sentinel() -> None:
 __all__ = [
     "DAEMON_HEARTBEAT_INTERVAL_SECONDS",
     "DAEMON_HEARTBEAT_STALE_AFTER_SECONDS",
+    "DAEMON_HEARTBEAT_STALE_WARN_SECONDS",
     "DaemonLifecycle",
     "install_signal_handlers",
     "lifecycle_status",

--- a/polylogue/daemon/status.py
+++ b/polylogue/daemon/status.py
@@ -2752,7 +2752,14 @@ def daemon_status_payload(
             "health": {
                 "overall_status": status.health.overall_status.value,
                 "checked_at": status.health.checked_at,
-                "alert_count": len(status.health.alerts),
+                # Non-OK alerts only (polylogue-7eo7 #1): counting every
+                # check run -- including the OK ones -- produced the
+                # self-contradicting "Health: ok (6 alerts)" line, since a
+                # fully healthy daemon always runs exactly len(fast checks)
+                # of them. ``checks_run`` keeps the total available for
+                # anyone who wants it.
+                "alert_count": sum(1 for a in status.health.alerts if a.severity != HealthSeverity.OK),
+                "checks_run": len(status.health.alerts),
                 "tier_summary": status.health.tier_summary,
             },
             "raw_parse_failures": status.raw_parse_failures,
@@ -2825,8 +2832,15 @@ def format_daemon_status_lines(payload: JSONDocument) -> list[str]:
     lifecycle = payload.get("daemon_lifecycle")
     if payload.get("daemon_liveness"):
         age = lifecycle.get("heartbeat_age_s") if isinstance(lifecycle, dict) else None
+        lifecycle_state = lifecycle.get("state") if isinstance(lifecycle, dict) else None
         suffix = f" (heartbeat {age}s ago)" if isinstance(age, int | float) else ""
-        lines.append(f"  Status: running{suffix}")
+        # A "stale" lifecycle state (missed >=1 scheduled beat but short of
+        # the "vanished" floor) used to print as flat "running" with no
+        # signal at all (polylogue-7eo7 #2) -- surface it here, in addition
+        # to the heartbeat_staleness health check that feeds the overall
+        # verdict.
+        marker = " [STALE]" if lifecycle_state == "stale" else ""
+        lines.append(f"  Status: running{marker}{suffix}")
     elif isinstance(lifecycle, dict):
         lines.append(f"  Status: {lifecycle.get('state', 'absent')} heartbeat")
     storage = payload.get("archive_storage")

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -3885,7 +3885,7 @@ def test_run_daemon_services_drains_servers_when_main_task_is_cancelled() -> Non
     assert interrupted_cleanup_calls == 1
 
 
-def test_run_daemon_services_schema_block_skips_db_background_work() -> None:
+def test_run_daemon_services_schema_block_skips_write_but_starts_health_check() -> None:
     from polylogue.daemon import cli as daemon_cli
     from polylogue.daemon.health import HealthAlert, HealthSeverity, HealthTier
 
@@ -3907,10 +3907,21 @@ def test_run_daemon_services_schema_block_skips_db_background_work() -> None:
         raise AssertionError("schema-blocked daemon must not start DB background work")
 
     lifecycle_tick_started = False
+    health_check_started = False
 
     async def lifecycle_heartbeat() -> None:
         nonlocal lifecycle_tick_started
         lifecycle_tick_started = True
+        await asyncio.Event().wait()
+
+    async def fake_health_check() -> None:
+        # polylogue-7eo7 #4: FAST-tier health checks are read-only and stay
+        # meaningful precisely when the watcher is schema-blocked -- unlike
+        # the other periodic loops here, this one MUST start even while
+        # blocked, or the daemon goes completely blind for the whole
+        # blocked duration.
+        nonlocal health_check_started
+        health_check_started = True
         await asyncio.Event().wait()
 
     server = FakeServer()
@@ -3927,7 +3938,7 @@ def test_run_daemon_services_schema_block_skips_db_background_work() -> None:
         patch.object(daemon_cli, "_periodic_heartbeat", side_effect=fail_background_work),
         patch.object(daemon_cli, "_periodic_lifecycle_heartbeat", lifecycle_heartbeat),
         patch.object(daemon_cli, "_periodic_convergence_check", side_effect=fail_background_work),
-        patch.object(daemon_cli, "_periodic_health_check", side_effect=fail_background_work),
+        patch.object(daemon_cli, "_periodic_health_check", fake_health_check),
         patch.object(daemon_cli, "_periodic_db_optimize", side_effect=fail_background_work),
         patch.object(daemon_cli, "_periodic_status_snapshot_refresh", side_effect=fail_background_work),
         patch.object(daemon_cli, "_periodic_drive_source_catchup", side_effect=fail_background_work),
@@ -3950,6 +3961,7 @@ def test_run_daemon_services_schema_block_skips_db_background_work() -> None:
     assert server.shutdown_called is False
     assert server.close_called is True
     assert lifecycle_tick_started is True
+    assert health_check_started is True
 
 
 def test_periodic_schema_preflight_recheck_exits_on_recovery(

--- a/tests/unit/daemon/test_daemon_lifecycle.py
+++ b/tests/unit/daemon/test_daemon_lifecycle.py
@@ -11,6 +11,7 @@ import signal
 import sqlite3
 import time
 from pathlib import Path
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -19,6 +20,7 @@ from polylogue.core.json import json_document
 from polylogue.daemon import lifecycle as lifecycle_module
 from polylogue.daemon.lifecycle import (
     DAEMON_HEARTBEAT_STALE_AFTER_SECONDS,
+    DAEMON_HEARTBEAT_STALE_WARN_SECONDS,
     DaemonLifecycle,
     install_signal_handlers,
     lifecycle_status,
@@ -86,6 +88,35 @@ def test_lifecycle_status_rejects_stale_unstopped_heartbeat(
     assert payload["heartbeat_age_s"] == DAEMON_HEARTBEAT_STALE_AFTER_SECONDS + 1
 
 
+def test_lifecycle_status_reports_stale_between_warn_and_vanished_floors(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """polylogue-7eo7 #2: a heartbeat missing one scheduled beat (past the
+    warn floor but short of the 2x "vanished" floor) used to report as flat
+    "fresh"/"running" with no signal at all -- the observed real case was
+    1369.8s against a 900s interval. It must now read "stale", not "fresh".
+    """
+    _bind_ops_db(monkeypatch, tmp_path)
+    lifecycle = DaemonLifecycle.start()
+    current_ms = 2_000_000_000_000
+    stale_ms = current_ms - int((DAEMON_HEARTBEAT_STALE_WARN_SECONDS + 1) * 1000)
+    with sqlite3.connect(tmp_path / "ops.db") as conn:
+        conn.execute(
+            "UPDATE daemon_lifecycle SET last_heartbeat_at_ms = ? WHERE run_id = ?",
+            (stale_ms, lifecycle.run_id),
+        )
+        conn.commit()
+
+    payload = lifecycle_status(now_ms=current_ms)
+
+    assert payload["state"] == "stale"
+    # Still considered "running" -- the process is alive, just behind on
+    # its heartbeat cadence, distinct from a genuinely vanished process.
+    assert payload["running"] is True
+    assert cast(float, payload["heartbeat_age_s"]) < DAEMON_HEARTBEAT_STALE_AFTER_SECONDS
+
+
 def test_cli_status_formats_a_stale_heartbeat_as_not_running(monkeypatch: pytest.MonkeyPatch) -> None:
     stale = {"state": "vanished", "running": False, "heartbeat_age_s": 1801.0}
     monkeypatch.setattr("polylogue.daemon.lifecycle.lifecycle_status", lambda: stale)
@@ -94,6 +125,20 @@ def test_cli_status_formats_a_stale_heartbeat_as_not_running(monkeypatch: pytest
     lines = format_daemon_status_lines(json_document({"daemon_liveness": False, "daemon_lifecycle": stale}))
 
     assert "  Status: vanished heartbeat" in lines
+
+
+def test_cli_status_marks_a_stale_but_still_running_heartbeat(monkeypatch: pytest.MonkeyPatch) -> None:
+    """polylogue-7eo7 #2: a "stale" lifecycle state (missed a beat, still
+    running) used to print as flat "Status: running (heartbeat ...s ago)"
+    with no signal at all. It must now carry a visible [STALE] marker.
+    """
+    stale = {"state": "stale", "running": True, "heartbeat_age_s": 1369.8}
+    monkeypatch.setattr("polylogue.daemon.lifecycle.lifecycle_status", lambda: stale)
+
+    assert _check_daemon_liveness() is True
+    lines = format_daemon_status_lines(json_document({"daemon_liveness": True, "daemon_lifecycle": stale}))
+
+    assert "  Status: running [STALE] (heartbeat 1369.8s ago)" in lines
 
 
 def test_sigterm_dumps_threads_and_persists_signal_before_exit(

--- a/tests/unit/daemon/test_daemon_status.py
+++ b/tests/unit/daemon/test_daemon_status.py
@@ -13,7 +13,7 @@ from polylogue.browser_capture.receiver import BrowserCaptureReceiverConfig
 from polylogue.core.json import JSONDocument
 from polylogue.daemon import status as status_module
 from polylogue.daemon.fts_status import FTSReadiness
-from polylogue.daemon.health import DaemonHealth
+from polylogue.daemon.health import DaemonHealth, HealthAlert, HealthSeverity, HealthTier
 from polylogue.daemon.status import (
     _insight_freshness_info,
     browser_capture_status_payload,
@@ -533,6 +533,90 @@ def test_daemon_status_check_health_failure_reports_error_not_ok(
     assert alert.severity == "error"
     assert "health backend unavailable" in alert.message
     assert "check_health() failed" in caplog.text
+
+
+def _health_payload(tmp_path: Path, health: DaemonHealth) -> JSONDocument:
+    db = tmp_path / "index.db"
+    fresh = {"state": "fresh", "running": True, "heartbeat_age_s": 1.0}
+    with (
+        patch("polylogue.daemon.status._active_status_db_path", return_value=db),
+        patch("polylogue.daemon.status._blob_size_info", return_value=0),
+        patch("polylogue.daemon.status._fts_readiness_info", return_value={}),
+        patch("polylogue.daemon.status._insight_freshness_info", return_value={}),
+        patch("polylogue.daemon.status.check_health", return_value=health),
+        patch("polylogue.daemon.lifecycle.lifecycle_status", return_value=fresh),
+    ):
+        return daemon_status_payload(sources=(), include_archive_debt=False)
+
+
+def test_health_alert_count_excludes_ok_severity_checks(tmp_path: Path) -> None:
+    """polylogue-7eo7 #1: ``alert_count`` used to count every fast check run,
+    including OK ones -- a fully healthy daemon (6 OK checks, 0 problems)
+    printed "Health: ok (6 alerts)", reading as a contradiction even though
+    nothing was wrong. It must report the number of actual problems.
+    """
+    all_ok = DaemonHealth(
+        overall_status=HealthSeverity.OK,
+        checked_at="2026-07-31T00:00:00Z",
+        alerts=[
+            HealthAlert(
+                check_name=f"check_{i}",
+                tier=HealthTier.FAST,
+                severity=HealthSeverity.OK,
+                message="fine",
+                checked_at="2026-07-31T00:00:00Z",
+            )
+            for i in range(6)
+        ],
+    )
+
+    payload = _health_payload(tmp_path, all_ok)
+    health = cast(dict[str, Any], payload["health"])
+
+    assert health["overall_status"] == "ok"
+    assert health["alert_count"] == 0
+    assert health["checks_run"] == 6
+
+    lines = format_daemon_status_lines(payload)
+    assert "Health: ok (0 alerts)" in lines
+
+
+def test_health_alert_count_reflects_a_real_problem_not_ok(tmp_path: Path) -> None:
+    """A single non-OK alert among otherwise-OK checks must show up in both
+    ``overall_status`` and the reported ``alert_count`` -- an "ok" verdict
+    must never co-occur with a nonzero problem count.
+    """
+    one_error = DaemonHealth(
+        overall_status=HealthSeverity.ERROR,
+        checked_at="2026-07-31T00:00:00Z",
+        alerts=[
+            HealthAlert(
+                check_name="daemon_liveness",
+                tier=HealthTier.FAST,
+                severity=HealthSeverity.OK,
+                message="fine",
+                checked_at="2026-07-31T00:00:00Z",
+            ),
+            HealthAlert(
+                check_name="hook_flow",
+                tier=HealthTier.FAST,
+                severity=HealthSeverity.ERROR,
+                message="claude-code: 3/5 recent session(s) have no hook events",
+                checked_at="2026-07-31T00:00:00Z",
+            ),
+        ],
+    )
+
+    payload = _health_payload(tmp_path, one_error)
+    health = cast(dict[str, Any], payload["health"])
+
+    assert health["overall_status"] == "error"
+    assert health["alert_count"] == 1
+    assert health["checks_run"] == 2
+
+    lines = format_daemon_status_lines(payload)
+    assert "Health: error (1 alerts)" in lines
+    assert not any("ok (" in line and "1" in line for line in lines if line.startswith("Health:"))
 
 
 def test_daemon_status_payload_and_plain_output_include_failed_files(tmp_path: Path) -> None:

--- a/tests/unit/daemon/test_health_check_paths.py
+++ b/tests/unit/daemon/test_health_check_paths.py
@@ -1,6 +1,6 @@
 """Per-tier health-check evidence: OK, degraded, and recovery paths.
 
-Each of the 13 registered checks in ``polylogue/daemon/health.py`` carries:
+Each of the 14 registered checks in ``polylogue/daemon/health.py`` carries:
 
 - an OK-path assertion on a healthy synthetic fixture, and
 - at least one representative degraded-path assertion exercising the
@@ -40,6 +40,7 @@ from polylogue.daemon.health import (
     _check_disk_space_fast,
     _check_embedding_coverage_expensive,
     _check_fts_readiness_medium,
+    _check_heartbeat_staleness_fast,
     _check_insight_freshness_medium,
     _check_raw_failures_medium,
     _check_repeated_stage_failures_medium,
@@ -164,6 +165,53 @@ def test_daemon_liveness_ok_and_recovery(
     assert good.severity == HealthSeverity.OK
     assert good.consecutive_failures == 0
     assert "running" in good.message
+
+
+# ---------------------------------------------------------------------------
+# FAST: heartbeat_staleness (polylogue-7eo7 #2)
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_staleness_ok_when_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    import polylogue.daemon.lifecycle as lifecycle_module_local
+
+    monkeypatch.setattr(
+        lifecycle_module_local,
+        "lifecycle_status",
+        lambda: {"state": "fresh", "heartbeat_age_s": 30.0},
+    )
+    alert = _check_heartbeat_staleness_fast()
+    assert alert.severity == HealthSeverity.OK
+
+
+def test_heartbeat_staleness_warning_between_warn_and_vanished_floors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The observed real case: 1369.8s against a 900s interval -- past one
+    missed beat, short of "vanished". Must not read as OK/"running" silence.
+    """
+    import polylogue.daemon.lifecycle as lifecycle_module_local
+
+    monkeypatch.setattr(
+        lifecycle_module_local,
+        "lifecycle_status",
+        lambda: {"state": "stale", "heartbeat_age_s": 1369.8},
+    )
+    alert = _check_heartbeat_staleness_fast()
+    assert alert.severity == HealthSeverity.WARNING
+    assert "1369.8" in alert.message
+
+
+def test_heartbeat_staleness_error_when_vanished(monkeypatch: pytest.MonkeyPatch) -> None:
+    import polylogue.daemon.lifecycle as lifecycle_module_local
+
+    monkeypatch.setattr(
+        lifecycle_module_local,
+        "lifecycle_status",
+        lambda: {"state": "vanished", "heartbeat_age_s": 1900.0},
+    )
+    alert = _check_heartbeat_staleness_fast()
+    assert alert.severity == HealthSeverity.ERROR
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/daemon/test_health_contract.py
+++ b/tests/unit/daemon/test_health_contract.py
@@ -56,6 +56,9 @@ if TYPE_CHECKING:
 EXPECTED_FAST_CHECKS: frozenset[str] = frozenset(
     {
         "daemon_liveness",
+        # polylogue-7eo7 #2: narrows the "fresh"/"vanished" binary with a
+        # WARNING tier for a heartbeat that has missed a scheduled beat.
+        "heartbeat_staleness",
         "schema_version",
         "disk_space",
         "wal_size",
@@ -67,6 +70,9 @@ EXPECTED_MEDIUM_CHECKS: frozenset[str] = frozenset(
     {
         "fts_readiness",
         "raw_failures",
+        # #3541: capture-completeness coverage measure -- pre-existing check
+        # this pinned list drifted out of sync with when it landed.
+        "capture_coverage",
         "stale_ingest_attempts",
         "insight_freshness",
         "repeated_stage_failures",


### PR DESCRIPTION
## Summary

Fixes two of the four observability defects audited in polylogue-7eo7 (alert-count/verdict contradiction, silent heartbeat staleness) plus the schema-blocked health-loop gap, and scopes the fourth (dead cursor-lag SLO check) as a documented follow-up rather than a silent no-op.

## Problem

An audit of the daemon health/status pipeline (polylogue-7eo7) found:

1. `polylogued status` printed `"Health: ok (6 alerts)"` while `hook_flow [error]` fires in the journal -- because `alert_count` counted every FAST-tier check run (including OK ones), not actual problems. A fully healthy daemon always shows exactly `len(fast checks)` "alerts", making "ok (N alerts)" read as a contradiction regardless of N.
2. `"Status: running (heartbeat 1369.8s ago)"` on a 15-minute (900s) interval produced no staleness signal at all -- the only existing threshold was the 2x-interval (1800s) "vanished" floor, so anything short of that read as flat "running".
3. `ops.db.cursor_lag_samples` has 0 rows ever: the SLO check reads a table whose only producer runs inside a MEDIUM-tier check, and `health_check_tiers` defaults to `"fast"` -- so the producer never executes under default daemon operation.
4. When the watcher is schema-blocked, `_periodic_health_check()` only started inside the `if not watcher_blocked:` branch in `run_daemon_services`, so the daemon ran with zero periodic health checks/notifications for the entire blocked duration -- exactly when an operator most needs to see "archive tier layout is not ready".

## Solution

- **#1**: `alert_count` in `daemon_status_payload()`'s `"health"` dict now counts only non-OK alerts; a new `checks_run` field carries the previous "every check" total for anyone who still wants it (`polylogue/daemon/status.py`).
- **#2**: New FAST-tier `heartbeat_staleness` check plus `DAEMON_HEARTBEAT_STALE_WARN_SECONDS` (1.5x `DAEMON_HEARTBEAT_INTERVAL_SECONDS`, derived, not hardcoded) fills the gap between "fresh" and the pre-existing 2x "vanished" floor with a WARNING-severity `"stale"` lifecycle state (`polylogue/daemon/lifecycle.py`, `polylogue/daemon/health.py`). `format_daemon_status_lines` renders a `[STALE]` marker on the plain-text status line so the signal is visible without reading alerts separately.
- **#4**: `_periodic_health_check()` moved into the unconditional `maintenance_tasks` list in `run_daemon_services` (`polylogue/daemon/cli.py`), so it now starts regardless of `watcher_blocked`. All FAST-tier checks are read-only (schema_version via `mode=ro` connections, disk/WAL space stats, hook flow, source availability, heartbeat staleness), so this does not reintroduce the archive-write concern the schema-block guard exists for.
- **#3 (deferred, findings recorded)**: `record_cursor_lag_sample` is only ever called from `_check_cursor_lag_anomaly_layer`, invoked by `_check_cursor_lag_medium` (MEDIUM tier). `health_check_tiers` defaults to `"fast"` (`polylogue/config.py`), and `docs/daemon.md` already documents MEDIUM/EXPENSIVE as deliberate "explicit operator diagnostics" -- not accidentally disabled. So the check is not dead code in the sense of being unreachable, but its only producer never runs under default daemon operation, making the table permanently empty in practice. Two real options for a follow-up: (a) decouple sample recording from the MEDIUM gate since it's a cheap read+write, not an expensive scan, or (b) make the gap explicit in status output (e.g. surface "0 samples, producer not scheduled" rather than silence). Left to a follow-up bead since either choice is a behavior decision, not a pure bug fix, and out of the "prioritize #1/#2" scope this bead itself calls for.

## Verification

```
devtools test tests/unit/daemon/test_health_check_paths.py tests/unit/daemon/test_health_contract.py \
  tests/unit/daemon/test_daemon_lifecycle.py tests/unit/daemon/test_daemon_status.py tests/unit/daemon/test_daemon_cli.py
# 241 passed
```

New tests added: `test_health_alert_count_excludes_ok_severity_checks` and `test_health_alert_count_reflects_a_real_problem_not_ok` (proves a nonzero-alert scenario no longer reports "ok" and an all-OK scenario reports `(0 alerts)` instead of `(6 alerts)`), `test_heartbeat_staleness_warning_between_warn_and_vanished_floors` and `test_lifecycle_status_reports_stale_between_warn_and_vanished_floors` (proves the exact observed 1369.8s/900s scenario now produces a WARNING alert and a `"stale"` lifecycle state), `test_cli_status_marks_a_stale_but_still_running_heartbeat` (proves the `[STALE]` marker renders), and `test_run_daemon_services_schema_block_skips_write_but_starts_health_check` (renamed/rewritten from the old `..._skips_db_background_work` test, which previously asserted the opposite -- that health checks must NOT start when blocked).

Also fixed an unrelated pre-existing drift in the same pinned-check-inventory test: `capture_coverage` (added in #3541) was missing from `EXPECTED_MEDIUM_CHECKS`, causing `test_medium_tier_inventory_pinned` to fail independent of this change.

`devtools verify --quick` passes (ruff format/check, mypy --strict, render all --check, layering, degrade-loudly, closure-matrix, and the rest of the static gate set) -- also ran automatically via the pre-push hook.

A broader `devtools test tests/unit/daemon/` run (2010 tests) shows 2009 passing; the one remaining failure (`test_no_token_in_log_or_print_calls` in `test_daemon_http_security.py`, about `polylogue/daemon/api_auth.py`) is unrelated and pre-existing -- this PR does not touch that file.

Not run: full `devtools verify` (seed-testmon, non-slow suite) -- started once, killed per operator instruction to avoid cross-turn backgrounding; the focused command above covers every file this PR touches.

Ref polylogue-7eo7