### PR TITLE
fix: stop freezing empty codex sidecar snapshot on transient error

### DIFF
--- a/polylogue/pipeline/services/ingest_batch/_core.py
+++ b/polylogue/pipeline/services/ingest_batch/_core.py
@@ -766,6 +766,8 @@ def _record_outcome(summary: _IngestBatchSummary, ir: IngestRecordResult) -> Non
             summary.max_result_raw_id = ir.raw_id
     if ir.schema_drift is not None:
         summary.schema_drift_observations.append(ir.schema_drift)
+    if ir.sessions_unenriched:
+        summary.counts["sessions_unenriched"] += 1
 
 
 def _observe_current_rss(summary: _IngestBatchSummary) -> None:
@@ -1441,8 +1443,19 @@ def _resolve_codex_sidecar_snapshots(
             try:
                 discovered = cast("dict[str, dict[str, str]]", spec.discover_sidecars([Path(source_path)]))
             except Exception:
+                # polylogue-azf7: a transient discovery failure (disk I/O,
+                # malformed sidecar this instant) must NOT be persisted as a
+                # snapshot. read_earliest_history_sidecar_for_path freezes
+                # the FIRST row ever written for (origin, source_path)
+                # (polylogue-ih67 AC#3/4); persisting {} here would freeze a
+                # permanently empty snapshot and no later successful
+                # discovery would ever be recorded or replayed again. Use
+                # the empty result for THIS ingest only and leave no
+                # snapshot behind, so the next ingest attempt still sees
+                # "no snapshot yet" and retries discovery from disk.
                 logger.exception("codex sidecar discovery failed for %s", source_path)
-                discovered = {}
+                resolved[source_path] = {}
+                continue
             resolved[source_path] = discovered
             try:
                 write_history_sidecar(

--- a/polylogue/pipeline/services/ingest_batch/_models.py
+++ b/polylogue/pipeline/services/ingest_batch/_models.py
@@ -87,6 +87,12 @@ class _IngestBatchSummary:
             "sidecar_blob_bytes_new": 0,
             "sidecar_blob_bytes_dedup": 0,
             "sidecar_blobs_written": 0,
+            # polylogue-azf7: records whose sessions materialized without
+            # provider assembly enrichment because on-demand sidecar
+            # discovery raised mid-ingest (see IngestRecordResult.sessions_
+            # unenriched). Surfaces silent title/enrichment degradation
+            # that previously only reached a log line.
+            "sessions_unenriched": 0,
         }
     )
     changed_counts: dict[str, int] = field(

--- a/polylogue/pipeline/services/ingest_worker.py
+++ b/polylogue/pipeline/services/ingest_worker.py
@@ -102,6 +102,12 @@ class IngestRecordResult:
     retryable: bool | None = False
     evidence_ref: str | None = None
     remediation: str | None = None
+    # polylogue-azf7: set when on-demand sidecar-assembly enrichment raised
+    # and this record's sessions were materialized unenriched (native-id
+    # title etc.) as a result. Distinct from ``error`` -- the record still
+    # succeeds -- so the batch summary can count silent degradation instead
+    # of it only reaching a log line.
+    sessions_unenriched: bool = False
 
 
 ParsePlanMode = Literal["payload", "stream"]
@@ -216,6 +222,7 @@ def _record_result(
     include_source_name: bool = False,
     schema_drift: SchemaDriftObservation | None = None,
     disposition: IngestAttemptDisposition | None = None,
+    sessions_unenriched: bool = False,
 ) -> IngestRecordResult:
     if disposition is None:
         disposition = success_disposition() if error is None else None
@@ -234,6 +241,7 @@ def _record_result(
             retryable=(disposition.retryable if disposition is not None else None),
             evidence_ref=(disposition.evidence_ref if disposition is not None else None),
             remediation=(disposition.remediation if disposition is not None else None),
+            sessions_unenriched=sessions_unenriched,
         ),
         measure_serialized_size=context.measure_serialized_size,
     )
@@ -592,7 +600,7 @@ def _enrich_parsed_sessions(
     context: _IngestContext,
     plan: _ParsePlan,
     parsed_sessions: list[ParsedSession],
-) -> list[ParsedSession]:
+) -> tuple[list[ParsedSession], bool]:
     """Apply the same provider assembly enrichment direct ingest uses.
 
     Canonical raw-record ingest historically bypassed provider assembly, so
@@ -612,27 +620,33 @@ def _enrich_parsed_sessions(
     ``None`` means the resolver never ran for this record (non-Codex, or a
     caller that bypasses the batch resolver, e.g. focused unit tests) and
     the prior on-demand disk-discovery behavior applies unchanged.
+
+    Returns ``(sessions, sessions_unenriched)`` -- the second element is
+    ``True`` only when on-demand discovery raised and the caller fell back
+    to the unenriched sessions (polylogue-azf7), so the batch summary can
+    surface a count of silently-degraded records instead of a log line
+    being the only trace.
     """
     from polylogue.sources.assembly import get_assembly_spec
 
     spec = get_assembly_spec(plan.provider)
     if spec is None:
-        return parsed_sessions
+        return parsed_sessions, False
     if context.raw_record.sidecar_snapshot is not None:
         sidecar_data = cast(SidecarData, context.raw_record.sidecar_snapshot)
-        return [spec.enrich_session(convo, sidecar_data) for convo in parsed_sessions]
+        return [spec.enrich_session(convo, sidecar_data) for convo in parsed_sessions], False
     source_path = context.raw_record.source_path
     if not source_path:
-        return parsed_sessions
+        return parsed_sessions, False
     try:
         sidecar_data = spec.discover_sidecars([Path(source_path)])
-        return [spec.enrich_session(convo, sidecar_data) for convo in parsed_sessions]
+        return [spec.enrich_session(convo, sidecar_data) for convo in parsed_sessions], False
     except Exception:
         logger.exception(
             "assembly enrichment failed for %s; keeping unenriched sessions",
             context.raw_record.raw_id,
         )
-        return parsed_sessions
+        return parsed_sessions, True
 
 
 def _materialize_parsed_sessions(
@@ -641,6 +655,7 @@ def _materialize_parsed_sessions(
     *,
     validation: _PlanValidation,
     parsed_sessions: list[ParsedSession],
+    sessions_unenriched: bool = False,
 ) -> IngestRecordResult:
     if not parsed_sessions:
         error = "parse: session artifact produced no materializable sessions"
@@ -692,6 +707,7 @@ def _materialize_parsed_sessions(
         sessions=session_payloads,
         include_source_name=True,
         schema_drift=validation.schema_drift,
+        sessions_unenriched=sessions_unenriched,
     )
 
 
@@ -736,11 +752,13 @@ def _run_parse_plan(
             disposition=classify_parse_exception(exc),
         )
 
+    enriched_sessions, sessions_unenriched = _enrich_parsed_sessions(context, plan, parsed_sessions)
     return _materialize_parsed_sessions(
         context,
         plan,
         validation=validation,
-        parsed_sessions=_enrich_parsed_sessions(context, plan, parsed_sessions),
+        parsed_sessions=enriched_sessions,
+        sessions_unenriched=sessions_unenriched,
     )
 
 

--- a/tests/unit/pipeline/test_ingest_batch_codex_sidecar_snapshot.py
+++ b/tests/unit/pipeline/test_ingest_batch_codex_sidecar_snapshot.py
@@ -117,6 +117,70 @@ def test_ambient_edit_after_first_resolution_does_not_alter_replay(tmp_path: Pat
     assert len(rows) == 1
 
 
+def test_transient_discovery_failure_does_not_freeze_an_empty_snapshot(
+    tmp_path: Path,
+    archive_root: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for polylogue-azf7.
+
+    Before the fix, ``_resolve_codex_sidecar_snapshots`` swallowed any
+    exception from ``discover_sidecars`` and persisted the resulting empty
+    ``{}`` via ``write_history_sidecar``. Because
+    ``read_earliest_history_sidecar_for_path`` replays the *first* persisted
+    row forever (polylogue-ih67 AC#3/4), a one-off transient error (disk
+    hiccup, a sidecar file mid-write) permanently froze an empty snapshot:
+    every subsequent ingest of that ``source_path`` -- even long after the
+    transient condition cleared -- would keep replaying the empty result and
+    enrichment could never recover.
+    """
+    from polylogue.sources import assembly_codex
+
+    session_id = "dddd1111-2222-3333-4444-555566667777"
+    rollout = _codex_runtime_root(tmp_path, session_id)
+    (rollout.parents[2] / "history.jsonl").write_text(
+        json.dumps({"session_id": session_id, "ts": 1, "text": "real title"}) + "\n",
+        encoding="utf-8",
+    )
+
+    original_discover = assembly_codex.CodexAssemblySpec.discover_sidecars
+    call_count = {"n": 0}
+
+    def flaky_discover(self: object, paths: object) -> object:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise OSError("simulated transient disk error during discovery")
+        return original_discover(self, paths)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(assembly_codex.CodexAssemblySpec, "discover_sidecars", flaky_discover)
+
+    # First attempt: discovery raises. This ingest's record gets an empty
+    # (unenriched) snapshot for its own materialization, but nothing may be
+    # persisted as the frozen "first" row.
+    record_first = _record(str(rollout))
+    _resolve_codex_sidecar_snapshots([record_first], archive_root=archive_root)
+    assert record_first.sidecar_snapshot == {}
+
+    with sqlite3.connect(str(archive_root / "source.db")) as conn:
+        rows = conn.execute("SELECT payload_json FROM history_sidecars").fetchall()
+    assert rows == [], "a transient discovery failure must not persist a frozen empty snapshot"
+
+    # Second attempt for the SAME source_path: discovery now succeeds. This
+    # must become the real first-ever persisted snapshot and must be read
+    # back correctly, not the empty result from the failed first attempt.
+    record_second = _record(str(rollout))
+    _resolve_codex_sidecar_snapshots([record_second], archive_root=archive_root)
+
+    assert record_second.sidecar_snapshot is not None
+    assert record_second.sidecar_snapshot["history_titles"][session_id] == "real title"
+
+    with sqlite3.connect(str(archive_root / "source.db")) as conn:
+        rows = conn.execute("SELECT payload_json FROM history_sidecars").fetchall()
+    assert len(rows) == 1
+    persisted = json.loads(rows[0][0])
+    assert persisted["history_titles"][session_id] == "real title"
+
+
 def test_non_codex_records_are_left_unresolved(tmp_path: Path, archive_root: Path) -> None:
     record = RawSessionRecord(
         raw_id="raw-claude",

--- a/tests/unit/pipeline/test_ingest_worker_assembly.py
+++ b/tests/unit/pipeline/test_ingest_worker_assembly.py
@@ -135,6 +135,45 @@ def test_canonical_ingest_message_fallback_without_sidecars(blob_store: BlobStor
     assert title_source == TitleSource.HEURISTIC.value
 
 
+def test_on_demand_enrichment_failure_is_counted_not_only_logged(
+    blob_store: BlobStore, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sibling of polylogue-azf7's frozen-snapshot bug (ingest_worker.py path).
+
+    When ``_resolve_codex_sidecar_snapshots`` hasn't run for a record (e.g. a
+    direct ``ingest_record`` call bypassing the batch orchestrator, as here),
+    ``_enrich_parsed_sessions`` discovers sidecars on demand. A raised
+    exception there used to be swallowed into a log line with sessions
+    silently kept unenriched and no trace in the returned result. The record
+    still reports ``error is None`` (it succeeds), but must now flag
+    ``sessions_unenriched=True`` so a batch summary can count it.
+    """
+    from polylogue.sources import assembly_codex
+
+    session_id = "eeee1111-2222-3333-4444-555566667777"
+    content = _codex_stream(session_id, "please fix the ingest bug")
+    rollout = _codex_runtime_root(tmp_path, session_id, content)
+    (rollout.parents[2] / "session_index.jsonl").write_text(
+        json.dumps({"id": session_id, "thread_name": "Ingest bug hunt"}) + "\n",
+        encoding="utf-8",
+    )
+
+    def raising_discover(self: object, paths: object) -> object:
+        raise OSError("simulated transient disk error during on-demand discovery")
+
+    monkeypatch.setattr(assembly_codex.CodexAssemblySpec, "discover_sidecars", raising_discover)
+
+    record = _record(blob_store, content, source_path=str(rollout))
+    result = ingest_record(record, str(tmp_path / "archive"), "advisory", blob_root_str=str(blob_store.root))
+
+    assert result.error is None
+    assert result.sessions, "expected the record to still materialize, just unenriched"
+    assert result.sessions_unenriched is True
+    # Unenriched: falls back to the parsed-content heuristic, not the
+    # sidecar thread name that discovery would otherwise have supplied.
+    assert result.sessions[0].parsed_session.title != "Ingest bug hunt"
+
+
 def test_runtime_schema_registry_singleton_is_race_safe_under_concurrent_first_access(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
A transient error during Codex sidecar discovery (disk I/O hiccup, a sidecar file caught mid-write) was being persisted as a permanently-frozen empty enrichment snapshot, so every future ingest of that source path replayed the empty result and title enrichment could never recover. A sibling, less severe instance existed in the per-record on-demand enrichment path (silent fallback, log-only, no summary visibility) and is fixed in the same change.

## Problem
`_resolve_codex_sidecar_snapshots` (`polylogue/pipeline/services/ingest_batch/_core.py`) caught any exception from `CodexAssemblySpec.discover_sidecars` and persisted the resulting empty `{}` via `write_history_sidecar`. `read_earliest_history_sidecar_for_path` (`storage/sqlite/archive_tiers/source_write.py`) deliberately replays only the FIRST persisted row for `(origin, source_path)` (polylogue-ih67 AC#3/4 — this freeze exists so an ambient edit to a live sidecar file can't silently change a previously acquired replay's title). Combining the two: a one-off transient error became a durable, uncorrectable data-quality defect, because the frozen "first" row was the empty one, and no later successful discovery attempt was ever recorded or replayed again.

The bead also named a sibling shape at `ingest_worker.py`'s per-record on-demand enrichment fallback (used when the batch resolver hasn't run — e.g. direct `ingest_record` calls). There, a discovery exception fell back to unenriched sessions with only a log line as evidence; the record still reports success and the degradation was invisible to the batch summary.

## Solution
- `_resolve_codex_sidecar_snapshots`: on a `discover_sidecars` exception, use the empty result for that one ingest attempt only and skip the `write_history_sidecar` call entirely — nothing is persisted, so the next ingest attempt for the same `source_path` still sees "no snapshot yet" and retries discovery from disk. Genuinely-empty discovery results (no exception, the spec just found nothing) are unaffected and still freeze on first write, preserving the ih67 replay-determinism guarantee — this only changes behavior on the *exception* path.
- `ingest_worker.py`: added `IngestRecordResult.sessions_unenriched: bool`, set when on-demand enrichment raises and the caller falls back to unenriched sessions. Threaded through `_enrich_parsed_sessions` (now returns `(sessions, unenriched)`), `_materialize_parsed_sessions`, and `_record_result`.
- `_IngestBatchSummary.counts["sessions_unenriched"]`: new counter incremented in `_record_outcome` (`ingest_batch/_core.py`) whenever a drained result reports `sessions_unenriched=True`, so silent enrichment degradation is now visible in the batch summary, not only in a log line.

## Verification
- `devtools test tests/unit/pipeline/test_ingest_worker_assembly.py tests/unit/pipeline/test_ingest_batch_codex_sidecar_snapshot.py tests/unit/pipeline/test_ingest_batch.py` — 73 passed. Includes two new regression tests:
  - `test_transient_discovery_failure_does_not_freeze_an_empty_snapshot`: simulates a one-time `OSError` on the first discovery attempt, asserts zero rows are persisted to `history_sidecars` after that attempt, then asserts a second attempt for the same `source_path` succeeds and persists the real title. Verified this test fails on the pre-fix code (`assert [('{}',)] == []`) and passes after the fix.
  - `test_on_demand_enrichment_failure_is_counted_not_only_logged`: simulates a discovery exception on the per-record path and asserts `IngestRecordResult.sessions_unenriched is True`.
- `devtools verify --quick` — format/lint/mypy --strict/render-all-check/layering/policy gates, exit 0.

Ref polylogue-azf7