### PR TITLE
fix(sources): find browser-capture provider past the 1MiB prefix

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -936,6 +936,24 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "workspace unknown-export-reclassification",
+        "workspace",
+        "Re-run the fixed browser-capture provider probe against stored unknown-export rows.",
+        "devtools.unknown_export_reclassification_report",
+        use_when=(
+            "polylogue-mvq8: before acting on browser-capture raw_sessions rows stamped "
+            "unknown-export by the pre-fix 1MiB prefix probe, get a read-only classification "
+            "of how many are re-detectable under the fixed structural (ijson) provider scan. "
+            "Never mutates origin or blob state; rewriting origin / re-parsing / re-indexing "
+            "a 'reclassifiable' row is a separate, explicitly operator-authorized step."
+        ),
+        examples=(
+            "devtools workspace unknown-export-reclassification",
+            "devtools workspace unknown-export-reclassification --json",
+            "devtools workspace unknown-export-reclassification --source-path-like '' --limit 500",
+        ),
+    ),
+    CommandSpec(
         "workspace temporal-read-profile",
         "workspace",
         "Measure read --view temporal phase timings on the active archive.",

--- a/devtools/unknown_export_reclassification_report.py
+++ b/devtools/unknown_export_reclassification_report.py
@@ -1,0 +1,146 @@
+"""Read-only report: re-detect provider for browser captures stamped ``unknown-export``.
+
+polylogue-mvq8: captures larger than 8MiB used to detect their provider via a
+1MiB byte-prefix probe that could miss ``session.provider`` entirely when a
+capture's ``raw_provider_payload`` (sorted before ``session`` in the
+receiver's key-sorted output) exceeded that window -- such rows were
+durably stamped ``unknown-export`` at acquisition time. This command runs
+``polylogue.storage.unknown_export_reclassification.plan_unknown_export_reclassification``
+against the live archive's ``source.db`` (opened strictly read-only) and
+reports, per stored ``unknown-export`` row, whether the now-fixed detection
+logic recovers a real provider.
+
+This is a dry-run classifier only. It never mutates ``source.db``, never
+rewrites a row's ``origin``, and never triggers re-parse/re-index -- acting
+on a "reclassifiable" verdict is a deliberately separate, explicitly
+operator-authorized follow-up.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from dataclasses import asdict
+from pathlib import Path
+from typing import TextIO
+
+from polylogue.paths import archive_root as default_archive_root
+from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.unknown_export_reclassification import (
+    DEFAULT_SOURCE_PATH_LIKE,
+    UnknownExportReclassificationCandidate,
+    plan_unknown_export_reclassification,
+)
+
+
+def _candidate_payload(candidate: UnknownExportReclassificationCandidate) -> dict[str, object]:
+    payload = asdict(candidate)
+    payload["recovered_provider"] = candidate.recovered_provider.value if candidate.recovered_provider else None
+    payload["recovered_origin"] = candidate.recovered_origin.value if candidate.recovered_origin else None
+    return payload
+
+
+def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive-root",
+        type=Path,
+        default=None,
+        help="Archive root to inspect; defaults to the configured active archive root.",
+    )
+    parser.add_argument(
+        "--source-path-like",
+        default=DEFAULT_SOURCE_PATH_LIKE,
+        help=(
+            "SQL LIKE pattern restricting which unknown-export rows to scan by "
+            "source_path (default: the browser-capture spool shape). Pass an "
+            "empty string to scan every unknown-export row regardless of source."
+        ),
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap the number of unknown-export rows scanned (unbounded by default).",
+    )
+    parser.add_argument(
+        "--sample-limit",
+        type=int,
+        default=10,
+        help="How many rows per bucket to print in the human-readable report.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the full classified plan as JSON.")
+    args = parser.parse_args(argv)
+
+    root = args.archive_root if args.archive_root is not None else default_archive_root()
+    source_db = root / "source.db"
+    if not source_db.exists():
+        print(f"no source.db at {source_db}", file=stdout)
+        return 1
+
+    source_path_like = args.source_path_like if args.source_path_like else None
+    conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+    try:
+        blob_store = BlobStore(root / "blob")
+        plan = plan_unknown_export_reclassification(
+            conn,
+            blob_store=blob_store,
+            source_path_like=source_path_like,
+            limit=args.limit,
+        )
+    finally:
+        conn.close()
+
+    if args.json:
+        payload = {
+            "scanned_count": plan.scanned_count,
+            "reclassifiable_count": len(plan.reclassifiable),
+            "reclassifiable_bytes": plan.reclassifiable_bytes,
+            "reclassifiable_by_origin": plan.reclassifiable_by_origin,
+            "still_unknown_count": len(plan.still_unknown),
+            "still_unknown_bytes": plan.still_unknown_bytes,
+            "blob_missing_count": len(plan.blob_missing),
+            "blob_missing_bytes": plan.blob_missing_bytes,
+            "reclassifiable_sample": [_candidate_payload(c) for c in plan.reclassifiable[: args.sample_limit]],
+            "still_unknown_sample": [_candidate_payload(c) for c in plan.still_unknown[: args.sample_limit]],
+            "blob_missing_sample": [_candidate_payload(c) for c in plan.blob_missing[: args.sample_limit]],
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=stdout)
+        return 0
+
+    def _mb(byte_count: int) -> str:
+        return f"{byte_count / (1024 * 1024):.1f} MB"
+
+    print(f"unknown-export rows scanned: {plan.scanned_count}", file=stdout)
+    print(
+        f"reclassifiable:  {len(plan.reclassifiable):>7}  ({_mb(plan.reclassifiable_bytes)})"
+        f"  -- by origin: {plan.reclassifiable_by_origin}",
+        file=stdout,
+    )
+    print(f"still unknown:   {len(plan.still_unknown):>7}  ({_mb(plan.still_unknown_bytes)})", file=stdout)
+    print(f"blob missing:    {len(plan.blob_missing):>7}  ({_mb(plan.blob_missing_bytes)})", file=stdout)
+    print("", file=stdout)
+    print(
+        "This is a read-only classification. No origin or blob state was mutated.",
+        file=stdout,
+    )
+    for label, bucket in (
+        ("reclassifiable", plan.reclassifiable),
+        ("still unknown", plan.still_unknown),
+        ("blob missing", plan.blob_missing),
+    ):
+        if not bucket:
+            continue
+        print(f"\n{label} sample (up to {args.sample_limit}):", file=stdout)
+        for candidate in bucket[: args.sample_limit]:
+            origin_note = f" -> {candidate.recovered_origin.value}" if candidate.recovered_origin else ""
+            print(
+                f"  {candidate.raw_id}  {candidate.blob_size}B  {candidate.source_path}{origin_note}",
+                file=stdout,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -248,6 +248,7 @@ These are the commands worth remembering during normal repo work:
 | `devtools workspace temporal-devloop` | Compose git and operating-log events into a temporal evidence window. |
 | `devtools workspace temporal-read-profile` | Measure read --view temporal phase timings on the active archive. |
 | `devtools workspace trajectory-report` | Self-contained HTML velocity/trajectory report over git + PR + bead history. |
+| `devtools workspace unknown-export-reclassification` | Re-run the fixed browser-capture provider probe against stored unknown-export rows. |
 | `devtools workspace verify-worktree` | Verify an agent lane's claimed worktree exists, is isolated, and is on the expected branch. |
 | `devtools workspace worktree-gc` | Safe worktree garbage collection — list and remove merged, squash-equivalent, or abandoned git worktrees. |
 

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -179,12 +179,12 @@ files:
     owner: archive-artifact-taxonomy
     reason: archive-domain semantics
   - path: polylogue/archive/artifact_taxonomy/runtime.py
-    loc: 564
+    loc: 569
     target: polylogue/archive/artifact_taxonomy/runtime.py
     owner: archive-artifact-taxonomy
     reason: archive-domain semantics
   - path: polylogue/archive/artifact_taxonomy/support.py
-    loc: 197
+    loc: 203
     target: polylogue/archive/artifact_taxonomy/support.py
     owner: archive-artifact-taxonomy
     reason: archive-domain semantics
@@ -524,7 +524,7 @@ files:
     owner: archive-raw-payload
     reason: archive-domain semantics
   - path: polylogue/archive/raw_payload/sampling_extract.py
-    loc: 292
+    loc: 309
     target: polylogue/archive/raw_payload/sampling_extract.py
     owner: archive-raw-payload
     reason: archive-domain semantics
@@ -799,7 +799,7 @@ files:
     target: polylogue/browser_capture/pairing.py
     owner: stable
   - path: polylogue/browser_capture/receiver.py
-    loc: 877
+    loc: 908
     target: polylogue/browser_capture/receiver.py
     owner: stable
   - path: polylogue/browser_capture/route_contracts.py
@@ -819,11 +819,11 @@ files:
     target: polylogue/cli/__main__.py
     owner: stable
   - path: polylogue/cli/archive_query.py
-    loc: 3039
+    loc: 3046
     target: polylogue/cli/archive_query.py
     owner: stable
   - path: polylogue/cli/click_app.py
-    loc: 693
+    loc: 697
     target: polylogue/cli/click_app.py
     owner: stable
   - path: polylogue/cli/click_command_registration.py
@@ -903,7 +903,7 @@ files:
     target: polylogue/cli/commands/excise.py
     owner: stable
   - path: polylogue/cli/commands/facets.py
-    loc: 136
+    loc: 140
     target: polylogue/cli/commands/facets.py
     owner: stable
   - path: polylogue/cli/commands/hooks.py
@@ -983,7 +983,7 @@ files:
     target: polylogue/cli/commands/maintenance/_raw_identity.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_rebuild_index.py
-    loc: 548
+    loc: 550
     target: polylogue/cli/commands/maintenance/_rebuild_index.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_run.py
@@ -1524,7 +1524,7 @@ files:
     target: polylogue/daemon/__init__.py
     owner: stable
   - path: polylogue/daemon/api_auth.py
-    loc: 135
+    loc: 172
     target: polylogue/daemon/api_auth.py
     owner: stable
   - path: polylogue/daemon/backup.py
@@ -1552,7 +1552,7 @@ files:
     target: polylogue/daemon/catchup_status.py
     owner: stable
   - path: polylogue/daemon/cli.py
-    loc: 2985
+    loc: 3021
     target: polylogue/daemon/cli.py
     owner: stable
   - path: polylogue/daemon/compare.py
@@ -1572,7 +1572,7 @@ files:
     target: polylogue/daemon/convergence_debt_status.py
     owner: stable
   - path: polylogue/daemon/convergence_stages.py
-    loc: 2097
+    loc: 2105
     target: polylogue/daemon/convergence_stages.py
     owner: stable
   - path: polylogue/daemon/convergence_standing_queries.py
@@ -1632,11 +1632,11 @@ files:
     target: polylogue/daemon/fts_startup.py
     owner: stable
   - path: polylogue/daemon/fts_status.py
-    loc: 524
+    loc: 532
     target: polylogue/daemon/fts_status.py
     owner: stable
   - path: polylogue/daemon/health.py
-    loc: 1471
+    loc: 1522
     target: polylogue/daemon/health.py
     owner: stable
   - path: polylogue/daemon/healthz.py
@@ -1652,7 +1652,7 @@ files:
     target: polylogue/daemon/judgment_automation.py
     owner: stable
   - path: polylogue/daemon/lifecycle.py
-    loc: 285
+    loc: 298
     target: polylogue/daemon/lifecycle.py
     owner: stable
   - path: polylogue/daemon/lineage_startup.py
@@ -1677,7 +1677,7 @@ files:
     target: polylogue/daemon/maintenance_registry_http.py
     owner: stable
   - path: polylogue/daemon/metrics.py
-    loc: 2018
+    loc: 2036
     target: polylogue/daemon/metrics.py
     owner: stable
   - path: polylogue/daemon/notification_backends/__init__.py
@@ -1737,7 +1737,7 @@ files:
     target: polylogue/daemon/socket_path.py
     owner: stable
   - path: polylogue/daemon/status.py
-    loc: 3208
+    loc: 3222
     target: polylogue/daemon/status.py
     owner: stable
   - path: polylogue/daemon/status_snapshot.py
@@ -2303,7 +2303,7 @@ files:
     target: polylogue/mcp/archive_support.py
     owner: stable
   - path: polylogue/mcp/call_log.py
-    loc: 407
+    loc: 409
     target: polylogue/mcp/call_log.py
     owner: stable
   - path: polylogue/mcp/cli.py
@@ -2536,16 +2536,16 @@ files:
     target: polylogue/pipeline/services/ingest_worker.py
     owner: stable
   - path: polylogue/pipeline/services/parsing.py
-    loc: 136
+    loc: 140
     target: polylogue/pipeline/services/parsing.py
     owner: stable
   - path: polylogue/pipeline/services/parsing_models.py
-    loc: 180
+    loc: 187
     target: polylogue/pipeline/services/parsing_models.py
     owner: stable
     cross_cut: { lifecycle: model }
   - path: polylogue/pipeline/services/parsing_workflow.py
-    loc: 454
+    loc: 504
     target: polylogue/pipeline/services/parsing_workflow.py
     owner: stable
   - path: polylogue/pipeline/services/planning.py
@@ -2795,7 +2795,7 @@ files:
     target: polylogue/schemas/drift_sentinel.py
     owner: stable
   - path: polylogue/schemas/drift_sentinel_sampling.py
-    loc: 91
+    loc: 122
     target: polylogue/schemas/drift_sentinel_sampling.py
     owner: stable
   - path: polylogue/schemas/field_stats/__init__.py
@@ -2831,7 +2831,7 @@ files:
     target: polylogue/schemas/generation/archive_workload_profile.py
     owner: stable
   - path: polylogue/schemas/generation/cluster_collection.py
-    loc: 315
+    loc: 332
     target: polylogue/schemas/generation/cluster_collection.py
     owner: stable
   - path: polylogue/schemas/generation/cluster_support.py
@@ -2851,7 +2851,7 @@ files:
     target: polylogue/schemas/generation/models.py
     owner: stable
   - path: polylogue/schemas/generation/observation_journal.py
-    loc: 1232
+    loc: 1321
     target: polylogue/schemas/generation/observation_journal.py
     owner: stable
   - path: polylogue/schemas/generation/packages.py
@@ -2968,7 +2968,7 @@ files:
     owner: stable
     cross_cut: { lifecycle: model }
   - path: polylogue/schemas/observation_runtime.py
-    loc: 355
+    loc: 359
     target: polylogue/schemas/observation_runtime.py
     owner: stable
     cross_cut: { lifecycle: runtime }
@@ -3061,7 +3061,7 @@ files:
     target: polylogue/schemas/schema_parser_coverage.py
     owner: stable
   - path: polylogue/schemas/shape_fingerprint.py
-    loc: 73
+    loc: 79
     target: polylogue/schemas/shape_fingerprint.py
     owner: stable
   - path: polylogue/schemas/synthetic/__init__.py
@@ -3340,7 +3340,7 @@ files:
     target: polylogue/sources/live/append_ingest.py
     owner: stable
   - path: polylogue/sources/live/batch.py
-    loc: 3223
+    loc: 3258
     target: polylogue/sources/live/batch.py
     owner: stable
   - path: polylogue/sources/live/batch_observability.py
@@ -3348,7 +3348,7 @@ files:
     target: polylogue/sources/live/batch_observability.py
     owner: stable
   - path: polylogue/sources/live/batch_support.py
-    loc: 600
+    loc: 643
     target: polylogue/sources/live/batch_support.py
     owner: stable
   - path: polylogue/sources/live/convergence_debt.py
@@ -3364,7 +3364,7 @@ files:
     target: polylogue/sources/live/convergence_outcome.py
     owner: stable
   - path: polylogue/sources/live/cursor.py
-    loc: 1449
+    loc: 1461
     target: polylogue/sources/live/cursor.py
     owner: stable
   - path: polylogue/sources/live/cursor_lifecycle.py
@@ -3376,7 +3376,7 @@ files:
     target: polylogue/sources/live/dedup.py
     owner: stable
   - path: polylogue/sources/live/deferred_cursor.py
-    loc: 54
+    loc: 77
     target: polylogue/sources/live/deferred_cursor.py
     owner: stable
   - path: polylogue/sources/live/hook_paste_enrichment.py
@@ -3400,7 +3400,7 @@ files:
     target: polylogue/sources/live/tool_result_sidecars.py
     owner: stable
   - path: polylogue/sources/live/watcher.py
-    loc: 1511
+    loc: 1515
     target: polylogue/sources/live/watcher.py
     owner: stable
   - path: polylogue/sources/origin_specs.py
@@ -3659,7 +3659,7 @@ files:
     target: polylogue/storage/artifacts/views.py
     owner: stable
   - path: polylogue/storage/attachment_relink.py
-    loc: 374
+    loc: 377
     target: TBD
     owner: storage-domain
   - path: polylogue/storage/backup_attestation.py
@@ -4181,7 +4181,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/archive_tiers_specs.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/bootstrap.py
-    loc: 276
+    loc: 306
     target: polylogue/storage/sqlite/archive_tiers/bootstrap.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/column_spec.py
@@ -4221,11 +4221,11 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/ingest_precedence.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/ops.py
-    loc: 375
+    loc: 401
     target: polylogue/storage/sqlite/archive_tiers/ops.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/ops_write.py
-    loc: 1715
+    loc: 1719
     target: polylogue/storage/sqlite/archive_tiers/ops_write.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/pricing_seed.py
@@ -4597,6 +4597,10 @@ files:
     owner: stable
   - path: polylogue/storage/table_existence.py
     loc: 69
+    target: TBD
+    owner: storage-domain
+  - path: polylogue/storage/unknown_export_reclassification.py
+    loc: 189
     target: TBD
     owner: storage-domain
   - path: polylogue/storage/usage.py

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -11,6 +11,8 @@ from io import BytesIO
 from pathlib import Path
 from typing import Protocol
 
+import ijson
+
 from polylogue.archive.artifact_taxonomy import classify_artifact, classify_artifact_path
 from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDecodeError, JSONValue
@@ -465,6 +467,24 @@ def _accumulate_stage_timings(target: dict[str, float], update: dict[str, float]
 
 
 def _browser_capture_prefix_probe(path: Path) -> tuple[bool, Provider | None]:
+    """Detect a browser-capture envelope and its provider for a large file.
+
+    The receiver serializes captures with ``sort_keys=True``
+    (``browser_capture/receiver.py``), so the envelope's ``raw_provider_payload``
+    field (an unbounded copy of the provider's own wire payload) sorts
+    alphabetically *before* ``session`` and therefore before
+    ``session.provider``. Once ``raw_provider_payload`` alone exceeds
+    ``_BROWSER_CAPTURE_PREFIX_PROBE_BYTES``, the provider marker never appears
+    in the leading prefix at all -- a >8MiB capture with a big enough leading
+    payload was permanently stamped ``unknown-export`` regardless of how many
+    times it was re-captured (polylogue-mvq8). The prefix regex below still
+    short-circuits the common case (small ``raw_provider_payload``, provider
+    marker within the first MiB); only when that is inconclusive but the
+    envelope is confirmed to be a browser capture does this fall back to a
+    memory-bounded structural scan (:func:`_browser_capture_provider_from_path`)
+    that finds ``session.provider`` regardless of where it falls in the
+    payload.
+    """
     if path.suffix.lower() != ".json":
         return False, None
     try:
@@ -475,14 +495,37 @@ def _browser_capture_prefix_probe(path: Path) -> tuple[bool, Provider | None]:
     if b"polylogue_capture_kind" not in prefix or b"browser_llm_session" not in prefix:
         return False, None
     match = _BROWSER_CAPTURE_PROVIDER_RE.search(prefix)
-    if match is None:
-        return True, None
+    if match is not None:
+        try:
+            provider_token = match.group(1).decode("utf-8")
+        except UnicodeDecodeError:
+            provider_token = None
+        if provider_token is not None:
+            provider = Provider.from_string(provider_token)
+            if provider is not Provider.UNKNOWN:
+                return True, provider
+    # The prefix confirmed a browser capture but didn't yield a usable
+    # provider marker -- ``session.provider`` may sit past this prefix.
+    return True, _browser_capture_provider_from_path(path)
+
+
+def _browser_capture_provider_from_path(path: Path) -> Provider | None:
+    """Stream-parse a browser-capture envelope to find ``session.provider``.
+
+    Memory-bounded regardless of payload size (an ``ijson`` event stream),
+    mirroring ``source_acquisition_components._stream_browser_capture_provider``
+    -- but reads directly from a filesystem path instead of the blob store,
+    since this probe runs before the file has been copied into a blob.
+    """
     try:
-        provider_token = match.group(1).decode("utf-8")
-    except UnicodeDecodeError:
-        return True, None
-    provider = Provider.from_string(provider_token)
-    return True, provider if provider is not Provider.UNKNOWN else None
+        with path.open("rb") as handle:
+            for element_prefix, event, value in ijson.parse(handle):
+                if event == "string" and element_prefix == "session.provider":
+                    provider = Provider.from_string(str(value))
+                    return provider if provider is not Provider.UNKNOWN else None
+    except (OSError, ijson.JSONError):
+        return None
+    return None
 
 
 def _jsonl_sample_from_path(path: Path, *, max_records: int = 32) -> list[JSONValue]:

--- a/polylogue/storage/unknown_export_reclassification.py
+++ b/polylogue/storage/unknown_export_reclassification.py
@@ -1,0 +1,189 @@
+"""Read-only reclassification report for browser captures stamped ``unknown-export``.
+
+polylogue-mvq8: a capture larger than ``_STREAMING_FULL_INGEST_BYTES`` (8MiB)
+detects its provider via ``sources/live/batch_support.py``'s
+``_browser_capture_prefix_probe``, which used to read only the first 1MiB
+(``_BROWSER_CAPTURE_PREFIX_PROBE_BYTES``) of the envelope. Because the
+receiver serializes envelopes with ``sort_keys=True``
+(``browser_capture/receiver.py``), ``raw_provider_payload`` (an unbounded
+copy of the provider's own wire payload) sorts alphabetically *before*
+``session`` -- so once ``raw_provider_payload`` alone exceeds that 1MiB
+window, ``session.provider`` never appeared in the prefix at all and the
+capture was permanently stamped ``unknown-export``.
+
+Fixing the probe (this bead's detection-side fix, now landed) only prevents
+*new* misclassification -- ``origin`` is stamped durably on the ``raw_sessions``
+row at acquisition time, so already-committed rows stay wrong until something
+re-detects them. This module is deliberately NOT a mutator. It mirrors
+``live_source_reconciliation.py``'s shape: given one ``unknown-export`` raw
+row's already-archived blob bytes, does the fixed detection logic
+(``_stream_browser_capture_provider``, a memory-bounded ``ijson`` scan
+identical to the one the acquisition path now uses) recover a real provider?
+Acting on a "reclassifiable" verdict -- rewriting ``origin``/``capture_mode``
+on the raw row, re-parsing, re-indexing -- is an explicitly separate,
+operator-authorized follow-up; nothing here mutates ``source.db`` or the
+blob store beyond reading.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Final
+
+from polylogue.core.enums import Origin, Provider
+from polylogue.core.sources import origin_from_provider
+from polylogue.sources.source_acquisition_components import _stream_browser_capture_provider
+from polylogue.storage.blob_store import BlobStore
+
+#: Default source-path scope: the browser-capture spool shape the mvq8 audit
+#: measured (23 rows / 641,613,073 bytes). Pass ``source_path_like=None`` to
+#: scan every ``unknown-export`` row regardless of where it came from.
+DEFAULT_SOURCE_PATH_LIKE: Final = "%browser-capture%"
+
+
+class UnknownExportReclassificationVerdict:
+    """Closed vocabulary for one ``unknown-export`` raw row's re-detection outcome."""
+
+    RECLASSIFIABLE: Final = "reclassifiable"
+    STILL_UNKNOWN: Final = "still_unknown"
+    BLOB_MISSING: Final = "blob_missing"
+
+
+@dataclass(frozen=True, slots=True)
+class UnknownExportReclassificationCandidate:
+    """One ``unknown-export`` raw row's re-detection classification."""
+
+    raw_id: str
+    source_path: str
+    blob_size: int
+    verdict: str
+    recovered_provider: Provider | None = None
+    recovered_origin: Origin | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UnknownExportReclassificationPlan:
+    """Read-only projection: how much stored ``unknown-export`` evidence is re-detectable.
+
+    Mirrors ``live_source_reconciliation.py``'s ``LiveSourceReconciliationPlan``
+    shape (report-first, no mutation) -- this is the report a genuinely
+    separate, explicitly operator-authorized pass would act on.
+    """
+
+    scanned_count: int
+    reclassifiable: tuple[UnknownExportReclassificationCandidate, ...]
+    still_unknown: tuple[UnknownExportReclassificationCandidate, ...]
+    blob_missing: tuple[UnknownExportReclassificationCandidate, ...]
+
+    @property
+    def reclassifiable_bytes(self) -> int:
+        return sum(candidate.blob_size for candidate in self.reclassifiable)
+
+    @property
+    def still_unknown_bytes(self) -> int:
+        return sum(candidate.blob_size for candidate in self.still_unknown)
+
+    @property
+    def blob_missing_bytes(self) -> int:
+        return sum(candidate.blob_size for candidate in self.blob_missing)
+
+    @property
+    def reclassifiable_by_origin(self) -> dict[str, int]:
+        """Count reclassifiable rows by their recovered origin, for a quick summary."""
+        counts: dict[str, int] = {}
+        for candidate in self.reclassifiable:
+            key = candidate.recovered_origin.value if candidate.recovered_origin is not None else "unknown"
+            counts[key] = counts.get(key, 0) + 1
+        return counts
+
+
+def plan_unknown_export_reclassification(
+    source_conn: sqlite3.Connection,
+    *,
+    blob_store: BlobStore,
+    source_path_like: str | None = DEFAULT_SOURCE_PATH_LIKE,
+    limit: int | None = None,
+) -> UnknownExportReclassificationPlan:
+    """Read-only: re-run the fixed provider probe against stored ``unknown-export`` rows.
+
+    Never mutates ``source.db`` and never touches the blob store beyond
+    reading -- safe to run against a live archive opened read-only
+    (``file:...?mode=ro``).
+    """
+    original_row_factory = source_conn.row_factory
+    source_conn.row_factory = sqlite3.Row
+    try:
+        query = (
+            "SELECT raw_id, source_path, blob_size, lower(hex(blob_hash)) AS blob_hash_hex "
+            "FROM raw_sessions WHERE origin = 'unknown-export'"
+        )
+        params: list[object] = []
+        if source_path_like is not None:
+            query += " AND source_path LIKE ?"
+            params.append(source_path_like)
+        query += " ORDER BY raw_id"
+        if limit is not None:
+            query += " LIMIT ?"
+            params.append(limit)
+        rows = source_conn.execute(query, tuple(params)).fetchall()
+
+        reclassifiable: list[UnknownExportReclassificationCandidate] = []
+        still_unknown: list[UnknownExportReclassificationCandidate] = []
+        blob_missing: list[UnknownExportReclassificationCandidate] = []
+        for row in rows:
+            raw_id = str(row["raw_id"])
+            source_path = str(row["source_path"])
+            blob_size = int(row["blob_size"] or 0)
+            blob_hash_hex = row["blob_hash_hex"]
+            if blob_hash_hex is None or not blob_store.exists(blob_hash_hex):
+                blob_missing.append(
+                    UnknownExportReclassificationCandidate(
+                        raw_id=raw_id,
+                        source_path=source_path,
+                        blob_size=blob_size,
+                        verdict=UnknownExportReclassificationVerdict.BLOB_MISSING,
+                    )
+                )
+                continue
+
+            provider = _stream_browser_capture_provider(blob_store, blob_hash_hex)
+            if provider is Provider.UNKNOWN:
+                still_unknown.append(
+                    UnknownExportReclassificationCandidate(
+                        raw_id=raw_id,
+                        source_path=source_path,
+                        blob_size=blob_size,
+                        verdict=UnknownExportReclassificationVerdict.STILL_UNKNOWN,
+                    )
+                )
+                continue
+
+            reclassifiable.append(
+                UnknownExportReclassificationCandidate(
+                    raw_id=raw_id,
+                    source_path=source_path,
+                    blob_size=blob_size,
+                    verdict=UnknownExportReclassificationVerdict.RECLASSIFIABLE,
+                    recovered_provider=provider,
+                    recovered_origin=origin_from_provider(provider),
+                )
+            )
+
+        return UnknownExportReclassificationPlan(
+            scanned_count=len(rows),
+            reclassifiable=tuple(reclassifiable),
+            still_unknown=tuple(still_unknown),
+            blob_missing=tuple(blob_missing),
+        )
+    finally:
+        source_conn.row_factory = original_row_factory
+
+
+__all__ = [
+    "DEFAULT_SOURCE_PATH_LIKE",
+    "UnknownExportReclassificationCandidate",
+    "UnknownExportReclassificationPlan",
+    "UnknownExportReclassificationVerdict",
+    "plan_unknown_export_reclassification",
+]

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -28,9 +28,11 @@ from polylogue.sources.live import LiveWatcher, WatchSource
 from polylogue.sources.live.append_ingest import ingest_append_plans
 from polylogue.sources.live.batch import _MAX_APPEND_PLAN_PAYLOAD_BYTES, LiveBatchProcessor, _ArchiveFullWriteResult
 from polylogue.sources.live.batch_support import (
+    _BROWSER_CAPTURE_PREFIX_PROBE_BYTES,
     _DEFER_APPEND,
     _AppendPlan,
     _AppendResult,
+    _browser_capture_prefix_probe,
     _detect_provider_from_path_sample,
     _FullIngestResult,
     _parse_path_as_session_artifact,
@@ -845,6 +847,50 @@ def test_large_browser_capture_prefix_planning_does_not_materialize_payload(
 
     assert _detect_provider_from_path_sample(target, Provider.UNKNOWN) is Provider.CHATGPT
     assert _parse_path_as_session_artifact(target, provider=Provider.CHATGPT) is True
+
+
+def test_browser_capture_prefix_probe_finds_provider_past_1mib_raw_payload(tmp_path: Path) -> None:
+    """polylogue-mvq8: session.provider beyond the 1MiB prefix must still detect.
+
+    Real receiver artifacts key-sort with ``raw_provider_payload`` (an
+    unbounded copy of the provider's own wire payload) sorting before
+    ``session`` alphabetically. Once ``raw_provider_payload`` alone exceeds
+    the 1MiB prefix-probe window, the plain byte-prefix regex never sees
+    ``session.provider`` and the capture was permanently misdetected as
+    ``unknown-export`` -- this reproduces that exact shape with real file
+    bytes (no probe-size monkeypatching) and asserts the provider is still
+    found.
+    """
+    target = tmp_path / "oversized-raw-payload.json"
+    huge_padding = "x" * (_BROWSER_CAPTURE_PREFIX_PROBE_BYTES + 64 * 1024)
+    capture_payload = {
+        "polylogue_capture_kind": "browser_llm_session",
+        "schema_version": 1,
+        "capture_id": "chatgpt:past-prefix",
+        "provenance": {
+            "source_url": "https://chatgpt.com/c/past-prefix",
+            "captured_at": "2026-04-24T00:00:00+00:00",
+            "adapter_name": "chatgpt-native-v1",
+        },
+        # Deliberately placed before ``session`` (as the real receiver's
+        # key-sorted output places it) and sized past the probe window.
+        "raw_provider_payload": {"padding": huge_padding},
+        "session": {
+            "provider": "chatgpt",
+            "provider_session_id": "past-prefix",
+            "turns": [{"provider_turn_id": "u1", "role": "user", "text": "hi"}],
+        },
+    }
+    target.write_text(json.dumps(capture_payload), encoding="utf-8")
+
+    # Confirm the fixture actually reproduces the bug shape: the provider
+    # marker sits past the probe window, and the file exceeds it too.
+    assert target.stat().st_size > _BROWSER_CAPTURE_PREFIX_PROBE_BYTES
+    assert target.read_bytes().find(b'"provider": "chatgpt"') > _BROWSER_CAPTURE_PREFIX_PROBE_BYTES
+
+    is_browser_capture, provider = _browser_capture_prefix_probe(target)
+    assert is_browser_capture is True
+    assert provider is Provider.CHATGPT
 
 
 def test_full_ingest_bootstraps_archive_root(

--- a/tests/unit/storage/test_unknown_export_reclassification.py
+++ b/tests/unit/storage/test_unknown_export_reclassification.py
@@ -1,0 +1,151 @@
+"""polylogue-mvq8: re-detection report for browser captures stamped unknown-export.
+
+Proves the report-only classifier against a real archive: an unknown-export
+raw row whose blob is actually a browser-capture envelope with a recoverable
+provider (the exact >1MiB raw_provider_payload shape that used to defeat the
+1MiB prefix probe), one that is genuinely not a browser capture at all (stays
+unknown), and one whose blob is missing from the store.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from polylogue.archive.revision_authority import RawRevisionAuthority, RawRevisionEnvelope, RawRevisionKind
+from polylogue.core.enums import Origin, Provider
+from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from polylogue.storage.unknown_export_reclassification import (
+    UnknownExportReclassificationVerdict,
+    plan_unknown_export_reclassification,
+)
+
+
+def _write_unknown_export_raw(archive: ArchiveStore, *, raw_id: str, payload: bytes, source_path: str) -> None:
+    archive.write_raw_payload(
+        provider=Provider.UNKNOWN,
+        payload=payload,
+        source_path=source_path,
+        source_index=-1,
+        acquired_at_ms=1_700_000_000_000,
+        raw_id=raw_id,
+        revision=RawRevisionEnvelope(
+            logical_source_key=f"unknown-export:{raw_id}",
+            kind=RawRevisionKind.FULL,
+            source_revision=f"{raw_id}-revision",
+            acquisition_generation=0,
+            authority=RawRevisionAuthority.QUARANTINED,
+        ),
+    )
+
+
+def _browser_capture_envelope_past_prefix(*, session_provider: str, provider_session_id: str) -> bytes:
+    """A browser-capture envelope whose ``session.provider`` sits past 1MiB.
+
+    Mirrors the real receiver's key-sorted output shape:
+    ``raw_provider_payload`` (unbounded) sorts before ``session``
+    alphabetically -- this is the exact repro shape polylogue-mvq8 measured.
+    """
+    huge_padding = "x" * (1024 * 1024 + 64 * 1024)
+    payload = {
+        "polylogue_capture_kind": "browser_llm_session",
+        "schema_version": 1,
+        "capture_id": f"{session_provider}:{provider_session_id}",
+        "provenance": {
+            "source_url": f"https://example.com/{provider_session_id}",
+            "captured_at": "2026-04-24T00:00:00+00:00",
+            "adapter_name": "test-adapter",
+        },
+        "raw_provider_payload": {"padding": huge_padding},
+        "session": {
+            "provider": session_provider,
+            "provider_session_id": provider_session_id,
+            "turns": [{"provider_turn_id": "u1", "role": "user", "text": "hi"}],
+        },
+    }
+    return json.dumps(payload).encode("utf-8")
+
+
+def test_plan_unknown_export_reclassification_classifies_every_row(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+
+    reclassifiable_payload = _browser_capture_envelope_past_prefix(
+        session_provider="chatgpt", provider_session_id="past-prefix"
+    )
+    not_a_browser_capture_payload = json.dumps({"some": "unrelated document"}).encode("utf-8")
+
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        _write_unknown_export_raw(
+            archive,
+            raw_id="raw-reclassifiable",
+            payload=reclassifiable_payload,
+            source_path="/spool/browser-capture/unknown/reclassifiable.json",
+        )
+        _write_unknown_export_raw(
+            archive,
+            raw_id="raw-still-unknown",
+            payload=not_a_browser_capture_payload,
+            source_path="/spool/browser-capture/unknown/still-unknown.json",
+        )
+        archive.commit()
+
+    blob_store = BlobStore(archive_root / "blob")
+    conn = sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True)
+    try:
+        plan = plan_unknown_export_reclassification(conn, blob_store=blob_store, source_path_like=None)
+    finally:
+        conn.close()
+
+    assert plan.scanned_count == 2
+    assert {c.raw_id for c in plan.reclassifiable} == {"raw-reclassifiable"}
+    assert {c.raw_id for c in plan.still_unknown} == {"raw-still-unknown"}
+    assert plan.blob_missing == ()
+
+    (reclassified,) = plan.reclassifiable
+    assert reclassified.verdict == UnknownExportReclassificationVerdict.RECLASSIFIABLE
+    assert reclassified.recovered_provider is Provider.CHATGPT
+    assert reclassified.recovered_origin is Origin.CHATGPT_EXPORT
+    assert reclassified.blob_size == len(reclassifiable_payload)
+
+    (still_unknown,) = plan.still_unknown
+    assert still_unknown.verdict == UnknownExportReclassificationVerdict.STILL_UNKNOWN
+    assert still_unknown.recovered_provider is None
+    assert still_unknown.recovered_origin is None
+
+
+def test_plan_unknown_export_reclassification_scopes_to_source_path_like(tmp_path: Path) -> None:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+
+    reclassifiable_payload = _browser_capture_envelope_past_prefix(
+        session_provider="claude-ai", provider_session_id="in-scope"
+    )
+
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        _write_unknown_export_raw(
+            archive,
+            raw_id="raw-in-scope",
+            payload=reclassifiable_payload,
+            source_path="/spool/browser-capture/unknown/in-scope.json",
+        )
+        _write_unknown_export_raw(
+            archive,
+            raw_id="raw-out-of-scope",
+            payload=reclassifiable_payload,
+            source_path="/inbox/unrelated/out-of-scope.json",
+        )
+        archive.commit()
+
+    blob_store = BlobStore(archive_root / "blob")
+    conn = sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True)
+    try:
+        plan = plan_unknown_export_reclassification(conn, blob_store=blob_store)
+    finally:
+        conn.close()
+
+    assert plan.scanned_count == 1
+    assert {c.raw_id for c in plan.reclassifiable} == {"raw-in-scope"}


### PR DESCRIPTION
## Summary

Fixes provider detection for browser captures larger than 8MiB whose provider marker falls beyond the acquisition-time 1MiB prefix probe, and adds a read-only report to classify already-committed `unknown-export` rows for future reclassification.

## Problem

`sources/live/batch_support.py::_browser_capture_prefix_probe` detected the provider for large (>8MiB) browser captures by reading only the first 1MiB (`_BROWSER_CAPTURE_PREFIX_PROBE_BYTES`) of the file and regex-matching `"provider": "..."` in that prefix. The receiver serializes capture envelopes with `sort_keys=True` (`browser_capture/receiver.py`), so `raw_provider_payload` (an unbounded copy of the provider's own wire payload) sorts alphabetically *before* `session` and therefore before `session.provider`. Once `raw_provider_payload` alone exceeds 1MiB, `session.provider` never appears in the prefix at all, and the row is permanently stamped `unknown-export` -- `origin` is stamped durably on the raw row at acquisition time, so a full reindex does not fix already-committed rows.

Measured by the audit that filed this bead: 23 distinct browser-capture paths / 641,613,073 bytes of raw rows sit under `origin='unknown-export'`; 8 conversations (108.8MB) are wholly absent from the index.

## Solution

1. `_browser_capture_prefix_probe` still tries the cheap 1MiB regex first (covers the common case and avoids a full scan for the majority of large non-browser-capture JSON files). When that's inconclusive but the envelope is confirmed to be a browser capture, it falls back to a new `_browser_capture_provider_from_path`, a memory-bounded `ijson` event scan that finds `session.provider` regardless of how far into the payload it falls -- mirroring the existing `source_acquisition_components._stream_browser_capture_provider` used on the blob-store acquisition path (that bounded reader already existed but wasn't wired into this route).

2. `polylogue/storage/unknown_export_reclassification.py`, a small, independent, read-only classifier mirroring `live_source_reconciliation.py`'s shape (the polylogue-u19l precedent): for each stored `unknown-export` raw row (scoped by `source_path LIKE '%browser-capture%'` by default), it re-runs the same bounded `ijson` scan against the already-archived blob and classifies it `reclassifiable` / `still_unknown` / `blob_missing`. Nothing here mutates `origin`, `source.db`, or the blob store -- wired as a dry-run-only `devtools workspace unknown-export-reclassification` report. Rewriting origin / re-parsing / re-indexing a "reclassifiable" row is a deliberately separate, explicitly operator-authorized follow-up, per this session's established pattern for anything touching already-committed raw classification.

3. Checked the bead's "the lane re-captures them forever" claim: it does not hold as a distinct infinite-retry defect. `LiveBatchProcessor._record_full_cursor` advances the cursor (via a content-hash fingerprint) after every successful full ingest regardless of the resolved origin, so an unchanged file is skipped on the next poll the same way whether or not the provider is misdetected. The "12 raw rows of ~23MB each" the bead measured reflects a live, actively-growing browser capture producing a new full-ingest each time its content changes -- normal snapshot-mode behavior for browser-capture sources (`_can_ingest_appends_directly` gates append-mode to non-browser-capture sources), not a retry loop. Before this fix, every growth increment of an actively-captured conversation got re-stamped `unknown-export`; after this fix, future growth increments classify correctly. This is a different shape from `polylogue-hat0` (append-plan deferral re-minting raw rows on every tick with zero cursor advancement), which was already fixed separately this session.

## Verification

- `devtools test tests/unit/sources/test_live_batch_support.py -k browser_capture` -- 7 passed, including the new `test_browser_capture_prefix_probe_finds_provider_past_1mib_raw_payload`, built with real file bytes (a >1MiB `raw_provider_payload` before `session`, no probe-size monkeypatching). Confirmed via `git stash` that this test fails against the pre-fix implementation (`assert None is Provider.CHATGPT`) and passes after.
- `devtools test tests/unit/storage/test_unknown_export_reclassification.py tests/unit/storage/test_live_source_reconciliation.py` -- 9 passed.
- Confirmed the 3 test failures seen in a broader `test_live_batch_support.py` run (`test_full_ingest_skips_durably_excised_content_without_aborting_batch`, `test_append_multi_session_payload_is_rejected_before_index_write`, `test_full_ingest_writes_archive_with_route_observability`) reproduce identically against pre-change master (`e808caf55`, checked in a separate worktree) -- pre-existing and unrelated to this change.
- `devtools render topology-projection` + `devtools render devtools-reference` regenerated for the two new modules; `devtools render all --check` clean.
- `devtools verify --quick` exit 0 (also ran automatically via the pre-push hook).

Ref polylogue-mvq8