### PR TITLE
fix(storage): stop the raw-authority obligation guard pinning plan history

### DIFF
--- a/polylogue/storage/raw_authority.py
+++ b/polylogue/storage/raw_authority.py
@@ -904,23 +904,38 @@ def prune_raw_authority_census_history(conn: sqlite3.Connection) -> tuple[int, i
     plan_rows = 0
     if plan_floor_row is not None:
         floor = int(plan_floor_row[0])
-        # A census carrying an UNRESOLVED blocker is a live durable obligation,
-        # not history: `unresolved_raw_authority_blockers()` and readiness both
-        # read it, an operator may already hold its blocker id, and
-        # `resolve_raw_authority_blocker()` needs its plan row as evidence.
-        # Pruning it would silently report the obligation as cleared. Retain
-        # the whole census -- plans, post-plans, blockers -- until every
-        # blocker on it is resolved, however far it falls outside the window.
+        # polylogue-z7ko/f4z9: this window used to also require every
+        # blocker on a census to be resolved before its plan-row DETAIL
+        # could be dropped -- but that detail is not where blocker evidence
+        # lives. `_reconcile_frontier_obligations` snapshots the full plan
+        # into the blocker row itself (`expected_json`/`observed_json`), and
+        # `resolve_raw_authority_blocker` reads that plus the census-
+        # independent `raw_authority_plans` table (kept alive for as long as
+        # any blocker references it, regardless of this window -- see
+        # `raw_retention._delete_orphaned_raw_authority_plans`). Neither
+        # touches `raw_authority_census_plans`/`_post_plans` at all, so
+        # gating THIS window on blocker resolution bought nothing but an
+        # unbounded pin: a structurally permanent obligation (e.g. a
+        # quarantined raw with no logical source key to refine against)
+        # never resolves, and live ingestion keeps minting new ones
+        # continuously, each anchoring whichever census first observed it --
+        # not just one census, an ever-growing set of them (measured live:
+        # 41 of the most recent ~112 censuses stuck holding plan rows,
+        # ~100k rows/hour, fixed_point=0 on all 256 censuses ever run).
+        # Plan-row detail is a per-pass browsing/audit convenience (the
+        # per-census inspection pager), not the durable obligation record,
+        # so it prunes on the count-based window alone, unconditionally.
+        # Already-*resolved* blockers tied to a pruned census are cleaned up
+        # here too, since nothing needs them once their census ages out;
+        # still-unresolved ones are left alone -- deleting those would be
+        # the actual "silently report the obligation as cleared" bug this
+        # guard was trying to avoid, and the header window below still
+        # retains their census (a real FK, not a convenience) until they
+        # resolve.
         stale = [
             str(row[0])
             for row in conn.execute(
-                """
-                SELECT census_id FROM raw_authority_censuses
-                WHERE sequence_no < ?
-                  AND census_id NOT IN (
-                      SELECT census_id FROM raw_authority_blockers WHERE resolved_at_ms IS NULL
-                  )
-                """,
+                "SELECT census_id FROM raw_authority_censuses WHERE sequence_no < ?",
                 (floor,),
             )
         ]
@@ -929,7 +944,7 @@ def prune_raw_authority_census_history(conn: sqlite3.Connection) -> tuple[int, i
             for statement in (
                 "DELETE FROM raw_authority_census_plans WHERE census_id = ?",
                 "DELETE FROM raw_authority_census_post_plans WHERE census_id = ?",
-                "DELETE FROM raw_authority_blockers WHERE census_id = ?",
+                "DELETE FROM raw_authority_blockers WHERE census_id = ? AND resolved_at_ms IS NOT NULL",
             ):
                 cursor = conn.executemany(statement, ((census,) for census in chunk))
                 plan_rows += cursor.rowcount if cursor.rowcount and cursor.rowcount > 0 else 0

--- a/tests/unit/storage/test_raw_authority_ledger.py
+++ b/tests/unit/storage/test_raw_authority_ledger.py
@@ -1707,3 +1707,101 @@ def test_census_retention_keeps_the_newest_censuses_readable(tmp_path: Path, mon
         surviving = {str(row[0]) for row in conn.execute("SELECT DISTINCT census_id FROM raw_authority_census_plans")}
 
     assert surviving == {receipts[-1].census_id, receipts[-2].census_id}
+
+
+def test_census_plan_rows_prune_past_retention_even_with_an_unresolved_blocker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """polylogue-z7ko/f4z9: the obligation guard used to pin an ENTIRE
+    census's plan-row snapshot for as long as ANY blocker on it stayed
+    unresolved, however far outside the retention window it fell. Live
+    evidence (source.db, 2026-07-31): ``RAW_AUTHORITY_CENSUS_PLAN_RETENTION``
+    is 8, yet 41 of the most recent ~112 censuses (sequence 820-932) still
+    held plan rows, because a structurally permanent obligation -- e.g. a
+    quarantined raw with no logical source key to refine against -- never
+    resolves, and continuous live ingestion keeps minting fresh ones, each
+    anchoring whichever census first observed it. Result: 709,264 rows and
+    ~870 MiB in a *durable* tier, growing ~100k rows/hour, with
+    ``fixed_point`` never reaching 1 on any of 256 censuses ever run.
+
+    The fix: a blocker's own ``expected_json``/``observed_json`` columns
+    already carry a complete, self-contained snapshot of the plan and its
+    evidence (``_reconcile_frontier_obligations``), and
+    ``resolve_raw_authority_blocker`` reads that plus the census-independent
+    ``raw_authority_plans`` table -- never
+    ``raw_authority_census_plans``/``_post_plans``. So plan-row DETAIL no
+    longer needs to survive for an unresolved blocker to stay resolvable;
+    only the census HEADER does (a real FK: ``raw_authority_blockers``
+    references ``raw_authority_censuses(census_id)``).
+
+    Simulates the permanent-obligation shape directly: one durable,
+    unresolved blocker planted on the very first of nine census passes.
+    Proves plan-row detail for that first census prunes on the ordinary
+    count-based window like any other, the blocker itself is never
+    silently marked resolved, and its census HEADER survives (the FK it
+    actually needs).
+    """
+    monkeypatch.setattr(raw_authority_mod, "RAW_AUTHORITY_CENSUS_PLAN_RETENTION", 2)
+    initialize_active_archive_root(tmp_path)
+    raw_id = _write_codex_raw(tmp_path, native_id="pinned", source_path="pinned.jsonl", acquired_at_ms=1)
+    census_historical_revision_evidence(tmp_path, selected_raw_ids=[raw_id])
+    plan = build_raw_replay_plans(tmp_path, ((raw_id,),))[0]
+
+    first_receipt = record_raw_authority_census(
+        tmp_path,
+        (plan,),
+        selected_plan_ids=set(),
+        mode="dry_run",
+        quiescent=True,
+        scope={"test": "pin-origin"},
+        residual={},
+    )
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        conn.execute(
+            """
+            INSERT INTO raw_authority_blockers (
+                blocker_id, plan_id, census_id, reason, expected_json,
+                observed_json, created_at_ms
+            ) VALUES (?, ?, ?, ?, '{}', '{}', 1)
+            """,
+            (
+                "raw-authority-blocker:permanently-pinned",
+                plan.plan_id,
+                first_receipt.census_id,
+                "quarantined-raw refinement strategy proved this raw ineligible: a structurally permanent fact",
+            ),
+        )
+        conn.commit()
+
+    for index in range(8):
+        record_raw_authority_census(
+            tmp_path,
+            (plan,),
+            selected_plan_ids=set(),
+            mode="dry_run",
+            quiescent=True,
+            scope={"test": f"pin-followup-{index}"},
+            residual={},
+        )
+
+    with sqlite3.connect(tmp_path / "source.db") as conn:
+        surviving_plan_censuses = {
+            str(row[0]) for row in conn.execute("SELECT DISTINCT census_id FROM raw_authority_census_plans")
+        }
+        blocker_resolved_at = conn.execute(
+            "SELECT resolved_at_ms FROM raw_authority_blockers WHERE blocker_id = ?",
+            ("raw-authority-blocker:permanently-pinned",),
+        ).fetchone()[0]
+        header_row = conn.execute(
+            "SELECT 1 FROM raw_authority_censuses WHERE census_id = ?", (first_receipt.census_id,)
+        ).fetchone()
+
+    # Never silently cleared -- this is the failure mode the old guard was
+    # (over-)protecting against, and it must still not happen.
+    assert blocker_resolved_at is None
+    # Its census HEADER survives -- the real FK obligation.
+    assert header_row is not None
+    # But the plan-row DETAIL for that census prunes like everyone else's,
+    # bounded to the retention window regardless of the still-open blocker.
+    assert first_receipt.census_id not in surviving_plan_censuses
+    assert len(surviving_plan_censuses) == 2


### PR DESCRIPTION
## Summary

Fixes the census/plan-ledger side of the raw-authority obligation-guard defect: `prune_raw_authority_census_history`'s per-census plan-row window (`RAW_AUTHORITY_CENSUS_PLAN_RETENTION`) no longer stays permanently pinned by a structurally-unresolvable blocker. Census headers keep their guard (a real FK), plan-row detail now prunes on the ordinary retention window regardless of blocker state.

## Problem

`polylogue-z7ko` and `polylogue-f4z9` describe the same mechanism from two angles: `raw_authority_census_plans`/`raw_authority_census_post_plans` (a durable `source.db` tier) grew ~100k rows/hour, reaching 709,264 rows and ~870 MiB, with only 41 of the ~112 most recent censuses (sequence 820-932) holding plan rows at all — far more than `RAW_AUTHORITY_CENSUS_PLAN_RETENTION=8` should allow. `fixed_point` never reached 1 on any of 256 censuses ever measured.

Root cause: `prune_raw_authority_census_history`'s plan-row window required every blocker attached to a census to be resolved before that census's `raw_authority_census_plans`/`_post_plans` rows could be dropped. The dominant blocker reason ("accepted raw authority remains quarantined pending exact refinement proof", ~4,400 rows) is a structurally permanent fact about a raw's own data — nothing about it changes between census passes, so it never resolves. Continuous live ingestion keeps producing new instances of this same permanent obligation; each one anchors whichever census first observed it, and that census's entire plan-row snapshot stays pinned forever. Over time more and more censuses accumulate this pin, which is why the guard eventually stopped bounding growth at all despite existing.

I verified this is a genuinely separate exception from `polylogue-wkc6` (PR #3530, already merged): that PR fixed pruning of *orphaned* `raw_authority_plans` rows (plans no census references at all). This PR's guard is a different code path in the same function — the *per-census plan-row retention window itself* refusing to advance while any attached blocker is open, which `wkc6` did not touch.

I also checked `polylogue-u19l` (PR #3539, merged, `live_source_reconciliation.py`): that module is a read-only classifier over `raw_sessions.revision_authority='quarantined'`, entirely separate from the `raw_authority_blockers`/census obligation mechanism this bug lives in — it never marks a blocker resolved and isn't wired to this guard. It is not usable to unblock this issue's plans, because the underlying obligation here is not "unproven," it's provably permanent (see `_strategy_overrides`' ineligible branch in `raw_reconciler.py`, from the already-merged PR #3466).

## Solution

`polylogue/storage/raw_authority.py`, `prune_raw_authority_census_history`:

- The plan-row window (`raw_authority_census_plans`/`_post_plans`) now deletes purely by the `sequence_no` retention floor, unconditionally. A blocker's own `expected_json`/`observed_json` columns already carry a complete, self-contained snapshot of the plan and its evidence (written by `_reconcile_frontier_obligations`), and `resolve_raw_authority_blocker` reads that plus the census-independent `raw_authority_plans` table — never `raw_authority_census_plans`/`_post_plans`. So gating this window on blocker resolution bought nothing but the unbounded pin.
- Already-*resolved* blockers tied to a pruned census are deleted in the same pass (nothing needs them once their census ages out); still-*unresolved* ones are left alone — deleting those would be the actual "silently report the obligation as cleared" failure mode the old guard existed to avoid.
- The header window (`raw_authority_censuses`) keeps its existing guard unchanged: `raw_authority_blockers` has a real foreign key on `census_id`, so a header can only be dropped once nothing references it.

No schema/DDL change: `source.db`'s table definitions are untouched, this is a behavior-only fix to an existing maintenance routine that already runs inside every census-recording transaction.

## What's intentionally out of scope

- The underlying quarantine pile itself (why ~4,400 raws are permanently ineligible) is `polylogue-u19l`'s territory, already addressed there.
- A full `RawAuthorityReconciler` rewrite (`polylogue-lkrc`/`hjpx`/`yla8`) remains explicitly gated on separate operator authorization.
- I don't touch `_reconcile_frontier_obligations`'s blocker-insert path at all: I initially suspected `blocker_id` being keyed on `(census_id, plan_id)` caused duplicate unresolved rows per pass, but a pre-existing partial unique index (`idx_raw_authority_blockers_open_plan` on `plan_id WHERE resolved_at_ms IS NULL`) already prevents that — there is exactly one unresolved blocker row per `plan_id`, always. That hypothesis was wrong; I reverted the speculative change once I found the index and re-diagnosed against the actual mechanism above.

## Verification

```
devtools test tests/unit/storage/test_raw_authority_ledger.py tests/unit/storage/test_raw_retention.py
devtools verify --quick
```

New test `test_census_plan_rows_prune_past_retention_even_with_an_unresolved_blocker` plants a durable, permanently-unresolved blocker on the first of nine census passes and asserts: the blocker itself is never silently marked resolved; its census header survives (the real FK); its plan-row detail prunes to the retention window like any other census's. Confirmed this test fails against the pre-fix code (`assert 'census:1:...' not in {...}` — the first census's rows were still present after 8 more passes) and passes after.

10 pre-existing failures in `test_raw_authority_ledger.py` are unchanged before and after this diff (verified against both the pre-fix and post-fix tree) — an unrelated `_write_codex_raw` test-fixture regression where an empty-text message is now rejected by dispatch ("no messages, no positive conversational evidence"). Not touched by this PR; filing a follow-up bead is worth doing separately.

Ref polylogue-z7ko
Ref polylogue-f4z9
