### PR TITLE
fix(daemon): requeue raw parse/validate backlog after interrupted ingest

### DIFF
--- a/polylogue/daemon/convergence_stages.py
+++ b/polylogue/daemon/convergence_stages.py
@@ -826,6 +826,119 @@ def make_sinex_publication_stage(
     )
 
 
+_RAW_PARSE_RECOVERY_BATCH_LIMIT = 200
+# Mirrors ``storage.repair.RAW_MATERIALIZATION_EXECUTE_BLOB_LIMIT_BYTES`` as a
+# local literal rather than importing it: new surface code (this stage lives
+# in ``daemon/``) should not import substrate (``storage``) internals
+# directly per this repo's layering ratchet, and ``repair_materialization``'s
+# ``max_payload_bytes`` is a plain bound this stage can restate on its own.
+_RAW_PARSE_RECOVERY_MAX_PAYLOAD_BYTES = 1024 * 1024 * 1024
+
+
+def _raw_parse_recovery_pending_count(db_path: Path, path: Path) -> int:
+    """Count raw rows under ``path`` acquired but never materialized.
+
+    Mirrors the non-terminal branch of ``repair.py``'s candidate query at the
+    cheap read-only level this stage's ``check`` needs: no materialized
+    ``sessions`` row for the raw (by raw_id or native-id alias) and no
+    terminal parse error recorded. It intentionally does not replicate the
+    full authority/quarantine/byte-authority classification -- that
+    refinement happens inside ``repair_raw_materialization`` itself during
+    ``execute``; this is only a cheap "is there plausibly pending work here"
+    probe so ``check`` stays fast and false positives just cost one wasted
+    ``execute`` call rather than silently missing real backlog.
+    """
+    source_db = db_path.parent / "source.db"
+    index_db = db_path.parent / "index.db"
+    if not source_db.exists():
+        return 0
+    normalized_root = str(path).rstrip("/")
+    try:
+        conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True, timeout=5.0)
+    except sqlite3.Error:
+        logger.warning("raw_parse_recovery: could not open source.db for %s; treating as no pending work", path)
+        return 0
+    try:
+        if index_db.exists():
+            conn.execute("ATTACH DATABASE ? AS index_tier", (str(index_db),))
+            materialized_join = """
+                LEFT JOIN index_tier.sessions AS s_by_raw ON s_by_raw.raw_id = r.raw_id
+                LEFT JOIN index_tier.sessions AS s_by_native
+                  ON r.native_id IS NOT NULL
+                 AND s_by_native.origin = r.origin
+                 AND s_by_native.native_id = r.native_id
+            """
+            materialized_where = "AND s_by_raw.raw_id IS NULL AND s_by_native.native_id IS NULL"
+        else:
+            materialized_join = ""
+            materialized_where = ""
+        row = conn.execute(
+            f"""
+            SELECT COUNT(*)
+            FROM raw_sessions AS r
+            {materialized_join}
+            WHERE (r.source_path = ? OR r.source_path LIKE ?)
+              AND r.parsed_at_ms IS NULL
+              AND r.parse_error IS NULL
+              {materialized_where}
+            """,
+            (normalized_root, f"{normalized_root}/%"),
+        ).fetchone()
+        return int(row[0] or 0) if row is not None else 0
+    except sqlite3.Error:
+        logger.warning("raw_parse_recovery: pending-count probe failed for %s; treating as no pending work", path)
+        return 0
+    finally:
+        conn.close()
+
+
+def make_raw_parse_recovery_stage(db_path: Path) -> ConvergenceStage:
+    """Requeue raw rows an interrupted ingest attempt never validated/parsed.
+
+    polylogue-61jg: when the daemon stops mid-batch,
+    ``CursorStore._mark_interrupted_ops_attempts`` stamps the dangling
+    ``ingest_attempts`` row ``interrupted`` and records one
+    ``raw_parse_recovery`` convergence-debt row per source path that attempt
+    covered. This stage is what actually drains that debt: ``check`` reports
+    whether raw rows under the path are still acquired but never
+    materialized, and ``execute`` re-drives ``repair_raw_materialization``
+    scoped to exactly that path via ``source_root`` -- the same replay engine
+    the archive-wide trickle conveyor and manual ``ops maintenance
+    rebuild-index`` already use, just requeued deterministically instead of
+    waiting for an accidental future touch of the same path.
+    """
+
+    def check(path: Path) -> bool:
+        return _raw_parse_recovery_pending_count(db_path, path) > 0
+
+    def execute(path: Path) -> StageExecuteReturn:
+        from polylogue.config import Config
+        from polylogue.product.raw_authority import repair_materialization
+
+        archive_root = db_path.parent
+        config = Config(archive_root=archive_root, render_root=archive_root, sources=[])
+        try:
+            repair_materialization(
+                config,
+                dry_run=False,
+                raw_artifact_limit=_RAW_PARSE_RECOVERY_BATCH_LIMIT,
+                max_payload_bytes=_RAW_PARSE_RECOVERY_MAX_PAYLOAD_BYTES,
+                source_root=path,
+            )
+        except Exception:
+            logger.warning("raw_parse_recovery: repair pass failed for %s", path, exc_info=True)
+            return False
+        return _raw_parse_recovery_pending_count(db_path, path) == 0
+
+    return ConvergenceStage(
+        name="raw_parse_recovery",
+        description="Requeue raw rows an interrupted ingest attempt never validated/parsed",
+        check=check,
+        execute=execute,
+        false_means_pending=True,
+    )
+
+
 def make_default_convergence_stages(
     db_path: Path,
     *,
@@ -856,6 +969,7 @@ def make_default_convergence_stages(
         )
     stages.extend(
         (
+            make_raw_parse_recovery_stage(db_path),
             make_fts_stage(db_path),
             make_embed_stage(db_path, defer=embed_defer),
             make_claude_workflow_stage(db_path),
@@ -2100,6 +2214,7 @@ __all__ = [
     "make_embed_stage",
     "make_fts_stage",
     "make_insights_stage",
+    "make_raw_parse_recovery_stage",
     "make_sinex_publication_stage",
     "make_standing_query_stage",
 ]

--- a/polylogue/product/raw_authority.py
+++ b/polylogue/product/raw_authority.py
@@ -91,6 +91,7 @@ def repair_materialization(
     max_payload_bytes: int,
     prefetch_cache: RawParsePrefetchCache | None = None,
     raw_artifact_id: str | None = None,
+    source_root: Path | None = None,
     max_pass_seconds: float | None = None,
 ) -> Any:
     """Run one bounded raw source->index convergence pass.
@@ -105,6 +106,12 @@ def repair_materialization(
     daemon's escalation-tier whale pass uses this to converge one
     resource-blocked component at a time under a widened ``max_payload_bytes``
     envelope instead of re-scanning the whole archive-wide backlog.
+
+    ``source_root`` (polylogue-61jg, default ``None``) scopes the pass to raws
+    whose ``source_path`` equals or is nested under this root -- the daemon's
+    ``raw_parse_recovery`` convergence stage uses this to re-drive exactly the
+    source path an interrupted ingest attempt covered, instead of relying on
+    the archive-wide trickle conveyor to reach it eventually.
 
     ``max_pass_seconds`` (polylogue-de2a, default ``None`` = unbounded) bounds
     this call's own wall-clock duration so a caller running it under a
@@ -123,6 +130,7 @@ def repair_materialization(
         max_payload_bytes=max_payload_bytes,
         prefetch_cache=prefetch_cache,
         raw_artifact_id=raw_artifact_id,
+        source_root=source_root,
         max_pass_seconds=max_pass_seconds,
     )
 

--- a/polylogue/sources/live/cursor.py
+++ b/polylogue/sources/live/cursor.py
@@ -171,6 +171,27 @@ def _optional_str(value: object) -> str | None:
     return value if isinstance(value, str) else None
 
 
+def _ingest_attempt_source_paths(source_path: object, source_paths_json: object) -> list[str]:
+    """Return the distinct source paths one ``ingest_attempts`` row covered.
+
+    ``source_paths_json`` is the authoritative multi-path record (a batch
+    attempt can span several files); ``source_path`` is the older
+    single-path column, kept as a fallback for rows/callers that never
+    populate the JSON list.
+    """
+    paths: list[str] = []
+    if isinstance(source_paths_json, str) and source_paths_json.strip():
+        try:
+            decoded = json.loads(source_paths_json)
+        except ValueError:
+            decoded = None
+        if isinstance(decoded, list):
+            paths.extend(str(item) for item in decoded if isinstance(item, str) and item)
+    if not paths and isinstance(source_path, str) and source_path:
+        paths.append(source_path)
+    return paths
+
+
 def _epoch_ms(value: str | None) -> int | None:
     if value is None:
         return None
@@ -313,10 +334,32 @@ class CursorStore:
             conn.close()
 
     def _mark_interrupted_ops_attempts(self) -> None:
+        """Stamp dangling 'running' attempts interrupted and register retry debt.
+
+        A daemon crash/restart mid-batch leaves ``ingest_attempts`` rows stuck
+        at ``status = 'running'``. This unconditionally sweeps them to
+        ``interrupted`` on the next ``CursorStore`` initialization, but until
+        polylogue-61jg the trail ended there: nothing registered the affected
+        source paths as retryable ``convergence_debt``, so validation/parse
+        for the interrupted batch waited for an accidental future touch (a
+        later unrelated re-acquire of the same path) instead of being driven
+        by the daemon's own convergence loop. Reading each affected attempt's
+        ``source_paths_json`` *before* the sweep and recording one
+        ``raw_parse_recovery`` debt row per distinct path closes that gap
+        using the same durable, restart-surviving retry substrate every other
+        convergence stage already uses (see
+        ``daemon.convergence_stages.make_raw_parse_recovery_stage``).
+        """
         now_ms = _epoch_ms(datetime.now(UTC).isoformat())
+        interrupted_source_paths: list[str] = []
 
         def write() -> None:
             with self._connect_ops() as conn:
+                rows = conn.execute(
+                    "SELECT source_path, source_paths_json FROM ingest_attempts WHERE status = 'running'"
+                ).fetchall()
+                for source_path, source_paths_json in rows:
+                    interrupted_source_paths.extend(_ingest_attempt_source_paths(source_path, source_paths_json))
                 conn.execute(
                     """
                     UPDATE ingest_attempts
@@ -332,6 +375,13 @@ class CursorStore:
                 conn.commit()
 
         best_effort_cursor_write("archive ops interrupted attempt recovery", write)
+        for source_path in dict.fromkeys(interrupted_source_paths):
+            self.record_convergence_debt(
+                stage="raw_parse_recovery",
+                subject_type="source_path",
+                subject_id=source_path,
+                error="daemon stopped before completing this ingest attempt",
+            )
 
     @staticmethod
     def _write_cursor_record_on_conn(conn: sqlite3.Connection, record: CursorRecord) -> None:

--- a/tests/unit/daemon/test_convergence_stages.py
+++ b/tests/unit/daemon/test_convergence_stages.py
@@ -1046,7 +1046,14 @@ def test_default_convergence_stages_always_register_embed_stage(
 
     stage_names = [stage.name for stage in make_default_convergence_stages(tmp_path / "archive.sqlite")]
 
-    assert stage_names == ["fts", "embed", "claude_workflow", "insights", "standing-queries"]
+    assert stage_names == [
+        "raw_parse_recovery",
+        "fts",
+        "embed",
+        "claude_workflow",
+        "insights",
+        "standing-queries",
+    ]
 
 
 def test_embed_stage_is_noop_when_disabled(

--- a/tests/unit/daemon/test_daemon_cli.py
+++ b/tests/unit/daemon/test_daemon_cli.py
@@ -548,6 +548,7 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
         max_payload_bytes: int,
         prefetch_cache: object = None,
         raw_artifact_id: str | None = None,
+        source_root: Path | None = None,
         max_pass_seconds: float | None = None,
     ) -> FakeResult:
         order.append("materialize")
@@ -558,6 +559,7 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
         calls["max_payload_bytes"] = max_payload_bytes
         calls["prefetch_cache"] = prefetch_cache
         calls["raw_artifact_id"] = raw_artifact_id
+        calls["source_root"] = source_root
         calls["max_pass_seconds"] = max_pass_seconds
         return FakeResult()
 
@@ -609,6 +611,7 @@ def test_drain_raw_materialization_once_uses_bounded_daemon_batch(
         "max_payload_bytes": daemon_cli._RAW_MATERIALIZATION_DAEMON_BLOB_LIMIT_BYTES,
         "prefetch_cache": None,
         "raw_artifact_id": None,
+        "source_root": None,
         "recover_archive_root": tmp_path / "archive",
         "frontier_archive_root": tmp_path / "archive",
         "frontier_limit": 8,

--- a/tests/unit/daemon/test_raw_parse_recovery.py
+++ b/tests/unit/daemon/test_raw_parse_recovery.py
@@ -1,0 +1,181 @@
+"""Regression coverage for polylogue-61jg: interrupted ingest requeue.
+
+Before this fix, ``CursorStore._mark_interrupted_ops_attempts`` stamped a
+dangling ``running`` ``ingest_attempts`` row ``interrupted`` on the next
+daemon start and stopped there -- nothing registered the affected source
+path as retryable ``convergence_debt``, so a raw row acquired but never
+validated/parsed waited for an accidental future touch instead of being
+requeued (2026-07-31 acquisition-completeness audit, F-07/F-08).
+
+These tests pin:
+1. An interrupted ingest attempt registers ``raw_parse_recovery``
+   convergence debt for every source path it covered (including the legacy
+   single-``source_path`` fallback for rows without ``source_paths_json``).
+2. ``make_raw_parse_recovery_stage``'s ``check``/``execute`` correctly
+   detects and drains a stuck raw row (acquired, never parsed, no
+   materialized session) for a given source path.
+3. End to end: a simulated daemon kill mid-batch (SIGKILL -> reopen
+   ``CursorStore``) demonstrably resumes parsing on next start once the
+   registered debt is drained by the daemon's convergence loop -- the
+   bead's AC3.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from polylogue.core.enums import Provider
+from polylogue.daemon.convergence import DaemonConverger
+from polylogue.daemon.convergence_stages import make_raw_parse_recovery_stage
+from polylogue.sources.live.cursor import CursorStore
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+_CHATGPT_CONVERSATION = {
+    "id": "conv-stuck",
+    "title": "stuck conversation",
+    "create_time": 1,
+    "current_node": "message-1",
+    "mapping": {
+        "message-1": {
+            "id": "message-1",
+            "parent": None,
+            "children": [],
+            "message": {
+                "id": "message-1",
+                "author": {"role": "user"},
+                "create_time": 1,
+                "content": {"content_type": "text", "parts": ["stuck raw content"]},
+            },
+        }
+    },
+}
+
+
+def _write_stuck_raw(archive_root: Path, *, source_path: str) -> str:
+    """Write a raw row with real conversational content that is never parsed.
+
+    Mirrors an ingest attempt that acquired bytes but was interrupted before
+    validation/parse ever ran: ``parsed_at_ms``/``validated_at_ms`` stay NULL
+    and no index session exists for it.
+    """
+    import json
+
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        return archive.write_raw_payload(
+            provider=Provider.CHATGPT,
+            payload=json.dumps([_CHATGPT_CONVERSATION]).encode(),
+            source_path=source_path,
+            acquired_at_ms=1,
+        )
+
+
+def _sessions_for_raw(archive_root: Path, raw_id: str) -> list[tuple[object, ...]]:
+    conn = sqlite3.connect(archive_root / "index.db")
+    try:
+        return list(conn.execute("SELECT native_id, raw_id FROM sessions WHERE raw_id = ?", (raw_id,)))
+    finally:
+        conn.close()
+
+
+def test_interrupted_ingest_attempt_registers_raw_parse_recovery_debt(tmp_path: Path) -> None:
+    db = tmp_path / "live.sqlite"
+    store = CursorStore(db)
+    src = tmp_path / "conv.json"
+    src.write_text("x")
+    store.begin_ingest_attempt(paths=[src], input_bytes=1, queued_file_count=1)
+
+    # Simulate SIGKILL: the attempt never finished. Reopening CursorStore is
+    # the daemon-restart recovery path.
+    reopened = CursorStore(db)
+
+    debts = reopened.list_convergence_debt(limit=50)
+    matching = [d for d in debts if d.stage == "raw_parse_recovery" and d.subject_id == str(src)]
+    assert len(matching) == 1, f"expected exactly one raw_parse_recovery debt row for {src}, got {debts}"
+    assert matching[0].subject_type == "source_path"
+
+
+def test_interrupted_attempt_without_source_paths_json_falls_back_to_source_path(tmp_path: Path) -> None:
+    """Legacy rows populate only ``source_path``, not the JSON list -- still requeued."""
+    db = tmp_path / "live.sqlite"
+    store = CursorStore(db)
+    src = tmp_path / "legacy.jsonl"
+    src.write_text("x")
+    attempt_id = store.begin_ingest_attempt(paths=[src], input_bytes=1, queued_file_count=1)
+
+    ops_db = db.with_name("ops.db")
+    conn = sqlite3.connect(ops_db)
+    try:
+        conn.execute(
+            "UPDATE ingest_attempts SET source_paths_json = '[]', source_path = ? WHERE attempt_id = ?",
+            (str(src), attempt_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    reopened = CursorStore(db)
+    debts = reopened.list_convergence_debt(limit=50)
+    matching = [d for d in debts if d.stage == "raw_parse_recovery" and d.subject_id == str(src)]
+    assert len(matching) == 1
+
+
+def test_raw_parse_recovery_stage_drains_a_stuck_raw_row(tmp_path: Path) -> None:
+    initialize_active_archive_root(tmp_path)
+    path = tmp_path / "stuck.json"
+    raw_id = _write_stuck_raw(tmp_path, source_path=str(path))
+
+    stage = make_raw_parse_recovery_stage(tmp_path / "index.db")
+
+    assert stage.check(path) is True, "stuck raw row was not detected as pending backlog"
+
+    result = stage.execute(path)
+    assert bool(result) is True
+
+    assert stage.check(path) is False, "raw row should be fully materialized after execute"
+
+    rows = _sessions_for_raw(tmp_path, raw_id)
+    assert len(rows) == 1
+    assert rows[0][0] == "conv-stuck"
+
+
+def test_raw_parse_recovery_stage_is_false_means_pending() -> None:
+    assert make_raw_parse_recovery_stage(Path("/nonexistent/index.db")).false_means_pending is True
+
+
+def test_daemon_restart_resumes_parsing_of_an_interrupted_batch(tmp_path: Path) -> None:
+    """End-to-end AC3: a daemon kill mid-batch demonstrably resumes on restart.
+
+    Models: attempt begins for a source path -> raw bytes for that path are
+    durably acquired -> the daemon dies before validation/parse ever runs ->
+    a fresh ``CursorStore`` open (the restart) registers retryable debt ->
+    the daemon's own convergence loop (``DaemonConverger`` with the
+    ``raw_parse_recovery`` stage) drains that debt and the session is
+    materialized, without any operator-triggered manual reprocess.
+    """
+    initialize_active_archive_root(tmp_path)
+    source_path = tmp_path / "batch.json"
+    source_path.write_text("placeholder")
+    raw_id = _write_stuck_raw(tmp_path, source_path=str(source_path))
+
+    live_db = tmp_path / "live.sqlite"
+    store = CursorStore(live_db, ops_db_path=tmp_path / "ops.db")
+    store.begin_ingest_attempt(paths=[source_path], input_bytes=1, queued_file_count=1)
+
+    # Simulate the crash + restart.
+    restarted_store = CursorStore(live_db, ops_db_path=tmp_path / "ops.db")
+    debts = restarted_store.list_convergence_debt(limit=50)
+    pending_paths = [Path(d.subject_id) for d in debts if d.stage == "raw_parse_recovery"]
+    assert source_path in pending_paths
+
+    converger = DaemonConverger(stages=(make_raw_parse_recovery_stage(tmp_path / "index.db"),))
+    states, _timings = converger.converge_batch(pending_paths)
+    assert states[source_path].converged is True
+
+    rows = _sessions_for_raw(tmp_path, raw_id)
+    assert len(rows) == 1
+    assert rows[0][0] == "conv-stuck"
+
+
+__all__: list[str] = []


### PR DESCRIPTION
## Summary

Interrupted ingest attempts now register durable, restart-surviving convergence debt so validation/parse resumes automatically after a daemon restart, instead of waiting for an accidental future touch of the same source path.

## Problem

2026-07-31 acquisition-completeness forensic audit (report: `/realm/inbox/polylogue-audits-2026-07-31/acquisition-completeness.html`, findings F-07/F-08) found 365 claude-code-session union-find groups (2.18 GB) and 588/1004 claude-ai-export conversations acquired but never validated/parsed. Root cause traced to `CursorStore._mark_interrupted_ops_attempts` (`polylogue/sources/live/cursor.py`): when the daemon stops mid-batch, the dangling `ingest_attempts` row is stamped `interrupted` on the next daemon start, and that is the end of the trail. `convergence_debt` (the retry substrate every other convergence stage uses) receives no entry for interrupted ingest work, so the affected source paths wait for an accidental future touch instead of being requeued by the daemon's own convergence loop. A manual reprocess/rebuild recovers the data, but the interrupted-attempt mechanism keeps re-accumulating it: 24 interrupted attempts spanning 2026-07-18 through 2026-07-31, ongoing at audit time.

Ref polylogue-61jg.

I confirmed this is a **different mechanism** than polylogue-hat0 (PR #3552, merged earlier this session). hat0 fixed a live-append quarantine/deferred-cursor loop (`sources/live/append_ingest.py` + `deferred_cursor.py`) where `byte_offset` never advanced for a specific quarantined append range, causing unbounded re-minting of overlapping raw rows on every watcher tick. This bug is a batch/bulk acquisition path (`ingest_attempts` + `raw_sessions` rows with `parsed_at_ms IS NULL`), touches unrelated files, and involves no append/deferred-cursor code.

## Solution

- `CursorStore._mark_interrupted_ops_attempts` now reads each affected attempt's `source_paths_json` (falling back to the legacy single `source_path` column for older rows) before sweeping status to `interrupted`, and records one `raw_parse_recovery` convergence-debt row per distinct path via the existing `record_convergence_debt`/`convergence_debt_retry` machinery -- the same durable, restart-surviving retry substrate every other convergence stage already uses, following this repo's `false_means_pending` pattern.
- New `daemon/convergence_stages.py` stage, `make_raw_parse_recovery_stage`: `check()` cheaply detects raw rows under a path that are acquired but not yet materialized (no index session by raw_id or native-id alias, `parsed_at_ms IS NULL`, no `parse_error`); `execute()` re-drives `storage.repair.repair_raw_materialization` scoped to exactly that path via a new `source_root` parameter (forwarded through `product/raw_authority.repair_materialization`, the CLI/daemon product boundary this repo's layering convention expects). The stage is registered first in `make_default_convergence_stages` so a recovered session feeds straight into FTS/embed/insights in the same convergence pass. `_drain_convergence_debt_once` already dispatches `convergence_debt` rows to stages by name, so no daemon wiring changes were needed beyond registering the new stage.

## Verification

- New `tests/unit/daemon/test_raw_parse_recovery.py` (5 tests): an interrupted attempt registers debt (both the `source_paths_json` path and the legacy `source_path` fallback); the new stage's `check`/`execute` drains a stuck raw row end to end (also asserts `false_means_pending`); a full simulated daemon-restart flow (`begin_ingest_attempt` -> simulated kill -> reopen `CursorStore` -> debt registered -> `DaemonConverger` drains it -> session materializes). Confirmed each test fails without the fix by stashing the production diff and rerunning (ImportError for the missing stage; debt never registered without the cursor.py change).
- `devtools test tests/unit/daemon/test_raw_parse_recovery.py tests/unit/daemon/test_convergence_stages.py tests/unit/daemon/test_daemon_cli.py tests/unit/daemon/test_ingest_worker_handoff.py tests/unit/storage/test_repair.py` -- 235 passed.
- `devtools verify --quick` -- exit 0 (ruff format/check, mypy --strict, render all --check, layering, degrade-loudly, and the rest of the quick gate all green).
- Not run: `devtools verify --all` (full non-integration suite).