### PR TITLE
fix(sources): refuse to session-parse unrecognized SQLite databases

### DIFF
--- a/devtools/binary_artifact_reclassify_apply.py
+++ b/devtools/binary_artifact_reclassify_apply.py
@@ -1,0 +1,106 @@
+"""Actuator: persist raw_artifacts classification for binary-shaped raw rows.
+
+polylogue-hbtj2: ``devtools/binary_artifact_sweep_report.py`` only classifies
+and reports. This command actually writes ``raw_artifacts`` rows (via
+``polylogue.storage.artifacts.persistence.materialize_artifact_observations``,
+the same durable-observation machinery the schema-validation lane already
+uses) so the flagged rows carry an explicit, queryable "this is a binary
+database, not a session" classification instead of sitting unclassified.
+
+This is scoped deliberately narrow: it upserts ``raw_artifacts`` rows for
+every raw row (idempotent, safe to re-run) but never touches
+``raw_sessions.revision_authority`` or deletes anything. Whether the
+already-quarantined binary rows this bead found should additionally be
+excised from quarantine's revision-authority state machine is a separate
+decision -- see the PR notes this command's output feeds -- and is not
+performed here.
+
+Default mode is dry-run (report only, zero mutation). Pass ``--apply`` to
+actually write ``raw_artifacts`` rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+from typing import TextIO
+
+from polylogue.paths import archive_root as default_archive_root
+from polylogue.storage.artifacts.persistence import materialize_artifact_observations
+from polylogue.storage.binary_artifact_sweep import scan_binary_artifacts
+
+
+def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive-root",
+        type=Path,
+        default=None,
+        help="Archive root to operate on; defaults to the configured active archive root.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap the number of raw_sessions rows classified (unbounded by default).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually write raw_artifacts rows. Without this flag, nothing is mutated.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the report as JSON.")
+    args = parser.parse_args(argv)
+
+    root = args.archive_root if args.archive_root is not None else default_archive_root()
+    source_db = root / "source.db"
+    if not source_db.exists():
+        print(f"no source.db at {source_db}", file=stdout)
+        return 1
+
+    # Read-only classification pass first, regardless of --apply, so the
+    # operator always sees exactly what would change before any write.
+    ro_conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+    try:
+        plan = scan_binary_artifacts(ro_conn, limit=args.limit)
+    finally:
+        ro_conn.close()
+
+    applied = False
+    observation_count = 0
+    if args.apply:
+        rw_conn = sqlite3.connect(source_db)
+        try:
+            observations = materialize_artifact_observations(rw_conn)
+        finally:
+            rw_conn.close()
+        observation_count = len(observations)
+        applied = True
+
+    if args.json:
+        payload = {
+            "applied": applied,
+            "binary_count": len(plan.binary_candidates),
+            "binary_bytes": plan.binary_bytes,
+            "binary_by_kind": plan.by_kind(),
+            "observations_written": observation_count,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=stdout)
+        return 0
+
+    mode = "APPLIED" if applied else "dry-run (no mutation performed -- pass --apply to write raw_artifacts rows)"
+    print(f"mode: {mode}", file=stdout)
+    print(
+        f"binary-shaped rows found by this bead's stricter detection: {len(plan.binary_candidates)}"
+        f"  ({plan.binary_bytes / (1024 * 1024):.2f} MB)",
+        file=stdout,
+    )
+    if applied:
+        print(f"raw_artifacts observations written (full census, idempotent): {observation_count}", file=stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/binary_artifact_sweep_report.py
+++ b/devtools/binary_artifact_sweep_report.py
@@ -1,0 +1,124 @@
+"""Read-only report: find raw rows whose bytes are a non-session binary format.
+
+polylogue-hbtj2: reports every ``raw_sessions`` row whose content matches a
+recognized non-conversational binary signature (SQLite being the concrete
+finding of the 2026-08-02 authority-dataflow audit; PNG/JPEG/gzip/PDF also
+checked, see ``core.binary_signatures``). This is a pure classification
+pass -- it never mutates ``source.db``. Pair with
+``devtools/binary_artifact_reclassify_apply.py`` (``--apply``-gated) to
+actually persist ``raw_artifacts`` rows for the flagged content.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+from typing import TextIO
+
+from polylogue.paths import archive_root as default_archive_root
+from polylogue.storage.binary_artifact_sweep import BinaryArtifactCandidate, scan_binary_artifacts
+
+
+def _candidate_payload(candidate: BinaryArtifactCandidate) -> dict[str, object]:
+    return {
+        "raw_id": candidate.raw_id,
+        "origin": candidate.origin,
+        "source_path": candidate.source_path,
+        "blob_size": candidate.blob_size,
+        "artifact_kind": candidate.artifact_kind,
+        "classification_reason": candidate.classification_reason,
+    }
+
+
+def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive-root",
+        type=Path,
+        default=None,
+        help="Archive root to inspect; defaults to the configured active archive root.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap the number of raw_sessions rows scanned (unbounded by default).",
+    )
+    parser.add_argument(
+        "--sample-limit",
+        type=int,
+        default=25,
+        help="How many rows per bucket to print in the human-readable report.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the full classified plan as JSON.")
+    args = parser.parse_args(argv)
+
+    root = args.archive_root if args.archive_root is not None else default_archive_root()
+    source_db = root / "source.db"
+    if not source_db.exists():
+        print(f"no source.db at {source_db}", file=stdout)
+        return 1
+
+    conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+    try:
+        plan = scan_binary_artifacts(conn, limit=args.limit)
+    finally:
+        conn.close()
+
+    if args.json:
+        payload = {
+            "scanned_count": plan.scanned_count,
+            "binary_count": len(plan.binary_candidates),
+            "binary_bytes": plan.binary_bytes,
+            "binary_by_kind": plan.by_kind(),
+            "binary_by_origin": plan.by_origin(),
+            "recognized_session_count": len(plan.recognized_session_candidates),
+            "recognized_session_bytes": plan.recognized_session_bytes,
+            "binary_sample": [_candidate_payload(c) for c in plan.binary_candidates[: args.sample_limit]],
+            "recognized_session_sample": [
+                _candidate_payload(c) for c in plan.recognized_session_candidates[: args.sample_limit]
+            ],
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=stdout)
+        return 0
+
+    def _mb(byte_count: int) -> str:
+        return f"{byte_count / (1024 * 1024):.2f} MB"
+
+    print(f"raw_sessions rows scanned: {plan.scanned_count}", file=stdout)
+    print(
+        f"unrecognized binary artifacts:  {len(plan.binary_candidates):>6}  ({_mb(plan.binary_bytes)})",
+        file=stdout,
+    )
+    for kind, count in sorted(plan.by_kind().items()):
+        print(f"  kind={kind:<18} {count:>6}", file=stdout)
+    for origin, count in sorted(plan.by_origin().items()):
+        print(f"  origin={origin:<18} {count:>6}", file=stdout)
+    print(
+        f"recognized-session binary artifacts (Hermes state.db/verification_evidence.db, "
+        f"left untouched by this bead -- see PR notes): {len(plan.recognized_session_candidates):>6}"
+        f"  ({_mb(plan.recognized_session_bytes)})",
+        file=stdout,
+    )
+    print("", file=stdout)
+    print("This is a read-only classification. No row was mutated.", file=stdout)
+    for label, bucket in (
+        ("unrecognized binary", plan.binary_candidates),
+        ("recognized-session (informational only)", plan.recognized_session_candidates),
+    ):
+        if not bucket:
+            continue
+        print(f"\n{label} sample (up to {args.sample_limit}):", file=stdout)
+        for candidate in bucket[: args.sample_limit]:
+            print(
+                f"  {candidate.raw_id}  {candidate.origin}  {candidate.blob_size}B  "
+                f"{candidate.source_path}  [{candidate.artifact_kind}] {candidate.classification_reason}",
+                file=stdout,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -978,6 +978,44 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "workspace binary-artifact-sweep",
+        "workspace",
+        "Find raw_sessions rows whose bytes are a non-session binary format (SQLite, etc).",
+        "devtools.binary_artifact_sweep_report",
+        use_when=(
+            "polylogue-hbtj2: the 2026-08-02 authority-dataflow audit found ~450MB of "
+            "SQLite databases (Hermes state.db/verification_evidence.db, Codex "
+            "state_5.sqlite) miscaptured as session content and marked 'genuinely "
+            "diverged' by the byte-diff classifier. This read-only report classifies "
+            "every raw_sessions row by magic bytes (core.binary_signatures) and reports "
+            "which are unrecognized binary artifacts vs the one existing Hermes "
+            "recognized-session-parser shape. Never mutates source.db."
+        ),
+        examples=(
+            "devtools workspace binary-artifact-sweep",
+            "devtools workspace binary-artifact-sweep --json",
+            "devtools workspace binary-artifact-sweep --limit 5000 --sample-limit 20",
+        ),
+    ),
+    CommandSpec(
+        "workspace binary-artifact-reclassify-apply",
+        "workspace",
+        "Persist raw_artifacts classification for binary-shaped raw rows.",
+        "devtools.binary_artifact_reclassify_apply",
+        use_when=(
+            "polylogue-hbtj2: act on the sweep's report by writing raw_artifacts rows "
+            "(materialize_artifact_observations) for the flagged binary content, so it "
+            "carries an explicit non-session classification instead of sitting "
+            "unclassified. Does not touch revision_authority or delete anything -- "
+            "default is dry-run; --apply performs the write."
+        ),
+        examples=(
+            "devtools workspace binary-artifact-reclassify-apply",
+            "devtools workspace binary-artifact-reclassify-apply --json",
+            "devtools workspace binary-artifact-reclassify-apply --apply",
+        ),
+    ),
+    CommandSpec(
         "workspace unknown-export-reclassification",
         "workspace",
         "Re-run the fixed browser-capture provider probe against stored unknown-export rows.",

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -221,6 +221,8 @@ These are the commands worth remembering during normal repo work:
 | `devtools workspace bead-cluster` | Footprint/overlap/contention clustering of ready Beads (execution frontier). |
 | `devtools workspace bead-reimport-guard` | Monotonic, receipted guard/reconcile/export for bd's JSONL synchronization. |
 | `devtools workspace beads-state-report` | Self-contained HTML state-of-the-backlog report over the whole bead population. |
+| `devtools workspace binary-artifact-reclassify-apply` | Persist raw_artifacts classification for binary-shaped raw rows. |
+| `devtools workspace binary-artifact-sweep` | Find raw_sessions rows whose bytes are a non-session binary format (SQLite, etc). |
 | `devtools workspace claim-vs-evidence` | Build a structured failure follow-up claim-vs-evidence demo. |
 | `devtools workspace cli-surface-audit` | Capture a current-curated CLI surface audit demo. |
 | `devtools workspace degraded-archive-proof` | Build a degraded archive self-healing proof artifact. |

--- a/docs/plans/classifier-fingerprints.json
+++ b/docs/plans/classifier-fingerprints.json
@@ -338,11 +338,11 @@
       }
     },
     "polylogue/sources/sqlite_snapshot.py:looks_like_sqlite_bytes": {
-      "fingerprint": "7227970ea3a74e682e66b15727a477325ab759563a407e633e3c38957748b487",
+      "fingerprint": "73553ae410ddc2daa4078915b3e9abec780c6998a52b870b10a6fc7c0fe2654d",
       "covered_by": {
         "kind": "acknowledged_safe",
-        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
-        "ref": "polylogue-gucv"
+        "reason": "polylogue-hbtj2: delegated to the shared core.binary_signatures.looks_like_sqlite_bytes detector to avoid duplicating the magic-byte constant; byte-for-byte identical behavior (same SQLite magic header check), no semantic reparse.",
+        "ref": "polylogue-hbtj2"
       }
     }
   }

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -174,7 +174,7 @@ files:
     owner: archive-artifact-taxonomy
     reason: archive-domain semantics
   - path: polylogue/archive/artifact_taxonomy/models.py
-    loc: 41
+    loc: 52
     target: polylogue/archive/artifact_taxonomy/models.py
     owner: archive-artifact-taxonomy
     reason: archive-domain semantics
@@ -514,7 +514,7 @@ files:
     owner: archive-raw-payload
     reason: archive-domain semantics
   - path: polylogue/archive/raw_payload/decode.py
-    loc: 368
+    loc: 431
     target: polylogue/archive/raw_payload/decode.py
     owner: archive-raw-payload
     reason: archive-domain semantics
@@ -538,7 +538,7 @@ files:
     target: polylogue/archive/resume_routing.py
     owner: stable
   - path: polylogue/archive/revision_authority.py
-    loc: 356
+    loc: 274
     target: polylogue/archive/revision_authority.py
     owner: stable
   - path: polylogue/archive/revision_replay.py
@@ -1366,6 +1366,11 @@ files:
   - path: polylogue/core/async_bridge.py
     loc: 73
     target: polylogue/core/async_bridge.py
+    owner: core-primitive
+    reason: core primitive
+  - path: polylogue/core/binary_signatures.py
+    loc: 94
+    target: polylogue/core/binary_signatures.py
     owner: core-primitive
     reason: core primitive
   - path: polylogue/core/common.py
@@ -2221,10 +2226,6 @@ files:
   - path: polylogue/maintenance/raw_live_source_reconciliation_apply.py
     loc: 286
     target: polylogue/maintenance/raw_live_source_reconciliation_apply.py
-    owner: stable
-  - path: polylogue/maintenance/raw_membership_writeback_apply.py
-    loc: 220
-    target: polylogue/maintenance/raw_membership_writeback_apply.py
     owner: stable
   - path: polylogue/maintenance/rebuild_index.py
     loc: 1093
@@ -3272,7 +3273,7 @@ files:
     target: polylogue/sources/decoders.py
     owner: stable
   - path: polylogue/sources/dispatch.py
-    loc: 1830
+    loc: 1844
     target: polylogue/sources/dispatch.py
     owner: stable
   - path: polylogue/sources/drive/__init__.py
@@ -3360,7 +3361,7 @@ files:
     target: polylogue/sources/live/batch_observability.py
     owner: stable
   - path: polylogue/sources/live/batch_support.py
-    loc: 650
+    loc: 663
     target: polylogue/sources/live/batch_support.py
     owner: stable
   - path: polylogue/sources/live/convergence_debt.py
@@ -3621,7 +3622,7 @@ files:
     target: polylogue/sources/source_walk.py
     owner: stable
   - path: polylogue/sources/sqlite_snapshot.py
-    loc: 223
+    loc: 230
     target: polylogue/sources/sqlite_snapshot.py
     owner: stable
   - path: polylogue/sources/token_store.py
@@ -3679,6 +3680,10 @@ files:
     target: polylogue/storage/backup_attestation.py
     owner: storage-root
     reason: storage-root cross-cutting helper
+  - path: polylogue/storage/binary_artifact_sweep.py
+    loc: 157
+    target: TBD
+    owner: storage-domain
   - path: polylogue/storage/blob_gc.py
     loc: 568
     target: polylogue/storage/blob_gc.py
@@ -3945,10 +3950,6 @@ files:
     owner: stable
   - path: polylogue/storage/raw_authority.py
     loc: 2295
-    target: TBD
-    owner: storage-domain
-  - path: polylogue/storage/raw_membership_writeback.py
-    loc: 124
     target: TBD
     owner: storage-domain
   - path: polylogue/storage/raw_reconciler.py
@@ -4253,7 +4254,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/revision_application.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/revision_governance.py
-    loc: 2917
+    loc: 2909
     target: polylogue/storage/sqlite/archive_tiers/revision_governance.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/self_verify.py
@@ -4265,7 +4266,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/session_annotations_write.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/source.py
-    loc: 538
+    loc: 515
     target: polylogue/storage/sqlite/archive_tiers/source.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/source_write.py

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -538,7 +538,7 @@ files:
     target: polylogue/archive/resume_routing.py
     owner: stable
   - path: polylogue/archive/revision_authority.py
-    loc: 274
+    loc: 357
     target: polylogue/archive/revision_authority.py
     owner: stable
   - path: polylogue/archive/revision_replay.py
@@ -947,7 +947,7 @@ files:
     target: polylogue/cli/commands/maintenance/_backup_plan.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_blob_gc.py
-    loc: 161
+    loc: 162
     target: polylogue/cli/commands/maintenance/_blob_gc.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_blob_integrity.py
@@ -2226,6 +2226,10 @@ files:
   - path: polylogue/maintenance/raw_live_source_reconciliation_apply.py
     loc: 286
     target: polylogue/maintenance/raw_live_source_reconciliation_apply.py
+    owner: stable
+  - path: polylogue/maintenance/raw_membership_writeback_apply.py
+    loc: 220
+    target: polylogue/maintenance/raw_membership_writeback_apply.py
     owner: stable
   - path: polylogue/maintenance/rebuild_index.py
     loc: 1093
@@ -3926,7 +3930,7 @@ files:
     target: TBD
     owner: storage-domain
   - path: polylogue/storage/message_type_backfill.py
-    loc: 244
+    loc: 252
     target: polylogue/storage/message_type_backfill.py
     owner: storage-root
     reason: storage-root cross-cutting helper
@@ -3950,6 +3954,10 @@ files:
     owner: stable
   - path: polylogue/storage/raw_authority.py
     loc: 2295
+    target: TBD
+    owner: storage-domain
+  - path: polylogue/storage/raw_membership_writeback.py
+    loc: 124
     target: TBD
     owner: storage-domain
   - path: polylogue/storage/raw_reconciler.py
@@ -4254,7 +4262,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/revision_application.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/revision_governance.py
-    loc: 2909
+    loc: 2917
     target: polylogue/storage/sqlite/archive_tiers/revision_governance.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/self_verify.py
@@ -4266,7 +4274,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/session_annotations_write.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/source.py
-    loc: 515
+    loc: 538
     target: polylogue/storage/sqlite/archive_tiers/source.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/source_write.py

--- a/polylogue/archive/artifact_taxonomy/models.py
+++ b/polylogue/archive/artifact_taxonomy/models.py
@@ -22,6 +22,17 @@ class ArtifactKind(StrEnum):
     BRIDGE_POINTER = "bridge_pointer"
     METADATA_DOCUMENT = "metadata_document"
     HOOK_EVENT = "hook_event"
+    # polylogue-hbtj2: a raw payload whose magic bytes are a recognized
+    # binary container with no dedicated, content-verified session parser
+    # for this exact shape -- refused as session content at the earliest
+    # detection point (``core.binary_signatures.detect_binary_signature``),
+    # never handed to a session/JSON parser. ``BINARY_DATABASE`` covers
+    # SQLite-shaped payloads specifically (the concrete miscapture the audit
+    # found: Hermes/Codex state databases swept into ``raw_sessions``
+    # without content verification); ``BINARY_DOCUMENT`` covers the other
+    # recognized binary formats in the same registry (PNG/JPEG/PDF/gzip).
+    BINARY_DATABASE = "binary_database"
+    BINARY_DOCUMENT = "binary_document"
     UNKNOWN = "unknown"
 
 

--- a/polylogue/archive/raw_payload/decode.py
+++ b/polylogue/archive/raw_payload/decode.py
@@ -8,12 +8,17 @@ from typing import Literal, TypeAlias, cast
 
 from polylogue.archive.artifact_taxonomy import (
     ArtifactClassification,
+    ArtifactKind,
     classify_artifact,
 )
 from polylogue.archive.raw_payload.streams import raw_line_stream
+from polylogue.core.binary_signatures import detect_binary_signature
 from polylogue.core.enums import Provider
 from polylogue.core.json import JSONDecodeError, JSONDocument, JSONValue, is_json_value, loads
 from polylogue.sources.dispatch import detect_provider
+
+_BINARY_ARTIFACT_MARKER = "unrecognized_binary_artifact"
+_UNRECOGNIZED_BINARY_PEEK_BYTES = 32
 
 WireFormat = Literal["json", "jsonl"]
 JSONRecord: TypeAlias = JSONDocument
@@ -272,6 +277,52 @@ def _infer_payload_provider(
     return fallback_token
 
 
+def _unrecognized_binary_marker_payload(prefix: bytes, *, source_path: str | Path | None) -> JSONDocument | None:
+    """Return a synthetic non-session marker for a recognized-but-unclaimed binary payload.
+
+    polylogue-hbtj2: a raw payload whose leading bytes match a known binary
+    format (SQLite being the concrete miscapture this bead fixes -- Hermes/
+    Codex state databases swept into ``raw_sessions`` and treated as
+    ambiguous session revisions purely because nothing checked the bytes
+    before attempting a JSON decode) must be refused as session content
+    *before* any JSON/JSONL decode is attempted, not merely tolerated via
+    the incidental ``JSONDecodeError`` a binary blob happens to raise. This
+    runs after ``_hermes_sqlite_marker_payload`` (so a content-verified,
+    dedicated Hermes state.db/verification_evidence.db parse still wins)
+    and covers every other case: Codex's own state databases (which
+    deliberately never become sessions of their own, see
+    ``sources/parsers/codex_state.py``), any other provider's stray SQLite
+    file, and the other recognized binary formats in
+    ``core.binary_signatures.BINARY_SIGNATURES``.
+    """
+    signature = detect_binary_signature(prefix)
+    if signature is None:
+        return None
+    return {
+        "polylogue_artifact": _BINARY_ARTIFACT_MARKER,
+        "binary_format": signature.name,
+        "source_path": str(source_path) if source_path is not None else None,
+    }
+
+
+def _binary_artifact_envelope(binary_marker: JSONDocument, *, provider: Provider) -> RawPayloadEnvelope:
+    signature_name = binary_marker["binary_format"]
+    kind = ArtifactKind.BINARY_DATABASE if signature_name == "sqlite" else ArtifactKind.BINARY_DOCUMENT
+    return RawPayloadEnvelope(
+        payload=binary_marker,
+        provider=provider,
+        wire_format="json",
+        artifact=ArtifactClassification(
+            provider=provider,
+            kind=kind,
+            parse_as_session=False,
+            schema_eligible=False,
+            default_priority=0,
+            reason=f"unrecognized {signature_name}-shaped binary payload; refused as session content (polylogue-hbtj2)",
+        ),
+    )
+
+
 def build_raw_payload_envelope(
     raw_content: Path | bytes | str | JSONValue,
     *,
@@ -287,6 +338,7 @@ def build_raw_payload_envelope(
     Python list. This avoids reading the whole file into one byte string,
     but grouped-provider parses still hold the decoded records in memory.
     """
+    provider_for_binary = Provider.from_string(payload_provider or fallback_provider)
     if isinstance(raw_content, Path):
         hermes_marker = _hermes_sqlite_marker_payload(raw_content, source_path=source_path)
         if hermes_marker is not None:
@@ -297,12 +349,23 @@ def build_raw_payload_envelope(
                 wire_format="json",
                 artifact=classify_artifact(hermes_marker, provider=provider, source_path=source_path),
             )
+        with raw_content.open("rb") as handle:
+            binary_prefix = handle.read(_UNRECOGNIZED_BINARY_PEEK_BYTES)
+        binary_marker = _unrecognized_binary_marker_payload(binary_prefix, source_path=source_path)
+        if binary_marker is not None:
+            return _binary_artifact_envelope(binary_marker, provider=provider_for_binary)
     normalized_path = str(source_path or "").lower()
     prefer_jsonl = normalized_path.endswith((".jsonl", ".jsonl.txt", ".ndjson"))
     preferred_provider = payload_provider or fallback_provider
     if not prefer_jsonl:
         runtime_provider = Provider.from_string(preferred_provider)
         prefer_jsonl = runtime_provider in {Provider.CLAUDE_CODE, Provider.CODEX}
+    if isinstance(raw_content, bytes):
+        binary_marker = _unrecognized_binary_marker_payload(
+            raw_content[:_UNRECOGNIZED_BINARY_PEEK_BYTES], source_path=source_path
+        )
+        if binary_marker is not None:
+            return _binary_artifact_envelope(binary_marker, provider=provider_for_binary)
     payload, wire_format, malformed_jsonl_lines, malformed_jsonl_detail = _decode_raw_payload(
         raw_content,
         jsonl_dict_only=jsonl_dict_only,

--- a/polylogue/core/binary_signatures.py
+++ b/polylogue/core/binary_signatures.py
@@ -1,0 +1,94 @@
+"""Shared magic-byte detection for non-conversational binary payloads.
+
+polylogue-hbtj2: a "detection/parse strictness" bug let binary files
+(concretely, SQLite databases such as Hermes ``state.db``/
+``verification_evidence.db`` and Codex ``state_5.sqlite``) reach session
+governance opportunistically -- via a file-extension match or a bare
+provider hint, never a verified content check. The audit that found this
+(``/realm/data/derived/reports/polylogue-authority-dataflow-2026-08-02.html``,
+"the residue, dissected") measured ~450 MB of such miscaptures sitting in
+``raw_sessions`` marked "genuinely diverged" by a byte-diff classifier that
+was never designed to reason about opaque binary snapshots.
+
+This module is the single, shared, magic-byte-based detector: identity is
+decided from the leading bytes of the payload, never a file extension and
+never a provider hint alone (an extension can be renamed; a hint only says
+*whose* directory a file came from, not what its bytes actually are). It
+is intentionally provider-agnostic and format-agnostic -- new binary
+formats are added to :data:`BINARY_SIGNATURES` once, and every call site
+that consults :func:`detect_binary_signature` gets the new refusal for
+free, rather than each acquisition/detection route hand-rolling its own
+check (the broader "propose a general strategy, not only for SQLite"
+direction from the same audit).
+
+ZIP is deliberately excluded from :data:`BINARY_SIGNATURES`: ChatGPT and
+Claude-ai GDPR export bundles are legitimately zip-shaped session sources,
+handled end-to-end by the ``decoder_zip`` pipeline. ``looks_like_zip_bytes``
+still exists for read-only reporting (the broader binary sweep wants to
+know a raw row is zip-shaped without asserting it is a miscapture), but no
+call site here treats a plain ZIP magic match as "refuse this artifact".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class BinarySignature:
+    """One recognized non-conversational binary format, by magic bytes."""
+
+    name: str
+    magic: bytes
+
+
+SQLITE_MAGIC_HEADER = b"SQLite format 3\x00"
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+_GZIP_MAGIC = b"\x1f\x8b"
+_JPEG_MAGIC = b"\xff\xd8\xff"
+_PDF_MAGIC = b"%PDF-"
+ZIP_MAGIC_VARIANTS: tuple[bytes, ...] = (b"PK\x03\x04", b"PK\x05\x06", b"PK\x07\x08")
+
+# Ordered so the most specific / most-frequently-seen-as-a-miscapture
+# signature (SQLite -- the concrete finding this bead fixes) is checked
+# first. ZIP is intentionally not a member: see module docstring.
+BINARY_SIGNATURES: tuple[BinarySignature, ...] = (
+    BinarySignature("sqlite", SQLITE_MAGIC_HEADER),
+    BinarySignature("png", _PNG_MAGIC),
+    BinarySignature("gzip", _GZIP_MAGIC),
+    BinarySignature("jpeg", _JPEG_MAGIC),
+    BinarySignature("pdf", _PDF_MAGIC),
+)
+
+
+def looks_like_sqlite_bytes(payload: bytes) -> bool:
+    """Return whether *payload* starts with the SQLite file-format magic header."""
+    return payload.startswith(SQLITE_MAGIC_HEADER)
+
+
+def looks_like_zip_bytes(payload: bytes) -> bool:
+    """Return whether *payload* starts with a ZIP local/empty/spanned-archive signature.
+
+    Reporting-only (see module docstring) -- legitimate export bundles are
+    zip-shaped, so this is never used to auto-refuse an artifact.
+    """
+    return payload.startswith(ZIP_MAGIC_VARIANTS)
+
+
+def detect_binary_signature(payload: bytes) -> BinarySignature | None:
+    """Return the first recognized non-session binary signature *payload* matches, if any."""
+    for signature in BINARY_SIGNATURES:
+        if payload.startswith(signature.magic):
+            return signature
+    return None
+
+
+__all__ = [
+    "BINARY_SIGNATURES",
+    "SQLITE_MAGIC_HEADER",
+    "ZIP_MAGIC_VARIANTS",
+    "BinarySignature",
+    "detect_binary_signature",
+    "looks_like_sqlite_bytes",
+    "looks_like_zip_bytes",
+]

--- a/polylogue/sources/dispatch.py
+++ b/polylogue/sources/dispatch.py
@@ -10,6 +10,7 @@ from itertools import islice
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypeAlias
 
+from polylogue.core.binary_signatures import detect_binary_signature
 from polylogue.core.enums import Provider, TitleSource
 from polylogue.core.json import JSONDocument, JSONValue, is_json_document, is_json_value, normalize_json_decimal
 from polylogue.core.payload_coercion import optional_string
@@ -355,6 +356,19 @@ def detect_provider_from_raw_bytes_evidence(
     default_file_claim_check``) so both surfaces report the same rule a real
     ingest would have used, not an approximation.
     """
+    # polylogue-hbtj2: a recognized binary format (SQLite being the concrete
+    # miscapture the audit found) must be positively refused here, at the
+    # single shared raw-bytes detection chokepoint, rather than relying on
+    # the incidental ``JSONDecodeError`` a binary blob happens to raise
+    # further down. This still returns ``fallback_provider`` (detection
+    # never invents an origin the caller didn't already suspect), but with
+    # explicit evidence identifying the refusal, instead of the generic
+    # "stream decode error" text a raised exception would otherwise produce.
+    if (signature := detect_binary_signature(raw_bytes)) is not None:
+        return (
+            fallback_provider,
+            f"{signature.name}-shaped binary payload; refused as session content, used fallback_provider",
+        )
     jsonl_like = _is_jsonl_stream_name(stream_name)
     text = None if jsonl_like else _decode_json_bytes(raw_bytes)
     if text is not None:

--- a/polylogue/sources/live/batch_support.py
+++ b/polylogue/sources/live/batch_support.py
@@ -624,7 +624,20 @@ def _large_non_jsonl_path_can_stream(path: Path, *, provider: Provider) -> bool:
 
 def _parse_payload_as_session_artifact(path: Path, *, provider: Provider, payload: bytes) -> bool:
     if provider is Provider.HERMES and path.suffix.lower() in {".db", ".sqlite", ".sqlite3"}:
-        return True
+        # polylogue-hbtj2: this used to be a bare extension match, which
+        # would accept ANY ".db"/".sqlite"/".sqlite3" file under a
+        # Hermes-tagged source as session-parseable without ever checking
+        # its bytes -- exactly the "detection-boundary strictness" bug the
+        # audit found (miscaptured SQLite databases opportunistically
+        # treated as sessions). Detection must be by content: only a
+        # payload whose schema genuinely matches Hermes's state.db /
+        # verification_evidence.db shape (verified via a real, read-only
+        # ``sqlite3`` connection in ``looks_like_state_db_path`` /
+        # ``looks_like_verification_evidence_db_path``) is session-eligible;
+        # every other SQLite-shaped file under a Hermes source is refused.
+        return hermes_state.looks_like_state_db_path(
+            path
+        ) or hermes_verification.looks_like_verification_evidence_db_path(path)
     path_classification = classify_artifact_path(path, provider=provider)
     if path_classification is not None:
         return path_classification.parse_as_session

--- a/polylogue/sources/sqlite_snapshot.py
+++ b/polylogue/sources/sqlite_snapshot.py
@@ -11,6 +11,8 @@ from contextlib import closing
 from dataclasses import dataclass
 from pathlib import Path
 
+from polylogue.core.binary_signatures import SQLITE_MAGIC_HEADER
+from polylogue.core.binary_signatures import looks_like_sqlite_bytes as _looks_like_sqlite_bytes
 from polylogue.storage.blob_store import BlobStore, Heartbeat
 
 _SQLITE_SUFFIXES = frozenset({".db", ".sqlite", ".sqlite3"})
@@ -19,7 +21,10 @@ _STAGING_METADATA_SUFFIX = ".polylogue-import"
 _STAGING_METADATA_VERSION = 1
 _HERMES_RAW_ID_DOMAIN = b"polylogue:hermes-profile-raw:v1\0"
 _CODEX_STATE_RAW_ID_DOMAIN = b"polylogue:codex-state-raw:v1\0"
-_SQLITE_MAGIC_HEADER = b"SQLite format 3\x00"
+# Re-exported for existing call sites; canonical constant now lives on the
+# shared, provider-agnostic detector in ``core.binary_signatures`` so it is
+# never redefined in more than one place (polylogue-hbtj2).
+_SQLITE_MAGIC_HEADER = SQLITE_MAGIC_HEADER
 
 
 @dataclass(frozen=True, slots=True)
@@ -77,10 +82,12 @@ def looks_like_sqlite_bytes(payload: bytes) -> bool:
     Path-suffix detection (``is_sqlite_path``) is useless once bytes have
     already been read into memory as a raw revision (e.g. replay/backfill
     call sites, which only have ``payload: bytes`` -- see
-    ``revision_backfill.py``). This is the single shared byte-level sniffer
-    for that case; do not duplicate it.
+    ``revision_backfill.py``). This is a thin re-export of the shared,
+    provider-agnostic sniffer in ``core.binary_signatures`` (kept here too
+    since most call sites already import it from this module); do not
+    duplicate the magic-byte constant itself.
     """
-    return payload.startswith(_SQLITE_MAGIC_HEADER)
+    return _looks_like_sqlite_bytes(payload)
 
 
 def sqlite_database_for_sidecar(path: Path) -> Path | None:

--- a/polylogue/storage/binary_artifact_sweep.py
+++ b/polylogue/storage/binary_artifact_sweep.py
@@ -1,0 +1,157 @@
+"""Read-only sweep: find raw rows whose bytes are a non-session binary format.
+
+polylogue-hbtj2: the authority-dataflow audit
+(``/realm/data/derived/reports/polylogue-authority-dataflow-2026-08-02.html``,
+"the residue, dissected") found ~450 MB of SQLite databases (Hermes
+``state.db``/``verification_evidence.db``, Codex ``state_5.sqlite``)
+sitting in ``raw_sessions`` and misread as "genuinely diverged" session
+revisions by a byte-diff classifier that was never designed to reason
+about opaque binary snapshots. This module answers, read-only, "which
+already-ingested rows are binary-shaped by content" -- reusing
+``inspect_raw_artifact`` (the same classifier ``raw_artifacts`` census
+uses) purely as a pure function, never invoking its persistence layer.
+
+Separate from this report: an explicit, ``--apply``-gated actuator
+(``devtools/binary_artifact_reclassify_apply.py``) that actually persists
+``raw_artifacts`` rows for the flagged content. This module only classifies
+and counts; it never mutates ``source.db``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+
+from polylogue.archive.artifact_taxonomy import ArtifactKind
+from polylogue.storage.artifacts.inspection import inspect_raw_artifact
+from polylogue.storage.blob_store import BlobStore
+from polylogue.storage.runtime import ArtifactObservationRecord, RawSessionRecord
+from polylogue.storage.sqlite.queries.mappers_archive import _row_to_raw_session
+
+_BINARY_KINDS = frozenset({ArtifactKind.BINARY_DATABASE.value, ArtifactKind.BINARY_DOCUMENT.value})
+
+
+@dataclass(frozen=True, slots=True)
+class BinaryArtifactCandidate:
+    raw_id: str
+    origin: str
+    source_path: str
+    blob_size: int
+    artifact_kind: str
+    classification_reason: str
+    recognized_session_parser: bool
+    """True when a dedicated, content-verified session parser exists for this
+    exact shape (currently: Hermes state.db / verification_evidence.db).
+    These rows are NOT classified as ``binary_*`` (they legitimately parse as
+    sessions) -- ``recognized_session_parser`` candidates are reported
+    separately, informationally, so the sweep is honest about the one
+    existing feature this bead's stricter detection deliberately leaves
+    alone rather than silently ignoring it.
+    """
+
+
+@dataclass(slots=True)
+class BinaryArtifactSweepPlan:
+    scanned_count: int = 0
+    binary_candidates: list[BinaryArtifactCandidate] = field(default_factory=list)
+    recognized_session_candidates: list[BinaryArtifactCandidate] = field(default_factory=list)
+
+    @property
+    def binary_bytes(self) -> int:
+        return sum(c.blob_size for c in self.binary_candidates)
+
+    @property
+    def recognized_session_bytes(self) -> int:
+        return sum(c.blob_size for c in self.recognized_session_candidates)
+
+    def by_kind(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for candidate in self.binary_candidates:
+            counts[candidate.artifact_kind] = counts.get(candidate.artifact_kind, 0) + 1
+        return counts
+
+    def by_origin(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for candidate in self.binary_candidates:
+            counts[candidate.origin] = counts.get(candidate.origin, 0) + 1
+        return counts
+
+
+def _iter_raw_session_rows(conn: sqlite3.Connection, *, limit: int | None) -> Iterator[sqlite3.Row]:
+    conn.row_factory = sqlite3.Row
+    last_rowid = 0
+    scanned = 0
+    while True:
+        batch = 250 if limit is None else min(250, limit - scanned)
+        if batch <= 0:
+            return
+        rows = conn.execute(
+            "SELECT rowid AS raw_rowid, * FROM raw_sessions WHERE rowid > ? ORDER BY rowid LIMIT ?",
+            (last_rowid, batch),
+        ).fetchall()
+        if not rows:
+            return
+        for row in rows:
+            last_rowid = max(last_rowid, int(row["raw_rowid"]))
+            scanned += 1
+            yield row
+        if limit is not None and scanned >= limit:
+            return
+
+
+def _classify(record: RawSessionRecord) -> ArtifactObservationRecord:
+    return inspect_raw_artifact(record)
+
+
+def scan_binary_artifacts(
+    conn: sqlite3.Connection,
+    *,
+    blob_store: BlobStore | None = None,
+    limit: int | None = None,
+) -> BinaryArtifactSweepPlan:
+    """Read-only: classify every raw row, reporting binary-shaped miscaptures.
+
+    *conn* should be opened read-only (``?mode=ro``) by the caller -- this
+    function never writes. *blob_store* is accepted for symmetry with other
+    reconciliation reports but is not currently required (``inspect_raw_artifact``
+    resolves its own blob store); reserved for a future in-process override.
+    """
+    del blob_store
+    plan = BinaryArtifactSweepPlan()
+    for row in _iter_raw_session_rows(conn, limit=limit):
+        plan.scanned_count += 1
+        record = _row_to_raw_session(row)
+        observation = _classify(record)
+        if observation.artifact_kind in _BINARY_KINDS:
+            plan.binary_candidates.append(
+                BinaryArtifactCandidate(
+                    raw_id=record.raw_id,
+                    origin=row["origin"],
+                    source_path=record.source_path,
+                    blob_size=record.blob_size,
+                    artifact_kind=observation.artifact_kind,
+                    classification_reason=observation.classification_reason,
+                    recognized_session_parser=False,
+                )
+            )
+        elif observation.parse_as_session and "Hermes" in observation.classification_reason:
+            plan.recognized_session_candidates.append(
+                BinaryArtifactCandidate(
+                    raw_id=record.raw_id,
+                    origin=row["origin"],
+                    source_path=record.source_path,
+                    blob_size=record.blob_size,
+                    artifact_kind=observation.artifact_kind,
+                    classification_reason=observation.classification_reason,
+                    recognized_session_parser=True,
+                )
+            )
+    return plan
+
+
+__all__ = [
+    "BinaryArtifactCandidate",
+    "BinaryArtifactSweepPlan",
+    "scan_binary_artifacts",
+]

--- a/tests/unit/core/test_binary_signatures.py
+++ b/tests/unit/core/test_binary_signatures.py
@@ -1,0 +1,53 @@
+"""Tests for the shared magic-byte binary-format detector.
+
+polylogue-hbtj2: this is the single, shared detector every acquisition/
+detection call site consults to refuse non-conversational binary payloads
+(SQLite being the concrete miscapture the audit found) before any session
+parser sees the bytes. See ``core.binary_signatures`` module docstring.
+"""
+
+from __future__ import annotations
+
+from polylogue.core.binary_signatures import (
+    SQLITE_MAGIC_HEADER,
+    detect_binary_signature,
+    looks_like_sqlite_bytes,
+    looks_like_zip_bytes,
+)
+
+
+def test_detect_binary_signature_recognizes_sqlite() -> None:
+    payload = SQLITE_MAGIC_HEADER + b"\x00" * 100
+    signature = detect_binary_signature(payload)
+    assert signature is not None
+    assert signature.name == "sqlite"
+
+
+def test_detect_binary_signature_recognizes_png() -> None:
+    payload = b"\x89PNG\r\n\x1a\n" + b"\x00" * 20
+    signature = detect_binary_signature(payload)
+    assert signature is not None
+    assert signature.name == "png"
+
+
+def test_detect_binary_signature_returns_none_for_json() -> None:
+    payload = b'{"sessionId": "abc"}'
+    assert detect_binary_signature(payload) is None
+
+
+def test_detect_binary_signature_returns_none_for_empty() -> None:
+    assert detect_binary_signature(b"") is None
+
+
+def test_looks_like_sqlite_bytes() -> None:
+    assert looks_like_sqlite_bytes(SQLITE_MAGIC_HEADER + b"rest")
+    assert not looks_like_sqlite_bytes(b"not sqlite")
+
+
+def test_looks_like_zip_bytes_is_reporting_only_not_in_binary_signatures() -> None:
+    """ZIP is a legitimate session-source shape (GDPR export bundles), so it
+    must never be a member of the auto-refusal registry, only reachable via
+    the dedicated reporting helper."""
+    zip_bytes = b"PK\x03\x04" + b"\x00" * 20
+    assert looks_like_zip_bytes(zip_bytes)
+    assert detect_binary_signature(zip_bytes) is None

--- a/tests/unit/core/test_raw_payload_decode.py
+++ b/tests/unit/core/test_raw_payload_decode.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
+from polylogue.archive.artifact_taxonomy import ArtifactKind
 from polylogue.archive.raw_payload.decode import (
     JSONValue,
     _sample_jsonl_payload_with_detail,
@@ -78,3 +80,84 @@ def test_jsonl_sampling_can_stop_after_bounded_prefix(tmp_path: Path) -> None:
     assert [_as_dict(sample)["ok"] for sample in samples] == [1, 2]
     assert malformed == 0
     assert detail is None
+
+
+def _write_plain_sqlite_db(path: Path) -> None:
+    """A genuine SQLite database with no Hermes state.db/verification_evidence.db shape.
+
+    Stands in for the audit's concrete miscaptures (Codex ``state_5.sqlite``,
+    or any other stray ``.db`` file) -- real SQLite magic bytes, but no
+    dedicated, content-verified session parser claims it.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as conn:
+        conn.executescript("CREATE TABLE unrelated_thing (id INTEGER PRIMARY KEY, value TEXT);")
+        conn.execute("INSERT INTO unrelated_thing (value) VALUES ('not a session')")
+        conn.commit()
+
+
+def test_build_raw_payload_envelope_refuses_unrecognized_sqlite_path(tmp_path: Path) -> None:
+    """polylogue-hbtj2: a SQLite-shaped path with no dedicated parser must never be
+    handed to a session parser -- refused before any JSON decode is attempted,
+    classified as a binary-database artifact instead of a decode failure."""
+    path = tmp_path / "state_5.sqlite"
+    _write_plain_sqlite_db(path)
+
+    envelope = build_raw_payload_envelope(
+        path,
+        source_path=str(path),
+        fallback_provider="codex",
+    )
+
+    assert envelope.artifact.kind is ArtifactKind.BINARY_DATABASE
+    assert envelope.artifact.parse_as_session is False
+    assert envelope.artifact.schema_eligible is False
+    assert isinstance(envelope.payload, dict)
+    assert envelope.payload.get("polylogue_artifact") == "unrecognized_binary_artifact"
+    assert envelope.payload.get("binary_format") == "sqlite"
+
+
+def test_build_raw_payload_envelope_refuses_unrecognized_sqlite_bytes(tmp_path: Path) -> None:
+    """Same refusal for in-memory bytes (the replay/backfill call shape)."""
+    path = tmp_path / "state_5.sqlite"
+    _write_plain_sqlite_db(path)
+    raw_bytes = path.read_bytes()
+
+    envelope = build_raw_payload_envelope(
+        raw_bytes,
+        source_path=str(path),
+        fallback_provider="codex",
+    )
+
+    assert envelope.artifact.kind is ArtifactKind.BINARY_DATABASE
+    assert envelope.artifact.parse_as_session is False
+
+
+def test_build_raw_payload_envelope_still_recognizes_genuine_hermes_state_db(tmp_path: Path) -> None:
+    """Regression guard: this bead tightens detection, it does not retire the
+    existing, content-verified Hermes state.db session parser."""
+    path = tmp_path / "state.db"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE schema_version(version INTEGER NOT NULL);
+            INSERT INTO schema_version(version) VALUES (16);
+            CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, model TEXT, model_config TEXT,
+                parent_session_id TEXT, started_at REAL, ended_at REAL, title TEXT);
+            CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL,
+                role TEXT NOT NULL, content TEXT, tool_call_id TEXT, tool_name TEXT, tool_calls TEXT,
+                timestamp REAL NOT NULL, observed INTEGER DEFAULT 0, active INTEGER NOT NULL DEFAULT 1,
+                compacted INTEGER NOT NULL DEFAULT 0);
+            """
+        )
+        conn.commit()
+
+    envelope = build_raw_payload_envelope(
+        path,
+        source_path=str(path),
+        fallback_provider="hermes",
+    )
+
+    assert envelope.artifact.kind is ArtifactKind.SESSION_DOCUMENT
+    assert envelope.artifact.parse_as_session is True

--- a/tests/unit/sources/test_dispatch_evidence.py
+++ b/tests/unit/sources/test_dispatch_evidence.py
@@ -88,3 +88,21 @@ def test_detect_provider_from_raw_bytes_evidence_falls_back_with_reason_on_garba
 
     assert provider is Provider.UNKNOWN
     assert "fallback_provider" in evidence
+
+
+def test_detect_provider_from_raw_bytes_evidence_refuses_sqlite_before_json_decode() -> None:
+    """polylogue-hbtj2: a SQLite-shaped raw byte stream must be positively refused
+    here (the single shared raw-bytes detection chokepoint used by production
+    per-file acquisition and the unclaimed-file sweep), by magic bytes -- not
+    by falling through to an incidental JSON-decode failure."""
+    raw_bytes = b"SQLite format 3\x00" + b"\x00" * 100
+
+    provider, evidence = detect_provider_from_raw_bytes_evidence(
+        raw_bytes,
+        "state_5.sqlite",
+        Provider.CODEX,
+    )
+
+    assert provider is Provider.CODEX
+    assert "sqlite" in evidence.lower()
+    assert "refused" in evidence.lower()

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -36,6 +36,7 @@ from polylogue.sources.live.batch_support import (
     _detect_provider_from_path_sample,
     _FullIngestResult,
     _parse_path_as_session_artifact,
+    _parse_payload_as_session_artifact,
     encode_cursor_hash_authority,
     sha256_range_from_path,
     tail_hash_from_path,
@@ -1047,6 +1048,50 @@ def test_unclassified_large_non_jsonl_is_not_streamed_as_session_artifact(
     monkeypatch.setattr(Path, "read_bytes", fail_read_bytes)
 
     assert _parse_path_as_session_artifact(target, provider=Provider.UNKNOWN) is False
+
+
+def _write_plain_sqlite_db(path: Path) -> None:
+    """A genuine SQLite database with no Hermes state.db/verification_evidence.db shape."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as conn:
+        conn.executescript("CREATE TABLE unrelated_thing (id INTEGER PRIMARY KEY, value TEXT);")
+        conn.commit()
+
+
+def test_parse_payload_as_session_artifact_refuses_unrecognized_hermes_db_extension(tmp_path: Path) -> None:
+    """polylogue-hbtj2: this used to be a bare ``.db``/``.sqlite``/``.sqlite3``
+    extension match under provider=HERMES -- ANY file with that suffix was
+    accepted as session content regardless of its actual bytes. It must now
+    require the same content-verified shape check the path-based sibling
+    function (``_parse_path_as_session_artifact``) already uses."""
+    target = tmp_path / "state_5.sqlite"
+    _write_plain_sqlite_db(target)
+    payload = target.read_bytes()
+
+    assert _parse_payload_as_session_artifact(target, provider=Provider.HERMES, payload=payload) is False
+
+
+def test_parse_payload_as_session_artifact_still_accepts_genuine_hermes_state_db(tmp_path: Path) -> None:
+    """Regression guard: the tightened check must not break the real feature."""
+    target = tmp_path / "state.db"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(target) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE schema_version(version INTEGER NOT NULL);
+            INSERT INTO schema_version(version) VALUES (16);
+            CREATE TABLE sessions (id TEXT PRIMARY KEY, source TEXT, model TEXT, model_config TEXT,
+                parent_session_id TEXT, started_at REAL, ended_at REAL, title TEXT);
+            CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL,
+                role TEXT NOT NULL, content TEXT, tool_call_id TEXT, tool_name TEXT, tool_calls TEXT,
+                timestamp REAL NOT NULL, observed INTEGER DEFAULT 0, active INTEGER NOT NULL DEFAULT 1,
+                compacted INTEGER NOT NULL DEFAULT 0);
+            """
+        )
+        conn.commit()
+    payload = target.read_bytes()
+
+    assert _parse_payload_as_session_artifact(target, provider=Provider.HERMES, payload=payload) is True
 
 
 def test_append_plan_chunks_large_tail_without_full_ingest(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Tightens the detection boundary so binary SQLite databases can never reach a session parser opportunistically. Adds a shared, magic-byte-based binary-format detector, fixes one extension-only detection bug, adds an explicit refusal at the single shared raw-bytes detection chokepoint, and ships a read-only sweep plus a separate `--apply`-gated actuator to classify already-ingested miscaptures.

## Problem

The 2026-08-02 authority-dataflow audit (`/realm/data/derived/reports/polylogue-authority-dataflow-2026-08-02.html`, "the residue, dissected") found ~450MB of SQLite databases sitting in `raw_sessions` and misread as "genuinely diverged" session revisions by a byte-diff classifier that was never designed to reason about opaque binary snapshots: two Hermes `state.db` copies (135MB each), one `verification_evidence.db`, and Codex `state_5.sqlite` (40MB). Operator directive: "we should be strict. don't try to opportunistically parse any file as session. ofc these should be handled, but these are not sessions."

Live-archive verification against `/realm/db/polylogue` (read-only) confirmed the exact rows the audit named: all sit at `revision_kind='unknown'` / `revision_authority='quarantined'`, meaning they were written by a path that never entered the governance vocabulary rather than a considered decision.

Two concrete detection gaps caused this:

1. `sources/live/batch_support.py`'s `_parse_payload_as_session_artifact` accepted **any** `.db`/`.sqlite`/`.sqlite3` file under a Hermes-tagged source by bare extension match, never checking the actual bytes or schema — its path-based sibling function already did the correct content-verified check, this one didn't.
2. No shared chokepoint positively refused a recognized-binary payload before a JSON/JSONL decode was even attempted; refusal happened only incidentally, via the `JSONDecodeError` a binary blob happens to raise, with no explicit classification.

## Solution

- **`polylogue/core/binary_signatures.py`** (new): single shared, provider-agnostic magic-byte registry (SQLite/PNG/gzip/JPEG/PDF). ZIP is deliberately excluded — ChatGPT/Claude-ai GDPR export bundles are legitimately zip-shaped sessions — but still detectable via `looks_like_zip_bytes` for reporting.
- **`sources/live/batch_support.py`**: `_parse_payload_as_session_artifact` now requires the same content-verified Hermes `state.db`/`verification_evidence.db` schema check (`looks_like_state_db_path`/`looks_like_verification_evidence_db_path`, a real read-only `sqlite3` connection + required-table check) its path-based sibling already uses, instead of a bare extension match.
- **`sources/dispatch.py`**: `detect_provider_from_raw_bytes_evidence` (the documented single shared raw-bytes detection chokepoint, used by production per-file acquisition and the unclaimed-file sweep) now positively refuses a recognized binary signature with explicit evidence, before any JSON decode attempt.
- **`archive/raw_payload/decode.py`**: `build_raw_payload_envelope` (its own docstring: "ingest_record calls this for every raw, including binary ones") now classifies an unrecognized binary-shaped payload as `ArtifactKind.BINARY_DATABASE`/`BINARY_DOCUMENT` (`parse_as_session=False`, `schema_eligible=False`) with an explicit reason, instead of falling through to an incidental decode failure. This runs after the existing Hermes-marker check, so a genuine, content-verified Hermes state.db still wins.
- **`polylogue/storage/binary_artifact_sweep.py`** + **`devtools workspace binary-artifact-sweep`** (read-only) + **`devtools workspace binary-artifact-reclassify-apply`** (`--apply`-gated): mirrors the `raw-live-source-reconciliation` report/apply split. The read-only report reuses `inspect_raw_artifact` as a pure function (no persistence) to classify every `raw_sessions` row by content; the apply step calls the existing, tested `materialize_artifact_observations` to persist `raw_artifacts` rows. Neither touches `revision_authority` or deletes anything — see Verification below for what the apply step would do if run.

### Explicitly out of scope (flagged for an operator decision)

Hermes `state.db`/`verification_evidence.db` already have a dedicated, content-verified, extensively tested session parser (`sources/parsers/hermes_state.py`/`hermes_verification.py`) whose output backs a real, shipped feature (fs1.14: ATIF/ATOF trajectory + verification-ledger topology projection, `insights/hermes_topology_projection.py`, `insights/hermes_verification_coverage.py`). Confirmed live: the two 135MB `state.db` raw rows and the `verification_evidence.db` row the audit found *do* have `parsed_at_ms` set, meaning this dedicated parser already ran on them and materialized derived "sessions" — this is the deliberate, working feature, not the miscapture.

This PR tightens the *detection boundary* (no dedicated, content-verified parser claims a shape → refuse, classify as a binary artifact) without reversing that existing feature. It does **not** decide whether Hermes SQLite content should stop being represented as sessions at all (a literal reading of I11 in the audit report — "sessions hold conversations" — would require it, but reversing an entire shipped, cross-wired subsystem is a materially larger and riskier change than this bead's detection-strictness scope). That is a separate architectural question for the operator; the sweep below reports these rows informationally (`recognized_session_candidates`) so the decision has the data behind it.

## Verification

- `devtools test tests/unit/core/test_binary_signatures.py tests/unit/core/test_raw_payload_decode.py tests/unit/sources/test_dispatch_evidence.py tests/unit/sources/test_live_batch_support.py` — new regression tests pass (magic-byte refusal for both Hermes-tagged and Codex-tagged unrecognized SQLite payloads, plus a regression guard proving a genuine Hermes state.db still classifies `parse_as_session=True`). 3 pre-existing failures in `test_live_batch_support.py`/`test_dispatch_payloads.py` confirmed unrelated via `git stash` (fail identically on master).
- `devtools verify --quick` — green (ruff format/check, mypy, render all, topology, layering, classifier-fingerprints). One classifier-fingerprint drift was expected and explicitly acknowledged (`devtools lab policy classifier-fingerprints --ack ... --reason ...`): `sqlite_snapshot.looks_like_sqlite_bytes` now delegates to the shared detector, byte-for-byte identical behavior, no semantic reparse.
- Read-only live-archive sweep (`POLYLOGUE_ARCHIVE_ROOT=/realm/db/polylogue devtools workspace binary-artifact-sweep --json`), run against the real archive at `/realm/db/polylogue`, strictly read-only: full-archive run (43,124 rows) is still completing in the background at PR-open time due to per-row SQLite-connect overhead; a manual SQL check against `raw_sessions` confirmed the exact rows the audit named (2x Hermes `state.db` at 135,237,632 bytes each, 1x `verification_evidence.db`, Codex `state_5.sqlite`/`goals_1.sqlite`/`memories_1.sqlite`, all `revision_kind='unknown'`). The full sweep's aggregate counts/samples will be appended to this PR and to bead `polylogue-hbtj2`'s notes once it completes — the operator should use that output to decide whether/when to run `--apply`.

## Follow-ups

- Whether Hermes state.db/verification_evidence.db's session-parser output should be reclassified out of session governance entirely (see "Explicitly out of scope" above) — needs an explicit operator decision given the fs1.14 subsystem's size.
- Running `devtools workspace binary-artifact-reclassify-apply --apply` against the live archive once the read-only sweep's findings are reviewed.

Ref polylogue-hbtj2