### PR TITLE
feat(storage): sweep and purge antigravity brain-metadata phantom sessions

### DIFF
--- a/devtools/antigravity_phantom_purge_apply.py
+++ b/devtools/antigravity_phantom_purge_apply.py
@@ -1,0 +1,116 @@
+"""Actuator: purge ``antigravity-session`` brain-metadata phantom sessions.
+
+polylogue-eo81 / polylogue-msia: ``devtools/antigravity_phantom_sweep_report.py``
+only classifies and reports. This command acts on that report:
+
+1. Deletes the flagged sessions via ``ArchiveStore.delete_sessions`` (the
+   same low-level primitive CLI ``delete`` / MCP ``write(operation=
+   'delete_session')`` already reach) -- a rebuild-safe removal, since the
+   ingest-side content classifier already refuses ``*.md.metadata.json`` as
+   session content (``AGENT_SIDECAR_META``, PR #3441) and will not
+   resurrect them on re-ingest.
+2. Persists an explicit ``raw_artifacts`` classification for each purged
+   session's raw row (``materialize_artifact_observations_for_raw_ids``),
+   scoped to exactly the affected raw ids rather than a full census, so the
+   raw payload carries a durable "this is a sidecar, not a session" record
+   instead of sitting unclassified once its session is gone.
+
+Default mode is dry-run (report only, zero mutation). Pass ``--apply`` to
+actually delete sessions and write ``raw_artifacts`` rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+from typing import TextIO
+
+from polylogue.paths import archive_root as default_archive_root
+from polylogue.storage.antigravity_phantom_sweep import scan_antigravity_phantom_sessions
+from polylogue.storage.artifacts.persistence import materialize_artifact_observations_for_raw_ids
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+
+def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive-root",
+        type=Path,
+        default=None,
+        help="Archive root to operate on; defaults to the configured active archive root.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap the number of candidate sessions considered (unbounded by default).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually delete sessions and write raw_artifacts rows. Without this flag, nothing is mutated.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the report as JSON.")
+    args = parser.parse_args(argv)
+
+    root = args.archive_root if args.archive_root is not None else default_archive_root()
+    index_db = root / "index.db"
+    source_db = root / "source.db"
+    if not index_db.exists():
+        print(f"no index.db at {index_db}", file=stdout)
+        return 1
+
+    # Read-only classification pass first, regardless of --apply, so the
+    # operator always sees exactly what would change before any write.
+    index_ro = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
+    source_ro = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) if source_db.exists() else None
+    try:
+        plan = scan_antigravity_phantom_sessions(index_ro, source_ro, limit=args.limit)
+    finally:
+        index_ro.close()
+        if source_ro is not None:
+            source_ro.close()
+
+    applied = False
+    deleted_count = 0
+    observation_count = 0
+    if args.apply and plan.candidates:
+        session_ids = plan.session_ids()
+        raw_ids = plan.raw_ids()
+
+        with ArchiveStore(root) as archive:
+            deleted_count = archive.delete_sessions(session_ids)
+
+        if raw_ids and source_db.exists():
+            source_rw = sqlite3.connect(source_db)
+            try:
+                observations = materialize_artifact_observations_for_raw_ids(source_rw, raw_ids)
+            finally:
+                source_rw.close()
+            observation_count = len(observations)
+        applied = True
+
+    if args.json:
+        payload = {
+            "applied": applied,
+            "candidate_count": len(plan.candidates),
+            "deleted_count": deleted_count,
+            "raw_artifacts_observations_written": observation_count,
+            "missing_raw_row_count": plan.missing_raw_row_count,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=stdout)
+        return 0
+
+    mode = "APPLIED" if applied else "dry-run (no mutation performed -- pass --apply to write)"
+    print(f"mode: {mode}", file=stdout)
+    print(f"brain-metadata phantom candidates found: {len(plan.candidates)}", file=stdout)
+    if applied:
+        print(f"sessions deleted: {deleted_count}", file=stdout)
+        print(f"raw_artifacts observations written (scoped to purged raw ids): {observation_count}", file=stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/antigravity_phantom_sweep_report.py
+++ b/devtools/antigravity_phantom_sweep_report.py
@@ -1,0 +1,114 @@
+"""Read-only report: list ``antigravity-session`` brain-metadata phantom sessions.
+
+polylogue-eo81 / polylogue-msia: every ``antigravity-session`` row (116/116
+in the live archive as of the forensic audit) is a 1-message fragment
+materialized from a per-artifact ``*.md.metadata.json`` sidecar, tagged
+``degraded:brain-metadata-fragment`` at ingest time (PR #1856). This is a
+pure classification pass over ``index.db``/``source.db`` -- it never
+mutates either tier. Pair with
+``devtools/antigravity_phantom_purge_apply.py`` (``--apply``-gated) to
+actually delete the flagged sessions and reclassify their raw rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+from typing import TextIO
+
+from polylogue.paths import archive_root as default_archive_root
+from polylogue.storage.antigravity_phantom_sweep import (
+    AntigravityPhantomCandidate,
+    scan_antigravity_phantom_sessions,
+)
+
+
+def _candidate_payload(candidate: AntigravityPhantomCandidate) -> dict[str, object]:
+    return {
+        "session_id": candidate.session_id,
+        "raw_id": candidate.raw_id,
+        "message_count": candidate.message_count,
+        "source_path": candidate.source_path,
+        "blob_size": candidate.blob_size,
+    }
+
+
+def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive-root",
+        type=Path,
+        default=None,
+        help="Archive root to inspect; defaults to the configured active archive root.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap the number of candidate sessions scanned (unbounded by default).",
+    )
+    parser.add_argument(
+        "--sample-limit",
+        type=int,
+        default=25,
+        help="How many candidates to print in the human-readable report.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the full classified plan as JSON.")
+    args = parser.parse_args(argv)
+
+    root = args.archive_root if args.archive_root is not None else default_archive_root()
+    index_db = root / "index.db"
+    source_db = root / "source.db"
+    if not index_db.exists():
+        print(f"no index.db at {index_db}", file=stdout)
+        return 1
+
+    index_conn = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
+    source_conn = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True) if source_db.exists() else None
+    try:
+        plan = scan_antigravity_phantom_sessions(index_conn, source_conn, limit=args.limit)
+    finally:
+        index_conn.close()
+        if source_conn is not None:
+            source_conn.close()
+
+    if args.json:
+        payload = {
+            "scanned_count": plan.scanned_count,
+            "candidate_count": len(plan.candidates),
+            "raw_bytes": plan.raw_bytes,
+            "missing_raw_row_count": plan.missing_raw_row_count,
+            "candidate_sample": [_candidate_payload(c) for c in plan.candidates[: args.sample_limit]],
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=stdout)
+        return 0
+
+    print(f"antigravity-session rows scanned: {plan.scanned_count}", file=stdout)
+    print(
+        f"brain-metadata phantom candidates: {len(plan.candidates):>6}  "
+        f"({plan.raw_bytes / 1024:.2f} KB of raw sidecar payload)",
+        file=stdout,
+    )
+    if plan.missing_raw_row_count:
+        print(
+            f"  (of which {plan.missing_raw_row_count} have no matching raw_sessions row -- "
+            "still purge-eligible on session-tag evidence alone)",
+            file=stdout,
+        )
+    print("", file=stdout)
+    print("This is a read-only classification. No row was mutated.", file=stdout)
+    if plan.candidates:
+        print(f"\nsample (up to {args.sample_limit}):", file=stdout)
+        for candidate in plan.candidates[: args.sample_limit]:
+            print(
+                f"  {candidate.session_id}  raw={candidate.raw_id}  "
+                f"messages={candidate.message_count}  {candidate.source_path}",
+                file=stdout,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -1016,6 +1016,46 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "workspace antigravity-phantom-sweep",
+        "workspace",
+        "List antigravity-session rows that are brain-metadata phantom fragments.",
+        "devtools.antigravity_phantom_sweep_report",
+        use_when=(
+            "polylogue-eo81 / polylogue-msia: every antigravity-session row (116/116, "
+            "measured 2026-07-31) is a 1-message fragment materialized from a "
+            "*.md.metadata.json sidecar under ~/.gemini/antigravity/brain/, tagged "
+            "degraded:brain-metadata-fragment at ingest time (PR #1856). Real "
+            "conversation content lives in conversations/*.pb, acquired separately by "
+            "PR #3441. This read-only report lists the phantom candidates and their "
+            "raw payload; never mutates index.db or source.db."
+        ),
+        examples=(
+            "devtools workspace antigravity-phantom-sweep",
+            "devtools workspace antigravity-phantom-sweep --json",
+            "devtools workspace antigravity-phantom-sweep --limit 200 --sample-limit 20",
+        ),
+    ),
+    CommandSpec(
+        "workspace antigravity-phantom-purge-apply",
+        "workspace",
+        "Delete antigravity brain-metadata phantom sessions and reclassify their raw rows.",
+        "devtools.antigravity_phantom_purge_apply",
+        use_when=(
+            "polylogue-eo81 / polylogue-msia: act on the sweep's report by deleting the "
+            "flagged sessions (ArchiveStore.delete_sessions -- rebuild-safe, since PR "
+            "#3441's ingest-side content classifier already refuses "
+            "*.md.metadata.json as session content) and persisting a scoped "
+            "raw_artifacts classification for their raw rows "
+            "(materialize_artifact_observations_for_raw_ids). Default is dry-run; "
+            "--apply performs both writes."
+        ),
+        examples=(
+            "devtools workspace antigravity-phantom-purge-apply",
+            "devtools workspace antigravity-phantom-purge-apply --json",
+            "devtools workspace antigravity-phantom-purge-apply --apply",
+        ),
+    ),
+    CommandSpec(
         "workspace unknown-export-reclassification",
         "workspace",
         "Re-run the fixed browser-capture provider probe against stored unknown-export rows.",

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -214,6 +214,8 @@ These are the commands worth remembering during normal repo work:
 | --- | --- |
 | `devtools demo real-slice-screen` | Read-only extraction + privacy screening of a candidate real-archive session slice. |
 | `devtools workspace affordance-usage` | Analyze agent affordance/tool usage from archive tool-use rows. |
+| `devtools workspace antigravity-phantom-purge-apply` | Delete antigravity brain-metadata phantom sessions and reclassify their raw rows. |
+| `devtools workspace antigravity-phantom-sweep` | List antigravity-session rows that are brain-metadata phantom fragments. |
 | `devtools workspace archive-schema-fast-forward` | Clone-forward the v35 archive tiers without raw replay. |
 | `devtools workspace backlog-calibration` | Measured lead-time/discovery/staleness distributions over the bead corpus. |
 | `devtools workspace basic-usage-demo-check` | Re-run the basic-usage demo suite's commands and assert output shape. |

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -3638,6 +3638,10 @@ files:
     target: polylogue/storage/__init__.py
     owner: storage-root
     reason: storage-root cross-cutting helper
+  - path: polylogue/storage/antigravity_phantom_sweep.py
+    loc: 133
+    target: TBD
+    owner: storage-domain
   - path: polylogue/storage/archive_identity.py
     loc: 464
     target: TBD
@@ -3664,7 +3668,7 @@ files:
     target: polylogue/storage/artifacts/inspection.py
     owner: stable
   - path: polylogue/storage/artifacts/persistence.py
-    loc: 80
+    loc: 118
     target: polylogue/storage/artifacts/persistence.py
     owner: stable
   - path: polylogue/storage/artifacts/queries.py

--- a/polylogue/storage/antigravity_phantom_sweep.py
+++ b/polylogue/storage/antigravity_phantom_sweep.py
@@ -1,0 +1,133 @@
+"""Read-only sweep: find ``antigravity-session`` phantom-metadata sessions.
+
+polylogue-eo81 / polylogue-msia: every ``antigravity-session`` row (116/116,
+measured 2026-07-31) was materialized from a per-artifact
+``~/.gemini/antigravity/brain/<uuid>/*.md.metadata.json`` sidecar -- one
+single-message "session" per metadata file, none of which hold real
+conversation content (the real content lives in ``conversations/*.pb``
+trajectories, acquired by a separate fix, PR #3441/polylogue-eo81). These
+degraded fragments are already tagged at ingest time
+(``session_tags.tag = 'degraded:brain-metadata-fragment'``, PR #1856) --
+this module's read-only job is to turn that existing tag into an explicit,
+countable purge candidate list, cross-checked against the raw payload each
+session's ``raw_id`` points at so a caller can see exactly what would be
+removed before anything is mutated.
+
+Separate from this report: an explicit, ``--apply``-gated actuator
+(``devtools/antigravity_phantom_purge_apply.py``) that actually deletes the
+flagged sessions (``ArchiveStore.delete_sessions``) and persists a
+``raw_artifacts`` classification for their raw rows
+(``materialize_artifact_observations_for_raw_ids``). This module only
+classifies and counts; it never mutates either tier.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+
+from polylogue.core.enums import Origin
+
+_PHANTOM_TAG = "degraded:brain-metadata-fragment"
+
+
+@dataclass(frozen=True, slots=True)
+class AntigravityPhantomCandidate:
+    session_id: str
+    raw_id: str | None
+    message_count: int
+    source_path: str | None
+    """``raw_sessions.source_path`` for ``raw_id``, when the raw row is still
+    present in ``source.db``. ``None`` if ``raw_id`` is unset or the raw row
+    is missing (reported honestly rather than assumed)."""
+    blob_size: int | None
+
+
+@dataclass(slots=True)
+class AntigravityPhantomSweepPlan:
+    scanned_count: int = 0
+    candidates: list[AntigravityPhantomCandidate] = field(default_factory=list)
+    missing_raw_row_count: int = 0
+    """Candidates whose ``raw_id`` no longer resolves to a ``source.db`` row
+    (e.g. already GC'd). Still included in ``candidates`` -- the session-tag
+    evidence alone is sufficient to purge the session -- but counted
+    separately so the report is honest about incomplete cross-checks."""
+
+    @property
+    def raw_bytes(self) -> int:
+        return sum(c.blob_size or 0 for c in self.candidates)
+
+    def session_ids(self) -> tuple[str, ...]:
+        return tuple(c.session_id for c in self.candidates)
+
+    def raw_ids(self) -> tuple[str, ...]:
+        return tuple(c.raw_id for c in self.candidates if c.raw_id is not None)
+
+
+def scan_antigravity_phantom_sessions(
+    index_conn: sqlite3.Connection,
+    source_conn: sqlite3.Connection | None = None,
+    *,
+    limit: int | None = None,
+) -> AntigravityPhantomSweepPlan:
+    """Read-only: list ``antigravity-session`` rows tagged as brain-metadata
+    fragments, cross-checked against their raw payload when *source_conn* is
+    given.
+
+    *index_conn* and *source_conn* should both be opened read-only
+    (``?mode=ro``) by the caller -- this function never writes.
+    """
+    index_conn.row_factory = sqlite3.Row
+    query = """
+        SELECT s.session_id, s.raw_id, s.message_count
+        FROM sessions AS s
+        JOIN session_tags AS t ON t.session_id = s.session_id
+        WHERE s.origin = ? AND t.tag = ?
+        ORDER BY s.session_id
+    """
+    params: list[object] = [Origin.ANTIGRAVITY_SESSION.value, _PHANTOM_TAG]
+    if limit is not None:
+        query += " LIMIT ?"
+        params.append(limit)
+    rows = index_conn.execute(query, params).fetchall()
+
+    raw_by_id: dict[str, sqlite3.Row] = {}
+    if source_conn is not None:
+        source_conn.row_factory = sqlite3.Row
+        raw_ids = [row["raw_id"] for row in rows if row["raw_id"] is not None]
+        for batch_start in range(0, len(raw_ids), 250):
+            batch = raw_ids[batch_start : batch_start + 250]
+            if not batch:
+                continue
+            placeholders = ",".join("?" for _ in batch)
+            found = source_conn.execute(
+                f"SELECT raw_id, source_path, blob_size FROM raw_sessions WHERE raw_id IN ({placeholders})",
+                batch,
+            ).fetchall()
+            for raw_row in found:
+                raw_by_id[raw_row["raw_id"]] = raw_row
+
+    plan = AntigravityPhantomSweepPlan()
+    for row in rows:
+        plan.scanned_count += 1
+        raw_id = row["raw_id"]
+        raw_row = raw_by_id.get(raw_id) if raw_id is not None else None
+        if raw_id is not None and source_conn is not None and raw_row is None:
+            plan.missing_raw_row_count += 1
+        plan.candidates.append(
+            AntigravityPhantomCandidate(
+                session_id=row["session_id"],
+                raw_id=raw_id,
+                message_count=row["message_count"],
+                source_path=raw_row["source_path"] if raw_row is not None else None,
+                blob_size=raw_row["blob_size"] if raw_row is not None else None,
+            )
+        )
+    return plan
+
+
+__all__ = [
+    "AntigravityPhantomCandidate",
+    "AntigravityPhantomSweepPlan",
+    "scan_antigravity_phantom_sessions",
+]

--- a/polylogue/storage/artifacts/persistence.py
+++ b/polylogue/storage/artifacts/persistence.py
@@ -10,6 +10,7 @@ durably stores the subset of columns it declares (#1743).
 from __future__ import annotations
 
 import sqlite3
+from collections.abc import Sequence
 
 from polylogue.storage.artifacts.inspection import inspect_raw_artifact
 from polylogue.storage.runtime import ArtifactObservationRecord
@@ -66,6 +67,39 @@ def materialize_artifact_observations(
     return records
 
 
+def materialize_artifact_observations_for_raw_ids(
+    conn: sqlite3.Connection,
+    raw_ids: Sequence[str],
+) -> list[ArtifactObservationRecord]:
+    """Inspect and persist ``raw_artifacts`` rows for exactly the given raw ids.
+
+    Scoped sibling of :func:`materialize_artifact_observations` for callers
+    that already know precisely which raw rows they care about (e.g. a
+    targeted phantom-session sweep) and want to avoid paying for a full
+    ``raw_sessions`` census just to refresh a handful of rows. Unknown raw
+    ids are silently skipped (no row to inspect); duplicates are de-duplicated.
+    """
+    unique_ids = list(dict.fromkeys(raw_ids))
+    if not unique_ids:
+        return []
+    conn.row_factory = sqlite3.Row
+    records: list[ArtifactObservationRecord] = []
+    for batch_start in range(0, len(unique_ids), 250):
+        batch = unique_ids[batch_start : batch_start + 250]
+        placeholders = ",".join("?" for _ in batch)
+        rows = conn.execute(
+            f"SELECT rowid AS raw_rowid, * FROM raw_sessions WHERE raw_id IN ({placeholders})",
+            batch,
+        ).fetchall()
+        for row in rows:
+            raw_record = _row_to_raw_session(row)
+            observation = inspect_raw_artifact(raw_record)
+            _upsert_artifact_observation(conn, observation)
+            records.append(observation)
+        conn.commit()
+    return records
+
+
 def ensure_artifact_observations(
     conn: sqlite3.Connection,
     *,
@@ -77,4 +111,8 @@ def ensure_artifact_observations(
     return len(materialize_artifact_observations(conn))
 
 
-__all__ = ["ensure_artifact_observations", "materialize_artifact_observations"]
+__all__ = [
+    "ensure_artifact_observations",
+    "materialize_artifact_observations",
+    "materialize_artifact_observations_for_raw_ids",
+]

--- a/tests/unit/storage/test_antigravity_phantom_sweep.py
+++ b/tests/unit/storage/test_antigravity_phantom_sweep.py
@@ -1,0 +1,264 @@
+"""polylogue-eo81 / polylogue-msia: sweep + purge for antigravity phantom sessions.
+
+Every ``antigravity-session`` row in the live archive was a 1-message
+fragment materialized from a ``*.md.metadata.json`` brain-artifact sidecar
+(``degraded:brain-metadata-fragment`` auto-tag, PR #1856) -- real
+conversation content lives in ``conversations/*.pb`` and is acquired
+separately (PR #3441). These tests build the phantom shape through the real
+production parser (:func:`parse_brain_metadata`) and the real archive writer
+(:meth:`ArchiveStore.write_raw_and_parsed`), then exercise the read-only
+sweep and the ``--apply``-gated purge actuator end to end against a
+throwaway archive -- never the live one.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from polylogue.archive.artifact_taxonomy import ArtifactKind
+from polylogue.core.enums import Origin
+from polylogue.sources.parsers.antigravity import BRAIN_METADATA_FRAGMENT_FLAG, parse_brain_metadata
+from polylogue.storage.antigravity_phantom_sweep import scan_antigravity_phantom_sessions
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+_METADATA_PAYLOAD: dict[str, Any] = {
+    "artifactType": "ARTIFACT_TYPE_OTHER",
+    "summary": "Some brain-artifact summary",
+    "updatedAt": "2026-04-01T10:00:00Z",
+}
+
+
+def _seed_phantom_session(
+    archive: ArchiveStore,
+    tmp_path: Path,
+    *,
+    work_dir: str,
+    artifact_name: str,
+    acquired_at_ms: int,
+) -> tuple[str, str]:
+    """Write one real brain-metadata phantom session; return (session_id, raw_id)."""
+    session_dir = tmp_path / "brain" / work_dir
+    session_dir.mkdir(parents=True, exist_ok=True)
+    metadata_path = session_dir / f"{artifact_name}.md.metadata.json"
+    payload_bytes = json.dumps(_METADATA_PAYLOAD).encode("utf-8")
+    metadata_path.write_bytes(payload_bytes)
+
+    session = parse_brain_metadata(_METADATA_PAYLOAD, metadata_path, work_dir)
+    assert BRAIN_METADATA_FRAGMENT_FLAG in session.ingest_flags
+    assert session.messages and len(session.messages) == 1
+
+    raw_id = f"raw-{work_dir}-{artifact_name}"
+    returned_raw_id, session_id = archive.write_raw_and_parsed(
+        session,
+        payload=payload_bytes,
+        source_path=str(metadata_path),
+        acquired_at_ms=acquired_at_ms,
+        raw_id=raw_id,
+    )
+    assert returned_raw_id == raw_id
+    return session_id, raw_id
+
+
+def _real_session(archive: ArchiveStore, tmp_path: Path, *, acquired_at_ms: int) -> tuple[str, str]:
+    """A non-phantom antigravity session (language-server export shape): two
+    real messages, no degraded flag -- must never be swept or purged."""
+    from polylogue.sources.parsers.antigravity import AntigravitySessionSummary, parse_markdown_export
+
+    source_path = tmp_path / "conversations" / "real-cascade.md"
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    markdown = "# Real conversation\n\nUser: hello\n\nAssistant: hi there\n"
+    source_path.write_text(markdown, encoding="utf-8")
+    summary = AntigravitySessionSummary(
+        cascade_id="real-cascade",
+        title="Real conversation",
+        workspace_name=None,
+        snippet=None,
+        last_modified_time=None,
+    )
+    session = parse_markdown_export(markdown, summary)
+    assert BRAIN_METADATA_FRAGMENT_FLAG not in session.ingest_flags
+
+    payload_bytes = markdown.encode("utf-8")
+    raw_id = "raw-real-cascade"
+    returned_raw_id, session_id = archive.write_raw_and_parsed(
+        session,
+        payload=payload_bytes,
+        source_path=str(source_path),
+        acquired_at_ms=acquired_at_ms,
+        raw_id=raw_id,
+    )
+    return session_id, returned_raw_id
+
+
+def test_scan_finds_only_tagged_phantom_sessions(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    with ArchiveStore(root) as archive:
+        phantom_id, phantom_raw_id = _seed_phantom_session(
+            archive,
+            tmp_path,
+            work_dir="7022699c-work",
+            artifact_name="plan",
+            acquired_at_ms=1_800_000_000_000,
+        )
+        real_id, real_raw_id = _real_session(archive, tmp_path, acquired_at_ms=1_800_000_000_100)
+
+    index_conn = sqlite3.connect(root / "index.db")
+    index_conn.row_factory = sqlite3.Row
+    source_conn = sqlite3.connect(root / "source.db")
+    source_conn.row_factory = sqlite3.Row
+    try:
+        plan = scan_antigravity_phantom_sessions(index_conn, source_conn)
+    finally:
+        index_conn.close()
+        source_conn.close()
+
+    assert plan.scanned_count == 1
+    assert len(plan.candidates) == 1
+    candidate = plan.candidates[0]
+    assert candidate.session_id == phantom_id
+    assert candidate.raw_id == phantom_raw_id
+    assert candidate.source_path is not None
+    assert candidate.source_path.endswith(".md.metadata.json")
+    assert plan.missing_raw_row_count == 0
+    assert candidate.session_id != real_id
+    assert phantom_raw_id != real_raw_id
+
+
+def test_scan_reports_missing_raw_row_honestly(tmp_path: Path) -> None:
+    root = tmp_path / "archive"
+    with ArchiveStore(root) as archive:
+        phantom_id, phantom_raw_id = _seed_phantom_session(
+            archive,
+            tmp_path,
+            work_dir="gc-work",
+            artifact_name="report",
+            acquired_at_ms=1_800_000_000_000,
+        )
+
+    # Simulate the raw row already having been GC'd out from under a still-tagged session.
+    source_conn = sqlite3.connect(root / "source.db")
+    try:
+        source_conn.execute("DELETE FROM raw_sessions WHERE raw_id = ?", (phantom_raw_id,))
+        source_conn.commit()
+    finally:
+        source_conn.close()
+
+    index_conn = sqlite3.connect(root / "index.db")
+    index_conn.row_factory = sqlite3.Row
+    source_conn = sqlite3.connect(root / "source.db")
+    source_conn.row_factory = sqlite3.Row
+    try:
+        plan = scan_antigravity_phantom_sessions(index_conn, source_conn)
+    finally:
+        index_conn.close()
+        source_conn.close()
+
+    assert len(plan.candidates) == 1
+    assert plan.candidates[0].session_id == phantom_id
+    assert plan.candidates[0].source_path is None
+    assert plan.missing_raw_row_count == 1
+
+
+def test_scan_works_without_source_connection(tmp_path: Path) -> None:
+    """The session-tag alone is sufficient evidence; source_conn is optional."""
+    root = tmp_path / "archive"
+    with ArchiveStore(root) as archive:
+        phantom_id, _ = _seed_phantom_session(
+            archive,
+            tmp_path,
+            work_dir="no-source-work",
+            artifact_name="task",
+            acquired_at_ms=1_800_000_000_000,
+        )
+
+    index_conn = sqlite3.connect(root / "index.db")
+    index_conn.row_factory = sqlite3.Row
+    try:
+        plan = scan_antigravity_phantom_sessions(index_conn, None)
+    finally:
+        index_conn.close()
+
+    assert len(plan.candidates) == 1
+    assert plan.candidates[0].session_id == phantom_id
+    assert plan.candidates[0].source_path is None
+    assert plan.missing_raw_row_count == 0  # not tracked when source_conn is absent
+
+
+def test_purge_apply_dry_run_deletes_nothing(tmp_path: Path) -> None:
+    from devtools.antigravity_phantom_purge_apply import main as purge_main
+
+    root = tmp_path / "archive"
+    with ArchiveStore(root) as archive:
+        phantom_id, _ = _seed_phantom_session(
+            archive,
+            tmp_path,
+            work_dir="dry-run-work",
+            artifact_name="notes",
+            acquired_at_ms=1_800_000_000_000,
+        )
+
+    exit_code = purge_main(["--archive-root", str(root), "--json"])
+    assert exit_code == 0
+
+    index_conn = sqlite3.connect(root / "index.db")
+    try:
+        count = index_conn.execute("SELECT COUNT(*) FROM sessions WHERE session_id = ?", (phantom_id,)).fetchone()[0]
+    finally:
+        index_conn.close()
+    assert count == 1, "dry-run must not delete the session"
+
+
+def test_purge_apply_deletes_sessions_and_reclassifies_raw_rows(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from devtools.antigravity_phantom_purge_apply import main as purge_main
+
+    root = tmp_path / "archive"
+    with ArchiveStore(root) as archive:
+        phantom_id, phantom_raw_id = _seed_phantom_session(
+            archive,
+            tmp_path,
+            work_dir="apply-work",
+            artifact_name="summary",
+            acquired_at_ms=1_800_000_000_000,
+        )
+        real_id, real_raw_id = _real_session(archive, tmp_path, acquired_at_ms=1_800_000_000_100)
+
+    exit_code = purge_main(["--archive-root", str(root), "--apply", "--json"])
+    assert exit_code == 0
+    output = json.loads(capsys.readouterr().out)
+    assert output["applied"] is True
+    assert output["deleted_count"] == 1
+    assert output["raw_artifacts_observations_written"] == 1
+
+    index_conn = sqlite3.connect(root / "index.db")
+    index_conn.row_factory = sqlite3.Row
+    try:
+        remaining = index_conn.execute("SELECT session_id, origin FROM sessions").fetchall()
+    finally:
+        index_conn.close()
+    remaining_ids = {row["session_id"] for row in remaining}
+    assert phantom_id not in remaining_ids, "phantom session must be purged"
+    assert real_id in remaining_ids, "real antigravity session must survive"
+    assert all(row["origin"] == Origin.ANTIGRAVITY_SESSION.value for row in remaining)
+
+    source_conn = sqlite3.connect(root / "source.db")
+    source_conn.row_factory = sqlite3.Row
+    try:
+        artifact_row = source_conn.execute(
+            "SELECT artifact_kind FROM raw_artifacts WHERE raw_id = ?", (phantom_raw_id,)
+        ).fetchone()
+        real_artifact_row = source_conn.execute(
+            "SELECT artifact_kind FROM raw_artifacts WHERE raw_id = ?", (real_raw_id,)
+        ).fetchone()
+    finally:
+        source_conn.close()
+    assert artifact_row is not None
+    assert artifact_row["artifact_kind"] == ArtifactKind.AGENT_SIDECAR_META.value
+    # The real session's raw row must not have been touched by this scoped run.
+    assert real_artifact_row is None


### PR DESCRIPTION
## Summary

Retroactive half of the antigravity-inversion finding (polylogue-eo81 / polylogue-msia, the same finding described in two beads): adds a read-only sweep and an `--apply`-gated actuator that delete the 116 already-materialized brain-metadata phantom sessions in the live archive and persist an explicit non-session classification for their raw rows.

## Problem

Every `antigravity-session` row in the live archive (116/116, measured 2026-07-31) is a 1-message fragment materialized from a per-artifact `~/.gemini/antigravity/brain/<uuid>/*.md.metadata.json` sidecar -- metadata, not conversation content. Real conversation content lives in `conversations/*.pb` trajectories.

Acquiring those `.pb` conversations was already fixed by PR #3441 (merged 2026-07-31): it calls Antigravity's own local language-server RPC (`ConvertTrajectoryToMarkdown`) to export each cascade to markdown -- not a raw protobuf parser, since the language server already exposes trajectory content over RPC -- and verified against all 44 real files on this machine (2,162 real messages, blob sizes matching on-disk `.pb` sizes). That PR also stopped classifying *future* metadata sidecars as sessions (`AGENT_SIDECAR_META`).

That fix is forward-only. The 116 already-materialized phantom sessions, and their still-unclassified raw rows in `source.db`, are untouched by it -- PR #3441's own notes call this out explicitly as deliberately out of scope, deferred to a follow-up. This PR is that follow-up.

## Solution

- `polylogue/storage/antigravity_phantom_sweep.py`: read-only `scan_antigravity_phantom_sessions()`. Joins `sessions` to `session_tags` on the existing `degraded:brain-metadata-fragment` auto-tag (written at ingest time by PR #1856) -- precise, already-present evidence, no new content classification needed. Cross-checks each candidate's `raw_id` against `source.db`'s `raw_sessions` row when a source connection is given, and reports (rather than assumes) when that raw row is already missing.
- `polylogue/storage/artifacts/persistence.py`: adds `materialize_artifact_observations_for_raw_ids()`, a scoped sibling of the existing `materialize_artifact_observations()` full census (from polylogue-hbtj2 / PR #3576), so an actuator that already knows exactly which raw ids it touched doesn't pay for a 43k-row census just to classify a handful of rows. (Also fixes a latent bug in the new function: the connection needs `row_factory = sqlite3.Row` set before `_row_to_raw_session` can read columns by name -- caught by this PR's own test.)
- `devtools/antigravity_phantom_sweep_report.py`: read-only report CLI (text or `--json`).
- `devtools/antigravity_phantom_purge_apply.py`: `--apply`-gated actuator. Dry-run by default; `--apply` calls `ArchiveStore.delete_sessions()` on the flagged session ids (the same primitive CLI `delete` / MCP `write(operation='delete_session')` already reach -- rebuild-safe, since PR #3441's ingest-side classifier already refuses `*.md.metadata.json` as session content and won't resurrect them on re-ingest) and `materialize_artifact_observations_for_raw_ids()` on their raw ids (persists an explicit `AGENT_SIDECAR_META` classification).
- Registered both as `devtools workspace antigravity-phantom-sweep` / `antigravity-phantom-purge-apply`, mirroring the binary-artifact-sweep pattern from polylogue-hbtj2.

## Real `.pb` conversation acquisition: already done, not attempted here

Item 2 of both beads' AC ("decide and, if tractable, implement real `.pb` conversation acquisition") was already resolved by PR #3441 before this session started. No protobuf reverse-engineering was needed: the fix routes through Antigravity's own local language-server export RPC rather than parsing the wire format directly. The only remaining step is operational (Sinnix redeploy of the daemon + a reingest pass to acquire the 44 real conversations), not code -- confirmed still pending as of this PR (`raw_sessions` has zero rows referencing `antigravity/conversations` in the live archive checked during this session).

## Verification

```
devtools test tests/unit/storage/test_antigravity_phantom_sweep.py
  -> 5 passed
```
Builds the phantom shape through the real production parser (`parse_brain_metadata`) and the real archive writer (`ArchiveStore.write_raw_and_parsed`), plus a co-located real antigravity session (`parse_markdown_export`, no degraded flag) to prove the sweep and purge never touch it. Confirms: dry-run mutates nothing; `--apply` deletes only the tagged phantom, leaves the real session and its raw row alone, and writes exactly one `raw_artifacts` row with `artifact_kind = AGENT_SIDECAR_META` for the purged raw id.

```
devtools test tests/unit/devtools/test_command_catalog.py tests/unit/devtools/test_render_devtools_reference.py tests/unit/devtools/test_devtools_main.py
  -> 17 passed
```

```
devtools verify --quick
  -> exit_code 0 (ruff format/check, mypy --strict, render all --check, topology,
     layering, closure-matrix, schema/manifest/policy lab checks)
```

Not run: `devtools verify --all` (no seeded testmon db in this worktree). `--quick` plus the two focused pytest runs above are the verification evidence for this PR.

Manual, read-only cross-check against the live archive (`/realm/db/polylogue`, no writes): confirmed the exact shape both beads describe -- 116 `antigravity-session` rows, all `message_count=1`, all tagged `degraded:brain-metadata-fragment`, all `raw_sessions.source_path` ending `.md.metadata.json`, zero existing `raw_artifacts` rows for any of them, and zero `raw_sessions` rows referencing `antigravity/conversations` (the redeploy+reingest for PR #3441's fix has not happened yet). This PR's actuator was not run against the live archive -- per instruction, only built and tested against fixtures.

Ref polylogue-eo81, polylogue-msia