### PR TITLE
feat(maintenance): purge agent-*.meta.json sidecar phantom sessions

### DIFF
--- a/devtools/agent_meta_sidecar_purge_apply.py
+++ b/devtools/agent_meta_sidecar_purge_apply.py
@@ -1,0 +1,115 @@
+"""Actuator: purge ``agent-*.meta.json`` subagent-sidecar phantom sessions.
+
+polylogue-ioz7: ``devtools/agent_meta_sidecar_sweep_report.py`` only
+classifies and reports. This command acts on the report by deleting the
+flagged ``sessions`` rows from ``index.db`` (via
+``polylogue.maintenance.agent_meta_sidecar_purge_apply``, which reuses the
+tested, incident-hardened ``ArchiveStore.delete_sessions`` bulk-delete
+primitive) and writing one immutable receipt per purged row.
+
+Default mode is dry-run (report only, zero mutation). Pass ``--apply`` to
+actually delete rows, which additionally requires ``--backup-manifest``
+pointing at a verified backup manifest that includes ``index.db`` (the
+default backup profile omits the rebuildable index tier -- use
+``polylogue backup --output-dir <dir> --profile full_evidence --verify`` or
+an equivalent profile). ``raw_sessions`` rows and blobs in ``source.db`` are
+never touched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import TextIO
+
+from polylogue.maintenance.agent_meta_sidecar_purge_apply import (
+    AgentMetaSidecarPurgeApplyError,
+    apply_agent_meta_sidecar_purge,
+)
+from polylogue.paths import archive_root as default_archive_root
+
+
+def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive-root",
+        type=Path,
+        default=None,
+        help="Archive root to operate on; defaults to the configured active archive root.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap the number of matching sessions classified/purged (unbounded by default).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually delete matched sessions. Without this flag, nothing is mutated.",
+    )
+    parser.add_argument(
+        "--backup-manifest",
+        type=Path,
+        default=None,
+        help="Verified backup manifest covering index.db. Required with --apply.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the report as JSON.")
+    args = parser.parse_args(argv)
+
+    root = args.archive_root if args.archive_root is not None else default_archive_root()
+
+    try:
+        report = apply_agent_meta_sidecar_purge(
+            root,
+            backup_manifest=args.backup_manifest,
+            limit=args.limit,
+            dry_run=not args.apply,
+        )
+    except (AgentMetaSidecarPurgeApplyError, FileNotFoundError) as exc:
+        print(f"refused: {exc}", file=stdout)
+        return 1
+
+    if args.json:
+        payload = {
+            "applied": report.applied,
+            "scanned_count": report.scanned_count,
+            "purged_count": report.purged_count,
+            "purged_bytes": report.purged_bytes,
+            "purged_session_ids": list(report.purged_session_ids),
+            "shape_mismatch_count": report.shape_mismatch_count,
+            "backup_manifest": str(report.backup_manifest) if report.backup_manifest is not None else None,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=stdout)
+        return 0
+
+    def _mb(byte_count: int) -> str:
+        return f"{byte_count / (1024 * 1024):.2f} MB"
+
+    mode = "APPLIED" if report.applied else "dry-run (no mutation performed -- pass --apply to purge)"
+    print(f"mode: {mode}", file=stdout)
+    print(f"agent-meta-sidecar sessions scanned: {report.scanned_count}", file=stdout)
+    print(
+        f"{'purged' if report.applied else 'purgeable'}: {report.purged_count:>7}  ({_mb(report.purged_bytes)})",
+        file=stdout,
+    )
+    if report.shape_mismatch_count:
+        print(
+            f"WARNING: {report.shape_mismatch_count} candidates fail the native_id shape cross-check "
+            "-- --apply is refused until this is investigated",
+            file=stdout,
+        )
+    if report.applied:
+        print(f"backup manifest used: {report.backup_manifest}", file=stdout)
+        print(
+            "Each purged session has an immutable receipt in "
+            "agent_meta_sidecar_purge_receipts. raw_sessions rows and blobs in "
+            "source.db were not touched.",
+            file=stdout,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/agent_meta_sidecar_sweep_report.py
+++ b/devtools/agent_meta_sidecar_sweep_report.py
@@ -1,0 +1,116 @@
+"""Read-only report: find ``agent-*.meta.json`` subagent-sidecar phantom sessions.
+
+polylogue-ioz7: reports every ``index.db`` session whose join to
+``source.raw_sessions`` matches the bead's repro predicate
+(``message_count=0 AND source_path LIKE '%.meta.json'``) -- pre-2026-07-28
+residue from a fixed producer bug that promoted a per-subagent metadata
+sidecar file into its own empty session. This is a pure classification pass
+-- it never mutates ``index.db`` or ``source.db``. Pair with
+``devtools/agent_meta_sidecar_purge_apply.py`` (``--apply``-gated) to
+actually delete the flagged ``sessions`` rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from pathlib import Path
+from typing import TextIO
+
+from polylogue.paths import archive_root as default_archive_root
+from polylogue.storage.agent_meta_sidecar_sweep import AgentMetaSidecarCandidate, scan_agent_meta_sidecar_sessions
+
+
+def _candidate_payload(candidate: AgentMetaSidecarCandidate) -> dict[str, object]:
+    return {
+        "session_id": candidate.session_id,
+        "origin": candidate.origin,
+        "native_id": candidate.native_id,
+        "raw_id": candidate.raw_id,
+        "source_path": candidate.source_path,
+        "blob_size": candidate.blob_size,
+        "native_id_matches_agent_meta_shape": candidate.native_id_matches_agent_meta_shape,
+    }
+
+
+def main(argv: list[str] | None = None, *, stdout: TextIO | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--archive-root",
+        type=Path,
+        default=None,
+        help="Archive root to inspect; defaults to the configured active archive root.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap the number of matching sessions returned (unbounded by default).",
+    )
+    parser.add_argument(
+        "--sample-limit",
+        type=int,
+        default=25,
+        help="How many rows to print in the human-readable report.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the full classified plan as JSON.")
+    args = parser.parse_args(argv)
+
+    root = args.archive_root if args.archive_root is not None else default_archive_root()
+    index_db = root / "index.db"
+    source_db = root / "source.db"
+    if not index_db.exists():
+        print(f"no index.db at {index_db}", file=stdout)
+        return 1
+    if not source_db.exists():
+        print(f"no source.db at {source_db}", file=stdout)
+        return 1
+
+    conn = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
+    try:
+        plan = scan_agent_meta_sidecar_sessions(conn, source_db, limit=args.limit)
+    finally:
+        conn.close()
+
+    if args.json:
+        payload = {
+            "scanned_count": plan.scanned_count,
+            "candidate_count": plan.candidate_count,
+            "candidate_bytes": plan.candidate_bytes,
+            "shape_mismatch_count": plan.shape_mismatch_count,
+            "by_origin": plan.by_origin(),
+            "sample": [_candidate_payload(c) for c in plan.candidates[: args.sample_limit]],
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True), file=stdout)
+        return 0
+
+    def _mb(byte_count: int) -> str:
+        return f"{byte_count / (1024 * 1024):.2f} MB"
+
+    print(
+        f"agent-*.meta.json sidecar phantom sessions: {plan.candidate_count:>6}  ({_mb(plan.candidate_bytes)} raw bytes)",
+        file=stdout,
+    )
+    for origin, count in sorted(plan.by_origin().items()):
+        print(f"  origin={origin:<24} {count:>6}", file=stdout)
+    if plan.shape_mismatch_count:
+        print(
+            f"WARNING: {plan.shape_mismatch_count} candidates match source_path but NOT the "
+            "'agent-<hash>.meta' native_id shape -- inspect before applying.",
+            file=stdout,
+        )
+    print("", file=stdout)
+    print("This is a read-only classification. No row was mutated.", file=stdout)
+    if plan.candidates:
+        print(f"\nsample (up to {args.sample_limit}):", file=stdout)
+        for candidate in plan.candidates[: args.sample_limit]:
+            print(
+                f"  {candidate.session_id}  raw={candidate.raw_id}  {candidate.blob_size}B  {candidate.source_path}",
+                file=stdout,
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -1056,6 +1056,50 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "workspace agent-meta-sidecar-sweep",
+        "workspace",
+        "Find agent-*.meta.json subagent-sidecar phantom sessions (message_count=0).",
+        "devtools.agent_meta_sidecar_sweep_report",
+        use_when=(
+            "polylogue-ioz7 (direct fix for the polylogue-b508 audit finding): before a "
+            "producer bug was fixed 2026-07-28, a per-subagent metadata sidecar file "
+            "(subagents/agent-<id>.meta.json) was materialized into the archive as its own "
+            "empty claude-code-session row, a duplicate phantom beside the real, correctly-"
+            "ingested subagent transcript. This read-only report classifies every zero-"
+            "message index session against the bead's own repro predicate "
+            "(message_count=0 AND raw_sessions.source_path LIKE '%.meta.json') -- 4,945 "
+            "rows matched on the live archive as of 2026-08-02. Never mutates index.db or "
+            "source.db."
+        ),
+        examples=(
+            "devtools workspace agent-meta-sidecar-sweep",
+            "devtools workspace agent-meta-sidecar-sweep --json",
+            "devtools workspace agent-meta-sidecar-sweep --limit 500 --sample-limit 20",
+        ),
+    ),
+    CommandSpec(
+        "workspace agent-meta-sidecar-purge-apply",
+        "workspace",
+        "Purge agent-*.meta.json subagent-sidecar phantom sessions from index.db.",
+        "devtools.agent_meta_sidecar_purge_apply",
+        use_when=(
+            "polylogue-ioz7: act on the sweep's report by deleting the flagged sessions rows "
+            "via ArchiveStore.delete_sessions (the tested, incident-hardened bulk-delete "
+            "primitive, not a plain per-row DELETE) and writing an immutable receipt per "
+            "purged row. raw_sessions rows and blobs in source.db are never touched, and "
+            "re-ingest cannot resurrect a purged row (the producer bug is already fixed). "
+            "Default is dry-run; --apply requires --backup-manifest pointing at a verified "
+            "backup that includes index.db (the default backup profile omits it -- use "
+            "'polylogue backup --profile full_evidence --verify')."
+        ),
+        examples=(
+            "devtools workspace agent-meta-sidecar-purge-apply",
+            "devtools workspace agent-meta-sidecar-purge-apply --json",
+            "devtools workspace agent-meta-sidecar-purge-apply --apply "
+            "--backup-manifest /realm/staging/polylogue-backup/manifest.json",
+        ),
+    ),
+    CommandSpec(
         "workspace unknown-export-reclassification",
         "workspace",
         "Re-run the fixed browser-capture provider probe against stored unknown-export rows.",

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -214,6 +214,8 @@ These are the commands worth remembering during normal repo work:
 | --- | --- |
 | `devtools demo real-slice-screen` | Read-only extraction + privacy screening of a candidate real-archive session slice. |
 | `devtools workspace affordance-usage` | Analyze agent affordance/tool usage from archive tool-use rows. |
+| `devtools workspace agent-meta-sidecar-purge-apply` | Purge agent-*.meta.json subagent-sidecar phantom sessions from index.db. |
+| `devtools workspace agent-meta-sidecar-sweep` | Find agent-*.meta.json subagent-sidecar phantom sessions (message_count=0). |
 | `devtools workspace antigravity-phantom-purge-apply` | Delete antigravity brain-metadata phantom sessions and reclassify their raw rows. |
 | `devtools workspace antigravity-phantom-sweep` | List antigravity-session rows that are brain-metadata phantom fragments. |
 | `devtools workspace archive-schema-fast-forward` | Clone-forward the v35 archive tiers without raw replay. |

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -538,7 +538,7 @@ files:
     target: polylogue/archive/resume_routing.py
     owner: stable
   - path: polylogue/archive/revision_authority.py
-    loc: 357
+    loc: 373
     target: polylogue/archive/revision_authority.py
     owner: stable
   - path: polylogue/archive/revision_replay.py
@@ -2183,6 +2183,10 @@ files:
     loc: 0
     target: polylogue/maintenance/__init__.py
     owner: stable
+  - path: polylogue/maintenance/agent_meta_sidecar_purge_apply.py
+    loc: 259
+    target: polylogue/maintenance/agent_meta_sidecar_purge_apply.py
+    owner: stable
   - path: polylogue/maintenance/archive_verification.py
     loc: 709
     target: polylogue/maintenance/archive_verification.py
@@ -3638,6 +3642,10 @@ files:
     target: polylogue/storage/__init__.py
     owner: storage-root
     reason: storage-root cross-cutting helper
+  - path: polylogue/storage/agent_meta_sidecar_sweep.py
+    loc: 151
+    target: TBD
+    owner: storage-domain
   - path: polylogue/storage/antigravity_phantom_sweep.py
     loc: 133
     target: TBD
@@ -3974,7 +3982,7 @@ files:
     owner: storage-root
     reason: storage-root cross-cutting helper
   - path: polylogue/storage/repair.py
-    loc: 7326
+    loc: 7355
     target: polylogue/storage/repair.py
     owner: storage-root
     reason: storage-root cross-cutting helper
@@ -4234,7 +4242,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/embeddings.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/index.py
-    loc: 2277
+    loc: 2307
     target: polylogue/storage/sqlite/archive_tiers/index.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/index_convergence.py
@@ -4266,7 +4274,7 @@ files:
     target: polylogue/storage/sqlite/archive_tiers/revision_application.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/revision_governance.py
-    loc: 2917
+    loc: 2931
     target: polylogue/storage/sqlite/archive_tiers/revision_governance.py
     owner: stable
   - path: polylogue/storage/sqlite/archive_tiers/self_verify.py
@@ -4342,7 +4350,7 @@ files:
     target: polylogue/storage/sqlite/finding_provenance.py
     owner: stable
   - path: polylogue/storage/sqlite/lifecycle.py
-    loc: 864
+    loc: 884
     target: polylogue/storage/sqlite/lifecycle.py
     owner: stable
   - path: polylogue/storage/sqlite/maintenance.py

--- a/polylogue/maintenance/agent_meta_sidecar_purge_apply.py
+++ b/polylogue/maintenance/agent_meta_sidecar_purge_apply.py
@@ -1,0 +1,259 @@
+"""Purge ``agent-*.meta.json`` subagent-sidecar phantom sessions from ``index.db``.
+
+polylogue-ioz7 (direct fix for the polylogue-b508 audit finding): before a
+producer fix landed 2026-07-28, a per-subagent metadata sidecar file
+(``subagents/agent-<id>.meta.json``) was materialized into the archive as its
+own, empty ``claude-code-session`` row -- a duplicate phantom standing beside
+the real, correctly-ingested subagent transcript. 4,945 such rows survive in
+the live archive as of 2026-08-02 (verified via
+``polylogue.storage.agent_meta_sidecar_sweep``). This module is the "act"
+half, following the identical safety pattern as
+``raw_membership_writeback_apply`` (polylogue-lb39z) and
+``binary_artifact_reclassify_apply`` (polylogue-hbtj2):
+
+* Dry-run by default. ``dry_run=False`` requires a verified backup manifest
+  that includes ``index.db`` -- the default ``rebuildable_cache_exclude``
+  backup profile omits it, so ``polylogue backup --profile full_evidence
+  --verify`` (or an equivalent profile that includes ``index``) is required.
+* Classification is re-run *live* against the current archive state
+  immediately before deletion, never trusting a previously computed plan.
+* Deletion goes through ``ArchiveStore.delete_sessions`` -- the same tested,
+  incident-hardened bulk-delete primitive (polylogue-meoz) that CLI ``delete``
+  and MCP ``write(operation='delete_session')`` already use, instead of a
+  plain per-row ``DELETE FROM sessions`` (which detonates per-row derived-
+  refresh triggers; see that method's docstring for the 2026-07-21 incident:
+  3h runtime, 375GB reads, zero commit, for 91 sessions).
+* Every purged row gets an immutable receipt in
+  ``agent_meta_sidecar_purge_receipts`` (index.db, v57).
+* ``raw_sessions`` rows and blobs in ``source.db`` are never touched, and
+  re-ingest cannot resurrect a purged row: the producer bug that created this
+  shape is already fixed, so a re-acquire of the same ``.meta.json`` sidecar
+  produces no session at all.
+* Refuses to apply (even under ``--force-shape-mismatch``'s absence) if any
+  matched candidate's ``native_id`` does not also match the expected
+  ``agent-<hash>.meta`` shape -- belt-and-suspenders beyond the bead's own
+  ``source_path``-only repro predicate, since live verification found the two
+  predicates agree on all 4,945 rows and a disagreement would mean the
+  candidate set has drifted from what was audited.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+from polylogue.config import Config
+from polylogue.maintenance.offline_guard import offline_maintenance_block_reason
+from polylogue.paths import render_root
+from polylogue.storage.agent_meta_sidecar_sweep import (
+    AgentMetaSidecarCandidate,
+    AgentMetaSidecarSweepPlan,
+    scan_agent_meta_sidecar_sessions,
+)
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from polylogue.storage.sqlite.migration_runner import validate_migration_backup_manifest
+
+TOOL_VERSION = "agent-meta-sidecar-purge-apply-v1"
+
+
+class AgentMetaSidecarPurgeApplyError(RuntimeError):
+    """Raised when applying the agent-meta-sidecar purge is refused."""
+
+
+@dataclass(frozen=True, slots=True)
+class AgentMetaSidecarPurgeApplyReport:
+    scanned_count: int
+    purged_count: int
+    purged_bytes: int
+    purged_session_ids: tuple[str, ...]
+    shape_mismatch_count: int
+    applied: bool
+    backup_manifest: Path | None = None
+
+    @classmethod
+    def from_plan(
+        cls,
+        plan: AgentMetaSidecarSweepPlan,
+        *,
+        applied: bool,
+        purged_session_ids: tuple[str, ...] = (),
+        backup_manifest: Path | None = None,
+    ) -> AgentMetaSidecarPurgeApplyReport:
+        by_id = {candidate.session_id: candidate for candidate in plan.candidates}
+        purged_bytes = (
+            sum(by_id[sid].blob_size for sid in purged_session_ids if sid in by_id) if applied else plan.candidate_bytes
+        )
+        return cls(
+            scanned_count=plan.scanned_count,
+            purged_count=len(purged_session_ids) if applied else plan.candidate_count,
+            purged_bytes=purged_bytes,
+            purged_session_ids=purged_session_ids,
+            shape_mismatch_count=plan.shape_mismatch_count,
+            applied=applied,
+            backup_manifest=backup_manifest,
+        )
+
+
+def _offline_config(archive_root: Path) -> Config:
+    return Config(archive_root=archive_root, render_root=render_root(), sources=[])
+
+
+def _checkpoint_live_tier(conn: sqlite3.Connection) -> None:
+    try:
+        row = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+    except sqlite3.Error as exc:
+        raise AgentMetaSidecarPurgeApplyError("could not checkpoint index.db before backup validation") from exc
+    if row is None:
+        raise AgentMetaSidecarPurgeApplyError("could not checkpoint index.db before backup validation")
+
+
+def _write_receipts(
+    index_db: Path,
+    candidates: tuple[AgentMetaSidecarCandidate, ...],
+    *,
+    purged_at_ms: int,
+    backup_manifest: Path,
+) -> None:
+    if not candidates:
+        return
+    conn = sqlite3.connect(index_db)
+    try:
+        with conn:
+            conn.executemany(
+                """
+                INSERT INTO agent_meta_sidecar_purge_receipts (
+                    session_id, origin, native_id, raw_id, source_path,
+                    purged_at_ms, tool_version, backup_manifest_path, detail
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, '')
+                """,
+                [
+                    (
+                        candidate.session_id,
+                        candidate.origin,
+                        candidate.native_id,
+                        candidate.raw_id,
+                        candidate.source_path,
+                        purged_at_ms,
+                        TOOL_VERSION,
+                        str(backup_manifest),
+                    )
+                    for candidate in candidates
+                ],
+            )
+    finally:
+        conn.close()
+
+
+def apply_agent_meta_sidecar_purge(
+    archive_root: Path,
+    *,
+    backup_manifest: Path | None = None,
+    limit: int | None = None,
+    dry_run: bool = True,
+) -> AgentMetaSidecarPurgeApplyReport:
+    """Classify agent-meta-sidecar phantom sessions, then purge them.
+
+    ``dry_run=True`` (the default) never opens a write transaction. It runs
+    the same classifier a real apply would and reports what it would do.
+
+    ``dry_run=False`` requires ``backup_manifest`` (covering ``index.db`` --
+    the default backup profile omits the rebuildable index tier, so a
+    ``full_evidence``-profile backup or equivalent is required), refuses if
+    any candidate fails the ``native_id`` shape cross-check, re-runs
+    classification live, deletes the matched sessions via
+    ``ArchiveStore.delete_sessions``, and writes one immutable receipt per
+    purged row.
+    """
+    index_db = archive_root / "index.db"
+    source_db = archive_root / "source.db"
+    if not index_db.exists():
+        raise FileNotFoundError(f"no index.db at {index_db}")
+    if not source_db.exists():
+        raise FileNotFoundError(f"no source.db at {source_db}")
+
+    if dry_run:
+        conn = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
+        try:
+            plan = scan_agent_meta_sidecar_sessions(conn, source_db, limit=limit)
+        finally:
+            conn.close()
+        return AgentMetaSidecarPurgeApplyReport.from_plan(plan, applied=False)
+
+    if backup_manifest is None:
+        raise AgentMetaSidecarPurgeApplyError(
+            "applying the agent-meta-sidecar purge requires a verified backup manifest "
+            "(--backup-manifest) that includes index.db, e.g. "
+            "'polylogue backup --output-dir <dir> --profile full_evidence --verify'"
+        )
+    if reason := offline_maintenance_block_reason(_offline_config(archive_root), active=True, dry_run=False):
+        raise AgentMetaSidecarPurgeApplyError(reason)
+
+    # uri=True enables URI-filename recognition for the whole connection,
+    # including the subsequent ATTACH DATABASE '?mode=ro' the classifier
+    # issues -- without it ATTACH would try (and fail) to open the literal
+    # string "file:...?mode=ro" as a plain filesystem path.
+    validate_conn = sqlite3.connect(str(index_db), uri=True)
+    try:
+        _checkpoint_live_tier(validate_conn)
+        validate_migration_backup_manifest(backup_manifest, ArchiveTier.INDEX, connection=validate_conn)
+        plan = scan_agent_meta_sidecar_sessions(validate_conn, source_db, limit=limit)
+    finally:
+        validate_conn.close()
+
+    if plan.shape_mismatch_count:
+        raise AgentMetaSidecarPurgeApplyError(
+            f"refusing to apply: {plan.shape_mismatch_count} candidate(s) match the source_path "
+            "predicate but not the expected 'agent-<hash>.meta' native_id shape -- inspect the "
+            "read-only sweep report before applying"
+        )
+
+    session_ids = tuple(candidate.session_id for candidate in plan.candidates)
+    purged_at_ms = int(time.time() * 1000)
+    purged: tuple[str, ...] = ()
+    if session_ids:
+        store = ArchiveStore(archive_root, read_only=False)
+        try:
+            store.delete_sessions(session_ids)
+        finally:
+            store.close()
+        # Re-check which session_ids are actually gone rather than trusting
+        # delete_sessions's aggregate count -- it returns a total, not a
+        # per-id verdict, so this is the only precise way to know exactly
+        # which rows a receipt may honestly be written for.
+        confirm_conn = sqlite3.connect(f"file:{index_db}?mode=ro", uri=True)
+        try:
+            placeholders = ", ".join("?" for _ in session_ids)
+            still_present = {
+                str(row[0])
+                for row in confirm_conn.execute(
+                    f"SELECT session_id FROM sessions WHERE session_id IN ({placeholders})", session_ids
+                ).fetchall()
+            }
+        finally:
+            confirm_conn.close()
+        purged = tuple(sid for sid in session_ids if sid not in still_present)
+        if purged:
+            _write_receipts(
+                index_db,
+                tuple(c for c in plan.candidates if c.session_id in purged),
+                purged_at_ms=purged_at_ms,
+                backup_manifest=backup_manifest,
+            )
+
+    return AgentMetaSidecarPurgeApplyReport.from_plan(
+        plan,
+        applied=True,
+        purged_session_ids=purged,
+        backup_manifest=backup_manifest,
+    )
+
+
+__all__ = [
+    "TOOL_VERSION",
+    "AgentMetaSidecarPurgeApplyError",
+    "AgentMetaSidecarPurgeApplyReport",
+    "apply_agent_meta_sidecar_purge",
+]

--- a/polylogue/storage/agent_meta_sidecar_sweep.py
+++ b/polylogue/storage/agent_meta_sidecar_sweep.py
@@ -1,0 +1,151 @@
+"""Read-only sweep: find ``agent-*.meta.json`` subagent-sidecar phantom sessions.
+
+polylogue-ioz7 (direct fix for the polylogue-b508 audit finding): before
+2026-07-28, a per-subagent metadata sidecar file
+(``~/.claude/projects/<project>/<session-uuid>/subagents/agent-<id>.meta.json``)
+was materialized into the archive as its own, empty ``claude-code-session``
+row -- a duplicate phantom standing beside the real subagent transcript
+(ingested separately and correctly under the same ``agent-<id>`` native id,
+without the ``.meta`` suffix). The producer bug is already fixed (raws
+acquired after 2026-07-28 correctly produce no session); this module answers,
+read-only, "which already-materialized index sessions are this exact
+residue" -- reusing the bead's own repro predicate as the classifier:
+
+    message_count = 0  AND  raw_sessions.source_path LIKE '%.meta.json'
+
+Live-archive verification (2026-08-02, read-only): exactly 4,945 sessions
+match, and all 4,945 also have ``native_id LIKE 'agent-%.meta'`` -- the two
+independent predicates agree completely, matching polylogue-b508's own
+audit numbers exactly.
+
+Separate from this module: an explicit, ``--apply``-gated actuator
+(``polylogue/maintenance/agent_meta_sidecar_purge_apply.py`` +
+``devtools/agent_meta_sidecar_purge_apply.py``) that actually deletes the
+flagged ``sessions`` rows from ``index.db`` (the rebuildable tier) --
+``raw_sessions`` rows and blobs in ``source.db`` are never touched, and
+re-ingest cannot resurrect a purged row because the producer no longer
+materializes this shape. This module only classifies and counts; it never
+mutates either tier.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_AGENT_META_NATIVE_ID_PATTERN = "agent-%.meta"
+_AGENT_META_SOURCE_PATH_PATTERN = "%.meta.json"
+
+
+@dataclass(frozen=True, slots=True)
+class AgentMetaSidecarCandidate:
+    session_id: str
+    origin: str
+    native_id: str
+    raw_id: str
+    source_path: str
+    blob_size: int
+    native_id_matches_agent_meta_shape: bool
+    """True when ``native_id`` also matches ``agent-<hash>.meta`` -- reported
+    for confidence, not required for the match: the bead's own repro
+    predicate is ``message_count=0 AND source_path LIKE '%.meta.json'``
+    alone. Live verification found the two predicates agree on all 4,945
+    live rows; this field lets the report flag it if a future row ever
+    disagrees, rather than assuming silently."""
+
+
+@dataclass(slots=True)
+class AgentMetaSidecarSweepPlan:
+    scanned_count: int = 0
+    candidates: list[AgentMetaSidecarCandidate] = field(default_factory=list)
+
+    @property
+    def candidate_count(self) -> int:
+        return len(self.candidates)
+
+    @property
+    def candidate_bytes(self) -> int:
+        return sum(c.blob_size for c in self.candidates)
+
+    @property
+    def shape_mismatch_count(self) -> int:
+        """Candidates matching the source_path predicate but not the native_id
+        shape -- always inspect these before relying on --apply; zero on the
+        live archive as of 2026-08-02."""
+        return sum(1 for c in self.candidates if not c.native_id_matches_agent_meta_shape)
+
+    def by_origin(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for candidate in self.candidates:
+            counts[candidate.origin] = counts.get(candidate.origin, 0) + 1
+        return counts
+
+
+def scan_agent_meta_sidecar_sessions(
+    index_conn: sqlite3.Connection,
+    source_db_path: Path,
+    *,
+    limit: int | None = None,
+) -> AgentMetaSidecarSweepPlan:
+    """Read-only: classify every zero-message session against the bead's repro predicate.
+
+    *index_conn* should be a connection to ``index.db`` (``?mode=ro`` is the
+    caller's responsibility, matching the sibling binary-artifact sweep).
+    *source_db_path* is attached read-only for the duration of this call and
+    detached before returning. This function never writes to either tier.
+    """
+    index_conn.row_factory = sqlite3.Row
+    index_conn.execute("ATTACH DATABASE ? AS src", (f"file:{source_db_path}?mode=ro",))
+    try:
+        query = """
+            SELECT
+                s.session_id AS session_id,
+                s.origin AS origin,
+                s.native_id AS native_id,
+                r.raw_id AS raw_id,
+                r.source_path AS source_path,
+                r.blob_size AS blob_size
+            FROM sessions s
+            JOIN src.raw_sessions r ON r.raw_id = s.raw_id
+            WHERE s.message_count = 0
+              AND r.source_path LIKE ?
+            ORDER BY s.session_id
+        """
+        params: tuple[object, ...] = (_AGENT_META_SOURCE_PATH_PATTERN,)
+        if limit is not None:
+            query += " LIMIT ?"
+            params = (*params, limit)
+        rows = index_conn.execute(query, params).fetchall()
+
+        plan = AgentMetaSidecarSweepPlan(scanned_count=len(rows))
+        for row in rows:
+            native_id = str(row["native_id"]) if row["native_id"] is not None else ""
+            plan.candidates.append(
+                AgentMetaSidecarCandidate(
+                    session_id=row["session_id"],
+                    origin=row["origin"],
+                    native_id=native_id,
+                    raw_id=row["raw_id"],
+                    source_path=row["source_path"],
+                    blob_size=int(row["blob_size"]) if row["blob_size"] is not None else 0,
+                    native_id_matches_agent_meta_shape=_native_id_matches_agent_meta_shape(native_id),
+                )
+            )
+        return plan
+    finally:
+        index_conn.execute("DETACH DATABASE src")
+
+
+def _native_id_matches_agent_meta_shape(native_id: str) -> bool:
+    if not native_id.startswith("agent-") or not native_id.endswith(".meta"):
+        return False
+    middle = native_id[len("agent-") : -len(".meta")]
+    return len(middle) > 0
+
+
+__all__ = [
+    "AgentMetaSidecarCandidate",
+    "AgentMetaSidecarSweepPlan",
+    "scan_agent_meta_sidecar_sessions",
+]

--- a/polylogue/storage/sqlite/archive_tiers/index.py
+++ b/polylogue/storage/sqlite/archive_tiers/index.py
@@ -297,7 +297,17 @@ INDEX_SCHEMA_VERSION = 55
 # re-parsing recovers the dropped rows on already-acquired raw evidence.
 # `polylogue ops reset --index && polylogued run` is required; deliberately
 # NOT executed by this declaration.
-INDEX_SCHEMA_VERSION = 56
+
+# polylogue-ioz7: adds `agent_meta_sidecar_purge_receipts`, an immutable
+# per-row audit record for `polylogue.maintenance.agent_meta_sidecar_purge_apply`
+# -- the targeted actuator that deletes the ~4,945 pre-2026-07-28
+# `agent-<hash>.meta.json` subagent-sidecar phantom sessions found by the
+# polylogue-b508 audit (a fixed producer bug materialized a per-subagent
+# metadata sidecar file into its own empty session, duplicate of the real,
+# correctly-ingested subagent transcript). Brand-new table, no existing
+# archive has any rows to migrate -- CONSTRAINT_ONLY/REPLACE_TABLE fast-
+# forwards to a plain create, same shape as v33's `insight_materialization`.
+INDEX_SCHEMA_VERSION = 57
 
 # polylogue-v6i3: shared WHEN-clause fragment gating the blocks_command_trigram
 # trigger BODIES on the same dedicated bulk-build guard row messages_fts's
@@ -2261,6 +2271,26 @@ ON session_tag_rollups(bucket_day DESC, source_name, tag);
 
 CREATE INDEX IF NOT EXISTS idx_session_tag_rollups_provider
 ON session_tag_rollups(source_name, tag);
+
+-- v57 (polylogue-ioz7): one immutable receipt per `sessions` row deleted by
+-- the agent-meta-sidecar purge actuator. No FK to `sessions` -- the whole
+-- point of the row is that the session it describes no longer exists.
+-- `raw_id` is likewise unconstrained here (source.db is a separate
+-- database file; the raw row and its blob are deliberately retained there).
+CREATE TABLE IF NOT EXISTS agent_meta_sidecar_purge_receipts (
+    session_id           TEXT PRIMARY KEY,
+    origin               TEXT NOT NULL,
+    native_id            TEXT NOT NULL,
+    raw_id               TEXT NOT NULL,
+    source_path          TEXT NOT NULL,
+    purged_at_ms         INTEGER NOT NULL CHECK(purged_at_ms >= 0),
+    tool_version         TEXT NOT NULL,
+    backup_manifest_path TEXT NOT NULL,
+    detail               TEXT NOT NULL DEFAULT ''
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_agent_meta_sidecar_purge_receipts_purged_at
+ON agent_meta_sidecar_purge_receipts(purged_at_ms);
 """
 
 # polylogue-a7xr.5 consolidated the FTS trigger CREATE statements into

--- a/polylogue/storage/sqlite/lifecycle.py
+++ b/polylogue/storage/sqlite/lifecycle.py
@@ -705,6 +705,26 @@ INDEX_DELTA_DECLARATIONS: tuple[IndexDeltaDeclaration, ...] = (
         # (`polylogue ops reset --index && polylogued run`).
         classes=(DerivedDeltaClass.SEMANTIC_REPARSE,),
     ),
+    IndexDeltaDeclaration(
+        version=57,
+        # polylogue-ioz7: adds `agent_meta_sidecar_purge_receipts`, a
+        # brand-new table with no rows on any existing archive -- see
+        # INDEX_SCHEMA_VERSION's v57 comment (archive_tiers/index.py).
+        # Same shape as v33's `insight_materialization` new-table delta.
+        classes=(DerivedDeltaClass.CONSTRAINT_ONLY, DerivedDeltaClass.INDEX_ONLY),
+        operations=(
+            FastForwardOperation(
+                name="v57-agent-meta-sidecar-purge-receipts",
+                kind=FastForwardOperationKind.REPLACE_TABLE,
+                objects=(("table", "agent_meta_sidecar_purge_receipts"),),
+            ),
+            FastForwardOperation(
+                name="v57-agent-meta-sidecar-purge-receipts",
+                kind=FastForwardOperationKind.CREATE_INDEX,
+                objects=(("index", "idx_agent_meta_sidecar_purge_receipts_purged_at"),),
+            ),
+        ),
+    ),
 )
 
 

--- a/tests/unit/maintenance/test_agent_meta_sidecar_purge_apply.py
+++ b/tests/unit/maintenance/test_agent_meta_sidecar_purge_apply.py
@@ -1,0 +1,318 @@
+"""polylogue-ioz7 (direct fix for polylogue-b508): purge agent-*.meta.json
+subagent-sidecar phantom sessions.
+
+Builds a fixture archive with:
+
+* two ``agent-<hash>.meta`` sidecar phantom sessions (message_count=0,
+  raw source_path ending in ``.meta.json``) -- the exact target shape;
+* the corresponding real subagent transcript sessions (non-empty,
+  ``agent-<hash>`` native_id, no ``.meta`` suffix, different raw source_path)
+  that must survive untouched;
+* a genuinely empty top-level session whose raw source_path is a plain
+  ``.jsonl`` (not ``.meta.json``) -- must also survive untouched, proving the
+  classifier does not fall back to a blanket "no messages" predicate.
+
+Proves:
+
+* the read-only classifier (``scan_agent_meta_sidecar_sessions``) matches
+  exactly the two sidecar phantoms, never the real transcripts or the
+  legitimately-empty session;
+* dry-run (the default) never mutates anything;
+* --apply deletes exactly the matched sessions, leaves raw_sessions/blobs in
+  source.db untouched, and writes one immutable receipt per purged row;
+* applying without a backup manifest is refused before anything is touched;
+* applying is refused if a candidate's native_id fails the agent-meta shape
+  cross-check (defense in depth beyond the bead's own source_path-only
+  predicate).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from polylogue.core.enums import Origin, Provider
+from polylogue.maintenance.agent_meta_sidecar_purge_apply import (
+    TOOL_VERSION,
+    AgentMetaSidecarPurgeApplyError,
+    apply_agent_meta_sidecar_purge,
+)
+from polylogue.storage.agent_meta_sidecar_sweep import scan_agent_meta_sidecar_sessions
+from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+_ACQUIRED_AT_MS = 1_700_000_000_000
+
+
+def _write_raw(archive: ArchiveStore, *, raw_id: str, source_path: str) -> None:
+    archive.write_raw_payload(
+        provider=Provider.CLAUDE_CODE,
+        payload=f"raw:{raw_id}".encode(),
+        source_path=source_path,
+        source_index=-1,
+        acquired_at_ms=_ACQUIRED_AT_MS,
+        raw_id=raw_id,
+    )
+
+
+def _insert_session(
+    conn: sqlite3.Connection,
+    *,
+    native_id: str,
+    origin: str,
+    raw_id: str,
+    message_count: int,
+) -> None:
+    content_hash = f"hash-{native_id}".encode().ljust(32, b"\x00")[:32]
+    conn.execute(
+        "INSERT INTO sessions (native_id, origin, raw_id, message_count, content_hash) VALUES (?, ?, ?, ?, ?)",
+        (native_id, origin, raw_id, message_count, content_hash),
+    )
+
+
+def _build_fixture_archive(tmp_path: Path) -> Path:
+    archive_root = tmp_path / "archive"
+    initialize_active_archive_root(archive_root)
+
+    with ArchiveStore.open_existing(archive_root, read_only=False) as archive:
+        # Two agent-meta.json sidecar phantoms -- the target shape.
+        _write_raw(
+            archive,
+            raw_id="raw-meta-1",
+            source_path="/home/x/.claude/projects/p/s1/subagents/agent-aaa111.meta.json",
+        )
+        _write_raw(
+            archive,
+            raw_id="raw-meta-2",
+            source_path="/home/x/.claude/projects/p/s1/subagents/agent-bbb222.meta.json",
+        )
+        # Real subagent transcripts (correctly ingested, non-empty, no .meta suffix).
+        _write_raw(
+            archive,
+            raw_id="raw-real-1",
+            source_path="/home/x/.claude/projects/p/s1/subagents/agent-aaa111.jsonl",
+        )
+        _write_raw(
+            archive,
+            raw_id="raw-real-2",
+            source_path="/home/x/.claude/projects/p/s1/subagents/agent-bbb222.jsonl",
+        )
+        # A legitimately-empty top-level session -- must never be swept up by
+        # a blanket "no messages" predicate.
+        _write_raw(
+            archive,
+            raw_id="raw-empty-legit",
+            source_path="/home/x/.claude/projects/p/s2.jsonl",
+        )
+        archive.commit()
+
+    conn = sqlite3.connect(archive_root / "index.db")
+    try:
+        _insert_session(
+            conn,
+            native_id="agent-aaa111.meta",
+            origin=Origin.CLAUDE_CODE_SESSION.value,
+            raw_id="raw-meta-1",
+            message_count=0,
+        )
+        _insert_session(
+            conn,
+            native_id="agent-bbb222.meta",
+            origin=Origin.CLAUDE_CODE_SESSION.value,
+            raw_id="raw-meta-2",
+            message_count=0,
+        )
+        _insert_session(
+            conn,
+            native_id="agent-aaa111",
+            origin=Origin.CLAUDE_CODE_SESSION.value,
+            raw_id="raw-real-1",
+            message_count=5,
+        )
+        _insert_session(
+            conn,
+            native_id="agent-bbb222",
+            origin=Origin.CLAUDE_CODE_SESSION.value,
+            raw_id="raw-real-2",
+            message_count=3,
+        )
+        _insert_session(
+            conn,
+            native_id="s2-uuid",
+            origin=Origin.CLAUDE_CODE_SESSION.value,
+            raw_id="raw-empty-legit",
+            message_count=0,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return archive_root
+
+
+def _session_ids(archive_root: Path) -> set[str]:
+    conn = sqlite3.connect(f"file:{archive_root / 'index.db'}?mode=ro", uri=True)
+    try:
+        return {row[0] for row in conn.execute("SELECT session_id FROM sessions").fetchall()}
+    finally:
+        conn.close()
+
+
+def _raw_ids(archive_root: Path) -> set[str]:
+    conn = sqlite3.connect(f"file:{archive_root / 'source.db'}?mode=ro", uri=True)
+    try:
+        return {row[0] for row in conn.execute("SELECT raw_id FROM raw_sessions").fetchall()}
+    finally:
+        conn.close()
+
+
+def _receipt_rows(archive_root: Path) -> dict[str, str]:
+    conn = sqlite3.connect(f"file:{archive_root / 'index.db'}?mode=ro", uri=True)
+    try:
+        rows = conn.execute("SELECT session_id, tool_version FROM agent_meta_sidecar_purge_receipts").fetchall()
+    finally:
+        conn.close()
+    return dict(rows)
+
+
+def test_classifier_matches_only_the_meta_sidecar_phantoms(tmp_path: Path) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    conn = sqlite3.connect(f"file:{archive_root / 'index.db'}?mode=ro", uri=True)
+    try:
+        plan = scan_agent_meta_sidecar_sessions(conn, archive_root / "source.db")
+    finally:
+        conn.close()
+
+    assert {c.session_id for c in plan.candidates} == {
+        "claude-code-session:agent-aaa111.meta",
+        "claude-code-session:agent-bbb222.meta",
+    }
+    assert plan.shape_mismatch_count == 0
+
+
+def test_dry_run_makes_zero_mutations(tmp_path: Path) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    before_sessions = _session_ids(archive_root)
+    before_raws = _raw_ids(archive_root)
+
+    report = apply_agent_meta_sidecar_purge(archive_root, dry_run=True)
+
+    assert report.applied is False
+    assert report.purged_count == 2
+    assert report.purged_session_ids == ()
+
+    assert _session_ids(archive_root) == before_sessions
+    assert _raw_ids(archive_root) == before_raws
+    assert _receipt_rows(archive_root) == {}
+
+
+def test_apply_purges_only_the_meta_sidecar_phantoms(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+
+    validated: list[tuple[Path, object]] = []
+
+    def _fake_validate(manifest: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
+        validated.append((manifest, tier))
+        assert connection.execute("SELECT 1").fetchone() == (1,)
+        return manifest.with_name("verification-receipt.json")
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.agent_meta_sidecar_purge_apply.validate_migration_backup_manifest",
+        _fake_validate,
+    )
+
+    before_raws = _raw_ids(archive_root)
+    manifest = tmp_path / "verified-backup" / "manifest.json"
+
+    report = apply_agent_meta_sidecar_purge(archive_root, backup_manifest=manifest, dry_run=False)
+
+    assert report.applied is True
+    assert report.purged_count == 2
+    assert set(report.purged_session_ids) == {
+        "claude-code-session:agent-aaa111.meta",
+        "claude-code-session:agent-bbb222.meta",
+    }
+    assert report.backup_manifest == manifest
+    assert validated == [(manifest, ArchiveTier.INDEX)]
+
+    remaining = _session_ids(archive_root)
+    assert remaining == {
+        "claude-code-session:agent-aaa111",
+        "claude-code-session:agent-bbb222",
+        "claude-code-session:s2-uuid",
+    }
+    # source.db is never touched -- raw rows and blobs for the purged
+    # sessions, including the deleted ones, are all retained.
+    assert _raw_ids(archive_root) == before_raws
+
+    receipts = _receipt_rows(archive_root)
+    assert set(receipts) == {
+        "claude-code-session:agent-aaa111.meta",
+        "claude-code-session:agent-bbb222.meta",
+    }
+    assert all(tool_version == TOOL_VERSION for tool_version in receipts.values())
+
+
+def test_apply_refuses_without_backup_manifest(tmp_path: Path) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    before_sessions = _session_ids(archive_root)
+
+    with pytest.raises(AgentMetaSidecarPurgeApplyError, match="backup manifest"):
+        apply_agent_meta_sidecar_purge(archive_root, backup_manifest=None, dry_run=False)
+
+    assert _session_ids(archive_root) == before_sessions
+    assert _receipt_rows(archive_root) == {}
+
+
+def test_apply_refuses_when_backup_manifest_invalid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+    before_sessions = _session_ids(archive_root)
+
+    def _reject(manifest: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
+        raise ValueError("backup manifest does not match live index.db")
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.agent_meta_sidecar_purge_apply.validate_migration_backup_manifest",
+        _reject,
+    )
+
+    manifest = tmp_path / "stale-backup" / "manifest.json"
+    with pytest.raises(ValueError, match="does not match"):
+        apply_agent_meta_sidecar_purge(archive_root, backup_manifest=manifest, dry_run=False)
+
+    assert _session_ids(archive_root) == before_sessions
+    assert _receipt_rows(archive_root) == {}
+
+
+def test_apply_refuses_on_native_id_shape_mismatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    archive_root = _build_fixture_archive(tmp_path)
+
+    # Corrupt one candidate's native_id so it no longer matches the expected
+    # 'agent-<hash>.meta' shape, even though its raw source_path still ends
+    # in '.meta.json' -- the actuator must refuse rather than delete it.
+    conn = sqlite3.connect(archive_root / "index.db")
+    try:
+        conn.execute("UPDATE sessions SET native_id = 'unexpected-shape' WHERE raw_id = 'raw-meta-1'")
+        conn.commit()
+    finally:
+        conn.close()
+
+    def _fake_validate(manifest: Path, tier: object, *, connection: sqlite3.Connection) -> Path:
+        return manifest.with_name("verification-receipt.json")
+
+    monkeypatch.setattr(
+        "polylogue.maintenance.agent_meta_sidecar_purge_apply.validate_migration_backup_manifest",
+        _fake_validate,
+    )
+
+    before_sessions = _session_ids(archive_root)
+    manifest = tmp_path / "verified-backup" / "manifest.json"
+
+    with pytest.raises(AgentMetaSidecarPurgeApplyError, match="native_id shape"):
+        apply_agent_meta_sidecar_purge(archive_root, backup_manifest=manifest, dry_run=False)
+
+    assert _session_ids(archive_root) == before_sessions
+    assert _receipt_rows(archive_root) == {}


### PR DESCRIPTION
## Summary

Adds a read-only classifier and a backup-manifest-gated, dry-run-by-default actuator to purge the 4,945 empty `agent-<hash>.meta` subagent-sidecar phantom sessions found by the polylogue-b508 audit, following the identical safety pattern as `raw_membership_writeback_apply` (polylogue-lb39z) and `binary_artifact_reclassify_apply` (polylogue-hbtj2).

## Problem

The 2026-07-31 dataset-forensics audit (polylogue-b508, `/realm/inbox/polylogue-audits-2026-07-31/dataset-forensics.html`) found 4,945 empty `claude-code-session` rows materialized from Claude Code subagent metadata sidecar files (`subagents/agent-<id>.meta.json`) before a producer fix landed 2026-07-28. Each `.meta` row is a duplicate phantom standing beside the real, correctly-ingested subagent transcript session (`%:agent-<id>` without the `.meta` suffix) -- sampled 300/300 in the original audit, confirmed the real transcript exists separately in every case.

polylogue-ioz7 is the direct fix for this finding: a targeted cleanup pass over the already-materialized historical residue. The producer bug itself is already fixed (raws acquired after 2026-07-28 correctly produce no session for this shape), so this PR is purely about removing the pre-existing rows.

Live-archive verification (read-only, `/realm/db/polylogue`): the bead's own repro predicate (`message_count=0 AND raw_sessions.source_path LIKE '%.meta.json'`) matches exactly 4,945 sessions. An independent `native_id` shape cross-check (`agent-<hash>.meta`) agrees on all 4,945 -- zero disagreement.

## Solution

- `polylogue/storage/agent_meta_sidecar_sweep.py` -- read-only classifier joining `sessions` to `source.raw_sessions` on the bead's exact repro predicate. Reports a `native_id` shape cross-check per candidate as a belt-and-suspenders signal, not a required match condition.
- `devtools/agent_meta_sidecar_sweep_report.py` + `devtools workspace agent-meta-sidecar-sweep` -- read-only report, never mutates either tier.
- `polylogue/maintenance/agent_meta_sidecar_purge_apply.py` + `devtools/agent_meta_sidecar_purge_apply.py` + `devtools workspace agent-meta-sidecar-purge-apply` -- the actuator:
  - Dry-run by default.
  - `--apply` requires `--backup-manifest` covering `index.db` -- the default backup profile (`rebuildable_cache_exclude`) omits the rebuildable index tier, so `polylogue backup --profile full_evidence --verify` (or an equivalent profile that includes `index`) is required.
  - Refuses to apply if any candidate fails the `native_id` shape cross-check.
  - Re-runs classification live, immediately before deletion, never trusting a previously computed plan.
  - Deletes via `ArchiveStore.delete_sessions` -- the same tested, incident-hardened bulk-delete primitive CLI `delete` and MCP `write(operation='delete_session')` already use, instead of a plain per-row `DELETE FROM sessions` (which detonates per-row derived-refresh triggers; see that method's docstring for the 2026-07-21 incident: 3h runtime, 375GB reads, zero commit, for 91 sessions).
  - Writes one immutable receipt per purged row in a new table, `agent_meta_sidecar_purge_receipts` (`index.db`, `INDEX_SCHEMA_VERSION` v57, declared `CONSTRAINT_ONLY`/`INDEX_ONLY` fast-forward -- brand-new table, no existing archive has rows to migrate, same shape as v33's `insight_materialization`).
  - `raw_sessions` rows and blobs in `source.db` are never touched, and re-ingest cannot resurrect a purged row since the producer bug is already fixed.

### Relationship to polylogue-zqph

`zqph` tracks a broader repair pass for the whole empty-session phantom class; its own reconcile note recommends a different remediation strategy for that broader scope -- a full `polylogue ops reset --index && polylogued run` reindex, which naturally admits only genuinely-valid sessions under the now-fixed classifiers rather than a per-shape targeted script. This PR's narrower, already-audited `.meta.json` shape is a safe, immediately actionable subset of that broader cleanup. It does not block, duplicate, or preempt `zqph`'s own decision on the reindex-vs-targeted-repair question for other phantom shapes (e.g. the `conversation_relationships.jsonl`-shaped phantoms `zqph` also describes).

## Verification

- `devtools test tests/unit/maintenance/test_agent_meta_sidecar_purge_apply.py` -- 6 passed: classifier matches only the two meta-sidecar phantoms (never the real transcripts or a legitimately-empty control session); dry-run makes zero mutations; `--apply` purges exactly the matched sessions and writes exactly one receipt each; `--apply` refuses without a backup manifest; `--apply` refuses when the manifest fails validation; `--apply` refuses on a `native_id` shape mismatch.
- `devtools test tests/unit/storage/test_index_fast_forward_lifecycle.py tests/unit/storage/test_index_fast_forward_executor.py tests/unit/storage/test_schema_policy_contracts.py tests/unit/storage/test_archive_tiers_ddl.py` -- 68 passed (v57 fast-forward declaration and DDL are consistent).
- `devtools lab policy schema-versioning` -- clean (0 undeclared index schema deltas).
- `devtools verify --quick` -- exit 0 (ruff format/check, mypy --strict, render all --check, topology, layering, closure-matrix, manifests, schema-versioning, classifier-fingerprints all green). Also ran automatically and passed on `git push` via the pre-push hook.
- Read-only live-archive checks against `/realm/db/polylogue` (never mutated): `devtools workspace agent-meta-sidecar-sweep --json` reports `candidate_count=4945, shape_mismatch_count=0`; `devtools workspace agent-meta-sidecar-purge-apply --json` (dry-run, no `--apply`) reports the same 4945 purgeable with zero mutation.

Ref polylogue-ioz7