### PR TITLE
fix(storage): widen empty-session repair to catch content-empty phantoms

### DIFF
--- a/polylogue/maintenance/targets.py
+++ b/polylogue/maintenance/targets.py
@@ -240,7 +240,7 @@ MAINTENANCE_TARGET_SPECS: tuple[MaintenanceTargetSpec, ...] = (
         mode=MaintenanceTargetMode.CLEANUP,
         category=MaintenanceCategory.ARCHIVE_CLEANUP,
         destructive=True,
-        description="Delete sessions that no longer contain any messages.",
+        description="Delete sessions with no real content (zero messages, or every message carries zero words).",
         include_in_archive_readiness=True,
         archive_readiness_unready_status=OutcomeStatus.WARNING,
     ),

--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -5206,8 +5206,10 @@ def has_orphaned_messages_sync(conn: sqlite3.Connection) -> bool:
 
 
 def count_empty_sessions_sync(conn: sqlite3.Connection) -> int:
-    """Count session rows that are debris: no messages AND a raw artifact the
-    current classifier positively refuses to admit as a session.
+    """Count session rows that are debris: no *content* (zero messages, or
+    every message carries zero words -- see ``_empty_session_candidate_ids``)
+    AND a raw artifact the current classifier positively refuses to admit as
+    a session.
 
     This deliberately does NOT count every message-less session, and it does
     NOT use ``raw_id IS NULL`` as the discriminator either (both were tried
@@ -5221,6 +5223,19 @@ def count_empty_sessions_sync(conn: sqlite3.Connection) -> int:
     it is WHAT THE ACQUIRED ARTIFACT IS: re-running each candidate's raw bytes
     through the same ``classify_artifact``/``inspect_raw_artifact`` pipeline
     live ingest uses, and counting only the ones it still refuses.
+
+    polylogue-21qj widened the candidate set beyond literally zero messages:
+    the live archive's ``claude-code-session:conversation_relationships``
+    phantom (a sinex graph-edge index misclassified as a session before
+    #3428) has 96,748 *message rows*, every one carrying zero blocks/words
+    (``session.word_count = 0``) -- a "no real content" session that the
+    original "no messages at all" predicate could never see. Broadening the
+    predicate to ``word_count = 0`` does not risk sweeping in a legitimate
+    all-tool-use session with no text turns: any such session's raw artifact
+    still carries genuine Claude Code envelope markers and is still admitted
+    by ``inspect_raw_artifact``, so the classifier gate below continues to
+    retain it. Only artifacts that positively fail current classification are
+    ever deleted, regardless of which candidate query found them.
 
     Kept in lockstep with ``repair_empty_sessions``: the counter and the
     deleter must agree, or the report says one thing and the repair does
@@ -5600,8 +5615,18 @@ def _sibling_source_db_path(conn: sqlite3.Connection) -> Path | None:
     return None
 
 
-def _empty_session_message_less_candidates(conn: sqlite3.Connection) -> list[tuple[str, str | None]]:
-    """Return ``(session_id, raw_id)`` for every session with zero messages."""
+def _empty_session_candidate_ids(conn: sqlite3.Connection) -> list[tuple[str, str | None]]:
+    """Return ``(session_id, raw_id)`` for every session with no real content:
+    zero messages, or every message present carries zero words.
+
+    The second branch (``s.word_count = 0`` with ``message_count`` possibly
+    nonzero) is what catches ``claude-code-session:conversation_relationships``
+    (polylogue-21qj): 96,748 message rows, none of them carrying any block/word
+    content, from a sinex graph-edge index misclassified as a session's turn
+    stream before #3428. ``sessions.word_count`` is a materialized aggregate
+    over every message the session owns, so this stays a single indexed
+    comparison rather than a per-message join.
+    """
     return [
         (row["session_id"], row["raw_id"])
         for row in conn.execute(
@@ -5609,6 +5634,7 @@ def _empty_session_message_less_candidates(conn: sqlite3.Connection) -> list[tup
             SELECT s.session_id AS session_id, s.raw_id AS raw_id
             FROM sessions s
             WHERE NOT EXISTS (SELECT 1 FROM messages m WHERE m.session_id = s.session_id)
+               OR s.word_count = 0
             """
         ).fetchall()
     ]
@@ -5656,7 +5682,7 @@ def _empty_session_debris_session_ids(conn: sqlite3.Connection) -> list[str]:
     Shared by ``count_empty_sessions_sync`` and ``repair_empty_sessions`` so
     the reported debt and the deleted rows can never diverge (polylogue-ne6k).
     """
-    candidates = _empty_session_message_less_candidates(conn)
+    candidates = _empty_session_candidate_ids(conn)
     if not candidates:
         return []
     source_db = _sibling_source_db_path(conn)

--- a/tests/unit/sources/test_artifact_taxonomy.py
+++ b/tests/unit/sources/test_artifact_taxonomy.py
@@ -82,6 +82,46 @@ def test_relationship_index_jsonl_conversation_field_is_metadata_not_session_str
     assert artifact.parse_as_session is False
 
 
+def test_analysis_signal_duplicate_messages_are_not_a_session() -> None:
+    """bd polylogue-21qj: ``analysis/signal/high_value_messages.jsonl`` is a
+    sinex-generated derivative index of "interesting" turns, copied verbatim
+    out of a real conversation (per-line shape: ``file``/``timestamp``/
+    ``type``/``content``, where ``type`` is the bare role word
+    ``"assistant"``/``"user"``, not a genuine record envelope). Unlike
+    ``conversation_relationships.jsonl``, its rows are real duplicated
+    conversation text rather than structurally empty pointer rows -- but it
+    must still never become its own ``claude-code-session``: the archive's
+    live copy of this file materialized 8,763 duplicate messages (827,894
+    words) that already exist verbatim in the session they were extracted
+    from. This shape has no ``_TYPE_ENVELOPE_MARKERS``/``_RECORDISH_KEYS`` hit
+    (``role`` is absent; the key is ``type``), so it falls through to the
+    ``analysis/`` directory heuristic exactly like ``problems_index.jsonl``.
+    """
+    records: list[JSONValue] = [
+        {
+            "file": "bad69218-73bd-490a-869a-2b3a30bf421b.jsonl",
+            "timestamp": "2025-06-13T17:40:52.056Z",
+            "type": "assistant",
+            "content": "Let me check the unified collector implementation for more context:",
+        },
+        {
+            "file": "bad69218-73bd-490a-869a-2b3a30bf421b.jsonl",
+            "timestamp": "2025-06-13T17:41:48.140Z",
+            "type": "user",
+            "content": "Search for ad-hoc solutions and pattern violations in the codebase.",
+        },
+    ]
+
+    artifact = classify_artifact(
+        records,
+        provider="claude-code",
+        source_path="/home/user/.claude/projects/x/analysis/signal/high_value_messages.jsonl",
+    )
+
+    assert artifact.kind is ArtifactKind.METADATA_DOCUMENT
+    assert artifact.parse_as_session is False
+
+
 def test_bare_tool_use_id_record_does_not_classify_as_session() -> None:
     """Regression for polylogue-9ykn: a record whose only distinguishing
     field is a ``tool_use_id``-shaped value (the real archive has 3 sessions

--- a/tests/unit/storage/test_empty_session_repair_provenance.py
+++ b/tests/unit/storage/test_empty_session_repair_provenance.py
@@ -32,7 +32,7 @@ from pathlib import Path
 import pytest
 
 from polylogue.storage.blob_store import BlobStore, reset_blob_store
-from polylogue.storage.repair import count_empty_sessions_sync
+from polylogue.storage.repair import _empty_session_debris_session_ids, count_empty_sessions_sync
 from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
 
@@ -82,11 +82,25 @@ def _insert_session(conn: sqlite3.Connection, *, native_id: str, raw_id: str | N
     return str(row[0])
 
 
-def _insert_message(conn: sqlite3.Connection, *, session_id: str, native_id: str) -> None:
+def _insert_message(
+    conn: sqlite3.Connection,
+    *,
+    session_id: str,
+    native_id: str,
+    position: int = 0,
+    word_count: int = 1,
+) -> None:
     conn.execute(
         "INSERT INTO messages (session_id, native_id, position, role, word_count, content_hash) "
-        "VALUES (?, ?, 0, 'user', 1, ?)",
-        (session_id, native_id, bytes(32)),
+        "VALUES (?, ?, ?, 'user', ?, ?)",
+        (session_id, native_id, position, word_count, bytes(32)),
+    )
+
+
+def _update_session_word_count(conn: sqlite3.Connection, *, session_id: str, word_count: int) -> None:
+    conn.execute(
+        "UPDATE sessions SET word_count = ? WHERE session_id = ?",
+        (word_count, session_id),
     )
 
 
@@ -101,10 +115,26 @@ def _seed(archive: Path) -> sqlite3.Connection:
     - ``no-provenance``: no ``raw_id`` at all -- no evidence either way, so it
       must be retained, not treated as debris by default.
     - ``healthy``: has a message, excluded regardless of provenance.
+    - ``all-empty-content-phantom``: many message rows (like a real
+      transcript), but every one carries zero words, backed by a
+      relationship-index-shaped raw artifact under an ``analysis/``
+      directory (polylogue-21qj's ``conversation_relationships.jsonl``
+      shape) -- debris, even though it is not literally message-less.
+    - ``all-empty-content-legit``: the same "many messages, all zero words"
+      shape, but backed by a genuine Claude Code record -- must be retained,
+      proving the broadened candidate query does not sweep in a legitimate
+      all-tool-use session with no text turns.
     """
     store = BlobStore(archive / "blob")
     legit_raw_id, legit_size = store.write_from_bytes(b'{"type":"summary","sessionId":"legit-empty-1"}\n')
     phantom_raw_id, phantom_size = store.write_from_bytes(b'{"agentType":"general-purpose"}')
+    relationship_index_bytes = (
+        b'{"conversation": "conv-1", "parent": "p-1", "child": "c-1", "type": "assistant", '
+        b'"timestamp": "2026-05-01T00:00:00.000Z"}\n'
+    )
+    relationship_index_raw_id, relationship_index_size = store.write_from_bytes(relationship_index_bytes)
+    legit_transcript_bytes = b'{"type":"summary","sessionId":"legit-all-empty-1"}\n'
+    legit_transcript_raw_id, legit_transcript_size = store.write_from_bytes(legit_transcript_bytes)
 
     with sqlite3.connect(archive / "source.db") as source_conn:
         _insert_raw_session(
@@ -121,6 +151,20 @@ def _seed(archive: Path) -> sqlite3.Connection:
             source_path="agent-1234.meta.json",
             blob_size=phantom_size,
         )
+        _insert_raw_session(
+            source_conn,
+            raw_id=relationship_index_raw_id,
+            native_id="conversation_relationships",
+            source_path="analysis/index/conversation_relationships.jsonl",
+            blob_size=relationship_index_size,
+        )
+        _insert_raw_session(
+            source_conn,
+            raw_id=legit_transcript_raw_id,
+            native_id="legit-all-empty",
+            source_path="conversation-all-empty.jsonl",
+            blob_size=legit_transcript_size,
+        )
         source_conn.commit()
 
     conn = sqlite3.connect(archive / "index.db")
@@ -130,6 +174,17 @@ def _seed(archive: Path) -> sqlite3.Connection:
     _insert_session(conn, native_id="no-provenance", raw_id=None)
     healthy_session_id = _insert_session(conn, native_id="healthy", raw_id=None)
     _insert_message(conn, session_id=healthy_session_id, native_id="m1")
+
+    phantom_many_id = _insert_session(conn, native_id="conversation_relationships", raw_id=relationship_index_raw_id)
+    for index in range(3):
+        _insert_message(conn, session_id=phantom_many_id, native_id=f"cr-{index}", position=index, word_count=0)
+    _update_session_word_count(conn, session_id=phantom_many_id, word_count=0)
+
+    legit_many_id = _insert_session(conn, native_id="legit-all-empty", raw_id=legit_transcript_raw_id)
+    for index in range(3):
+        _insert_message(conn, session_id=legit_many_id, native_id=f"le-{index}", position=index, word_count=0)
+    _update_session_word_count(conn, session_id=legit_many_id, word_count=0)
+
     conn.commit()
     return conn
 
@@ -137,7 +192,44 @@ def _seed(archive: Path) -> sqlite3.Connection:
 def test_only_the_positively_refused_artifact_counts_as_debris(archive: Path) -> None:
     conn = _seed(archive)
     try:
-        assert count_empty_sessions_sync(conn) == 1
+        # "phantom" (message-less) and "conversation_relationships" (many
+        # messages, all zero words) -- both positively refused by the
+        # current classifier. "legit-empty" and "legit-all-empty" are the
+        # sibling shapes backed by a genuine record and must be excluded.
+        assert count_empty_sessions_sync(conn) == 2
+    finally:
+        conn.close()
+
+
+def test_all_empty_content_session_with_phantom_raw_counts_as_debris(archive: Path) -> None:
+    """polylogue-21qj: a session with real message rows that all carry zero
+    words (the ``conversation_relationships`` shape -- 96,748 message rows on
+    the live archive, none with any block/word content) must be treated as
+    debris when its raw artifact is a relationship-index-shaped, ``analysis/``
+    -directory file that the current classifier positively refuses. The prior
+    predicate (``NOT EXISTS messages``) could never see this session at all,
+    since it is not literally message-less.
+    """
+    conn = _seed(archive)
+    try:
+        debris_ids = _empty_session_debris_session_ids(conn)
+        assert "claude-code-session:conversation_relationships" in debris_ids
+    finally:
+        conn.close()
+
+
+def test_all_empty_content_session_with_legit_raw_is_retained(archive: Path) -> None:
+    """Sibling of the test above: the identical 'many messages, all zero
+    words' shape must NOT become debris when its raw artifact is a genuine
+    Claude Code record (e.g. an all-tool-use session with no text turns) --
+    the widened candidate query only ever proposes candidates; the classifier
+    gate is what actually decides, and it must still retain a legitimate
+    zero-word session.
+    """
+    conn = _seed(archive)
+    try:
+        debris_ids = _empty_session_debris_session_ids(conn)
+        assert "claude-code-session:legit-all-empty" not in debris_ids
     finally:
         conn.close()
 
@@ -153,9 +245,11 @@ def test_blanket_predicate_would_have_swept_up_legitimate_sessions(archive: Path
             ).fetchone()[0]
         )
         # The blanket predicate sweeps in the legitimately-empty session and
-        # the no-provenance session too -- three total, not one.
+        # the no-provenance session too -- three total, not two -- and it
+        # cannot see "conversation_relationships"/"legit-all-empty" at all
+        # (they are not message-less).
         assert blanket == 3
-        assert count_empty_sessions_sync(conn) == 1, (
+        assert count_empty_sessions_sync(conn) == 2, (
             "classifier-aware count must exclude the legitimate and no-provenance sessions"
         )
     finally:
@@ -177,6 +271,6 @@ def test_raw_id_is_null_predicate_would_have_missed_the_phantom(archive: Path) -
             ).fetchone()[0]
         )
         assert raw_id_null_predicate == 1  # only "no-provenance" -- the wrong row
-        assert count_empty_sessions_sync(conn) == 1  # only "phantom" -- the right row
+        assert count_empty_sessions_sync(conn) == 2  # "phantom" + "conversation_relationships" -- the right rows
     finally:
         conn.close()


### PR DESCRIPTION
## Summary

Widens `polylogue/storage/repair.py`'s `empty_sessions` maintenance-repair target so it also catches sessions that have message rows but zero real content (all-zero-word messages), not only literally message-less sessions. Adds the one missing regression test among 6 named phantom-artifact shapes.

## Problem

polylogue-21qj found 6 non-transcript files under watched `~/.claude/projects` trees had been ingested as `claude-code-session` rows in the live archive: a sinex analysis-index (`conversation_relationships.jsonl`, 96,748 empty messages), a derived duplicate-messages index (`high_value_messages.jsonl`, 8,763 real duplicate messages), an empty problem-index (`problems_index.jsonl`), 3x oversized-tool-output spill files (`tool-results/toolu_*.json`), and a workflow journal (`journal.jsonl`).

Investigating against the live archive (read-only, `/realm/db/polylogue`) and the current checkout found **5 of the 6 shapes are already refused at detection time** by prior merged work (#3426 self-generated `analysis/` dir guard, #3428 `looks_like_code` envelope-marker requirement, c6190d7db letting record content override the `analysis/` guard, and the pre-existing `workflow_journal` `OriginArtifactRule`). Verified live: reran each real file's exact byte content (read from `source.db` + the blob store, since 2 of 3 sinex files no longer exist on disk) through `classify_artifact`/`detect_provider_evidence` — all return `parse_as_session=False`.

For cleanup, `polylogue-ne6k` had already built exactly the classifier + dry-run-gated actuator pattern this bead asked for (`repair.py`'s `empty_sessions` target, wired through `polylogue maintenance repair --target empty_sessions`, dry-run by default) — but scoped to literally message-less sessions (`NOT EXISTS messages`). `conversation_relationships` has 96,748 message rows (every one carrying zero blocks/words), so it fell outside that predicate and was never even a repair candidate.

## Solution

- Widened `_empty_session_candidate_ids` (renamed from `_empty_session_message_less_candidates`) to also propose sessions where `sessions.word_count = 0` regardless of `message_count`. The existing positive-classification gate (`_raw_artifact_positively_fails_classification`) remains the sole deletion authority — a legitimate all-tool-use session with no text turns still passes classification and is retained (pinned by `test_all_empty_content_session_with_legit_raw_is_retained`).
- Added `test_all_empty_content_session_with_phantom_raw_counts_as_debris`, pinning that a `conversation_relationships`-shaped session (many zero-word message rows, relationship-index-shaped raw artifact under `analysis/`) is now flagged.
- Added `test_analysis_signal_duplicate_messages_are_not_a_session` to `test_artifact_taxonomy.py`, the missing regression pin for the 6th named shape (`high_value_messages.jsonl`'s real field shape: `file`/`timestamp`/`type`/`content`).
- Updated the `empty_sessions` maintenance-target description to reflect the broader predicate.

`high_value_messages.jsonl` (8,763 non-empty messages, 827,894 words) is deliberately excluded from the purge — its content is real duplicated conversation text, and investigation found the real source session (`bad69218-...`) is stuck `revision_authority='quarantined'` and never parsed, so this phantom is currently the archive's only queryable copy of that content. Blanket deletion would be real data loss, not garbage collection. Deferred to polylogue-6bebe.

## Verification

- `devtools test tests/unit/storage/test_empty_session_repair_provenance.py tests/unit/sources/test_artifact_taxonomy.py` — 15 passed.
- `devtools verify --quick` — exit 0, all 19 steps green (also ran again automatically via the pre-push hook).
- Read-only measurement against the live archive: before this change, `conversation_relationships` was absent from `_empty_session_debris_session_ids`'s output; after, it is flagged alongside the already-flagged `problems_index`/`journal`/3x `toolu_*`. Total flagged debris across the archive went from 5023 to 5076 rows (+53 — this generalization also catches other same-shaped phantoms archive-wide, not only the 5 named in this bead).
- Pre-existing, unrelated failure found and **not** fixed here: `tests/unit/maintenance/test_planner_contract.py` and `test_planner_filter_narrowing.py` fail with a `TypeError` (row_factory not set on a test fixture's index connection) on master (120cf6f6b) too, confirmed via `git stash` before this change. Filed as polylogue-9rdky.

Ref polylogue-21qj, polylogue-gvgi (closed as duplicate), polylogue-6bebe, polylogue-9rdky