### PR TITLE
feat(devtools): add capture-time raw-authority safeguards

### DIFF
--- a/devtools/command_catalog.py
+++ b/devtools/command_catalog.py
@@ -1475,6 +1475,43 @@ COMMAND_SPECS: tuple[CommandSpec, ...] = (
         ),
     ),
     CommandSpec(
+        "lab policy raw-payload-hash-purity",
+        "verification lab",
+        "Verify no raw-capture write path splices a synthesized literal onto captured bytes before hashing.",
+        "devtools.verify_raw_payload_hash_purity",
+        use_when=(
+            "Prevent a regression of polylogue-u19l's confirmed bug: sources/live/batch.py used to prepend a "
+            "synthetic session_meta header onto every Codex append capture before hashing/storing it, so the "
+            "stored blob was never a literal byte-slice of the live file, permanently defeating live-source "
+            "byte-identity verification for ~59GB of raw rows. Statically forbids concatenating a synthesized "
+            "literal (bytes/str constant, f-string, json.dumps()/.encode() result) onto captured bytes anywhere "
+            "in the raw-capture write-path modules (WRITE_PATH_MODULES)."
+        ),
+        examples=("devtools lab policy raw-payload-hash-purity", "devtools lab policy raw-payload-hash-purity --json"),
+    ),
+    CommandSpec(
+        "lab policy position-derived-identity",
+        "verification lab",
+        "Verify no parser mints cross-revision comparison identity from positional/index data.",
+        "devtools.verify_position_derived_identity",
+        use_when=(
+            "Prevent a regression of polylogue-hith/qkuq's already-fixed attachment-id bug (a synthetic id "
+            "seeded partly by array index was unstable across export vintages that reorder/insert entries, "
+            "manufacturing false divergence in revision-authority membership comparison) and catch new "
+            "occurrences of the same shape (polylogue-gysk3 found the identical hazard still live for "
+            "provider_message_id, the sole input to message_identity_hash). Statically scans "
+            "polylogue/sources/parsers/ for an identity-bearing field constructed from an f-string/format/"
+            "concatenation referencing a loop index/position variable, either inline or via a local variable."
+        ),
+        examples=(
+            "devtools lab policy position-derived-identity",
+            "devtools lab policy position-derived-identity --json",
+            "devtools lab policy position-derived-identity --ack "
+            "'polylogue/sources/parsers/foo.py:parse:provider_message_id' "
+            "--reason 'tracked in polylogue-xxxx, not fixed inline' --ref polylogue-xxxx",
+        ),
+    ),
+    CommandSpec(
         "lab policy backlog-hygiene",
         "verification lab",
         "Verify Beads backlog structure invariants (.beads/issues.jsonl).",

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -1796,6 +1796,20 @@ def build_verify_steps(
                 # fixture was regenerated to match a `healed_tiers` field the
                 # demo receipts code had already grown).
                 ("lab policy demo-tour-freshness", _devtools_cmd("lab policy demo-tour-freshness")),
+                # Static, archive-independent, sub-second: forbids the exact
+                # byte-mutation-before-hashing pattern that produced
+                # polylogue-u19l's Codex append-header bug (a synthesized
+                # literal spliced onto captured bytes before they reached the
+                # content hasher, permanently defeating live-source
+                # byte-identity verification for ~59GB of raw rows).
+                ("lab policy raw-payload-hash-purity", _devtools_cmd("lab policy raw-payload-hash-purity")),
+                # Static, archive-independent, sub-second: forbids a NEW
+                # occurrence of polylogue-hith/qkuq's already-fixed
+                # attachment-id bug shape (comparison identity minted from
+                # positional/index data, unstable across export vintages
+                # that reorder entries) -- polylogue-gysk3 found the same
+                # hazard still live for provider_message_id.
+                ("lab policy position-derived-identity", _devtools_cmd("lab policy position-derived-identity")),
                 # Publication gate. Committed provider schema packages are
                 # public artifacts; this blocks local provenance
                 # (bundle_scopes/representative_paths) and scans for secrets.

--- a/devtools/verify_position_derived_identity.py
+++ b/devtools/verify_position_derived_identity.py
@@ -1,0 +1,387 @@
+"""Verify no parser mints comparison identity from positional/index data.
+
+Background
+----------
+
+polylogue-hith/qkuq found and fixed a concrete bug: the Claude.ai attachment
+parser's synthetic id (``att-<hash(message_id:name:index)>``) was seeded
+partly by array index, so a re-export that reordered or inserted attachment
+entries silently produced a different id for "the same" attachment,
+manufacturing false divergence in revision-authority membership comparison.
+The fix was not to remove the synthetic-id *generator* (still legitimate as
+a last-resort storage/display id, seed no longer includes ``index``) but to
+make ``attachment_identity_hash`` (``polylogue/pipeline/ids.py``) stop
+reading either the real or synthetic attachment id at all for comparison
+purposes.
+
+polylogue-gysk3 found the identical hazard still live one level up:
+``message_identity_hash`` (``polylogue/pipeline/ids.py``) hashes a message's
+``id`` directly, and that id IS ``provider_message_id`` -- multiple parsers
+construct it as ``f"msg-{index}"`` or similar whenever the raw record
+carries no native id of its own. Fixing every existing instance is a
+separate, higher-risk follow-on (polylogue-gysk3); this lint (ds4b4 item 3)
+is the preventive half -- it stops a *new* occurrence of the same shape from
+being added silently, in a parser or anywhere else, without requiring every
+already-known instance to be ripped out first.
+
+What this lint checks
+----------------------
+
+Scans ``polylogue/sources/parsers/`` (and ``base_support.py``-style shared
+parser helpers alongside it) for an assignment or keyword argument whose
+target name is in ``IDENTITY_FIELD_NAMES`` (fields whose value is used as
+cross-revision comparison identity, not just a display/storage label) where
+the value expression is an f-string, ``str.format()`` call, or ``+``
+concatenation that references a variable named like a loop index/position
+(``index``, ``idx``, ``i``, ``pos``, ``position`` -- ``ENUMERATE_VAR_NAMES``).
+
+Every currently-known instance is recorded in the acknowledgment manifest
+(``docs/plans/position-derived-identity-acks.json``), each referencing
+polylogue-gysk3 (the tracked follow-up to actually fix them). A *new*
+occurrence with no manifest entry fails the gate -- it must either avoid
+positional identity, or be explicitly acknowledged (naming a tracked
+follow-up bead/issue) via ``--ack``.
+
+Scope and false-positive discipline
+------------------------------------
+
+Only ``IDENTITY_FIELD_NAMES`` trips this lint -- an ordinary loop variable
+named ``index`` used for anything else (slicing, logging, an unrelated
+counter) is untouched. ``ENUMERATE_VAR_NAMES`` is deliberately narrow (common
+loop-counter spellings); a differently-named counter is a residual
+false-negative, not a false-positive, and acceptable for a preventive lint of
+this kind (the goal is to catch the common, already-observed shape, not
+build a full data-flow/taint analysis). Position-derived values used for
+purely *structural* addressing that is never compared across independent
+captures of the same logical entity (e.g. ``blocks.block_id`` -- see
+CLAUDE.md's data model section) are out of scope by construction: this lint
+only matches the specific field-name list, not every f-string containing an
+index.
+
+Wired into ``devtools verify --lab`` (like classifier-fingerprints):
+static, archive-independent, sub-second.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypedDict
+
+from devtools import repo_root as _get_root
+
+ROOT = _get_root()
+PARSERS_ROOT = ROOT / "polylogue" / "sources" / "parsers"
+MANIFEST_PATH = ROOT / "docs" / "plans" / "position-derived-identity-acks.json"
+
+#: Field names whose value is used as cross-revision comparison identity
+#: (not just a storage/display label). Extend deliberately, with review --
+#: this is the allowlist that scopes the whole lint.
+IDENTITY_FIELD_NAMES = frozenset({"provider_message_id"})
+
+#: Common loop-counter/index spellings. Deliberately narrow (see module
+#: docstring's false-positive-discipline section).
+ENUMERATE_VAR_NAMES = frozenset({"index", "idx", "i", "pos", "position"})
+
+_REF_PATTERN = re.compile(r"^(polylogue-[a-z0-9][a-z0-9.]*|#\d+)$")
+_MIN_REASON_LEN = 15
+
+
+def _references_enumerate_var(node: ast.AST) -> bool:
+    return any(isinstance(sub, ast.Name) and sub.id in ENUMERATE_VAR_NAMES for sub in ast.walk(node))
+
+
+def _value_is_position_derived(value: ast.expr) -> bool:
+    if isinstance(value, ast.JoinedStr):
+        return _references_enumerate_var(value)
+    if isinstance(value, ast.BinOp) and isinstance(value.op, ast.Add):
+        return _references_enumerate_var(value)
+    if isinstance(value, ast.Call):
+        func = value.func
+        name = func.attr if isinstance(func, ast.Attribute) else func.id if isinstance(func, ast.Name) else None
+        if name == "format" and _references_enumerate_var(value):
+            return True
+        # `str(x or f"...{index}")`, `str(x or f"...{index}")` etc: unwrap a
+        # single-arg str()/BoolOp `or` chain to reach the fallback literal.
+        if name == "str" and len(value.args) == 1:
+            return _value_is_position_derived(value.args[0])
+    if isinstance(value, ast.BoolOp) and isinstance(value.op, ast.Or):
+        return any(_value_is_position_derived(v) for v in value.values)
+    return False
+
+
+@dataclass(frozen=True, slots=True)
+class PositionIdentityFinding:
+    qualname: str
+    path: str
+    lineno: int
+    field: str
+
+
+def _enclosing_function_name(stack: list[ast.AST]) -> str:
+    for node in reversed(stack):
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            return node.name
+    return "<module>"
+
+
+def _resolve_via_local_bindings(value: ast.expr, bindings: dict[str, ast.expr], *, depth: int = 0) -> bool:
+    """Follow a bare-name reference back to its last local assignment.
+
+    The common shape in this codebase is not inline construction at the
+    identity-field keyword/assign site -- it is ``msg_id = ... or
+    f"msg-{idx}"`` a few lines earlier, then ``provider_message_id=msg_id``.
+    A one-hop-per-name, last-write-wins backward resolution (approximating
+    straight-line control flow, which is what these parsers use) catches
+    that without a full data-flow analysis. ``depth`` guards against
+    pathological self-referential rebinding.
+    """
+    if depth > 5:
+        return False
+    if _value_is_position_derived(value):
+        return True
+    if isinstance(value, ast.Name) and value.id in bindings:
+        return _resolve_via_local_bindings(bindings[value.id], bindings, depth=depth + 1)
+    if isinstance(value, ast.Call) and len(value.args) == 1:
+        func = value.func
+        name = func.attr if isinstance(func, ast.Attribute) else func.id if isinstance(func, ast.Name) else None
+        if name == "str":
+            return _resolve_via_local_bindings(value.args[0], bindings, depth=depth + 1)
+    if isinstance(value, ast.BoolOp) and isinstance(value.op, ast.Or):
+        return any(_resolve_via_local_bindings(v, bindings, depth=depth + 1) for v in value.values)
+    return False
+
+
+def _scan_module(source: str, *, rel_path: str) -> list[PositionIdentityFinding]:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    findings: list[PositionIdentityFinding] = []
+    ordinal_by_key: dict[str, int] = {}
+    stack: list[ast.AST] = []
+    # Reset per function: a straight-line, last-write-wins map of local
+    # simple-name bindings, rebuilt fresh at each FunctionDef so a name in
+    # one function never leaks into another's resolution.
+    bindings_by_function: dict[int, dict[str, ast.expr]] = {}
+
+    def _current_bindings() -> dict[str, ast.expr]:
+        for node in reversed(stack):
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+                return bindings_by_function.setdefault(id(node), {})
+        return bindings_by_function.setdefault(0, {})
+
+    def _record(field: str, value: ast.expr, *, lineno: int) -> None:
+        if not _resolve_via_local_bindings(value, _current_bindings()):
+            return
+        func_name = _enclosing_function_name(stack)
+        key = f"{rel_path}:{func_name}:{field}"
+        ordinal = ordinal_by_key.get(key, 0)
+        ordinal_by_key[key] = ordinal + 1
+        qualname = key if ordinal == 0 else f"{key}#{ordinal}"
+        findings.append(PositionIdentityFinding(qualname=qualname, path=rel_path, lineno=lineno, field=field))
+
+    class _Visitor(ast.NodeVisitor):
+        def generic_visit(self, node: ast.AST) -> None:
+            stack.append(node)
+            super().generic_visit(node)
+            stack.pop()
+
+        def visit_Assign(self, node: ast.Assign) -> None:
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    if target.id in IDENTITY_FIELD_NAMES:
+                        _record(target.id, node.value, lineno=node.lineno)
+                    _current_bindings()[target.id] = node.value
+            self.generic_visit(node)
+
+        def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+            if isinstance(node.target, ast.Name) and node.value is not None:
+                if node.target.id in IDENTITY_FIELD_NAMES:
+                    _record(node.target.id, node.value, lineno=node.lineno)
+                _current_bindings()[node.target.id] = node.value
+            self.generic_visit(node)
+
+        def visit_Call(self, node: ast.Call) -> None:
+            for kw in node.keywords:
+                if kw.arg in IDENTITY_FIELD_NAMES:
+                    _record(kw.arg, kw.value, lineno=kw.value.lineno)
+            self.generic_visit(node)
+
+    _Visitor().visit(tree)
+    return findings
+
+
+def collect_position_derived_identity(root: Path = PARSERS_ROOT) -> dict[str, PositionIdentityFinding]:
+    """Return every in-scope finding, keyed by a line-shift-stable qualname.
+
+    Exposed standalone so a test can feed a synthetic source string via
+    ``_scan_module`` directly.
+    """
+    found: dict[str, PositionIdentityFinding] = {}
+    if not root.exists():
+        return found
+    for path in sorted(root.rglob("*.py")):
+        rel = path.relative_to(ROOT).as_posix()
+        source = path.read_text(encoding="utf-8")
+        for finding in _scan_module(source, rel_path=rel):
+            found[finding.qualname] = finding
+    return found
+
+
+@dataclass(frozen=True, slots=True)
+class AckEntry:
+    reason: str
+    ref: str
+
+
+class ManifestJSON(TypedDict):
+    acknowledged: dict[str, dict[str, str]]
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> dict[str, AckEntry]:
+    if not path.exists():
+        return {}
+    raw: ManifestJSON = json.loads(path.read_text(encoding="utf-8"))
+    return {
+        qualname: AckEntry(reason=str(data["reason"]), ref=str(data["ref"]))
+        for qualname, data in raw.get("acknowledged", {}).items()
+    }
+
+
+def save_manifest(entries: dict[str, AckEntry], path: Path = MANIFEST_PATH) -> None:
+    payload: ManifestJSON = {
+        "acknowledged": {
+            qualname: {"reason": entry.reason, "ref": entry.ref} for qualname, entry in sorted(entries.items())
+        }
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=False) + "\n", encoding="utf-8")
+
+
+def _validate_ack(reason: str, ref: str) -> str | None:
+    if len(reason.strip()) < _MIN_REASON_LEN:
+        return f"reason too short (must explain the tracked follow-up, >= {_MIN_REASON_LEN} chars)"
+    if not _REF_PATTERN.match(ref):
+        return "ref must be a bead id (polylogue-xxxx) or issue number (#N)"
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class DriftReport:
+    unacknowledged: tuple[str, ...]
+    stale: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.unacknowledged and not self.stale
+
+
+def compute_drift_report(
+    current: dict[str, PositionIdentityFinding] | None = None,
+    manifest: dict[str, AckEntry] | None = None,
+) -> DriftReport:
+    if current is None:
+        current = collect_position_derived_identity()
+    if manifest is None:
+        manifest = load_manifest()
+    unacknowledged = tuple(sorted(q for q in current if q not in manifest))
+    stale = tuple(sorted(q for q in manifest if q not in current))
+    return DriftReport(unacknowledged=unacknowledged, stale=stale)
+
+
+def _format_report(report: DriftReport, current: dict[str, PositionIdentityFinding]) -> str:
+    lines = [
+        f"unacknowledged position-derived identity constructions: {len(report.unacknowledged)}",
+        f"stale manifest entries (finding no longer exists): {len(report.stale)}",
+    ]
+    if report.unacknowledged:
+        lines.append("")
+        lines.append(
+            "New position-derived comparison-identity constructions (see module docstring -- "
+            "polylogue-hith/qkuq's already-fixed attachment-id bug, polylogue-gysk3's tracked "
+            "message-id sibling):"
+        )
+        for qualname in report.unacknowledged:
+            finding = current[qualname]
+            lines.append(f"  {finding.path}:{finding.lineno} ({finding.field}) [{qualname}]")
+        lines.append(
+            "  Fix: either derive identity from provider-native data instead of position, or "
+            "acknowledge with `devtools lab policy position-derived-identity --ack <qualname> "
+            "--reason '...' --ref <bead-or-issue>` naming a tracked follow-up."
+        )
+    if report.stale:
+        lines.append("")
+        lines.append("Manifest entries whose finding no longer exists (remove them):")
+        for qualname in report.stale:
+            lines.append(f"  {qualname}")
+        lines.append(f"  Fix: edit {MANIFEST_PATH.relative_to(ROOT)} and delete the stale entry.")
+    if report.ok:
+        lines.append("")
+        lines.append("Position-derived identity policy intact.")
+    return "\n".join(lines)
+
+
+def _cmd_ack(qualname: str, *, reason: str, ref: str) -> int:
+    current = collect_position_derived_identity()
+    if qualname not in current:
+        print(f"error: {qualname!r} is not a currently discovered finding", file=sys.stderr)
+        return 2
+    problem = _validate_ack(reason, ref)
+    if problem is not None:
+        print(f"error: {problem}", file=sys.stderr)
+        return 2
+    manifest = load_manifest()
+    manifest[qualname] = AckEntry(reason=reason, ref=ref)
+    save_manifest(manifest)
+    print(f"recorded {qualname}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    parser.add_argument(
+        "--ack",
+        metavar="QUALNAME",
+        help="record an acknowledged position-derived identity finding, naming a tracked follow-up",
+    )
+    parser.add_argument("--reason", help="justification text for --ack (required with --ack)")
+    parser.add_argument("--ref", help="bead id (polylogue-xxxx) or issue number (#N) for --ack (required with --ack)")
+    args = parser.parse_args(argv)
+
+    if args.ack:
+        if not args.reason or not args.ref:
+            parser.error("--ack requires --reason and --ref")
+        return _cmd_ack(args.ack, reason=args.reason, ref=args.ref)
+
+    current = collect_position_derived_identity()
+    report = compute_drift_report(current)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "unacknowledged": list(report.unacknowledged),
+                    "stale": list(report.stale),
+                    "ok": report.ok,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(_format_report(report, current))
+
+    return 0 if report.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/devtools/verify_raw_payload_hash_purity.py
+++ b/devtools/verify_raw_payload_hash_purity.py
@@ -1,0 +1,217 @@
+"""Verify no raw-capture write path mutates bytes before they reach the hasher.
+
+Background
+----------
+
+Polylogue-u19l found a concrete, confirmed bug: ``sources/live/batch.py``'s
+``_append_payload_for_provider`` used to prepend a synthetic
+``{"type":"session_meta","payload":{"id":...}}`` line ahead of every Codex
+append-mode capture's real tail bytes, *before* those bytes were hashed and
+stored as the raw's content (``session_meta + b"\\n" + payload``, the exact
+shape this lint forbids). That made the stored blob architecturally never a
+literal byte-slice of the live file, permanently defeating any live-source
+byte-identity re-verification even when the live file was completely
+untouched (~59 GB of quarantined raw rows, ~95% of which were, in fact,
+directly re-verifiable once the synthetic header was accounted for).
+
+The fix (PR #3539, polylogue-u19l) carries the identity as sidecar metadata
+(``raw_sessions.native_id``) instead of splicing it into the hashed bytes.
+This lint (polylogue-ds4b4 item 2) generalizes the regression test: it
+statically forbids the *pattern* that produced the bug -- concatenating a
+freshly synthesized literal (a bytes/str constant, or the result of a
+``json.dumps``/``.encode()`` call) onto a name/attribute reference -- anywhere
+in the raw-capture write-path modules, not just in the one function that
+already got fixed.
+
+What this lint checks
+----------------------
+
+For every module in ``WRITE_PATH_MODULES`` (the modules that construct or
+carry the ``bytes`` that ultimately reach ``write_raw_payload``/
+``BlobPublisher.write_from_bytes`` -- the content-hashing boundary for raw
+session capture), parse the AST and flag every ``BinOp`` using ``+`` where at
+least one operand is a freshly synthesized literal (a bytes/str ``Constant``,
+an f-string, or a call to something that looks like serialization --
+``dumps``/``encode``) and the other operand is not itself another literal of
+the same kind (i.e. this is a synthesize-and-splice, not two literals being
+joined for an unrelated purpose, e.g. building a log message).
+
+Scope and false-positive discipline
+------------------------------------
+
+In scope: only the fixed module list below -- the modules on the raw-capture
+write path. An unrelated string-concatenation elsewhere in the codebase (log
+messages, error text, SQL fragments) never fires. Within scope, ordinary
+byte-slicing, ``.join()``, and passing a bare ``Name``/``Attribute`` through
+unmodified are unaffected -- only literal-onto-variable splicing trips the
+gate. There is no ack/exception mechanism: unlike classifier-fingerprint
+drift (where a change can be a deliberate, reviewed decision), byte-mutation
+before the content hasher has no legitimate use case on this write path --
+identity/metadata belongs in a sidecar column, never spliced into the hashed
+payload. If a genuinely new, legitimate need for payload-adjacent literal
+bytes arises, it belongs in ``WRITE_PATH_MODULES`` exclusion criteria (edit
+this module's own scope, with review), not a per-line escape hatch.
+
+Wired into ``devtools verify --lab`` alongside the other static policy
+checks: archive-independent, sub-second.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from dataclasses import dataclass
+
+from devtools import repo_root as _get_root
+
+ROOT = _get_root()
+
+# The raw-capture write path: every module that constructs, transforms, or
+# forwards the bytes that ultimately reach a raw payload hasher
+# (``write_raw_payload`` / ``BlobPublisher.write_from_bytes``) for
+# ``raw_sessions`` capture. Deliberately a fixed, reviewed list, not a
+# directory glob -- widening scope to "everything under sources/" would
+# false-positive on unrelated string building far from any hashed payload.
+WRITE_PATH_MODULES: tuple[str, ...] = (
+    "polylogue/sources/live/batch.py",
+    "polylogue/sources/live/batch_support.py",
+    "polylogue/sources/live/append_ingest.py",
+    "polylogue/pipeline/services/archive_ingest.py",
+    "polylogue/pipeline/services/acquisition_records.py",
+    "polylogue/pipeline/services/ingest_batch/_core.py",
+    "polylogue/sources/source_acquisition_components.py",
+    "polylogue/sources/drive/__init__.py",
+    "polylogue/storage/sqlite/archive_tiers/archive.py",
+    "polylogue/storage/sqlite/archive_tiers/revision_governance.py",
+)
+
+_SERIALIZE_CALL_NAMES = {"dumps", "json_dumps", "encode"}
+
+
+@dataclass(frozen=True, slots=True)
+class HashPurityViolation:
+    path: str
+    lineno: int
+    col_offset: int
+    detail: str
+
+
+def _looks_synthesized(node: ast.expr) -> bool:
+    """A literal or serialization-call operand -- the "freshly minted" half."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, bytes | str):
+        return True
+    if isinstance(node, ast.JoinedStr):  # f-string
+        return True
+    if isinstance(node, ast.Call):
+        func = node.func
+        name = func.attr if isinstance(func, ast.Attribute) else func.id if isinstance(func, ast.Name) else None
+        if name in _SERIALIZE_CALL_NAMES:
+            return True
+    return False
+
+
+def _looks_like_captured_bytes(node: ast.expr) -> bool:
+    """A bare reference operand -- plausibly the read/captured payload."""
+    return isinstance(node, ast.Name | ast.Attribute | ast.Subscript)
+
+
+def _scan_binop(node: ast.BinOp, *, path: str) -> HashPurityViolation | None:
+    if not isinstance(node.op, ast.Add):
+        return None
+    left, right = node.left, node.right
+    synthesized_left, synthesized_right = _looks_synthesized(left), _looks_synthesized(right)
+    captured_left, captured_right = _looks_like_captured_bytes(left), _looks_like_captured_bytes(right)
+    # Flag only an asymmetric splice: one side freshly synthesized, the other
+    # a bare reference. Two literals joined together (e.g. building a fixed
+    # log-message prefix) or two references concatenated (e.g. joining two
+    # already-captured buffers) are not the hazard this lint targets.
+    if (synthesized_left and captured_right) or (synthesized_right and captured_left):
+        return HashPurityViolation(
+            path=path,
+            lineno=node.lineno,
+            col_offset=node.col_offset,
+            detail="literal/serialized value concatenated onto a bare reference before hashing",
+        )
+    return None
+
+
+def scan_source_for_payload_concatenation(source: str, *, path: str) -> list[HashPurityViolation]:
+    """Return every literal-onto-reference splice in *source*.
+
+    Exposed standalone (not just via the CLI) so a test can feed a synthetic
+    source-string fixture directly, mirroring
+    ``verify_timestamp_doctrine.scan_ddl_for_text_timestamps``.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    violations: list[HashPurityViolation] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.BinOp):
+            violation = _scan_binop(node, path=path)
+            if violation is not None:
+                violations.append(violation)
+    return violations
+
+
+def _collect_write_path_violations(modules: tuple[str, ...] = WRITE_PATH_MODULES) -> list[HashPurityViolation]:
+    violations: list[HashPurityViolation] = []
+    for rel in modules:
+        full_path = ROOT / rel
+        if not full_path.exists():
+            continue
+        source = full_path.read_text(encoding="utf-8")
+        violations.extend(scan_source_for_payload_concatenation(source, path=rel))
+    return violations
+
+
+def _format_report(violations: list[HashPurityViolation]) -> str:
+    if not violations:
+        return (
+            f"Raw-payload hash purity intact: no write-path module concatenates a "
+            f"synthesized literal onto captured bytes before hashing ({len(WRITE_PATH_MODULES)} modules scanned)."
+        )
+    lines = [f"Raw-payload hash-purity violations: {len(violations)}", ""]
+    for violation in violations:
+        lines.append(f"  {violation.path}:{violation.lineno}: {violation.detail}")
+    lines.append("")
+    lines.append(
+        "Policy violation (polylogue-ds4b4/u19l): a raw-capture write path must never splice a "
+        "synthesized literal (bytes/str constant, f-string, json.dumps()/.encode() result) onto "
+        "captured bytes before they reach the content hasher. Carry identity/metadata as sidecar "
+        "data (a separate column/return value), and reconstruct any parseable header at READ time "
+        "instead, per _append_payload_for_provider's docstring in polylogue/sources/live/batch.py."
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    violations = _collect_write_path_violations()
+
+    if args.json:
+        payload = {
+            "violations": [
+                {"path": v.path, "lineno": v.lineno, "col_offset": v.col_offset, "detail": v.detail} for v in violations
+            ],
+            "modules_scanned": list(WRITE_PATH_MODULES),
+            "ok": not violations,
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        print(_format_report(violations))
+
+    return 0 if not violations else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -147,6 +147,8 @@ These are the commands worth remembering during normal repo work:
 | `devtools lab policy demo-tour-freshness` | Verify a freshly-run demo tour matches the committed docs/examples/demo-tour/ evidence artifacts. |
 | `devtools lab policy docs-drift` | Verify checkable factual claims in the Reference-docs table against current source. |
 | `devtools lab policy insight-honesty` | Verify every registered insight product is rigor-contracted or exempt. |
+| `devtools lab policy position-derived-identity` | Verify no parser mints cross-revision comparison identity from positional/index data. |
+| `devtools lab policy raw-payload-hash-purity` | Verify no raw-capture write path splices a synthesized literal onto captured bytes before hashing. |
 | `devtools lab policy schema-versioning` | Verify durable-tier migration and derived-tier rebuild boundaries. |
 | `devtools lab policy timestamp-doctrine` | Verify durable-tier DDL never stores a timestamp column as TEXT. |
 | `devtools lab probe bead-pr-reconciliation` | Surface beads whose referenced PR merged but the bead is still open. |

--- a/docs/plans/position-derived-identity-acks.json
+++ b/docs/plans/position-derived-identity-acks.json
@@ -1,0 +1,92 @@
+{
+  "acknowledged": {
+    "polylogue/sources/parsers/antigravity.py:_messages_from_markdown:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/antigravity.py:_messages_from_markdown:provider_message_id#1": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/base_support.py:extract_messages_from_list:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/chatgpt.py:extract_messages_from_mapping:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/claude/ai_parser.py:_design_assistant_messages:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/claude/ai_parser.py:_design_user_message:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/claude/code_parser.py:_parse_code_records:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/claude/code_parser.py:_parse_code_records:provider_message_id#1": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/claude/code_parser.py:_parse_code_records:provider_message_id#2": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/claude/common.py:normalize_chat_messages:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/codex.py:_code_mode_exec_envelopes:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/codex.py:_codex_event_message:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/codex.py:_codex_reasoning_message:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/codex.py:_codex_tool_message:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/codex.py:_codex_tool_message:provider_message_id#1": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/codex.py:_parse_records:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/codex.py:_parse_records:provider_message_id#1": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/drive.py:parse_chunked_prompt:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/grok.py:parse_conversation:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/grok.py:parse_conversation:provider_message_id#1": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/local_agent.py:_parse_gemini_message:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    },
+    "polylogue/sources/parsers/local_agent.py:_parse_hermes_message:provider_message_id": {
+      "reason": "Existing instance found during polylogue-ds4b4 item 3's preventive-lint audit; fixing message_identity_hash to exclude position-derived provider_message_id (the attachment_identity_hash-class fix) is tracked separately, not fixed inline here.",
+      "ref": "polylogue-gysk3"
+    }
+  }
+}

--- a/tests/unit/devtools/test_verify_position_derived_identity.py
+++ b/tests/unit/devtools/test_verify_position_derived_identity.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from devtools import verify_position_derived_identity as lint
+
+
+def test_scan_flags_inline_fstring_identity() -> None:
+    fixture_source = """
+def parse(records):
+    for index, record in enumerate(records):
+        provider_message_id = f"msg-{index}"
+"""
+    findings = lint._scan_module(fixture_source, rel_path="fixture.py")
+    assert len(findings) == 1
+    assert findings[0].field == "provider_message_id"
+    assert findings[0].qualname == "fixture.py:parse:provider_message_id"
+
+
+def test_scan_flags_keyword_argument_construction() -> None:
+    fixture_source = """
+def build(records):
+    for index, record in enumerate(records):
+        messages.append(ParsedMessage(provider_message_id=f"msg-{index}", role=role))
+"""
+    findings = lint._scan_module(fixture_source, rel_path="fixture.py")
+    assert len(findings) == 1
+
+
+def test_scan_follows_bare_name_to_local_binding() -> None:
+    """The dominant real-codebase shape: build a local var first (``msg_id =
+    ... or f"msg-{idx}"``), then pass the bare name as the identity kwarg a
+    few lines later (chatgpt.py/base_support.py/drive.py's actual shape)."""
+    fixture_source = """
+def build(records):
+    for idx, record in enumerate(records):
+        msg_id = record.get("id") or f"msg-{idx}"
+        messages.append(ParsedMessage(provider_message_id=msg_id, role=role))
+"""
+    findings = lint._scan_module(fixture_source, rel_path="fixture.py")
+    assert len(findings) == 1
+
+
+def test_scan_ignores_provider_native_identity() -> None:
+    """A real provider-native id (no index fallback at all) is not flagged."""
+    fixture_source = """
+def build(records):
+    for index, record in enumerate(records):
+        provider_message_id = record["uuid"]
+"""
+    assert lint._scan_module(fixture_source, rel_path="fixture.py") == []
+
+
+def test_scan_ignores_index_used_for_unrelated_purpose() -> None:
+    """An ``index`` variable used for something other than an in-scope
+    identity field name must not be flagged -- only IDENTITY_FIELD_NAMES
+    trips this lint."""
+    fixture_source = """
+def build(records):
+    for index, record in enumerate(records):
+        log.info(f"processing record {index}")
+        display_label = f"item-{index}"
+"""
+    assert lint._scan_module(fixture_source, rel_path="fixture.py") == []
+
+
+def test_scan_deduplicates_multiple_findings_in_one_function_with_ordinal() -> None:
+    fixture_source = """
+def build_a(records):
+    for index, record in enumerate(records):
+        provider_message_id = f"a-{index}"
+
+def build_a_second(records):
+    for index, record in enumerate(records):
+        provider_message_id = f"b-{index}"
+"""
+    findings = lint._scan_module(fixture_source, rel_path="fixture.py")
+    assert {f.qualname for f in findings} == {
+        "fixture.py:build_a:provider_message_id",
+        "fixture.py:build_a_second:provider_message_id",
+    }
+
+
+def test_real_parsers_directory_findings_are_all_acknowledged(capsys: pytest.CaptureFixture[str]) -> None:
+    """Every currently-known instance (polylogue-gysk3's tracked follow-up)
+    must be recorded in the committed manifest -- this is the regression
+    test that a NEW, unacknowledged occurrence would fail."""
+    assert lint.main(["--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["unacknowledged"] == []
+    assert payload["stale"] == []
+
+
+def test_main_reports_unacknowledged_finding_and_nonzero_exit(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake_finding = lint.PositionIdentityFinding(
+        qualname="fixture.py:build:provider_message_id",
+        path="fixture.py",
+        lineno=3,
+        field="provider_message_id",
+    )
+    monkeypatch.setattr(lint, "collect_position_derived_identity", lambda: {fake_finding.qualname: fake_finding})
+    monkeypatch.setattr(lint, "load_manifest", lambda: {})
+    assert lint.main(["--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert payload["unacknowledged"] == [fake_finding.qualname]
+
+
+def test_ack_validation_rejects_short_reason_and_bad_ref() -> None:
+    assert lint._validate_ack("too short", "polylogue-abcd") is not None
+    assert lint._validate_ack("a sufficiently long justification here", "not-a-valid-ref") is not None
+    assert lint._validate_ack("a sufficiently long justification here", "polylogue-abcd") is None
+    assert lint._validate_ack("a sufficiently long justification here", "#123") is None

--- a/tests/unit/devtools/test_verify_raw_payload_hash_purity.py
+++ b/tests/unit/devtools/test_verify_raw_payload_hash_purity.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from devtools import verify_raw_payload_hash_purity as lint
+
+
+def test_scan_flags_the_historical_codex_header_splice_pattern() -> None:
+    """polylogue-u19l's actual bug: a json-serialized header literal spliced
+    ahead of the captured payload before hashing/storing it."""
+    fixture_source = """
+def _append_payload_for_provider(path, source_name, payload):
+    session_meta = json_dumps({"type": "session_meta", "payload": {"id": identity}}).encode()
+    return session_meta + b"\\n" + payload
+"""
+    violations = lint.scan_source_for_payload_concatenation(fixture_source, path="fixture.py")
+    assert len(violations) == 1
+    assert violations[0].path == "fixture.py"
+    assert "concatenated" in violations[0].detail
+
+
+def test_scan_flags_reversed_operand_order() -> None:
+    """The captured reference can appear on either side of the ``+``."""
+    fixture_source = """
+def build(payload):
+    return payload + b"-trailer"
+"""
+    violations = lint.scan_source_for_payload_concatenation(fixture_source, path="fixture.py")
+    assert len(violations) == 1
+
+
+def test_scan_ignores_bare_reference_passthrough() -> None:
+    """The fixed shape: identity carried as a sidecar return value, payload
+    bytes returned untouched -- no concatenation at all."""
+    fixture_source = """
+def _append_payload_for_provider(path, source_name, payload):
+    identity = self._existing_provider_session_id(path)
+    return payload, identity
+"""
+    assert lint.scan_source_for_payload_concatenation(fixture_source, path="fixture.py") == []
+
+
+def test_scan_ignores_two_literals_joined() -> None:
+    """Two literals concatenated (e.g. building a fixed log-message prefix)
+    is not the splice-onto-captured-bytes hazard this lint targets."""
+    fixture_source = """
+def log_prefix():
+    return "codex_append_identity_resolved" + "_as_sidecar_hint"
+"""
+    assert lint.scan_source_for_payload_concatenation(fixture_source, path="fixture.py") == []
+
+
+def test_scan_ignores_two_references_joined() -> None:
+    """Two already-captured buffers joined together (not a synthesize-and-
+    splice) is not flagged."""
+    fixture_source = """
+def combine(prefix_bytes, tail_bytes):
+    return prefix_bytes + tail_bytes
+"""
+    assert lint.scan_source_for_payload_concatenation(fixture_source, path="fixture.py") == []
+
+
+def test_scan_flags_fstring_splice() -> None:
+    fixture_source = """
+def build(payload, identity):
+    return f"id:{identity}\\n".encode() + payload
+"""
+    violations = lint.scan_source_for_payload_concatenation(fixture_source, path="fixture.py")
+    assert len(violations) == 1
+
+
+def test_real_write_path_modules_currently_pass(capsys: pytest.CaptureFixture[str]) -> None:
+    """The real raw-capture write path (post polylogue-u19l fix, PR #3539)
+    must currently be clean -- this locks the fix in as a regression test."""
+    assert lint.main(["--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+    assert payload["violations"] == []
+    assert payload["modules_scanned"] == list(lint.WRITE_PATH_MODULES)
+
+
+def test_main_reports_violation_and_nonzero_exit(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        lint,
+        "_collect_write_path_violations",
+        lambda: [
+            lint.HashPurityViolation(
+                path="polylogue/sources/live/batch.py",
+                lineno=1,
+                col_offset=0,
+                detail="literal/serialized value concatenated onto a bare reference before hashing",
+            )
+        ],
+    )
+    assert lint.main(["--json"]) == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert len(payload["violations"]) == 1

--- a/tests/unit/sources/test_live_batch_support.py
+++ b/tests/unit/sources/test_live_batch_support.py
@@ -2069,6 +2069,89 @@ def test_live_append_chain_survives_post_ingest_compaction(
     assert cursor_record.byte_offset == len(payload) + sum(len(chunk) for chunk in append_chunks)
 
 
+def test_append_ingest_proves_byte_authority_at_capture_without_reconciler(tmp_path: Path) -> None:
+    """polylogue-ds4b4 item 1: the common append case must prove itself at
+    capture time, never deferring to the batch ``RawAuthorityReconciler``.
+
+    ``append_ingest.py``'s ``_ingest_append_plans_archive`` already resolves
+    the byte-contiguous predecessor via ``raw_append_revision_parent`` and,
+    once found, immediately classifies+applies the revision in the SAME
+    ingest call (``archive.classify_raw_revision_cohort`` /
+    ``apply_raw_revision_replay``) -- there is no code path where a normal,
+    single-predecessor append is left ``quarantined`` for a later async pass
+    to pick up. This test locks that invariant in: after one full capture
+    followed by one ordinary append, (a) the append's own raw row is
+    ``revision_authority='byte_proven'`` immediately, (b) the append's
+    content is already visible in ``index.db`` (``sessions``/``messages``)
+    before any convergence/reconciler pass has run, and (c) the heavier,
+    batch-oriented ``raw_authority_censuses`` bookkeeping table (owned by
+    ``RawAuthorityReconciler``, not this synchronous per-key classifier) has
+    zero rows -- proving the reconciler was never invoked for this raw.
+    """
+    root = tmp_path / "sessions"
+    root.mkdir()
+    path = root / "capture-proof.jsonl"
+    baseline = (
+        b'{"type":"session_meta","payload":{"id":"capture-proof","timestamp":"2026-06-02T00:00:00Z"}}\n'
+        b'{"type":"response_item","payload":{"type":"message","id":"message-0","role":"user",'
+        b'"content":[{"type":"input_text","text":"zero"}]}}\n'
+    )
+    path.write_bytes(baseline)
+    index_db = tmp_path / "index.db"
+    source_db = tmp_path / "source.db"
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+    from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+    initialize_archive_database(index_db, ArchiveTier.INDEX)
+    initialize_archive_database(source_db, ArchiveTier.SOURCE)
+    cursor = CursorStore(index_db)
+    processor = LiveBatchProcessor(
+        cast(Any, SimpleNamespace(archive_root=tmp_path, backend=SimpleNamespace(db_path=index_db))),
+        (WatchSource(name="codex", root=root),),
+        cursor=cursor,
+        parser_fingerprint="test-parser",
+    )
+    baseline_result = asyncio.run(processor.ingest_files([path]))
+    assert baseline_result.succeeded_file_count == 1
+
+    append_chunk = (
+        b'{"type":"response_item","payload":{"type":"message","id":"message-1","role":"assistant",'
+        b'"content":[{"type":"output_text","text":"one"}]}}\n'
+    )
+    with path.open("ab") as handle:
+        handle.write(append_chunk)
+    append_result = asyncio.run(processor.ingest_files([path]))
+
+    assert append_result.append_file_count == 1
+    assert append_result.succeeded_file_count == 1
+    assert append_result.failed_file_count == 0
+
+    with sqlite3.connect(source_db) as conn:
+        append_row = conn.execute(
+            "SELECT revision_kind, revision_authority, parsed_at_ms, parse_error "
+            "FROM raw_sessions WHERE revision_kind = 'append'"
+        ).fetchone()
+        assert append_row is not None
+        assert append_row[0] == "append"
+        # Proven synchronously, at capture time -- not left 'quarantined'
+        # for a later reconciler pass to resolve.
+        assert append_row[1] == "byte_proven"
+        assert append_row[2] is not None
+        assert append_row[3] is None
+        # The heavy batch census/plan/blocker ledger belongs to the
+        # separate, async RawAuthorityReconciler (daemon convergence /
+        # offline backfill). A normal single-predecessor append must never
+        # touch it.
+        assert conn.execute("SELECT COUNT(*) FROM raw_authority_censuses").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM raw_authority_blockers").fetchone()[0] == 0
+
+    with sqlite3.connect(index_db) as conn:
+        assert {str(row[0]) for row in conn.execute("SELECT native_id FROM messages")} == {
+            "message-0",
+            "message-1",
+        }
+
+
 def test_full_ingest_cursor_hands_off_captured_prefix_after_growth_during_proof(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

Delivers polylogue-ds4b4 (raw-authority redesign Phase 3): a regression test proving raw authority is already proven at capture time for the common append case, a lab-policy lint generalizing the u19l Codex-header byte-mutation fix into a standing guard, and a preventive lint against position-derived synthetic identity in parsers.

## Problem

polylogue-ds4b4 asked for three things:

1. Prove raw authority at capture time instead of deferring to the async reconciler, at least for the common case.
2. Generalize the u19l fix (Codex append captures used to splice a synthetic `session_meta` header onto captured bytes before hashing, permanently defeating live-source byte-identity verification for ~59GB of raw rows) into a standing regression guard, not just a one-off fix.
3. Add a schema-lint rule flagging position-derived synthetic identity in parser code, checking existing parsers for a concrete instance first.

## Solution

**Item 1 -- already implemented, now locked in by a test.** `append_ingest.py`'s `_ingest_append_plans_archive` resolves the byte-contiguous predecessor via `raw_append_revision_parent` and, once found, classifies+applies the revision synchronously in the same ingest call (`archive.classify_raw_revision_cohort` / `apply_raw_revision_replay`) -- there is no code path where a normal single-predecessor append is left `quarantined` for `RawAuthorityReconciler` to pick up later. `test_append_ingest_proves_byte_authority_at_capture_without_reconciler` (`tests/unit/sources/test_live_batch_support.py`) proves: the append raw is `revision_authority='byte_proven'` immediately, its content is already in `index.db`, and the heavy `raw_authority_censuses`/`raw_authority_blockers` tables (owned by the async reconciler) have zero rows.

**Item 2 -- `devtools/verify_raw_payload_hash_purity.py`.** An AST lint over the raw-capture write-path modules (`sources/live/batch.py`, `batch_support.py`, `append_ingest.py`, the pipeline ingest/acquisition modules, `archive_tiers/{archive,revision_governance}.py`) forbidding the exact shape that produced u19l's bug: a synthesized literal (bytes/str constant, f-string, `json.dumps()`/`.encode()` result) concatenated onto a bare reference before it reaches the content hasher. Confirmed it flags a fixture reproducing the historical bug and passes clean against the current (fixed) code. No ack mechanism -- there is no legitimate exception on this write path. Wired into `devtools lab policy raw-payload-hash-purity` and `devtools verify --quick`/`--lab`.

**Item 3 -- `devtools/verify_position_derived_identity.py`.** Investigated existing parsers first (per the bead's instruction) and found a live, unfixed sibling of the already-fixed polylogue-hith/qkuq attachment-id bug: `message_identity_hash` (`polylogue/pipeline/ids.py`) hashes `provider_message_id` directly, and multiple parsers construct that id as `f"msg-{index}"` when no provider-native id exists -- unstable across export vintages that reorder entries, the identical hazard class hith/qkuq already fixed for attachments. Filed as **polylogue-gysk3** (fixing every existing instance reworks a core identity function used archive-wide -- separate, higher-risk follow-on, not rushed into this PR per the bead's own conservative-scope instruction). Shipped the preventive lint: an AST scan of `polylogue/sources/parsers/` flagging new position-derived `provider_message_id` construction (inline or via a local variable, following the dominant `msg_id = ... or f"msg-{idx}"` shape), with an ack-manifest (`docs/plans/position-derived-identity-acks.json`) recording the 22 currently-known instances against polylogue-gysk3. Wired into `devtools lab policy position-derived-identity` and `devtools verify --quick`/`--lab`.

Item 4 (blob-GC invariant verification against Phase 2's verdict vocabulary) is explicitly blocked on polylogue-w6hql (Phase 2, not yet started) and is not attempted here.

## Verification

```
devtools test tests/unit/devtools/test_verify_position_derived_identity.py \
  tests/unit/devtools/test_verify_raw_payload_hash_purity.py \
  tests/unit/sources/test_live_batch_support.py \
  -k "not (test_full_ingest_skips_durably_excised_content_without_aborting_batch or test_append_multi_session_payload_is_rejected_before_index_write or test_full_ingest_writes_archive_with_route_observability)"
# 91 passed
```

The 3 excluded tests are pre-existing order/parallelism-dependent flakes, confirmed to reproduce identically against this branch's base with the new files removed (`git stash`) -- unrelated to this change, and the exact set PR #3539 already documented as pre-existing.

```
devtools verify --quick
# exit 0 -- format, lint, mypy --strict, render all --check, all lab policy
# checks including the two new ones (raw-payload-hash-purity,
# position-derived-identity)
```

Ref polylogue-ds4b4, polylogue-lb39z, polylogue-u19l, polylogue-hith

🤖 Generated with [Claude Code](https://claude.com/claude-code)