### PR TITLE
fix(devtools): wire lab-policy gates into the live CI, not just build_verify_steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,29 @@ version: 2.1
 # CircleCI free-tier CI while GitHub Actions is billing-locked (and a cheap
 # second opinion afterwards). Credit budget: ~30k credits/month on the free
 # plan. Design keeps the per-push cost low and the heavy work nightly:
-#   - quick-gate (PRs + master pushes): generated-surface check, public
-#     claims, ruff, mypy. No pytest — mirrors `devtools verify --quick`
-#     semantics; the test suite's pre-merge gate remains local `devtools
-#     verify` (testmon), same as the repo's GitHub-era policy where the
-#     heavy suite ran post-merge only.
-#   - nightly (scheduled pipeline named "nightly"): full coverage suite +
-#     dependency audit + distribution verify on a larger executor.
+#   - quick-gate (PRs + master pushes): public claims + `devtools verify
+#     --quick` itself (not a hand-picked subset of its steps -- see
+#     polylogue-ze5i: this job used to reimplement ruff/mypy/render-all as
+#     separate `run` steps and silently diverged from what
+#     devtools/verify.py's `if not commit:` block actually gates, so
+#     schema-versioning/classifier-fingerprints/demo-tour-freshness and
+#     every other check added to that block over time never ran in real CI
+#     even though `.github/workflows/ci.yml` referenced them -- that GHA
+#     workflow does not execute, only CircleCI does). No pytest; the test
+#     suite's pre-merge gate remains local `devtools verify` (testmon), same
+#     as the repo's GitHub-era policy where the heavy suite ran post-merge
+#     only.
+#   - lab-policies (scheduled pipeline named "nightly"): the `lab policy *`
+#     checks that stay --lab-only because they scan the whole Beads/backlog
+#     corpus rather than the current diff (backlog-hygiene, bead-graph) or
+#     are otherwise not cheap/deterministic enough for every push
+#     (timestamp-doctrine, insight-honesty, demo-packet-registry, docs-drift,
+#     campaign-archive-boundaries). Runs nightly so a policy that fails
+#     continuously is at least visible somewhere, per polylogue-ze5i AC2,
+#     instead of only reachable via a human remembering `devtools verify
+#     --lab`.
+#   - full-suite (scheduled pipeline named "nightly"): full coverage suite +
+#     dependency audit on a larger executor.
 #   - release-verify (v* tags): build artifacts and store them.
 # Operator setup (one-time, UI): Project Settings → Advanced → "Only build
 # pull requests" ON; add a scheduled pipeline named "nightly" (master,
@@ -53,24 +69,58 @@ jobs:
             - mypy-v1-master
             - mypy-v1-
       - run:
-          name: Generated surfaces in sync
-          command: ~/.local/bin/uv run devtools render all --check
-      - run:
           name: Public claims gate
           command: ~/.local/bin/uv run devtools verify public-claims --json
       - run:
-          name: Ruff lint
-          command: ~/.local/bin/uv run ruff check polylogue/ tests/ devtools/
-      - run:
-          name: Ruff format
-          command: ~/.local/bin/uv run ruff format --check polylogue/ tests/ devtools/
-      - run:
-          name: Mypy (strict)
-          command: ~/.local/bin/uv run mypy polylogue/
+          name: devtools verify --quick
+          command: ~/.local/bin/uv run devtools verify --quick
       - save_cache:
           key: mypy-v1-{{ .Branch }}-{{ epoch }}
           paths:
             - .mypy_cache
+
+  lab-policies:
+    docker:
+      - image: cimg/python:3.13
+    resource_class: medium
+    environment: *polylogue_ci_env
+    steps:
+      - bootstrap
+      # Each currently-red check runs with `when: always` so one failure
+      # doesn't hide the pass/fail signal of the others in the same job --
+      # backlog-hygiene and bead-graph are known-red until the pre-existing
+      # backlog debt they report is triaged (tracked separately; see
+      # polylogue-ze5i notes), and that must not mask a genuine regression
+      # in timestamp-doctrine/insight-honesty/demo-packet-registry/
+      # docs-drift/campaign-archive-boundaries going unnoticed.
+      - run:
+          name: lab policy timestamp-doctrine
+          command: ~/.local/bin/uv run devtools lab policy timestamp-doctrine
+          when: always
+      - run:
+          name: lab policy insight-honesty
+          command: ~/.local/bin/uv run devtools lab policy insight-honesty
+          when: always
+      - run:
+          name: lab policy demo-packet-registry
+          command: ~/.local/bin/uv run devtools lab policy demo-packet-registry
+          when: always
+      - run:
+          name: lab policy docs-drift
+          command: ~/.local/bin/uv run devtools lab policy docs-drift
+          when: always
+      - run:
+          name: lab policy campaign-archive-boundaries
+          command: ~/.local/bin/uv run devtools lab policy campaign-archive-boundaries
+          when: always
+      - run:
+          name: lab policy backlog-hygiene (known backlog debt, see polylogue-ze5i)
+          command: ~/.local/bin/uv run devtools lab policy backlog-hygiene
+          when: always
+      - run:
+          name: lab policy bead-graph (known backlog debt, see polylogue-ze5i)
+          command: ~/.local/bin/uv run devtools lab policy bead-graph
+          when: always
 
   full-suite:
     docker:
@@ -131,3 +181,4 @@ workflows:
         - equal: [nightly, << pipeline.schedule.name >>]
     jobs:
       - full-suite
+      - lab-policies

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -1786,6 +1786,16 @@ def build_verify_steps(
                 # concrete case that shipped green against the version-keyed
                 # gate above).
                 ("lab policy classifier-fingerprints", _devtools_cmd("lab policy classifier-fingerprints")),
+                # ~15-30s, fully deterministic (wall-clock timing is masked
+                # before comparison, see devtools/verify_demo_tour_freshness.py).
+                # Unlike backlog-hygiene/bead-graph below, this check's failure
+                # count does not scale with total backlog/bead-corpus size --
+                # it is a fixed-cost diff against one committed fixture that
+                # only drifts when demo/insight code actually changes shape
+                # (polylogue-ze5i: moved out of --lab after the committed
+                # fixture was regenerated to match a `healed_tiers` field the
+                # demo receipts code had already grown).
+                ("lab policy demo-tour-freshness", _devtools_cmd("lab policy demo-tour-freshness")),
                 # Publication gate. Committed provider schema packages are
                 # public artifacts; this blocks local provenance
                 # (bundle_scopes/representative_paths) and scans for secrets.
@@ -1883,12 +1893,22 @@ def build_verify_steps(
         steps.append(("lab policy timestamp-doctrine", _devtools_cmd("lab policy timestamp-doctrine")))
         steps.append(("lab policy insight-honesty", _devtools_cmd("lab policy insight-honesty")))
         steps.append(("lab policy demo-packet-registry", _devtools_cmd("lab policy demo-packet-registry")))
-        steps.append(("lab policy demo-tour-freshness", _devtools_cmd("lab policy demo-tour-freshness")))
         steps.append(("lab policy docs-drift", _devtools_cmd("lab policy docs-drift")))
-        steps.append(("lab policy backlog-hygiene", _devtools_cmd("lab policy backlog-hygiene")))
         steps.append(
             ("lab policy campaign-archive-boundaries", _devtools_cmd("lab policy campaign-archive-boundaries"))
         )
+        # backlog-hygiene and bead-graph are corpus-wide backlog-debt scans
+        # (findings scale with the total count of open Beads issues, not
+        # with this change's diff) -- they stay --lab-only/scheduled rather
+        # than default- or CI-gated. Gating either on a merge would block
+        # every PR in the repo until the entire pre-existing backlog is
+        # cleaned up (485 backlog-hygiene findings / 225 missing-AC beads
+        # measured 2026-08-02), which is periodic hygiene debt, not a
+        # per-change regression signal. Wired into the CircleCI nightly
+        # schedule instead (polylogue-ze5i) so continuous failure is at
+        # least visible, and the backlog itself is tracked by follow-up
+        # beads rather than left to rot silently.
+        steps.append(("lab policy backlog-hygiene", _devtools_cmd("lab policy backlog-hygiene")))
         steps.append(("lab policy bead-graph", _devtools_cmd("lab policy bead-graph")))
     return steps
 

--- a/docs/examples/demo-tour/command-output/01-claim-versus-receipt.txt
+++ b/docs/examples/demo-tour/command-output/01-claim-versus-receipt.txt
@@ -29,7 +29,7 @@ source material:
   blob_sha256: 9fd0dbdb080058070935924534a903cc63a8dcba571f6b2734f92a96576b59d7
 
 completion-claim experiment:
-  sample manifest: 1ac82163253902faf5578dafcbddfb99ea1f4fe170397613520b713a0688bc25
+  sample manifest: b0e1b4cf11bd3f10c1dd8953e7b3a48eb1a9ab5fcc9992d3eabda85f69fef0a0
   denominator: 2
 unsupported by structural evidence: 0 (0.0%)
 neutral prior outcome: 0 (0.0%)

--- a/docs/examples/demo-tour/command-output/01-claim-versus-receipt.txt
+++ b/docs/examples/demo-tour/command-output/01-claim-versus-receipt.txt
@@ -29,7 +29,7 @@ source material:
   blob_sha256: 9fd0dbdb080058070935924534a903cc63a8dcba571f6b2734f92a96576b59d7
 
 completion-claim experiment:
-  sample manifest: b0e1b4cf11bd3f10c1dd8953e7b3a48eb1a9ab5fcc9992d3eabda85f69fef0a0
+  sample manifest: 7bb101310d6665b8b501c788667b50b4fcec5bf0eae2ccf90aec364c0ce2732a
   denominator: 2
 unsupported by structural evidence: 0 (0.0%)
 neutral prior outcome: 0 (0.0%)

--- a/docs/examples/demo-tour/report.json
+++ b/docs/examples/demo-tour/report.json
@@ -28,7 +28,7 @@
     "result": "pass",
     "triggered": false
   },
-  "first_result_s": 8.54,
+  "first_result_s": 2.284,
   "non_claims": [
     "The deterministic tour does not establish field prevalence, production scale, or provider completeness.",
     "The deterministic tour does not establish memory uplift, invoice accuracy, selective deletion, or the Sinex backend.",
@@ -350,6 +350,7 @@
         "ok": true
       }
     ],
+    "healed_tiers": [],
     "message_count": 71,
     "overlays_seeded": true,
     "session_count": 19,
@@ -384,7 +385,7 @@
         "demo",
         "receipts"
       ],
-      "duration_s": 2.44,
+      "duration_s": 2.284,
       "exit_code": 0,
       "name": "claim versus receipt",
       "output_path": "command-output/01-claim-versus-receipt.txt"
@@ -395,7 +396,7 @@
         "polylogue",
         "actions where is_error:true | group by tool | count"
       ],
-      "duration_s": 2.767,
+      "duration_s": 3.266,
       "exit_code": 0,
       "name": "failed actions aggregate",
       "output_path": "command-output/02-failed-actions-aggregate.txt"
@@ -410,7 +411,7 @@
         "--view",
         "chronicle"
       ],
-      "duration_s": 2.826,
+      "duration_s": 2.776,
       "exit_code": 0,
       "name": "composed lineage",
       "output_path": "command-output/03-composed-lineage.txt"
@@ -422,13 +423,13 @@
         "analyze",
         "--facets"
       ],
-      "duration_s": 2.73,
+      "duration_s": 2.88,
       "exit_code": 0,
       "name": "archive facets",
       "output_path": "command-output/04-archive-facets.txt"
     }
   ],
-  "total_duration_s": 16.865,
+  "total_duration_s": 17.456,
   "transcript_path": "transcript.txt",
   "verify": {
     "absolute_path_leaks": [],

--- a/docs/examples/demo-tour/report.json
+++ b/docs/examples/demo-tour/report.json
@@ -28,7 +28,7 @@
     "result": "pass",
     "triggered": false
   },
-  "first_result_s": 2.284,
+  "first_result_s": 3.165,
   "non_claims": [
     "The deterministic tour does not establish field prevalence, production scale, or provider completeness.",
     "The deterministic tour does not establish memory uplift, invoice accuracy, selective deletion, or the Sinex backend.",
@@ -385,7 +385,7 @@
         "demo",
         "receipts"
       ],
-      "duration_s": 2.284,
+      "duration_s": 3.164,
       "exit_code": 0,
       "name": "claim versus receipt",
       "output_path": "command-output/01-claim-versus-receipt.txt"
@@ -396,7 +396,7 @@
         "polylogue",
         "actions where is_error:true | group by tool | count"
       ],
-      "duration_s": 3.266,
+      "duration_s": 3.281,
       "exit_code": 0,
       "name": "failed actions aggregate",
       "output_path": "command-output/02-failed-actions-aggregate.txt"
@@ -411,7 +411,7 @@
         "--view",
         "chronicle"
       ],
-      "duration_s": 2.776,
+      "duration_s": 2.451,
       "exit_code": 0,
       "name": "composed lineage",
       "output_path": "command-output/03-composed-lineage.txt"
@@ -423,13 +423,13 @@
         "analyze",
         "--facets"
       ],
-      "duration_s": 2.88,
+      "duration_s": 2.358,
       "exit_code": 0,
       "name": "archive facets",
       "output_path": "command-output/04-archive-facets.txt"
     }
   ],
-  "total_duration_s": 17.456,
+  "total_duration_s": 13.532,
   "transcript_path": "transcript.txt",
   "verify": {
     "absolute_path_leaks": [],

--- a/docs/examples/demo-tour/report.md
+++ b/docs/examples/demo-tour/report.md
@@ -40,8 +40,8 @@ The semantic fixture verifier runs before the narrated commands and checks plant
 
 ## Timings
 
-- First evidence result: 8.540s (budget 30s)
-- Full tour: 16.865s (budget 420s)
+- First evidence result: 2.284s (budget 30s)
+- Full tour: 17.456s (budget 420s)
 
 ## Archive
 
@@ -55,10 +55,10 @@ The semantic fixture verifier runs before the narrated commands and checks plant
 
 | Step | Exit | Duration | Bytes | Output |
 | --- | ---: | ---: | ---: | --- |
-| claim versus receipt | 0 | 2.440s | 1399 | `command-output/01-claim-versus-receipt.txt` |
-| failed actions aggregate | 0 | 2.767s | 62 | `command-output/02-failed-actions-aggregate.txt` |
-| composed lineage | 0 | 2.826s | 936 | `command-output/03-composed-lineage.txt` |
-| archive facets | 0 | 2.730s | 1652 | `command-output/04-archive-facets.txt` |
+| claim versus receipt | 0 | 2.284s | 1399 | `command-output/01-claim-versus-receipt.txt` |
+| failed actions aggregate | 0 | 3.266s | 62 | `command-output/02-failed-actions-aggregate.txt` |
+| composed lineage | 0 | 2.776s | 936 | `command-output/03-composed-lineage.txt` |
+| archive facets | 0 | 2.880s | 1652 | `command-output/04-archive-facets.txt` |
 
 ## Problems
 

--- a/docs/examples/demo-tour/report.md
+++ b/docs/examples/demo-tour/report.md
@@ -40,8 +40,8 @@ The semantic fixture verifier runs before the narrated commands and checks plant
 
 ## Timings
 
-- First evidence result: 2.284s (budget 30s)
-- Full tour: 17.456s (budget 420s)
+- First evidence result: 3.165s (budget 30s)
+- Full tour: 13.532s (budget 420s)
 
 ## Archive
 
@@ -55,10 +55,10 @@ The semantic fixture verifier runs before the narrated commands and checks plant
 
 | Step | Exit | Duration | Bytes | Output |
 | --- | ---: | ---: | ---: | --- |
-| claim versus receipt | 0 | 2.284s | 1399 | `command-output/01-claim-versus-receipt.txt` |
-| failed actions aggregate | 0 | 3.266s | 62 | `command-output/02-failed-actions-aggregate.txt` |
-| composed lineage | 0 | 2.776s | 936 | `command-output/03-composed-lineage.txt` |
-| archive facets | 0 | 2.880s | 1652 | `command-output/04-archive-facets.txt` |
+| claim versus receipt | 0 | 3.164s | 1399 | `command-output/01-claim-versus-receipt.txt` |
+| failed actions aggregate | 0 | 3.281s | 62 | `command-output/02-failed-actions-aggregate.txt` |
+| composed lineage | 0 | 2.451s | 936 | `command-output/03-composed-lineage.txt` |
+| archive facets | 0 | 2.358s | 1652 | `command-output/04-archive-facets.txt` |
 
 ## Problems
 

--- a/docs/examples/demo-tour/transcript.txt
+++ b/docs/examples/demo-tour/transcript.txt
@@ -1,12 +1,12 @@
 # prepare deterministic proof archive
-Seeded 19 sessions, 71 messages, and 8 user-state assertions in 6.084s. Fixture audit: 40/40 declared constructs satisfied.
+Seeded 19 sessions, 71 messages, and 8 user-state assertions in 6.232s. Fixture audit: 40/40 declared constructs satisfied.
 
 # verify evidence before presenting it
-Verification passed in 0.016s; 0 path leaks and 0 semantic problems. The complete fixture and verification audit remains in report.json.
+Verification passed in 0.019s; 0 path leaks and 0 semantic problems. The complete fixture and verification audit remains in report.json.
 
 $ polylogue demo receipts
 Start with a falsifiable disagreement: assistant prose claims the tests pass, while the provider-normalized tool result says exit 1. A later run repairs the result, and a prose-only 'error' control demonstrates why keyword matching is not the oracle.
-exit=0 duration=2.440s bytes=1399
+exit=0 duration=2.284s bytes=1399
 Polylogue evidence receipt
 archive: <demo-archive>
 verdict: contradicted_at_claim_time_then_repaired
@@ -38,7 +38,7 @@ source material:
   blob_sha256: 9fd0dbdb080058070935924534a903cc63a8dcba571f6b2734f92a96576b59d7
 
 completion-claim experiment:
-  sample manifest: 1ac82163253902faf5578dafcbddfb99ea1f4fe170397613520b713a0688bc25
+  sample manifest: b0e1b4cf11bd3f10c1dd8953e7b3a48eb1a9ab5fcc9992d3eabda85f69fef0a0
   denominator: 2
 unsupported by structural evidence: 0 (0.0%)
 neutral prior outcome: 0 (0.0%)
@@ -47,14 +47,14 @@ contradicted without recorded repair: 1 (50.0%)
 
 $ polylogue 'actions where is_error:true | group by tool | count'
 Now aggregate the same structural field across providers. This query counts normalized failed actions; it does not search prose for the word 'error'.
-exit=0 duration=2.767s bytes=62
+exit=0 duration=3.266s bytes=62
 tool=Bash count=4
 tool=exec_command count=2
 tool=Edit count=1
 
 $ polylogue --id codex-session:demo-lineage-fork read --view chronicle
 Read a fork as one logical chronicle: inherited parent messages remain attributable to their origin while the fork contributes only its divergent tail.
-exit=0 duration=2.826s bytes=936
+exit=0 duration=2.776s bytes=936
 # Session Chronicle
 
 - Sessions: 1
@@ -101,7 +101,7 @@ _No distinct matching prose in the last edge._
 
 $ polylogue analyze --facets
 Only after inspecting evidence, zoom out to the archive across 8 origins, with deferred families labeled rather than silently guessed.
-exit=0 duration=2.730s bytes=1652
+exit=0 duration=2.880s bytes=1652
 Facets (global) — matched result set:
   readiness: ready (cost_class=cheap; budget 0.01s/2.00s)
   sessions: 19  messages: 71

--- a/docs/examples/demo-tour/transcript.txt
+++ b/docs/examples/demo-tour/transcript.txt
@@ -1,12 +1,12 @@
 # prepare deterministic proof archive
-Seeded 19 sessions, 71 messages, and 8 user-state assertions in 6.232s. Fixture audit: 40/40 declared constructs satisfied.
+Seeded 19 sessions, 71 messages, and 8 user-state assertions in 2.245s. Fixture audit: 40/40 declared constructs satisfied.
 
 # verify evidence before presenting it
-Verification passed in 0.019s; 0 path leaks and 0 semantic problems. The complete fixture and verification audit remains in report.json.
+Verification passed in 0.032s; 0 path leaks and 0 semantic problems. The complete fixture and verification audit remains in report.json.
 
 $ polylogue demo receipts
 Start with a falsifiable disagreement: assistant prose claims the tests pass, while the provider-normalized tool result says exit 1. A later run repairs the result, and a prose-only 'error' control demonstrates why keyword matching is not the oracle.
-exit=0 duration=2.284s bytes=1399
+exit=0 duration=3.164s bytes=1399
 Polylogue evidence receipt
 archive: <demo-archive>
 verdict: contradicted_at_claim_time_then_repaired
@@ -38,7 +38,7 @@ source material:
   blob_sha256: 9fd0dbdb080058070935924534a903cc63a8dcba571f6b2734f92a96576b59d7
 
 completion-claim experiment:
-  sample manifest: b0e1b4cf11bd3f10c1dd8953e7b3a48eb1a9ab5fcc9992d3eabda85f69fef0a0
+  sample manifest: 7bb101310d6665b8b501c788667b50b4fcec5bf0eae2ccf90aec364c0ce2732a
   denominator: 2
 unsupported by structural evidence: 0 (0.0%)
 neutral prior outcome: 0 (0.0%)
@@ -47,14 +47,14 @@ contradicted without recorded repair: 1 (50.0%)
 
 $ polylogue 'actions where is_error:true | group by tool | count'
 Now aggregate the same structural field across providers. This query counts normalized failed actions; it does not search prose for the word 'error'.
-exit=0 duration=3.266s bytes=62
+exit=0 duration=3.281s bytes=62
 tool=Bash count=4
 tool=exec_command count=2
 tool=Edit count=1
 
 $ polylogue --id codex-session:demo-lineage-fork read --view chronicle
 Read a fork as one logical chronicle: inherited parent messages remain attributable to their origin while the fork contributes only its divergent tail.
-exit=0 duration=2.776s bytes=936
+exit=0 duration=2.451s bytes=936
 # Session Chronicle
 
 - Sessions: 1
@@ -101,7 +101,7 @@ _No distinct matching prose in the last edge._
 
 $ polylogue analyze --facets
 Only after inspecting evidence, zoom out to the archive across 8 origins, with deferred families labeled rather than silently guessed.
-exit=0 duration=2.880s bytes=1652
+exit=0 duration=2.358s bytes=1652
 Facets (global) — matched result set:
   readiness: ready (cost_class=cheap; budget 0.01s/2.00s)
   sessions: 19  messages: 71

--- a/tests/unit/devtools/test_verify.py
+++ b/tests/unit/devtools/test_verify.py
@@ -96,6 +96,8 @@ def test_quick_verify_omits_pytest() -> None:
         "verify degrade-loudly",
         "verify hash-boundary-census",
         "lab policy schema-versioning",
+        "lab policy classifier-fingerprints",
+        "lab policy demo-tour-freshness",
         "schema promotion audit",
     ]
 


### PR DESCRIPTION
## Summary

Closes the gate-placement question in polylogue-ze5i for all 10 `devtools lab policy *` checks. Promotes `demo-tour-freshness` (previously red) into the default verify gate alongside `schema-versioning`/`classifier-fingerprints`, fixes CircleCI's `quick-gate` job so it actually runs that gate instead of a stale hand-picked subset, and wires the remaining 7 `--lab`-only checks into a new nightly CircleCI job so a continuously-failing policy is at least visible.

## Problem

Measured 2026-07-28 (polylogue-ze5i): schema-versioning, demo-tour-freshness, backlog-hygiene, and bead-graph all sat behind `devtools verify --lab`, which no standing gate runs. A migration-number collision (PR #3566/#3568) made the live archive briefly unqueryable and was only caught by hand afterward (PR #3573).

A prior session moved `schema-versioning` (and `classifier-fingerprints`) out of `--lab` into `devtools/verify.py`'s default `if not commit:` block. But investigating further this session found that promotion was hollow in practice: CircleCI's `quick-gate` job -- the only CI that actually runs in this repo (GitHub Actions is billing-locked/dark; `.github/workflows/ci.yml` references `schema-versioning` but does not execute) -- hand-picked five discrete steps (`render all --check`, `public-claims`, ruff, mypy) instead of calling `devtools verify --quick`. None of `verify topology`/`verify layering`/`schema-versioning`/`classifier-fingerprints`/`schema promotion audit`/etc. (~17 steps total) ever ran in live CI.

`demo-tour-freshness` itself was red: the committed `docs/examples/demo-tour/` fixture was missing a `healed_tiers` key the demo receipts code had already grown.

## Solution

- `devtools/verify.py`: moved `lab policy demo-tour-freshness` from the `if lab:` block into the default `if not commit:` block, with a comment on why it's safe to gate every push (deterministic -- wall-clock timing already masked before comparison -- and fixed-cost against one committed fixture, unlike the corpus-scanning `backlog-hygiene`/`bead-graph`). Added an explanatory comment on why those two stay `--lab`-only.
- `docs/examples/demo-tour/`: regenerated via `polylogue demo tour --out-dir polylogue-demo-tour --force` and copied the fresh evidence in, fixing the drift.
- `.circleci/config.yml`: replaced `quick-gate`'s four hand-picked steps with a single `devtools verify --quick` call (public-claims stays separate since it isn't part of that block) -- this self-heals going forward, since any future addition to `build_verify_steps`' default block is automatically covered without a matching CircleCI edit. Added a `lab-policies` job wired into the existing nightly scheduled workflow, running the 7 checks that remain intentionally `--lab`-only (`timestamp-doctrine`, `insight-honesty`, `demo-packet-registry`, `docs-drift`, `campaign-archive-boundaries`, `backlog-hygiene`, `bead-graph`), each step using `when: always` so the two known-red corpus-scan checks don't mask a regression in the other five.
- `tests/unit/devtools/test_verify.py`: fixed `test_quick_verify_omits_pytest`'s hardcoded step list, which was already failing on master before this change (missing `classifier-fingerprints`, added in an earlier PR without a matching test update).
- Filed polylogue-2bp5f (485 backlog-hygiene findings) and polylogue-83nhi (225 beads missing acceptance criteria) to track the corpus-wide debt those two checks report, since fixing it is out of scope for a gate-placement change.
- Closed polylogue-ze5i with the full per-policy classification table and rationale.

## Verification

- `devtools test tests/unit/devtools/test_verify.py` -- 88 passed.
- `devtools verify --quick` -- green end-to-end, ~90-105s total.
- Anti-vacuity: reintroduced the exact migration-number-collision shape (`INDEX_SCHEMA_VERSION` bump with no `lifecycle.py` delta declaration) and confirmed `devtools verify --quick` -- the exact command now wired into CircleCI's `quick-gate` -- fails with `Policy violation: each index schema bump needs a declared delta class`; reverted.
- Anti-vacuity: injected drift into `docs/examples/demo-tour/report.json` and confirmed `devtools lab policy demo-tour-freshness` catches it; reverted.
- `python -c "import yaml; yaml.safe_load(open('.circleci/config.yml'))"` parses cleanly; `devtools verify ci-workflows` passes (one pre-existing, unrelated warning on `.github/workflows/ci.yml`, not touched here).

Not run: the actual CircleCI pipeline (can't trigger from here) -- verified locally that the exact command it now calls (`devtools verify --quick`) behaves as claimed.

Ref polylogue-ze5i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Verification now includes additional policy checks, improving detection of stale demo content and classification issues.
  - Nightly validation now covers the complete policy-check suite, including known backlog items.

- **Documentation**
  - Refreshed demo-tour examples with current manifest identifiers, timing data, output sizes, and report metadata.
  - Updated recorded transcripts and reports while preserving command results and exit statuses.

- **Tests**
  - Updated verification expectations to reflect the expanded quick-check coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->