### PR TITLE
feat(storage): add a read surface for web_content_constructs

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -300,9 +300,10 @@ Usage: polylogue read [OPTIONS] [REF]
 Projection:
   -v, --view VIEW[,VIEW...]       What to render (summary, transcript,
                                   dialogue, messages, raw, hooks, events,
-                                  file-edits, agent-policies, context,
-                                  context-image, neighbors, correlation,
-                                  temporal, chronicle).  [default: summary]
+                                  file-edits, agent-policies, web-content,
+                                  context, context-image, neighbors,
+                                  correlation, temporal, chronicle).
+                                  [default: summary]
   --render TEXT                   Render expression, e.g. layout:context-
                                   image,timestamps:include-
                                   available,format:markdown. Known keys:

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -70,7 +70,7 @@ files:
     owner: stable
     cross_cut: { api: async }
   - path: polylogue/api/archive.py
-    loc: 7347
+    loc: 7404
     target: polylogue/api/archive.py
     owner: stable
     cross_cut: { api: async }
@@ -731,7 +731,7 @@ files:
     owner: archive-viewport
     reason: archive-domain semantics
   - path: polylogue/archive/viewport/profiles.py
-    loc: 418
+    loc: 446
     target: polylogue/archive/viewport/profiles.py
     owner: archive-viewport
     reason: archive-domain semantics
@@ -1031,7 +1031,7 @@ files:
     target: polylogue/cli/commands/scan_secrets.py
     owner: stable
   - path: polylogue/cli/commands/status.py
-    loc: 2428
+    loc: 2433
     target: polylogue/cli/commands/status.py
     owner: stable
   - path: polylogue/cli/commands/status_diagnostics.py
@@ -1059,7 +1059,7 @@ files:
     target: polylogue/cli/machine_main.py
     owner: stable
   - path: polylogue/cli/messages.py
-    loc: 382
+    loc: 431
     target: polylogue/cli/messages.py
     owner: stable
   - path: polylogue/cli/onboarding.py
@@ -1119,11 +1119,11 @@ files:
     target: polylogue/cli/query_verbs.py
     owner: stable
   - path: polylogue/cli/read_view_handlers.py
-    loc: 260
+    loc: 267
     target: polylogue/cli/read_view_handlers.py
     owner: stable
   - path: polylogue/cli/read_view_registry.py
-    loc: 116
+    loc: 117
     target: polylogue/cli/read_view_registry.py
     owner: stable
   - path: polylogue/cli/read_views/__init__.py
@@ -1173,6 +1173,10 @@ files:
   - path: polylogue/cli/read_views/streaming_markdown.py
     loc: 234
     target: polylogue/cli/read_views/streaming_markdown.py
+    owner: stable
+  - path: polylogue/cli/read_views/web_content_constructs.py
+    loc: 56
+    target: polylogue/cli/read_views/web_content_constructs.py
     owner: stable
   - path: polylogue/cli/root_request.py
     loc: 195
@@ -2360,7 +2364,7 @@ files:
     target: polylogue/mcp/server.py
     owner: stable
   - path: polylogue/mcp/server_cutover.py
-    loc: 2348
+    loc: 2367
     target: polylogue/mcp/server_cutover.py
     owner: stable
   - path: polylogue/mcp/server_prompts.py
@@ -4004,7 +4008,7 @@ files:
     target: polylogue/storage/repository/archive/search.py
     owner: stable
   - path: polylogue/storage/repository/archive/sessions.py
-    loc: 434
+    loc: 459
     target: polylogue/storage/repository/archive/sessions.py
     owner: stable
   - path: polylogue/storage/repository/archive/tree.py
@@ -4087,7 +4091,7 @@ files:
     owner: storage-root
     reason: storage-root cross-cutting helper
   - path: polylogue/storage/runtime/__init__.py
-    loc: 110
+    loc: 112
     target: polylogue/storage/runtime/__init__.py
     owner: stable
   - path: polylogue/storage/runtime/archive/__init__.py
@@ -4095,7 +4099,7 @@ files:
     target: polylogue/storage/runtime/archive/__init__.py
     owner: stable
   - path: polylogue/storage/runtime/archive/records.py
-    loc: 413
+    loc: 456
     target: polylogue/storage/runtime/archive/records.py
     owner: stable
   - path: polylogue/storage/runtime/raw/__init__.py
@@ -4410,7 +4414,7 @@ files:
     target: polylogue/storage/sqlite/queries/mappers.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/mappers_archive.py
-    loc: 287
+    loc: 317
     target: polylogue/storage/sqlite/queries/mappers_archive.py
     owner: stable
   - path: polylogue/storage/sqlite/queries/mappers_insight_aggregates.py
@@ -4560,6 +4564,10 @@ files:
     loc: 183
     target: polylogue/storage/sqlite/queries/tool_usage.py
     owner: stable
+  - path: polylogue/storage/sqlite/queries/web_content_constructs.py
+    loc: 103
+    target: polylogue/storage/sqlite/queries/web_content_constructs.py
+    owner: stable
   - path: polylogue/storage/sqlite/queries/work_evidence.py
     loc: 239
     target: polylogue/storage/sqlite/queries/work_evidence.py
@@ -4573,7 +4581,7 @@ files:
     target: polylogue/storage/sqlite/query_store.py
     owner: stable
   - path: polylogue/storage/sqlite/query_store_archive.py
-    loc: 384
+    loc: 404
     target: polylogue/storage/sqlite/query_store_archive.py
     owner: stable
   - path: polylogue/storage/sqlite/query_store_insight_profiles.py
@@ -4654,7 +4662,7 @@ files:
     target: polylogue/surfaces/payloads.py
     owner: stable
   - path: polylogue/surfaces/projection_spec.py
-    loc: 297
+    loc: 299
     target: polylogue/surfaces/projection_spec.py
     owner: stable
   - path: polylogue/surfaces/temporal_evidence.py

--- a/polylogue/api/archive.py
+++ b/polylogue/api/archive.py
@@ -5598,6 +5598,63 @@ class PolylogueArchiveMixin:
             for edit in edits
         ]
 
+    async def get_web_content_constructs(
+        self,
+        session_id: str,
+        *,
+        construct_type: str | None = None,
+    ) -> list[dict[str, object]] | None:
+        """Return typed web-export constructs (search results, canvas, ...) for one session.
+
+        polylogue-kktg: ``web_content_constructs`` holds 155k+ rows written
+        every ingest from the ChatGPT/Claude parsers (search queries/
+        results, canvas documents, content references, image results, async
+        tasks, selected sources, token budgets, voice notes) but before this
+        reader had no production reader at all -- every existing SELECT
+        against it exists only to DELETE orphans or as a demo smoke-probe
+        COUNT(*). This is the read surface.
+
+        ``construct_type`` optionally narrows to one
+        ``core.enums.WebConstructType`` value (e.g. ``"search_result"``).
+
+        Returns ``None`` when the session does not exist (distinct from an
+        empty list, meaning the session exists but has no captured web
+        constructs).
+        """
+        resolved = await self.repository.resolve_id(session_id)
+        resolved_id = str(resolved) if resolved is not None else session_id
+        session = await self.repository.get(resolved_id)
+        if session is None:
+            return None
+        constructs = await self.repository.get_web_content_constructs(resolved_id, construct_type=construct_type)
+        return [
+            {
+                "construct_id": construct.construct_id,
+                "message_id": str(construct.message_id),
+                "block_id": construct.block_id,
+                "position": construct.position,
+                "provider": construct.provider,
+                "construct_type": construct.construct_type,
+                "provider_key": construct.provider_key,
+                "title": construct.title,
+                "url": construct.url,
+                "text": construct.text,
+                "source_id": construct.source_id,
+                "group_id": construct.group_id,
+                "group_title": construct.group_title,
+                "query": construct.query,
+                "asset_pointer": construct.asset_pointer,
+                "mime_type": construct.mime_type,
+                "status": construct.status,
+                "task_id": construct.task_id,
+                "task_type": construct.task_type,
+                "rank": construct.rank,
+                "start_index": construct.start_index,
+                "end_index": construct.end_index,
+            }
+            for construct in constructs
+        ]
+
     async def get_agent_policies(self, session_id: str) -> list[dict[str, object]] | None:
         """Return sandbox/approval/network policy facts recorded for one session.
 

--- a/polylogue/archive/viewport/profiles.py
+++ b/polylogue/archive/viewport/profiles.py
@@ -214,6 +214,34 @@ READ_VIEW_PROFILES: tuple[SessionViewProfile, ...] = (
         degraded_states=("missing session", "session with no recorded agent-policy facts"),
     ),
     SessionViewProfile(
+        view_id="web-content",
+        label="Web Content",
+        owner="polylogue.cli.read_views.web_content_constructs.run_read_web_content_constructs",
+        purpose=(
+            "Typed web-export constructs projected from ChatGPT/Claude web payloads: search queries/results, "
+            "canvas documents, content references, image results, async tasks, selected sources, token budgets, "
+            "voice notes -- 155k+ rows written every ingest with no prior reader (polylogue-kktg)."
+        ),
+        input_scope="single session id",
+        included_kinds=(
+            "search query",
+            "search result",
+            "canvas",
+            "content reference",
+            "image result",
+            "async task",
+            "selected source",
+            "token budget",
+            "voice note",
+        ),
+        lossiness="raw",
+        evidence_policy="required",
+        privacy_policy="renders the substrate's own structured web-construct payload verbatim, bounded by the source parser",
+        formats=("json",),
+        machine_payload="web content construct list payload",
+        degraded_states=("missing session", "session with no captured web content constructs"),
+    ),
+    SessionViewProfile(
         view_id="context",
         label="Context",
         owner="polylogue.context.preamble.compose_context_preamble",

--- a/polylogue/cli/commands/status.py
+++ b/polylogue/cli/commands/status.py
@@ -498,6 +498,11 @@ _ARCHIVE_FACADE_ROUTES: dict[str, tuple[str, str, str]] = {
         "compiles a context image and records its delivery receipt through user.db",
     ),
     "get_file_edits": ("archive_routed", "index", "reads materialized file-edit evidence rows from index.db"),
+    "get_web_content_constructs": (
+        "archive_routed",
+        "index",
+        "reads materialized web-export construct rows (search/canvas/image/...) from index.db",
+    ),
     "get_hook_event_summary_for_session": (
         "archive_routed",
         "source",

--- a/polylogue/cli/messages.py
+++ b/polylogue/cli/messages.py
@@ -329,6 +329,54 @@ def run_session_file_edits(
     run_coroutine_sync(_run())
 
 
+def run_session_web_content_constructs(
+    env: AppEnv,
+    request: RootModeRequest,
+    *,
+    session_id: str,
+    output_format: str = "json",
+) -> None:
+    """Execute the web-content verb.
+
+    Renders typed web-export constructs (polylogue-kktg): search queries/
+    results, canvas documents, content references, image results, async
+    tasks, selected sources, token budgets, and voice notes projected from
+    ChatGPT/Claude web payloads -- persisted on every ingest into the
+    dedicated ``web_content_constructs`` table but, before this view,
+    reachable only through an orphan-integrity DELETE sweep or a demo
+    smoke-probe COUNT(*), never a real reader.
+    """
+    from polylogue.api import Polylogue
+
+    async def _run() -> None:
+        async with Polylogue.open(config=cast(Config, request.params.get("_config"))) as api:
+            constructs = await api.get_web_content_constructs(session_id)
+
+            if constructs is None:
+                env.ui.error(f"Session not found: {session_id}")
+                return
+
+            payload = {
+                "session_id": session_id,
+                "total": len(constructs),
+                "web_content_constructs": constructs,
+            }
+
+            if output_format == "json":
+                import json as _json
+
+                # Machine output uses raw stdout so Rich markup never rewrites
+                # JSON bytes and read-view delivery can capture file/clipboard
+                # targets consistently.
+                click.echo(_json.dumps(payload, indent=2))
+            else:
+                import yaml
+
+                click.echo(yaml.dump(payload))
+
+    run_coroutine_sync(_run())
+
+
 def run_session_agent_policies(
     env: AppEnv,
     request: RootModeRequest,
@@ -379,4 +427,5 @@ __all__ = [
     "run_session_agent_policies",
     "run_session_events",
     "run_session_file_edits",
+    "run_session_web_content_constructs",
 ]

--- a/polylogue/cli/read_view_handlers.py
+++ b/polylogue/cli/read_view_handlers.py
@@ -48,6 +48,7 @@ from polylogue.cli.read_views.messages import (
 from polylogue.cli.read_views.neighbors import build_neighbor_options, run_read_neighbors
 from polylogue.cli.read_views.query_set import run_query_set_read_view
 from polylogue.cli.read_views.standard import run_read_dialogue, run_read_summary_or_transcript, run_read_temporal
+from polylogue.cli.read_views.web_content_constructs import run_read_web_content_constructs
 from polylogue.cli.shared.types import AppEnv
 
 if TYPE_CHECKING:
@@ -116,6 +117,12 @@ READ_VIEW_HANDLERS: dict[str, ReadViewHandler] = {
         "agent-policies",
         "required",
         run_read_agent_policies,
+        default_format="json",
+    ),
+    "web-content": ReadViewHandler(
+        "web-content",
+        "required",
+        run_read_web_content_constructs,
         default_format="json",
     ),
     "context": ReadViewHandler(

--- a/polylogue/cli/read_view_registry.py
+++ b/polylogue/cli/read_view_registry.py
@@ -58,6 +58,7 @@ READ_VIEW_HANDLER_METADATA: dict[str, ReadViewHandlerMetadata] = {
     "events": ReadViewHandlerMetadata("events", "required", EVENTS_READ_VIEW_OPTION_NAMES),
     "file-edits": ReadViewHandlerMetadata("file-edits", "required"),
     "agent-policies": ReadViewHandlerMetadata("agent-policies", "required"),
+    "web-content": ReadViewHandlerMetadata("web-content", "required"),
     "context": ReadViewHandlerMetadata("context", "required", CONTEXT_READ_VIEW_OPTION_NAMES),
     "context-image": ReadViewHandlerMetadata("context-image", "none", CONTEXT_IMAGE_READ_VIEW_OPTION_NAMES),
     "neighbors": ReadViewHandlerMetadata("neighbors", "query_or_session", NEIGHBOR_READ_VIEW_OPTION_NAMES),

--- a/polylogue/cli/read_views/web_content_constructs.py
+++ b/polylogue/cli/read_views/web_content_constructs.py
@@ -1,0 +1,56 @@
+"""Web-content-construct evidence read-view handler.
+
+Renders ``web_content_constructs`` (polylogue-kktg): a 155k+-row index
+relation that had a complete, tested write path from the ChatGPT/Claude
+parsers but no reader above the storage layer -- every production SELECT
+against it existed only to DELETE orphans (an integrity sweep) or as a demo
+smoke-probe COUNT(*).
+"""
+
+from __future__ import annotations
+
+import io
+
+import click
+
+from polylogue.cli.read_views.base import ReadViewInvocation, deliver_content
+from polylogue.cli.root_request import RootModeRequest
+from polylogue.cli.shared.types import AppEnv
+
+__all__ = ["run_read_web_content_constructs"]
+
+
+def run_read_web_content_constructs(env: AppEnv, request: RootModeRequest, invocation: ReadViewInvocation) -> None:
+    """Route the web-content view to the web-content-construct evidence renderer."""
+
+    from polylogue.cli.messages import run_session_web_content_constructs
+
+    assert invocation.session_id is not None
+    output_format = invocation.output_format or "json"
+
+    if invocation.destination in ("file", "clipboard", "stdout"):
+        buf = io.StringIO()
+
+        def _captured_echo(message: object = None, **_kwargs: object) -> None:
+            buf.write(str(message or "") + "\n")
+
+        _orig_echo = click.echo
+        click.echo = _captured_echo  # type: ignore[assignment]
+        try:
+            run_session_web_content_constructs(
+                env,
+                request,
+                session_id=invocation.session_id,
+                output_format=output_format,
+            )
+        finally:
+            click.echo = _orig_echo
+        deliver_content(env, buf.getvalue(), destination=invocation.destination, out_path=invocation.out_path)
+        return
+
+    run_session_web_content_constructs(
+        env,
+        request,
+        session_id=invocation.session_id,
+        output_format=output_format,
+    )

--- a/polylogue/mcp/server_cutover.py
+++ b/polylogue/mcp/server_cutover.py
@@ -846,6 +846,12 @@ def register_cutover_read_tools(mcp: ToolRegistrar, hooks: ServerCallbacks) -> N
         policy facts (e.g. Codex ``agent_policy`` events) recorded on the
         session's own timeline.
 
+        ``projection="web-content"`` returns typed web-export constructs
+        captured from ChatGPT/Claude web payloads for the session -- search
+        queries/results, canvas documents, content references, image
+        results, async tasks, selected sources, token budgets, and voice
+        notes (polylogue-kktg).
+
         ``ref="cost-outlook:<plan_name>"`` projects the current billing cycle
         for a configured subscription plan (the standalone ``cost_outlook``
         MCP tool retired by the six-tool cutover, #3095/polylogue-t46.8, has
@@ -889,6 +895,19 @@ def register_cutover_read_tools(mcp: ToolRegistrar, hooks: ServerCallbacks) -> N
                     return hooks.error_json(f"object not found: {ref}", code="not_found", tool="get")
                 return hooks.json_payload(
                     MCPRootPayload(root={"session_id": session_id, "total": len(policies), "agent_policies": policies})
+                )
+            if projection == "web-content" and session_id is not None:
+                constructs = await hooks.get_polylogue().get_web_content_constructs(session_id)
+                if constructs is None:
+                    return hooks.error_json(f"object not found: {ref}", code="not_found", tool="get")
+                return hooks.json_payload(
+                    MCPRootPayload(
+                        root={
+                            "session_id": session_id,
+                            "total": len(constructs),
+                            "web_content_constructs": constructs,
+                        }
+                    )
                 )
             return hooks.json_payload(await hooks.get_polylogue().resolve_ref(normalized))
 

--- a/polylogue/storage/repository/archive/sessions.py
+++ b/polylogue/storage/repository/archive/sessions.py
@@ -25,6 +25,7 @@ from polylogue.storage.runtime import (
     SessionCommitRecord,
     SessionRecord,
     SessionRefRecord,
+    WebContentConstructRecord,
 )
 from polylogue.storage.sqlite.archive_tiers.write import ArchiveAgentPolicy
 
@@ -166,6 +167,30 @@ class RepositoryArchiveSessionMixin:
     async def get_session_commits(self, session_id: str) -> list[SessionCommitRecord]:
         """Read checkout-HEAD commit evidence (polylogue-cijx.3) for a session."""
         return await self.queries.get_session_commits(session_id)
+
+    async def get_web_content_constructs(
+        self,
+        session_id: str,
+        *,
+        construct_type: str | None = None,
+    ) -> list[WebContentConstructRecord]:
+        """Read typed web-export constructs (polylogue-kktg) for a session.
+
+        Search queries/results, canvas documents, content references, image
+        results, async tasks, selected sources, token budgets, and voice
+        notes projected from ChatGPT/Claude web payloads
+        (``core.enums.WebConstructType``) -- written every ingest into the
+        dedicated ``web_content_constructs`` table but, before this reader,
+        reachable only through an orphan-integrity DELETE sweep or a demo
+        smoke-probe COUNT(*).
+        """
+        return await self.queries.get_web_content_constructs(session_id, construct_type=construct_type)
+
+    async def get_web_content_constructs_batch(
+        self,
+        session_ids: list[str],
+    ) -> dict[str, list[WebContentConstructRecord]]:
+        return await self.queries.get_web_content_constructs_batch(session_ids)
 
     async def get_messages_paginated(
         self,

--- a/polylogue/storage/runtime/__init__.py
+++ b/polylogue/storage/runtime/__init__.py
@@ -38,6 +38,7 @@ from polylogue.storage.runtime.archive.records import (
     SessionEventRecord,
     SessionRecord,
     SessionRefRecord,
+    WebContentConstructRecord,
 )
 from polylogue.storage.runtime.raw.records import (
     ArtifactObservationRecord,
@@ -81,6 +82,7 @@ __all__ = [
     "SessionRecord",
     "SessionRefRecord",
     "SessionCommitRecord",
+    "WebContentConstructRecord",
     "DaySessionSummaryRecord",
     "LINEAGE_TRUNCATION_DANGLING_BRANCH_POINT",
     "LINEAGE_TRUNCATION_DEPTH_LIMIT",

--- a/polylogue/storage/runtime/archive/records.py
+++ b/polylogue/storage/runtime/archive/records.py
@@ -343,6 +343,49 @@ class SessionRefRecord(BaseModel):
         return v
 
 
+class WebContentConstructRecord(BaseModel):
+    """One ``web_content_constructs`` row (polylogue-kktg).
+
+    Typed web-export constructs projected out of ChatGPT/Claude web
+    payloads -- search queries/results, canvas documents, content
+    references, image results, async tasks, selected sources, token
+    budgets, voice notes (``core.enums.WebConstructType``). Written every
+    ingest (``archive_tiers/write.py::_write_web_constructs``) but had no
+    reader above the storage layer before this record/query pair.
+    """
+
+    construct_id: str
+    session_id: SessionId
+    message_id: MessageId
+    block_id: str
+    position: int
+    provider: str
+    construct_type: str
+    provider_key: str | None = None
+    title: str | None = None
+    url: str | None = None
+    text: str | None = None
+    source_id: str | None = None
+    group_id: str | None = None
+    group_title: str | None = None
+    query: str | None = None
+    asset_pointer: str | None = None
+    mime_type: str | None = None
+    status: str | None = None
+    task_id: str | None = None
+    task_type: str | None = None
+    rank: int | None = None
+    start_index: int | None = None
+    end_index: int | None = None
+
+    @field_validator("construct_id", "session_id", "message_id", "block_id", "provider", "construct_type")
+    @classmethod
+    def non_empty_string(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("Field cannot be empty")
+        return v
+
+
 class SessionCommitRecord(BaseModel):
     """One ``session_commits`` row (polylogue-cijx.3): the repo checkout's
     HEAD commit at the moment this session was captured, as the provider's

--- a/polylogue/storage/sqlite/queries/mappers_archive.py
+++ b/polylogue/storage/sqlite/queries/mappers_archive.py
@@ -31,6 +31,7 @@ from polylogue.storage.runtime import (
     SessionCommitRecord,
     SessionRecord,
     SessionRefRecord,
+    WebContentConstructRecord,
 )
 from polylogue.storage.sqlite.queries.mappers_support import (
     _json_object,
@@ -168,6 +169,34 @@ def _row_to_session_ref(row: sqlite3.Row) -> SessionRefRecord:
     )
 
 
+def _row_to_web_content_construct(row: sqlite3.Row) -> WebContentConstructRecord:
+    return WebContentConstructRecord(
+        construct_id=row["construct_id"],
+        session_id=SessionId(row["session_id"]),
+        message_id=MessageId(row["message_id"]),
+        block_id=row["block_id"],
+        position=int(row["position"]),
+        provider=row["provider"],
+        construct_type=row["construct_type"],
+        provider_key=_row_text(row, "provider_key"),
+        title=_row_text(row, "title"),
+        url=_row_text(row, "url"),
+        text=_row_text(row, "text"),
+        source_id=_row_text(row, "source_id"),
+        group_id=_row_text(row, "group_id"),
+        group_title=_row_text(row, "group_title"),
+        query=_row_text(row, "query"),
+        asset_pointer=_row_text(row, "asset_pointer"),
+        mime_type=_row_text(row, "mime_type"),
+        status=_row_text(row, "status"),
+        task_id=_row_text(row, "task_id"),
+        task_type=_row_text(row, "task_type"),
+        rank=_row_int(row, "rank"),
+        start_index=_row_int(row, "start_index"),
+        end_index=_row_int(row, "end_index"),
+    )
+
+
 def _row_to_session_commit(row: sqlite3.Row) -> SessionCommitRecord:
     return SessionCommitRecord(
         session_id=SessionId(row["session_id"]),
@@ -284,4 +313,5 @@ __all__ = [
     "_row_to_session_ref",
     "_row_to_message",
     "_row_to_raw_session",
+    "_row_to_web_content_construct",
 ]

--- a/polylogue/storage/sqlite/queries/web_content_constructs.py
+++ b/polylogue/storage/sqlite/queries/web_content_constructs.py
@@ -1,0 +1,103 @@
+"""Async reads for ``web_content_constructs`` (polylogue-kktg).
+
+``web_content_constructs`` is written every ingest from the ChatGPT/Claude
+parsers (search queries/results, canvas documents, content references,
+image results, async tasks, selected sources, token budgets, voice notes --
+``core.enums.WebConstructType``, ``archive_tiers/write.py::
+_write_web_constructs``), 155k+ live rows, but had no reader above the
+storage layer: every production SELECT against it existed only to DELETE
+orphans (an integrity sweep) or as a demo smoke-probe COUNT(*). Follows the
+same shape as ``queries/file_edits.py``/``queries/session_refs.py``
+(single-session + session-batch reads over the dedicated
+``idx_web_constructs_session_type`` index).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+
+import aiosqlite
+
+from polylogue.storage.runtime import WebContentConstructRecord
+from polylogue.storage.sqlite.queries.mappers_archive import _row_to_web_content_construct
+
+__all__ = [
+    "get_web_content_constructs_for_session",
+    "get_web_content_constructs_for_session_batch",
+]
+
+_SELECT_COLUMNS = (
+    "construct_id, session_id, message_id, block_id, position, provider, construct_type, "
+    "provider_key, title, url, text, source_id, group_id, group_title, query, asset_pointer, "
+    "mime_type, status, task_id, task_type, rank, start_index, end_index"
+)
+
+
+async def get_web_content_constructs_for_session(
+    conn: aiosqlite.Connection,
+    session_id: str,
+    *,
+    construct_type: str | None = None,
+) -> list[WebContentConstructRecord]:
+    """Return all web-content-construct rows for one session, ordered by message/block/position.
+
+    ``construct_type`` optionally narrows to a single
+    ``core.enums.WebConstructType`` value (e.g. ``"search_result"``),
+    pushing the filter down onto the dedicated
+    ``idx_web_constructs_session_type`` index instead of filtering in
+    Python.
+    """
+    if construct_type is not None:
+        rows = await (
+            await conn.execute(
+                f"""
+                SELECT {_SELECT_COLUMNS}
+                FROM web_content_constructs
+                WHERE session_id = ? AND construct_type = ?
+                ORDER BY message_id, block_id, position
+                """,
+                (session_id, construct_type),
+            )
+        ).fetchall()
+    else:
+        rows = await (
+            await conn.execute(
+                f"""
+                SELECT {_SELECT_COLUMNS}
+                FROM web_content_constructs
+                WHERE session_id = ?
+                ORDER BY message_id, block_id, position
+                """,
+                (session_id,),
+            )
+        ).fetchall()
+    return [_row_to_web_content_construct(row) for row in rows]
+
+
+async def get_web_content_constructs_for_session_batch(
+    conn: aiosqlite.Connection,
+    session_ids: Sequence[str],
+) -> dict[str, list[WebContentConstructRecord]]:
+    """Return web-content-construct rows for many sessions, grouped by session_id."""
+    if not session_ids:
+        return {}
+    placeholders = ", ".join("?" for _ in session_ids)
+    rows = await (
+        await conn.execute(
+            f"""
+            SELECT {_SELECT_COLUMNS}
+            FROM web_content_constructs
+            WHERE session_id IN ({placeholders})
+            ORDER BY session_id, message_id, block_id, position
+            """,
+            tuple(session_ids),
+        )
+    ).fetchall()
+    result: dict[str, list[WebContentConstructRecord]] = defaultdict(list)
+    for session_id in session_ids:
+        result.setdefault(session_id, [])
+    for row in rows:
+        record = _row_to_web_content_construct(row)
+        result[str(record.session_id)].append(record)
+    return dict(result)

--- a/polylogue/storage/sqlite/query_store_archive.py
+++ b/polylogue/storage/sqlite/query_store_archive.py
@@ -20,6 +20,7 @@ from polylogue.storage.runtime import (
     SessionEventRecord,
     SessionRecord,
     SessionRefRecord,
+    WebContentConstructRecord,
 )
 from polylogue.storage.search.models import SessionSearchEvidenceRow, SessionSearchResult
 from polylogue.storage.sqlite.archive_tiers.write import ArchiveAgentPolicy
@@ -34,6 +35,7 @@ from polylogue.storage.sqlite.queries import session_refs as session_refs_q
 from polylogue.storage.sqlite.queries import sessions as sessions_q
 from polylogue.storage.sqlite.queries import stats as stats_q
 from polylogue.storage.sqlite.queries import tool_usage as tool_usage_q
+from polylogue.storage.sqlite.queries import web_content_constructs as web_content_constructs_q
 from polylogue.storage.sqlite.queries.messages import MaterialOriginFilter, MessageTypeName
 from polylogue.storage.sqlite.queries.stats import (
     AggregateMessageStats,
@@ -303,6 +305,24 @@ class SQLiteQueryStoreArchiveMixin:
     async def get_session_commits(self, session_id: str) -> list[SessionCommitRecord]:
         async with self._connection_factory() as conn:
             return await session_commits_q.get_session_commits(conn, session_id)
+
+    async def get_web_content_constructs(
+        self,
+        session_id: str,
+        *,
+        construct_type: str | None = None,
+    ) -> list[WebContentConstructRecord]:
+        async with self._connection_factory() as conn:
+            return await web_content_constructs_q.get_web_content_constructs_for_session(
+                conn, session_id, construct_type=construct_type
+            )
+
+    async def get_web_content_constructs_batch(
+        self,
+        session_ids: list[str],
+    ) -> dict[str, list[WebContentConstructRecord]]:
+        async with self._connection_factory() as conn:
+            return await web_content_constructs_q.get_web_content_constructs_for_session_batch(conn, session_ids)
 
     async def iter_messages(
         self,

--- a/polylogue/surfaces/projection_spec.py
+++ b/polylogue/surfaces/projection_spec.py
@@ -27,6 +27,7 @@ class EvidenceFamily(str, Enum):
     EVENTS = "events"
     FILE_EDITS = "file-edits"
     AGENT_POLICIES = "agent-policies"
+    WEB_CONTENT = "web-content"
     CONTEXT = "context"
     CHRONICLE = "chronicle"
     NEIGHBORS = "neighbors"
@@ -160,6 +161,7 @@ READ_VIEW_PROJECTION_FAMILIES: dict[str, tuple[EvidenceFamily, ...]] = {
     "events": (EvidenceFamily.EVENTS,),
     "file-edits": (EvidenceFamily.FILE_EDITS,),
     "agent-policies": (EvidenceFamily.AGENT_POLICIES,),
+    "web-content": (EvidenceFamily.WEB_CONTENT,),
     "context": (EvidenceFamily.CONTEXT, EvidenceFamily.MESSAGES),
     "context-image": (EvidenceFamily.CONTEXT, EvidenceFamily.MESSAGES),
     "chronicle": (EvidenceFamily.CHRONICLE, EvidenceFamily.SESSIONS, EvidenceFamily.MESSAGES),

--- a/tests/unit/api/test_facade_contracts.py
+++ b/tests/unit/api/test_facade_contracts.py
@@ -91,6 +91,7 @@ READ_BY_ID_NONE_METHODS: frozenset[str] = frozenset(
         "get_session_events",
         "get_file_edits",
         "get_agent_policies",
+        "get_web_content_constructs",
     }
 )
 

--- a/tests/unit/cli/test_file_edits_and_agent_policies_views.py
+++ b/tests/unit/cli/test_file_edits_and_agent_policies_views.py
@@ -169,3 +169,81 @@ def test_read_view_agent_policies_surfaces_sandbox_facts(
     assert policy["approval_policy"] == "never"
     assert policy["sandbox_policy"] == "danger-full-access"
     assert policy["network_policy"] == "true"
+
+
+def test_read_view_web_content_surfaces_search_constructs(
+    cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``read --view web-content`` (polylogue-kktg).
+
+    ``web_content_constructs`` holds 155k+ live rows written every ingest
+    from the ChatGPT/Claude parsers, but before this view had no production
+    reader at all: every existing SELECT against it exists only to DELETE
+    orphans or as a demo smoke-probe COUNT(*). This exercises the real
+    ``read --view web-content`` verb end to end.
+    """
+    from polylogue.core.enums import BlockType, Provider, Role, WebConstructType
+    from polylogue.sources.parsers.base import ParsedContentBlock, ParsedMessage, ParsedSession, ParsedWebConstruct
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+
+    archive_root = tmp_path / "archive"
+    monkeypatch.setenv("POLYLOGUE_ARCHIVE_ROOT", str(archive_root))
+
+    with ArchiveStore(archive_root) as archive_db:
+        parsed = ParsedSession(
+            source_name=Provider.CHATGPT,
+            provider_session_id="cli-web-content-1",
+            title="CLI web-content view session",
+            messages=[
+                ParsedMessage(
+                    provider_message_id="m1",
+                    role=Role.ASSISTANT,
+                    position=0,
+                    blocks=[
+                        ParsedContentBlock(
+                            type=BlockType.TEXT,
+                            text="Searching the web",
+                            web_constructs=[
+                                ParsedWebConstruct(
+                                    construct_type=WebConstructType.SEARCH_RESULT,
+                                    title="Polylogue",
+                                    url="https://example.com/polylogue",
+                                    text="A local AI chat archiver",
+                                    rank=1,
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+        archive_db.write_raw_and_parsed(
+            parsed,
+            payload=b'{"raw": "chatgpt payload"}',
+            source_path="/tmp/raw.jsonl",
+            acquired_at_ms=1735689600000,
+        )
+
+    session_id = "chatgpt-export:cli-web-content-1"
+
+    result = cli_runner.invoke(
+        click_cli,
+        ["--plain", "--id", session_id, "read", "--view", "web-content", "-f", "json"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["total"] == 1
+    construct = payload["web_content_constructs"][0]
+    assert construct["construct_type"] == "search_result"
+    assert construct["title"] == "Polylogue"
+    assert construct["url"] == "https://example.com/polylogue"
+    assert construct["rank"] == 1
+
+    missing = cli_runner.invoke(
+        click_cli,
+        ["--plain", "--id", "chatgpt-export:does-not-exist", "read", "--view", "web-content"],
+        catch_exceptions=False,
+    )
+    assert "not found" in missing.output.lower()

--- a/tests/unit/storage/test_unread_wire_batch_v46.py
+++ b/tests/unit/storage/test_unread_wire_batch_v46.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from polylogue.core.enums import BlockType, Provider, Role
+from polylogue.core.enums import BlockType, Provider, Role, WebConstructType
 from polylogue.sources.parsers.base import (
     ParsedContentBlock,
     ParsedFileEdit,
     ParsedMessage,
     ParsedSession,
     ParsedSessionRef,
+    ParsedWebConstruct,
 )
 from polylogue.storage.repository import SessionRepository
 from polylogue.storage.sqlite.async_sqlite import SQLiteBackend
@@ -399,6 +400,100 @@ async def test_session_refs_empty_for_session_without_refs(tmp_path: Path) -> No
         await repo.close()
 
     assert refs == []
+
+
+async def test_web_content_constructs_round_trip_search_result(tmp_path: Path) -> None:
+    """web_content_constructs (polylogue-kktg): a 155k+-row relation with no prior reader.
+
+    Fails if the writer stops resolving/inserting ``web_content_constructs``
+    rows (a revert of ``_write_web_constructs``), or if
+    ``repository.get_web_content_constructs`` stops reading them back.
+    """
+    backend = SQLiteBackend(db_path=tmp_path / "web-content.db")
+    repo = SessionRepository(backend=backend)
+    try:
+        session_id = await ingest_session(
+            ParsedSession(
+                source_name=Provider.CHATGPT,
+                provider_session_id="web-content-1",
+                title="Web content session",
+                messages=[
+                    ParsedMessage(
+                        provider_message_id="m1",
+                        role=Role.ASSISTANT,
+                        position=0,
+                        blocks=[
+                            ParsedContentBlock(
+                                type=BlockType.TEXT,
+                                text="Searching the web",
+                                web_constructs=[
+                                    ParsedWebConstruct(
+                                        construct_type=WebConstructType.SEARCH_QUERY,
+                                        query="polylogue archive",
+                                    ),
+                                    ParsedWebConstruct(
+                                        construct_type=WebConstructType.SEARCH_RESULT,
+                                        title="Polylogue",
+                                        url="https://example.com/polylogue",
+                                        text="A local AI chat archiver",
+                                        rank=1,
+                                    ),
+                                ],
+                            ),
+                        ],
+                    ),
+                ],
+            ),
+            backend=backend,
+        )
+        constructs = await repo.get_web_content_constructs(session_id)
+        search_results = await repo.get_web_content_constructs(session_id, construct_type="search_result")
+    finally:
+        await repo.close()
+
+    assert len(constructs) == 2
+    by_type = {c.construct_type: c for c in constructs}
+    query_construct = by_type["search_query"]
+    assert query_construct.session_id == session_id
+    assert query_construct.query == "polylogue archive"
+    assert query_construct.message_id == f"{session_id}:m1"
+    assert query_construct.block_id == f"{session_id}:m1:0"
+
+    result_construct = by_type["search_result"]
+    assert result_construct.title == "Polylogue"
+    assert result_construct.url == "https://example.com/polylogue"
+    assert result_construct.text == "A local AI chat archiver"
+    assert result_construct.rank == 1
+
+    assert len(search_results) == 1
+    assert search_results[0].construct_type == "search_result"
+
+
+async def test_web_content_constructs_empty_for_session_without_constructs(tmp_path: Path) -> None:
+    backend = SQLiteBackend(db_path=tmp_path / "web-content-empty.db")
+    repo = SessionRepository(backend=backend)
+    try:
+        session_id = await ingest_session(
+            ParsedSession(
+                source_name=Provider.CHATGPT,
+                provider_session_id="no-web-content",
+                messages=[
+                    ParsedMessage(
+                        provider_message_id="m1",
+                        role=Role.USER,
+                        text="hi",
+                        position=0,
+                        blocks=[ParsedContentBlock(type=BlockType.TEXT, text="hi")],
+                    ),
+                ],
+            ),
+            backend=backend,
+        )
+        constructs = await repo.get_web_content_constructs(session_id)
+    finally:
+        await repo.close()
+
+    assert constructs == []
 
 
 async def test_session_links_parent_tool_use_block_id_resolves_via_tool_id(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`web_content_constructs` holds 155,287 live rows written every ingest from the ChatGPT/Claude parsers (search queries/results, canvas documents, content references, image results, async tasks, selected sources, token budgets, voice notes) but had no production reader at all. This PR adds the missing read path end to end.

## Problem

Audited 2026-07-31 (shipped-but-dead census). Every production SELECT against `web_content_constructs`, exhaustively:
- `pipeline/services/ingest_batch/_core.py` -- an orphan-integrity sweep that reads the table only to DELETE from it
- `demo/constructs.py` -- a `SELECT COUNT(*) ... WHERE construct_type='token_budget'` demo smoke probe
- `write.py` -- DELETEs

There was no `queries/` module, no repository accessor, no typed record, no CLI/MCP/DSL/insight path anywhere, even though the schema was built expecting reads: `index.py` declares dedicated indexes on `(session_id, construct_type)`, `message_id`, `url`, and `query`, none of which were ever used by a query.

## Solution

Followed the file_edits/session_refs pattern (polylogue-nua7/polylogue-2qx.4):

- `WebContentConstructRecord` (`storage/runtime/archive/records.py`) plus its row mapper (`queries/mappers_archive.py`).
- `storage/sqlite/queries/web_content_constructs.py`: session and batch reads over the existing `idx_web_constructs_session_type` index, with an optional `construct_type` filter pushed down to SQL.
- `SQLiteQueryStore` / `SessionRepository` / `Polylogue` API wrappers (`get_web_content_constructs[_batch]`), returning `None` for a missing session (distinct from an empty list).
- CLI: a new `read --view web-content` verb (`cli/read_views/web_content_constructs.py`), registered in `read_view_registry.py`, `read_view_handlers.py`, `archive/viewport/profiles.py` (view metadata), and `surfaces/projection_spec.py` (`EvidenceFamily.WEB_CONTENT`).
- MCP: `get(ref, projection="web-content")` returns the same payload through the existing consolidated `get` tool -- no new MCP tool needed, so `EXPECTED_TOOL_NAMES` is unaffected.

Not done in this slice: an archive-wide aggregate/insight over `construct_type` distribution (e.g. "how many search results vs canvas docs across the whole archive"). Filed as polylogue-923uc (P2) rather than left implicit.

## Verification

- `devtools test tests/unit/storage/test_unread_wire_batch_v46.py tests/unit/cli/test_file_edits_and_agent_policies_views.py` -- 15 passed, including a real-writer round trip (`ParsedWebConstruct` -> `_write_web_constructs` -> `repo.get_web_content_constructs`, asserting `construct_type`/`query`/`title`/`url`/`rank` and the `construct_type` filter) and a real CLI `read --view web-content` invocation surfacing a captured `search_result` construct plus a not-found path.
- `devtools test tests/unit/api/test_facade_contracts.py tests/unit/mcp/test_server_surfaces.py tests/unit/cli/test_query_discovery_help.py tests/unit/cli/test_query_verbs_runtime.py` -- 366 passed, 1 pre-existing unrelated failure (`test_archive_tiers_api_raw_artifacts_read_source_tier`, a hardcoded-date assertion that also fails on `master` with no changes applied, confirmed via `git stash`).
- `devtools render all --check` -- clean (regenerated `docs/cli-reference.md` and `docs/plans/topology-target.yaml` for the new modules/verb).
- `devtools verify --quick` -- exit 0 (ran twice, once manually and once via the pre-push hook).

Ref polylogue-kktg