### PR TITLE
fix(cli): print archive-root provenance banner on hooks commands

### DIFF
--- a/polylogue/cli/commands/hooks.py
+++ b/polylogue/cli/commands/hooks.py
@@ -88,8 +88,26 @@ def _render_status(status: HookHarnessStatus, *, coverage: bool) -> list[str]:
 
 
 @click.group("hooks")
-def hooks_command() -> None:
-    """Install and monitor Claude Code/Codex capture hooks."""
+@click.pass_context
+def hooks_command(ctx: click.Context) -> None:
+    """Install and monitor Claude Code/Codex capture hooks.
+
+    Prints the resolved archive root and its provenance (env override /
+    config file / default) before dispatching to any subcommand -- same
+    banner ``ops maintenance`` prints (``_shared.print_archive_root_provenance``,
+    polylogue-l1qg). ``hooks install``/``status`` resolve the hook sidecar
+    dir from the archive root too (``polylogue.paths.hooks_sidecar_dir``), so
+    a stray ``POLYLOGUE_ARCHIVE_ROOT`` left over from a devshell/demo session
+    silently pointed installs and status checks at the wrong sidecar spool
+    with no warning -- the exact silent-redirect hazard l1qg fixed for
+    ``ops maintenance``, reproduced live for ``hooks`` on 2026-08-02.
+    """
+    from polylogue.cli.commands.maintenance._shared import print_archive_root_provenance
+    from polylogue.cli.shared.types import AppEnv
+
+    env = ctx.obj
+    if isinstance(env, AppEnv):
+        print_archive_root_provenance(env)
 
 
 @hooks_command.command("install")

--- a/tests/unit/cli/test_hooks.py
+++ b/tests/unit/cli/test_hooks.py
@@ -74,7 +74,7 @@ def test_install_recommended_is_idempotent_and_preserves_unrelated_hooks(isolate
         catch_exceptions=False,
     )
     assert first.exit_code == 0, first.output
-    first_payload = json.loads(first.output)
+    first_payload = json.loads(first.stdout)
     assert first_payload["changed"] is True
     assert first_payload["written"] is True
 
@@ -94,7 +94,7 @@ def test_install_recommended_is_idempotent_and_preserves_unrelated_hooks(isolate
         catch_exceptions=False,
     )
     assert second.exit_code == 0, second.output
-    second_payload = json.loads(second.output)
+    second_payload = json.loads(second.stdout)
     assert second_payload["changed"] is False
     assert second_payload["written"] is False
     assert target.read_bytes() == before_second
@@ -158,7 +158,7 @@ def test_install_dry_run_does_not_create_settings(isolated_hook_home: Path) -> N
         ["--plain", "hooks", "install", "--harness", "claude-code", "--dry-run", "--json"],
         catch_exceptions=False,
     )
-    payload = json.loads(result.output)
+    payload = json.loads(result.stdout)
     assert result.exit_code == 0
     assert payload["changed"] is True
     assert payload["written"] is False
@@ -256,7 +256,7 @@ def test_status_reports_wired_vs_recommended(isolated_hook_home: Path) -> None:
         ["--plain", "hooks", "status", "--harness", "claude-code", "--json"],
         catch_exceptions=False,
     )
-    payload = json.loads(status.output)["harnesses"][0]
+    payload = json.loads(status.stdout)["harnesses"][0]
     assert payload["wired_events"] == ["SessionStart"]
     assert payload["missing_recommended_events"] == [
         "UserPromptSubmit",


### PR DESCRIPTION
## Summary
Extends polylogue-l1qg's archive-root provenance banner (currently only on `ops maintenance` commands) to the `hooks` command group.

## Problem
`hooks install`/`hooks status` resolve the hook sidecar dir from the archive root (`polylogue.paths.hooks_sidecar_dir`). A stray `POLYLOGUE_ARCHIVE_ROOT` left over from a devshell/demo session silently redirects these commands to the wrong sidecar spool with no warning — the exact hazard l1qg fixed for `ops maintenance`, reproduced live 2026-08-02: this session's own shell inherited `POLYLOGUE_ARCHIVE_ROOT=/tmp/polylogue-archive` from `.claude/settings.json`'s cloud-lane env block, and `polylogue hooks install --dry-run --json` silently reported `changed: false` against that scratch path while the real `~/.claude/settings.json` still had a stale sidecar-dir baked in from an earlier archive-root migration (the incident polylogue-k8wv tracks).

## Solution
Mirrors `maintenance_group`'s `print_archive_root_provenance` wiring exactly: `hooks_command` now takes `@click.pass_context` and prints the same "Archive root: ... [source: ...]" banner to stderr before dispatching to any subcommand.

Fixed 4 existing `tests/unit/cli/test_hooks.py` tests that parsed `CliRunner.result.output` (mixed stdout+stderr in Click 8.2+) as JSON — same breakage class l1qg's PR #3529 fixed elsewhere; switched to `result.stdout`.

## Verification
`devtools test tests/unit/cli/ -k hooks`: 18 passed. `devtools verify --quick`: exit 0. Manually reproduced the banner: `POLYLOGUE_ARCHIVE_ROOT=/tmp/polylogue-archive-test polylogue hooks status` now prints `Archive root: /tmp/polylogue-archive-test [source: POLYLOGUE_ARCHIVE_ROOT environment variable]` before the status output.

Ref polylogue-l1qg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hook command output now includes archive-root provenance when available.
* **Bug Fixes**
  * Improved hook command output handling for install, dry-run, and status operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->