### PR TITLE
feat(devtools): bead-cluster footprints read description text

### DIFF
--- a/devtools/bead_cluster.py
+++ b/devtools/bead_cluster.py
@@ -1,7 +1,8 @@
 """bead-cluster: execution-frontier clustering for polylogue Beads.
 
 Implements polylogue-2yax: reads bd ready (or a supplied JSON export), extracts
-file/package/resource footprints from each bead's design+notes+ac text, builds
+file/package/resource footprints from each bead's design+notes+ac+description
+text, builds
 a weighted overlap graph, and emits:
 
   - FRONTIER-READY   -- horizon:frontier, no blocking deps -> claim now
@@ -167,6 +168,7 @@ _BROAD_PACKAGES: frozenset[str] = frozenset(
         "polylogue/",
         ".agent/",
         ".agent/scratch/",
+        ".agent/handoffs/",
         "storage/sqlite/",
         "pipeline/",
         "docs/",
@@ -212,7 +214,17 @@ class Footprint:
 
 
 def _extract_footprint(item: BeadDict) -> Footprint:
-    text = " ".join(filter(None, [item.get("design", ""), item.get("notes", ""), item.get("acceptance_criteria", "")]))
+    text = " ".join(
+        filter(
+            None,
+            [
+                item.get("design", ""),
+                item.get("notes", ""),
+                item.get("acceptance_criteria", ""),
+                item.get("description", ""),
+            ],
+        )
+    )
     labels: list[str] = item.get("labels", [])
 
     # Raw file paths (most specific footprint signal)

--- a/tests/unit/devtools/test_bead_cluster.py
+++ b/tests/unit/devtools/test_bead_cluster.py
@@ -54,6 +54,13 @@ def test_extract_footprint_finds_file_paths_and_packages() -> None:
     assert "tests/unit/" in fp.packages
 
 
+def test_extract_footprint_reads_description_text() -> None:
+    bead = _bead("polylogue-a")
+    bead["description"] = "Measured drift in polylogue/storage/sqlite/connection_profile.py on 2026-07-31."
+    fp = bead_cluster._extract_footprint(bead)
+    assert "polylogue/storage/sqlite/connection_profile.py" in fp.files
+
+
 def test_extract_footprint_falls_back_to_area_labels_when_no_files() -> None:
     bead = _bead("polylogue-a", design="no file paths here", labels=["area:mcp"])
     fp = bead_cluster._extract_footprint(bead)

--- a/tests/unit/devtools/test_bead_cluster.py
+++ b/tests/unit/devtools/test_bead_cluster.py
@@ -61,6 +61,15 @@ def test_extract_footprint_reads_description_text() -> None:
     assert "polylogue/storage/sqlite/connection_profile.py" in fp.files
 
 
+def test_agent_handoffs_package_suppressed_but_file_keys_remain() -> None:
+    bead = _bead("polylogue-a")
+    bead["description"] = "Provenance: .agent/handoffs/2026-08-01-lane7.md covers the prior attempt."
+    fp = bead_cluster._extract_footprint(bead)
+    keys = fp.overlap_keys()
+    assert ".agent/handoffs/" not in keys
+    assert ".agent/handoffs/2026-08-01-lane7.md" in keys
+
+
 def test_extract_footprint_falls_back_to_area_labels_when_no_files() -> None:
     bead = _bead("polylogue-a", design="no file paths here", labels=["area:mcp"])
     fp = bead_cluster._extract_footprint(bead)


### PR DESCRIPTION
## Summary

`devtools workspace bead-cluster`'s footprint extractor now includes bead `description` text alongside design+notes+acceptance_criteria, and `.agent/handoffs/` joins the broad-package suppression list.

## Problem

Audit-born beads carry their file evidence in the description field, which the extractor ignored. Measured on the live bead set: 313 of 759 open beads had zero overlap keys, and 17 of the 27 live beads in the `polylogue-a7gmk` pre-reindex program were footprint-blind, so dependency-wave planning was conflict-blind for 63% of that program.

## Solution

One-line extraction change plus one guard: description joins the extraction text, and `.agent/handoffs/` is suppressed as an overlap package because with descriptions included it reaches document frequency 120 (handoff docs cited as provenance across unrelated beads) and would create spurious overlap edges. Individual handoff file paths remain valid keys. Prototyped against the live bead set before implementing: coverage rises 446 to 588 of 759 open beads, 9 of the 17 blind reindex beads gain real footprints, and the top remaining df token is tests/unit/ at 98, which the existing weighted clustering already discounts.

## Verification

`devtools test tests/unit/devtools/test_bead_cluster.py`: 30 passed, including a new test pinning description-sourced extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deployment synchronization task covering package updates, durable migrations, deployment, schema verification, and final validation.
  * Improved change-footprint detection by including task descriptions, excluding handoff files from broad package analysis, and retaining individual handoff file details.

* **Tests**
  * Added regression coverage to verify file paths are detected from task descriptions and handoff file details remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->