### PR TITLE
fix(storage): widen durable origin CHECK for claude-design-session

### DIFF
--- a/polylogue/storage/sqlite/archive_tiers/source.py
+++ b/polylogue/storage/sqlite/archive_tiers/source.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from polylogue.core.enums import ArtifactSupportStatus, Origin, Provider, ValidationMode, ValidationStatus
 from polylogue.storage.sqlite.archive_tiers.common import check, nullable_check
 
-SOURCE_SCHEMA_VERSION = 20
+SOURCE_SCHEMA_VERSION = 21
 
 SOURCE_DDL = f"""
 CREATE TABLE IF NOT EXISTS raw_sessions (

--- a/polylogue/storage/sqlite/migration_runner.py
+++ b/polylogue/storage/sqlite/migration_runner.py
@@ -667,6 +667,16 @@ def migrate_archive_tier(
         assert backup_manifest is not None
         validate_migration_backup_manifest(backup_manifest, tier, connection=conn)
 
+    # Durable-tier migrations rebuild tables via create-copy-drop-rename;
+    # with foreign_keys ON, DROP TABLE on a referenced parent performs an
+    # implicit DELETE FROM and fires ON DELETE CASCADE into every referencing
+    # table. Production migration connections are bare sqlite3.connect (FK
+    # OFF by SQLite default), but that safety was implicit -- enforce it by
+    # construction here, outside the transaction (the pragma is a no-op
+    # inside one), and restore the caller's state afterwards.
+    foreign_keys_were_on = bool(conn.execute("PRAGMA foreign_keys").fetchone()[0])
+    if foreign_keys_were_on:
+        conn.execute("PRAGMA foreign_keys = OFF")
     try:
         conn.execute("BEGIN IMMEDIATE")
         # Authoritative re-read: a concurrent migration may have advanced (or
@@ -719,9 +729,13 @@ def migrate_archive_tier(
     except Exception:
         if conn.in_transaction:
             conn.rollback()
+        if foreign_keys_were_on:
+            conn.execute("PRAGMA foreign_keys = ON")
         raise
     else:
         conn.commit()
+        if foreign_keys_were_on:
+            conn.execute("PRAGMA foreign_keys = ON")
     return MigrationResult(
         tier=tier,
         from_version=start_version,

--- a/polylogue/storage/sqlite/migrations/source/021_widen_origin_check_claude_design.sql
+++ b/polylogue/storage/sqlite/migrations/source/021_widen_origin_check_claude_design.sql
@@ -1,0 +1,291 @@
+-- Widen the durable ``origin`` CHECK on the five source-tier tables that
+-- carry it (raw_sessions, raw_artifacts, raw_hook_events, otlp_spans,
+-- history_sidecars) to the current twelve-value core.enums.Origin
+-- vocabulary.
+--
+-- Migration 009 baked an eleven-value literal list into these tables' CHECK
+-- constraints the last time it rebuilt them. core.enums.Origin later gained
+-- a twelfth token, 'claude-design-session' (bd polylogue-tbun -- Claude
+-- Design is a distinct product with its own wire format, not claude.ai with
+-- a flag; see sources/parsers/claude/ai_parser.py's design-chat parser), and
+-- the CHECK constraint SQLite bakes into a table's schema at CREATE time is
+-- never re-derived at runtime. archive_tiers/source.py's canonical DDL for
+-- all five tables already generates this CHECK from the enum via
+-- check()/nullable_check() -- so a *fresh* bootstrap has always accepted the
+-- full vocabulary -- but any already-migrated source.db still carries the
+-- stale eleven-value literal and raises sqlite3.IntegrityError the instant a
+-- claude-design-session raw payload is acquired (bd polylogue-052vs).
+--
+-- SQLite cannot ALTER a CHECK constraint, so each table is rebuilt: create a
+-- differently-named table with the widened CHECK, copy every row across by
+-- explicit column name (never positionally -- migration 009's own comment
+-- on raw_sessions documents why: ad hoc ALTER TABLE ADD COLUMN steps append
+-- physically, so a column's position in an existing database does not
+-- necessarily match its position in the current canonical DDL text), drop
+-- the original, then rename the new table into the original's name.
+--
+-- Because this never renames the *original* table away (only a freshly
+-- created, never-referenced temporary table is renamed into the final
+-- slot), SQLite's automatic foreign-key-reference rewrite on
+-- ``ALTER TABLE ... RENAME TO`` -- which rewrites *other* tables'
+-- ``REFERENCES`` clauses to track a table that gets renamed away from its
+-- original name -- never fires here. The seven other durable tables that
+-- hold a ``REFERENCES raw_sessions(raw_id)`` foreign key
+-- (raw_capture_observations, raw_session_memberships, raw_membership_census,
+-- raw_live_source_reconciliation_receipts, raw_membership_writeback_receipts,
+-- raw_append_chain_backfill_receipts, raw_authority_parser_census) never
+-- need to be touched: their FK text still says ``REFERENCES raw_sessions``,
+-- and a table with that exact name exists again the instant the final
+-- rename statement below completes. Migration-runner connections
+-- (migration_runner.py, cli/commands/maintenance/_migrate_tier.py,
+-- archive_tiers/bootstrap.py) never set ``PRAGMA foreign_keys = ON`` before
+-- applying a migration, so the intervening ``DROP TABLE`` steps below also
+-- never trigger SQLite's drop-time cascading-delete behavior against rows in
+-- those other tables.
+--
+-- raw_artifacts/raw_hook_events/otlp_spans/history_sidecars are each guarded
+-- with a preceding ``CREATE TABLE IF NOT EXISTS`` in their stale (pre-021)
+-- shape, mirroring migration 009's own precedent (its header comment: "Older
+-- valid source tiers can therefore lack them. Create empty v7-shaped tables
+-- so every supported predecessor ... follows the same copy-forward path
+-- below") -- some already-migrated archives, and test fixtures that jump
+-- straight to a mid-chain ``PRAGMA user_version`` without replaying every
+-- earlier migration, may never have created one of these four adjunct
+-- tables at all.
+
+CREATE TABLE IF NOT EXISTS raw_artifacts (
+    artifact_id              TEXT PRIMARY KEY,
+    raw_id                   TEXT NOT NULL REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
+    origin                   TEXT NOT NULL CHECK (origin IN ('claude-code-session', 'codex-session', 'gemini-cli-session', 'hermes-session', 'antigravity-session', 'beads-issue', 'grok-export', 'chatgpt-export', 'claude-ai-export', 'aistudio-drive', 'unknown-export')),
+    source_path              TEXT NOT NULL,
+    source_index             INTEGER NOT NULL DEFAULT 0,
+    artifact_kind            TEXT NOT NULL,
+    support_status           TEXT NOT NULL CHECK (support_status IN ('supported_parseable', 'recognized_unparsed', 'unsupported_parseable', 'decode_failed', 'partial_decode', 'unknown')),
+    classification_reason    TEXT NOT NULL,
+    parse_as_session         INTEGER NOT NULL DEFAULT 0 CHECK(parse_as_session IN (0, 1)),
+    schema_eligible          INTEGER NOT NULL DEFAULT 0 CHECK(schema_eligible IN (0, 1)),
+    malformed_jsonl_lines    INTEGER NOT NULL DEFAULT 0 CHECK(malformed_jsonl_lines >= 0),
+    decode_error             TEXT,
+    cohort_id                TEXT,
+    link_group_key           TEXT,
+    sidecar_agent_type       TEXT,
+    first_observed_at_ms     INTEGER NOT NULL,
+    last_observed_at_ms      INTEGER NOT NULL
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS raw_hook_events (
+    hook_event_id   TEXT PRIMARY KEY,
+    origin          TEXT NOT NULL CHECK (origin IN ('claude-code-session', 'codex-session', 'gemini-cli-session', 'hermes-session', 'antigravity-session', 'beads-issue', 'grok-export', 'chatgpt-export', 'claude-ai-export', 'aistudio-drive', 'unknown-export')),
+    native_id       TEXT,
+    session_native_id TEXT,
+    source_path     TEXT NOT NULL,
+    event_type      TEXT NOT NULL,
+    payload_json    TEXT NOT NULL,
+    observed_at_ms  INTEGER NOT NULL
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS otlp_spans (
+    span_id           TEXT PRIMARY KEY,
+    trace_id          TEXT NOT NULL,
+    parent_span_id    TEXT,
+    origin            TEXT CHECK ((origin IN ('claude-code-session', 'codex-session', 'gemini-cli-session', 'hermes-session', 'antigravity-session', 'beads-issue', 'grok-export', 'chatgpt-export', 'claude-ai-export', 'aistudio-drive', 'unknown-export') OR origin IS NULL)),
+    session_native_id TEXT,
+    name              TEXT NOT NULL,
+    kind              TEXT,
+    attributes_json   TEXT NOT NULL DEFAULT '{}',
+    events_json       TEXT NOT NULL DEFAULT '[]',
+    started_at_ms     INTEGER,
+    ended_at_ms       INTEGER,
+    received_at_ms    INTEGER NOT NULL
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS history_sidecars (
+    sidecar_id      TEXT PRIMARY KEY,
+    origin          TEXT NOT NULL CHECK (origin IN ('claude-code-session', 'codex-session', 'gemini-cli-session', 'hermes-session', 'antigravity-session', 'beads-issue', 'grok-export', 'chatgpt-export', 'claude-ai-export', 'aistudio-drive', 'unknown-export')),
+    source_path     TEXT NOT NULL,
+    payload_json    TEXT NOT NULL,
+    observed_at_ms  INTEGER NOT NULL,
+    content_hash    BLOB NOT NULL CHECK(length(content_hash) = 32)
+) STRICT;
+
+CREATE TABLE raw_sessions__021ff (
+    raw_id                  TEXT PRIMARY KEY,
+    origin                  TEXT NOT NULL CHECK (origin IN ('claude-code-session', 'codex-session', 'gemini-cli-session', 'hermes-session', 'antigravity-session', 'beads-issue', 'grok-export', 'chatgpt-export', 'claude-ai-export', 'claude-design-session', 'aistudio-drive', 'unknown-export')),
+    capture_mode            TEXT CHECK ((capture_mode IN ('chatgpt', 'claude-ai', 'claude-design', 'claude-code', 'codex', 'gemini', 'gemini-cli', 'hermes', 'antigravity', 'beads', 'grok', 'drive', 'unknown') OR capture_mode IS NULL)),
+    native_id               TEXT,
+    source_path             TEXT NOT NULL,
+    source_index            INTEGER NOT NULL DEFAULT 0,
+    blob_hash               BLOB NOT NULL CHECK(length(blob_hash) = 32),
+    blob_size               INTEGER NOT NULL CHECK(blob_size >= 0),
+    acquired_at_ms          INTEGER NOT NULL,
+    file_mtime_ms           INTEGER,
+    parsed_at_ms            INTEGER,
+    parse_error             TEXT,
+    validated_at_ms         INTEGER,
+    validation_status       TEXT CHECK ((validation_status IN ('passed', 'failed', 'skipped') OR validation_status IS NULL)),
+    validation_error        TEXT,
+    validation_drift_count  INTEGER NOT NULL DEFAULT 0 CHECK(validation_drift_count >= 0),
+    validation_mode         TEXT CHECK ((validation_mode IN ('off', 'advisory', 'strict') OR validation_mode IS NULL)),
+    detection_warnings_json TEXT NOT NULL DEFAULT '[]',
+    logical_source_key      TEXT,
+    revision_kind           TEXT NOT NULL DEFAULT 'unknown' CHECK(revision_kind IN ('full', 'append', 'unknown')),
+    source_revision         TEXT,
+    predecessor_source_revision TEXT,
+    predecessor_raw_id      TEXT,
+    baseline_raw_id         TEXT,
+    append_start_offset     INTEGER CHECK(append_start_offset >= 0),
+    append_end_offset       INTEGER CHECK(append_end_offset > append_start_offset),
+    acquisition_generation  INTEGER CHECK(acquisition_generation >= 0),
+    revision_authority      TEXT NOT NULL DEFAULT 'quarantined' CHECK(revision_authority IN ('asserted', 'byte_proven', 'quarantined')),
+    revision_authority_evidence TEXT
+        CHECK(revision_authority_evidence IS NULL OR revision_authority_evidence IN ('live_source_verification_v1'))
+) STRICT;
+
+INSERT INTO raw_sessions__021ff (
+    raw_id, origin, capture_mode, native_id, source_path, source_index, blob_hash, blob_size,
+    acquired_at_ms, file_mtime_ms, parsed_at_ms, parse_error, validated_at_ms,
+    validation_status, validation_error, validation_drift_count, validation_mode,
+    detection_warnings_json, logical_source_key, revision_kind, source_revision,
+    predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
+    append_start_offset, append_end_offset, acquisition_generation,
+    revision_authority, revision_authority_evidence
+)
+SELECT
+    raw_id, origin, capture_mode, native_id, source_path, source_index, blob_hash, blob_size,
+    acquired_at_ms, file_mtime_ms, parsed_at_ms, parse_error, validated_at_ms,
+    validation_status, validation_error, validation_drift_count, validation_mode,
+    detection_warnings_json, logical_source_key, revision_kind, source_revision,
+    predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
+    append_start_offset, append_end_offset, acquisition_generation,
+    revision_authority, revision_authority_evidence
+FROM raw_sessions;
+
+DROP TABLE raw_sessions;
+ALTER TABLE raw_sessions__021ff RENAME TO raw_sessions;
+
+CREATE INDEX idx_raw_sessions_origin ON raw_sessions(origin);
+CREATE INDEX idx_raw_sessions_origin_native ON raw_sessions(origin, native_id) WHERE native_id IS NOT NULL;
+CREATE INDEX idx_raw_sessions_source_path ON raw_sessions(source_path, source_index);
+CREATE INDEX idx_raw_sessions_parse_ready ON raw_sessions(raw_id) WHERE parsed_at_ms IS NULL AND validated_at_ms IS NOT NULL AND (validation_status IS NULL OR validation_status != 'failed');
+CREATE INDEX idx_raw_sessions_logical_revision ON raw_sessions(logical_source_key, acquisition_generation, raw_id) WHERE logical_source_key IS NOT NULL;
+CREATE INDEX idx_raw_sessions_blob_hash ON raw_sessions(blob_hash);
+CREATE INDEX idx_raw_sessions_blob_hash_raw_id ON raw_sessions(blob_hash, raw_id);
+
+
+CREATE TABLE raw_artifacts__021ff (
+    artifact_id              TEXT PRIMARY KEY,
+    raw_id                   TEXT NOT NULL REFERENCES raw_sessions(raw_id) ON DELETE CASCADE,
+    origin                   TEXT NOT NULL CHECK (origin IN ('claude-code-session', 'codex-session', 'gemini-cli-session', 'hermes-session', 'antigravity-session', 'beads-issue', 'grok-export', 'chatgpt-export', 'claude-ai-export', 'claude-design-session', 'aistudio-drive', 'unknown-export')),
+    source_path              TEXT NOT NULL,
+    source_index             INTEGER NOT NULL DEFAULT 0,
+    artifact_kind            TEXT NOT NULL,
+    support_status           TEXT NOT NULL CHECK (support_status IN ('supported_parseable', 'recognized_unparsed', 'unsupported_parseable', 'decode_failed', 'partial_decode', 'unknown')),
+    classification_reason    TEXT NOT NULL,
+    parse_as_session         INTEGER NOT NULL DEFAULT 0 CHECK(parse_as_session IN (0, 1)),
+    schema_eligible          INTEGER NOT NULL DEFAULT 0 CHECK(schema_eligible IN (0, 1)),
+    malformed_jsonl_lines    INTEGER NOT NULL DEFAULT 0 CHECK(malformed_jsonl_lines >= 0),
+    decode_error             TEXT,
+    cohort_id                TEXT,
+    link_group_key           TEXT,
+    sidecar_agent_type       TEXT,
+    first_observed_at_ms     INTEGER NOT NULL,
+    last_observed_at_ms      INTEGER NOT NULL
+) STRICT;
+
+INSERT INTO raw_artifacts__021ff (
+    artifact_id, raw_id, origin, source_path, source_index, artifact_kind, support_status,
+    classification_reason, parse_as_session, schema_eligible, malformed_jsonl_lines,
+    decode_error, cohort_id, link_group_key, sidecar_agent_type,
+    first_observed_at_ms, last_observed_at_ms
+)
+SELECT
+    artifact_id, raw_id, origin, source_path, source_index, artifact_kind, support_status,
+    classification_reason, parse_as_session, schema_eligible, malformed_jsonl_lines,
+    decode_error, cohort_id, link_group_key, sidecar_agent_type,
+    first_observed_at_ms, last_observed_at_ms
+FROM raw_artifacts;
+
+DROP TABLE raw_artifacts;
+ALTER TABLE raw_artifacts__021ff RENAME TO raw_artifacts;
+
+CREATE UNIQUE INDEX idx_raw_artifacts_source_identity ON raw_artifacts(origin, source_path, source_index);
+CREATE INDEX idx_raw_artifacts_raw_id ON raw_artifacts(raw_id);
+
+
+CREATE TABLE raw_hook_events__021ff (
+    hook_event_id   TEXT PRIMARY KEY,
+    origin          TEXT NOT NULL CHECK (origin IN ('claude-code-session', 'codex-session', 'gemini-cli-session', 'hermes-session', 'antigravity-session', 'beads-issue', 'grok-export', 'chatgpt-export', 'claude-ai-export', 'claude-design-session', 'aistudio-drive', 'unknown-export')),
+    native_id       TEXT,
+    session_native_id TEXT,
+    source_path     TEXT NOT NULL,
+    event_type      TEXT NOT NULL,
+    payload_json    TEXT NOT NULL,
+    observed_at_ms  INTEGER NOT NULL
+) STRICT;
+
+INSERT INTO raw_hook_events__021ff (
+    hook_event_id, origin, native_id, session_native_id, source_path, event_type,
+    payload_json, observed_at_ms
+)
+SELECT
+    hook_event_id, origin, native_id, session_native_id, source_path, event_type,
+    payload_json, observed_at_ms
+FROM raw_hook_events;
+
+DROP TABLE raw_hook_events;
+ALTER TABLE raw_hook_events__021ff RENAME TO raw_hook_events;
+
+CREATE INDEX idx_raw_hook_events_session ON raw_hook_events(origin, session_native_id, observed_at_ms);
+
+
+CREATE TABLE otlp_spans__021ff (
+    span_id           TEXT PRIMARY KEY,
+    trace_id          TEXT NOT NULL,
+    parent_span_id    TEXT,
+    origin            TEXT CHECK ((origin IN ('claude-code-session', 'codex-session', 'gemini-cli-session', 'hermes-session', 'antigravity-session', 'beads-issue', 'grok-export', 'chatgpt-export', 'claude-ai-export', 'claude-design-session', 'aistudio-drive', 'unknown-export') OR origin IS NULL)),
+    session_native_id TEXT,
+    name              TEXT NOT NULL,
+    kind              TEXT,
+    attributes_json   TEXT NOT NULL DEFAULT '{}',
+    events_json       TEXT NOT NULL DEFAULT '[]',
+    started_at_ms     INTEGER,
+    ended_at_ms       INTEGER,
+    received_at_ms    INTEGER NOT NULL
+) STRICT;
+
+INSERT INTO otlp_spans__021ff (
+    span_id, trace_id, parent_span_id, origin, session_native_id, name, kind,
+    attributes_json, events_json, started_at_ms, ended_at_ms, received_at_ms
+)
+SELECT
+    span_id, trace_id, parent_span_id, origin, session_native_id, name, kind,
+    attributes_json, events_json, started_at_ms, ended_at_ms, received_at_ms
+FROM otlp_spans;
+
+DROP TABLE otlp_spans;
+ALTER TABLE otlp_spans__021ff RENAME TO otlp_spans;
+
+CREATE INDEX idx_otlp_spans_trace ON otlp_spans(trace_id, started_at_ms DESC);
+CREATE INDEX idx_otlp_spans_session ON otlp_spans(origin, session_native_id, started_at_ms DESC) WHERE session_native_id IS NOT NULL;
+
+
+CREATE TABLE history_sidecars__021ff (
+    sidecar_id      TEXT PRIMARY KEY,
+    origin          TEXT NOT NULL CHECK (origin IN ('claude-code-session', 'codex-session', 'gemini-cli-session', 'hermes-session', 'antigravity-session', 'beads-issue', 'grok-export', 'chatgpt-export', 'claude-ai-export', 'claude-design-session', 'aistudio-drive', 'unknown-export')),
+    source_path     TEXT NOT NULL,
+    payload_json    TEXT NOT NULL,
+    observed_at_ms  INTEGER NOT NULL,
+    content_hash    BLOB NOT NULL CHECK(length(content_hash) = 32)
+) STRICT;
+
+INSERT INTO history_sidecars__021ff (
+    sidecar_id, origin, source_path, payload_json, observed_at_ms, content_hash
+)
+SELECT
+    sidecar_id, origin, source_path, payload_json, observed_at_ms, content_hash
+FROM history_sidecars;
+
+DROP TABLE history_sidecars;
+ALTER TABLE history_sidecars__021ff RENAME TO history_sidecars;
+
+CREATE UNIQUE INDEX idx_history_sidecars_path_hash ON history_sidecars(origin, source_path, content_hash);

--- a/polylogue/storage/sqlite/migrations/source/021_widen_origin_check_claude_design.sql
+++ b/polylogue/storage/sqlite/migrations/source/021_widen_origin_check_claude_design.sql
@@ -36,12 +36,22 @@
 -- raw_append_chain_backfill_receipts, raw_authority_parser_census) never
 -- need to be touched: their FK text still says ``REFERENCES raw_sessions``,
 -- and a table with that exact name exists again the instant the final
--- rename statement below completes. Migration-runner connections
--- (migration_runner.py, cli/commands/maintenance/_migrate_tier.py,
--- archive_tiers/bootstrap.py) never set ``PRAGMA foreign_keys = ON`` before
--- applying a migration, so the intervening ``DROP TABLE`` steps below also
--- never trigger SQLite's drop-time cascading-delete behavior against rows in
--- those other tables.
+-- rename statement below completes. Every production connection factory
+-- that reaches ``migrate_archive_tier`` (``archive_tiers/bootstrap.py``'s
+-- ``initialize_archive_database``, ``cli/commands/maintenance/_migrate_tier.py``)
+-- opens a bare ``sqlite3.connect(path)`` with no ``PRAGMA foreign_keys``
+-- statement of its own, so ``foreign_keys`` is OFF on every one of those
+-- paths by SQLite's own default -- verified by inspecting both call sites.
+-- ``migrate_archive_tier`` no longer relies on that being merely incidental,
+-- though: it now disables ``foreign_keys`` for the duration of its own
+-- migration work (outside the ``BEGIN IMMEDIATE`` transaction, since the
+-- pragma is a no-op once a transaction is open) and restores the caller's
+-- original setting afterwards, so the intervening ``DROP TABLE`` steps
+-- below never trigger SQLite's drop-time cascading-delete behavior against
+-- rows in those other tables even if a caller's connection had
+-- ``foreign_keys = ON`` already (regression-tested by
+-- ``test_migrate_archive_tier_neutralizes_foreign_key_cascade_during_rebuild``
+-- in ``tests/unit/storage/test_durable_migrations.py``).
 --
 -- raw_artifacts/raw_hook_events/otlp_spans/history_sidecars are each guarded
 -- with a preceding ``CREATE TABLE IF NOT EXISTS`` in their stale (pre-021)
@@ -164,10 +174,13 @@ DROP TABLE raw_sessions;
 ALTER TABLE raw_sessions__021ff RENAME TO raw_sessions;
 
 CREATE INDEX idx_raw_sessions_origin ON raw_sessions(origin);
-CREATE INDEX idx_raw_sessions_origin_native ON raw_sessions(origin, native_id) WHERE native_id IS NOT NULL;
+CREATE INDEX idx_raw_sessions_origin_native ON raw_sessions(origin, native_id)
+WHERE native_id IS NOT NULL;
 CREATE INDEX idx_raw_sessions_source_path ON raw_sessions(source_path, source_index);
-CREATE INDEX idx_raw_sessions_parse_ready ON raw_sessions(raw_id) WHERE parsed_at_ms IS NULL AND validated_at_ms IS NOT NULL AND (validation_status IS NULL OR validation_status != 'failed');
-CREATE INDEX idx_raw_sessions_logical_revision ON raw_sessions(logical_source_key, acquisition_generation, raw_id) WHERE logical_source_key IS NOT NULL;
+CREATE INDEX idx_raw_sessions_parse_ready ON raw_sessions(raw_id)
+WHERE parsed_at_ms IS NULL AND validated_at_ms IS NOT NULL AND (validation_status IS NULL OR validation_status != 'failed');
+CREATE INDEX idx_raw_sessions_logical_revision ON raw_sessions(logical_source_key, acquisition_generation, raw_id)
+WHERE logical_source_key IS NOT NULL;
 CREATE INDEX idx_raw_sessions_blob_hash ON raw_sessions(blob_hash);
 CREATE INDEX idx_raw_sessions_blob_hash_raw_id ON raw_sessions(blob_hash, raw_id);
 
@@ -266,7 +279,8 @@ DROP TABLE otlp_spans;
 ALTER TABLE otlp_spans__021ff RENAME TO otlp_spans;
 
 CREATE INDEX idx_otlp_spans_trace ON otlp_spans(trace_id, started_at_ms DESC);
-CREATE INDEX idx_otlp_spans_session ON otlp_spans(origin, session_native_id, started_at_ms DESC) WHERE session_native_id IS NOT NULL;
+CREATE INDEX idx_otlp_spans_session ON otlp_spans(origin, session_native_id, started_at_ms DESC)
+WHERE session_native_id IS NOT NULL;
 
 
 CREATE TABLE history_sidecars__021ff (

--- a/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
+++ b/tests/unit/cli/__snapshots__/test_plain_cli_snapshots.ambr
@@ -1017,8 +1017,8 @@
         "path": "<PATH>",
         "exists": true,
         "size_bytes": <SIZE_BYTES>,
-        "expected_user_version": 20,
-        "user_version": 20,
+        "expected_user_version": 21,
+        "user_version": 21,
         "version_status": "ok",
         "table_counts": {
           "raw_sessions": 2,

--- a/tests/unit/storage/test_durable_migrations.py
+++ b/tests/unit/storage/test_durable_migrations.py
@@ -769,9 +769,38 @@ def _source_v20_ddl_with_stale_origin_check() -> str:
     widens, or skipping one of the five tables, must make this fixture (and
     the pre-migration IntegrityError assertion built on it) diverge from a
     genuine pre-021 archive.
+
+    ``capture_mode`` is also moved out of ``raw_sessions``'s declared column
+    list and re-added via a trailing ``ALTER TABLE ... ADD COLUMN``, so it
+    sits physically last -- exactly where migration 008's real
+    ``ALTER TABLE raw_sessions ADD COLUMN capture_mode ...`` put it in a
+    genuine v20 archive, and NOT in the position ``SOURCE_DDL`` declares it
+    (second column, right after ``origin``). Without this, the fixture's
+    physical and logical column order would coincide and a ``SELECT *``
+    copy-forward would pass against it despite being wrong on a real
+    archive -- see ``test_source_tier_v20_widens_origin_check_for_claude_design_session``'s
+    docstring, whose column-order anti-vacuity claim depends on this
+    mismatch actually existing.
     """
     stale = SOURCE_DDL.replace(", 'claude-design-session'", "")
     assert "claude-design-session" not in stale
+    capture_mode_declaration = (
+        "    capture_mode            TEXT CHECK ((capture_mode IN ('chatgpt', 'claude-ai', 'claude-design', "
+        "'claude-code', 'codex', 'gemini', 'gemini-cli', 'hermes', 'antigravity', 'beads', 'grok', 'drive', "
+        "'unknown') OR capture_mode IS NULL)),\n"
+    )
+    assert capture_mode_declaration in stale
+    stale = stale.replace(capture_mode_declaration, "")
+    raw_sessions_close = "        CHECK(revision_authority_evidence IS NULL OR revision_authority_evidence IN ('live_source_verification_v1'))\n) STRICT;\n"
+    assert raw_sessions_close in stale
+    stale = stale.replace(
+        raw_sessions_close,
+        raw_sessions_close
+        + "\nALTER TABLE raw_sessions ADD COLUMN capture_mode TEXT CHECK ((capture_mode IN ('chatgpt', "
+        "'claude-ai', 'claude-design', 'claude-code', 'codex', 'gemini', 'gemini-cli', 'hermes', 'antigravity', "
+        "'beads', 'grok', 'drive', 'unknown') OR capture_mode IS NULL));\n",
+        1,
+    )
     return stale
 
 
@@ -948,6 +977,76 @@ def test_source_tier_v20_widens_origin_check_for_claude_design_session(
             conn.execute("SELECT COUNT(*) FROM raw_sessions WHERE origin = 'claude-design-session'").fetchone()[0] == 1
         )
         assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
+def test_migrate_archive_tier_neutralizes_foreign_key_cascade_during_rebuild(
+    workspace_env: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    """``migrate_archive_tier``'s create-copy-drop-rename table rebuild
+    (migration 021 among others) must survive a caller connection that has
+    ``PRAGMA foreign_keys = ON``.
+
+    ``DROP TABLE raw_sessions`` with ``foreign_keys`` enabled performs an
+    implicit ``DELETE FROM`` before removing the table, which fires
+    ``ON DELETE CASCADE`` into every table declaring
+    ``REFERENCES raw_sessions(raw_id)`` -- exactly the position seven real
+    durable tables are in (``raw_capture_observations``,
+    ``raw_session_memberships``, ``raw_membership_census``,
+    ``raw_live_source_reconciliation_receipts``,
+    ``raw_membership_writeback_receipts``,
+    ``raw_append_chain_backfill_receipts``, ``raw_authority_parser_census``,
+    plus ``raw_artifacts`` which migration 021 itself rebuilds). Production
+    callers (``archive_tiers/bootstrap.py``'s ``initialize_archive_database``,
+    ``cli/commands/maintenance/_migrate_tier.py``) reach ``migrate_archive_tier``
+    through a bare ``sqlite3.connect(path)`` with no ``PRAGMA foreign_keys``
+    statement of their own, so ``foreign_keys`` is OFF by SQLite's own
+    default on every production path today -- but that safety was only
+    implicit, never enforced by the runner itself, and a caller that opens
+    its own connection with foreign keys already enabled (as this test
+    does, and as any future caller reasonably might) had no protection.
+    ``migrate_archive_tier`` now disables ``foreign_keys`` for the duration
+    of its own migration work and restores the caller's original setting
+    afterwards, regardless of which value it started at.
+
+    Anti-vacuity: this test fails without that enforcement (verified by
+    temporarily reverting it) -- the scratch child row below gets
+    cascade-deleted the instant ``raw_sessions`` is dropped mid-migration.
+    """
+    db_path = workspace_env["archive_root"] / "source.db"
+    _create_source_v20_with_stale_origin_check(db_path, archive_root=workspace_env["archive_root"])
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE scratch_raw_sessions_child (
+                raw_id TEXT PRIMARY KEY REFERENCES raw_sessions(raw_id) ON DELETE CASCADE
+            )
+            """
+        )
+        conn.execute("INSERT INTO scratch_raw_sessions_child (raw_id) VALUES ('raw-preexisting')")
+        conn.commit()
+
+    manifest = _verified_backup_manifest(tmp_path / "backup-v20-fk-cascade")
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("PRAGMA foreign_keys = ON")
+        assert bool(conn.execute("PRAGMA foreign_keys").fetchone()[0]) is True
+
+        result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
+        assert result.to_version == SOURCE_SCHEMA_VERSION == 21
+
+        # The scratch child row survived the raw_sessions rebuild instead of
+        # being cascade-deleted when the original raw_sessions was dropped.
+        assert conn.execute(
+            "SELECT raw_id FROM scratch_raw_sessions_child WHERE raw_id = 'raw-preexisting'"
+        ).fetchone() == ("raw-preexisting",)
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+        # The runner restores the caller's foreign_keys setting afterwards.
+        assert bool(conn.execute("PRAGMA foreign_keys").fetchone()[0]) is True
+    finally:
+        conn.close()
 
 
 def test_source_tier_fresh_bootstrap_accepts_claude_design_session(

--- a/tests/unit/storage/test_durable_migrations.py
+++ b/tests/unit/storage/test_durable_migrations.py
@@ -489,7 +489,7 @@ def test_source_tier_v1_migrates_to_current_without_native_uniqueness(
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
         assert result.from_version == 1
         assert result.to_version == SOURCE_SCHEMA_VERSION
-        assert result.applied_versions == (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)
+        assert result.applied_versions == (2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         columns = {str(row[1]) for row in conn.execute("PRAGMA table_info('raw_sessions')")}
         assert "predecessor_source_revision" in columns
@@ -577,8 +577,8 @@ def test_source_publication_backfill_requires_verified_backup(
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
 
         assert result.from_version == 9
-        assert result.to_version == SOURCE_SCHEMA_VERSION == 20
-        assert result.applied_versions == (10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)
+        assert result.to_version == SOURCE_SCHEMA_VERSION == 21
+        assert result.applied_versions == (10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
         assert result.backup_receipt == manifest.with_name("verification-receipt.json")
         tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
         assert {
@@ -732,8 +732,8 @@ def test_source_tier_v7_expands_origin_checks_with_verified_backup(
     with sqlite3.connect(db_path) as conn:
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
         assert result.from_version == 7
-        assert result.to_version == SOURCE_SCHEMA_VERSION == 20
-        assert result.applied_versions == (8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)
+        assert result.to_version == SOURCE_SCHEMA_VERSION == 21
+        assert result.applied_versions == (8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
         assert conn.execute(
             """
             SELECT predecessor_source_revision, predecessor_raw_id, baseline_raw_id,
@@ -759,6 +759,221 @@ def test_source_tier_v7_expands_origin_checks_with_verified_backup(
             ("beads-raw", "beads-issue", "polylogue-7fj", "/repo/.beads/interactions.jsonl", 0, b"b" * 32, 1, 2),
         )
         assert conn.execute("SELECT raw_id FROM raw_sessions WHERE origin = 'beads-issue'").fetchone()
+
+
+def _source_v20_ddl_with_stale_origin_check() -> str:
+    """``SOURCE_DDL`` with the origin CHECK narrowed back to its pre-021
+    (v20) eleven-value list, reproducing the exact shape migration 021
+    exists to repair. Reverting migration 021's SQL to drop
+    ``'claude-design-session'`` from any of the five origin CHECKs it
+    widens, or skipping one of the five tables, must make this fixture (and
+    the pre-migration IntegrityError assertion built on it) diverge from a
+    genuine pre-021 archive.
+    """
+    stale = SOURCE_DDL.replace(", 'claude-design-session'", "")
+    assert "claude-design-session" not in stale
+    return stale
+
+
+def _create_source_v20_with_stale_origin_check(path: Path, *, archive_root: Path) -> None:
+    """A v20 source tier whose five origin-bearing tables still carry
+    migration 009's eleven-value CHECK (bd polylogue-052vs)."""
+    path.unlink(missing_ok=True)
+    # A verified backup checks that every raw_sessions.blob_hash resolves to a
+    # real blob-store entry -- write one instead of an arbitrary byte string.
+    blob_hash_hex, blob_size = BlobStore(archive_root / "blob").write_from_bytes(b"preexisting-design-fixture")
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(_source_v20_ddl_with_stale_origin_check())
+        conn.execute("PRAGMA user_version = 20")
+        conn.execute(
+            """
+            INSERT INTO raw_sessions (
+                raw_id, origin, native_id, source_path, source_index, blob_hash, blob_size, acquired_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "raw-preexisting",
+                "claude-code-session",
+                "session-1",
+                "/preexisting.jsonl",
+                0,
+                bytes.fromhex(blob_hash_hex),
+                blob_size,
+                1,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_artifacts (
+                artifact_id, raw_id, origin, source_path, artifact_kind, support_status,
+                classification_reason, first_observed_at_ms, last_observed_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "artifact-preexisting",
+                "raw-preexisting",
+                "claude-code-session",
+                "/preexisting.jsonl",
+                "session",
+                "supported_parseable",
+                "ok",
+                1,
+                1,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, session_native_id, source_path, event_type, payload_json, observed_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("hook-preexisting", "claude-code-session", "session-1", "/preexisting.jsonl", "PreToolUse", "{}", 1),
+        )
+        conn.execute(
+            """
+            INSERT INTO otlp_spans (
+                span_id, trace_id, origin, session_native_id, name, received_at_ms
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("span-preexisting", "trace-1", "claude-code-session", "session-1", "op", 1),
+        )
+        conn.execute(
+            """
+            INSERT INTO history_sidecars (
+                sidecar_id, origin, source_path, payload_json, observed_at_ms, content_hash
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("sidecar-preexisting", "claude-code-session", "/preexisting.jsonl", "{}", 1, b"b" * 32),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_source_tier_v20_widens_origin_check_for_claude_design_session(
+    workspace_env: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    """Migration 021 widens the durable ``origin`` CHECK on all five
+    source-tier tables that carry it (raw_sessions, raw_artifacts,
+    raw_hook_events, otlp_spans, history_sidecars) to accept
+    ``claude-design-session`` (bd polylogue-052vs).
+
+    Anti-vacuity: reverting migration 021's rebuild of any one of the five
+    tables (or narrowing its CHECK literal back to the stale eleven-value
+    list) makes the corresponding post-migration INSERT below raise
+    ``sqlite3.IntegrityError`` again. Dropping the explicit column-name
+    copy-forward in favor of ``SELECT *`` (or getting a column name wrong)
+    makes the pre-existing-row assertions fail instead, since a v20 archive
+    that ran migration 008's ``ALTER TABLE ADD COLUMN`` has ``capture_mode``
+    physically appended, not in its logical/declared position.
+    """
+    db_path = workspace_env["archive_root"] / "source.db"
+    _create_source_v20_with_stale_origin_check(db_path, archive_root=workspace_env["archive_root"])
+
+    with sqlite3.connect(db_path) as conn:
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO raw_sessions (raw_id, origin, source_path, blob_hash, blob_size, acquired_at_ms) "
+                "VALUES ('pre', 'claude-design-session', '/pre.json', ?, 1, 1)",
+                (b"c" * 32,),
+            )
+        conn.rollback()
+
+    manifest = _verified_backup_manifest(tmp_path / "backup-v20-origin")
+
+    with sqlite3.connect(db_path) as conn:
+        result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
+        assert result.from_version == 20
+        assert result.to_version == SOURCE_SCHEMA_VERSION == 21
+        assert result.applied_versions == (21,)
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 21
+
+        # Every pre-existing row from the v20 fixture survived the rebuild.
+        assert conn.execute(
+            "SELECT raw_id, origin, source_path FROM raw_sessions WHERE raw_id = 'raw-preexisting'"
+        ).fetchone() == ("raw-preexisting", "claude-code-session", "/preexisting.jsonl")
+        assert conn.execute(
+            "SELECT artifact_id FROM raw_artifacts WHERE artifact_id = 'artifact-preexisting'"
+        ).fetchone() == ("artifact-preexisting",)
+        assert conn.execute(
+            "SELECT hook_event_id FROM raw_hook_events WHERE hook_event_id = 'hook-preexisting'"
+        ).fetchone() == ("hook-preexisting",)
+        assert conn.execute("SELECT span_id FROM otlp_spans WHERE span_id = 'span-preexisting'").fetchone() == (
+            "span-preexisting",
+        )
+        assert conn.execute(
+            "SELECT sidecar_id FROM history_sidecars WHERE sidecar_id = 'sidecar-preexisting'"
+        ).fetchone() == ("sidecar-preexisting",)
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+        # And every table now accepts claude-design-session.
+        conn.execute(
+            "INSERT INTO raw_sessions (raw_id, origin, source_path, blob_hash, blob_size, acquired_at_ms) "
+            "VALUES ('design-raw', 'claude-design-session', '/design.json', ?, 1, 2)",
+            (b"d" * 32,),
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_artifacts (
+                artifact_id, raw_id, origin, source_path, artifact_kind, support_status,
+                classification_reason, first_observed_at_ms, last_observed_at_ms
+            ) VALUES ('design-artifact', 'design-raw', 'claude-design-session', '/design.json', 'session',
+                      'supported_parseable', 'ok', 2, 2)
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO raw_hook_events (
+                hook_event_id, origin, session_native_id, source_path, event_type, payload_json, observed_at_ms
+            ) VALUES ('design-hook', 'claude-design-session', 'design-session-1', '/design.json', 'PreToolUse', '{}', 2)
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO otlp_spans (span_id, trace_id, origin, session_native_id, name, received_at_ms)
+            VALUES ('design-span', 'trace-design', 'claude-design-session', 'design-session-1', 'op', 2)
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO history_sidecars (sidecar_id, origin, source_path, payload_json, observed_at_ms, content_hash)
+            VALUES ('design-sidecar', 'claude-design-session', '/design.json', '{}', 2, ?)
+            """,
+            (b"e" * 32,),
+        )
+        conn.commit()
+        assert (
+            conn.execute("SELECT COUNT(*) FROM raw_sessions WHERE origin = 'claude-design-session'").fetchone()[0] == 1
+        )
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
+def test_source_tier_fresh_bootstrap_accepts_claude_design_session(
+    workspace_env: dict[str, Path],
+) -> None:
+    """A freshly bootstrapped source.db (``SOURCE_DDL``, no migration
+    involved) already accepts ``claude-design-session`` --
+    ``archive_tiers/source.py`` generates the origin CHECK from
+    ``core.enums.Origin`` directly via ``check()``/``nullable_check()``, so
+    fresh archives never had this bug. Hard-coding any of the five origin
+    CHECKs in ``source.py`` back to a literal list that omits
+    ``claude-design-session`` makes the INSERT below raise
+    ``sqlite3.IntegrityError``.
+    """
+    db_path = workspace_env["archive_root"] / "source.db"
+    with sqlite3.connect(db_path) as conn:
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
+        conn.execute(
+            "INSERT INTO raw_sessions (raw_id, origin, source_path, blob_hash, blob_size, acquired_at_ms) "
+            "VALUES ('fresh-design', 'claude-design-session', '/fresh.json', ?, 1, 1)",
+            (b"f" * 32,),
+        )
+        conn.commit()
+        assert conn.execute("SELECT origin FROM raw_sessions WHERE raw_id = 'fresh-design'").fetchone() == (
+            "claude-design-session",
+        )
 
 
 def _create_source_v2_with_pending_blob_refs(path: Path) -> None:
@@ -894,7 +1109,7 @@ def test_source_tier_v2_migrates_to_v3_dropping_pending_blob_refs(
 
         assert result.from_version == 2
         assert result.to_version == SOURCE_SCHEMA_VERSION
-        assert result.applied_versions == (3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)
+        assert result.applied_versions == (3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         assert not conn.execute(
             "SELECT 1 FROM sqlite_master WHERE type='table' AND name='pending_blob_refs'"
@@ -952,7 +1167,7 @@ def test_source_tier_v3_adds_publication_reservations_with_verified_backup_recei
     conn = sqlite3.connect(db_path)
     try:
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
-        assert result.applied_versions == (4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20)
+        assert result.applied_versions == (4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21)
         assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == SOURCE_SCHEMA_VERSION
         conn.execute(
             """
@@ -992,6 +1207,12 @@ def test_source_tier_v13_adds_raw_sessions_blob_hash_index(
     migrating to "current" also picks up migration 016 (polylogue-buns, added
     after this test), which is not additive-no-backup, so a verified backup
     manifest is required for the full chain.
+
+    ``raw_sessions`` carries every column a real v13 archive would have after
+    migration 009's rebuild (v5/v6/v8 additive columns folded in) -- migration
+    021's explicit column-name copy-forward (unlike 014-020, which never touch
+    ``raw_sessions``'s column shape) fails with "no such column" against a
+    fixture that only carries the handful of columns 014 itself cares about.
     """
     db_path = workspace_env["archive_root"] / "source.db"
     db_path.unlink(missing_ok=True)
@@ -1008,7 +1229,26 @@ def test_source_tier_v13_adds_raw_sessions_blob_hash_index(
                 source_index            INTEGER NOT NULL DEFAULT 0,
                 blob_hash               BLOB NOT NULL CHECK(length(blob_hash) = 32),
                 blob_size               INTEGER NOT NULL CHECK(blob_size >= 0),
-                acquired_at_ms          INTEGER NOT NULL
+                acquired_at_ms          INTEGER NOT NULL,
+                file_mtime_ms           INTEGER,
+                parsed_at_ms            INTEGER,
+                parse_error             TEXT,
+                validated_at_ms         INTEGER,
+                validation_status       TEXT,
+                validation_error        TEXT,
+                validation_drift_count  INTEGER NOT NULL DEFAULT 0 CHECK(validation_drift_count >= 0),
+                validation_mode         TEXT,
+                detection_warnings_json TEXT NOT NULL DEFAULT '[]',
+                logical_source_key      TEXT,
+                revision_kind           TEXT NOT NULL DEFAULT 'unknown',
+                source_revision         TEXT,
+                predecessor_source_revision TEXT,
+                predecessor_raw_id      TEXT,
+                baseline_raw_id         TEXT,
+                append_start_offset     INTEGER,
+                append_end_offset       INTEGER,
+                acquisition_generation  INTEGER,
+                revision_authority      TEXT NOT NULL DEFAULT 'quarantined'
             ) STRICT;
             PRAGMA user_version = 13;
             """
@@ -1021,14 +1261,15 @@ def test_source_tier_v13_adds_raw_sessions_blob_hash_index(
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
 
         assert result.from_version == 13
-        assert result.to_version == SOURCE_SCHEMA_VERSION == 20
+        assert result.to_version == SOURCE_SCHEMA_VERSION == 21
         # v13 -> current also picks up migrations 015 (polylogue-hord), 016
         # (polylogue-buns), 017 (polylogue-byw3y), 018 (polylogue-u19l), 019
-        # (polylogue-lb39z item 2), and 020 (polylogue-lb39z item 3), all added
-        # after this test -- a v13 fixture migrating to "current" is exactly
-        # the shape a real archive frozen at v13 would go through.
-        assert result.applied_versions == (14, 15, 16, 17, 18, 19, 20)
-        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 20
+        # (polylogue-lb39z item 2), 020 (polylogue-lb39z item 3), and 021
+        # (polylogue-052vs), all added after this test -- a v13 fixture
+        # migrating to "current" is exactly the shape a real archive frozen
+        # at v13 would go through.
+        assert result.applied_versions == (14, 15, 16, 17, 18, 19, 20, 21)
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 21
         indexes_after = {row[1] for row in conn.execute("PRAGMA index_list('raw_sessions')")}
         assert "idx_raw_sessions_blob_hash" in indexes_after
         assert "idx_raw_sessions_blob_hash_raw_id" in indexes_after
@@ -1059,6 +1300,12 @@ def test_source_tier_v14_adds_raw_sessions_blob_hash_raw_id_index(
     not additive-no-backup, so a verified backup manifest is required for the
     full chain. Migration 017 (polylogue-byw3y, also added after this test)
     is pure-additive too and does not change that requirement.
+
+    ``raw_sessions`` carries every column a real v14 archive would have after
+    migration 009's rebuild (v5/v6/v8 additive columns folded in) -- migration
+    021's explicit column-name copy-forward (unlike 015-020, which never touch
+    ``raw_sessions``'s column shape) fails with "no such column" against a
+    fixture that only carries the handful of columns 015 itself cares about.
     """
     db_path = workspace_env["archive_root"] / "source.db"
     db_path.unlink(missing_ok=True)
@@ -1075,7 +1322,26 @@ def test_source_tier_v14_adds_raw_sessions_blob_hash_raw_id_index(
                 source_index            INTEGER NOT NULL DEFAULT 0,
                 blob_hash               BLOB NOT NULL CHECK(length(blob_hash) = 32),
                 blob_size               INTEGER NOT NULL CHECK(blob_size >= 0),
-                acquired_at_ms          INTEGER NOT NULL
+                acquired_at_ms          INTEGER NOT NULL,
+                file_mtime_ms           INTEGER,
+                parsed_at_ms            INTEGER,
+                parse_error             TEXT,
+                validated_at_ms         INTEGER,
+                validation_status       TEXT,
+                validation_error        TEXT,
+                validation_drift_count  INTEGER NOT NULL DEFAULT 0 CHECK(validation_drift_count >= 0),
+                validation_mode         TEXT,
+                detection_warnings_json TEXT NOT NULL DEFAULT '[]',
+                logical_source_key      TEXT,
+                revision_kind           TEXT NOT NULL DEFAULT 'unknown',
+                source_revision         TEXT,
+                predecessor_source_revision TEXT,
+                predecessor_raw_id      TEXT,
+                baseline_raw_id         TEXT,
+                append_start_offset     INTEGER,
+                append_end_offset       INTEGER,
+                acquisition_generation  INTEGER,
+                revision_authority      TEXT NOT NULL DEFAULT 'quarantined'
             ) STRICT;
             CREATE INDEX idx_raw_sessions_blob_hash ON raw_sessions(blob_hash);
             PRAGMA user_version = 14;
@@ -1089,9 +1355,9 @@ def test_source_tier_v14_adds_raw_sessions_blob_hash_raw_id_index(
         result = migrate_archive_tier(conn, ArchiveTier.SOURCE, backup_manifest=manifest)
 
         assert result.from_version == 14
-        assert result.to_version == SOURCE_SCHEMA_VERSION == 20
-        assert result.applied_versions == (15, 16, 17, 18, 19, 20)
-        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 20
+        assert result.to_version == SOURCE_SCHEMA_VERSION == 21
+        assert result.applied_versions == (15, 16, 17, 18, 19, 20, 21)
+        assert int(conn.execute("PRAGMA user_version").fetchone()[0]) == 21
         indexes_after = {row[1] for row in conn.execute("PRAGMA index_list('raw_sessions')")}
         assert "idx_raw_sessions_blob_hash_raw_id" in indexes_after
         plan = conn.execute(


### PR DESCRIPTION
## Summary

Migration 021 widens the durable `origin` CHECK on the five source-tier tables that carry it (`raw_sessions`, `raw_artifacts`, `raw_hook_events`, `otlp_spans`, `history_sidecars`) so an already-migrated `source.db` accepts `claude-design-session`, matching what a fresh bootstrap already accepts.

## Problem

`core.enums.Origin` has 12 values, but migration `009_expand_origin_vocabulary.sql` baked an 11-value literal `origin IN (...)` CHECK into these five tables when it last rebuilt them. `claude-design-session` (bd polylogue-tbun) was added to the enum after migration 009 shipped and is actively produced by `polylogue/sources/parsers/claude/ai_parser.py`'s design-chat parser. `archive_tiers/source.py`'s canonical DDL for all five tables already generates this CHECK from the enum via `check()`/`nullable_check()`, so a fresh bootstrap has always accepted the full vocabulary — but any already-migrated `source.db` still carries the stale literal and raises `sqlite3.IntegrityError` the instant a design-session raw payload is acquired.

## Solution

- New additive migration `polylogue/storage/sqlite/migrations/source/021_widen_origin_check_claude_design.sql`, bumping `SOURCE_SCHEMA_VERSION` to 21 (`archive_tiers/source.py`). SQLite cannot `ALTER` a CHECK, so each of the five tables is rebuilt: create a differently-named table with the widened CHECK, copy every row across by explicit column name (never `SELECT *` — migration 009's own precedent documents why: ad hoc `ALTER TABLE ADD COLUMN` steps append physically, so a column's position in an existing database doesn't necessarily match its declared position), drop the original, rename the new table into place.
- The rename step never renames the *original* table away (only a freshly created, never-referenced temp table is renamed into the final slot), so SQLite's automatic foreign-key-reference rewrite on `ALTER TABLE ... RENAME TO` — which rewrites *other* tables' `REFERENCES` clauses to track a table renamed away from its original name — never fires. Verified empirically (in-process sqlite3) that the seven other durable tables holding a `REFERENCES raw_sessions(raw_id)` foreign key keep valid FK text and cascade-delete behavior without being touched. Also verified migration-runner connections never set `PRAGMA foreign_keys = ON` before applying a migration, so `DROP TABLE` mid-migration never triggers SQLite's drop-time cascading-delete semantics against those tables' rows.
- `raw_artifacts`/`raw_hook_events`/`otlp_spans`/`history_sidecars` are each guarded with a preceding `CREATE TABLE IF NOT EXISTS` in their stale shape, mirroring migration 009's own precedent for archives (or synthetic fixtures) that jump to a mid-chain `user_version` without ever creating one of these adjunct tables.
- `archive_tiers/source.py` needed no DDL change: all five tables' origin CHECKs were already generator-tied to `core.enums.Origin` (item 2 of the original ask was already satisfied on inspection).

## Tests

`tests/unit/storage/test_durable_migrations.py`:
- `test_source_tier_v20_widens_origin_check_for_claude_design_session`: builds a v20 fixture with the stale 11-value CHECK on all five tables (pre-existing rows via a real `BlobStore`-backed blob), asserts the CHECK actually rejects `claude-design-session` beforehand, applies the migration, asserts every pre-existing row across all five tables survived, `PRAGMA foreign_key_check` is clean, and every table now accepts `claude-design-session`. Reverting the migration's rebuild of any one table, or narrowing its CHECK literal back, makes the corresponding INSERT raise `IntegrityError` again.
- `test_source_tier_fresh_bootstrap_accepts_claude_design_session`: a freshly bootstrapped `source.db` already accepts the value (regression guard on `source.py`'s generator-tied CHECKs).
- Updated the pre-existing v1/v2/v3/v7/v13/v14/publication-backfill migration tests' `applied_versions`/`SOURCE_SCHEMA_VERSION` assertions for the new 021 step, and widened the synthetic v13/v14 `raw_sessions` fixtures to the full v9-rebuilt column set (021's explicit column-name copy-forward needs those columns to exist, unlike migrations 014-020 which never touch `raw_sessions`'s column shape).
- Regenerated one syrupy snapshot (`test_json_status_snapshot`) that pinned `SOURCE_SCHEMA_VERSION=20`.

## Verification

- `devtools test tests/unit/storage/test_durable_migrations.py`: 42 passed
- `devtools test tests/unit/cli/test_plain_cli_snapshots.py -k test_json_status_snapshot`: passed after snapshot update
- `devtools lab policy schema-versioning`: ok
- `devtools verify --quick`: ok (23 steps, exit 0)
- `devtools verify --seed-testmon --skip-slow`: attempted twice; the first full run (before this PR's testmon cache existed) surfaced 8 pre-existing failures in files this change never touches (`test_filters_props.py`, `test_sampling.py`, `test_campaign_receipt_reconciliation.py`, `test_raw_authority_scale_proof.py`, `test_prepare.py`, `test_claude_code_normalization_laws.py`) — confirmed unrelated by content and by `git status` showing this PR's diff never touches those files. A second attempt hit an xdist `Different tests were collected between gw1 and gw0` collection-race error against a partially-seeded `.cache/testmon/` left by the interrupted first attempt; that stale cache was removed (`.cache/` is disposable) rather than re-run to completion given the pre-existing failures were already independently confirmed unrelated.

## Scope left out

- The eleven pre-existing test failures/collection race above are not addressed here — out of scope for this fix and untouched by the diff.
- `docs/schema.md`'s `SOURCE_SCHEMA_VERSION = 18` reference was already stale before this change (current was 20, now 21) and is not gated by any drift check in `devtools verify --quick`; left as pre-existing drift rather than expanding this PR's scope.

Ref polylogue-052vs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing Claude design session origins in source archives.
  * Preserved existing archived data and relationships during schema updates.
* **Bug Fixes**
  * Improved migration compatibility for both existing databases and fresh installations.
  * Updated CLI status reporting to reflect the latest source archive schema version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->