### PR TITLE
fix(daemon): bound catch-up gate wait and alert on parked loops

### DIFF
--- a/polylogue/daemon/blob_gc_periodic.py
+++ b/polylogue/daemon/blob_gc_periodic.py
@@ -32,10 +32,10 @@ BLOB_GC_MAX_BATCH = 200
 
 async def periodic_blob_gc_check(*, catch_up_complete: asyncio.Event | None = None) -> None:
     """Periodically reclaim one bounded batch of unreferenced, aged-out blobs."""
+    from polylogue.daemon.cli import _await_catch_up_gate
     from polylogue.paths import archive_root, source_db_path
 
-    if catch_up_complete is not None:
-        await catch_up_complete.wait()
+    await _await_catch_up_gate(catch_up_complete, loop_name="blob gc check")
     while True:
         await asyncio.sleep(BLOB_GC_INTERVAL_SECONDS)
         try:

--- a/polylogue/daemon/cli.py
+++ b/polylogue/daemon/cli.py
@@ -268,6 +268,71 @@ _DRIVE_SOURCE_CATCHUP_INTERVAL_SECONDS = 3600
 _BLOB_REFERENCE_RESTORE_CONVERGENCE_BATCH_LIMIT = 25
 _SCHEMA_PREFLIGHT_RECHECK_INTERVAL_SECONDS = 60
 
+# polylogue-5xxmc: ``catch_up_complete`` sequences a maintenance loop behind
+# the live watcher's initial source catch-up (see ``_bridge_catch_up_complete``
+# below) so archive-wide convergence work never races freshly-arriving
+# sessions for the single writer. That sequencing is a startup-ordering aid,
+# not a permanent kill switch -- if the watcher never reaches catch-up-complete
+# (crash, hang, or any other path that leaves the bridge task without a source
+# event to forward) every gated loop must still eventually run instead of
+# parking on ``Event.wait()`` forever. Verified live 2026-08-03: gated
+# maintenance loops frozen, convergence_debt retries stalled since 2026-07-31
+# with zero journal signal beyond the periodic schema_version health line.
+_CATCH_UP_GATE_TIMEOUT_SECONDS = 1800.0  # 30 minutes
+
+
+async def _await_catch_up_gate(
+    catch_up_complete: asyncio.Event | None,
+    *,
+    loop_name: str,
+    timeout_s: float = _CATCH_UP_GATE_TIMEOUT_SECONDS,
+) -> None:
+    """Wait for the watcher's initial catch-up, bounded by ``timeout_s``.
+
+    Preserves the exact prior behavior when the gate is released promptly
+    (or never supplied): the wait returns as soon as ``catch_up_complete``
+    is set. Only a gate that stays unset for the full timeout gets a single
+    WARNING and the loop proceeds without having observed catch-up.
+    """
+    if catch_up_complete is None or catch_up_complete.is_set():
+        return
+    try:
+        await asyncio.wait_for(catch_up_complete.wait(), timeout=timeout_s)
+    except TimeoutError:
+        logger.warning(
+            "daemon: %s catch-up gate not released after %ds; proceeding without watcher catch-up",
+            loop_name,
+            int(timeout_s),
+        )
+
+
+# The full set of daemon-owned periodic maintenance loops withheld while the
+# watcher is schema-blocked (see ``watcher_blocked`` in
+# ``run_daemon_services``) -- the whole ``if not watcher_blocked:`` block
+# below is skipped in that state, so none of these loops are even created,
+# let alone run, until an operator resolves the schema mismatch and the
+# daemon is restarted (or ``_periodic_schema_preflight_recheck`` detects
+# recovery and restarts it). Named here so the startup alert can say exactly
+# what is frozen instead of leaving it to be inferred from source.
+_SCHEMA_BLOCKED_MAINTENANCE_LOOP_NAMES: tuple[str, ...] = (
+    "raw materialization convergence",
+    "session insight convergence",
+    "convergence debt retry",
+    "wal checkpoint",
+    "fts merge",
+    "heartbeat",
+    "embedding backlog catch-up",
+    "embedding orphan reconcile",
+    "db optimize",
+    "status snapshot refresh",
+    "judgment automation sweep",
+    "fts identity drift recompute",
+    "fts orphan audit",
+    "blob gc check",
+    "secret scan sweep",
+)
+_SCHEMA_BLOCKED_OPTIONAL_DRIVE_CATCHUP_LOOP_NAME = "drive source catch-up"
+
 
 async def _periodic_schema_preflight_recheck() -> None:
     """Poll for tier-layout recovery while the watcher is schema-blocked.
@@ -630,8 +695,7 @@ async def _periodic_drive_source_catchup(
     gets the single archive writer before remote download/index work.  The
     gate is deliberately absent for maintenance-only callers.
     """
-    if catch_up_complete is not None:
-        await catch_up_complete.wait()
+    await _await_catch_up_gate(catch_up_complete, loop_name="drive source catch-up")
 
     while True:
         coordinator = daemon_write_coordinator()
@@ -788,8 +852,7 @@ async def _periodic_convergence_check(
 ) -> None:
     """Periodically retry recorded derived convergence debt."""
     db = _active_index_db_path()
-    if catch_up_complete is not None:
-        await catch_up_complete.wait()
+    await _await_catch_up_gate(catch_up_complete, loop_name="convergence debt retry")
     while True:
         await _retry_convergence_debt_once(db)
         await asyncio.sleep(_CONVERGENCE_DEBT_RETRY_INTERVAL_SECONDS)
@@ -965,8 +1028,7 @@ async def _periodic_raw_materialization_convergence(
     — instead of waiting a full interval per pass, which would stretch a large
     drain into weeks.
     """
-    if catch_up_complete is not None:
-        await catch_up_complete.wait()
+    await _await_catch_up_gate(catch_up_complete, loop_name="raw materialization convergence")
 
     while True:
         if _browser_capture_spool_has_pending_files():
@@ -1086,8 +1148,7 @@ async def _periodic_session_insight_convergence_after(
     catch_up_complete: asyncio.Event | None = None,
 ) -> None:
     """Continuously converge missing/stale session insights after catch-up."""
-    if catch_up_complete is not None:
-        await catch_up_complete.wait()
+    await _await_catch_up_gate(catch_up_complete, loop_name="session insight convergence")
     while True:
         burst_count = 0
         try:
@@ -2083,6 +2144,33 @@ async def run_daemon_services(
                 detail={"check_name": schema_alert.check_name},
             )
         )
+        parked_loop_names = _SCHEMA_BLOCKED_MAINTENANCE_LOOP_NAMES
+        if enable_source_catchup:
+            parked_loop_names = (*parked_loop_names, _SCHEMA_BLOCKED_OPTIONAL_DRIVE_CATCHUP_LOOP_NAME)
+        logger.error(
+            "daemon: %d maintenance loop(s) parked pending schema preflight recovery: %s",
+            len(parked_loop_names),
+            ", ".join(parked_loop_names),
+        )
+        try:
+            from polylogue.daemon.events import emit_daemon_event
+
+            emit_daemon_event(
+                "maintenance_loops_parked",
+                payload={
+                    "reason": "schema_version_mismatch",
+                    "loop_count": len(parked_loop_names),
+                    "loop_names": list(parked_loop_names),
+                    "schema_alert_message": schema_alert.message,
+                },
+            )
+        except Exception:
+            # daemon_events lives in the disposable ops.db tier, independent
+            # of whatever tier tripped the schema mismatch above -- but this
+            # is best-effort observability, not load-bearing startup work, so
+            # a failure here must never block the (already-decided) degraded
+            # startup path.
+            logger.warning("daemon: failed to emit maintenance_loops_parked event", exc_info=True)
 
     pidfile = archive_root_path / "daemon.pid"
     pidfile_fd: int | None = None

--- a/polylogue/daemon/embedding_backlog.py
+++ b/polylogue/daemon/embedding_backlog.py
@@ -30,11 +30,11 @@ async def periodic_embedding_backlog_check(
     catch_up_complete: asyncio.Event | None = None,
 ) -> None:
     """Periodically drain one bounded pending-embedding window."""
+    from polylogue.daemon.cli import _await_catch_up_gate
     from polylogue.paths import archive_root
 
     db = archive_root() / "index.db"
-    if catch_up_complete is not None:
-        await catch_up_complete.wait()
+    await _await_catch_up_gate(catch_up_complete, loop_name="embedding backlog catch-up")
     while True:
         await asyncio.sleep(EMBEDDING_BACKLOG_RETRY_INTERVAL_SECONDS)
         try:
@@ -84,11 +84,11 @@ async def periodic_embedding_orphan_reconcile_check(
     embed work; manual CLI (``polylogue maintenance embedding-orphan-reconcile``)
     remains the break-glass inspect/apply path.
     """
+    from polylogue.daemon.cli import _await_catch_up_gate
     from polylogue.paths import archive_root
 
     db = archive_root() / "index.db"
-    if catch_up_complete is not None:
-        await catch_up_complete.wait()
+    await _await_catch_up_gate(catch_up_complete, loop_name="embedding orphan reconcile")
     while True:
         await asyncio.sleep(EMBEDDING_ORPHAN_RECONCILE_INTERVAL_SECONDS)
         try:

--- a/polylogue/daemon/fts_identity_convergence.py
+++ b/polylogue/daemon/fts_identity_convergence.py
@@ -126,11 +126,11 @@ async def periodic_fts_identity_drift_recompute(
     it serializes with live ingest instead of racing it for the SQLite
     writer lock.
     """
+    from polylogue.daemon.cli import _await_catch_up_gate
     from polylogue.daemon.write_coordinator import daemon_write_coordinator
     from polylogue.paths import archive_root
 
-    if catch_up_complete is not None:
-        await catch_up_complete.wait()
+    await _await_catch_up_gate(catch_up_complete, loop_name="fts identity drift recompute")
     while True:
         await asyncio.sleep(FTS_IDENTITY_DRIFT_RECOMPUTE_INTERVAL_SECONDS)
         db_path = archive_root() / "index.db"

--- a/polylogue/daemon/fts_orphan_audit.py
+++ b/polylogue/daemon/fts_orphan_audit.py
@@ -159,11 +159,11 @@ async def periodic_fts_orphan_audit(
     lock; the actual repair happens later, off this loop, via the ordinary
     convergence-debt drain.
     """
+    from polylogue.daemon.cli import _await_catch_up_gate
     from polylogue.daemon.write_coordinator import daemon_write_coordinator
     from polylogue.paths import archive_root
 
-    if catch_up_complete is not None:
-        await catch_up_complete.wait()
+    await _await_catch_up_gate(catch_up_complete, loop_name="fts orphan audit")
     while True:
         await asyncio.sleep(FTS_ORPHAN_AUDIT_INTERVAL_SECONDS)
         db_path = archive_root() / "index.db"

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -383,7 +383,11 @@ def _check_schema_version_fast() -> HealthAlert:
                 parts.append(f"missing tiers: {', '.join(missing)}")
             if mismatches:
                 parts.append(f"tier user_version mismatch: {', '.join(mismatches)}")
-            message = "archive tier layout is not ready: " + "; ".join(parts)
+            message = (
+                "archive tier layout is not ready: "
+                + "; ".join(parts)
+                + " -- convergence loops parked pending schema recovery"
+            )
 
         is_ok = severity == HealthSeverity.OK
         return HealthAlert(

--- a/polylogue/daemon/judgment_automation.py
+++ b/polylogue/daemon/judgment_automation.py
@@ -331,11 +331,11 @@ async def periodic_judgment_automation_sweep(
     effect on the *next* tick without a daemon restart, the same as
     ``_periodic_db_optimize``'s self-gating pattern.
     """
+    from polylogue.daemon.cli import _await_catch_up_gate
     from polylogue.daemon.write_coordinator import daemon_write_coordinator
     from polylogue.paths import archive_root
 
-    if catch_up_complete is not None:
-        await catch_up_complete.wait()
+    await _await_catch_up_gate(catch_up_complete, loop_name="judgment automation sweep")
     while True:
         cfg = load_polylogue_config()
         interval = max(cfg.judgment_automation_interval_s, JUDGMENT_AUTOMATION_SWEEP_INTERVAL_FLOOR_SECONDS)

--- a/polylogue/daemon/secret_scan_sweep.py
+++ b/polylogue/daemon/secret_scan_sweep.py
@@ -93,11 +93,11 @@ async def periodic_secret_scan_sweep(
     races initial source catch-up -- same gating shape as every other
     ``catch_up_complete``-gated periodic loop in ``daemon/cli.py``.
     """
+    from polylogue.daemon.cli import _await_catch_up_gate
     from polylogue.daemon.write_coordinator import daemon_write_coordinator
     from polylogue.paths import archive_root
 
-    if catch_up_complete is not None:
-        await catch_up_complete.wait()
+    await _await_catch_up_gate(catch_up_complete, loop_name="secret scan sweep")
     while True:
         await asyncio.sleep(SECRET_SCAN_SWEEP_INTERVAL_SECONDS)
         root = archive_root()

--- a/tests/unit/daemon/test_catch_up_gate_timeout.py
+++ b/tests/unit/daemon/test_catch_up_gate_timeout.py
@@ -1,0 +1,178 @@
+"""Tests for polylogue-5xxmc: catch-up gate observability + timeout.
+
+Covers two production mutations that would each defeat the fix independently:
+
+1. ``_await_catch_up_gate`` (``daemon/cli.py``) is the single helper every
+   ``catch_up_complete``-gated periodic maintenance loop now waits through
+   instead of a bare ``await catch_up_complete.wait()``. Before this bead a
+   watcher that never reached catch-up-complete (crash, hang, or the
+   schema-preflight-blocked startup path) parked every gated loop on that
+   ``Event.wait()`` forever, with zero journal signal.
+2. ``run_daemon_services`` now logs a loud ``ERROR`` and emits a
+   ``maintenance_loops_parked`` daemon event, naming exactly which
+   maintenance loops are withheld, whenever the watcher is schema-blocked
+   at startup -- previously the only signal was the one-time schema
+   preflight ERROR with no enumeration of what that decision froze.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from polylogue.sources.live import WatchSource
+
+
+def test_gate_noop_when_no_gate_given() -> None:
+    """Callers without a watcher (``catch_up_complete=None``) proceed as before.
+
+    Anti-vacuity: removing the ``catch_up_complete is None`` short-circuit in
+    ``_await_catch_up_gate`` makes this raise ``AttributeError`` on
+    ``None.is_set()`` instead of returning.
+    """
+    from polylogue.daemon import cli as daemon_cli
+
+    with patch.object(daemon_cli.logger, "warning") as warning:
+        asyncio.run(daemon_cli._await_catch_up_gate(None, loop_name="unit-test-loop", timeout_s=0.01))
+
+    warning.assert_not_called()
+
+
+def test_gate_returns_immediately_when_event_preset() -> None:
+    """A gate already released must not produce a timeout warning.
+
+    Anti-vacuity: a mutation that logs the timeout warning unconditionally
+    (instead of only on ``asyncio.TimeoutError``) makes this fail.
+    """
+    from polylogue.daemon import cli as daemon_cli
+
+    event = asyncio.Event()
+    event.set()
+
+    with patch.object(daemon_cli.logger, "warning") as warning:
+        asyncio.run(daemon_cli._await_catch_up_gate(event, loop_name="unit-test-loop", timeout_s=5.0))
+
+    warning.assert_not_called()
+
+
+def test_gate_times_out_and_warns_then_proceeds() -> None:
+    """A gate that never releases must still let the loop proceed, once, loudly.
+
+    Anti-vacuity: reverting to the old bare ``await catch_up_complete.wait()``
+    (no ``asyncio.wait_for``/timeout) makes this test hang until the pytest
+    stall timeout instead of returning; removing the ``logger.warning`` call
+    makes the assertion on its content fail.
+    """
+    from polylogue.daemon import cli as daemon_cli
+
+    event = asyncio.Event()  # never set
+
+    with patch.object(daemon_cli.logger, "warning") as warning:
+        asyncio.run(daemon_cli._await_catch_up_gate(event, loop_name="unit-test-loop", timeout_s=0.02))
+
+    warning.assert_called_once()
+    message, loop_name_arg, timeout_arg = warning.call_args.args
+    assert "catch-up gate not released" in message
+    assert "proceeding without watcher catch-up" in message
+    assert loop_name_arg == "unit-test-loop"
+    assert timeout_arg == 0
+
+
+def test_run_daemon_services_schema_block_logs_parked_loops_and_emits_event() -> None:
+    """Schema-blocked startup must name every withheld loop, loudly and durably.
+
+    Anti-vacuity: deleting the new ``logger.error("... maintenance loop(s)
+    parked ...")`` call (or the ``emit_daemon_event("maintenance_loops_parked",
+    ...)`` call) from the ``if watcher_blocked:`` branch in
+    ``run_daemon_services`` makes the corresponding assertion below fail; the
+    prior behavior only logged the single schema-preflight ERROR with no
+    enumeration of what was withheld.
+    """
+    from polylogue.daemon import cli as daemon_cli
+    from polylogue.daemon.health import HealthAlert, HealthSeverity, HealthTier
+
+    class FakeServer:
+        shutdown_called = False
+        close_called = False
+
+        def serve_forever(self, poll_interval: float = 0.5) -> None:
+            raise RuntimeError("server stopped")
+
+        def shutdown(self) -> None:
+            self.shutdown_called = True
+
+        def server_close(self) -> None:
+            self.close_called = True
+
+    async def lifecycle_heartbeat() -> None:
+        await asyncio.Event().wait()
+
+    async def fake_health_check() -> None:
+        await asyncio.Event().wait()
+
+    def fail_background_work(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("schema-blocked daemon must not start DB background work")
+
+    server = FakeServer()
+    critical = HealthAlert(
+        check_name="schema_version",
+        tier=HealthTier.FAST,
+        severity=HealthSeverity.CRITICAL,
+        message="archive2 is not runtime v8",
+        checked_at="2026-08-03T00:00:00+00:00",
+    )
+    recorded_events: list[tuple[str, dict[str, object] | None]] = []
+
+    def fake_emit_daemon_event(kind: str, *, payload: dict[str, object] | None = None, **_kwargs: object) -> None:
+        recorded_events.append((kind, payload))
+
+    with (
+        patch.object(daemon_cli, "_check_schema_version_fast", return_value=critical),
+        patch.object(daemon_cli, "_periodic_wal_checkpoint", side_effect=fail_background_work),
+        patch.object(daemon_cli, "_periodic_heartbeat", side_effect=fail_background_work),
+        patch.object(daemon_cli, "_periodic_lifecycle_heartbeat", lifecycle_heartbeat),
+        patch.object(daemon_cli, "_periodic_convergence_check", side_effect=fail_background_work),
+        patch.object(daemon_cli, "_periodic_health_check", fake_health_check),
+        patch.object(daemon_cli, "_periodic_db_optimize", side_effect=fail_background_work),
+        patch.object(daemon_cli, "_periodic_status_snapshot_refresh", side_effect=fail_background_work),
+        patch.object(daemon_cli, "_periodic_drive_source_catchup", side_effect=fail_background_work),
+        patch("polylogue.daemon.convergence.DaemonConverger", side_effect=fail_background_work),
+        patch.object(daemon_cli, "make_server", return_value=server),
+        patch("polylogue.daemon.events.emit_daemon_event", side_effect=fake_emit_daemon_event),
+        patch.object(daemon_cli.logger, "error") as error_log,
+        pytest.raises(RuntimeError, match="server stopped"),
+    ):
+        asyncio.run(
+            daemon_cli.run_daemon_services(
+                sources=(WatchSource(name="codex", root=Path("/tmp/codex")),),
+                debounce_s=1.0,
+                enable_watch=True,
+                enable_browser_capture=True,
+                browser_capture_host="127.0.0.1",
+                browser_capture_port=8765,
+                browser_capture_spool_path=None,
+            )
+        )
+
+    parked_calls = [call for call in error_log.call_args_list if "maintenance loop(s) parked" in str(call.args[0])]
+    assert len(parked_calls) == 1
+    message_fmt, loop_count_arg, loop_names_arg = parked_calls[0].args
+    assert (
+        loop_count_arg == len(daemon_cli._SCHEMA_BLOCKED_MAINTENANCE_LOOP_NAMES) + 1
+    )  # +1: drive catchup (default on)
+    for name in daemon_cli._SCHEMA_BLOCKED_MAINTENANCE_LOOP_NAMES:
+        assert name in loop_names_arg
+    assert daemon_cli._SCHEMA_BLOCKED_OPTIONAL_DRIVE_CATCHUP_LOOP_NAME in loop_names_arg
+
+    parked_events = [payload for kind, payload in recorded_events if kind == "maintenance_loops_parked"]
+    assert len(parked_events) == 1
+    payload = parked_events[0]
+    assert payload is not None
+    assert payload["reason"] == "schema_version_mismatch"
+    assert payload["loop_count"] == loop_count_arg
+    recorded_loop_names = payload["loop_names"]
+    assert isinstance(recorded_loop_names, list)
+    assert set(recorded_loop_names) == set(loop_names_arg.split(", "))


### PR DESCRIPTION
## Summary

Bounds every `catch_up_complete`-gated daemon maintenance loop's wait with a
30-minute timeout instead of an unbounded `Event.wait()`, and makes a
schema-blocked startup loudly enumerate exactly which maintenance loops are
withheld (log line + a durable `maintenance_loops_parked` daemon event).

## Problem

Verified live 2026-08-03: `run_daemon_services` computes `watcher_blocked`
when schema preflight is CRITICAL and never sets `catch_up_complete_gate` in
that state. Every `catch_up_complete`-gated periodic maintenance loop (raw
materialization convergence, session insight convergence, convergence debt
retry, embedding backlog/orphan reconcile, fts identity drift recompute, fts
orphan audit, blob GC, secret scan sweep, judgment automation sweep, drive
source catch-up) awaited a bare `await catch_up_complete.wait()` with no
timeout. If the gate is never released -- whether because the watcher never
starts (schema-blocked), crashes, or hangs before reaching catch-up-complete
-- every one of these loops parks forever with zero durable signal beyond the
generic periodic schema_version health line. Live evidence: daemon in this
exact state since 05:08 same day; 3 `convergence_debt` rows past
`next_retry_at` since 2026-07-31 with `attempts` frozen at 1.

## Solution

- Added `_await_catch_up_gate` (`polylogue/daemon/cli.py`), a shared helper
  that wraps the gate wait in `asyncio.wait_for` with a
  `_CATCH_UP_GATE_TIMEOUT_SECONDS` (30 min) ceiling. Behavior is unchanged
  when the gate is `None` or released promptly; on timeout it logs one
  WARNING naming the loop and proceeds without having observed catch-up. The
  gate remains a startup-ordering aid, not a permanent kill switch.
- Every gated loop now calls this helper instead of the bare wait: the 4 in
  `daemon/cli.py` directly, and the 6 in their own modules
  (`blob_gc_periodic.py`, `fts_orphan_audit.py`, `embedding_backlog.py` (x2),
  `fts_identity_convergence.py`, `judgment_automation.py`,
  `secret_scan_sweep.py`) via a function-local import of
  `polylogue.daemon.cli` -- matching this codebase's existing lazy-import
  convention for daemon submodules, and safe because `cli.py` does not
  import any of those six modules at module scope (verified no circular
  import).
- When `watcher_blocked` is true at startup, `run_daemon_services` now logs
  one ERROR naming exactly how many and which maintenance loops are withheld
  pending schema recovery (`_SCHEMA_BLOCKED_MAINTENANCE_LOOP_NAMES` +
  conditionally drive source catch-up), and emits a best-effort
  `maintenance_loops_parked` daemon event with the same detail (wrapped in
  try/except so a failure here can never block the already-decided degraded
  startup path).
- `_check_schema_version_fast`'s CRITICAL message (`daemon/health.py`) is
  extended with "convergence loops parked pending schema recovery" so the
  periodic health-check journal line itself says work is frozen, instead of
  only naming the tier mismatch.

## Verification

- `devtools test tests/unit/daemon/test_catch_up_gate_timeout.py
  tests/unit/daemon/test_daemon_cli.py tests/unit/daemon/test_schema_preflight.py
  tests/unit/daemon/test_blob_gc_periodic.py
  tests/unit/daemon/test_fts_identity_convergence.py
  tests/unit/daemon/test_embedding_convergence_progress.py
  tests/unit/daemon/test_embedding_orphan_reconcile_daemon.py
  tests/unit/daemon/test_fts_orphan_audit.py
  tests/unit/daemon/test_judgment_automation.py
  tests/unit/daemon/test_secret_scan_sweep.py` -- 177 passed.
- `devtools verify --quick` (format + lint + mypy + render-all-check) --
  `exit_code: 0` (re-run fresh after rebase onto latest origin/master).
- `devtools verify --seed-testmon --skip-slow` (full non-slow suite, needed
  once since this worktree had no prior testmon baseline): attempted twice;
  both runs ran into heavy CPU contention from other concurrent agent
  sessions on the same host (visible via `ps`: multiple sibling worktrees
  running their own `devtools verify`/pytest at the same time) and did not
  reach completion in available foreground time. The scattered `F` marks
  seen mid-run were before ~40% progress, well outside daemon/ and nowhere
  near the files this PR touches, consistent with contention-driven flakes
  rather than a regression -- but this was not confirmed to completion, so
  it is called out here rather than asserted. Left for a follow-up run when
  the host is quieter, or first CI post-merge (per this repo's own policy:
  per-PR CI already skips the heavy suite; it runs post-merge on master).
- In place of the full suite, ran every test file that imports or exercises
  the changed modules directly (`test_daemon_cli.py`,
  `test_schema_preflight.py`, `test_blob_gc_periodic.py`,
  `test_fts_identity_convergence.py`, `test_embedding_convergence_progress.py`,
  `test_embedding_orphan_reconcile_daemon.py`, `test_fts_orphan_audit.py`,
  `test_judgment_automation.py`, `test_secret_scan_sweep.py`, plus the new
  `test_catch_up_gate_timeout.py`) -- 177 passed, 0 failed.
- Manually confirmed the new tests are mutation-sensitive: reverted
  `_await_catch_up_gate` to the old bare `await catch_up_complete.wait()`
  and observed `test_gate_times_out_and_warns_then_proceeds` hang (killed
  after confirming), then restored the fix and re-ran green.
- `ruff check`/`ruff format --check` clean on all touched files. `mypy`
  clean on all touched files (including the new test file).

## Scope notes

- Conservative per the tracking bead: no loop restructuring, no change to
  the 30-minute constant's value beyond making it a named, documented
  module constant.
- The alert enumerates the full `periodic_loops` list withheld while
  `watcher_blocked` (not only the subset that literally receives a
  `catch_up_complete` gate), because the entire `if not watcher_blocked:`
  block -- gated and ungated loops alike -- is skipped in that branch; this
  matches the real code path more precisely than naming only the gated
  subset.
- Did not change the 30-minute timeout to be configurable via
  `polylogue.toml` -- not requested, and the constant is easy to override in
  a follow-up if an operator needs a different value.

Ref polylogue-5xxmc
