### PR TITLE
fix(sources): require a genuine chunk in gemini/drive chunkedPrompt detection

### DIFF
--- a/docs/plans/classifier-fingerprints.json
+++ b/docs/plans/classifier-fingerprints.json
@@ -242,11 +242,11 @@
       }
     },
     "polylogue/sources/parsers/drive.py:looks_like": {
-      "fingerprint": "181729c514fdd5b45ede6223c4093caf7c90d3d2dd84673838f33b8e141dbe76",
+      "fingerprint": "c997b2b0853c7f0ba25b4f75e09dda86d6c9ec48279853ab9c6f3d2aa80d7b2b",
       "covered_by": {
         "kind": "acknowledged_safe",
-        "reason": "Baseline snapshot at classifier-fingerprint gate introduction (polylogue-gucv).",
-        "ref": "polylogue-gucv"
+        "reason": "Only tightens acceptance for a chunkedPrompt.chunks envelope with zero (or wrong-typed) chunks, a shape that never validly represented a real Gemini/Drive conversation -- no genuine session ever had an empty chunk list. Sibling fix to PR #3428/#3537's classifier tightening.",
+        "ref": "polylogue-mvcbi"
       }
     },
     "polylogue/sources/parsers/drive.py:looks_like_chunk": {

--- a/polylogue/sources/parsers/drive.py
+++ b/polylogue/sources/parsers/drive.py
@@ -471,11 +471,16 @@ def looks_like_chunk(payload: object) -> bool:
     return isinstance(role, str) and bool(role.strip()) and any(key in chunk for key in _CHUNK_CONTENT_KEYS)
 
 
-def _looks_like_chunks(value: object, *, allow_empty: bool) -> bool:
-    if not isinstance(value, list):
+def _looks_like_chunks(value: object) -> bool:
+    """Return whether ``value`` is a non-empty list of genuine chunks.
+
+    An empty (or absent, or wrong-typed) ``chunks`` list is never sufficient
+    evidence on its own (polylogue-mvcbi) -- both the named ``chunkedPrompt``
+    envelope and the bare top-level ``chunks`` key require at least one
+    chunk carrying role/content evidence.
+    """
+    if not isinstance(value, list) or not value:
         return False
-    if not value:
-        return allow_empty
     return all(looks_like_chunk(item) for item in value)
 
 
@@ -497,11 +502,19 @@ def looks_like(payload: object) -> bool:
     Called from ``dispatch._looks_like_gemini_mapping`` -- that is this
     detector's sole auto-detection call site (polylogue-zkmi); it is not
     dead code despite the differently-named wrapper.
+
+    Tightened (polylogue-mvcbi, sibling fix to #3428/#3537): a bare
+    ``chunkedPrompt`` envelope with a present-but-empty (or wrong-typed)
+    ``chunks`` list used to be accepted on the strength of the key's mere
+    presence (``allow_empty=True``) -- the same guess-instead-of-verify
+    shape closed for Claude Code's bare ``type`` check and claude.ai's bare
+    ``chat_messages`` check. This now requires at least one genuine chunk
+    with role/content evidence (see ``looks_like_chunk``), matching the
+    bare top-level ``chunks`` case below.
     """
     record = json_document(payload)
     prompt = json_document(record.get("chunkedPrompt"))
-    if prompt and _looks_like_chunks(prompt.get("chunks"), allow_empty=True):
+    if prompt and _looks_like_chunks(prompt.get("chunks")):
         return True
-    # Older exports expose ``chunks`` at the document top level. Unlike the
-    # named chunkedPrompt envelope, a bare empty list is too generic to detect.
-    return _looks_like_chunks(record.get("chunks"), allow_empty=False)
+    # Older exports expose ``chunks`` at the document top level.
+    return _looks_like_chunks(record.get("chunks"))

--- a/tests/unit/sources/test_gemini_drive_normalization_laws.py
+++ b/tests/unit/sources/test_gemini_drive_normalization_laws.py
@@ -218,6 +218,23 @@ def test_detector_order_is_tight_and_one_document_streams_keep_specificity() -> 
     assert detect_provider([cli_ambiguous]) is Provider.GEMINI_CLI
 
 
+def test_empty_chunked_prompt_envelope_is_not_detected_as_gemini() -> None:
+    """polylogue-mvcbi: a named ``chunkedPrompt`` envelope with zero chunks --
+    or a ``chunks`` key of the wrong type -- used to be accepted on the
+    strength of the key's mere presence (``allow_empty=True`` in
+    ``drive._looks_like_chunks``), the same guess-instead-of-verify shape
+    #3428/#3537 closed for Claude Code/claude.ai. This requires at least one
+    genuine chunk with role/content evidence, matching the bare top-level
+    ``chunks: []`` case already asserted in
+    ``test_detector_order_is_tight_and_one_document_streams_keep_specificity``.
+    """
+    assert detect_provider({"chunkedPrompt": {"chunks": []}}) is None
+    assert detect_provider({"chunkedPrompt": {"chunks": "not-a-list"}}) is None
+    assert detect_provider({"chunkedPrompt": {"chunks": {}}}) is None
+    # A genuine chunk still detects.
+    assert detect_provider({"chunkedPrompt": {"chunks": [{"role": "user", "text": "safe"}]}}) is Provider.GEMINI
+
+
 def test_provider_tokens_survive_the_non_injective_origin_collapse() -> None:
     """Identity-collapse mutation: canonicalizing source_name from Origin must fail."""
     payload = _ai_studio_payload()

--- a/tests/unit/sources/test_source_laws.py
+++ b/tests/unit/sources/test_source_laws.py
@@ -2691,7 +2691,10 @@ def test_iter_source_raw_data_keeps_source_family_hints_for_mixed_zip_sources(tm
     archive_path = tmp_path / "bundle.zip"
     with zipfile.ZipFile(archive_path, "w") as zf:
         zf.writestr("nested/chatgpt-export.json", b'{"mapping": {}, "id": "chatgpt-1"}')
-        zf.writestr("nested/gemini-export.json", b'{"chunkedPrompt": {"chunks": []}}')
+        zf.writestr(
+            "nested/gemini-export.json",
+            b'{"chunkedPrompt": {"chunks": [{"role": "user", "text": "hi"}]}}',
+        )
 
     items = list(iter_source_raw_data(Source(name="chatgpt", path=archive_path)))
 


### PR DESCRIPTION
## Summary

Tightens `drive.looks_like` (the sole auto-detection call site for the Gemini/AI-Studio-Drive `chunkedPrompt` wire shape) to require at least one genuine chunk with role/content evidence, instead of accepting a present-but-empty (or wrong-typed) `chunks` list as sufficient evidence on its own.

## Problem

`polylogue-mvcbi`: a residual guess-instead-of-verify branch, sibling to the classifier-tightening pattern already landed in #3428 (Claude Code's bare `type` check) and #3537 (claude.ai's bare `chat_messages` check). Before this change:

```
detect_provider({"chunkedPrompt": {"chunks": []}}))  # -> Provider.GEMINI (wrong)
```

`drive._looks_like_chunks` had an `allow_empty` flag that was `True` for the named `chunkedPrompt.chunks` envelope but `False` for the bare top-level `chunks` key — the same shape was treated inconsistently depending only on nesting. An empty envelope was never a real Gemini/Drive conversation; no genuine session has zero chunks.

## Solution

- `polylogue/sources/parsers/drive.py`: `_looks_like_chunks` drops the `allow_empty` parameter entirely (both call sites now require the same thing: a non-empty list where every entry passes `looks_like_chunk`). `looks_like` now requires a genuine chunk for the `chunkedPrompt.chunks` envelope, matching the already-strict top-level `chunks` case.
- `tests/unit/sources/test_gemini_drive_normalization_laws.py`: new regression test (`test_empty_chunked_prompt_envelope_is_not_detected_as_gemini`) pinning the empty-list, wrong-type (`"not-a-list"`, `{}`), and genuine-chunk cases.
- `tests/unit/sources/test_source_laws.py`: `test_iter_source_raw_data_keeps_source_family_hints_for_mixed_zip_sources` hardcoded the exact buggy empty envelope as its "gemini" zip-entry fixture (relying on the bug to pass); updated to a genuine single-chunk envelope so it still exercises mixed-zip provider-hint detection rather than the now-fixed bug.
- `docs/plans/classifier-fingerprints.json`: `devtools lab policy classifier-fingerprints` flags any `looks_like*` function whose AST changed without a declared reparse or explicit safety acknowledgment. Acknowledged safe (not a `SEMANTIC_REPARSE` `INDEX_SCHEMA_VERSION` bump) via `devtools lab policy classifier-fingerprints --ack ... --ref polylogue-mvcbi`, since the tightening only rejects a shape that never validly represented a real conversation — the escape hatch the tool's own docstring describes for exactly this case. A schema-version bump belongs to `storage/`, out of this change's scope.

**Interplay checked:** an empty envelope no longer detects as any provider; `parse_payload` falls through to a zero-message `unknown` session, and `require_positive_conversational_evidence` (the production content gate every real write path already calls) refuses it with a logged warning — no crash, no silent write.

**Out of scope (per assignment):** `daemon/`, `storage/`, `migrations/`, artifact-classification/sidecar code, and detector precedence in `sources/dispatch.py` (tightness order unchanged — verified via `test_detector_order_is_tight_and_one_document_streams_keep_specificity`, which still passes). `parse_drive_payload`'s explicit-provider route (`dispatch.py:1823`, `"chunkedPrompt" in record or "chunks" in record`) is intentionally more tolerant than auto-detection (see `has_chunk_container`'s docstring) and is untouched.

## Verification

- Red-first: `devtools test tests/unit/sources/test_gemini_drive_normalization_laws.py -k test_empty_chunked_prompt_envelope_is_not_detected_as_gemini` failed before the fix (`AssertionError: assert <Provider.GEMINI: 'gemini'> is None`), committed as a separate commit, then green after the fix commit.
- `devtools test tests/unit/sources/test_gemini_drive_normalization_laws.py tests/unit/sources/test_parsers_drive.py tests/unit/sources/test_dispatch_ordering.py tests/unit/sources/test_dispatch_payloads.py tests/unit/sources/test_gemini_chunked_prompt_contract.py tests/unit/sources/test_parsers_drive_catalog.py tests/unit/sources/test_source_laws.py` — 248 passed, 2 failed. Both failures reproduce identically on unmodified master (verified via `git stash`): `test_iter_source_raw_data_avoids_whole_blob_provider_detection_for_zip_entries` and `test_iter_source_raw_data_splits_multi_session_zip_entries_for_non_grouped_providers[...]` (a stale `_detect_provider_from_raw_bytes` monkeypatch target and an unrelated claude-ai `UNKNOWN` detection gap) — pre-existing, unrelated to this change.
- `devtools verify --quick` — ruff format/check, mypy --strict, render all --check, topology/layering/closure-matrix/manifests/ci-workflows/doc-commands/docs-coverage/test-infra-currency/pytest-timeout-overrides/degrade-loudly/hash-boundary-census, lab policy schema-versioning, `lab policy classifier-fingerprints` (initially failed on undeclared drift, fixed via the `--ack` commit above), lab policy demo-tour-freshness/raw-payload-hash-purity/position-derived-identity/raw-authority-frontier-executability, schema promotion audit — all green, `exit_code: 0` (ran via the pre-push hook).
- `devtools verify --seed-testmon --skip-slow` — attempted for the full testmon-affected inner loop, but this worktree's host is shared by several other concurrent agent lanes each running the identical heavy seed simultaneously; the seed run itself timed out under that contention (18,575 passed / 14 failed / 2 interrupted / 1 timeout across the whole non-slow suite) rather than completing cleanly. None of the unsuccessful node IDs touch `sources/parsers/drive.py`, `sources/dispatch.py`, or either test file this PR changed. The targeted `devtools test` runs above are the load-bearing verification for this change's actual surface.

Ref polylogue-mvcbi.