### PR TITLE
feat(tests): add distributional generation mode + pathology composer

### DIFF
--- a/tests/infra/pathology_composer.py
+++ b/tests/infra/pathology_composer.py
@@ -1,0 +1,465 @@
+"""Archive-level pathology composer (polylogue-amrpx, zoo v1 engine).
+
+Pathologies are structures that emerge across a *corpus* -- a chain of
+revisions, a lineage of forked sessions, a raw bundle of several sessions --
+not something a single per-record schema-conformant generator can produce
+(``tests/infra/strategies/schema_driven.py`` generates one record's worth of
+data; nothing there decides how many revisions of a session exist, or
+whether two sessions share a divergent tail).
+
+This module is the missing layer: pure functions that take already-generated
+per-record payloads or building blocks (a ``Session``/``Message`` pair from
+``tests/infra/builders.py``, or a batch of ``schema_conformant_payload()``
+draws) and *compose* them into the archive-level arrangements
+``polylogue-yazae``'s zoo enumerates. Nothing here writes to a database --
+callers feed the returned ``Session`` objects into ``SessionBuilder``
+(``tests/infra/storage_records.py``) or ``write_parsed_session_to_archive``
+when a live-archive integration test is wanted; the composed structure
+itself is the deliverable and is fully inspectable without one.
+
+Each function's docstring names the production pathology and bead/issue that
+motivated it, per the bead's requirement that zoo members carry provenance.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from polylogue.archive.models import Session
+from polylogue.archive.session.branch_type import BranchType
+from polylogue.core.types import SessionId
+from tests.infra.builders import make_conv, make_msg
+
+JSONRecord = dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class ComposedPathology:
+    """A named archive-level pathological arrangement plus provenance.
+
+    ``sessions`` holds domain-level ``Session`` objects for pathologies that
+    are naturally expressed post-parse (revision chains, lineage, whale
+    components, quarantined heads). ``raw_payloads`` holds wire-level JSON
+    structures for pathologies that are fundamentally about *raw acquisition
+    shape* (multi-session bundles, vintage variant pairs) rather than
+    anything a parsed ``Session`` could represent.
+    """
+
+    name: str
+    pathology: str
+    motivated_by: str
+    description: str
+    sessions: tuple[Session, ...] = ()
+    raw_payloads: tuple[object, ...] = ()
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# 1. Append revision chain
+# ---------------------------------------------------------------------------
+
+
+def compose_append_revision_chain(
+    *,
+    session_id: str = "revision-chain",
+    revision_count: int = 4,
+    messages_per_revision: int = 2,
+    with_self_describing_identity: bool = True,
+) -> ComposedPathology:
+    """N growing revisions of one logical session sharing a single archive id.
+
+    Motivated by #2467 (session lineage duplication) and the content-hash
+    idempotency model (``CLAUDE.md`` "Content-hash idempotency"): re-ingesting
+    the same ``native_id`` with more messages appended produces a differing
+    content hash, which the writer treats as an *update* to the same session
+    row, not a new one. Real providers append to the same on-disk JSONL
+    across turns (Claude Code, Codex), so this is the single most common
+    non-adversarial archive-level shape a per-record generator cannot
+    express: it is a property of a *sequence* of writes, not one record.
+
+    ``with_self_describing_identity`` toggles whether every revision embeds
+    an explicit stable identity marker in its metadata (mirroring providers
+    whose wire format repeats a conversation id inside every record) versus
+    relying purely on the archive computing identity from session id/native
+    id alone (mirroring providers where identity is positional/filename-only
+    and no revision self-describes as "the same conversation").
+    """
+    if revision_count < 1:
+        raise ValueError("revision_count must be >= 1")
+    if messages_per_revision < 1:
+        raise ValueError("messages_per_revision must be >= 1")
+
+    revisions: list[Session] = []
+    for revision_index in range(1, revision_count + 1):
+        message_count = revision_index * messages_per_revision
+        messages = [
+            make_msg(
+                id=f"m{i}",
+                role="user" if i % 2 == 1 else "assistant",
+                text=f"revision {revision_index} message {i}",
+            )
+            for i in range(1, message_count + 1)
+        ]
+        metadata: dict[str, object] = {"revision_index": revision_index}
+        if with_self_describing_identity:
+            metadata["source_identity"] = session_id
+        revisions.append(
+            make_conv(
+                id=session_id,
+                title=f"{session_id} (revision {revision_index})",
+                messages=messages,
+                metadata=metadata,
+            )
+        )
+
+    return ComposedPathology(
+        name=session_id,
+        pathology="append-revision-chain",
+        motivated_by="#2467 (session lineage duplication); content-hash idempotency model",
+        description=(
+            f"{revision_count} growing revisions of session {session_id!r}, "
+            f"{'with' if with_self_describing_identity else 'without'} a self-describing "
+            "identity marker in metadata."
+        ),
+        sessions=tuple(revisions),
+        metadata={"revision_count": revision_count, "with_self_describing_identity": with_self_describing_identity},
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Fork / prefix-tail lineage
+# ---------------------------------------------------------------------------
+
+
+def compose_fork_prefix_tail_lineage(
+    *,
+    parent_id: str = "lineage-parent",
+    child_id: str = "lineage-child",
+    shared_prefix_len: int = 3,
+    child_tail_len: int = 2,
+    cycle_candidate: bool = False,
+) -> ComposedPathology:
+    """A parent session plus a child that replays the parent's prefix.
+
+    Motivated by #2467 / ``docs/design/session-lineage-model.md``: forks,
+    resumes, and auto-compactions physically replay the parent's prefix
+    rather than referencing it, so the archive's lineage normalization
+    (``session_links``, ``branch_point_message_id``, ``inheritance``) exists
+    specifically to recompose parent-up-to-branch + child-tail on read
+    instead of storing the shared prefix twice. This composer produces that
+    exact shape at the domain level: the child's message id prefix is
+    identical to the parent's (same ids, same text) up to the branch point,
+    followed by a divergent tail.
+
+    ``cycle_candidate=True`` additionally sets ``parent.parent_id =
+    child.id``, producing a genuine 2-cycle -- the shape
+    ``TopologyEdgeStatus.QUARANTINED`` (cycle-break, ``core/enums.py``)
+    exists to detect and break.
+    """
+    if shared_prefix_len < 1:
+        raise ValueError("shared_prefix_len must be >= 1")
+    if child_tail_len < 1:
+        raise ValueError("child_tail_len must be >= 1")
+
+    shared_messages = [
+        make_msg(id=f"m{i}", role="user" if i % 2 == 1 else "assistant", text=f"shared message {i}")
+        for i in range(1, shared_prefix_len + 1)
+    ]
+    parent_tail = [
+        make_msg(
+            id=f"m{shared_prefix_len + i}",
+            role="user" if (shared_prefix_len + i) % 2 == 1 else "assistant",
+            text=f"parent-only message {shared_prefix_len + i}",
+        )
+        for i in range(1, 2)
+    ]
+    parent = make_conv(
+        id=parent_id,
+        title="Lineage parent",
+        messages=[*shared_messages, *parent_tail],
+    )
+
+    child_tail = [
+        make_msg(
+            id=f"c{i}",
+            role="user" if i % 2 == 1 else "assistant",
+            text=f"child-divergent message {i}",
+        )
+        for i in range(1, child_tail_len + 1)
+    ]
+    child = make_conv(
+        id=child_id,
+        title="Lineage child",
+        messages=[*shared_messages, *child_tail],
+        parent_id=SessionId(parent_id),
+        branch_type=BranchType.CONTINUATION,
+    )
+
+    if cycle_candidate:
+        parent = parent.model_copy(update={"parent_id": SessionId(child_id)})
+
+    return ComposedPathology(
+        name=f"{parent_id}->{child_id}",
+        pathology="fork-prefix-tail-lineage" + ("-cycle-candidate" if cycle_candidate else ""),
+        motivated_by="#2467; docs/design/session-lineage-model.md; TopologyEdgeStatus.QUARANTINED",
+        description=(
+            f"Child {child_id!r} shares its first {shared_prefix_len} message ids/texts with "
+            f"parent {parent_id!r}, then diverges for {child_tail_len} messages."
+            + (
+                f" parent_id is set on BOTH sessions ({parent_id!r}<->{child_id!r}), a genuine cycle."
+                if cycle_candidate
+                else ""
+            )
+        ),
+        sessions=(parent, child),
+        metadata={
+            "shared_prefix_len": shared_prefix_len,
+            "child_tail_len": child_tail_len,
+            "cycle_candidate": cycle_candidate,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Multi-session bundle (grouped JSONL)
+# ---------------------------------------------------------------------------
+
+
+def compose_multi_session_bundle(
+    records: Sequence[JSONRecord],
+    *,
+    session_count: int = 3,
+) -> ComposedPathology:
+    """Interleave generated per-record payloads into one grouped-JSONL raw.
+
+    Motivated by the grouped-JSONL raw shape ``sources/dispatch.py``'s
+    ``_lower_payload_specs`` explicitly handles: one raw acquisition unit
+    (e.g. one file on disk) containing several sessions' worth of JSONL
+    lines, distinguished only by a per-line ``sessionId`` field, not by
+    file/document boundaries. No per-record generator produces this: it's a
+    property of how many DIFFERENT session ids appear across a batch of
+    records, and their relative ordering.
+
+    Takes already-generated per-record payloads (e.g. draws from
+    ``schema_conformant_payload``) and partitions them round-robin across
+    ``session_count`` synthetic session ids, stamping each record's
+    ``sessionId`` key, then interleaves them (preserving each record's
+    original relative order within its assigned session) into one JSONL text.
+    """
+    if session_count < 2:
+        raise ValueError("session_count must be >= 2 to be a genuine multi-session bundle")
+    if not records:
+        raise ValueError("records must be non-empty")
+
+    session_ids = [f"bundle-session-{i}" for i in range(session_count)]
+    lines: list[str] = []
+    per_session_counts: dict[str, int] = dict.fromkeys(session_ids, 0)
+    for index, record in enumerate(records):
+        session_id = session_ids[index % session_count]
+        stamped: JSONRecord = dict(record)
+        stamped["sessionId"] = session_id
+        lines.append(json.dumps(stamped))
+        per_session_counts[session_id] += 1
+
+    grouped_jsonl = "\n".join(lines) + "\n"
+
+    return ComposedPathology(
+        name="multi-session-bundle",
+        pathology="multi-session-bundle",
+        motivated_by="sources/dispatch.py _lower_payload_specs grouped-JSONL split by sessionId",
+        description=(
+            f"{len(records)} records interleaved across {session_count} session ids "
+            f"({per_session_counts}) in one grouped-JSONL raw blob."
+        ),
+        raw_payloads=(grouped_jsonl,),
+        metadata={"session_ids": session_ids, "lines_per_session": per_session_counts, "total_lines": len(lines)},
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Whale-scale component
+# ---------------------------------------------------------------------------
+
+
+def compose_whale_scale_component(
+    *,
+    session_id: str = "whale-component",
+    declared_message_count: int = 50_000,
+    declared_size_bytes: int = 2 * 1024**3,
+    materialized_message_count: int = 32,
+) -> ComposedPathology:
+    """A session structurally describing a whale-scale component without allocating it.
+
+    Motivated by t93b (whale-scale component handling). Real whale sessions
+    are multi-GiB / tens-of-thousands-of-messages Claude Code JSONL exports;
+    actually materializing that in a test fixture would itself be the
+    resource-abuse anti-pattern the global operating contract forbids. This
+    composer builds a small, bounded number of REAL messages
+    (``materialized_message_count``, capped well below the declared scale)
+    and carries the intended full scale as session metadata
+    (``declared_message_count`` / ``declared_size_bytes``) so a harness that
+    wants to exercise whale-scale *code paths* (streaming parse, chunked
+    materialize) can recognize the pathology and apply its own scale-up
+    strategy, without this composer ever holding gigabytes in memory.
+    """
+    if materialized_message_count < 1:
+        raise ValueError("materialized_message_count must be >= 1")
+    if materialized_message_count > 512:
+        raise ValueError("materialized_message_count is meant to stay small; the whale is in the metadata, not here")
+    if materialized_message_count > declared_message_count:
+        raise ValueError("materialized_message_count must not exceed declared_message_count")
+
+    messages = [
+        make_msg(id=f"m{i}", role="user" if i % 2 == 1 else "assistant", text=f"whale message {i}")
+        for i in range(1, materialized_message_count + 1)
+    ]
+    session = make_conv(
+        id=session_id,
+        title="Whale-scale component",
+        messages=messages,
+        metadata={
+            "_whale_scale": {
+                "declared_message_count": declared_message_count,
+                "declared_size_bytes": declared_size_bytes,
+                "materialized_message_count": materialized_message_count,
+            }
+        },
+    )
+
+    return ComposedPathology(
+        name=session_id,
+        pathology="whale-scale-component",
+        motivated_by="t93b (whale-scale component handling)",
+        description=(
+            f"Session declares {declared_message_count} messages / {declared_size_bytes} bytes "
+            f"but materializes only {materialized_message_count} real messages; the intended "
+            "scale lives in metadata['_whale_scale'] for a harness to act on."
+        ),
+        sessions=(session,),
+        metadata={
+            "declared_message_count": declared_message_count,
+            "declared_size_bytes": declared_size_bytes,
+            "materialized_message_count": materialized_message_count,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Quarantined-head arrangement
+# ---------------------------------------------------------------------------
+
+
+def compose_quarantined_head_arrangement(
+    *,
+    child_id: str = "quarantined-child",
+    missing_parent_id: str = "never-ingested-parent",
+) -> ComposedPathology:
+    """A child session whose parent reference is deliberately never resolved.
+
+    Motivated by ``session_links``'s topology-edge persistence
+    (``CLAUDE.md`` "Lineage normalization"): a parser can assert a parent
+    reference before the parent itself is ever ingested (or the parent is
+    permanently absent -- deleted export, never-captured session). Storage
+    persists the edge as unresolved rather than dropping it, and
+    ``TopologyEdgeStatus`` distinguishes ``unresolved`` from
+    ``quarantined`` (a genuine cycle-break). This composer returns only the
+    child half of that arrangement -- the missing parent is described, not
+    included -- so a harness can ingest the child alone and assert the
+    resulting topology edge is unresolved (or, if the harness later ingests
+    a conflicting same-id parent forming a cycle, quarantined).
+    """
+    child = make_conv(
+        id=child_id,
+        title="Session with an unresolved parent reference",
+        messages=[make_msg(id="m1", text="orphaned head")],
+        parent_id=SessionId(missing_parent_id),
+        branch_type=BranchType.CONTINUATION,
+    )
+
+    return ComposedPathology(
+        name=child_id,
+        pathology="quarantined-head-arrangement",
+        motivated_by="session_links topology-edge persistence; TopologyEdgeStatus.unresolved/quarantined",
+        description=(
+            f"Session {child_id!r} references parent {missing_parent_id!r}, which is NOT "
+            "included in this arrangement -- the harness controls whether/when the parent "
+            "ever arrives."
+        ),
+        sessions=(child,),
+        metadata={"missing_parent_native_id": missing_parent_id, "expected_topology_status": "unresolved"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Vintage-variant pair
+# ---------------------------------------------------------------------------
+
+
+def compose_vintage_variant_pair(
+    *,
+    turns: Sequence[tuple[str, str]] | None = None,
+) -> ComposedPathology:
+    """Two structurally different wire payloads encoding identical content.
+
+    Motivated by 0qfy/uqwd (export-vintage variant pairs: same logical
+    content, different wire shape across a provider's schema versions --
+    e.g. gemini-cli v1 vs v2, claude-ai v1 vs v2 package schemas in
+    ``polylogue/schemas/providers/*/versions/``). This is a wire-level
+    pathology, not something a parsed ``Session`` can represent (parsing
+    normalizes the shape difference away), so this composer returns two raw
+    JSON documents directly: an "old" flat shape and a "new" nested shape,
+    both encoding the same ``(role, text)`` turns. ``extract_old_shape`` /
+    ``extract_new_shape`` mirror what two different parser versions would
+    do, letting a test prove extracted content is equal despite the wire
+    difference.
+    """
+    resolved_turns = turns or (("user", "Hello"), ("assistant", "Hi there!"), ("user", "How are you?"))
+
+    old_shape: JSONRecord = {
+        "id": "vintage-pair",
+        "messages": [{"role": role, "text": text} for role, text in resolved_turns],
+    }
+    new_shape: JSONRecord = {
+        "id": "vintage-pair",
+        "conversation": {
+            "turns": [{"speaker": role, "content": {"parts": [text]}} for role, text in resolved_turns],
+        },
+    }
+
+    return ComposedPathology(
+        name="vintage-variant-pair",
+        pathology="vintage-variant-pair",
+        motivated_by="0qfy/uqwd (export-vintage variant pairs)",
+        description=(
+            f"Old (flat 'messages') and new (nested 'conversation.turns') wire shapes both "
+            f"encoding the identical {len(resolved_turns)}-turn content."
+        ),
+        raw_payloads=(old_shape, new_shape),
+        metadata={"turns": list(resolved_turns)},
+    )
+
+
+def extract_old_shape_turns(payload: JSONRecord) -> list[tuple[str, str]]:
+    """Extract (role, text) turns from ``compose_vintage_variant_pair``'s old shape."""
+    return [(entry["role"], entry["text"]) for entry in payload["messages"]]
+
+
+def extract_new_shape_turns(payload: JSONRecord) -> list[tuple[str, str]]:
+    """Extract (role, text) turns from ``compose_vintage_variant_pair``'s new shape."""
+    return [(entry["speaker"], entry["content"]["parts"][0]) for entry in payload["conversation"]["turns"]]
+
+
+__all__ = [
+    "ComposedPathology",
+    "compose_append_revision_chain",
+    "compose_fork_prefix_tail_lineage",
+    "compose_multi_session_bundle",
+    "compose_whale_scale_component",
+    "compose_quarantined_head_arrangement",
+    "compose_vintage_variant_pair",
+    "extract_old_shape_turns",
+    "extract_new_shape_turns",
+]

--- a/tests/infra/strategies/schema_driven.py
+++ b/tests/infra/strategies/schema_driven.py
@@ -1,14 +1,48 @@
 """Schema-driven Hypothesis strategies for crashlessness testing.
 
-Generates structurally valid but adversarial data from real provider
-JSON schemas, stripping test-irrelevant extensions and nested older
-metaschema declarations that upset ``hypothesis-jsonschema``.
+Two generation modes, both driven by the same registry schemas
+(polylogue-amrpx):
+
+- ``"adversarial"`` (default, unchanged behaviour): structurally valid but
+  distribution-blind data. All ``x-polylogue-*`` inference annotations are
+  stripped except ``x-polylogue-values``, which becomes a JSON Schema
+  ``enum`` so at least finite value domains are respected.
+- ``"distributional"``: additionally threads the subset of inference
+  annotations that are (a) actually emitted by the current schema packages
+  and (b) expressible as plain JSON Schema constraints without fabricating
+  semantics hypothesis-jsonschema doesn't already support:
+
+  - ``x-polylogue-frequency`` (per-field presence probability): fields
+    observed present in >= ``HIGH_FREQUENCY_REQUIRED_THRESHOLD`` of sampled
+    records are promoted into the enclosing object's ``required`` list, so
+    distributional-mode payloads reliably carry near-universal fields that
+    adversarial mode may freely omit.
+  - ``x-polylogue-range`` ([min, max] observed numeric range): becomes
+    ``minimum``/``maximum`` on numeric properties.
+  - ``x-polylogue-array-lengths`` ([min, max] observed array length):
+    becomes ``minItems``/``maxItems``.
+  - ``x-polylogue-format`` (inference-side format token): mapped to the
+    subset of standard JSON Schema ``format`` values hypothesis-jsonschema
+    actually generates conformant data for (date-time/uri/email); unknown or
+    unsupported tokens (uuid4, mime-type, ...) are left unmapped rather than
+    guessed at.
+
+  Annotations seen in committed schema packages but NOT threaded here
+  (follow-up material, not fabricated): ``x-polylogue-observed-distribution``
+  (hash-bucketed histogram, no retained values to sample from),
+  ``x-polylogue-string-lengths`` (attached at the document root as a
+  JSONPath list rather than per-node, so consuming it needs a path-matching
+  pass), ``x-polylogue-mutually-exclusive`` / ``x-polylogue-foreign-keys``
+  (cross-field relational constraints, not single-node schema keywords),
+  ``x-polylogue-dynamic-keys``, ``x-polylogue-semantic-role``,
+  ``x-polylogue-time-deltas``, ``x-polylogue-exact-structure-ids``.
 """
 
 from __future__ import annotations
 
 import copy
 from functools import cache
+from typing import Literal, cast
 
 from hypothesis import strategies as st
 from hypothesis.strategies import SearchStrategy
@@ -17,13 +51,38 @@ from hypothesis_jsonschema import from_schema
 from polylogue.core.json import JSONDocument, JSONValue, json_document, require_json_value
 from polylogue.schemas.registry import SchemaRegistry
 
+GenerationMode = Literal["adversarial", "distributional"]
 
-def strip_schema_extensions(schema: JSONValue, *, is_root: bool = True) -> JSONValue:
+#: Presence frequency (0..1) above which a field is promoted into the
+#: enclosing object's ``required`` list in distributional mode. Chosen high
+#: enough that it only fires for fields that are, in practice, near-universal
+#: on the sampled corpus -- not a tuned statistical threshold.
+HIGH_FREQUENCY_REQUIRED_THRESHOLD = 0.9
+
+#: ``x-polylogue-format`` tokens that map onto a standard JSON Schema
+#: ``format`` value hypothesis-jsonschema generates conformant strings for.
+#: Tokens with no safe standard equivalent (``uuid4``, ``mime-type``, ...)
+#: are deliberately left unmapped -- see module docstring.
+_FORMAT_TOKEN_MAP: dict[str, str] = {
+    "iso8601": "date-time",
+    "url": "uri",
+    "email": "email",
+}
+
+
+def strip_schema_extensions(
+    schema: JSONValue,
+    *,
+    is_root: bool = True,
+    mode: GenerationMode = "adversarial",
+) -> JSONValue:
     """Recursively remove generator-hostile keys from a JSON schema.
 
     ``x-polylogue-values`` is the exception: it is translated into JSON
     Schema ``enum`` before the extension key is stripped so the same finite
-    value-domain annotation constrains Hypothesis generation.
+    value-domain annotation constrains Hypothesis generation. In
+    ``mode="distributional"``, additional annotations documented in the
+    module docstring are threaded into standard JSON Schema keywords.
     """
     if isinstance(schema, dict):
         cleaned: JSONDocument = {}
@@ -34,13 +93,15 @@ def strip_schema_extensions(schema: JSONValue, *, is_root: bool = True) -> JSONV
                 if is_root:
                     cleaned[key] = "https://json-schema.org/draft/2020-12/schema"
                 continue
-            cleaned[key] = strip_schema_extensions(value, is_root=False)
+            cleaned[key] = strip_schema_extensions(value, is_root=False, mode=mode)
         enum_values = _polylogue_value_enum(schema)
         if enum_values and "enum" not in cleaned:
             cleaned["enum"] = enum_values
+        if mode == "distributional":
+            _apply_distributional_annotations(schema, cleaned)
         return cleaned
     if isinstance(schema, list):
-        return [strip_schema_extensions(item, is_root=False) for item in schema]
+        return [strip_schema_extensions(item, is_root=False, mode=mode) for item in schema]
     return schema
 
 
@@ -51,8 +112,86 @@ def _polylogue_value_enum(schema: JSONDocument) -> list[JSONValue]:
     return [require_json_value(value, context="x-polylogue-values item") for value in values]
 
 
+def _schema_type_includes(schema: JSONDocument, name: str) -> bool:
+    declared = schema.get("type")
+    if isinstance(declared, str):
+        return declared == name
+    if isinstance(declared, list):
+        return name in declared
+    return False
+
+
+def _numeric_bound_pair(value: JSONValue | None) -> tuple[float, float] | None:
+    """Read a ``[min, max]`` numeric pair, or ``None`` if not one.
+
+    Rejects ``bool`` (a ``JSONValue`` numeric-looking subtype of ``int`` that
+    is never a legitimate observed bound) and any out-of-order pair.
+    """
+    if not isinstance(value, list) or len(value) != 2:
+        return None
+    low, high = value
+    if isinstance(low, bool) or isinstance(high, bool):
+        return None
+    if not isinstance(low, (int, float)) or not isinstance(high, (int, float)):
+        return None
+    if low > high:
+        return None
+    return float(low), float(high)
+
+
+def _apply_distributional_annotations(schema: JSONDocument, cleaned: JSONDocument) -> None:
+    """Thread real inference annotations from ``schema`` into ``cleaned``.
+
+    Reads from the original (uncleaned) ``schema`` node -- the ``x-polylogue-*``
+    keys are already stripped out of ``cleaned`` by the time this runs -- and
+    only ever *adds* constraints via ``setdefault``, never overriding an
+    explicit schema-declared bound.
+    """
+    if _schema_type_includes(schema, "number") or _schema_type_includes(schema, "integer"):
+        numeric_bounds = _numeric_bound_pair(schema.get("x-polylogue-range"))
+        if numeric_bounds is not None:
+            low, high = numeric_bounds
+            cleaned.setdefault("minimum", low)
+            cleaned.setdefault("maximum", high)
+
+    if _schema_type_includes(schema, "array"):
+        array_bounds = _numeric_bound_pair(schema.get("x-polylogue-array-lengths"))
+        if array_bounds is not None:
+            low_len, high_len = array_bounds
+            cleaned.setdefault("minItems", int(low_len))
+            cleaned.setdefault("maxItems", int(high_len))
+
+    format_token = schema.get("x-polylogue-format")
+    if isinstance(format_token, str) and _schema_type_includes(schema, "string"):
+        mapped_format = _FORMAT_TOKEN_MAP.get(format_token)
+        if mapped_format is not None:
+            cleaned.setdefault("format", mapped_format)
+
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        high_frequency_fields: set[str] = set()
+        for name, prop_schema in properties.items():
+            if not isinstance(prop_schema, dict):
+                continue
+            frequency = prop_schema.get("x-polylogue-frequency")
+            if isinstance(frequency, bool) or not isinstance(frequency, (int, float)):
+                continue
+            if frequency >= HIGH_FREQUENCY_REQUIRED_THRESHOLD:
+                high_frequency_fields.add(name)
+        if high_frequency_fields:
+            existing_required = cleaned.get("required")
+            existing: set[str] = set()
+            if isinstance(existing_required, list):
+                existing = {item for item in existing_required if isinstance(item, str)}
+            cleaned["required"] = cast(JSONValue, sorted(existing | high_frequency_fields))
+
+
 @st.composite
-def schema_conformant_payload(draw: st.DrawFn, provider: str) -> JSONValue:
+def schema_conformant_payload(
+    draw: st.DrawFn,
+    provider: str,
+    mode: GenerationMode = "adversarial",
+) -> JSONValue:
     """Generate a payload conformant to a provider's JSON schema.
 
     Loads the latest schema for the given provider from the registry,
@@ -61,18 +200,23 @@ def schema_conformant_payload(draw: st.DrawFn, provider: str) -> JSONValue:
 
     Args:
         provider: Provider name (chatgpt, claude-ai, claude-code, codex, gemini)
+        mode: ``"adversarial"`` (default) generates structurally valid but
+            distribution-blind data. ``"distributional"`` additionally
+            threads the real inference annotations documented in the module
+            docstring, so generated payloads approximate observed archive
+            distribution instead of only schema conformance.
 
     Returns:
         A dict/list conformant to the provider's schema.
     """
-    return draw(_schema_strategy(provider))
+    return draw(_schema_strategy(provider, mode))
 
 
 @cache
-def _schema_strategy(provider: str) -> SearchStrategy[JSONValue]:
+def _schema_strategy(provider: str, mode: GenerationMode = "adversarial") -> SearchStrategy[JSONValue]:
     registry = SchemaRegistry()
     raw_schema = registry.get_schema(provider, version="latest")
     if raw_schema is None:
         return st.fixed_dictionaries({})
-    cleaned = json_document(strip_schema_extensions(copy.deepcopy(raw_schema)))
+    cleaned = json_document(strip_schema_extensions(copy.deepcopy(raw_schema), mode=mode))
     return from_schema(cleaned)

--- a/tests/infra/test_pathology_composer.py
+++ b/tests/infra/test_pathology_composer.py
@@ -1,0 +1,247 @@
+"""Tests proving each pathology composer's claimed structural property.
+
+These are pure structural assertions on the returned ``ComposedPathology``
+(no archive/database writes) -- see the module docstring in
+``pathology_composer.py`` for why a live write is not required to prove the
+claimed shape.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.infra.pathology_composer import (
+    ComposedPathology,
+    compose_append_revision_chain,
+    compose_fork_prefix_tail_lineage,
+    compose_multi_session_bundle,
+    compose_quarantined_head_arrangement,
+    compose_vintage_variant_pair,
+    compose_whale_scale_component,
+    extract_new_shape_turns,
+    extract_old_shape_turns,
+)
+
+# ---------------------------------------------------------------------------
+# 1. Append revision chain
+# ---------------------------------------------------------------------------
+
+
+def test_revision_chain_has_claimed_length_and_growing_message_counts() -> None:
+    result = compose_append_revision_chain(revision_count=5, messages_per_revision=3)
+
+    assert len(result.sessions) == 5
+    message_counts = [len(session.messages) for session in result.sessions]
+    assert message_counts == [3, 6, 9, 12, 15]
+
+
+def test_revision_chain_all_revisions_share_one_archive_session_id() -> None:
+    result = compose_append_revision_chain(session_id="chain-abc", revision_count=3)
+
+    ids = {session.id for session in result.sessions}
+    assert ids == {"chain-abc"}
+
+
+def test_revision_chain_self_describing_identity_toggle() -> None:
+    with_identity = compose_append_revision_chain(session_id="rc", with_self_describing_identity=True)
+    without_identity = compose_append_revision_chain(session_id="rc", with_self_describing_identity=False)
+
+    assert all(session.metadata.get("source_identity") == "rc" for session in with_identity.sessions)
+    assert all("source_identity" not in session.metadata for session in without_identity.sessions)
+
+
+def test_revision_chain_rejects_degenerate_parameters() -> None:
+    with pytest.raises(ValueError):
+        compose_append_revision_chain(revision_count=0)
+    with pytest.raises(ValueError):
+        compose_append_revision_chain(messages_per_revision=0)
+
+
+# ---------------------------------------------------------------------------
+# 2. Fork / prefix-tail lineage
+# ---------------------------------------------------------------------------
+
+
+def test_lineage_child_shares_exact_message_id_and_text_prefix_with_parent() -> None:
+    result = compose_fork_prefix_tail_lineage(shared_prefix_len=4, child_tail_len=2)
+    parent, child = result.sessions
+
+    parent_prefix = [(m.id, m.text) for m in list(parent.messages)[:4]]
+    child_prefix = [(m.id, m.text) for m in list(child.messages)[:4]]
+    assert parent_prefix == child_prefix
+
+
+def test_lineage_child_tail_diverges_from_parent() -> None:
+    result = compose_fork_prefix_tail_lineage(shared_prefix_len=3, child_tail_len=2)
+    parent, child = result.sessions
+
+    parent_ids = {m.id for m in parent.messages}
+    child_tail_ids = {m.id for m in list(child.messages)[3:]}
+    assert child_tail_ids.isdisjoint(parent_ids)
+    assert len(child_tail_ids) == 2
+
+
+def test_lineage_child_parent_id_points_at_parent() -> None:
+    result = compose_fork_prefix_tail_lineage(parent_id="p1", child_id="c1")
+    parent, child = result.sessions
+
+    assert child.parent_id == "p1"
+    assert parent.id == "p1"
+
+
+def test_lineage_cycle_candidate_produces_genuine_two_cycle() -> None:
+    result = compose_fork_prefix_tail_lineage(parent_id="p2", child_id="c2", cycle_candidate=True)
+    parent, child = result.sessions
+
+    assert child.parent_id == "p2"
+    assert parent.parent_id == "c2"
+
+
+def test_lineage_without_cycle_candidate_parent_has_no_parent_id() -> None:
+    result = compose_fork_prefix_tail_lineage(cycle_candidate=False)
+    parent, _child = result.sessions
+
+    assert parent.parent_id is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Multi-session bundle
+# ---------------------------------------------------------------------------
+
+
+def test_multi_session_bundle_has_claimed_session_multiplicity() -> None:
+    records = [{"seq": i} for i in range(9)]
+    result = compose_multi_session_bundle(records, session_count=3)
+
+    (grouped_jsonl,) = result.raw_payloads
+    assert isinstance(grouped_jsonl, str)
+    lines = [json.loads(line) for line in grouped_jsonl.splitlines() if line]
+    session_ids = {entry["sessionId"] for entry in lines}
+
+    assert len(lines) == 9
+    assert len(session_ids) == 3
+
+
+def test_multi_session_bundle_preserves_all_input_records() -> None:
+    expected_markers = [f"rec-{i}" for i in range(6)]
+    records = [{"seq": i, "marker": marker} for i, marker in enumerate(expected_markers)]
+    result = compose_multi_session_bundle(records, session_count=2)
+
+    (grouped_jsonl,) = result.raw_payloads
+    assert isinstance(grouped_jsonl, str)
+    lines = [json.loads(line) for line in grouped_jsonl.splitlines() if line]
+    markers = sorted(entry["marker"] for entry in lines)
+    assert markers == sorted(expected_markers)
+
+
+def test_multi_session_bundle_rejects_single_session_count() -> None:
+    with pytest.raises(ValueError):
+        compose_multi_session_bundle([{"a": 1}], session_count=1)
+
+
+def test_multi_session_bundle_rejects_empty_records() -> None:
+    with pytest.raises(ValueError):
+        compose_multi_session_bundle([], session_count=2)
+
+
+# ---------------------------------------------------------------------------
+# 4. Whale-scale component
+# ---------------------------------------------------------------------------
+
+
+def test_whale_component_materializes_far_fewer_messages_than_declared() -> None:
+    result = compose_whale_scale_component(declared_message_count=50_000, materialized_message_count=16)
+    (session,) = result.sessions
+
+    assert len(session.messages) == 16
+    scale = session.metadata["_whale_scale"]
+    assert isinstance(scale, dict)
+    assert scale["declared_message_count"] == 50_000
+    assert scale["materialized_message_count"] == 16
+    assert len(session.messages) < scale["declared_message_count"]
+
+
+def test_whale_component_rejects_materializing_the_actual_scale() -> None:
+    with pytest.raises(ValueError):
+        compose_whale_scale_component(materialized_message_count=10_000)
+
+
+def test_whale_component_rejects_materialized_exceeding_declared() -> None:
+    with pytest.raises(ValueError):
+        compose_whale_scale_component(declared_message_count=10, materialized_message_count=20)
+
+
+# ---------------------------------------------------------------------------
+# 5. Quarantined-head arrangement
+# ---------------------------------------------------------------------------
+
+
+def test_quarantined_head_parent_reference_is_not_among_returned_sessions() -> None:
+    result = compose_quarantined_head_arrangement(child_id="child-x", missing_parent_id="ghost-parent")
+
+    session_ids = {session.id for session in result.sessions}
+    assert "child-x" in session_ids
+    assert "ghost-parent" not in session_ids
+    assert result.sessions[0].parent_id == "ghost-parent"
+
+
+def test_quarantined_head_metadata_names_the_missing_parent() -> None:
+    result = compose_quarantined_head_arrangement(missing_parent_id="ghost-2")
+    assert result.metadata["missing_parent_native_id"] == "ghost-2"
+
+
+# ---------------------------------------------------------------------------
+# 6. Vintage-variant pair
+# ---------------------------------------------------------------------------
+
+
+def test_vintage_variant_pair_has_different_wire_shape() -> None:
+    result = compose_vintage_variant_pair()
+    old_shape, new_shape = result.raw_payloads
+    assert isinstance(old_shape, dict)
+    assert isinstance(new_shape, dict)
+
+    assert "messages" in old_shape
+    assert "conversation" in new_shape
+    assert "messages" not in new_shape
+    assert "conversation" not in old_shape
+
+
+def test_vintage_variant_pair_extracted_content_is_equal_despite_shape_difference() -> None:
+    turns = (("user", "one"), ("assistant", "two"), ("user", "three"))
+    result = compose_vintage_variant_pair(turns=turns)
+    old_shape, new_shape = result.raw_payloads
+    assert isinstance(old_shape, dict)
+    assert isinstance(new_shape, dict)
+
+    old_turns = extract_old_shape_turns(old_shape)
+    new_turns = extract_new_shape_turns(new_shape)
+
+    assert old_turns == new_turns == list(turns)
+
+
+# ---------------------------------------------------------------------------
+# ComposedPathology provenance contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        compose_append_revision_chain(),
+        compose_fork_prefix_tail_lineage(),
+        compose_multi_session_bundle([{"a": 1}, {"b": 2}]),
+        compose_whale_scale_component(),
+        compose_quarantined_head_arrangement(),
+        compose_vintage_variant_pair(),
+    ],
+)
+def test_every_composed_pathology_carries_provenance(result: ComposedPathology) -> None:
+    """Every zoo member must be labeled with the pathology it carries and the
+    bead/issue that motivated it (polylogue-yazae growth rule)."""
+    assert result.pathology
+    assert result.motivated_by
+    assert result.description
+    assert result.sessions or result.raw_payloads

--- a/tests/unit/sources/test_schema_driven.py
+++ b/tests/unit/sources/test_schema_driven.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import copy
 
-from polylogue.core.json import JSONValue
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from polylogue.core.json import JSONValue, json_document
 from polylogue.schemas.registry import SchemaRegistry
-from tests.infra.strategies.schema_driven import strip_schema_extensions
+from tests.infra.strategies.schema_driven import schema_conformant_payload, strip_schema_extensions
 
 
 def _collect_schema_paths(schema: object, *, path: str = "root") -> list[tuple[str, str]]:
@@ -51,3 +54,151 @@ def test_strip_schema_extensions_translates_polylogue_values_to_enum() -> None:
     assert isinstance(role_schema, dict)
     assert "x-polylogue-values" not in role_schema
     assert role_schema["enum"] == ["user", "assistant"]
+
+
+def test_distributional_mode_still_respects_polylogue_values_enum() -> None:
+    """Both modes translate x-polylogue-values -- distributional adds MORE
+    constraints on top, it never loosens the finite value-domain one."""
+    raw_schema: JSONValue = {
+        "type": "object",
+        "properties": {
+            "role": {"type": "string", "x-polylogue-values": ["user", "assistant"]},
+        },
+    }
+
+    for mode in ("adversarial", "distributional"):
+        cleaned = strip_schema_extensions(copy.deepcopy(raw_schema), mode=mode)
+        assert isinstance(cleaned, dict)
+        properties = cleaned["properties"]
+        assert isinstance(properties, dict)
+        role_schema = properties["role"]
+        assert isinstance(role_schema, dict)
+        assert role_schema["enum"] == ["user", "assistant"], mode
+
+
+def test_distributional_mode_threads_range_into_minimum_maximum() -> None:
+    raw_schema: JSONValue = {
+        "type": "object",
+        "properties": {
+            "elapsedTimeSeconds": {
+                "type": "integer",
+                "x-polylogue-range": [2.0, 566.0],
+            },
+        },
+    }
+
+    adversarial = strip_schema_extensions(copy.deepcopy(raw_schema), mode="adversarial")
+    distributional = strip_schema_extensions(copy.deepcopy(raw_schema), mode="distributional")
+
+    assert isinstance(adversarial, dict)
+    adversarial_properties = adversarial["properties"]
+    assert isinstance(adversarial_properties, dict)
+    adversarial_field = adversarial_properties["elapsedTimeSeconds"]
+    assert isinstance(adversarial_field, dict)
+    assert "minimum" not in adversarial_field and "maximum" not in adversarial_field
+
+    assert isinstance(distributional, dict)
+    distributional_properties = distributional["properties"]
+    assert isinstance(distributional_properties, dict)
+    distributional_field = distributional_properties["elapsedTimeSeconds"]
+    assert isinstance(distributional_field, dict)
+    assert distributional_field["minimum"] == 2.0
+    assert distributional_field["maximum"] == 566.0
+
+
+def test_distributional_mode_threads_array_lengths_into_min_max_items() -> None:
+    raw_schema: JSONValue = {
+        "type": "object",
+        "properties": {
+            "chat_messages": {
+                "type": "array",
+                "items": {"type": "string"},
+                "x-polylogue-array-lengths": [1, 379],
+            },
+        },
+    }
+
+    distributional = strip_schema_extensions(copy.deepcopy(raw_schema), mode="distributional")
+    assert isinstance(distributional, dict)
+    properties = distributional["properties"]
+    assert isinstance(properties, dict)
+    field = properties["chat_messages"]
+    assert isinstance(field, dict)
+    assert field["minItems"] == 1
+    assert field["maxItems"] == 379
+
+
+def test_distributional_mode_promotes_high_frequency_field_to_required() -> None:
+    """A field observed present >= the high-frequency threshold is forced
+    present in distributional mode; adversarial mode leaves it optional."""
+    raw_schema: JSONValue = {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "x-polylogue-frequency": 0.999},
+            "rare_field": {"type": "string", "x-polylogue-frequency": 0.01},
+        },
+    }
+
+    adversarial = strip_schema_extensions(copy.deepcopy(raw_schema), mode="adversarial")
+    distributional = strip_schema_extensions(copy.deepcopy(raw_schema), mode="distributional")
+
+    assert isinstance(adversarial, dict)
+    assert "required" not in adversarial
+
+    assert isinstance(distributional, dict)
+    assert distributional["required"] == ["id"]
+
+
+def test_distributional_mode_maps_known_format_tokens() -> None:
+    raw_schema: JSONValue = {
+        "type": "object",
+        "properties": {
+            "created_at": {"type": "string", "x-polylogue-format": "iso8601"},
+            "uuid": {"type": "string", "x-polylogue-format": "uuid4"},
+        },
+    }
+
+    distributional = strip_schema_extensions(copy.deepcopy(raw_schema), mode="distributional")
+    assert isinstance(distributional, dict)
+    properties = distributional["properties"]
+    assert isinstance(properties, dict)
+    created_at_schema = properties["created_at"]
+    uuid_schema = properties["uuid"]
+    assert isinstance(created_at_schema, dict)
+    assert isinstance(uuid_schema, dict)
+    assert created_at_schema["format"] == "date-time"
+    # uuid4 has no safe standard-format equivalent -- deliberately unmapped.
+    assert "format" not in uuid_schema
+
+
+@settings(max_examples=25, suppress_health_check=[HealthCheck.too_slow])
+@given(st.data())
+def test_distributional_mode_generated_values_respect_range_annotation(data: st.DataObject) -> None:
+    """Measurable distribution difference: distributional-mode draws are
+    always inside the annotated observed range; adversarial mode has no such
+    guarantee (an unconstrained JSON Schema integer spans a far wider domain)."""
+    raw_schema: JSONValue = {
+        "type": "object",
+        "properties": {
+            "elapsedTimeSeconds": {"type": "integer", "x-polylogue-range": [2, 566]},
+        },
+        "required": ["elapsedTimeSeconds"],
+    }
+    distributional = json_document(strip_schema_extensions(copy.deepcopy(raw_schema), mode="distributional"))
+
+    from hypothesis_jsonschema import from_schema
+
+    payload = data.draw(from_schema(distributional))
+    assert isinstance(payload, dict)
+    value = payload["elapsedTimeSeconds"]
+    assert 2 <= value <= 566
+
+
+def test_schema_conformant_payload_accepts_mode_parameter() -> None:
+    """Smoke-check the public entry point threads `mode` through to the
+    registry-backed strategy cache without raising (real registry schema)."""
+    from hypothesis import strategies as hyp_st
+
+    for mode in ("adversarial", "distributional"):
+        strategy = schema_conformant_payload("claude-code", mode=mode)
+        assert isinstance(strategy, hyp_st.SearchStrategy)


### PR DESCRIPTION
## Summary

Implements polylogue-amrpx phase 1: a distributional generation mode for schema-driven Hypothesis strategies, plus a new archive-level pathology composer that assembles generated records into corpus-level pathological arrangements (revision chains, fork lineages, multi-session bundles, whale components, quarantined heads, vintage-variant pairs). This is the generative engine polylogue-yazae's pathology-zoo (currently hand-built v0) is meant to consume as v1.

## Problem

`tests/infra/strategies/schema_driven.py`'s `strip_schema_extensions` stripped every `x-polylogue-*` inference annotation except `x-polylogue-values`, so hypothesis-jsonschema output was structurally valid but distribution-blind: it never reflected field-presence frequency, observed numeric ranges, array-length bounds, or format hints the schema packages actually carry. Separately, `polylogue-yazae`'s pathology zoo needs archive-*level* structures (a chain of revisions, a fork lineage, a multi-session raw bundle) that no per-record generator can produce -- that's a property of a sequence/corpus of writes, not any single record.

An inventory of the committed schema packages (`polylogue/schemas/providers/*/versions/*/elements/*.schema.json.gz`, 16 files) found these `x-polylogue-*` annotation kinds actually emitted (counts across all files):

| annotation | count | shape |
| --- | --- | --- |
| `x-polylogue-frequency` | 1613 | float 0..1, per-field presence probability |
| `x-polylogue-observed-distribution` | 1276 | hash-bucketed histogram, `values_retained` usually `False` |
| `x-polylogue-format` | 310 | string token (`iso8601`, `uuid4`, `url`, `mime-type`, ...) |
| `x-polylogue-range` | 277 | `[min, max]` numeric pair |
| `x-polylogue-array-lengths` | 257 | `[min, max]` observed array length |
| `x-polylogue-values` | 458 | finite value domain (already threaded pre-existing) |
| `x-polylogue-multiline` | 163 | bool |
| `x-polylogue-semantic-role` | 82 | string label |
| `x-polylogue-evidence` / `-score` | 73 each | provenance metadata, not a generation constraint |
| `x-polylogue-string-lengths` | 14 (root-attached) | JSONPath list of length stats, attached at document root |
| `x-polylogue-dynamic-keys` | 16 | bool |
| `x-polylogue-mutually-exclusive` | 12 | cross-field relation (`{fields: [...], parent: ...}`) |
| `x-polylogue-foreign-keys` | 4 | cross-field relation |
| `x-polylogue-time-deltas` | 3 | — |
| `x-polylogue-exact-structure-ids` | 8 | — |

## Solution

**Distributional mode** (`tests/infra/strategies/schema_driven.py`): `strip_schema_extensions` and `schema_conformant_payload` gained a `mode: Literal["adversarial", "distributional"]` parameter. `"adversarial"` (default) is unchanged. `"distributional"` additionally threads:

- `x-polylogue-frequency` -- fields observed present >= 0.9 are promoted into the enclosing object's `required` list (adversarial mode may freely omit them).
- `x-polylogue-range` -- becomes `minimum`/`maximum` on numeric properties.
- `x-polylogue-array-lengths` -- becomes `minItems`/`maxItems` on arrays.
- `x-polylogue-format` -- known tokens (`iso8601`->`date-time`, `url`->`uri`, `email`->`email`) map to the standard JSON Schema `format` values hypothesis-jsonschema actually generates conformant data for. `uuid4`/`mime-type` are deliberately left unmapped -- no safe standard-format equivalent, so no fabricated semantics.

**Deferred, not exploited** (documented in the module docstring as follow-up material, not silently dropped): `x-polylogue-observed-distribution` (hash-bucketed, `values_retained: False` in the common case -- nothing to sample from), `x-polylogue-string-lengths` (attached at the schema *root* as a JSONPath list rather than per-node, so consuming it needs a path-matching pass this PR doesn't build), `x-polylogue-mutually-exclusive` / `x-polylogue-foreign-keys` (cross-field relational constraints, not expressible as a single-node schema keyword), `x-polylogue-dynamic-keys` / `x-polylogue-semantic-role` / `x-polylogue-time-deltas` / `x-polylogue-exact-structure-ids` (no generation-relevant semantics identified yet).

**Pathology composer** (new `tests/infra/pathology_composer.py`): six pure functions, each returning a `ComposedPathology` (pathology label, motivating bead/issue, description, composed `Session`/raw-payload structures -- no database writes):

- `compose_append_revision_chain` -- N growing revisions sharing one archive session id, with/without a self-describing identity marker in metadata (#2467; content-hash idempotency model).
- `compose_fork_prefix_tail_lineage` -- parent + child sharing an exact message id/text prefix then diverging, plus a `cycle_candidate` variant that sets both sessions' `parent_id` at each other (#2467; `TopologyEdgeStatus.QUARANTINED`).
- `compose_multi_session_bundle` -- interleaves already-generated per-record payloads into one grouped-JSONL raw blob split by `sessionId` (mirrors `sources/dispatch.py`'s `_lower_payload_specs` grouped-JSONL handling).
- `compose_whale_scale_component` -- materializes a small, bounded message count while carrying the intended full scale (`declared_message_count`/`declared_size_bytes`) in session metadata, so no test ever allocates actual whale-scale data (t93b).
- `compose_quarantined_head_arrangement` -- a child session referencing a parent id deliberately not included, for harness-controlled topology-resolution testing.
- `compose_vintage_variant_pair` -- two wire-shape variants (flat vs nested) encoding identical `(role, text)` content, plus extraction helpers proving equality despite the shape difference (0qfy/uqwd).

Built on `tests/infra/builders.py`'s `make_conv`/`make_msg` (the public `Session`/`Message` domain models already used across the test suite) rather than inventing a parallel representation, per the bead's explicit "integrate, don't parallel-invent" instruction. Composers are DB-free by design: each test proves the claimed structural property (chain length/growth, exact prefix equality, bundle multiplicity, whale metadata vs materialized count, missing-parent exclusion, content equality across wire shapes) directly on the returned dataclass.

## Verification

- `devtools test tests/unit/sources/test_schema_driven.py` -- 9 passed (includes a deterministic minimum/maximum-injection test and a `@given`-based check that distributional draws always respect the annotated range).
- `devtools test tests/infra/test_pathology_composer.py` -- 26 passed.
- `mypy --strict` on all four changed/new files -- `Success: no issues found in 4 source files`.
- `ruff check` / `ruff format --check` -- clean.
- `devtools render all --check` -- clean (no `out of sync`); not required for `tests/` changes but confirmed anyway per repo gotcha.
- Pre-push hook ran `devtools verify --quick` (format+lint+mypy+render-all-check) -- exit 0.
- Not run: `devtools verify --all` (full non-integration suite) -- left for CI's post-merge heavy `test` job per this repo's per-PR test-skip policy; the two focused `devtools test` runs above cover every changed line.

## Scope left out (follow-up material)

- `x-polylogue-observed-distribution`, `x-polylogue-string-lengths`, `x-polylogue-mutually-exclusive`, `x-polylogue-foreign-keys`, `x-polylogue-dynamic-keys`, `x-polylogue-semantic-role`, `x-polylogue-time-deltas`, `x-polylogue-exact-structure-ids` -- all listed in the module docstring with the specific reason each was not threaded.
- The pathology composer does not itself write to a live archive (`SessionBuilder.save()` / `write_parsed_session_to_archive`); it produces the structures a harness feeds into those, which is `polylogue-yazae`'s remaining scope (registry pytest binding, differ canary set, parse-equivalence tests).
- `tnqqt`'s refreshed schemas were explicitly not blocked on -- current registry schemas already carry enough annotation richness for this machinery, per the bead.

Ref polylogue-amrpx; feeds polylogue-yazae