### PR TITLE
feat(devtools): auto-bootstrap testmon seed for fresh worktrees

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,7 +342,9 @@ testmon-affected set.
 - `mypy --strict` (via `devtools verify`) is the primary net for type/identifier
   refactors — trust it. Config in `pyproject.toml`, no exclude list.
 - Seed testmon on a fresh checkout / after harness or dependency changes:
-  `devtools verify --seed-testmon --skip-slow`.
+  `devtools verify --seed-testmon --skip-slow`. A linked worktree auto-bootstraps
+  its testmon cache from the main checkout's valid seed instead (`devtools/testmon_bootstrap.py`),
+  so this is only needed when the main checkout itself has no seed yet.
 - Reserve `devtools verify --all` (full non-integration run) for
   harness/dependency changes or a final pre-PR diagnostic.
 - `devtools verify --quick` = format + lint + mypy + `render all --check`

--- a/devtools/testmon_bootstrap.py
+++ b/devtools/testmon_bootstrap.py
@@ -1,0 +1,250 @@
+"""Bootstrap a fresh worktree's pytest-testmon cache from the main checkout.
+
+The hazard this closes (polylogue-mq4vx): every fresh agent worktree lane
+re-seeds pytest-testmon from scratch. `devtools verify --seed-testmon` seeds
+the affected-selection dependency database with a full non-integration pytest
+run; that run costs real wall-clock (the main checkout's
+``.cache/testmon/testmondata`` is ~28MB, built from the whole non-integration
+suite). A linked worktree with no local seed either pays that cost again or
+hits the unseeded-refusal preflight in ``devtools/verify.py``
+(``_testmon_preflight``) and blocks entirely.
+
+But the seed database is copyable. ``pytest-testmon`` records ``file_fp``
+entries keyed by path **relative to the invoking repo root**, each with a
+per-file content checksum (``fsha``). A worktree is a distinct working tree
+sharing the same relative layout as the main checkout, so a testmondata file
+copied verbatim from main is immediately meaningful there: any file that
+differs between the worktree and the main checkout at copy time
+self-invalidates (its ``fsha`` won't match), and testmon correctly treats the
+tests that depend on it as affected on the very next run. No merge or rewrite
+is needed -- a straight copy is a valid seed.
+
+This module owns exactly one decision and one action:
+
+- :func:`decide_testmon_bootstrap` -- pure decision, no I/O beyond reading the
+  two candidate seed files (local + main). Testable with plain tmp dirs.
+- :func:`bootstrap_testmon_seed_files` -- the copy action once bootstrapping
+  has been decided.
+- :func:`maybe_bootstrap_testmon_seed` -- the orchestrator `devtools verify`
+  calls: detects whether ``repo_root`` is a linked worktree (via
+  ``git rev-parse --absolute-git-dir --git-common-dir``, the same mechanism
+  ``devtools/verify_worktree.py`` uses), finds the main checkout, and wires
+  the decision to the action.
+
+Concurrency: the main checkout may be mid-seed (a live ``--seed-testmon`` run
+appending to its own testmondata) at the exact moment a worktree bootstraps
+from it. ``testmondata`` is a real sqlite database, so a naive byte copy of an
+open, actively-written file can capture a torn, inconsistent snapshot. This
+copies it through :meth:`sqlite3.Connection.backup`, sqlite's own online-backup
+API -- built for copying a live database without an exclusive lock, immune to
+concurrent writers by design. ``seed.json`` is a small file written atomically
+by ``verify.py`` (write-temp-then-rename), so a plain read-then-atomic-write
+copy is enough for it; there is no partial-write window to observe.
+
+This module NEVER writes to the main checkout's copy of either file --
+only reads from main, only writes to ``repo_root``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+TESTMON_DATA_RELPATH = ".cache/testmon/testmondata"
+TESTMON_SEED_STAMP_RELPATH = ".cache/testmon/seed.json"
+
+
+@dataclass(frozen=True)
+class BootstrapDecision:
+    """Whether a worktree's testmon cache should be bootstrapped from main, and why."""
+
+    should_bootstrap: bool
+    reason: str
+    main_testmon_data: Path | None = None
+    main_seed_stamp: Path | None = None
+
+
+def _is_valid_complete_seed_stamp(seed_stamp: Path, *, protocol_version: int) -> bool:
+    """Mirror the validity check `devtools.verify._testmon_preflight` applies."""
+    if not seed_stamp.is_file():
+        return False
+    try:
+        stamp = json.loads(seed_stamp.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(stamp, dict):
+        return False
+    return stamp.get("protocol_version") == protocol_version and stamp.get("status") == "complete"
+
+
+def decide_testmon_bootstrap(
+    *,
+    is_linked_worktree: bool,
+    local_testmon_data: Path,
+    local_seed_stamp: Path,
+    main_testmon_data: Path,
+    main_seed_stamp: Path,
+    protocol_version: int,
+) -> BootstrapDecision:
+    """Decide whether to copy the main checkout's testmon seed into a worktree.
+
+    Pure with respect to process state (no subprocess, no git): every input is
+    an already-resolved path or flag, so this is directly unit-testable with
+    tmp dirs standing in for "local worktree" and "main checkout".
+    """
+    if not is_linked_worktree:
+        return BootstrapDecision(False, "repo_root is not a linked worktree; nothing to bootstrap")
+    if local_testmon_data.is_file() and local_seed_stamp.is_file():
+        return BootstrapDecision(False, "local .cache/testmon already has a testmondata + seed stamp")
+    if not _is_valid_complete_seed_stamp(main_seed_stamp, protocol_version=protocol_version):
+        return BootstrapDecision(
+            False,
+            "main checkout has no valid complete testmon seed stamp to bootstrap from",
+        )
+    if not main_testmon_data.is_file():
+        return BootstrapDecision(
+            False,
+            "main checkout seed stamp is valid but its testmondata file is missing",
+        )
+    return BootstrapDecision(
+        True,
+        f"main checkout has a valid complete testmon seed ({main_seed_stamp}); bootstrapping worktree cache",
+        main_testmon_data=main_testmon_data,
+        main_seed_stamp=main_seed_stamp,
+    )
+
+
+def _atomic_copy_bytes(src: Path, dst: Path) -> None:
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dst.with_name(f"{dst.name}.{os.getpid()}.tmp")
+    tmp.write_bytes(src.read_bytes())
+    tmp.replace(dst)
+
+
+def _atomic_copy_sqlite_db(src: Path, dst: Path) -> None:
+    """Copy a (possibly concurrently-written) sqlite db via the online backup API.
+
+    `sqlite3.Connection.backup` is designed to snapshot a live database without
+    requiring an exclusive lock on the source, so this tolerates the main
+    checkout mid-write. The destination is built at a temp path and only
+    `rename`d into place once the backup completes, so a reader never observes
+    a partially-copied file at `dst`.
+    """
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dst.with_name(f"{dst.name}.{os.getpid()}.tmp")
+    tmp.unlink(missing_ok=True)
+    src_conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
+    try:
+        dst_conn = sqlite3.connect(tmp)
+        try:
+            src_conn.backup(dst_conn)
+        finally:
+            dst_conn.close()
+    finally:
+        src_conn.close()
+    tmp.replace(dst)
+
+
+def bootstrap_testmon_seed_files(
+    decision: BootstrapDecision,
+    *,
+    local_testmon_data: Path,
+    local_seed_stamp: Path,
+) -> None:
+    """Perform the copy `decision` describes. No-op unless `should_bootstrap`."""
+    if not decision.should_bootstrap:
+        return
+    assert decision.main_testmon_data is not None
+    assert decision.main_seed_stamp is not None
+    _atomic_copy_sqlite_db(decision.main_testmon_data, local_testmon_data)
+    _atomic_copy_bytes(decision.main_seed_stamp, local_seed_stamp)
+
+
+def _git_worktree_info(repo_root: Path) -> tuple[bool, Path] | None:
+    """Return `(is_linked_worktree, main_checkout_path)`, or None if undeterminable.
+
+    Same `git rev-parse --absolute-git-dir --git-common-dir` mechanism
+    `devtools/verify_worktree.py:inspect_worktree` uses: a linked worktree's
+    git-dir (`.git/worktrees/<name>`) differs from the shared
+    git-common-dir; a main checkout's git-dir *is* the common-dir.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--absolute-git-dir", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    lines = result.stdout.splitlines()
+    if len(lines) < 2:
+        return None
+    git_dir = Path(lines[0]).resolve()
+    raw_common = Path(lines[1])
+    common_dir = raw_common.resolve() if raw_common.is_absolute() else (repo_root / raw_common).resolve()
+    is_linked = git_dir != common_dir
+    main_checkout = common_dir.parent
+    return is_linked, main_checkout
+
+
+def maybe_bootstrap_testmon_seed(
+    repo_root: Path,
+    *,
+    testmon_data_relpath: str = TESTMON_DATA_RELPATH,
+    seed_stamp_relpath: str = TESTMON_SEED_STAMP_RELPATH,
+    protocol_version: int,
+) -> str | None:
+    """Bootstrap `repo_root`'s testmon seed from its main checkout if warranted.
+
+    Returns a one-line message to log on success, or ``None`` when no
+    bootstrap happened (not a linked worktree, already seeded locally, or the
+    main checkout has nothing valid to offer). Called from
+    `devtools/verify.py` before `_testmon_preflight`, so a freshly-bootstrapped
+    worktree passes that preflight instead of refusing.
+    """
+    info = _git_worktree_info(repo_root)
+    if info is None:
+        return None
+    is_linked_worktree, main_checkout = info
+    if main_checkout == repo_root.resolve():
+        return None
+    local_testmon_data = repo_root / testmon_data_relpath
+    local_seed_stamp = repo_root / seed_stamp_relpath
+    main_testmon_data = main_checkout / testmon_data_relpath
+    main_seed_stamp = main_checkout / seed_stamp_relpath
+    decision = decide_testmon_bootstrap(
+        is_linked_worktree=is_linked_worktree,
+        local_testmon_data=local_testmon_data,
+        local_seed_stamp=local_seed_stamp,
+        main_testmon_data=main_testmon_data,
+        main_seed_stamp=main_seed_stamp,
+        protocol_version=protocol_version,
+    )
+    if not decision.should_bootstrap:
+        return None
+    bootstrap_testmon_seed_files(
+        decision,
+        local_testmon_data=local_testmon_data,
+        local_seed_stamp=local_seed_stamp,
+    )
+    return (
+        f"verify: bootstrapped pytest-testmon seed from main checkout {main_checkout} "
+        f"into {local_testmon_data.parent} (worktree had no local seed)"
+    )
+
+
+__all__ = [
+    "TESTMON_DATA_RELPATH",
+    "TESTMON_SEED_STAMP_RELPATH",
+    "BootstrapDecision",
+    "decide_testmon_bootstrap",
+    "bootstrap_testmon_seed_files",
+    "maybe_bootstrap_testmon_seed",
+]

--- a/devtools/verify.py
+++ b/devtools/verify.py
@@ -55,6 +55,7 @@ from devtools.pytest_supervisor import (
     update_receipt,
     write_termination_request,
 )
+from devtools.testmon_bootstrap import maybe_bootstrap_testmon_seed
 from devtools.verify_runs import (
     CURRENT_CONTAINMENT_PATH,
     CURRENT_EVENTS_DIR,
@@ -2559,6 +2560,12 @@ def main(argv: list[str] | None = None) -> int:
         tier = "testmon"
 
     full_pytest = bool(args.all or args.full)
+    bootstrap_message = maybe_bootstrap_testmon_seed(
+        ROOT,
+        protocol_version=TESTMON_SEED_PROTOCOL_VERSION,
+    )
+    if bootstrap_message is not None:
+        sys.stderr.write(bootstrap_message + "\n")
     preflight_error = _testmon_preflight(
         seed_testmon=bool(args.seed_testmon),
         full_pytest=full_pytest,

--- a/tests/unit/devtools/test_testmon_bootstrap.py
+++ b/tests/unit/devtools/test_testmon_bootstrap.py
@@ -1,0 +1,239 @@
+"""Tests for the worktree testmon-seed bootstrap (devtools/testmon_bootstrap.py).
+
+Covers polylogue-mq4vx: a fresh agent worktree lane starts with no local
+`.cache/testmon/testmondata`, either paying the full `--seed-testmon` cost
+again or hitting the unseeded-refusal preflight in `devtools/verify.py`. The
+main checkout's testmondata is copyable (file_fp entries are relative paths
+with per-file checksums, so a stale copy self-invalidates changed files), so
+`maybe_bootstrap_testmon_seed` copies it in before that preflight runs.
+
+These tests target `decide_testmon_bootstrap` (the pure decision) and
+`bootstrap_testmon_seed_files` (the copy action) directly with tmp dirs --
+not the full `devtools verify` pipeline, per the bootstrap's own module
+docstring contract.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from devtools.testmon_bootstrap import (
+    BootstrapDecision,
+    bootstrap_testmon_seed_files,
+    decide_testmon_bootstrap,
+)
+
+PROTOCOL_VERSION = 3
+
+
+def _write_valid_seed_stamp(path: Path, *, protocol_version: int = PROTOCOL_VERSION) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"protocol_version": protocol_version, "status": "complete"}))
+
+
+def _write_sqlite_db(path: Path, *, rows: tuple[str, ...] = ("a", "b")) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("CREATE TABLE file_fp (path TEXT, fsha TEXT)")
+        conn.executemany("INSERT INTO file_fp VALUES (?, ?)", [(row, f"sha-{row}") for row in rows])
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_not_a_linked_worktree_never_bootstraps(tmp_path: Path) -> None:
+    """The main checkout itself must never "bootstrap from itself"."""
+    decision = decide_testmon_bootstrap(
+        is_linked_worktree=False,
+        local_testmon_data=tmp_path / "local" / "testmondata",
+        local_seed_stamp=tmp_path / "local" / "seed.json",
+        main_testmon_data=tmp_path / "main" / "testmondata",
+        main_seed_stamp=tmp_path / "main" / "seed.json",
+        protocol_version=PROTOCOL_VERSION,
+    )
+    assert decision == BootstrapDecision(False, decision.reason)
+    assert not decision.should_bootstrap
+
+
+def test_local_seed_already_present_skips_bootstrap(tmp_path: Path) -> None:
+    """A worktree that already seeded itself must not be clobbered by main's copy."""
+    local_data = tmp_path / "local" / "testmondata"
+    local_stamp = tmp_path / "local" / "seed.json"
+    _write_sqlite_db(local_data)
+    _write_valid_seed_stamp(local_stamp)
+    main_data = tmp_path / "main" / "testmondata"
+    main_stamp = tmp_path / "main" / "seed.json"
+    _write_sqlite_db(main_data)
+    _write_valid_seed_stamp(main_stamp)
+
+    decision = decide_testmon_bootstrap(
+        is_linked_worktree=True,
+        local_testmon_data=local_data,
+        local_seed_stamp=local_stamp,
+        main_testmon_data=main_data,
+        main_seed_stamp=main_stamp,
+        protocol_version=PROTOCOL_VERSION,
+    )
+    assert not decision.should_bootstrap
+    assert "already has" in decision.reason
+
+
+def test_main_seed_absent_skips_bootstrap(tmp_path: Path) -> None:
+    decision = decide_testmon_bootstrap(
+        is_linked_worktree=True,
+        local_testmon_data=tmp_path / "local" / "testmondata",
+        local_seed_stamp=tmp_path / "local" / "seed.json",
+        main_testmon_data=tmp_path / "main" / "testmondata",
+        main_seed_stamp=tmp_path / "main" / "seed.json",
+        protocol_version=PROTOCOL_VERSION,
+    )
+    assert not decision.should_bootstrap
+    assert "no valid complete testmon seed stamp" in decision.reason
+
+
+def test_main_seed_stamp_wrong_protocol_version_skips_bootstrap(tmp_path: Path) -> None:
+    main_stamp = tmp_path / "main" / "seed.json"
+    _write_valid_seed_stamp(main_stamp, protocol_version=PROTOCOL_VERSION + 1)
+    _write_sqlite_db(tmp_path / "main" / "testmondata")
+
+    decision = decide_testmon_bootstrap(
+        is_linked_worktree=True,
+        local_testmon_data=tmp_path / "local" / "testmondata",
+        local_seed_stamp=tmp_path / "local" / "seed.json",
+        main_testmon_data=tmp_path / "main" / "testmondata",
+        main_seed_stamp=main_stamp,
+        protocol_version=PROTOCOL_VERSION,
+    )
+    assert not decision.should_bootstrap
+    assert "no valid complete testmon seed stamp" in decision.reason
+
+
+def test_main_seed_stamp_incomplete_status_skips_bootstrap(tmp_path: Path) -> None:
+    main_stamp = tmp_path / "main" / "seed.json"
+    main_stamp.parent.mkdir(parents=True, exist_ok=True)
+    main_stamp.write_text(json.dumps({"protocol_version": PROTOCOL_VERSION, "status": "incomplete"}))
+    _write_sqlite_db(tmp_path / "main" / "testmondata")
+
+    decision = decide_testmon_bootstrap(
+        is_linked_worktree=True,
+        local_testmon_data=tmp_path / "local" / "testmondata",
+        local_seed_stamp=tmp_path / "local" / "seed.json",
+        main_testmon_data=tmp_path / "main" / "testmondata",
+        main_seed_stamp=main_stamp,
+        protocol_version=PROTOCOL_VERSION,
+    )
+    assert not decision.should_bootstrap
+
+
+def test_main_seed_stamp_unreadable_json_skips_bootstrap(tmp_path: Path) -> None:
+    main_stamp = tmp_path / "main" / "seed.json"
+    main_stamp.parent.mkdir(parents=True, exist_ok=True)
+    main_stamp.write_text("{not valid json")
+    _write_sqlite_db(tmp_path / "main" / "testmondata")
+
+    decision = decide_testmon_bootstrap(
+        is_linked_worktree=True,
+        local_testmon_data=tmp_path / "local" / "testmondata",
+        local_seed_stamp=tmp_path / "local" / "seed.json",
+        main_testmon_data=tmp_path / "main" / "testmondata",
+        main_seed_stamp=main_stamp,
+        protocol_version=PROTOCOL_VERSION,
+    )
+    assert not decision.should_bootstrap
+
+
+def test_valid_seed_stamp_but_missing_testmondata_skips_bootstrap(tmp_path: Path) -> None:
+    """A seed stamp claims completeness but the db file itself vanished -- don't copy nothing."""
+    main_stamp = tmp_path / "main" / "seed.json"
+    _write_valid_seed_stamp(main_stamp)
+
+    decision = decide_testmon_bootstrap(
+        is_linked_worktree=True,
+        local_testmon_data=tmp_path / "local" / "testmondata",
+        local_seed_stamp=tmp_path / "local" / "seed.json",
+        main_testmon_data=tmp_path / "main" / "testmondata",
+        main_seed_stamp=main_stamp,
+        protocol_version=PROTOCOL_VERSION,
+    )
+    assert not decision.should_bootstrap
+    assert "testmondata file is missing" in decision.reason
+
+
+def test_valid_main_seed_and_empty_local_bootstraps(tmp_path: Path) -> None:
+    main_data = tmp_path / "main" / "testmondata"
+    main_stamp = tmp_path / "main" / "seed.json"
+    _write_sqlite_db(main_data)
+    _write_valid_seed_stamp(main_stamp)
+
+    decision = decide_testmon_bootstrap(
+        is_linked_worktree=True,
+        local_testmon_data=tmp_path / "local" / "testmondata",
+        local_seed_stamp=tmp_path / "local" / "seed.json",
+        main_testmon_data=main_data,
+        main_seed_stamp=main_stamp,
+        protocol_version=PROTOCOL_VERSION,
+    )
+    assert decision.should_bootstrap
+    assert decision.main_testmon_data == main_data
+    assert decision.main_seed_stamp == main_stamp
+
+
+def test_local_seed_missing_only_stamp_still_bootstraps(tmp_path: Path) -> None:
+    """Partial local state (e.g. a stale stamp with no db, or vice versa) still needs a fresh copy."""
+    local_stamp = tmp_path / "local" / "seed.json"
+    _write_valid_seed_stamp(local_stamp)
+    main_data = tmp_path / "main" / "testmondata"
+    main_stamp = tmp_path / "main" / "seed.json"
+    _write_sqlite_db(main_data)
+    _write_valid_seed_stamp(main_stamp)
+
+    decision = decide_testmon_bootstrap(
+        is_linked_worktree=True,
+        local_testmon_data=tmp_path / "local" / "testmondata",
+        local_seed_stamp=local_stamp,
+        main_testmon_data=main_data,
+        main_seed_stamp=main_stamp,
+        protocol_version=PROTOCOL_VERSION,
+    )
+    assert decision.should_bootstrap
+
+
+def test_bootstrap_seed_files_copies_db_and_stamp(tmp_path: Path) -> None:
+    main_data = tmp_path / "main" / "testmondata"
+    main_stamp = tmp_path / "main" / "seed.json"
+    _write_sqlite_db(main_data, rows=("x", "y", "z"))
+    _write_valid_seed_stamp(main_stamp)
+    local_data = tmp_path / "local" / "testmondata"
+    local_stamp = tmp_path / "local" / "seed.json"
+
+    decision = BootstrapDecision(
+        True,
+        "test",
+        main_testmon_data=main_data,
+        main_seed_stamp=main_stamp,
+    )
+    bootstrap_testmon_seed_files(decision, local_testmon_data=local_data, local_seed_stamp=local_stamp)
+
+    assert local_stamp.read_text() == main_stamp.read_text()
+    conn = sqlite3.connect(local_data)
+    try:
+        rows = conn.execute("SELECT path, fsha FROM file_fp ORDER BY path").fetchall()
+    finally:
+        conn.close()
+    assert rows == [("x", "sha-x"), ("y", "sha-y"), ("z", "sha-z")]
+    # No temp files left behind.
+    assert sorted(p.name for p in local_data.parent.iterdir()) == ["seed.json", "testmondata"]
+
+
+def test_bootstrap_seed_files_noop_when_decision_says_no(tmp_path: Path) -> None:
+    local_data = tmp_path / "local" / "testmondata"
+    local_stamp = tmp_path / "local" / "seed.json"
+    decision = BootstrapDecision(False, "not needed")
+
+    bootstrap_testmon_seed_files(decision, local_testmon_data=local_data, local_seed_stamp=local_stamp)
+
+    assert not local_data.exists()
+    assert not local_stamp.exists()


### PR DESCRIPTION
## Summary
A linked git worktree with no local `.cache/testmon/testmondata` now bootstraps its pytest-testmon seed cache from the main checkout instead of re-seeding from scratch or hitting the unseeded-refusal preflight in `devtools verify`.

## Problem
Every fresh agent worktree lane starts with an empty testmon cache. The main checkout's `.cache/testmon/testmondata` is ~28MB, built from a full non-integration pytest run (`devtools verify --seed-testmon`). A worktree lane either pays that cost again or is blocked outright by the preflight in `devtools/verify.py:_testmon_preflight`, which refuses the default affected-selection path when no seed is present.

The seed database is copyable: pytest-testmon's `file_fp` entries are keyed by path *relative* to the invoking repo root, each carrying a per-file content checksum (`fsha`). A worktree shares the main checkout's relative layout, so a straight copy is immediately valid there -- any file that differs at copy time self-invalidates (its `fsha` won't match) and testmon correctly treats dependent tests as affected on the very next run.

## Solution
`devtools/testmon_bootstrap.py` (new module) owns one decision and one action:

- `decide_testmon_bootstrap` -- pure decision (no subprocess, no git): given `is_linked_worktree` plus local/main testmondata + seed-stamp paths, decides whether to bootstrap. Mirrors the same protocol-version + `status == "complete"` validity check `_testmon_preflight` applies to a seed stamp.
- `bootstrap_testmon_seed_files` -- performs the copy. `testmondata` (a real sqlite db that may be mid-write in a concurrently-seeding main checkout) is copied via `sqlite3.Connection.backup`, sqlite's own online-backup API, immune to concurrent writers by design; `seed.json` is copied via read-then-atomic-rename. Both write only to a temp path, then `rename` into place -- the main checkout's copies are never touched.
- `maybe_bootstrap_testmon_seed` -- the orchestrator: detects a linked worktree via `git rev-parse --absolute-git-dir --git-common-dir` (the same mechanism `devtools/verify_worktree.py:inspect_worktree` already uses to distinguish a linked worktree from a main checkout), resolves the main checkout, and wires the decision to the action.

Wired into `devtools/verify.py:main()` immediately before the existing `_testmon_preflight` call, logging one line to stderr on a successful bootstrap.

`CLAUDE.md`'s testing section now notes the auto-bootstrap in the same sentence that documents `--seed-testmon`.

## Verification
- `devtools test tests/unit/devtools/test_testmon_bootstrap.py` -- 11 passed (decision function: not-a-worktree, already-seeded-locally, main-seed-missing, wrong-protocol-version, incomplete-status, unreadable-json, missing-testmondata-despite-valid-stamp, valid-bootstrap, partial-local-state-still-bootstraps, plus the copy action itself and its no-op path).
- `devtools test tests/unit/devtools/test_checkout_guard.py` -- 10 passed, unaffected by the new import.
- `devtools verify --quick` -- all 23 steps green (format, lint, mypy, render-all-check, topology, layering, closure-matrix, manifests, ci-workflows, doc-commands, docs-coverage, test-infra-currency, pytest-timeout-overrides, degrade-loudly, hash-boundary-census, schema/lab policy checks, schema promotion audit), exit 0.
- Not run: the full non-integration pytest suite (per-PR CI skips it; runs post-merge on master per repo convention).

Ref polylogue-mq4vx