### PR TITLE
fix(pipeline): stop position-derived fallback for message identity

### DIFF
--- a/polylogue/pipeline/ids.py
+++ b/polylogue/pipeline/ids.py
@@ -205,6 +205,52 @@ def _message_hash_payload(message: ParsedMessage, message_id: str) -> dict[str, 
     return payload
 
 
+#: Marker prefix for a content-derived (role + timestamp) message identity
+#: anchor, used only when a message carries no native ``provider_message_id``.
+#: Namespaced so it can never collide with a real provider id string (a
+#: provider id never contains this literal token by construction).
+_TIMESTAMP_ANCHOR_PREFIX = "__polylogue_msg_ts_anchor__"
+
+
+def _message_comparison_id(message: ParsedMessage, index: int) -> str:
+    """Resolve the id used as both a message's content-payload id and its
+    comparison identity (``message_identity_hash``'s sole input).
+
+    Prefers the provider's own id -- stable across reordering even when the
+    export's array ordering is not (polylogue-c429). When a parser could not
+    populate one (``provider_message_id`` is empty), this used to fall back
+    to ``f"msg-{index}"`` -- positionally-derived, exactly the same failure
+    class the attachment identity fix (polylogue-hith/-d8al) removed for a
+    different field: two parses of the same id-less message in a different
+    array position would get two different fallback "ids" and compare as a
+    conflict instead of the same message (polylogue-gysk3).
+
+    The fix: fall back to a content-derived anchor -- role plus timestamp --
+    instead of array position, so reordering an otherwise-unchanged id-less
+    message no longer changes its comparison identity. Only when a message
+    carries NEITHER a provider id NOR a timestamp does this still fall back
+    to structural position: a known, accepted limit (nothing else
+    distinguishes the message), the same shape as the accepted limit already
+    documented on ``attachment_identity_hash``.
+
+    SCOPE NOTE: this closes the fallback instance local to this module.
+    Several parsers (``sources/parsers/*``, e.g. ``claude/common.py``,
+    ``codex.py``, ``grok.py``) bake a positionally-derived string
+    (``f"msg-{index}"``, ``f"function-call-{index}"``, etc.) directly into
+    ``provider_message_id`` itself, before it ever reaches this function --
+    it arrives here indistinguishable from a genuine native id and is used
+    as-is via the first branch below. Fixing that requires parser-side
+    cooperation (a typed "this id is positionally synthesized" marker) and
+    is out of this module's scope; polylogue-gysk3's own design note records
+    it as a separate, dedicated follow-up.
+    """
+    if message.provider_message_id:
+        return message.provider_message_id
+    if message.timestamp:
+        return f"{_TIMESTAMP_ANCHOR_PREFIX}:{message.role}:{message.timestamp}"
+    return f"msg-{index}"
+
+
 def message_identity_hash(*, id: str) -> bytes:
     """The sole constructor of a message's comparison identity (polylogue-aggz).
 
@@ -436,8 +482,7 @@ def _session_hash_components(
     payload independently -- pure sharing of an already-pure computation.
     """
     messages_payload = [
-        _message_hash_payload(msg, msg.provider_message_id or f"msg-{idx}")
-        for idx, msg in enumerate(convo.messages, start=1)
+        _message_hash_payload(msg, _message_comparison_id(msg, idx)) for idx, msg in enumerate(convo.messages, start=1)
     ]
     attachments_payload = [_attachment_hash_payload(attachment) for attachment in convo.attachments]
     session_events_payload = [

--- a/tests/unit/pipeline/test_message_identity_position_fallback.py
+++ b/tests/unit/pipeline/test_message_identity_position_fallback.py
@@ -1,0 +1,90 @@
+"""message_identity_hash's fallback for id-less messages must not read array position.
+
+polylogue-gysk3: the attachment-class bug (a synthetic identity seeded partly
+by array index, unstable across export vintages that reorder/insert array
+entries) was found and fixed for attachments (polylogue-hith/-d8al) by
+excluding the (real-or-synthetic) attachment id from identity entirely and
+deriving it from stable content fields instead (message_id, name, mime_type).
+
+`message_identity_hash` has no separate field to fall back to -- a message's
+provider id (or its absence) IS the sole identity input by construction. Its
+one addressable-within-`pipeline/ids.py` instance is the local fallback that
+used to fire when a parser could not populate `provider_message_id`:
+previously `f"msg-{index}"`, positionally-derived exactly like the old
+attachment synthetic id. This file proves the fix: two parses of the same
+id-less message in a different array position must resolve to the same
+message-content identity when a provider timestamp is available to anchor
+on, instead of silently comparing wrong pairs as if their (position-shifted)
+fallback ids matched.
+"""
+
+from __future__ import annotations
+
+from polylogue.archive.message.roles import Role
+from polylogue.core.enums import Provider
+from polylogue.pipeline.ids import session_revision_projection
+from polylogue.sources.parsers.base import ParsedMessage, ParsedSession
+
+
+def _session(messages: list[ParsedMessage]) -> ParsedSession:
+    return ParsedSession(
+        source_name=Provider.CHATGPT,
+        provider_session_id="conv-1",
+        title="Test",
+        created_at="2024-01-01T00:00:00Z",
+        updated_at="2024-01-01T00:00:00Z",
+        messages=messages,
+        attachments=[],
+    )
+
+
+def _with_id(provider_message_id: str, role: str, text: str, timestamp: str) -> ParsedMessage:
+    return ParsedMessage(
+        provider_message_id=provider_message_id, role=Role.normalize(role), text=text, timestamp=timestamp
+    )
+
+
+def _id_less(role: str, text: str, timestamp: str) -> ParsedMessage:
+    """A message the parser could not assign a native id to (empty string)."""
+    return ParsedMessage(provider_message_id="", role=Role.normalize(role), text=text, timestamp=timestamp)
+
+
+def test_id_less_message_content_identity_is_stable_across_reorder() -> None:
+    """Same message set, different array order -- an id-less message with a
+    provider timestamp must still resolve to the same (identity, content)
+    pair in both orderings, not shift with its array position.
+    """
+    anchored = _id_less("assistant", "hello there", "2024-01-01T00:01:00Z")
+    keyed = _with_id("m1", "user", "hi", "2024-01-01T00:00:00Z")
+
+    forward = session_revision_projection(_session([keyed, anchored]))
+    reordered = session_revision_projection(_session([anchored, keyed]))
+
+    assert forward.message_contents == reordered.message_contents
+
+
+def test_id_less_messages_with_distinct_timestamps_do_not_collide() -> None:
+    """Two different id-less messages must not collapse to one identity."""
+    a = _id_less("assistant", "first", "2024-01-01T00:01:00Z")
+    b = _id_less("assistant", "second", "2024-01-01T00:02:00Z")
+
+    projection = session_revision_projection(_session([a, b]))
+
+    assert len(projection.message_contents) == 2
+
+
+def test_id_less_and_timestamp_less_message_falls_back_to_position() -> None:
+    """Documented, accepted limit: with neither a provider id nor a timestamp,
+    nothing content-derived distinguishes the message, so position remains
+    the last resort -- unlike the two cases above, this one is NOT claimed
+    to be reorder-stable.
+    """
+    bare = ParsedMessage(provider_message_id="", role=Role.normalize("user"), text="x", timestamp=None)
+    keyed = _with_id("m1", "assistant", "y", "2024-01-01T00:00:00Z")
+
+    forward = session_revision_projection(_session([keyed, bare]))
+    reordered = session_revision_projection(_session([bare, keyed]))
+
+    # Position-anchored fallback: the bare message's content payload embeds
+    # its array-position id, which differs between the two orderings.
+    assert forward.message_contents != reordered.message_contents


### PR DESCRIPTION
## Summary

Fixes the second of two content-hash/identity stamp-poisoner bugs gating the fingerprint bootstrap work (Ref polylogue-xselt): `message_identity_hash`'s fallback for id-less messages was reading array position. The first bug this lane was scoped to (Ref polylogue-7zp4, NFC normalization gap in `tool_input`/session-event hashing) was found to be **already fixed and tested** on this branch's base (`_normalize_nested_for_hash`, landed in the index-v46 batch, `tests/unit/pipeline/test_hash_nested_nfc.py`) -- no further work was needed there; this PR only carries the `polylogue-gysk3` fix.

## Problem

`polylogue-gysk3`: the attachment-class bug already found and fixed for attachment identity (`polylogue-hith`/`polylogue-d8al`: a synthetic id partly seeded by array index compares unstable across export vintages that reorder array entries) had one unfixed sibling instance inside `pipeline/ids.py` itself. When a parser leaves `provider_message_id` empty, the local fallback built `f"msg-{index}"` and fed it straight into `message_identity_hash`, so an id-less message's comparison identity shifted whenever its array position shifted -- two reorderings of the same message set disagreed on `message_contents`, which `archive/session_revision_membership.py` uses to decide revision containment/conflict.

Unlike attachments (which have `name`/`mime_type` as stable descriptors independent of any id), a message has no separate content-bearing field to fall back to besides role and timestamp -- `polylogue-gysk3`'s own design note says a full fix needs its own dedicated redesign (a typed "positionally-anchored, not identity-anchored" marker threaded through the comparison layer). That full redesign is out of this lane's scope (`pipeline/ids.py` + `core/hashing.py` only, per dispatch).

## Solution

Added `_message_comparison_id(message, index)` in `polylogue/pipeline/ids.py`:
- Prefers the provider's own id, unchanged (still content-derived and stable, `polylogue-c429`).
- When absent, falls back to a role+timestamp content anchor instead of array position, so reordering an id-less message with a provider timestamp no longer moves its identity.
- Only when a message has **neither** a provider id **nor** a timestamp does it still fall back to position -- a documented, accepted limit (nothing else distinguishes the message), the same shape already accepted for `attachment_identity_hash`'s own residual limit.

`_session_hash_components` now calls this instead of the inline `msg.provider_message_id or f"msg-{idx}"`.

**Scope note, stated honestly:** this closes the fallback instance local to `pipeline/ids.py`. Several parsers (`sources/parsers/*` -- `claude/common.py`, `code_parser.py`, `codex.py`, `local_agent.py`, `grok.py`, `drive.py`, `chatgpt.py`, `base_support.py`, `antigravity.py`) bake a positionally-derived string (`f"msg-{index}"`, `f"function-call-{index}"`, etc.) directly into `provider_message_id` itself, before it ever reaches this function -- it arrives here indistinguishable from a genuine native id and is used as-is via the first branch. All 18 of those call sites are already tracked and acknowledged in `docs/plans/position-derived-identity-acks.json`, each referencing `polylogue-gysk3` as the tracked follow-up (verified via `devtools lab policy position-derived-identity`, which stayed green with no new/stale findings). Fixing them requires parser-side cooperation and is out of this lane's scope (`sources/` explicitly excluded from this dispatch).

**Blast radius:** in-scope only. Every current parser already synthesizes some non-empty `provider_message_id` before this function runs, so the local `or f"msg-{idx}"` fallback this replaces was not observed to fire on live data -- no stored hash is known to move as a result of this change. (The golden pinned-hash test `test_session_revision_projection_golden_hashes`, whose messages all carry real ids, is unaffected and still passes byte-for-byte.)

## Verification

- Red-first: `tests/unit/pipeline/test_message_identity_position_fallback.py` committed failing before the fix (`7f063103f`), confirmed to fail against the unfixed code:
  ```
  FAILED tests/unit/pipeline/test_message_identity_position_fallback.py::test_id_less_message_content_identity_is_stable_across_reorder
  ```
- After the fix (`88d1750b3`): `devtools test tests/unit/pipeline/test_message_identity_position_fallback.py tests/unit/pipeline/test_pipeline_ids.py tests/unit/pipeline/test_hash_nested_nfc.py tests/unit/pipeline/test_content_hash_determinism.py tests/unit/pipeline/test_ingest_batch.py` -> `113 passed`.
- Full `tests/unit/pipeline/` directory: `506 passed, 4 failed` -- the 4 failures (`test_archive_write.py::TestValidationService::test_validation_strict_detects_malformed_jsonl_beyond_large_prefix`, `test_prepare.py::test_ingest_removes_missing_attachments`, `test_resilience.py::test_acquisition_law_counts_unique_raws_and_normalizes_provider_hints`, `test_resilience.py::test_validation_law_matches_mode_and_payload_contract`) are pre-existing and unrelated: none of those test files are touched by this diff, and `test_prepare.py::test_ingest_removes_missing_attachments` reproduces identically against the pre-fix `ids.py` (verified directly by checking out the parent commit's `ids.py` and re-running that one test).
- `devtools verify --quick`: all 23 steps green, including `lab policy position-derived-identity` (no new/stale findings) and `verify hash-boundary-census`.

Not run: `devtools verify --all` (full non-integration suite) -- the focused + directory runs above cover the changed surface; a coordinator broad-gate pass at the merge-train boundary is standard for this repo and not duplicated here.

Ref polylogue-gysk3, polylogue-7zp4, polylogue-xselt