### PR TITLE
fix(daemon): default health_check_tiers to fast,medium

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -239,7 +239,7 @@ max_per_hour = 12
 
 [health]
 check_interval_s = 300
-check_tiers = "fast"
+check_tiers = "fast,medium" # add ",expensive" to also poll DB/blob/embedding checks
 blob_integrity_sample_size = 100
 
 # Convergence-debt alert thresholds. The daemon raises a typed HealthAlert

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -518,18 +518,21 @@ These run automatically inside the daemon process:
 | WAL checkpoint | Every 5 minutes | Keeps the WAL file bounded via `PRAGMA wal_checkpoint(TRUNCATE)` |
 | Heartbeat | Every 15 minutes | Logs session/message counts as structured heartbeat |
 | FTS convergence | Every 10 minutes | Verifies FTS coverage, rebuilds if messages are unindexed |
-| Health checks | Configurable (default 5 min) | Runs bounded FAST health checks by default, sends notifications on non-OK status. MEDIUM and EXPENSIVE checks are explicit operator diagnostics. |
+| Health checks | Configurable (default 5 min) | Runs FAST + MEDIUM health checks by default, sends notifications on non-OK status. EXPENSIVE checks remain an explicit operator diagnostic. |
 | FTS startup check | Once at startup | Rebuilds the FTS index if messages exist but aren't indexed (covers gaps from pre-daemon data) |
 | Judgment automation | Configurable (default 1 hour), off by default | Judges auto-judgeable assertion candidates per policy and escalates the residue; see [Judgment Automation](#judgment-automation) below. |
 
 Health check tier and interval are configurable via `polylogue.toml` (the
 `[health]` table's `check_interval_s`/`check_tiers` keys back the
-`health_check_interval_s`/`health_check_tiers` config attributes):
+`health_check_interval_s`/`health_check_tiers` config attributes). The default
+`check_tiers` is `"fast,medium"`; set `"fast,medium,expensive"` to also poll
+the EXPENSIVE tier periodically (DB integrity, blob integrity/reference debt,
+embedding coverage), which is otherwise an explicit operator diagnostic:
 
 ```toml
 [health]
 check_interval_s = 300
-check_tiers = "fast"
+check_tiers = "fast,medium"
 ```
 
 ### Judgment Automation

--- a/docs/plans/degrade-loudly-allowlist.yaml
+++ b/docs/plans/degrade-loudly-allowlist.yaml
@@ -154,6 +154,12 @@ entries:
   occurrence: 0
   reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
 - path: polylogue/daemon/health.py
+  function: <module>._check_health_tier_coverage_fast
+  exceptions:
+  - Exception
+  occurrence: 0
+  reason: 'See _check_daemon_liveness_fast: same HealthAlert(severity=ERROR) pattern.'
+- path: polylogue/daemon/health.py
   function: <module>._check_heartbeat_staleness_fast
   exceptions:
   - Exception

--- a/polylogue/config.py
+++ b/polylogue/config.py
@@ -487,7 +487,7 @@ class PolylogueConfig:
 
     @property
     def health_check_tiers(self) -> str:
-        return str(self._data.get("health_check_tiers", "fast"))
+        return str(self._data.get("health_check_tiers", "fast,medium"))
 
     @property
     def health_blob_integrity_sample_size(self) -> int:
@@ -1813,7 +1813,7 @@ def _default_config_values(bootstrap: _BootstrapPaths | None = None) -> dict[str
         "notification_email_use_starttls": True,
         "notification_email_max_per_hour": 12,
         "health_check_interval_s": 300,
-        "health_check_tiers": "fast",
+        "health_check_tiers": "fast,medium",
         "health_blob_integrity_sample_size": 100,
         "health_convergence_debt": {},
         "health_cursor_lag": {},

--- a/polylogue/daemon/health.py
+++ b/polylogue/daemon/health.py
@@ -1,11 +1,20 @@
 """Tiered daemon health checks with typed alerts and severity escalation.
 
 Health checks are grouped into three tiers by cost:
-- FAST: sub-1s checks (liveness, disk space, WAL size, source availability)
+- FAST: sub-1s checks (liveness, disk space, WAL size, source availability,
+  and a tier-coverage notice naming which of MEDIUM/EXPENSIVE are switched
+  off via ``health_check_tiers`` so degraded coverage is never silent)
 - MEDIUM: sub-10s queries (FTS readiness, insight freshness, stale attempts,
-  repeated stage failures, raw failures)
+  repeated stage failures, raw failures, convergence debt, cursor lag)
 - EXPENSIVE: longer-running checks (DB integrity, blob integrity, blob
   reference debt, embedding coverage)
+
+``health_check_tiers`` (:mod:`polylogue.config`) defaults to ``"fast,medium"``
+so the periodic daemon loop actually runs the MEDIUM tier -- previously it
+defaulted to ``"fast"`` alone and MEDIUM (cursor lag, FTS readiness, insight
+freshness, stale attempts, repeated stage failures, convergence debt) never
+ran in production. EXPENSIVE remains opt-in; the FAST-tier coverage check
+above keeps naming it as off so that omission is labeled, not silent.
 
 Each check produces a ``HealthAlert`` with severity, message, and checked_at.
 Alerts accrue a ``consecutive_failures`` counter that carries forward across
@@ -477,6 +486,47 @@ def _check_hook_flow_fast() -> HealthAlert:
         )
 
 
+def _check_health_tier_coverage_fast() -> HealthAlert:
+    """Name which health tiers ``health_check_tiers`` leaves switched off.
+
+    A stalled cursor used to be indistinguishable from "MEDIUM tier never
+    configured" (polylogue-y0ven): both looked like silence. This FAST
+    check reads the same ``health_check_tiers`` config the periodic loop
+    resolves, and reports at OK severity (it never itself pages) which of
+    MEDIUM/EXPENSIVE are not part of that configured set, so the daemon's
+    own health payload always states its coverage instead of quietly
+    omitting it. EXPENSIVE stays off by default (DB integrity, blob
+    integrity/reference debt, and embedding coverage scans are explicit
+    operator diagnostics, not periodic-loop material) so this check is
+    expected to keep naming it.
+    """
+    now = datetime.now(UTC).isoformat()
+    try:
+        from polylogue.config import load_polylogue_config
+
+        cfg = load_polylogue_config()
+        configured = resolve_health_tiers(cfg.health_check_tiers)
+    except Exception as exc:
+        return HealthAlert(
+            check_name="health_tier_coverage",
+            tier=HealthTier.FAST,
+            severity=HealthSeverity.ERROR,
+            message=f"could not resolve configured health tiers: {exc}",
+            checked_at=now,
+            consecutive_failures=_record_failure("health_tier_coverage", False),
+        )
+    off = [tier.value for tier in (HealthTier.MEDIUM, HealthTier.EXPENSIVE) if tier not in configured]
+    message = f"health tiers off: {', '.join(off)}" if off else "all health tiers configured (fast, medium, expensive)"
+    return HealthAlert(
+        check_name="health_tier_coverage",
+        tier=HealthTier.FAST,
+        severity=HealthSeverity.OK,
+        message=message,
+        checked_at=now,
+        consecutive_failures=_record_failure("health_tier_coverage", True),
+    )
+
+
 def _run_fast_checks() -> list[HealthAlert]:
     return [
         _check_daemon_liveness_fast(),
@@ -486,6 +536,7 @@ def _run_fast_checks() -> list[HealthAlert]:
         _check_wal_size_fast(),
         _check_source_availability_fast(),
         _check_hook_flow_fast(),
+        _check_health_tier_coverage_fast(),
     ]
 
 

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -466,7 +466,7 @@ class TestPolylogueConfigDefaults:
         from polylogue.config import load_polylogue_config
 
         cfg = load_polylogue_config()
-        assert cfg.health_check_tiers == "fast"
+        assert cfg.health_check_tiers == "fast,medium"
 
     def test_source_roots_default(self, workspace_env: dict[str, Path]) -> None:
         from polylogue.config import load_polylogue_config

--- a/tests/unit/daemon/test_health_check_endpoint_tiers.py
+++ b/tests/unit/daemon/test_health_check_endpoint_tiers.py
@@ -67,8 +67,8 @@ def _ok_health() -> DaemonHealth:
     return DaemonHealth(overall_status=HealthSeverity.OK, checked_at="now", alerts=[], tier_summary={})
 
 
-def test_health_check_endpoint_defaults_to_fast_tier(monkeypatch: pytest.MonkeyPatch) -> None:
-    """With the default config the endpoint must run FAST-only checks."""
+def test_health_check_endpoint_defaults_to_fast_and_medium_tiers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With the default config the endpoint must run FAST+MEDIUM (polylogue-y0ven)."""
     import polylogue.daemon.health as health_module
 
     captured: dict[str, object] = {}
@@ -84,12 +84,12 @@ def test_health_check_endpoint_defaults_to_fast_tier(monkeypatch: pytest.MonkeyP
     handler._send_json = send_json  # type: ignore[method-assign]
     handler._handle_health_check()
 
-    assert captured["tiers"] == {HealthTier.FAST}
+    assert captured["tiers"] == {HealthTier.FAST, HealthTier.MEDIUM}
     assert send_json.call_args.args[1]["status"] == "healthy"
 
 
 def test_health_check_endpoint_honors_config_override(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Operators can opt into a heavier polled tier set via config."""
+    """Operators can opt into the EXPENSIVE tier via config."""
     import polylogue.daemon.health as health_module
     from polylogue import config as config_module
 
@@ -100,7 +100,7 @@ def test_health_check_endpoint_honors_config_override(monkeypatch: pytest.Monkey
         return _ok_health()
 
     class _Cfg:
-        health_check_tiers = "fast,medium"
+        health_check_tiers = "fast,medium,expensive"
 
     monkeypatch.setattr(health_module, "check_health", _fake_check_health)
     monkeypatch.setattr(config_module, "load_polylogue_config", lambda: _Cfg())
@@ -109,4 +109,62 @@ def test_health_check_endpoint_honors_config_override(monkeypatch: pytest.Monkey
     handler._send_json = MagicMock()  # type: ignore[method-assign]
     handler._handle_health_check()
 
-    assert captured["tiers"] == {HealthTier.FAST, HealthTier.MEDIUM}
+    assert captured["tiers"] == {HealthTier.FAST, HealthTier.MEDIUM, HealthTier.EXPENSIVE}
+
+
+def test_health_tier_coverage_names_off_tiers_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default config runs fast+medium; the FAST notice must name EXPENSIVE as off.
+
+    This is the polylogue-y0ven silence-labeling requirement: a stalled
+    MEDIUM/EXPENSIVE tier used to be indistinguishable from "never
+    configured". The FAST-tier coverage check must always say which tiers
+    are off instead of the daemon's health payload staying quiet about it.
+    """
+    from polylogue import config as config_module
+    from polylogue.daemon.health import HealthSeverity, _check_health_tier_coverage_fast
+
+    class _Cfg:
+        health_check_tiers = "fast,medium"
+
+    monkeypatch.setattr(config_module, "load_polylogue_config", lambda: _Cfg())
+
+    alert = _check_health_tier_coverage_fast()
+
+    assert alert.check_name == "health_tier_coverage"
+    assert alert.tier == HealthTier.FAST
+    assert alert.severity == HealthSeverity.OK
+    assert "expensive" in alert.message
+    assert "medium" not in alert.message.split(":", 1)[-1]
+
+
+def test_health_tier_coverage_reports_nothing_off_when_all_tiers_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from polylogue import config as config_module
+    from polylogue.daemon.health import HealthSeverity, _check_health_tier_coverage_fast
+
+    class _Cfg:
+        health_check_tiers = "fast,medium,expensive"
+
+    monkeypatch.setattr(config_module, "load_polylogue_config", lambda: _Cfg())
+
+    alert = _check_health_tier_coverage_fast()
+
+    assert alert.severity == HealthSeverity.OK
+    assert "off" not in alert.message
+    assert "fast, medium, expensive" in alert.message
+
+
+def test_health_tier_coverage_names_multiple_off_tiers(monkeypatch: pytest.MonkeyPatch) -> None:
+    from polylogue import config as config_module
+    from polylogue.daemon.health import _check_health_tier_coverage_fast
+
+    class _Cfg:
+        health_check_tiers = "fast"
+
+    monkeypatch.setattr(config_module, "load_polylogue_config", lambda: _Cfg())
+
+    alert = _check_health_tier_coverage_fast()
+
+    assert "medium" in alert.message
+    assert "expensive" in alert.message

--- a/tests/unit/daemon/test_health_contract.py
+++ b/tests/unit/daemon/test_health_contract.py
@@ -64,6 +64,9 @@ EXPECTED_FAST_CHECKS: frozenset[str] = frozenset(
         "wal_size",
         "source_availability",
         "hook_flow",
+        # polylogue-y0ven: names which of MEDIUM/EXPENSIVE are switched off
+        # via `health_check_tiers` so degraded coverage is never silent.
+        "health_tier_coverage",
     }
 )
 EXPECTED_MEDIUM_CHECKS: frozenset[str] = frozenset(


### PR DESCRIPTION
## Summary
`health_check_tiers` defaulted to `"fast"` alone, so the daemon's periodic health loop and the `/api/health/check` endpoint never ran the MEDIUM tier in production. Default is now `"fast,medium"`, and a new FAST-tier check names any tier that remains off so degraded coverage is never silent.

## Problem
`polylogue/config.py:1816` set `"health_check_tiers": "fast"` as the default (mirrored by the `PolylogueConfig.health_check_tiers` property fallback). MEDIUM-tier checks -- cursor lag (static ladder + anomaly band), FTS readiness, insight freshness, stale ingest attempts, repeated stage failures, raw failures, capture coverage, schema drift, and convergence debt -- never ran unless an operator hand-edited `polylogue.toml`. Concretely: `cursor_lag_samples` has 0 rows in the live archive's history, because `_check_cursor_lag_medium`'s anomaly layer is the only code path that writes to that table and it never executed. A genuinely stalled ingest cursor was indistinguishable from "MEDIUM tier was just never configured" -- both looked like silence.

## Solution
- `polylogue/config.py`: `health_check_tiers` default changed from `"fast"` to `"fast,medium"` in both the `PolylogueConfig` property fallback and `_default_config_values()`.
- `polylogue/daemon/health.py`: added `_check_health_tier_coverage_fast()`, a new FAST-tier check wired into `_run_fast_checks()`. It reads the configured `health_check_tiers`, resolves it the same way the periodic loop does, and reports at OK severity (so it never itself pages) which of MEDIUM/EXPENSIVE are switched off -- e.g. `"health tiers off: expensive"` under the new default. EXPENSIVE intentionally stays off by default (DB integrity, blob integrity/reference debt, and embedding coverage scans are explicit operator diagnostics per existing docs/comments), so this check is expected to keep naming it; the point is that the omission is now labeled in every health payload instead of being indistinguishable from a stalled tier.
- `docs/daemon.md` / `docs/configuration.md`: updated the example `[health]` TOML blocks and the daemon-owned-tasks table to describe the new default and the coverage check.
- `docs/plans/degrade-loudly-allowlist.yaml`: added the allowlist entry for the new check's broad `except Exception` (same typed-`HealthAlert(severity=ERROR)` pattern as its siblings, per the existing entries for this file).
- Tests: `test_health_tiers_default` now expects `"fast,medium"`; `test_health_check_endpoint_defaults_to_fast_and_medium_tiers` (renamed) asserts the endpoint resolves `{FAST, MEDIUM}` by default; `test_health_check_endpoint_honors_config_override` now exercises opting into EXPENSIVE (the meaningfully distinct override now that MEDIUM is default); `EXPECTED_FAST_CHECKS` gained `health_tier_coverage`; three new tests cover the coverage check directly (names EXPENSIVE as off under the default, reports nothing off when all three are configured, names both MEDIUM and EXPENSIVE off when only FAST is configured).

### Cost of enabling MEDIUM by default
Measured directly (calling the tier-runner functions, not through the daemon loop) against a freshly seeded demo archive (19 sessions / 71 messages):

| check | best-of-5 (ms) |
|---|---|
| `_run_medium_checks()` (all 8) | 45.27 |
| `cursor_lag` (static ladder + anomaly band, incl. sample write + GC) | 20.88 |
| `fts_readiness` | 5.98 |
| `stale_ingest_attempts` | 4.19 |
| `repeated_stage_failures` | 4.10 |
| `insight_freshness` | 3.44 |
| `convergence_debt` | 2.25 |
| `capture_coverage` | 1.46 |
| `raw_failures` | 1.37 |
| `schema_drift` | 0.97 |

Every MEDIUM check does bounded work: `COUNT(*)` over an indexed rowid table, `LIMIT`-bounded subqueries (`ORDER BY ... LIMIT 20`), or small per-family aggregates -- none scan proportional to message/block volume. Nothing here needs a separate gate behind EXPENSIVE; this matches the module docstring's existing "sub-10s" MEDIUM-tier classification. Fixture scale is small (demo archive, not the multi-tens-of-thousands-of-sessions production archive), so this is evidence of query shape rather than a production load test, but no check performs a full unbounded scan that would degrade with corpus size.

## Verification
- `devtools test tests/unit/daemon/test_health_check_endpoint_tiers.py tests/unit/daemon/test_health_contract.py tests/unit/core/test_config.py` -> 129 passed
- `devtools test tests/unit/daemon/test_daemon_cli.py tests/unit/daemon/test_daemon_status.py tests/unit/daemon/test_daemon_http_contracts.py tests/unit/daemon/test_health_contracts.py tests/unit/daemon/test_notifications.py tests/unit/daemon/test_notification_backends.py tests/unit/daemon/test_notification_webhook.py tests/unit/daemon/test_schema_preflight.py` -> 273 passed
- `devtools render all --check` -> exit 0, no `out of sync` lines
- `devtools verify --quick` -> exit 0 (format, lint, mypy, render-all-check, layering, closure-matrix, schema/policy lints, degrade-loudly, hash-boundary-census, schema-promotion-audit; 20 steps)

Not run: the full `devtools verify --all` / heavy `test` suite (per-PR CI already skips it; this repo's convention is to run it post-merge on master).

Ref polylogue-y0ven