### PR TITLE
refactor(cli): split maintenance run/blob-integrity preview from apply

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -174,6 +174,31 @@ interrupted operation. This command always mutates; it carries no
 polylogue ops maintenance run --target session_insights --output-format json
 ```
 
+### Blob-reference integrity — preview and apply pairs
+
+`polylogue ops maintenance blob-reference-debt` and
+`blob-reference-recovery-plan` are read-only classification/planning
+commands. The two commands that can actually mutate the archive each
+follow the same preview/apply split as `run`/`run-preview`: a dedicated
+read-only `-preview` command with no `--yes`/`--apply` flag, and a lean
+apply command that always mutates.
+
+```bash
+# Read-only: simulate what a replace-from-source pass would change.
+polylogue ops maintenance blob-reference-replace-from-source-preview --output-format json
+
+# Apply: always mutates; --manifest-file is required.
+polylogue ops maintenance blob-reference-replace-from-source \
+  --manifest-file /tmp/replace.jsonl --output-format json
+
+# Read-only: simulate what an orphan prune would remove.
+polylogue ops maintenance blob-reference-prune-orphans-preview --output-format json
+
+# Apply: always mutates; writes a quarantine JSONL before deleting rows.
+polylogue ops maintenance blob-reference-prune-orphans \
+  --quarantine-file /tmp/quarantine.jsonl --output-format json
+```
+
 ### `polylogue ops maintenance verify-archive` — coherence gate
 
 Read-only. Runs a fixed registry of independent checks over the whole

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -96,7 +96,9 @@ unknown target is rejected at the CLI boundary.
 Heuristics:
 
 - **Preview before plan, plan before run.** `preview` is read-only;
-  `plan` is a dry-run summary; `run` is the only mutating verb.
+  `plan` is a dry-run summary; `run-preview` is a heavier, resumable
+  dry run that exercises the real execution path; `run` is the only
+  mutating verb.
 - **Prefer the narrowest target.** `--target session_insights` is
   cheaper and safer than rebuilding everything.
 - **Do not reach for `reset` to "fix a stale projection."** That is
@@ -146,16 +148,29 @@ polylogue ops maintenance plan --output-format json | jq .
 `MaintenanceOperationEnvelope` so the CLI output is byte-for-byte
 identical to the daemon HTTP and MCP responses.
 
+### `polylogue ops maintenance run-preview` — resumable dry run
+
+Read-only. Runs the exact same resumable replay path as `run` --
+including per-target repair simulation and checkpoint tracking -- but
+never mutates the archive. This is a heavier, more faithful dry run than
+`plan`: it exercises the same code each target's real `execute` step would
+take, not just an affected-row estimate. Use it to combine the safety of
+`plan` with the full execution-path code before committing to `run`.
+
+```bash
+polylogue ops maintenance run-preview
+polylogue ops maintenance run-preview --target session_insights --output-format json
+```
+
 ### `polylogue ops maintenance run` — execute
 
 Runs the resolved targets. Per-target failures are isolated as
 `FailureSample` entries; one failing target does not abort the rest.
-Use `--dry-run` to combine the safety of `plan` with the full
-execution-path code, or pass `--operation-id <uuid>` together with
-`--resume` to pick up an interrupted operation.
+Pass `--operation-id <uuid>` together with `--resume` to pick up an
+interrupted operation. This command always mutates; it carries no
+`--dry-run` flag -- use `run-preview` for the read-only twin.
 
 ```bash
-polylogue ops maintenance run --dry-run
 polylogue ops maintenance run --target session_insights --output-format json
 ```
 

--- a/docs/plans/topology-target.yaml
+++ b/docs/plans/topology-target.yaml
@@ -931,7 +931,7 @@ files:
     target: polylogue/cli/commands/judge.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/__init__.py
-    loc: 173
+    loc: 191
     target: polylogue/cli/commands/maintenance/__init__.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_archive_plan.py
@@ -955,7 +955,7 @@ files:
     target: polylogue/cli/commands/maintenance/_blob_gc.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_blob_integrity.py
-    loc: 436
+    loc: 533
     target: polylogue/cli/commands/maintenance/_blob_integrity.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_blob_publications.py
@@ -987,8 +987,12 @@ files:
     target: polylogue/cli/commands/maintenance/_rebuild_index.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_run.py
-    loc: 173
+    loc: 218
     target: polylogue/cli/commands/maintenance/_run.py
+    owner: stable
+  - path: polylogue/cli/commands/maintenance/_run_preview.py
+    loc: 100
+    target: polylogue/cli/commands/maintenance/_run_preview.py
     owner: stable
   - path: polylogue/cli/commands/maintenance/_shared.py
     loc: 143
@@ -1561,7 +1565,7 @@ files:
     target: polylogue/daemon/catchup_status.py
     owner: stable
   - path: polylogue/daemon/cli.py
-    loc: 3021
+    loc: 3109
     target: polylogue/daemon/cli.py
     owner: stable
   - path: polylogue/daemon/compare.py
@@ -1645,7 +1649,7 @@ files:
     target: polylogue/daemon/fts_status.py
     owner: stable
   - path: polylogue/daemon/health.py
-    loc: 1583
+    loc: 1638
     target: polylogue/daemon/health.py
     owner: stable
   - path: polylogue/daemon/healthz.py
@@ -2472,7 +2476,7 @@ files:
     target: polylogue/pipeline/__init__.py
     owner: stable
   - path: polylogue/pipeline/ids.py
-    loc: 587
+    loc: 632
     target: polylogue/pipeline/ids.py
     owner: stable
   - path: polylogue/pipeline/ingest_outcomes.py
@@ -3518,7 +3522,7 @@ files:
     target: polylogue/sources/parsers/codex_state.py
     owner: stable
   - path: polylogue/sources/parsers/drive.py
-    loc: 507
+    loc: 520
     target: polylogue/sources/parsers/drive.py
     owner: stable
   - path: polylogue/sources/parsers/drive_support.py
@@ -4370,7 +4374,7 @@ files:
     target: polylogue/storage/sqlite/maintenance.py
     owner: stable
   - path: polylogue/storage/sqlite/migration_runner.py
-    loc: 742
+    loc: 756
     target: polylogue/storage/sqlite/migration_runner.py
     owner: stable
   - path: polylogue/storage/sqlite/migrations/__init__.py

--- a/polylogue/cli/commands/maintenance/__init__.py
+++ b/polylogue/cli/commands/maintenance/__init__.py
@@ -46,7 +46,13 @@ _COMMANDS: tuple[tuple[str, str, str, str], ...] = (
         "migrate_tier_command",
         "Apply additive migrations for one durable archive tier.",
     ),
-    ("run", "_run", "run_command", "Run (or dry-run) maintenance backfill operations."),
+    (
+        "run-preview",
+        "_run_preview",
+        "run_preview_command",
+        "Preview a maintenance run (dry, resumable) without executing. Read-only.",
+    ),
+    ("run", "_run", "run_command", "Execute maintenance backfill operations."),
     (
         "rebuild-index",
         "_rebuild_index",
@@ -110,10 +116,22 @@ _COMMANDS: tuple[tuple[str, str, str, str], ...] = (
         "Plan recovery for raw-backed missing blobs without mutating archive state.",
     ),
     (
+        "blob-reference-replace-from-source-preview",
+        "_blob_integrity",
+        "blob_reference_replace_from_source_preview_command",
+        "Preview raw-backed blob-reference replacement without mutating the archive.",
+    ),
+    (
         "blob-reference-replace-from-source",
         "_blob_integrity",
         "blob_reference_replace_from_source_command",
         "Replace raw-backed missing blob refs with current source-derived bytes.",
+    ),
+    (
+        "blob-reference-prune-orphans-preview",
+        "_blob_integrity",
+        "blob_reference_prune_orphans_preview_command",
+        "Preview orphan blob_refs pruning without mutating the archive.",
     ),
     (
         "blob-reference-prune-orphans",

--- a/polylogue/cli/commands/maintenance/_blob_integrity.py
+++ b/polylogue/cli/commands/maintenance/_blob_integrity.py
@@ -250,18 +250,65 @@ def _render_blob_reference_recovery_plan_plain(report: BlobReferenceRecoveryPlan
             click.echo(f"  {sample.action} {sample.blob_hash} origin={sample.origin} {source}")
 
 
-@click.command("blob-reference-replace-from-source")
-@click.option(
-    "--yes",
-    "apply",
-    is_flag=True,
-    help="Apply the replacement. Without this flag the command is a dry run.",
-)
+@click.command("blob-reference-replace-from-source-preview")
 @click.option(
     "--manifest-file",
     type=click.Path(dir_okay=False, path_type=Path),
     default=None,
-    help="JSONL destination for before/after replacement rows. Required with --yes.",
+    help="Optional JSONL destination for the would-be before/after replacement rows.",
+)
+@click.option("--max-count", type=int, default=None, help="Maximum number of candidate rows to process.")
+@click.option(
+    "--sample-limit",
+    type=int,
+    default=30,
+    show_default=True,
+    help="Maximum number of representative replacement rows to include.",
+)
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+    help="Output format.",
+)
+def blob_reference_replace_from_source_preview_command(
+    manifest_file: Path | None,
+    max_count: int | None,
+    sample_limit: int,
+    output_format: str,
+) -> None:
+    """Preview raw-backed blob-reference replacement without mutating the archive."""
+    from polylogue.storage.blob_integrity import replace_raw_backed_blob_reference_debt_from_source
+
+    report = replace_raw_backed_blob_reference_debt_from_source(
+        archive_root() / "source.db",
+        dry_run=True,
+        manifest_path=manifest_file,
+        max_count=max_count,
+        sample_size=sample_limit,
+    )
+    payload = {
+        "mode": "blob_reference_replace_from_source",
+        "mutates": False,
+        "writes_manifest": manifest_file is not None,
+        **report.to_dict(),
+    }
+
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    _render_blob_reference_replace_from_source_plain(report)
+
+
+@click.command("blob-reference-replace-from-source")
+@click.option(
+    "--manifest-file",
+    type=click.Path(dir_okay=False, path_type=Path),
+    required=True,
+    help="JSONL destination for before/after replacement rows.",
 )
 @click.option("--max-count", type=int, default=None, help="Maximum number of candidate rows to process.")
 @click.option(
@@ -280,28 +327,30 @@ def _render_blob_reference_recovery_plan_plain(report: BlobReferenceRecoveryPlan
     help="Output format.",
 )
 def blob_reference_replace_from_source_command(
-    apply: bool,
-    manifest_file: Path | None,
+    manifest_file: Path,
     max_count: int | None,
     sample_limit: int,
     output_format: str,
 ) -> None:
-    """Replace raw-backed missing blob refs with current source-derived bytes."""
+    """Replace raw-backed missing blob refs with current source-derived bytes.
+
+    Always mutates the archive. Use
+    ``blob-reference-replace-from-source-preview`` for a read-only dry run
+    of the same candidate set.
+    """
     from polylogue.storage.blob_integrity import replace_raw_backed_blob_reference_debt_from_source
 
-    if apply and manifest_file is None:
-        raise click.UsageError("--manifest-file is required with --yes")
     report = replace_raw_backed_blob_reference_debt_from_source(
         archive_root() / "source.db",
-        dry_run=not apply,
+        dry_run=False,
         manifest_path=manifest_file,
         max_count=max_count,
         sample_size=sample_limit,
     )
     payload = {
         "mode": "blob_reference_replace_from_source",
-        "mutates": apply,
-        "writes_manifest": manifest_file is not None,
+        "mutates": True,
+        "writes_manifest": True,
         **report.to_dict(),
     }
 
@@ -342,12 +391,62 @@ def _render_blob_reference_replace_from_source_plain(report: BlobReferenceSource
             )
 
 
+@click.command("blob-reference-prune-orphans-preview")
+@click.option(
+    "--max-count",
+    type=int,
+    default=None,
+    help="Maximum number of orphan blob-reference rows to preview.",
+)
+@click.option(
+    "--sample-limit",
+    type=int,
+    default=30,
+    show_default=True,
+    help="Maximum number of representative samples to include.",
+)
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+    help="Output format.",
+)
+def blob_reference_prune_orphans_preview_command(
+    max_count: int | None,
+    sample_limit: int,
+    output_format: str,
+) -> None:
+    """Preview orphan blob_refs pruning without mutating the archive."""
+    from polylogue.storage.blob_integrity import prune_orphan_blob_reference_debt
+
+    report = prune_orphan_blob_reference_debt(
+        archive_root() / "source.db",
+        dry_run=True,
+        quarantine_path=None,
+        max_count=max_count,
+        sample_size=sample_limit,
+    )
+    payload = {
+        "mode": "blob_reference_prune_orphans",
+        "mutates": False,
+        **report.to_dict(),
+    }
+
+    if output_format == "json":
+        click.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    _render_blob_reference_prune_orphans_plain(report)
+
+
 @click.command("blob-reference-prune-orphans")
 @click.option(
     "--max-count",
     type=int,
     default=None,
-    help="Maximum number of orphan blob-reference rows to prune or preview.",
+    help="Maximum number of orphan blob-reference rows to prune.",
 )
 @click.option(
     "--sample-limit",
@@ -361,14 +460,9 @@ def _render_blob_reference_replace_from_source_plain(report: BlobReferenceSource
     type=click.Path(dir_okay=False, path_type=Path),
     default=None,
     help=(
-        "JSONL destination for rows removed by --yes. Defaults to "
+        "JSONL destination for rows removed. Defaults to "
         "<archive-root>/.maintenance-state/blob-ref-quarantine/<timestamp>.jsonl."
     ),
-)
-@click.option(
-    "--yes",
-    is_flag=True,
-    help="Delete orphan blob_refs after writing them to the quarantine JSONL.",
 )
 @click.option(
     "--output-format",
@@ -382,22 +476,25 @@ def blob_reference_prune_orphans_command(
     max_count: int | None,
     sample_limit: int,
     quarantine_file: Path | None,
-    yes: bool,
     output_format: str,
 ) -> None:
-    """Quarantine and prune missing blob_refs that no longer have raw rows."""
+    """Quarantine and prune missing blob_refs that no longer have raw rows.
+
+    Always mutates the archive. Use ``blob-reference-prune-orphans-preview``
+    for a read-only dry run of the same candidate set.
+    """
     from polylogue.storage.blob_integrity import prune_orphan_blob_reference_debt
 
     report = prune_orphan_blob_reference_debt(
         archive_root() / "source.db",
-        dry_run=not yes,
+        dry_run=False,
         quarantine_path=quarantine_file,
         max_count=max_count,
         sample_size=sample_limit,
     )
     payload = {
         "mode": "blob_reference_prune_orphans",
-        "mutates": bool(yes),
+        "mutates": True,
         **report.to_dict(),
     }
 

--- a/polylogue/cli/commands/maintenance/_run.py
+++ b/polylogue/cli/commands/maintenance/_run.py
@@ -1,4 +1,13 @@
-"""``maintenance run``: execute (or dry-run) maintenance backfill operations."""
+"""``maintenance run``: execute maintenance backfill operations.
+
+The read-only twin of this command is ``maintenance run-preview``
+(:mod:`polylogue.cli.commands.maintenance._run_preview`) -- same target
+catalog, resume, and scope-filter surface, but the command type itself is
+non-mutating (no ``--dry-run``/``--apply`` flag to remember). Both commands
+share :func:`_execute_and_render`, which threads ``dry_run`` straight into
+:func:`polylogue.maintenance.replay.execute_replay`; the underlying replay
+semantics are byte-identical to the previous fused ``run --dry-run`` mode.
+"""
 
 from __future__ import annotations
 
@@ -27,11 +36,6 @@ _MAINTENANCE_TARGET_HELP = build_maintenance_target_catalog().help_text()
     multiple=True,
     type=click.Choice(MAINTENANCE_TARGET_NAMES),
     help=_MAINTENANCE_TARGET_HELP,
-)
-@click.option(
-    "--dry-run",
-    is_flag=True,
-    help="Preview what would happen without executing",
 )
 @click.option(
     "--operation-id",
@@ -64,6 +68,48 @@ _MAINTENANCE_TARGET_HELP = build_maintenance_target_catalog().help_text()
 def run_command(
     env: AppEnv,
     targets: tuple[str, ...],
+    operation_id: str | None,
+    resume_cursor: str | None,
+    output_format: str,
+    session_ids: tuple[str, ...],
+    origin: str | None,
+    source_family: str | None,
+    source_root: str | None,
+    since: str | None,
+    until: str | None,
+    failure_kind: str | None,
+    parser_version: str | None,
+) -> None:
+    """Execute maintenance backfill operations.
+
+    Executes targeted rebuilds using existing repair infrastructure.
+    Per-target failures are isolated: one failing target does not abort
+    the remaining work. Use --operation-id together with --resume to
+    pick up an interrupted operation from its last checkpoint. For a
+    read-only dry run of the same replay path, use ``run-preview``.
+    """
+    _execute_and_render(
+        env=env,
+        targets=targets,
+        dry_run=False,
+        operation_id=operation_id,
+        resume_cursor=resume_cursor,
+        output_format=output_format,
+        session_ids=session_ids,
+        origin=origin,
+        source_family=source_family,
+        source_root=source_root,
+        since=since,
+        until=until,
+        failure_kind=failure_kind,
+        parser_version=parser_version,
+    )
+
+
+def _execute_and_render(
+    *,
+    env: AppEnv,
+    targets: tuple[str, ...],
     dry_run: bool,
     operation_id: str | None,
     resume_cursor: str | None,
@@ -77,12 +123,11 @@ def run_command(
     failure_kind: str | None,
     parser_version: str | None,
 ) -> None:
-    """Run (or dry-run) maintenance backfill operations.
+    """Shared body for ``run`` and ``run-preview``: execute_replay + render.
 
-    Executes targeted rebuilds using existing repair infrastructure.
-    Per-target failures are isolated: one failing target does not abort
-    the remaining work. Use --operation-id together with --resume to
-    pick up an interrupted operation from its last checkpoint.
+    ``dry_run`` is fixed per caller (``False`` for ``run``, ``True`` for
+    ``run-preview``) rather than exposed as a CLI flag -- the command name
+    is the read/write signal, not an option an operator can forget.
     """
     from polylogue.maintenance.envelope import envelope_from_operation
     from polylogue.maintenance.planner import BackfillStatus

--- a/polylogue/cli/commands/maintenance/_run_preview.py
+++ b/polylogue/cli/commands/maintenance/_run_preview.py
@@ -1,0 +1,100 @@
+"""``maintenance run-preview``: read-only dry run of a maintenance replay.
+
+Read-only twin of ``maintenance run`` (:mod:`polylogue.cli.commands.maintenance._run`).
+Shares the same target catalog, resume/operation-id, and scope-filter surface,
+and calls the identical :func:`polylogue.maintenance.replay.execute_replay`
+machinery -- resumable per-target checkpointing included -- with ``dry_run``
+fixed to ``True`` instead of exposed as a flag. This command never mutates the
+archive; it exercises the same repair-simulation code path each target's
+``execute`` step would take, which is why it is a distinct verb rather than a
+lighter estimate like ``maintenance plan``.
+"""
+
+from __future__ import annotations
+
+import click
+
+from polylogue.cli.commands.maintenance._run import _execute_and_render
+from polylogue.cli.commands.maintenance._shared import _apply_scope_filter_options
+from polylogue.cli.shared.types import AppEnv
+from polylogue.maintenance.targets import MAINTENANCE_TARGET_NAMES, build_maintenance_target_catalog
+
+_MAINTENANCE_TARGET_HELP = build_maintenance_target_catalog().help_text()
+
+
+@click.command("run-preview")
+@click.option(
+    "--target",
+    "targets",
+    multiple=True,
+    type=click.Choice(MAINTENANCE_TARGET_NAMES),
+    help=_MAINTENANCE_TARGET_HELP,
+)
+@click.option(
+    "--operation-id",
+    "operation_id",
+    type=str,
+    default=None,
+    help=(
+        "Reuse a previous operation id to resume an interrupted preview; omit to mint a fresh uuid for a new operation."
+    ),
+)
+@click.option(
+    "--resume",
+    "resume_cursor",
+    type=str,
+    default=None,
+    help=(
+        "Explicit resume cursor (e.g. 'target:2'). When omitted and "
+        "--operation-id matches a persisted state file, the cursor is "
+        "loaded automatically."
+    ),
+)
+@click.option(
+    "--output-format",
+    "output_format",
+    type=click.Choice(["plain", "json"]),
+    default="plain",
+    show_default=True,
+    help="Output format. ``json`` emits the shared MaintenanceOperationEnvelope.",
+)
+@_apply_scope_filter_options
+@click.pass_obj
+def run_preview_command(
+    env: AppEnv,
+    targets: tuple[str, ...],
+    operation_id: str | None,
+    resume_cursor: str | None,
+    output_format: str,
+    session_ids: tuple[str, ...],
+    origin: str | None,
+    source_family: str | None,
+    source_root: str | None,
+    since: str | None,
+    until: str | None,
+    failure_kind: str | None,
+    parser_version: str | None,
+) -> None:
+    """Preview maintenance backfill operations without executing. Read-only.
+
+    Runs the same resumable replay path as ``run`` -- including per-target
+    repair simulation and checkpoint tracking -- but never mutates the
+    archive. Use --operation-id together with --resume to pick up an
+    interrupted preview from its last checkpoint.
+    """
+    _execute_and_render(
+        env=env,
+        targets=targets,
+        dry_run=True,
+        operation_id=operation_id,
+        resume_cursor=resume_cursor,
+        output_format=output_format,
+        session_ids=session_ids,
+        origin=origin,
+        source_family=source_family,
+        source_root=source_root,
+        since=since,
+        until=until,
+        failure_kind=failure_kind,
+        parser_version=parser_version,
+    )

--- a/tests/unit/cli/test_archive_maintenance_cli.py
+++ b/tests/unit/cli/test_archive_maintenance_cli.py
@@ -1008,11 +1008,43 @@ def test_blob_reference_replace_from_source_cli_requires_manifest_for_apply(
 ) -> None:
     result = cli_runner.invoke(
         cli,
-        ["--plain", "ops", "maintenance", "blob-reference-replace-from-source", "--yes"],
+        ["--plain", "ops", "maintenance", "blob-reference-replace-from-source"],
     )
 
     assert result.exit_code != 0
-    assert "--manifest-file is required with --yes" in result.output
+    assert "--manifest-file" in result.output
+
+
+def test_blob_reference_replace_from_source_preview_cli_does_not_require_manifest(
+    cli_workspace: dict[str, Path],
+    cli_runner: CliRunner,
+) -> None:
+    source = cli_workspace["archive_root"] / "exports" / "recoverable.json"
+    _seed_blob_reference_debt(cli_workspace["archive_root"], source)
+
+    result = cli_runner.invoke(
+        cli,
+        [
+            "--plain",
+            "ops",
+            "maintenance",
+            "blob-reference-replace-from-source-preview",
+            "--output-format",
+            "json",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["mode"] == "blob_reference_replace_from_source"
+    assert payload["mutates"] is False
+    assert payload["writes_manifest"] is False
+    assert payload["candidate_rows"] == 1
+    assert payload["replaced_rows"] == 0
+    with sqlite3.connect(cli_workspace["archive_root"] / "source.db") as conn:
+        refs = conn.execute("SELECT blob_hash FROM blob_refs WHERE source_path = ?", (str(source),)).fetchall()
+    assert refs, "preview must not mutate blob_refs"
 
 
 def test_blob_reference_replace_from_source_cli_applies_with_manifest(
@@ -1030,7 +1062,6 @@ def test_blob_reference_replace_from_source_cli_applies_with_manifest(
             "ops",
             "maintenance",
             "blob-reference-replace-from-source",
-            "--yes",
             "--manifest-file",
             str(manifest),
             "--output-format",
@@ -1052,7 +1083,7 @@ def test_blob_reference_replace_from_source_cli_applies_with_manifest(
     assert manifest_rows[0]["old_blob_hash"] != manifest_rows[0]["new_blob_hash"]
 
 
-def test_blob_reference_prune_orphans_cli_dry_run_keeps_refs(
+def test_blob_reference_prune_orphans_preview_cli_keeps_refs(
     cli_workspace: dict[str, Path],
     cli_runner: CliRunner,
 ) -> None:
@@ -1065,7 +1096,7 @@ def test_blob_reference_prune_orphans_cli_dry_run_keeps_refs(
             "--plain",
             "ops",
             "maintenance",
-            "blob-reference-prune-orphans",
+            "blob-reference-prune-orphans-preview",
             "--output-format",
             "json",
         ],
@@ -1099,7 +1130,6 @@ def test_blob_reference_prune_orphans_cli_apply_quarantines_deleted_refs(
             "ops",
             "maintenance",
             "blob-reference-prune-orphans",
-            "--yes",
             "--quarantine-file",
             str(quarantine_file),
             "--output-format",

--- a/tests/unit/cli/test_maintenance_registration.py
+++ b/tests/unit/cli/test_maintenance_registration.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 from polylogue.cli.click_app import cli as root_cli
 from polylogue.cli.commands.maintenance._plan import plan_command
 from polylogue.cli.commands.maintenance._run import run_command
+from polylogue.cli.commands.maintenance._run_preview import run_preview_command
 from polylogue.cli.commands.maintenance._status import status_command
 
 
@@ -40,6 +41,11 @@ def test_maintenance_run_is_click_command() -> None:
     assert isinstance(run_command, click.Command)
 
 
+def test_maintenance_run_preview_is_click_command() -> None:
+    """run-preview is a Click Command on the maintenance group."""
+    assert isinstance(run_preview_command, click.Command)
+
+
 def test_maintenance_appears_in_ops_help() -> None:
     """polylogue ops --help includes the maintenance subcommand."""
     runner = CliRunner()
@@ -49,12 +55,13 @@ def test_maintenance_appears_in_ops_help() -> None:
 
 
 def test_maintenance_group_has_plan_and_run() -> None:
-    """maintenance group lists plan and run as subcommands."""
+    """maintenance group lists plan, run, and run-preview as subcommands."""
     maintenance_group = _registered_maintenance_command()
     ctx = click.Context(maintenance_group)
     cmds = maintenance_group.list_commands(ctx)  # type: ignore[attr-defined]
     assert "plan" in cmds
     assert "run" in cmds
+    assert "run-preview" in cmds
 
 
 def test_maintenance_plan_help_output() -> None:
@@ -66,11 +73,26 @@ def test_maintenance_plan_help_output() -> None:
 
 
 def test_maintenance_run_help_output() -> None:
-    """polylogue ops maintenance run --help shows run help."""
+    """polylogue ops maintenance run --help shows run help.
+
+    ``run`` is the lean apply-only command post-split (polylogue-oou3c): it
+    no longer carries a ``--dry-run`` flag -- ``run-preview`` is the
+    dedicated read-only twin instead.
+    """
     runner = CliRunner()
     result = runner.invoke(root_cli, ["ops", "maintenance", "run", "--help"])
     assert result.exit_code == 0
-    assert "--dry-run" in result.output
+    assert "--dry-run" not in result.output
+    assert "--operation-id" in result.output
+
+
+def test_maintenance_run_preview_help_output() -> None:
+    """polylogue ops maintenance run-preview --help shows the preview help."""
+    runner = CliRunner()
+    result = runner.invoke(root_cli, ["ops", "maintenance", "run-preview", "--help"])
+    assert result.exit_code == 0
+    assert "Read-only" in result.output or "read-only" in result.output.lower()
+    assert "--operation-id" in result.output
 
 
 def test_maintenance_status_is_click_command() -> None:


### PR DESCRIPTION
## Summary
Splits three fused CLI verbs in `polylogue/cli/commands/maintenance/` along the preview/apply seam the maintenance group already establishes elsewhere (`preview`/`plan`/`run`, `archive-plan`/`archive-init`): a read-only `-preview` command with no `--apply`/`--yes` flag at all, plus a lean apply command whose flags are only what execution needs.

## Problem
- `maintenance run` fused `--dry-run` + resume/operation-id + scope filters + target catalog into one verb, so a mutating and a non-mutating invocation were indistinguishable by command name alone.
- `blob-reference-replace-from-source` and `blob-reference-prune-orphans` fused apply/dry-run behind a `--yes` flag plus diagnostic sample-limit options, the same anti-pattern.

## Solution
- `polylogue/cli/commands/maintenance/_run.py`: `run` now always executes (no `--dry-run`). The shared body (`execute_replay` call + output rendering) moved into a private `_execute_and_render` helper so behavior stays byte-identical.
- `polylogue/cli/commands/maintenance/_run_preview.py` (new): `run-preview` calls the identical `_execute_and_render` helper with `dry_run=True` fixed — same resumable per-target checkpointing as before, just no flag to forget.
- `polylogue/cli/commands/maintenance/_blob_integrity.py`: `blob-reference-replace-from-source` now always applies (`--manifest-file` required, no `--yes`); new `blob-reference-replace-from-source-preview` is the read-only twin (`--manifest-file` optional, still writes a would-be manifest if given). `blob-reference-prune-orphans` now always prunes (no `--yes`); new `blob-reference-prune-orphans-preview` drops `--quarantine-file` entirely since it's meaningless without a mutation.
- `polylogue/cli/commands/maintenance/__init__.py`: registers the two new preview commands.
- `docs/maintenance.md`: documents `run-preview` and the blob-reference preview/apply pairs.
- `docs/plans/topology-target.yaml`: regenerated for the new `_run_preview.py` module.

Out of scope per the tracking mission: `_rebuild_index.py`'s own `--plan` fusion (separate tracked design) and `_shared.py` (owned by a parallel lane) are untouched.

## Verification
- `devtools test tests/unit/cli/test_archive_maintenance_cli.py tests/unit/cli/test_maintenance_registration.py` — 72 passed.
- `devtools verify --quick` — all 23 steps ok, including `verify docs-coverage` (the new preview commands are documented, not baselined).
- `devtools render all --check` — no "out of sync" surfaces.

Not run: `devtools verify --all` (full non-integration suite) — left for CI / a follow-up pass if requested.