### PR TITLE
perf: scope raw-materialization derived rebuilds to the replayed component

### DIFF
--- a/polylogue/storage/repair.py
+++ b/polylogue/storage/repair.py
@@ -41,7 +41,6 @@ from polylogue.pipeline.ids import session_id as make_session_id
 from polylogue.storage.archive_identity import archive_file_set_root
 from polylogue.storage.blob_repair import count_orphaned_blobs_sync, repair_orphaned_blobs_data
 from polylogue.storage.blob_store import BlobStore
-from polylogue.storage.fts.fts_lifecycle import rebuild_command_trigram_index_sync, rebuild_fts_index_sync
 from polylogue.storage.insights.session.repair_assessment import (
     assess_session_insight_repairs,
 )
@@ -76,8 +75,6 @@ from polylogue.storage.raw_authority import (
     validate_raw_replay_application_receipt,
     validate_raw_replay_plan,
 )
-from polylogue.storage.sqlite.action_pairs import rebuild_all_action_pairs_sync
-from polylogue.storage.sqlite.delegation_facts import rebuild_all_delegation_facts_sync
 
 if TYPE_CHECKING:
     # ``revision_backfill`` imports ``ArchiveStore``, which (via
@@ -6229,9 +6226,12 @@ def repair_raw_materialization(
     duration -- and therefore the writer-coordinator hold a caller runs it
     under -- independently of ``raw_artifact_limit``. Live evidence showed a
     16-64 component limit alone did not bound hold time: per-component cost
-    (parse, replay, then a full FTS/action-pairs/delegation-facts rebuild) is
-    itself long enough that a modest component count still produced 188s+
-    holds. Both the CENSUS loop and the REPLAY loop check elapsed time only
+    (parse, replay, then -- at the time, before polylogue-qsagp rescoped it to
+    a per-session refresh -- a full archive-wide FTS/trigram/action-pairs/
+    delegation-facts rebuild) was itself long enough that a modest component
+    count still produced 188s+ holds. The bound below remains load-bearing
+    independent of that fix: parse/replay cost alone can still vary widely
+    per component. Both the CENSUS loop and the REPLAY loop check elapsed time only
     *between* components, at the same point they already commit and requery
     candidates -- a genuine transaction-boundary checkpoint, not a mid-write
     yield (a mid-hold SQLite transaction cannot safely release the write lock
@@ -6856,10 +6856,30 @@ def repair_raw_materialization(
                 # components through here — per-row trigger mode would
                 # detonate exactly like the 2026-07-22 live-writer stall.
                 bulk_fts=True,
-                # A single authority component can expand into many logical
-                # sessions.  Defer writer-hot derived surfaces for that
-                # component and rebuild them once below.
-                bulk_build=True,
+                # polylogue-qsagp: ``bulk_build=True`` is the broader
+                # bulk-GENERATION-build lifecycle (``maintenance/rebuild_index.py``'s
+                # single from-empty replay that always finishes with one
+                # archive-wide messages_fts/blocks_command_trigram/action_pairs/
+                # delegation_facts repopulate before readiness). This is the
+                # opposite shape: an incremental per-component trickle pass over
+                # an already-live, already-large archive, so there is no
+                # once-at-the-end readiness step to defer to -- the archive-wide
+                # rebuild that used to run after every component here (measured
+                # 8.22 GiB FTS text / 5.07M trigram rows / 1.9M action_pairs
+                # rows, 188s+ writer holds) was that terminal-pass shape
+                # replayed at the wrong scale. ``bulk_build=False`` (with
+                # ``bulk_fts`` still True) keeps every per-session refresh of
+                # those four derived surfaces exactly in sync with each
+                # session write via the already-existing session/component-
+                # scoped writers (``refresh_action_pairs``,
+                # ``refresh_delegation_facts_for_session``,
+                # ``_bulk_fts_session_guard``'s session-scoped FTS/trigram
+                # delete+reinsert) -- O(sessions touched by this component),
+                # not O(archive). Receipt validation
+                # (``raw_authority.py``'s postflight snapshot) reads only raw/
+                # session/heads tables, never these derived surfaces, so this
+                # rescoping changes no validated postcondition.
+                bulk_build=False,
             )
         except RawRevisionReplayResourceBlockedError as exc:
             metrics["raw_materialization_resource_blocked_count"] = max(
@@ -6915,13 +6935,12 @@ def repair_raw_materialization(
             execution_outcomes.append(outcome)
             continue
         replay_parts.append(part)
-        with closing(sqlite3.connect(archive_root / "index.db", timeout=600)) as derived_conn:
-            derived_conn.execute("PRAGMA busy_timeout = 600000")
-            rebuild_fts_index_sync(derived_conn)
-            rebuild_command_trigram_index_sync(derived_conn)
-            rebuild_all_action_pairs_sync(derived_conn)
-            rebuild_all_delegation_facts_sync(derived_conn)
-            derived_conn.commit()
+        # polylogue-qsagp: the archive-wide rebuild_fts_index_sync/
+        # rebuild_command_trigram_index_sync/rebuild_all_action_pairs_sync/
+        # rebuild_all_delegation_facts_sync quartet that used to run here after
+        # every component is gone -- ``backfill_historical_revision_evidence``
+        # above now runs with ``bulk_build=False``, so each session it wrote
+        # already got its own session-scoped derived-surface refresh inline.
         current = _raw_materialization_candidate_ids(
             config,
             raw_artifact_id=raw_artifact_id,

--- a/tests/unit/storage/test_repair.py
+++ b/tests/unit/storage/test_repair.py
@@ -2456,6 +2456,116 @@ def test_raw_materialization_isolates_failed_component_and_continues_batch(
     assert [outcome.status.value for outcome in result.plan_outcomes].count("executed") == 2
 
 
+def test_raw_materialization_replay_scopes_derived_rebuild_to_touched_component(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """polylogue-qsagp: replaying ONE authority component must refresh
+    FTS/trigram/action_pairs/delegation_facts only for the session(s) that
+    component touched -- never the archive-wide ``rebuild_fts_index_sync`` /
+    ``rebuild_command_trigram_index_sync`` / ``rebuild_all_action_pairs_sync`` /
+    ``rebuild_all_delegation_facts_sync`` quartet ``maintenance/rebuild_index.py``'s
+    terminal blue-green pass owns. Proven at fixture scale with N pre-existing,
+    fully materialized sessions already holding real ``action_pairs`` rows
+    (each carries one Codex ``function_call``/``function_call_output`` pair):
+    patching all four archive-wide rebuild functions to raise, then replaying
+    exactly one NEW single-session component, must still succeed without
+    tripping any of them. Reverting ``bulk_build=False`` back to ``True`` in
+    ``repair_raw_materialization`` (the exact regression this guards) makes
+    this test fail immediately on the patched raise, not on some indirect
+    symptom.
+    """
+    from polylogue.core.enums import Provider
+    from polylogue.storage.fts import fts_lifecycle as fts_lifecycle_mod
+    from polylogue.storage.sqlite import action_pairs as action_pairs_mod
+    from polylogue.storage.sqlite import delegation_facts as delegation_facts_mod
+    from polylogue.storage.sqlite.archive_tiers.archive import ArchiveStore
+    from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_active_archive_root
+
+    def _tool_call_payload(native_id: str) -> bytes:
+        return (
+            f'{{"type":"session_meta","payload":{{"id":"{native_id}"}}}}\n'.encode()
+            + b'{"type":"response_item","payload":{"type":"message","role":"user",'
+            b'"content":[{"type":"input_text","text":"run a command"}]}}\n'
+            b'{"type":"response_item","payload":{"type":"function_call","id":"fc_1",'
+            b'"call_id":"call_abc","name":"exec_command","arguments":"{\\"cmd\\": \\"ls\\"}"}}\n'
+            b'{"type":"response_item","payload":{"type":"function_call_output",'
+            b'"call_id":"call_abc","output":"file1.txt"}}\n'
+        )
+
+    initialize_active_archive_root(tmp_path)
+    existing_native_ids = [f"existing-{index}" for index in range(8)]
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        for index, native_id in enumerate(existing_native_ids):
+            archive.write_raw_payload(
+                provider=Provider.CODEX,
+                payload=_tool_call_payload(native_id),
+                source_path=f"{native_id}.jsonl",
+                acquired_at_ms=index + 1,
+            )
+
+    config = _config(tmp_path)
+    baseline = repair_mod.repair_raw_materialization(config)
+    assert baseline.success is True
+    assert baseline.repaired_count == len(existing_native_ids)
+
+    with sqlite3.connect(tmp_path / "index.db") as index_conn:
+        watched_session_id = index_conn.execute(
+            "SELECT session_id FROM sessions WHERE session_id LIKE ? ORDER BY session_id LIMIT 1",
+            (f"%{existing_native_ids[0]}",),
+        ).fetchone()[0]
+        pre_action_pair_rowids = {
+            row[0]
+            for row in index_conn.execute("SELECT rowid FROM action_pairs WHERE session_id = ?", (watched_session_id,))
+        }
+        pre_delegation_fact_count = index_conn.execute("SELECT COUNT(*) FROM delegation_facts").fetchone()[0]
+    assert pre_action_pair_rowids, "fixture must actually populate action_pairs for the watched session"
+
+    def _fail(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("archive-wide derived rebuild must not run for a single-component replay")
+
+    monkeypatch.setattr(fts_lifecycle_mod, "rebuild_fts_index_sync", _fail)
+    monkeypatch.setattr(fts_lifecycle_mod, "rebuild_command_trigram_index_sync", _fail)
+    monkeypatch.setattr(action_pairs_mod, "rebuild_all_action_pairs_sync", _fail)
+    monkeypatch.setattr(delegation_facts_mod, "rebuild_all_delegation_facts_sync", _fail)
+
+    with ArchiveStore.open_existing(tmp_path, read_only=False) as archive:
+        archive.write_raw_payload(
+            provider=Provider.CODEX,
+            payload=_tool_call_payload("new-component"),
+            source_path="new-component.jsonl",
+            acquired_at_ms=1000,
+        )
+
+    result = repair_mod.repair_raw_materialization(config)
+
+    assert result.success is True
+    assert result.repaired_count == 1
+
+    with sqlite3.connect(tmp_path / "index.db") as index_conn:
+        post_action_pair_rowids = {
+            row[0]
+            for row in index_conn.execute("SELECT rowid FROM action_pairs WHERE session_id = ?", (watched_session_id,))
+        }
+        post_delegation_fact_count = index_conn.execute("SELECT COUNT(*) FROM delegation_facts").fetchone()[0]
+        new_action_pair_rows = index_conn.execute(
+            "SELECT COUNT(*) FROM action_pairs WHERE session_id LIKE '%new-component'"
+        ).fetchone()[0]
+
+    # An archive-wide ``DELETE FROM action_pairs; INSERT ...`` rebuild
+    # reassigns every row (including the untouched watched session's) a fresh
+    # rowid; a session-scoped refresh never touches rows for a session
+    # outside this component at all. Same rowids proves this component's
+    # replay left the unrelated session's action_pairs rows alone.
+    assert post_action_pair_rowids == pre_action_pair_rowids
+    assert new_action_pair_rows > 0
+    # delegation_facts has no rows to rowid-compare in this fixture (no
+    # delegation links), but the count must grow by exactly what the new
+    # component's own session-scoped refresh contributes -- zero here --
+    # not shrink to zero and be rebuilt, which the patched raise already
+    # rules out.
+    assert post_delegation_fact_count == pre_delegation_fact_count
+
+
 def test_raw_materialization_transient_failure_retries_with_same_plan_id_then_succeeds(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes the P1 perf defect in `polylogue-qsagp`: `repair_raw_materialization`'s per-component replay loop ran four archive-wide derived-surface rebuilds after every single replayed authority component, turning an incremental trickle pass into an O(archive) operation per component.

## Problem

`storage/repair.py`'s replay loop called `backfill_historical_revision_evidence(..., bulk_build=True)` and then, after every component, ran `rebuild_fts_index_sync` + `rebuild_command_trigram_index_sync` + `rebuild_all_action_pairs_sync` + `rebuild_all_delegation_facts_sync` unconditionally. All four are archive-wide: measured live at 5,006,199 FTS rows / 8.22 GiB text, 5,070,427 trigram rows, 1,908,650 `action_pairs` rows. `bulk_build=True` is documented (`write_parsed_session_to_archive`'s own docstring) as the bulk-*generation*-build lifecycle for `maintenance/rebuild_index.py`'s single from-empty replay that finishes with one archive-wide repopulate before readiness -- it was copy-pasted into this incremental per-component loop at the wrong scale. The function's own docstring already records the consequence: a modest component count producing 188s+ writer holds.

## Solution

Pass `bulk_build=False` (keeping `bulk_fts=True`) to `backfill_historical_revision_evidence`. `write_parsed_session_to_archive` already runs a session/component-scoped refresh of all four derived surfaces inline for every session it writes whenever `bulk_build` is `False`: `refresh_action_pairs`, `refresh_delegation_facts_for_session`, and `_bulk_fts_session_guard`'s session-scoped FTS/trigram delete+reinsert. These are the "already exist" scoped variants named in the bead -- no new SQL was written. The post-loop archive-wide rebuild block is removed entirely.

Receipt validation (`raw_authority.py`'s postflight snapshot) reads only raw/session/heads tables, never these derived surfaces, so this rescoping changes no validated postcondition.

Modules touched: `polylogue/storage/repair.py` (the replay loop only; also dropped the now-unused archive-wide rebuild imports and updated an adjacent docstring that referenced the old behavior).

## Verification

New test `test_raw_materialization_replay_scopes_derived_rebuild_to_touched_component` (`tests/unit/storage/test_repair.py`): seeds 8 pre-existing, fully materialized sessions, each carrying a real Codex `function_call`/`function_call_output` pair that populates `action_pairs`. It then patches all four archive-wide rebuild functions to raise, and replays exactly one new single-session component through the real `repair_raw_materialization` entry point.

- Proves the archive-wide functions are never invoked during a single-component replay (the raise never fires).
- Proves an unrelated, untouched session's `action_pairs` rows keep their exact original rowids across the replay -- an archive-wide `DELETE FROM action_pairs; INSERT ...` rebuild reassigns every row a fresh rowid; a session-scoped refresh never touches rows outside the replayed component at all.

Anti-vacuity, confirmed by temporarily reverting the fix two independent ways:
- Reverting only `bulk_build=False` back to `True` (with the archive-wide rebuild call already removed) breaks the fixture's own baseline setup, because `action_pairs` never gets populated for the pre-existing sessions at all -- proving the per-session refresh path is what the fix actually depends on.
- Restoring the deleted archive-wide rebuild call (with `bulk_build=False`) trips the patched raise directly on the new component's replay -- the exact regression this test guards against.

Ran:
- `devtools test tests/unit/storage/test_repair.py` -> 67 passed
- `devtools verify --quick` -> exit_code 0 (ruff format/check, mypy, render all, topology, layering, closure-matrix, manifests, ci-workflows, doc-commands, docs-coverage, test-infra-currency, pytest-timeout-overrides, degrade-loudly, hash-boundary-census, all lab policy checks, schema promotion audit)

Not run: the full non-affected-only test suite (per-PR CI already skips it; `devtools verify --all` is a heavier gate reserved for harness/dependency changes or a final pre-merge diagnostic).

Ref polylogue-qsagp