### PR TITLE
feat(verification): registry phase 1 - ground-truth checks + head-only sampling

### DIFF
--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -32,6 +32,7 @@ reality.
 
 from __future__ import annotations
 
+import re
 import sqlite3
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
@@ -632,6 +633,423 @@ def _check_lineage_sanity(archive_root: Path, sample_limit: int) -> ArchiveVerif
 
 
 # ---------------------------------------------------------------------------
+# Check: enum-superset-CHECK (I2, polylogue-t0m73)
+# ---------------------------------------------------------------------------
+
+#: Column names that carry the ``Origin`` vocabulary and are generated via
+#: ``check("origin", Origin)`` / ``check("dst_origin", Origin)`` at DDL-build
+#: time (``archive_tiers/*.py``). Restricted to these two, word-boundary
+#: anchored columns rather than every enum-backed column in the schema:
+#: several other CHECK-constrained column names (``status``, ``kind``) are
+#: reused across tables with *unrelated*, hand-written literal vocabularies,
+#: so a blind column-name match would false-positive on those. ``origin`` is
+#: the column this class of bug was actually found on live (2026-08-03:
+#: ``Origin`` gained ``claude-design-session`` after several tables' DDL had
+#: already been written to disk with the older literal list -- a CHECK
+#: constraint is baked into the table at creation time and does not
+#: retroactively track a later enum change).
+_ORIGIN_CHECK_COLUMN_PATTERN = re.compile(
+    r"[(,\s][\"'`\[]?(origin|dst_origin)[\"'`\]]?\s+TEXT[^,]*?CHECK\s*\([^)]*?\bIN\s*\(([^)]*)\)",
+    re.IGNORECASE,
+)
+
+
+def _check_enum_superset(archive_root: Path, _sample_limit: int) -> ArchiveVerificationCheck:
+    """Every live ``origin``/``dst_origin`` CHECK list is a superset of ``Origin``.
+
+    A CHECK constraint is generated from :class:`polylogue.core.enums.Origin`
+    at DDL-build time, but once a table exists on disk its CHECK text is
+    frozen -- SQLite has no ``ALTER ... CHECK``. If ``Origin`` gains a member
+    after a table was created (an additive-derived or additive-durable
+    change that didn't trigger a full DDL rebuild for every affected table),
+    the *live* archive's CHECK list silently falls behind the vocabulary
+    production code can write, and the next insert with the new value either
+    raises or -- if some path writes around it -- corrupts silently. This
+    check reads ``sqlite_master`` on the live tiers and compares the CHECK
+    text actually on disk against the *current* Python enum, so it is
+    ground-truth against reality (the disk), not against the code that
+    would generate a fresh table today.
+    """
+    from polylogue.core.enums import Origin
+
+    origins = {o.value for o in Origin}
+    bad: dict[str, Any] = {}
+    examined_any = False
+    for db_name in ("source.db", "index.db"):
+        db_path = archive_root / db_name if db_name == "source.db" else _resolve_index_path(archive_root)
+        if not db_path.exists():
+            continue
+        examined_any = True
+        try:
+            conn = _open_ro(db_path)
+        except sqlite3.Error as exc:
+            return _error_check("enum-superset-check", f"could not open {db_name}: {exc}", exc=exc)
+        try:
+            rows = conn.execute(
+                "SELECT name, sql FROM sqlite_master WHERE type = 'table' AND sql LIKE '%origin%IN (%'"
+            ).fetchall()
+        except sqlite3.Error as exc:
+            return _error_check("enum-superset-check", f"could not read {db_name}: {exc}", exc=exc)
+        finally:
+            conn.close()
+
+        for table_name, ddl in rows:
+            for match in _ORIGIN_CHECK_COLUMN_PATTERN.finditer(ddl or ""):
+                column, allowed_list = match.group(1), match.group(2)
+                allowed = set(re.findall(r"'([^']*)'", allowed_list))
+                missing = sorted(origins - allowed)
+                if missing:
+                    bad[f"{db_name}:{table_name}.{column}"] = missing
+
+    if not examined_any:
+        return _skip_check("enum-superset-check", "neither source.db nor index.db present")
+    if bad:
+        return ArchiveVerificationCheck(
+            name="enum-superset-check",
+            status=OutcomeStatus.ERROR,
+            summary=f"{len(bad)} CHECK list(s) missing current Origin member(s): {sorted(bad)}",
+            count=len(bad),
+            details=[f"{key}: missing {values}" for key, values in sorted(bad.items())],
+            evidence={"missing_by_column": bad, "current_origin_vocabulary": sorted(origins)},
+        )
+    return ArchiveVerificationCheck(
+        name="enum-superset-check",
+        status=OutcomeStatus.OK,
+        summary="every origin/dst_origin CHECK list on disk covers the current Origin enum",
+        evidence={"current_origin_vocabulary": sorted(origins)},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Check: blob_refs join-liveness per ref_type (I3, polylogue-t0m73)
+# ---------------------------------------------------------------------------
+
+#: ``blob_refs.ref_type`` -> the source-tier table + PK column it must join
+#: to. GC's oracle for "is this blob still referenced" is exactly this join
+#: (a ``blob_refs`` row with no live referent is orphaned bookkeeping, not
+#: proof the blob itself is unreferenced -- the join direction the schema
+#: intends), so a ref_type this check doesn't recognize is itself a gap the
+#: check surfaces via `_error_check`, not a silent skip.
+_BLOB_REF_REFERENT_TABLES: dict[str, tuple[str, str]] = {
+    "raw_payload": ("raw_sessions", "raw_id"),
+    "attachment": ("raw_artifacts", "artifact_id"),
+    "sidecar": ("history_sidecars", "sidecar_id"),
+}
+
+
+def _check_blob_refs_liveness(archive_root: Path, sample_limit: int) -> ArchiveVerificationCheck:
+    """Every ``blob_refs`` row resolves in its referent table for its ``ref_type``.
+
+    ``blob_refs`` is the durable GC substrate: a blob is eligible for
+    collection only once every referencing row is gone. An orphaned
+    ``blob_refs`` row (its referent already deleted, e.g. by a cascading
+    raw replace) is stale bookkeeping that either wastes retention (the blob
+    looks referenced forever) or -- worse -- signals the delete path forgot
+    to clean up ``blob_refs`` alongside the referent, which is a correctness
+    bug in the GC liveness contract itself.
+    """
+    source_path = _tier_path(archive_root, ArchiveTier.SOURCE)
+    if not source_path.exists():
+        return _skip_check("blob-refs-liveness", "source.db not present")
+
+    try:
+        conn = _open_ro(source_path)
+    except sqlite3.Error as exc:
+        return _error_check("blob-refs-liveness", f"could not open source.db: {exc}", exc=exc)
+
+    try:
+        if not table_exists(conn, "blob_refs"):
+            return _skip_check("blob-refs-liveness", "blob_refs table not present")
+
+        try:
+            ref_types = {str(row[0]) for row in conn.execute("SELECT DISTINCT ref_type FROM blob_refs")}
+        except sqlite3.Error as exc:
+            return _error_check("blob-refs-liveness", f"could not read blob_refs: {exc}", exc=exc)
+
+        unknown_ref_types = sorted(ref_types - set(_BLOB_REF_REFERENT_TABLES))
+        if unknown_ref_types:
+            return _error_check(
+                "blob-refs-liveness",
+                f"blob_refs has ref_type(s) this check doesn't recognize: {unknown_ref_types} "
+                "(update _BLOB_REF_REFERENT_TABLES)",
+            )
+
+        orphans_by_type: dict[str, int] = {}
+        samples_by_type: dict[str, list[str]] = {}
+        try:
+            for ref_type, (referent_table, referent_column) in _BLOB_REF_REFERENT_TABLES.items():
+                if not table_exists(conn, referent_table):
+                    return _error_check(
+                        "blob-refs-liveness",
+                        f"referent table {referent_table!r} for ref_type={ref_type!r} does not exist",
+                    )
+                count = conn.execute(
+                    f"""
+                    SELECT COUNT(*) FROM blob_refs b
+                    WHERE b.ref_type = ? AND NOT EXISTS (
+                        SELECT 1 FROM {referent_table} r WHERE r.{referent_column} = b.ref_id
+                    )
+                    """,
+                    (ref_type,),
+                ).fetchone()[0]
+                orphans_by_type[ref_type] = int(count)
+                if count:
+                    samples_by_type[ref_type] = [
+                        str(row[0])
+                        for row in conn.execute(
+                            f"""
+                            SELECT DISTINCT b.ref_id FROM blob_refs b
+                            WHERE b.ref_type = ? AND NOT EXISTS (
+                                SELECT 1 FROM {referent_table} r WHERE r.{referent_column} = b.ref_id
+                            )
+                            LIMIT ?
+                            """,
+                            (ref_type, sample_limit),
+                        )
+                    ]
+        except sqlite3.Error as exc:
+            return _error_check("blob-refs-liveness", f"could not read source.db: {exc}", exc=exc)
+    finally:
+        conn.close()
+
+    total_orphans = sum(orphans_by_type.values())
+    status = OutcomeStatus.ERROR if total_orphans else OutcomeStatus.OK
+    summary = (
+        "; ".join(f"{ref_type} orphans={count:,}" for ref_type, count in orphans_by_type.items() if count)
+        if total_orphans
+        else "every blob_refs row resolves in its referent table"
+    )
+    return ArchiveVerificationCheck(
+        name="blob-refs-liveness",
+        status=status,
+        summary=summary,
+        count=total_orphans,
+        details=[f"{ref_type}:{ref_id}" for ref_type, ids in samples_by_type.items() for ref_id in ids],
+        evidence={"orphans_by_ref_type": orphans_by_type, "orphan_samples_by_ref_type": samples_by_type},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Check: embeddings refs resolve in the index tier (I4, polylogue-t0m73)
+# ---------------------------------------------------------------------------
+
+
+def _check_embeddings_refs_liveness(archive_root: Path, sample_limit: int) -> ArchiveVerificationCheck:
+    """Every ``message_embedding_refs`` row resolves to a live index message.
+
+    embeddings.db is a rebuildable derived tier keyed off index.db's message
+    ids; an embedding ref outliving the message it was computed for (e.g. a
+    session full-replace deleting messages without the embedding catch-up
+    stage draining the corresponding refs) is exactly the feu0-class bug:
+    dead vector rows that read back as "embedded" for content that no
+    longer exists in the index.
+    """
+    embeddings_path = _tier_path(archive_root, ArchiveTier.EMBEDDINGS)
+    index_path = _resolve_index_path(archive_root)
+    if not embeddings_path.exists():
+        return _skip_check("embeddings-refs-liveness", "embeddings.db not present")
+    if not index_path.exists():
+        return _skip_check("embeddings-refs-liveness", "index.db not present")
+
+    try:
+        conn = _open_ro(embeddings_path)
+    except sqlite3.Error as exc:
+        return _error_check("embeddings-refs-liveness", f"could not open embeddings.db: {exc}", exc=exc)
+
+    try:
+        if not table_exists(conn, "message_embedding_refs"):
+            return _skip_check("embeddings-refs-liveness", "message_embedding_refs table not present")
+
+        try:
+            conn.execute("ATTACH DATABASE ? AS idx_tier", (f"file:{index_path}?mode=ro",))
+        except sqlite3.Error as exc:
+            return _error_check("embeddings-refs-liveness", f"could not attach index.db: {exc}", exc=exc)
+
+        try:
+            total, orphans = conn.execute(
+                """
+                SELECT COUNT(*), SUM(
+                    CASE WHEN NOT EXISTS (
+                        SELECT 1 FROM idx_tier.messages m WHERE m.message_id = r.message_id
+                    ) THEN 1 ELSE 0 END
+                )
+                FROM message_embedding_refs r
+                """
+            ).fetchone()
+            orphans = int(orphans or 0)
+            orphan_sample = [
+                str(row[0])
+                for row in conn.execute(
+                    """
+                    SELECT r.message_id FROM message_embedding_refs r
+                    WHERE NOT EXISTS (SELECT 1 FROM idx_tier.messages m WHERE m.message_id = r.message_id)
+                    LIMIT ?
+                    """,
+                    (sample_limit,),
+                )
+            ]
+        except sqlite3.Error as exc:
+            return _error_check("embeddings-refs-liveness", f"could not read embeddings/index tiers: {exc}", exc=exc)
+    finally:
+        conn.close()
+
+    status = OutcomeStatus.ERROR if orphans else OutcomeStatus.OK
+    return ArchiveVerificationCheck(
+        name="embeddings-refs-liveness",
+        status=status,
+        summary=(
+            f"{int(total or 0):,} embedding ref(s), {orphans:,} orphaned (no live index message)"
+            if orphans
+            else f"all {int(total or 0):,} embedding ref(s) resolve to a live index message"
+        ),
+        count=orphans,
+        details=[f"orphan:{message_id}" for message_id in orphan_sample],
+        evidence={"ref_count": int(total or 0), "orphan_count": orphans, "orphan_sample": orphan_sample},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Check: session parent-chain acyclicity (I5, polylogue-t0m73)
+# ---------------------------------------------------------------------------
+
+
+def _check_session_lineage_acyclic(archive_root: Path, _sample_limit: int) -> ArchiveVerificationCheck:
+    """``sessions.parent_session_id`` never closes a cycle.
+
+    ``lineage-sanity`` (above) already covers ``session_links``' dangling
+    ``resolved_dst_session_id`` / ``branch_point_message_id`` references --
+    this check adds the one I5 sub-invariant that has no existing coverage:
+    the derived ``parent_session_id`` chain resolvers walk to recompose a
+    session's inherited prefix must terminate. A cycle here would make
+    prefix recomposition (see the lineage-normalization doc in
+    ``storage/sqlite/archive_tiers/write.py``) loop forever or silently
+    truncate depending on the walker's own defenses -- this check proves
+    the graph itself is acyclic independent of any particular walker's
+    resilience to being handed a cycle.
+    """
+    index_path = _resolve_index_path(archive_root)
+    if not index_path.exists():
+        return _skip_check("session-lineage-acyclic", "index.db not present")
+
+    try:
+        conn = _open_ro(index_path)
+    except sqlite3.Error as exc:
+        return _error_check("session-lineage-acyclic", f"could not open index.db: {exc}", exc=exc)
+
+    try:
+        try:
+            parents: dict[str, str] = dict(
+                conn.execute(
+                    "SELECT session_id, parent_session_id FROM sessions WHERE parent_session_id IS NOT NULL"
+                ).fetchall()
+            )
+        except sqlite3.Error as exc:
+            return _error_check("session-lineage-acyclic", f"could not read index.db: {exc}", exc=exc)
+    finally:
+        conn.close()
+
+    # Walk each node's parent chain once; nodes already proven part of some
+    # walk (cyclic or not) are never re-walked, so this is O(n) total despite
+    # the outer loop over every node.
+    resolved: set[str] = set()
+    cycle_members: set[str] = set()
+    for start in parents:
+        if start in resolved:
+            continue
+        path: list[str] = []
+        node = start
+        while node in parents and node not in resolved:
+            if node in path:
+                cycle_members.update(path[path.index(node) :])
+                break
+            path.append(node)
+            node = parents[node]
+        resolved.update(path)
+
+    status = OutcomeStatus.ERROR if cycle_members else OutcomeStatus.OK
+    return ArchiveVerificationCheck(
+        name="session-lineage-acyclic",
+        status=status,
+        summary=(
+            f"{len(cycle_members)} session(s) on a parent_session_id cycle"
+            if cycle_members
+            else f"{len(parents):,} parent-linked session(s), parent chain is acyclic"
+        ),
+        count=len(cycle_members),
+        details=sorted(cycle_members)[:10],
+        evidence={"linked_session_count": len(parents), "cycle_member_sample": sorted(cycle_members)[:10]},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Check: sessions.message_count projection drift (I8, polylogue-t0m73)
+# ---------------------------------------------------------------------------
+
+
+def _check_message_count_projection(archive_root: Path, sample_limit: int) -> ArchiveVerificationCheck:
+    """``sessions.message_count`` matches the actual materialized row count.
+
+    ``message_count`` is a write-time projection (set when a session is
+    written, not a generated column), so it can drift from the underlying
+    ``messages`` rows if a partial write, a bug in the write path, or a
+    manual repair touches one but not the other. Ground truth is
+    ``COUNT(*)`` over ``messages`` itself, joined back to ``sessions``.
+    """
+    index_path = _resolve_index_path(archive_root)
+    if not index_path.exists():
+        return _skip_check("message-count-projection", "index.db not present")
+
+    try:
+        conn = _open_ro(index_path)
+    except sqlite3.Error as exc:
+        return _error_check("message-count-projection", f"could not open index.db: {exc}", exc=exc)
+
+    try:
+        try:
+            drift_count = conn.execute(
+                """
+                SELECT COUNT(*) FROM (
+                    SELECT s.session_id FROM sessions s
+                    LEFT JOIN (SELECT session_id, COUNT(*) AS n FROM messages GROUP BY session_id) m
+                        ON m.session_id = s.session_id
+                    WHERE COALESCE(m.n, 0) != s.message_count
+                )
+                """
+            ).fetchone()[0]
+            drift_sample = [
+                str(row[0])
+                for row in conn.execute(
+                    """
+                    SELECT s.session_id FROM sessions s
+                    LEFT JOIN (SELECT session_id, COUNT(*) AS n FROM messages GROUP BY session_id) m
+                        ON m.session_id = s.session_id
+                    WHERE COALESCE(m.n, 0) != s.message_count
+                    LIMIT ?
+                    """,
+                    (sample_limit,),
+                )
+            ]
+        except sqlite3.Error as exc:
+            return _error_check("message-count-projection", f"could not read index.db: {exc}", exc=exc)
+    finally:
+        conn.close()
+
+    status = OutcomeStatus.ERROR if drift_count else OutcomeStatus.OK
+    return ArchiveVerificationCheck(
+        name="message-count-projection",
+        status=status,
+        summary=(
+            f"{drift_count} session(s) with drifted message_count"
+            if drift_count
+            else "sessions.message_count matches COUNT(messages) for every session"
+        ),
+        count=drift_count,
+        details=[f"session:{session_id}" for session_id in drift_sample],
+        evidence={"drifted_session_count": drift_count, "drifted_session_sample": drift_sample},
+    )
+
+
+# ---------------------------------------------------------------------------
 # Check 6: planner stats presence (polylogue-l3tk class)
 # ---------------------------------------------------------------------------
 
@@ -762,6 +1180,33 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
         "lineage-sanity",
         "session_links.resolved_dst_session_id / branch_point_message_id resolve to real sessions/messages.",
         _check_lineage_sanity,
+    ),
+    ArchiveVerificationCheckSpec(
+        "enum-superset-check",
+        "Live origin/dst_origin CHECK lists on disk are a superset of the current Origin enum (polylogue-t0m73 I2).",
+        _check_enum_superset,
+    ),
+    ArchiveVerificationCheckSpec(
+        "blob-refs-liveness",
+        "Every blob_refs row resolves in its ref_type's referent table -- the GC liveness oracle is a join, "
+        "not membership in blob_refs itself (polylogue-t0m73 I3).",
+        _check_blob_refs_liveness,
+    ),
+    ArchiveVerificationCheckSpec(
+        "embeddings-refs-liveness",
+        "message_embedding_refs resolve to live index.db messages (feu0-class dead-vector detection, "
+        "polylogue-t0m73 I4).",
+        _check_embeddings_refs_liveness,
+    ),
+    ArchiveVerificationCheckSpec(
+        "session-lineage-acyclic",
+        "sessions.parent_session_id chains never close a cycle (polylogue-t0m73 I5).",
+        _check_session_lineage_acyclic,
+    ),
+    ArchiveVerificationCheckSpec(
+        "message-count-projection",
+        "sessions.message_count matches COUNT(messages) per session (polylogue-t0m73 I8).",
+        _check_message_count_projection,
     ),
     ArchiveVerificationCheckSpec(
         "planner-stats",

--- a/polylogue/maintenance/archive_verification.py
+++ b/polylogue/maintenance/archive_verification.py
@@ -13,6 +13,21 @@ rather than only getting a red light.
 New checks slot into :data:`ARCHIVE_VERIFICATION_CHECKS` without touching
 :func:`verify_archive` or its callers -- the registry is the extension point
 for future checks (blob-reference debt, cost rollups, ...).
+
+**Registry contract rule (polylogue-in24n):** a check's universe must be a
+ground-truth table, never a derived ledger of the mechanism under audit. The
+canonical violation this rule exists to prevent: an earlier version of
+``source-index-coverage`` computed its universe from ``raw_membership_census``
+(the *census machinery's own bookkeeping* of what it considered complete)
+instead of ``raw_sessions`` (the durable, ground-truth table every acquired
+raw lands in regardless of what any downstream census/reconciliation stage
+later decides about it). Because the census never blesses a quarantined or
+unreconciled raw, that raw was invisible to the check by construction -- the
+check reported OK while a real, large materialization gap sat underneath it.
+When adding a new check, ask: "if the mechanism I'm checking silently drops a
+row from its own ledger, does my universe query still see that row?" If the
+answer is no, the check is auditing the mechanism against itself, not against
+reality.
 """
 
 from __future__ import annotations
@@ -245,68 +260,180 @@ def _check_pointer_coherence(archive_root: Path, _sample_limit: int) -> ArchiveV
 
 
 def _check_source_index_coverage(archive_root: Path, sample_limit: int) -> ArchiveVerificationCheck:
+    """Every logical source's head is indexed OR carries a typed refusal.
+
+    Universe (polylogue-in24n, invariant I1): ``raw_sessions`` logical heads --
+    the latest revision per ``(origin, COALESCE(native_id, source_path))`` --
+    which is a ground-truth table every acquired raw lands in, not a ledger a
+    downstream reconciliation stage can silently omit rows from. A logical
+    head counts as covered when *any* raw in its revision group is
+    materialized into ``index.db``. An uncovered head must be typed as one
+    of: ``parse_error`` (raw_sessions.parse_error set), ``non_session`` /
+    ``census_failed`` (raw_membership_census recorded a terminal non-complete
+    verdict), or ``quarantined`` (raw_sessions.revision_authority --
+    reconciliation hasn't granted it authority to write yet, WARN-level
+    evidence, not blocking). An uncovered head matching none of those is an
+    *untyped* gap -- a materialization failure no other subsystem has
+    explained -- and is the only ERROR-gating condition here besides orphans
+    (index sessions whose raw_id doesn't exist in source.db at all).
+    """
     source_path = _tier_path(archive_root, ArchiveTier.SOURCE)
     index_path = _resolve_index_path(archive_root)
     if not source_path.exists() or not index_path.exists():
         return _skip_check("source-index-coverage", "source.db or index.db not present")
 
     try:
-        source_conn = _open_ro(source_path)
+        conn = _open_ro(source_path)
     except sqlite3.Error as exc:
         return _error_check("source-index-coverage", f"could not open source.db: {exc}", exc=exc)
+
     try:
-        if table_exists(source_conn, "raw_membership_census"):
-            censused_complete = {
-                str(row[0])
-                for row in source_conn.execute(
-                    "SELECT raw_id FROM raw_membership_census WHERE status = 'complete' AND member_count > 0"
+        try:
+            conn.execute("ATTACH DATABASE ? AS idx_tier", (f"file:{index_path}?mode=ro",))
+        except sqlite3.Error as exc:
+            return _error_check("source-index-coverage", f"could not attach index.db: {exc}", exc=exc)
+
+        try:
+            has_census = table_exists(conn, "raw_membership_census")
+            census_expr = (
+                "(SELECT c.status FROM raw_membership_census c WHERE c.raw_id = r.raw_id)" if has_census else "NULL"
+            )
+
+            # A read-only connection (``query_only=ON``, connection-wide, not
+            # per-attached-db) cannot ``CREATE TEMP VIEW`` -- the temp schema
+            # is still a write. Repeat the heads CTE per query instead; it is
+            # a plain in-query derived table, not a persisted write.
+            heads_cte = f"""
+                WITH heads AS (
+                    SELECT
+                        r.raw_id,
+                        r.parse_error,
+                        r.revision_authority,
+                        {census_expr} AS census_status,
+                        MAX(EXISTS(SELECT 1 FROM idx_tier.sessions s WHERE s.raw_id = r.raw_id))
+                            OVER (PARTITION BY r.origin, COALESCE(r.native_id, r.source_path)) AS any_indexed,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY r.origin, COALESCE(r.native_id, r.source_path)
+                            ORDER BY r.acquired_at_ms DESC, r.raw_id DESC
+                        ) AS rn
+                    FROM raw_sessions r
                 )
-            }
-        else:
-            censused_complete = set()
-        all_raw_ids = {str(row[0]) for row in source_conn.execute("SELECT raw_id FROM raw_sessions")}
-    except sqlite3.Error as exc:
-        return _error_check("source-index-coverage", f"could not read source.db: {exc}", exc=exc)
+            """
+            untyped_predicate = """
+                rn = 1 AND any_indexed = 0 AND parse_error IS NULL
+                  AND COALESCE(census_status, '') NOT IN ('non_session', 'failed')
+                  AND revision_authority != 'quarantined'
+            """
+            quarantined_predicate = """
+                rn = 1 AND any_indexed = 0 AND parse_error IS NULL
+                  AND COALESCE(census_status, '') NOT IN ('non_session', 'failed')
+                  AND revision_authority = 'quarantined'
+            """
+
+            total_heads = int(conn.execute(f"{heads_cte} SELECT COUNT(*) FROM heads WHERE rn = 1").fetchone()[0])
+
+            counts = conn.execute(
+                f"""
+                {heads_cte}
+                SELECT
+                  SUM(CASE WHEN any_indexed = 0 AND parse_error IS NOT NULL THEN 1 ELSE 0 END),
+                  SUM(CASE WHEN any_indexed = 0 AND parse_error IS NULL
+                            AND census_status = 'non_session' THEN 1 ELSE 0 END),
+                  SUM(CASE WHEN any_indexed = 0 AND parse_error IS NULL
+                            AND COALESCE(census_status, '') != 'non_session'
+                            AND census_status = 'failed' THEN 1 ELSE 0 END),
+                  SUM(CASE WHEN {quarantined_predicate.replace("rn = 1 AND ", "")} THEN 1 ELSE 0 END),
+                  SUM(CASE WHEN {untyped_predicate.replace("rn = 1 AND ", "")} THEN 1 ELSE 0 END)
+                FROM heads WHERE rn = 1
+                """
+            ).fetchone()
+            parse_error_n, non_session_n, census_failed_n, quarantined_n, untyped_n = (
+                int(value or 0) for value in counts
+            )
+
+            untyped_sample = [
+                str(row[0])
+                for row in conn.execute(
+                    f"{heads_cte} SELECT raw_id FROM heads WHERE {untyped_predicate} LIMIT ?",
+                    (sample_limit,),
+                )
+            ]
+            quarantined_sample = [
+                str(row[0])
+                for row in conn.execute(
+                    f"{heads_cte} SELECT raw_id FROM heads WHERE {quarantined_predicate} LIMIT ?",
+                    (sample_limit,),
+                )
+            ]
+
+            orphan_count = conn.execute(
+                """
+                SELECT COUNT(*) FROM idx_tier.sessions s
+                WHERE s.raw_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM raw_sessions r WHERE r.raw_id = s.raw_id)
+                """
+            ).fetchone()[0]
+            orphan_sample = [
+                str(row[0])
+                for row in conn.execute(
+                    """
+                    SELECT DISTINCT s.raw_id FROM idx_tier.sessions s
+                    WHERE s.raw_id IS NOT NULL
+                      AND NOT EXISTS (SELECT 1 FROM raw_sessions r WHERE r.raw_id = s.raw_id)
+                    LIMIT ?
+                    """,
+                    (sample_limit,),
+                )
+            ]
+        except sqlite3.Error as exc:
+            return _error_check("source-index-coverage", f"could not read source/index tiers: {exc}", exc=exc)
     finally:
-        source_conn.close()
+        conn.close()
 
-    try:
-        index_conn = _open_ro(index_path)
-    except sqlite3.Error as exc:
-        return _error_check("source-index-coverage", f"could not open index.db: {exc}", exc=exc)
-    try:
-        session_raw_ids = {
-            str(row[0]) for row in index_conn.execute("SELECT DISTINCT raw_id FROM sessions WHERE raw_id IS NOT NULL")
-        }
-    except sqlite3.Error as exc:
-        return _error_check("source-index-coverage", f"could not read index.db: {exc}", exc=exc)
-    finally:
-        index_conn.close()
+    unindexed_head_count = parse_error_n + non_session_n + census_failed_n + quarantined_n + untyped_n
+    blocking = untyped_n > 0 or int(orphan_count or 0) > 0
+    warning = quarantined_n > 0
 
-    missing_work = sorted(censused_complete - session_raw_ids)
-    orphans = sorted(session_raw_ids - all_raw_ids)
+    if blocking:
+        status = OutcomeStatus.ERROR
+    elif warning:
+        status = OutcomeStatus.WARNING
+    else:
+        status = OutcomeStatus.OK
 
-    status = OutcomeStatus.ERROR if (missing_work or orphans) else OutcomeStatus.OK
-    summary = (
-        f"{len(censused_complete):,} complete-census raw(s), {len(session_raw_ids):,} raw-backed session(s); "
-        f"missing_work={len(missing_work):,} orphans={len(orphans):,}"
-    )
+    parts = [f"{total_heads:,} logical source head(s), {unindexed_head_count:,} unindexed"]
+    if untyped_n:
+        parts.append(f"untyped={untyped_n:,}")
+    if quarantined_n:
+        parts.append(f"quarantined={quarantined_n:,} (WARN evidence, not blocking)")
+    if parse_error_n:
+        parts.append(f"parse_error={parse_error_n:,}")
+    if non_session_n or census_failed_n:
+        parts.append(f"declared-non-session={non_session_n + census_failed_n:,}")
+    if orphan_count:
+        parts.append(f"orphans={int(orphan_count):,}")
+    summary = "; ".join(parts)
+
     return ArchiveVerificationCheck(
         name="source-index-coverage",
         status=status,
         summary=summary,
-        count=len(missing_work) + len(orphans),
+        count=untyped_n + int(orphan_count or 0),
         details=[
-            *(f"missing-work:{raw_id}" for raw_id in missing_work[:sample_limit]),
-            *(f"orphan:{raw_id}" for raw_id in orphans[:sample_limit]),
+            *(f"untyped:{raw_id}" for raw_id in untyped_sample),
+            *(f"orphan:{raw_id}" for raw_id in orphan_sample),
         ],
         evidence={
-            "censused_complete_raw_count": len(censused_complete),
-            "raw_backed_session_count": len(session_raw_ids),
-            "missing_work_count": len(missing_work),
-            "missing_work_sample": missing_work[:sample_limit],
-            "orphan_count": len(orphans),
-            "orphan_sample": orphans[:sample_limit],
+            "logical_head_count": total_heads,
+            "unindexed_head_count": unindexed_head_count,
+            "untyped_count": untyped_n,
+            "untyped_sample": untyped_sample,
+            "parse_error_count": parse_error_n,
+            "non_session_count": non_session_n,
+            "census_failed_count": census_failed_n,
+            "quarantined_count": quarantined_n,
+            "quarantined_sample": quarantined_sample,
+            "orphan_count": int(orphan_count or 0),
+            "orphan_sample": orphan_sample,
         },
     )
 
@@ -622,7 +749,8 @@ ARCHIVE_VERIFICATION_CHECKS: tuple[ArchiveVerificationCheckSpec, ...] = (
     ),
     ArchiveVerificationCheckSpec(
         "source-index-coverage",
-        "Complete-census raw sessions with no materialized index session, and index sessions with no backing raw.",
+        "Every raw_sessions logical head is indexed or typed (parse_error/non_session/quarantined); "
+        "untyped gaps and index-orphans (raw_id ground truth, not the census ledger, polylogue-in24n) block.",
         _check_source_index_coverage,
     ),
     ArchiveVerificationCheckSpec(

--- a/polylogue/schemas/sampling_db.py
+++ b/polylogue/schemas/sampling_db.py
@@ -249,12 +249,26 @@ def _iter_schema_units_from_db(
     max_samples: int | None = None,
     full_corpus: bool = False,
     terminal_recorder: ObservationTerminalRecorder | None = None,
+    logical_heads_only: bool = False,
 ) -> Iterator[SchemaUnit]:
     """Yield clusterable schema units from raw_sessions.
 
     Raw acquisition rows live in the ``source.db`` tier (#1743). Given an
     ``index.db`` path, the sibling ``source.db`` of the same archive root holds
     ``raw_sessions``; it is opened read-write but only read here.
+
+    ``logical_heads_only`` (default ``False``, opt-in): restrict the sampled
+    rows to one per logical source -- the latest revision per
+    ``(origin, COALESCE(native_id, source_path))``, the same grouping the
+    archive-verification I1 coverage check uses for its universe. Schema
+    inference's ordinary use (discovering every shape a provider's wire
+    format can take) wants every revision, since an older revision can carry
+    a field shape a later one dropped. Value-*distribution* callers (field
+    value frequency/statistics, not shape discovery) want the opposite: a
+    session re-acquired N times would otherwise contribute its field values
+    N times, skewing a distribution toward whichever sources happen to have
+    the most revisions rather than reflecting the archive's actual logical
+    session population.
     """
     source_name = Provider.from_string(source_name)
     source_db_path = db_path.parent / "source.db"
@@ -264,17 +278,32 @@ def _iter_schema_units_from_db(
     query_provider = config.db_source_name or source_name
     origins = _sample_origins_for_provider(Provider.from_string(query_provider), config)
     placeholders = ",".join("?" for _ in origins)
-    with connection_context(source_db_path) as conn:
-        conn.row_factory = sqlite3.Row
-        cursor = conn.execute(
-            f"""
+    if logical_heads_only:
+        query = f"""
+            WITH heads AS (
+                SELECT
+                    source_path, origin, raw_id, blob_hash, file_mtime_ms, acquired_at_ms,
+                    validation_status,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY origin, COALESCE(native_id, source_path)
+                        ORDER BY acquired_at_ms DESC, raw_id DESC
+                    ) AS rn
+                FROM raw_sessions
+                WHERE origin IN ({placeholders})
+            )
+            SELECT source_path, origin, raw_id, blob_hash, file_mtime_ms, acquired_at_ms, validation_status
+            FROM heads WHERE rn = 1
+        """
+    else:
+        query = f"""
             SELECT source_path, origin, raw_id, blob_hash, file_mtime_ms, acquired_at_ms,
                    validation_status
             FROM raw_sessions
             WHERE origin IN ({placeholders})
-            """,
-            origins,
-        )
+        """
+    with connection_context(source_db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        cursor = conn.execute(query, origins)
         batch_size = 1 if config.sample_granularity == "record" else 100
         # Content-hash dedup: distinct ``raw_id``s legitimately collapse onto the
         # same ``blob_hash`` (unchanged re-acquisition, duplicate exports). Byte-
@@ -424,6 +453,7 @@ def _iter_samples_from_db(
     db_path: Path,
     config: ProviderConfig,
     with_conv_ids: Literal[False] = False,
+    logical_heads_only: bool = False,
 ) -> Iterator[SchemaSample]: ...
 
 
@@ -434,6 +464,7 @@ def _iter_samples_from_db(
     db_path: Path,
     config: ProviderConfig,
     with_conv_ids: Literal[True],
+    logical_heads_only: bool = False,
 ) -> Iterator[tuple[SchemaSample, str | None]]: ...
 
 
@@ -443,10 +474,19 @@ def _iter_samples_from_db(
     db_path: Path,
     config: ProviderConfig,
     with_conv_ids: bool = False,
+    logical_heads_only: bool = False,
 ) -> Iterator[SchemaSample | tuple[SchemaSample, str | None]]:
-    """Yield individual sample dicts from the database."""
+    """Yield individual sample dicts from the database.
+
+    ``logical_heads_only`` (default ``False``, opt-in) passes through to
+    :func:`_iter_schema_units_from_db` -- see its docstring for why a
+    value-distribution caller wants this and a shape-discovery caller does
+    not.
+    """
     source_name = Provider.from_string(source_name)
-    for unit in _iter_schema_units_from_db(source_name, db_path=db_path, config=config):
+    for unit in _iter_schema_units_from_db(
+        source_name, db_path=db_path, config=config, logical_heads_only=logical_heads_only
+    ):
         for sample in unit.schema_samples:
             if with_conv_ids:
                 yield sample, unit.session_id

--- a/tests/unit/core/test_schema_generation.py
+++ b/tests/unit/core/test_schema_generation.py
@@ -235,6 +235,105 @@ class TestGetSampleCountFromDb:
         assert get_sample_count_from_db("claude-ai", db_path=db_path) == 0
 
 
+class TestLogicalHeadsOnly:
+    """``_iter_schema_units_from_db(..., logical_heads_only=True)``.
+
+    polylogue-t0m73 phase 1: an opt-in flag restricting the sampling query
+    to one row per logical source (latest revision per
+    ``(origin, COALESCE(native_id, source_path))``) for value-distribution
+    callers, who would otherwise have a re-acquired session contribute its
+    field values once per revision. Default is unchanged (every revision
+    sampled) for schema-shape discovery, which wants every revision since
+    an older one can carry a shape a later one dropped.
+
+    The two seeded raw rows use *different* blob_hash values deliberately:
+    ``_iter_schema_units_from_db``'s own content-hash dedup already skips a
+    later raw_id that shares an earlier one's exact blob_hash (unrelated,
+    pre-existing behavior -- see its docstring), which would mask whether
+    ``logical_heads_only`` is doing anything. Both rows' payload decode is
+    left to fail naturally (no real blob file backs either hash) -- the
+    terminal recorder still observes every row the query selects before
+    decode is attempted, so this proves the *query's* row selection without
+    needing a real, parseable ChatGPT export.
+    """
+
+    def _seed_two_revisions(self, source_db_path: Path) -> None:
+        import sqlite3
+
+        from polylogue.storage.sqlite.archive_tiers.bootstrap import initialize_archive_database
+        from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+
+        initialize_archive_database(source_db_path, ArchiveTier.SOURCE)
+        conn = sqlite3.connect(source_db_path)
+        try:
+            conn.execute(
+                """
+                INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms)
+                VALUES ('raw-old', 'chatgpt-export', 'conv-1', '/x/old.json', ?, 10, 100)
+                """,
+                (b"\x11" * 32,),
+            )
+            conn.execute(
+                """
+                INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms)
+                VALUES ('raw-new', 'chatgpt-export', 'conv-1', '/x/new.json', ?, 200, 200)
+                """,
+                (b"\x22" * 32,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_default_samples_every_revision(self, tmp_path: Path) -> None:
+        from polylogue.core.enums import Provider
+        from polylogue.schemas.observation_identity import resolve_provider_config
+        from polylogue.schemas.sampling_db import _iter_schema_units_from_db
+
+        self._seed_two_revisions(tmp_path / "source.db")
+        config = resolve_provider_config(Provider.CHATGPT)
+
+        seen_raw_ids: list[str] = []
+
+        def _record(*, raw_id: str, status: object, artifact_kind: object, source_path: object, reason: object) -> None:
+            seen_raw_ids.append(raw_id)
+
+        list(
+            _iter_schema_units_from_db(
+                Provider.CHATGPT,
+                db_path=tmp_path / "index.db",
+                config=config,
+                terminal_recorder=_record,
+            )
+        )
+
+        assert sorted(seen_raw_ids) == ["raw-new", "raw-old"]
+
+    def test_logical_heads_only_samples_just_the_latest_revision(self, tmp_path: Path) -> None:
+        from polylogue.core.enums import Provider
+        from polylogue.schemas.observation_identity import resolve_provider_config
+        from polylogue.schemas.sampling_db import _iter_schema_units_from_db
+
+        self._seed_two_revisions(tmp_path / "source.db")
+        config = resolve_provider_config(Provider.CHATGPT)
+
+        seen_raw_ids: list[str] = []
+
+        def _record(*, raw_id: str, status: object, artifact_kind: object, source_path: object, reason: object) -> None:
+            seen_raw_ids.append(raw_id)
+
+        list(
+            _iter_schema_units_from_db(
+                Provider.CHATGPT,
+                db_path=tmp_path / "index.db",
+                config=config,
+                terminal_recorder=_record,
+                logical_heads_only=True,
+            )
+        )
+
+        assert seen_raw_ids == ["raw-new"]  # the later of the two revisions is the logical head
+
+
 class TestGenerateSchemaFromSamples:
     """Focused schema-generation edge cases beyond the general laws."""
 

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -484,6 +484,11 @@ def test_missing_archive_root_reports_skips_not_crashes(tmp_path: Path) -> None:
     assert names_by_status["source-index-coverage"] is OutcomeStatus.SKIP
     assert names_by_status["fts-parity"] is OutcomeStatus.SKIP
     assert names_by_status["lineage-sanity"] is OutcomeStatus.SKIP
+    assert names_by_status["enum-superset-check"] is OutcomeStatus.SKIP
+    assert names_by_status["blob-refs-liveness"] is OutcomeStatus.SKIP
+    assert names_by_status["embeddings-refs-liveness"] is OutcomeStatus.SKIP
+    assert names_by_status["session-lineage-acyclic"] is OutcomeStatus.SKIP
+    assert names_by_status["message-count-projection"] is OutcomeStatus.SKIP
     assert names_by_status["planner-stats"] is OutcomeStatus.SKIP
     assert names_by_status["counts-summary"] is OutcomeStatus.SKIP
 
@@ -518,6 +523,183 @@ def test_unknown_check_name_raises_value_error(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="unknown archive verification check"):
         verify_archive(tmp_path, checks=("not-a-real-check",))
+
+
+def test_enum_superset_check_passes_on_current_schema(tmp_path: Path) -> None:
+    """Freshly bootstrapped DDL is always generated from the current enum
+    (I2's failure mode requires a DDL frozen at an *older* enum version, which
+    a fresh fixture can't reproduce) -- this proves the check reads clean
+    against the schema this branch actually ships, not just that it never
+    trips."""
+    _seed_coherent_archive(tmp_path)
+
+    report = verify_archive(tmp_path, checks=("enum-superset-check",))
+
+    check = _check(report, "enum-superset-check")
+    assert check.status is OutcomeStatus.OK
+    assert check.evidence["current_origin_vocabulary"]
+
+
+def test_blob_ref_with_no_referent_trips_blob_refs_liveness(tmp_path: Path) -> None:
+    """RED TWIN (I3): a blob_refs row surviving its referent's deletion is
+    exactly the GC-liveness bug class this check exists to catch -- proves
+    it fails on the specific incoherence it claims to detect, not merely
+    that some check fails."""
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "source.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO blob_refs(blob_hash, ref_id, ref_type, size_bytes, acquired_at_ms)
+            VALUES (?, 'raw-does-not-exist', 'raw_payload', 10, 100)
+            """,
+            (b"f" * 32,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("blob-refs-liveness",))
+
+    check = _check(report, "blob-refs-liveness")
+    assert check.status is OutcomeStatus.ERROR
+    assert check.evidence["orphans_by_ref_type"]["raw_payload"] == 1
+    assert "raw-does-not-exist" in check.evidence["orphan_samples_by_ref_type"]["raw_payload"]
+
+
+def test_blob_refs_liveness_passes_on_coherent_archive(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "source.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO blob_refs(blob_hash, ref_id, ref_type, size_bytes, acquired_at_ms)
+            VALUES (?, 'raw-1', 'raw_payload', 10, 100)
+            """,
+            (b"a" * 32,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("blob-refs-liveness",))
+
+    check = _check(report, "blob-refs-liveness")
+    assert check.status is OutcomeStatus.OK
+    assert check.evidence["orphans_by_ref_type"] == {"raw_payload": 0, "attachment": 0, "sidecar": 0}
+
+
+def test_orphaned_embedding_ref_trips_embeddings_refs_liveness(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "embeddings.db")
+    try:
+        conn.execute(
+            """
+            INSERT INTO message_embedding_refs(message_id, session_id, origin, embedding_input_hash)
+            VALUES ('codex-session:session:no-such-message', 'codex-session:session', 'codex-session', ?)
+            """,
+            (b"g" * 32,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("embeddings-refs-liveness",))
+
+    check = _check(report, "embeddings-refs-liveness")
+    assert check.status is OutcomeStatus.ERROR
+    assert check.evidence["orphan_count"] == 1
+    assert "codex-session:session:no-such-message" in check.evidence["orphan_sample"]
+
+
+def test_embeddings_refs_liveness_passes_on_coherent_archive(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+
+    report = verify_archive(tmp_path, checks=("embeddings-refs-liveness",))
+
+    check = _check(report, "embeddings-refs-liveness")
+    assert check.status is OutcomeStatus.OK
+    assert check.evidence["orphan_count"] == 0
+
+
+def _insert_bare_session(conn: sqlite3.Connection, native_id: str, content_byte: bytes) -> None:
+    conn.execute(
+        """
+        INSERT INTO sessions(native_id, origin, content_hash, message_count)
+        VALUES (?, 'codex-session', ?, 0)
+        """,
+        (native_id, content_byte * 32),
+    )
+
+
+def test_parent_session_id_cycle_trips_session_lineage_acyclic(tmp_path: Path) -> None:
+    """RED TWIN (I5): two sessions whose parent_session_id point at each
+    other is the exact cycle the lineage-prefix-recomposition walker must
+    never be handed -- proves this check detects it, not merely that some
+    check fails."""
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "index.db")
+    try:
+        _insert_bare_session(conn, "cycle-a", b"\xa1")
+        _insert_bare_session(conn, "cycle-b", b"\xb2")
+        conn.commit()
+        conn.execute("UPDATE sessions SET parent_session_id = 'codex-session:cycle-b' WHERE native_id = 'cycle-a'")
+        conn.execute("UPDATE sessions SET parent_session_id = 'codex-session:cycle-a' WHERE native_id = 'cycle-b'")
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("session-lineage-acyclic",))
+
+    check = _check(report, "session-lineage-acyclic")
+    assert check.status is OutcomeStatus.ERROR
+    assert check.evidence["cycle_member_sample"]
+    assert {"codex-session:cycle-a", "codex-session:cycle-b"} <= set(check.evidence["cycle_member_sample"])
+
+
+def test_session_lineage_acyclic_passes_on_coherent_archive(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "index.db")
+    try:
+        _insert_bare_session(conn, "child", b"\xc3")
+        conn.commit()
+        conn.execute("UPDATE sessions SET parent_session_id = 'codex-session:session' WHERE native_id = 'child'")
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("session-lineage-acyclic",))
+
+    check = _check(report, "session-lineage-acyclic")
+    assert check.status is OutcomeStatus.OK
+    assert check.evidence["linked_session_count"] == 1
+
+
+def test_drifted_message_count_trips_message_count_projection(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+    conn = _connect(tmp_path / "index.db")
+    try:
+        conn.execute("UPDATE sessions SET message_count = 99 WHERE session_id = 'codex-session:session'")
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = verify_archive(tmp_path, checks=("message-count-projection",))
+
+    check = _check(report, "message-count-projection")
+    assert check.status is OutcomeStatus.ERROR
+    assert check.evidence["drifted_session_count"] == 1
+    assert "codex-session:session" in check.evidence["drifted_session_sample"]
+
+
+def test_message_count_projection_passes_on_coherent_archive(tmp_path: Path) -> None:
+    _seed_coherent_archive(tmp_path)
+
+    report = verify_archive(tmp_path, checks=("message-count-projection",))
+
+    check = _check(report, "message-count-projection")
+    assert check.status is OutcomeStatus.OK
+    assert check.evidence["drifted_session_count"] == 0
 
 
 def test_report_to_json_is_json_document(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -20,6 +20,7 @@ from polylogue.maintenance.archive_verification import (
 )
 from polylogue.storage.sqlite.archive_tiers.bootstrap import ARCHIVE_TIER_SPECS, initialize_active_archive_root
 from polylogue.storage.sqlite.archive_tiers.types import ArchiveTier
+from tests.infra.workload_artifacts import SeededArchiveArtifact
 
 
 def _connect(path: Path) -> sqlite3.Connection:
@@ -700,6 +701,25 @@ def test_message_count_projection_passes_on_coherent_archive(tmp_path: Path) -> 
     check = _check(report, "message-count-projection")
     assert check.status is OutcomeStatus.OK
     assert check.evidence["drifted_session_count"] == 0
+
+
+@pytest.mark.parametrize("check_name", ARCHIVE_VERIFICATION_CHECK_NAMES)
+def test_every_registry_check_does_not_error_on_the_real_pipeline_corpus(
+    check_name: str, seeded_archive: SeededArchiveArtifact
+) -> None:
+    """Every check in the registry, run individually against a real-pipeline
+    (acquire->parse->materialize->index), multi-provider synthetic corpus,
+    must not report ``error``. This is the anti-vacuity backstop for the
+    whole registry: a check that only ever runs against a single
+    hand-inserted row (the other tests in this file) could pass by never
+    actually exercising realistic multi-session, multi-provider shape.
+    ``verify_archive`` is read-only, so the session-scoped fixture root is
+    read directly with no per-test clone.
+    """
+    report = verify_archive(seeded_archive.root, checks=(check_name,))
+
+    check = _check(report, check_name)
+    assert check.status is not OutcomeStatus.ERROR, f"{check_name}: {check.summary}\n{check.evidence}"
 
 
 def test_report_to_json_is_json_document(tmp_path: Path) -> None:

--- a/tests/unit/maintenance/test_archive_verification.py
+++ b/tests/unit/maintenance/test_archive_verification.py
@@ -162,14 +162,23 @@ def test_invalid_pointer_file_is_reported_as_error(tmp_path: Path) -> None:
     assert "invalid active index pointer" in check.summary
 
 
-def test_raw_with_complete_census_and_no_session_is_missing_work(tmp_path: Path) -> None:
+def test_raw_with_no_typed_refusal_and_no_session_is_untyped_gap(tmp_path: Path) -> None:
+    """A head with a real authority grant (not quarantined) and no parse
+    error or declared-non-session census verdict that never materialized is
+    the exact bug class I1 exists to catch: a silent, unexplained
+    materialization failure. Ground truth is ``raw_sessions`` itself -- the
+    census row here is deliberately 'complete' (would have satisfied the old,
+    buggy universe) to prove the fix is about typing, not about the census.
+    """
     _seed_coherent_archive(tmp_path)
     source_conn = _connect(tmp_path / "source.db")
     try:
         source_conn.execute(
             """
-            INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms)
-            VALUES ('raw-orphaned-work', 'codex-session', 'never-materialized', '/y', ?, 10, 100)
+            INSERT INTO raw_sessions(
+                raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, revision_authority
+            )
+            VALUES ('raw-orphaned-work', 'codex-session', 'never-materialized', '/y', ?, 10, 100, 'byte_proven')
             """,
             (b"b" * 32,),
         )
@@ -187,9 +196,103 @@ def test_raw_with_complete_census_and_no_session_is_missing_work(tmp_path: Path)
 
     check = _check(report, "source-index-coverage")
     assert check.status is OutcomeStatus.ERROR
-    assert check.evidence["missing_work_count"] == 1
-    assert "raw-orphaned-work" in check.evidence["missing_work_sample"]
+    assert check.evidence["untyped_count"] == 1
+    assert "raw-orphaned-work" in check.evidence["untyped_sample"]
     assert check.evidence["orphan_count"] == 0
+
+
+def test_quarantined_head_with_no_session_is_warning_not_error(tmp_path: Path) -> None:
+    """The polylogue-in24n bug class in reverse: a quarantined raw (the
+    default ``revision_authority``) that never materialized is a *typed*
+    gap -- reconciliation hasn't granted it write authority yet -- and must
+    surface as WARN-level evidence, not silently invisible (the old bug) and
+    not a hard ERROR (quarantine is an ordinary, common, self-explaining
+    state; see t0m73/in24n live counts: 7,191 of 7,200 unindexed heads).
+    """
+    _seed_coherent_archive(tmp_path)
+    source_conn = _connect(tmp_path / "source.db")
+    try:
+        source_conn.execute(
+            """
+            INSERT INTO raw_sessions(raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms)
+            VALUES ('raw-quarantined', 'codex-session', 'not-yet-reconciled', '/z', ?, 10, 100)
+            """,
+            (b"c" * 32,),
+        )
+        source_conn.commit()
+    finally:
+        source_conn.close()
+
+    report = verify_archive(tmp_path, checks=("source-index-coverage",))
+
+    check = _check(report, "source-index-coverage")
+    assert check.status is OutcomeStatus.WARNING
+    assert not report.blocking
+    assert check.evidence["quarantined_count"] == 1
+    assert "raw-quarantined" in check.evidence["quarantined_sample"]
+    assert check.evidence["untyped_count"] == 0
+
+
+def test_parse_error_head_with_no_session_is_ok(tmp_path: Path) -> None:
+    """A head that failed to parse is explained by ``raw_sessions.parse_error``
+    itself -- not a coverage problem this check should flag at all."""
+    _seed_coherent_archive(tmp_path)
+    source_conn = _connect(tmp_path / "source.db")
+    try:
+        source_conn.execute(
+            """
+            INSERT INTO raw_sessions(
+                raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms,
+                revision_authority, parse_error
+            )
+            VALUES ('raw-parse-error', 'codex-session', 'unparseable', '/w', ?, 10, 100, 'byte_proven', 'boom')
+            """,
+            (b"d" * 32,),
+        )
+        source_conn.commit()
+    finally:
+        source_conn.close()
+
+    report = verify_archive(tmp_path, checks=("source-index-coverage",))
+
+    check = _check(report, "source-index-coverage")
+    assert check.status is OutcomeStatus.OK
+    assert check.evidence["parse_error_count"] == 1
+    assert check.evidence["untyped_count"] == 0
+    assert check.evidence["quarantined_count"] == 0
+
+
+def test_non_session_census_head_with_no_session_is_ok(tmp_path: Path) -> None:
+    """A head the census declared not-a-session (e.g. a settings/config
+    artifact) is a declared refusal, not a materialization gap."""
+    _seed_coherent_archive(tmp_path)
+    source_conn = _connect(tmp_path / "source.db")
+    try:
+        source_conn.execute(
+            """
+            INSERT INTO raw_sessions(
+                raw_id, origin, native_id, source_path, blob_hash, blob_size, acquired_at_ms, revision_authority
+            )
+            VALUES ('raw-non-session', 'codex-session', 'not-a-session', '/v', ?, 10, 100, 'byte_proven')
+            """,
+            (b"e" * 32,),
+        )
+        source_conn.execute(
+            """
+            INSERT INTO raw_membership_census(raw_id, parser_fingerprint, status, member_count, censused_at_ms)
+            VALUES ('raw-non-session', 'fp', 'non_session', 0, 100)
+            """
+        )
+        source_conn.commit()
+    finally:
+        source_conn.close()
+
+    report = verify_archive(tmp_path, checks=("source-index-coverage",))
+
+    check = _check(report, "source-index-coverage")
+    assert check.status is OutcomeStatus.OK
+    assert check.evidence["non_session_count"] == 1
+    assert check.evidence["untyped_count"] == 0
 
 
 def test_index_session_with_no_backing_raw_is_orphan(tmp_path: Path) -> None:
@@ -213,7 +316,7 @@ def test_index_session_with_no_backing_raw_is_orphan(tmp_path: Path) -> None:
     assert check.status is OutcomeStatus.ERROR
     assert check.evidence["orphan_count"] == 1
     assert "raw-does-not-exist" in check.evidence["orphan_sample"]
-    assert check.evidence["missing_work_count"] == 0
+    assert check.evidence["untyped_count"] == 0
 
 
 def test_deleted_fts_row_trips_message_fts_parity(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Phase 1 of the archive-verification registry productization: fixes the
source-index-coverage check's wrong-universe bug, adds 5 new ground-truth
checks migrated from the 2026-08-03 whole-archive invariant audit prototype,
parametrizes every registry check against the real-pipeline synthetic
corpus, and adds an opt-in head-only sampling mode for schema-inference
value-distribution use.

## Problem

A 2026-08-03 whole-archive invariant audit (prototype at
`.agent/scratch/archive-invariants-2026-08-03.py`, gitignored) found 7 of
10 invariants red on the live archive, none wired into the routine
`verify-archive` registry (`maintenance/archive_verification.py`). The
most severe finding: `_check_source_index_coverage` computed its universe
from `raw_membership_census` (the census machinery's own bookkeeping of
what it considered complete), so ~7,200 unindexed logical sources the
census never blessed were invisible to the check by construction -- it
reported OK while a real materialization gap sat underneath it.

## Solution

- **`source-index-coverage` rewrite** (Ref polylogue-in24n): universe is
  now `raw_sessions` logical heads (latest revision per `(origin,
  COALESCE(native_id, source_path))`), a ground-truth table every acquired
  raw lands in. An uncovered head must be typed as `parse_error`,
  `non_session`/`census_failed` (declared census verdict), or
  `quarantined` (WARN-level evidence, not blocking); anything else is an
  untyped gap and blocks alongside index-orphans. Added the registry
  contract rule to the module docstring: a check's universe must be a
  ground-truth table, never a derived ledger of the mechanism under audit.
- **5 new checks** (Ref polylogue-t0m73 phase 1), following the existing
  per-check error-isolation/evidence-dict/sample_limit pattern:
  - `enum-superset-check` (I2): live `origin`/`dst_origin` CHECK lists on
    disk are a superset of the current `Origin` enum -- catches the live
    incoherence the audit found (`Origin` gained `claude-design-session`
    after several tables' DDL was already written; a CHECK is frozen at
    table-creation time).
  - `blob-refs-liveness` (I3): every `blob_refs` row resolves in its
    `ref_type`'s referent table.
  - `embeddings-refs-liveness` (I4): `message_embedding_refs` resolve to a
    live index message (the feu0 dead-vector-row class).
  - `session-lineage-acyclic` (I5, partial): `sessions.parent_session_id`
    chains never close a cycle. `lineage-sanity` already covers
    `session_links`' dangling refs, so this adds only the uncovered
    sub-invariant. Not migrated: the prototype's status-IS-NULL predicate
    (polylogue-5dfu narrowed `TopologyEdgeStatus` so NULL is expected for
    the ordinary case -- gating on it would false-positive on a healthy
    fixture).
  - `message-count-projection` (I8): `sessions.message_count` matches
    `COUNT(*)` over `messages`.
  - Not migrated this phase: I6/I7 (need ops.db access patterns and a
    design decision on I6's criterion per t0m73's own rescope note), I9/I10
    (both passed live, lower urgency).
- **Parametrized real-corpus test**: one test iterates every registry
  check (12 total) against the session-scoped `seeded_archive` fixture
  (real acquire->parse->materialize->index pipeline, multi-provider
  synthetic corpus), asserting none report `error` -- the anti-vacuity
  backstop proving checks aren't only ever exercised against a single
  hand-inserted row.
- **`schemas/sampling_db.py` head-only sampling**: `_iter_schema_units_from_db`
  / `_iter_samples_from_db` gain an opt-in `logical_heads_only: bool = False`.
  Schema-shape discovery wants every revision (an older one can carry a
  shape a later one dropped); value-distribution work wants one row per
  logical source so a many-times-reacquired session doesn't skew a
  distribution. Default unchanged.

## Verification

- `devtools test tests/unit/maintenance/test_archive_verification.py` --
  42 passed (21 original + 4 new source-index-coverage cases + 8 new
  per-check OK/RED pairs, including RED TWINs for `blob-refs-liveness`
  and `session-lineage-acyclic` + 12 real-corpus parametrized cases + 1
  registry-count assertion).
- `devtools test tests/unit/core/test_schema_generation.py` -- 34 passed,
  1 skipped (2 new `logical_heads_only` cases).
- `devtools verify --quick` -- ok (mypy --strict, render all --check,
  layering, schema-versioning policy all green), run twice during this
  branch's work plus once more via the pre-push hook on this push.

## Not migrated (with reason)

- I6 (daemon liveness) and I7 (FTS drift sampler): read ops.db tables this
  check has no access pattern for yet; t0m73's own rescope note says I6's
  criterion needs a design change (gap>0 AND no recent convergence
  activity) before it's productizable.
- I9 (raw_revision_heads pointers) and I10 (user-tier ObjectRef
  anchoring): both passed live and are lower urgency; left for a
  follow-up phase.

Ref polylogue-in24n
Ref polylogue-t0m73

Co-Authored-By: Claude <noreply@anthropic.com>